### PR TITLE
[HiCache] Make LayerSplit MLA cache backup CP-aware

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -52,11 +52,7 @@ device_module = get_device_module()
 
 def should_skip_mla_storage_backup(config: HiCacheStorageConfig) -> bool:
     """Skip redundant MLA TP writers only when context parallelism is disabled."""
-    return (
-        config.is_mla_model
-        and config.attn_cp_size == 1
-        and config.tp_rank != 0
-    )
+    return config.is_mla_model and config.attn_cp_size == 1 and config.tp_rank != 0
 
 
 class LayerLoadingEvent:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -50,6 +50,15 @@ logger = logging.getLogger(__name__)
 device_module = get_device_module()
 
 
+def should_skip_mla_storage_backup(config: HiCacheStorageConfig) -> bool:
+    """Skip redundant MLA TP writers only when context parallelism is disabled."""
+    return (
+        config.is_mla_model
+        and config.attn_cp_size == 1
+        and config.tp_rank != 0
+    )
+
+
 class LayerLoadingEvent:
     def __init__(self, num_layers: int):
         self._num_layers = num_layers
@@ -553,12 +562,9 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
-        # for MLA models, only one rank needs to backup the KV cache
-        self.backup_skip = (
-            self.storage_config.is_mla_model
-            # todo: load balancing
-            and self.storage_config.tp_rank != 0
-        )
+        # MLA KV is TP-replicated without CP, but CP ranks own distinct token
+        # shards and must all publish their part of the cache to storage.
+        self.backup_skip = should_skip_mla_storage_backup(self.storage_config)
 
         # Use storage backend factory for dynamic backend creation
         from sglang.srt.mem_cache.storage import StorageBackendFactory

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -42,6 +42,12 @@ if _is_cuda or _is_hip:
         transfer_kv_per_layer_mla,
         transfer_kv_per_layer_mla_pf_lf,
     )
+    try:
+        from sgl_kernel.kvcacheio import transfer_kv_per_layer_mla_lf_pf
+    except ImportError:
+        # Added by the companion kernel change; keep this module importable
+        # while downstream builds pick up the new operator.
+        transfer_kv_per_layer_mla_lf_pf = None
 
 logger = logging.getLogger(__name__)
 
@@ -310,9 +316,19 @@ class DSAIndexerPoolHost(HostKVCache):
                     item_size=self.indexer_page_stride_size,
                 )
             elif self.layout == "page_first":
-                raise ValueError(
-                    "Layer-sharded DSA indexer HiCache backup with page_first "
-                    "layout is not supported without a per-layer LF->PF kernel."
+                if transfer_kv_per_layer_mla_lf_pf is None:
+                    raise RuntimeError(
+                        "Layer-sharded DSA page-first backup requires the "
+                        "per-layer LF-to-PF kernel."
+                    )
+                transfer_kv_per_layer_mla_lf_pf(
+                    src=device_pool.index_k_with_scale_buffer[device_layer_id],
+                    dst=self.index_k_with_scale_buffer,
+                    src_indices=device_page_indices,
+                    dst_indices=host_page_indices,
+                    layer_id=host_layer_id,
+                    item_size=self.indexer_page_stride_size,
+                    dst_layout_dim=self.indexer_layout_dim,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -337,6 +353,11 @@ class DSAIndexerPoolHost(HostKVCache):
         self, device_pool, host_indices, device_indices, io_backend
     ):
         if self._is_device_layer_sharded(device_pool):
+            # Per-layer generic kernels dereference both index arrays on device.
+            if io_backend == "kernel" and not host_indices.is_cuda:
+                host_indices = host_indices.to(
+                    device_indices.device, non_blocking=True
+                )
             for layer_id in self._owned_device_layer_ids(device_pool):
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -42,6 +42,7 @@ if _is_cuda or _is_hip:
         transfer_kv_per_layer_mla,
         transfer_kv_per_layer_mla_pf_lf,
     )
