### PR TITLE
fix(quant): load mixed-precision compressed-tensors W4A8-FP8 checkpoints

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -263,12 +263,69 @@ class CompressedTensorsConfig(QuantizationConfig):
 
     @property
     def weight_block_size(self) -> Optional[List[int]]:
-        """Get the weight block size from the quantization config."""
+        """Get the weight block size from the quantization config.
+
+        A mixed-precision checkpoint may have no "Linear" target at all, or may
+        use it for a scheme that has no block structure (for example group-wise
+        INT4 routed experts alongside block-FP8 attention layers). Fall back to
+        any target that declares one so block-FP8 layers still find their block
+        size.
+        """
+        targets = list(self.target_scheme_map)
         if "Linear" in self.target_scheme_map:
-            weights_config = self.target_scheme_map["Linear"].get("weights")
-            if weights_config and hasattr(weights_config, "block_structure"):
-                return weights_config.block_structure
+            targets = ["Linear"] + [t for t in targets if t != "Linear"]
+        for target in targets:
+            scheme = self.target_scheme_map[target]
+            if not scheme:
+                continue
+            block_structure = getattr(scheme.get("weights"), "block_structure", None)
+            if block_structure:
+                return block_structure
         return None
+
+    def can_fuse_shared_expert(self) -> bool:
+        """Whether the shared experts may be folded into the routed-expert kernel.
+
+        A mixed-precision checkpoint can keep the shared experts at a higher
+        precision than the routed experts -- block-FP8 shared experts beside
+        group-wise INT4 routed experts, for example. Folding them would load the
+        shared weights through the routed-expert scheme and silently mis-read
+        them, so compare the two schemes and refuse when they differ.
+        """
+        if not self.target_scheme_map:
+            return True
+
+        lookup_stub = torch.nn.Module()
+
+        def weights_for(layer_name: str) -> Optional[QuantizationArgs]:
+            if should_ignore_layer(
+                layer_name,
+                ignore=self.ignore,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return None
+            try:
+                matched_target = find_matched_target(
+                    layer_name=layer_name,
+                    module=lookup_stub,
+                    targets=self.target_scheme_map.keys(),
+                    fused_mapping=self.packed_modules_mapping,
+                )
+            except ValueError:
+                return None
+            scheme = self.target_scheme_map.get(matched_target)
+            return scheme.get("weights") if scheme else None
+
+        routed = weights_for("model.layers.0.mlp.experts.0.gate_proj")
+        if routed is None:
+            # Routed experts are not described here; leave the decision alone.
+            return True
+
+        for suffix in ("gate_proj", "up_proj", "down_proj"):
+            shared = weights_for(f"model.layers.0.mlp.shared_experts.{suffix}")
+            if shared is None or shared != routed:
+                return False
+        return True
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> CompressedTensorsConfig:
@@ -442,12 +499,20 @@ class CompressedTensorsConfig(QuantizationConfig):
             and is_dynamic
         )
 
-    def _is_wint4afp8(self, weight_quant: BaseModel, input_quant: BaseModel) -> bool:
+    def _is_wint4afp8(
+        self,
+        weight_quant: BaseModel,
+        input_quant: BaseModel,
+        format: Optional[str] = None,
+    ) -> bool:
         """Detect W4AFP8: packed INT4 weights + 8-bit dynamic per-token activations."""
         if weight_quant is None or input_quant is None:
             return False
