### PR TITLE
[LMCache] Propagate cache_salt through the MP integration

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -74,9 +74,9 @@ class RadixKey:
         # Extra key for caller-defined cache classification.
         self.extra_key = extra_key
         # Cache salt is kept distinct so it cannot collide with extra_key.
-        # It namespaces the in-process radix tree and external KV events;
-        # external L3/remote storage keys remain token-only and are outside
-        # this contract.
+        # It namespaces the in-process radix tree and external KV events.
+        # External storage namespacing is connector-specific; LMCache MP
+        # propagates it only when the connector advertises cache-salt support.
         self.cache_salt = cache_salt or None
         # bigram view over token_ids: length = max(0, len(token_ids) - 1)
         self.is_bigram = is_bigram

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -171,21 +171,7 @@ class LMCRadixCache(RadixCache):
         self._mp_load_back_markers: dict[str, _LMCacheLoadBackMarker] = {}
 
     def _mp_supports_cache_salt(self) -> bool:
-        return (
-            getattr(self.lmcache_connector, "supports_cache_salt", False) is True
-        )
-
-    def _require_mp_cache_salt_support(
-        self, cache_salt: Optional[str]
-    ) -> bool:
-        supports_cache_salt = self._mp_supports_cache_salt()
-        if cache_salt and not supports_cache_salt:
-            raise RuntimeError(
-                "This request uses cache_salt, but the installed LMCache MP "
-                "connector does not support cache-salt namespacing. Upgrade "
-                "LMCache before serving salted requests."
-            )
-        return supports_cache_salt
+        return getattr(self.lmcache_connector, "supports_cache_salt", False) is True
 
     def reset(self):
         super().reset()
@@ -237,7 +223,14 @@ class LMCRadixCache(RadixCache):
         the held read locks and returns the radix-only result.
         """
         token_ids = key.raw_token_ids()
-        supports_cache_salt = self._require_mp_cache_salt_support(key.cache_salt)
+        supports_cache_salt = self._mp_supports_cache_salt()
+        if key.cache_salt and not supports_cache_salt:
+            logger.warning(
+                "Skipping LMCache MP lookup for a salted request because "
+                "the installed connector does not support cache-salt "
+                "namespacing. Upgrade LMCache to enable external storage."
+            )
+            return base_res
         if supports_cache_salt:
             matched = self.lmcache_connector.lookup_kv(
                 token_ids, req.rid, cache_salt=key.cache_salt or ""
@@ -466,10 +459,6 @@ class LMCRadixCache(RadixCache):
     ) -> None:
         """On request completion, insert device KV into radix and store to LMCache."""
 
-        supports_cache_salt = False
-        if is_insert and self._mode is LMCacheMode.MP:
-            supports_cache_salt = self._require_mp_cache_salt_support(req.cache_salt)
-
         super().cache_finished_req(
             req, is_insert=is_insert, kv_len_to_handle=kv_len_to_handle
         )
@@ -478,6 +467,19 @@ class LMCRadixCache(RadixCache):
                 self._mp_load_back_markers.pop(req.rid, None)
                 self.lmcache_connector.end_session(req.rid)
             return
+
+        supports_cache_salt = False
+        if self._mode is LMCacheMode.MP:
+            supports_cache_salt = self._mp_supports_cache_salt()
+            if req.cache_salt and not supports_cache_salt:
+                logger.warning(
+                    "Skipping LMCache MP store for a salted request because "
+                    "the installed connector does not support cache-salt "
+                    "namespacing. Upgrade LMCache to enable external storage."
+                )
+                self._mp_load_back_markers.pop(req.rid, None)
+                self.lmcache_connector.end_session(req.rid)
+                return
 
         topk = get_spec().speculative_eagle_topk
         enable_kv_committed_len = topk is None or topk == 1
@@ -516,14 +518,16 @@ class LMCRadixCache(RadixCache):
         )
         if self._mode is LMCacheMode.MP and supports_cache_salt:
             store_metadata_kwargs["cache_salt"] = req.cache_salt or ""
-        store_md = StoreMetadata(**store_metadata_kwargs)
         if self._mode is LMCacheMode.MP:
-            self.lmcache_connector.store_kv(store_md)
-            # MP store_kv blocks until the daemon's signal event fires, so the slots are safe to evict immediately.
-            self._mp_load_back_markers.pop(req.rid, None)
-            self.dec_lock_ref(new_last_node)
-            self.lmcache_connector.end_session(req.rid)
+            try:
+                self.lmcache_connector.store_kv(StoreMetadata(**store_metadata_kwargs))
+                # MP store_kv blocks until the daemon's signal event fires, so the slots are safe to evict immediately.
+            finally:
+                self._mp_load_back_markers.pop(req.rid, None)
+                self.dec_lock_ref(new_last_node)
+                self.lmcache_connector.end_session(req.rid)
         elif self._mode is LMCacheMode.IP:
+            store_md = StoreMetadata(**store_metadata_kwargs)
             with device_stream_context(self.store_stream):
                 self.lmcache_connector.store_kv(store_md)
             # Layerwise store is async on store_stream; defer the unlock to evict()'s store_stream.synchronize().

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -170,6 +170,23 @@ class LMCRadixCache(RadixCache):
         self._node_lock = threading.Lock()
         self._mp_load_back_markers: dict[str, _LMCacheLoadBackMarker] = {}
 
+    def _mp_supports_cache_salt(self) -> bool:
+        return (
+            getattr(self.lmcache_connector, "supports_cache_salt", False) is True
+        )
+
+    def _require_mp_cache_salt_support(
+        self, cache_salt: Optional[str]
+    ) -> bool:
+        supports_cache_salt = self._mp_supports_cache_salt()
+        if cache_salt and not supports_cache_salt:
+            raise RuntimeError(
+                "This request uses cache_salt, but the installed LMCache MP "
+                "connector does not support cache-salt namespacing. Upgrade "
+                "LMCache before serving salted requests."
+            )
+        return supports_cache_salt
+
     def reset(self):
         super().reset()
         if hasattr(self, "_in_flight_nodes"):
@@ -220,7 +237,13 @@ class LMCRadixCache(RadixCache):
         the held read locks and returns the radix-only result.
         """
         token_ids = key.raw_token_ids()
