### PR TITLE
[Kernel] Add SM90 native Q8KV8 sparse prefill kernel with Tests and Benchmark

### DIFF
--- a/python/sglang/kernels/jit/csrc/attention/fp8_mha_fwd_q8kv8_sm90.cuh
+++ b/python/sglang/kernels/jit/csrc/attention/fp8_mha_fwd_q8kv8_sm90.cuh
@@ -1,0 +1,396 @@
+#pragma once
+
+#include "../sparse_mla_q8kv8_prefill_sm90/config.h"
+#include "../sparse_mla_q8kv8_prefill_sm90/helpers.h"
+#include <cuda_fp8.h>
+
+using namespace cute;
+
+#include "../sparse_mla_q8kv8_prefill_sm90/dense_fp8_transpose_v.h"
+#include "../sparse_mla_q8kv8_prefill_sm90/dense_fp8_utils.h"
+
+namespace sglang {
+namespace q8kv8_sm90 {
+
+constexpr int kHeadDim = 128;
+constexpr int kBlockSize = 128;
+constexpr int kMmaRows = 64;
+constexpr int kTokenTile = 64;
+constexpr int kNumStages = 2;
+
+using fp8_t = cutlass::float_e4m3_t;
+using bf16_t = cutlass::bfloat16_t;
+
+using SmemLayoutQ = decltype(coalesce(
+    tile_to_shape(GMMA::Layout_K_SW64_Atom<fp8_t>{}, Shape<Int<kMmaRows>, Int<kHeadDim>>{}, Step<_1, _2>{}),
+    Shape<_1, _1>{}));
+using SmemLayoutK = decltype(coalesce(
+    tile_to_shape(GMMA::Layout_K_SW64_Atom<fp8_t>{}, Shape<Int<kTokenTile>, Int<kHeadDim>>{}, Step<_1, _2>{}),
+    Shape<_1, _1>{}));
+using SmemLayoutVt = decltype(coalesce(
+    tile_to_shape(GMMA::Layout_K_SW64_Atom<fp8_t>{}, Shape<Int<kHeadDim>, Int<kTokenTile>>{}, Step<_1, _2>{}),
+    Shape<_1, _1>{}));
+using TiledMmaQK = decltype(make_tiled_mma(GMMA::MMA_64x64x32_F32E4M3E4M3_SS_TN<>{}, Layout<Shape<_1, _1, _1>>{}));
+using TiledMmaPV = decltype(make_tiled_mma(GMMA::MMA_64x128x32_F32E4M3E4M3_RS_TN<>{}, Layout<Shape<_1, _1, _1>>{}));
+
+struct SharedStorage {
+  array_aligned<fp8_t, cosize_v<SmemLayoutQ>> q;
+  array_aligned<fp8_t, kNumStages * cosize_v<SmemLayoutK>> k;
+  array_aligned<fp8_t, kNumStages * cosize_v<SmemLayoutK>> v;
+  array_aligned<fp8_t, kNumStages * cosize_v<SmemLayoutVt>> vt;
+  int32_t slots[kNumStages][kTokenTile];
+  bool valid[kNumStages][kTokenTile];
+  int32_t batch;
+  int32_t q_position;
+  int32_t seq_len;
+  int64_t request;
+};
+
+__device__ __forceinline__ void copy_16B(fp8_t* dst, const fp8_t* src, bool pred) {
+  if (pred) {
+    *reinterpret_cast<int4*>(dst) = *reinterpret_cast<const int4*>(src);
+  } else {
+    *reinterpret_cast<int4*>(dst) = make_int4(0, 0, 0, 0);
+  }
+}
+
+__device__ __forceinline__ void copy_q_16B(fp8_t* dst, const fp8_t* src, bool pred) {
+  if (pred && (reinterpret_cast<uintptr_t>(src) & 0xf) == 0) {
+    *reinterpret_cast<int4*>(dst) = *reinterpret_cast<const int4*>(src);
+    return;
+  }
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    dst[i] = pred ? src[i] : fp8_t(0.0f);
+  }
+}
+
+__device__ __forceinline__ void load_kv_tile(
+    SharedStorage& storage,
+    const fp8_t* k_cache,
+    const fp8_t* v_cache,
+    const int32_t* req_to_token,
+    int stage,
+    int selected_block,
+    int tile,
+    int kv_head,
+    int num_kv_heads,
+    int max_slots,
+    int req_stride,
+    int tid,
+    int64_t cache_policy) {
+  constexpr int kVectorsPerRow = kHeadDim / 16;
+  Tensor sK = make_tensor(make_smem_ptr(storage.k.data() + stage * cosize_v<SmemLayoutK>), SmemLayoutK{});
+  Tensor sV = make_tensor(make_smem_ptr(storage.v.data() + stage * cosize_v<SmemLayoutK>), SmemLayoutK{});
+
+  if (tid < kTokenTile) {
+    const int logical_position = selected_block * kBlockSize + tile * kTokenTile + tid;
+    const bool is_valid =
+        selected_block >= 0 && logical_position < storage.seq_len && logical_position <= storage.q_position;
+    storage.valid[stage][tid] = is_valid;
+    storage.slots[stage][tid] =
+        is_valid ? req_to_token[storage.request * static_cast<int64_t>(req_stride) + logical_position] : 0;
+    if (storage.slots[stage][tid] < 0) {
+      storage.slots[stage][tid] += max_slots;
+    } else if (storage.slots[stage][tid] >= max_slots) {
+      storage.slots[stage][tid] -= max_slots;
+    }
+  }
+  __syncthreads();
+
+  for (int vector_idx = tid; vector_idx < kTokenTile * kVectorsPerRow; vector_idx += blockDim.x) {
+    const int token = vector_idx / kVectorsPerRow;
+    const int col = (vector_idx % kVectorsPerRow) * 16;
+    const int64_t cache_offset =
+        (static_cast<int64_t>(storage.slots[stage][token]) * num_kv_heads + kv_head) * kHeadDim + col;
+    sm90::cp_async_cacheglobal_l2_prefetch_256B(
+        k_cache + cache_offset, &sK(token, col), storage.valid[stage][token], cache_policy);
+    sm90::cp_async_cacheglobal_l2_prefetch_256B(
+        v_cache + cache_offset, &sV(token, col), storage.valid[stage][token], cache_policy);
+  }
+}
+
+__global__ void fp8_mha_fwd_q8kv8_kernel(
+    bf16_t* __restrict__ output,
+    const fp8_t* __restrict__ q,
+    const fp8_t* __restrict__ k_cache,
+    const fp8_t* __restrict__ v_cache,
+    const int32_t* __restrict__ req_to_token,
+    const int64_t* __restrict__ slot_ids,
+    const int32_t* __restrict__ topk_idx,
+    const int32_t* __restrict__ cu_seqlens,
+    const int32_t* __restrict__ seq_lens,
+    const int32_t* __restrict__ prefix_lens,
+    int total_q,
+    int num_q_heads,
+    int num_kv_heads,
+    int max_slots,
+    int req_stride,
+    int topk,
+    int batch_size,
+    int64_t q_stride_0,
+    int64_t q_stride_1,
+    int64_t q_stride_2,
+    float effective_sm_scale,
+    float v_scale) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
+  const int q_idx = blockIdx.x;
+  const int kv_head = blockIdx.y;
+  const int tid = threadIdx.x;
+  const int group_size = num_q_heads / num_kv_heads;
+
+  extern __shared__ char smem[];
+  SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem);
+  Tensor sQ = make_tensor(make_smem_ptr(storage.q.data()), SmemLayoutQ{});
+
+  if (tid == 0) {
+    int batch = 0;
+    while (batch + 1 < batch_size && q_idx >= cu_seqlens[batch + 1]) {
+      ++batch;
+    }
+    storage.batch = batch;
+    storage.q_position = prefix_lens[batch] + q_idx - cu_seqlens[batch];
+    storage.seq_len = seq_lens[batch];
+    storage.request = slot_ids[batch];
+  }
+
+  constexpr int kVectorsPerRow = kHeadDim / 16;
+  for (int vector_idx = tid; vector_idx < kMmaRows * kVectorsPerRow; vector_idx += blockDim.x) {
+    const int row = vector_idx / kVectorsPerRow;
+    const int col = (vector_idx % kVectorsPerRow) * 16;
+    fp8_t* dst = &sQ(row, col);
+    if (row < group_size) {
+      const int q_head = kv_head * group_size + row;
+      const int64_t q_offset = static_cast<int64_t>(q_idx) * q_stride_0 + static_cast<int64_t>(q_head) * q_stride_1 +
+                               static_cast<int64_t>(col) * q_stride_2;
+      copy_q_16B(dst, q + q_offset, true);
+    } else {
+      copy_q_16B(dst, nullptr, false);
+    }
+  }
+  __syncthreads();
+
+  Tensor rP = partition_fragment_C(TiledMmaQK{}, Shape<Int<kMmaRows>, Int<kTokenTile>>{});
+  Tensor rO = partition_fragment_C(TiledMmaPV{}, Shape<Int<kMmaRows>, Int<kHeadDim>>{});
+  cute::fill(rO, 0.0f);
+
+  using RP8Layout = decltype(flash::convert_layout_acc_Aregs<TiledMmaPV>(rP.layout()));
+  Tensor rP8 = make_tensor<fp8_t>(RP8Layout{});
+  float running_max[2] = {-INFINITY, -INFINITY};
+  float running_sum[2] = {0.0f, 0.0f};
+
+  SmemTransposeFp8_64x64<kTokenTile, kHeadDim> transpose;
+  using Transpose = SmemTransposeFp8_64x64<kTokenTile, kHeadDim>;
+  using SrcLayout = typename Transpose::SmemLayoutTransposeV;
+  using DstLayout = typename Transpose::SmemLayoutTransposeVt;
+  const int64_t cache_policy = sm90::createpolicy_evict_first();
+
+  constexpr int kTilesPerBlock = kBlockSize / kTokenTile;
+  const int total_tiles = topk * kTilesPerBlock;
+  if (total_tiles > 0) {
+    const int selected_block = topk_idx[(kv_head * total_q + q_idx) * topk];
+    load_kv_tile(
+        storage,
+        k_cache,
+        v_cache,
+        req_to_token,
+        0,
+        selected_block,
+        0,
+        kv_head,
+        num_kv_heads,
+        max_slots,
+        req_stride,
+        tid,
+        cache_policy);
+    asm volatile("cp.async.commit_group;\n" ::);
+    asm volatile("cp.async.wait_group 0;\n" ::);
+    fence_view_async_shared();
+    __syncthreads();
+  }
+
+  for (int tile_idx = 0; tile_idx < total_tiles; ++tile_idx) {
+    const int stage = tile_idx % kNumStages;
+    Tensor sK = make_tensor(make_smem_ptr(storage.k.data() + stage * cosize_v<SmemLayoutK>), SmemLayoutK{});
+    Tensor sVt = make_tensor(make_smem_ptr(storage.vt.data() + stage * cosize_v<SmemLayoutVt>), SmemLayoutVt{});
+
+    const int next_tile_idx = tile_idx + 1;
+    if (next_tile_idx < total_tiles) {
+      const int next_selected_idx = next_tile_idx / kTilesPerBlock;
+      const int next_tile = next_tile_idx % kTilesPerBlock;
+      const int next_selected_block = topk_idx[(kv_head * total_q + q_idx) * topk + next_selected_idx];
+      load_kv_tile(
+          storage,
+          k_cache,
+          v_cache,
+          req_to_token,
+          stage ^ 1,
+          next_selected_block,
+          next_tile,
+          kv_head,
+          num_kv_heads,
+          max_slots,
+          req_stride,
+          tid,
+          cache_policy);
+      asm volatile("cp.async.commit_group;\n" ::);
+    }
+
+    Tensor sVSrc = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(storage.v.data() + stage * cosize_v<SmemLayoutK>), SrcLayout{}));
+    Tensor sVtDst = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(storage.vt.data() + stage * cosize_v<SmemLayoutVt>), DstLayout{}));
+    transpose.transpose_pair(
+        flatten(sVSrc(_, 0, 0)), flatten(sVtDst(_, 0, 0)), flatten(sVSrc(_, 0, 1)), flatten(sVtDst(_, 0, 1)));
+    fence_view_async_shared();
+    __syncthreads();
+
+    sm90::gemm_ss(true, TiledMmaQK{}, sQ, sK, rP, tid);
+    warpgroup_commit_batch();
+    warpgroup_wait<0>();
+    warpgroup_fence_operand(rP);
+    warpgroup_fence_operand(rO);
+    warpgroup_fence_operand(rP8);
+
+#pragma unroll
+    for (int row_idx = 0; row_idx < 2; ++row_idx) {
+#pragma unroll
+      for (int i = row_idx * 2; i < size(rP); i += 4) {
+        const int col = 8 * (i / 4) + (tid % 4) * 2;
+        if (!storage.valid[stage][col]) {
+          rP(i) = -INFINITY;
+        }
+        if (!storage.valid[stage][col + 1]) {
+          rP(i + 1) = -INFINITY;
+        }
+      }
+    }
+
+#pragma unroll
+    for (int row_idx = 0; row_idx < 2; ++row_idx) {
+      float tile_max = -INFINITY;
+#pragma unroll
+      for (int i = row_idx * 2; i < size(rP); i += 4) {
+        tile_max = max(tile_max, max(rP(i), rP(i + 1)));
+      }
+      tile_max = max(tile_max, __shfl_xor_sync(0xffffffff, tile_max, 1));
+      tile_max = max(tile_max, __shfl_xor_sync(0xffffffff, tile_max, 2));
+      tile_max *= effective_sm_scale;
+      const float new_max = max(running_max[row_idx], tile_max);
+      const float old_scale = expf(running_max[row_idx] - new_max);
+      float tile_sum = 0.0f;
+#pragma unroll
+      for (int i = row_idx * 2; i < size(rP); i += 4) {
+        rP(i) = expf(rP(i) * effective_sm_scale - new_max);
+        rP(i + 1) = expf(rP(i + 1) * effective_sm_scale - new_max);
+        tile_sum += rP(i) + rP(i + 1);
+      }
+#pragma unroll
+      for (int i = row_idx * 2; i < size(rO); i += 4) {
+        rO(i) *= old_scale;
+        rO(i + 1) *= old_scale;
+      }
+      running_sum[row_idx] = running_sum[row_idx] * old_scale + tile_sum;
+      running_max[row_idx] = new_max;
+    }
+
+    flash::permute_Cregs_fp8(rP);
+    Tensor rPAcc = make_tensor(rP.data(), flash::convert_layout_acc_Aregs<TiledMmaPV>(rP.layout()));
+    flash::convert_type_out(rPAcc, rP8);
+
+    sm90::gemm_rs(false, TiledMmaPV{}, rP8, sVt, rO, tid);
+    warpgroup_commit_batch();
+
+    if (next_tile_idx < total_tiles) {
+      asm volatile("cp.async.wait_group 0;\n" ::);
+      fence_view_async_shared();
+      __syncthreads();
+    }
+  }
+
+  warpgroup_wait<0>();
+  warpgroup_fence_operand(rO);
+  warpgroup_fence_operand(rP8);
+
+  running_sum[0] += __shfl_xor_sync(0xffffffff, running_sum[0], 1);
+  running_sum[0] += __shfl_xor_sync(0xffffffff, running_sum[0], 2);
+  running_sum[1] += __shfl_xor_sync(0xffffffff, running_sum[1], 1);
+  running_sum[1] += __shfl_xor_sync(0xffffffff, running_sum[1], 2);
+
+  warpgroup_fence_operand(rO);
+#pragma unroll
+  for (int row_idx = 0; row_idx < 2; ++row_idx) {
+    const int row = sm90::get_AorC_row_idx(row_idx, tid);
+    if (row < group_size) {
+      const int q_head = kv_head * group_size + row;
+      const float scale = running_sum[row_idx] > 0.0f ? v_scale / running_sum[row_idx] : 0.0f;
+#pragma unroll
+      for (int i = row_idx * 2; i < size(rO); i += 4) {
+        const int col = 8 * (i / 4) + (tid % 4) * 2;
+        const int64_t output_offset = (static_cast<int64_t>(q_idx) * num_q_heads + q_head) * kHeadDim + col;
+        output[output_offset] = static_cast<bf16_t>(rO(i) * scale);
+        output[output_offset + 1] = static_cast<bf16_t>(rO(i + 1) * scale);
+      }
+    }
+  }
+#else
+  if (cute::thread0()) {
+    CUTE_INVALID_CONTROL_PATH("fp8_mha_fwd_q8kv8_kernel requires sm90");
+  }
+#endif
+}
+
+inline void launch_fp8_mha_fwd_q8kv8_sm90(
+    bf16_t* output,
+    const fp8_t* q,
+    const fp8_t* k_cache,
+    const fp8_t* v_cache,
+    const int32_t* req_to_token,
+    const int64_t* slot_ids,
+    const int32_t* topk_idx,
+    const int32_t* cu_seqlens,
+    const int32_t* seq_lens,
+    const int32_t* prefix_lens,
+    int total_q,
+    int num_q_heads,
+    int num_kv_heads,
+    int max_slots,
+    int req_stride,
+    int topk,
+    int batch_size,
+    int64_t q_stride_0,
+    int64_t q_stride_1,
+    int64_t q_stride_2,
+    float effective_sm_scale,
+    float v_scale,
+    cudaStream_t stream) {
+  auto kernel = &fp8_mha_fwd_q8kv8_kernel;
+  constexpr size_t smem_size = sizeof(SharedStorage);
+  KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+  kernel<<<dim3(total_q, num_kv_heads), 128, smem_size, stream>>>(
+      output,
+      q,
+      k_cache,
+      v_cache,
+      req_to_token,
+      slot_ids,
+      topk_idx,
+      cu_seqlens,
+      seq_lens,
+      prefix_lens,
+      total_q,
+      num_q_heads,
+      num_kv_heads,
+      max_slots,
+      req_stride,
+      topk,
+      batch_size,
+      q_stride_0,
+      q_stride_1,
+      q_stride_2,
+      effective_sm_scale,
+      v_scale);
+}
+
+}  // namespace q8kv8_sm90
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/attention/minimax_sparse_gqa_q8kv8_sm90.cuh
+++ b/python/sglang/kernels/jit/csrc/attention/minimax_sparse_gqa_q8kv8_sm90.cuh
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include "fp8_mha_fwd_q8kv8_sm90.cuh"
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace sglang {
+
+void minimax_sparse_gqa_q8kv8_sm90(
+    tvm::ffi::TensorView output,
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView k_cache,
+    tvm::ffi::TensorView v_cache,
+    tvm::ffi::TensorView req_to_token,
+    tvm::ffi::TensorView slot_ids,
+    tvm::ffi::TensorView topk_idx,
+    tvm::ffi::TensorView cu_seqlens,
+    tvm::ffi::TensorView seq_lens,
+    tvm::ffi::TensorView prefix_lens,
+    int64_t total_q,
+    int64_t num_q_heads,
+    int64_t num_kv_heads,
+    int64_t max_slots,
+    int64_t req_stride,
+    int64_t topk,
+    int64_t batch_size,
+    int64_t q_stride_0,
+    int64_t q_stride_1,
+    int64_t q_stride_2,
+    double sm_scale,
+    double q_scale,
+    double k_scale,
+    double v_scale,
+    int64_t cuda_stream) {
+  const DLDevice device = q.device();
+  cudaSetDevice(device.device_id);
+  auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+
+  q8kv8_sm90::launch_fp8_mha_fwd_q8kv8_sm90(
+      static_cast<q8kv8_sm90::bf16_t*>(output.data_ptr()),
+      static_cast<const q8kv8_sm90::fp8_t*>(q.data_ptr()),
+      static_cast<const q8kv8_sm90::fp8_t*>(k_cache.data_ptr()),
+      static_cast<const q8kv8_sm90::fp8_t*>(v_cache.data_ptr()),
+      static_cast<const int32_t*>(req_to_token.data_ptr()),
+      static_cast<const int64_t*>(slot_ids.data_ptr()),
+      static_cast<const int32_t*>(topk_idx.data_ptr()),
+      static_cast<const int32_t*>(cu_seqlens.data_ptr()),
+      static_cast<const int32_t*>(seq_lens.data_ptr()),
+      static_cast<const int32_t*>(prefix_lens.data_ptr()),
+      static_cast<int>(total_q),
+      static_cast<int>(num_q_heads),
+      static_cast<int>(num_kv_heads),
+      static_cast<int>(max_slots),
+      static_cast<int>(req_stride),
+      static_cast<int>(topk),
+      static_cast<int>(batch_size),
+      q_stride_0,
+      q_stride_1,
+      q_stride_2,
+      static_cast<float>(sm_scale * q_scale * k_scale),
+      static_cast<float>(v_scale),
+      stream);
+  host::RuntimeDeviceCheck();
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/sgl_native_q8kv8.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/sgl_native_q8kv8.py
@@ -1,0 +1,170 @@
+"""Native SM90 sparse GQA prefill with FP8 E4M3 Q/K/V and FP8 P."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+class SglNativeQ8KV8BuildError(RuntimeError):
+    """Raised when the native Q8KV8 JIT module cannot be built or loaded."""
+
+
+@cache_once
+def _jit_native_q8kv8_module() -> Module:
+    return load_jit(
+        "minimax_sparse_gqa_q8kv8_sm90",
+        cuda_files=["attention/minimax_sparse_gqa_q8kv8_sm90.cuh"],
+        cuda_wrappers=[("dispatch", "minimax_sparse_gqa_q8kv8_sm90")],
+        extra_cuda_cflags=[
+            "-O3",
+            "-DNDEBUG",
+            "-DCUTE_USE_PACKED_TUPLE=1",
+            "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
+            "--use_fast_math",
+        ],
+        extra_dependencies=["cutlass"],
+    )
+
+
+def _unit_scale(value: Optional[float]) -> float:
+    return 1.0 if value is None else float(value)
+
+
+@torch.no_grad()
+def sgl_native_q8kv8_sparse_prefill(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    req_to_token: torch.Tensor,
+    slot_ids: torch.Tensor,
+    topk_idx: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    block_size_k: int,
+    sm_scale: Optional[float] = None,
+    q_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Run the SGL-native FP8-Q/FP8-KV sparse GQA prefill kernel."""
+    tensors = {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "req_to_token": req_to_token,
+        "slot_ids": slot_ids,
+        "topk_idx": topk_idx,
+        "cu_seqlens": cu_seqlens,
+        "seq_lens": seq_lens,
+        "prefix_lens": prefix_lens,
+    }
+    for name, tensor in tensors.items():
+        if not tensor.is_cuda:
+            raise ValueError(f"{name} must be a CUDA tensor")
+        if name != "q" and not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+
+    if q.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"q must have dtype torch.float8_e4m3fn, got {q.dtype}")
+    if q.stride(-1) != 1:
+        raise ValueError(
+            "q last dimension must be contiguous, "
+            f"got shape={tuple(q.shape)}, stride={tuple(q.stride())}"
+        )
+    if k_cache.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"k_cache must have dtype torch.float8_e4m3fn, got {k_cache.dtype}"
+        )
+    if v_cache.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"v_cache must have dtype torch.float8_e4m3fn, got {v_cache.dtype}"
+        )
+    if req_to_token.dtype != torch.int32:
+        raise ValueError("req_to_token must have dtype torch.int32")
+    if slot_ids.dtype != torch.int64:
+        raise ValueError("slot_ids must have dtype torch.int64")
+    for name, tensor in (
+        ("topk_idx", topk_idx),
+        ("cu_seqlens", cu_seqlens),
+        ("seq_lens", seq_lens),
+        ("prefix_lens", prefix_lens),
+    ):
+        if tensor.dtype != torch.int32:
+            raise ValueError(f"{name} must have dtype torch.int32")
+
+    if q.ndim != 3 or k_cache.ndim != 3 or v_cache.ndim != 3:
+        raise ValueError("q, k_cache, and v_cache must be rank-3 tensors")
+    total_q, num_q_heads, head_dim = q.shape
+    max_slots, num_kv_heads, k_head_dim = k_cache.shape
+    if v_cache.shape != k_cache.shape:
+        raise ValueError("k_cache and v_cache must have identical shapes")
+    if head_dim != 128 or k_head_dim != 128:
+        raise ValueError("the native Q8KV8 kernel requires head_dim=128")
+    if block_size_k != 128:
+        raise ValueError("the native Q8KV8 kernel requires block_size_k=128")
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError("num_q_heads must be divisible by num_kv_heads")
+    group_size = num_q_heads // num_kv_heads
+    if group_size not in (1, 2, 4, 8, 16):
+        raise ValueError(f"unsupported local GQA group size: {group_size}")
+    if topk_idx.ndim != 3 or topk_idx.shape[:2] != (num_kv_heads, total_q):
+        raise ValueError("topk_idx must have shape [num_kv_heads, total_q, topk]")
+    batch_size = cu_seqlens.numel() - 1
+    if slot_ids.numel() != batch_size:
+        raise ValueError("slot_ids length must match the prefill batch size")
+    if seq_lens.numel() != batch_size or prefix_lens.numel() != batch_size:
+        raise ValueError("sequence metadata length must match the prefill batch size")
+    if torch.cuda.get_device_capability(q.device)[0] != 9:
+        raise ValueError("the native Q8KV8 kernel requires SM90")
+
+    if sm_scale is None:
+        sm_scale = head_dim**-0.5
+    output = torch.empty(
+        (total_q, num_q_heads, head_dim), dtype=torch.bfloat16, device=q.device
+    )
+    if total_q == 0:
+        return output
+    with torch.cuda.device(q.device):
+        stream = torch._C._cuda_getCurrentRawStream(q.device.index)
+        try:
+            module = _jit_native_q8kv8_module()
+        except (ImportError, RuntimeError) as err:
+            raise SglNativeQ8KV8BuildError(
+                "failed to build or load the native Q8KV8 JIT module"
+            ) from err
+        module.dispatch(
+            output,
+            q,
+            k_cache,
+            v_cache,
+            req_to_token,
+            slot_ids,
+            topk_idx,
+            cu_seqlens,
+            seq_lens,
+            prefix_lens,
+            int(total_q),
+            int(num_q_heads),
+            int(num_kv_heads),
+            int(max_slots),
+            int(req_to_token.shape[1]),
+            int(topk_idx.shape[2]),
+            int(batch_size),
+            int(q.stride(0)),
+            int(q.stride(1)),
+            int(q.stride(2)),
+            float(sm_scale),
+            _unit_scale(q_scale),
+            _unit_scale(k_scale),
+            _unit_scale(v_scale),
+            int(stream),
+        )
+    return output

