### PR TITLE
[Fix][DeepSeek V4] DSpark crash when CLI block size overrides config

### DIFF
--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -62,7 +62,7 @@ from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
     read_ragged_verify_mode,
 )
-from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.utils import add_prefix, is_npu, log_info_on_rank0
 from sglang.srt.utils.invariants import Bucket, InClosedRange, Invariant, expect
 
 logger = logging.getLogger(__name__)
@@ -694,11 +694,15 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
                 "DSpark V4 draft requires markov_rank > 0, "
                 f"got markov_rank={dspark_config.markov_rank}."
             )
-        self.gamma = int(
-            dspark_config.resolve_gamma(default=int(config.num_hidden_layers))
+        # No gamma copy here: the runtime resolves it (CLI block size can
+        # override the checkpoint), and it is passed in per call.
+        log_info_on_rank0(
+            logger,
+            "DSpark V4 draft checkpoint block_size="
+            f"{dspark_config.resolve_gamma(default=None)}; the effective gamma "
+            "is owned by the runtime config.",
         )
         self.sample_from_anchor = get_dspark_sample_from_anchor(config)
-        self.block_size = self.gamma
         if dspark_config.target_layer_ids is not None:
             self.num_stages = len(dspark_config.target_layer_ids)
         else:
@@ -890,15 +894,17 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         anchor_tokens: torch.Tensor,
         sampled_tokens: torch.Tensor,
         x_post_hc: torch.Tensor,
+        gamma: int,
     ) -> Optional[torch.Tensor]:
         confidence_head = self.confidence_head
         if confidence_head is None:
             return None
+        gamma = int(gamma)
         bs = int(anchor_tokens.shape[0])
-        x_post_hc = x_post_hc.view(bs, self.gamma, -1)
+        x_post_hc = x_post_hc.view(bs, gamma, -1)
         if confidence_head.with_markov:
             prev_seq = torch.cat(
-                [anchor_tokens.view(-1, 1), sampled_tokens[:, : self.gamma - 1]], dim=1
+                [anchor_tokens.view(-1, 1), sampled_tokens[:, : gamma - 1]], dim=1
             )
             markov_embed_stack = self.markov_head.get_prev_embeddings(prev_seq)
         else:

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -268,6 +268,7 @@ class DSparkVerifyPlanner:
                     anchor_tokens=anchor_tokens,
                     sampled_tokens=draft_tokens,
                     x_post_hc=confidence_tap,
+                    gamma=self.gamma,
                 )
         assert draft_hidden is not None
         return compute_confidence(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The runtime resolves gamma from the CLI flag (3 here) and every component uses
it, but `DeepseekV4ForCausalLMDSpark` kept a second copy parsed from the
checkpoint config (5) and used it in `compute_confidence`.

The CLI override itself is fine -- no draft weight is shaped by gamma, it is just
the runtime block length. The model should not hold its own copy.


## Modifications

- Drop `self.gamma` / `self.block_size` from `DeepseekV4ForCausalLMDSpark`.
- `compute_confidence` now takes `gamma` as a keyword argument.
- `DSparkVerifyPlanner` passes `gamma=self.gamma` (from `DSparkRuntimeConfig`).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33363992244](https://github.com/sgl-project/sglang/actions/runs/33363992244)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33363992026](https://github.com/sgl-project/sglang/actions/runs/33363992026)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #33363992231](https://github.com/sgl-project/sglang/actions/runs/33363992231)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->