+
     try:
         from sgl_kernel.kvcacheio import transfer_kv_per_layer_mla_lf_pf
     except ImportError:
@@ -355,9 +356,7 @@ class DSAIndexerPoolHost(HostKVCache):
         if self._is_device_layer_sharded(device_pool):
             # Per-layer generic kernels dereference both index arrays on device.
             if io_backend == "kernel" and not host_indices.is_cuda:
-                host_indices = host_indices.to(
-                    device_indices.device, non_blocking=True
-                )
+                host_indices = host_indices.to(device_indices.device, non_blocking=True)
             for layer_id in self._owned_device_layer_ids(device_pool):
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -42,6 +42,7 @@ if _is_cuda or _is_hip:
         transfer_kv_per_layer_mla,
         transfer_kv_per_layer_mla_pf_lf,
     )
+
     try:
         from sgl_kernel.kvcacheio import transfer_kv_per_layer_mla_lf_pf
     except ImportError:
@@ -448,9 +449,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 and not self.can_use_jit
                 and not host_indices.is_cuda
             ):
-                host_indices = host_indices.to(
-                    device_indices.device, non_blocking=True
-                )
+                host_indices = host_indices.to(device_indices.device, non_blocking=True)
             for layer_id in self._owned_device_layer_ids(device_pool):
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -42,6 +42,12 @@ if _is_cuda or _is_hip:
         transfer_kv_per_layer_mla,
         transfer_kv_per_layer_mla_pf_lf,
     )
+    try:
+        from sgl_kernel.kvcacheio import transfer_kv_per_layer_mla_lf_pf
+    except ImportError:
+        # Added by the companion kernel change; keep this module importable
+        # while downstream builds pick up the new operator.
+        transfer_kv_per_layer_mla_lf_pf = None
 if _is_npu:
     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
 
@@ -386,9 +392,19 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         element_dim=self.kv_cache_dim,
                     )
                 else:
