### PR TITLE
fix(staging): make empty staging rings reusable

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -243,8 +243,12 @@ class StagingAllocator:
                 self.alloc_order.pop(0)
 
             if not self.allocations:
+                # An empty ring makes the entire prior round reusable. Start a
+                # fresh round at offset zero so the watermark cannot stay stale.
+                self.round += 1
+                self.head = 0
                 self.watermark_round = self.round
-                self.watermark_tail = self.head
+                self.watermark_tail = 0
             elif self.alloc_order:
                 off, _, rnd = self.allocations[self.alloc_order[0]]
                 self.watermark_round = rnd

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -108,8 +108,17 @@ class DecodeStagingHandler:
         if receiver is None or not receiver.bootstrap_infos:
             return
         key = tuple(str(bi) for bi in receiver.bootstrap_infos)
-        if key not in self._wm_subscribers:
-            self._wm_subscribers[key] = (receiver, session_id)
+        if key in self._wm_subscribers:
+            return
+
+        self._wm_subscribers[key] = (receiver, session_id)
+        # Watermark state is per prefill session. Send the current value so a
+        # new session's first allocation cannot wait on a missed update.
+        self._send_watermark(
+            receiver,
+            session_id,
+            self.staging_allocator.get_watermark(),
+        )
 
     def num_writers_for(self, receiver) -> int:
         """Compute all TP and PP writers expected for a staging chunk."""
@@ -443,26 +452,28 @@ class DecodeStagingHandler:
         return True
 
     def _free_and_send_watermark(
-        self, alloc_id: int, decode_req: DecodeRequest
+        self, alloc_id: int, _decode_req: DecodeRequest
     ) -> None:
         """Free a staging allocation and broadcast watermark to all prefills."""
         self.staging_allocator.free(alloc_id)
         post_wm = self.staging_allocator.get_watermark()
-        room = decode_req.req.bootstrap_room
-        wm_round, wm_tail = post_wm
+        for receiver, session_id in list(self._wm_subscribers.values()):
+            self._send_watermark(receiver, session_id, post_wm)
+
+    @staticmethod
+    def _send_watermark(receiver, session_id: str, watermark) -> None:
+        """Send one allocator watermark to a registered prefill session."""
+        wm_round, wm_tail = watermark
         wm_round_b = str(wm_round).encode("ascii")
         wm_tail_b = str(wm_tail).encode("ascii")