+        # Prefer the matched config_group's format, as _get_scheme_from_parts
+        # does: the top-level format is "mixed-precision" when groups disagree.
+        quant_format = format if format is not None else self.quant_format
         return (
-            self.quant_format == CompressionFormat.pack_quantized.value
+            quant_format == CompressionFormat.pack_quantized.value
             and weight_quant.num_bits == 4
             and weight_quant.type == QuantizationType.INT
             and weight_quant.symmetric
@@ -818,6 +883,7 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         weight_quant = scheme_dict.get("weights")
         input_quant = scheme_dict.get("input_activations")
+        scheme_format = scheme_dict.get("format")
 
         if self._is_wNa16_group_channel(weight_quant, input_quant):
             if not _is_npu:
@@ -883,7 +949,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 raise NotImplementedError(
                     "The W8A8Int8 Fused MoE scheme is implemented only for NPU for now."
                 )
-        elif self._is_wint4afp8(weight_quant, input_quant):
+        elif self._is_wint4afp8(weight_quant, input_quant, scheme_format):
             # On NPU prefer the dedicated NPU W4A8Int8 path when activations are INT8.
             if _is_npu and self._is_dynamic_token_w4a8(weight_quant, input_quant):
                 logger.info_once("Using NPUCompressedTensorsW4A8Int8DynamicMoE")

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
@@ -11,7 +11,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import torch
-from compressed_tensors import CompressionFormat
 
 from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
@@ -84,17 +83,16 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
         input_quant,
     ):
         self.quant_config = quant_config
-        config = self.quant_config.target_scheme_map["Linear"].get("weights")
-        self.num_bits = config.num_bits
-        self.packed_factor = 32 // config.num_bits
-        self.group_size = config.group_size
         self.weight_quant = weight_quant
         self.input_quant = input_quant
+        # Use the scheme matched for this layer rather than target_scheme_map
+        # ["Linear"]: a mixed-precision checkpoint may not carry a "Linear"
+        # target, or may use it to describe a different scheme.
+        self.num_bits = weight_quant.num_bits
+        self.packed_factor = 32 // weight_quant.num_bits
+        self.group_size = weight_quant.group_size
 
-        assert config.symmetric, "Only symmetric quantization is supported"
-        assert (
-            self.quant_config.quant_format == CompressionFormat.pack_quantized.value
-        ), f"W4AFP8MoE requires pack-quantized format, got {self.quant_config.quant_format}"
+        assert weight_quant.symmetric, "Only symmetric quantization is supported"
 
     @classmethod
     def get_min_capability(cls) -> int:

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -78,6 +78,12 @@ def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
+# Block-FP8 weight scales are called "weight_scale_inv" by the DeepSeek/GLM fp8
+# checkpoints and "weight_scale" by compressed-tensors. Both reach this loader
+# for the DSA indexer projections.
+_BLOCK_FP8_SCALE_SUFFIXES = (".weight_scale_inv", ".weight_scale")
+
+
 def _get_indexer_weight_block_size(
     quant_config: Optional[QuantizationConfig],
 ) -> List[int]:
@@ -107,7 +113,7 @@ def _load_fused_indexer_wk(
         return False
 
     if ".indexer.weights_proj." in name:
-        is_scale = name.endswith(".weight_scale_inv")
+        is_scale = name.endswith(_BLOCK_FP8_SCALE_SUFFIXES)
         if not is_scale and loaded_weight.dtype != torch.float8_e4m3fn:
             w = _clone_if_runai_streamed_tensor(loaded_weight)
             fused_param.data[-w.shape[0] :].copy_(w)
@@ -127,7 +133,7 @@ def _load_fused_indexer_wk(
         return True
 
     # wk: a bf16 checkpoint copies straight in; block-fp8 needs weight + scale.
-    is_scale = name.endswith(".weight_scale_inv")
+    is_scale = name.endswith(_BLOCK_FP8_SCALE_SUFFIXES)
     if not is_scale and loaded_weight.dtype != torch.float8_e4m3fn:
         w = _clone_if_runai_streamed_tensor(loaded_weight)
         fused_param.data[: w.shape[0]].copy_(w)

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import
     CompressedTensorsConfig,
 )
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW4AFP8MoE,
     CompressedTensorsWNA16,
 )
 from sglang.srt.layers.quantization.compressed_tensors.utils import (
@@ -91,6 +92,53 @@ WNA16_GROUP = {
         "dynamic": False,
     },
     "input_activations": None,
+}
+
+
+# Block-FP8 attention / shared-expert / dense-MLP projections, as produced by
+# requantizing a DeepSeek-style FP8 release.
+FP8_BLOCK_TARGET = "re:.*\\.mlp\\.shared_experts\\.(gate|up|down)_proj$"
+FP8_BLOCK_GROUP = {
+    "format": "float-quantized",
+    "targets": [FP8_BLOCK_TARGET],
+    "weights": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "block",
+        "block_structure": [128, 128],
+        "dynamic": False,
+    },
+    "input_activations": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "group",
+        "group_size": 128,
+        "dynamic": True,
+    },
+}
+
+# W4A8: group-128 INT4 routed experts with dynamic per-token FP8 activations.
+W4A8_TARGET = "re:.*\\.mlp\\.experts\\.\\d+\\.(gate|up|down)_proj$"
+W4A8_GROUP = {
+    "format": "pack-quantized",
+    "targets": [W4A8_TARGET],
+    "weights": {
+        "num_bits": 4,
+        "type": "int",
+        "symmetric": True,
+        "strategy": "group",
+        "group_size": 128,
+        "dynamic": False,
+    },
+    "input_activations": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "token",
+        "dynamic": True,
+    },
 }
 
 
