### PR TITLE
fix(kda): preserve split-grid program ids

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -92,8 +92,6 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         tl.extra.cuda.gdc_wait()
         tl.extra.cuda.gdc_launch_dependents()
 
-    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:


### PR DESCRIPTION
## Summary

- keep the `(NV, N, HV)` program-id mapping selected by `SPLIT_N_HV_GRID`
- remove the stale flattened-grid assignments that immediately overwrite `i_k`, `i_n`, and `i_hv`

When the split grid is active, the duplicate assignments reinterpret axis 0 as `i_k`. For `NV > 1`, that produces out-of-range K tiles and corrupts the recurrent state; in GLM-5.3-Flash serving on MI355X this surfaced as BF16 NaNs and invalid KPool page-table values.

## Validation

Run on one locked AMD Instinct MI355X (gfx950), after a 30-s idle sampling window:

```text
python -m pytest -q -s \
  test/registered/attention/test_kda_kernels.py::TestKDAFusedSigmoidGatingRecurrent::test_kda_fused_sigmoid_gating_recurrent \
  test/registered/kernels/test_kda_replayssm_fold.py::TestKDAReplaySSMFoldParity::test_safe_gate

2 passed
output max abs diff: 0
state max abs diff: 1.1921e-07
```

This is intentionally based on PR #36507 so it can be merged into that feature branch before the parent lands.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33391984979](https://github.com/sgl-project/sglang/actions/runs/33391984979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33391984687](https://github.com/sgl-project/sglang/actions/runs/33391984687)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33391984966](https://github.com/sgl-project/sglang/actions/runs/33391984966)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->