-        matched = self.lmcache_connector.lookup_kv(token_ids, req.rid)
+        supports_cache_salt = self._require_mp_cache_salt_support(key.cache_salt)
+        if supports_cache_salt:
+            matched = self.lmcache_connector.lookup_kv(
+                token_ids, req.rid, cache_salt=key.cache_salt or ""
+            )
+        else:
+            matched = self.lmcache_connector.lookup_kv(token_ids, req.rid)
         if matched <= value.numel():
             # Release the read locks; keep the pending session for end_session.
             self.lmcache_connector.release_pending(req.rid)
@@ -443,6 +466,10 @@ class LMCRadixCache(RadixCache):
     ) -> None:
         """On request completion, insert device KV into radix and store to LMCache."""
 
+        supports_cache_salt = False
+        if is_insert and self._mode is LMCacheMode.MP:
+            supports_cache_salt = self._require_mp_cache_salt_support(req.cache_salt)
+
         super().cache_finished_req(
             req, is_insert=is_insert, kv_len_to_handle=kv_len_to_handle
         )
@@ -480,13 +507,16 @@ class LMCRadixCache(RadixCache):
         assert new_last_node is not None
 
         self.inc_lock_ref(new_last_node)
-        store_md = StoreMetadata(
+        store_metadata_kwargs = dict(
             last_node=new_last_node,
             token_ids=token_ids,
             kv_indices=kv_indices,
             offset=0,
             request_id=req.rid,
         )
+        if self._mode is LMCacheMode.MP and supports_cache_salt:
+            store_metadata_kwargs["cache_salt"] = req.cache_salt or ""
+        store_md = StoreMetadata(**store_metadata_kwargs)
         if self._mode is LMCacheMode.MP:
             self.lmcache_connector.store_kv(store_md)
             # MP store_kv blocks until the daemon's signal event fires, so the slots are safe to evict immediately.

--- a/test/registered/unit/mem_cache/test_lmcache_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_lmcache_radix_cache.py
@@ -1,0 +1,344 @@
+"""CPU-only contract tests for the SGLang LMCache MP integration."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py"
+)
+_MODULE_NAME = "_sglang_lmc_radix_cache_under_test"
+
+
+class _RadixKey:
+    def __init__(
+        self,
+        token_ids,
+        extra_key=None,
+        is_bigram=False,
+        limit=None,
+        cache_salt=None,
+    ):
+        self.token_ids = token_ids
+        self.extra_key = extra_key
+        self.is_bigram = is_bigram
+        self.limit = limit
+        self.cache_salt = cache_salt
+
+    def raw_token_ids(self):
+        return self.token_ids
+
+    def __len__(self):
+        return len(self.token_ids)
+
+    def __getitem__(self, item):
+        return type(self)(
+            self.token_ids[item],
+            self.extra_key,
+            self.is_bigram,
+            cache_salt=self.cache_salt,
+        )
+
+
+class _TreeNode:
+    def __init__(self, priority=0):
+        self.priority = priority
+        self.children = {}
+
+
+@dataclass
+class _MatchPrefixParams:
+    key: _RadixKey
+    req: object = None
+
+
+@dataclass
+class _MatchResult:
+    device_indices: torch.Tensor
+    last_device_node: object
+    last_host_node: object = None
+    best_match_node: object = None
+    host_hit_length: int = 0
+
+
+@dataclass
+class _StoreMetadata:
+    last_node: object
+    token_ids: list[int]
+    kv_indices: torch.Tensor
+    offset: int
+    request_id: str = ""
+    cache_salt: str = ""
+
+
+@dataclass
+class _LoadMetadata:
+    token_ids: list[int]
+    slot_mapping: torch.Tensor
+    offset: int
+    prefix_pad: int = 0
+    request_id: str = ""
+
+
+class _RadixCache:
+    def match_prefix(self, params):
+        return self._base_match_result
+
+    def cache_finished_req(self, req, is_insert=True, *, kv_len_to_handle):
+        self._base_finished_calls.append((req, is_insert, kv_len_to_handle))
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_target_module():
+    base_prefix_cache = types.ModuleType(
+        "sglang.srt.mem_cache.base_prefix_cache"
+    )
+    for name in (
+        "EvictParams",
+        "EvictResult",
+        "InitLoadBackParams",
+    ):
+        setattr(base_prefix_cache, name, type(name, (), {}))
+    base_prefix_cache.MatchPrefixParams = _MatchPrefixParams
+    base_prefix_cache.MatchResult = _MatchResult
+
+    radix_cache = types.ModuleType("sglang.srt.mem_cache.radix_cache")
+    radix_cache.RadixCache = _RadixCache
+    radix_cache.RadixKey = _RadixKey
+    radix_cache.TreeNode = _TreeNode
+
+    runtime_context = types.ModuleType("sglang.srt.runtime_context")
+    runtime_context.get_memory = lambda: SimpleNamespace(lmcache_config_file="")
+    runtime_context.get_spec = lambda: SimpleNamespace(speculative_eagle_topk=None)
+
+    utils = types.ModuleType("sglang.srt.utils")
+    utils.create_device_stream = Mock()
+    utils.device_stream_context = lambda stream: nullcontext()
+
+    mp_adapter = types.ModuleType(
+        "lmcache.integration.sglang.multi_process_adapter"
+    )
+    mp_adapter.LMCacheMPConnector = type("LMCacheMPConnector", (), {})
+
+    sglang_adapter = types.ModuleType("lmcache.integration.sglang.sglang_adapter")
+    sglang_adapter.LMCacheLayerwiseConnector = type(
+        "LMCacheLayerwiseConnector", (), {}
+    )
+    sglang_adapter.LoadMetadata = _LoadMetadata
+    sglang_adapter.StoreMetadata = _StoreMetadata
+
+    lmcache_utils = types.ModuleType("lmcache.integration.sglang.utils")
+    lmcache_utils.lmcache_get_config = Mock()
+
+    stubs = {
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.mem_cache": _package("sglang.srt.mem_cache"),
+        "sglang.srt.mem_cache.storage": _package(
+            "sglang.srt.mem_cache.storage"
+        ),
+        "sglang.srt.mem_cache.storage.lmcache": _package(
+            "sglang.srt.mem_cache.storage.lmcache"
+        ),
+        base_prefix_cache.__name__: base_prefix_cache,
+        radix_cache.__name__: radix_cache,
+        runtime_context.__name__: runtime_context,
+        utils.__name__: utils,
+        "lmcache": _package("lmcache"),
+        "lmcache.integration": _package("lmcache.integration"),
+        "lmcache.integration.sglang": _package("lmcache.integration.sglang"),
+        mp_adapter.__name__: mp_adapter,
+        sglang_adapter.__name__: sglang_adapter,
+        lmcache_utils.__name__: lmcache_utils,
+    }
+
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, stubs):
+        sys.modules[_MODULE_NAME] = module
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestLMCacheMPCacheSalt(CustomTestCase):
+    def setUp(self):
+        self.module = _load_target_module()
+
+    def _lookup_tree(self, connector):
+        tree = object.__new__(self.module.LMCRadixCache)
+        tree.lmcache_connector = connector
+        tree._mp_load_back_markers = {}
+        return tree
+
+    def _store_tree(self, connector):
+        tree = object.__new__(self.module.LMCRadixCache)
+        tree._mode = self.module.LMCacheMode.MP
+        tree.lmcache_connector = connector
+        tree.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.arange(8, dtype=torch.int64).reshape(1, 8)
+        )
+        tree._base_match_result = _MatchResult(
+            device_indices=torch.empty(0, dtype=torch.int64),
+            last_device_node=_TreeNode(),
+        )
+        tree._base_finished_calls = []
+        tree._mp_load_back_markers = {}
+        tree.inc_lock_ref = Mock()
+        tree.dec_lock_ref = Mock()
+        return tree
+
+    @staticmethod
+    def _base_match_result():
+        node = _TreeNode()
+        return _MatchResult(
+            device_indices=torch.empty(0, dtype=torch.int64),
+            last_device_node=node,
+            last_host_node=node,
+            best_match_node=node,
+        )
+
+    @staticmethod
+    def _req(cache_salt):
+        return SimpleNamespace(
+            rid="request-1",
+            origin_input_ids=[11, 12, 13],
+            output_ids=[],
+            extra_key=None,
+            cache_salt=cache_salt,
+            kv=SimpleNamespace(req_pool_idx=0, kv_committed_len=3),
+        )
+
+    def test_lookup_forwards_cache_salt_when_connector_supports_it(self):
+        connector = SimpleNamespace(
+            supports_cache_salt=True,
+            lookup_kv=Mock(return_value=0),
+            release_pending=Mock(),
+        )
+        tree = self._lookup_tree(connector)
+        key = _RadixKey([11, 12, 13], cache_salt="tenant-a")
+
+        tree._mp_match_prefix(
+            key,
+            self._base_match_result(),
+            torch.empty(0, dtype=torch.int64),
+            _TreeNode(),
+            self._req("tenant-a"),
+        )
+
+        connector.lookup_kv.assert_called_once_with(
+            [11, 12, 13], "request-1", cache_salt="tenant-a"
+        )
+
+    def test_store_forwards_cache_salt_when_connector_supports_it(self):
+        connector = SimpleNamespace(
+            supports_cache_salt=True,
+            store_kv=Mock(),
+            end_session=Mock(),
+        )
+        tree = self._store_tree(connector)
+
+        tree.cache_finished_req(
+            self._req("tenant-a"), is_insert=True, kv_len_to_handle=3
+        )
+
+        store_metadata = connector.store_kv.call_args.args[0]
+        self.assertEqual(store_metadata.cache_salt, "tenant-a")
+
+    def test_legacy_connector_keeps_unsalted_lookup_compatible(self):
+        connector = SimpleNamespace(
+            lookup_kv=Mock(return_value=0),
+            release_pending=Mock(),
+        )
+        tree = self._lookup_tree(connector)
+
+        tree._mp_match_prefix(
+            _RadixKey([11, 12, 13]),
+            self._base_match_result(),
+            torch.empty(0, dtype=torch.int64),
+            _TreeNode(),
+            self._req(None),
+        )
+
+        connector.lookup_kv.assert_called_once_with([11, 12, 13], "request-1")
+
+    def test_legacy_connector_rejects_salted_lookup_before_external_access(self):
+        connector = SimpleNamespace(
+            lookup_kv=Mock(return_value=0),
+            release_pending=Mock(),
+        )
+        tree = self._lookup_tree(connector)
+
+        with self.assertRaisesRegex(RuntimeError, "cache_salt"):
+            tree._mp_match_prefix(
+                _RadixKey([11, 12, 13], cache_salt="tenant-a"),
+                self._base_match_result(),
+                torch.empty(0, dtype=torch.int64),
+                _TreeNode(),
+                self._req("tenant-a"),
+            )
+
+        connector.lookup_kv.assert_not_called()
+
+    def test_legacy_connector_keeps_unsalted_store_compatible(self):
+        class LegacyStoreMetadata:
+            def __init__(
+                self, last_node, token_ids, kv_indices, offset, request_id=""
+            ):
+                self.last_node = last_node
+                self.token_ids = token_ids
+                self.kv_indices = kv_indices
+                self.offset = offset
+                self.request_id = request_id
+
+        connector = SimpleNamespace(
+            store_kv=Mock(),
+            end_session=Mock(),
+        )
+        tree = self._store_tree(connector)
+        self.module.StoreMetadata = LegacyStoreMetadata
+
+        tree.cache_finished_req(
+            self._req(None), is_insert=True, kv_len_to_handle=3
+        )
+
+        connector.store_kv.assert_called_once()
+
+    def test_legacy_connector_rejects_salted_store_before_mutating_cache(self):
+        connector = SimpleNamespace(
+            store_kv=Mock(),
+            end_session=Mock(),
+        )
+        tree = self._store_tree(connector)
+
+        with self.assertRaisesRegex(RuntimeError, "cache_salt"):
+            tree.cache_finished_req(
+                self._req("tenant-a"), is_insert=True, kv_len_to_handle=3
+            )
+
+        self.assertEqual(tree._base_finished_calls, [])
+        connector.store_kv.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_lmcache_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_lmcache_radix_cache.py
@@ -111,9 +111,7 @@ def _package(name):
 
 
 def _load_target_module():
-    base_prefix_cache = types.ModuleType(
-        "sglang.srt.mem_cache.base_prefix_cache"
-    )
+    base_prefix_cache = types.ModuleType("sglang.srt.mem_cache.base_prefix_cache")
     for name in (
         "EvictParams",
         "EvictResult",
@@ -136,15 +134,11 @@ def _load_target_module():
     utils.create_device_stream = Mock()
     utils.device_stream_context = lambda stream: nullcontext()
 
-    mp_adapter = types.ModuleType(
-        "lmcache.integration.sglang.multi_process_adapter"
-    )
+    mp_adapter = types.ModuleType("lmcache.integration.sglang.multi_process_adapter")
     mp_adapter.LMCacheMPConnector = type("LMCacheMPConnector", (), {})
 
     sglang_adapter = types.ModuleType("lmcache.integration.sglang.sglang_adapter")
-    sglang_adapter.LMCacheLayerwiseConnector = type(
-        "LMCacheLayerwiseConnector", (), {}
-    )
+    sglang_adapter.LMCacheLayerwiseConnector = type("LMCacheLayerwiseConnector", (), {})
     sglang_adapter.LoadMetadata = _LoadMetadata
     sglang_adapter.StoreMetadata = _StoreMetadata
 
@@ -154,9 +148,7 @@ def _load_target_module():
     stubs = {
         "sglang.srt": _package("sglang.srt"),
         "sglang.srt.mem_cache": _package("sglang.srt.mem_cache"),
-        "sglang.srt.mem_cache.storage": _package(
-            "sglang.srt.mem_cache.storage"
-        ),
+        "sglang.srt.mem_cache.storage": _package("sglang.srt.mem_cache.storage"),
         "sglang.srt.mem_cache.storage.lmcache": _package(
             "sglang.srt.mem_cache.storage.lmcache"
         ),
@@ -282,29 +274,30 @@ class TestLMCacheMPCacheSalt(CustomTestCase):
 
         connector.lookup_kv.assert_called_once_with([11, 12, 13], "request-1")
 
-    def test_legacy_connector_rejects_salted_lookup_before_external_access(self):
+    def test_legacy_connector_skips_salted_lookup_before_external_access(self):
         connector = SimpleNamespace(
             lookup_kv=Mock(return_value=0),
             release_pending=Mock(),
         )
         tree = self._lookup_tree(connector)
+        base_res = self._base_match_result()
 
-        with self.assertRaisesRegex(RuntimeError, "cache_salt"):
-            tree._mp_match_prefix(
+        with self.assertLogs(self.module.logger, level="WARNING") as logs:
+            result = tree._mp_match_prefix(
                 _RadixKey([11, 12, 13], cache_salt="tenant-a"),
-                self._base_match_result(),
+                base_res,
                 torch.empty(0, dtype=torch.int64),
                 _TreeNode(),
                 self._req("tenant-a"),
             )
 
+        self.assertIs(result, base_res)
+        self.assertIn("Skipping LMCache MP lookup", logs.output[0])
         connector.lookup_kv.assert_not_called()
 
     def test_legacy_connector_keeps_unsalted_store_compatible(self):
         class LegacyStoreMetadata:
-            def __init__(
-                self, last_node, token_ids, kv_indices, offset, request_id=""
-            ):
+            def __init__(self, last_node, token_ids, kv_indices, offset, request_id=""):
                 self.last_node = last_node
                 self.token_ids = token_ids
                 self.kv_indices = kv_indices
@@ -318,26 +311,44 @@ class TestLMCacheMPCacheSalt(CustomTestCase):
         tree = self._store_tree(connector)
         self.module.StoreMetadata = LegacyStoreMetadata
 
-        tree.cache_finished_req(
-            self._req(None), is_insert=True, kv_len_to_handle=3
-        )
+        tree.cache_finished_req(self._req(None), is_insert=True, kv_len_to_handle=3)
 
         connector.store_kv.assert_called_once()
 
-    def test_legacy_connector_rejects_salted_store_before_mutating_cache(self):
+    def test_legacy_connector_skips_salted_store_after_local_cleanup(self):
         connector = SimpleNamespace(
             store_kv=Mock(),
             end_session=Mock(),
         )
         tree = self._store_tree(connector)
 
-        with self.assertRaisesRegex(RuntimeError, "cache_salt"):
+        with self.assertLogs(self.module.logger, level="WARNING") as logs:
             tree.cache_finished_req(
                 self._req("tenant-a"), is_insert=True, kv_len_to_handle=3
             )
 
-        self.assertEqual(tree._base_finished_calls, [])
+        self.assertEqual(len(tree._base_finished_calls), 1)
+        self.assertIn("Skipping LMCache MP store", logs.output[0])
         connector.store_kv.assert_not_called()
+        connector.end_session.assert_called_once_with("request-1")
+
+    def test_mp_store_failure_always_releases_local_and_external_state(self):
+        connector = SimpleNamespace(
+            supports_cache_salt=True,
+            store_kv=Mock(side_effect=ValueError("invalid cache_salt")),
+            end_session=Mock(),
+        )
+        tree = self._store_tree(connector)
+        tree._mp_load_back_markers["request-1"] = object()
+
+        with self.assertRaisesRegex(ValueError, "invalid cache_salt"):
+            tree.cache_finished_req(
+                self._req("tenant-a"), is_insert=True, kv_len_to_handle=3
+            )
+
+        self.assertNotIn("request-1", tree._mp_load_back_markers)
+        tree.dec_lock_ref.assert_called_once()
+        connector.end_session.assert_called_once_with("request-1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #37160. Companion LMCache change: LMCache/LMCache#4842.

SGLang already carries `cache_salt` in `RadixKey` and `Req`, but the current LMCache MP handoff drops it. Salted requests can therefore use token-only external keys.

This draft is paired with the LMCache connector API change and remains draft while that direction is reviewed.

## Modifications

- Pass `RadixKey.cache_salt` into salt-aware LMCache MP lookups.
- Pass `Req.cache_salt` into salt-aware STORE metadata.
- Detect the connector's explicit `supports_cache_salt` capability.
- Preserve unsalted compatibility with older LMCache versions.
- For salted requests on an older connector, skip unsafe external lookup/store operations while preserving local radix behavior and request cleanup.
- Ensure MP STORE or metadata failures release the node lock, load marker, and LMCache session.
- Update the `RadixKey` contract comment to describe connector-specific external namespacing.

## Accuracy Tests

Not applicable. This changes external cache-key routing and does not alter model execution.

## Speed Tests and Profiling

Not applicable.

## Validation

```text
Focused CPU/mocked LMCache MP contract tests: 7 passed
```

Ruff, Black, isort, codespell, registered-test validation, Python compilation, and `git diff --check` pass for the changed files.

## Compatibility and scope

- A salt-aware LMCache connector performs salted external lookup/store.
- An older connector remains compatible for unsalted requests.
- Salted requests with an older connector stay local instead of falling back to token-only external keys.
- This draft covers MP mode only. IP/XPU and `extra_key` / LoRA namespacing remain follow-ups.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused unit coverage.
- [x] Update the affected cache-key contract comment; no user documentation page is required.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33378378998](https://github.com/sgl-project/sglang/actions/runs/33378378998)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33378378841](https://github.com/sgl-project/sglang/actions/runs/33378378841)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33378379010](https://github.com/sgl-project/sglang/actions/runs/33378379010)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->