### PR TITLE
[Fix] deepep_v2: pass expert_start/num_experts in ep_scatter_from_psum

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -1267,6 +1267,7 @@ def ep_scatter_from_psum(
     m_indices: torch.Tensor,
     output_index: torch.Tensor,
     scale_ue8m0: bool = False,
+    expert_start: int = 0,
 ):
     BLOCK_E = 128
     BLOCK_D = 128
@@ -1315,6 +1316,8 @@ def ep_scatter_from_psum(
         output_index,
         output_index.stride(0),
         output_index.stride(1),
+        expert_start,
+        num_experts,
         topk_num=recv_topk.shape[1],
         num_warps=num_warps,
         HIDDEN_SIZE=hidden_size,

--- a/test/registered/kernels/ops/moe/test_ep_scatter.py
+++ b/test/registered/kernels/ops/moe/test_ep_scatter.py
@@ -1,0 +1,175 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import ep_scatter_from_psum
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+dev = "cuda"
+BLOCK_D = 128
+BLOCK_E = 128
+
+
+def _build(num_tokens, num_experts, top_k, pad_frac, expert_start, seed):
+    """Route tokens to local experts, then describe the routing the way the
+    DeepEPv2 permute path does: an INCLUSIVE prefix sum over local experts, and
+    `recv_topk` holding expert ids offset by `expert_start` (-1 = padding)."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    local_ids = torch.full((num_tokens, top_k), -1, dtype=torch.int32)
+    counts = [0] * num_experts
+    for t in range(num_tokens):
+        experts = torch.randperm(num_experts, generator=g)[:top_k].tolist()
+        for slot, e in enumerate(experts):
+            if pad_frac > 0 and torch.rand(1, generator=g).item() < pad_frac:
+                continue
+            local_ids[t, slot] = e
+            counts[e] += 1
+
+    psum = torch.tensor(counts, dtype=torch.int32).cumsum(0).to(torch.int32)
+    recv_topk = torch.where(local_ids >= 0, local_ids + expert_start, local_ids)
+    return local_ids.to(dev), recv_topk.to(dev), psum.to(dev)
+
+
+def _run(recv_topk, psum, hidden, dtype, expert_start):
+    num_tokens = recv_topk.shape[0]
+    total = int(psum[-1].item())
+    scale_hidden = hidden // BLOCK_D
+    is_fp8 = dtype != torch.bfloat16
+
+    recv_x = torch.randn(num_tokens, hidden, dtype=torch.bfloat16, device=dev).to(dtype)
+    if is_fp8:
+        recv_x_scale = torch.rand(
+            num_tokens, scale_hidden, dtype=torch.float32, device=dev
+        )
+        output_tensor_scale = torch.zeros(
+            total, scale_hidden, dtype=torch.float32, device=dev
+        )
+    else:
+        recv_x_scale = None
+        output_tensor_scale = None
+
+    output_tensor = torch.zeros(total, hidden, dtype=dtype, device=dev)
+    # m_indices is padded up to BLOCK_E; -1 marks slots no expert owns.
+    m_indices = torch.full(
+        ((total + BLOCK_E - 1) // BLOCK_E * BLOCK_E,), -1, dtype=torch.int32, device=dev
+    )
+    expert_start_loc = torch.empty_like(psum)
+    output_index = torch.empty_like(recv_topk)
+
+    # Leave expert_start at its default in the local-id case, so this exercises
+    # the call shape the DeepEPv2 permute path actually uses.
+    kwargs = {"expert_start": expert_start} if expert_start else {}
+    ep_scatter_from_psum(
+        recv_x,
+        recv_x_scale,
+        recv_topk,
+        psum,
+        expert_start_loc,
+        output_tensor,
+        output_tensor_scale,
+        m_indices,
+        output_index,
+        **kwargs,
+    )
+    return dict(
+        recv_x=recv_x,
+        recv_x_scale=recv_x_scale,
+        output_tensor=output_tensor,
+        output_tensor_scale=output_tensor_scale,
+        m_indices=m_indices,
+        expert_start_loc=expert_start_loc,
+        output_index=output_index,
+        total=total,
+    )
+
+
+def _check(out, local_ids, psum):
+    """The scatter's destination slots are chosen by atomic_add, so the order
+    within one expert is not deterministic. Assert the invariants instead — they
+    pin the result down completely apart from that order."""
+    output_index = out["output_index"]
+    total = out["total"]
+    valid = local_ids >= 0
+
+    # 1. -1 sentinel exactly on the padding lanes. The post-permute kernel gates
+    #    on this, so a stale value here silently reads a garbage row.
+    assert torch.equal(output_index < 0, ~valid)
+
+    # 2. Every valid lane lands inside its own expert's slab.
+    starts = torch.cat([torch.zeros(1, dtype=psum.dtype, device=dev), psum[:-1]])
+    e = local_ids[valid].long()
+    dst = output_index[valid].long()
+    assert torch.all(dst >= starts[e]) and torch.all(dst < psum[e])
+
+    # 3. ... and the slabs are filled exactly, with no slot used twice.
+    assert dst.numel() == total
+    assert torch.equal(torch.sort(dst).values, torch.arange(total, device=dev))
+
+    # 4. m_indices agrees with the routing, and the BLOCK_E tail stays -1.
+    assert torch.equal(out["m_indices"][dst], local_ids[valid].to(torch.int32))
+    assert torch.all(out["m_indices"][total:] == -1)
+
+    # 5. expert_start_loc has been advanced to each expert's end.
+    assert torch.equal(out["expert_start_loc"], psum)
+
+    # 6. The rows themselves arrived, scales included.
+    src = torch.nonzero(valid)[:, 0]
+    assert torch.equal(
+        out["output_tensor"][dst].view(torch.uint8),
+        out["recv_x"][src].view(torch.uint8),
+    )
+    if out["recv_x_scale"] is not None:
+        assert torch.equal(out["output_tensor_scale"][dst], out["recv_x_scale"][src])
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 256, 4096])
+@pytest.mark.parametrize("pad_frac", [0.0, 0.3])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_ep_scatter_from_psum(num_tokens, pad_frac, dtype):
+    num_experts, top_k, hidden = 8, 8, 512
+    local_ids, recv_topk, psum = _build(
+        num_tokens, num_experts, top_k, pad_frac, 0, seed=num_tokens
+    )
+    out = _run(recv_topk, psum, hidden, dtype, 0)
+    _check(out, local_ids, psum)
+
+
+@pytest.mark.parametrize("expert_start", [0, 8, 120])
+def test_ep_scatter_from_psum_expert_start(expert_start):
+    """`expert_start` shifts which global ids count as local. Offsetting both the
+    ids and `expert_start` must not change the result, and out-of-range ids must
+    be dropped like padding."""
+    num_tokens, num_experts, top_k, hidden = 512, 8, 8, 512
+    local_ids, recv_topk, psum = _build(
+        num_tokens, num_experts, top_k, 0.2, expert_start, seed=7
+    )
+    out = _run(recv_topk, psum, hidden, torch.float8_e4m3fn, expert_start)
+    _check(out, local_ids, psum)
+
+
+def test_ep_scatter_from_psum_drops_non_local_experts():
+    num_tokens, num_experts, top_k, hidden = 256, 8, 8, 512
+    expert_start = 8
+    local_ids, recv_topk, psum = _build(
+        num_tokens, num_experts, top_k, 0.0, expert_start, seed=11
+    )
+    # Send half of slot 0 to an expert this rank does not own; it must be treated
+    # exactly like padding, not scattered somewhere out of bounds.
+    foreign = torch.arange(num_tokens, device=dev) % 2 == 0
+    recv_topk[foreign, 0] = expert_start + num_experts + 3
+    dropped = local_ids[foreign, 0].clone()
+    local_ids[foreign, 0] = -1
+    counts = torch.bincount(dropped.long(), minlength=num_experts).to(psum.dtype)
+    psum = (
+        (torch.cat([psum[:1], psum[1:] - psum[:-1]]) - counts).cumsum(0).to(psum.dtype)
+    )
+
+    out = _run(recv_topk, psum, hidden, torch.float8_e4m3fn, expert_start)
+    _check(out, local_ids, psum)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`ep_scatter_from_psum` launches `_fwd_kernel_ep_scatter_2` without the `expert_start`
and `num_experts` parameters the kernel has required since 5f216fc3, so **every rank
dies on the first forward pass** when `--moe-a2a-backend deepep_v2` is used:

```
sglang/srt/layers/moe/moe_runner/deep_gemm.py:1677 in pre_permute_deepep_v2_to_deep_gemm
    ep_scatter_from_psum(
sglang/kernels/ops/moe/ep_moe_kernels.py:1297 in ep_scatter_from_psum
    _fwd_kernel_ep_scatter_2[(grid,)](
TypeError: dynamic_func() missing 2 required positional arguments: 'expert_start' and 'num_experts'
```

Still present on `main` @ 29578d55.

5f216fc3 ("qwen 3.8 rebase", #35758) generalised `_fwd_kernel_ep_scatter_2` from local
to global expert ids:

```diff
-    expert_id = tl.load(recv_topk + ...)
-    if expert_id >= 0:
+    global_expert_id = tl.load(recv_topk + ...)
+    expert_id = global_expert_id - expert_start
+    valid = (expert_id >= 0) & (expert_id < num_experts)
+    tl.store(output_index_ptr, -1)
+    if valid:
```

It added the two parameters and updated the `ep_scatter` call site. The other call
site, `ep_scatter_from_psum`, had landed two days earlier in a3ae667d (#35634, DeepEPv2
ElasticBuffer MoE A2A backend) and was not updated. `ep_scatter_from_psum` is reached
only from `pre_permute_deepep_v2_to_deep_gemm`, i.e. only with
`--moe-a2a-backend deepep_v2`, so the omission is invisible to every other backend and
fatal for that one. Nothing in CI exercises the path.

Reproduces on any `deepep_v2` server that reaches the non-masked permute path. Ours:
GLM-4.6-style MoE (GLM-5.1-FP8) on 4x p5en.48xlarge (H200, EFA), prefill `TP=16 EP=16`,
`--moe-a2a-backend deepep_v2 --deepep-v2-mode hybrid`. The crash lands after weight
load and ElasticBuffer init, so everything up to it looks healthy. The masked path
(`expand_to_masked_slab`) returns early and does not reach this launch.

## Modifications

1. `ep_scatter_from_psum` passes `expert_start` and `num_experts` to
   `_fwd_kernel_ep_scatter_2`, and takes `expert_start: int = 0` — the same defaulted
   parameter `ep_scatter` already has.

   `expert_start=0` restores the pre-5f216fc3 behaviour rather than assuming it. The
   old kernel indexed `expert_start_loc + expert_id` directly, and this function is
   called with an `expert_start_loc` of length `num_local_experts`: `deep_gemm.py`
   builds it as `torch.empty_like(psum_num_recv_tokens_per_expert)` and reads that same
   shape as `num_local_experts` a few lines earlier. Global ids would therefore have
   indexed out of bounds on every rank but rank 0 from the day #35634 merged — the
   DeepEPv2 dispatch delivers already-local ids with `-1` padding, so `local_id - 0`
   reproduces the old behaviour exactly and `-1` still fails the `>= 0` test. Exposing
   the parameter rather than hard-coding `0` gives a future caller holding global ids
   somewhere to say so; happy to pass a literal `0` instead if you would rather not
   widen the signature.

   `num_experts` is `psum_num_recv_tokens_per_expert.shape[0]`, which the function
   already computes for the `_fwd_kernel_ep_scatter_psum_init` grid. The psum is an
   inclusive prefix sum of length `num_local_experts`
   (`_fwd_kernel_ep_scatter_psum_init` reads `psum[e-1]..psum[e]` as expert `e`'s
   span), so the new `expert_id < num_experts` bound is exact — no off-by-one.

   This also satisfies the requirement that `output_index` be `-1`-initialised, which
   the same commit introduced when it switched `post_reorder_deepgemm_triton_kernel`
   from gating on `expert_id >= 0` to `dst_idx >= 0` (`output_index =
   torch.empty_like(topk_ids)` is otherwise uninitialised).

2. New `test/registered/kernels/ops/moe/test_ep_scatter.py`. Neither `ep_scatter` nor
   `ep_scatter_from_psum` had any coverage, which is exactly why a signature change
   could update one call site and leave the other broken.

   Destination slots are chosen by `atomic_add`, so the order within one expert is not
   deterministic. The test asserts the invariants that pin the result down regardless:
   the `-1` sentinel lands exactly on the padding lanes; every valid lane lands inside
   its own expert's slab; the slabs form a bijection onto `[0, total)`; `m_indices`
   agrees with the routing and its `BLOCK_E` tail stays `-1`; `expert_start_loc` ends
   at the prefix sum; and the rows and FP8 scales themselves arrive. Parametrised over
   `num_tokens in {1, 8, 256, 4096}`, padding fraction, and bf16 / `float8_e4m3fn`,
   plus cases for a nonzero `expert_start` and for expert ids this rank does not own.

   It leaves `expert_start` at its default in the local-id case, so it exercises the
   call shape the DeepEPv2 permute path actually uses — which is what makes it a
   regression test for this bug rather than only for the signature.

## Accuracy Tests

The new unit test passes (20/20) and fails on an unpatched tree with exactly the
`TypeError` above, so the before/after is observed rather than asserted (H200, one GPU):

```
A: main + this PR      ->  20 passed in 8.57s
B: main, unpatched     ->  TypeError: dynamic_func() missing 2 required positional
                           arguments: 'expert_start' and 'num_experts'
```

Also checked structurally: both launch sites now supply all 22 parameters preceding the
first `tl.constexpr`, and the two added arguments land on the kernel's `expert_start` /
`num_experts` formals rather than merely making the count add up.

There is no end-to-end accuracy comparison to offer, because the path cannot execute a
single forward pass without this change — there is no pre-fix baseline to diff against.
Correctness rests on the argument above that this restores pre-5f216fc3 semantics
exactly, plus the invariant checks in the test. Glad to add a gsm8k run on
`--moe-a2a-backend deepep_v2` if you would like one attached.

## Speed Tests and Profiling

None: the change passes two additional scalar arguments to an existing kernel launch
and adds no work. Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — not applicable, no user-facing behaviour change
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — see above; speed is not applicable and end-to-end accuracy has no pre-fix baseline
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc @Qiaolin-Yu (5f216fc3, #35758) @MengYu10151 (a3ae667d, #35634) — and whoever on the
`/python/sglang/kernels` CODEOWNERS list is on rotation. I cannot trigger CI myself.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33366659160](https://github.com/sgl-project/sglang/actions/runs/33366659160)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33366659073](https://github.com/sgl-project/sglang/actions/runs/33366659073)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33366659163](https://github.com/sgl-project/sglang/actions/runs/33366659163)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->