### PR TITLE
feat: add external customized MoE provider seam

### DIFF
--- a/python/sglang/srt/layers/moe/__init__.py
+++ b/python/sglang/srt/layers/moe/__init__.py
@@ -1,3 +1,8 @@
+from sglang.srt.layers.moe.customized import (
+    CustomizedMoELayer,
+    CustomizedMoEProvider,
+    register_customized_moe_provider,
+)
 from sglang.srt.layers.moe.moe_runner import MoeRunner, MoeRunnerConfig
 from sglang.srt.layers.moe.utils import (
     DeepEPMode,
@@ -23,6 +28,9 @@ __all__ = [
     "MoeRunner",
     "MoeRunnerConfig",
     "MoeRunnerBackend",
+    "CustomizedMoELayer",
+    "CustomizedMoEProvider",
+    "register_customized_moe_provider",
     "initialize_moe_config",
     "get_moe_a2a_backend",
     "get_moe_runner_backend",

--- a/python/sglang/srt/layers/moe/customized.py
+++ b/python/sglang/srt/layers/moe/customized.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import torch
+
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
+    from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+
+
+@dataclass(frozen=True)
+class CustomizedMoELayer:
+    """The two layer-local objects owned by an out-of-tree MoE provider."""
+
+    method: FusedMoEMethodBase
+    dispatcher_factory: Callable[[MoeRunnerConfig], BaseDispatcher]
+
+
+@runtime_checkable
+class CustomizedMoEProvider(Protocol):
+    """Prepare one customized MoE layer without importing the provider here."""
+
+    def prepare_layer(
+        self,
+        *,
+        layer: torch.nn.Module,
+        prefix: str,
+        native_method: FusedMoEMethodBase,
+        runner_config: MoeRunnerConfig,
+    ) -> CustomizedMoELayer: ...
+
+
+_provider: CustomizedMoEProvider | None = None
+
+
+def register_customized_moe_provider(provider: CustomizedMoEProvider) -> None:
+    """Register the process-local provider loaded by an SGLang plugin."""
+
+    global _provider
+    if not isinstance(provider, CustomizedMoEProvider):
+        raise TypeError("customized MoE provider does not implement the provider API")
+    if _provider is not None:
+        raise ValueError("a customized MoE provider is already registered")
+    _provider = provider
+
+
+def get_customized_moe_provider() -> CustomizedMoEProvider:
+    if _provider is None:
+        raise RuntimeError(
+            "moe-a2a-backend=customized requires a registered customized MoE provider"
+        )
+    return _provider

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -29,6 +29,10 @@ from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     get_moe_runner_backend,
 )
+from sglang.srt.layers.moe.customized import (
+    CustomizedMoELayer,
+    get_customized_moe_provider,
+)
 from sglang.srt.layers.moe.kt_ep_wrapper import (
     KTEPWrapperMethod,
     create_kt_config_from_server_args,
@@ -207,6 +211,10 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             num_local_experts=moe_runner_config.num_local_experts,
             hidden_size=moe_runner_config.hidden_size,
             moe_runner_config=moe_runner_config,
+        )
+    elif a2a_backend.is_customized():
+        raise RuntimeError(
+            "customized dispatchers are constructed by their layer provider"
         )
     else:
         raise NotImplementedError(f"Unsupported a2a backend: {a2a_backend}")
@@ -452,6 +460,24 @@ class FusedMoE(torch.nn.Module):
                     self.use_flashinfer_trtllm_moe,
                     self.use_deep_gemm,
                 )
+        customized_layer: CustomizedMoELayer | None = None
+        if get_moe_a2a_backend().is_customized():
+            customized_layer = get_customized_moe_provider().prepare_layer(
+                layer=self,
+                prefix=prefix,
+                native_method=self.quant_method,
+                runner_config=self.moe_runner_config,
+            )
+            if not isinstance(customized_layer, CustomizedMoELayer):
+                raise TypeError(
+                    "CustomizedMoEProvider.prepare_layer must return CustomizedMoELayer"
+                )
+            if not isinstance(customized_layer.method, FusedMoEMethodBase):
+                raise TypeError(
+                    "CustomizedMoELayer.method must be a FusedMoEMethodBase"
+                )
+            self.quant_method = customized_layer.method
+
         _validate_hpc_ops_quant_method(self.quant_method)
         _validate_deepep_v2_quant_method(self.quant_method)
         nvfp4_deferred = envs.SGLANG_ENABLE_MOE_DEFERRED_FINALIZE.get() and isinstance(
@@ -492,7 +518,16 @@ class FusedMoE(torch.nn.Module):
         )
 
         self.quant_method.create_moe_runner(self, self.moe_runner_config)
