### PR TITLE
[CI] Batch CPU test workers

### DIFF
--- a/.github/workflows/_pr-test-stage-cpu.yml
+++ b/.github/workflows/_pr-test-stage-cpu.yml
@@ -158,7 +158,7 @@ jobs:
           SGLANG_SKIP_RUST_TESTS: ${{ fromJson(inputs.check_changes).rust_workspace == 'true' && 'false' || 'true' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite ${{ inputs.self_name }} --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(inputs.partitions)[inputs.self_name].size }} --partition-model-file /tmp/partition-model.json $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite ${{ inputs.self_name }} --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(inputs.partitions)[inputs.self_name].size }} --partition-model-file /tmp/partition-model.json --fork-worker-batch-size 20 $CONTINUE_ON_ERROR_FLAG
 
       # PRs save only what the base lacks; the implicit if: success() keeps a
       # half-downloaded cache unpublished.

--- a/python/sglang/test/ci/fork_test_worker.py
+++ b/python/sglang/test/ci/fork_test_worker.py
@@ -33,6 +33,10 @@ def _normalize_exit_code(code) -> int:
 
 def _run_file(filename: str) -> int:
     sys.argv = [filename, "-f"]
+    # Match ``python /path/to/test.py``: tests may import helper modules that
+    # live next to the executed file. runpy.run_path() does not update
+    # sys.path[0] for us, and this child exits after the file finishes.
+    sys.path[0] = os.path.dirname(os.path.abspath(filename))
     try:
         runpy.run_path(filename, run_name="__main__")
         return 0

--- a/test/registered/unit/test_fork_test_worker.py
+++ b/test/registered/unit/test_fork_test_worker.py
@@ -54,14 +54,28 @@ class TestForkTestWorker(CustomTestCase):
                         assert "SGLANG_FORK_WORKER_TEST" not in os.environ
                         raise SystemExit(3)
                         """))
+                helper = Path(tmpdir) / "sibling_helper.py"
+                helper.write_text("VALUE = 42\n")
+                sibling_import = Path(tmpdir) / "sibling_import.py"
+                sibling_import.write_text(textwrap.dedent("""
+                        import os
+                        import sys
+
+                        from sibling_helper import VALUE
+
+                        assert sys.path[0] == os.path.dirname(__file__)
+                        assert VALUE == 42
+                        """))
 
                 results = []
-                for filename in (first, second):
+                for filename in (first, second, sibling_import):
                     process.stdin.write(json.dumps({"filename": str(filename)}) + "\n")
                     process.stdin.flush()
                     results.append(json.loads(result_stream.readline()))
 
-                self.assertEqual([result["returncode"] for result in results], [0, 3])
+                self.assertEqual(
+                    [result["returncode"] for result in results], [0, 3, 0]
+                )
                 self.assertTrue(all(result["elapsed"] >= 0 for result in results))
 
                 process.stdin.write(json.dumps({"command": "stop"}) + "\n")


### PR DESCRIPTION
## Motivation

The base-A CPU lane now executes hundreds of small test files. The latest seven-day timing model assigns 6,671 seconds across 556 files, while most individual files finish in about 11-13 seconds. A large share of that time is repeated interpreter startup and imports.

PR #36887 introduced an opt-in preloaded fork worker for JIT kernel tests. Every test file still runs in a fresh fork child, so Python globals, environment changes, exit codes, fail-fast behavior, per-file timeouts, and timing records remain isolated.

## Modifications

- Enable the existing fork worker in the reusable CPU test workflow with `--fork-worker-batch-size 20`, matching the batch size already used by the JIT kernel lane.
- Make forked execution preserve normal script import semantics by setting `sys.path[0]` to the test file directory. This lets tests import adjacent helpers just as they do under `python /path/to/test.py`.
- Extend the fork-worker protocol test to cover an adjacent helper import in addition to Python-global and environment isolation.

The runner default remains 1, so no other suite changes behavior. The CPU workflow does not enable smart retry, so the fork worker is active for this lane. A failed or timed-out file closes the current worker before the suite continues or exits.

## Validation

- `pre-commit run --files .github/workflows/_pr-test-stage-cpu.yml python/sglang/test/ci/fork_test_worker.py test/registered/unit/test_fork_test_worker.py`
  - YAML, AST, registry, ruff, isort, formatting, codespell, and the other available hooks passed.
  - The workflow-name hook could not import PyYAML from the host environment, so it was rerun directly below with an ephemeral dependency.
- `uv run --with pyyaml python scripts/lint/check_workflow_job_names.py`
- Python bytecode compilation for both changed Python files.
- Ruby YAML parse of `_pr-test-stage-cpu.yml`.
- `git diff --check`.
- [CPU CI run #33394941492](https://github.com/sgl-project/sglang/actions/runs/33394941492): 12/12 partitions and 556/556 files passed.

The first CI attempt exposed that `runpy.run_path()` did not preserve the test script directory on `sys.path`. Six partitions passed and the other six stopped at tests importing adjacent helpers. The follow-up commit restores normal script import semantics; the clean rerun passed without an exclusion list.

## Accuracy Tests

Not applicable; no model or runtime behavior changes.

## Speed Tests and Profiling

Measured from the successful CPU run:

- Latest seven-day live timing-model baseline: 6,671 cumulative per-file seconds.
- This PR: 4,394 cumulative per-file seconds across the same 556 files.
- Reduction: 2,277 seconds, or 34.1%.
- Total `Run test` step time across 12 hosted runners: 4,679 seconds (78.0 runner-minutes).
- Slowest partition: 447 seconds (7m27s), below the 15-minute job timeout.

Each file still runs in a fresh child; the saving comes from amortizing twelve common-module preloads per partition instead of launching a fresh interpreter for every file.

## Checklist

- [x] Format and workflow validation completed.
- [x] Isolation and sibling-import behavior covered by a unit test.
- [x] Full CPU CI passed without exclusions.
- [x] No documentation change is required.
- [x] No inference accuracy or serving-speed change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33394941492](https://github.com/sgl-project/sglang/actions/runs/33394941492)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33394940998](https://github.com/sgl-project/sglang/actions/runs/33394940998)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33394941065](https://github.com/sgl-project/sglang/actions/runs/33394941065)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->