### PR TITLE
test(ci): register base-a ascend backend unit tests to nightly-1-npu-a2

### DIFF
--- a/test/registered/unit/npu/attention/test_npu_ascend_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_backend.py
@@ -13,6 +13,7 @@ import torch
 from sglang.test.ci.ci_register import register_npu_ci
 
 register_npu_ci(est_time=5, suite="base-a-test-1-npu-a2")
+register_npu_ci(est_time=5, suite="nightly-1-npu-a2", nightly=True)
 
 # Mock NPU-only modules before importing the source module.
 for _ in (

--- a/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
@@ -13,6 +13,7 @@ import torch
 from sglang.test.ci.ci_register import register_npu_ci
 
 register_npu_ci(est_time=4, suite="base-a-test-1-npu-a2")
+register_npu_ci(est_time=4, suite="nightly-1-npu-a2", nightly=True)
 
 for mod in (
     "torch_npu",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Register the two base-a Ascend attention backend unit test files into the nightly pipeline (`nightly-1-npu-a2`), so that the base-a unit tests are also covered by the nightly CI, mirroring how the base-b suites map to their nightly counterparts (`base-b-test-X-npu-a3` <-> `nightly-X-npu-a3`).

## Modifications

- `test/registered/unit/npu/attention/test_npu_ascend_backend.py`: add `register_npu_ci(est_time=5, suite="nightly-1-npu-a2", nightly=True)`.
- `test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py`: add `register_npu_ci(est_time=4, suite="nightly-1-npu-a2", nightly=True)`.

## Accuracy Tests

N/A. This change only registers existing unit tests into the nightly CI pipeline; no model behavior is affected.

## Speed Tests and Profiling

N/A.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33392308526](https://github.com/sgl-project/sglang/actions/runs/33392308526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33392308127](https://github.com/sgl-project/sglang/actions/runs/33392308127)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33392308300](https://github.com/sgl-project/sglang/actions/runs/33392308300)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->