### PR TITLE
fix: resolve GLM-5.3-flash  post-rebase CI regressions

### DIFF
--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -321,8 +321,8 @@ def disable_breakable_cudagraph_if_incompatible(server_args: Any):
                 name,
             )
             declare_resolution(
-                "_disable_breakable_cudagraph_if_incompatible",
                 server_args,
+                "_disable_breakable_cudagraph_if_incompatible",
                 cuda_graph_config=with_phase(
                     cfg.cuda_graph_config, Phase.PREFILL, backend=Backend.DISABLED
                 ),

--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -19,11 +19,6 @@ import torch
 from transformers import AutoProcessor
 
 from sglang.srt.configs.model_config import ModelConfig
-from sglang.srt.distributed.parallel_state import (
-    get_attn_tensor_model_parallel_rank,
-    get_attn_tensor_model_parallel_world_size,
-    get_attn_tp_group,
-)
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.cache import parse_content_hash, snapshot_media
@@ -485,7 +480,7 @@ class EncoderPreprocessor:
             torch.distributed.all_reduce(
                 ok,
                 op=torch.distributed.ReduceOp.MIN,
-                group=get_attn_tp_group().cpu_group,
+                group=get_parallel().attn_tp_group.cpu_group,
             )
         if not int(ok.item()):
             if local_error is not None:
@@ -579,7 +574,8 @@ class EncoderPreprocessor:
                     ]
                 )
             else:
-                tp_size = get_attn_tensor_model_parallel_world_size()
+                parallel = get_parallel()
+                tp_size = parallel.attn_tp_size
                 sampled = None
                 if len(video_items) == 1:
                     vr = video_items[0]
@@ -600,7 +596,7 @@ class EncoderPreprocessor:
                     result = await self._dp_sharded_decode_single_video(
                         video_items[0],
                         video_configs[0],
-                        tp_rank=get_attn_tensor_model_parallel_rank(),
+                        tp_rank=parallel.attn_tp_rank,
                         tp_size=tp_size,
                         video_processor_kwargs=video_processor_kwargs,
                         precomputed_indices=sampled,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -24,6 +24,7 @@ from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
     get_disagg,
+    get_parallel,
 )
 from sglang.srt.utils import is_hip, is_npu
 
@@ -171,13 +172,13 @@ def unified_memory_disagg_move_gate(scheduler):
     )
 
 
-def should_bypass_dsa_cp_prefix_cache(server_args) -> bool:
+def should_bypass_dsa_cp_prefix_cache() -> bool:
     """Bypass prefix cache under DSA Prefill CP until CP-aware radix resharding
     exists; without it, cache hits let attention read non-local page rows."""
     return (
-        server_args.disaggregation_mode == DisaggregationMode.PREFILL.value
-        and server_args.attn_cp_size > 1
-        and server_args.enable_dsa_prefill_context_parallel
+        get_disagg().disaggregation_mode == DisaggregationMode.PREFILL.value
+        and get_parallel().attn_cp_size > 1
+        and get_parallel().enable_dsa_prefill_context_parallel
     )
 
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
@@ -47,7 +47,7 @@ from sglang.srt.model_executor.forward_context import (
     get_token_to_kv_pool,
 )
 from sglang.srt.model_executor.runner import get_is_capture_mode
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import get_device, get_parallel
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
@@ -154,7 +154,7 @@ class IndexerKPool(MultiPlatformOp):
                 base=rope_theta,  # type: ignore
                 rope_scaling=rope_scaling,
                 is_neox_style=is_neox_style,
-                device=get_server_args().device,
+                device=get_device().device,
             )
         self.block_size = block_size
         self.scale_fmt = scale_fmt

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -239,7 +239,7 @@ def build_kv_cache(
 
     retraction_backup = resolve_decode_retraction_backup(tp_worker=tp_worker)
 
-    bypass_dsa_cp_prefix_cache = should_bypass_dsa_cp_prefix_cache(server_args)
+    bypass_dsa_cp_prefix_cache = should_bypass_dsa_cp_prefix_cache()
     disable_radix_cache = (
         get_memory().disable_radix_cache
         or (model_config.is_multimodal and uses_transformers_backend)

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -60,7 +60,10 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.layers.moe.utils import (
+    get_moe_a2a_backend,
+    is_shared_experts_fusion_disabled,
+)
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -118,7 +121,7 @@ from sglang.srt.multimodal.mm_utils import (
     run_dp_presharded_mrope_vision_model,
     run_dp_sharded_mrope_vision_model,
 )
-from sglang.srt.runtime_context import get_forward, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_forward, get_mm, get_parallel, get_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils.common import (
     BumpAllocator,
@@ -622,7 +625,7 @@ class Glm5NextDecoderLayer(nn.Module):
         rope_scaling = config.rope_scaling
         max_position_embeddings = config.max_position_embeddings
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
-            get_server_args().speculative_algorithm
+            get_spec().speculative_algorithm
         )
         self.dsa_enable_prefill_cp = dsa_enable_prefill_cp
         self.mla_enable_prefill_cp = mla_enable_prefill_cp
@@ -1321,7 +1324,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                         text_config.hidden_size,
                         quant_config=quant_config,
                         prefix=add_prefix("lm_head", prefix),
-                        use_attn_tp_group=get_server_args().enable_dp_lm_head,
+                        use_attn_tp_group=get_parallel().enable_dp_lm_head,
                     )
             else:
                 self.lm_head = PPMissingLayer()
@@ -1361,7 +1364,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                 text_config.mhc,
             )
 
