### PR TITLE
[Hicache] Support Mamba branching setting by env

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -696,6 +696,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MAMBA_OFFLOAD_HIT_RATE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Fraction of the request length used for the Mamba branching checkpoint when Full-KV and Mamba prefix hit lengths are equal. Must be in <code>(0, 1]</code>; the aligned result is clipped to the existing Mamba hit and request length.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>1.0</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_EMBEDDINGS_SPARSE_HEAD</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Name of the sparse-embeddings head to expose for embedding models.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set</td>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -201,6 +201,16 @@ class EnvFloat(EnvField):
             raise ValueError(f'"{value}" is not a valid float value')
 
 
+class EnvPositiveFraction(EnvFloat):
+    """A float in the interval [0, 1]."""
+
+    def parse(self, value: str) -> float:
+        parsed = super().parse(value)
+        if not 0 <= parsed <= 1:
+            raise ValueError(f'"{value}" is not in the interval [0, 1]')
+        return parsed
+
+
 class GateGemvMode(IntEnum):
     """Small-batch Inkling gate linear implementation.
 
@@ -1255,6 +1265,7 @@ class Envs:
     # ===================================================================
     SGLANG_MAMBA_CONV_DTYPE = EnvStr("bfloat16")
     SGLANG_MAMBA_SSM_DTYPE = EnvStr(None)
+    SGLANG_MAMBA_OFFLOAD_HIT_RATE = EnvPositiveFraction(1.0)
     # Kill-switch for the fused per-slot conv clear/copy kernel (MambaPool);
     # falls back to the per-conv-type Python loop.
     SGLANG_DISABLE_FUSED_MAMBA_SLOT_OPS = EnvBool(False)

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefParams,
     EvictParams,
@@ -162,18 +163,32 @@ class MambaComponent(TreeComponent):
         last_node = result.best_match_node
 
         mamba_boundary_len = len(result.device_indices) + result.host_hit_length
+        full_kv_hit_length_aligned = (
+            result.full_kv_hit_length
+            // self.mamba_checkpoint_grid
+            * self.mamba_checkpoint_grid
+        )
 
         # Full KV may extend beyond the latest reusable Mamba state. The branching
         # point is the last Mamba-cache-chunk-aligned position within the Full-KV hit
         # that lies beyond the current Mamba boundary. With HiCache, incremental
         # persistence of a new branching state is currently write-through only;
         # write-back eviction may discard the device-only state.
-        aligned_seqlen = (
-            result.full_kv_hit_length // self.mamba_checkpoint_grid
-        ) * self.mamba_checkpoint_grid
-        branching_seqlen = (
-            aligned_seqlen if aligned_seqlen > mamba_boundary_len else None
-        )
+        if full_kv_hit_length_aligned > mamba_boundary_len:
+            branching_seqlen = full_kv_hit_length_aligned
+        else:
+            # Enable shorter Mamba states positions via hit rate
+            mamba_offload_hit_rate = envs.SGLANG_MAMBA_OFFLOAD_HIT_RATE.get()
+            request_length = len(params.req.full_untruncated_fill_ids)
+            aligned_seqlen = (
+                int(request_length * mamba_offload_hit_rate)
+                // self.mamba_checkpoint_grid
+            ) * self.mamba_checkpoint_grid
+            branching_seqlen = (
+                aligned_seqlen
+                if (mamba_offload_hit_rate < 1 and aligned_seqlen > mamba_boundary_len)
+                else None
+            )
 
         # HiCache: if mamba was evicted from device but has host backup,
         # ensure mamba_host_hit_length >= 1 so load_back is triggered.

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -98,6 +98,18 @@ class TestEnvField(unittest.TestCase):
             self.assertIs(envs.SGLANG_TEST_RETRACT.get(), False)
         self.assertIn("Invalid value", str(caught[0].message))
 
+    def test_mamba_offload_hit_rate_accepts_only_positive_fractions(self):
+        with envs.SGLANG_MAMBA_OFFLOAD_HIT_RATE.override(0.5):
+            self.assertEqual(envs.SGLANG_MAMBA_OFFLOAD_HIT_RATE.get(), 0.5)
+
+        for invalid in (-0.1, 1.1, "nan"):
+            with self.subTest(invalid=invalid):
+                with envs.SGLANG_MAMBA_OFFLOAD_HIT_RATE.override(invalid):
+                    with warnings.catch_warnings(record=True) as caught:
+                        warnings.simplefilter("always")
+                        self.assertEqual(envs.SGLANG_MAMBA_OFFLOAD_HIT_RATE.get(), 1.0)
+                    self.assertIn("interval [0, 1]", str(caught[0].message))
+
 
 class TestDeprecatedEnvRegistry(unittest.TestCase):
     def _apply(self, old_name, deprecation):


### PR DESCRIPTION
## Motivation
This PR optimizes cache hit ratio for single‑turn inference scenarios of hybrid‑Mamba models such as Kimi‑K3.

For multi‑turn conversations, storing the Mamba state at the end of each request is sufficient. However, real‑world deployments also feature single‑turn workloads, where different requests may share reusable prefixes. Previous PR https://github.com/sgl-project/sglang/pull/31181 enables mamba state creation at full‑KV branching points. This works well when single‑turn requests share **exactly identical** prefixes.

We have encountered a distinct real‑world case: single‑turn requests do share common prefixes, but the shared prefix lengths fluctuate around a threshold rather than being perfectly identical.

For example: Request 1 has length 6000; Request 2 shares a prefix of length 5120 with Request 1; Request 3 shares a prefix of length 4992 with Request 1. Given a page_size of 64, neither Request 2 nor Request 3 achieves a cache hit under the existing implementation. This happens because Request 1 stores its Mamba state at offset 5952 (near its end), while Request 2 store at length of 5120.

Our solution pre‑computes a stable prefix threshold and uses an environment variable to specify the storage location for the first incoming request, instead of requiring multiple iterations to obtain a stable prefix. In the scenario above, with a hit‑ratio coefficient set to 0.8, Request 1 will persist its Mamba state at offset 4800. Consequently, both Request 2 and Request 3 can hit the prefix up to length 4800. Therefore, the hit ratio is improved compared with the existing approach.

Note that requests do not universally reuse one single prefix. Instead, requests form small groups (e.g., dozens per group): one group shares prefix A, another group shares prefix B, with minimal overlap between A and B.

## Modifications
Introduce an environment variable to control where to store the Mamba state when the Mamba state length matches the full sequence length. When this environment variable is not set, or the full‑KV hit length is greater than the Mamba length, or the Mamba hit length exceeds the configured hit‑rate threshold, the original branch policy remains unaffected.

## Speed Tests and Profiling
On our production workloads, built upon PRs https://github.com/sgl-project/sglang/pull/31181 and https://github.com/sgl-project/sglang/pull/33639, this optimization further improves the KV‑cache hit rate by approximately 7%.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33358896364](https://github.com/sgl-project/sglang/actions/runs/33358896364)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33358896291](https://github.com/sgl-project/sglang/actions/runs/33358896291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33358896361](https://github.com/sgl-project/sglang/actions/runs/33358896361)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->