--- a/test/manual/kernels/bench_minimax_sparse_gqa_q8kv8_sm90.py
+++ b/test/manual/kernels/bench_minimax_sparse_gqa_q8kv8_sm90.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from typing import Callable
+
+import torch
+
+from sglang.kernels.ops.attention.minimax_sparse.prefill.sgl_native_q8kv8 import (
+    sgl_native_q8kv8_sparse_prefill,
+)
+from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
+    flash_prefill_with_gqa_share_sparse,
+)
+
+
+def make_case(total_q: int, seq_len: int, topk: int):
+    device = "cuda"
+    torch.manual_seed(20260826 + total_q + seq_len + topk)
+    q_bf16 = (torch.randn(total_q, 4, 128, device=device) * 0.2).to(torch.bfloat16)
+    k_cache = (torch.randn(seq_len, 1, 128, device=device) * 0.2).to(
+        torch.float8_e4m3fn
+    )
+    v_cache = (torch.randn(seq_len, 1, 128, device=device) * 0.2).to(
+        torch.float8_e4m3fn
+    )
+
+    page_size = 128
+    pages = seq_len // page_size
+    page_perm = torch.randperm(pages, device=device)
+    req_to_token = torch.empty(1, seq_len, dtype=torch.int32, device=device)
+    offsets = torch.arange(page_size, device=device, dtype=torch.int32)
+    for logical_page in range(pages):
+        physical_page = page_perm[logical_page]
+        req_to_token[0, logical_page * page_size : (logical_page + 1) * page_size] = (
+            physical_page * page_size + offsets
+        )
+
+    slot_ids = torch.zeros(1, dtype=torch.int64, device=device)
+    selected = torch.arange(pages - topk, pages, dtype=torch.int32, device=device)
+    topk_idx = selected.view(1, 1, topk).expand(1, total_q, topk).contiguous()
+    cu_seqlens = torch.tensor([0, total_q], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    prefix_lens = torch.tensor([seq_len - total_q], dtype=torch.int32, device=device)
+    return (
+        q_bf16,
+        k_cache,
+        v_cache,
+        req_to_token,
+        slot_ids,
+        topk_idx,
+        cu_seqlens,
+        seq_lens,
+        prefix_lens,
+    )
+
+
+def quant_q(q_bf16: torch.Tensor, q_scale: float | None) -> torch.Tensor:
+    if q_scale is not None:
+        q_bf16 = q_bf16 / q_scale
+    return q_bf16.to(torch.float8_e4m3fn)
+
+
+def measure(
+    fn: Callable[[], torch.Tensor], warmup: int, repeats: int
+) -> tuple[float, torch.Tensor]:
+    output = None
+    for _ in range(warmup):
+        output = fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        output = fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return statistics.median(samples), output
+
+
+def diff_stats(lhs: torch.Tensor, rhs: torch.Tensor) -> tuple[float, float, float]:
+    diff = (lhs.float() - rhs.float()).abs().flatten()
+    return (
+        diff.max().item(),
+        diff.mean().item(),
+        torch.quantile(diff, 0.99).item(),
+    )
+
+
+def run_shape(
+    round_idx: int,
+    total_q: int,
+    seq_len: int,
+    topk: int,
+    warmup: int,
+    repeats: int,
+) -> None:
+    args = make_case(total_q=total_q, seq_len=seq_len, topk=topk)
+    q_bf16, k, v, req, slots, topk_idx, cu, seq, prefix = args
+    q_fp8 = quant_q(q_bf16, q_scale=None)
+
+    def triton_baseline():
+        return flash_prefill_with_gqa_share_sparse(
+            q=q_bf16,
+            k_cache=k,
+            v_cache=v,
+            sink=None,
+            req_to_token=req,
+            slot_ids=slots,
+            topk_idx=topk_idx,
+            block_size_q=1,
+            block_size_k=128,
+            cu_seqlens=cu,
+            seq_lens=seq,
+            prefix_lens=prefix,
+            max_seqlen_q=total_q,
+        )
+
+    def native_kernel_only():
+        return sgl_native_q8kv8_sparse_prefill(
+            q=q_fp8,
+            k_cache=k,
+            v_cache=v,
+            req_to_token=req,
+            slot_ids=slots,
+            topk_idx=topk_idx,
+            cu_seqlens=cu,
+            seq_lens=seq,
+            prefix_lens=prefix,
+            block_size_k=128,
+        )
+
+    def native_with_q_quant():
+        return sgl_native_q8kv8_sparse_prefill(
+            q=quant_q(q_bf16, q_scale=None),
+            k_cache=k,
+            v_cache=v,
+            req_to_token=req,
+            slot_ids=slots,
+            topk_idx=topk_idx,
+            cu_seqlens=cu,
+            seq_lens=seq,
+            prefix_lens=prefix,
+            block_size_k=128,
+        )
+
+    triton_ms, triton_out = measure(triton_baseline, warmup=warmup, repeats=repeats)
+    native_ms, native_out = measure(native_kernel_only, warmup=warmup, repeats=repeats)
+    native_with_quant_ms, native_with_quant_out = measure(
+        native_with_q_quant, warmup=warmup, repeats=repeats
+    )
+    max_abs, mean_abs, p99_abs = diff_stats(native_out, triton_out)
+    max_abs_q, mean_abs_q, p99_abs_q = diff_stats(native_with_quant_out, triton_out)
+
+    print(
+        "| "
+        f"{round_idx} | {seq_len:,} | {topk} | {total_q} | "
+        f"{triton_ms:.4f} | {native_ms:.4f} | "
+        f"{triton_ms / native_ms:.3f}x | {(1.0 - native_ms / triton_ms) * 100.0:.1f}% | "
+        f"{native_with_quant_ms:.4f} | {triton_ms / native_with_quant_ms:.3f}x | "
+        f"{(1.0 - native_with_quant_ms / triton_ms) * 100.0:.1f}% | "
+        f"{max_abs:.6f} | {mean_abs:.6f} | {p99_abs:.6f} | "
+        f"{max_abs_q:.6f} | {mean_abs_q:.6f} | {p99_abs_q:.6f} |"
+    )
+
+
+def parse_csv_ints(value: str) -> list[int]:
+    return [int(x) for x in value.split(",") if x]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seq-lens", default="8192")
+    parser.add_argument("--total-qs", default="32,128")
+    parser.add_argument("--topk", type=int, default=16)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=100)
+    parser.add_argument("--rounds", type=int, default=2)
+    args = parser.parse_args()
+
+    print(
+        "| round | seq_len | topk | total_q | triton_bf16q_fp8kv_ms | "
+        "native_q8kv8_kernel_ms | kernel_speedup | kernel_latency_reduction | "
+        "native_with_q_quant_ms | with_quant_speedup | with_quant_latency_reduction | "
+        "kernel_max_abs | kernel_mean_abs | kernel_p99_abs | "
+        "with_quant_max_abs | with_quant_mean_abs | with_quant_p99_abs |"
+    )
+    print(
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+    )
+    for round_idx in range(1, args.rounds + 1):
+        for seq_len in parse_csv_ints(args.seq_lens):
+            for total_q in parse_csv_ints(args.total_qs):
+                run_shape(
+                    round_idx=round_idx,
+                    total_q=total_q,
+                    seq_len=seq_len,
+                    topk=args.topk,
+                    warmup=args.warmup,
+                    repeats=args.repeats,
+                )
+
+
+if __name__ == "__main__":
+    started = time.time()
+    main()
+    print(f"\nelapsed_s={time.time() - started:.2f}")

