### PR TITLE
test: force torch path in hash_topk remap test on XPU

### DIFF
--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -24,6 +24,7 @@ def _set_dummy_server_args():
 
 
 def test_hash_topk_remaps_per_rank_fused_shared_slots(monkeypatch):
+    monkeypatch.setattr(hash_topk_module, "_is_xpu", False)
     monkeypatch.setattr(
         hash_topk_module, "has_per_rank_fused_shared_slots", lambda *_args: True
     )


### PR DESCRIPTION
## Summary
- `test_hash_topk_remaps_per_rank_fused_shared_slots` fails on XPU nightly with `NotImplementedError: Could not run 'sgl_kernel::hash_topk' with arguments from the 'CPU' backend`.
- The test overrides `SGLANG_OPT_USE_FUSED_HASH_TOPK=False` intending to exercise `HashTopK._forward_torch`, but `HashTopK.forward` checks `_is_xpu` first (`python/sglang/srt/layers/moe/hash_topk.py:225`) and short-circuits to `_forward_xpu`, which invokes the XPU-only `sgl_kernel::hash_topk` on the CPU tensors the test constructs.
- Monkeypatch `hash_topk_module._is_xpu = False` in the test so the intended torch fallback path runs on XPU CI too. The test is `register_cpu_ci`-marked and exercises platform-independent remapping logic, so this restores the original intent without changing production behavior.

## Test plan
- [ ] Run `pytest test/registered/moe/test_hash_topk.py::test_hash_topk_remaps_per_rank_fused_shared_slots` on XPU (BMG) — should pass.
- [ ] Run the same test on CPU — should still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33386275493](https://github.com/sgl-project/sglang/actions/runs/33386275493)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33386275390](https://github.com/sgl-project/sglang/actions/runs/33386275390)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33386275605](https://github.com/sgl-project/sglang/actions/runs/33386275605)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->