### PR TITLE
[Rust server] Support parallel sampling (n > 1) on native /generate

### DIFF
--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -31,7 +31,10 @@ use super::frame::{
 use super::guard::AbortGuard;
 use super::submit::submit;
 use crate::message::ids::Rid;
-use crate::message::request::{GenerateBody, GenerateRequest, RequestKind};
+use crate::message::request::{
+    GenerateBody, GenerateRequest, RequestKind, check_parallel_sample_budget,
+    expand_parallel_samples,
+};
 use crate::message::response::{ChunkEvent, ResponseItem};
 use crate::message::sampling::SamplingParams;
 use crate::utils::{
@@ -207,7 +210,7 @@ async fn generate(
     let stream = body.stream;
     // Fan `text`/`input_ids`/`sampling_params` (scalar or list) into per-request
     // payloads. `is_batch` = list form → the response is a JSON array.
-    let (mut payloads, is_batch) = match body.into_requests() {
+    let (mut payloads, is_batch, num_samples) = match body.into_requests() {
         Ok(v) => v,
         // The error carries its own status (a bad batch is `Validation` → 400).
         Err(e) => {
@@ -215,6 +218,13 @@ async fn generate(
             return native_error(code, &e.to_string(), stream);
         }
     };
+    // Parallel sampling admission. Everything here runs BEFORE `prefetch_all` so a
+    // request that will be refused never downloads a byte of media.
+    if num_samples > 1
+        && let Some(refusal) = admit_parallel_sampling(&state, &payloads, num_samples, stream)
+    {
+        return refusal;
+    }
     // Python starts APIServerReqTimeStats after request normalization and before
     // tokenization / multimodal preprocessing / scheduler dispatch. Start at the
     // equivalent boundary: into_requests() has normalized the body, while prefetch
@@ -225,16 +235,91 @@ async fn generate(
     if let Err(e) = super::prefetch::prefetch_all(&mut payloads).await {
         return native_error(StatusCode::BAD_REQUEST, &e, stream);
     }
-    if !is_batch {
-        // `into_requests` guarantees exactly one payload for a non-batch body.
+    // Fan out AFTER prefetch: media resolves once per prompt, not once per sample.
+    payloads = expand_parallel_samples(payloads, num_samples);
+    if wants_array(is_batch, num_samples) {
+        generate_batch(&state, payloads, stream, timing).await
+    } else {
+        // `into_requests` guarantees exactly one payload for a non-batch body, and
+        // `num_samples == 1` leaves it un-expanded.
         let payload = payloads
             .into_iter()
             .next()
             .expect("into_requests yields >=1 payload");
         generate_single(&state, payload, stream, timing).await
-    } else {
-        generate_batch(&state, payloads, stream, timing).await
     }
+}
+
+/// Whether the response is a JSON array rather than a single object.
+///
+/// A predicate, not an inline condition, because getting it wrong is a silent API
+/// break in the `n == 1` direction: a plain `/generate` would start answering
+/// `[{..}]` instead of `{..}`. Cheap to lock down in a unit test this way.
+fn wants_array(is_batch: bool, num_samples: usize) -> bool {
+    is_batch || num_samples > 1
+}
+
+/// Admission checks for `n > 1`, in the order that keeps the failure modes clean.
+/// Returns the refusal to send, or `None` to proceed.
+///
+/// `Option`, not `Result<(), Response>`: there is no success value to carry, so a
+/// `Result` would be an enum whose size is entirely the 128-byte `Response` in its
+/// error arm (`clippy::result_large_err`) — and "an optional refusal" is what this
+/// actually computes.
+fn admit_parallel_sampling(
+    state: &AppState,
+    payloads: &[GenerateRequest],
+    num_samples: usize,
+    stream: bool,
+) -> Option<Response> {
+    // Multimodal: not ported yet. BOTH conditions are required — on a text-only
+    // model the mm fields are inert (the intake FSM gates them behind
+    // `mm.enabled && has_multimodal()`), so a request carrying a stray
+    // `image_data` works today and must keep working.
+    if state.server_args.model_is_multimodal()
+        && payloads.iter().any(GenerateRequest::has_multimodal)
+    {
+        return Some(native_error(
+            StatusCode::BAD_REQUEST,
+            "parallel sampling (n > 1) is not supported for multimodal requests",
+            stream,
+        ));
+    }
+    // PD disaggregation: not ported yet. Python gives all `n` samples of a prompt
+    // the SAME `bootstrap_room`, so neither copying that nor "fixing" it is
+    // defensible until the P/D room protocol is settled — see
+    // `expand_parallel_samples`.
+    if state.server_args.is_disaggregation() {
+        return Some(native_error(
+            StatusCode::BAD_REQUEST,
+            "parallel sampling (n > 1) is not supported in disaggregated (PD) mode",
+            stream,
+        ));
+    }
+    // Validate BEFORE cloning. Deferring this to the intake FSM would let one bad
+    // parameter be reported once per sibling, and `generate_batch` packs per-item
+    // errors into a 200 array — so a request that is a clean 400 at `n == 1` would
+    // come back as `200 + [err, err, err]`. Only for `n > 1`: at `n == 1` this
+    // stays in the FSM's `Normalizing` step, which deliberately keeps the
+    // stop-string work off the API runtime.
+    for payload in payloads {
+        let mut sp = payload.sampling_params.clone();
+        if let Err(e) = sp.normalize(
+            state.server_args.skip_tokenizer_init,
+            state.server_args.model_config.vocab_size,
+        ) {
+            let code = StatusCode::from_u16(e.http_status()).unwrap_or(StatusCode::BAD_REQUEST);
+            return Some(native_error(code, &e.to_string(), stream));
+        }
+    }
+    // Request count is capped in `into_requests`; this is the memory bound. The two
+    // are independent: 4096 copies of a 10 MB prompt clears the count cap and still
+    // asks for ~40 GB.
+    if let Err(e) = check_parallel_sample_budget(payloads, num_samples) {
+        let code = StatusCode::from_u16(e.http_status()).unwrap_or(StatusCode::BAD_REQUEST);
+        return Some(native_error(code, &e.to_string(), stream));
+    }
+    None
 }
 
 /// Answer an error raised *before* anything was submitted, in the shape the client
@@ -542,8 +627,9 @@ fn terminal_stream_frame_string(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::config::{DisaggregationMode, ServerArgs};
     use crate::message::response::ChunkEvent;
-    use crate::tokenizer_manager::wiring::Senders;
+    use crate::tokenizer_manager::wiring::{Senders, TmEvent};
     use crate::utils::error::Error;
     use futures::StreamExt;
     use std::time::Duration;
@@ -554,6 +640,178 @@ mod tests {
             tokenizer_tx: flume::unbounded().0,
             detokenizer_tx: vec![],
         }
+    }
+
+    /// An `AppState` that KEEPS the intake receiver, so a test can see what the
+    /// handler actually submitted.
+    ///
+    /// `senders()` above drops every receiver on the floor, which is fine for the
+    /// frame-shaping tests but useless here — and worse than useless: a dropped
+    /// receiver disconnects the channel, so `submit` fails and the handler answers
+    /// 503, i.e. the test fails for a reason unrelated to what it is checking.
+    fn test_state(server_args: ServerArgs) -> (Arc<AppState>, flume::Receiver<TmEvent>) {
+        let (tok_manager_tx, tok_manager_rx) = flume::unbounded();
+        let state = AppState {
+            senders: Senders {
+                tok_manager_tx,
+                abort_tx: flume::unbounded().0,
+                tokenizer_tx: flume::unbounded().0,
+                detokenizer_tx: vec![],
+            },
+            response_buf: 16,
+            server_args: Arc::new(server_args),
+            chat_formatter: None,
+            response_activity: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        };
+        (Arc::new(state), tok_manager_rx)
+    }
+
+    fn body(json: &str) -> Result<Json<GenerateBody>, JsonRejection> {
+        Ok(Json(serde_json::from_str(json).expect("valid body")))
+    }
+
+    /// Drive `generate` far enough to see the refusal, with nothing to answer the
+    /// submitted requests. Only valid for paths that reject before submitting.
+    async fn refuse(state: Arc<AppState>, json: &str) -> StatusCode {
+        generate(State(state), body(json)).await.status()
+    }
+
+    // ----- parallel sampling: admission + routing -----
+
+    /// The response is an array exactly when the body was a list OR `n > 1`.
+    ///
+    /// Worth its own predicate and its own test: getting the `n == 1` side wrong
+    /// silently turns every plain `/generate` reply from `{..}` into `[{..}]`.
+    #[test]
+    fn array_response_iff_batch_or_multi_sample() {
+        assert!(!wants_array(false, 1), "plain request stays an object");
+        assert!(wants_array(true, 1), "list body is an array");
+        assert!(wants_array(false, 3), "n > 1 is an array");
+        assert!(wants_array(true, 3));
+    }
+
+    /// `n > 1` with media is refused on a MULTIMODAL model, and nothing is
+    /// submitted.
+    #[tokio::test]
+    async fn multimodal_parallel_sampling_is_refused() {
+        let mut sa = ServerArgs::default();
+        sa.model_config.is_multimodal = true;
+        let (state, rx) = test_state(sa);
+        let status = refuse(
+            state,
+            r#"{"text": "a", "image_data": "u", "sampling_params": {"n": 3}}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(rx.is_empty(), "nothing may reach the scheduler");
+    }
+
+    /// …but the SAME body on a text-only model is admitted, because there the mm
+    /// fields are inert (the intake FSM gates them behind `mm.enabled`). This is
+    /// the half of the guard that a "simplification" to a single condition would
+    /// silently drop, turning working requests into 400s.
+    #[tokio::test]
+    async fn stray_media_on_a_text_model_still_runs() {
+        let (state, rx) = test_state(ServerArgs::default());
+        let handle = tokio::spawn(generate(
+            State(state),
+            body(r#"{"text": "a", "image_data": "u", "sampling_params": {"n": 3}}"#),
+        ));
+        let mut submitted = Vec::new();
+        for _ in 0..3 {
+            match rx.recv_async().await {
+                Ok(TmEvent::Intake(req)) => submitted.push(req),
+                other => panic!(
+                    "expected an intake event, got {other:?}",
+                    other = other.is_ok()
+                ),
+            }
+        }
+        assert_eq!(submitted.len(), 3, "text-only model must admit n > 1");
+        handle.abort();
+    }
+
+    /// PD disaggregation is refused for now: Python gives all `n` samples of a
+    /// prompt one `bootstrap_room`, so the pairing protocol has to be settled
+    /// before this can be honored.
+    #[tokio::test]
+    async fn pd_parallel_sampling_is_refused() {
+        let sa = ServerArgs {
+            disaggregation_mode: DisaggregationMode::Prefill,
+            ..Default::default()
+        };
+        let (state, rx) = test_state(sa);
+        let status = refuse(state, r#"{"text": "a", "sampling_params": {"n": 3}}"#).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(rx.is_empty(), "nothing may reach the scheduler");
+    }
+
+    /// A bad sampling parameter is ONE 400 and ZERO submissions.
+    ///
+    /// The "zero submissions" half is the point. Validating after the fan-out also
+    /// fails the request, but as `200 + [err, err, err]` (per-item errors are
+    /// packed into the batch array) — and by then three requests are already on
+    /// the scheduler burning GPU. A status-code-only assertion would not tell the
+    /// two apart, because 200 and 400 never get confused.
+    #[tokio::test]
+    async fn bad_params_reject_before_any_request_is_submitted() {
+        let (state, rx) = test_state(ServerArgs::default());
+        let status = refuse(
+            state,
+            r#"{"text": "a", "sampling_params": {"n": 3, "top_p": -1}}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            rx.is_empty(),
+            "no sibling may be submitted before validation"
+        );
+    }
+
+    /// At `n == 1` the same bad parameter is NOT caught up front: the request is
+    /// submitted and the intake FSM's `Normalizing` step rejects it, exactly as
+    /// before this feature.
+    ///
+    /// That placement is deliberate — normalization does the stop-string work, and
+    /// the FSM runs it on a core-bound thread rather than the API runtime — so the
+    /// early-validation path must stay scoped to `n > 1`. Asserting the eventual
+    /// 400 here is not possible without a fake scheduler; what matters, and what
+    /// this pins, is that the single-request path is untouched.
+    #[tokio::test]
+    async fn one_sample_still_defers_validation_to_the_fsm() {
+        let (state, rx) = test_state(ServerArgs::default());
+        let handle = tokio::spawn(generate(
+            State(state),
+            body(r#"{"text": "a", "sampling_params": {"top_p": -1}}"#),
+        ));
+        let event = rx
+            .recv_async()
+            .await
+            .expect("n == 1 must still submit; the FSM does the rejecting");
+        assert!(matches!(event, TmEvent::Intake(_)));
+        handle.abort();
+    }
+
+    /// `n = 3` submits exactly three requests, with the `{rid}_{i}` ids the client
+    /// will see echoed back as `meta_info.id`.
+    #[tokio::test]
+    async fn three_samples_submit_three_requests() {
+        let (state, rx) = test_state(ServerArgs::default());
+        let handle = tokio::spawn(generate(
+            State(state),
+            body(r#"{"text": "a", "rid": "r", "sampling_params": {"n": 3}}"#),
+        ));
+        let mut rids = Vec::new();
+        for _ in 0..3 {
+            match rx.recv_async().await {
+                Ok(TmEvent::Intake(req)) => rids.push(req.rid.client_facing().to_owned()),
+                _ => panic!("expected an intake event"),
+            }
+        }
+        rids.sort();
+        assert_eq!(rids, ["r_0", "r_1", "r_2"]);
+        assert!(rx.is_empty(), "exactly three, no more");
+        handle.abort();
     }
 
     fn frame(rid: u64, text: &str) -> ResponseItem {

--- a/rust/sglang-server/src/message/ids.rs
+++ b/rust/sglang-server/src/message/ids.rs
@@ -26,7 +26,7 @@ const UNIQ_SEP: u8 = b'#';
 const UNIQ_DIGITS: usize = 16;
 /// Total bytes appended. Fixed-width by construction — both halves are `u32`
 /// formatted `{:08x}` — which is what makes stripping a slice, not a search.
-const UNIQ_SUFFIX_LEN: usize = 1 + UNIQ_DIGITS;
+pub(crate) const UNIQ_SUFFIX_LEN: usize = 1 + UNIQ_DIGITS;
 
 #[derive(Clone, Debug)]
 pub struct Rid {

--- a/rust/sglang-server/src/message/request.rs
+++ b/rust/sglang-server/src/message/request.rs
@@ -12,7 +12,7 @@ use super::io_struct::{ControlRequest, TokenizedGenerateReqInput};
 use super::response::ResponseSink;
 use super::sampling::{SamplingParams, SamplingParamsInput};
 use super::types::{OneOrMany, OneOrManyItem, TokenIds};
-use crate::message::ids::Rid;
+use crate::message::ids::{Rid, UNIQ_SUFFIX_LEN};
 use crate::utils::fsm::RequestState;
 use crate::utils::{environ::env_u64, error::Error};
 
@@ -132,7 +132,7 @@ impl GenerateBody {
     /// `GenerateReqInput.normalize_batch_and_arguments`; an invalid/inconsistent
     /// batch is [`Error::Validation`], which the handler surfaces with the
     /// variant's own status (400).
-    pub fn into_requests(self) -> Result<(Vec<GenerateRequest>, bool), Error> {
+    pub fn into_requests(self) -> Result<(Vec<GenerateRequest>, bool, usize), Error> {
         let GenerateBody {
             rid,
             text,
@@ -175,6 +175,47 @@ impl GenerateBody {
                 "batch size {declared_n} exceeds the maximum of {}",
                 *MAX_BATCH_REQS_PER_HTTP_REQ
             )));
+        }
+
+        // Parallel sampling (`sampling_params.n`). Read and bounded HERE, before a
+        // single column is allocated, for the same reason `declared_n` is: the
+        // columns below are `vec![_; n]`, so a body that will be rejected must be
+        // rejected first.
+        //
+        // `n` is `i64` on the wire, so it can arrive negative or astronomically
+        // large. `as usize` would turn `-1` into `usize::MAX` and slip past every
+        // bound below, and a plain `declared_n * num_samples` would wrap in release
+        // builds — hence the explicit `try_from` + `checked_mul`. Same shape as
+        // `api_server::openai::completions`, which already caps `prompts * n`.
+        let common_n: i64 = match &sampling_params {
+            None => 1,
+            Some(SamplingParamsInput::One(sp)) => sp.n,
+            Some(SamplingParamsInput::Many(v)) => {
+                // Python `_handle_parallel_sampling` requires one `n` for the batch.
+                let first = v.first().map_or(1, |sp| sp.n);
+                if v.iter().any(|sp| sp.n != first) {
+                    return Err(Error::Validation(
+                        "the same n is required for all entries of sampling_params".into(),
+                    ));
+                }
+                first
+            }
+        };
+        if common_n < 1 {
+            return Err(Error::Validation(format!(
+                "n must be at least 1, got {common_n}"
+            )));
+        }
+        let num_samples = usize::try_from(common_n)
+            .map_err(|_| Error::Validation(format!("n is too large: {common_n}")))?;
+        match declared_n.checked_mul(num_samples) {
+            Some(total) if total <= *MAX_BATCH_REQS_PER_HTTP_REQ => {}
+            _ => {
+                return Err(Error::Validation(format!(
+                    "prompt count times n exceeds the maximum of {}",
+                    *MAX_BATCH_REQS_PER_HTTP_REQ
+                )));
+            }
         }
 
         // Per-item (text, input_ids) columns + whether the input used list form.
@@ -224,7 +265,7 @@ impl GenerateBody {
         }
 
         // A list is per-item; a single object broadcasts to every item.
-        let sps: Vec<SamplingParams> = match sampling_params {
+        let mut sps: Vec<SamplingParams> = match sampling_params {
             None => vec![SamplingParams::default(); n],
             Some(SamplingParamsInput::Many(v)) => {
                 if v.len() != n {
@@ -260,6 +301,14 @@ impl GenerateBody {
                 vec![*sp; n]
             }
         };
+        // The base requests carry `n = 1`: parallel sampling is a frontend fan-out
+        // (`expand_parallel_samples`), and the scheduler never reads `n` — Python's
+        // does not either. `SamplingParams::verify` keeps rejecting anything else as
+        // an internal invariant, so a request that skipped the fan-out cannot reach
+        // the ring silently claiming n samples and get one.
+        for sp in &mut sps {
+            sp.n = 1;
+        }
 
         // rid: absent → mint one uuid per item here, so every request carries its
         // final rid from this point on; a single string fans out as `{rid}_{i}`
@@ -439,7 +488,7 @@ impl GenerateBody {
                 .filter_map(|v| v.as_str().map(str::to_owned))
                 .collect();
         }
-        Ok((requests, is_batch))
+        Ok((requests, is_batch, num_samples))
     }
 }
 
@@ -665,7 +714,13 @@ pub struct GenerateRequest {
 ///
 /// Constructed directly only by tests: `api_server::prefetch` fills its
 /// `prefetched` field, everything else gets it packed inside a `GenerateRequest`.
-#[derive(Debug, Default)]
+///
+/// `Clone` is a DEEP copy, and parallel sampling depends on that: `take_mm_work`
+/// MOVES these fields out of the request, so two siblings sharing one `MmData`
+/// would leave whichever reached `Encoding` second with nothing. `prefetched`'s
+/// `Bytes` are refcounted handles to immutable buffers, so sharing those is safe
+/// and the media is not duplicated — only the handle array is.
+#[derive(Debug, Default, Clone)]
 pub struct MmData {
     pub image_data: Option<rmpv::Value>,
     pub video_data: Option<rmpv::Value>,
@@ -680,6 +735,43 @@ pub struct MmData {
 }
 
 impl GenerateRequest {
+    /// One parallel-sampling sibling of `self`: same prompt, same params, its own
+    /// `rid`.
+    ///
+    /// Written out rather than `#[derive(Clone)]` on `GenerateRequest`: every
+    /// stage below MOVES its request (`take_mm_work` empties the mm fields, the
+    /// `izip!` fan-out consumes each column by value), so the one deep copy in the
+    /// pipeline should be visible at the call site instead of available anywhere.
+    ///
+    /// `sampling_params.n` is already 1 — `into_requests` set it on the base — so
+    /// this does not touch it. `bootstrap_room` is copied VERBATIM, deliberately:
+    /// see `expand_parallel_samples`.
+    fn fork(&self, rid: Rid) -> Self {
+        Self {
+            rid,
+            text: self.text.clone(),
+            input_ids: self.input_ids.clone(),
+            skip_special_tokens: self.skip_special_tokens,
+            sampling_params: self.sampling_params.clone(),
+            stream: self.stream,
+            return_logprob: self.return_logprob,
+            logprob_start_len: self.logprob_start_len,
+            top_logprobs_num: self.top_logprobs_num,
+            token_ids_logprob: self.token_ids_logprob.clone(),
+            return_sampling_mask: self.return_sampling_mask,
+            return_hidden_states: self.return_hidden_states,
+            return_text_in_logprobs: self.return_text_in_logprobs,
+            bootstrap_host: self.bootstrap_host.clone(),
+            bootstrap_port: self.bootstrap_port,
+            bootstrap_room: self.bootstrap_room,
+            bootstrap_pair_key: self.bootstrap_pair_key.clone(),
+            decode_tp_size: self.decode_tp_size,
+            routed_dp_rank: self.routed_dp_rank,
+            disagg_prefill_dp_rank: self.disagg_prefill_dp_rank,
+            mm: self.mm.clone(),
+        }
+    }
+
     /// True when the client already supplied token ids → skip tokenization.
     pub fn already_tokenized(&self) -> bool {
         self.input_ids.as_ref().is_some_and(|v| !v.is_empty())
@@ -788,6 +880,118 @@ fn flatten_column<T>(column: Vec<Option<Option<T>>>) -> Vec<Option<T>> {
     column.into_iter().map(Option::flatten).collect()
 }
 
+/// Expand each base request into `n` parallel-sampling siblings, prompt-major
+/// (`p0s0, p0s1, …, p1s0, …`) so the response array matches Python's
+/// `_handle_batch_request` ordering and the OpenAI adapters' `prompt_index * n +
+/// sample_index`.
+///
+/// Called from the HTTP handler AFTER `prefetch_all`, never from
+/// [`GenerateBody::into_requests`]: prefetch resolves media per request, so
+/// expanding first would download the same URL `n` times.
+///
+/// `bootstrap_room` is carried over UNCHANGED. It looks like each sibling needs a
+/// distinct room (it is the P↔D pairing key), but Python gives all `n` samples of
+/// one prompt the same room — `_normalize_bootstrap_params` computes
+/// `batch_size * n` rooms and then `_handle_batch_request` only ever reads the
+/// first `batch_size` of them. Diverging here would break drop-in parity;
+/// copying it is only sound because the caller rejects `n > 1` under PD.
+///
+/// Only [`expand_parallel_samples`] is exported, not [`GenerateRequest::fork`]:
+/// a bare `fork` invites forgetting the fresh rid, and two live requests sharing
+/// an rid would collide on the detok table.
+pub(crate) fn expand_parallel_samples(
+    base: Vec<GenerateRequest>,
+    n: usize,
+) -> Vec<GenerateRequest> {
+    if n <= 1 {
+        return base;
+    }
+    let mut out = Vec::with_capacity(base.len().saturating_mul(n));
+    for req in base {
+        // The last sibling consumes `req` instead of cloning it, so an `n`-way
+        // expansion performs `n - 1` deep copies rather than `n`.
+        for s in 0..n - 1 {
+            let rid = Rid::from_client(&format!("{}_{s}", req.rid.client_facing()));
+            out.push(req.fork(rid));
+        }
+        let rid = Rid::from_client(&format!("{}_{}", req.rid.client_facing(), n - 1));
+        out.push(GenerateRequest { rid, ..req });
+    }
+    out
+}
+
+/// Bytes one request would cost to clone, counting every variable-length field
+/// [`GenerateRequest::fork`] copies or regenerates.
+///
+/// Missing a field here is a hole, not an inaccuracy: a tiny prompt with a huge
+/// `token_ids_logprob` (or a very long rid) sails past both the request-count cap
+/// and any prompt-size intuition.
+///
+/// Container overhead counts. `impl HeapBytes for String` returns only `len()`,
+/// so summing it over a `Vec<String>` scores a million empty strings as zero —
+/// while the handle array alone is ~24 MB. This mirrors what
+/// `impl HeapBytes for rmpv::Value` already does for arrays (`NODE + ..` per
+/// element).
+fn clone_bytes(req: &GenerateRequest, sample_index_digits: usize) -> usize {
+    // Each sibling mints `{client_rid}_{i}` and `Rid::from_client` appends a
+    // fixed-width uniquifier, so the rid is rebuilt per sibling, not shared.
+    let rid = req
+        .rid
+        .client_facing()
+        .len()
+        .saturating_add(1 + sample_index_digits + UNIQ_SUFFIX_LEN);
+    // Serialized-JSON × measured heap factor is how the broadcast path already
+    // sizes `SamplingParams`; it is the only estimator that reaches
+    // `custom_params` (a `serde_json::Value`, which `HeapBytes` does not cover).
+    let sampling = serde_json::to_string(&req.sampling_params)
+        .map_or(0, |s| s.len())
+        .saturating_mul(JSON_TO_HEAP_FACTOR);
+    let mm = req.mm.as_deref().map_or(0, |m| {
+        m.image_data
+            .heap_bytes()
+            .saturating_add(m.video_data.heap_bytes())
+            .saturating_add(m.audio_data.heap_bytes())
+            // Handles only: the `Bytes` payloads are refcounted, so the media
+            // itself is shared rather than duplicated.
+            .saturating_add(m.prefetched.len().saturating_mul(size_of::<Bytes>()))
+            .saturating_add(vec_string_bytes(&m.mm_hashes))
+    });
+    rid.saturating_add(req.text.heap_bytes())
+        .saturating_add(req.input_ids.heap_bytes())
+        .saturating_add(req.token_ids_logprob.heap_bytes())
+        .saturating_add(sampling)
+        .saturating_add(req.bootstrap_host.heap_bytes())
+        .saturating_add(req.bootstrap_pair_key.heap_bytes())
+        .saturating_add(mm)
+}
+
+/// `Vec<String>`: the handle array plus the contents (see [`clone_bytes`]).
+fn vec_string_bytes(v: &[String]) -> usize {
+    v.len()
+        .saturating_mul(size_of::<String>())
+        .saturating_add(v.iter().map(String::len).sum::<usize>())
+}
+
+/// Reject a parallel-sampling expansion whose clones would exceed
+/// [`MAX_BROADCAST_CLONE_BYTES`]. The request-count cap in `into_requests` does
+/// NOT imply this one: 4096 copies of a 10 MB prompt is ~40 GB, and a failed Rust
+/// allocation calls `abort()`, which is uncatchable and takes the scheduler
+/// process down with the frontend.
+pub(crate) fn check_parallel_sample_budget(
+    payloads: &[GenerateRequest],
+    num_samples: usize,
+) -> Result<(), Error> {
+    if num_samples <= 1 {
+        return Ok(());
+    }
+    let digits = (num_samples - 1).to_string().len();
+    let per_clone = payloads
+        .iter()
+        .map(|req| clone_bytes(req, digits))
+        .fold(0usize, usize::saturating_add);
+    check_broadcast_budget(per_clone, num_samples, "parallel samples")
+}
+
 /// Reject a broadcast whose clones would exceed [`MAX_BROADCAST_CLONE_BYTES`].
 fn check_broadcast_budget(per_clone: usize, n: usize, name: &str) -> Result<(), Error> {
     // `n == 1` is not a broadcast — there is one value and one prompt, so nothing
@@ -838,7 +1042,14 @@ mod tests {
     /// `sampling::tests::TEST_VOCAB`).
     const TEST_VOCAB: u64 = 1000;
 
+    /// The base requests + `is_batch`, dropping `num_samples` — most tests here
+    /// predate parallel sampling and only care about the fan-out columns.
     fn requests(body: &str) -> Result<(Vec<GenerateRequest>, bool), Error> {
+        requests_n(body).map(|(reqs, is_batch, _)| (reqs, is_batch))
+    }
+
+    /// Full `into_requests` output, for the parallel-sampling tests.
+    fn requests_n(body: &str) -> Result<(Vec<GenerateRequest>, bool, usize), Error> {
         serde_json::from_str::<GenerateBody>(body)
             .unwrap()
             .into_requests()
@@ -907,10 +1118,282 @@ mod tests {
     fn split_validates_inputs() {
         assert!(requests(r#"{"text": "a", "input_ids": [1]}"#).is_err());
         assert!(requests(r#"{"stream": true}"#).is_err());
-        // Parallel sampling is rejected where Python reads it — in the params,
-        // at normalization, not here.
-        let (mut ps, _) = requests(r#"{"text": "a", "sampling_params": {"n": 2}}"#).unwrap();
-        assert!(ps[0].sampling_params.normalize(false, TEST_VOCAB).is_err());
+    }
+
+    /// `into_requests` reads `n` but does NOT expand: it returns the BASE requests
+    /// plus the sample count, and the handler expands after `prefetch_all`.
+    ///
+    /// Asserting an expanded length here would be the wrong shape and would push
+    /// the expansion back into this function — which is exactly what must not
+    /// happen, since prefetch resolves media per request and would then fetch the
+    /// same URL `n` times.
+    #[test]
+    fn into_requests_reads_n_without_expanding() {
+        let (mut base, is_batch, num_samples) =
+            requests_n(r#"{"text": "a", "sampling_params": {"n": 2}}"#).unwrap();
+        assert!(!is_batch, "one prompt stays a single request");
+        assert_eq!(base.len(), 1, "into_requests must not expand");
+        assert_eq!(num_samples, 2);
+        // The base carries n=1, so the invariant in `verify` passes downstream.
+        assert_eq!(base[0].sampling_params.n, 1);
+        assert!(base[0].sampling_params.normalize(false, TEST_VOCAB).is_ok());
+
+        let expanded = expand_parallel_samples(base, num_samples);
+        assert_eq!(expanded.len(), 2, "expansion happens here");
+    }
+
+    /// `n` is read from `sampling_params`; a TOP-LEVEL `n` stays ignored (Python's
+    /// `GenerateReqInput` has no such field either — see
+    /// `unported_generate_req_input_fields_are_ignored`).
+    #[test]
+    fn top_level_n_is_not_parallel_sampling() {
+        let (_, _, num_samples) = requests_n(r#"{"text": "a", "n": 5}"#).unwrap();
+        assert_eq!(num_samples, 1, "top-level n must not drive the fan-out");
+    }
+
+    /// `n` is `i64` on the wire, so out-of-range values must be rejected rather
+    /// than cast: `as usize` turns -1 into `usize::MAX`, and a plain multiply
+    /// wraps in release builds — either one slips past every cap below.
+    #[test]
+    fn out_of_range_n_is_rejected_not_cast() {
+        for body in [
+            r#"{"text": "a", "sampling_params": {"n": 0}}"#,
+            r#"{"text": "a", "sampling_params": {"n": -1}}"#,
+            r#"{"text": "a", "sampling_params": {"n": 9223372036854775807}}"#,
+        ] {
+            assert!(
+                requests_n(body).is_err(),
+                "{body} must be rejected, not wrapped or cast"
+            );
+        }
+    }
+
+    /// `prompts * n` is capped by the same knob as the batch itself, and the
+    /// product is computed with `checked_mul` so it cannot wrap into range.
+    #[test]
+    fn prompt_count_times_n_is_capped() {
+        let cap = *MAX_BATCH_REQS_PER_HTTP_REQ;
+        let body = format!(
+            r#"{{"text": ["a", "b"], "sampling_params": {{"n": {}}}}}"#,
+            cap / 2 + 1
+        );
+        let err = requests_n(&body).expect_err("2 * (cap/2 + 1) exceeds the cap");
+        assert!(err.to_string().contains("exceeds the maximum"), "{err}");
+    }
+
+    /// A `sampling_params` LIST must agree on `n` (Python
+    /// `_handle_parallel_sampling` raises for the same reason).
+    #[test]
+    fn sampling_params_list_must_agree_on_n() {
+        let body = r#"{"text": ["a", "b"], "sampling_params": [{"n": 2}, {"n": 3}]}"#;
+        let err = requests_n(body).expect_err("mismatched n must be rejected");
+        assert!(err.to_string().contains("same n"), "{err}");
+    }
+
+    // ----- check_parallel_sample_budget -----
+
+    /// A request whose only large field is `f`, ready to weigh.
+    fn budget_req(f: impl FnOnce(&mut GenerateRequest)) -> GenerateRequest {
+        let mut req = GenerateRequest {
+            rid: Rid::from("r".to_string()),
+            text: Some("hi".into()),
+            ..Default::default()
+        };
+        f(&mut req);
+        req
+    }
+
+    fn over_budget(req: GenerateRequest, n: usize) -> bool {
+        check_parallel_sample_budget(std::slice::from_ref(&req), n).is_err()
+    }
+
+    /// A small prompt fanned out wide is fine — the cap must not reject ordinary
+    /// parallel sampling.
+    #[test]
+    fn budget_allows_small_prompt_with_large_n() {
+        assert!(!over_budget(budget_req(|_| {}), 1024));
+    }
+
+    /// `n == 1` is not an expansion, so nothing is weighed at all.
+    #[test]
+    fn budget_is_skipped_for_one_sample() {
+        let huge = budget_req(|r| r.text = Some("x".repeat(MAX_BROADCAST_CLONE_BYTES)));
+        assert!(!over_budget(huge, 1));
+    }
+
+    /// Every variable-length field `fork` copies is weighed. Each of these is a
+    /// standalone bypass: the prompt stays tiny, so neither the request-count cap
+    /// nor a prompt-size heuristic would catch it.
+    #[test]
+    fn budget_covers_every_cloned_field() {
+        let big = MAX_BROADCAST_CLONE_BYTES / 8;
+        let cases: Vec<(&str, GenerateRequest)> = vec![
+            ("text", budget_req(|r| r.text = Some("x".repeat(big)))),
+            ("rid", budget_req(|r| r.rid = Rid::from("x".repeat(big)))),
+            (
+                "token_ids_logprob",
+                budget_req(|r| r.token_ids_logprob = Some(vec![7; big])),
+            ),
+            (
+                "bootstrap_host",
+                budget_req(|r| r.bootstrap_host = Some("x".repeat(big))),
+            ),
+            (
+                "bootstrap_pair_key",
+                budget_req(|r| r.bootstrap_pair_key = Some("x".repeat(big))),
+            ),
+            (
+                "custom_params",
+                budget_req(|r| {
+                    r.sampling_params.custom_params =
+                        Some(serde_json::json!({ "k": "x".repeat(big) }));
+                }),
+            ),
+            (
+                "image_data",
+                budget_req(|r| {
+                    r.mm = Some(Box::new(MmData {
+                        image_data: Some(rmpv::Value::from("x".repeat(big))),
+                        ..Default::default()
+                    }));
+                }),
+            ),
+        ];
+        for (field, req) in cases {
+            assert!(
+                over_budget(req, 64),
+                "{field} must count toward the clone budget"
+            );
+        }
+    }
+
+    /// `Vec<String>` is weighed by its HANDLE ARRAY plus contents, not contents
+    /// alone. A million EMPTY strings sums to zero bytes of content while the
+    /// handles alone are ~24 MB — summing `len()` would wave this straight
+    /// through. A single long string would pass either way, which is why the
+    /// empties are the case that actually locks the hole.
+    #[test]
+    fn budget_counts_container_handles_not_just_contents() {
+        let empties = MAX_BROADCAST_CLONE_BYTES / size_of::<String>();
+        let req = budget_req(|r| {
+            r.mm = Some(Box::new(MmData {
+                mm_hashes: vec![String::new(); empties],
+                ..Default::default()
+            }));
+        });
+        assert!(
+            over_budget(req, 4),
+            "a Vec of empty Strings still costs its handle array"
+        );
+    }
+
+    /// The reverse hazard: `prefetched` holds refcounted `Bytes`, so cloning a
+    /// sibling shares the media instead of duplicating it. Counting the payload
+    /// would 400 legitimate multimodal requests — only the handle array is real.
+    #[test]
+    fn budget_ignores_shared_media_payloads() {
+        let media = Bytes::from(vec![0u8; MAX_BROADCAST_CLONE_BYTES]);
+        let req = budget_req(|r| {
+            r.mm = Some(Box::new(MmData {
+                prefetched: vec![media],
+                ..Default::default()
+            }));
+        });
+        assert!(
+            !over_budget(req, 64),
+            "refcounted media must not be charged per sibling"
+        );
+    }
+
+    // ----- expand_parallel_samples -----
+
+    /// One prompt, `n = 3`: three siblings with distinct `{rid}_{i}` ids, each
+    /// carrying `n = 1` (the scheduler never fans out).
+    #[test]
+    fn expansion_mints_one_sibling_per_sample() {
+        let (base, _, num_samples) =
+            requests_n(r#"{"text": "a", "rid": "r", "sampling_params": {"n": 3}}"#).unwrap();
+        let out = expand_parallel_samples(base, num_samples);
+
+        assert_eq!(out.len(), 3);
+        let client_rids: Vec<&str> = out.iter().map(|r| r.rid.client_facing()).collect();
+        assert_eq!(client_rids, ["r_0", "r_1", "r_2"]);
+        // Internally unique too — the detok table is keyed by the full rid, and two
+        // live requests sharing a key would evict each other's sink.
+        let uniq: HashSet<&str> = out.iter().map(|r| r.rid.as_str()).collect();
+        assert_eq!(uniq.len(), 3, "sibling rids must be internally distinct");
+        assert!(out.iter().all(|r| r.sampling_params.n == 1));
+    }
+
+    /// Two prompts × `n = 3` come back PROMPT-MAJOR (`p0s0 p0s1 p0s2 p1s0 …`),
+    /// matching Python's `_handle_batch_request` order and the OpenAI adapters'
+    /// `prompt_index * n + sample_index`.
+    #[test]
+    fn expansion_is_prompt_major() {
+        let (base, _, num_samples) =
+            requests_n(r#"{"text": ["a", "b"], "sampling_params": {"n": 3}}"#).unwrap();
+        let out = expand_parallel_samples(base, num_samples);
+
+        assert_eq!(out.len(), 6);
+        let texts: Vec<&str> = out.iter().map(|r| r.text.as_deref().unwrap()).collect();
+        assert_eq!(texts, ["a", "a", "a", "b", "b", "b"]);
+    }
+
+    /// `bootstrap_room` is carried over UNCHANGED.
+    ///
+    /// The tempting "fix" is to make it unique across the flattened index, since
+    /// the room is the P↔D pairing key. Python does not: it computes
+    /// `batch_size * n` rooms and then only ever reads the first `batch_size`, so
+    /// all `n` samples of a prompt share one. Offsetting here would break drop-in
+    /// parity; the handler refuses `n > 1` under PD instead.
+    #[test]
+    fn expansion_leaves_bootstrap_room_untouched() {
+        let (base, _, num_samples) = requests_n(
+            r#"{"text": ["a", "b"], "bootstrap_room": 100, "sampling_params": {"n": 2}}"#,
+        )
+        .unwrap();
+        // The per-prompt offset the batch fan-out already applied.
+        assert_eq!(
+            base.iter().map(|r| r.bootstrap_room).collect::<Vec<_>>(),
+            [Some(100), Some(101)]
+        );
+        let out = expand_parallel_samples(base, num_samples);
+        assert_eq!(
+            out.iter().map(|r| r.bootstrap_room).collect::<Vec<_>>(),
+            [Some(100), Some(100), Some(101), Some(101)],
+            "siblings share their prompt's room, as in Python"
+        );
+    }
+
+    /// `n == 1` is a no-op: the base requests pass through untouched, so a plain
+    /// `/generate` never pays for the expansion path.
+    #[test]
+    fn expansion_is_a_noop_for_one_sample() {
+        let (base, _, num_samples) = requests_n(r#"{"text": "a", "rid": "r"}"#).unwrap();
+        assert_eq!(num_samples, 1);
+        let rid_before = base[0].rid.as_str().to_owned();
+        let out = expand_parallel_samples(base, num_samples);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].rid.as_str(), rid_before, "rid must not be re-minted");
+    }
+
+    /// Multimodal payloads are copied to every sibling — `take_mm_work` MOVES them
+    /// out of whichever request reaches `Encoding`, so siblings must not share.
+    #[test]
+    fn expansion_gives_every_sibling_its_own_mm() {
+        let (base, _, num_samples) =
+            requests_n(r#"{"text": "a", "image_data": "u", "sampling_params": {"n": 3}}"#).unwrap();
+        let mut out = expand_parallel_samples(base, num_samples);
+        assert_eq!(out.len(), 3);
+        assert!(out.iter().all(GenerateRequest::has_multimodal));
+
+        // Draining one leaves the others intact.
+        let _ = out[0].take_mm_work();
+        assert!(!out[0].has_multimodal());
+        assert!(
+            out[1].has_multimodal() && out[2].has_multimodal(),
+            "siblings must own independent MmData"
+        );
     }
 
     /// Unported `GenerateReqInput` fields are IGNORED, not rejected.

--- a/rust/sglang-server/src/message/sampling.rs
+++ b/rust/sglang-server/src/message/sampling.rs
@@ -476,13 +476,17 @@ impl SamplingParams {
                 "Only one of regex, json_schema, or ebnf can be set".into()
             ));
         }
-        // Not a Python restriction: the rust from_scheduler maps one rid to one response,
-        // so parallel sampling would drop all but the first sample. This is the
-        // only place it is rejected — `n` lives in `sampling_params`, where
-        // Python reads it, and the `/generate` body has no `n` of its own.
+        // INTERNAL INVARIANT, not a client-facing limit. Parallel sampling is a
+        // frontend fan-out: `GenerateBody::into_requests` reads `n`, validates it,
+        // and sets it to 1 on the base request; `expand_parallel_samples` then
+        // makes that many siblings. The scheduler never reads `n` (neither does
+        // Python's), and the response path maps one rid to one response — so a
+        // request that reached here still claiming n samples skipped the fan-out
+        // and would silently get one. Fail loudly instead.
         if self.n != 1 {
             return Err(bad(format!(
-                "n must be 1 (parallel sampling is not supported), got {}",
+                "internal: sampling_params.n must be 1 by the time params are \
+                 normalized (parallel sampling expands before this point), got {}",
                 self.n
             )));
         }
@@ -773,7 +777,7 @@ mod tests {
             (r#"{"temperature": -0.1}"#, "temperature"),
             (r#"{"max_new_tokens": -1}"#, "max_new_tokens"),
             (r#"{"regex": "a", "ebnf": "b"}"#, "Only one of"),
-            (r#"{"n": 2}"#, "n must be 1"),
+            (r#"{"n": 2}"#, "sampling_params.n must be 1"),
             (r#"{"beam_width": 2}"#, "beam_width must be 1"),
             (r#"{"beam_width": 0}"#, "beam_width must be at least 1"),
         ] {

--- a/test/registered/core/test_srt_endpoint.py
+++ b/test/registered/core/test_srt_endpoint.py
@@ -31,8 +31,8 @@ from sglang.test.test_utils import (
     run_logprob_check,
 )
 
-register_cuda_ci(est_time=260, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=260, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=280, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=280, suite="stage-b-test-1-gpu-small-amd")
 
 SERVER_ENV = {"SGLANG_USE_PICKLE_IPC": "0"}
 
@@ -108,6 +108,54 @@ class TestSRTEndpoint(CustomTestCase):
 
         print(json.dumps(response_json, indent=2))
         print("=" * 100)
+
+        # One response object per (prompt, sample). `batch=True` sends the prompt
+        # in list form, which makes the reply an array on its own; `n > 1` does
+        # the same. Both inputs matter, so both are exercised below.
+        num_prompts = len(text) if batch else 1
+        expects_array = batch or n > 1
+        num_choices = num_prompts * n
+
+        if stream:
+            # Frames carry `index` only when there is more than one response to
+            # tell apart. Asserting the n == 1 side matters as much as the other:
+            # tagging a single request would be a wire change for every existing
+            # streaming client.
+            indexes = {f["index"] for f in response_json if "index" in f}
+            if expects_array:
+                self.assertEqual(indexes, set(range(num_choices)))
+            else:
+                self.assertEqual(indexes, set(), "a lone request carries no index")
+            return
+
+        if expects_array:
+            self.assertIsInstance(response_json, list)
+            self.assertEqual(len(response_json), num_choices)
+            items = response_json
+        else:
+            # NOT a one-element list: turning `{..}` into `[{..}]` here would
+            # silently break every caller that does not pass `n`.
+            self.assertIsInstance(response_json, dict)
+            items = [response_json]
+
+        # Each entry stands on its own, and the ids are distinct so a caller can
+        # tell the samples apart.
+        for item in items:
+            self.assertIn("text", item)
+            self.assertIn("id", item["meta_info"])
+        self.assertEqual(len({item["meta_info"]["id"] for item in items}), num_choices)
+
+    def test_simple_decode(self):
+        self.run_decode()
+
+    def test_simple_decode_batch(self):
+        self.run_decode(batch=True)
+
+    def test_parallel_sample(self):
+        self.run_decode(n=3)
+
+    def test_parallel_sample_stream(self):
+        self.run_decode(n=3, stream=True)
 
     def test_logprob(self):
         self.run_decode(


### PR DESCRIPTION
## Motivation

Implements item 15 (Parallel Sampling) of the Rust server migration RFC, #23206.

Native `/generate` on the Rust frontend rejects `sampling_params.n != 1`, while the
OpenAI adapters already support `n` by fanning one request out into `n` single-sample
ones. This ports that same shape to `/generate`.

Parallel sampling stays a frontend concern: the scheduler never reads `n` — neither
does Python's, which does the fan-out in `TokenizerManager._handle_batch_request` — so
nothing on the msgpack wire or the Python side changes.

## Modifications

**`message/request.rs`**: all of parallel sampling lives in `GenerateRequest::into_requests(&ServerArgs)`.

- `n` is read and bounded **before any per-item column is allocated**. It is `i64` on the wire, so it is range-checked and converted with `usize::try_from`, not cast (`-1 as usize` would slip past every bound). A `sampling_params` list must agree on one `n`.
- `prompts × n` uses `checked_mul` and is capped by the existing `batch_size_exceeds_limit` / `SGLANG_MAX_BATCH_REQS_PER_HTTP_REQ` rather than a new constant. The new code has no saturating arithmetic: every overflow is a 400.
- Base requests are built with `SamplingParams { n: 1, ..sp }`, so the scheduler still only ever sees `n = 1`.
- For `n > 1`, `admit_parallel_sampling` runs before anything is expanded or submitted:
  - multimodal fields refuse the request (any model);
  - PD mode refuses it;
  - sampling params are normalized once, so one bad value is **one 400** rather than `200 + [err; n]`;
  - the per-sample rid suffix is checked against `MAX_RID_LEN`;
  - the clone budget is checked.
- `expand_parallel_samples` fans out prompt-major with rid `{rid}_{s}`, using `#[derive(Clone)]`. The last sibling is moved, so `n` samples cost `n − 1` clones.
- The clone budget bounds memory before it is allocated, since the request-count cap does not imply it: 4096 copies of a 10 MB prompt clear the count and still ask for ~40 GB, and a failed Rust allocation `abort()`s. `clone_bytes` weighs every variable-length field with checked arithmetic, and container handles count, not just their contents.
- The response is an array iff the body was a list **or** `n > 1`, which is the existing `is_batch` flag.

**`api_server/native_api.rs`**: `generate()` keeps its upstream shape; it only passes `&state.server_args` into `into_requests`.

**`message/ids.rs`**: `MAX_RID_LEN` moved here from `to_scheduler.rs`, so the request layer and intake share one constant.

**`message/sampling.rs`**: `verify` keeps rejecting `n != 1`, demoted from a client-facing limit to an internal invariant. A request that skips the fan-out fails loudly instead of silently getting one sample.

### `bootstrap_room` is deliberately left alone

It looks like each sibling needs a distinct room, since it is the P↔D pairing key. Python
does not do that: `_normalize_bootstrap_params` computes `batch_size * n` rooms and then
`_handle_batch_request` only ever reads the first `batch_size`, so all `n` samples of a
prompt share one. Offsetting here would diverge from the reference implementation;
copying it verbatim would replicate behavior whose intent is unclear. This PR refuses
`n > 1` under PD instead and changes no room logic.

### Non-goals

| Deferred | Why |
|---|---|
| Multimodal + `n > 1` | Refused for any request carrying multimodal fields, since encoder support (RFC item 7) is still WIP. It never reaches the fan-out (`debug_assert`), so mm data is never cloned. |
| PD + `n > 1` | The P/D room protocol has to be settled first (above). |
| Prefix warm-up | Python sends one `max_new_tokens=0` request before fanning out so the remaining `n-1` prefills hit the radix cache. Measured at ~8% here (see below), so this is an optimization and needs its own error-handling and cancellation design. Separate PR. |

## Accuracy Tests

Run on an RTX 4090 24GB, driver 580.173.02, CUDA toolkit 13.0, torch 2.13.0+cu130, flashinfer 0.6.18 (default backends), `SGLANG_RUST_SERVER=1`, `meta-llama/Llama-3.2-1B-Instruct`.

**Rust**: `cargo fmt --check` and `cargo clippy -p sglang-server --all-targets -- -D warnings` are clean. `cargo test -p sglang-server`: **293 passed, 0 failed**, 19 of them new. The new tests cover:
- fan-out shape, prompt-major order and rid uniqueness;
- `bootstrap_room` left untouched;
- the `n` range and `prompts × n` cap;
- the rid-suffix boundary;
- the mm and PD guards;
- the memory budget.

**`TestRustServerEndpoint`**: `Ran 22 tests — OK (skipped=5)`, so **17 passed, 0 failed**.
- `run_decode` previously printed its response and asserted nothing. This PR gives it assertions and restores the decode-shape tests dropped in #25831. `test_parallel_sample`, `test_parallel_sample_stream`, `test_simple_decode` and `test_simple_decode_batch` all pass.
- The 5 skips are the existing "not implemented by the embedded Rust server yet" cases (`test_cache_tokens` and four `custom_logit_processor` tests).

**Manual e2e against a live server**: 12/12 pass.

| # | Request | Expected | Observed |
|---|---|---|---|
| 1 | `n=3` | 200, JSON array of 3 | 200, list of 3 |
| 2 | `n=3` | 3 distinct texts | distinct |
| 3 | `n=3` | distinct `meta_info.id` | `…_0`, `…_1`, `…_2` |
| 4 | `n=1` | single object, not `[{…}]` | object |
| 5 | 2 prompts × `n=2` | 4 items | 4 items |
| 6 | stream `n=3` | `index` in {0,1,2} | 36 frames, index = [0,1,2] |
| 7 | stream `n=1` | no `index` | 12 frames, no index |
| 8 | text-only model + `image_data` + `n=3` | 400 from the mm guard | `parallel sampling (n > 1) is not supported for requests with multimodal fields` |
| 9 | 125-byte rid + `n=11` (suffixed length exactly 128) | 200 | 200 |
| 10 | 126-byte rid + `n=11` | 400 with reason | `rid is 126 bytes; with n = 11 each sample's rid gains 3 bytes, over the 128-byte limit` |
| 11 | `n=3` + `top_p=-1` | one 400 | `top_p must be in (0, 1], got -1` |
| 12 | `n=i64::MAX` | 400, no overflow | `prompt count times n (9223372036854775807) exceeds the maximum …` |

## Speed Tests and Profiling

### `n = 1`: no regression (`bench_serving` A/B)

Same machine and same Python tree; only `rust/` is swapped: base = `1da8ac10e1` (merge-base), head = this PR. Rounds alternate base → head → base → head, so run-to-run drift shows up. The command is `sglang.benchmark.serving --backend sglang --dataset-name random-ids --random-range-ratio 1.0 --seed 1`.

**throughput**: 1000 prompts, in 256 / out 128, concurrency 64

| metric | base r1 | base r2 | head r1 | head r2 | head vs base |
|---|---|---|---|---|---|
| req/s | 13.9 | 14.3 | 14.8 | 14.4 | +3.5% |
| out tok/s | 1777.0 | 1835.3 | 1895.8 | 1842.2 | +3.5% |
| median TTFT ms | 279.0 | 274.7 | 270.5 | 272.5 | −1.9% |
| p99 TTFT ms | 894.9 | 901.6 | 843.6 | 649.8 | −16.9% |
| median E2E ms | 4633.2 | 4477.2 | 4360.7 | 4492.6 | −2.8% |

**frontend-bound**: 3000 prompts, in 32 / out 4, concurrency 256. The tiny outputs make frontend overhead dominate.

| metric | base r1 | base r2 | head r1 | head r2 | head vs base |
|---|---|---|---|---|---|
| req/s | 220.3 | 233.5 | 248.4 | 236.3 | +6.8% |
| out tok/s | 881.1 | 934.0 | 993.7 | 945.3 | +6.8% |
| median TTFT ms | 488.3 | 458.2 | 452.6 | 464.1 | −3.1% |
| p99 TTFT ms | 1331.7 | 1292.5 | 1271.8 | 1217.3 | −5.2% |
| median E2E ms | 891.6 | 839.2 | 818.2 | 845.1 | −3.9% |

Base alone varies by ~3% (throughput) and ~6% (frontend-bound) between its two rounds, so this reads as **no regression**, not a speedup. That fits the code: before its early return, an `n = 1` request only adds one field read and two integer comparisons.

### What `n > 1` actually costs

Same ~1000-token prompt, `n = 4`, cold radix cache each round (per-run unique prefix),
5 rounds, median, Qwen2.5-0.5B on one consumer GPU (measured before the review round, which did not change the fan-out itself):

| | Median | vs `n = 4` |
|---|---|---|
| `n = 4` in one request | 239.9 ms | — |
| 4 concurrent `n = 1` requests | 233.9 ms | 1.03x |
| warm-up (`max_new_tokens=0`) then `n = 4` | 221.6 ms | 0.92x |

Two things worth recording:

**Python's runtime warning does not hold on this path.** It suggests callers "duplicate
the requests n times or use many threads" for better performance; measured, that is
1.03x — i.e. the same. Concurrent separate requests land in the same scheduler batch and
perform the same `n` prefills, so there is no cache reuse to win.

**Prefix warm-up is worth ~8% here.** Batched
prefill means `n` copies is far cheaper than `n` times the cost. This is a 0.5B model
with a ~1000-token prompt, where prefill is not dominant; the ratio should grow with
model size and prompt length, but this measurement does not establish by how much. It
does lower the follow-up's priority.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35696891324](https://github.com/sgl-project/sglang/actions/runs/35696891324)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35696891084](https://github.com/sgl-project/sglang/actions/runs/35696891084)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35696891213](https://github.com/sgl-project/sglang/actions/runs/35696891213)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->