--- a/test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py
+++ b/test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py
@@ -1,0 +1,199 @@
+import importlib
+import math
+
+import pytest
+import torch
+
+from sglang.srt.utils import is_sm90_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+MODULE_NAME = "sglang.kernels.ops.attention.minimax_sparse.prefill.sgl_native_q8kv8"
+FP8 = torch.float8_e4m3fn
+
+
+def _make_case(num_q_heads: int, num_kv_heads: int):
+    torch.manual_seed(7)
+    device = "cuda"
+    total_q, head_dim, block_size = 2, 128, 128
+    seq_len, prefix_len, topk = 256, 254, 2
+    q = (torch.randn(total_q, num_q_heads, head_dim, device=device) * 0.2).to(FP8)
+    k = (torch.randn(seq_len, num_kv_heads, head_dim, device=device) * 0.2).to(FP8)
+    v = (torch.randn(seq_len, num_kv_heads, head_dim, device=device) * 0.2).to(FP8)
+    req_to_token = torch.randperm(seq_len, device=device, dtype=torch.int64).to(
+        torch.int32
+    )[None, :]
+    slot_ids = torch.zeros(1, device=device, dtype=torch.int64)
+    topk_idx = (
+        torch.tensor([0, 1], device=device, dtype=torch.int32)
+        .view(1, 1, topk)
+        .expand(num_kv_heads, total_q, topk)
+        .contiguous()
+    )
+    cu_seqlens = torch.tensor([0, total_q], device=device, dtype=torch.int32)
+    seq_lens = torch.tensor([seq_len], device=device, dtype=torch.int32)
+    prefix_lens = torch.tensor([prefix_len], device=device, dtype=torch.int32)
+    return (
+        q,
+        k,
+        v,
+        req_to_token,
+        slot_ids,
+        topk_idx,
+        cu_seqlens,
+        seq_lens,
+        prefix_lens,
+        block_size,
+    )
+
+
+def _reference(
+    q,
+    k,
+    v,
+    req_to_token,
+    topk_idx,
+    prefix_len,
+    block_size,
+    sm_scale,
+    q_scale,
+    k_scale,
+    v_scale,
+):
+    total_q, num_q_heads, head_dim = q.shape
+    num_kv_heads = k.shape[1]
+    group_size = num_q_heads // num_kv_heads
+    out = torch.zeros(
+        total_q, num_q_heads, head_dim, device=q.device, dtype=torch.float32
+    )
+    qf = q.float() * q_scale
+    kf = k.float() * k_scale
+    vf = v.float() * v_scale
+    mapping = req_to_token[0].long()
+
+    for qi in range(total_q):
+        q_position = prefix_len + qi
+        for qh in range(num_q_heads):
+            kvh = qh // group_size
+            running_max = -math.inf
+            running_sum = 0.0
+            accumulator = torch.zeros(head_dim, device=q.device, dtype=torch.float32)
+            for selected_block in topk_idx[kvh, qi].tolist():
+                if selected_block < 0:
+                    continue
+                for offset in range(block_size):
+                    logical_position = selected_block * block_size + offset
+                    if logical_position > q_position:
+                        continue
+                    slot = mapping[logical_position]
+                    score = torch.dot(qf[qi, qh], kf[slot, kvh]).item() * sm_scale
+                    new_max = max(running_max, score)
+                    old_scale = math.exp(running_max - new_max)
+                    probability = math.exp(score - new_max)
+                    probability_fp8 = (
+                        torch.tensor(probability, device=q.device, dtype=torch.float32)
+                        .to(FP8)
+                        .float()
+                        .item()
+                    )
+                    accumulator = (
+                        accumulator * old_scale + probability_fp8 * vf[slot, kvh]
+                    )
+                    running_sum = running_sum * old_scale + probability
+                    running_max = new_max
+            if running_sum:
+                out[qi, qh] = accumulator / running_sum
+    return out.to(torch.bfloat16)
+
+
+@pytest.mark.skipif(
+    not is_sm90_supported(), reason="native Q8KV8 sparse GQA requires SM90 CUDA"
+)
+@pytest.mark.parametrize("num_q_heads,num_kv_heads", [(4, 1), (8, 2)])
+@pytest.mark.parametrize(
+    "q_scale,k_scale,v_scale", [(1.0, 1.0, 1.0), (0.75, 1.25, 0.625)]
+)
+def test_native_q8kv8_matches_fp8_probability_reference(
+    num_q_heads, num_kv_heads, q_scale, k_scale, v_scale
+):
+    native_module = importlib.import_module(MODULE_NAME)
+    (
+        q,
+        k,
+        v,
+        req_to_token,
+        slot_ids,
+        topk_idx,
+        cu_seqlens,
+        seq_lens,
+        prefix_lens,
+        block_size,
+    ) = _make_case(num_q_heads, num_kv_heads)
+    sm_scale = q.shape[-1] ** -0.5
+
+    actual = native_module.sgl_native_q8kv8_sparse_prefill(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        req_to_token=req_to_token,
+        slot_ids=slot_ids,
+        topk_idx=topk_idx,
+        cu_seqlens=cu_seqlens,
+        seq_lens=seq_lens,
+        prefix_lens=prefix_lens,
+        block_size_k=block_size,
+        sm_scale=sm_scale,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    expected = _reference(
+        q,
+        k,
+        v,
+        req_to_token,
+        topk_idx,
+        prefix_lens.item(),
+        block_size,
+        sm_scale,
+        q_scale,
+        k_scale,
+        v_scale,
+    )
+
+    assert actual.dtype == torch.bfloat16
+    assert actual.is_contiguous()
+    torch.testing.assert_close(actual.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not is_sm90_supported(), reason="native Q8KV8 sparse GQA requires SM90 CUDA"
+)
+def test_native_q8kv8_accepts_strided_q_with_contiguous_last_dim():
+    native_module = importlib.import_module(MODULE_NAME)
+    args = list(_make_case(4, 1))
+    q = args[0]
+    storage = torch.empty(
+        q.shape[0], q.shape[1], q.shape[2] + 1, device=q.device, dtype=q.dtype
+    )
+    q_strided = storage[..., : q.shape[-1]]
+    q_strided.copy_(q)
+    assert not q_strided.is_contiguous()
+    assert q_strided.stride(-1) == 1
+    args[0] = q_strided
+
+    output = native_module.sgl_native_q8kv8_sparse_prefill(
+        q=args[0],
+        k_cache=args[1],
+        v_cache=args[2],
+        req_to_token=args[3],
+        slot_ids=args[4],
+        topk_idx=args[5],
+        cu_seqlens=args[6],
+        seq_lens=args[7],
+        prefix_lens=args[8],
+        block_size_k=args[9],
+    )
+    assert output.shape == q.shape
+    assert torch.isfinite(output).all()

--- a/test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py
+++ b/test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py
@@ -110,7 +110,10 @@ def _reference(
 @pytest.mark.skipif(
     not is_sm90_supported(), reason="native Q8KV8 sparse GQA requires SM90 CUDA"
 )
-@pytest.mark.parametrize("num_q_heads,num_kv_heads", [(4, 1), (8, 2)])
+@pytest.mark.parametrize(
+    "num_q_heads,num_kv_heads",
+    [(16, 16), (16, 8), (16, 4), (16, 2), (16, 1)],
+)
 @pytest.mark.parametrize(
     "q_scale,k_scale,v_scale", [(1.0, 1.0, 1.0), (0.75, 1.25, 0.625)]
 )
@@ -174,6 +177,18 @@ def test_native_q8kv8_accepts_strided_q_with_contiguous_last_dim():
     native_module = importlib.import_module(MODULE_NAME)
     args = list(_make_case(4, 1))
     q = args[0]
+    expected = native_module.sgl_native_q8kv8_sparse_prefill(
+        q=q,
+        k_cache=args[1],
+        v_cache=args[2],
+        req_to_token=args[3],
+        slot_ids=args[4],
+        topk_idx=args[5],
+        cu_seqlens=args[6],
+        seq_lens=args[7],
+        prefix_lens=args[8],
+        block_size_k=args[9],
+    )
     storage = torch.empty(
         q.shape[0], q.shape[1], q.shape[2] + 1, device=q.device, dtype=q.dtype
     )
@@ -183,7 +198,7 @@ def test_native_q8kv8_accepts_strided_q_with_contiguous_last_dim():
     assert q_strided.stride(-1) == 1
     args[0] = q_strided
 
-    output = native_module.sgl_native_q8kv8_sparse_prefill(
+    actual = native_module.sgl_native_q8kv8_sparse_prefill(
         q=args[0],
         k_cache=args[1],
         v_cache=args[2],
@@ -195,5 +210,5 @@ def test_native_q8kv8_accepts_strided_q_with_contiguous_last_dim():
         prefix_lens=args[8],
         block_size_k=args[9],
     )
-    assert output.shape == q.shape
-    assert torch.isfinite(output).all()
+    assert actual.shape == q.shape
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)


### PR DESCRIPTION
## Summary
This PR adds an SM90-native Q8KV8 sparse GQA prefill JIT kernel for MiniMax-M3, together with its Python operator and registered CUDA correctness tests.
* **Performance:** The native Q8KV8 kernel is 1.62x–1.73x faster than the Triton BF16-Q/FP8-KV sparse prefill baseline in the tested kernel-only cases on NVIDIA H20.
* **Correctness:** The registered CUDA suite passes all 11 cases, covering numerical correctness, strided Q addressing, and local GQA group sizes 1/2/4/8/16.

## Motivation
MiniMax-M3 sparse prefill currently falls back to a Triton implementation on SM90 for its Step-3 sparse attention computation. The existing path widens FP8 K/V values for BF16-Q/FP8-KV computation instead of using Hopper's native FP8 Tensor Core path for both QK and PV.

This PR adds an SM90-native Q8KV8 implementation that keeps Q/K/V and softmax probabilities in FP8 E4M3, uses FP32 accumulation, and returns BF16 output. It removes the widening work from the attention inner loop and enables native FP8 WGMMA for the sparse GQA prefill shape used by MiniMax-M3.

## Modifications
Included in this PR:

* An SM90-native Q8KV8 sparse GQA prefill CUDA kernel.

* A JIT-loaded Python operator under `sglang.kernels`.

* Registered CUDA correctness tests for numerical accuracy, strided Q input, and supported GQA group sizes.

* A manual benchmark comparing the native kernel with the Triton BF16-Q/FP8-KV sparse prefill baseline.

File | Role
-- | --
python/sglang/kernels/jit/csrc/attention/fp8_mha_fwd_q8kv8_sm90.cuh | SM90 FP8 attention kernel implementation
python/sglang/kernels/jit/csrc/attention/minimax_sparse_gqa_q8kv8_sm90.cuh | MiniMax sparse GQA launch and dispatch layer
python/sglang/kernels/ops/attention/minimax_sparse/prefill/sgl_native_q8kv8.py | JIT-loaded Python operator and input validation
test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py | Registered CUDA correctness coverage
test/manual/kernels/bench_minimax_sparse_gqa_q8kv8_sm90.py | Manual correctness and performance benchmark

## Kernel Implementation
* **Native FP8 attention on Hopper:** QK and PV use SM90 WGMMA with FP8 E4M3 operands. Accumulation is performed in FP32, and the final output is stored in BF16.

* **Online softmax:** Row-wise maximum and normalization are updated tile by tile without materializing the full attention matrix.

* **Two-stage shared-memory pipeline:** K, V, and transposed V tiles use double buffering to overlap global-memory movement with Tensor Core work.

* **Deferred PV wait:** The PV completion wait is delayed across tile iterations so the next tile's preparation and QK issue can overlap with the current tile's PV work.

* **Direct output epilogue:** The final normalized result is written directly to global memory.

* **Sparse GQA specialization:** The kernel supports `head_dim=128`, `block_size=128`, and local GQA group sizes 1/2/4/8/16.

* **Stride-aware Q addressing:** Strided Q tensors are supported when `q.stride(-1) == 1`; the operator does not force a contiguous copy.

* **Validated Python API:** The wrapper validates dtype, shape, layout, architecture, sparse metadata, and supported specialization constraints before launch.

## Experimental Results
All results below were collected on NVIDIA H20.
### Correctness
```bash
python3 -m pytest -q \
  test/registered/kernels/ops/attention/test_minimax_sparse_gqa_q8kv8_sm90.py

11 passed
```
The tests compare the native implementation against the existing Triton BF16-Q/FP8-KV sparse prefill path and cover all supported local GQA group sizes together with non-contiguous Q layouts.

Sequence length | Top-k | Total Q | Max abs error | Mean abs error | P99 abs error
-- | -- | -- | -- | -- | --
8,192 | 16 | 32 | 0.000397 | 0.000073 | 0.000244
8,192 | 16 | 128 | 0.000427 | 0.000074 | 0.000244
### Performance
Kernel-only
Total Q | Triton BF16-Q/FP8-KV | Native Q8KV8 | Speedup | Latency reduction
-- | -- | -- | -- | --
32 | 0.1591 / 0.1586 ms | 0.0918 / 0.0914 ms | 1.73x / 1.74x | 42.3% / 42.4%
128 | 0.1655 / 0.1649 ms | 0.1022 / 0.1022 ms | 1.62x / 1.61x | 38.3% / 38.0%

Including Q quantization
Total Q | Triton BF16-Q/FP8-KV | Native with Q quantization | Speedup | Latency reduction
-- | -- | -- | -- | --
32 | 0.1591 / 0.1586 ms | 0.1027 / 0.1033 ms | 1.55x / 1.54x | 35.5% / 34.9%
128 | 0.1655 / 0.1649 ms | 0.1137 / 0.1141 ms | 1.46x / 1.45x | 31.3% / 30.8%


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33370453888](https://github.com/sgl-project/sglang/actions/runs/33370453888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33370453773](https://github.com/sgl-project/sglang/actions/runs/33370453773)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33370453822](https://github.com/sgl-project/sglang/actions/runs/33370453822)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->