### PR TITLE
[diffusion] vae: retry decode with tiling once on OOM instead of failing

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -259,14 +259,20 @@ class DecodingStage(PipelineStage):
             with temporary_module_dtype(
                 self.vae, vae_dtype, enabled=should_cast_vae
             ) as vae:
+                retry_with_tiling = False
                 try:
                     decode_output = self._get_vae_decode_fn(vae, server_args)(latents)
                 except Exception as error:
-                    if "out of memory" in str(error).lower():
-                        # decode runs after denoising, so the DiT and encoders
-                        # are idle but may still hold VRAM; freeing them is the
-                        # lever here. --vae-cpu-offload is not: it moves VAE
-                        # weights, not the activations that overflow.
+                    is_oom = "out of memory" in str(error).lower()
+                    if is_oom and not server_args.pipeline_config.vae_tiling:
+                        retry_with_tiling = hasattr(
+                            self.vae, "enable_tiling"
+                        ) and hasattr(self.vae, "disable_tiling")
+                    # decode runs after denoising, so the DiT and encoders
+                    # are idle but may still hold VRAM; freeing them is the
+                    # lever here. --vae-cpu-offload is not: it moves VAE
+                    # weights, not the activations that overflow.
+                    if is_oom and not retry_with_tiling:
                         if not server_args.pipeline_config.vae_tiling:
                             logger.warning(
                                 "OOM detected during VAE decoding. Enable "
@@ -282,7 +288,33 @@ class DecodingStage(PipelineStage):
                                 "lower the tile size in the model's VAE config, "
                                 "then reduce resolution or frame count."
                             )
-                    raise
+                    if not retry_with_tiling:
+                        raise
+
+                if retry_with_tiling:
+                    logger.warning(
+                        "Full-frame VAE decode ran out of memory; falling back "
+                        "to tiled decode and retrying once. Output may have "
+                        "minor seams at tile boundaries. Pass --vae-tiling to "
+                        "enable this by default, or free components that "
+                        "already finished with --cpu-offload-components "
+                        "dit,text_encoder."
+                    )
+                    if not current_platform.is_cpu():
+                        torch.get_device_module().empty_cache()
+                    self.vae.enable_tiling()
+                    try:
+                        # Raw path, not _get_vae_decode_fn: enable_tiling()
+                        # changes control flow, so a graph compiled for the
+                        # untiled path would be unsound here, and recompiling
+                        # under an OOM is its own risk.
+                        decode_output = self.vae.decode(latents)
+                    except Exception:
+                        logger.warning("Tiled fallback decode also failed.")
+                        raise
+                    finally:
+                        self.vae.disable_tiling()
+
                 image = _ensure_tensor_decode_output(decode_output)
 
         # De-normalize image to [0, 1] range

