### PR TITLE
[Feature] Batch-level hybrid speculative decoding

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -930,6 +930,7 @@
               "docs/advanced_features/hisparse_guide",
               "docs/advanced_features/speculative_decoding",
               "docs/advanced_features/adaptive_speculative_decoding",
+              "docs/advanced_features/hybrid_speculative_decoding",
               "docs/advanced_features/structured_outputs",
               "docs/advanced_features/structured_outputs_for_reasoning_models",
               "docs/advanced_features/tool_parser",

--- a/docs/docs/advanced_features/hybrid_speculative_decoding.mdx
+++ b/docs/docs/advanced_features/hybrid_speculative_decoding.mdx
@@ -77,6 +77,7 @@ Retrieval is selected for the whole decode batch only when the number of qualify
 Both workers stay live across route switches, so routing can change on the next decode step without rebuilding state:
 
 - The CUDA graph runners and attention backends of both workers are captured at init and switched when the route changes.
+- Each verify width owns a shape-matched graph capture. Compatible buffers use the same registry-managed reuse as adaptive speculative decoding, rather than sharing one route's capture buffers directly.
 - The suffix tree and the EAGLE draft KV are updated with accepted tokens every step, so either worker can be picked on the next step.
 - The prompt is inserted into the NGRAM trie, so drafts can also match against the input.
 

--- a/docs/docs/advanced_features/hybrid_speculative_decoding.mdx
+++ b/docs/docs/advanced_features/hybrid_speculative_decoding.mdx
@@ -1,0 +1,88 @@
+---
+title: "Hybrid Speculative Decoding"
+metatags:
+    description: "Run retrieval-based and neural draft workers side by side and let SGLang route each decode batch to the better one with hybrid speculative decoding."
+---
+
+Hybrid speculative decoding keeps a retrieval-based draft worker (NGRAM) and a neural draft worker (EAGLE3) ready at the same time, then selects one worker per pure-decode batch.
+It is designed for workloads where acceptance varies between repetition-heavy and open-ended output. Retrieval-based methods shine on repetition but degrade badly without it, while draft-model-based methods are stable across workloads but leave speedup on the table when local repetition is high.
+Statically picking one method is never optimal, so the hybrid controller routes per decode batch and stays close to the better of the two.
+
+## Current support
+
+- Retrieval role: `NGRAM`
+- Neural role: `EAGLE3`, which requires a draft checkpoint
+- Each role has independent speculative parameters, including its own draft width
+- Routing happens at the decode-batch level; prefill and mixed extend/decode batches use the neural route
+
+## Usage
+
+Set `--speculative-algorithm HYBRID` and pass a JSON object to `--speculative-hybrid-config`.
+The `retrieval` and `neural` objects contain an `algorithm` plus normal `ServerArgs` field names written with underscores.
+The two routing thresholds `min_continuation_ratio` and `min_matching_ratio` sit next to the role objects and are both **required**.
+
+```bash Example
+python3 -m sglang.launch_server \
+    --model-path Qwen/Qwen3.5-35B-A3B \
+    --speculative-algorithm HYBRID \
+    --speculative-hybrid-config '{
+      "retrieval": {
+        "algorithm": "NGRAM",
+        "speculative_num_draft_tokens": 6,
+        "speculative_ngram_min_bfs_breadth": 1,
+        "speculative_ngram_max_bfs_breadth": 1,
+        "speculative_ngram_match_type": "PROB"
+      },
+      "neural": {
+        "algorithm": "EAGLE3",
+        "speculative_draft_model_path": "/path/to/eagle3-draft-model",
+        "speculative_num_draft_tokens": 4,
+        "speculative_eagle_topk": 1,
+        "speculative_num_steps": 3
+      },
+      "min_continuation_ratio": 1.0,
+      "min_matching_ratio": 0.5
+    }' \
+    --mem-fraction-static 0.8 \
+    --max-running-requests 8 \
+    --cuda-graph-max-bs 8
+```
+
+## Routing policy
+
+The controller evaluates a two-level threshold heuristic before drafting.
+
+### Request level: `min_continuation_ratio`
+
+A request **qualifies** for retrieval when its retrieval draft quality score reaches the `min_continuation_ratio` fraction of the retrieval draft.
+The score weights the actual draft length by the suffix-match length and normalizes it by the draft width:
+
+```text
+score = continuation_length * suffix_match_length / speculative_num_draft_tokens
+qualifies when score >= min_continuation_ratio * (speculative_num_draft_tokens - 1)
+```
+
+The longer the suffix match, the more likely the retrieved draft is accepted.
+
+- Required; must be in `(0, 1]`.
+
+### Batch level: `min_matching_ratio`
+
+Retrieval is selected for the whole decode batch only when the number of qualifying requests is at least `batch_size * min_matching_ratio`.
+
+- Required; must be in `(0, 1]`.
+
+## State handling
+
+Both workers stay live across route switches, so routing can change on the next decode step without rebuilding state:
+
+- The CUDA graph runners and attention backends of both workers are captured at init and switched when the route changes.
+- The suffix tree and the EAGLE draft KV are updated with accepted tokens every step, so either worker can be picked on the next step.
+- The prompt is inserted into the NGRAM trie, so drafts can also match against the input.
+
+## Observability
+
+Set the environment variable `SGLANG_LOG_HYBRID_SPEC` to a positive batch interval to log route decisions and per-route acceptance statistics. The log covers average continuation length, average suffix-match length, qualifying request count, and the accept length and accept rate of each route.
+
+- Breakable prefill CUDA graphs are incompatible with EAGLE3 aux hidden-state capture; run with `--cuda-graph-backend-prefill tc_piecewise` or `disabled` instead. The incompatibility is not hybrid specific and also affects plain EAGLE3.
+- Routing is decided per decode batch; routing individual requests inside a mixed batch is future work.

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -35,6 +35,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
 - **You have a DFlash draft checkpoint**: Use **DFLASH** with `--speculative-algorithm DFLASH` and `--speculative-draft-model-path ...`.
 - **You have a smaller draft LLM**: Use **STANDALONE** (`--speculative-algorithm STANDALONE`).
 - **No extra model available**: Use **NGRAM** (`--speculative-algorithm NGRAM`, CUDA-only).
+- **Acceptance varies between repetitive and open-ended batches**: Use [**Hybrid speculative decoding**](./hybrid_speculative_decoding) to route each batch between NGRAM retrieval and an EAGLE3 draft model.
 
 ### Method comparison (mini table)
 
