### PR TITLE
[CI] Speed up lint: cache pre-commit envs + mint, drop redundant work

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      MINT_VERSION: 4.2.559
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
       # detection silently re-adds NEW files under docs_new/ on merge without a
@@ -33,11 +33,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: .pre-commit-config.yaml
 
       - name: Install pre-commit hook
         run: |
           python -m pip install pre-commit
           pre-commit install
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       # The clippy-rust-workspace pre-commit hook compiles the rust/ workspace
       # (debug profile); cache cargo registry + target across runs.
@@ -66,19 +74,20 @@ jobs:
       - name: Check cookbook authoring contracts
         run: node docs/scripts/check_cookbook_configs.mjs
 
+      - name: Cache mint
+        uses: actions/cache@v4
+        with:
+          path: ~/.mint-cli
+          key: mint-${{ runner.os }}-${{ env.MINT_VERSION }}
+
       # Hard gate: docs internal links/anchors/redirects must resolve.
       # mint is pinned for reproducibility (its heading-slug rules are
       # version-sensitive); bump deliberately after re-verifying locally.
       - name: Check docs links (Mintlify broken-links)
         run: |
-          npm install -g mint@4.2.559
+          if [ ! -x "$HOME/.mint-cli/node_modules/.bin/mint" ]; then
+            npm install --prefix "$HOME/.mint-cli" "mint@${MINT_VERSION}"
+          fi
+          export PATH="$HOME/.mint-cli/node_modules/.bin:$PATH"
           cd docs
           mint broken-links --check-anchors --check-redirects
-
-      - name: Run sgl-kernel clang-format checks
-        uses: DoozyX/clang-format-lint-action@v0.20
-        with:
-          source: python/sglang/kernels/aot
-          extensions: h,c,cpp,hpp,cu,cuh,cc
-          clangFormatVersion: 20
-          style: file

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
       MINT_VERSION: 4.2.559
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
       # detection silently re-adds NEW files under docs_new/ on merge without a


### PR DESCRIPTION
## Motivation

The lint job has crept from ~4m20s (early June) to ~7m36s (e.g. run [33360547828](https://github.com/sgl-project/sglang/actions/runs/33360547828/job/99390908592)). Most of the growth is black-jupyter scaling with the repo (143s → 218s since June), which is left for a **separate PR** (black → ruff-format). This PR removes everything else the job redoes every run — about 85–90s of it.

## Modifications

Measured against the run above:

| Change | Saving |
|---|---|
| Cache `~/.cache/pre-commit` | ~35s: every run cloned + pip-installed all nine hook environments. Key is config hash + Python location, same scheme as the official `pre-commit/action`. |
| Cache the pinned `mint` install | ~38s: `npm install -g mint@4.2.559` was 38s of the 57s docs-links step (the check itself is ~19s). mint now installs into `~/.mint-cli` and restores from a cache keyed on the pinned version, single-sourced in `MINT_VERSION`. |
| Drop the DoozyX clang-format step | ~15s (5s run + 10s docker image build). Redundant: the `mirrors-clang-format` pre-commit hook (same clang-format major, 20) already covers `python/sglang/kernels/aot` — `identify` tags all of `.h/.hpp/.cc/.cpp/.cu/.cuh` as c++/cuda, the path is not in the config excludes, and running the hook over all 306 files in that tree processes the 180 C/CUDA ones and passes. |
| pip cache for the pre-commit install | a few seconds, via `setup-python`'s built-in cache. |

`fetch-depth: 0` is kept: nothing in the job currently reads history, but future diff-vs-base steps (the pattern that originally required it in #26322) shouldn't silently assume an unavailable merge-base.

Validated on this PR's own runs: first run passes with caches cold; the rerun with warm caches drops env installs to 0 and the mint step from 57s to 20s. Note caches only become visible to other PRs once a push-to-main run populates them after merge.

Expected job time after this PR: **~6min**, of which ~218s is black-jupyter (follow-up PR).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)