--- a/python/sglang/multimodal_gen/test/unit/test_decode_oom_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_decode_oom_fallback.py
@@ -1,0 +1,151 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import DecodingStage
+
+_DECODING_MODULE = "sglang.multimodal_gen.runtime.pipelines_core.stages.decoding"
+
+
+def _make_server_args(*, vae_tiling: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        enable_torch_compile=False,
+        disable_autocast=True,
+        pipeline_config=SimpleNamespace(
+            vae_tiling=vae_tiling,
+            get_decode_scale_and_shift=lambda device, dtype, vae: (1.0, None),
+            preprocess_decoding=lambda latents, server_args, vae: latents,
+        ),
+    )
+
+
+class FakeVAE(nn.Module):
+    """Mock VAE whose decode() outcome is fully controlled by `decode_side_effect`."""
+
+    def __init__(
+        self,
+        decode_side_effect,
+        *,
+        with_enable_tiling: bool = True,
+        with_disable_tiling: bool = True,
+    ):
+        super().__init__()
+        self.decode = MagicMock(side_effect=decode_side_effect)
+        if with_enable_tiling:
+            self.enable_tiling = MagicMock()
+        if with_disable_tiling:
+            self.disable_tiling = MagicMock()
+
+
+def _oom_error() -> RuntimeError:
+    return RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
+
+
+class TestDecodeOomTiledFallback(unittest.TestCase):
+    def _decode(
+        self, stage: DecodingStage, server_args: SimpleNamespace
+    ) -> torch.Tensor:
+        latents = torch.zeros(1, 4, 1, 8, 8)
+        with (
+            patch(
+                f"{_DECODING_MODULE}.get_local_torch_device",
+                return_value=torch.device("cpu"),
+            ),
+            patch(f"{_DECODING_MODULE}.current_platform") as mock_platform,
+        ):
+            mock_platform.is_cpu.return_value = True
+            return stage.decode(latents, server_args, vae_dtype=torch.float32)
+
+    def test_oom_then_success_retries_with_tiling(self):
+        success = torch.zeros(1, 3, 1, 8, 8)
+        vae = FakeVAE(decode_side_effect=[_oom_error(), success])
+        manager = MagicMock()
+        manager.attach_mock(vae.decode, "decode")
+        manager.attach_mock(vae.enable_tiling, "enable_tiling")
+        manager.attach_mock(vae.disable_tiling, "disable_tiling")
+
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=False)
+
+        with self.assertLogs(_DECODING_MODULE, level="WARNING") as logs:
+            self._decode(stage, server_args)
+
+        self.assertEqual(
+            [c[0] for c in manager.mock_calls],
+            ["decode", "enable_tiling", "decode", "disable_tiling"],
+        )
+        self.assertTrue(
+            any("falling back to tiled decode" in msg for msg in logs.output)
+        )
+
+    def test_no_enable_tiling_support_does_not_retry(self):
+        vae = FakeVAE(
+            decode_side_effect=[_oom_error()],
+            with_enable_tiling=False,
+            with_disable_tiling=False,
+        )
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=False)
+
+        with self.assertRaises(RuntimeError):
+            self._decode(stage, server_args)
+
+        self.assertEqual(vae.decode.call_count, 1)
+
+    def test_enable_only_no_disable_tiling_does_not_retry(self):
+        vae = FakeVAE(decode_side_effect=[_oom_error()], with_disable_tiling=False)
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=False)
+
+        with self.assertRaises(RuntimeError):
+            self._decode(stage, server_args)
+
+        self.assertEqual(vae.decode.call_count, 1)
+        # condition (c) requires both enable_tiling and disable_tiling; a VAE
+        # missing disable_tiling must not retry even though enable_tiling exists.
+        vae.enable_tiling.assert_not_called()
+
+    def test_vae_tiling_already_enabled_does_not_retry(self):
+        vae = FakeVAE(decode_side_effect=[_oom_error()])
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=True)
+
+        with self.assertRaises(RuntimeError):
+            self._decode(stage, server_args)
+
+        self.assertEqual(vae.decode.call_count, 1)
+        # enable_tiling() here comes from the pre-existing vae_tiling=True
+        # gate at the top of decode(), not from the new retry path.
+        vae.enable_tiling.assert_called_once()
+        vae.disable_tiling.assert_not_called()
+
+    def test_non_oom_exception_propagates_immediately(self):
+        vae = FakeVAE(decode_side_effect=[ValueError("bad shape")])
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=False)
+
+        with self.assertRaises(ValueError):
+            self._decode(stage, server_args)
+
+        self.assertEqual(vae.decode.call_count, 1)
+        vae.enable_tiling.assert_not_called()
+        vae.disable_tiling.assert_not_called()
+
+    def test_tiled_retry_also_oom_still_restores_tiling_state(self):
+        vae = FakeVAE(decode_side_effect=[_oom_error(), _oom_error()])
+        stage = DecodingStage(vae)
+        server_args = _make_server_args(vae_tiling=False)
+
+        with self.assertRaises(RuntimeError):
+            self._decode(stage, server_args)
+
+        self.assertEqual(vae.decode.call_count, 2)
+        vae.enable_tiling.assert_called_once()
+        vae.disable_tiling.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Today, when a full-frame VAE decode hits CUDA OOM, `DecodingStage` logs
advice (added in #35353) and the whole generation dies — after all the
denoising compute has already been spent. On consumer GPUs this is the
most common terminal failure mode: on an 8GB RTX 4070 Laptop, Sana 600M
at its default 1024×1024 reliably survives 20 denoising steps and then
crashes in exactly this spot (#34482). The advice can only help on the
*next* run; the current request is unrecoverable.

This PR turns that advice into a one-shot automatic fallback: if tiling
is off and the VAE supports toggling it at runtime, free the cache,
enable tiling, and retry the decode once. The worst case is the same
crash as today; the best case is a completed request with tiled output.

**Open design question for maintainers**: tiled decode can introduce
minor seams at tile boundaries, so this trades a guaranteed crash for a
possible (small, bounded) quality difference, and does so automatically.
The retry logs a prominent warning telling the user what happened and
how to make the choice explicit (`--vae-tiling`, or freeing components
via offload flags). If you'd rather gate the auto-retry behind a flag or
env var, happy to adjust — took "crash is strictly worse" as the default
stance. cc @mickqian who authored the advice-based handling in #35353.

## Modifications

`runtime/pipelines_core/stages/decoding.py` (one hunk inside
`DecodingStage.decode`):

- In the existing OOM `except` branch: if `--vae-tiling` is off and the
  VAE exposes **both** `enable_tiling` and `disable_tiling`, mark the
  decode for a single tiled retry instead of re-raising.
- The retry runs after the `except` block exits (not inside it), so the
  original exception's traceback — which pins the failed attempt's
  activation tensors — is released before `empty_cache()` and the second
  attempt.
- The retry empties the device cache, enables tiling, decodes, and
  restores the untiled state in a `finally` — so a VAE shared across
  requests is never left silently tiled.
- The retry calls `self.vae.decode(latents)` directly instead of going
  through `_get_vae_decode_fn`: that helper only (optionally) wraps
  `vae.decode` in torch.compile, and a graph compiled for the untiled
  path is unsound once `enable_tiling()` changes control flow —
  recompiling while already under memory pressure is its own risk.
- Behavior is unchanged in every other case: tiling already on → same
  advice + raise as today; VAE can't toggle tiling at runtime → same
  advice + raise; non-OOM exceptions propagate untouched.
- Why `hasattr` for the capability probe rather than the
  `try/except AttributeError` style used earlier in this function: the
  retry decision must be made *before* choosing to swallow the OOM, and
  it must confirm `disable_tiling` exists too, or the finally-restore
  above would be impossible and the VAE would stay tiled for subsequent
  requests. VAE wrappers are genuinely heterogeneous here (see #34482 /
  #34514 — AutoencoderDC only recently grew these methods).

`test/unit/test_decode_oom_fallback.py` (new): 6 unit tests with a mock
VAE covering: OOM→success retry (exact call order `decode` →
`enable_tiling` → `decode` → `disable_tiling`, plus the user-facing
warning), retry-also-OOMs (state still restored, error propagates),
no-retry when tiling already on, no-retry when `enable_tiling` missing,
no-retry when only `disable_tiling` missing, and non-OOM exceptions
propagating immediately. Picked up automatically by the `unit` suite
(directory discovery, no registry edit needed).

## Accuracy Tests

No change on the normal path — the fallback only activates where today's
behavior is a crash. The tiled output produced by the fallback is
identical to what a user gets today by passing `--vae-tiling` explicitly.

## Speed Tests and Profiling

No happy-path impact: one extra local bool; the fallback work happens
only after an OOM that is terminal today.

Unit tests (container `lmsysorg/sglang:dev`, repo mounted, on top of
`881cbfe54c`):

```
python -m pytest python/sglang/multimodal_gen/test/unit/test_decode_oom_fallback.py -v
# 6 passed

python -m pytest python/sglang/multimodal_gen/test/unit/test_decoding_stage_parallelism.py \
  python/sglang/multimodal_gen/test/unit/test_vae_fast_path_gate.py \
  python/sglang/multimodal_gen/test/unit/test_vae_spatial_parallel_decode.py \
  python/sglang/multimodal_gen/test/unit/test_vae_decoder_store.py \
  python/sglang/multimodal_gen/test/unit/test_vae_loader_decode_dtype.py -q
# 38 passed, 12 subtests passed
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33356767479](https://github.com/sgl-project/sglang/actions/runs/33356767479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33356767357](https://github.com/sgl-project/sglang/actions/runs/33356767357)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33356767466](https://github.com/sgl-project/sglang/actions/runs/33356767466)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->