### PR TITLE
[HiCache] Add storage-preserving flush for UnifiedRadixCache

### DIFF
--- a/docs/docs/basic_usage/native_api.mdx
+++ b/docs/docs/basic_usage/native_api.mdx
@@ -128,10 +128,14 @@ Flush the radix cache. It will be automatically triggered when the model weights
 
 Parameters:
 - `timeout` (query, float, default `0`, unit: seconds): Wait time for idle state before flushing. `0` means fail fast if not idle. When HiCache async operations are in-flight, a non-zero timeout allows the server to wait until idle before flushing, avoiding unnecessary 400 errors.
+- `preserve_hicache_storage` (query, bool, default `false`): Before flushing, synchronously checkpoint all evictable cache-mode `UnifiedRadixCache` state to the configured HiCache storage backend. The request fails without clearing the in-memory cache if hierarchical storage is unavailable, buffer-only host mode is active, cache entries are protected, or the checkpoint cannot finish.
 
 ```bash Command
 # With timeout (wait up to 30s for idle state)
 curl -s -X POST "http://127.0.0.1:30000/flush_cache?timeout=30"
+
+# Preserve HiCache state across a graceful server restart
+curl -s -X POST "http://127.0.0.1:30000/flush_cache?timeout=30&preserve_hicache_storage=true"
 ```
 
 ```python Example

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -979,9 +979,15 @@ async def classify_request(obj: EmbeddingReqInput, request: Request):
 
 @app.api_route("/flush_cache", methods=["GET", "POST"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
+async def flush_cache(
+    timeout: float = Query(0.0, ge=0.0),
+    preserve_hicache_storage: bool = Query(False),
+):
     """Flush the radix cache."""
-    ret = await _global_state.tokenizer_manager.flush_cache(timeout_s=timeout)
+    ret = await _global_state.tokenizer_manager.flush_cache(
+        timeout_s=timeout,
+        preserve_hicache_storage=preserve_hicache_storage,
+    )
     if ret.success:
         content = (
             "Cache flushed.\nPlease check backend logs for more details. "

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1654,6 +1654,7 @@ class ClearHiCacheReqOutput(BaseReq, kw_only=True):
 
 class FlushCacheReqInput(BaseReq, kw_only=True):
     timeout_s: Optional[float] = None
+    preserve_hicache_storage: bool = False
 
 
 class FlushCacheReqOutput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4570,9 +4570,95 @@ class Scheduler(
 
         return DetachHiCacheStorageReqOutput(success=False, message=msg)
 
-    def flush_cache(self, empty_cache: bool = True):
+    def _checkpoint_hicache_storage(self) -> bool:
+        """Persist all evictable UnifiedRadixCache state before a cache reset."""
+        if not self.enable_hierarchical_cache or not self.enable_hicache_storage:
+            logger.warning(
+                "Cannot preserve HiCache storage because hierarchical storage "
+                "is not enabled."
+            )
+            return False
+        if self.server_args.hicache_host_memory_mode != "cache":
+            logger.warning(
+                "Preserving HiCache storage before flush currently requires "
+                "--hicache-host-memory-mode cache."
+            )
+            return False
+
+        from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+        from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+        tree_cache = self.tree_cache
+        if not isinstance(tree_cache, UnifiedRadixCache):
+            logger.warning(
+                "Preserving HiCache storage before flush currently requires "
+                "UnifiedRadixCache, got %s.",
+                type(tree_cache).__name__,
+            )
+            return False
+
+        protected = (
+            tree_cache.full_protected_size(),
+            tree_cache.swa_protected_size(),
+            tree_cache.mamba_protected_size(),
+        )
+        if any(protected):
+            logger.warning(
+                "Cannot checkpoint HiCache while cache entries are protected: "
+                "full=%d swa=%d mamba=%d",
+                *protected,
+            )
+            return False
+
+        requested = EvictParams(
+            num_tokens=tree_cache.full_evictable_size(),
+            swa_num_tokens=tree_cache.swa_evictable_size(),
+            mamba_num=tree_cache.mamba_evictable_size(),
+        )
+        if requested.num_tokens or requested.swa_num_tokens or requested.mamba_num:
+            tree_cache.evict(requested)
+            remaining = (
+                tree_cache.full_evictable_size(),
+                tree_cache.swa_evictable_size(),
+                tree_cache.mamba_evictable_size(),
+            )
+            if any(remaining):
+                logger.warning(
+                    "HiCache checkpoint eviction was incomplete: "
+                    "full=%d swa=%d mamba=%d",
+                    *remaining,
+                )
+                return False
+
+        tree_cache.writing_check(write_back=True)
+        deadline = time.monotonic() + 300.0
+        while tree_cache.ongoing_backup:
+            tree_cache.check_hicache_events()
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "HiCache checkpoint timed out with %d storage writes pending.",
+                    len(tree_cache.ongoing_backup),
+                )
+                return False
+            time.sleep(0.01)
+
+        logger.info(
+            "HiCache checkpoint completed before flush: full=%d swa=%d mamba=%d",
+            requested.num_tokens,
+            requested.swa_num_tokens,
+            requested.mamba_num,
+        )
+        return True
+
+    def flush_cache(
+        self,
+        empty_cache: bool = True,
+        preserve_hicache_storage: bool = False,
+    ):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
         if self.is_fully_idle():
+            if preserve_hicache_storage and not self._checkpoint_hicache_storage():
+                return False
             self.cur_batch_for_debug = None
             self.last_batch = None
             self.tree_cache.reset()

--- a/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
+++ b/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
@@ -12,7 +12,7 @@ class SchedulerFlushWrapper:
     def __init__(
         self,
         *,
-        flush_cache: Callable[[], bool],
+        flush_cache: Callable[[bool], bool],
         is_fully_idle: Callable[[], bool],
         ipc_channels: SchedulerIpcChannels,
     ) -> None:
@@ -30,10 +30,14 @@ class SchedulerFlushWrapper:
 
         timeout_s = float(recv_req.timeout_s or 0.0)
         if timeout_s <= 0.0:
-            return FlushCacheReqOutput(success=self._flush_cache())
+            return FlushCacheReqOutput(
+                success=self._flush_cache(recv_req.preserve_hicache_storage)
+            )
 
         if self._is_fully_idle():
-            return FlushCacheReqOutput(success=self._flush_cache())
+            return FlushCacheReqOutput(
+                success=self._flush_cache(recv_req.preserve_hicache_storage)
+            )
 
         self._pending = (recv_req, time.monotonic() + timeout_s)
         return None
@@ -45,7 +49,7 @@ class SchedulerFlushWrapper:
         pending_req, deadline = self._pending
 
         if self._is_fully_idle():
-            success = self._flush_cache()
+            success = self._flush_cache(pending_req.preserve_hicache_storage)
             self._pending = None
             self._ipc_channels.send_to_tokenizer.send_output(
                 FlushCacheReqOutput(success=success), pending_req

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -302,11 +302,18 @@ class TokenizerControlMixin:
         )
 
     async def flush_cache(
-        self: TokenizerManager, timeout_s: Optional[float] = None
+        self: TokenizerManager,
+        timeout_s: Optional[float] = None,
+        preserve_hicache_storage: bool = False,
     ) -> FlushCacheReqOutput:
         self.auto_create_handle_loop()
         result = (
-            await self.flush_cache_communicator(FlushCacheReqInput(timeout_s=timeout_s))
+            await self.flush_cache_communicator(
+                FlushCacheReqInput(
+                    timeout_s=timeout_s,
+                    preserve_hicache_storage=preserve_hicache_storage,
+                )
+            )
         )[0]
         if result.success and self.mm_processor is not None:
             self.mm_processor.clear_preprocess_cache()

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -11,6 +11,8 @@ from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.scheduler_components.flush_wrapper import (
     SchedulerFlushWrapper,
 )
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, EvictResult
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
 register_cpu_ci(est_time=14, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="base-c-test-cpu")
@@ -37,7 +39,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
         output = scheduler.flush_wrapper.handle(FlushCacheReqInput(timeout_s=None))
 
         self.assertFalse(output.success)
-        scheduler.flush_cache.assert_called_once()
+        scheduler.flush_cache.assert_called_once_with(False)
 
     def test_immediate_flush_when_idle(self):
         """Positive timeout but already idle → flush immediately."""
@@ -47,7 +49,21 @@ class TestSchedulerFlushCache(unittest.TestCase):
         output = scheduler.flush_wrapper.handle(FlushCacheReqInput(timeout_s=5.0))
 
         self.assertTrue(output.success)
-        scheduler.flush_cache.assert_called_once()
+        scheduler.flush_cache.assert_called_once_with(False)
+
+    def test_preserve_hicache_storage_is_forwarded(self):
+        scheduler = self._new_scheduler()
+        scheduler.is_fully_idle.return_value = True
+
+        output = scheduler.flush_wrapper.handle(
+            FlushCacheReqInput(
+                timeout_s=5.0,
+                preserve_hicache_storage=True,
+            )
+        )
+
+        self.assertTrue(output.success)
+        scheduler.flush_cache.assert_called_once_with(True)
 
     def test_defers_when_busy(self):
         """Positive timeout + busy → defers, returns None."""
@@ -82,13 +98,16 @@ class TestSchedulerFlushCache(unittest.TestCase):
     def test_pending_flush_completes_on_idle(self):
         scheduler = self._new_scheduler()
         scheduler.is_fully_idle.return_value = True
-        req = FlushCacheReqInput(timeout_s=1.0)
+        req = FlushCacheReqInput(
+            timeout_s=1.0,
+            preserve_hicache_storage=True,
+        )
         scheduler.flush_wrapper._pending = (req, 111.0)
 
         scheduler.flush_wrapper.check_pending()
 
         self.assertIsNone(scheduler.flush_wrapper._pending)
-        scheduler.flush_cache.assert_called_once()
+        scheduler.flush_cache.assert_called_once_with(True)
         out = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args.args[0]
         self.assertTrue(out.success)
 
@@ -121,6 +140,75 @@ class TestSchedulerFlushCache(unittest.TestCase):
 
         self.assertIsNotNone(scheduler.flush_wrapper._pending)
         scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_checkpoint_hicache_storage_drains_all_components(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = True
+        scheduler.enable_hicache_storage = True
+        scheduler.server_args = MagicMock(hicache_host_memory_mode="cache")
+        scheduler.tree_cache = UnifiedRadixCache.__new__(UnifiedRadixCache)
+        scheduler.tree_cache.full_evictable_size = MagicMock(side_effect=[10, 0])
+        scheduler.tree_cache.swa_evictable_size = MagicMock(side_effect=[4, 0])
+        scheduler.tree_cache.mamba_evictable_size = MagicMock(side_effect=[2, 0])
+        scheduler.tree_cache.full_protected_size = MagicMock(return_value=0)
+        scheduler.tree_cache.swa_protected_size = MagicMock(return_value=0)
+        scheduler.tree_cache.mamba_protected_size = MagicMock(return_value=0)
+        scheduler.tree_cache.evict = MagicMock(
+            return_value=EvictResult(
+                num_tokens_evicted=10,
+                swa_num_tokens_evicted=4,
+                mamba_num_evicted=2,
+            )
+        )
+        scheduler.tree_cache.writing_check = MagicMock()
+        scheduler.tree_cache.check_hicache_events = MagicMock()
+        scheduler.tree_cache.ongoing_backup = {1: object()}
+
+        def drain_backup():
+            scheduler.tree_cache.ongoing_backup.clear()
+
+        scheduler.tree_cache.check_hicache_events.side_effect = drain_backup
+
+        self.assertTrue(scheduler._checkpoint_hicache_storage())
+        scheduler.tree_cache.evict.assert_called_once_with(
+            EvictParams(num_tokens=10, swa_num_tokens=4, mamba_num=2)
+        )
+        scheduler.tree_cache.writing_check.assert_called_once_with(write_back=True)
+        scheduler.tree_cache.check_hicache_events.assert_called_once()
+
+    def test_checkpoint_hicache_storage_requires_storage_backend(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = True
+        scheduler.enable_hicache_storage = False
+        scheduler.server_args = MagicMock(hicache_host_memory_mode="cache")
+        scheduler.tree_cache = MagicMock()
+
+        self.assertFalse(scheduler._checkpoint_hicache_storage())
+        scheduler.tree_cache.evict.assert_not_called()
+
+    def test_checkpoint_hicache_storage_rejects_buffer_only_mode(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = True
+        scheduler.enable_hicache_storage = True
+        scheduler.server_args = MagicMock(hicache_host_memory_mode="buffer_only")
+        scheduler.tree_cache = MagicMock()
+
+        self.assertFalse(scheduler._checkpoint_hicache_storage())
+        scheduler.tree_cache.evict.assert_not_called()
+
+    def test_checkpoint_hicache_storage_rejects_protected_entries(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = True
+        scheduler.enable_hicache_storage = True
+        scheduler.server_args = MagicMock(hicache_host_memory_mode="cache")
+        scheduler.tree_cache = UnifiedRadixCache.__new__(UnifiedRadixCache)
+        scheduler.tree_cache.full_protected_size = MagicMock(return_value=1)
+        scheduler.tree_cache.swa_protected_size = MagicMock(return_value=0)
+        scheduler.tree_cache.mamba_protected_size = MagicMock(return_value=0)
+        scheduler.tree_cache.evict = MagicMock()
+
+        self.assertFalse(scheduler._checkpoint_hicache_storage())
+        scheduler.tree_cache.evict.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`/flush_cache` currently resets the device/host radix state immediately. With HiCache `write_back`, only evicted leaves are guaranteed to reach persistent storage; hot shared root nodes can remain device-only. A graceful restart after `flush_cache` can therefore leave many storage pages on disk but no contiguous root-to-leaf hash chain to restore.

This adds an opt-in, fail-closed way to checkpoint cache-mode `UnifiedRadixCache` state before the normal flush.

## Modifications

- Add the `preserve_hicache_storage` query parameter to `/flush_cache` and propagate it through `FlushCacheReqInput`.
- Forward the option through both immediate and deferred `SchedulerFlushWrapper` paths.
- Before reset, when requested:
  - require cache-mode UnifiedRadixCache with hierarchical storage enabled;
  - reject protected cache entries;
  - evict all Full, SWA, and Mamba evictable state;
  - wait for device-to-host writes and all storage acknowledgements;
  - fail without clearing memory if the checkpoint is incomplete or times out.
- Document the new Native API parameter and usage.
- Add unit coverage for propagation, all-component checkpointing, missing storage, buffer-only mode, and protected entries.

The existing behavior remains unchanged unless `preserve_hicache_storage=true` is supplied.

## Accuracy Tests

No model forward path or generated output is changed.

Downstream validation used a Full+Mamba Qwen3.8 cache on two DGX Spark nodes. A 50K checkpoint persisted 50,048 Full tokens and 3 Mamba slots; restored output matched the cold run. 130K and 160K restored outputs also matched their cold-run needles and requested suffixes.

## Speed Tests and Profiling

Downstream file-backend checkpoint wall time:

- 50K: 3.44 s
- 130K: 7.48 s
- 160K: 8.89 s

Validation on the rebased branch:

- `pre-commit run --files ...`: passed
- `test_scheduler_flush_cache.py`: 12 passed in an isolated SGLang container
- `python -m py_compile` for all changed Python files: passed

## Checklist

- [x] Format your code according to pre-commit.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed evidence.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33344797244](https://github.com/sgl-project/sglang/actions/runs/33344797244)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33344797222](https://github.com/sgl-project/sglang/actions/runs/33344797222)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33344797414](https://github.com/sgl-project/sglang/actions/runs/33344797414)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->