@@ -815,6 +816,10 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)
 ```
+
+---
+
+If your workload mixes repetition-heavy and open-ended batches, see [Hybrid Speculative Decoding](./hybrid_speculative_decoding), which routes each pure-decode batch between a retrieval worker (NGRAM) and a neural worker (EAGLE3).
 
 ---
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
@@ -141,7 +141,7 @@ void Ngram::insertWorker() {
   }
 }
 
-Result Ngram::batchMatch(
+std::pair<Result, std::vector<int32_t>> Ngram::batchMatch(
     const std::vector<int64_t>& state_ids,
     const std::vector<std::vector<int32_t>>& tokens,
     const std::vector<size_t>& total_lens) {
@@ -175,6 +175,8 @@ Result Ngram::batchMatch(
   const size_t trie_budget = total_draft_token_num - (per_sam_budget * num_sams);
 
   Result merged;
+  std::vector<int32_t> match_lens;
+  match_lens.reserve(state_ids.size());
   for (size_t i = 0; i < state_ids.size(); ++i) {
     const auto& suffix = tokens[i];
     if (suffix.empty()) {
@@ -188,6 +190,7 @@ Result Ngram::batchMatch(
           suffix.data(), suffix.size(), suffix.back(), total_draft_token_num, param_, state, total_lens[i]);
       merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
       merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
+      match_lens.push_back(res.match_len);
       continue;
     }
 
@@ -202,8 +205,9 @@ Result Ngram::batchMatch(
 
     merged.token.insert(merged.token.end(), combined.token.begin(), combined.token.end());
     merged.mask.insert(merged.mask.end(), combined.mask.begin(), combined.mask.end());
+    match_lens.push_back(combined.match_len);
   }
-  return merged;
+  return {std::move(merged), std::move(match_lens)};
 }
 
 void Ngram::eraseMatchState(const std::vector<int64_t>& state_ids) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
@@ -63,7 +63,10 @@ class Ngram {
 
   std::vector<std::pair<std::string, int64_t>> listExternalCorpora() const;
 
-  Result batchMatch(
+  // Returns (merged draft Result, per-request match_len array). match_len is a
+  // scalar on each per-request Result but the batch needs one value per
+  // request, so it travels as a separate vector alongside the merged Result.
+  std::pair<Result, std::vector<int32_t>> batchMatch(
       const std::vector<int64_t>& state_ids,
       const std::vector<std::vector<int32_t>>& tokens,
       const std::vector<size_t>& total_lens);

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -59,7 +59,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       const tvm::ffi::TensorView offsets,
       const tvm::ffi::TensorView total_lens_tv,
       const tvm::ffi::TensorView out_tokens,
-      const tvm::ffi::TensorView out_mask) {
+      const tvm::ffi::TensorView out_mask,
+      const tvm::ffi::TensorView out_match_len) {
     auto* sid = static_cast<const int64_t*>(state_ids_tv.data_ptr());
     auto* data = static_cast<const int32_t*>(tokens_flat.data_ptr());
     auto* offs = static_cast<const int64_t*>(offsets.data_ptr());
@@ -74,8 +75,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       total_lens[i] = static_cast<size_t>(tlens[i]);
     }
 
-    auto result = ngram_->batchMatch(state_ids, tokens, total_lens);
-    write_result_(result, out_tokens, out_mask);
+    auto [result, match_lens] = ngram_->batchMatch(state_ids, tokens, total_lens);
+    write_result_(result, out_tokens, out_mask, match_lens, out_match_len);
   }
 
   void erase_match_state(const tvm::ffi::TensorView state_ids_tv) {
@@ -132,9 +133,14 @@ struct NgramCorpusObj : public tvm::ffi::Object {
 
  private:
   void write_result_(
-      const ngram::Result& result, const tvm::ffi::TensorView& out_tokens, const tvm::ffi::TensorView& out_mask) {
+      const ngram::Result& result,
+      const tvm::ffi::TensorView& out_tokens,
+      const tvm::ffi::TensorView& out_mask,
+      const std::vector<int32_t>& match_lens,
+      const tvm::ffi::TensorView& out_match_len) {
     auto* out_tok = static_cast<int32_t*>(out_tokens.data_ptr());
     auto* out_msk = static_cast<uint8_t*>(out_mask.data_ptr());
+    auto* out_ml = static_cast<int32_t*>(out_match_len.data_ptr());
     if (result.token.size() > static_cast<size_t>(out_tokens.size(0))) {
       throw std::runtime_error(
           "out_tokens buffer too small: " + std::to_string(out_tokens.size(0)) + " < " +
@@ -145,8 +151,14 @@ struct NgramCorpusObj : public tvm::ffi::Object {
           "out_mask buffer too small: " + std::to_string(out_mask.size(0)) + " < " +
           std::to_string(result.mask.size()));
     }
+    if (match_lens.size() > static_cast<size_t>(out_match_len.size(0))) {
+      throw std::runtime_error(
+          "out_match_len buffer too small: " + std::to_string(out_match_len.size(0)) + " < " +
+          std::to_string(match_lens.size()));
+    }
     std::memcpy(out_tok, result.token.data(), result.token.size() * sizeof(int32_t));
     std::memcpy(out_msk, result.mask.data(), result.mask.size() * sizeof(uint8_t));
+    std::memcpy(out_ml, match_lens.data(), match_lens.size() * sizeof(int32_t));
   }
 
   std::unique_ptr<ngram::Ngram> ngram_;

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
@@ -122,7 +122,9 @@ Result combineRootResults_(int last_token, int draft_token_num, const Result& pr
     merged_paths.emplace_back(path);
   }
 
-  return buildResultFromLeafPaths_(last_token, draft_token_num, merged_paths);
+  auto combined = buildResultFromLeafPaths_(last_token, draft_token_num, merged_paths);
+  combined.match_len = std::max(primary.match_len, secondary.match_len);
+  return combined;
 }
 
 void Result::truncate(size_t n) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
@@ -12,6 +12,8 @@ namespace ngram {
 struct Result {
   std::vector<int32_t> token;
   std::vector<uint8_t> mask;
+  // Per-request max suffix-match depth (longest expandable context suffix).
+  int32_t match_len = 0;
 
   void truncate(size_t n);
 };

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -181,6 +181,10 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
 Result SuffixAutomaton::buildRecency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
   auto anchors = match(context, len, param.max_trie_depth);
+  int32_t max_d = 0;
+  for (const auto& anchor : anchors) {
+    max_d = std::max(max_d, anchor.matched_len);
+  }
   const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
   const double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
   std::vector<Node> tree(draft_token_num + 1);
@@ -211,12 +215,18 @@ Result SuffixAutomaton::buildRecency(
       }
     }
   }
-  return fillResult(last_token, draft_token_num + 1, tree, root);
+  auto info = fillResult(last_token, draft_token_num + 1, tree, root);
+  info.match_len = max_d;
+  return info;
 }
 
 Result SuffixAutomaton::buildFrequency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
   auto anchors = match(context, len, param.max_trie_depth);
+  int32_t max_d = 0;
+  for (const auto& anchor : anchors) {
+    max_d = std::max(max_d, anchor.matched_len);
+  }
   struct CompareByProb {
     bool operator()(
         const std::tuple<int, int32_t, int, double>& lhs, const std::tuple<int, int32_t, int, double>& rhs) const {
@@ -279,7 +289,9 @@ Result SuffixAutomaton::buildFrequency(
       addToHeap(pos, child_state, prob);
     }
   }
-  return fillResult(last_token, draft_token_num + 1, tree, root);
+  auto info = fillResult(last_token, draft_token_num + 1, tree, root);
+  info.match_len = max_d;
+  return info;
 }
 
 }  // namespace ngram

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
@@ -226,6 +226,9 @@ Result Trie::buildRecency(
     MatchState& state,
     size_t total_len) const {
   auto anchors = match(context, len, state, total_len);
+  int32_t max_d = 0;
+  if (anchors.size()) max_d = anchors[0].second;
+
   const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
   double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
 
@@ -260,7 +263,9 @@ Result Trie::buildRecency(
     }
   }
 
-  return fillResult(last_token, draft_token_num + 1, tree, root);
+  auto info = fillResult(last_token, draft_token_num + 1, tree, root);
+  info.match_len = max_d;
+  return info;
 }
 
 Result Trie::buildFrequency(
@@ -272,6 +277,9 @@ Result Trie::buildFrequency(
     MatchState& state,
     size_t total_len) const {
   auto anchors = match(context, len, state, total_len);
+  int32_t max_d = 0;
+  if (anchors.size()) max_d = anchors[0].second;
+
   struct CompareByLastDouble {
     bool operator()(
         const std::tuple<double, const TrieNode*, double>& a,
@@ -327,7 +335,9 @@ Result Trie::buildFrequency(
     }
   }
 
-  return fillResult(last_token, draft_token_num + 1, tree, root);
+  auto info = fillResult(last_token, draft_token_num + 1, tree, root);
+  info.match_len = max_d;
+  return info;
 }
 
 }  // namespace ngram

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -79,7 +79,7 @@ def get_ngram_corpus_cls():
             state_ids: List[int],
             batch_tokens: List[List[int]],
             total_lens: List[int],
-        ) -> Tuple[np.ndarray, np.ndarray]:
+        ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
             tokens_flat, offsets = _to_csr(batch_tokens)
             batch_size = len(batch_tokens)
             d = self._draft_token_num
@@ -88,13 +88,22 @@ def get_ngram_corpus_cls():
             total_lens_t = torch.tensor(total_lens, dtype=torch.int64)
             out_tokens = torch.zeros(batch_size * d, dtype=torch.int32)
             out_mask = torch.zeros(batch_size * d * d, dtype=torch.uint8)
+            out_match_len = torch.zeros(batch_size, dtype=torch.int32)
 
             self.batch_match_stateful(  # type: ignore
-                state_ids_t, tokens_flat, offsets, total_lens_t, out_tokens, out_mask
+                state_ids_t,
+                tokens_flat,
+                offsets,
+                total_lens_t,
+                out_tokens,
+                out_mask,
+                out_match_len,
             )
 
-            return out_tokens.numpy().astype(np.int64), out_mask.numpy().astype(
-                np.int64
+            return (
+                out_tokens.numpy().astype(np.int64),
+                out_mask.numpy().astype(np.int64),
+                out_match_len.numpy().astype(np.int64),
             )
 
         def erase_states(self, state_ids: List[int]) -> None:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -169,10 +169,8 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             f"speculative_algorithm == EAGLE, got {cfg.speculative_algorithm}."
         )
 
-    if cfg.speculative_adaptive:
-        _maybe_disable_adaptive(server_args)
-        if cfg.speculative_adaptive:
-            _init_adaptive_speculative_params(server_args)
+    if cfg.speculative_adaptive and (algo is None or not algo.is_hybrid()):
+        configure_adaptive_speculative_decoding(server_args)
 
     if algo is not None:
         # A registered algorithm's callback lives outside this tree and sets
@@ -982,6 +980,80 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         )
 
 
+def _handle_hybrid(server_args: ServerArgs) -> None:
+    cfg = resolving_view(server_args)
+    if cfg.speculative_hybrid_config is None:
+        raise ValueError(
+            "HYBRID speculative decoding requires --speculative-hybrid-config."
+        )
+    try:
+        config = json.loads(cfg.speculative_hybrid_config)
+    except json.JSONDecodeError as exc:
+        raise ValueError("--speculative-hybrid-config must be a JSON object.") from exc
+    if not isinstance(config, dict):
+        raise ValueError("--speculative-hybrid-config must be a JSON object.")
+
+    neural = config.get("neural")
+    if not isinstance(neural, dict):
+        return
+
+    # TokenizerManager and target memory-pool initialization run before the
+    # controller creates role-specific ServerArgs copies. Bootstrap EAGLE-only
+    # settings from the neural role, but size target verify buffers for the
+    # widest configured route. The controller captures a width-specific graph
+    # for every route over those shared buffers after worker initialization.
+    neural_overrides = {}
+    for field in (
+        "speculative_num_steps",
+        "speculative_eagle_topk",
+        "speculative_num_draft_tokens",
+        "speculative_draft_model_path",
+        "speculative_draft_model_revision",
+    ):
+        value = neural.get(field)
+        if value is not None:
+            neural_overrides[field] = value
+    declare_resolution(server_args, "_handle_hybrid.neural", **neural_overrides)
+
+    # HYBRID needs the neural overrides installed before adaptive validation
+    # and initial-step selection. The generic hook cannot do this earlier
+    # because it deliberately knows nothing about role-specific JSON fields.
+    if resolving_view(server_args).speculative_adaptive:
+        configure_adaptive_speculative_decoding(server_args)
+
+    # The initial target verify graph supplies the largest shared static
+    # buffers. Route-specific graphs and attention metadata are created later
+    # by HybridController, but this bootstrap width must cover NGRAM too.
+    role_widths = [
+        config.get(role, {}).get("speculative_num_draft_tokens")
+        for role in ("retrieval", "neural")
+        if isinstance(config.get(role), dict)
+        and config[role].get("speculative_num_draft_tokens") is not None
+    ]
+    if role_widths and all(isinstance(width, int) for width in role_widths):
+        from sglang.srt.arg_groups.overrides import (
+            max_speculative_num_draft_tokens,
+        )
+
+        max_width = max_speculative_num_draft_tokens(server_args)
+        declare_resolution(
+            server_args,
+            "_handle_hybrid.max_width",
+            speculative_num_draft_tokens=max(max(role_widths), max_width or 0),
+        )
+
+    if resolving_view(server_args).max_running_requests is None:
+        declare_resolution(
+            server_args,
+            "_handle_hybrid",
+            max_running_requests=48,
+        )
+        logger.warning(
+            "Max running requests is reset to 48 for HYBRID speculative decoding. "
+            "You can override this by explicitly setting --max-running-requests."
+        )
+
+
 def _handle_ngram(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
     if cfg.device not in ("cuda", "cpu"):
@@ -1087,6 +1159,13 @@ def _maybe_disable_adaptive(server_args: ServerArgs) -> None:
             "_maybe_disable_adaptive",
             speculative_adaptive=False,
         )
+
+
+def configure_adaptive_speculative_decoding(server_args: ServerArgs) -> None:
+    """Validate and initialize adaptive parameters for one worker config."""
+    _maybe_disable_adaptive(server_args)
+    if resolving_view(server_args).speculative_adaptive:
+        _init_adaptive_speculative_params(server_args)
 
 
 def _init_adaptive_speculative_params(server_args: ServerArgs) -> None:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -341,6 +341,8 @@ class Envs:
     SGLANG_LOG_REQUEST_HEADERS = EnvTuple(tuple())
     SGLANG_LOG_SCHEDULER_STATUS_TARGET = EnvStr("")
     SGLANG_LOG_SCHEDULER_STATUS_INTERVAL = EnvFloat(60.0)
+    # Log Hybrid speculative scheduling every N pure decode batches; 0 disables it.
+    SGLANG_LOG_HYBRID_SPEC = EnvInt(0)
     SGLANG_ENABLE_RANK_CONSENSUS_CHECKER = EnvBool(False)
 
     # ===================================================================

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -736,7 +736,16 @@ def general_mm_embed_routine(
                                         )
                                     )
             forward_batch.mm_inputs = None
-            forward_batch.mm_input_embeds = input_embeds
+            # EAGLE reuses the target-side embeddings for draft prefill. The
+            # target model may mutate its input in place (for example, through
+            # fused residual/RMSNorm), so preserve the pre-forward values for
+            # the draft worker instead of handing it the aliased tensor.
+            forward_batch.mm_input_embeds = (
+                input_embeds.clone()
+                if forward_batch.spec_algorithm is not None
+                and forward_batch.spec_algorithm.is_eagle()
+                else input_embeds
+            )
         else:
             input_embeds = embed_tokens(input_ids)
         # Copy to pre-allocated buffer if available (for CUDA graph address stability)

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import ScheduleBatch
     from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
     from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.hybrid_info import HybridVerifyInput
     from sglang.srt.speculative.ngram_info import NgramVerifyInput
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
@@ -40,7 +41,7 @@ def decide_needs_cpu_seq_lens(
         # FIXME: support TBO without seq lens cpu value
         return True
     algo = SpeculativeAlgorithm.from_string(get_spec().speculative_algorithm)
-    if algo.is_ngram():
+    if algo.is_ngram() or algo.is_hybrid():
         # ngram's USE_FULL_MASK verify path reads seq_lens_cpu per req to size
         # the tree mask, regardless of the attn backend (e.g. Triton opts out).
         return True
@@ -165,6 +166,14 @@ class RelayPayload:
             draft_probs=getattr(draft_input, "draft_probs", None),
             dsa_topk_indices=draft_input.dsa_topk_indices,
         )
+
+    @classmethod
+    def from_hybrid(cls, draft_input: HybridVerifyInput) -> RelayPayload:
+        eagle_payload = cls.from_draft_input(draft_input.eagle_draft_input)
+        ngram_payload = cls.from_ngram(draft_input.ngram_verify_input)
+        eagle_payload.accept_tokens = ngram_payload.accept_tokens
+        eagle_payload.accept_lens = ngram_payload.accept_lens
+        return eagle_payload
 
 
 class ConfidenceRelay(msgspec.Struct):
@@ -404,17 +413,29 @@ class FutureMap:
         )
 
     def _resolve_spec_extras(self, batch: ScheduleBatch) -> None:
-        if self.spec_algo.is_ngram():
+        if self.spec_algo.is_hybrid():
             draft_input = batch.spec_info
-            if draft_input is None or draft_input.future_indices is None:
+            if draft_input is None:
                 return
-            indices = draft_input.future_indices
-            if indices.shape[0] == 0:
-                return
-            draft_input.accept_tokens = self.accept_tokens_buf[indices].flatten()
-            draft_input.accept_lens = self.accept_lens_buf[indices]
+            self._resolve_ngram_input(draft_input.ngram_verify_input)
+            self._resolve_draft_input(draft_input.eagle_draft_input)
             return
-        draft_input: EagleDraftInput = batch.spec_info
+        if self.spec_algo.is_ngram():
+            self._resolve_ngram_input(batch.spec_info)
+            return
+
+        self._resolve_draft_input(batch.spec_info)
+
+    def _resolve_ngram_input(self, draft_input: NgramVerifyInput) -> None:
+        if draft_input is None or draft_input.future_indices is None:
+            return
+        indices = draft_input.future_indices
+        if indices.shape[0] == 0:
+            return
+        draft_input.accept_tokens = self.accept_tokens_buf[indices].flatten()
+        draft_input.accept_lens = self.accept_lens_buf[indices]
+
+    def _resolve_draft_input(self, draft_input: EagleDraftInput) -> None:
         if draft_input is None:
             # FIXME(lsyin): only prefill; not compatible with mixed mode
             return
@@ -598,11 +619,25 @@ class FutureMap:
         if indices.shape[0] == 0:
             # DP idle: payload is empty stub; lazy-init shape peek would IndexError.
             return
-        if self.spec_algo.is_ngram():
-            self._maybe_init_ngram_bufs(payload)
-            self.accept_tokens_buf[indices] = payload.accept_tokens
-            self.accept_lens_buf[indices] = payload.accept_lens
+        if self.spec_algo.is_hybrid():
+            self._stash_ngram(indices, payload)
+            self._stash_draft(indices, payload)
             return
+        if self.spec_algo.is_ngram():
+            self._stash_ngram(indices, payload)
+            return
+        self._stash_draft(indices, payload)
+
+    def _stash_ngram(self, indices: torch.Tensor, payload: RelayPayload) -> None:
+        self._maybe_init_ngram_bufs(payload)
+        self.accept_tokens_buf[indices] = payload.accept_tokens.to(
+            self.accept_tokens_buf.dtype
+        )
+        self.accept_lens_buf[indices] = payload.accept_lens.to(
+            self.accept_lens_buf.dtype
+        )
+
+    def _stash_draft(self, indices: torch.Tensor, payload: RelayPayload) -> None:
         self._maybe_init_forward_bufs(payload)
         self._maybe_init_dsa_topk_indices_buf(payload)
         self.output_tokens_buf[indices] = payload.bonus_tokens.to(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1020,13 +1020,17 @@ class Scheduler(
         DraftWorkerClass = self.spec_algorithm.create_worker(self.server_args)
         self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
 
-        if self.spec_algorithm.is_ngram():
+        if self.spec_algorithm.is_ngram() or self.spec_algorithm.is_hybrid():
             from sglang.srt.speculative.external_corpus_manager import (
                 ExternalCorpusManager,
             )
 
             self.external_corpus_manager = ExternalCorpusManager(
-                self.draft_worker,
+                (
+                    self.draft_worker.retrieval_worker
+                    if self.spec_algorithm.is_hybrid()
+                    else self.draft_worker
+                ),
                 self.ipc_channels.send_to_tokenizer.send_output,
             )
         else:
@@ -4337,6 +4341,11 @@ class Scheduler(
         batch_result: GenerationBatchResult,
     ) -> None:
         """Stash this iter's relay payload for next iter's resolve_forward_inputs."""
+        if self.spec_algorithm.is_hybrid():
+            if batch_result.next_draft_input is not None:
+                payload = RelayPayload.from_hybrid(batch_result.next_draft_input)
+                self.future_map.stash(future_indices, payload)
+            return
         if self.spec_algorithm.is_ngram():
             if batch_result.next_draft_input is not None:
                 payload = RelayPayload.from_ngram(batch_result.next_draft_input)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -742,9 +742,28 @@ class SchedulerBatchResultProcessor:
         # Feed the adaptive controller now that accept_lens is on CPU,
         # instead of doing a synchronous GPU→CPU copy in the worker hot path.
         # BaseSpecWorker provides a no-op default for non-adaptive workers.
-        self.model_worker.on_verify_complete_cpu(
-            result.num_correct_drafts_per_req_cpu, batch_size=len(batch.reqs)
-        )
+        # Only HybridController needs the producer route. Under overlap this
+        # callback is delayed by one iteration, so Hybrid results carry their
+        # route instead of reading the controller's current state. Leaf workers
+        # keep the route-free BaseSpecWorker protocol.
+        if result.spec_route is None:
+            self.model_worker.on_verify_complete_cpu(
+                result.num_correct_drafts_per_req_cpu,
+                batch_size=len(batch.reqs),
+            )
+        else:
+            self.model_worker.on_verify_complete_cpu(
+                result.num_correct_drafts_per_req_cpu,
+                batch_size=len(batch.reqs),
+                route=result.spec_route,
+            )
+
+        if hasattr(self.model_worker, "update_hybrid_stats"):
+            self.model_worker.update_hybrid_stats(
+                result.spec_route,
+                result,
+                batch.forward_mode.is_decode() and not batch.is_extend_in_batch,
+            )
 
         # Advance the grammar FSM over this batch's committed tokens (idempotent):
         # the EAGLE overlap path already did this inside verify() via the grammar
@@ -752,7 +771,6 @@ class SchedulerBatchResultProcessor:
         # grammar (the queued batch.copy() does not carry has_grammar) and consumes
         # result.grammar_retained_tokens below instead of re-advancing.
         self.advance_grammar_fsm(result, batch)
-
         predict_tokens = []
         for i, req in enumerate(batch.reqs):
             accept_tokens = next_token_ids[i * stride : i * stride + accept_lens[i]]
@@ -762,6 +780,7 @@ class SchedulerBatchResultProcessor:
                 # kv_committed_len already holds the committed prefix.
                 pass
             else:
+                previous_kv_committed_len = req.kv.kv_committed_len
                 if req.grammar is not None:
                     # FSM already advanced + truncated by advance_grammar_fsm; reuse
                     # the retained (grammar-legal) run instead of advancing again.
@@ -781,6 +800,18 @@ class SchedulerBatchResultProcessor:
                 if cap_lens is not None:
                     req.spec_num_cap_tokens += cap_lens[i]
                     req.update_spec_cap_lens_histogram(cap_lens[i])
+
+                if req.kv.kv_committed_len > req.kv.kv_allocated_len:
+                    raise RuntimeError(
+                        "Spec result committed beyond its KV reservation: "
+                        f"rid={req.rid}, batch_index={i}, route={result.spec_route}, "
+                        f"stride={stride}, accept_lens={accept_lens}, "
+                        f"previous_kv_committed_len={previous_kv_committed_len}, "
+                        f"kv_committed_len={req.kv.kv_committed_len}, "
+                        f"kv_allocated_len={req.kv.kv_allocated_len}, "
+                        f"req_rids={[item.rid for item in batch.reqs]}, "
+                        f"req_pool_indices={batch.req_pool_indices.cpu().tolist()}"
+                    )
 
             predict_tokens.append(accept_tokens)
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -599,7 +599,6 @@ class TpModelWorker(BaseTpWorker):
         skip_attn_backend_init: Optional[bool] = None,  # deprecated
         *,
         capture_hidden_mode: Optional[CaptureHiddenMode] = None,
-        skip_cuda_graph: bool = False,
     ) -> GenerationBatchResult:
         # Get forward batch from schedule batch
         if batch is not None:
@@ -621,15 +620,6 @@ class TpModelWorker(BaseTpWorker):
 
         # Deprecated kwarg: pre-planners mark the batch themselves now.
         forward_batch.apply_deprecated_skip_attn_backend_init(skip_attn_backend_init)
-        if skip_cuda_graph:
-            forward_batch.disable_cuda_graph = True
-        elif is_verify:
-            graph_runners = getattr(
-                self.model_runner, "hybrid_target_verify_graph_runners", None
-            )
-            source_width = getattr(forward_batch.spec_info, "draft_token_num", None)
-            if graph_runners is not None and source_width in graph_runners:
-                forward_batch.cuda_graph_runner = graph_runners[source_width]
 
         if self.is_dllm():
             return self._forward_batch_generation_dllm(forward_batch, batch)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -599,6 +599,7 @@ class TpModelWorker(BaseTpWorker):
         skip_attn_backend_init: Optional[bool] = None,  # deprecated
         *,
         capture_hidden_mode: Optional[CaptureHiddenMode] = None,
+        skip_cuda_graph: bool = False,
     ) -> GenerationBatchResult:
         # Get forward batch from schedule batch
         if batch is not None:
@@ -620,6 +621,15 @@ class TpModelWorker(BaseTpWorker):
 
         # Deprecated kwarg: pre-planners mark the batch themselves now.
         forward_batch.apply_deprecated_skip_attn_backend_init(skip_attn_backend_init)
+        if skip_cuda_graph:
+            forward_batch.disable_cuda_graph = True
+        elif is_verify:
+            graph_runners = getattr(
+                self.model_runner, "hybrid_target_verify_graph_runners", None
+            )
+            source_width = getattr(forward_batch.spec_info, "draft_token_num", None)
+            if graph_runners is not None and source_width in graph_runners:
+                forward_batch.cuda_graph_runner = graph_runners[source_width]
 
         if self.is_dllm():
             return self._forward_batch_generation_dllm(forward_batch, batch)

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -85,6 +85,13 @@ class GenerationBatchResult:
     grammar_advanced: bool = False
     grammar_retained_tokens: Optional[list] = None
 
+    # The route ("retrieval" / "neural") that actually produced this result.
+    # Only set by HybridController; every other worker leaves this None. The
+    # result travels with its own producer identity so a delayed, CPU-side
+    # consumer (e.g. HybridController.on_verify_complete_cpu under overlap)
+    # never misattributes it to whichever route is currently active.
+    spec_route: Optional[str] = None
+
     # FIXME(lsyin): maybe move to a better place?
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None

--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -810,16 +810,18 @@ def build_prefill_registry(
     enable_num_token_non_padded: bool = False,
     require_gathered_buffer: bool = False,
     enable_prefill_cp: bool = False,
-    register_input_embeds: bool = True,
+    register_input_embeds: Optional[bool] = None,
     share_pool: bool = True,
     source: Optional[Any] = None,
 ) -> CudaGraphBufferRegistry:
     """Registry mirroring the **token-axis** FB-shared buffers for the
     piecewise / breakable / full (prefill) cuda-graph runners.
 
-    ``register_input_embeds`` (default ``True``) registers the multimodal
-    ``input_embeds`` slot; the eager extend path passes ``False`` so it is
-    carried from the batch (a read input) rather than written in-graph.
+    ``register_input_embeds`` defaults to ``is_multimodal``. Callers may also
+    enable it for a text-only model that consumes externally composed
+    embeddings, such as an EAGLE draft model serving a multimodal target.
+    The eager extend path passes ``False`` so embeddings are carried from the
+    batch (a read input) rather than written in-graph.
 
     Padding policies match the inline copy/zero in
     ``PiecewiseCudaGraphRunner.load_batch``: ``input_ids`` / ``positions``
@@ -872,6 +874,9 @@ def build_prefill_registry(
             padding_policy=PaddingPolicy.ZERO,
         ),
     ]
+    if register_input_embeds is None:
+        register_input_embeds = is_multimodal
+
     if is_multimodal:
         slots.append(
             GraphSlot(
@@ -883,17 +888,17 @@ def build_prefill_registry(
                 slice_fn=lambda buf, n: buf[:, :n],
             )
         )
-        if register_input_embeds:
-            slots.append(
-                GraphSlot(
-                    "input_embeds",
-                    lambda _bs2, mt: (mt, hidden_size),
-                    embed_dtype,
-                    axis="tokens",
-                    padding_policy=PaddingPolicy.ZERO,
-                    copy_from_fb=False,
-                )
+    if register_input_embeds:
+        slots.append(
+            GraphSlot(
+                "input_embeds",
+                lambda _bs2, mt: (mt, hidden_size),
+                embed_dtype,
+                axis="tokens",
+                padding_policy=PaddingPolicy.ZERO,
+                copy_from_fb=False,
             )
+        )
     if enable_mamba_track:
         slots.append(GraphSlot("mamba_track_indices", _bs, torch.int64, axis="bs"))
         slots.append(GraphSlot("mamba_track_mask", _bs, torch.bool, axis="bs"))

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1758,10 +1758,14 @@ class ModelRunner:
                 if self.device == "cpu"
                 else forward_batch.forward_mode.is_cuda_graph
             )
+            cuda_graph_runner = getattr(
+                forward_batch, "cuda_graph_runner", self.decode_cuda_graph_runner
+            )
             can_run_graph = bool(
-                mode_check()
-                and self.decode_cuda_graph_runner
-                and self.decode_cuda_graph_runner.can_run_graph(forward_batch)
+                not getattr(forward_batch, "disable_cuda_graph", False)
+                and mode_check()
+                and cuda_graph_runner
+                and cuda_graph_runner.can_run_graph(forward_batch)
             )
 
             if (
@@ -1774,7 +1778,10 @@ class ModelRunner:
 
             # Replay cuda graph if applicable
             if can_run_graph:
-                ret = self.decode_cuda_graph_runner.execute(
+                cuda_graph_runner = getattr(
+                    forward_batch, "cuda_graph_runner", self.decode_cuda_graph_runner
+                )
+                ret = cuda_graph_runner.execute(
                     forward_batch,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -77,8 +78,22 @@ def _resolve_eagle_aux_hidden_state(
     spec_algorithm: SpeculativeAlgorithm,
     is_draft_worker: bool,
 ) -> None:
+    hybrid_neural_is_eagle3 = False
+    if spec_algorithm.is_hybrid():
+        try:
+            hybrid_config = json.loads(get_spec().speculative_hybrid_config)
+        except (TypeError, json.JSONDecodeError):
+            hybrid_config = {}
+        hybrid_neural_is_eagle3 = (
+            str(hybrid_config.get("neural", {}).get("algorithm", "")).upper()
+            == "EAGLE3"
+        )
     if (
-        (spec_algorithm.is_eagle() or spec_algorithm.is_standalone())
+        (
+            spec_algorithm.is_eagle()
+            or spec_algorithm.is_standalone()
+            or hybrid_neural_is_eagle3
+        )
         and not is_draft_worker
         and get_spec().speculative_draft_model_path
     ):
@@ -108,7 +123,7 @@ def _resolve_eagle_aux_hidden_state(
                 draft_model_config.swa_attention_layer_ids
             )
 
-        if spec_algorithm.is_eagle3():
+        if spec_algorithm.is_eagle3() or hybrid_neural_is_eagle3:
             config.eagle_use_aux_hidden_state = True
             try:
                 eagle_config = getattr(
@@ -120,7 +135,7 @@ def _resolve_eagle_aux_hidden_state(
                 config.eagle_aux_hidden_state_layer_ids = eagle_config[
                     "eagle_aux_hidden_state_layer_ids"
                 ]
-            except:
+            except (AttributeError, KeyError, TypeError):
                 # if there is no aux layer, set to None
                 config.eagle_aux_hidden_state_layer_ids = None
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1521,6 +1521,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if (
             self.model_runner.spec_algorithm.is_eagle()
             or self.model_runner.spec_algorithm.is_standalone()
+            or self.model_runner.spec_algorithm.is_hybrid()
         ):
             from sglang.srt.speculative.eagle_info import EagleVerifyInput
 

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -322,6 +322,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             and is_eagle
             and model_runner.is_draft_worker
         )
+        # The draft checkpoint is text-only, but a multimodal target supplies
+        # already-composed embeddings to it. BCG must capture that explicit-
+        # embedding path; otherwise replay bakes in embed_tokens(input_ids) and
+        # multimodal sentinel ids index outside the draft vocabulary.
+        self._use_draft_input_embeds = is_breakable_eagle_draft
         if is_breakable_eagle_draft:
             self.capture_hidden_mode = CaptureHiddenMode.LAST
         elif (is_eagle and not model_runner.is_draft_worker) or (
@@ -349,6 +354,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             hidden_size=input_embeds_hidden_size,
             dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
+            enable_input_embeds=(self.is_multimodal or self._use_draft_input_embeds),
             pp_size=self.pp_size,
             is_first_pp_rank=self.model_runner.pp_group.is_first_rank,
             hc_hidden_size=getattr(
@@ -382,6 +388,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             enable_prefill_cp=(
                 is_dsa_enable_prefill_cp() or is_mla_prefill_cp_enabled()
             ),
+            register_input_embeds=(self.is_multimodal or self._use_draft_input_embeds),
             source=self.buffers,
         )
 
@@ -1552,6 +1559,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             pp_proxy_tensors=kwargs.get("pp_proxy_tensors"),
         )
 
+        if self._use_draft_input_embeds:
+            # Keep one address-stable embedding input for the captured draft
+            # body. Multimodal requests provide target-composed embeddings;
+            # text requests compute the small embedding lookup eagerly while
+            # retaining the full transformer body in BCG.
+            draft_input_embeds = forward_batch.mm_input_embeds
+            if draft_input_embeds is None:
+                draft_input_embeds = self.layer_model.embed_tokens(
+                    forward_batch.input_ids
+                )
+            self.buffer_registry.get_slot("input_embeds").buffer[:num_tokens].copy_(
+                draft_input_embeds
+            )
+
         registry = self.buffer_registry
 
         def _slot(name):
@@ -1793,6 +1814,15 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             # MTP consumes the target model's live multimodal embeddings in its
             # eager wrapper before the captured transformer body is replayed.
             tail_batch.mm_input_embeds = forward_batch.mm_input_embeds
+        model_kwargs = kwargs
+        if self._use_draft_input_embeds:
+            # LlamaForCausalLM forwards this argument into the draft
+            # transformer. That selects the same explicit-embedding branch as
+            # capture instead of replaying the captured token lookup.
+            model_kwargs = {
+                **kwargs,
+                "input_embeds": static_forward_batch.input_embeds,
+            }
         try:
             with self._prefill_forward_context(
                 static_forward_batch,
@@ -1803,7 +1833,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     tail_batch.input_ids,
                     tail_batch.positions,
                     tail_batch,
-                    **kwargs,
+                    **model_kwargs,
                 )
         finally:
             self.layer_model.forward = original_layer_forward

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -378,6 +378,7 @@ class PrefillInputBuffers(ForwardInputBuffers):
         hidden_size: int,
         dtype: torch.dtype,
         enable_mamba_track: bool,
+        enable_input_embeds: Optional[bool] = None,
         pp_size: int = 1,
         is_first_pp_rank: bool = False,
         hc_hidden_size: Optional[int] = None,
@@ -403,11 +404,17 @@ class PrefillInputBuffers(ForwardInputBuffers):
             )
             positions = torch.zeros((max_num_tokens,), dtype=torch.int64)
 
-            if is_multimodal:
+            if enable_input_embeds is None:
+                enable_input_embeds = is_multimodal
+
+            if enable_input_embeds:
                 input_embeds = torch.zeros((max_num_tokens, hidden_size), dtype=dtype)
-                mrope_positions = torch.zeros((3, max_num_tokens), dtype=torch.int64)
             else:
                 input_embeds = None
+
+            if is_multimodal:
+                mrope_positions = torch.zeros((3, max_num_tokens), dtype=torch.int64)
+            else:
                 mrope_positions = None
 
             pp_proxy_tensors = (

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1659,6 +1659,11 @@ class Qwen3_5ForCausalLM(nn.Module):
         for layer_id in self.layers_to_capture:
             setattr(self.layers[layer_id], "_is_layer_to_capture", True)
 
+    def set_eagle3_layers_to_capture(self, layers_to_capture: list[int]):
+        self.layers_to_capture = layers_to_capture
+        for layer_id in self.layers_to_capture:
+            setattr(self.layers[layer_id], "_is_layer_to_capture", True)
+
     @property
     def start_layer(self) -> int:
         return self._start_layer

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1630,17 +1630,24 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        if not self.pp_group.is_last_rank:
+            return
         self.capture_aux_hidden_states = True
         self.model.capture_aux_hidden_states = True
         if layer_ids is None:
             num_layers = self.config.num_hidden_layers
-            self.model.layers_to_capture = [
+            layers_to_capture = [
                 2,
                 num_layers // 2,
                 num_layers - 3,
-            ]  # Specific layers for EAGLE3 support
+            ]
         else:
-            self.model.layers_to_capture = [val + 1 for val in layer_ids]
+            layers_to_capture = [val + 1 for val in layer_ids]
+
+        if hasattr(self.model, "set_eagle3_layers_to_capture"):
+            self.model.set_eagle3_layers_to_capture(layers_to_capture)
+        else:
+            self.model.layers_to_capture = layers_to_capture
 
 
 def _require_vision(model) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2067,12 +2067,7 @@ class ServerArgs:
     # -------------------------------------------------------------------------
     speculative_algorithm: A[
         Optional[str],
-        "Speculative algorithm. Builtins: EAGLE, EAGLE3, NEXTN, STANDALONE, NGRAM, DFLASH, DSPARK, UNO. Or any name registered via `SpeculativeAlgorithm.register`.",
-        NS("spec"),
-    ] = None
-    uno_lora_path: A[
-        Optional[str],
-        "Path to the UNO draft LoRA checkpoint.",
+        "Speculative algorithm. Builtins: EAGLE, EAGLE3, NEXTN, STANDALONE, NGRAM, HYBRID, DFLASH, DSPARK, UNO. HYBRID routes each batch between EAGLE and NGRAM. Or any name registered via `SpeculativeAlgorithm.register`.",
         NS("spec"),
     ] = None
     speculative_draft_model_path: A[
@@ -2278,6 +2273,11 @@ class ServerArgs:
     speculative_adaptive_config: A[
         Optional[str],
         "Path to a JSON config file for adaptive speculative decoding tuning knobs.",
+        NS("spec"),
+    ] = None
+    speculative_hybrid_config: A[
+        Optional[str],
+        "HYBRID only. JSON object declaring retrieval and neural workers. Each role contains algorithm plus ServerArgs overrides directly; required min_continuation_ratio gates retrieval quality per request and min_matching_ratio sets the fraction of qualifying requests needed to route a batch to retrieval.",
         NS("spec"),
     ] = None
 

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Mapping, Protocol
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -91,6 +91,11 @@ class AdaptiveController:
     @property
     def candidate_steps(self) -> list[int]:
         return self.params.candidate_steps
+
+    @property
+    def states(self) -> Mapping[int, SpecRuntimeState]:
+        """All initialized states, exposed read-only to an outer controller."""
+        return self._states
 
     def register(self, state: SpecRuntimeState, steps: int | None = None) -> None:
         """Register a pre-built runtime state.

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -53,19 +53,25 @@ DEFAULT_ADAPTIVE_CONFIG: dict[str, dict] = {
 
 def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     """Return why adaptive spec cannot run under the given server args, or None if supported."""
-
     cfg = resolving_view(server_args)
+    algorithm = cfg.speculative_algorithm
+    topk = cfg.speculative_eagle_topk
+    if algorithm == "HYBRID":
+        try:
+            hybrid_config = json.loads(cfg.speculative_hybrid_config)
+        except (TypeError, json.JSONDecodeError):
+            return "the HYBRID config is not a valid JSON object"
+        neural_config = hybrid_config.get("neural", {})
+        algorithm = str(neural_config.get("algorithm", "")).upper()
+        topk = neural_config.get("speculative_eagle_topk", topk)
 
-    if cfg.speculative_algorithm not in ("EAGLE", "EAGLE3"):
+    if algorithm not in ("EAGLE", "EAGLE3"):
         return (
-            f"speculative_algorithm={cfg.speculative_algorithm} "
+            f"neural speculative_algorithm={algorithm} "
             "(only EAGLE/EAGLE3 are supported)"
         )
-    if cfg.speculative_eagle_topk is not None and cfg.speculative_eagle_topk != 1:
-        return (
-            f"speculative_eagle_topk={cfg.speculative_eagle_topk} "
-            "(only topk=1 is supported)"
-        )
+    if topk is not None and topk != 1:
+        return f"speculative_eagle_topk={topk} (only topk=1 is supported)"
     if resolved_view(server_args).enable_dp_attention:
         return (
             "enable_dp_attention=True is not supported "

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -116,6 +116,10 @@ class EagleDraftWorkerBase(ABC):
         self.draft_worker.init_cuda_graphs(capture_decode_cuda_graph=False)
         self._capture_cuda_graphs()
 
+    def init_hybrid_draft_extend_widths(self, widths: tuple[int, ...]) -> None:
+        """Pre-initialize draft-extend resources needed for Hybrid source widths."""
+        return None
+
     def _rebuild_topk1_chain_buffers(self) -> None:
         # For topk=1 the draft tree degenerates to a chain, so parent_list and
         # top_scores_index are runtime-invariant. Must be rebuilt after any
@@ -328,7 +332,9 @@ class BaseSpecWorker(ABC):
         return True, "Succeeded to update model weights."
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
     ) -> None:
         """Hook called after verify finishes and accept counts are on CPU.
 
@@ -352,3 +358,33 @@ class BaseSpecWorker(ABC):
         the runtime state before each draft round.
         """
         pass
+
+    def get_retrieval_info(self, batch) -> tuple[list[int], list[int]]:
+        """Prepare retrieval drafts and return real per-request suffix continuations.
+
+        The worker owns the algorithm-specific corpus lookup. If the controller
+        selects retrieval for this batch, its subsequent forward must reuse the
+        prepared drafts rather than repeat the lookup. Returns a
+        ``(continuation_lengths, match_lens)`` pair: ``continuation_lengths`` is
+        the per-request non-padding draft length, and ``match_lens`` is the
+        per-request longest expandable corpus suffix-match depth backing that
+        draft.
+        """
+        raise NotImplementedError
+
+    def update_runtime_state_from_hybrid(
+        self,
+        batch,
+        batch_result,
+        bonus_tokens: torch.Tensor | None = None,
+        source_draft_token_num: int | None = None,
+    ) -> None:
+        """Update local runtime state after another Hybrid worker executed a batch.
+
+        ``bonus_tokens`` lets neural draft workers update draft KV and hidden
+        states after retrieval verify. Retrieval workers consume the accept path
+        in ``batch_result`` to update corpus and match-trie state; on extend
+        they index the prompt prefix visible in this batch. Implementations must
+        not execute a second target forward.
+        """
+        raise NotImplementedError

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -332,9 +332,7 @@ class BaseSpecWorker(ABC):
         return True, "Succeeded to update model weights."
 
     def on_verify_complete_cpu(
-        self,
-        num_correct_drafts_per_req: list[int],
-        batch_size: int = 0,
+        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
     ) -> None:
         """Hook called after verify finishes and accept counts are on CPU.
 

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -102,7 +102,7 @@ class NgramCorpus:
         req_ids: List[str],
         batch_tokens: List[List[int]],
         total_lens: List[int],
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         state_ids = [self._get_state_id(rid) for rid in req_ids]
         return self._obj.match_stateful(state_ids, batch_tokens, total_lens)
 
@@ -191,10 +191,11 @@ if __name__ == "__main__":
 
     corpus.synchronize()
     queries = [[1, 2, 3], [3, 44], [3, 6, 999]]
-    decoding_ids, decoding_masks = corpus.batch_get(
+    decoding_ids, decoding_masks, decoding_match_lens = corpus.batch_get(
         req_ids=[f"query-{i}" for i in range(len(queries))],
         batch_tokens=queries,
         total_lens=[len(q) for q in queries],
     )
 
     corpus.debug_result(decoding_ids, decoding_masks)
+    logger.info(f"match_lens: {decoding_match_lens.tolist()}")

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -89,6 +89,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         *,
         draft_extend_attn_backend=None,
         speculative_num_steps: Optional[int] = None,
+        num_tokens_per_bs: Optional[int] = None,
     ):
         # Parse args
         self.eagle_worker = eagle_worker
@@ -115,6 +116,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             if speculative_num_steps is None
             else speculative_num_steps
         )
+        self.num_tokens_per_bs_override = num_tokens_per_bs
         self.draft_extend_attn_backend = (
             draft_extend_attn_backend or eagle_worker.draft_extend_attn_backend
         )
@@ -131,11 +133,16 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         self.capture_forward_mode = self.forward_mode
         self.capture_hidden_mode = CaptureHiddenMode.LAST
 
-        self.capture_bs, _ = get_batch_sizes_to_capture(model_runner)
-
         # Static capture width: full tree width (num_draft_tokens), not
         # num_steps + 1 -- topk > 1 draft-extend overflows the buffers.
-        self.captured_req_width = resolve_num_tokens_per_req(phase="draft_extend")
+        self.captured_req_width = (
+            resolve_num_tokens_per_req(phase="draft_extend")
+            if self.num_tokens_per_bs_override is None
+            else self.num_tokens_per_bs_override
+        )
+        self.capture_bs, _ = get_batch_sizes_to_capture(
+            model_runner, self.captured_req_width
+        )
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.captured_req_width
 

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -507,6 +507,23 @@ def get_draft_recurrent_hidden_state_spec(
     )
 
 
+def get_target_verify_attn_backend(target_worker: TpModelWorker, draft_token_num: int):
+    """Return the attention backend paired with a Hybrid verify width.
+
+    Hybrid owns one target-verify CUDA graph per draft width. Tree-mask
+    preparation and post-draft metadata updates must use the backend captured
+    with that graph; otherwise they write one static buffer and replay another.
+    """
+    graph_runners = getattr(
+        target_worker.model_runner, "hybrid_target_verify_graph_runners", None
+    )
+    if graph_runners is not None:
+        graph_runner = graph_runners.get(draft_token_num)
+        if graph_runner is not None:
+            return graph_runner.attn_backend
+    return target_worker.model_runner.attn_backend
+
+
 def eagle_prepare_for_verify(
     verify_input: EagleVerifyInput,
     req_to_token_pool: ReqToTokenPool,
@@ -574,18 +591,24 @@ def eagle_prepare_for_verify(
         return_hidden_states_before_norm=False,
     )
 
-    # Run attention backend plan and cuda graph preparation
+    # Hybrid captures one target-verify graph per configured source width.
+    # The runners reuse physical buffers sized to the widest route while their
+    # attention metadata and replay graph remain shape-specific.
+    target_graph_runners = getattr(
+        target_worker.model_runner, "hybrid_target_verify_graph_runners", None
+    )
+    cuda_graph_runner = (
+        target_graph_runners.get(verify_input.draft_token_num)
+        if target_graph_runners is not None
+        else target_worker.model_runner.decode_cuda_graph_runner
+    )
     can_run_cuda_graph = bool(
-        target_worker.model_runner.decode_cuda_graph_runner
-        and target_worker.model_runner.decode_cuda_graph_runner.can_run_graph(
-            verify_forward_batch
-        )
+        cuda_graph_runner and cuda_graph_runner.can_run_graph(verify_forward_batch)
     )
     if can_run_cuda_graph:
-        target_worker.model_runner.decode_cuda_graph_runner.load_batch(
-            verify_forward_batch
-        )
+        cuda_graph_runner.load_batch(verify_forward_batch)
         verify_forward_batch.mark_forward_metadata_ready()
+        verify_forward_batch.cuda_graph_runner = cuda_graph_runner
     # Non-cuda-graph: defer init to forward_extend, which runs after
     # `_forward_raw -> prepare_mlp_sync_batch` pads the batch. Initing
     # here would use pre-pad shapes and trip DSv4 indexer shape match.

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -507,23 +507,6 @@ def get_draft_recurrent_hidden_state_spec(
     )
 
 
-def get_target_verify_attn_backend(target_worker: TpModelWorker, draft_token_num: int):
-    """Return the attention backend paired with a Hybrid verify width.
-
-    Hybrid owns one target-verify CUDA graph per draft width. Tree-mask
-    preparation and post-draft metadata updates must use the backend captured
-    with that graph; otherwise they write one static buffer and replay another.
-    """
-    graph_runners = getattr(
-        target_worker.model_runner, "hybrid_target_verify_graph_runners", None
-    )
-    if graph_runners is not None:
-        graph_runner = graph_runners.get(draft_token_num)
-        if graph_runner is not None:
-            return graph_runner.attn_backend
-    return target_worker.model_runner.attn_backend
-
-
 def eagle_prepare_for_verify(
     verify_input: EagleVerifyInput,
     req_to_token_pool: ReqToTokenPool,
@@ -591,17 +574,9 @@ def eagle_prepare_for_verify(
         return_hidden_states_before_norm=False,
     )
 
-    # Hybrid captures one target-verify graph per configured source width.
-    # The runners reuse physical buffers sized to the widest route while their
-    # attention metadata and replay graph remain shape-specific.
-    target_graph_runners = getattr(
-        target_worker.model_runner, "hybrid_target_verify_graph_runners", None
-    )
-    cuda_graph_runner = (
-        target_graph_runners.get(verify_input.draft_token_num)
-        if target_graph_runners is not None
-        else target_worker.model_runner.decode_cuda_graph_runner
-    )
+    # The active speculative runtime state installs its verify graph before
+    # this preparation step, following the adaptive runtime-state contract.
+    cuda_graph_runner = target_worker.model_runner.decode_cuda_graph_runner
     can_run_cuda_graph = bool(
         cuda_graph_runner and cuda_graph_runner.can_run_graph(verify_forward_batch)
     )
@@ -996,8 +971,6 @@ def eagle_sample(
 
 def eagle_prepare_for_decode(batch: ScheduleBatch):
     batch.maybe_evict_swa()
-
-    bs = batch.batch_size()
 
     # Accumulate penalty
     # This is a relaxed version of penalties for speculative decoding.

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -21,6 +21,7 @@ from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     eagle_prepare_for_verify,
     eagle_sample,
+    get_target_verify_attn_backend,
 )
 from sglang.srt.speculative.spec_utils import (
     GrammarTree,
@@ -345,7 +346,9 @@ def build_eagle_verify_input(
     # Write straight into the backend's buffer when it owns one and this batch
     # fits; an eager batch past the captured max_bs falls back to allocating.
     bs = batch.seq_lens.shape[0]
-    target_attn_backend = target_worker.model_runner.attn_backend
+    target_attn_backend = get_target_verify_attn_backend(
+        target_worker, num_draft_tokens
+    )
     verify_mask = target_attn_backend.verify_mask
     if verify_mask is None:
         tree_mask_buf, mask_mode, fill_mask = None, tree_mask_mode, True
@@ -524,13 +527,17 @@ def run_eagle_verify(
         # Some values such as custom_mask and position depend on the output of draft,
         # so the previous plan step used the wrong values. Here, we need to run the related
         # computation again to update them to the correct values.
-        target_worker.model_runner.attn_backend.update_verify_buffers_to_fill_after_draft(
+        target_attn_backend = get_target_verify_attn_backend(
+            target_worker, verify_input.draft_token_num
+        )
+        cuda_graph_runner = getattr(
+            verify_forward_batch,
+            "cuda_graph_runner",
+            target_worker.model_runner.decode_cuda_graph_runner,
+        )
+        target_attn_backend.update_verify_buffers_to_fill_after_draft(
             verify_input,
-            (
-                target_worker.model_runner.decode_cuda_graph_runner.bs
-                if can_run_cuda_graph
-                else None
-            ),
+            (cuda_graph_runner.bs if can_run_cuda_graph else None),
         )
 
     # Must stay ahead of the target verify launch below.

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -21,7 +21,6 @@ from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     eagle_prepare_for_verify,
     eagle_sample,
-    get_target_verify_attn_backend,
 )
 from sglang.srt.speculative.spec_utils import (
     GrammarTree,
@@ -346,9 +345,7 @@ def build_eagle_verify_input(
     # Write straight into the backend's buffer when it owns one and this batch
     # fits; an eager batch past the captured max_bs falls back to allocating.
     bs = batch.seq_lens.shape[0]
-    target_attn_backend = get_target_verify_attn_backend(
-        target_worker, num_draft_tokens
-    )
+    target_attn_backend = target_worker.model_runner.attn_backend
     verify_mask = target_attn_backend.verify_mask
     if verify_mask is None:
         tree_mask_buf, mask_mode, fill_mask = None, tree_mask_mode, True
@@ -527,9 +524,7 @@ def run_eagle_verify(
         # Some values such as custom_mask and position depend on the output of draft,
         # so the previous plan step used the wrong values. Here, we need to run the related
         # computation again to update them to the correct values.
-        target_attn_backend = get_target_verify_attn_backend(
-            target_worker, verify_input.draft_token_num
-        )
+        target_attn_backend = target_worker.model_runner.attn_backend
         cuda_graph_runner = getattr(
             verify_forward_batch,
             "cuda_graph_runner",

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1293,7 +1293,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
-            return batch_output
+                return batch_output
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1473,9 +1473,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self,
-        num_correct_drafts_per_req: list[int],
-        batch_size: int = 0,
+        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
     ) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import time
 from dataclasses import replace
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import torch
 
@@ -128,6 +128,22 @@ _is_xpu = is_xpu()
 
 
 logger = logging.getLogger(__name__)
+
+
+def _shift_mm_input_embeds_for_draft_prefill(
+    mm_input_embeds: torch.Tensor, extend_lens: List[int]
+) -> torch.Tensor:
+    """Shift target embeddings per request to match EAGLE draft input IDs."""
+    shifted_embeds = torch.empty_like(mm_input_embeds)
+    pt = 0
+    for extend_len in extend_lens:
+        request_embeds = mm_input_embeds[pt : pt + extend_len]
+        shifted_embeds[pt : pt + extend_len].copy_(
+            torch.cat((request_embeds[1:], request_embeds[-1:]))
+        )
+        pt += extend_len
+    assert pt == mm_input_embeds.shape[0]
+    return shifted_embeds
 
 
 class EagleDraftWorker(EagleDraftWorkerBase):
@@ -512,6 +528,28 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 f"avail mem={after_mem:.2f} GB.",
             )
 
+    def build_draft_extend_runtime_resource(
+        self,
+        num_tokens_per_bs: int,
+    ) -> tuple[Any, Any]:
+        """Build one shape-bound extend backend/graph for a controller."""
+        backend = DraftBackendFactory(
+            self.draft_runner,
+            self.topk,
+            self.speculative_num_steps,
+            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+        ).create_draft_extend_backend()
+        primary_graph_runner = self.cuda_graph_runner_for_draft_extend
+        if backend is None or primary_graph_runner is None:
+            return backend, None
+
+        graph_runner_cls = type(primary_graph_runner)
+        kwargs = {
+            "draft_extend_attn_backend": backend,
+            "num_tokens_per_bs": num_tokens_per_bs,
+        }
+        return backend, graph_runner_cls(self, **kwargs)
+
     def draft(self, batch: ScheduleBatch):
         draft_input: EagleDraftInput = batch.spec_info
         forward_batch, can_run_decode_cuda_graph = prepare_for_draft(
@@ -811,6 +849,10 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 pt += extend_len
             assert pt == batch.input_ids.numel()
             batch.input_ids = new_input_ids
+            if mm_input_embeds is not None:
+                mm_input_embeds = _shift_mm_input_embeds_for_draft_prefill(
+                    mm_input_embeds, batch.extend_lens
+                )
 
         # Draft-extend spec_info for the extend forward; carries only
         # hidden_states + shape info.
@@ -910,26 +952,32 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         return buf[:num_tokens]
 
     def _draft_extend_for_decode(
-        self, batch: ScheduleBatch, batch_result: GenerationBatchResult
+        self,
+        batch: ScheduleBatch,
+        batch_result: GenerationBatchResult,
+        source_draft_token_num: Optional[int] = None,
     ):
+        # The source verify tree defines the layout of hidden states and accept
+        # paths. It is not necessarily this EAGLE worker's next draft width.
+        source_draft_token_num = (
+            self.speculative_num_draft_tokens
+            if source_draft_token_num is None
+            else source_draft_token_num
+        )
+        cuda_graph_runner = self.cuda_graph_runner_for_draft_extend
+        draft_extend_attn_backend = self.draft_extend_attn_backend
         # Batch 2: Draft extend
         draft_extend_input = EagleDraftExtendInput(
             hidden_states=batch_result.logits_output.hidden_states,
             # accept_lens includes the bonus token; correct drafts exclude it.
             num_correct_drafts=batch_result.accept_lens - 1,
             num_accept_tokens=batch_result.accept_lens,
-            # Draft-extend fills the whole tree width (num_draft_tokens) per req,
-            # not num_steps + 1, so DP MLP-sync padding stays consistent for topk > 1.
-            num_tokens_per_req=self.speculative_num_draft_tokens,
-            num_tokens_for_logprob_per_req=self.speculative_num_draft_tokens,
+            num_tokens_per_req=source_draft_token_num,
+            num_tokens_for_logprob_per_req=source_draft_token_num,
         )
         select_index = (
-            torch.arange(
-                0,
-                len(batch.seq_lens) * self.speculative_num_draft_tokens,
-                self.speculative_num_draft_tokens,
-                device=self.device,
-            )
+            torch.arange(len(batch.seq_lens), device=self.device)
+            * source_draft_token_num
             + batch_result.accept_lens
             - 1
         )
@@ -938,56 +986,64 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         # synchronization issues with .to() inside the plan stream context.
         next_token_ids = batch_result.next_token_ids.to(torch.int64)
 
-        # Prepare for draft extend in a separate stream
-        with self.plan_stream_ctx:
-            forward_batch = prepare_for_draft_extend(
-                draft_extend_input,
-                batch,
-                next_token_ids,
-                self.speculative_num_draft_tokens,
-                self.draft_runner,
-                self.cuda_graph_runner_for_draft_extend,
-                return_hidden_states_before_norm=False,
-            )
+        # The eager forward builds metadata from the active runner backend;
+        # switch to the resource whose width matches the source verify tree.
+        previous_attn_backend = self.draft_runner.attn_backend
+        if draft_extend_attn_backend is not None:
+            self.draft_runner.attn_backend = draft_extend_attn_backend
 
-        if self.plan_stream:
-            torch.get_device_module(self.device).current_stream().wait_stream(
-                self.plan_stream
-            )
-
-        # Run draft extend batch in the main compute stream
-        can_run_decode_cuda_graph = (
-            self.cuda_graph_runner_for_draft_extend
-            and self.cuda_graph_runner_for_draft_extend.can_run_graph(forward_batch)
-        )
-
-        # Eager path publishes the indexer top-k into a worker buffer (the graph
-        # path uses the runner's static buffer). Gathered at select_index below.
-        if self.seed_dsa_topk_from_draft_extend and not can_run_decode_cuda_graph:
-            forward_batch.spec_info.dsa_seed_topk_capture = (
-                self._get_dsa_extend_topk_buf(forward_batch.input_ids.shape[0])
-            )
-
-        canary_ctx = (
-            context_tuple(
-                c.with_ops_outside_graph(
-                    single_forward_indices=[0],
-                    maybe_inaccurate_forward_batch=forward_batch,
-                ),
-                c.with_active_single_forward_manager(0),
-            )
-            if (c := self.draft_runner.canary_manager) is not None
-            else contextlib.nullcontext()
-        )
-        with canary_ctx:
-            if can_run_decode_cuda_graph:
-                draft_logits_output = self.cuda_graph_runner_for_draft_extend.execute(
-                    forward_batch, select_index
+        try:
+            # Prepare for draft extend in a separate stream
+            with self.plan_stream_ctx:
+                forward_batch = prepare_for_draft_extend(
+                    draft_extend_input,
+                    batch,
+                    next_token_ids,
+                    source_draft_token_num,
+                    self.draft_runner,
+                    cuda_graph_runner,
+                    return_hidden_states_before_norm=False,
                 )
-            else:
-                draft_logits_output = self.draft_runner.forward(
-                    forward_batch
-                ).logits_output
+
+            if self.plan_stream:
+                torch.get_device_module(self.device).current_stream().wait_stream(
+                    self.plan_stream
+                )
+
+            # Run draft extend batch in the main compute stream
+            can_run_decode_cuda_graph = bool(
+                cuda_graph_runner and cuda_graph_runner.can_run_graph(forward_batch)
+            )
+
+            # Eager path publishes the indexer top-k into a worker buffer (the
+            # graph path uses the selected runner's static buffer).
+            if self.seed_dsa_topk_from_draft_extend and not can_run_decode_cuda_graph:
+                forward_batch.spec_info.dsa_seed_topk_capture = (
+                    self._get_dsa_extend_topk_buf(forward_batch.input_ids.shape[0])
+                )
+
+            canary_ctx = (
+                context_tuple(
+                    c.with_ops_outside_graph(
+                        single_forward_indices=[0],
+                        maybe_inaccurate_forward_batch=forward_batch,
+                    ),
+                    c.with_active_single_forward_manager(0),
+                )
+                if (c := self.draft_runner.canary_manager) is not None
+                else contextlib.nullcontext()
+            )
+            with canary_ctx:
+                if can_run_decode_cuda_graph:
+                    draft_logits_output = cuda_graph_runner.execute(
+                        forward_batch, select_index
+                    )
+                else:
+                    draft_logits_output = self.draft_runner.forward(
+                        forward_batch
+                    ).logits_output
+        finally:
+            self.draft_runner.attn_backend = previous_attn_backend
 
         maybe_detect_nan(
             draft_logits_output.next_token_logits,
@@ -1003,7 +1059,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         dsa_seed_topk_indices = None
         if self.seed_dsa_topk_from_draft_extend:
             if can_run_decode_cuda_graph:
-                dsa_extend_topk_capture = self.cuda_graph_runner_for_draft_extend.buffers.dsa_seed_topk_capture
+                dsa_extend_topk_capture = (
+                    cuda_graph_runner.buffers.dsa_seed_topk_capture
+                )
             else:
                 dsa_extend_topk_capture = forward_batch.spec_info.dsa_seed_topk_capture
             # Fancy indexing returns a fresh tensor (detached from the buffer).
@@ -1068,6 +1126,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ps: ParallelState,
         nccl_port: int,
         target_worker: TpModelWorker,
+        spec_stage_span_prefix: str = "",
     ):
         super().__init__()
 
@@ -1084,6 +1143,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             get_spec().speculative_algorithm
         )
+        self.spec_stage_span_prefix = spec_stage_span_prefix
 
         # Only the last PP stage runs the draft; other EAGLEWorkerV2 instances
         # return proxies so scheduler dispatch remains rank-uniform.
@@ -1102,6 +1162,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # Adaptive speculative
         self.adaptive_controller: Optional[AdaptiveController] = None
+        self._active_runtime_state: Optional[SpecRuntimeState] = None
         if get_spec().speculative_adaptive and self._hosts_draft:
             self.adaptive_controller = AdaptiveController(
                 self,
@@ -1136,6 +1197,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
             or self._draft_worker.draft_runner.attn_backend,
         )
 
+    def alloc_memory_pool(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ):
+        self._draft_worker.alloc_memory_pool(
+            memory_pool_config, req_to_token_pool, token_to_kv_pool_allocator
+        )
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+
+    def init_attention_backends(self):
+        self._draft_worker.init_attention_backends()
+
     def init_cuda_graphs(self):
         super().init_cuda_graphs()
         # Build adaptive runtime states after target and draft backends exist.
@@ -1147,18 +1223,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
             ):
-                self.adaptive_controller.register(
-                    SpecRuntimeState(
-                        speculative_num_steps=self.speculative_num_steps,
-                        speculative_num_draft_tokens=self.speculative_num_draft_tokens,
-                        draft_attn_backend=self._draft_worker.draft_attn_backend,
-                        cuda_graph_runner=self._draft_worker.cuda_graph_runner,
-                        target_attn_backend=self._target_worker.model_runner.attn_backend,
-                        target_graph_runner=self._target_worker.model_runner.decode_cuda_graph_runner,
-                        draft_extend_attn_backend=self._draft_worker.draft_extend_attn_backend,
-                        cuda_graph_runner_for_draft_extend=self._draft_worker.cuda_graph_runner_for_draft_extend,
+                if not getattr(self.server_args, "_hybrid_managed_runtime", False):
+                    self.adaptive_controller.register(
+                        SpecRuntimeState(
+                            speculative_num_steps=self.speculative_num_steps,
+                            speculative_num_draft_tokens=self.speculative_num_draft_tokens,
+                            draft_attn_backend=self._draft_worker.draft_attn_backend,
+                            cuda_graph_runner=self._draft_worker.cuda_graph_runner,
+                            target_attn_backend=self._target_worker.model_runner.attn_backend,
+                            target_graph_runner=self._target_worker.model_runner.decode_cuda_graph_runner,
+                            draft_extend_attn_backend=self._draft_worker.draft_extend_attn_backend,
+                            cuda_graph_runner_for_draft_extend=self._draft_worker.cuda_graph_runner_for_draft_extend,
+                        )
                     )
-                )
                 self.adaptive_controller.init_states(
                     cuda_graph_bs=(
                         None
@@ -1206,7 +1283,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 ),
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
-                spec_stage_span("draft_extend"),
+                spec_stage_span(self.spec_stage_span_prefix + "_draft_extend_prefill"),
             ):
                 batch_output.next_draft_input = (
                     self.draft_worker._draft_extend_for_prefill(
@@ -1216,7 +1293,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
-                return batch_output
+            return batch_output
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1248,12 +1325,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     ),
                     speculative_moe_backend_context(),
                     speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft"),
+                    spec_stage_span(self.spec_stage_span_prefix + "_draft"),
                 ):
                     verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
-            batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
+            with spec_stage_span(self.spec_stage_span_prefix + "_verify"):
+                batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
             # Publish before draft_extend so the fence is at verify-end.
             if on_publish is not None:
                 on_publish(batch_output.new_seq_lens)
@@ -1269,11 +1347,45 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     ),
                     speculative_moe_backend_context(),
                     speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft_extend"),
+                    spec_stage_span(
+                        self.spec_stage_span_prefix + "_draft_extend_decode"
+                    ),
                 ):
                     self.draft_worker._draft_extend_for_decode(batch, batch_output)
 
             return batch_output
+
+    def sync_hybrid_state(
+        self,
+        batch: ScheduleBatch,
+        batch_result,
+    ) -> EagleDraftInput:
+        """Advance EAGLE state after a retrieval verify and return its native input."""
+        with spec_stage_span(
+            self.spec_stage_span_prefix + "_draft_extend_decode_retrieval"
+        ):
+            source_draft_token_num = batch_result.speculative_num_draft_tokens
+            accept_tokens = batch_result.next_draft_input.accept_tokens.view(
+                len(batch.reqs), source_draft_token_num
+            )
+            bonus_indices = (batch_result.accept_lens - 1).to(torch.long).unsqueeze(1)
+            bonus_tokens = accept_tokens.gather(1, bonus_indices).squeeze(1)
+
+            batch_result.next_draft_input = EagleDraftInput(
+                bonus_tokens=bonus_tokens,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+            )
+            with (
+                self.draft_worker.draft_tp_context(
+                    self.draft_worker.draft_runner.tp_group
+                ),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+            ):
+                self.draft_worker._draft_extend_for_decode(
+                    batch, batch_result, source_draft_token_num=source_draft_token_num
+                )
+            return batch_result.next_draft_input
 
     def _build_trivial_verify_input(self, batch: ScheduleBatch) -> EagleVerifyInput:
         """Build a 1-node EagleVerifyInput rooted at the previous bonus token.
@@ -1361,7 +1473,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
     ) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(
@@ -1371,6 +1485,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def activate_step_by_batch(self, batch_size: int) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.activate_step_by_batch(batch_size)
+
+    @property
+    def adaptive_runtime_states(self):
+        if self.adaptive_controller is None:
+            return {}
+        return self.adaptive_controller.states
 
     # -- Adaptive speculative decoding protocol --
 
@@ -1454,16 +1574,17 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
     def apply_runtime_state(self, state: SpecRuntimeState) -> None:
         """Apply a pre-built runtime state to this worker."""
-        if self.speculative_num_steps == state.speculative_num_steps:
+        if getattr(self, "_active_runtime_state", None) is state:
             return
 
-        log_info_on_rank0(
-            logger,
-            "Switch adaptive runtime state: "
-            f"steps {self.speculative_num_steps} -> {state.speculative_num_steps}, "
-            f"draft_tokens {self.speculative_num_draft_tokens} -> "
-            f"{state.speculative_num_draft_tokens}",
-        )
+        if self.speculative_num_steps != state.speculative_num_steps:
+            log_info_on_rank0(
+                logger,
+                "Switch adaptive runtime state: "
+                f"steps {self.speculative_num_steps} -> {state.speculative_num_steps}, "
+                f"draft_tokens {self.speculative_num_draft_tokens} -> "
+                f"{state.speculative_num_draft_tokens}",
+            )
 
         # Top-level
         self.speculative_num_steps = state.speculative_num_steps
@@ -1498,6 +1619,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             speculative_num_steps=state.speculative_num_steps,
             speculative_num_draft_tokens=state.speculative_num_draft_tokens,
         )
+        self._active_runtime_state = state
 
     @contextlib.contextmanager
     def _override_worker_state(

--- a/python/sglang/srt/speculative/hybrid_controller.py
+++ b/python/sglang/srt/speculative/hybrid_controller.py
@@ -491,8 +491,6 @@ class HybridController(BaseSpecWorker):
             graph_runners[width] = target_graph_runner
             attn_backends[width] = target_attn_backend
 
-        target_runner.hybrid_target_verify_graph_runners = graph_runners
-        target_runner.hybrid_target_verify_attn_backends = attn_backends
         self._target_verify_graph_runners = graph_runners
         self._target_verify_attn_backends = attn_backends
 
@@ -600,8 +598,6 @@ class HybridController(BaseSpecWorker):
 
         if route == "neural":
             self.neural_worker.apply_runtime_state(spec_state)
-            self._active_runtime_state = state
-            return
 
         target_runner.attn_backend = spec_state.target_attn_backend
         target_runner.decode_cuda_graph_runner = spec_state.target_graph_runner

--- a/python/sglang/srt/speculative/hybrid_controller.py
+++ b/python/sglang/srt/speculative/hybrid_controller.py
@@ -1,0 +1,900 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+import torch
+
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.runtime_context import get_context, get_spec
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
+from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.hybrid_info import HybridVerifyInput
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+logger = logging.getLogger(__name__)
+
+
+class HybridSpecWorker(Protocol):
+    """Common worker surface managed by :class:`HybridController`."""
+
+    server_args: ServerArgs
+    speculative_num_steps: int
+    speculative_num_draft_tokens: int
+
+    @property
+    def target_worker(self) -> TpModelWorker: ...
+
+    @property
+    def draft_worker(self) -> Any: ...
+
+    @property
+    def last_shared_read_runner(self) -> Any: ...
+
+    @property
+    def spec_v2_attn_backends(self) -> tuple: ...
+
+    def alloc_memory_pool(self, **kwargs) -> None: ...
+
+    def init_attention_backends(self) -> None: ...
+
+    def init_cuda_graphs(self) -> None: ...
+
+    def clear_cache_pool(self) -> None: ...
+
+    def forward_batch_generation(
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
+    ) -> Any: ...
+
+    def on_verify_complete_cpu(
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+    ) -> None: ...
+
+    def activate_step_by_batch(self, batch_size: int) -> None: ...
+
+    def sync_hybrid_state(self, batch: ScheduleBatch, batch_result: Any) -> Any: ...
+
+
+@dataclass(frozen=True)
+class HybridWorkerConfig:
+    role: str
+    algorithm: SpeculativeAlgorithm
+    overrides: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class HybridRuntimeState:
+    """A route and its complete adaptive-style speculative runtime state."""
+
+    route: str
+    worker: HybridSpecWorker
+    spec_state: SpecRuntimeState
+
+
+@dataclass
+class HybridRouteStats:
+    """Per-route scheduling and acceptance metrics, reset on flush_cache."""
+
+    # Per-route request-level counters. Keep their definition aligned with
+    # MetricsReporter.update_spec_metrics(), which backs bench_serving's
+    # avg_spec_accept_length: each verified request contributes one forward.
+    retrieval_forward_ct: int = 0
+    retrieval_num_accept_tokens: float = 0.0
+    retrieval_num_draft_tokens: int = 0
+    neural_forward_ct: int = 0
+    neural_num_accept_tokens: float = 0.0
+    neural_num_draft_tokens: int = 0
+
+    # Retrieval routing-decision helpers, accumulated over pure decode requests.
+    total_continuation_length: float = 0.0
+    total_match_length: float = 0.0
+    matching_req_ct: int = 0
+
+    # Batch-level counter: incremented once per pure-decode forward_batch_generation
+    # call regardless of batch size, so the debug-log interval
+    # (SGLANG_LOG_HYBRID_SPEC) fires every N *batches* as documented, not every
+    # N accumulated requests (which would drift with dynamic batch size).
+    pure_decode_batch_ct: int = 0
+
+    def reset(self) -> None:
+        for f in self.__dataclass_fields__:
+            setattr(self, f, 0)
+
+    @property
+    def retrieval_accept_length(self) -> float:
+        return (
+            self.retrieval_num_accept_tokens / self.retrieval_forward_ct
+            if self.retrieval_forward_ct
+            else 0.0
+        )
+
+    @property
+    def retrieval_accept_rate(self) -> float:
+        return (
+            (self.retrieval_num_accept_tokens - self.retrieval_forward_ct)
+            / self.retrieval_num_draft_tokens
+            if self.retrieval_num_draft_tokens
+            else 0.0
+        )
+
+    @property
+    def neural_accept_length(self) -> float:
+        return (
+            self.neural_num_accept_tokens / self.neural_forward_ct
+            if self.neural_forward_ct
+            else 0.0
+        )
+
+    @property
+    def neural_accept_rate(self) -> float:
+        return (
+            (self.neural_num_accept_tokens - self.neural_forward_ct)
+            / self.neural_num_draft_tokens
+            if self.neural_num_draft_tokens
+            else 0.0
+        )
+
+    @property
+    def avg_continuation_length(self) -> float:
+        return (
+            self.total_continuation_length / self.total_forward_ct
+            if self.total_forward_ct
+            else 0.0
+        )
+
+    @property
+    def avg_match_length(self) -> float:
+        return (
+            self.total_match_length / self.total_forward_ct
+            if self.total_forward_ct
+            else 0.0
+        )
+
+    @property
+    def total_forward_ct(self) -> int:
+        return self.retrieval_forward_ct + self.neural_forward_ct
+
+
+class HybridController(BaseSpecWorker):
+    """JSON-configured, batch-level speculative worker router.
+
+    Each configured worker owns an independent ServerArgs copy, so draft-token
+    counts and other algorithm-specific settings are allowed to differ. The
+    controller only assumes that the configured retrieval worker is NGRAM and
+    that the neural worker exposes a draft-extend phase; worker classes
+    themselves are always resolved through ``SpeculativeAlgorithm.create_worker``.
+    """
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        ps: ParallelState,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        super().__init__()
+        self.server_args = server_args
+        self._target_worker = target_worker
+        config = self._load_config(get_spec().speculative_hybrid_config)
+        self.routing = {
+            "min_continuation_ratio": config["min_continuation_ratio"],
+            "min_matching_ratio": config["min_matching_ratio"],
+        }
+        self.worker_configs = self._parse_worker_configs(config)
+        self.workers = self._create_workers(gpu_id, ps, nccl_port)
+        self.retrieval_worker = self.workers["retrieval"]
+        self.neural_worker = self.workers["neural"]
+        if not callable(getattr(self.retrieval_worker, "get_retrieval_info", None)):
+            raise ValueError(
+                "HYBRID retrieval worker must implement get_retrieval_info."
+            )
+        for role, worker in self.workers.items():
+            if not callable(getattr(worker, "sync_hybrid_state", None)):
+                raise ValueError(
+                    f"HYBRID {role} worker must implement sync_hybrid_state."
+                )
+        adaptive_controller = getattr(self.neural_worker, "adaptive_controller", None)
+        adaptive_widths = (
+            {steps + 1 for steps in adaptive_controller.candidate_steps}
+            if adaptive_controller is not None
+            else set()
+        )
+        self._runtime_widths = tuple(
+            sorted(
+                {
+                    self.retrieval_worker.speculative_num_draft_tokens,
+                    self.neural_worker.speculative_num_draft_tokens,
+                    *adaptive_widths,
+                }
+            )
+        )
+        self.min_continuation = (
+            self.retrieval_worker.speculative_num_draft_tokens - 1
+        ) * self.routing["min_continuation_ratio"]
+
+        self._last_route = "neural"
+        # Scheduler queries this before preparing the next batch. Track the
+        # worker that actually performed the final shared-buffer read; a
+        # retrieval verify is followed by neural draft-extend during warm-up.
+        self._last_shared_buffer_reader = self.neural_worker
+
+        # Per-route scheduling metrics, reset on flush_cache.
+        self._route_stats = HybridRouteStats()
+        self._runtime_states: dict[tuple[str, int | None], HybridRuntimeState] = {}
+        self._active_runtime_state: HybridRuntimeState | None = None
+        self.log_interval = envs.SGLANG_LOG_HYBRID_SPEC.get()
+
+    @staticmethod
+    def _load_config(config_json: str) -> dict[str, Any]:
+        try:
+            config = json.loads(config_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError("HYBRID config must be a JSON object.") from exc
+        if not isinstance(config, dict):
+            raise ValueError("HYBRID config must be a JSON object.")
+        for role in ("retrieval", "neural"):
+            if not isinstance(config.get(role), dict):
+                raise ValueError(f"HYBRID config requires a {role} object.")
+        for name in ("min_continuation_ratio", "min_matching_ratio"):
+            if name not in config:
+                raise ValueError(f"HYBRID config requires {name}.")
+        for name in ("min_continuation_ratio", "min_matching_ratio"):
+            value = config[name]
+            if not isinstance(value, (int, float)) or not 0 < value <= 1:
+                raise ValueError(f"HYBRID {name} must be in (0, 1].")
+        return config
+
+    @staticmethod
+    def _parse_worker_configs(config: dict[str, Any]) -> dict[str, HybridWorkerConfig]:
+        configs = {}
+        for role in ("retrieval", "neural"):
+            raw = config[role]
+            algorithm_name = raw.get("algorithm")
+            if not isinstance(algorithm_name, str):
+                raise ValueError(f"HYBRID {role}.algorithm must be a string.")
+            algorithm = SpeculativeAlgorithm.from_string(algorithm_name)
+            if algorithm.is_none() or algorithm.is_hybrid():
+                raise ValueError(
+                    f"Unsupported nested HYBRID algorithm: {algorithm_name}."
+                )
+            overrides = {key: value for key, value in raw.items() if key != "algorithm"}
+            configs[role] = HybridWorkerConfig(role, algorithm, overrides)
+        return configs
+
+    def _create_workers(
+        self, gpu_id: int, ps: ParallelState, nccl_port: int
+    ) -> dict[str, HybridSpecWorker]:
+        from sglang.srt.arg_groups.speculative_hook import (
+            configure_adaptive_speculative_decoding,
+        )
+
+        workers: dict[str, HybridSpecWorker] = {}
+        base_config = self.server_args.resolved_dict()
+        for role, worker_config in self.worker_configs.items():
+            unknown = set(worker_config.overrides) - set(
+                self.server_args.__dataclass_fields__
+            )
+            if unknown:
+                raise ValueError(
+                    f"Unknown ServerArgs override for {role}: {sorted(unknown)}."
+                )
+            changes = {
+                "speculative_algorithm": worker_config.algorithm.name,
+                **worker_config.overrides,
+            }
+            changes["speculative_adaptive"] = bool(
+                role == "neural"
+                and changes.get(
+                    "speculative_adaptive", base_config["speculative_adaptive"]
+                )
+            )
+            worker_server_args = self.server_args.replace_resolved(
+                f"hybrid.{role}", **changes
+            )
+            object.__setattr__(
+                worker_server_args, "_hybrid_managed_runtime", role == "neural"
+            )
+            if changes["speculative_adaptive"]:
+                configure_adaptive_speculative_decoding(worker_server_args)
+            worker_config.algorithm.handle_server_args(worker_server_args)
+            worker_cls = worker_config.algorithm.create_worker(worker_server_args)
+            role_config = worker_server_args.resolved_dict()
+            context_changes = {
+                key: value
+                for key, value in role_config.items()
+                if base_config.get(key) != value
+            }
+            restore = {key: base_config[key] for key in context_changes}
+            get_context().override(f"hybrid.{role}.construct", **context_changes)
+            try:
+                workers[role] = cast(
+                    HybridSpecWorker,
+                    worker_cls(
+                        server_args=worker_server_args,
+                        gpu_id=gpu_id,
+                        ps=ps,
+                        nccl_port=nccl_port,
+                        target_worker=self._target_worker,
+                        spec_stage_span_prefix=role,
+                    ),
+                )
+            finally:
+                get_context().override("hybrid.restore", **restore)
+        return workers
+
+    @property
+    def target_worker(self):
+        return self._target_worker
+
+    @property
+    def draft_worker(self):
+        return self.neural_worker.draft_worker
+
+    @property
+    def last_shared_read_runner(self):
+        return self._last_shared_buffer_reader.last_shared_read_runner
+
+    @property
+    def spec_v2_attn_backends(self) -> tuple:
+        # Scheduler setup needs the union because routes may switch at every
+        # batch boundary; workers initialize their own backends up front.
+        if self._runtime_states:
+            return tuple(
+                dict.fromkeys(
+                    backend
+                    for state in self._runtime_states.values()
+                    for backend in (
+                        state.spec_state.draft_attn_backend,
+                        state.spec_state.target_attn_backend,
+                        state.spec_state.draft_extend_attn_backend,
+                    )
+                    if backend is not None
+                )
+            )
+        return tuple(
+            dict.fromkeys(
+                backend
+                for worker in self.workers.values()
+                for backend in worker.spec_v2_attn_backends
+            )
+        )
+
+    def alloc_memory_pool(self, **kwargs):
+        for worker in self.workers.values():
+            worker.alloc_memory_pool(**kwargs)
+
+    def init_attention_backends(self):
+        for worker in self.workers.values():
+            worker.init_attention_backends()
+
+    def init_cuda_graphs(self):
+        target_runner = self._target_worker.model_runner
+        bootstrap_target_graph_runner = target_runner.decode_cuda_graph_runner
+        bootstrap_target_attn_backend = target_runner.attn_backend
+        # Prefill CUDA graphs are captured against this general-purpose backend.
+        # Route-specific target-verify backends may use different static metadata,
+        # so replaying a prefill graph while one of them is installed corrupts the
+        # graph's cache/index inputs.
+        self._target_prefill_attn_backend = bootstrap_target_attn_backend
+        bootstrap_width = max(self._runtime_widths)
+        for worker in self.workers.values():
+            worker.init_cuda_graphs()
+        self._init_draft_extend_resources()
+        self._init_target_verify_resources(
+            bootstrap_width,
+            bootstrap_target_graph_runner,
+            bootstrap_target_attn_backend,
+        )
+        self._init_runtime_states()
+
+    def _init_draft_extend_resources(self) -> None:
+        draft_worker = self.neural_worker.draft_worker
+        neural_width = self.neural_worker.speculative_num_draft_tokens
+        adaptive_states = getattr(self.neural_worker, "adaptive_runtime_states", {})
+        resources = {
+            state.speculative_num_draft_tokens: (
+                state.draft_extend_attn_backend,
+                state.cuda_graph_runner_for_draft_extend,
+            )
+            for state in adaptive_states.values()
+        }
+        resources.setdefault(
+            neural_width,
+            (
+                draft_worker.draft_extend_attn_backend,
+                draft_worker.cuda_graph_runner_for_draft_extend,
+            ),
+        )
+        builder = getattr(draft_worker, "build_draft_extend_runtime_resource", None)
+        if not callable(builder):
+            raise ValueError(
+                "HYBRID neural worker must build draft-extend runtime resources."
+            )
+        for width in self._runtime_widths:
+            if width in resources:
+                continue
+            with (
+                draft_worker.draft_tp_context(draft_worker.draft_runner.tp_group),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+            ):
+                resources[width] = builder(num_tokens_per_bs=width)
+        self._draft_extend_resources = resources
+
+    def _init_target_verify_resources(
+        self,
+        bootstrap_width: int,
+        bootstrap_graph_runner,
+        bootstrap_attn_backend,
+    ) -> None:
+        """Build route-width target resources with adaptive-style graph buffers."""
+        from sglang.srt.model_executor.runner import DecodeCudaGraphRunner
+
+        target_runner = self._target_worker.model_runner
+        adaptive_states = getattr(self.neural_worker, "adaptive_runtime_states", {})
+        graph_runners = {
+            state.speculative_num_draft_tokens: state.target_graph_runner
+            for state in adaptive_states.values()
+        }
+        attn_backends = {
+            state.speculative_num_draft_tokens: state.target_attn_backend
+            for state in adaptive_states.values()
+        }
+        max_width = max(self._runtime_widths)
+        if bootstrap_width != max_width:
+            raise ValueError(
+                "HYBRID target bootstrap width must be the maximum runtime width: "
+                f"bootstrap={bootstrap_width}, maximum={max_width}."
+            )
+        graph_runners[bootstrap_width] = bootstrap_graph_runner
+        attn_backends[bootstrap_width] = bootstrap_attn_backend
+        for width in self._runtime_widths:
+            if width in graph_runners:
+                continue
+            bootstrap_workspace = target_runner.init_new_workspace
+            with self.neural_worker._override_worker_state(width - 1, width):
+                try:
+                    target_attn_backend = target_runner._get_attention_backend(
+                        init_new_workspace=True
+                    )
+                finally:
+                    target_runner.init_new_workspace = bootstrap_workspace
+
+                target_graph_runner = None
+                if bootstrap_graph_runner is not None:
+                    target_graph_runner = DecodeCudaGraphRunner(
+                        target_runner,
+                        attn_backend=target_attn_backend,
+                        speculative_num_steps=width - 1,
+                        speculative_num_draft_tokens=width,
+                    )
+            graph_runners[width] = target_graph_runner
+            attn_backends[width] = target_attn_backend
+
+        target_runner.hybrid_target_verify_graph_runners = graph_runners
+        target_runner.hybrid_target_verify_attn_backends = attn_backends
+        self._target_verify_graph_runners = graph_runners
+        self._target_verify_attn_backends = attn_backends
+
+    def _init_runtime_states(self) -> None:
+        """Build complete route states after every backend/graph is initialized."""
+        target_runner = self._target_worker.model_runner
+        draft_worker = self.neural_worker.draft_worker
+        graph_runners = self._target_verify_graph_runners
+        attn_backends = self._target_verify_attn_backends
+        draft_extend_resources = self._draft_extend_resources
+        states = {}
+
+        def build_state(route, worker, source_state=None):
+            width = (
+                source_state.speculative_num_draft_tokens
+                if source_state is not None
+                else worker.speculative_num_draft_tokens
+            )
+            target_graph_runner = graph_runners.get(width)
+            target_attn_backend = attn_backends.get(width)
+            if target_attn_backend is None and target_graph_runner is not None:
+                target_attn_backend = target_graph_runner.attn_backend
+            if target_attn_backend is None:
+                target_attn_backend = target_runner.attn_backend
+            draft_extend_attn_backend, draft_extend_graph_runner = (
+                draft_extend_resources[width]
+            )
+            spec_state = SpecRuntimeState(
+                speculative_num_steps=(
+                    source_state.speculative_num_steps
+                    if source_state is not None
+                    else worker.speculative_num_steps
+                ),
+                speculative_num_draft_tokens=width,
+                draft_attn_backend=(
+                    source_state.draft_attn_backend
+                    if source_state is not None
+                    else draft_worker.draft_attn_backend
+                ),
+                cuda_graph_runner=(
+                    source_state.cuda_graph_runner
+                    if source_state is not None
+                    else draft_worker.cuda_graph_runner
+                ),
+                target_attn_backend=target_attn_backend,
+                target_graph_runner=target_graph_runner,
+                draft_extend_attn_backend=draft_extend_attn_backend,
+                cuda_graph_runner_for_draft_extend=draft_extend_graph_runner,
+            )
+            key = (
+                (route, spec_state.speculative_num_steps)
+                if route == "neural"
+                else (route, None)
+            )
+            states[key] = HybridRuntimeState(
+                route=route,
+                worker=worker,
+                spec_state=spec_state,
+            )
+
+        build_state("retrieval", self.retrieval_worker)
+        adaptive_states = getattr(self.neural_worker, "adaptive_runtime_states", {})
+        if adaptive_states:
+            for source_state in adaptive_states.values():
+                build_state("neural", self.neural_worker, source_state)
+        else:
+            build_state("neural", self.neural_worker)
+        self._runtime_states = states
+        self._apply_runtime_state(self._last_route)
+
+    def _apply_runtime_state(self, route: str) -> None:
+        """Atomically switch target verify resources at a route boundary.
+
+        Like ``EAGLEWorkerV2.apply_runtime_state``, never combine a backend
+        from one width with the graph captured for another width.  The helper
+        is deliberately invoked before draft preparation so all later
+        metadata writes and target replay use this same state.
+        """
+        key = (
+            (route, self.neural_worker.speculative_num_steps)
+            if route == "neural"
+            else (route, None)
+        )
+        state = self._runtime_states.get(key)
+        if state is None:
+            raise RuntimeError(f"HYBRID runtime state is missing for route={route}.")
+        if state is self._active_runtime_state:
+            # An extend/mixed batch temporarily installs the backend used to
+            # capture target prefill graphs. Restore the route's verify backend
+            # even when the rest of the runtime state is already active.
+            target_runner = self._target_worker.model_runner
+            target_runner.attn_backend = state.spec_state.target_attn_backend
+            target_runner.decode_cuda_graph_runner = (
+                state.spec_state.target_graph_runner
+            )
+            return
+
+        spec_state = state.spec_state
+        target_runner = self._target_worker.model_runner
+        get_context().override(
+            "hybrid.route",
+            speculative_num_steps=spec_state.speculative_num_steps,
+            speculative_num_draft_tokens=spec_state.speculative_num_draft_tokens,
+        )
+
+        if route == "neural":
+            self.neural_worker.apply_runtime_state(spec_state)
+            self._active_runtime_state = state
+            return
+
+        target_runner.attn_backend = spec_state.target_attn_backend
+        target_runner.decode_cuda_graph_runner = spec_state.target_graph_runner
+
+        draft_worker = self.neural_worker.draft_worker
+        draft_worker.draft_attn_backend = spec_state.draft_attn_backend
+        draft_worker.draft_runner.draft_attn_backend = spec_state.draft_attn_backend
+        draft_worker.cuda_graph_runner = spec_state.cuda_graph_runner
+        draft_worker.draft_extend_attn_backend = spec_state.draft_extend_attn_backend
+        if spec_state.draft_extend_attn_backend is not None:
+            draft_worker.draft_runner.attn_backend = (
+                spec_state.draft_extend_attn_backend
+            )
+        draft_worker.cuda_graph_runner_for_draft_extend = (
+            spec_state.cuda_graph_runner_for_draft_extend
+        )
+        self._active_runtime_state = state
+
+    def _apply_target_prefill_backend(self) -> None:
+        """Install the backend paired with the target prefill CUDA graphs."""
+        self._target_worker.model_runner.attn_backend = (
+            self._target_prefill_attn_backend
+        )
+
+    def clear_cache_pool(self):
+        for worker in self.workers.values():
+            worker.clear_cache_pool()
+        self._route_stats.reset()
+
+    def on_verify_complete_cpu(
+        self, num_correct_drafts_per_req, batch_size=0, route: str | None = None
+    ):
+        # Verification statistics belong to the route that produced them. In
+        # particular, feeding NGRAM acceptance into neural adaptive tuning
+        # would corrupt its step selection after a route switch.
+        #
+        # Under overlap scheduling this hook runs as a delayed CPU callback
+        # (see batch_result_processor._resolve_spec_v2_tokens), one iteration
+        # after the forward that produced ``num_correct_drafts_per_req``. A
+        # later batch may already have switched ``self._last_route`` by then,
+        # so prefer the route stamped on the originating result
+        # (``GenerationBatchResult.spec_route``) and only fall back to
+        # ``self._last_route`` for callers that predate that field.
+        target_route = route if route is not None else self._last_route
+        self.workers[target_route].on_verify_complete_cpu(
+            num_correct_drafts_per_req, batch_size=batch_size
+        )
+
+    def activate_step_by_batch(self, batch_size: int):
+        # Give each role a batch-boundary activation opportunity. Retrieval is
+        # currently static, while the neural role owns draft steps; calling both
+        # is necessary for future retrieval/adaptive workers and avoids keeping
+        # inactive route state stale.
+        for worker in self.workers.values():
+            worker.activate_step_by_batch(batch_size)
+
+    def _match_continuation_lengths(self, batch: ScheduleBatch) -> list[int]:
+        """Measure the current suffix's actual retrieval continuation.
+
+        The retrieval worker performs the same lookup it will use for drafting;
+        the controller only consumes its per-request continuation lengths.
+        """
+        return self.retrieval_worker.get_retrieval_info(batch)
+
+    def _should_use_retrieval(
+        self, batch: ScheduleBatch, lengths: tuple[list[int], list[int]]
+    ) -> bool:
+        if not batch.forward_mode.is_decode() or batch.is_extend_in_batch:
+            return False
+        # Weight each request's continuation by its match_len so a long but
+        # shallow (low-confidence) match cannot outweigh a shorter, deeper one.
+        cont_lens, match_lens = lengths
+        qualifying = sum(
+            cont_len * match_len / self.retrieval_worker.speculative_num_draft_tokens
+            >= self.min_continuation
+            for cont_len, match_len in zip(cont_lens, match_lens)
+        )
+        min_matching = len(cont_lens) * self.routing["min_matching_ratio"]
+        return qualifying >= min_matching
+
+    def _build_ngram_relay_input(
+        self,
+        batch: ScheduleBatch,
+        result: Any,
+        source_input: NgramVerifyInput | None = None,
+    ) -> NgramVerifyInput:
+        """Normalize an accepted path into NGRAM's native fixed-width relay."""
+        bs = len(batch.reqs)
+        relay_width = max(self._runtime_widths)
+        if source_input is not None:
+            source_width = source_input.draft_token_num
+            accept_rows = source_input.accept_tokens.reshape(bs, source_width)
+            accept_lens = source_input.accept_lens
+            new_seq_lens = source_input.new_seq_lens
+        else:
+            if not isinstance(result.next_token_ids, torch.Tensor):
+                raise TypeError("HYBRID requires tensor next_token_ids.")
+            accept_rows = result.next_token_ids.reshape(bs, -1)
+            source_width = accept_rows.shape[1]
+            accept_lens = result.accept_lens
+            if accept_lens is None:
+                accept_lens = torch.ones(
+                    bs,
+                    dtype=torch.int32,
+                    device=result.next_token_ids.device,
+                )
+            new_seq_lens = result.new_seq_lens
+
+        if source_width > relay_width:
+            raise ValueError(
+                f"HYBRID accepted-path width {source_width} exceeds relay width "
+                f"{relay_width}."
+            )
+        relay_rows = torch.zeros(
+            (bs, relay_width),
+            dtype=accept_rows.dtype,
+            device=accept_rows.device,
+        )
+        relay_rows[:, :source_width] = accept_rows
+        return NgramVerifyInput(
+            draft_token_num=relay_width,
+            new_seq_lens=new_seq_lens,
+            accept_tokens=relay_rows.flatten(),
+            accept_lens=accept_lens,
+        )
+
+    def forward_batch_generation(
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
+    ):
+        is_pure_decode = batch.forward_mode.is_decode() and not batch.is_extend_in_batch
+        hybrid_input = (
+            batch.spec_info if isinstance(batch.spec_info, HybridVerifyInput) else None
+        )
+        if is_pure_decode:
+            if hybrid_input is not None:
+                batch.spec_info = hybrid_input.ngram_verify_input
+            lengths = self._match_continuation_lengths(batch)
+        else:
+            lengths = ([], [])
+
+        if self._should_use_retrieval(batch, lengths):
+            self._apply_runtime_state("retrieval")
+            batch.capture_hidden_mode = CaptureHiddenMode.FULL
+            result = self.retrieval_worker.forward_batch_generation(
+                batch,
+                on_publish=on_publish,
+                grammar_barrier=grammar_barrier,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+            ngram_input = result.next_draft_input
+            if not isinstance(ngram_input, NgramVerifyInput):
+                raise TypeError("HYBRID retrieval route must return NgramVerifyInput.")
+            eagle_input = self.neural_worker.sync_hybrid_state(batch, result)
+            if not isinstance(eagle_input, EagleDraftInput):
+                raise TypeError("HYBRID neural sync must return EagleDraftInput.")
+            ngram_input = self._build_ngram_relay_input(
+                batch, result, source_input=ngram_input
+            )
+            last_shared_buffer_reader = self.neural_worker
+            route = "retrieval"
+        else:
+            if hybrid_input is not None:
+                batch.spec_info = hybrid_input.eagle_draft_input
+            self.neural_worker.activate_step_by_batch(batch.seq_lens.shape[0])
+            self._apply_runtime_state("neural")
+            if not is_pure_decode:
+                self._apply_target_prefill_backend()
+            result = self.neural_worker.forward_batch_generation(
+                batch,
+                on_publish=on_publish,
+                grammar_barrier=grammar_barrier,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+            eagle_input = result.next_draft_input
+            if not isinstance(eagle_input, EagleDraftInput):
+                raise TypeError("HYBRID neural route must return EagleDraftInput.")
+            self.retrieval_worker.sync_hybrid_state(batch, result)
+            ngram_input = self._build_ngram_relay_input(batch, result)
+            last_shared_buffer_reader = self.neural_worker
+            route = "neural"
+        result.next_draft_input = HybridVerifyInput(eagle_input, ngram_input)
+        self._last_shared_buffer_reader = last_shared_buffer_reader
+
+        self._update_route_stats(route, result, lengths, is_pure_decode)
+
+        # Stamp the producer route on the result itself. Overlap scheduling
+        # processes this result on a delayed CPU callback
+        # (on_verify_complete_cpu); by then ``self._last_route`` may already
+        # reflect a *later* batch's route, so the attribution must travel
+        # with the result rather than be read from live controller state.
+        result.spec_route = route
+        return result
+
+    def _update_route_stats(
+        self,
+        route: str,
+        result,
+        continuation_lengths: tuple[list[int], list[int]],
+        is_pure_decode: bool,
+    ) -> None:
+        """Update all stats except accept tokens during hybrid route"""
+        stats = self._route_stats
+        bs = len(continuation_lengths[0]) if continuation_lengths[0] is not None else 0
+
+        if is_pure_decode:
+            if route == "retrieval":
+                stats.retrieval_forward_ct += bs
+                stats.retrieval_num_draft_tokens += bs * (
+                    self.retrieval_worker.speculative_num_draft_tokens - 1
+                )
+            else:
+                stats.neural_forward_ct += bs
+                stats.neural_num_draft_tokens += bs * (
+                    self.neural_worker.speculative_num_draft_tokens - 1
+                )
+
+            cont_lens, match_lens = continuation_lengths
+            stats.total_continuation_length += sum(cont_lens)
+            stats.total_match_length += sum(match_lens)
+            stats.matching_req_ct += sum(
+                cont_len
+                * match_len
+                / self.retrieval_worker.speculative_num_draft_tokens
+                >= self.min_continuation
+                for cont_len, match_len in zip(cont_lens, match_lens)
+            )
+            stats.pure_decode_batch_ct += 1
+
+        if (
+            is_pure_decode
+            and self.log_interval > 0
+            and stats.pure_decode_batch_ct % self.log_interval == 0
+        ):
+            cont_info = (
+                f"cont_len={continuation_lengths[0]} "
+                f"match_len={continuation_lengths[1]} "
+                f"min_cont={self.min_continuation} "
+                if continuation_lengths
+                else ""
+            )
+            logger.info(
+                "HybridSpec route=%s bs=%d %s",
+                route,
+                bs,
+                cont_info,
+            )
+
+        if route != self._last_route:
+            logger.debug("Hybrid speculative route switched to %s", route)
+            self._last_route = route
+
+    def update_hybrid_stats(
+        self,
+        route: str,
+        result,
+        is_pure_decode: bool,
+    ) -> None:
+        """Update accept tokens during batch result processing."""
+        stats = self._route_stats
+        bs = len(result.accept_lens) if result.accept_lens is not None else 0
+        accept_lens = result.accept_lens
+
+        if is_pure_decode:
+            if route == "retrieval":
+                if accept_lens is not None:
+                    stats.retrieval_num_accept_tokens += float(accept_lens.sum().item())
+            else:
+                if accept_lens is not None:
+                    stats.neural_num_accept_tokens += float(accept_lens.sum().item())
+
+        if (
+            is_pure_decode
+            and self.log_interval > 0
+            and stats.pure_decode_batch_ct % self.log_interval == 0
+        ):
+            logger.info(
+                "HybridSpec route=%s bs=%d "
+                "avg_cont=%.2f avg_match=%.2f matching_req_ct=%d | "
+                "retrieval: forward_ct=%d accept_len=%.2f accept_rate=%.2f | "
+                "neural: forward_ct=%d accept_len=%.2f accept_rate=%.2f",
+                route,
+                bs,
+                stats.avg_continuation_length,
+                stats.avg_match_length,
+                stats.matching_req_ct,
+                stats.retrieval_forward_ct,
+                stats.retrieval_accept_length,
+                stats.retrieval_accept_rate,
+                stats.neural_forward_ct,
+                stats.neural_accept_length,
+                stats.neural_accept_rate,
+            )

--- a/python/sglang/srt/speculative/hybrid_info.py
+++ b/python/sglang/srt/speculative/hybrid_info.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+
+
+class HybridVerifyInput(SpecInput):
+    """Next-iteration state shared by Hybrid's EAGLE and NGRAM routes.
+
+    Each route keeps using its native input type. This wrapper only composes
+    their scheduler and overlap-relay lifecycles so a route switch does not
+    overload either native type with state owned by the other algorithm.
+    """
+
+    def __init__(
+        self,
+        eagle_draft_input: EagleDraftInput,
+        ngram_verify_input: NgramVerifyInput,
+    ) -> None:
+        super().__init__(SpecInputType.HYBRID_VERIFY)
+        self.eagle_draft_input = eagle_draft_input
+        self.ngram_verify_input = ngram_verify_input
+
+    @property
+    def future_indices(self) -> Optional[torch.Tensor]:
+        return self.eagle_draft_input.future_indices
+
+    @future_indices.setter
+    def future_indices(self, value: Optional[torch.Tensor]) -> None:
+        self.eagle_draft_input.future_indices = value
+        self.ngram_verify_input.future_indices = value
+
+    @property
+    def dsa_topk_indices(self) -> Optional[torch.Tensor]:
+        return self.eagle_draft_input.dsa_topk_indices
+
+    @dsa_topk_indices.setter
+    def dsa_topk_indices(self, value: Optional[torch.Tensor]) -> None:
+        self.eagle_draft_input.dsa_topk_indices = value
+
+    @property
+    def future_dsa_topk_indices_available(self) -> bool:
+        return self.eagle_draft_input.future_dsa_topk_indices_available
+
+    @future_dsa_topk_indices_available.setter
+    def future_dsa_topk_indices_available(self, value: bool) -> None:
+        self.eagle_draft_input.future_dsa_topk_indices_available = value
+
+    def filter_batch(
+        self,
+        new_indices: torch.Tensor,
+        new_indices_cpu: Optional[List[int]] = None,
+    ) -> None:
+        self.eagle_draft_input.filter_batch(new_indices, new_indices_cpu)
+        self.ngram_verify_input.filter_batch(new_indices, new_indices_cpu)
+
+    def merge_batch(self, spec_info: HybridVerifyInput) -> None:
+        if not isinstance(spec_info, HybridVerifyInput):
+            raise TypeError(
+                "HybridVerifyInput can only merge another HybridVerifyInput."
+            )
+        self.eagle_draft_input.merge_batch(spec_info.eagle_draft_input)
+        self.ngram_verify_input.merge_batch(spec_info.ngram_verify_input)

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -329,9 +329,9 @@ class NGRAMWorker(BaseSpecWorker):
         total_draft_token_num = len(req_drafts)
 
         # Check if speculative decoding is needed; here we always enforce it
-        assert (
-            total_draft_token_num == bs * self.draft_token_num
-        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+        assert total_draft_token_num == bs * self.draft_token_num, (
+            f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+        )
         return req_drafts, mask, match_lens
 
     def get_retrieval_info(self, batch: ScheduleBatch) -> tuple[list[int], list[int]]:

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -32,6 +32,7 @@ from sglang.srt.speculative.spec_utils import (
     move_accept_tokens_to_target_kvcache,
     prepare_mamba_track_for_verify,
     record_stream_for_v2_verify,
+    spec_stage_span,
 )
 from sglang.srt.utils import is_cpu
 from sglang.srt.utils.async_probe import maybe_detect_inf, maybe_detect_nan
@@ -88,6 +89,7 @@ class NGRAMWorker(BaseSpecWorker):
         ps: ParallelState,
         nccl_port: int,
         target_worker: TpModelWorker,
+        spec_stage_span_prefix: str = "",
     ):
         super().__init__()
 
@@ -105,13 +107,20 @@ class NGRAMWorker(BaseSpecWorker):
         # req_to_token_pool / token_to_kv_pool_allocator are set in
         # alloc_memory_pool(), after the target pools are allocated.
         self.device = get_device().device
+        self.spec_stage_span_prefix = spec_stage_span_prefix
 
         self.adaptive_controller = None
         # rids of the last decode batch; used to erase corpus match state for
         # requests that left the batch (see forward_batch_generation).
         self._prev_decode_rids: set = set()
         self.grammar_tree_host: Optional[tuple] = None
-
+        # A retrieval route query prepares these CPU drafts before the controller
+        # chooses a route. HybridController always calls
+        # get_retrieval_info() on the current batch immediately
+        # before choosing a route within the same forward_batch_generation call,
+        # so a non-None cache here is always fresh for this batch; no per-batch
+        # identity check is needed.
+        self._hybrid_prepared_drafts = None
         self.ngram_corpus = NgramCorpus(
             min_bfs_breadth=get_spec().speculative_ngram_min_bfs_breadth,
             max_bfs_breadth=get_spec().speculative_ngram_max_bfs_breadth,
@@ -151,6 +160,7 @@ class NGRAMWorker(BaseSpecWorker):
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
         self._prev_decode_rids = set()
+        self._hybrid_prepared_drafts = None
 
     def update_weights_from_tensor(self, recv_req):
         # NGRAM has no draft weights of its own — the n-gram corpus is a CPU
@@ -232,7 +242,9 @@ class NGRAMWorker(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
     ) -> None:
         # Signature must match BaseSpecWorker.on_verify_complete_cpu; the
         # result processor calls it with batch_size as a keyword argument.
@@ -241,7 +253,7 @@ class NGRAMWorker(BaseSpecWorker):
 
     def _prepare_draft_tokens(
         self, batch: ScheduleBatch
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         bs = len(batch.reqs)
         stride = self.draft_token_num
 
@@ -271,25 +283,31 @@ class NGRAMWorker(BaseSpecWorker):
                 batch.spec_info.accept_tokens,
                 batch.spec_info.accept_lens,
             )
+            prev_token_stride = batch.spec_info.draft_token_num
             if not prev_token_ids.is_cpu:
                 prev_token_ids = prev_token_ids.cpu()
                 prev_accept_lens = prev_accept_lens.cpu()
             # Worker-level staging: written here at draft prep, consumed by
             # _update_ngram_corpus after verify within the same forward call.
-            self.prev_token_ids = prev_token_ids.tolist()
+            self.prev_token_ids = prev_token_ids.flatten().tolist()
             self.prev_accept_lens = prev_accept_lens.tolist()
+            self.prev_token_stride = prev_token_stride
             assert bs == len(self.prev_accept_lens)
         else:
             # _update_ngram_corpus still reads the staging; fill it empty.
             self.prev_token_ids = []
             self.prev_accept_lens = [0] * bs
+            self.prev_token_stride = stride
 
         self.ngram_corpus.synchronize()
         batch_tokens = []
         total_lens = []
         for i in range(bs):
             prev_tokens = (
-                self.prev_token_ids[i * stride : i * stride + self.prev_accept_lens[i]]
+                self.prev_token_ids[
+                    i * self.prev_token_stride : i * self.prev_token_stride
+                    + self.prev_accept_lens[i]
+                ]
                 if use_prev_tokens
                 else []
             )
@@ -300,7 +318,7 @@ class NGRAMWorker(BaseSpecWorker):
             )
             batch_tokens.append(check_token)
             total_lens.append(base_lens[i] + len(prev_tokens))
-        req_drafts, mask = self.ngram_corpus.batch_get(
+        req_drafts, mask, match_lens = self.ngram_corpus.batch_get(
             req_ids, batch_tokens, total_lens
         )
         total_draft_token_num = len(req_drafts)
@@ -309,14 +327,29 @@ class NGRAMWorker(BaseSpecWorker):
         assert total_draft_token_num == bs * self.draft_token_num, (
             f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
         )
-        return req_drafts, mask
+        return req_drafts, mask, match_lens
 
-    def _prepare_for_speculative_decoding(self, batch: ScheduleBatch):
+    def get_retrieval_info(self, batch: ScheduleBatch) -> tuple[list[int], list[int]]:
+        """Probe the corpus with the current suffix and report continuation.
+
+        Reuses ``_prepare_draft_tokens`` for the actual lookup so the probe and
+        an eventual real draft prep never disagree. The (drafts, mask,
+        match_lens) result is cached in ``_hybrid_prepared_drafts`` so a route
+        that does choose ``retrieval`` reuses this exact lookup instead of
+        querying the corpus again.
+        """
+        drafts, mask, match_lens = self._prepare_draft_tokens(batch)
+        self._hybrid_prepared_drafts = (drafts, mask, match_lens)
+        bs = len(batch.reqs)
+        draft_rows = drafts.reshape(bs, self.draft_token_num)
+        return (draft_rows[:, 1:] != 0).sum(axis=1).tolist(), match_lens.tolist()
+
+    def _prepare_for_speculative_decoding(self, batch: ScheduleBatch) -> bool:
         # Decode-only: extend goes through the plain target forward, and an
         # IDLE batch must keep its forward_mode instead of being rewritten to
         # TARGET_VERIFY below (relevant once DP attention support lands).
         if not batch.forward_mode.is_decode():
-            return
+            return False
 
         bs = len(batch.reqs)
 
@@ -338,7 +371,12 @@ class NGRAMWorker(BaseSpecWorker):
                 for i in range(bs)
             ]
 
-        req_drafts, mask = self._prepare_draft_tokens(batch)
+        if self._hybrid_prepared_drafts is not None:
+            req_drafts, mask, _ = self._hybrid_prepared_drafts
+            self._hybrid_prepared_drafts = None
+        else:
+            req_drafts, mask, _ = self._prepare_draft_tokens(batch)
+        mask_rows = mask.reshape(bs, self.draft_token_num, self.draft_token_num)
         tree_mask.copy_(torch.from_numpy(mask), non_blocking=True)
         draft_tokens.copy_(torch.from_numpy(req_drafts), non_blocking=True)
 
@@ -361,7 +399,7 @@ class NGRAMWorker(BaseSpecWorker):
         # Testing shows about 8% performance improvement (the effect is roughly proportional to batch size).
         if USE_FULL_MASK and not _is_cpu:
             tree_mask = []
-            mask = mask.reshape(bs, self.draft_token_num, self.draft_token_num)
+            mask = mask_rows
             # TODO(siyuan): the for loop here leads to significant overhead in large batch size. Can be written into a kernel.
             for i in range(bs):
                 req_mask = torch.cat(
@@ -399,10 +437,50 @@ class NGRAMWorker(BaseSpecWorker):
             retrieve_next_sibling=retrieve_next_sibling,
             draft_token_num=self.draft_token_num,
         )
+        return True
+
+    def sync_hybrid_state(
+        self,
+        batch: ScheduleBatch,
+        batch_result,
+    ) -> None:
+        """Update retrieval corpus and match state after a neural batch.
+
+        Decode accepts are staged with their producer width, so the next suffix
+        lookup observes overlap-delayed output tokens. Extend batches have no
+        accepted draft path; index their currently visible prompt prefix instead.
+        """
+        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
+            self._insert_extend_into_ngram_corpus(batch)
+            return
+        cur_rids = {req.rid for req in batch.reqs}
+        departed_rids = self._prev_decode_rids - cur_rids
+        if departed_rids:
+            self.ngram_corpus.erase_match_state(list(departed_rids))
+        self._prev_decode_rids = cur_rids
+        self._update_ngram_corpus(batch)
+
+    def _insert_extend_into_ngram_corpus(self, batch: ScheduleBatch) -> None:
+        """Index the prompt tokens newly visible after this extend iteration."""
+        batch_tokens = []
+        for req in batch.reqs:
+            prev_len = len(req.prefix_indices)
+            processed_len = min(
+                len(req.origin_input_ids), prev_len + req.extend_range.length
+            )
+            if processed_len <= prev_len:
+                continue
+            if req.extend_batch_idx == 1:
+                start = 0
+            else:
+                start = max(0, prev_len - (self.max_trie_depth - 1))
+            batch_tokens.append(list(req.origin_input_ids[start:processed_len]))
+        if batch_tokens:
+            self.ngram_corpus.batch_put(batch_tokens)
 
     def _update_ngram_corpus(self, batch: ScheduleBatch):
         batch_tokens = []
-        i, stride = 0, self.draft_token_num
+        i = 0
         # Same splice condition as _prepare_draft_tokens: only overlap mode
         # has accepted tokens missing from req.output_ids.
         use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
@@ -413,7 +491,10 @@ class NGRAMWorker(BaseSpecWorker):
             #     put_ids = req.origin_input_ids + req.output_ids
             # else:
             prev_tokens = (
-                self.prev_token_ids[i * stride : i * stride + self.prev_accept_lens[i]]
+                self.prev_token_ids[
+                    i * self.prev_token_stride : i * self.prev_token_stride
+                    + self.prev_accept_lens[i]
+                ]
                 if use_prev_tokens
                 else []
             )
@@ -427,116 +508,133 @@ class NGRAMWorker(BaseSpecWorker):
         self.ngram_corpus.batch_put(batch_tokens)
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, pp_proxy_tensors=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         fwd_stream = torch.get_device_module(self.device).current_stream()
         record_stream_for_v2_verify(batch, None, fwd_stream)
         bs = len(batch.reqs)
 
-        set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
-        self._prepare_for_speculative_decoding(batch)
-        set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+        with spec_stage_span(self.spec_stage_span_prefix + "_draft"):
+            # CPU-side corpus suffix lookup + tree-mask/positions construction
+            # (Triton reconstruct_indices_from_tree_mask) and NgramVerifyInput
+            # assembly. No target-model GPU forward happens in this span; it
+            # is the retrieval analogue of EAGLE's "prepare + replay" draft.
+            set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+            self._prepare_for_speculative_decoding(batch)
+            set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
 
         verify_input: NgramVerifyInput = batch.spec_info
         accept_lens = torch.ones(bs, dtype=torch.int32, device=self.device)
 
         if batch.forward_mode.is_target_verify():
-            batch_result = self.target_worker.forward_batch_generation(
-                batch, pp_proxy_tensors=pp_proxy_tensors, is_verify=True
-            )
-
-            logits_output, can_run_cuda_graph = (
-                batch_result.logits_output,
-                batch_result.can_run_cuda_graph,
-            )
-
-            verify_input: NgramVerifyInput = batch.spec_info
-            grammar_mask = None
-            if batch.has_grammar:
-                # From the host tree rather than the device output: no readback to
-                # wait on, and deriving here keeps it under the verify forward.
-                mask, req_drafts = self.grammar_tree_host
-                retrieve_next_token_cpu, retrieve_next_sibling_cpu = _derive_tree_links(
-                    mask, bs, self.draft_token_num
-                )
-                grammar_mask = build_grammar_vocab_mask(
-                    reqs=batch.reqs,
-                    tree=GrammarTree.from_host(
-                        retrieve_next_token_cpu,
-                        retrieve_next_sibling_cpu,
-                        torch.from_numpy(req_drafts).to(torch.int64).view(bs, -1),
-                    ),
-                    sampling_info=batch.sampling_info,
-                    device=verify_input.retrieve_next_token.device,
-                    # Host corpus lookup, so NGRAM stays synchronous: nothing pending.
-                    barrier=None,
+            with spec_stage_span(self.spec_stage_span_prefix + "_verify"):
+                batch_result = self.target_worker.forward_batch_generation(
+                    batch, pp_proxy_tensors=pp_proxy_tensors, is_verify=True
                 )
 
-            # Sample
-            maybe_detect_nan(
-                logits_output.next_token_logits, "verify: target model logits"
-            )
-            maybe_detect_inf(
-                logits_output.next_token_logits, "verify: target model logits"
-            )
-            (
-                predict,
-                accept_lens,
-                accept_index,
-            ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
-            new_seq_lens = batch.seq_lens + accept_lens
-            commit_mamba_states_after_verify(
-                self.target_worker,
-                batch,
-                accept_lens,
-                accept_index,
-                self.draft_token_num,
-            )
-            accept_tokens = predict[accept_index].flatten()
-            next_token_ids = accept_tokens
+                logits_output, can_run_cuda_graph = (
+                    batch_result.logits_output,
+                    batch_result.can_run_cuda_graph,
+                )
 
-            # The KV mover expects drafts-only counts. NGRAM's
-            # accept_lens includes the bonus token, matching scheduler output.
-            num_correct_drafts_per_req = accept_lens - 1
-            move_accept_tokens_to_target_kvcache(
-                batch,
-                accept_index,
-                num_correct_drafts_per_req,
-                self.token_to_kv_pool_allocator,
-            )
-            if batch.return_logprob:
-                compute_spec_logprobs(
-                    batch,
-                    logits_output,
+                verify_input: NgramVerifyInput = batch.spec_info
+                grammar_mask = None
+                if batch.has_grammar:
+                    # From the host tree rather than the device output: no readback to
+                    # wait on, and deriving here keeps it under the verify forward.
+                    mask, req_drafts = self.grammar_tree_host
+                    retrieve_next_token_cpu, retrieve_next_sibling_cpu = (
+                        _derive_tree_links(mask, bs, self.draft_token_num)
+                    )
+                    grammar_mask = build_grammar_vocab_mask(
+                        reqs=batch.reqs,
+                        tree=GrammarTree.from_host(
+                            retrieve_next_token_cpu,
+                            retrieve_next_sibling_cpu,
+                            torch.from_numpy(req_drafts).to(torch.int64).view(bs, -1),
+                        ),
+                        sampling_info=batch.sampling_info,
+                        device=verify_input.retrieve_next_token.device,
+                        # Standalone NGRAM stays synchronous and receives no barrier;
+                        # Hybrid may route here after an EAGLE batch, whose committed
+                        # tokens must advance the grammar FSM before tree traversal.
+                        barrier=grammar_barrier,
+                    )
+                # Sample
+                maybe_detect_nan(
+                    logits_output.next_token_logits, "verify: target model logits"
+                )
+                maybe_detect_inf(
+                    logits_output.next_token_logits, "verify: target model logits"
+                )
+                (
                     predict,
-                    accept_index=accept_index,
+                    accept_lens,
+                    accept_index,
+                ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
+                new_seq_lens = batch.seq_lens + accept_lens
+                commit_mamba_states_after_verify(
+                    self.target_worker,
+                    batch,
+                    accept_lens,
+                    accept_index,
+                    self.draft_token_num,
                 )
+                accept_tokens = predict[accept_index].flatten()
+                next_token_ids = accept_tokens
 
-            if on_publish is not None:
-                on_publish(new_seq_lens)
+                # The KV mover expects drafts-only counts. NGRAM's
+                # accept_lens includes the bonus token, matching scheduler output.
+                num_correct_drafts_per_req = accept_lens - 1
+                move_accept_tokens_to_target_kvcache(
+                    batch,
+                    accept_index,
+                    num_correct_drafts_per_req,
+                    self.token_to_kv_pool_allocator,
+                )
+                if batch.return_logprob:
+                    compute_spec_logprobs(
+                        batch,
+                        logits_output,
+                        predict,
+                        accept_index=accept_index,
+                    )
 
-            self._update_ngram_corpus(batch)
-            # Erase match state of requests that left the decode batch.
-            # req.finished() is unusable here: under overlap it flips at result
-            # processing, one iteration after the request left the batch.
-            # The last batch's entries persist while idle (bounded, small).
-            cur_rids = {req.rid for req in batch.reqs}
-            departed_rids = self._prev_decode_rids - cur_rids
-            if departed_rids:
-                self.ngram_corpus.erase_match_state(list(departed_rids))
-            self._prev_decode_rids = cur_rids
-            batch.forward_mode = ForwardMode.DECODE
+                if on_publish is not None:
+                    on_publish(new_seq_lens)
+
+                self._update_ngram_corpus(batch)
+                # Erase match state of requests that left the decode batch.
+                # req.finished() is unusable here: under overlap it flips at result
+                # processing, one iteration after the request left the batch.
+                # The last batch's entries persist while idle (bounded, small).
+                cur_rids = {req.rid for req in batch.reqs}
+                departed_rids = self._prev_decode_rids - cur_rids
+                if departed_rids:
+                    self.ngram_corpus.erase_match_state(list(departed_rids))
+                self._prev_decode_rids = cur_rids
+                batch.forward_mode = ForwardMode.DECODE
 
         else:
             batch_result = self.target_worker.forward_batch_generation(
                 batch, pp_proxy_tensors=pp_proxy_tensors
             )
+            if batch.forward_mode.is_extend():
+                self._insert_extend_into_ngram_corpus(batch)
             logits_output, predict, can_run_cuda_graph = (
                 batch_result.logits_output,
                 batch_result.next_token_ids,
                 batch_result.can_run_cuda_graph,
             )
-            new_seq_lens = batch.seq_lens.clone()
+            new_seq_lens = (
+                batch.seq_lens.clone()
+                if batch.forward_mode.is_extend()
+                else batch.seq_lens + 1
+            )
 
             accept_tokens = torch.zeros(
                 bs, self.draft_token_num, dtype=torch.int32, device=self.device
@@ -548,7 +646,6 @@ class NGRAMWorker(BaseSpecWorker):
             if on_publish is not None:
                 on_publish(new_seq_lens)
 
-        # Construct the next draft input
         next_draft_input = NgramVerifyInput(
             draft_token_num=self.draft_token_num,
             new_seq_lens=new_seq_lens,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -324,9 +324,9 @@ class NGRAMWorker(BaseSpecWorker):
         total_draft_token_num = len(req_drafts)
 
         # Check if speculative decoding is needed; here we always enforce it
-        assert total_draft_token_num == bs * self.draft_token_num, (
-            f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
-        )
+        assert (
+            total_draft_token_num == bs * self.draft_token_num
+        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
         return req_drafts, mask, match_lens
 
     def get_retrieval_info(self, batch: ScheduleBatch) -> tuple[list[int], list[int]]:

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 
 import numpy as np
 import torch
-from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
 from sglang.kernels.ops.speculative.cache_locs import (
     assign_extend_cache_locs_func as assign_extend_cache_locs_func,
@@ -34,10 +33,18 @@ from sglang.srt.speculative.spec_utils import (
     record_stream_for_v2_verify,
     spec_stage_span,
 )
-from sglang.srt.utils import is_cpu
+from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_musa
 from sglang.srt.utils.async_probe import maybe_detect_inf, maybe_detect_nan
 
 _is_cpu = is_cpu()
+_is_cuda = is_cuda()
+_is_hip = is_hip()
+_is_musa = is_musa()
+
+# Guarded like eagle_utils's sgl_kernel imports: hosts with no accelerator
+# (CPU CI runners) cannot load sgl_kernel at all.
+if _is_cuda or _is_hip or _is_musa or _is_cpu:
+    from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
 logger = logging.getLogger(__name__)
 
@@ -242,9 +249,7 @@ class NGRAMWorker(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self,
-        num_correct_drafts_per_req: list[int],
-        batch_size: int = 0,
+        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
     ) -> None:
         # Signature must match BaseSpecWorker.on_verify_complete_cpu; the
         # result processor calls it with batch_size as a keyword argument.

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -44,6 +44,7 @@ class SpeculativeAlgorithm(Enum):
     FROZEN_KV_MTP = auto()
     STANDALONE = auto()
     NGRAM = auto()
+    HYBRID = auto()
     NONE = auto()
 
     @classmethod
@@ -104,6 +105,7 @@ class SpeculativeAlgorithm(Enum):
             SpeculativeAlgorithm.EAGLE,
             SpeculativeAlgorithm.EAGLE3,
             SpeculativeAlgorithm.FROZEN_KV_MTP,
+            SpeculativeAlgorithm.HYBRID,
         )
 
     def is_eagle3(self) -> bool:
@@ -129,6 +131,9 @@ class SpeculativeAlgorithm(Enum):
 
     def is_ngram(self) -> bool:
         return self == SpeculativeAlgorithm.NGRAM
+
+    def is_hybrid(self) -> bool:
+        return self == SpeculativeAlgorithm.HYBRID
 
     def supports_target_verify_for_draft(self) -> bool:
         return self.is_dflash_family()
@@ -169,7 +174,7 @@ class SpeculativeAlgorithm(Enum):
     def carries_draft_hidden_states(self) -> bool:
         """Whether the disagg prefill->decode transfer carries draft hidden
         states (EAGLE-family only; STANDALONE's vanilla draft ignores them)."""
-        return self.is_eagle()
+        return self.is_eagle() or self.is_hybrid()
 
     def create_future_map(
         self,
@@ -211,7 +216,7 @@ class SpeculativeAlgorithm(Enum):
         return None
 
     def need_topk(self) -> bool:
-        return self.is_eagle() or self.is_standalone()
+        return self.is_eagle() or self.is_standalone() or self.is_hybrid()
 
     def handle_server_args(self, server_args: ServerArgs) -> None:
         """Hook for per-algorithm server args mutation.
@@ -223,6 +228,7 @@ class SpeculativeAlgorithm(Enum):
             _handle_dspark,
             _handle_eagle_family,
             _handle_frozen_kv_mtp,
+            _handle_hybrid,
             _handle_ngram,
             _handle_uno,
         )
@@ -241,6 +247,8 @@ class SpeculativeAlgorithm(Enum):
             _handle_dspark(server_args)
         elif self.is_frozen_kv_mtp():
             _handle_frozen_kv_mtp(server_args)
+        elif self.is_hybrid():
+            _handle_hybrid(server_args)
         elif self.is_eagle() or self.is_standalone():
             _handle_eagle_family(server_args)
         elif self.is_ngram():
@@ -250,9 +258,37 @@ class SpeculativeAlgorithm(Enum):
         self, server_args: ServerArgs
     ) -> Optional[int]:
         """Return the largest draft-token width this algorithm may use."""
+        import json
+
         from sglang.srt.arg_groups.overrides import resolving_view
 
         cfg = resolving_view(server_args)
+        if self.is_hybrid():
+            # Each role carries its own width in the hybrid JSON config, so
+            # the capacity must cover the widest route.
+            widths = []
+            if cfg.speculative_num_draft_tokens is not None:
+                widths.append(cfg.speculative_num_draft_tokens)
+            try:
+                hybrid_config = json.loads(cfg.speculative_hybrid_config)
+            except (TypeError, json.JSONDecodeError):
+                hybrid_config = {}
+            for role in ("retrieval", "neural"):
+                role_config = hybrid_config.get(role, {})
+                if isinstance(role_config, dict):
+                    width = role_config.get("speculative_num_draft_tokens")
+                    if isinstance(width, int):
+                        widths.append(width)
+            if cfg.speculative_adaptive:
+                from sglang.srt.speculative.adaptive_spec_params import (
+                    resolve_candidate_steps_from_config,
+                )
+
+                candidate_steps = resolve_candidate_steps_from_config(
+                    cfg_path=cfg.speculative_adaptive_config,
+                )
+                widths.append(max(candidate_steps) + 1)
+            return max(widths) if widths else None
         if cfg.speculative_num_draft_tokens is None:
             return None
         if not cfg.speculative_adaptive:
@@ -334,7 +370,11 @@ class SpeculativeAlgorithm(Enum):
 
         # EAGLE / EAGLE3 / STANDALONE / MULTI_LAYER always use the V2 worker,
         # even with overlap disabled (scheduler drives it synchronously).
-        if self.is_eagle() and cfg.enable_multi_layer_eagle:
+        if self.is_hybrid():
+            from sglang.srt.speculative.hybrid_controller import HybridController
+
+            return HybridController
+        elif self.is_eagle() and cfg.enable_multi_layer_eagle:
             from sglang.srt.speculative.multi_layer_eagle_worker_v2 import (
                 MultiLayerEagleWorkerV2,
             )
@@ -371,6 +411,7 @@ class SpecInputType(IntEnum):
     UNO_STATE = auto()
     UNO_DRAFT = auto()
     UNO_VERIFY = auto()
+    HYBRID_VERIFY = auto()
 
 
 class SpecInput(ABC):
@@ -418,6 +459,7 @@ class SpecInput(ABC):
             SpecInputType.DFLASH_VERIFY,
             SpecInputType.NGRAM_VERIFY,
             SpecInputType.UNO_VERIFY,
+            SpecInputType.HYBRID_VERIFY,
         }
 
 

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -97,6 +97,9 @@ class CustomSpecAlgo:
     def is_ngram(self) -> bool:
         return False
 
+    def is_hybrid(self) -> bool:
+        return False
+
     def supports_target_verify_for_draft(self) -> bool:
         return False
 

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -6,6 +6,7 @@ token, so the over-drafted suffix is never committed to KV nor emitted.
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
@@ -64,7 +65,7 @@ class _FakeBatch:
         self.spec_algorithm = _FakeSpecAlgorithm()
 
 
-def _make_processor() -> SchedulerBatchResultProcessor:
+def _make_processor(model_worker=None) -> SchedulerBatchResultProcessor:
     return SchedulerBatchResultProcessor(
         is_generation=True,
         disaggregation_mode=None,
@@ -79,7 +80,9 @@ def _make_processor() -> SchedulerBatchResultProcessor:
         metrics_collector=None,
         metrics_reporter=SimpleNamespace(),
         draft_worker=None,
-        model_worker=SimpleNamespace(on_verify_complete_cpu=lambda *a, **k: None),
+        model_worker=(
+            model_worker or SimpleNamespace(on_verify_complete_cpu=lambda *a, **k: None)
+        ),
         logprob_result_processor=None,
         output_streamer=SimpleNamespace(),
         beam_coordinator=SimpleNamespace(),
@@ -98,14 +101,16 @@ def _make_req(terminate_after: int) -> Req:
     )
     req.grammar = _FakeGrammar(terminate_after=terminate_after)
     req.kv.kv_committed_len = 0
+    req.kv.kv_allocated_len = 16
     return req
 
 
-def _make_result(num_draft_tokens, accept_lens, flat_tokens):
+def _make_result(num_draft_tokens, accept_lens, flat_tokens, spec_route=None):
     return GenerationBatchResult(
         next_token_ids=torch.tensor(flat_tokens, dtype=torch.long),
         accept_lens=torch.tensor(accept_lens, dtype=torch.long),
         speculative_num_draft_tokens=num_draft_tokens,
+        spec_route=spec_route,
     )
 
 
@@ -152,6 +157,28 @@ def _commit_disagg_handoff(
 
 
 class TestSpecV2GrammarTruncation(CustomTestCase):
+    def test_leaf_worker_callback_omits_hybrid_route(self):
+        req = _make_req(terminate_after=99)
+        model_worker = SimpleNamespace(on_verify_complete_cpu=MagicMock())
+        proc = _make_processor(model_worker)
+        result = _make_result(4, [3], [101, 102, 103, 0])
+
+        proc._resolve_spec_v2_tokens(result, _FakeBatch([req]))
+
+        model_worker.on_verify_complete_cpu.assert_called_once_with([2], batch_size=1)
+
+    def test_hybrid_controller_callback_receives_producer_route(self):
+        req = _make_req(terminate_after=99)
+        model_worker = SimpleNamespace(on_verify_complete_cpu=MagicMock())
+        proc = _make_processor(model_worker)
+        result = _make_result(4, [3], [101, 102, 103, 0], spec_route="retrieval")
+
+        proc._resolve_spec_v2_tokens(result, _FakeBatch([req]))
+
+        model_worker.on_verify_complete_cpu.assert_called_once_with(
+            [2], batch_size=1, route="retrieval"
+        )
+
     def test_resolve_truncates_after_grammar_completion(self):
         req = _make_req(terminate_after=2)
         proc = _make_processor()
@@ -173,6 +200,20 @@ class TestSpecV2GrammarTruncation(CustomTestCase):
 
         self.assertEqual(predict_tokens, [[201, 202, 203]])
         self.assertEqual(req.kv.kv_committed_len, 3)
+
+    def test_finished_overlap_result_skips_released_kv_invariant(self):
+        req = _make_req(terminate_after=99)
+        req.grammar = None
+        req.finished_reason = SimpleNamespace()
+        req.kv.kv_committed_len = 7
+        req.kv.kv_allocated_len = 0
+        proc = _make_processor()
+        result = _make_result(4, [3], [201, 202, 203, 0])
+
+        predict_tokens = proc._resolve_spec_v2_tokens(result, _FakeBatch([req]))
+
+        self.assertEqual(predict_tokens, [[201, 202, 203]])
+        self.assertEqual(req.kv.kv_committed_len, 7)
 
 
 class TestReasoningTokenAccounting(CustomTestCase):

--- a/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
+++ b/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
@@ -1366,6 +1366,41 @@ class TestBuildPrefillRegistry(unittest.TestCase):
         )
         self.assertIs(fb_view.input_embeds, embeds)
 
+    def test_text_only_draft_can_allocate_registered_input_embeds(self):
+        from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+            build_prefill_registry,
+        )
+        from sglang.srt.model_executor.runner_utils.buffers import (
+            PrefillInputBuffers,
+        )
+
+        buffers = PrefillInputBuffers.create(
+            device=torch.device("cpu"),
+            max_bs=2,
+            max_num_tokens=8,
+            cache_loc_dtype=torch.int64,
+            is_multimodal=False,
+            hidden_size=4,
+            dtype=torch.float32,
+            enable_mamba_track=False,
+            enable_input_embeds=True,
+        )
+        reg = build_prefill_registry(
+            device=torch.device("cpu"),
+            max_bs=2,
+            max_num_token=8,
+            cache_loc_dtype=torch.int64,
+            is_multimodal=False,
+            hidden_size=4,
+            embed_dtype=torch.float32,
+            register_input_embeds=True,
+            share_pool=False,
+            source=buffers,
+        )
+
+        self.assertIs(reg.get_slot("input_embeds").buffer, buffers.input_embeds)
+        self.assertFalse(reg.has_slot("mrope_positions"))
+
 
 class TestPrefillNumTokenNonPaddedPostFill(unittest.TestCase):
     """The prefill registry must re-derive the attn-TP-local pad boundary from

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -80,6 +80,7 @@ class _FakeBatchRegistry:
             "input_ids": _FakeGraphSlot(torch.arange(4, dtype=torch.int64)),
             "positions": _FakeGraphSlot(torch.arange(4, dtype=torch.int64)),
             "out_cache_loc": _FakeGraphSlot(torch.arange(4, dtype=torch.int64)),
+            "input_embeds": _FakeGraphSlot(torch.zeros(4, 8)),
         }
 
     def fill_from(self, *_args, **_kwargs):
@@ -194,7 +195,7 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         self.assertEqual(tuple(trimmed["hidden_states"].shape), (3, 4))
         self.assertEqual(tuple(trimmed["residual"].shape), (3, 4))
 
-    def test_static_batch_preserves_consumed_multimodal_embeddings(self):
+    def test_static_batch_uses_address_stable_draft_embeddings(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner.capture_num_tokens = [4]
         runner.buffer_registry = _FakeBatchRegistry()
@@ -204,6 +205,12 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         runner.has_mha_companion_layers = False
         runner._prefill_static_buffers = None
         runner.static_draft_hidden_states = None
+        runner._use_draft_input_embeds = True
+        runner.layer_model = SimpleNamespace(
+            embed_tokens=lambda _input_ids: self.fail(
+                "multimodal draft replay must use target-composed embeddings"
+            )
+        )
         runner.capture_return_pooled_hidden_states = False
         runner._next_token_logits_buffer = lambda _rows: None
         runner._prefill_logits_buffer_rows = lambda _batch: 1
@@ -234,6 +241,20 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         static_batch = runner.load_batch(forward_batch)
 
         self.assertIs(static_batch.mm_input_embeds, mm_input_embeds)
+        self.assertTrue(torch.equal(static_batch.input_embeds[:3], mm_input_embeds))
+
+        text_input_embeds = torch.randn(3, 8)
+        runner.layer_model.embed_tokens = lambda input_ids: (
+            text_input_embeds
+            if torch.equal(input_ids, forward_batch.input_ids)
+            else self.fail("text draft lookup received unexpected token ids")
+        )
+        forward_batch.mm_input_embeds = None
+
+        static_batch = runner.load_batch(forward_batch)
+
+        self.assertIsNone(static_batch.mm_input_embeds)
+        self.assertTrue(torch.equal(static_batch.input_embeds[:3], text_input_embeds))
 
     def test_eagle_target_full_reaches_graph_construction(self):
         override = get_context().override_server_args(

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
@@ -200,6 +200,7 @@ class TestPrefillCudaGraphRunnerHelpers(CustomTestCase):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner._is_full_backend = False
         runner._input_embeds_arg_idx = None
+        runner._use_draft_input_embeds = False
         runner.buffer_registry = SimpleNamespace(has_slot=lambda _name: False)
         runner.backend = SimpleNamespace(replay=lambda *_args, **_kwargs: None)
         runner.layer_model = SimpleNamespace(forward=lambda *_args, **_kwargs: None)

--- a/test/registered/unit/models/test_qwen3_eagle_capture.py
+++ b/test/registered/unit/models/test_qwen3_eagle_capture.py
@@ -1,0 +1,60 @@
+"""Regression tests for Qwen3-VL and Qwen3.5 EAGLE3 layer capture."""
+
+import unittest
+from types import SimpleNamespace
+
+from torch import nn
+
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5ForCausalLM,
+    Qwen3_5ForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _mock_wrapper(wrapper_cls, backbone, *, num_hidden_layers=12):
+    wrapper = wrapper_cls.__new__(wrapper_cls)
+    nn.Module.__init__(wrapper)
+    wrapper.pp_group = SimpleNamespace(is_last_rank=True)
+    wrapper.config = SimpleNamespace(num_hidden_layers=num_hidden_layers)
+    wrapper.model = backbone
+    wrapper.capture_aux_hidden_states = False
+    return wrapper
+
+
+class TestQwen3EagleCapture(CustomTestCase):
+    def test_qwen3_vl_keeps_native_layer_list_path(self):
+        backbone = SimpleNamespace(
+            capture_aux_hidden_states=False,
+            layers_to_capture=[],
+        )
+        wrapper = _mock_wrapper(Qwen3VLForConditionalGeneration, backbone)
+
+        wrapper.set_eagle3_layers_to_capture([1, 4, 8])
+
+        self.assertTrue(wrapper.capture_aux_hidden_states)
+        self.assertTrue(backbone.capture_aux_hidden_states)
+        self.assertEqual(backbone.layers_to_capture, [2, 5, 9])
+
+    def test_qwen3_5_marks_decoder_layers(self):
+        layers = [SimpleNamespace() for _ in range(12)]
+        backbone = Qwen3_5ForCausalLM.__new__(Qwen3_5ForCausalLM)
+        backbone.layers = layers
+        backbone.layers_to_capture = []
+        wrapper = _mock_wrapper(Qwen3_5ForConditionalGeneration, backbone)
+
+        wrapper.set_eagle3_layers_to_capture([1, 4, 8])
+
+        self.assertTrue(wrapper.capture_aux_hidden_states)
+        self.assertEqual(backbone.layers_to_capture, [2, 5, 9])
+        self.assertTrue(layers[2]._is_layer_to_capture)
+        self.assertTrue(layers[5]._is_layer_to_capture)
+        self.assertTrue(layers[9]._is_layer_to_capture)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import get_context
 from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
@@ -135,114 +134,6 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
         worker = _make_worker(num_steps=3, num_draft_tokens=3)
         with self.assertRaises(AssertionError):
             worker._rebuild_topk1_chain_buffers()
-
-    def test_draft_worker_construction_enters_all_contexts(self):
-        events = []
-
-        @contextlib.contextmanager
-        def recording_context(name):
-            events.append(("enter", name))
-            try:
-                yield
-            finally:
-                events.append(("exit", name))
-
-        context_factories = {
-            "empty_context": lambda: recording_context("tp"),
-            "draft_pp_context": lambda: recording_context("pp"),
-            "speculative_moe_backend_context": lambda: recording_context("moe"),
-            "speculative_moe_a2a_backend_context": lambda: recording_context("moe_a2a"),
-            "draft_model_build_scope": lambda: recording_context("draft_model"),
-        }
-
-        def fake_tp_worker(**_kwargs):
-            self.assertEqual(
-                [event for event in events if event[0] == "enter"],
-                [
-                    ("enter", "tp"),
-                    ("enter", "pp"),
-                    ("enter", "moe"),
-                    ("enter", "moe_a2a"),
-                    ("enter", "draft_model"),
-                ],
-            )
-            return SimpleNamespace(
-                model_runner=SimpleNamespace(
-                    model_config=SimpleNamespace(hf_config=SimpleNamespace())
-                )
-            )
-
-        spec = SimpleNamespace(
-            speculative_eagle_topk=1,
-            speculative_use_rejection_sampling=False,
-            speculative_num_steps=3,
-            speculative_num_draft_tokens=4,
-            speculative_algorithm="EAGLE3",
-        )
-        target_worker = SimpleNamespace(
-            model_runner=SimpleNamespace(
-                model_config=SimpleNamespace(context_len=1024)
-            ),
-            random_seed=0,
-        )
-
-        with contextlib.ExitStack() as stack:
-            stack.enter_context(
-                patch(
-                    "sglang.srt.speculative.eagle_worker_v2.get_device",
-                    return_value=SimpleNamespace(device=DEVICE),
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "sglang.srt.speculative.eagle_worker_v2.get_parallel",
-                    return_value=SimpleNamespace(enable_dp_attention=False),
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "sglang.srt.speculative.eagle_worker_v2.get_spec",
-                    return_value=spec,
-                )
-            )
-            stack.enter_context(
-                patch.object(EagleDraftWorker, "_rebuild_topk1_chain_buffers")
-            )
-            stack.enter_context(
-                patch(
-                    "sglang.srt.speculative.eagle_worker_v2.TpModelWorker",
-                    side_effect=fake_tp_worker,
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "sglang.srt.speculative.eagle_worker_v2.get_plan_stream",
-                    return_value=(None, None),
-                )
-            )
-            for name, factory in context_factories.items():
-                stack.enter_context(
-                    patch(f"sglang.srt.speculative.eagle_worker_v2.{name}", factory)
-                )
-
-            EagleDraftWorker(
-                server_args=SimpleNamespace(),
-                gpu_id=0,
-                ps=ParallelState.trivial(),
-                nccl_port=12345,
-                target_worker=target_worker,
-            )
-
-        self.assertEqual(
-            [event for event in events if event[0] == "exit"],
-            [
-                ("exit", "draft_model"),
-                ("exit", "moe_a2a"),
-                ("exit", "moe"),
-                ("exit", "pp"),
-                ("exit", "tp"),
-            ],
-        )
 
     def test_idle_draft_runs_each_eager_forward_without_tree_layout(self):
         worker = object.__new__(EagleDraftWorker)

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import get_context
 from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
@@ -134,6 +135,114 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
         worker = _make_worker(num_steps=3, num_draft_tokens=3)
         with self.assertRaises(AssertionError):
             worker._rebuild_topk1_chain_buffers()
+
+    def test_draft_worker_construction_enters_all_contexts(self):
+        events = []
+
+        @contextlib.contextmanager
+        def recording_context(name):
+            events.append(("enter", name))
+            try:
+                yield
+            finally:
+                events.append(("exit", name))
+
+        context_factories = {
+            "empty_context": lambda: recording_context("tp"),
+            "draft_pp_context": lambda: recording_context("pp"),
+            "speculative_moe_backend_context": lambda: recording_context("moe"),
+            "speculative_moe_a2a_backend_context": lambda: recording_context("moe_a2a"),
+            "draft_model_build_scope": lambda: recording_context("draft_model"),
+        }
+
+        def fake_tp_worker(**_kwargs):
+            self.assertEqual(
+                [event for event in events if event[0] == "enter"],
+                [
+                    ("enter", "tp"),
+                    ("enter", "pp"),
+                    ("enter", "moe"),
+                    ("enter", "moe_a2a"),
+                    ("enter", "draft_model"),
+                ],
+            )
+            return SimpleNamespace(
+                model_runner=SimpleNamespace(
+                    model_config=SimpleNamespace(hf_config=SimpleNamespace())
+                )
+            )
+
+        spec = SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_use_rejection_sampling=False,
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+            speculative_algorithm="EAGLE3",
+        )
+        target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                model_config=SimpleNamespace(context_len=1024)
+            ),
+            random_seed=0,
+        )
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "sglang.srt.speculative.eagle_worker_v2.get_device",
+                    return_value=SimpleNamespace(device=DEVICE),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.speculative.eagle_worker_v2.get_parallel",
+                    return_value=SimpleNamespace(enable_dp_attention=False),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.speculative.eagle_worker_v2.get_spec",
+                    return_value=spec,
+                )
+            )
+            stack.enter_context(
+                patch.object(EagleDraftWorker, "_rebuild_topk1_chain_buffers")
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.speculative.eagle_worker_v2.TpModelWorker",
+                    side_effect=fake_tp_worker,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.speculative.eagle_worker_v2.get_plan_stream",
+                    return_value=(None, None),
+                )
+            )
+            for name, factory in context_factories.items():
+                stack.enter_context(
+                    patch(f"sglang.srt.speculative.eagle_worker_v2.{name}", factory)
+                )
+
+            EagleDraftWorker(
+                server_args=SimpleNamespace(),
+                gpu_id=0,
+                ps=ParallelState.trivial(),
+                nccl_port=12345,
+                target_worker=target_worker,
+            )
+
+        self.assertEqual(
+            [event for event in events if event[0] == "exit"],
+            [
+                ("exit", "draft_model"),
+                ("exit", "moe_a2a"),
+                ("exit", "moe"),
+                ("exit", "pp"),
+                ("exit", "tp"),
+            ],
+        )
 
     def test_idle_draft_runs_each_eager_forward_without_tree_layout(self):
         worker = object.__new__(EagleDraftWorker)

--- a/test/registered/unit/spec/test_hybrid_controller.py
+++ b/test/registered/unit/spec/test_hybrid_controller.py
@@ -164,6 +164,8 @@ class TestHybridRuntimeSwitch(CustomTestCase):
         controller._target_prefill_attn_backend = "target-prefill"
 
         def apply_runtime_state(state):
+            if neural_worker._active_runtime_state is state:
+                return
             neural_worker.speculative_num_steps = state.speculative_num_steps
             neural_worker.speculative_num_draft_tokens = (
                 state.speculative_num_draft_tokens
@@ -221,6 +223,9 @@ class TestHybridRuntimeSwitch(CustomTestCase):
         self.controller._apply_runtime_state("neural")
 
         self.assertEqual(self.target_runner.attn_backend, "target-step7")
+        self.assertEqual(
+            self.target_runner.decode_cuda_graph_runner, "target-graph-step7"
+        )
         self.assertEqual(self.draft_worker.cuda_graph_runner, "draft-graph-step7")
         self.assertEqual(
             self.draft_worker.cuda_graph_runner_for_draft_extend,
@@ -240,10 +245,115 @@ class TestHybridRuntimeSwitch(CustomTestCase):
         self.controller._apply_runtime_state("retrieval")
 
         self.assertEqual(self.neural_worker.speculative_num_steps, 7)
+        self.assertEqual(self.target_runner.attn_backend, "target-retrieval")
+        self.assertEqual(
+            self.target_runner.decode_cuda_graph_runner, "target-graph-retrieval"
+        )
         self.assertEqual(
             self.draft_worker.cuda_graph_runner_for_draft_extend,
             "extend-graph-retrieval",
         )
+
+    def test_retrieval_to_neural_restores_target_verify_resources(self):
+        neural_spec_state = _runtime_state("neural", steps=3, width=4)
+        self.controller._runtime_states = {
+            ("neural", 3): HybridRuntimeState(
+                "neural", self.neural_worker, neural_spec_state
+            ),
+            ("retrieval", None): HybridRuntimeState(
+                "retrieval",
+                SimpleNamespace(),
+                _runtime_state("retrieval", steps=5, width=6),
+            ),
+        }
+
+        self.controller._apply_runtime_state("neural")
+        self.controller._apply_runtime_state("retrieval")
+        self.controller._apply_runtime_state("neural")
+
+        # EAGLE's second apply is a no-op because it still considers the neural
+        # state active. The outer controller must restore target verify itself.
+        self.assertEqual(self.target_runner.attn_backend, "target-neural")
+        self.assertEqual(
+            self.target_runner.decode_cuda_graph_runner, "target-graph-neural"
+        )
+
+
+class TestHybridGraphResources(CustomTestCase):
+    @patch(
+        "sglang.srt.speculative.hybrid_controller.speculative_moe_a2a_backend_context",
+        return_value=nullcontext(),
+    )
+    @patch(
+        "sglang.srt.speculative.hybrid_controller.speculative_moe_backend_context",
+        return_value=nullcontext(),
+    )
+    def test_draft_extend_resources_do_not_inject_primary_buffers(self, _moe, _moe_a2a):
+        draft_worker = SimpleNamespace(
+            draft_extend_attn_backend="extend-4",
+            cuda_graph_runner_for_draft_extend="extend-graph-4",
+            draft_runner=SimpleNamespace(tp_group=object()),
+            draft_tp_context=MagicMock(return_value=nullcontext()),
+            build_draft_extend_runtime_resource=MagicMock(
+                return_value=("extend-6", "extend-graph-6")
+            ),
+        )
+        controller = object.__new__(HybridController)
+        controller.neural_worker = SimpleNamespace(
+            speculative_num_draft_tokens=4,
+            adaptive_runtime_states={},
+            draft_worker=draft_worker,
+        )
+        controller._runtime_widths = (4, 6)
+
+        controller._init_draft_extend_resources()
+
+        draft_worker.build_draft_extend_runtime_resource.assert_called_once_with(
+            num_tokens_per_bs=6
+        )
+        self.assertEqual(
+            controller._draft_extend_resources,
+            {
+                4: ("extend-4", "extend-graph-4"),
+                6: ("extend-6", "extend-graph-6"),
+            },
+        )
+
+    def test_target_verify_resources_use_width_local_graph_construction(self):
+        target_runner = SimpleNamespace(
+            init_new_workspace=False,
+            _get_attention_backend=MagicMock(return_value="target-4"),
+        )
+        graph4 = object()
+        bootstrap_graph = object()
+        controller = object.__new__(HybridController)
+        controller._target_worker = SimpleNamespace(model_runner=target_runner)
+        controller.neural_worker = SimpleNamespace(
+            adaptive_runtime_states={},
+            _override_worker_state=MagicMock(return_value=nullcontext()),
+        )
+        controller._runtime_widths = (4, 6)
+
+        with patch(
+            "sglang.srt.model_executor.runner.DecodeCudaGraphRunner",
+            return_value=graph4,
+        ) as graph_runner:
+            controller._init_target_verify_resources(
+                bootstrap_width=6,
+                bootstrap_graph_runner=bootstrap_graph,
+                bootstrap_attn_backend="target-6",
+            )
+
+        graph_runner.assert_called_once_with(
+            target_runner,
+            attn_backend="target-4",
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+        )
+        self.assertIs(controller._target_verify_graph_runners[4], graph4)
+        self.assertIs(controller._target_verify_graph_runners[6], bootstrap_graph)
+        self.assertFalse(hasattr(target_runner, "hybrid_target_verify_graph_runners"))
+        self.assertFalse(hasattr(target_runner, "hybrid_target_verify_attn_backends"))
 
 
 class TestHybridDraftInputRelay(CustomTestCase):

--- a/test/registered/unit/spec/test_hybrid_controller.py
+++ b/test/registered/unit/spec/test_hybrid_controller.py
@@ -112,7 +112,7 @@ class TestHybridServerArgs(CustomTestCase):
                     json.dumps({k: v for k, v in full.items() if k != missing})
                 )
         for name in ("min_continuation_ratio", "min_matching_ratio"):
-            with self.assertRaisesRegex(ValueError, rf"{name} must be in \\(0, 1\\]"):
+            with self.assertRaisesRegex(ValueError, rf"{name} must be in \(0, 1\]"):
                 HybridController._load_config(json.dumps({**full, name: 1.5}))
 
 

--- a/test/registered/unit/spec/test_hybrid_controller.py
+++ b/test/registered/unit/spec/test_hybrid_controller.py
@@ -1,0 +1,565 @@
+"""CPU contracts for HYBRID speculative runtime-state routing."""
+
+import json
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.arg_groups.overrides import (
+    max_speculative_num_draft_tokens as max_speculative_num_draft_tokens_before_publish,
+)
+from sglang.srt.arg_groups.overrides import (
+    resolving_view,
+)
+from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.mem_cache.allocation_sizing import get_alloc_reserve_per_decode
+from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
+from sglang.srt.runtime_context import (
+    get_context,
+    max_speculative_num_draft_tokens,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_worker_v2 import EAGLEWorkerV2
+from sglang.srt.speculative.hybrid_controller import (
+    HybridController,
+    HybridRuntimeState,
+)
+from sglang.srt.speculative.hybrid_info import HybridVerifyInput
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
+from sglang.srt.speculative.spec_info import (
+    SpeculativeAlgorithm,
+    create_dummy_verify_input,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _hybrid_config(*, adaptive=False):
+    neural = {
+        "algorithm": "EAGLE3",
+        "speculative_num_steps": 3,
+        "speculative_num_draft_tokens": 4,
+        "speculative_eagle_topk": 1,
+    }
+    if adaptive:
+        neural["speculative_adaptive"] = True
+    return json.dumps(
+        {
+            "retrieval": {
+                "algorithm": "NGRAM",
+                "speculative_num_draft_tokens": 6,
+            },
+            "neural": neural,
+            "min_continuation_ratio": 1.0,
+            "min_matching_ratio": 0.5,
+        }
+    )
+
+
+def _runtime_state(name, *, steps, width):
+    return SpecRuntimeState(
+        speculative_num_steps=steps,
+        speculative_num_draft_tokens=width,
+        draft_attn_backend=f"draft-{name}",
+        cuda_graph_runner=f"draft-graph-{name}",
+        target_attn_backend=f"target-{name}",
+        target_graph_runner=f"target-graph-{name}",
+        draft_extend_attn_backend=f"extend-{name}",
+        cuda_graph_runner_for_draft_extend=f"extend-graph-{name}",
+    )
+
+
+class TestHybridServerArgs(CustomTestCase):
+    def test_max_width_includes_widest_role_and_controls_overlap_reserve(self):
+        with get_context().override_server_args(
+            speculative_algorithm="HYBRID",
+            speculative_hybrid_config=_hybrid_config(),
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=6,
+            page_size=1,
+        ):
+            self.assertEqual(max_speculative_num_draft_tokens(), 6)
+            self.assertEqual(get_alloc_reserve_per_decode(), 12)
+
+    def test_top_level_adaptive_is_owned_by_neural_role(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "HYBRID"
+        args.speculative_hybrid_config = _hybrid_config(adaptive=True)
+        args.speculative_adaptive = True
+        args.device = "cuda"
+
+        handle_speculative_decoding(args)
+
+        cfg = resolving_view(args)
+        self.assertTrue(cfg.speculative_adaptive)
+        self.assertEqual(cfg.speculative_num_steps, 3)
+        self.assertEqual(cfg.speculative_num_draft_tokens, 8)
+        self.assertEqual(max_speculative_num_draft_tokens_before_publish(args), 8)
+
+    def test_routing_thresholds_are_required(self):
+        full = json.loads(_hybrid_config())
+        for missing in ("min_continuation_ratio", "min_matching_ratio"):
+            with self.assertRaisesRegex(ValueError, rf"requires {missing}"):
+                HybridController._load_config(
+                    json.dumps({k: v for k, v in full.items() if k != missing})
+                )
+        for name in ("min_continuation_ratio", "min_matching_ratio"):
+            with self.assertRaisesRegex(ValueError, rf"{name} must be in \\(0, 1\\]"):
+                HybridController._load_config(
+                    json.dumps({**full, name: 1.5})
+                )
+
+
+class TestHybridRuntimeSwitch(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._context_override = get_context().override_server_args(
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=6,
+        )
+        self._context_override.install()
+        self.addCleanup(self._context_override.restore)
+
+        draft_worker = SimpleNamespace(
+            draft_attn_backend=None,
+            draft_runner=SimpleNamespace(
+                draft_attn_backend=None,
+                attn_backend=None,
+            ),
+            cuda_graph_runner=None,
+            draft_extend_attn_backend=None,
+            cuda_graph_runner_for_draft_extend=None,
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+            _rebuild_topk1_chain_buffers=MagicMock(),
+        )
+        neural_worker = SimpleNamespace(
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+            server_args=SimpleNamespace(
+                speculative_num_steps=3,
+                speculative_num_draft_tokens=4,
+            ),
+            draft_worker=draft_worker,
+            _active_runtime_state=None,
+        )
+        target_runner = SimpleNamespace(
+            server_args=SimpleNamespace(
+                speculative_num_steps=3,
+                speculative_num_draft_tokens=6,
+            ),
+            attn_backend=None,
+            decode_cuda_graph_runner=None,
+        )
+        controller = object.__new__(HybridController)
+        controller.neural_worker = neural_worker
+        controller._target_worker = SimpleNamespace(model_runner=target_runner)
+        controller._active_runtime_state = None
+        controller._target_prefill_attn_backend = "target-prefill"
+
+        def apply_runtime_state(state):
+            neural_worker.speculative_num_steps = state.speculative_num_steps
+            neural_worker.speculative_num_draft_tokens = (
+                state.speculative_num_draft_tokens
+            )
+            neural_worker._active_runtime_state = state
+            draft_worker.draft_attn_backend = state.draft_attn_backend
+            draft_worker.draft_runner.draft_attn_backend = state.draft_attn_backend
+            draft_worker.cuda_graph_runner = state.cuda_graph_runner
+            draft_worker.draft_extend_attn_backend = state.draft_extend_attn_backend
+            draft_worker.draft_runner.attn_backend = state.draft_extend_attn_backend
+            draft_worker.cuda_graph_runner_for_draft_extend = (
+                state.cuda_graph_runner_for_draft_extend
+            )
+            draft_worker._rebuild_topk1_chain_buffers()
+            target_runner.attn_backend = state.target_attn_backend
+            target_runner.decode_cuda_graph_runner = state.target_graph_runner
+
+        neural_worker.apply_runtime_state = MagicMock(side_effect=apply_runtime_state)
+
+        self.controller = controller
+        self.neural_worker = neural_worker
+        self.draft_worker = draft_worker
+        self.target_runner = target_runner
+
+    def test_same_state_restores_verify_backend_without_reapplying_worker(self):
+        spec_state = _runtime_state("neural", steps=3, width=4)
+        state = HybridRuntimeState("neural", self.neural_worker, spec_state)
+        self.controller._runtime_states = {("neural", 3): state}
+
+        self.controller._apply_runtime_state("neural")
+        self.controller._apply_target_prefill_backend()
+        self.assertEqual(self.target_runner.attn_backend, "target-prefill")
+        self.controller._apply_runtime_state("neural")
+
+        self.assertEqual(self.target_runner.attn_backend, "target-neural")
+        self.assertEqual(
+            self.target_runner.decode_cuda_graph_runner, "target-graph-neural"
+        )
+        self.neural_worker.apply_runtime_state.assert_called_once_with(spec_state)
+        self.draft_worker._rebuild_topk1_chain_buffers.assert_called_once_with()
+
+    def test_neural_route_uses_current_adaptive_step(self):
+        state3 = HybridRuntimeState(
+            "neural", self.neural_worker, _runtime_state("step3", steps=3, width=4)
+        )
+        state7 = HybridRuntimeState(
+            "neural", self.neural_worker, _runtime_state("step7", steps=7, width=8)
+        )
+        self.controller._runtime_states = {
+            ("neural", 3): state3,
+            ("neural", 7): state7,
+        }
+        self.neural_worker.speculative_num_steps = 7
+
+        self.controller._apply_runtime_state("neural")
+
+        self.assertEqual(self.target_runner.attn_backend, "target-step7")
+        self.assertEqual(self.draft_worker.cuda_graph_runner, "draft-graph-step7")
+        self.assertEqual(
+            self.draft_worker.cuda_graph_runner_for_draft_extend,
+            "extend-graph-step7",
+        )
+        self.assertEqual(self.neural_worker.speculative_num_draft_tokens, 8)
+
+    def test_retrieval_route_does_not_change_neural_step(self):
+        retrieval_state = HybridRuntimeState(
+            "retrieval",
+            SimpleNamespace(),
+            _runtime_state("retrieval", steps=5, width=6),
+        )
+        self.controller._runtime_states = {("retrieval", None): retrieval_state}
+        self.neural_worker.speculative_num_steps = 7
+
+        self.controller._apply_runtime_state("retrieval")
+
+        self.assertEqual(self.neural_worker.speculative_num_steps, 7)
+        self.assertEqual(
+            self.draft_worker.cuda_graph_runner_for_draft_extend,
+            "extend-graph-retrieval",
+        )
+
+
+class TestHybridDraftInputRelay(CustomTestCase):
+    def test_ngram_dummy_verify_keeps_native_input(self):
+        with get_context().override_server_args(
+            speculative_algorithm="NGRAM",
+            speculative_num_steps=5,
+            speculative_num_draft_tokens=6,
+            speculative_eagle_topk=-1,
+        ):
+            verify_input = create_dummy_verify_input(
+                SpeculativeAlgorithm.NGRAM,
+                custom_mask=torch.ones(1, dtype=torch.bool),
+                num_tokens_per_req=6,
+                is_draft_worker=False,
+            )
+
+        self.assertIsInstance(verify_input, NgramVerifyInput)
+        self.assertEqual(verify_input.draft_token_num, 6)
+
+    @patch(
+        "sglang.srt.speculative.eagle_worker_v2.speculative_moe_a2a_backend_context",
+        return_value=nullcontext(),
+    )
+    @patch(
+        "sglang.srt.speculative.eagle_worker_v2.speculative_moe_backend_context",
+        return_value=nullcontext(),
+    )
+    @patch(
+        "sglang.srt.speculative.eagle_worker_v2.spec_stage_span",
+        return_value=nullcontext(),
+    )
+    def test_retrieval_result_becomes_eagle_input_after_draft_extend(
+        self, _span, _moe, _moe_a2a
+    ):
+        draft_extend = MagicMock()
+        draft_worker = SimpleNamespace(
+            draft_runner=SimpleNamespace(tp_group=object()),
+            draft_tp_context=MagicMock(return_value=nullcontext()),
+            _draft_extend_for_decode=draft_extend,
+        )
+        worker = object.__new__(EAGLEWorkerV2)
+        worker._draft_worker = draft_worker
+        worker.spec_stage_span_prefix = "neural"
+
+        accept_tokens = torch.tensor([[10, 11, 0, 0, 0, 0], [20, 21, 22, 0, 0, 0]])
+        source_input = NgramVerifyInput(
+            draft_token_num=6,
+            new_seq_lens=torch.tensor([100, 200]),
+            accept_tokens=accept_tokens.flatten(),
+            accept_lens=torch.tensor([2, 3]),
+        )
+        result = SimpleNamespace(
+            speculative_num_draft_tokens=6,
+            next_draft_input=source_input,
+            accept_lens=source_input.accept_lens,
+        )
+        batch = SimpleNamespace(reqs=[SimpleNamespace(), SimpleNamespace()])
+
+        eagle_input = worker.sync_hybrid_state(batch, result)
+
+        self.assertIsInstance(result.next_draft_input, EagleDraftInput)
+        self.assertIs(eagle_input, result.next_draft_input)
+        self.assertEqual(eagle_input.bonus_tokens.tolist(), [11, 22])
+        self.assertEqual(
+            source_input.accept_tokens.tolist(), accept_tokens.flatten().tolist()
+        )
+        draft_extend.assert_called_once_with(batch, result, source_draft_token_num=6)
+
+    def test_hybrid_filter_merge_reuses_native_inputs(self):
+        eagle_first = EagleDraftInput(
+            topk_p=torch.tensor([[0.1]]),
+            topk_index=torch.tensor([[1]]),
+            hidden_states=torch.tensor([[10.0]]),
+            bonus_tokens=torch.tensor([4]),
+        )
+        eagle_second = EagleDraftInput(
+            topk_p=torch.tensor([[0.2]]),
+            topk_index=torch.tensor([[2]]),
+            hidden_states=torch.tensor([[20.0]]),
+            bonus_tokens=torch.tensor([10]),
+        )
+        ngram_first = NgramVerifyInput(
+            draft_token_num=6,
+            new_seq_lens=torch.tensor([100]),
+            accept_tokens=torch.tensor([1, 2, 3, 4, 0, 0]),
+            accept_lens=torch.tensor([4]),
+        )
+        ngram_second = NgramVerifyInput(
+            draft_token_num=6,
+            new_seq_lens=torch.tensor([200]),
+            accept_tokens=torch.tensor([5, 6, 7, 8, 9, 10]),
+            accept_lens=torch.tensor([6]),
+        )
+
+        first = HybridVerifyInput(eagle_first, ngram_first)
+        second = HybridVerifyInput(eagle_second, ngram_second)
+        first.merge_batch(second)
+        selected = torch.tensor([1])
+        first.filter_batch(selected)
+
+        self.assertEqual(first.eagle_draft_input.bonus_tokens.tolist(), [10])
+        self.assertEqual(first.eagle_draft_input.topk_index.tolist(), [[2]])
+        self.assertEqual(
+            first.ngram_verify_input.accept_tokens.tolist(), [5, 6, 7, 8, 9, 10]
+        )
+        self.assertEqual(first.ngram_verify_input.accept_lens.tolist(), [6])
+
+    def test_hybrid_future_indices_are_shared_by_both_native_inputs(self):
+        hybrid_input = HybridVerifyInput(
+            EagleDraftInput(),
+            NgramVerifyInput(draft_token_num=6, new_seq_lens=torch.tensor([11, 12])),
+        )
+
+        hybrid_input.future_indices = torch.tensor([3, 7])
+        hybrid_input.filter_batch(torch.tensor([1]))
+
+        self.assertEqual(hybrid_input.eagle_draft_input.future_indices.tolist(), [7])
+        self.assertEqual(hybrid_input.ngram_verify_input.future_indices.tolist(), [7])
+
+    def test_hybrid_overlap_reuses_both_native_relay_paths(self):
+        eagle_input = EagleDraftInput(
+            topk_p=torch.tensor([[0.25]]),
+            topk_index=torch.tensor([[3]]),
+            hidden_states=torch.tensor([[2.0]]),
+            bonus_tokens=torch.tensor([9]),
+        )
+        ngram_input = NgramVerifyInput(
+            draft_token_num=6,
+            new_seq_lens=torch.tensor([12]),
+            accept_tokens=torch.tensor([7, 8, 9, 0, 0, 0]),
+            accept_lens=torch.tensor([3]),
+        )
+        hybrid_input = HybridVerifyInput(eagle_input, ngram_input)
+        payload = RelayPayload.from_hybrid(hybrid_input)
+
+        self.assertIs(payload.bonus_tokens, eagle_input.bonus_tokens)
+        self.assertIs(payload.topk_p, eagle_input.topk_p)
+        self.assertEqual(payload.accept_tokens.tolist(), [[7, 8, 9, 0, 0, 0]])
+        self.assertIs(payload.accept_lens, ngram_input.accept_lens)
+
+        future_map = object.__new__(FutureMap)
+        future_map.spec_algo = SpeculativeAlgorithm.HYBRID
+        future_map._stash_ngram = MagicMock()
+        future_map._stash_draft = MagicMock()
+        indices = torch.tensor([4])
+        future_map.stash(indices, payload)
+        future_map._stash_ngram.assert_called_once_with(indices, payload)
+        future_map._stash_draft.assert_called_once_with(indices, payload)
+
+        future_map._resolve_ngram_input = MagicMock()
+        future_map._resolve_draft_input = MagicMock()
+        future_map._resolve_spec_extras(SimpleNamespace(spec_info=hybrid_input))
+        future_map._resolve_ngram_input.assert_called_once_with(ngram_input)
+        future_map._resolve_draft_input.assert_called_once_with(eagle_input)
+
+    def test_ngram_relay_accepts_route_dtype_changes(self):
+        future_map = object.__new__(FutureMap)
+        future_map.accept_tokens_buf = torch.zeros((8, 6), dtype=torch.int64)
+        future_map.accept_lens_buf = torch.zeros(8, dtype=torch.int32)
+        future_map._maybe_init_ngram_bufs = MagicMock()
+        payload = RelayPayload(
+            bonus_tokens=None,
+            accept_tokens=torch.tensor([[1, 2, 0, 0, 0, 0]], dtype=torch.int32),
+            accept_lens=torch.tensor([2], dtype=torch.int64),
+        )
+
+        future_map._stash_ngram(torch.tensor([3]), payload)
+
+        self.assertEqual(future_map.accept_tokens_buf[3].tolist(), [1, 2, 0, 0, 0, 0])
+        self.assertEqual(future_map.accept_lens_buf[3].item(), 2)
+
+
+class TestHybridForwardDispatch(CustomTestCase):
+    def test_extend_installs_target_prefill_backend(self):
+        result = SimpleNamespace(
+            next_draft_input=EagleDraftInput(),
+            next_token_ids=torch.tensor([7]),
+            accept_lens=None,
+            new_seq_lens=torch.tensor([11]),
+        )
+        retrieval_worker = SimpleNamespace(sync_hybrid_state=MagicMock())
+        neural_worker = SimpleNamespace(
+            speculative_num_draft_tokens=4,
+            activate_step_by_batch=MagicMock(),
+            forward_batch_generation=MagicMock(return_value=result),
+        )
+        controller = object.__new__(HybridController)
+        controller.retrieval_worker = retrieval_worker
+        controller.neural_worker = neural_worker
+        controller._apply_runtime_state = MagicMock()
+        controller._apply_target_prefill_backend = MagicMock()
+        controller._update_route_stats = MagicMock()
+        controller._runtime_widths = (4, 6)
+        batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(is_decode=MagicMock(return_value=False)),
+            is_extend_in_batch=False,
+            seq_lens=torch.ones(1, dtype=torch.int32),
+            reqs=[SimpleNamespace()],
+            spec_info=None,
+        )
+
+        controller.forward_batch_generation(batch)
+
+        controller._apply_runtime_state.assert_called_once_with("neural")
+        controller._apply_target_prefill_backend.assert_called_once_with()
+        neural_worker.forward_batch_generation.assert_called_once()
+        retrieval_worker.sync_hybrid_state.assert_called_once_with(batch, result)
+        self.assertIsInstance(result.next_draft_input, HybridVerifyInput)
+
+    def test_forwards_scheduler_callbacks_to_selected_worker(self):
+        for route in ("retrieval", "neural"):
+            with self.subTest(route=route):
+                if route == "retrieval":
+                    native_next_input = NgramVerifyInput(
+                        draft_token_num=6,
+                        new_seq_lens=torch.tensor([11]),
+                        accept_tokens=torch.tensor([7, 0, 0, 0, 0, 0]),
+                        accept_lens=torch.tensor([1]),
+                    )
+                else:
+                    native_next_input = EagleDraftInput()
+                result = SimpleNamespace(
+                    next_draft_input=native_next_input,
+                    next_token_ids=torch.tensor([7]),
+                    accept_lens=torch.tensor([1]),
+                    new_seq_lens=torch.tensor([11]),
+                    speculative_num_draft_tokens=6 if route == "retrieval" else 1,
+                )
+                initial_eagle_input = EagleDraftInput()
+                initial_ngram_input = NgramVerifyInput(
+                    draft_token_num=6, new_seq_lens=torch.tensor([10])
+                )
+                initial_hybrid_input = HybridVerifyInput(
+                    initial_eagle_input, initial_ngram_input
+                )
+
+                def forward_selected(batch, **_kwargs):
+                    expected_input = (
+                        initial_ngram_input
+                        if route == "retrieval"
+                        else initial_eagle_input
+                    )
+                    self.assertIs(batch.spec_info, expected_input)
+                    return result
+
+                retrieval_worker = SimpleNamespace(
+                    speculative_num_draft_tokens=6,
+                    forward_batch_generation=MagicMock(side_effect=forward_selected),
+                    sync_hybrid_state=MagicMock(),
+                )
+                neural_worker = SimpleNamespace(
+                    speculative_num_draft_tokens=4,
+                    forward_batch_generation=MagicMock(side_effect=forward_selected),
+                    sync_hybrid_state=MagicMock(return_value=EagleDraftInput()),
+                    activate_step_by_batch=MagicMock(),
+                )
+                controller = object.__new__(HybridController)
+                controller.retrieval_worker = retrieval_worker
+                controller.neural_worker = neural_worker
+                controller._match_continuation_lengths = MagicMock(
+                    return_value=([1], [1])
+                )
+                controller._should_use_retrieval = MagicMock(
+                    return_value=route == "retrieval"
+                )
+                controller._apply_runtime_state = MagicMock()
+                controller._update_route_stats = MagicMock()
+                controller._runtime_widths = (4, 6)
+
+                batch = SimpleNamespace(
+                    forward_mode=SimpleNamespace(
+                        is_decode=MagicMock(return_value=True)
+                    ),
+                    is_extend_in_batch=False,
+                    seq_lens=torch.ones(1, dtype=torch.int32),
+                    reqs=[SimpleNamespace()],
+                    spec_info=initial_hybrid_input,
+                )
+                on_publish = MagicMock()
+                grammar_barrier = MagicMock()
+                pp_proxy_tensors = object()
+
+                actual = controller.forward_batch_generation(
+                    batch,
+                    on_publish=on_publish,
+                    grammar_barrier=grammar_barrier,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
+
+                selected_worker = (
+                    retrieval_worker if route == "retrieval" else neural_worker
+                )
+                other_worker = (
+                    neural_worker if route == "retrieval" else retrieval_worker
+                )
+                selected_worker.forward_batch_generation.assert_called_once_with(
+                    batch,
+                    on_publish=on_publish,
+                    grammar_barrier=grammar_barrier,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
+                other_worker.forward_batch_generation.assert_not_called()
+                other_worker.sync_hybrid_state.assert_called_once_with(batch, result)
+                self.assertIs(actual, result)
+                self.assertEqual(result.spec_route, route)
+                self.assertIsInstance(result.next_draft_input, HybridVerifyInput)
+                self.assertIsInstance(
+                    result.next_draft_input.eagle_draft_input, EagleDraftInput
+                )
+                self.assertIsInstance(
+                    result.next_draft_input.ngram_verify_input, NgramVerifyInput
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_hybrid_controller.py
+++ b/test/registered/unit/spec/test_hybrid_controller.py
@@ -15,8 +15,8 @@ from sglang.srt.arg_groups.overrides import (
     resolving_view,
 )
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
-from sglang.srt.mem_cache.allocation_sizing import get_alloc_reserve_per_decode
 from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
+from sglang.srt.mem_cache.allocation_sizing import get_alloc_reserve_per_decode
 from sglang.srt.runtime_context import (
     get_context,
     max_speculative_num_draft_tokens,
@@ -113,9 +113,7 @@ class TestHybridServerArgs(CustomTestCase):
                 )
         for name in ("min_continuation_ratio", "min_matching_ratio"):
             with self.assertRaisesRegex(ValueError, rf"{name} must be in \\(0, 1\\]"):
-                HybridController._load_config(
-                    json.dumps({**full, name: 1.5})
-                )
+                HybridController._load_config(json.dumps({**full, name: 1.5}))
 
 
 class TestHybridRuntimeSwitch(CustomTestCase):

--- a/test/registered/unit/spec/test_multimodal_draft_embeddings.py
+++ b/test/registered/unit/spec/test_multimodal_draft_embeddings.py
@@ -1,0 +1,80 @@
+"""Regression tests for multimodal EAGLE draft-prefill embeddings."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.managers.mm_utils import general_mm_embed_routine
+from sglang.srt.speculative.eagle_worker_v2 import (
+    _shift_mm_input_embeds_for_draft_prefill,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _MutatingLanguageModel:
+    pp_group = SimpleNamespace(is_first_rank=True)
+
+    def get_input_embeddings(self):
+        return lambda input_ids: input_ids
+
+    def __call__(self, *, input_ids, forward_batch, input_embeds, **kwargs):
+        del input_ids, forward_batch, kwargs
+        input_embeds.add_(100)
+        return input_embeds
+
+
+class TestMultimodalDraftEmbeddings(CustomTestCase):
+    def test_target_forward_cannot_mutate_draft_embedding_snapshot(self):
+        input_embeds = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        expected = input_embeds.clone()
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: False,
+                is_target_verify=lambda: False,
+            ),
+            contains_mm_inputs=lambda: True,
+            mm_inputs=[SimpleNamespace(mm_items=[])],
+            extend_prefix_lens_cpu=[0],
+            extend_seq_lens_cpu=[3],
+            input_embeds=None,
+            spec_algorithm=SpeculativeAlgorithm.EAGLE3,
+            mm_input_embeds=None,
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.mm_utils.embed_mm_inputs",
+                return_value=(input_embeds, {}),
+            ),
+            patch("sglang.srt.managers.mm_utils.get_server_args", return_value=None),
+        ):
+            general_mm_embed_routine(
+                torch.arange(3),
+                forward_batch,
+                _MutatingLanguageModel(),
+            )
+
+        self.assertTrue(torch.equal(forward_batch.mm_input_embeds, expected))
+        self.assertFalse(
+            forward_batch.mm_input_embeds.data_ptr() == input_embeds.data_ptr()
+        )
+
+    def test_shift_preserves_request_boundaries(self):
+        embeds = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+
+        shifted = _shift_mm_input_embeds_for_draft_prefill(embeds, [2, 1, 3])
+
+        expected = torch.stack(
+            (embeds[1], embeds[1], embeds[2], embeds[4], embeds[5], embeds[5])
+        )
+        self.assertTrue(torch.equal(shifted, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -50,11 +50,12 @@ def _batch_get(
     corpus: NgramCorpus,
     batch_tokens: list[list[int]],
 ):
-    return corpus.batch_get(
+    ids, masks, _match_lens = corpus.batch_get(
         req_ids=[uuid.uuid4().hex for _ in range(len(batch_tokens))],
         batch_tokens=batch_tokens,
         total_lens=[len(tokens) for tokens in batch_tokens],
     )
+    return ids, masks
 
 
 def _batch_get_with_state(
@@ -63,7 +64,8 @@ def _batch_get_with_state(
     current_tokens: list[int],
     total_len: int,
 ):
-    return corpus.batch_get([req_id], [current_tokens], [total_len])
+    ids, masks, _match_lens = corpus.batch_get([req_id], [current_tokens], [total_len])
+    return ids, masks
 
 
 class _IntTokenizer:
@@ -176,6 +178,14 @@ class TestNgramCorpusBFS(CustomTestCase):
 
     def test_masks(self):
         np.testing.assert_array_equal(self.masks.tolist(), EXPECTED_BFS_MASKS)
+
+    def test_match_lengths(self):
+        _, _, match_lens = self.corpus.batch_get(
+            req_ids=[uuid.uuid4().hex for _ in QUERY_SEQUENCES],
+            batch_tokens=QUERY_SEQUENCES,
+            total_lens=[len(tokens) for tokens in QUERY_SEQUENCES],
+        )
+        self.assertEqual(match_lens.tolist(), [3, 2, 0])
 
 
 class TestNgramCorpusProb(CustomTestCase):

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import unittest
 import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 
@@ -186,6 +188,38 @@ class TestNgramCorpusBFS(CustomTestCase):
             total_lens=[len(tokens) for tokens in QUERY_SEQUENCES],
         )
         self.assertEqual(match_lens.tolist(), [3, 2, 0])
+
+
+class TestNgramWorkerCorpusSync(CustomTestCase):
+    def test_extend_uses_request_range(self):
+        from sglang.srt.speculative.ngram_worker import NGRAMWorker
+        from sglang.srt.utils.common import Range
+
+        worker = object.__new__(NGRAMWorker)
+        worker.max_trie_depth = 4
+        worker.ngram_corpus = MagicMock()
+        batch = SimpleNamespace(
+            reqs=[
+                SimpleNamespace(
+                    origin_input_ids=list(range(6)),
+                    prefix_indices=[10, 11],
+                    extend_range=Range(2, 4),
+                    extend_batch_idx=1,
+                ),
+                SimpleNamespace(
+                    origin_input_ids=list(range(10)),
+                    prefix_indices=[10, 11, 12, 13, 14],
+                    extend_range=Range(5, 8),
+                    extend_batch_idx=2,
+                ),
+            ]
+        )
+
+        worker._insert_extend_into_ngram_corpus(batch)
+
+        worker.ngram_corpus.batch_put.assert_called_once_with(
+            [[0, 1, 2, 3], [2, 3, 4, 5, 6, 7]]
+        )
 
 
 class TestNgramCorpusProb(CustomTestCase):

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -8,6 +9,38 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestNgramExtendCorpusSync(CustomTestCase):
+    def test_uses_extend_range_after_req_accessor_removal(self):
+        from sglang.srt.speculative.ngram_worker import NGRAMWorker
+        from sglang.srt.utils.common import Range
+
+        worker = object.__new__(NGRAMWorker)
+        worker.max_trie_depth = 4
+        worker.ngram_corpus = MagicMock()
+        batch = SimpleNamespace(
+            reqs=[
+                SimpleNamespace(
+                    origin_input_ids=list(range(6)),
+                    prefix_indices=[10, 11],
+                    extend_range=Range(2, 4),
+                    extend_batch_idx=1,
+                ),
+                SimpleNamespace(
+                    origin_input_ids=list(range(10)),
+                    prefix_indices=[10, 11, 12, 13, 14],
+                    extend_range=Range(5, 8),
+                    extend_batch_idx=2,
+                ),
+            ]
+        )
+
+        worker._insert_extend_into_ngram_corpus(batch)
+
+        worker.ngram_corpus.batch_put.assert_called_once_with(
+            [[0, 1, 2, 3], [2, 3, 4, 5, 6, 7]]
+        )
 
 
 class TestNgramLastCorrectStepIndices(CustomTestCase):
@@ -47,7 +80,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_linear_chain_partial_accept(self):
-        bs, draft_token_num = 3, 5
+        draft_token_num = 5
         accept_indices = torch.tensor(
             [
                 [0, 1, 2, -1, -1],
@@ -65,7 +98,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_tree_structure_non_sequential(self):
-        bs, draft_token_num = 2, 6
+        draft_token_num = 6
         accept_indices = torch.tensor(
             [
                 [0, 2, 5, -1, -1, -1],
@@ -82,7 +115,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_single_request_zero_drafts(self):
-        bs, draft_token_num = 1, 4
+        draft_token_num = 4
         accept_indices = torch.tensor([[0, -1, -1, -1]], dtype=torch.int32)
         num_correct_drafts = torch.tensor([0], dtype=torch.int32)
 

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -1,5 +1,4 @@
 import unittest
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -9,38 +8,6 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
-
-
-class TestNgramExtendCorpusSync(CustomTestCase):
-    def test_uses_extend_range_after_req_accessor_removal(self):
-        from sglang.srt.speculative.ngram_worker import NGRAMWorker
-        from sglang.srt.utils.common import Range
-
-        worker = object.__new__(NGRAMWorker)
-        worker.max_trie_depth = 4
-        worker.ngram_corpus = MagicMock()
-        batch = SimpleNamespace(
-            reqs=[
-                SimpleNamespace(
-                    origin_input_ids=list(range(6)),
-                    prefix_indices=[10, 11],
-                    extend_range=Range(2, 4),
-                    extend_batch_idx=1,
-                ),
-                SimpleNamespace(
-                    origin_input_ids=list(range(10)),
-                    prefix_indices=[10, 11, 12, 13, 14],
-                    extend_range=Range(5, 8),
-                    extend_batch_idx=2,
-                ),
-            ]
-        )
-
-        worker._insert_extend_into_ngram_corpus(batch)
-
-        worker.ngram_corpus.batch_put.assert_called_once_with(
-            [[0, 1, 2, 3], [2, 3, 4, 5, 6, 7]]
-        )
 
 
 class TestNgramLastCorrectStepIndices(CustomTestCase):
@@ -80,7 +47,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_linear_chain_partial_accept(self):
-        draft_token_num = 5
+        bs, draft_token_num = 3, 5
         accept_indices = torch.tensor(
             [
                 [0, 1, 2, -1, -1],
@@ -98,7 +65,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_tree_structure_non_sequential(self):
-        draft_token_num = 6
+        bs, draft_token_num = 2, 6
         accept_indices = torch.tensor(
             [
                 [0, 2, 5, -1, -1, -1],
@@ -115,7 +82,7 @@ class TestNgramLastCorrectStepIndices(CustomTestCase):
         self.assertTrue(torch.equal(result, expected))
 
     def test_single_request_zero_drafts(self):
-        draft_token_num = 4
+        bs, draft_token_num = 1, 4
         accept_indices = torch.tensor([[0, -1, -1, -1]], dtype=torch.int32)
         num_correct_drafts = torch.tensor([0], dtype=torch.int32)
 

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -534,6 +534,7 @@ class _FakeResolvedArgs:
     speculative_num_draft_tokens: A[int | None, Arg(help="d"), NS("spec")] = None
     speculative_adaptive: A[bool, Arg(help="a"), NS("spec")] = False
     speculative_adaptive_config: A[str | None, Arg(help="c"), NS("spec")] = None
+    speculative_hybrid_config: A[str | None, Arg(help="hc"), NS("spec")] = None
     load_format: A[str, Arg(help="lf"), NS("model")] = "auto"
     remote_instance_weight_loader_backend: A[str, Arg(help="rb"), NS("model")] = "nccl"
     remote_instance_weight_loader_start_seed_via_transfer_engine: A[
@@ -1343,6 +1344,23 @@ class TestAdaptiveDraftBoundLifecycle(_IsolatedServerArgs):
             )
         )
         self.assertEqual(max_speculative_num_draft_tokens(), 7)
+
+
+class TestHybridDraftBound(_IsolatedServerArgs):
+    def test_largest_worker_width_wins(self):
+        get_context().set_server_args(
+            _FakeResolvedArgs(
+                speculative_algorithm="HYBRID",
+                speculative_num_draft_tokens=3,
+                speculative_hybrid_config=json.dumps(
+                    {
+                        "retrieval": {"speculative_num_draft_tokens": 5},
+                        "neural": {"speculative_num_draft_tokens": 4},
+                    }
+                ),
+            )
+        )
+        self.assertEqual(max_speculative_num_draft_tokens(), 5)
 
 
 class TestNamedAccessorsCallWhatTheyWrap(CustomTestCase):

--- a/test/registered/unit/test_supplied_instance_exposure_ratchet.py
+++ b/test/registered/unit/test_supplied_instance_exposure_ratchet.py
@@ -124,6 +124,15 @@ _LATE_RESOLUTION_DYNAMIC_SITES = {
 # there is exposure only through that caller's own reads.
 _CALLER_SUPPLIED_LATE_SITES = frozenset({"runtime_context.py"})
 
+# `get_context().override(..., **expansion)` sites that forward caller-chosen
+# fields, the expansion analogue of the by-name `update_server_args` exemption
+# in `_expanded_override_keys`: the hybrid controller republishes each worker's
+# resolved-config diff at construction (and the base values on teardown), so
+# the key set is the user's --speculative-hybrid-config, not this file's. The
+# controller's own reads go through its locally constructed worker
+# ServerArgs, never the global record, so no exposure flows through the keys.
+_OVERRIDE_FORWARDING_SITES = frozenset({"speculative/hybrid_controller.py"})
+
 # Resolution also branches on ambient environment; those shapes are explicit
 # entries so the written set is the same on every host. `SGLANG_IS_IN_CI`
 # makes resolution fill `soft_watchdog_timeout`.
@@ -816,6 +825,8 @@ class TestSuppliedInstanceExposure(CustomTestCase):
                         continue
                     if kw.arg:
                         written.add(kw.arg)
+                    elif rel in _OVERRIDE_FORWARDING_SITES:
+                        continue
                     else:
                         written |= _expanded_override_keys(rel, tree, node, kw)
         return written


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Retrieval-based methods (NGRAM, suffix decoding) shine on repetition-heavy outputs but degrade badly otherwise, while draft-model-based methods (EAGLE, DFLASH) are stable across workloads but leave speedup on the table when local repetition is high. Acceptance length varies per request and per output position, so statically picking one method is never optimal.

This PR adds a hybrid spec speculative algorithm that routes per decode batch between a retrieval worker and a neural worker, staying close to the better of the two.

## Modifications

<!-- Detail the changes made in this pull request. -->
* Add a `HYBRID` speculative algorithm, where a hybrid controller manages the retrieval and neural spec workers and picks one per decode step.
* **Routing policy** , a threshold heuristic evaluated before draft
  * At the batch level, retrieval is chosen only if the number of qualifying requests is at least `bs * min_matching_ratio`.
  * At the request level, a request qualifies when its retrieval draft quality score reaches the `min_continuation_ratio` fraction of the retrieval draft. The score weights the actual draft length by the suffix-match length and normalizes it by the draft width. The longer the suffix match, the more likely the retrieved draft  is accpeted.
* **State handling**
  * CUDA graph runners / attention backends of both workers are captured at init and switched on routing change
  * The suffix tree and the EAGLE draft KV are updated with accepted tokens every step, so either worker can be picked in the next step.
* **NGRAM worker extensions**
  The prompt is inserted into the trie so drafts can also match against the input, and the worker now returns the suffix-match length, which the routing policy consumes as the weight on the actual draft length when scoring retrieval draft quality.
* **Qwen3.5 EAGLE3 compatibility**
  On `main` branch, EAGLE3 with a Qwen3.5 target crashes at startup because the outer wrapper unpacks the inner model's output as `(hidden_states, aux_hidden_states)` while the inner model returns a plain tensor. This PR adds `set_eagle3_layers_to_capture` on the inner model.
 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
On GSM8K (Qwen3.5-35B-A3B, H20-141GB), hybrid reaches 86.0% accuracy vs 87.0% for autoregressive decoding with benchmark/gsm8k/bench_sglang.py.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Benchmarks run on H20-141GB with Qwen3.5-35B-A3B and the hybrid args：

```bash
--speculative-algorithm hybrid \
--speculative-hybrid-config '{
  "retrieval": {
    "algorithm": "NGRAM",
    "speculative_num_draft_tokens": 6,
    "speculative_ngram_min_bfs_breadth": 1,
    "speculative_ngram_max_bfs_breadth": 1,
    "speculative_ngram_match_type": "PROB"
  },
  "neural": {
    "algorithm": "EAGLE3",
    "speculative_draft_model_path": "/workdir/models/jiapingW/Qwen3.5-35B-A3B-Eagle3-Specforge/",
    "speculative_num_draft_tokens": 4,
    "speculative_eagle_topk": 1,
    "speculative_num_steps": 3
  },
  "min_continuation_ratio": 1,
  "min_matching_ratio": 0.5
}'
```

Output throughput is in tok/s, parentheses show the average acceptance length. The last column compares hybrid throughput against the best of EAGLE3, NGRAM and autoregressive decoding.

**AdaLEval-textsort**

| bs | hybrid | eagle3 | ngram | autoregressive | hybrid vs best single |
| --: | -----: | -----: | ----: | -------------: | --------------------: |
| 1 | 562.01 (4.74) | 481.99 (3.48) | 561.03 (4.70) | 254.09 | +0.2% |
| 2 | 852.10 (5.03) | 716.22 (3.48) | 812.43 (4.50) | 422.78 | **+4.9%** |
| 4 | 1163.54 (4.43) | 1057.47 (3.49) | 1217.95 (4.75) | 667.24 | -4.5% |
| 8 | 1538.45 (4.46) | 1401.33 (3.48) | 1412.64 (4.20) | 912.50 | **+8.9%** |

**InstructCoder**

| bs | hybrid | eagle3 | ngram | autoregressive | hybrid vs best single |
| --: | -----: | -----: | ----: | -------------: | --------------------: |
| 1 | 394.95 (2.96) | 412.55 (2.74) | 250.30 (1.87) | 261.41 | -4.3% |
| 2 | 584.86 (2.78) | 636.40 (2.73) | 393.89 (1.86) | 441.42 | -8.1% |
| 4 | 915.52 (2.77) | 957.97 (2.73) | 613.72 (1.88) | 708.32 | -4.4% |
| 8 | 1261.14 (2.76) | 1301.22 (2.74) | 798.15 (1.83) | 934.58 | -3.1% |

**GSM8K**

| bs | hybrid | eagle3 | ngram | autoregressive | hybrid vs best single |
| --: | -----: | -----: | ----: | -------------: | --------------------: |
| 1 | 387.25 (2.89) | 462.72 (3.07) | 235.06 (1.80) | 263.79 | -16.3% |
| 2 | 569.89 (2.72) | 702.71 (3.05) | 368.37 (1.79) | 444.06 | -18.9% |
| 4 | 941.57 (2.87) | 1064.67 (3.06) | 578.10 (1.80) | 714.61 | -11.6% |
| 8 | 1412.35 (2.98) | 1484.08 (3.06) | 774.10 (1.77) | 965.44 | -4.8% |

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [X] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33776959715](https://github.com/sgl-project/sglang/actions/runs/33776959715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33776959301](https://github.com/sgl-project/sglang/actions/runs/33776959301)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33776959874](https://github.com/sgl-project/sglang/actions/runs/33776959874)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->