-        for _key, (receiver, session_id) in list(self._wm_subscribers.items()):
-            sid_b = session_id.encode("ascii")
-            for bootstrap_info in receiver.bootstrap_infos:
-                try:
-                    sock, lock = receiver._connect_to_bootstrap_server(bootstrap_info)
-                    with lock:
-                        sock.send_multipart(
-                            [b"WATERMARK", wm_round_b, wm_tail_b, sid_b]
-                        )
-                except Exception:
-                    pass
+        sid_b = session_id.encode("ascii")
+        for bootstrap_info in receiver.bootstrap_infos:
+            try:
+                sock, lock = receiver._connect_to_bootstrap_server(bootstrap_info)
+                with lock:
+                    sock.send_multipart([b"WATERMARK", wm_round_b, wm_tail_b, sid_b])
+            except Exception:
+                pass
 
 
 def is_watermark_ready(

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -9,7 +9,11 @@ import torch
 
 from sglang.srt.disaggregation.base.conn import KVArgs, StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.staging_buffer import (
+    StagingAllocator,
+)
 from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingHandler,
     handle_staging_req,
 )
 from sglang.srt.disaggregation.common.utils import (
@@ -218,6 +222,37 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
     def test_mismatched_nonempty_lengths_raise(self):
         with self.assertRaises(ValueError):
             group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
+
+
+class TestStagingWatermark(unittest.TestCase):
+    @patch("sglang.srt.disaggregation.common.staging_buffer.StagingBuffer")
+    def test_empty_ring_restarts_at_zero(self, staging_buffer):
+        staging_buffer.return_value.data_ptr = 0
+        allocator = StagingAllocator(100, "cpu", 0)
+        alloc_id, _, _ = allocator.assign(60)
+
+        allocator.free(alloc_id)
+
+        self.assertEqual(allocator.get_watermark(), (1, 0))
+        self.assertEqual(allocator.assign(70)[1:], (0, 1))
+
+    def test_new_watermark_subscriber_receives_current_allocator_state(self):
+        sock = Mock()
+        bootstrap_info = {"host": "prefill", "port": 7200}
+        receiver = Mock(
+            bootstrap_infos=[bootstrap_info],
+        )
+        receiver._connect_to_bootstrap_server.return_value = (sock, threading.Lock())
+        handler = object.__new__(DecodeStagingHandler)
+        handler.staging_allocator = Mock()
+        handler.staging_allocator.get_watermark.return_value = (3, 0)
+        handler._wm_subscribers = {}
+
+        handler.register_wm_subscriber(receiver, "session-new")
+
+        sock.send_multipart.assert_called_once_with(
+            [b"WATERMARK", b"3", b"0", b"session-new"]
+        )
 
 
 class TestMooncakePPStaging(unittest.TestCase):


### PR DESCRIPTION
## Motivation

With PD disaggregation staging enabled, the decode-side staging allocator can leave an empty ring at the previous allocation head. If a later allocation wraps into a new round and extends past that stale head, the prefill-side readiness check waits for a watermark that cannot advance because the ring is already empty.

Staging allocations are contiguous: if an allocation does not fit in the remaining tail, the whole allocation moves to offset zero in the next round. For example, after `[0, 60)` is freed in a 100-byte ring, the old state kept watermark `(0, 60)`; a subsequent 70-byte allocation became `(round=1, offset=0, end=70)` and waited forever on `70 <= 60`, even though no live allocation remained.

An empty ring is therefore restarted at offset zero in a new logical round. Advancing the round is necessary to keep the watermark monotonic while its tail returns to zero. The allocator persists across requests, while each prefill session learns watermark state independently, so a new subscriber also receives the allocator's current watermark snapshot instead of assuming the startup value `(0, 0)`.

Neither change relaxes overlap protection: the head is reset only while the allocation set is empty, and prefill continues to gate every wrapped allocation with the existing round/watermark check.

This was reproduced with `SGLANG_DISAGG_STAGING_BUFFER=1` in a heterogeneous attention-TP PD setup:

```text
prefill: --disaggregation-mode prefill --tp-size 4 --dp-size 4 --ep-size 4 --enable-dp-attention
decode:  --disaggregation-mode decode  --tp-size 8 --dp-size 1 --ep-size 1 --disable-attn-tp-gather
load:    concurrency=1, native batch-size-1 CUDA graph
```

The affected run stopped during warmup after completing 4 of 11 requests, with 3 requests left in flight.

## Modifications

- When the last staging allocation is freed, start a fresh allocator round at offset zero and publish watermark `(round, 0)`.
- Send the current allocator watermark immediately when a new prefill endpoint subscribes.
- Reuse one watermark-send helper for initial snapshots and updates after frees.
- Add two small regression tests for the empty-ring state transition and initial subscriber watermark delivery.

## Accuracy Tests

This change does not modify model math, logits, or sampling, so a model-accuracy comparison is not applicable.

Correctness before/after on the same C1 contract:

| Revision | Result |
| --- | --- |
| Upstream baseline, staging enabled | Warmup stopped at 4/11 completed, 3 requests in flight |
| Baseline + this fix, staging enabled | Warmup 11/11; profile 846/846 completed, 0 errors, 0 cancellations; TTFT and ITL coverage 100% |

The E2E comparison used upstream commit `0a585d5bb108cab8f0922b483d7f55812f05e245`, with only the two production files from this change overlaid in the fixed arm. The fixed run used a 3,600-second request window. An allocator-reset-only arm still stopped at 4/11, which verifies that the initial subscriber watermark is also required.

Two focused unit tests cover the allocator state transition and subscription snapshot. Local collection is blocked by missing runtime dependencies in the development environment; Python compilation, diff checks, isort, Black, Ruff, codespell, and the relevant repository lint checks pass.

## Speed Tests and Profiling

The baseline does not produce a valid steady-state performance result because requests remain in flight indefinitely. The completed fixed run reported:

- Request throughput: 0.23306 requests/s
- Input/output throughput: 21,388.87 / 217.35 tokens/s
- TTFT P50: 408.66 ms
- Interactivity P50/P90: 686.37 / 711.28 tokens/s/user

This PR makes no speedup claim; it restores forward progress in the staging path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No public API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33345458063](https://github.com/sgl-project/sglang/actions/runs/33345458063)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33345457949](https://github.com/sgl-project/sglang/actions/runs/33345457949)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33345458058](https://github.com/sgl-project/sglang/actions/runs/33345458058)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->