### PR TITLE
Capture allocator history to investigate CUDA-graph memory corruption

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1339,6 +1339,11 @@ class Envs:
     # Eager forward wraps the ForwardBatch's own tensors instead of copying them
     # into the CUDA graph buffer registry (no per-iter device-to-device copy).
     SGLANG_EAGER_INPUT_NO_COPY = EnvBool(False)
+    # Directory for allocator-history forensics snapshots (unset = disabled).
+    # Snapshots map damaged addresses to the allocation site of the block a
+    # captured CUDA graph still writes through.
+    SGLANG_MEM_FORENSICS_DIR = EnvStr(None)
+    SGLANG_MEM_FORENSICS_MAX_ENTRIES = EnvInt(300000)
 
     # ===================================================================
     # Tokenizer, request state, embeddings, and reasoning controls

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -347,6 +347,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
     resolve_image_processor_backend,
 )
+from sglang.srt.utils.mem_forensics import maybe_dump_memory_forensics
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -1846,6 +1847,10 @@ class Scheduler(
         # Triton kernel device-load is a lazy first-use at serving time.
         triton_load_watch.install()
         triton_load_watch.mark_serving_started()
+
+        # Snapshot allocator state while every capture-era block is still
+        # alive; damaged addresses at runtime resolve against this dump.
+        maybe_dump_memory_forensics("ready")
 
         if use_mlx():
             # MLX overlap uses mx.async_eval for CPU/GPU overlap,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -225,6 +225,7 @@ from sglang.srt.utils import (
     slow_rank_detector,
 )
 from sglang.srt.utils.device_timer import device_timer_ctx
+from sglang.srt.utils.mem_forensics import maybe_start_memory_forensics
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
@@ -432,6 +433,10 @@ class ModelRunner:
         # Get available memory before model loading.
         # Stored for later use by alloc_memory_pool().
         self.init_torch_distributed()
+
+        # Allocator-history recording must begin before any lazily created
+        # buffer that a captured CUDA graph may later reference.
+        maybe_start_memory_forensics()
 
         # Init forward stream for overlap schedule
         self.forward_stream = torch.get_device_module(self.device).Stream()

