### PR TITLE
test: re-enable FlashInfer NVFP4 per-token coverage

### DIFF
--- a/test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py
+++ b/test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py
@@ -77,14 +77,6 @@ class FlashinferNvFp4OnlineMoeBackendBase:
             )
 
 
-# Only this class is affected, but the file runs with failfast, so leaving it
-# enabled also cuts off the class that sorts after it.
-@unittest.skip(
-    "flashinfer-ai/flashinfer#4486: on SM100/SM103 the TRTLLM_GEN tile-192 BMM "
-    "path returns non-finite MoE output from FlashInfer 0.6.16.post4 on, so the "
-    "first real prefill trips the sampler NaN assert and gsm8k scores 0.0. "
-    "See #34629 for the package bisect."
-)
 class TestFlashinferTrtllmGenMoeBackendNvFp4Online(
     FlashinferNvFp4OnlineMoeBackendBase, CustomTestCase
 ):

--- a/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py
+++ b/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py
@@ -273,12 +273,6 @@ class TestFlashinferTrtllmGenMoeBackendBF16Routed(
     backend = "flashinfer_trtllm_routed"
 
 
-@unittest.skip(
-    "flashinfer-ai/flashinfer#4486: on SM100/SM103 the TRTLLM_GEN tile-192 BMM "
-    "path returns non-finite MoE output from FlashInfer 0.6.16.post4 on, so the "
-    "first real prefill trips the sampler NaN assert and gsm8k scores 0.0. "
-    "See #34629 for the package bisect."
-)
 class TestFlashinferTrtllmGenMoeBackendNvFp4PerTokenActivationRouted(
     FlashinferTrtllmGenMoeBackendNVFP4Base, CustomTestCase
 ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

@humansand

FlashInfer 0.6.18 fixes the SM100/SM103 TRTLLM_GEN tile-192 BMM non-finite-output bug tracked by [flashinfer#4486](https://github.com/flashinfer-ai/flashinfer/issues/4486). The two per-token NVFP4 paths disabled during the affected-package period now pass on B300 with the [0.6.18 release](https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.6.18).

## Modifications

- Re-enable `TestFlashinferTrtllmGenMoeBackendNvFp4Online`.
- Re-enable `TestFlashinferTrtllmGenMoeBackendNvFp4PerTokenActivationRouted`.
- Remove the now-stale failfast comment associated with the first skip.
- Make no runtime, backend, or environment-fallback change.

## Accuracy Tests

- **Commit:** `87885950d54ae313afb4a7e5c1a9f0f19ead7697` (base `9a9e1671794eb803aabe2867be85ac0d83834e59`).
- **Image:** `lmsysorg/sglang:nightly-dev-cu13-20260831-bb5e6198` (amd64 `sha256:3c75c6f7f8e6eaeebdcf92ef47caef818608134252ad5898f4c670b7911768a6`).
- **Hardware:** one C2 bare devbox with 8 NVIDIA B300 GPUs (SM103); the two model tests ran concurrently on disjoint 4-GPU sets.
- **Runtime:** Python 3.12.3, PyTorch `2.13.0+cu130`, CUDA 13.0, driver 590.48.01.
- **FlashInfer:** `flashinfer-python==0.6.18`, `flashinfer-cubin==0.6.18`, `flashinfer-jit-cache==0.6.18+cu130`, installed from the v0.6.18 release assets.

Exact commands:

```bash
export VALIDATION_ROOT=/sgl-workspace/flashinfer-0618-unskip
export PYTHONPATH="$VALIDATION_ROOT/sglang/python"
export HF_HOME=/sgl-workspace/pr35120-ci-fix/hf-cache
cd "$VALIDATION_ROOT/sglang"

pre-commit run --files \
  test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py \
  test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py

CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_CACHE_DIR=/sgl-workspace/pr35120-ci-fix/cache/temp-unskip-online-per-token-current \
FLASHINFER_WORKSPACE_BASE=/sgl-workspace/pr35120-ci-fix/cache/temp-unskip-online-per-token-current/flashinfer \
python3 test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py \
  TestFlashinferTrtllmGenMoeBackendNvFp4Online.test_gsm8k -v

CUDA_VISIBLE_DEVICES=4,5,6,7 \
SGLANG_CACHE_DIR=/sgl-workspace/pr35120-ci-fix/cache/temp-unskip-routed-per-token-current \
FLASHINFER_WORKSPACE_BASE=/sgl-workspace/pr35120-ci-fix/cache/temp-unskip-routed-per-token-current/flashinfer \
python3 test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py \
  TestFlashinferTrtllmGenMoeBackendNvFp4PerTokenActivationRouted.test_gsm8k -v
```

Raw summaries:

```text
pre-commit on both changed files: PASS

TestFlashinferTrtllmGenMoeBackendNvFp4Online.test_gsm8k
Total latency: 4.505 s
Score: 0.955
Output throughput: 6415.455 token/s
Ran 1 test in 155.672s
OK

TestFlashinferTrtllmGenMoeBackendNvFp4PerTokenActivationRouted.test_gsm8k
Total latency: 4.213 s
Score: 0.915
Output throughput: 5604.900 token/s
Ran 1 test in 155.411s
OK
```

Complete-log SHA-256: online `c013dc1db0a6ba763ec7eeeb53c6db02664d6ad34b1b7571690f68504d485e71`; routed `c5b4ef34077ff55e6bca120399b3cfb0c321e012a66767671ef06ec7422958cd`; pre-commit `521808170dc57d3676d1c0c3ad3ee31ffc60480b0cd8e00d7f70cb09ba1152d3`.

The model tests reused FlashInfer 0.6.18 JIT caches populated by an earlier run of the same two paths. The target SGLang checkout and installed FlashInfer package versions were verified explicitly. No additional missing-period bug fix was necessary.

## Speed Tests and Profiling

Not applicable: this PR changes test registration only. The throughput above is incidental correctness-run output, not a controlled performance benchmark.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not required for a test-only change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy is above; speed is not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33358892966](https://github.com/sgl-project/sglang/actions/runs/33358892966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33358892766](https://github.com/sgl-project/sglang/actions/runs/33358892766)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33358892868](https://github.com/sgl-project/sglang/actions/runs/33358892868)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->