### PR TITLE
Prevent full CUDA-graph serving from corrupting MHC and DSA tensors

### DIFF
--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -18,7 +18,23 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
+)
 from sglang.srt.utils.common import is_gfx1250_supported
+
+
+@torch.compiler.disable
+def _retain_mhc_capture_owners(*tensors: torch.Tensor) -> None:
+    """Retain scratch tensors whose addresses a full graph capture records.
+
+    No-op outside an active full-graph capture scope. The compiler-disable
+    boundary keeps the retention side effect out of any enclosing Dynamo
+    graph, which would otherwise trace it away.
+    """
+    for tensor in tensors:
+        retain_full_cuda_graph_owner(tensor)
+
 
 logger = logging.getLogger(__name__)
 
@@ -1040,6 +1056,7 @@ def mhc_pre(
         gemm_out_sqrsum = torch.empty(
             n_splits, num_tokens, dtype=torch.float32, device=residual.device
         )
+        _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
 
         from sglang.srt.layers.deep_gemm_wrapper.entrypoint import tf32_hc_prenorm_gemm
 
@@ -1081,6 +1098,7 @@ def mhc_pre(
             partial_sqrsum = torch.empty(
                 n_splits_pre, num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(partial_out, partial_sqrsum)
             kernel_0(
                 residual_flat.view(num_tokens, hc_hidden_size),
                 fn_flat,
@@ -1103,6 +1121,7 @@ def mhc_pre(
             gemm_out_sqrsum = torch.empty(
                 n_splits, num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
             assert n_splits == 1, (
                 "The simple TileLang version gemm_sqrsum doesn't support split-k"
             )
@@ -1129,6 +1148,10 @@ def mhc_pre(
         )
         if not norm_weight_bf.is_contiguous():
             norm_weight_bf = norm_weight_bf.contiguous()
+        if norm_weight_bf is not norm_weight:
+            # Only a converted or contiguous copy has a dying owner; the
+            # caller's own parameter tensor outlives the graph already.
+            _retain_mhc_capture_owners(norm_weight_bf)
         mhc_pre_big_fuse_with_norm_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
@@ -1615,6 +1638,7 @@ def mhc_fused_post_pre(
     if num_tokens <= fma_token_threshold:
         # Small-batch path: one TileLang launch computes hc_post, the bf16
         # residual write, GEMM partials, and the RMS square-sum partials.
+        _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
         mhc_fused_post_pre_fma_tilelang(
             comb_res_mix.view(num_tokens, hc_mult, hc_mult),
             residual_flat,
@@ -1646,6 +1670,7 @@ def mhc_fused_post_pre(
         if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
             import deep_gemm
 
+            _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
             deep_gemm.tf32_hc_prenorm_gemm(
                 residual_cur.view(num_tokens, hc_hidden_size),
                 fn,
@@ -1662,6 +1687,7 @@ def mhc_fused_post_pre(
             gemm_out_sqrsum_1d = torch.empty(
                 num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(gemm_out_mul_2d, gemm_out_sqrsum_1d)
             _mhc_pre_gemm_sqrsum_dispatch()(
                 residual_cur.view(num_tokens, hc_hidden_size),
                 fn,
@@ -1708,6 +1734,10 @@ def mhc_fused_post_pre(
         )
         if not norm_weight_bf.is_contiguous():
             norm_weight_bf = norm_weight_bf.contiguous()
+        if norm_weight_bf is not norm_weight:
+            # Only a converted or contiguous copy has a dying owner; the
+            # caller's own parameter tensor outlives the graph already.
+            _retain_mhc_capture_owners(norm_weight_bf)
         mhc_pre_big_fuse_with_norm_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -38,6 +38,9 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
+)
 from sglang.srt.runtime_context import (
     get_device,
     get_exec,
@@ -740,7 +743,18 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         target_heads = 32
         q_fp8 = torch.nn.functional.pad(q_fp8, (0, 0, 0, target_heads - num_heads))
         weights = torch.nn.functional.pad(weights, (0, target_heads - num_heads))
+        Indexer._retain_padded_head_capture_owners(q_fp8, weights)
         return q_fp8, weights, num_heads
+
+    @staticmethod
+    @torch.compiler.disable
+    def _retain_padded_head_capture_owners(
+        q_fp8: torch.Tensor, weights: torch.Tensor
+    ) -> None:
+        # The padded tensors, not their sources, are what the captured
+        # kernels record; no-op outside an active full-graph capture scope.
+        retain_full_cuda_graph_owner(q_fp8)
+        retain_full_cuda_graph_owner(weights)
 
     def _mask_init_and_local_tokens(
         self,
@@ -776,6 +790,21 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             logits.scatter_(dim=1, index=local_idxs, value=float("inf"))
         return logits
 
+    @torch.compiler.disable
+    def _retain_full_graph_capture_owner(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Retain a tensor whose address a full CUDA graph capture records.
+
+        CUDA graphs replay through raw device pointers, so every tensor a
+        captured kernel reads or writes must stay allocated for the graph's
+        lifetime. The retain call is a no-op outside an active full-graph
+        capture scope; during capture the backend stores the owner with the
+        captured shape and releases it on recapture or cleanup. The
+        ``torch.compiler.disable`` boundary keeps the Python side effect out
+        of any enclosing Dynamo graph, which would otherwise trace it away.
+        """
+        retain_full_cuda_graph_owner(tensor)
+        return tensor
+
     def _get_topk_paged(
         self,
         forward_batch: ForwardBatch,
@@ -787,6 +816,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
+        weights = self._retain_full_graph_capture_owner(weights)
         page_size = get_token_to_kv_pool().page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
         if _is_hip:
@@ -1005,6 +1035,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
             )
 
+        logits = self._retain_full_graph_capture_owner(logits)
         # NOTE(dark): logits should be cleaned in topk_transform
         self._mask_init_and_local_tokens(logits, seqlens_32)
         topk_result = metadata.topk_transform(logits, self.index_topk)
@@ -1096,6 +1127,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
+        weights = self._retain_full_graph_capture_owner(weights)
         assert forward_batch.forward_mode.is_extend_without_speculative()
 
         page_size = get_token_to_kv_pool().page_size
@@ -1220,6 +1252,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
+            logits = self._retain_full_graph_capture_owner(logits)
             self._mask_init_and_local_tokens(logits, seq_lens_expanded, ks)
             raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
             topk_result[:q_offset] = raw_topk_result
@@ -1298,6 +1331,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 cu_seqlens_q_chunk = cu_seqlens_q_full[start:end]
                 batch_idx_chunk = token_to_batch_idx[start:end]
 
+            logits_chunk = self._retain_full_graph_capture_owner(logits_chunk)
             raw_topk_chunk = metadata.topk_transform(
                 logits_chunk,
                 self.index_topk,
@@ -1389,6 +1423,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             dtype=torch.float32,
             device=x_meta.device,
         )
+        dummy_logits = self._retain_full_graph_capture_owner(dummy_logits)
         raw_topk_result = metadata.topk_transform(dummy_logits, self.index_topk)
         if topk_result is not None:
             # PCG/BCG: fill the valid prefix of the padded static buffer and

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -30,6 +30,9 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.model_executor.runner_backend.base_cuda_graph_backend import (
     BaseCudaGraphBackend,
 )
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
 from sglang.srt.model_executor.runner_utils.pool import (
     GraphPoolPrecarve,
     get_or_create_global_graph_memory_pool,
@@ -88,6 +91,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
     ) -> None:
         self._graphs: Dict[Any, torch.cuda.CUDAGraph] = {}
         self._outputs: Dict[Any, Any] = {}
+        self._capture_owners: Dict[Any, tuple[Any, ...]] = {}
         self._pool = None
         self._cuda_graph_runner = cuda_graph_runner
         self._device_module = cuda_graph_runner.device_module
@@ -172,6 +176,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx = self._device_module.graph
 
         with (
+            collect_full_cuda_graph_owners() as capture_owners,
             graph_pool_capture_scope(),
             graph_ctx(cuda_graph=graph, pool=self._pool, stream=self._capture_stream),
         ):
@@ -190,6 +195,9 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
 
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = out
+        if capture_inputs is not None:
+            capture_owners.append(capture_inputs)
+        self._capture_owners[shape_key] = tuple(capture_owners)
 
     def can_run(self, forward_batch: ForwardBatch, shape_key: ShapeKey) -> bool:
         return shape_key in self._graphs
@@ -212,4 +220,5 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         self._graphs.clear()
         self._outputs.clear()
         self._output_buffer = None
+        self._capture_owners.clear()
         self._pool = None

--- a/python/sglang/srt/model_executor/runner_utils/capture_owner.py
+++ b/python/sglang/srt/model_executor/runner_utils/capture_owner.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator, Optional
+
+_full_cuda_graph_owners: ContextVar[Optional[list[Any]]] = ContextVar(
+    "full_cuda_graph_owners", default=None
+)
+
+
+@contextmanager
+def collect_full_cuda_graph_owners() -> Iterator[list[Any]]:
+    """Collect tensor owners whose addresses are recorded by one full graph."""
+
+    owners: list[Any] = []
+    token = _full_cuda_graph_owners.set(owners)
+    try:
+        yield owners
+    finally:
+        _full_cuda_graph_owners.reset(token)
+
+
+def retain_full_cuda_graph_owner(owner: Any) -> bool:
+    """Retain ``owner`` when called from an active full-graph capture."""
+
+    owners = _full_cuda_graph_owners.get()
+    if owners is None:
+        return False
+    owners.append(owner)
+    return True

--- a/test/registered/kernel/attention/test_dsa_capture_owner_cuda.py
+++ b/test/registered/kernel/attention/test_dsa_capture_owner_cuda.py
@@ -8,7 +8,7 @@ from sglang.srt.model_executor.runner_utils.capture_owner import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")

--- a/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
@@ -5,6 +5,9 @@ import torch
 
 import sglang.kernels.ops.layernorm.mhc as mhc
 from sglang.kernels.ops.layernorm.mhc import mhc_fused_post_pre, mhc_post, mhc_pre
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
@@ -19,6 +22,11 @@ def test_mhc_fused_post_pre_matches_unfused(
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for TileLang mHC kernels")
 
+    # This SM120 regression exercises the same TileLang prenorm fallback used
+    # by the GLM serving profile. Server-argument normalization disables the
+    # optional DeepGEMM path before model loading; the standalone kernel test
+    # must establish that profile explicitly.
+    monkeypatch.setenv("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "0")
     monkeypatch.setattr(mhc, "is_dsa_prefill_cp_round_robin_split", lambda: False)
     # This is a single-process kernel unit test with no TP group initialized.
     # mhc_pre / mhc_fused_post_pre allocate the MoE input in the symmetric-memory
@@ -78,25 +86,27 @@ def test_mhc_fused_post_pre_matches_unfused(
             norm_weight=norm_weight,
             norm_eps=norm_eps,
         )
-    residual_out, post_out, comb_out, layer_out = mhc_fused_post_pre(
-        x,
-        residual,
-        post_prev,
-        comb_prev,
-        fn,
-        hc_scale,
-        hc_base,
-        rms_eps,
-        hc_eps,
-        hc_eps,
-        2.0,
-        sinkhorn_repeat,
-        norm_weight=norm_weight,
-        norm_eps=norm_eps,
-    )
+    with collect_full_cuda_graph_owners() as capture_owners:
+        residual_out, post_out, comb_out, layer_out = mhc_fused_post_pre(
+            x,
+            residual,
+            post_prev,
+            comb_prev,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_eps,
+            hc_eps,
+            2.0,
+            sinkhorn_repeat,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+        )
 
     torch.cuda.synchronize()
     if num_tokens == 0:
+        assert capture_owners == []
         assert residual_out.shape == residual.shape
         assert post_out.shape == (0, hc_mult, 1)
         assert comb_out.shape == (0, hc_mult, hc_mult)
@@ -106,6 +116,25 @@ def test_mhc_fused_post_pre_matches_unfused(
         assert comb_out.dtype == torch.float32
         assert layer_out.dtype == torch.bfloat16
         return
+
+    assert len(capture_owners) == 2
+    gemm_out_mul_owner, gemm_out_sqrsum_owner = capture_owners
+    assert gemm_out_mul_owner.dtype == torch.float32
+    assert gemm_out_sqrsum_owner.dtype == torch.float32
+    if num_tokens <= 32:
+        # Small-batch path: the split-K pair is the kernel operand set.
+        assert gemm_out_mul_owner.ndim == 3
+        assert gemm_out_mul_owner.shape[1:] == (num_tokens, hc_mult3)
+        assert gemm_out_sqrsum_owner.ndim == 2
+        assert gemm_out_sqrsum_owner.shape == gemm_out_mul_owner.shape[:2]
+    else:
+        # Large-batch TileLang fallback (DeepGEMM prenorm disabled): the
+        # reallocated 2-D/1-D pair is the real kernel operand set and must
+        # be the retained owners, not the discarded split-K allocations.
+        assert gemm_out_mul_owner.ndim == 2
+        assert gemm_out_mul_owner.shape == (num_tokens, hc_mult3)
+        assert gemm_out_sqrsum_owner.ndim == 1
+        assert gemm_out_sqrsum_owner.shape == (num_tokens,)
 
     assert residual_ref is not None
     assert post_ref is not None
@@ -122,6 +151,65 @@ def test_mhc_fused_post_pre_matches_unfused(
     layer_atol = 2e-2 if use_norm else 2e-3
     layer_rtol = 2e-2 if use_norm else 2e-3
     torch.testing.assert_close(layer_out, layer_ref, atol=layer_atol, rtol=layer_rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_norm_weight_conversion_copy_is_retained(monkeypatch):
+    monkeypatch.setenv("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "0")
+    monkeypatch.setattr(mhc, "is_dsa_prefill_cp_round_robin_split", lambda: False)
+    monkeypatch.setattr(mhc, "use_symmetric_memory", lambda *a, **kw: nullcontext())
+    monkeypatch.setattr(mhc, "is_allocation_symmetric", lambda: False)
+    monkeypatch.setattr(mhc, "get_tp_group", lambda: None)
+    torch.manual_seed(20260830)
+    device = torch.device("cuda")
+    hc_mult, hidden_size, num_tokens = 4, 4096, 8
+    hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+    hc_hidden_size = hc_mult * hidden_size
+
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16) * 0.1
+    residual = (
+        torch.randn(
+            num_tokens, hc_mult, hidden_size, device=device, dtype=torch.bfloat16
+        )
+        * 0.1
+    )
+    post_prev = torch.rand(num_tokens, hc_mult, 1, device=device, dtype=torch.float32)
+    comb_prev = (
+        torch.rand(num_tokens, hc_mult, hc_mult, device=device, dtype=torch.float32)
+        * 0.25
+    )
+    fn = (
+        torch.randn(hc_mult3, hc_hidden_size, device=device, dtype=torch.float32) * 0.01
+    )
+    hc_scale = torch.tensor([0.5, 0.25, 0.25], device=device, dtype=torch.float32)
+    hc_base = torch.zeros(hc_mult3, device=device, dtype=torch.float32)
+    # A float32 norm weight forces the bf16 conversion copy inside the kernel.
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.float32)
+
+    with collect_full_cuda_graph_owners() as capture_owners:
+        mhc_fused_post_pre(
+            x,
+            residual,
+            post_prev,
+            comb_prev,
+            fn,
+            hc_scale,
+            hc_base,
+            1e-6,
+            1e-4,
+            1e-4,
+            2.0,
+            2,
+            norm_weight=norm_weight,
+            norm_eps=1e-6,
+        )
+    torch.cuda.synchronize()
+
+    assert len(capture_owners) == 3
+    converted = capture_owners[-1]
+    assert converted.dtype == torch.bfloat16
+    assert converted.shape == (hidden_size,)
+    assert converted is not norm_weight
 
 
 if __name__ == "__main__":

--- a/test/registered/layers/attention/test_dsa_capture_owner_cuda.py
+++ b/test/registered/layers/attention/test_dsa_capture_owner_cuda.py
@@ -1,0 +1,200 @@
+import pytest
+import torch
+
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.layers.attention.dsa.utils import fp8_mqa_logits_make_fused_kv
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_outer_torch_compile_preserves_capture_owner():
+    torch.manual_seed(48)
+    indexer = object.__new__(Indexer)
+    values = torch.randn(16, 32, device="cuda")
+
+    def outer(value):
+        produced = value.float().square()
+        produced = indexer._retain_full_graph_capture_owner(produced)
+        return produced.to(torch.int32)
+
+    compiled_outer = torch.compile(
+        outer, mode="max-autotune-no-cudagraphs", dynamic=False
+    )
+    compiled_outer(values)
+    torch.cuda.synchronize()
+
+    with collect_full_cuda_graph_owners() as owners:
+        output = compiled_outer(values)
+    torch.cuda.synchronize()
+
+    assert output.dtype == torch.int32
+    assert len(owners) == 1
+    assert owners[0].dtype == torch.float32
+    expected_replay = values.float().square()
+    torch.testing.assert_close(owners[0], expected_replay)
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        compiled_outer(values)
+        compiled_outer(values)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with collect_full_cuda_graph_owners() as capture_owners:
+        with torch.cuda.graph(graph, stream=capture_stream):
+            captured_output = compiled_outer(values)
+
+    del captured_output
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert len(capture_owners) == 1
+    torch.testing.assert_close(capture_owners[0], expected_replay)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_deepgemm_paged_logits_owner_survives_shared_pool_capture():
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("DeepGEMM paged MQA requires SM90 or newer")
+    deep_gemm = pytest.importorskip("deep_gemm")
+
+    torch.manual_seed(52)
+    torch._dynamo.reset()
+    batch_size = 24
+    max_context_len = 2240
+    block_size = 64
+    num_heads = 32
+    head_dim = 128
+    num_blocks = max_context_len // block_size
+
+    q_fp8 = torch.randn(batch_size, 1, num_heads, head_dim, device="cuda").to(
+        torch.float8_e4m3fn
+    )
+    kv_fp8 = torch.randn(num_blocks, block_size, head_dim, device="cuda").to(
+        torch.float8_e4m3fn
+    )
+    kv_scales = torch.ones(num_blocks, block_size, device="cuda")
+    kv_fused = fp8_mqa_logits_make_fused_kv(kv_fp8, kv_scales, block_size, head_dim)
+    weights = torch.randn(batch_size, num_heads, device="cuda")
+    context_lens = torch.full(
+        (batch_size, 1), max_context_len, dtype=torch.int32, device="cuda"
+    )
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device="cuda").repeat(
+        batch_size, 1
+    )
+    schedule = deep_gemm.get_paged_mqa_logits_metadata(
+        context_lens, block_size, deep_gemm.get_num_sms()
+    )
+    indexer = object.__new__(Indexer)
+
+    def outer(query):
+        logits = deep_gemm.fp8_paged_mqa_logits(
+            query,
+            kv_fused,
+            weights,
+            context_lens,
+            block_table,
+            schedule,
+            max_context_len,
+            clean_logits=False,
+        )
+        logits = indexer._retain_full_graph_capture_owner(logits)
+        return logits[:, :1]
+
+    compiled_outer = torch.compile(
+        outer, mode="max-autotune-no-cudagraphs", dynamic=False
+    )
+    expected = compiled_outer(q_fp8).detach().clone()
+    torch.cuda.synchronize()
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        compiled_outer(q_fp8)
+        compiled_outer(q_fp8)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+
+    pool = torch.cuda.graph_pool_handle()
+    graph = torch.cuda.CUDAGraph()
+    with collect_full_cuda_graph_owners() as capture_owners:
+        with torch.cuda.graph(graph, pool=pool, stream=capture_stream):
+            captured_output = compiled_outer(q_fp8)
+
+    assert len(capture_owners) == 1
+    owner = capture_owners[0]
+    assert owner.shape == (batch_size, max_context_len)
+    assert owner.dtype == torch.float32
+    assert (
+        owner.untyped_storage().data_ptr()
+        == captured_output.untyped_storage().data_ptr()
+    )
+
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(owner[:, :1], expected)
+    del captured_output
+    expected_owner = owner.detach().clone()
+
+    # A second capture sharing the pool must not receive the retained
+    # owner's storage; without retention the freed block is reusable and
+    # replaying the first graph would overwrite the second graph's tensor.
+    other_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(other_graph, pool=pool, stream=capture_stream):
+        other = torch.empty_like(owner)
+        other.fill_(17.0)
+    owner_start = owner.untyped_storage().data_ptr()
+    owner_end = owner_start + owner.untyped_storage().nbytes()
+    other_start = other.untyped_storage().data_ptr()
+    other_end = other_start + other.untyped_storage().nbytes()
+    assert owner_end <= other_start or other_end <= owner_start
+    del other
+
+    other_graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(owner, expected_owner)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_backend_stores_helper_retained_owner_with_the_shape():
+    from unittest import mock
+
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    indexer = object.__new__(Indexer)
+    runner = mock.Mock()
+    runner.device_module = torch.cuda
+    runner.model_runner.tp_group.barrier = lambda: None
+    runner.enable_profile_cuda_graph = False
+    backend = FullCudaGraphBackend(runner)
+
+    values = torch.randn(8, device="cuda")
+    produced = {}
+
+    def forward_fn():
+        tensor = values.float().square()
+        produced["tensor"] = indexer._retain_full_graph_capture_owner(tensor)
+        return object()
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with backend.capture_session(stream):
+        backend.capture_one("shape", forward_fn)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    assert produced["tensor"] in backend._capture_owners["shape"]
+    backend.cleanup()
+    assert backend._capture_owners == {}
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/unit/layers/attention/test_dsa_capture_owner.py
+++ b/test/registered/unit/layers/attention/test_dsa_capture_owner.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer as indexer_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestRetainFullGraphCaptureOwner(unittest.TestCase):
+    def test_noop_outside_capture_scope(self):
+        indexer = object.__new__(Indexer)
+        tensor = torch.empty(4)
+        result = indexer._retain_full_graph_capture_owner(tensor)
+        self.assertIs(result, tensor)
+
+    def test_records_owner_inside_capture_scope(self):
+        indexer = object.__new__(Indexer)
+        tensor = torch.empty(4)
+        with collect_full_cuda_graph_owners() as owners:
+            result = indexer._retain_full_graph_capture_owner(tensor)
+        self.assertIs(result, tensor)
+        self.assertEqual(owners, [tensor])
+
+    def test_retention_survives_enclosing_torch_compile(self):
+        # Dynamo traces away plain Python side effects; the helper's
+        # torch.compiler.disable boundary must force it to execute.
+        indexer = object.__new__(Indexer)
+
+        def outer(value):
+            produced = value.float().square()
+            produced = indexer._retain_full_graph_capture_owner(produced)
+            return produced.to(torch.int32)
+
+        compiled_outer = torch.compile(outer, dynamic=False)
+        values = torch.randn(8)
+        compiled_outer(values)
+
+        with collect_full_cuda_graph_owners() as owners:
+            output = compiled_outer(values)
+
+        self.assertEqual(output.dtype, torch.int32)
+        self.assertEqual(len(owners), 1)
+        self.assertEqual(owners[0].dtype, torch.float32)
+        torch.testing.assert_close(owners[0], values.float().square())
+
+    def test_paged_path_retains_weights_and_logits_before_consumers(self):
+        indexer = object.__new__(Indexer)
+        indexer.sm_count = 1
+        indexer.index_topk = 2048
+        indexer.paged_mqa_logits_backend = mock.Mock()
+        indexer.paged_mqa_logits_backend.is_cutedsl.return_value = False
+        indexer.paged_mqa_logits_backend.is_aiter.return_value = False
+        indexer._get_index_k_read_buffer = mock.Mock(
+            return_value=torch.empty(1, 64 * 132)
+        )
+        indexer._mask_init_and_local_tokens = mock.Mock(
+            side_effect=lambda logits, seqlens: events.append(("mask", logits))
+        )
+
+        q_fp8 = torch.empty(24, 32, 128)
+        weights = torch.empty(24, 32, 1)
+        seqlens = torch.full((24,), 2240, dtype=torch.int32)
+        block_tables = torch.zeros(24, 35, dtype=torch.int32)
+        logits = torch.empty(24, 2240)
+        topk = torch.empty(24, 2051, dtype=torch.int32)
+        events = []
+
+        forward_batch = mock.Mock()
+        forward_batch.forward_mode.is_target_verify.return_value = True
+        forward_batch.forward_mode.is_draft_extend_v2.return_value = False
+        metadata = mock.Mock()
+        metadata.get_page_table_64.return_value = block_tables
+        metadata.get_seqlens_expanded.return_value = seqlens
+        metadata.get_seqlens_int32.return_value = seqlens
+        metadata.get_dsa_extend_len_cpu.return_value = [1] * 24
+        metadata.paged_mqa_schedule_metadata = torch.empty(1, dtype=torch.int32)
+
+        def topk_transform(candidate, topk_count):
+            events.append(("topk", candidate))
+            return topk
+
+        metadata.topk_transform.side_effect = topk_transform
+
+        def retain(candidate):
+            events.append(("retain", candidate))
+            return candidate
+
+        def produce_logits(*args, **kwargs):
+            events.append(("produce", args[3]))
+            return logits
+
+        indexer._retain_full_graph_capture_owner = retain
+        pool = mock.Mock(page_size=64)
+        with (
+            mock.patch.object(
+                indexer_module, "get_token_to_kv_pool", return_value=pool
+            ),
+            mock.patch.object(indexer_module, "_is_hip", False),
+            mock.patch.object(indexer_module, "_is_cuda", True),
+            mock.patch.object(indexer_module, "deep_gemm", mock.Mock(), create=True),
+            mock.patch.object(
+                indexer_module,
+                "deepgemm_paged_mqa_logits_split",
+                side_effect=produce_logits,
+            ),
+        ):
+            result = indexer._get_topk_paged(forward_batch, 0, q_fp8, weights, metadata)
+
+        self.assertIs(result, topk)
+        kinds = [kind for kind, _ in events]
+        self.assertEqual(kinds, ["retain", "produce", "retain", "mask", "topk"])
+        self.assertIs(events[0][1], weights)
+        # The producer receives the squeezed view of the retained owner.
+        self.assertEqual(events[1][1].shape, (24, 32))
+        self.assertEqual(
+            events[1][1].untyped_storage().data_ptr(),
+            weights.untyped_storage().data_ptr(),
+        )
+        self.assertIs(events[2][1], logits)
+        self.assertIs(events[3][1], logits)
+        self.assertIs(events[4][1], logits)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
+++ b/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
@@ -20,7 +20,9 @@ profiler stepping) is pure-Python and runs on CPU.
 """
 
 import contextlib
+import gc
 import unittest
+import weakref
 from types import SimpleNamespace
 from unittest import mock
 
@@ -29,6 +31,9 @@ import torch
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
     FullCudaGraphBackend,
+)
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -56,6 +61,7 @@ def _make_backend(runner):
     backend = FullCudaGraphBackend.__new__(FullCudaGraphBackend)
     backend._graphs = {}
     backend._outputs = {}
+    backend._capture_owners = {}
     backend._pool = None
     backend._capture_stream = None
     backend._precarve = SimpleNamespace(
@@ -136,6 +142,57 @@ class TestCaptureOneNoProfiling(CustomTestCase):
         self.assertEqual(small.shape, (2, 2))
         self.assertEqual(large.data_ptr(), small.data_ptr())
         self.assertEqual(backend._output_buffer.shape, (4, 2))
+
+    def test_retains_only_capture_owners_and_releases_on_replacement(self):
+        runner = _make_runner(enable_profile=False, profiler=None)
+        backend = _make_backend(runner)
+        shape_key = ShapeKey(size=4)
+        captured_refs = []
+
+        class Owner:
+            pass
+
+        def forward_fn():
+            owner = Owner()
+            if retain_full_cuda_graph_owner(owner):
+                captured_refs.append(weakref.ref(owner))
+            return object()
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH-1"):
+            backend.capture_one(shape_key, forward_fn)
+
+        self.assertEqual(len(captured_refs), 1)
+        self.assertIsNotNone(captured_refs[0]())
+        self.assertEqual(len(backend._capture_owners[shape_key]), 1)
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH-2"):
+            backend.capture_one(shape_key, forward_fn)
+        gc.collect()
+
+        self.assertEqual(len(captured_refs), 2)
+        self.assertIsNone(captured_refs[0]())
+        self.assertIsNotNone(captured_refs[1]())
+        self.assertEqual(len(backend._capture_owners[shape_key]), 1)
+
+        backend.cleanup()
+        gc.collect()
+        self.assertIsNone(captured_refs[1]())
+        self.assertEqual(backend._capture_owners, {})
+
+    def test_capture_inputs_are_retained_with_the_shape(self):
+        runner = _make_runner(enable_profile=False, profiler=None)
+        backend = _make_backend(runner)
+        shape_key = ShapeKey(size=2)
+        capture_inputs = object()
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH"):
+            backend.capture_one(
+                shape_key, lambda: object(), capture_inputs=capture_inputs
+            )
+
+        self.assertIn(capture_inputs, backend._capture_owners[shape_key])
+        backend.cleanup()
+        self.assertEqual(backend._capture_owners, {})
 
     def test_enable_flag_set_but_no_profiler_attr_does_not_step(self):
         # The runner advertises the flag but never created a profiler; the


### PR DESCRIPTION
## Motivation

Full CUDA graphs record raw pointers. Temporary MHC and DSA tensors can lose their Python owners after capture, allowing a later capture to reuse storage that an earlier graph still accesses.

## Modifications

Retain capture inputs and affected MHC/DSA tensors per captured shape. Replace owners on recapture and release them during cleanup. Keep retention outside compiler tracing, which otherwise removes the side effect. Other graph backends take no-op calls; kernel math and tensor layouts are unchanged.

## Accuracy Tests

Author validation at `00e34a411f` on main `afe90a8bc9` on one RTX PRO 6000 Blackwell Max-Q (SM120): 3 tests passed. Targets: `test/registered/kernel/attention/test_dsa_capture_owner_cuda.py`.

Author CPU validation at `4ee21703a0`: 11 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `00e34a411f` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

Author tests on SM120 passed 11 CPU ownership/backend tests, two CUDA graph ownership tests and 25 MHC tests. The unsupported DeepGEMM paged-MQA case was deselected. Tests cover compiled retention, shared graph pools, recapture, cleanup and numerical comparisons; they do not rule out every source of graph corruption.

## Speed Tests and Profiling

Retention extends buffer lifetimes and can retain the full unchunked logits allocation. No isolated throughput benchmark was repeated for this rebase.

## Checklist

- [x] Format changed code and retain CPU/CUDA regressions.
- [x] State memory cost and validation scope.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282188711](https://github.com/sgl-project/sglang/actions/runs/34282188711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282187875](https://github.com/sgl-project/sglang/actions/runs/34282187875)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282189311](https://github.com/sgl-project/sglang/actions/runs/34282189311)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