--- a/python/sglang/srt/utils/mem_forensics.py
+++ b/python/sglang/srt/utils/mem_forensics.py
@@ -1,0 +1,163 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Allocator-history forensics for CUDA-graph buffer lifetime debugging.
+
+When ``SGLANG_MEM_FORENSICS_DIR`` names a directory, the model runner starts
+CUDA caching-allocator history recording (with Python allocation stacks)
+during initialization, and each scheduler writes one
+``torch.cuda.memory._snapshot`` pickle tagged ``ready`` when it reaches its
+event loop, after every CUDA graph capture has completed. Failure handlers
+may call :func:`maybe_dump_memory_forensics` with their own tag for a second
+snapshot. Mapping a corrupted tensor's ``data_ptr`` onto the ``ready``
+snapshot names the allocation site of a block a captured graph recorded.
+
+Recording is started once per process and left active. The allocator keeps
+one process-wide history recorder, so another feature that calls
+``torch.cuda.memory._record_memory_history`` itself (the ``MEM`` activity of
+the torch profiler, the CUDA graph runner's capture-debug path) stops or
+reconfigures it. A dump therefore checks the snapshot for history entries
+first: when there are none, it re-arms recording with the configured
+parameters, writes nothing, and leaves the tag unconsumed, so the next
+request for that tag writes a snapshot whose history starts at the re-arm.
+Limitation: the first request after another profiler stopped recording only
+re-arms, and the snapshot that follows carries no history from before that
+point. Both entry points return without touching ``torch.cuda`` unless the
+directory variable is set, and dump failures are logged and never raised, so
+the original failure path of a caller is preserved even on a faulted CUDA
+context.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import threading
+import time
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_started = False
+_dumped_tags: set[str] = set()
+
+
+def memory_forensics_enabled() -> bool:
+    return bool(envs.SGLANG_MEM_FORENSICS_DIR.get())
+
+
+def _rank_label() -> str:
+    try:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            return str(torch.distributed.get_rank())
+    except Exception:
+        pass
+    return "na"
+
+
+def _start_recording() -> None:
+    torch.cuda.memory._record_memory_history(
+        enabled="all",
+        context="all",
+        stacks="python",
+        max_entries=envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.get(),
+    )
+
+
+def _snapshot_has_history(snapshot) -> bool:
+    return any(snapshot.get("device_traces") or [])
+
+
+def maybe_start_memory_forensics() -> None:
+    """Begin allocator-history recording once per process when enabled."""
+    global _started
+    if not memory_forensics_enabled():
+        return
+    with _lock:
+        if _started:
+            return
+        try:
+            if not torch.cuda.is_available():
+                return
+            _start_recording()
+        except Exception:
+            logger.exception("Memory forensics recording failed to start")
+            return
+        _started = True
+        logger.info(
+            "Memory forensics recording started (dir=%s, max_entries=%d)",
+            envs.SGLANG_MEM_FORENSICS_DIR.get(),
+            envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.get(),
+        )
+
+
+def maybe_dump_memory_forensics(tag: str) -> None:
+    """Write one snapshot pickle per (process, tag).
+
+    The snapshot is written to a temporary file and moved into place
+    atomically; the tag is consumed only after a successful write, so a
+    transient failure does not suppress a later retry. A snapshot without
+    history entries is not written: recording is re-armed instead and the
+    tag stays unconsumed (see the module docstring). File names embed the
+    distributed rank, the PID, and a nanosecond timestamp, so concurrent
+    data-parallel replicas, restarts, and multiple servers sharing the
+    directory cannot collide.
+    """
+    if not _started:
+        return
+    with _lock:
+        if tag in _dumped_tags:
+            return
+        out_dir = envs.SGLANG_MEM_FORENSICS_DIR.get()
+        path = os.path.join(
+            out_dir,
+            f"mem-forensics-{tag}-rank{_rank_label()}"
+            f"-pid{os.getpid()}-{time.time_ns()}.pickle",
+        )
+        try:
+            snapshot = torch.cuda.memory._snapshot()
+            if not _snapshot_has_history(snapshot):
+                # Another memory profiler stopped the process-wide recorder.
+                # Re-arm now and defer the dump: the next request for this
+                # tag writes a snapshot with history from this point on.
+                _start_recording()
+                logger.warning(
+                    "Memory forensics snapshot %r deferred: allocator history "
+                    "was not being recorded (another memory profiler stopped "
+                    "it); recording re-armed, the next request for this tag "
+                    "writes a snapshot.",
+                    tag,
+                )
+                return
+            os.makedirs(out_dir, exist_ok=True)
+            tmp_path = path + ".tmp"
+            try:
+                with open(tmp_path, "wb") as file:
+                    pickle.dump(snapshot, file)
+                os.replace(tmp_path, path)
+            except BaseException:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except Exception:
+            logger.exception("Memory forensics dump failed for tag %r", tag)
+            return
+        _dumped_tags.add(tag)
+        logger.info("Memory forensics snapshot written: %s", path)

--- a/test/registered/unit/utils/test_mem_forensics.py
+++ b/test/registered/unit/utils/test_mem_forensics.py
@@ -1,0 +1,184 @@
+"""Unit tests for allocator-history forensics gating and dump lifecycle."""
+
+import os
+import pickle
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import mem_forensics
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+LOGGER = "sglang.srt.utils.mem_forensics"
+WITH_HISTORY = {"segments": [], "device_traces": [[{"action": "alloc"}]]}
+NO_HISTORY = {"segments": [], "device_traces": [[], []]}
+
+
+class MemForensicsTest(unittest.TestCase):
+    def setUp(self):
+        mem_forensics._started = False
+        mem_forensics._dumped_tags = set()
+
+    def test_disabled_without_directory(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override(None):
+            with mock.patch.object(
+                torch.cuda.memory, "_record_memory_history"
+            ) as record:
+                mem_forensics.maybe_start_memory_forensics()
+        self.assertFalse(record.called)
+        self.assertFalse(mem_forensics._started)
+
+    def test_start_records_once_with_configured_parameters(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
+            with envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(1234):
+                with mock.patch.object(
+                    torch.cuda, "is_available", return_value=True
+                ), mock.patch.object(
+                    torch.cuda.memory, "_record_memory_history"
+                ) as record:
+                    mem_forensics.maybe_start_memory_forensics()
+                    mem_forensics.maybe_start_memory_forensics()
+        self.assertEqual(record.call_count, 1)
+        self.assertEqual(record.call_args.kwargs["enabled"], "all")
+        self.assertEqual(record.call_args.kwargs["context"], "all")
+        self.assertEqual(record.call_args.kwargs["stacks"], "python")
+        self.assertEqual(record.call_args.kwargs["max_entries"], 1234)
+        self.assertTrue(mem_forensics._started)
+
+    def test_start_failure_is_contained_and_not_marked_started(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
+            with mock.patch.object(
+                torch.cuda, "is_available", return_value=True
+            ), mock.patch.object(
+                torch.cuda.memory,
+                "_record_memory_history",
+                side_effect=RuntimeError("driver"),
+            ):
+                mem_forensics.maybe_start_memory_forensics()
+        self.assertFalse(mem_forensics._started)
+
+    def test_dump_writes_one_snapshot_per_tag(self):
+        snapshot = WITH_HISTORY
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=snapshot
+                ), mock.patch.object(
+                    torch.cuda.memory, "_record_memory_history"
+                ) as record:
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+            names = sorted(os.listdir(out_dir))
+            self.assertEqual(len(names), 2)
+            self.assertEqual(
+                sorted(name.split("-")[2] for name in names),
+                ["corruption", "ready"],
+            )
+            for name in names:
+                self.assertIn(f"pid{os.getpid()}", name)
+                self.assertTrue(name.endswith(".pickle"))
+            with open(os.path.join(out_dir, names[0]), "rb") as file:
+                self.assertEqual(pickle.load(file), snapshot)
+        # History was present, so nothing was re-armed.
+        self.assertFalse(record.called)
+
+    def test_dump_is_noop_before_start(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+
+    def test_failed_dump_never_raises_and_allows_retry(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory,
+                    "_snapshot",
+                    side_effect=RuntimeError("faulted context"),
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+                self.assertEqual(os.listdir(out_dir), [])
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+            names = os.listdir(out_dir)
+            self.assertEqual(len(names), 1)
+
+    def test_failed_write_leaves_no_partial_file(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                ), mock.patch.object(pickle, "dump", side_effect=OSError("disk full")):
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+            self.assertNotIn("ready", mem_forensics._dumped_tags)
+
+    def test_dump_without_history_rearms_and_defers_to_next_request(self):
+        # Sequence from the review: a MEM torch profile ran and stopped the
+        # process-wide recorder, then a retained phase asks for a snapshot.
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(
+                out_dir
+            ), envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(4321):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                ), mock.patch.object(
+                    torch.cuda.memory, "_record_memory_history"
+                ) as record, self.assertLogs(
+                    LOGGER, level="WARNING"
+                ) as logs:
+                    mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
+                # Re-armed with the configured parameters, nothing written,
+                # tag still open.
+                self.assertEqual(record.call_count, 1)
+                self.assertEqual(record.call_args.kwargs["enabled"], "all")
+                self.assertEqual(record.call_args.kwargs["stacks"], "python")
+                self.assertEqual(record.call_args.kwargs["max_entries"], 4321)
+                self.assertEqual(os.listdir(out_dir), [])
+                self.assertNotIn("retained-kda:extend", mem_forensics._dumped_tags)
+                self.assertTrue(any("re-armed" in line for line in logs.output))
+                # The next request for the same tag finds history and writes.
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                ), mock.patch.object(
+                    torch.cuda.memory, "_record_memory_history"
+                ) as record:
+                    mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
+                self.assertFalse(record.called)
+                names = os.listdir(out_dir)
+                self.assertEqual(len(names), 1)
+                self.assertIn("retained-kda:extend", names[0])
+            self.assertIn("retained-kda:extend", mem_forensics._dumped_tags)
+
+    def test_rearm_failure_is_contained_and_keeps_tag_open(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                ), mock.patch.object(
+                    torch.cuda.memory,
+                    "_record_memory_history",
+                    side_effect=RuntimeError("driver"),
+                ), self.assertLogs(
+                    LOGGER, level="ERROR"
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+            self.assertNotIn("ready", mem_forensics._dumped_tags)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_mem_forensics.py
+++ b/test/registered/unit/utils/test_mem_forensics.py
@@ -36,11 +36,12 @@ class MemForensicsTest(unittest.TestCase):
     def test_start_records_once_with_configured_parameters(self):
         with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
             with envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(1234):
-                with mock.patch.object(
-                    torch.cuda, "is_available", return_value=True
-                ), mock.patch.object(
-                    torch.cuda.memory, "_record_memory_history"
-                ) as record:
+                with (
+                    mock.patch.object(torch.cuda, "is_available", return_value=True),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
                     mem_forensics.maybe_start_memory_forensics()
                     mem_forensics.maybe_start_memory_forensics()
         self.assertEqual(record.call_count, 1)
@@ -52,12 +53,13 @@ class MemForensicsTest(unittest.TestCase):
 
     def test_start_failure_is_contained_and_not_marked_started(self):
         with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
-            with mock.patch.object(
-                torch.cuda, "is_available", return_value=True
-            ), mock.patch.object(
-                torch.cuda.memory,
-                "_record_memory_history",
-                side_effect=RuntimeError("driver"),
+            with (
+                mock.patch.object(torch.cuda, "is_available", return_value=True),
+                mock.patch.object(
+                    torch.cuda.memory,
+                    "_record_memory_history",
+                    side_effect=RuntimeError("driver"),
+                ),
             ):
                 mem_forensics.maybe_start_memory_forensics()
         self.assertFalse(mem_forensics._started)
@@ -67,11 +69,14 @@ class MemForensicsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as out_dir:
             with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
                 mem_forensics._started = True
-                with mock.patch.object(
-                    torch.cuda.memory, "_snapshot", return_value=snapshot
-                ), mock.patch.object(
-                    torch.cuda.memory, "_record_memory_history"
-                ) as record:
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=snapshot
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
                     mem_forensics.maybe_dump_memory_forensics("ready")
                     mem_forensics.maybe_dump_memory_forensics("ready")
                     mem_forensics.maybe_dump_memory_forensics("corruption")
@@ -117,9 +122,12 @@ class MemForensicsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as out_dir:
             with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
                 mem_forensics._started = True
-                with mock.patch.object(
-                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
-                ), mock.patch.object(pickle, "dump", side_effect=OSError("disk full")):
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                    ),
+                    mock.patch.object(pickle, "dump", side_effect=OSError("disk full")),
+                ):
                     mem_forensics.maybe_dump_memory_forensics("ready")
             self.assertEqual(os.listdir(out_dir), [])
             self.assertNotIn("ready", mem_forensics._dumped_tags)
@@ -128,17 +136,20 @@ class MemForensicsTest(unittest.TestCase):
         # Sequence from the review: a MEM torch profile ran and stopped the
         # process-wide recorder, then a retained phase asks for a snapshot.
         with tempfile.TemporaryDirectory() as out_dir:
-            with envs.SGLANG_MEM_FORENSICS_DIR.override(
-                out_dir
-            ), envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(4321):
+            with (
+                envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir),
+                envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(4321),
+            ):
                 mem_forensics._started = True
-                with mock.patch.object(
-                    torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
-                ), mock.patch.object(
-                    torch.cuda.memory, "_record_memory_history"
-                ) as record, self.assertLogs(
-                    LOGGER, level="WARNING"
-                ) as logs:
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                    self.assertLogs(LOGGER, level="WARNING") as logs,
+                ):
                     mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
                 # Re-armed with the configured parameters, nothing written,
                 # tag still open.
@@ -150,11 +161,14 @@ class MemForensicsTest(unittest.TestCase):
                 self.assertNotIn("retained-kda:extend", mem_forensics._dumped_tags)
                 self.assertTrue(any("re-armed" in line for line in logs.output))
                 # The next request for the same tag finds history and writes.
-                with mock.patch.object(
-                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
-                ), mock.patch.object(
-                    torch.cuda.memory, "_record_memory_history"
-                ) as record:
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
                     mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
                 self.assertFalse(record.called)
                 names = os.listdir(out_dir)
@@ -166,14 +180,16 @@ class MemForensicsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as out_dir:
             with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
                 mem_forensics._started = True
-                with mock.patch.object(
-                    torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
-                ), mock.patch.object(
-                    torch.cuda.memory,
-                    "_record_memory_history",
-                    side_effect=RuntimeError("driver"),
-                ), self.assertLogs(
-                    LOGGER, level="ERROR"
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory,
+                        "_record_memory_history",
+                        side_effect=RuntimeError("driver"),
+                    ),
+                    self.assertLogs(LOGGER, level="ERROR"),
                 ):
                     mem_forensics.maybe_dump_memory_forensics("ready")
             self.assertEqual(os.listdir(out_dir), [])


### PR DESCRIPTION
## Motivation

A stale CUDA-graph pointer can overwrite a tensor owned by unrelated code. The later failure identifies the corrupted tensor, not the allocation that the graph originally captured, making the cause difficult to trace.

This PR adds an opt-in way to retain allocator history and save snapshots after graph capture. Investigators can map an affected address to allocation stacks. It is a diagnostic aid, not a memory-corruption fix; #37168 addresses specific captured-tensor lifetime defects.

## Modifications

Set `SGLANG_MEM_FORENSICS_DIR` to start PyTorch allocation-history recording after distributed initialization and save a `ready` snapshot after all scheduler captures complete. Additional tags can be requested by failure handlers. Snapshots have unique rank/PID/timestamp names and use atomic writes; a failed write can be retried.

If another profiler has stopped history recording, re-arm it and defer that tag's snapshot instead of saving a history-less result. Failures are logged, not raised. With the directory unset, the helpers do not call CUDA.

## Accuracy Tests

Author CPU validation at `a1c86f9371`: 9 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `7b542b2563` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

CPU tests substitute recorder and snapshot operations to check disabled behavior, one-time initialization, configured history limits, one successful write per tag, retry after write failure, atomic-write cleanup, and re-arming after history has been disabled. They validate recorder lifecycle and failure handling, not whether a snapshot identifies a particular GPU writer.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/utils/test_mem_forensics.py
```

No model-path or tensor-value change. No exact-head full-model diagnostic receipt is attached to this PR.

## Speed Tests and Profiling

Disabled by default. Enabled recording captures Python allocation stacks and consumes history storage. No isolated overhead benchmark is attached.

## Checklist

- [x] Format changed code and add CPU lifecycle tests.
- [x] Document opt-in behavior and evidence limitations.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282192716](https://github.com/sgl-project/sglang/actions/runs/34282192716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282192545](https://github.com/sgl-project/sglang/actions/runs/34282192545)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282192656](https://github.com/sgl-project/sglang/actions/runs/34282192656)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
