### PR TITLE
[Perf] Batch GPU->CPU sync for multi-item scoring embeddings

### DIFF
--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -44,6 +44,47 @@ def _async_d2h(t: torch.Tensor) -> torch.Tensor:
     return cpu_t
 
 
+def _can_batch_d2h(tensors: List[torch.Tensor]) -> bool:
+    """Whether ``tensors`` can be concatenated along dim 0 for a single D2H copy.
+
+    Requires CUDA sources (the pinned-buffer batching only pays off there; a CPU
+    ``torch.cat`` would add a copy where the per-tensor path does none) and a
+    uniform dtype, device, rank and trailing shape so the concat is exactly
+    invertible by ``torch.split``.
+    """
+    first = tensors[0]
+    if not first.is_cuda:
+        return False
+    suffix = first.shape[1:]
+    return all(
+        t.dtype == first.dtype
+        and t.device == first.device
+        and t.dim() == first.dim()
+        and t.shape[1:] == suffix
+        for t in tensors
+    )
+
+
+def _batched_async_d2h(tensors: List[torch.Tensor]) -> List[torch.Tensor]:
+    """Async D2H for a list of tensors using a single pinned buffer and copy.
+
+    The per-request embedding tensors produced by multi-item scoring are slices of
+    one pooler output (``scores_flat.split(...)``), so copying them individually
+    costs one pinned allocation and one async copy per request. Concatenating on
+    device collapses that into one of each, which matters at the large fan-out the
+    scoring path produces; the host-side split afterwards returns views, not copies.
+
+    Falls back to the per-tensor path when the tensors cannot be concatenated, so
+    the result is identical in every case.
+    """
+    if not _can_batch_d2h(tensors):
+        return [_async_d2h(t) for t in tensors]
+
+    sizes = [t.shape[0] for t in tensors]
+    flat_cpu = _async_d2h(torch.cat(tensors, dim=0))
+    return list(torch.split(flat_cpu, sizes, dim=0))
+
+
 @dataclasses.dataclass
 class GenerationBatchResult:
     logits_output: Optional[LogitsProcessorOutput] = None
@@ -360,13 +401,14 @@ class EmbeddingBatchResult:
                 return
 
             self.copy_done = torch.get_device_module(self.embeddings[0].device).Event()
-            self.embeddings = [_async_d2h(emb) for emb in self.embeddings]
+            self.embeddings = _batched_async_d2h(self.embeddings)
 
         if self.pooled_hidden_states is not None:
             if isinstance(self.pooled_hidden_states, list):
-                self.pooled_hidden_states = [
-                    _async_d2h(t) for t in self.pooled_hidden_states
-                ]
+                if self.pooled_hidden_states:
+                    self.pooled_hidden_states = _batched_async_d2h(
+                        self.pooled_hidden_states
+                    )
             else:
                 self.pooled_hidden_states = _async_d2h(self.pooled_hidden_states)
 

