### PR TITLE
[Bugfix] Preserve Qwen3.5 encoder weights under PP

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2194,7 +2194,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     weight_loader(lm_head_param, loaded_weight)
             layer_id = get_layer_id(name)
             if (
-                layer_id is not None
+                name.startswith("model.layers.")
+                and layer_id is not None
                 and hasattr(self, "start_layer")
                 and (layer_id < self.start_layer or layer_id >= self.end_layer)
             ):
@@ -2457,7 +2458,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
             layer_id = get_layer_id(name)
             if (
-                layer_id is not None
+                name.startswith("model.layers.")
+                and layer_id is not None
                 and hasattr(self, "start_layer")
                 and (layer_id < self.start_layer or layer_id >= self.end_layer)
             ):

--- a/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
@@ -1,12 +1,25 @@
 import unittest
 from types import SimpleNamespace
 
+import torch
+
 from sglang.srt.layers.utils import PPMissingLayer
-from sglang.srt.models.qwen3_5 import Qwen3_5MoeForConditionalGeneration
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _RecordingParam:
+    def __init__(self):
+        self.loaded_weight = None
+
+    def weight_loader(self, _param, loaded_weight, *args, **kwargs):
+        self.loaded_weight = loaded_weight
 
 
 class TestQwen3_5PipelineParallel(CustomTestCase):
@@ -63,6 +76,55 @@ class TestQwen3_5PipelineParallel(CustomTestCase):
         )
 
         self.assertEqual(num_fused_shared_experts, 0)
+
+    def test_pp_filter_only_applies_to_language_model_layers(self):
+        for model_cls in (
+            Qwen3_5ForConditionalGeneration,
+            Qwen3_5MoeForConditionalGeneration,
+        ):
+            with self.subTest(model_cls=model_cls.__name__):
+                decoder_weight = _RecordingParam()
+                skipped_weight = _RecordingParam()
+                visual_weight = _RecordingParam()
+                params = {
+                    "model.layers.0.norm.weight": decoder_weight,
+                    "model.layers.5.norm.weight": skipped_weight,
+                    "visual.layers.5.norm.weight": visual_weight,
+                }
+                model = object.__new__(model_cls)
+                model.config = SimpleNamespace(
+                    tie_word_embeddings=False,
+                    num_experts=1,
+                    encoder_only=False,
+                )
+                model.model = SimpleNamespace(start_layer=0, end_layer=1)
+                model.pp_group = SimpleNamespace(
+                    is_first_rank=True,
+                    is_last_rank=False,
+                )
+                model.enable_shared_expert_fusion = False
+                model.named_parameters = lambda remove_duplicate=False: iter(
+                    params.items()
+                )
+
+                decoder_loaded = torch.ones(1)
+                skipped_loaded = torch.full((1,), 2)
+                visual_loaded = torch.full((1,), 3)
+                loaded_params = model_cls.load_weights(
+                    model,
+                    [
+                        ("model.layers.0.norm.weight", decoder_loaded),
+                        ("model.layers.5.norm.weight", skipped_loaded),
+                        ("model.visual.layers.5.norm.weight", visual_loaded),
+                    ],
+                )
+
+                self.assertIs(decoder_weight.loaded_weight, decoder_loaded)
+                self.assertIsNone(skipped_weight.loaded_weight)
+                self.assertIs(visual_weight.loaded_weight, visual_loaded)
+                self.assertIn("model.layers.0.norm.weight", loaded_params)
+                self.assertIn("visual.layers.5.norm.weight", loaded_params)
+                self.assertNotIn("model.layers.5.norm.weight", loaded_params)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #37186. Qwen3.5 pipeline-parallel weight loading can interpret encoder layer names as decoder layer IDs and drop encoder weights outside the local decoder layer range.

## Modifications

- Restrict PP layer-range filtering in both Qwen3.5 conditional-generation loaders to `model.layers.*` decoder weights.
- Add CPU-only regression coverage for the dense and MoE loaders.

## Accuracy Tests

Not applicable: this change only affects checkpoint weight routing. No GPU or end-to-end model accuracy validation was run.

## Speed Tests and Profiling

Not applicable.

## Validation

- `pre-commit run --files python/sglang/srt/models/qwen3_5.py test/registered/unit/models/test_qwen3_5_pipeline_parallel.py` passed.
- Python syntax compilation passed.


## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33362909363](https://github.com/sgl-project/sglang/actions/runs/33362909363)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33362909211](https://github.com/sgl-project/sglang/actions/runs/33362909211)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33362909382](https://github.com/sgl-project/sglang/actions/runs/33362909382)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->