### PR TITLE
[MLX] Fix MLX startup crash in preloaded weight accounting

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -107,6 +107,11 @@ class MlxModelRunnerStub(ModelRunner):
     # that path working instead of raising AttributeError.
     prefill_aware_swa = False
 
+    @property
+    def preloaded_weights_bytes(self) -> int:
+        """No PyTorch weights are loaded; MLX manages weights separately."""
+        return 0
+
     @staticmethod
     def validate_startup_weight_load_mode(server_args) -> None:
         if server_args.is_startup_weight_load_overlap:

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
@@ -105,6 +105,29 @@ class TestMlxRunnerPoolContract(unittest.TestCase):
         MlxModelRunnerStub.init_attention_backends(runner)
         self.assertIsNone(runner.attn_backend)
 
+    def test_stub_overrides_preloaded_weights_bytes(self):
+        """``preloaded_weights_bytes`` must not touch the base ``loader``."""
+        self.assertIn(
+            "preloaded_weights_bytes",
+            vars(MlxModelRunnerStub),
+            msg=(
+                "MlxModelRunnerStub lost its preloaded_weights_bytes override. "
+                "The base implementation reads self.loader, which the MLX stub "
+                "never creates (PyTorch weights are not loaded). Without it "
+                "every MLX startup crashes in Scheduler.init_target_memory_pool."
+            ),
+        )
+        self.assertIsNot(
+            MlxModelRunnerStub.preloaded_weights_bytes,
+            ModelRunner.preloaded_weights_bytes,
+            msg="preloaded_weights_bytes must be overridden on the MLX stub, "
+            "not inherited from ModelRunner.",
+        )
+
+    def test_stub_preloaded_weights_bytes_is_zero(self):
+        runner = object.__new__(MlxModelRunnerStub)
+        self.assertEqual(runner.preloaded_weights_bytes, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`MlxModelRunnerStub` intentionally skips PyTorch weight loading and never creates a `loader`, but the base `ModelRunner.preloaded_weights_bytes` property dereferences `self.loader`. This caused every MLX backend startup to crash in `Scheduler.init_target_memory_pool` with `AttributeError: 'MlxModelRunnerStub' object has no attribute 'loader'`. This PR fixes the startup crash.

## Modifications

- Override `preloaded_weights_bytes` in `MlxModelRunnerStub` to return `0` (no PyTorch weights are loaded on the MLX path; weights are managed by the dedicated MLX runner), consistent with the existing no-op overrides for `alloc_memory_pool` and `init_attention_backends`.
- Add contract tests in `test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py` to guard the override against future base-class drift.

## Accuracy Tests

N/A - this is a startup-path fix only; no kernel or model forward logic changed, so model outputs are unaffected.

## Speed Tests and Profiling

N/A - no inference performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->