-        self.use_data_parallel = get_server_args().mm_enable_dp_encoder
+        self.use_data_parallel = get_mm().mm_enable_dp_encoder
         self.visual = None
         if not self.language_only:
             self.visual = Glm5NextVisionModel(
@@ -1420,22 +1423,11 @@ class Glm5NextForConditionalGeneration(nn.Module):
         return None
 
     def determine_num_fused_shared_experts(self):
-        self.num_fused_shared_experts = 0
-        if get_server_args().disable_shared_experts_fusion:
-            return
-
-        disable_reason = type(self).shared_experts_fusion_disable_reason(
-            self.config, self.quant_config
+        self.num_fused_shared_experts = (
+            0 if is_shared_experts_fusion_disabled() else self.config.n_shared_experts
         )
-
-        if disable_reason is not None:
-            log_info_on_rank0(
-                logger,
-                f"{disable_reason} Shared experts fusion optimization is disabled.",
-            )
+        if self.num_fused_shared_experts == 0:
             return
-
-        self.num_fused_shared_experts = self.config.n_shared_experts
         assert (
             self.num_fused_shared_experts == 1
         ), f"Only 1 fused shared expert is supported for {type(self).__name__}"

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -452,6 +452,7 @@ class TestNixlTransferWorker(CustomTestCase):
         mgr.decode_kv_args_table = {
             "agent": SimpleNamespace(
                 decode_tp_size=1,
+                decode_tp_rank=0,
                 dst_kv_ptrs=[0],
                 dst_aux_ptrs=[0],
                 gpu_id=0,
@@ -475,6 +476,8 @@ class TestNixlTransferWorker(CustomTestCase):
         mgr.is_mla_backend = False
         mgr.is_hybrid_mla_backend = False
         mgr.attn_tp_size = 1
+        mgr.attn_tp_rank = 0
+        mgr.attn_cp_rank = 0
         mgr.transfer_source_rank = 0
         mgr.kv_args = SimpleNamespace(engine_rank=0, kv_data_ptrs=[0])
         mgr.exceptions = {}

--- a/test/registered/unit/layers/quantization/test_fp8_moe_runner_ownership.py
+++ b/test/registered/unit/layers/quantization/test_fp8_moe_runner_ownership.py
@@ -129,7 +129,9 @@ class TestFp8MoERunnerOwnership(CustomTestCase):
             patch("sglang.srt.layers.quantization.fp8._use_aiter", True),
             patch("sglang.srt.layers.quantization.fp8._is_fp8_fnuz", False),
             patch.object(method, "_convert_mxfp8_moe_to_block_fp8"),
-            patch("sglang.srt.layers.quantization.fp8.shuffle_weight") as shuffle,
+            patch(
+                "sglang.srt.layers.quantization.fp8.shuffle_weight", create=True
+            ) as shuffle,
         ):
             method.process_weights_after_loading_block_quant(layer)
 
@@ -150,7 +152,9 @@ class TestFp8MoERunnerOwnership(CustomTestCase):
             patch("sglang.srt.layers.quantization.fp8._use_aiter", True),
             patch("sglang.srt.layers.quantization.fp8._is_fp8_fnuz", False),
             patch.object(method, "_convert_mxfp8_moe_to_block_fp8"),
-            patch("sglang.srt.layers.quantization.fp8.shuffle_weight") as shuffle,
+            patch(
+                "sglang.srt.layers.quantization.fp8.shuffle_weight", create=True
+            ) as shuffle,
         ):
             method.process_weights_after_loading_block_quant(layer)
 
@@ -179,6 +183,7 @@ class TestFp8MoERunnerOwnership(CustomTestCase):
             patch(
                 "sglang.srt.layers.quantization.fp8.shuffle_weight",
                 side_effect=add_one,
+                create=True,
             ) as shuffle,
         ):
             method.process_weights_after_loading_block_quant(layer)

--- a/test/registered/unit/managers/test_generation_auxiliary_output.py
+++ b/test/registered/unit/managers/test_generation_auxiliary_output.py
@@ -472,6 +472,7 @@ def test_disaggregated_prefill_consumes_auxiliary_output_after_commit():
         disagg_prefill_inflight_queue=[],
         send_kv_chunk=Mock(),
         metrics_reporter=SimpleNamespace(report_prefill_stats=Mock()),
+        maybe_send_health_check_signal=Mock(),
     )
 
     with patch("sglang.srt.disaggregation.prefill.maybe_cache_unfinished_req"):
