### PR TITLE
[CI][RFC] Persist black's formatting cache across lint runs (alternative to #37210)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,8 +57,22 @@ jobs:
           workspaces: rust
           shared-key: "rust-workspace-lint"
 
+      - name: Restore black cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/black
+          key: black-cache-${{ github.run_id }}
+          restore-keys: black-cache-
+
       - name: Run pre-commit checks
         run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure
+
+      - name: Save black cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/black
+          key: black-cache-${{ github.run_id }}
 
       - name: Run lychee docs checks (offline references)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2


### PR DESCRIPTION
## Motivation

black-jupyter is the dominant cost of the lint job: **218s** of the ~6min job, up from 143s in June (it scales with the repo), with ±20% runner jitter (observed 218s→260s across two runs of the same commit).

It turns out this is cacheable with zero churn: **black 26's on-disk cache has a content-hash fallback**. When a file's mtime/size don't match the cache entry — as they never do on a fresh CI checkout — black re-hashes the file and still skips it if the content is unchanged. Measured on this repo: populate the cache, `touch` all 6,008 files (worst case: every mtime invalidated, exactly what a fresh checkout does), and a warm `--check` runs in **1.9s vs 13.7s cold** (152s CPU → 1.5s CPU, ~100x).

So persisting `~/.cache/black` across runs cuts black's CI cost from ~218s to a hash pass (~10–15s on the runner's 4 vCPUs), with only genuinely changed files paying the formatting cost.

**Draft / RFC — alternative to #37210** (black → ruff-format). The two solve the same problem; adopt one, not both:
- this PR: ~95% of the win, a few workflow lines, **zero reformat churn**, keeps black as the style authority;
- #37210: slightly faster still, no cache machinery, one tool (ruff) for lint+format — at the cost of a one-time 1,397-file mechanical reformat.

## Modifications

- `Restore black cache` (`actions/cache/restore`) before the pre-commit step, `Save black cache` (`actions/cache/save`) after it.
- Restore/save is split so **only push-to-main runs publish cache entries**; PRs restore main's latest via `restore-keys` (Actions cache scoping already prevents PR-created caches from leaking anywhere useful, so PRs saving would just be storage noise).
- The per-`run_id` key is the standard rolling-cache pattern: Actions cache entries are immutable, so an evolving cache needs a fresh key each save plus a prefix `restore-keys` match. Entries are a few MB (a pickle of per-file hash records); old ones age out via normal LRU eviction.
- Cache invalidation is automatic: black keys its cache directory by black version + format mode, so bumping the pinned black rev starts a fresh cache (one slow run) with no key changes needed here.

## Expected effect

Lint drops from ~6min to **~3–3.5min**, and the job's only repo-growth-scaling and jitter-dominating term becomes a cheap hash pass. First run after merge still pays full price (populates the cache); the second main push onward, and all PRs, get the fast path.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33366708099](https://github.com/sgl-project/sglang/actions/runs/33366708099)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33366707901](https://github.com/sgl-project/sglang/actions/runs/33366707901)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->