-                    raise ValueError(
-                        "Layer-sharded MLA HiCache backup with page_first layout "
-                        "requires the JIT one-layer kernel."
+                    if transfer_kv_per_layer_mla_lf_pf is None:
+                        raise RuntimeError(
+                            "Layer-sharded MLA page-first backup requires the "
+                            "per-layer LF-to-PF kernel."
+                        )
+                    transfer_kv_per_layer_mla_lf_pf(
+                        src=device_pool.kv_buffer[device_layer_id],
+                        dst=self.kv_buffer,
+                        src_indices=device_indices,
+                        dst_indices=host_indices,
+                        layer_id=host_layer_id,
+                        item_size=self.token_stride_size,
+                        dst_layout_dim=self.layout_dim,
                     )
             else:
                 raise ValueError(
@@ -424,6 +440,17 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         host_indices = self.maybe_dcp_kernel_indices(host_indices)
         device_indices = self.maybe_dcp_kernel_indices(device_indices)
         if self._is_device_layer_sharded(device_pool):
+            # The staged all-layer JIT accepts CPU destination indices, but the
+            # generic per-layer fallback reads both index arrays on the GPU.
+            if (
+                io_backend == "kernel"
+                and self.layout == "page_first"
+                and not self.can_use_jit
+                and not host_indices.is_cuda
+            ):
+                host_indices = host_indices.to(
+                    device_indices.device, non_blocking=True
+                )
             for layer_id in self._owned_device_layer_ids(device_pool):
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -573,12 +573,23 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 self.attn_cp_size = 1
 
             self.enable_pp = self.pp_size > 1
+            self.enable_cp = self.attn_cp_size > 1
+            self.cp_suffix = (
+                f"cp{self.attn_cp_rank}_{self.attn_cp_size}"
+                if self.enable_cp
+                else ""
+            )
+
+            mha_suffix_parts = [str(self.local_rank)]
+            mla_suffix_parts = []
             if self.enable_pp:
-                self.mha_suffix = f"{self.local_rank}_{self.pp_rank}"
-                self.mla_suffix = f"{self.pp_rank}"
-            else:
-                self.mha_suffix = f"{self.local_rank}"
-                self.mla_suffix = ""
+                mha_suffix_parts.append(str(self.pp_rank))
+                mla_suffix_parts.append(str(self.pp_rank))
+            if self.enable_cp:
+                mha_suffix_parts.append(self.cp_suffix)
+                mla_suffix_parts.append(self.cp_suffix)
+            self.mha_suffix = "_".join(mha_suffix_parts)
+            self.mla_suffix = "_".join(mla_suffix_parts)
 
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads
@@ -589,12 +600,25 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 )
                 base_rank = self.local_rank * self.split_factor
                 target_ranks = [base_rank + i for i in range(self.split_factor)]
-                if self.enable_pp:
-                    self.mha_suffix = [
-                        f"{rank}_{self.pp_rank}" for rank in target_ranks
-                    ]
-                else:
-                    self.mha_suffix = [f"{rank}" for rank in target_ranks]
+                self.mha_suffix = []
+                for rank in target_ranks:
+                    suffix_parts = [str(rank)]
+                    if self.enable_pp:
+                        suffix_parts.append(str(self.pp_rank))
+                    if self.enable_cp:
+                        suffix_parts.append(self.cp_suffix)
+                    self.mha_suffix.append("_".join(suffix_parts))
+
+            logger.info(
+                "Mooncake cache key suffixes initialized: mla=%r, mha=%r, "
+                "pp=%d/%d, attn_cp=%d/%d",
+                self.mla_suffix,
+                self.mha_suffix,
+                self.pp_rank,
+                self.pp_size,
+                self.attn_cp_rank,
+                self.attn_cp_size,
+            )
 
             self.registered_pools = {}
 
@@ -725,7 +749,8 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         return self._use_group_semantics
 
     def _make_group_id(self, logical_key: str) -> str:
-        return f"sglang-hicache:{logical_key}"
+        cp_group_suffix = f":{self.cp_suffix}" if self.enable_cp else ""
+        return f"sglang-hicache:{logical_key}{cp_group_suffix}"
 
     def _expand_group_ids(
         self, logical_keys: List[str], key_multiplier: int

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -575,9 +575,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             self.enable_pp = self.pp_size > 1
             self.enable_cp = self.attn_cp_size > 1
             self.cp_suffix = (
-                f"cp{self.attn_cp_rank}_{self.attn_cp_size}"
-                if self.enable_cp
-                else ""
+                f"cp{self.attn_cp_rank}_{self.attn_cp_size}" if self.enable_cp else ""
             )
 
             mha_suffix_parts = [str(self.local_rank)]

--- a/test/registered/unit/mem_cache/test_hicache_cp_backup_skip.py
+++ b/test/registered/unit/mem_cache/test_hicache_cp_backup_skip.py
@@ -1,0 +1,43 @@
+import unittest
+
+from sglang.srt.managers.cache_controller import should_skip_mla_storage_backup
+from sglang.srt.mem_cache.hicache_storage import HiCacheStorageConfig
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_config(*, is_mla_model=True, tp_rank=1, attn_cp_size=1):
+    return HiCacheStorageConfig(
+        tp_rank=tp_rank,
+        tp_size=8,
+        pp_rank=0,
+        pp_size=1,
+        attn_cp_rank=tp_rank if attn_cp_size > 1 else 0,
+        attn_cp_size=attn_cp_size,
+        is_mla_model=is_mla_model,
+        enable_storage_metrics=False,
+        is_page_first_layout=True,
+        model_name="test",
+    )
+
+
+class TestHiCacheCPBackupSkip(CustomTestCase):
+    def test_nonzero_mla_tp_rank_skips_without_cp(self):
+        self.assertTrue(should_skip_mla_storage_backup(_make_config()))
+
+    def test_mla_cp_ranks_all_write_storage(self):
+        for rank in range(8):
+            config = _make_config(tp_rank=rank, attn_cp_size=8)
+            self.assertFalse(should_skip_mla_storage_backup(config))
+
+    def test_rank_zero_and_non_mla_never_skip(self):
+        self.assertFalse(should_skip_mla_storage_backup(_make_config(tp_rank=0)))
+        self.assertFalse(
+            should_skip_mla_storage_backup(_make_config(is_mla_model=False))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -152,9 +152,7 @@ def _cpu_jit_one_layer_mla_copy(
     cache_dst[indices_dst] = cache_src[indices_src]
 
 
-def _cpu_per_layer_mla_lf_pf_copy(
-    *, src, dst, src_indices, dst_indices, layer_id, **_
-):
+def _cpu_per_layer_mla_lf_pf_copy(*, src, dst, src_indices, dst_indices, layer_id, **_):
     src_indices = src_indices.to(dtype=torch.int64, device="cpu")
     dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
     dst[dst_indices, layer_id] = src[src_indices]

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -152,6 +152,14 @@ def _cpu_jit_one_layer_mla_copy(
     cache_dst[indices_dst] = cache_src[indices_src]
 
 
+def _cpu_per_layer_mla_lf_pf_copy(
+    *, src, dst, src_indices, dst_indices, layer_id, **_
+):
+    src_indices = src_indices.to(dtype=torch.int64, device="cpu")
+    dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
+    dst[dst_indices, layer_id] = src[src_indices]
+
+
 def _cpu_per_layer_pf_lf_copy(
     *,
     src,
@@ -588,6 +596,61 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
             self.assertTrue(torch.equal(layer[device_indices], expected[layer_id]))
             self.assertTrue(
                 torch.equal(host.kv_buffer[host_indices, layer_id], expected[layer_id])
+            )
+
+    def test_layer_sharded_mla_page_first_backup_uses_per_layer_fallback(self):
+        full_layer_num = 4
+        owned_start, owned_end = 1, 3
+        host_indices = _indices(0, 4)
+        device_indices = _indices(4, 8)
+        kv_cache_dim = 5
+        device_layers = [
+            (torch.arange(8 * kv_cache_dim, dtype=torch.uint8) + layer_id * 20)
+            .reshape(8, 1, kv_cache_dim)
+            .clone()
+            for layer_id in range(full_layer_num)
+        ]
+        device_pool = SimpleNamespace(
+            layer_num=full_layer_num,
+            layer_shard_enabled=True,
+            layer_shard_size=2,
+            kv_buffer=device_layers,
+        )
+        device_pool._owned_local_layer_range = lambda: (owned_start, owned_end)
+
+        host = MLATokenToKVPoolHost.__new__(MLATokenToKVPoolHost)
+        host.device_pool = device_pool
+        host.layout = "page_first"
+        host.layer_num = owned_end - owned_start
+        host.kv_cache_dim = kv_cache_dim
+        host.token_stride_size = kv_cache_dim
+        host.layout_dim = host.token_stride_size * host.layer_num
+        host.dtype = torch.uint8
+        host.can_use_jit = False
+        host.can_use_write_back_jit = False
+        host.dcp_size = 1
+        host.dcp_rank = 0
+        host.mtp_draft_device_pools = ()
+        host.kv_buffer = torch.zeros(
+            8, host.layer_num, 1, kv_cache_dim, dtype=torch.uint8
+        )
+
+        with mock.patch(
+            f"{MLA_POOL_HOST_MODULE}.transfer_kv_per_layer_mla_lf_pf",
+            side_effect=_cpu_per_layer_mla_lf_pf_copy,
+            create=True,
+        ) as fallback:
+            host.backup_from_device_all_layer(
+                device_pool, host_indices, device_indices, io_backend="kernel"
+            )
+
+        self.assertEqual(fallback.call_count, host.layer_num)
+        for host_layer, device_layer in enumerate(range(owned_start, owned_end)):
+            self.assertTrue(
+                torch.equal(
+                    host.kv_buffer[host_indices, host_layer],
+                    device_layers[device_layer][device_indices],
+                )
             )
 
     @unittest.skip(

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -386,12 +386,8 @@ class TestMooncakeGroupSemantics(CustomTestCase):
         call1 = fake_store1.batch_put_calls[0]
         self.assertEqual(call0["keys"], ["page0_cp0_8_k"])
         self.assertEqual(call1["keys"], ["page0_cp1_8_k"])
-        self.assertEqual(
-            call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"]
-        )
-        self.assertEqual(
-            call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"]
-        )
+        self.assertEqual(call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"])
+        self.assertEqual(call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"])
 
     def test_mla_cp_ranks_use_distinct_v2_indexer_keys(self):
         store0, fake_store0 = _make_store(
@@ -420,12 +416,8 @@ class TestMooncakeGroupSemantics(CustomTestCase):
         call1 = fake_store1.batch_put_calls[0]
         self.assertEqual(call0["keys"], ["page0_cp0_8_indexer"])
         self.assertEqual(call1["keys"], ["page0_cp1_8_indexer"])
-        self.assertEqual(
-            call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"]
-        )
-        self.assertEqual(
-            call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"]
-        )
+        self.assertEqual(call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"])
+        self.assertEqual(call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"])
 
     def test_split_heads_group_ids(self):
         store, fake_store = _make_store(

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -205,6 +205,8 @@ def _make_config(
     should_split_heads=False,
     tp_rank=0,
     tp_size=1,
+    attn_cp_rank=0,
+    attn_cp_size=1,
     tp_lcm_size=None,
 ):
     extra_config = {
@@ -221,8 +223,8 @@ def _make_config(
         tp_size=tp_size,
         pp_rank=0,
         pp_size=1,
-        attn_cp_rank=0,
-        attn_cp_size=1,
+        attn_cp_rank=attn_cp_rank,
+        attn_cp_size=attn_cp_size,
         is_mla_model=is_mla_model,
         enable_storage_metrics=False,
         is_page_first_layout=True,
@@ -243,6 +245,8 @@ def _make_store(
     should_split_heads=False,
     tp_rank=0,
     tp_size=1,
+    attn_cp_rank=0,
+    attn_cp_size=1,
     tp_lcm_size=None,
 ):
     fake_store_cls = _fake_store_class()
@@ -254,6 +258,8 @@ def _make_store(
         should_split_heads=should_split_heads,
         tp_rank=tp_rank,
         tp_size=tp_size,
+        attn_cp_rank=attn_cp_rank,
+        attn_cp_size=attn_cp_size,
         tp_lcm_size=tp_lcm_size,
     )
 
@@ -362,6 +368,64 @@ class TestMooncakeGroupSemantics(CustomTestCase):
         call = fake_store.batch_put_calls[0]
         self.assertEqual(call["keys"], ["page0__k"])
         self.assertEqual(call["args"][0].group_ids, ["sglang-hicache:page0"])
+
+    def test_mla_cp_ranks_use_distinct_v1_keys(self):
+        store0, fake_store0 = _make_store(
+            is_mla_model=True, attn_cp_rank=0, attn_cp_size=8
+        )
+        store1, fake_store1 = _make_store(
+            is_mla_model=True, attn_cp_rank=1, attn_cp_size=8
+        )
+        store0.register_mem_pool_host(FakeHostKVCache(objects_per_page=1))
+        store1.register_mem_pool_host(FakeHostKVCache(objects_per_page=1))
+
+        self.assertEqual(store0.batch_set_v1(["page0"], torch.tensor([0])), [True])
+        self.assertEqual(store1.batch_set_v1(["page0"], torch.tensor([0])), [True])
+
+        call0 = fake_store0.batch_put_calls[0]
+        call1 = fake_store1.batch_put_calls[0]
+        self.assertEqual(call0["keys"], ["page0_cp0_8_k"])
+        self.assertEqual(call1["keys"], ["page0_cp1_8_k"])
+        self.assertEqual(
+            call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"]
+        )
+        self.assertEqual(
+            call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"]
+        )
+
+    def test_mla_cp_ranks_use_distinct_v2_indexer_keys(self):
+        store0, fake_store0 = _make_store(
+            is_mla_model=True, attn_cp_rank=0, attn_cp_size=8
+        )
+        store1, fake_store1 = _make_store(
+            is_mla_model=True, attn_cp_rank=1, attn_cp_size=8
+        )
+        store0.register_mem_host_pool_v2(FakeIndexerPool(), PoolName.INDEXER)
+        store1.register_mem_host_pool_v2(FakeIndexerPool(), PoolName.INDEXER)
+
+        def make_transfer():
+            return PoolTransfer(
+                name=PoolName.INDEXER,
+                keys=["page0"],
+                host_indices=torch.tensor([0]),
+            )
+
+        self.assertEqual(
+            store0.batch_set_v2([make_transfer()])[PoolName.INDEXER], [True]
+        )
+        self.assertEqual(
+            store1.batch_set_v2([make_transfer()])[PoolName.INDEXER], [True]
+        )
+        call0 = fake_store0.batch_put_calls[0]
+        call1 = fake_store1.batch_put_calls[0]
+        self.assertEqual(call0["keys"], ["page0_cp0_8_indexer"])
+        self.assertEqual(call1["keys"], ["page0_cp1_8_indexer"])
+        self.assertEqual(
+            call0["args"][0].group_ids, ["sglang-hicache:page0:cp0_8"]
+        )
+        self.assertEqual(
+            call1["args"][0].group_ids, ["sglang-hicache:page0:cp1_8"]
+        )
 
     def test_split_heads_group_ids(self):
         store, fake_store = _make_store(


### PR DESCRIPTION
## Motivation
Make GLM-5.2 LayerSplit context-parallel cache backup compatible with page-first HiCache storage and Mooncake L3. CP ranks own distinct token shards, so each rank must publish its cache under rank-scoped keys.

Depends on #37231 for the per-layer LF-to-PF transfer operator.

## Modifications
- Keep MLA storage backup enabled on every CP rank while preserving the single-writer behavior without CP.
- Add CP rank/size suffixes to Mooncake object keys and group IDs.
- Use the per-layer LF-to-PF fallback for layer-sharded MLA and DSA page-first write-back.
- Add CPU unit coverage for backup selection, Mooncake key isolation, and fallback dispatch.

## Accuracy Tests
- H20, CUDA 12.9: LayerSplit MLA page-first fallback -> `1 passed`.
- H20, CUDA 12.9: DSA indexer page-first fallback -> `1 passed`.
- H20 development environment: CP backup, Mooncake key isolation, and HiCache dispatch -> `24 passed, 1 skipped`.
- `git diff --check` and Python AST parsing passed for changed files.

## Speed Tests and Profiling
No end-to-end serving benchmark was run for this runtime-only change. The underlying LF-to-PF kernel microbenchmark is reported in #37231.

## Checklist
- [x] Format code with pre-commit.
- [x] Add unit tests according to the contribution guide.
- [ ] Update documentation according to the contribution guide.
- [x] Provide targeted NVIDIA GPU validation.
- [ ] Run GLM-5.2 CP + HiCache + Mooncake end-to-end validation.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33382072906](https://github.com/sgl-project/sglang/actions/runs/33382072906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33382072655](https://github.com/sgl-project/sglang/actions/runs/33382072655)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33382072894](https://github.com/sgl-project/sglang/actions/runs/33382072894)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->