### PR TITLE
fix(gateway): bump wfaas to 1.0.2 so ContinueNextStep unblocks dependents

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -84,7 +84,7 @@ openai-protocol = { version = "=1.0.0", features = ["axum"] }
 tool-parser = "=1.0.0"
 llm-tokenizer = "=1.3.2"
 smg-auth = "=1.0.0"
-wfaas = "=1.0.0"
+wfaas = "=1.0.2"
 data-connector = "=1.0.0"
 smg-mcp = "=1.0.0"
 smg-wasm = "=1.0.0"


### PR DESCRIPTION
## Motivation

`sgl-model-gateway` pins `wfaas = "=1.0.0"`. In wfaas 1.0.0 and 1.0.1, a step
whose failure action is `FailureAction::ContinueNextStep` does not actually let
the workflow continue past it — any step that `depends_on` it never runs.

The mechanism, in `wfaas-1.0.0/src/engine.rs`:

- A step that fails with `ContinueNextStep` is recorded in the tracker as
  `skipped` (line 748), but the value sent to the scheduler is computed
  separately and is `StepResult::Failure` (line 723).
- The scheduler enqueues a step's dependents only on `Success | Skip`
  (line 817), so the dependents are never enqueued.
- With nothing ready, nothing running and nothing waiting, the scheduler takes
  its deadlock branch and sets `WorkflowStatus::Failed` (line 612).

`create_local_worker_workflow()` in
`src/core/steps/worker/local/mod.rs` is exactly this shape:

```
detect_connection_mode
  └── discover_metadata        FailureAction::ContinueNextStep
        └── discover_dp_info
              └── create_worker
                    └── register_workers
                          └── submit_tokenizer_job / update_policies / activate_workers
```

So when `discover_metadata` fails — a newly started worker whose
`/get_server_info` is slow to accept a connection is enough, since the step has
a 10 s timeout and three attempts — the whole `AddWorker` workflow is marked
Failed and the worker is never registered. That is the opposite of what
`ContinueNextStep` was declared on that step to achieve: the metadata it fetches
is optional, and the worker should still be added without it.

We hit this in production on a fork of this gateway: a rolled pod was never
picked up, and the router served a stale worker set until it was restarted.

**wfaas already fixed this in 1.0.2**, published 2026-02-23:

```rust
FailureAction::ContinueNextStep => {
    t.skipped.insert(step_id.clone());
    // Signal as Skip so dependents get scheduled
    (StepResult::Skip, true)
}
```

The gateway never picked the fix up. Before #19224 the pin was `~1.0.0`, which
would have resolved to 1.0.2 automatically. #19224 changed all 11 internal
crates to `=1.0.0` on 2026-02-24 — one day after 1.0.2 was published — to stop
unrelated patch releases (`smg-wasm`'s `WasmModuleManager::new()` return type,
etc.) from breaking the Docker CI build. That was the right call for CI
stability, but the wfaas fix was collateral damage, and the pin has not been
revisited since.

### Relationship to #32322

#32322 (open, mine) adds a periodic LIST reconcile to k8s service discovery.
Part of it, `forget_lost_registration`, exists for exactly the state this bug
produces: membership in `tracked_pods` records that an `AddWorker` job was
*submitted*, not that it succeeded, so a pod whose workflow failed afterwards
stays tracked, is short-circuited out of the add path, and never reaches the
registry. That reconcile untracks such a pod so the next tick re-submits it.

The two are complementary, and neither depends on the other — they can land in
either order:

- **#32322 without this PR** — a `discover_metadata` failure still fails the
  whole `AddWorker` workflow. The pod is recovered, but only on a later resync
  tick, and again on every recurrence.
- **This PR without #32322** — an `AddWorker` that fails for some *other*
  reason, or a pod whose event never arrives at all because the watch is dead
  or silently stale, is still never recovered.

In short: #32322 makes this failure recoverable, and this PR removes one of its
most common causes. `forget_lost_registration`'s doc comment lists the causes it
knew about (`detect_connection_mode` exhausting `worker_startup_timeout_secs`, a
failing DP discovery, a workflow that never starts); the wfaas scheduler bug is
another, and unlike those it fires on a plain transient hiccup in one optional
HTTP call.

## Modifications

One line in `sgl-model-gateway/Cargo.toml`:

```diff
-wfaas = "=1.0.0"
+wfaas = "=1.0.2"
```

1.0.2 is the smallest version that carries the fix, and it keeps the exact-pin
discipline #19224 introduced. The published `1.0.0 → 1.0.2` delta is **entirely
non-breaking** — no public API changes at all:

| file | change |
| -- | -- |
| `src/engine.rs` | the `ContinueNextStep` signal fix above; dedup of `pending_check` indices so a `depends_on_any` step with several finishing dependencies still launches once; `#[expect(clippy::disallowed_methods)]` attributes; inline format args |
| `src/event.rs` | `#[expect(clippy::disallowed_methods)]` attributes only |
| `Cargo.toml` | version bump, `[lints] workspace = true` |
| `README.md` | added in 1.0.1 |

(1.0.0 → 1.0.1 is metadata and a README only.) 1.1.0 is the current latest if
you would rather jump further, but it is a larger delta and 1.0.2 is sufficient
for this bug.

## Verification

**The bug, and the fix, against the published crates.** Three tests against an
unmodified `wfaas` dependency, varying only the pinned version. The first is
upstream wfaas's own shape (`test_workflow_continue_on_failure`, whose second
step declares no `depends_on`, so it would have run regardless); the second adds
the one thing that test never exercises, a dependent; the third is this
gateway's `AddWorker` shape.

| test | 1.0.0 | 1.0.1 | 1.0.2 | 1.1.0 |
| -- | -- | -- | -- | -- |
| independent step runs after ContinueNextStep (control) | pass | pass | pass | pass |
| **dependent** step runs after ContinueNextStep | **FAIL** | **FAIL** | pass | pass |
| gateway `AddWorker` shape reaches `create_worker` | **FAIL** | **FAIL** | pass | pass |

The gate discriminates in both directions: it fails on the pinned version and
passes on the bumped one. The test file is short and self-contained; happy to
attach it or land it under `sgl-model-gateway/tests/` if you would like a
regression test in-tree.

**Build.** `cargo check --all-targets` on this branch, toolchain 1.90 as pinned
by `rust-toolchain.toml`.

## Accuracy Tests

Not applicable — no model output is affected.

## Speed Tests and Profiling

Not applicable — no hot-path code changes. The dedup in 1.0.2 removes redundant
step launches, so if anything it does slightly less work.

## Checklist

- [x] Format your code according to the Format code with pre-commit — one-line manifest change, no code.
- [ ] Add unit tests according to the Run and add unit tests — the reproduction above is not in-tree; say the word and I will add it.
- [x] Update documentation according to Write documentations — no documented behavior changes.
- [x] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33387783065](https://github.com/sgl-project/sglang/actions/runs/33387783065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33387782754](https://github.com/sgl-project/sglang/actions/runs/33387782754)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->