### PR TITLE
[Scheduler] Add strict prefill/decode phase separation

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3290,15 +3290,15 @@ class Scheduler(
             running_batch = prefill_plan.running_batch
 
         need_mlp_sync = self.require_mlp_sync
-        if (
-            need_mlp_sync
-            and not self.spec_algorithm.is_none()
-            and not get_spec().speculative_skip_dp_mlp_sync
+        if need_mlp_sync and (
+            get_schedule().enable_prefill_decode_phase_separation
+            or (
+                not self.spec_algorithm.is_none()
+                and not get_spec().speculative_skip_dp_mlp_sync
+            )
         ):
-            # NOTE: This branch makes sure prefill and decode batches will not be mixed when spec and dp-attn is enabled.
-            # Before merging the new batch into running batch:
-            # 1. All new batches are none -> need_mlp_sync remains true (sync is needed for decode batch).
-            # 2. All new batches are some (prefill / idle) -> we do not need prepare mlp sync one more time.
+            # A peer prefill turns None into IDLE and preserves local decode.
+            # All-None keeps need_mlp_sync set for the selected decode below.
             new_batch = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(new_batch)
             need_mlp_sync = new_batch is None
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -720,6 +720,16 @@ class ServerArgs:
         "The number of decode rounds to run after a prefill batch before scheduling the next prefill. In data-parallel attention mode, the interval is synchronized across all DP ranks. Set to 0 to disable.",
         NS("schedule"),
     ] = 0
+    enable_prefill_decode_phase_separation: A[
+        bool,
+        (
+            "Keep prefill and decode phases separate across data-parallel "
+            "attention ranks. When any rank schedules prefill, ranks without "
+            "prefill execute an idle batch and preserve their running decode "
+            "batch for a later iteration."
+        ),
+        NS("schedule"),
+    ] = False
     enable_dynamic_chunking: A[
         bool,
         "Enable dynamic chunk size adjustment for pipeline parallelism. When enabled, chunk sizes are dynamically calculated based on fitted function to maintain consistent execution time across chunks.",

--- a/test/registered/unit/managers/test_scheduler_prefill_decode_interval.py
+++ b/test/registered/unit/managers/test_scheduler_prefill_decode_interval.py
@@ -2,13 +2,16 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import maybe_stub_sgl_kernel
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
+from sglang.srt.managers.schedule_batch import NextBatchPlan
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.runtime_context import get_context
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
@@ -69,6 +72,64 @@ class TestPrefillDecodeInterval(unittest.TestCase):
         )
 
         self.assertEqual(scheduler._prefill_decode_interval_remaining, 1)
+
+
+class TestPrefillDecodePhaseSeparation(CustomTestCase):
+    def test_peer_prefill_preserves_local_decode(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._pending_chunked_abort_req = None
+        scheduler._abort_on_waiting_timeout = MagicMock()
+        scheduler._abort_on_running_timeout = MagicMock()
+        scheduler.dllm_config = None
+        scheduler.enable_fpm = False
+        scheduler.enable_hisparse = False
+        scheduler.chunked_req = None
+        scheduler.require_mlp_sync = True
+        scheduler.spec_algorithm = SimpleNamespace(is_none=lambda: True)
+        scheduler.prefill_decode_interval = 0
+        scheduler._prefill_decode_interval_remaining = 0
+        scheduler.ngram_embedding_manager = MagicMock()
+        scheduler.ngram_embedding_manager.prepare_for_forward.side_effect = (
+            lambda batch, **_: batch
+        )
+
+        running_batch = MagicMock(name="running_decode_batch")
+        running_batch.is_empty.return_value = False
+        running_batch.is_prefill_only = False
+        scheduler.get_new_batch_prefill = MagicMock(
+            return_value=NextBatchPlan(
+                batch_to_run=None, running_batch=running_batch
+            )
+        )
+        scheduler.update_running_batch = MagicMock(
+            side_effect=AssertionError("running decode must be preserved")
+        )
+
+        idle_batch = MagicMock(name="peer_prefill_idle_batch")
+        scheduler.dp_attn_adapter = MagicMock()
+        scheduler.dp_attn_adapter.maybe_prepare_mlp_sync_batch.side_effect = [
+            idle_batch,
+            idle_batch,
+        ]
+        scheduler.dp_attn_adapter.maybe_convert_decode_to_extend.return_value = (
+            idle_batch
+        )
+
+        with (
+            get_context().override_server_args(
+                enable_prefill_decode_phase_separation=True
+            ),
+            patch("sglang.srt.managers.scheduler.set_schedule_time_batch"),
+        ):
+            plan = scheduler.get_next_batch_to_run(running_batch, last_batch=None)
+
+        self.assertIs(plan.batch_to_run, idle_batch)
+        self.assertIs(plan.running_batch, running_batch)
+        scheduler.update_running_batch.assert_not_called()
+        self.assertEqual(
+            scheduler.dp_attn_adapter.maybe_prepare_mlp_sync_batch.call_args_list,
+            [call(None), call(idle_batch, need_sync=False)],
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -157,6 +157,15 @@ class TestPrepareServerArgs(CustomTestCase):
         ):
             ServerArgs(model_path="dummy", prefill_decode_interval=-1).resolve_once()
 
+    def test_prefill_decode_phase_separation(self):
+        args = prepare_server_args(
+            ["--model-path", "dummy", "--enable-prefill-decode-phase-separation"]
+        )
+        args.resolve_once()
+        self.assertTrue(
+            resolution_result(args, "enable_prefill_decode_phase_separation")
+        )
+
     def test_dsv4_prefill_backend_cli_choices(self):
         parser = server_args_module.argparse.ArgumentParser()
         ServerArgs.add_cli_args(parser)


### PR DESCRIPTION
## Motivation

DP-attention ranks schedule their local prefill work independently. `prefill_decode_interval` can delay later prefill admissions, but it does not prevent one rank from running prefill while a peer rank runs decode in the same global DP step. Decode-to-extend conversion makes the forward mode homogeneous; it does not guarantee token-phase separation.

Some serving policies need the stronger invariant that a global step is prefill-only or decode-only. This PR adds that invariant as an opt-in mode. When any DP-attention rank schedules prefill, ranks without local prefill run an idle batch and preserve their running decode batch for a later scheduler iteration.

The option is disabled by default because it adds scheduler synchronization and can trade throughput for phase isolation.

## Modifications

- Add `--enable-prefill-decode-phase-separation` (default: off).
- Run the existing pre-decode DP MLP synchronization path when strict separation is enabled, including non-speculative decoding.
- Preserve the local running decode batch when a peer rank has selected prefill.
- Add a scheduler regression test for the peer-prefill/local-decode case and a real CLI parsing test.

## Accuracy Tests

This changes scheduling only; it does not modify model math, kernels, or token sampling.

End-to-end Kimi-K3 MXFP4 validation with DP attention:

- C16: 798/798 completions, zero request errors, zero process restarts, and zero decode steps while any DP rank was in prefill.
- C128: 1,128/1,128 completions, zero request errors, zero process restarts, and zero decode steps while any DP rank was in prefill.

The C128 run exercised substantial asymmetric prefill traffic, so the zero-overlap result covers the path introduced here rather than an all-ranks-prefill-only case.

## Speed Tests and Profiling

The C16 validation produced 398.5 output tok/s and 1.95M total tokens/minute, with 32.5 ms median inter-token latency. The initial C128 stress run produced 790 output tok/s and 4.72M total tokens/minute, with 147.5 ms median inter-token latency. These numbers characterize the tested deployment rather than promise a speedup; strict phase separation is an isolation policy and may intentionally idle decode ranks during asymmetric prefill.

## Tests

- Scheduler unit tests: 5 passed
- ServerArgs unit tests: 186 passed
- Ruff and repository AST/diff/registered-test/bare-pytest checks passed

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). The generated CLI help documents the new opt-in flag; no existing default changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33344535869](https://github.com/sgl-project/sglang/actions/runs/33344535869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33344535754](https://github.com/sgl-project/sglang/actions/runs/33344535754)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33344535856](https://github.com/sgl-project/sglang/actions/runs/33344535856)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->