### PR TITLE
[Kernel] Add per-layer LF-to-PF KV transfer for LayerSplit HiCache

### DIFF
--- a/python/sglang/kernels/aot/csrc/common_extension.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension.cc
@@ -314,6 +314,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "int item_size, int src_layout_dim, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_per_layer_mla_pf_lf", torch::kCUDA, &transfer_kv_per_layer_mla_pf_lf);
   m.def(
+      "transfer_kv_per_layer_mla_lf_pf(Tensor src, Tensor dst, Tensor src_indices, Tensor dst_indices, int layer_id, "
+      "int item_size, int dst_layout_dim, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_mla_lf_pf", torch::kCUDA, &transfer_kv_per_layer_mla_lf_pf);
+  m.def(
       "transfer_kv_all_layer_mla(Tensor src_layers, Tensor dst_layers, Tensor src_indices, Tensor dst_indices, int "
       "item_size, int num_layers, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_all_layer_mla", torch::kCUDA, &transfer_kv_all_layer_mla);

--- a/python/sglang/kernels/aot/csrc/common_extension_musa.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_musa.cc
@@ -230,6 +230,10 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "int item_size, int src_layout_dim, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_per_layer_mla_pf_lf", torch::kMUSA, &transfer_kv_per_layer_mla_pf_lf);
   m.def(
+      "transfer_kv_per_layer_mla_lf_pf(Tensor src, Tensor dst, Tensor src_indices, Tensor dst_indices, int layer_id, "
+      "int item_size, int dst_layout_dim, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_mla_lf_pf", torch::kMUSA, &transfer_kv_per_layer_mla_lf_pf);
+  m.def(
       "transfer_kv_all_layer_mla(Tensor src_layers, Tensor dst_layers, Tensor src_indices, Tensor dst_indices, int "
       "item_size, int num_layers, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_all_layer_mla", torch::kMUSA, &transfer_kv_all_layer_mla);

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -194,6 +194,10 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "int item_size, int src_layout_dim, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_per_layer_mla_pf_lf", torch::kCUDA, &transfer_kv_per_layer_mla_pf_lf);
   m.def(
+      "transfer_kv_per_layer_mla_lf_pf(Tensor src, Tensor dst, Tensor src_indices, Tensor dst_indices, int layer_id, "
+      "int item_size, int dst_layout_dim, int block_quota, int num_warps_per_block) -> ()");
+  m.impl("transfer_kv_per_layer_mla_lf_pf", torch::kCUDA, &transfer_kv_per_layer_mla_lf_pf);
+  m.def(
       "transfer_kv_all_layer_mla(Tensor src_layers, Tensor dst_layers, Tensor src_indices, Tensor dst_indices, int "
       "item_size, int num_layers, int block_quota, int num_warps_per_block) -> ()");
   m.impl("transfer_kv_all_layer_mla", torch::kCUDA, &transfer_kv_all_layer_mla);

--- a/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
+++ b/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
@@ -662,6 +662,39 @@ void transfer_kv_per_layer_mla_pf_lf(
       num_warps_per_block);
 }
 