-        self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
+        if customized_layer is None:
+            self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
+        else:
+            self.dispatcher = customized_layer.dispatcher_factory(
+                self.moe_runner_config
+            )
+            if not isinstance(self.dispatcher, BaseDispatcher):
+                raise TypeError(
+                    "CustomizedMoELayer.dispatcher_factory must return BaseDispatcher"
+                )
         # Dispatchers are not nn.Modules, so they cannot register their own
         # buffers; the AITER expert mask would not survive a memory-saver resume.
         expert_mask = getattr(self.dispatcher, "expert_mask_gpu", None)
@@ -518,7 +553,8 @@ class FusedMoE(torch.nn.Module):
             self.moe_runner_config.inplace = False
 
         self.should_fuse_routed_scaling_factor_in_topk = (
-            _fuses_routed_scaling_factor_in_topk(self.quant_method)
+            customized_layer is None
+            and _fuses_routed_scaling_factor_in_topk(self.quant_method)
         )
 
         self.routing_method_type = routing_method_type

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -182,6 +182,7 @@ class DispatchOutputFormat(Enum):
     FLASHINFER = "flashinfer"
     DEEPEP_V2 = "deepep_v2"
     ASCEND_TP = "ascend_tp"
+    CUSTOMIZED = "customized"
 
     def is_standard(self) -> bool:
         return self == DispatchOutputFormat.STANDARD
@@ -206,6 +207,9 @@ class DispatchOutputFormat(Enum):
 
     def is_deepep_v2(self) -> bool:
         return self == DispatchOutputFormat.DEEPEP_V2
+
+    def is_customized(self) -> bool:
+        return self == DispatchOutputFormat.CUSTOMIZED
 
 
 @runtime_checkable
@@ -275,6 +279,7 @@ class CombineInputFormat(Enum):
     FLASHINFER = "flashinfer"
     DEEPEP_V2 = "deepep_v2"
     ASCEND_TP = "ascend_tp"
+    CUSTOMIZED = "customized"
 
 
 @runtime_checkable

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -89,6 +89,7 @@ class LinearMethodBase(QuantizeMethodBase):
 
 class FusedMoEMethodBase(QuantizeMethodBase):
     runner: MoeRunner | None = None
+    loads_expert_weights = True
 
     def create_weights(
         self,

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -917,6 +917,20 @@ class GptOssForCausalLM(nn.Module):
         is_nextn: bool = False,
         weight_name_mapping: dict = None,
     ):
+        loads_expert_weights = all(
+            getattr(layer.mlp.experts.quant_method, "loads_expert_weights", True)
+            for layer in self.model.layers[self.start_layer : self.end_layer]
+            if isinstance(layer.mlp, GptOssSparseMoeBlock)
+        )
+        if not loads_expert_weights:
+            self._load_normal_weights(
+                weights,
+                is_nextn=is_nextn,
+                weight_name_mapping=weight_name_mapping,
+                skip_expert_weights=True,
+            )
+            return
+
         quant_config_name = (
             self.quant_config.get_name() if self.quant_config is not None else None
         )
@@ -1142,6 +1156,7 @@ class GptOssForCausalLM(nn.Module):
         is_nextn: bool,
         weight_name_mapping: dict,
         other_loaded_param_names=[],
+        skip_expert_weights: bool = False,
     ):
         if is_nextn:
             logging.warning(
@@ -1218,11 +1233,14 @@ class GptOssForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
-            loaded_weight = _WeightCreator.maybe_materialize(loaded_weight)
-
             # Apply weight name mapping if provided
             if weight_name_mapping and name in weight_name_mapping:
                 name = weight_name_mapping[name]
+
+            if skip_expert_weights and ".mlp.experts." in name:
+                continue
+
+            loaded_weight = _WeightCreator.maybe_materialize(loaded_weight)
 
             layer_id = get_layer_id(name)
             if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2362,6 +2362,7 @@ class ServerArgs:
             "deepep_v2",
             "ascend_tp",
             "pplx",
+            "customized",
         ],
         Arg(
             help="Choose the backend for MoE A2A.",
@@ -2377,6 +2378,7 @@ class ServerArgs:
                 "deepep_v2",
                 "pplx",
                 "ascend_tp",
+                "customized",
             ],
             resolvable=True,
         ),

