### PR TITLE
fix: resolve remaining GLM-5.3 rebase regressions

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -92,8 +92,6 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         tl.extra.cuda.gdc_wait()
         tl.extra.cuda.gdc_launch_dependents()
 
-    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:

--- a/python/sglang/kernels/ops/attention/helion/kda_prefill.py
+++ b/python/sglang/kernels/ops/attention/helion/kda_prefill.py
@@ -1314,6 +1314,7 @@ def chunk_kda(
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
     output_intermediate_states: bool = False,
+    beta_is_raw: bool = False,
     **kwargs: object,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Match the public forward contract of SGLang's Triton ``chunk_kda``."""
@@ -1327,6 +1328,8 @@ def chunk_kda(
         raise ValueError("g and beta must cover every q token")
     g = g[:, :num_tokens]
     beta = beta[:, :num_tokens]
+    if beta_is_raw:
+        beta = beta.float().sigmoid()
     if num_tokens == 1:
         # Tracing constant-folds size-one dimensions, but the resulting kernel
         # can share a cache entry with longer inputs. Keep T=1 on Triton so a

--- a/python/sglang/srt/configs/hybrid_arch.py
+++ b/python/sglang/srt/configs/hybrid_arch.py
@@ -115,7 +115,9 @@ def kimi_linear_config(model_config: ModelConfig):
 
 def glm5_next_config(model_config: ModelConfig):
     hf_config = model_config.hf_config
-    if hf_config.model_type == "glm5_next" and not model_config.is_draft_model:
+    if getattr(hf_config, "model_type", None) == "glm5_next" and not getattr(
+        model_config, "is_draft_model", False
+    ):
         return hf_config.get_text_config()
     return None
 

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -12,6 +12,7 @@ from sglang.srt.model_executor.graph_memory_usage import (
     merge_graph_time_usage,
 )
 from sglang.srt.runtime_context import get_disagg, get_exec, get_memory, get_schedule
+from sglang.srt.speculative.spec_utils import get_plan_stream
 
 if TYPE_CHECKING:
     from sglang.srt.managers.io_struct import (
@@ -62,6 +63,42 @@ class EagleDraftWorkerBase(ABC):
     def __init__(self) -> None:
         self._specialized_graph_memory_usage: dict[str, float] = {}
         self._specialized_graph_time_usage: dict[str, float] = {}
+
+    def _init_handoff_events(self) -> None:
+        self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+        # Keep handoff events outside captured graphs; per-kind rings avoid
+        # re-recording an event with a pending wait.
+        handoff_ring_size = 8
+        if self.plan_stream is not None:
+            event_cls = torch.get_device_module(self.device).Event
+            self._verify_handoff_events = [
+                event_cls() for _ in range(handoff_ring_size)
+            ]
+            self._draft_extend_handoff_events = [
+                event_cls() for _ in range(handoff_ring_size)
+            ]
+        else:
+            self._verify_handoff_events = []
+            self._draft_extend_handoff_events = []
+        self._verify_handoff_index = 0
+        self._draft_extend_handoff_index = 0
+        self._pending_verify_handoff_event = None
+
+    def _record_handoff_event(self, kind: str, stream):
+        if self.plan_stream is None:
+            return None
+        if kind == "verify":
+            events = self._verify_handoff_events
+            index = self._verify_handoff_index
+            self._verify_handoff_index += 1
+        else:
+            assert kind == "draft_extend"
+            events = self._draft_extend_handoff_events
+            index = self._draft_extend_handoff_index
+            self._draft_extend_handoff_index += 1
+        event = events[index % len(events)]
+        event.record(stream)
+        return event
 
     @abstractmethod
     def draft():

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -195,40 +195,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
         self.tree_mask_mode = default_tree_mask_mode()
 
-        self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
-        # Keep handoff events outside captured graphs; per-kind rings avoid
-        # re-recording an event with a pending wait.
-        handoff_ring_size = 8
-        if self.plan_stream is not None:
-            event_cls = torch.get_device_module(self.device).Event
-            self._verify_handoff_events = [
-                event_cls() for _ in range(handoff_ring_size)
-            ]
-            self._draft_extend_handoff_events = [
-                event_cls() for _ in range(handoff_ring_size)
-            ]
-        else:
-            self._verify_handoff_events = []
-            self._draft_extend_handoff_events = []
-        self._verify_handoff_index = 0
-        self._draft_extend_handoff_index = 0
-        self._pending_verify_handoff_event = None
-
-    def _record_handoff_event(self, kind: str, stream):
-        if self.plan_stream is None:
-            return None
-        if kind == "verify":
-            events = self._verify_handoff_events
-            index = self._verify_handoff_index
-            self._verify_handoff_index += 1
-        else:
-            assert kind == "draft_extend"
-            events = self._draft_extend_handoff_events
-            index = self._draft_extend_handoff_index
-            self._draft_extend_handoff_index += 1
-        event = events[index % len(events)]
-        event.record(stream)
-        return event
+        self._init_handoff_events()
 
     def alloc_memory_pool(
         self,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -172,6 +172,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         # None so inherited probes (spec_v2_attn_backends, adaptive) stay typed.
         self.draft_extend_attn_backend = None
         self.cuda_graph_runner_for_draft_extend = None
+        self._init_handoff_events()
 
     def alloc_memory_pool(
         self,
@@ -509,7 +510,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             self.speculative_num_draft_tokens,
         )
 
-        return FrozenKVMTPVerifyInput(
+        verify_input = FrozenKVMTPVerifyInput(
             draft_token=draft_tokens,
             custom_mask=tree_mask,
             positions=position,
@@ -524,6 +525,12 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
             seq_lens_sum=batch.seq_lens_sum,
             seq_lens_cpu=batch.seq_lens_cpu,
         )
+        # Gate plan-stream GPU work on the forward-stream point that finalized
+        # the verify tree, matching the regular EAGLE draft worker contract.
+        self._pending_verify_handoff_event = self._record_handoff_event(
+            "verify", torch.get_device_module(self.device).current_stream()
+        )
+        return verify_input
 
     def draft_forward(self, forward_batch: ForwardBatch):
         spec_info = forward_batch.spec_info

--- a/test/registered/cp/test_dsa_trtllm_fp8_cp.py
+++ b/test/registered/cp/test_dsa_trtllm_fp8_cp.py
@@ -4,15 +4,16 @@ import torch
 
 from sglang.srt.layers.attention.dsa_backend import (
     _should_all_gather_dsa_trtllm_fp8_kv,
-    _should_return_dsa_trtllm_lse,
+    _should_return_dsa_dcp_lse,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
-class TestDSATRTLLMFP8CP(unittest.TestCase):
+class TestDSATRTLLMFP8CP(CustomTestCase):
     def test_nope_kv_is_not_gathered_again(self):
         self.assertFalse(
             _should_all_gather_dsa_trtllm_fp8_kv(
@@ -50,13 +51,13 @@ class TestDSATRTLLMFP8CP(unittest.TestCase):
 
     def test_dcp_decode_and_verify_request_lse(self):
         self.assertTrue(
-            _should_return_dsa_trtllm_lse(
+            _should_return_dsa_dcp_lse(
                 forward_mode=ForwardMode.DECODE,
                 dcp_enabled=True,
             )
         )
         self.assertTrue(
-            _should_return_dsa_trtllm_lse(
+            _should_return_dsa_dcp_lse(
                 forward_mode=ForwardMode.TARGET_VERIFY,
                 dcp_enabled=True,
             )
@@ -64,13 +65,13 @@ class TestDSATRTLLMFP8CP(unittest.TestCase):
 
     def test_non_dcp_and_prefill_do_not_request_lse(self):
         self.assertFalse(
-            _should_return_dsa_trtllm_lse(
+            _should_return_dsa_dcp_lse(
                 forward_mode=ForwardMode.DECODE,
                 dcp_enabled=False,
             )
         )
         self.assertFalse(
-            _should_return_dsa_trtllm_lse(
+            _should_return_dsa_dcp_lse(
                 forward_mode=ForwardMode.EXTEND,
                 dcp_enabled=True,
             )

--- a/test/registered/kernels/ops/attention/test_kda_helion.py
+++ b/test/registered/kernels/ops/attention/test_kda_helion.py
@@ -706,6 +706,7 @@ def _compare_prefill(
     A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
+    beta_is_raw: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     batch, tokens, heads, key_dim = q.shape
     value_dim = v.size(-1)
@@ -740,7 +741,8 @@ def _compare_prefill(
     k_rows = reference_k.view(batch * tokens, heads, key_dim)
     v_rows = v.view(batch * tokens, heads, value_dim).float()
     gate_rows = reference_gate.view(batch * tokens, heads, key_dim)
-    beta_rows = beta.view(batch * tokens, heads).float()
+    reference_beta = beta.float().sigmoid() if beta_is_raw else beta
+    beta_rows = reference_beta.view(batch * tokens, heads).float()
     out_rows = reference_out.view(batch * tokens, heads, value_dim)
 
     if cu_seqlens is None:
@@ -811,6 +813,7 @@ def _compare_prefill(
         A_log=A_log,
         dt_bias=dt_bias,
         lower_bound=lower_bound,
+        beta_is_raw=beta_is_raw,
     )
 
     assert helion_out.data_ptr() == helion_v.data_ptr()
@@ -850,6 +853,31 @@ def test_fixed_partial_prefill_and_state_pool_contract() -> None:
 
     untouched = torch.tensor([0, 2, 4], device="cuda")
     assert torch.equal(helion_state[untouched], state[untouched])
+
+
+def test_raw_beta_prefill_contract() -> None:
+    torch.manual_seed(811)
+    batch, tokens, heads, key_dim, value_dim = 2, 17, 2, 32, 32
+    q = torch.randn(batch, tokens, heads, key_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn(
+        batch, tokens, heads, value_dim, device="cuda", dtype=torch.bfloat16
+    )
+    gate = torch.randn_like(q) * 0.2
+    raw_beta = torch.randn(batch, tokens, heads, device="cuda")
+    indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    state = torch.randn(5, heads, value_dim, key_dim, device="cuda") * 0.01
+
+    _compare_prefill(
+        q,
+        k,
+        v,
+        gate,
+        raw_beta,
+        state,
+        indices,
+        beta_is_raw=True,
+    )
 
 
 @pytest.mark.parametrize("is_varlen", [False, True], ids=["fixed", "varlen"])

--- a/test/registered/kernels/ops/attention/test_kda_helion.py
+++ b/test/registered/kernels/ops/attention/test_kda_helion.py
@@ -863,7 +863,9 @@ def test_raw_beta_prefill_contract() -> None:
     v = torch.randn(
         batch, tokens, heads, value_dim, device="cuda", dtype=torch.bfloat16
     )
-    gate = torch.randn_like(q) * 0.2
+    # Keep the recurrent decay contractive so the raw-beta check measures the
+    # sigmoid conversion instead of amplifying BF16 round-off exponentially.
+    gate = -torch.rand_like(q) * 0.2
     raw_beta = torch.randn(batch, tokens, heads, device="cuda")
     indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
     state = torch.randn(5, heads, value_dim, key_dim, device="cuda") * 0.01

--- a/test/registered/kernels/ops/attention/test_kda_helion.py
+++ b/test/registered/kernels/ops/attention/test_kda_helion.py
@@ -859,14 +859,23 @@ def test_raw_beta_prefill_contract() -> None:
     torch.manual_seed(811)
     batch, tokens, heads, key_dim, value_dim = 2, 17, 2, 32, 32
     q = torch.randn(batch, tokens, heads, key_dim, device="cuda", dtype=torch.bfloat16)
-    k = torch.randn_like(q)
+    # Keep the unnormalized recurrence numerically contractive while still
+    # exercising the no-QK-L2-normalization path. Unit-scale random keys make
+    # (I - beta * k k^T) expansive and obscure the raw-beta contract with
+    # exponentially amplified BF16 round-off.
+    k = torch.randn_like(q) * 0.05
     v = torch.randn(
         batch, tokens, heads, value_dim, device="cuda", dtype=torch.bfloat16
     )
     # Keep the recurrent decay contractive so the raw-beta check measures the
     # sigmoid conversion instead of amplifying BF16 round-off exponentially.
     gate = -torch.rand_like(q) * 0.2
-    raw_beta = torch.randn(batch, tokens, heads, device="cuda")
+    raw_beta = torch.linspace(
+        -2,
+        2,
+        steps=batch * tokens * heads,
+        device="cuda",
+    ).reshape(batch, tokens, heads)
     indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
     state = torch.randn(5, heads, value_dim, key_dim, device="cuda") * 0.01
 

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -8,12 +8,13 @@ from sglang.srt.speculative.adaptive_spec_params import (
     resolve_candidate_steps_from_config,
 )
 from sglang.test.ci.ci_register import register_cpu_ci, register_xpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_xpu_ci(est_time=10, suite="stage-a-test-1-gpu-xpu")
 
 
-class TestAdaptiveStepSlot(unittest.TestCase):
+class TestAdaptiveStepSlot(CustomTestCase):
     def _make_params_from_config(self, initial_steps: int, config: dict):
         return AdaptiveStepSlot(initial_steps=initial_steps, cfg=config)
 
@@ -244,11 +245,11 @@ class TestAdaptiveStepSlot(unittest.TestCase):
         self.assertEqual(params.ceiling_coeff, 0)
 
 
-class TestAdaptiveSpeculativeParams(unittest.TestCase):
+class TestAdaptiveSpeculativeParams(CustomTestCase):
     def test_default_config_loads(self):
         params = AdaptiveSpeculativeParams(initial_steps=3)
         self.assertEqual(params._bs_list, [1, 8, 32, 64])
-        self.assertEqual(params._slots[1].candidate_steps, [1, 3, 7])
+        self.assertEqual(params._slots[1].candidate_steps, [1, 3, 5, 7])
         self.assertEqual(params._slots[8].candidate_steps, [0, 1, 3])
         self.assertEqual(params._slots[32].candidate_steps, [0, 1])
         self.assertEqual(params._slots[64].candidate_steps, [0])
@@ -339,18 +340,18 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertEqual(params._slots[1].up_hysteresis, 0.1)
 
 
-class TestBatchSizeRouting(unittest.TestCase):
+class TestBatchSizeRouting(CustomTestCase):
     """BS-aware routing: batch size selects the slot, CUDA-graph BS pads first."""
 
     def _params(self):
-        # Slots: bs=1 -> [1,3,7], bs=8 -> [1,3], bs=32 -> [1].
+        # Slots: bs=1 -> [1,3,5,7], bs=8 -> [0,1,3], bs=32 -> [0,1].
         return AdaptiveSpeculativeParams(initial_steps=3)
 
     def test_routes_to_floor_slot_without_cuda_graph(self):
         params = self._params()
         # A batch maps to the largest slot BS <= batch (floor), capped at the top slot.
-        self.assertEqual(params._route(1).candidate_steps, [1, 3, 7])
-        self.assertEqual(params._route(7).candidate_steps, [1, 3, 7])
+        self.assertEqual(params._route(1).candidate_steps, [1, 3, 5, 7])
+        self.assertEqual(params._route(7).candidate_steps, [1, 3, 5, 7])
         self.assertEqual(params._route(8).candidate_steps, [0, 1, 3])
         self.assertEqual(params._route(31).candidate_steps, [0, 1, 3])
         self.assertEqual(params._route(32).candidate_steps, [0, 1])
@@ -373,6 +374,8 @@ class TestBatchSizeRouting(unittest.TestCase):
         self.assertEqual(params.cuda_graph_bs_for_step(1), [4, 8, 16, 32])
         # step=3 lives in the bs=1 and bs=8 slots: graphs 4,8,16 floor into them.
         self.assertEqual(params.cuda_graph_bs_for_step(3), [4, 8, 16])
+        # step=5 lives only in the bs=1 slot: only graph BS 4 floors into it.
+        self.assertEqual(params.cuda_graph_bs_for_step(5), [4])
         # step=7 lives only in the bs=1 slot: only graph BS 4 floors into it.
         self.assertEqual(params.cuda_graph_bs_for_step(7), [4])
 
@@ -392,12 +395,10 @@ class TestBatchSizeRouting(unittest.TestCase):
         self.assertEqual(params.get_steps_for_batch(32), 1)
 
 
-class TestResolveCandidateSteps(unittest.TestCase):
+class TestResolveCandidateSteps(CustomTestCase):
     def test_default_config(self):
         steps = resolve_candidate_steps_from_config()
-        self.assertIn(1, steps)
-        self.assertIn(3, steps)
-        self.assertIn(7, steps)
+        self.assertEqual(steps, [0, 1, 3, 5, 7])
 
     def test_config_file(self):
         with tempfile.NamedTemporaryFile("w", suffix=".json") as f:


### PR DESCRIPTION
## Summary

Follow-up fixes for deterministic CI regressions found after #37235 was merged into #36507:

- honor Helion KDA prefill `beta_is_raw` and cover the raw-beta contract
- make GLM5 hybrid-config detection tolerate minimal and non-GLM fixtures
- update the DSA CP unit test for the generalized DCP LSE helper name
- align adaptive-spec expectations with the current GLM-5.3 defaults
- restore plan-stream handoff initialization and verify-event publication for Frozen-KV MTP

The fused sigmoid-gating split-grid fix originally carried here is now present in the base branch through #37250, so it no longer appears in this PR diff.

## Root causes

- Helion KDA accepted `beta_is_raw` only through `**kwargs`, silently ignoring it.
- `glm5_next_config` assumed every model/config fixture exposed `model_type` and `is_draft_model`.
- Tests retained a private helper name and GLM-5.3 adaptive defaults from before the rebase.
- Plan-stream handoff support initialized its event state only in the regular EAGLE worker. Frozen-KV MTP inherited code that consumed `_pending_verify_handoff_event` without ever creating or publishing it.
- The first raw-beta fixture used a mathematically expansive unnormalized recurrence, which amplified ordinary BF16 differences and produced a false failure. The final fixture keeps the no-QK-L2 path while using contractive keys and deterministic raw beta spanning `[-2, 2]`.

## Validation

No full CI was requested for this PR. Validation used dedicated devboxes and precise `/rerun-test` jobs only; queued reruns were cancelled after equivalent devbox coverage completed.

On H100 RX devboxes:

- `test_kda_helion.py` with Helion 1.4.0: 26 passed
- `test_frozen_kv_mtp.py`: both top-k configurations passed, each with 200 GSM8K samples
- `test_gemma4_mtp_31b_extra.py`: passed the complete real-model Frozen-KV MTP e2e; top-k 1 and 3 both exceeded the 0.75 accuracy threshold
- adaptive-spec, decode-bookkeeping, and SWA KV-pool regression set: 37 tests plus 12 subtests passed
- complete Kimi-K3 prerequisite kernel file: 12 passed

Latest lint passed:
- https://github.com/sgl-project/sglang/actions/runs/33426961755

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33426962241](https://github.com/sgl-project/sglang/actions/runs/33426962241)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33426961816](https://github.com/sgl-project/sglang/actions/runs/33426961816)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33426961924](https://github.com/sgl-project/sglang/actions/runs/33426961924)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->