+void transfer_kv_per_layer_mla_lf_pf(
+    const at::Tensor src,
+    at::Tensor dst,
+    const at::Tensor src_indices,
+    const at::Tensor dst_indices,
+    int64_t layer_id,
+    int64_t item_size,
+    int64_t dst_layout_dim,
+    int64_t block_quota,
+    int64_t num_warps_per_block) {
+  at::Tensor empty;
+  // src already points at one layer, so a zero layer stride keeps its base
+  // fixed while layer_id selects the destination slot in page-first storage.
+  transfer_kv_launcher<get_global_offset_lf<const char>, get_global_offset_pf<char>, true>(
+      src,
+      dst,
+      empty,
+      empty,
+      src_indices,
+      dst_indices,
+      layer_id,
+      1,
+      item_size,
+      0,
+      dst_layout_dim,
+      empty,
+      empty,
+      empty,
+      empty,
+      block_quota,
+      num_warps_per_block);
+}
+
 void transfer_kv_all_layer_mla(
     const at::Tensor src_layers,
     const at::Tensor dst_layers,

--- a/python/sglang/kernels/aot/include/sgl_kernel_ops.h
+++ b/python/sglang/kernels/aot/include/sgl_kernel_ops.h
@@ -579,6 +579,17 @@ void transfer_kv_per_layer_mla_pf_lf(
     int64_t block_quota,
     int64_t num_warps_per_block);
 
+void transfer_kv_per_layer_mla_lf_pf(
+    const at::Tensor src,
+    at::Tensor dst,
+    const at::Tensor src_indices,
+    const at::Tensor dst_indices,
+    int64_t layer_id,
+    int64_t item_size,
+    int64_t dst_layout_dim,
+    int64_t block_quota,
+    int64_t num_warps_per_block);
+
 void transfer_kv_all_layer_mla(
     const at::Tensor src_layers,
     const at::Tensor dst_layers,

--- a/python/sglang/kernels/aot/python/sgl_kernel/kvcacheio.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/kvcacheio.py
@@ -296,6 +296,30 @@ def transfer_kv_per_layer_mla_pf_lf(
     )
 
 
+def transfer_kv_per_layer_mla_lf_pf(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    layer_id: int,
+    item_size: int,
+    dst_layout_dim: int,
+    block_quota: int = 2,
+    num_warps_per_block: int = 16 if _is_hip else 32,
+):
+    torch.ops.sgl_kernel.transfer_kv_per_layer_mla_lf_pf.default(
+        src,
+        dst,
+        src_indices,
+        dst_indices,
+        layer_id,
+        item_size,
+        dst_layout_dim,
+        block_quota,
+        num_warps_per_block,
+    )
+
+
 def transfer_kv_all_layer_mla(
     src_layers: torch.Tensor,
     dst_layers: torch.Tensor,

--- a/python/sglang/kernels/aot/tests/test_kvcacheio.py
+++ b/python/sglang/kernels/aot/tests/test_kvcacheio.py
@@ -12,6 +12,8 @@ from sgl_kernel.kvcacheio import (
     transfer_kv_per_layer,
     transfer_kv_per_layer_direct_pf_lf,
     transfer_kv_per_layer_mla,
+    transfer_kv_per_layer_mla_lf_pf,
+    transfer_kv_per_layer_mla_pf_lf,
 )
 
 from sglang.srt.utils import get_cuda_version, is_hip
@@ -364,6 +366,64 @@ def test_transfer_kv(
         torch.testing.assert_close(dst_v_pool_direct, dst_v_pool_ref)
 
     torch.set_default_dtype(original_dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_transfer_kv_per_layer_mla_page_first_roundtrip(dtype):
+    """Cover layer-sharded GLM MLA write-back when JIT rejects 656 bytes."""
+    device = "cuda"
+    page_size = 64
+    num_layers = 3
+    total_items = page_size * 6
+    element_dim = 328
+    layer_id = 1
+
+    src = torch.arange(total_items * element_dim, device=device, dtype=dtype).reshape(
+        total_items, 1, element_dim
+    )
+    dst = torch.zeros(total_items, num_layers, 1, element_dim, dtype=dtype).pin_memory()
+
+    src_pages = torch.tensor([4, 1], dtype=torch.int64)
+    dst_pages = torch.tensor([0, 3], dtype=torch.int64)
+    src_indices_host = torch.cat(
+        [torch.arange(page * page_size, (page + 1) * page_size) for page in src_pages]
+    )
+    dst_indices_host = torch.cat(
+        [torch.arange(page * page_size, (page + 1) * page_size) for page in dst_pages]
+    )
+    src_indices = src_indices_host.to(device)
+    dst_indices = dst_indices_host.to(device)
+
+    item_size = element_dim * dtype.itemsize
+    assert item_size == 656
+    transfer_kv_per_layer_mla_lf_pf(
+        src=src,
+        dst=dst,
+        src_indices=src_indices,
+        dst_indices=dst_indices,
+        layer_id=layer_id,
+        item_size=item_size,
+        dst_layout_dim=num_layers * item_size,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(dst[dst_indices_host, layer_id], src[src_indices].cpu())
+    assert torch.count_nonzero(dst[:, 0]) == 0
+    assert torch.count_nonzero(dst[:, 2]) == 0
+
+    roundtrip = torch.zeros_like(src)
+    load_indices = torch.arange(src_indices.numel(), device=device)
+    transfer_kv_per_layer_mla_pf_lf(
+        src=dst,
+        dst=roundtrip,
+        src_indices=dst_indices,
+        dst_indices=load_indices,
+        layer_id=layer_id,
+        item_size=item_size,
+        src_layout_dim=num_layers * item_size,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(roundtrip[load_indices], src[src_indices])
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
## Motivation
Enable layer-sharded MLA/DSA HiCache write-back for page-first host storage when the JIT path cannot handle the per-item size. This covers the GLM-5.2 LayerSplit CP path without changing cache quantization behavior.

## Modifications
- Add CUDA, MUSA, and ROCm registration for a per-layer LF-to-PF transfer operator.
- Expose the operator through the Python kvcacheio bindings.
- Add BF16/FP16 round-trip coverage for the new transfer path.

## Accuracy Tests
- H20, CUDA 12.9: `test_kvcacheio.py -k page_first_roundtrip` -> `2 passed`.
- The test covers BF16 and FP16 round trips through the new operator.

## Speed Tests and Profiling
H20 microbenchmark, 8192 items, 656 bytes/item, 100 iterations:

```text
LF-to-PF per-layer: 0.2747 ms, 19.56 GB/s
LF-to-LF per-layer: 0.1892 ms, 28.40 GB/s
```

LF-to-PF is a layout-transforming fallback, so this is a directional kernel comparison rather than an end-to-end serving throughput result.

## Checklist
- [x] Format code with pre-commit.
- [x] Add unit tests according to the contribution guide.
- [ ] Update documentation according to the contribution guide.
- [x] Provide GPU accuracy and directional benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33379044561](https://github.com/sgl-project/sglang/actions/runs/33379044561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33379044418](https://github.com/sgl-project/sglang/actions/runs/33379044418)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33379044517](https://github.com/sgl-project/sglang/actions/runs/33379044517)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->