@@ -186,6 +234,91 @@ class TestMixedPrecisionFormat(CustomTestCase):
         self.assertEqual(scheme.pack_factor, 32 // 4)
         self.assertEqual(scheme.strategy, "group")
         self.assertEqual(scheme.group_size, 128)
+
+
+class TestW4AFP8MixedPrecision(CustomTestCase):
+    """INT4 routed experts beside block-FP8 shared experts.
+
+    Every lookup below used to key off ``target_scheme_map["Linear"]`` or the
+    top-level format, neither of which a multi-group checkpoint has to provide.
+    """
+
+    def _config(self):
+        return CompressedTensorsConfig.from_config(
+            _mixed_precision_config(W4A8_GROUP, FP8_BLOCK_GROUP)
+        )
+
+    def test_wint4afp8_detected_from_group_format(self):
+        # The top-level format is "mixed-precision"; the INT4 group declares
+        # "pack-quantized". Reading only the former detects nothing.
+        quant_config = self._config()
+        scheme = quant_config.target_scheme_map[W4A8_TARGET]
+        self.assertTrue(
+            quant_config._is_wint4afp8(
+                scheme["weights"], scheme["input_activations"], scheme["format"]
+            )
+        )
+        self.assertFalse(
+            quant_config._is_wint4afp8(
+                scheme["weights"], scheme["input_activations"], "mixed-precision"
+            )
+        )
+
+    def test_weight_block_size_falls_back_to_any_block_group(self):
+        # No "Linear" target at all: the block size still has to be found, or
+        # block-FP8 layers cannot shard their scales.
+        quant_config = self._config()
+        self.assertNotIn("Linear", quant_config.target_scheme_map)
+        self.assertEqual(quant_config.weight_block_size, [128, 128])
+
+    def test_weight_block_size_ignores_non_block_linear_target(self):
+        # A "Linear" target that describes the group-wise INT4 experts has no
+        # block structure; the block-FP8 group's must still win.
+        groups = (dict(W4A8_GROUP, targets=["Linear"]), FP8_BLOCK_GROUP)
+        quant_config = CompressedTensorsConfig.from_config(
+            _mixed_precision_config(*groups)
+        )
+        self.assertIn("Linear", quant_config.target_scheme_map)
+        self.assertEqual(quant_config.weight_block_size, [128, 128])
+
+    def test_moe_scheme_reads_matched_group_not_linear(self):
+        # Top-level format stays "mixed-precision"; the scheme must still
+        # take num_bits / group_size from the matched INT4 group.
+        quant_config = self._config()
+        scheme_dict = quant_config.target_scheme_map[W4A8_TARGET]
+        self.assertEqual(quant_config.quant_format, "mixed-precision")
+
+        scheme = CompressedTensorsW4AFP8MoE(
+            quant_config,
+            weight_quant=scheme_dict["weights"],
+            input_quant=scheme_dict["input_activations"],
+        )
+        self.assertEqual(scheme.num_bits, 4)
+        self.assertEqual(scheme.group_size, 128)
+        self.assertEqual(scheme.packed_factor, 32 // 4)
+
+    def test_shared_experts_fusion_refused_on_precision_mismatch(self):
+        # Folding block-FP8 shared experts into the INT4 routed-expert kernel
+        # would load them through the wrong scheme.
+        self.assertFalse(self._config().can_fuse_shared_expert())
+
+    def test_shared_experts_fusion_allowed_when_schemes_agree(self):
+        uniform = dict(W4A8_GROUP, targets=["Linear"])
+        quant_config = CompressedTensorsConfig.from_config(
+            _mixed_precision_config(uniform)
+        )
+        self.assertTrue(quant_config.can_fuse_shared_expert())
+
+    def test_shared_experts_fusion_refused_when_shared_is_unquantized(self):
+        # Shared experts listed in `ignore` stay in the model dtype.
+        quant_config = CompressedTensorsConfig.from_config(
+            _mixed_precision_config(
+                W4A8_GROUP,
+                FP8_BLOCK_GROUP,
+                ignore=["re:.*\\.mlp\\.shared_experts\\..*"],
+            )
+        )
+        self.assertFalse(quant_config.can_fuse_shared_expert())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation
  A compressed-tensors checkpoint with **more than one `config_groups` entry** (top-level `format: mixed-precision`) could 
  not be loaded natively. The motivating case is GLM-5.3 W4A8: group-128 INT4 routed experts beside official block-FP8 
  (128×128) attention / shared-expert / dense MLP layers.
  Four lookups keyed off `target_scheme_map["Linear"]` or the top-level format, neither of which a multi-group config has 
  to provide:
  1. **W4AFP8 MoE detection** used the global `quant_format`. When groups disagree that is `mixed-precision`, so 
  `_is_wint4afp8` never matched and `CompressedTensorsW4AFP8MoE` also asserted on the global format.
  2. **`weight_block_size`** only read the `"Linear"` target. A mixed-precision config may omit `Linear`, or use it for the
  INT4 experts (no `block_structure`), so block-FP8 layers could not shard their scales.
  3. **Shared-expert fusion** folded block-FP8 shared experts into the INT4 routed-expert kernel (`_load_w2` then failed 
  with a scale-shape mismatch). Quark already refuses fusion when the schemes differ; compressed-tensors did not.
  4. **DSA indexer** only treated `.weight_scale_inv` as a block-FP8 scale. Compressed-tensors stores the same tensor as 
  `.weight_scale`.
  ## Modifications
  - `_is_wint4afp8(..., format=None)` prefers the matched group's format; `get_moe_scheme` passes `scheme_dict["format"]`.
  - `CompressedTensorsW4AFP8MoE` takes `num_bits` / `group_size` / `packed_factor` from the constructor `weight_quant` 
  instead of `target_scheme_map["Linear"]`, and no longer requires the *global* format to be `pack-quantized`.
  - `weight_block_size` prefers `"Linear"` then any target that declares `block_structure`.
  - `CompressedTensorsConfig.can_fuse_shared_expert()` compares routed vs shared expert weight schemes (and `ignore`); 
  `quant_blocks_shared_experts_fusion` already calls this hook.
  - Fused DSA indexer loading accepts both `.weight_scale_inv` and `.weight_scale`.
  ## Accuracy Tests
  CPU unit tests in `test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py` 
  (`TestW4AFP8MixedPrecision`): detection from group format, block-size fallback, MoE scheme fields, fusion refuse/allow. 
  **12 passed** on `lmsysorg/sglang:dev`.
  GPU smoke on 8×H20-3e (SM90) with a published GLM-5.3 W4A8 mixed-precision checkpoint (no `Linear` hack, no 
  `sitecustomize` rename): fusion disabled with the expected log, model loaded, chat replies were sane (`4` / `Paris` / 
  Chinese self-intro).
  This PR does not change kernels; uniform pack-quantized W4A8-FP8 checkpoints should keep the previous fusion behavior 
  when routed and shared experts share a scheme.
  ## Speed Tests and Profiling
  N/A — config / loader only.
  ## Checklist
  - [x] Format your code according to the [Format code with 
  pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit 
  tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write 
  documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the 
  accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the 
  speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style 
  [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33364692264](https://github.com/sgl-project/sglang/actions/runs/33364692264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33364691928](https://github.com/sgl-project/sglang/actions/runs/33364691928)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33364692071](https://github.com/sgl-project/sglang/actions/runs/33364692071)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->