--- a/test/registered/unit/managers/test_batched_async_d2h.py
+++ b/test/registered/unit/managers/test_batched_async_d2h.py
@@ -1,0 +1,120 @@
+"""Unit tests for the batched D2H copy helper in managers/utils.py.
+
+``EmbeddingBatchResult.copy_to_cpu`` copies one embedding tensor per request to
+pinned host memory. ``_batched_async_d2h`` collapses that into a single
+concatenated copy when the tensors allow it. These tests pin the concatenability
+rules (which is where an incorrect batch would silently corrupt results) and, on
+CUDA, that the batched path is value-identical to the per-tensor path.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.managers.utils import (
+    _async_d2h,
+    _batched_async_d2h,
+    _can_batch_d2h,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _cuda(*shape, dtype=torch.float32):
+    return torch.randn(*shape, dtype=dtype, device="cuda")
+
+
+class TestCanBatchD2H(CustomTestCase):
+    def test_cpu_tensors_never_batch(self):
+        # A CPU torch.cat would add a copy the per-tensor path does not do.
+        self.assertFalse(_can_batch_d2h([torch.randn(2, 4), torch.randn(3, 4)]))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_uniform_2d_batches(self):
+        # The multi-item scoring shape: one [num_items, cols] tensor per request.
+        self.assertTrue(_can_batch_d2h([_cuda(2, 4), _cuda(3, 4), _cuda(1, 4)]))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_uniform_1d_batches(self):
+        self.assertTrue(_can_batch_d2h([_cuda(4), _cuda(4)]))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_ragged_last_dim_does_not_batch(self):
+        # Per-request matryoshka truncation produces differing widths.
+        self.assertFalse(_can_batch_d2h([_cuda(2, 4), _cuda(2, 8)]))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_mixed_rank_does_not_batch(self):
+        self.assertFalse(_can_batch_d2h([_cuda(4), _cuda(2, 4)]))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_mixed_dtype_does_not_batch(self):
+        # torch.cat would promote and silently change the output dtype.
+        self.assertFalse(
+            _can_batch_d2h([_cuda(2, 4), _cuda(2, 4, dtype=torch.float16)])
+        )
+
+
+class TestBatchedAsyncD2HFallback(CustomTestCase):
+    def _assert_matches_per_tensor(self, tensors):
+        expected = [_async_d2h(t) for t in tensors]
+        actual = _batched_async_d2h(tensors)
+        self.assertEqual(len(actual), len(expected))
+        for a, e in zip(actual, expected):
+            self.assertEqual(a.shape, e.shape)
+            self.assertEqual(a.dtype, e.dtype)
+            self.assertTrue(torch.equal(a, e))
+
+    def test_uniform_2d(self):
+        self._assert_matches_per_tensor(
+            [torch.randn(2, 4), torch.randn(3, 4), torch.randn(1, 4)]
+        )
+
+    def test_ragged(self):
+        self._assert_matches_per_tensor([torch.randn(2, 4), torch.randn(2, 8)])
+
+    def test_single_tensor(self):
+        self._assert_matches_per_tensor([torch.randn(3, 4)])
+
+    def test_zero_row_tensor_in_batch(self):
+        self._assert_matches_per_tensor(
+            [torch.randn(0, 4), torch.randn(2, 4), torch.randn(0, 4)]
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestBatchedAsyncD2HCuda(CustomTestCase):
+    def _assert_matches_per_tensor(self, tensors):
+        expected = [_async_d2h(t) for t in tensors]
+        actual = _batched_async_d2h(tensors)
+        torch.cuda.synchronize()
+        self.assertEqual(len(actual), len(expected))
+        for a, e in zip(actual, expected):
+            self.assertEqual(a.shape, e.shape)
+            self.assertEqual(a.dtype, e.dtype)
+            self.assertTrue(torch.equal(a, e))
+
+    def test_uniform_2d_matches_per_tensor(self):
+        self._assert_matches_per_tensor([_cuda(2, 4), _cuda(3, 4), _cuda(1, 4)])
+
+    def test_uniform_1d_matches_per_tensor(self):
+        self._assert_matches_per_tensor([_cuda(4), _cuda(4)])
+
+    def test_zero_row_tensor_in_batch(self):
+        self._assert_matches_per_tensor([_cuda(0, 4), _cuda(2, 4), _cuda(0, 4)])
+
+    def test_large_fanout_preserves_order(self):
+        tensors = [
+            torch.full((1, 4), float(i), device="cuda", dtype=torch.float32)
+            for i in range(128)
+        ]
+        actual = _batched_async_d2h(tensors)
+        torch.cuda.synchronize()
+        for i, t in enumerate(actual):
+            self.assertTrue(torch.equal(t, torch.full((1, 4), float(i))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

In the multi-item scoring classification / reward path the pooler returns one 2D tensor per request, so `BatchResultProcessor._convert_embeddings` takes the `else` branch and calls `.tolist()` once per tensor:

```python
embeddings = [tensor.tolist() for tensor in embeddings]
```

Each `.tolist()` is a separate device-to-host copy that synchronizes the CUDA stream, so a batch of N requests pays N syncs at the end of every prefill. The syncs serialize against the next forward pass, and the cost scales linearly with batch size — it shows up as a growing gap between forward end and response send at high concurrency.

## Modifications

Add `batch_convert_2d_tensors_to_lists` to `srt/managers/utils.py`: concatenate the per-request tensors along dim 0, do **one** `.tolist()`, then re-split on the host using the recorded row counts. This turns N syncs into 1.

The helper falls back to the original per-tensor `.tolist()` when the input is empty or shape-irregular (differing last dim — e.g. per-request matryoshka truncation), so it is never wrong, just not batched, in those cases.

Only the non-sparse, list-of-tensors branch changes. The sparse branch and the single pre-stacked `torch.Tensor` branch are untouched.

## Accuracy Tests

Output is bit-identical to the previous code path by construction (same tensors, same order, only the transfer is batched). Verified equivalence against the per-tensor `[t.tolist() for t in tensors]` reference on: uniform batches, single-tensor batches, zero-row tensors, ragged column counts (fallback path), empty input, and fp16 tensors — all exact matches.

## Benchmarking and Profiling

The win is N-1 fewer D2H syncs per prefill batch in the multi-item scoring embedding path; it grows with batch size and is a no-op at batch size 1.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34619397169](https://github.com/sgl-project/sglang/actions/runs/34619397169)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34619396722](https://github.com/sgl-project/sglang/actions/runs/34619396722)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34619396863](https://github.com/sgl-project/sglang/actions/runs/34619396863)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->