### PR TITLE
fix(ci): update attention backend test fixtures

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_attention_backend_selector.py
+++ b/python/sglang/multimodal_gen/test/unit/test_attention_backend_selector.py
@@ -333,6 +333,7 @@ class TestComponentAttentionBackendScope(unittest.TestCase):
                 return object()
 
         class _Args:
+            component_precisions = {}
             component_quantizations = {}
 
             @staticmethod
@@ -411,6 +412,7 @@ class TestComponentAttentionBackendScope(unittest.TestCase):
                 return object()
 
         class _Args:
+            component_precisions = {}
             component_quantizations = {}
 
             @staticmethod
@@ -475,6 +477,7 @@ class TestComponentAttentionBackendScope(unittest.TestCase):
                 return object()
 
         class _Args:
+            component_precisions = {}
             component_quantizations = {}
             pipeline_config = SimpleNamespace(native_only_components=())
 
@@ -525,6 +528,7 @@ class TestComponentAttentionBackendScope(unittest.TestCase):
                 return object()
 
         class _Args:
+            component_precisions = {}
             component_quantizations = {}
             pipeline_config = SimpleNamespace(native_only_components=())
 


### PR DESCRIPTION
## Summary

- add `component_precisions` to the `ServerArgs` test doubles used by the attention backend tests
- restore the five affected unit tests without changing runtime behavior

## Root cause

Four local `_Args` test doubles model `ServerArgs` but omit `component_precisions`. Component loading reads that field before reaching the intended attention backend assertions, so the tests fail with `AttributeError`.

## Testing

- `git diff --check`
- `/opt/homebrew/bin/python3.11 -m py_compile python/sglang/multimodal_gen/test/unit/test_attention_backend_selector.py`
- targeted pytest deferred to CI because the local Python environment is missing `cloudpickle`

Failing root job: https://github.com/sgl-project/sglang/actions/runs/33363118556/job/99398398459

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33371989582](https://github.com/sgl-project/sglang/actions/runs/33371989582)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33371989495](https://github.com/sgl-project/sglang/actions/runs/33371989495)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33371989592](https://github.com/sgl-project/sglang/actions/runs/33371989592)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->