### PR TITLE
[CI] Fix unreachable FakeReq field initialization

### DIFF
--- a/test/registered/unit/mem_cache/test_streaming_session_unit.py
+++ b/test/registered/unit/mem_cache/test_streaming_session_unit.py
@@ -83,16 +83,36 @@ class _FakeReq:
         self.skip_lock_node_ids = {}
         self.mamba_pool_idx = None
         self.mamba_ping_pong_track_buffer = None
-
-    def detach_kv(self):
-        kv, self.kv = self.kv, ReqKvInfo()
-        return kv
         self.mamba_next_track_idx = None
+        self.mamba_last_track_idx = None
         self.mamba_last_track_seqlen = None
         self.mamba_branching_seqlen = None
         self.to_finish = None
         self.finished_reason = None
         self.finished_len = None
+
+    def detach_kv(self):
+        kv, self.kv = self.kv, ReqKvInfo()
+        return kv
+
+
+def test_session_slot_round_trip_preserves_mamba_state():
+    req = _FakeReq("session-a", req_pool_idx=0, committed=4, allocated=4)
+    req.mamba_next_track_idx = 1
+    req.mamba_last_track_idx = 0
+    req.mamba_last_track_seqlen = 3
+    req.mamba_branching_seqlen = 2
+
+    slot = SessionSlot()
+    slot.save_from_req(req, is_first=True)
+
+    next_req = _FakeReq("session-a", req_pool_idx=1, committed=0, allocated=0)
+    slot.restore_to_req(next_req)
+
+    assert next_req.mamba_next_track_idx == 1
+    assert next_req.mamba_last_track_idx == 0
+    assert next_req.mamba_last_track_seqlen == 3
+    assert next_req.mamba_branching_seqlen == 2
 
 
 def test_preabort_detaches_session_and_preserves_slot():


### PR DESCRIPTION
## Summary

- move `_FakeReq` field initialization out of unreachable code after `detach_kv()` returns
- initialize the missing `mamba_last_track_idx` field used by `SessionSlot`
- add a session-slot Mamba state round-trip regression test

## Context

#37108 inserted `detach_kv()` before the remaining `_FakeReq` field initialization. This left those assignments after `return kv`, so tests that call `SessionSlot.save_from_req()` fail with `AttributeError: _FakeReq has no attribute mamba_next_track_idx`. This was exposed by #34565.

## Validation

- `pre-commit run --files test/registered/unit/mem_cache/test_streaming_session_unit.py`
- Targeted pytest was not run locally because pytest is unavailable in the host Python environment; the added registered CPU test will run in CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33354107825](https://github.com/sgl-project/sglang/actions/runs/33354107825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33354107741](https://github.com/sgl-project/sglang/actions/runs/33354107741)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33354107827](https://github.com/sgl-project/sglang/actions/runs/33354107827)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->