@@ -488,6 +489,7 @@ def test_disaggregated_prefill_consumes_auxiliary_output_after_commit():
         host_output,
         [0],
     )
+    scheduler.maybe_send_health_check_signal.assert_called_once_with()
 
 
 def test_logprob_only_reuses_preprocessing_without_observer_lifecycle():

--- a/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
@@ -32,6 +32,7 @@ def _make_scheduler(pending_req, *, chunked_req, running_reqs) -> Scheduler:
     sched.chunked_req = chunked_req
     sched._pending_chunked_abort_req = pending_req
     sched.waiting_queue = []
+    sched.mm_receiver = None
     sched.dllm_config = None
     sched.grammar_manager = Mock()
     sched.disaggregation_mode = None

--- a/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
@@ -19,8 +19,7 @@ class _FakeReq:
 
     def __init__(self, rid: str):
         self.rid = rid
-        self.req_pool_idx = 1
-        self.mamba_pool_idx = None
+        self.kv = SimpleNamespace(req_pool_idx=1)
         self.to_finish = None
         self._finished = False
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -746,7 +746,7 @@ class TestEagleConfigurator(CustomTestCase):
 
                 expected = (
                     full_pt * (16 + 4 * dcp_size)
-                    + mr.server_args.swa_full_tokens_ratio * swa_pt * 16
+                    + get_schedule().swa_full_tokens_ratio * swa_pt * 16
                 )
                 self.assertEqual(cfg._cell_size, expected)
 

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -270,6 +270,7 @@ class TestCudaVmmFeatureTransport(unittest.TestCase):
         from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
         manager = object.__new__(TokenizerManager)
+        manager.rid_to_state = {}
         transport = MagicMock()
         transport.prepare_for_dispatch.return_value = []
         manager.cuda_vmm_feature_transport = transport
@@ -297,6 +298,7 @@ class TestCudaVmmFeatureTransport(unittest.TestCase):
         )
 
         manager = object.__new__(tokenizer_manager.TokenizerManager)
+        manager.rid_to_state = {}
         transport = MagicMock()
         manager._dispatch_to_scheduler = MagicMock(
             side_effect=RuntimeError("send failed")
@@ -331,6 +333,7 @@ class TestCudaVmmFeatureTransport(unittest.TestCase):
         )
 
         manager = object.__new__(tokenizer_manager.TokenizerManager)
+        manager.rid_to_state = {}
         transport = MagicMock()
         manager._dispatch_to_scheduler = MagicMock()
         time_stats = MagicMock()

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -204,6 +204,7 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
                 worker.speculative_num_steps = 1
                 worker.speculative_num_draft_tokens = 2
                 worker.device = DEVICE
+                worker.plan_stream = None
                 worker.tree_mask_mode = None
                 worker.seed_dsa_topk_from_draft_extend = seed_enabled
                 worker.index_share_for_mtp_iteration = True


### PR DESCRIPTION
## Summary

- migrate GLM-5.3 and DSA call sites to resolved runtime-context accessors
- align GLM-5.3 shared-expert fusion with the post-rebase loader decision
- repair CPU-only fixtures for conditional FP8 symbols and newly required runtime fields
- fix the swapped declare_resolution arguments that crashed incompatible breakable CUDA graph startup paths

## Validation

- pre-commit hooks pass with Python 3.12
- 97 affected unit tests pass on an RX B300 devbox
- monitored source runs:
  - https://github.com/sgl-project/sglang/actions/runs/33377696903
  - https://github.com/sgl-project/sglang/actions/runs/33377696787

## Stack

Base: #36507

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33381969329](https://github.com/sgl-project/sglang/actions/runs/33381969329)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33381969199](https://github.com/sgl-project/sglang/actions/runs/33381969199)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33381969478](https://github.com/sgl-project/sglang/actions/runs/33381969478)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->