--- a/test/registered/unit/layers/moe/test_customized_moe_provider.py
+++ b/test/registered/unit/layers/moe/test_customized_moe_provider.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe import MoeA2ABackend, MoeRunnerBackend
+from sglang.srt.layers.moe import customized as customized_module
+from sglang.srt.layers.moe.customized import (
+    CustomizedMoELayer,
+    get_customized_moe_provider,
+    register_customized_moe_provider,
+)
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
+from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+from sglang.srt.runtime_context import get_context, get_flags, get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+class _Method(FusedMoEMethodBase, torch.nn.Module):
+    loads_expert_weights = False
+
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    def create_weights(self, **kwargs):
+        self.events.append(("weights", kwargs["num_experts"]))
+
+    def create_moe_runner(self, layer, moe_runner_config):
+        self.events.append(("runner", moe_runner_config.layer_id))
+        self.runner = SimpleNamespace()
+
+    def apply(self, layer, dispatch_output):
+        raise AssertionError("not exercised by this lifecycle test")
+
+
+class _Dispatcher(BaseDispatcher):
+    def dispatch(self, hidden_states, topk_output):
+        raise AssertionError("not exercised by this lifecycle test")
+
+    def combine(self, combine_input):
+        raise AssertionError("not exercised by this lifecycle test")
+
+
+class _Provider:
+    def __init__(self, events):
+        self.events = events
+
+    def prepare_layer(self, *, layer, prefix, native_method, runner_config):
+        self.events.append(
+            ("prepare", prefix, type(native_method), runner_config.layer_id)
+        )
+        method = _Method(self.events)
+        return CustomizedMoELayer(
+            method=method,
+            dispatcher_factory=lambda config: _Dispatcher(),
+        )
+
+
+@pytest.fixture(autouse=True)
+def isolated_provider(monkeypatch):
+    monkeypatch.setattr(customized_module, "_provider", None)
+
+
+def test_customized_provider_owns_full_layer_lifecycle() -> None:
+    events = []
+    register_customized_moe_provider(_Provider(events))
+
+    with (
+        get_context().override_server_args(model_path="dummy"),
+        get_flags().moe.override(
+            runner_backend=MoeRunnerBackend.AUTO,
+            a2a_backend=MoeA2ABackend.CUSTOMIZED,
+        ),
+        get_parallel().override(
+            moe_ep_size=1,
+            moe_ep_rank=0,
+            moe_tp_size=1,
+            moe_tp_rank=0,
+            tp_size=1,
+            tp_rank=0,
+        ),
+    ):
+        layer = FusedMoE(
+            num_experts=32,
+            hidden_size=8,
+            intermediate_size=16,
+            layer_id=3,
+            prefix="model.layers.3.mlp.experts",
+            quant_method=UnquantizedFusedMoEMethod(),
+        )
+
+    assert isinstance(layer.quant_method, _Method)
+    assert isinstance(layer.dispatcher, _Dispatcher)
+    assert layer.quant_method.loads_expert_weights is False
+    assert [event[0] for event in events] == ["prepare", "weights", "runner"]
+
+
+def test_registration_is_single_owner_and_required() -> None:
+    with pytest.raises(RuntimeError, match="requires a registered"):
+        get_customized_moe_provider()
+
+    provider = _Provider([])
+    register_customized_moe_provider(provider)
+    assert get_customized_moe_provider() is provider
+    with pytest.raises(ValueError, match="already registered"):
+        register_customized_moe_provider(_Provider([]))


### PR DESCRIPTION
## Summary

- add a process-local provider seam for out-of-tree customized MoE backends
- let a provider install a layer-local `FusedMoEMethodBase` and dispatcher
- allow an external method to skip loading local expert weights
- preserve SGLang standard top-k tensors and keep the seam vendor-neutral
- cover registration, layer substitution, dispatcher construction, and expert-weight skipping

The accelerator transport, topology, and lifecycle remain outside SGLang. This patch contains no d-Matrix or Corsair dependency.

## Validation

- `git diff --check origin/main..HEAD`: pass
- Python syntax compilation for the new provider and unit test: pass with an isolated bytecode cache
- focused pytest was not run locally because this checkout does not have pytest installed; draft CI is expected to run it

This is intentionally a draft for API and ownership review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33336198197](https://github.com/sgl-project/sglang/actions/runs/33336198197)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33336198033](https://github.com/sgl-project/sglang/actions/runs/33336198033)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33336198165](https://github.com/sgl-project/sglang/actions/runs/33336198165)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->