### PR TITLE
[Model] Support DeepSeek-V4-Flash-Vision multimodal

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
@@ -48,10 +48,14 @@ def _combine_topk_swa_indices_kernel(
     gather_lens_ptr,
     compressed_base_ptr,
     swa_base_ptr,
+    swa_win_starts_ptr,
+    swa_win_lens_ptr,
     top_k,
     COMPRESS_RATIO: tl.constexpr,
     WINDOW_SIZE: tl.constexpr,
+    SWA_BLOCK: tl.constexpr,
     PADDED_TOP_K: tl.constexpr,
+    HAS_SWA_WIN: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     worker_id = tl.program_id(1)
@@ -80,7 +84,14 @@ def _combine_topk_swa_indices_kernel(
         # min((pos+1)//compress_ratio, topk_tokens) valid entries. Caller
         # passes top_k=0 for SWA-only layers to zero this out.
         topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, top_k)
-        swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
+        if HAS_SWA_WIN:
+            # Per-query visible window (image spans), already in absolute
+            # sequence positions.
+            swa_len = tl.load(swa_win_lens_ptr + token_idx)
+            swa_start = tl.load(swa_win_starts_ptr + token_idx)
+        else:
+            swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
+            swa_start = pos - swa_len + 1
 
         combined_row = token_idx.to(tl.int64) * combined_indices_stride
         topk_row = token_idx.to(tl.int64) * topk_indices_stride
@@ -97,13 +108,13 @@ def _combine_topk_swa_indices_kernel(
             mask=mask,
         )
 
-        offset = tl.arange(0, WINDOW_SIZE)
+        offset = tl.arange(0, SWA_BLOCK)
         # Workspace SWA index: swa_base[r] + (gather_offset_in_buffer).
-        # For positions [pos - swa_len + 1, pos], the buffer offsets are
-        # [pos - swa_len + 1 - gather_start, pos - gather_start].
+        # For positions [swa_start, swa_start + swa_len), the buffer offsets
+        # are [swa_start - gather_start, swa_start + swa_len - gather_start).
         tl.store(
             combined_indices_ptr + combined_row + topk_len + offset,
-            swa_base + offset + pos - swa_len + 1 - gather_start,
+            swa_base + offset + swa_start - gather_start,
             mask=offset < swa_len,
         )
 

--- a/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
@@ -254,6 +254,7 @@ class BuildPageTablePositions:
         max_seq_len: int,
         page_size: int,
         swa_window: int,
+        swa_topk_lengths_override: Optional[torch.Tensor] = None,
     ) -> PageTablePositionsResult:
         return build_page_table_positions(
             req_to_token=req_to_token,
@@ -262,6 +263,7 @@ class BuildPageTablePositions:
             max_seq_len=max_seq_len,
             page_size=page_size,
             swa_window=swa_window,
+            swa_topk_lengths_override=swa_topk_lengths_override,
         )
 
     @classmethod
@@ -274,6 +276,7 @@ class BuildPageTablePositions:
         max_seq_len: int,
         page_size: int,
         swa_window: int,
+        swa_topk_lengths_override: Optional[torch.Tensor] = None,
     ) -> PageTablePositionsResult:
         return build_page_table_positions_triton(
             req_to_token=req_to_token,
@@ -282,6 +285,7 @@ class BuildPageTablePositions:
             max_seq_len=max_seq_len,
             page_size=page_size,
             swa_window=swa_window,
+            swa_topk_lengths_override=swa_topk_lengths_override,
         )
 
 
@@ -293,6 +297,7 @@ def build_page_table_positions(
     max_seq_len: int,
     page_size: int,
     swa_window: int,
+    swa_topk_lengths_override: Optional[torch.Tensor] = None,
 ) -> PageTablePositionsResult:
     seq_lens_casual = seq_lens_casual.to(torch.int32)
     positions_casual = seq_lens_casual - 1
@@ -300,7 +305,11 @@ def build_page_table_positions(
         req_pool_indices_repeated.to(torch.int64), :max_seq_len:page_size
     ]
     page_table = (page_table // page_size).to(torch.int32)
-    swa_topk_lengths = torch.clamp(seq_lens_casual, max=swa_window)
+    if swa_topk_lengths_override is not None:
+        # Per-token visible-window lengths (image spans); otherwise causal.
+        swa_topk_lengths = swa_topk_lengths_override
+    else:
+        swa_topk_lengths = torch.clamp(seq_lens_casual, max=swa_window)
     return PageTablePositionsResult(
         seq_lens_casual=seq_lens_casual,
         positions_casual=positions_casual,
@@ -318,17 +327,22 @@ def _page_table_positions_kernel(
     positions_out_ptr,
     page_table_ptr,
     topk_out_ptr,
+    topk_override_ptr,
     rt_stride,
     num_pages,
     page_size,
     swa_window,
     BLOCK_P: tl.constexpr,
+    HAS_TOPK_OVERRIDE: tl.constexpr,
 ):
     row = tl.program_id(0)
     seq_len = tl.load(seq_lens_ptr + row).to(tl.int32)
     tl.store(seq_lens_out_ptr + row, seq_len)
     tl.store(positions_out_ptr + row, seq_len - 1)
-    tl.store(topk_out_ptr + row, tl.minimum(seq_len, swa_window))
+    if HAS_TOPK_OVERRIDE:
+        tl.store(topk_out_ptr + row, tl.load(topk_override_ptr + row))
+    else:
+        tl.store(topk_out_ptr + row, tl.minimum(seq_len, swa_window))
 
     rp = tl.load(req_pool_ptr + row).to(tl.int64)
     base = req_to_token_ptr + rp * rt_stride
@@ -350,6 +364,7 @@ def build_page_table_positions_triton(
     max_seq_len: int,
     page_size: int,
     swa_window: int,
+    swa_topk_lengths_override: Optional[torch.Tensor] = None,
 ) -> PageTablePositionsResult:
     num_q = seq_lens_casual.shape[0]
     num_pages = (max_seq_len + page_size - 1) // page_size
@@ -368,11 +383,17 @@ def build_page_table_positions_triton(
         positions_out,
         page_table,
         topk_out,
+        (
+            swa_topk_lengths_override
+            if swa_topk_lengths_override is not None
+            else seq_lens_casual
+        ),
         req_to_token.stride(0),
         num_pages,
         page_size,
         swa_window,
         BLOCK_P=BLOCK_P,
+        HAS_TOPK_OVERRIDE=swa_topk_lengths_override is not None,
     )
     return PageTablePositionsResult(
         seq_lens_casual=seq_lens_out,
@@ -399,6 +420,8 @@ class BuildCausalSwaPageIndices:
         seq_lens_casual: torch.Tensor,
         swa_window: int,
         page_index_aligned_size: int,
+        win_starts: Optional[torch.Tensor] = None,
+        win_lens: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return build_causal_swa_page_indices(
             req_to_token=req_to_token,
@@ -407,6 +430,8 @@ class BuildCausalSwaPageIndices:
             seq_lens_casual=seq_lens_casual,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            win_starts=win_starts,
+            win_lens=win_lens,
         )
 
     @classmethod
@@ -419,6 +444,8 @@ class BuildCausalSwaPageIndices:
         seq_lens_casual: torch.Tensor,
         swa_window: int,
         page_index_aligned_size: int,
+        win_starts: Optional[torch.Tensor] = None,
+        win_lens: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return build_causal_swa_page_indices_triton(
             req_to_token=req_to_token,
@@ -427,6 +454,8 @@ class BuildCausalSwaPageIndices:
             seq_lens_casual=seq_lens_casual,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            win_starts=win_starts,
+            win_lens=win_lens,
         )
 
 
@@ -438,10 +467,30 @@ def build_causal_swa_page_indices(
     seq_lens_casual: torch.Tensor,
     swa_window: int,
     page_index_aligned_size: int,
+    win_starts: Optional[torch.Tensor] = None,
+    win_lens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     device = seq_lens_casual.device
-    pos_causal = seq_lens_casual - 1
     num_qo_tokens = seq_lens_casual.size(0)
+    if win_starts is not None:
+        # Per-token visible windows (image spans): row i covers
+        # [win_starts[i], win_starts[i] + win_lens[i]); width covers the max.
+        assert win_lens is not None
+        window_width = int(win_lens.max().item())
+        padded_width = (
+            (window_width + page_index_aligned_size - 1) // page_index_aligned_size
+        ) * page_index_aligned_size
+        offsets = win_starts.unsqueeze(1) + torch.arange(
+            padded_width, dtype=torch.int32, device=device
+        ).unsqueeze(0)
+        invalid_offset_mask = offsets >= (win_starts + win_lens).unsqueeze(1)
+        offsets.masked_fill_(invalid_offset_mask, 0)
+        raw_indices = req_to_token[req_pool_indices_repeated[:, None], offsets]
+        assert raw_indices.shape == (num_qo_tokens, padded_width)
+        raw_indices.masked_fill_(invalid_offset_mask, -1)
+        return full_to_swa_mapping[raw_indices].to(torch.int32)
+
+    pos_causal = seq_lens_casual - 1
     offsets = pos_causal.unsqueeze(1) - torch.arange(
         swa_window, dtype=torch.int32, device=device
     ).unsqueeze(0)
@@ -469,23 +518,33 @@ def _causal_swa_page_indices_kernel(
     full_to_swa_ptr,
     req_pool_ptr,
     seq_lens_ptr,
+    win_starts_ptr,
+    win_lens_ptr,
     out_ptr,
     rt_stride,
     swa_window,
     padded_width,
     BLOCK_K: tl.constexpr,
+    HAS_WIN: tl.constexpr,
 ):
     row = tl.program_id(0)
     pos = tl.load(seq_lens_ptr + row).to(tl.int64) - 1
     rp = tl.load(req_pool_ptr + row).to(tl.int64)
     base = req_to_token_ptr + rp * rt_stride
     out_base = out_ptr + row.to(tl.int64) * padded_width
+    if HAS_WIN:
+        win_start = tl.load(win_starts_ptr + row).to(tl.int64)
+        win_len = tl.load(win_lens_ptr + row).to(tl.int64)
 
     for k0 in range(0, padded_width, BLOCK_K):
         k = k0 + tl.arange(0, BLOCK_K)
         kmask = k < padded_width
-        off = pos - k.to(tl.int64)
-        valid = (k < swa_window) & (off >= 0) & kmask
+        if HAS_WIN:
+            off = win_start + k.to(tl.int64)
+            valid = (k < win_len) & kmask
+        else:
+            off = pos - k.to(tl.int64)
+            valid = (k < swa_window) & (off >= 0) & kmask
         full_loc = tl.load(base + tl.where(valid, off, 0), mask=valid, other=-1).to(
             tl.int64
         )
@@ -501,10 +560,17 @@ def build_causal_swa_page_indices_triton(
     seq_lens_casual: torch.Tensor,
     swa_window: int,
     page_index_aligned_size: int,
+    win_starts: Optional[torch.Tensor] = None,
+    win_lens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     num_qo_tokens = seq_lens_casual.size(0)
+    if win_lens is not None:
+        # Per-token visible windows (image spans); width covers the max len.
+        window_width = int(win_lens.max().item())
+    else:
+        window_width = swa_window
     padded_width = (
-        (swa_window + page_index_aligned_size - 1) // page_index_aligned_size
+        (window_width + page_index_aligned_size - 1) // page_index_aligned_size
     ) * page_index_aligned_size
     out = torch.empty(
         (num_qo_tokens, padded_width),
@@ -517,10 +583,13 @@ def build_causal_swa_page_indices_triton(
         full_to_swa_mapping,
         req_pool_indices_repeated,
         seq_lens_casual,
+        win_starts if win_starts is not None else seq_lens_casual,
+        win_lens if win_lens is not None else seq_lens_casual,
         out,
         req_to_token.stride(0),
         swa_window,
         padded_width,
         BLOCK_K=BLOCK_K,
+        HAS_WIN=win_starts is not None,
     )
     return out

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -757,8 +757,8 @@ def prewarm_mhc_pre(
     hc_mult, hidden_size = residual.shape[-2], residual.shape[-1]
     max_num_tokens = get_schedule().chunked_prefill_size
     if max_num_tokens is None or max_num_tokens <= 0:
-        # Chunked prefill is disabled (e.g. forced off for DeepSeek-V4-Vision);
-        # prewarm with a representative default bucket range instead.
+        # Chunked prefill is disabled; prewarm with a representative default
+        # bucket range instead.
         max_num_tokens = 16384
     buckets = get_mhc_pre_token_count_representatives(
         max_num_tokens, hc_mult * hidden_size

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -756,6 +756,10 @@ def prewarm_mhc_pre(
 
     hc_mult, hidden_size = residual.shape[-2], residual.shape[-1]
     max_num_tokens = get_schedule().chunked_prefill_size
+    if max_num_tokens is None or max_num_tokens <= 0:
+        # Chunked prefill is disabled (e.g. forced off for DeepSeek-V4-Vision);
+        # prewarm with a representative default bucket range instead.
+        max_num_tokens = 16384
     buckets = get_mhc_pre_token_count_representatives(
         max_num_tokens, hc_mult * hidden_size
     )

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from sglang.srt.arg_groups.overrides import (
     _deepseek_v4_kv_cache_dtype,
     declare_resolution,
+    model_config_of,
     resolving_view,
     run_post_process_pass,
 )
@@ -218,3 +219,40 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
         f"dp_size={cfg.dp_size}, moe_dense_tp_size={cfg.moe_dense_tp_size}, "
         f"attn_cp_size={cfg.attn_cp_size}, ep_size={cfg.ep_size}, tp_size={cfg.tp_size}"
     )
+
+
+def validate_deepseek_v4_vision(server_args: ServerArgs) -> None:
+    """Validate the execution paths and minimum budget for atomic image blocks."""
+    cfg = resolving_view(server_args)
+    hf_config = model_config_of(server_args).hf_config
+    if "DeepseekV4ForCausalLM" not in hf_config.architectures or not getattr(
+        hf_config, "vision_n_layers", 0
+    ):
+        return
+    if cfg.enable_prefill_cp or cfg.enable_dsa_prefill_context_parallel:
+        raise ValueError(
+            "DeepSeek-V4 vision does not support prefill context parallelism."
+        )
+    if (
+        get_platform().is_hip
+        and envs.SGLANG_HACK_FLASHMLA_BACKEND.get() == "unified_kv_triton"
+    ):
+        raise ValueError(
+            "DeepSeek-V4 vision requires KV storage for complete image blocks."
+        )
+    # Chunk endpoints are page-aligned before image alignment. An image may
+    # start anywhere in a page, so leave room for that partial page too.
+    max_span = hf_config.vision_max_n_token
+    page_size = cfg.page_size
+    min_chunk = ((max_span + page_size - 2) // page_size + 1) * page_size
+    if (
+        cfg.chunked_prefill_size is not None
+        and 0 < cfg.chunked_prefill_size < min_chunk
+    ):
+        raise ValueError(
+            f"DeepSeek-V4 vision requires a per-rank --chunked-prefill-size "
+            f"of at least {min_chunk} (image budget {max_span}, page size {page_size}), "
+            "or -1 to disable chunked prefill."
+        )
+    if cfg.enable_dynamic_chunking:
+        raise ValueError("DeepSeek-V4 vision does not support dynamic chunk sizes.")

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -595,10 +595,10 @@ def handle_model_capability_adjustments(server_args: Any):
     hf_config = model_config.hf_config
 
     # DeepSeek-V4-Vision: the visible-window attention inside image spans
-    # assumes every image span is prefilled in a single extend with no
-    # prefix reuse (spans split by chunked prefill or partially hit by radix
-    # cache silently degrade to a causal window). Force both off so the
-    # assumption always holds.
+    # assumes every image span is prefilled in a single extend. Chunked
+    # prefill truncation points are span-aligned by the scheduler (see
+    # image_span_aligned_extend_end), but a radix prefix hit ending mid-span
+    # would still cut a span, so prefix caching stays off for this model.
     is_dsv4_vision = (
         "DeepseekV4ForCausalLM" in getattr(hf_config, "architectures", [])
         and getattr(hf_config, "vision_n_layers", 0) > 0
@@ -607,17 +607,12 @@ def handle_model_capability_adjustments(server_args: Any):
         declare_resolution(
             server_args,
             "_handle_model_capability_adjustments",
-            chunked_prefill_size=-1,
-        )
-        declare_resolution(
-            server_args,
-            "_handle_model_capability_adjustments",
             disable_radix_cache=True,
         )
         logger.warning(
-            "DeepSeek-V4-Vision detected: forcing --chunked-prefill-size=-1 "
-            "and --disable-radix-cache (image-span visible-window attention "
-            "requires single-shot prefill without prefix reuse)."
+            "DeepSeek-V4-Vision detected: forcing --disable-radix-cache "
+            "(a prefix hit ending inside an image span would cut the span; "
+            "chunked prefill is span-aligned and stays enabled)."
         )
 
     # HRM-Text needs bidirectional prompt attention (prefill), which only

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -594,27 +594,6 @@ def handle_model_capability_adjustments(server_args: Any):
     model_config = model_config_of(server_args)
     hf_config = model_config.hf_config
 
-    # DeepSeek-V4-Vision: the visible-window attention inside image spans
-    # assumes every image span is prefilled in a single extend. Chunked
-    # prefill truncation points are span-aligned by the scheduler (see
-    # image_span_aligned_extend_end), but a radix prefix hit ending mid-span
-    # would still cut a span, so prefix caching stays off for this model.
-    is_dsv4_vision = (
-        "DeepseekV4ForCausalLM" in getattr(hf_config, "architectures", [])
-        and getattr(hf_config, "vision_n_layers", 0) > 0
-    )
-    if is_dsv4_vision:
-        declare_resolution(
-            server_args,
-            "_handle_model_capability_adjustments",
-            disable_radix_cache=True,
-        )
-        logger.warning(
-            "DeepSeek-V4-Vision detected: forcing --disable-radix-cache "
-            "(a prefix hit ending inside an image span would cut the span; "
-            "chunked prefill is span-aligned and stays enabled)."
-        )
-
     # HRM-Text needs bidirectional prompt attention (prefill), which only
     # the Triton backend honors at the kernel level. Radix/prefix reuse is
     # also unsafe: the recurrent forward writes direction-dependent KV

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -594,6 +594,32 @@ def handle_model_capability_adjustments(server_args: Any):
     model_config = model_config_of(server_args)
     hf_config = model_config.hf_config
 
+    # DeepSeek-V4-Vision: the visible-window attention inside image spans
+    # assumes every image span is prefilled in a single extend with no
+    # prefix reuse (spans split by chunked prefill or partially hit by radix
+    # cache silently degrade to a causal window). Force both off so the
+    # assumption always holds.
+    is_dsv4_vision = (
+        "DeepseekV4ForCausalLM" in getattr(hf_config, "architectures", [])
+        and getattr(hf_config, "vision_n_layers", 0) > 0
+    )
+    if is_dsv4_vision:
+        declare_resolution(
+            server_args,
+            "_handle_model_capability_adjustments",
+            chunked_prefill_size=-1,
+        )
+        declare_resolution(
+            server_args,
+            "_handle_model_capability_adjustments",
+            disable_radix_cache=True,
+        )
+        logger.warning(
+            "DeepSeek-V4-Vision detected: forcing --chunked-prefill-size=-1 "
+            "and --disable-radix-cache (image-span visible-window attention "
+            "requires single-shot prefill without prefix reuse)."
+        )
+
     # HRM-Text needs bidirectional prompt attention (prefill), which only
     # the Triton backend honors at the kernel level. Radix/prefix reuse is
     # also unsafe: the recurrent forward writes direction-dependent KV

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1548,7 +1548,7 @@ def _moe_runner_fusion_disable(view: Any) -> dict:
         # experts; the mxfp4 runner's quant method fuses the scaling factor
         # into top-k, so the combination fails at model build time.
         hf_config = model_config_of(view).hf_config
-        if getattr(hf_config, "architectures", [None])[0] == "DeepseekV4ForCausalLM":
+        if hf_config.architectures[0] == "DeepseekV4ForCausalLM":
             logger.warning(
                 "DeepSeek-V4 with the FlashInfer MXFP4 MoE runner requires "
                 "--disable-shared-experts-fusion; setting it automatically."

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1542,6 +1542,18 @@ def _moe_runner_fusion_disable(view: Any) -> dict:
             "FlashInfer TRTLLM routed MoE is enabled. --disable-shared-experts-fusion is automatically set."
         )
         return {"disable_shared_experts_fusion": True}
+    if runner == "flashinfer_mxfp4":
+        # DeepSeek-V4 hash-routing layers (HashTopK) reject
+        # apply_routed_scaling_factor_on_output together with fused shared
+        # experts; the mxfp4 runner's quant method fuses the scaling factor
+        # into top-k, so the combination fails at model build time.
+        hf_config = model_config_of(view).hf_config
+        if getattr(hf_config, "architectures", [None])[0] == "DeepseekV4ForCausalLM":
+            logger.warning(
+                "DeepSeek-V4 with the FlashInfer MXFP4 MoE runner requires "
+                "--disable-shared-experts-fusion; setting it automatically."
+            )
+            return {"disable_shared_experts_fusion": True}
     return {}
 
 

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_vision
 from sglang.srt.arg_groups.overrides import (
     _page_size_default,
     _pipeline_parallel_overlap_disable,
@@ -361,8 +362,6 @@ def run_resolution_pipeline(server_args: Any) -> None:
     # Validate after all batch-size declarations are visible.
     validate_deepep_v2_speculative_draft(server_args)
     validate_deepep_v2_dispatch_token_budget(server_args)
-
-    from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_vision
 
     validate_deepseek_v4_vision(server_args)
     server_args._resolution_finished = True

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -362,4 +362,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
     validate_deepep_v2_speculative_draft(server_args)
     validate_deepep_v2_dispatch_token_budget(server_args)
 
+    from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_vision
+
+    validate_deepseek_v4_vision(server_args)
     server_args._resolution_finished = True

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -15,6 +15,7 @@ from sglang.srt.batch_overlap.operations import (
 )
 from sglang.srt.batch_overlap.operations_strategy import OperationsStrategy
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.dsv4.visible_window import iter_image_spans
 from sglang.srt.layers.communicator import (
     CommunicateContext,
     CommunicateSummableTensorPairFn,
@@ -444,6 +445,12 @@ class TboDPAttentionPreparer:
                 and enable_a2a_moe
                 and (resolved_deepep_mode.is_low_latency())
             )
+            # TBO child batches do not preserve image attention metadata.
+            if local_can_run_tbo and local_batch.is_extend_in_batch:
+                local_can_run_tbo = not any(
+                    any(iter_image_spans(mm_input))
+                    for mm_input in (local_batch.multimodal_inputs or [])
+                )
         else:
             self.local_tbo_split_seq_index = 0
             local_can_run_tbo = True

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -845,6 +845,22 @@ class TboForwardBatchPreparer:
             )
         )
 
+        routing_ids = batch.dsv4_routing_input_ids
+        image_mask = batch.dsv4_image_mask
+        output_dict.update(
+            dsv4_routing_input_ids=(
+                routing_ids[start_token_index:end_token_index]
+                if routing_ids is not None
+                else None
+            ),
+            dsv4_image_mask=(
+                image_mask[start_token_index:end_token_index]
+                if image_mask is not None
+                else None
+            ),
+            dsv4_has_image_tokens=batch.dsv4_has_image_tokens,
+        )
+
         errors = []
         for field in dataclasses.fields(ForwardBatch):
             if getattr(batch, field.name) is not None and field.name not in output_dict:
@@ -854,23 +870,7 @@ class TboForwardBatchPreparer:
         if len(errors) > 0:
             raise Exception(f"{len(errors)} errors happen:\n" + "\n\n".join(errors))
 
-        child = ForwardBatch(**output_dict)
-        # DeepSeek-V4-Vision: carry the pre-clamp routing ids to the child so
-        # the MoE gate can still see the mm pad sentinels after the parent's
-        # input_ids got clamped by embed_mm_inputs.
-        routing_ids = getattr(batch, "dsv4_routing_input_ids", None)
-        if routing_ids is not None:
-            child.dsv4_routing_input_ids = routing_ids[
-                start_token_index:end_token_index
-            ]
-        # Also carry the hoisted image-token mask and its host-side flag (the
-        # child's mask may have no sentinel left; inheriting the parent's flag
-        # is a conservative superset and only costs the eager fallback).
-        image_mask = getattr(batch, "dsv4_image_mask", None)
-        if image_mask is not None:
-            child.dsv4_image_mask = image_mask[start_token_index:end_token_index]
-            child.dsv4_has_image_tokens = getattr(batch, "dsv4_has_image_tokens", False)
-        return child
+        return ForwardBatch(**output_dict)
 
     @classmethod
     def compute_tbo_children_num_token_non_padded(cls, batch: ForwardBatch):

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -847,7 +847,16 @@ class TboForwardBatchPreparer:
         if len(errors) > 0:
             raise Exception(f"{len(errors)} errors happen:\n" + "\n\n".join(errors))
 
-        return ForwardBatch(**output_dict)
+        child = ForwardBatch(**output_dict)
+        # DeepSeek-V4-Vision: carry the pre-clamp routing ids to the child so
+        # the MoE gate can still see the mm pad sentinels after the parent's
+        # input_ids got clamped by embed_mm_inputs.
+        routing_ids = getattr(batch, "dsv4_routing_input_ids", None)
+        if routing_ids is not None:
+            child.dsv4_routing_input_ids = routing_ids[
+                start_token_index:end_token_index
+            ]
+        return child
 
     @classmethod
     def compute_tbo_children_num_token_non_padded(cls, batch: ForwardBatch):

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -856,6 +856,13 @@ class TboForwardBatchPreparer:
             child.dsv4_routing_input_ids = routing_ids[
                 start_token_index:end_token_index
             ]
+        # Also carry the hoisted image-token mask and its host-side flag (the
+        # child's mask may have no sentinel left; inheriting the parent's flag
+        # is a conservative superset and only costs the eager fallback).
+        image_mask = getattr(batch, "dsv4_image_mask", None)
+        if image_mask is not None:
+            child.dsv4_image_mask = image_mask[start_token_index:end_token_index]
+            child.dsv4_has_image_tokens = getattr(batch, "dsv4_has_image_tokens", False)
         return child
 
     @classmethod

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -383,6 +383,17 @@ class ModelConfig:
                 logger.info(
                     f"Multimodal is disabled for {self.hf_config.model_type}. To enable it, set --enable-multimodal."
                 )
+            elif self.hf_config.architectures[
+                0
+            ] == "DeepseekV4ForCausalLM" and not getattr(
+                self.hf_config, "vision_n_layers", 0
+            ):
+                enable_multimodal = False
+                logger.info(
+                    "Multimodal is disabled for this DeepseekV4 checkpoint: "
+                    "vision_n_layers not found in the model config "
+                    "(likely a text-only DeepseekV4 variant)."
+                )
             elif self.hf_config.architectures[0] in MIMO_V2_MULTIMODAL_ARCHS and not (
                 hasattr(self.hf_config, "vision_config")
                 and hasattr(self.hf_config, "audio_config")
@@ -1887,6 +1898,7 @@ multimodal_model_archs = [
     "CLIPModel",
     "Cohere2VisionForConditionalGeneration",
     "DeepseekVL2ForCausalLM",
+    "DeepseekV4ForCausalLM",
     "Ernie4_5_VLMoeForConditionalGeneration",
     "MiniMaxM3SparseForConditionalGeneration",
     "Gemma3ForConditionalGeneration",

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -13,10 +13,6 @@ import json
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-# ============================================================
-# Special Tokens
-# ============================================================
-
 bos_token: str = "<｜begin▁of▁sentence｜>"
 eos_token: str = "<｜end▁of▁sentence｜>"
 thinking_start_token: str = "<think>"
@@ -40,9 +36,6 @@ DS_TASK_SP_TOKENS = {
 }
 VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
 
-# ============================================================
-# Templates
-# ============================================================
 
 system_msg_template: str = "{content}"
 user_msg_template: str = "{content}"
@@ -82,12 +75,6 @@ REASONING_EFFORT_PROMPTS: Dict[str, str] = {
 }
 DEFAULT_REASONING_EFFORT = "low"
 
-# --- sglang compatibility shim -------------------------------------------
-# Previous sglang adapter exposed two reasoning-effort "profiles" keyed off
-# the checkpoint's bundled encoder: "preview" (original V4 text release) and
-# "official" (current upstream). The prompt texts are unchanged upstream, so
-# the profiles map onto the flat levels: preview/high == "", preview/max ==
-# upstream "high", official/* == upstream level of the same name.
 REASONING_EFFORT_PROFILES: Dict[str, Dict[str, str]] = {
     "preview": {"high": "", "max": REASONING_EFFORT_PROMPTS["high"]},
     "official": REASONING_EFFORT_PROMPTS,
@@ -104,8 +91,6 @@ def resolve_profile_reasoning_effort(
         return {"high": "low", "max": "high"}.get(reasoning_effort, reasoning_effort)
     return reasoning_effort
 
-
-# --- end sglang compatibility shim ---------------------------------------
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -133,10 +118,6 @@ Otherwise, output directly after {thinking_end_token} with tool calls or final r
 
 You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
 """
-
-# ============================================================
-# Utility Functions
-# ============================================================
 
 
 def to_json(value: Any) -> str:
@@ -177,23 +158,21 @@ def tool_calls_to_openai_format(tool_calls):
     ]
 
 
-def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
-    """
-    Encode tool call arguments into DSML parameter format.
-
-    Args:
-        tool_call: Dict with "name" and "arguments" (JSON string) keys.
-
-    Returns:
-        DSML-formatted parameter string.
-    """
+def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
+    """Encode tool call arguments into DSML parameter format."""
     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
     P_dsml_strs = []
 
-    try:
-        arguments = json.loads(tool_call["arguments"])
-    except Exception as err:
-        arguments = {"arguments": tool_call["arguments"]}
+    raw_arguments = tool_call["arguments"]
+    if isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        try:
+            arguments = json.loads(raw_arguments)
+        except (TypeError, ValueError):
+            arguments = {"arguments": raw_arguments}
+    if not isinstance(arguments, dict):
+        arguments = {"arguments": raw_arguments}
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(
@@ -210,16 +189,7 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
 def decode_dsml_to_arguments(
     tool_name: str, tool_args: Dict[str, Tuple[str, str]]
 ) -> Dict[str, str]:
-    """
-    Decode DSML parameters back to a tool call dict.
-
-    Args:
-        tool_name: Name of the tool.
-        tool_args: Dict mapping param_name -> (value, is_string_flag).
-
-    Returns:
-        Dict with "name" and "arguments" (JSON string) keys.
-    """
+    """Decode DSML parameters back to a tool call dict."""
 
     def _decode_value(key: str, value: str, string: str):
         if string == "true":
@@ -237,15 +207,7 @@ def decode_dsml_to_arguments(
 
 
 def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
-    """
-    Render tool schemas into the system prompt format.
-
-    Args:
-        tools: List of tool schema dicts (each with name, description, parameters).
-
-    Returns:
-        Formatted tools section string.
-    """
+    """Render tool schemas into the system prompt format."""
     tools_json = [to_json(t) for t in tools]
 
     return TOOLS_TEMPLATE.format(
@@ -279,11 +241,6 @@ def attach_task_to_last_user_message(messages: List[Dict[str, Any]], task: str) 
     messages[idx]["task"] = task
 
 
-# ============================================================
-# Message Rendering
-# ============================================================
-
-
 def render_message(
     index: int,
     messages: List[Dict[str, Any]],
@@ -291,23 +248,7 @@ def render_message(
     drop_thinking: bool = True,
     reasoning_effort: Optional[str] = None,
 ) -> str:
-    """
-    Render a single message at the given index into its encoded string form.
-
-    This is the core function that converts each message in the conversation
-    into the DeepSeek-V4 format.
-
-    Args:
-        index: Index of the message to render.
-        messages: Full list of messages in the conversation.
-        thinking_mode: Either "chat" or "thinking".
-        drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
-            None is treated as "low".
-
-    Returns:
-        Encoded string for this message.
-    """
+    """Render a single message at the given index into its encoded string form."""
     assert 0 <= index < len(messages)
     assert thinking_mode in [
         "chat",
@@ -490,28 +431,8 @@ def render_message(
     return prompt
 
 
-# ============================================================
-# Preprocessing
-# ============================================================
-
-
 def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """
-    Merge tool messages into the preceding user message using content_blocks format.
-
-    DeepSeek-V4 does not have a standalone "tool" role; instead, tool results
-    are encoded as <tool_result> blocks within user messages.
-
-    This function converts a standard OpenAI-format conversation (with separate
-    "tool" role messages) into V4 format where tool results are merged into
-    user messages.
-
-    Args:
-        messages: List of message dicts in OpenAI format.
-
-    Returns:
-        Processed message list with tool messages merged into user messages.
-    """
+    """Merge tool messages into the preceding user message using content_blocks format."""
     merged: List[Dict[str, Any]] = []
 
     for msg in messages:
@@ -564,16 +485,7 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 def sort_tool_results_by_call_order(
     messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
-    """
-    Sort tool_result blocks within user messages by the order of tool_calls
-    in the preceding assistant message.
-
-    Args:
-        messages: Preprocessed message list (after merge_tool_messages).
-
-    Returns:
-        Message list with sorted tool result blocks.
-    """
+    """Sort tool_result blocks within user messages by the order of tool_calls"""
     last_tool_call_order: Dict[str, int] = {}
 
     for msg in messages:
@@ -607,11 +519,6 @@ def sort_tool_results_by_call_order(
     return messages
 
 
-# ============================================================
-# Main Encoding Function
-# ============================================================
-
-
 def _encode_messages_text(
     messages: List[Dict[str, Any]],
     thinking_mode: str,
@@ -620,28 +527,7 @@ def _encode_messages_text(
     add_default_bos_token: bool = True,
     reasoning_effort: Optional[str] = None,
 ) -> str:
-    """
-    Encode a list of messages into the DeepSeek-V4 prompt format.
-
-    This is the main entry point for encoding conversations. It handles:
-    - BOS token insertion
-    - Thinking mode with optional reasoning content dropping
-    - Tool message merging into user messages
-    - Multi-turn conversation context
-
-    Args:
-        messages: List of message dicts to encode.
-        thinking_mode: Either "chat" or "thinking".
-        context: Optional preceding context messages (already encoded prefix).
-        drop_thinking: If True, drop reasoning_content from earlier assistant turns
-                      (only keep reasoning for messages after the last user message).
-        add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
-            Only takes effect in thinking mode. None is treated as "low".
-
-    Returns:
-        The encoded prompt string.
-    """
+    """Encode a list of messages into the DeepSeek-V4 prompt format."""
     context = context if context else []
 
     # Preprocess: merge tool messages and sort tool results
@@ -707,11 +593,6 @@ def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         # developer and other roles before last_user_idx are dropped
 
     return result
-
-
-# ============================================================
-# Vision Message Preprocessing
-# ============================================================
 
 
 def parse_tagged_text(text: str) -> Union[str, List[Dict[str, Any]]]:
@@ -854,12 +735,29 @@ def encode_messages(
     add_default_bos_token: bool = True,
     reasoning_effort: Optional[str] = None,
     return_multi_modal_data: bool = False,
+    reasoning_effort_profile: Optional[str] = None,
 ) -> Any:
     """Encode text or multimodal messages through one canonical public entrypoint.
 
     Text-only calls preserve the original string-returning API. When
     return_multi_modal_data is true, the result is ``(prompt, media_data)``.
     """
+    if reasoning_effort_profile is not None:
+        if reasoning_effort_profile not in REASONING_EFFORT_PROFILES:
+            raise ValueError(
+                f"Invalid reasoning effort profile: {reasoning_effort_profile!r}"
+            )
+        if (
+            reasoning_effort is not None
+            and reasoning_effort
+            not in REASONING_EFFORT_PROFILES[reasoning_effort_profile]
+        ):
+            raise ValueError(
+                f"Invalid reasoning effort {reasoning_effort!r} for profile {reasoning_effort_profile!r}"
+            )
+        reasoning_effort = resolve_profile_reasoning_effort(
+            reasoning_effort_profile, reasoning_effort
+        )
     context = context or []
     processed_context, _ = process_image_messages(context) if context else ([], [])
     processed_messages, images = process_image_messages(messages)
@@ -917,20 +815,10 @@ def encode_case(
     return prompt, media_data["images"]
 
 
-# ============================================================
-# Parsing (Decoding model output)
-# ============================================================
-
-
 def _read_until_stop(
     index: int, text: str, stop: List[str]
 ) -> Tuple[int, str, Optional[str]]:
-    """
-    Read text from index until one of the stop strings is found.
-
-    Returns:
-        Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
-    """
+    """Read text from index until one of the stop strings is found."""
     min_pos = len(text)
     matched_stop = None
 
@@ -951,17 +839,7 @@ def _read_until_stop(
 def parse_tool_calls(
     index: int, text: str
 ) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
-    """
-    Parse DSML tool calls from text starting at the given index.
-
-    Args:
-        index: Starting position in text.
-        text: The full text to parse.
-
-    Returns:
-        Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
-        Each tool call dict has "name" and "arguments" keys.
-    """
+    """Parse DSML tool calls from text starting at the given index."""
     tool_calls: List[Dict[str, Any]] = []
     stop_token = None
     tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
@@ -1024,26 +902,7 @@ def parse_tool_calls(
 
 
 def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
-    """
-    Parse a model completion text into a structured assistant message.
-
-    This function takes the raw text output from the model (a single assistant turn)
-    and extracts:
-    - reasoning_content (thinking block)
-    - content (summary/response)
-    - tool_calls (if any)
-
-    NOTE: This function is designed to parse only correctly formatted strings and
-    will raise ValueError for malformed output.
-
-    Args:
-        text: The raw completion text (including EOS token).
-        thinking_mode: Either "chat" or "thinking".
-
-    Returns:
-        Dict with keys: "role", "content", "reasoning_content", "tool_calls".
-        tool_calls are in OpenAI format.
-    """
+    """Parse a model completion text into a structured assistant message."""
     summary_content, reasoning_content, tool_calls = "", "", []
     index, stop_token = 0, None
     tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -1,9 +1,11 @@
-# Adapted from the DeepSeek-V4 release reference implementation.
+# Adapted from the DeepSeek-V4-Flash-Vision-Exp release reference implementation
+# (encoding/encoding_dsv4.py), with sglang-specific compatibility shims at the
+# bottom of the "Reasoning Effort" section and in "Task Support".
 """
-DeepSeek-V4 Encoding
+DeepSeek-V4 Text and Vision Encoding
 
 A self-contained implementation for encoding/decoding DeepSeek-V4 chat messages
-with tool calling, thinking mode, and quick instruction task support.
+with tool calling, thinking mode, quick instruction tasks, and image content blocks.
 """
 
 import copy
@@ -24,6 +26,8 @@ dsml_token: str = "｜DSML｜"
 USER_SP_TOKEN = "<｜User｜>"
 ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
 LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+IMAGE_TAG_PATTERN = re.compile(r"<image>(.*?)</image>", re.DOTALL)
 
 # Task special tokens for internal classification tasks
 DS_TASK_SP_TOKENS = {
@@ -60,29 +64,48 @@ tool_calls_block_name: str = "tool_calls"
 
 tool_output_template: str = "<tool_result>{content}</tool_result>"
 
-REASONING_EFFORT_PREVIEW_MAX = (
-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
-)
-
-REASONING_EFFORT_OFFICIAL_MAX = (
-    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
-    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
-    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
-)
-
-REASONING_EFFORT_PROFILES = {
-    "preview": {
-        "high": "",
-        "max": REASONING_EFFORT_PREVIEW_MAX,
-    },
-    "official": {
-        "low": "",
-        "high": REASONING_EFFORT_PREVIEW_MAX,
-        "max": REASONING_EFFORT_OFFICIAL_MAX,
-    },
+# Reasoning effort levels. In thinking mode, the prompt for the selected level is
+# prepended at the very beginning of the conversation. `low` is the default and
+# adds nothing.
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+    ),
 }
+DEFAULT_REASONING_EFFORT = "low"
+
+# --- sglang compatibility shim -------------------------------------------
+# Previous sglang adapter exposed two reasoning-effort "profiles" keyed off
+# the checkpoint's bundled encoder: "preview" (original V4 text release) and
+# "official" (current upstream). The prompt texts are unchanged upstream, so
+# the profiles map onto the flat levels: preview/high == "", preview/max ==
+# upstream "high", official/* == upstream level of the same name.
+REASONING_EFFORT_PROFILES: Dict[str, Dict[str, str]] = {
+    "preview": {"high": "", "max": REASONING_EFFORT_PROMPTS["high"]},
+    "official": REASONING_EFFORT_PROMPTS,
+}
+
+
+def resolve_profile_reasoning_effort(
+    profile: str, reasoning_effort: Optional[str]
+) -> Optional[str]:
+    """Translate a legacy (profile, effort) pair to a flat upstream effort."""
+    if reasoning_effort is None:
+        return None
+    if profile == "preview":
+        return {"high": "low", "max": "high"}.get(reasoning_effort, reasoning_effort)
+    return reasoning_effort
+
+
+# --- end sglang compatibility shim ---------------------------------------
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -159,7 +182,7 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
     Encode tool call arguments into DSML parameter format.
 
     Args:
-        tool_call: Dict with "name" and "arguments" keys.
+        tool_call: Dict with "name" and "arguments" (JSON string) keys.
 
     Returns:
         DSML-formatted parameter string.
@@ -167,14 +190,10 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
     P_dsml_strs = []
 
-    raw_arguments = tool_call["arguments"]
-    arguments = (
-        json.loads(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
-    )
-    if not isinstance(arguments, dict):
-        raise ValueError(
-            "Assistant tool call function.arguments must be a JSON object."
-        )
+    try:
+        arguments = json.loads(tool_call["arguments"])
+    except Exception as err:
+        arguments = {"arguments": tool_call["arguments"]}
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(
@@ -248,7 +267,10 @@ def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
 
 
 def attach_task_to_last_user_message(messages: List[Dict[str, Any]], task: str) -> None:
-    """Set `task` on the most recent user/developer message; raise if none exists."""
+    """Set `task` on the most recent user/developer message; raise if none exists.
+
+    sglang addition (used by serving_chat for the OpenAI `task` request field).
+    """
     idx = find_last_user_index(messages)
     if idx == -1:
         raise ValueError(
@@ -268,7 +290,6 @@ def render_message(
     thinking_mode: str,
     drop_thinking: bool = True,
     reasoning_effort: Optional[str] = None,
-    reasoning_effort_profile: str = "preview",
 ) -> str:
     """
     Render a single message at the given index into its encoded string form.
@@ -281,9 +302,8 @@ def render_message(
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level. The preview profile accepts
-            "high" and "max"; the official profile accepts "low", "high", and "max".
-        reasoning_effort_profile: DeepSeek-V4 effort mapping ("preview" or "official").
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            None is treated as "low".
 
     Returns:
         Encoded string for this message.
@@ -311,21 +331,13 @@ def render_message(
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    if reasoning_effort_profile not in REASONING_EFFORT_PROFILES:
-        raise ValueError(
-            f"Invalid reasoning effort profile: {reasoning_effort_profile!r}; "
-            f"expected one of {list(REASONING_EFFORT_PROFILES)}"
-        )
-    effort_prompts = REASONING_EFFORT_PROFILES[reasoning_effort_profile]
-    if reasoning_effort is None:
-        reasoning_effort = "low" if reasoning_effort_profile == "official" else "high"
-    if reasoning_effort not in effort_prompts:
-        raise ValueError(
-            f"Invalid reasoning effort {reasoning_effort!r} for profile "
-            f"{reasoning_effort_profile!r}; expected one of {list(effort_prompts)}"
-        )
+    # Reasoning effort prefix (only at index 0 in thinking mode; "low" adds nothing)
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    assert (
+        reasoning_effort in REASONING_EFFORT_PROMPTS
+    ), f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
     if index == 0 and thinking_mode == "thinking":
-        prompt += effort_prompts[reasoning_effort]
+        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")
@@ -528,24 +540,20 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     }
                 )
         elif role == "user":
-            text_block = {"type": "text", "text": msg.get("content", "")}
+            content_blocks = msg.get("content_blocks")
+            if content_blocks is None:
+                content_blocks = [{"type": "text", "text": msg.get("content", "")}]
             if (
                 merged
                 and merged[-1].get("role") == "user"
                 and "content_blocks" in merged[-1]
                 and merged[-1].get("task") is None
             ):
-                merged[-1]["content_blocks"].append(text_block)
+                merged[-1]["content_blocks"].extend(content_blocks)
             else:
-                new_msg = {
-                    "role": "user",
-                    "content": msg.get("content", ""),
-                    "content_blocks": [text_block],
-                }
-                # Preserve extra fields (task, wo_eos, mask, etc.)
-                for key in ("task", "wo_eos", "mask"):
-                    if key in msg:
-                        new_msg[key] = msg[key]
+                # Preserve structured content and all message-level metadata.
+                new_msg = msg
+                new_msg["content_blocks"] = content_blocks
                 merged.append(new_msg)
         else:
             merged.append(msg)
@@ -604,14 +612,13 @@ def sort_tool_results_by_call_order(
 # ============================================================
 
 
-def encode_messages(
+def _encode_messages_text(
     messages: List[Dict[str, Any]],
     thinking_mode: str,
     context: Optional[List[Dict[str, Any]]] = None,
     drop_thinking: bool = True,
     add_default_bos_token: bool = True,
     reasoning_effort: Optional[str] = None,
-    reasoning_effort_profile: str = "preview",
 ) -> str:
     """
     Encode a list of messages into the DeepSeek-V4 prompt format.
@@ -629,9 +636,8 @@ def encode_messages(
         drop_thinking: If True, drop reasoning_content from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level. The preview profile accepts
-            "high" and "max"; the official profile accepts "low", "high", and "max".
-        reasoning_effort_profile: DeepSeek-V4 effort mapping ("preview" or "official").
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            Only takes effect in thinking mode. None is treated as "low".
 
     Returns:
         The encoded prompt string.
@@ -671,7 +677,6 @@ def encode_messages(
             thinking_mode=thinking_mode,
             drop_thinking=effective_drop_thinking,
             reasoning_effort=reasoning_effort,
-            reasoning_effort_profile=reasoning_effort_profile,
         )
 
     return prompt
@@ -702,6 +707,214 @@ def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         # developer and other roles before last_user_idx are dropped
 
     return result
+
+
+# ============================================================
+# Vision Message Preprocessing
+# ============================================================
+
+
+def parse_tagged_text(text: str) -> Union[str, List[Dict[str, Any]]]:
+    """Convert ``<image>path</image>`` text into standard content blocks."""
+    matches = list(IMAGE_TAG_PATTERN.finditer(text))
+    remaining = IMAGE_TAG_PATTERN.sub("", text)
+    if "<image>" in remaining or "</image>" in remaining:
+        raise ValueError("Malformed <image>path</image> tag")
+    if not matches:
+        return text
+
+    blocks: List[Dict[str, Any]] = []
+    cursor = 0
+    for match in matches:
+        if match.start() > cursor:
+            blocks.append({"type": "text", "text": text[cursor : match.start()]})
+        path = match.group(1)
+        if not path:
+            raise ValueError("Image path must not be empty")
+        blocks.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": path},
+            }
+        )
+        cursor = match.end()
+    if cursor < len(text):
+        blocks.append({"type": "text", "text": text[cursor:]})
+    return blocks
+
+
+def _is_image_block(block: Dict[str, Any]) -> bool:
+    """Return whether a content block is an OpenAI/Anthropic/internal image."""
+    return isinstance(block, dict) and block.get("type") in ("image", "image_url")
+
+
+def _extract_image(block: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a supported image block into an internal image record."""
+    record: Dict[str, Any] = {"type": "image"}
+    if block.get("type") == "image_url":
+        image_url = block.get("image_url")
+        if isinstance(image_url, str):
+            record["url"] = image_url
+        else:
+            record["url"] = (image_url or {}).get("url", "")
+    else:
+        for key in ("source", "url", "data"):
+            if key in block:
+                record[key] = block[key]
+    if not any(record.get(key) for key in ("source", "url", "data")):
+        raise ValueError("Image block does not contain a valid source")
+    return record
+
+
+def _process_image_blocks(
+    blocks: List[Any], image_placeholder: str = IMAGE_PLACEHOLDER
+) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    """Replace image blocks and collect their records in one ordered traversal."""
+    new_blocks: List[Any] = []
+    images: List[Dict[str, Any]] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            new_blocks.append(block)
+            continue
+        if _is_image_block(block):
+            new_blocks.append({"type": "text", "text": image_placeholder})
+            images.append(_extract_image(block))
+        elif block.get("type") == "tool_result" and isinstance(
+            block.get("content"), list
+        ):
+            block = copy.copy(block)
+            block["content"], nested_images = _process_image_blocks(
+                block["content"], image_placeholder
+            )
+            new_blocks.append(block)
+            images.extend(nested_images)
+        elif block.get("type") == "text":
+            text = block.get("text") or ""
+            if IMAGE_PLACEHOLDER in text:
+                raise ValueError(
+                    f"Text block contains image placeholder '{IMAGE_PLACEHOLDER}': "
+                    f"'{text[:100]}'. Images should be separate content blocks."
+                )
+            new_blocks.append(block)
+        else:
+            new_blocks.append(block)
+    return new_blocks, images
+
+
+def _validate_no_image_sp_tokens(msg: Dict[str, Any]) -> None:
+    """Reject user-supplied image placeholder tokens in textual fields."""
+    content = msg.get("content")
+    if isinstance(content, str) and IMAGE_PLACEHOLDER in content:
+        raise ValueError(
+            f"Message content contains image special token '{IMAGE_PLACEHOLDER}'. "
+            "Images should be provided as image content blocks."
+        )
+    reasoning_content = msg.get("reasoning_content")
+    if isinstance(reasoning_content, str) and IMAGE_PLACEHOLDER in reasoning_content:
+        raise ValueError(
+            f"reasoning_content contains image special token '{IMAGE_PLACEHOLDER}'"
+        )
+
+
+def process_image_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Normalize image blocks and return their records in prompt order."""
+    processed: List[Dict[str, Any]] = []
+    images: List[Dict[str, Any]] = []
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        _validate_no_image_sp_tokens(msg)
+
+        if isinstance(msg.get("content"), list) and "content_blocks" not in msg:
+            msg["content_blocks"] = msg.pop("content")
+
+        if msg.get("content_blocks"):
+            msg["content_blocks"], message_images = _process_image_blocks(
+                msg["content_blocks"]
+            )
+            images.extend(message_images)
+            if not isinstance(msg.get("content"), str):
+                texts = [
+                    block.get("text", "")
+                    for block in msg["content_blocks"]
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                msg["content"] = "\n\n".join(texts)
+
+        processed.append(msg)
+    return processed, images
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Optional[str] = None,
+    return_multi_modal_data: bool = False,
+) -> Any:
+    """Encode text or multimodal messages through one canonical public entrypoint.
+
+    Text-only calls preserve the original string-returning API. When
+    return_multi_modal_data is true, the result is ``(prompt, media_data)``.
+    """
+    context = context or []
+    processed_context, _ = process_image_messages(context) if context else ([], [])
+    processed_messages, images = process_image_messages(messages)
+    prompt = _encode_messages_text(
+        processed_messages,
+        thinking_mode=thinking_mode,
+        context=processed_context if processed_context else None,
+        drop_thinking=drop_thinking,
+        add_default_bos_token=add_default_bos_token,
+        reasoning_effort=reasoning_effort,
+    )
+    if return_multi_modal_data:
+        return prompt, {"images": images}
+    return prompt
+
+
+def load_cases(input_file: str) -> List[Dict[str, Any]]:
+    """Load one or more OpenAI-format conversation cases from JSON."""
+    with open(input_file) as file:
+        data = json.load(file)
+    if isinstance(data, dict):
+        data = [data]
+    elif data and isinstance(data[0], dict) and "role" in data[0]:
+        data = [{"messages": data}]
+
+    cases = []
+    for case in data:
+        messages = copy.deepcopy(case["messages"])
+        if "tools" in case:
+            if not messages:
+                raise ValueError("A case with tools must contain at least one message")
+            messages[0]["tools"] = case["tools"]
+        cases.append(
+            {
+                "messages": messages,
+                "context": case.get("context"),
+                "thinking_mode": case.get("thinking_mode"),
+                "reasoning_effort": case.get("reasoning_effort"),
+            }
+        )
+    return cases
+
+
+def encode_case(
+    case: Dict[str, Any], thinking_mode: str
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Encode one JSON case and return its current-turn image records."""
+    prompt, media_data = encode_messages(
+        case["messages"],
+        thinking_mode=case.get("thinking_mode") or thinking_mode,
+        context=case.get("context"),
+        reasoning_effort=case.get("reasoning_effort"),
+        return_multi_modal_data=True,
+    )
+    return prompt, media_data["images"]
 
 
 # ============================================================

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1262,14 +1262,18 @@ class OpenAIServingChat(OpenAIServingBase):
             # DeepSeek-V4-Vision: keep image content blocks for the encoder —
             # it replaces them with <｜deepseek_image｜> placeholders and
             # returns the image records in prompt order (see below).
-            dsv4_with_images = self.chat_encoding_spec == "dsv4" and any(
-                isinstance(m.get("content"), list)
+            dsv4_with_images = (
+                is_multimodal
+                and self.chat_encoding_spec == "dsv4"
                 and any(
-                    isinstance(c, dict)
-                    and c.get("type") in ("image", "image_url", "input_image")
-                    for c in m["content"]
+                    isinstance(m.get("content"), list)
+                    and any(
+                        isinstance(c, dict)
+                        and c.get("type") in ("image", "image_url", "input_image")
+                        for c in m["content"]
+                    )
+                    for m in messages
                 )
-                for m in messages
             )
 
             if not dsv4_with_images:

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -91,6 +91,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.utils.common import ImageData
 from sglang.srt.utils.weight_versions import build_endpoint_weight_version_metadata
 
 if TYPE_CHECKING:
@@ -1258,27 +1259,45 @@ class OpenAIServingChat(OpenAIServingBase):
             # dsv4/dsv32 encoding path
             messages = copy.deepcopy(messages)
 
-            # dsv4/dsv32 are text-only and consume string content; flatten
-            # OpenAI parts-list content here so the encoder sees a plain string.
-            for i, msg in enumerate(messages):
-                if isinstance(msg.get("content"), list):
-                    messages[i] = process_content_for_template_format(
-                        msg, "string", [], [], [], []
-                    )
-
-            for msg in messages:
-                if msg.get("content") is None:
-                    msg["content"] = ""
-                processed_msg = process_content_for_template_format(
-                    msg,
-                    template_content_format,
-                    image_data,
-                    video_data,
-                    audio_data,
-                    modalities,
-                    use_dpsk_v32_encoding=self.chat_encoding_spec == "dsv32",
+            # DeepSeek-V4-Vision: keep image content blocks for the encoder —
+            # it replaces them with <｜deepseek_image｜> placeholders and
+            # returns the image records in prompt order (see below).
+            dsv4_with_images = self.chat_encoding_spec == "dsv4" and any(
+                isinstance(m.get("content"), list)
+                and any(
+                    isinstance(c, dict)
+                    and c.get("type") in ("image", "image_url", "input_image")
+                    for c in m["content"]
                 )
-                msg.update(processed_msg)
+                for m in messages
+            )
+
+            if not dsv4_with_images:
+                # dsv4/dsv32 are text-only and consume string content; flatten
+                # OpenAI parts-list content here so the encoder sees a plain string.
+                for i, msg in enumerate(messages):
+                    if isinstance(msg.get("content"), list):
+                        messages[i] = process_content_for_template_format(
+                            msg, "string", [], [], [], []
+                        )
+
+                for msg in messages:
+                    if msg.get("content") is None:
+                        msg["content"] = ""
+                    processed_msg = process_content_for_template_format(
+                        msg,
+                        template_content_format,
+                        image_data,
+                        video_data,
+                        audio_data,
+                        modalities,
+                        use_dpsk_v32_encoding=self.chat_encoding_spec == "dsv32",
+                    )
+                    msg.update(processed_msg)
+            else:
+                for msg in messages:
+                    if msg.get("content") is None:
+                        msg["content"] = ""
 
             # Handle continue_final_message: separate final assistant message
             messages, assistant_prefix = self._handle_last_assistant_message(
@@ -1304,18 +1323,39 @@ class OpenAIServingChat(OpenAIServingBase):
                     reasoning_effort_profile
                 ]
                 v4_reasoning_effort = (
-                    effort_source if effort_source in accepted_efforts else None
+                    encoding_dsv4.resolve_profile_reasoning_effort(
+                        reasoning_effort_profile, effort_source
+                    )
+                    if effort_source in accepted_efforts
+                    else None
                 )
                 if request.task is not None:
                     encoding_dsv4.attach_task_to_last_user_message(
                         messages, request.task
                     )
-                real_input = encoding_dsv4.encode_messages(
-                    messages,
-                    thinking_mode=thinking_mode,
-                    reasoning_effort=v4_reasoning_effort,
-                    reasoning_effort_profile=reasoning_effort_profile,
-                )
+                if dsv4_with_images:
+                    real_input, media_data = encoding_dsv4.encode_messages(
+                        messages,
+                        thinking_mode=thinking_mode,
+                        reasoning_effort=v4_reasoning_effort,
+                        return_multi_modal_data=True,
+                    )
+                    for record in media_data["images"]:
+                        url = record.get("url") or record.get("data")
+                        if url:
+                            image_data.append(ImageData(url=url))
+                else:
+                    real_input = encoding_dsv4.encode_messages(
+                        messages,
+                        thinking_mode=thinking_mode,
+                        reasoning_effort=v4_reasoning_effort,
+                    )
+                if is_multimodal:
+                    # Multimodal dsv4: hand the rendered text (with
+                    # <｜deepseek_image｜> placeholders) to the MM processor,
+                    # which re-tokenizes it — the standard VLM flow expects a
+                    # text prompt, and an empty one is rejected downstream.
+                    prompt = real_input
                 prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
             else:
                 real_input = encoding_dsv32.encode_messages(

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1429,7 +1429,11 @@ class DeepseekV4AttnBackend(
         )
         # ``swa_window_size`` on the pool is its storage page size, not the
         # model's SWA window, so pass both explicitly.
-        core_attn_metadata = getattr(self.forward_metadata, "core_attn_metadata", None)
+        core_attn_metadata = (
+            self.forward_metadata.core_attn_metadata
+            if isinstance(self.forward_metadata, DSV4Metadata)
+            else None
+        )
         swa_win_starts = swa_win_lens = None
         if (
             core_attn_metadata is not None
@@ -1674,7 +1678,11 @@ class DeepseekV4AttnBackend(
         translating the zero-padded out_cache_loc writes to the dummy slot.
         """
         out_cache_loc = forward_batch.out_cache_loc
-        core = getattr(self.forward_metadata, "core_attn_metadata", None)
+        core = (
+            self.forward_metadata.core_attn_metadata
+            if isinstance(self.forward_metadata, DSV4Metadata)
+            else None
+        )
         cached = core.swa_out_cache_loc if core is not None else None
         if (
             cached is not None

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -638,7 +638,6 @@ class DeepseekV4AttnBackend(
         self.is_draft_runner = model_runner.is_draft_worker
         self._verify_mask = None
         self.cuda_graph_swa_out_cache_loc: Optional[torch.Tensor] = None
-        self._visible_window_unified_warned = False
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
@@ -2224,41 +2223,18 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool,
         padded_num_tokens: int,
     ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
-        """Per-token SWA visible-window (start, len) overrides for image spans.
-
-        Returns None (causal windows everywhere) unless this extend chunk
-        fully contains at least one image sentinel span. Spans cut by the
-        chunk boundary degrade to the causal window (with a one-time warning
-        from ``compute_visible_window_overrides``).
-        """
+        """Build variable-size image windows for an eager, non-CP prefill."""
+        if forward_batch is None or not forward_batch.contains_image_inputs():
+            return None
+        if cp_v2_active or use_prefill_cuda_graph:
+            raise ValueError(
+                "DeepSeek-V4 image prefill requires eager execution without CP."
+            )
         if (
-            forward_batch is None
-            or cp_v2_active
-            or use_prefill_cuda_graph
-            or not forward_batch.contains_image_inputs()
-            # The gpu_only ForwardBatch path leaves the *_cpu mirrors unset;
-            # without host-side lens we cannot resolve span containment, so
-            # degrade to causal windows.
-            or forward_batch.extend_prefix_lens_cpu is None
+            forward_batch.extend_prefix_lens_cpu is None
             or forward_batch.extend_seq_lens_cpu is None
         ):
-            return None
-        # unified_kv keeps SWA KV in a true sliding_window-sized ring, so
-        # positions outside [pos-127, pos] have no storage there; degrade
-        # image spans to the causal window on that (HIP-oriented) layout.
-        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
-            is_unified_kv_triton,
-        )
-
-        if is_unified_kv_triton():
-            if not self._visible_window_unified_warned:
-                logger.warning(
-                    "DSV4 visible-window attention for image spans is not "
-                    "supported with unified_kv (SWA ring holds only "
-                    "sliding_window slots); falling back to causal windows."
-                )
-                self._visible_window_unified_warned = True
-            return None
+            raise ValueError("DeepSeek-V4 image prefill requires CPU sequence lengths.")
         overrides = compute_visible_window_overrides(
             mm_inputs=forward_batch.mm_inputs,
             extend_prefix_lens=forward_batch.extend_prefix_lens_cpu,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -62,6 +62,9 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillWorkspace,
     use_dsv4_q8kv8_sparse_prefill,
 )
+from sglang.srt.layers.attention.dsv4.visible_window import (
+    compute_visible_window_overrides,
+)
 from sglang.srt.layers.attention.verify_mask import (
     VerifyMask,
     maybe_create_verify_mask,
@@ -178,6 +181,12 @@ class DSV4AttnMetadata:
     swa_topk_lengths: torch.Tensor
 
     c4_sparse_topk: int
+    # Per-token SWA visible-window overrides (image spans, prefill only).
+    # None on pure-text batches: the kernels then use the causal window.
+    # Already baked into swa_page_indices/swa_topk_lengths; kept for the
+    # sparse-prefill combine path, which re-derives SWA indices per layer.
+    swa_win_starts: Optional[torch.Tensor] = None
+    swa_win_lens: Optional[torch.Tensor] = None
     # SWA KV-store write target (out_cache_loc translated to SWA space), computed
     # once per iteration in make_core_attn_metadata and read by the store path.
     swa_out_cache_loc: Optional[torch.Tensor] = None
@@ -243,6 +252,9 @@ class DSV4AttnMetadata:
                 "c1_flashmla_metadata",
                 "c4_flashmla_metadata",
                 "c128_flashmla_metadata",
+                # Prefill-only optional overrides; not part of any graph.
+                "swa_win_starts",
+                "swa_win_lens",
             ],
         )
 
@@ -270,6 +282,10 @@ class DSV4AttnMetadata:
             "c1_flashmla_metadata",
             "c4_flashmla_metadata",
             "c128_flashmla_metadata",
+            # Image-span batches never replay prefill graphs (forced eager),
+            # so these stay None on every captured/replayed metadata.
+            "swa_win_starts",
+            "swa_win_lens",
         ]
         # Keep graph-captured tensor objects alive for fields that captured
         # kernels read by address; overwrite only their contents.
@@ -622,6 +638,7 @@ class DeepseekV4AttnBackend(
         self.is_draft_runner = model_runner.is_draft_worker
         self._verify_mask = None
         self.cuda_graph_swa_out_cache_loc: Optional[torch.Tensor] = None
+        self._visible_window_unified_warned = False
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
@@ -773,6 +790,12 @@ class DeepseekV4AttnBackend(
             is_prefill=True,
             dspark_block_size=dspark_block_size,
             num_tokens=num_tokens if cp_v2_active else None,
+            swa_window_overrides=self._compute_swa_visible_window_overrides(
+                forward_batch=forward_batch,
+                cp_v2_active=cp_v2_active,
+                use_prefill_cuda_graph=use_prefill_cuda_graph,
+                padded_num_tokens=padded_num_tokens,
+            ),
         )
         if cp_v2_active:
             core_attn_metadata.apply_cp_reindex(num_tokens=num_tokens)
@@ -1407,6 +1430,14 @@ class DeepseekV4AttnBackend(
         )
         # ``swa_window_size`` on the pool is its storage page size, not the
         # model's SWA window, so pass both explicitly.
+        core_attn_metadata = getattr(self.forward_metadata, "core_attn_metadata", None)
+        swa_win_starts = swa_win_lens = None
+        if (
+            core_attn_metadata is not None
+            and core_attn_metadata.swa_win_starts is not None
+        ):
+            swa_win_starts = core_attn_metadata.swa_win_starts[:num_qo_tokens]
+            swa_win_lens = core_attn_metadata.swa_win_lens[:num_qo_tokens]
         return SparsePrefillChunkCache.build(
             seq_lens=forward_batch.seq_lens.to(torch.int32),
             extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
@@ -1418,6 +1449,8 @@ class DeepseekV4AttnBackend(
             num_qo_tokens=num_qo_tokens,
             max_seq_len=max(seq_lens_cpu_list),
             total_swa=total_swa,
+            swa_win_starts=swa_win_starts,
+            swa_win_lens=swa_win_lens,
         )
 
     def _build_forward_metadata(
@@ -2183,6 +2216,61 @@ class DeepseekV4AttnBackend(
         req_pool_indices_repeated = req_pool_indices[idx_to_req_repeated]
         return seq_lens_casual, req_pool_indices_repeated
 
+    def _compute_swa_visible_window_overrides(
+        self,
+        *,
+        forward_batch: Optional[ForwardBatch],
+        cp_v2_active: bool,
+        use_prefill_cuda_graph: bool,
+        padded_num_tokens: int,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+        """Per-token SWA visible-window (start, len) overrides for image spans.
+
+        Returns None (causal windows everywhere) unless this extend chunk
+        fully contains at least one image sentinel span. Spans cut by the
+        chunk boundary degrade to the causal window (with a one-time warning
+        from ``compute_visible_window_overrides``).
+        """
+        if (
+            forward_batch is None
+            or cp_v2_active
+            or use_prefill_cuda_graph
+            or not forward_batch.contains_image_inputs()
+            # The gpu_only ForwardBatch path leaves the *_cpu mirrors unset;
+            # without host-side lens we cannot resolve span containment, so
+            # degrade to causal windows.
+            or forward_batch.extend_prefix_lens_cpu is None
+            or forward_batch.extend_seq_lens_cpu is None
+        ):
+            return None
+        # unified_kv keeps SWA KV in a true sliding_window-sized ring, so
+        # positions outside [pos-127, pos] have no storage there; degrade
+        # image spans to the causal window on that (HIP-oriented) layout.
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_triton,
+        )
+
+        if is_unified_kv_triton():
+            if not self._visible_window_unified_warned:
+                logger.warning(
+                    "DSV4 visible-window attention for image spans is not "
+                    "supported with unified_kv (SWA ring holds only "
+                    "sliding_window slots); falling back to causal windows."
+                )
+                self._visible_window_unified_warned = True
+            return None
+        overrides = compute_visible_window_overrides(
+            mm_inputs=forward_batch.mm_inputs,
+            extend_prefix_lens=forward_batch.extend_prefix_lens_cpu,
+            extend_seq_lens=forward_batch.extend_seq_lens_cpu,
+            swa_window=SWA_WINDOW,
+            padded_num_tokens=padded_num_tokens,
+        )
+        if overrides is None:
+            return None
+        win_starts, win_lens = overrides
+        return self._move_to_device(win_starts), self._move_to_device(win_lens)
+
     def make_core_attn_metadata(
         self,
         req_to_token: torch.Tensor,
@@ -2194,8 +2282,13 @@ class DeepseekV4AttnBackend(
         is_prefill: bool = False,
         dspark_block_size: Optional[int] = None,
         num_tokens: Optional[int] = None,
+        swa_window_overrides: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> DSV4AttnMetadata:
         assert self.swa_page_size == SWA_WINDOW
+
+        win_starts = win_lens = None
+        if swa_window_overrides is not None:
+            win_starts, win_lens = swa_window_overrides
 
         prep = BuildPageTablePositions.execute(
             req_to_token=req_to_token,
@@ -2204,6 +2297,7 @@ class DeepseekV4AttnBackend(
             max_seq_len=max_seq_len,
             page_size=self.page_size,
             swa_window=SWA_WINDOW,
+            swa_topk_lengths_override=win_lens,
         )
         seq_lens_casual = prep.seq_lens_casual
 
@@ -2232,6 +2326,8 @@ class DeepseekV4AttnBackend(
                 seq_lens_casual=seq_lens_casual,
                 swa_window=SWA_WINDOW,
                 page_index_aligned_size=PAGE_INDEX_ALIGNED_SIZE,
+                win_starts=win_starts,
+                win_lens=win_lens,
             )
             swa_topk_lengths = prep.swa_topk_lengths
 
@@ -2248,6 +2344,9 @@ class DeepseekV4AttnBackend(
             swa_topk_lengths=swa_topk_lengths,
             c4_sparse_topk=self.c4_topk,
         )
+        if win_starts is not None:
+            core_attn_metadata.swa_win_starts = win_starts
+            core_attn_metadata.swa_win_lens = win_lens
 
         if need_compress:
             core_attn_metadata.init_compression_metadata(num_tokens)

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -123,6 +123,9 @@ def combine_topk_swa_indices(
     topk: int,
     out_indices: Optional[torch.Tensor] = None,
     out_lens: Optional[torch.Tensor] = None,
+    swa_win_starts: Optional[torch.Tensor] = None,
+    swa_win_lens: Optional[torch.Tensor] = None,
+    swa_win_max_len: Optional[int] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Combine topk + SWA indices into a single ``flash_mla_sparse_fwd`` row.
 
@@ -143,7 +146,8 @@ def combine_topk_swa_indices(
             value) for SWA-only layers since topk=0 disables this branch.
         swa_base: (num_reqs,) int32. Flat workspace offset where request
             r's SWA region begins.
-        window_size: SWA window size.
+        window_size: SWA window size (the causal window; also the width when
+            no visible-window overrides are given).
         compress_ratio: must be ``>= 1`` even when topk==0.
         topk: configured topk; pass 0 for SWA-only layers.
         out_indices: optional preallocated ``(num_tokens, combined_topk)``
@@ -153,6 +157,14 @@ def combine_topk_swa_indices(
             valid-prefix length must hold across reuses).
         out_lens: optional preallocated ``(num_tokens,)`` int32 buffer; the
             kernel fully overwrites it, so any dtype-correct buffer works.
+        swa_win_starts: optional (num_tokens,) int32 per-query window start
+            (absolute seq position) for the visible window of image spans.
+            Must be paired with ``swa_win_lens``; None keeps the causal
+            window ``[pos - swa_len + 1, pos]``.
+        swa_win_lens: optional (num_tokens,) int32 per-query window length.
+        swa_win_max_len: optional precomputed ``int(swa_win_lens.max())`` to
+            avoid a device sync per call; combined width and the kernel's SWA
+            arange are sized to ``max(window_size, swa_win_max_len)``.
 
     Returns:
         combined_indices: (num_tokens, padded_topk_swa) int32, padded to a
@@ -170,9 +182,19 @@ def combine_topk_swa_indices(
         topk_indices.shape[-1] >= topk
     ), f"topk_indices width {topk_indices.shape[-1]} must be >= topk {topk}"
 
+    has_swa_win = swa_win_lens is not None
+    eff_window = window_size
+    if has_swa_win:
+        assert swa_win_starts is not None
+        assert swa_win_starts.dtype == torch.int32
+        assert swa_win_lens.dtype == torch.int32
+        if swa_win_max_len is None:
+            swa_win_max_len = int(swa_win_lens.max().item())
+        eff_window = max(window_size, swa_win_max_len)
+
     num_tokens = topk_indices.shape[0]
     num_reqs = seq_lens.shape[0]
-    combined_topk = combined_topk_width(topk, window_size)
+    combined_topk = combined_topk_width(topk, eff_window)
     if out_indices is None:
         combined_indices = torch.full(
             (num_tokens, combined_topk),
@@ -205,10 +227,14 @@ def combine_topk_swa_indices(
         gather_lens,
         compressed_base,
         swa_base,
+        swa_win_starts if has_swa_win else combined_lens,
+        swa_win_lens if has_swa_win else combined_lens,
         top_k=topk,
         COMPRESS_RATIO=compress_ratio,
         WINDOW_SIZE=window_size,
+        SWA_BLOCK=triton.next_power_of_2(eff_window),
         PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
+        HAS_SWA_WIN=has_swa_win,
     )
     return combined_indices, combined_lens
 
@@ -317,6 +343,15 @@ class SparsePrefillChunkCache:
     swa_gather_lens: torch.Tensor  # (num_reqs,) int32
     swa_offsets: torch.Tensor  # (num_reqs+1,) int32
 
+    # Optional per-query visible-window overrides (DSV4-VL image spans). The
+    # existing union gather [seq_len - extend - (W-1), seq_len) already covers
+    # every visible window, since a visible window [win_start, span_end) of a
+    # fully-contained span satisfies win_start >= span_start - (W-1) >=
+    # seq_len - extend - (W-1) and span_end <= seq_len.
+    swa_win_starts: Optional[torch.Tensor] = None  # (num_qo_tokens,) int32
+    swa_win_lens: Optional[torch.Tensor] = None  # (num_qo_tokens,) int32
+    swa_win_max_len: Optional[int] = None
+
     # c0 pre-computed combine output (entire input set is chunk-invariant).
     c0_combined_indices: torch.Tensor = field(default=None)
     c0_combined_lens: torch.Tensor = field(default=None)
@@ -348,6 +383,8 @@ class SparsePrefillChunkCache:
         num_qo_tokens: int,
         max_seq_len: int,
         total_swa: int,
+        swa_win_starts: Optional[torch.Tensor] = None,
+        swa_win_lens: Optional[torch.Tensor] = None,
     ) -> "SparsePrefillChunkCache":
         device = seq_lens.device
         num_reqs = seq_lens.shape[0]
@@ -367,6 +404,12 @@ class SparsePrefillChunkCache:
             )
         )
 
+        swa_win_max_len = None
+        if swa_win_lens is not None:
+            assert swa_win_starts is not None
+            # Computed once per chunk; reused by every layer's combine.
+            swa_win_max_len = int(swa_win_lens.max().item())
+
         cache = cls(
             num_reqs=num_reqs,
             num_qo_tokens=num_qo_tokens,
@@ -379,6 +422,9 @@ class SparsePrefillChunkCache:
             swa_first_pos=swa_first_pos,
             swa_gather_lens=swa_gather_lens,
             swa_offsets=swa_offsets,
+            swa_win_starts=swa_win_starts,
+            swa_win_lens=swa_win_lens,
+            swa_win_max_len=swa_win_max_len,
         )
 
         # Pre-compute the c0 combine output: TOPK=0, compressed_base=0,
@@ -396,6 +442,9 @@ class SparsePrefillChunkCache:
             window_size=swa_window_size,
             compress_ratio=1,
             topk=0,
+            swa_win_starts=swa_win_starts,
+            swa_win_lens=swa_win_lens,
+            swa_win_max_len=swa_win_max_len,
         )
         return cache
 
@@ -450,6 +499,9 @@ class SparsePrefillChunkCache:
             window_size=self.swa_window_size,
             compress_ratio=128,
             topk=c128_max,
+            swa_win_starts=self.swa_win_starts,
+            swa_win_lens=self.swa_win_lens,
+            swa_win_max_len=self.swa_win_max_len,
         )
 
         self.c128_flat_token_ids = flat_c128_ids
@@ -501,6 +553,14 @@ class SparsePrefillChunkCache:
         self.c4_compressed_base = compressed_base
         self.c4_swa_base = swa_base
 
+    @property
+    def eff_swa_window_size(self) -> int:
+        """SWA width the combine output must hold: the causal window, or the
+        max visible-window length when image-span overrides are present."""
+        if self.swa_win_max_len is None:
+            return self.swa_window_size
+        return max(self.swa_window_size, self.swa_win_max_len)
+
     def combine_c4_layer(
         self,
         c4_sparse_raw_indices: torch.Tensor,
@@ -517,7 +577,10 @@ class SparsePrefillChunkCache:
         if self.c4_combined_indices is None:
             device = self.seq_lens.device
             self.c4_combined_indices = torch.full(
-                (self.num_qo_tokens, combined_topk_width(topk, self.swa_window_size)),
+                (
+                    self.num_qo_tokens,
+                    combined_topk_width(topk, self.eff_swa_window_size),
+                ),
                 -1,
                 dtype=torch.int32,
                 device=device,
@@ -537,4 +600,7 @@ class SparsePrefillChunkCache:
             topk=topk,
             out_indices=self.c4_combined_indices,
             out_lens=self.c4_combined_lens,
+            swa_win_starts=self.swa_win_starts,
+            swa_win_lens=self.swa_win_lens,
+            swa_win_max_len=self.swa_win_max_len,
         )

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -15,10 +15,15 @@ Image blocks are atomic across chunk boundaries and cache matches. This module
 is torch-free so scheduling can use the same boundaries as attention metadata.
 """
 
-from typing import List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import MultimodalInputs
 
 
-def iter_image_spans(mm_input):
+def iter_image_spans(
+    mm_input: Optional["MultimodalInputs"],
+) -> Iterator[Tuple[int, int]]:
     """Yield half-open DSV4 image blocks, including compression padding."""
     if mm_input is None:
         return
@@ -39,7 +44,7 @@ def _iter_visible_window_spans(
     mm_inputs,
     prefix_lens: Sequence[int],
     extend_lens: Sequence[int],
-):
+) -> Iterator[Tuple[int, int, int]]:
     for req_idx, mm_input in enumerate(mm_inputs or []):
         prefix = int(prefix_lens[req_idx])
         extend_end = prefix + int(extend_lens[req_idx])
@@ -59,7 +64,6 @@ def has_visible_window_span(
     mm_inputs,
     prefix_lens: Sequence[int],
     extend_lens: Sequence[int],
-    swa_window: int,
 ) -> bool:
     """True iff any request's extend chunk needs per-token visible-window
     overrides (and is therefore ineligible for fixed-shape prefill cuda

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -11,100 +11,48 @@ where ``left_i`` is the distance of token ``i`` from the span start and ``W``
 is the SWA window (128). Tokens outside any span keep the causal window
 ``[max(0, i - (W-1)), i]``.
 
-A span that is not fully contained in the current extend chunk is still
-served when its early raw KV is guaranteed present (a radix match whose end
-is within ``swa_window`` of the span start — the match validator keeps the
-trailing ``swa_window`` of a matched prefix resident). Deeper cuts (a chunk
-split without span alignment, or a radix hit deeper into the span) degrade
-to the causal window with a one-time warning.
-
-This module is deliberately torch-free so scheduler-side code (dp_attn vote,
-prefill cuda graph runner) can import it without pulling in the attention
-backend.
+Image blocks are atomic across chunk boundaries and cache matches. This module
+is torch-free so scheduling can use the same boundaries as attention metadata.
 """
 
-import logging
 from typing import List, Optional, Sequence, Tuple
 
-logger = logging.getLogger(__name__)
 
-_degraded_span_warned = False
-
-
-def _warn_degraded_span_once() -> None:
-    global _degraded_span_warned
-    if _degraded_span_warned:
+def iter_image_spans(mm_input):
+    """Yield half-open DSV4 image blocks, including compression padding."""
+    if mm_input is None:
         return
-    logger.warning(
-        "DSV4 visible-window: an image span is not fully contained in this "
-        "extend chunk (chunked prefill or radix-cache hit); the span falls "
-        "back to the plain causal window."
-    )
-    _degraded_span_warned = True
-
-
-def _is_dsv4_sentinel_item(item) -> bool:
-    """True iff an mm item is a DeepSeek-V4 sentinel block.
-
-    Only the DSV4 mm processor emits these keys; other VLMs' items never
-    carry them, which makes the span machinery in this module a no-op for
-    every other model (they keep their previous chunked-prefill / radix
-    behavior).
-    """
-    data = item.model_specific_data
-    return data is not None and "perm" in data and "types" in data
+    for item in mm_input.mm_items:
+        data = item.model_specific_data
+        if (
+            item.is_image()
+            and item.offsets
+            and data is not None
+            and "perm" in data
+            and "types" in data
+        ):
+            for start, end in item.offsets:
+                yield int(start), int(end) + 1
 
 
 def _iter_visible_window_spans(
     mm_inputs,
     prefix_lens: Sequence[int],
     extend_lens: Sequence[int],
-    swa_window: int,
 ):
-    """Yield (req_idx, span_start, span_end_exclusive) for each image span the
-    current extend may apply the visible window to:
-
-    - spans fully contained in the extend; or
-    - spans partially covered by the cached prefix (span_start < prefix) whose
-      early raw KV is guaranteed present: ``span_start >= prefix - (swa_window
-      - 1)``. The radix match validator guarantees the trailing ``swa_window``
-      tokens of a matched prefix keep their raw SWA KV, and the sparse-prefill
-      workspace gathers ``extend + (swa_window - 1)`` positions back, so the
-      extend's visible window (which reaches back to span_start) can be served
-      from the pool. ``swa_window - 1`` rather than ``swa_window``: at exactly
-      one window of depth the sparse workspace coordinate would underflow.
-
-    Spans partially overlapping the extend/prefix without that guarantee are
-    genuine cuts (a radix hit deeper than ``swa_window`` into the span, or a
-    chunk split without span alignment): they degrade to the causal window
-    with a one-time warning. Spans entirely before the prefix or entirely
-    after the chunk are irrelevant here and must not warn.
-    """
     for req_idx, mm_input in enumerate(mm_inputs or []):
-        if mm_input is None:
-            continue
         prefix = int(prefix_lens[req_idx])
         extend_end = prefix + int(extend_lens[req_idx])
-        for item in mm_input.mm_items:
-            if not item.is_image() or not item.offsets:
+        for start, end in iter_image_spans(mm_input):
+            if end <= prefix or start >= extend_end:
                 continue
-            if not _is_dsv4_sentinel_item(item):
-                continue
-            for span_start, span_end_incl in item.offsets:
-                # item.offsets start at the first compress-pad token, but the
-                # reference's bidirectional span starts at IMAGE_START. The
-                # compress pads (0-3 tokens) keep the plain causal window, so
-                # skip them here to avoid widening the span.
-                compress_pad = 3 - span_start % 4
-                image_start = span_start + compress_pad
-                if image_start >= prefix and span_end_incl < extend_end:
-                    yield req_idx, int(image_start), int(span_end_incl) + 1
-                elif image_start < prefix <= span_end_incl and image_start >= prefix - (
-                    swa_window - 1
-                ):
-                    yield req_idx, int(image_start), int(span_end_incl) + 1
-                elif span_start < extend_end and span_end_incl >= prefix:
-                    _warn_degraded_span_once()
+            if start < prefix or end > extend_end:
+                raise ValueError(
+                    f"DeepSeek-V4 image block [{start}, {end}) crosses "
+                    f"the prefill range [{prefix}, {extend_end})."
+                )
+            # Compression padding is causal; IMAGE_START is at position 3 mod 4.
+            yield req_idx, start + 3 - start % 4, end
 
 
 def has_visible_window_span(
@@ -117,10 +65,7 @@ def has_visible_window_span(
     overrides (and is therefore ineligible for fixed-shape prefill cuda
     graphs)."""
     return any(
-        True
-        for _ in _iter_visible_window_spans(
-            mm_inputs, prefix_lens, extend_lens, swa_window
-        )
+        True for _ in _iter_visible_window_spans(mm_inputs, prefix_lens, extend_lens)
     )
 
 
@@ -135,17 +80,15 @@ def compute_visible_window_overrides(
     """Per-token SWA window (start, length) for every extend token.
 
     Defaults to the causal window ``[max(0, pos-(W-1)), pos]``; tokens inside
-    a fully contained image span get the visible window instead. Returns None
-    when no span is fully contained in this chunk (pure causal behavior).
+    an image span get the visible window instead. Returns None on text chunks.
+    Partial image blocks are rejected instead of silently changing attention.
 
     The returned lists have length ``padded_num_tokens``; padding rows carry
     the (start=0, len=1) values that match the padded causal metadata
     (``seq_lens_casual == 1``).
     """
     spans = list(
-        _iter_visible_window_spans(
-            mm_inputs, extend_prefix_lens, extend_seq_lens, swa_window
-        )
+        _iter_visible_window_spans(mm_inputs, extend_prefix_lens, extend_seq_lens)
     )
     if not spans:
         return None
@@ -153,21 +96,16 @@ def compute_visible_window_overrides(
     win_starts: List[int] = []
     win_lens: List[int] = []
     req_flat_base: List[int] = []
-    req_prefix: List[int] = []
     for prefix, extend_len in zip(extend_prefix_lens, extend_seq_lens):
         prefix, extend_len = int(prefix), int(extend_len)
         req_flat_base.append(len(win_starts) - prefix)
-        req_prefix.append(prefix)
         for pos in range(prefix, prefix + extend_len):
             win_starts.append(max(pos - (swa_window - 1), 0))
             win_lens.append(min(pos + 1, swa_window))
 
     for req_idx, span_start, span_end in spans:
         flat_base = req_flat_base[req_idx]
-        # For a partially cached span only the tail is in this extend; the
-        # window's left edge may still point into the prefix (valid — those
-        # slots are guaranteed by the match validator).
-        for pos in range(max(span_start, req_prefix[req_idx]), span_end):
+        for pos in range(span_start, span_end):
             left = pos - span_start
             win_start = max(0, pos - (swa_window - 1) - max(0, left - (swa_window - 1)))
             i = flat_base + pos
@@ -182,52 +120,18 @@ def compute_visible_window_overrides(
 
 
 def image_span_aligned_extend_end(mm_input, extend_end: int) -> int:
-    """Move a chunked-prefill truncation point past any image span it cuts.
+    """Shrink a chunk boundary to the start of any image block it cuts.
 
-    The visible-window attention above requires every image sentinel span to
-    be prefilled in a single extend. If ``extend_end`` (absolute position in
-    the request's padded input ids) falls strictly inside a span, it is moved
-    to the span end, overshooting the chunk budget by at most one span (a few
-    hundred tokens — the budget is a scheduling heuristic, not a hard memory
-    limit). Extending is preferred over shrinking to the span start because
-    shrinking can make zero progress when the span starts at the current
-    position.
+    The result never exceeds the token/KV budget. Callers must defer the
+    request if shrinking leaves no tokens to prefill.
     """
-    if mm_input is None:
-        return extend_end
-    for item in mm_input.mm_items:
-        if not item.is_image() or not item.offsets:
-            continue
-        if not _is_dsv4_sentinel_item(item):
-            continue
-        for span_start, span_end_incl in item.offsets:
-            span_end = span_end_incl + 1
-            if span_start < extend_end < span_end:
-                extend_end = span_end
+    for start, end in iter_image_spans(mm_input):
+        if start < extend_end < end:
+            extend_end = start
     return extend_end
 
 
-def image_span_cut_point(mm_input, position: int, swa_window: int) -> Optional[int]:
-    """Return the span start when a radix match of length ``position`` must be
-    truncated to that start, else None.
-
-    A match ending inside an image span is only a problem when it ends deeper
-    than ``swa_window - 1`` into the span: the match validator guarantees the
-    trailing ``swa_window`` tokens of the prefix keep their raw SWA KV and the
-    sparse-prefill workspace gathers ``swa_window - 1`` positions back, so a
-    shallow mid-span match leaves the span's early KV readable and the
-    visible window can still be served (see _iter_visible_window_spans). A
-    deeper match must be re-issued capped to the span start, fully
-    re-prefilling the span.
-    """
-    if mm_input is None:
-        return None
-    for item in mm_input.mm_items:
-        if not item.is_image() or not item.offsets:
-            continue
-        if not _is_dsv4_sentinel_item(item):
-            continue
-        for span_start, span_end_incl in item.offsets:
-            if span_start < position - (swa_window - 1) and position <= span_end_incl:
-                return int(span_start)
-    return None
+def image_span_cut_point(mm_input, position: int) -> Optional[int]:
+    """Cap a device/host prefix match at an image block's start."""
+    aligned = image_span_aligned_extend_end(mm_input, position)
+    return aligned if aligned < position else None

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -57,11 +57,14 @@ def _iter_fully_contained_image_spans(
             if not item.is_image() or not item.offsets:
                 continue
             for span_start, span_end_incl in item.offsets:
-                # Degrade to the causal window when the span is cut by this
-                # chunk (chunked prefill / radix-cache hit mid-span).
                 if span_start >= prefix and span_end_incl < extend_end:
                     yield req_idx, int(span_start), int(span_end_incl) + 1
-                else:
+                elif span_start < extend_end and span_end_incl >= prefix:
+                    # Genuine cut: the span overlaps this chunk (or the prefix)
+                    # but is not fully inside it — chunked prefill without
+                    # span alignment, or a radix hit mid-span. Spans that lie
+                    # entirely before the prefix or entirely after this chunk
+                    # are irrelevant here and must not warn.
                     _warn_degraded_span_once()
 
 
@@ -129,3 +132,27 @@ def compute_visible_window_overrides(
         win_starts.extend([0] * pad)
         win_lens.extend([1] * pad)
     return win_starts, win_lens
+
+
+def image_span_aligned_extend_end(mm_input, extend_end: int) -> int:
+    """Move a chunked-prefill truncation point past any image span it cuts.
+
+    The visible-window attention above requires every image sentinel span to
+    be prefilled in a single extend. If ``extend_end`` (absolute position in
+    the request's padded input ids) falls strictly inside a span, it is moved
+    to the span end, overshooting the chunk budget by at most one span (a few
+    hundred tokens — the budget is a scheduling heuristic, not a hard memory
+    limit). Extending is preferred over shrinking to the span start because
+    shrinking can make zero progress when the span starts at the current
+    position.
+    """
+    if mm_input is None:
+        return extend_end
+    for item in mm_input.mm_items:
+        if not item.is_image() or not item.offsets:
+            continue
+        for span_start, span_end_incl in item.offsets:
+            span_end = span_end_incl + 1
+            if span_start < extend_end < span_end:
+                extend_end = span_end
+    return extend_end

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -54,10 +54,13 @@ def _iter_visible_window_spans(
 
     - spans fully contained in the extend; or
     - spans partially covered by the cached prefix (span_start < prefix) whose
-      early raw KV is guaranteed present: ``span_start >= prefix - swa_window``.
-      The radix match validator guarantees the trailing ``swa_window`` tokens
-      of a matched prefix keep their raw SWA KV, so the extend's visible
-      window (which reaches back to span_start) can be served from the pool.
+      early raw KV is guaranteed present: ``span_start >= prefix - (swa_window
+      - 1)``. The radix match validator guarantees the trailing ``swa_window``
+      tokens of a matched prefix keep their raw SWA KV, and the sparse-prefill
+      workspace gathers ``extend + (swa_window - 1)`` positions back, so the
+      extend's visible window (which reaches back to span_start) can be served
+      from the pool. ``swa_window - 1`` rather than ``swa_window``: at exactly
+      one window of depth the sparse workspace coordinate would underflow.
 
     Spans partially overlapping the extend/prefix without that guarantee are
     genuine cuts (a radix hit deeper than ``swa_window`` into the span, or a
@@ -76,9 +79,8 @@ def _iter_visible_window_spans(
             for span_start, span_end_incl in item.offsets:
                 if span_start >= prefix and span_end_incl < extend_end:
                     yield req_idx, int(span_start), int(span_end_incl) + 1
-                elif (
-                    span_start < prefix <= span_end_incl
-                    and span_start >= prefix - swa_window
+                elif span_start < prefix <= span_end_incl and span_start >= prefix - (
+                    swa_window - 1
                 ):
                     yield req_idx, int(span_start), int(span_end_incl) + 1
                 elif span_start < extend_end and span_end_incl >= prefix:
@@ -188,8 +190,9 @@ def image_span_cut_point(mm_input, position: int, swa_window: int) -> Optional[i
     truncated to that start, else None.
 
     A match ending inside an image span is only a problem when it ends deeper
-    than ``swa_window`` into the span: the match validator guarantees the
-    trailing ``swa_window`` tokens of the prefix keep their raw SWA KV, so a
+    than ``swa_window - 1`` into the span: the match validator guarantees the
+    trailing ``swa_window`` tokens of the prefix keep their raw SWA KV and the
+    sparse-prefill workspace gathers ``swa_window - 1`` positions back, so a
     shallow mid-span match leaves the span's early KV readable and the
     visible window can still be served (see _iter_visible_window_spans). A
     deeper match must be re-issued capped to the span start, fully
@@ -201,6 +204,6 @@ def image_span_cut_point(mm_input, position: int, swa_window: int) -> Optional[i
         if not item.is_image() or not item.offsets:
             continue
         for span_start, span_end_incl in item.offsets:
-            if span_start < position - swa_window and position <= span_end_incl:
+            if span_start < position - (swa_window - 1) and position <= span_end_incl:
                 return int(span_start)
     return None

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -11,10 +11,12 @@ where ``left_i`` is the distance of token ``i`` from the span start and ``W``
 is the SWA window (128). Tokens outside any span keep the causal window
 ``[max(0, i - (W-1)), i]``.
 
-A span that is not fully contained in the current extend chunk (chunked
-prefill split or radix-cache hit in the middle of the span) degrades to the
-causal window, with a one-time warning (the supported deployment disables
-both, so this should never fire there).
+A span that is not fully contained in the current extend chunk is still
+served when its early raw KV is guaranteed present (a radix match whose end
+is within ``swa_window`` of the span start — the match validator keeps the
+trailing ``swa_window`` of a matched prefix resident). Deeper cuts (a chunk
+split without span alignment, or a radix hit deeper into the span) degrade
+to the causal window with a one-time warning.
 
 This module is deliberately torch-free so scheduler-side code (dp_attn vote,
 prefill cuda graph runner) can import it without pulling in the attention
@@ -41,13 +43,28 @@ def _warn_degraded_span_once() -> None:
     _degraded_span_warned = True
 
 
-def _iter_fully_contained_image_spans(
+def _iter_visible_window_spans(
     mm_inputs,
     prefix_lens: Sequence[int],
     extend_lens: Sequence[int],
+    swa_window: int,
 ):
-    """Yield (req_idx, span_start, span_end_exclusive) for each image sentinel
-    span fully contained in that request's extend range."""
+    """Yield (req_idx, span_start, span_end_exclusive) for each image span the
+    current extend may apply the visible window to:
+
+    - spans fully contained in the extend; or
+    - spans partially covered by the cached prefix (span_start < prefix) whose
+      early raw KV is guaranteed present: ``span_start >= prefix - swa_window``.
+      The radix match validator guarantees the trailing ``swa_window`` tokens
+      of a matched prefix keep their raw SWA KV, so the extend's visible
+      window (which reaches back to span_start) can be served from the pool.
+
+    Spans partially overlapping the extend/prefix without that guarantee are
+    genuine cuts (a radix hit deeper than ``swa_window`` into the span, or a
+    chunk split without span alignment): they degrade to the causal window
+    with a one-time warning. Spans entirely before the prefix or entirely
+    after the chunk are irrelevant here and must not warn.
+    """
     for req_idx, mm_input in enumerate(mm_inputs or []):
         if mm_input is None:
             continue
@@ -59,26 +76,29 @@ def _iter_fully_contained_image_spans(
             for span_start, span_end_incl in item.offsets:
                 if span_start >= prefix and span_end_incl < extend_end:
                     yield req_idx, int(span_start), int(span_end_incl) + 1
+                elif (
+                    span_start < prefix <= span_end_incl
+                    and span_start >= prefix - swa_window
+                ):
+                    yield req_idx, int(span_start), int(span_end_incl) + 1
                 elif span_start < extend_end and span_end_incl >= prefix:
-                    # Genuine cut: the span overlaps this chunk (or the prefix)
-                    # but is not fully inside it — chunked prefill without
-                    # span alignment, or a radix hit mid-span. Spans that lie
-                    # entirely before the prefix or entirely after this chunk
-                    # are irrelevant here and must not warn.
                     _warn_degraded_span_once()
 
 
-def has_fully_contained_image_span(
+def has_visible_window_span(
     mm_inputs,
     prefix_lens: Sequence[int],
     extend_lens: Sequence[int],
+    swa_window: int,
 ) -> bool:
-    """True iff any request's extend chunk fully contains an image span, i.e.
-    the batch needs per-token visible-window overrides and is ineligible for
-    fixed-shape prefill cuda graphs."""
+    """True iff any request's extend chunk needs per-token visible-window
+    overrides (and is therefore ineligible for fixed-shape prefill cuda
+    graphs)."""
     return any(
         True
-        for _ in _iter_fully_contained_image_spans(mm_inputs, prefix_lens, extend_lens)
+        for _ in _iter_visible_window_spans(
+            mm_inputs, prefix_lens, extend_lens, swa_window
+        )
     )
 
 
@@ -101,8 +121,8 @@ def compute_visible_window_overrides(
     (``seq_lens_casual == 1``).
     """
     spans = list(
-        _iter_fully_contained_image_spans(
-            mm_inputs, extend_prefix_lens, extend_seq_lens
+        _iter_visible_window_spans(
+            mm_inputs, extend_prefix_lens, extend_seq_lens, swa_window
         )
     )
     if not spans:
@@ -111,16 +131,21 @@ def compute_visible_window_overrides(
     win_starts: List[int] = []
     win_lens: List[int] = []
     req_flat_base: List[int] = []
+    req_prefix: List[int] = []
     for prefix, extend_len in zip(extend_prefix_lens, extend_seq_lens):
         prefix, extend_len = int(prefix), int(extend_len)
         req_flat_base.append(len(win_starts) - prefix)
+        req_prefix.append(prefix)
         for pos in range(prefix, prefix + extend_len):
             win_starts.append(max(pos - (swa_window - 1), 0))
             win_lens.append(min(pos + 1, swa_window))
 
     for req_idx, span_start, span_end in spans:
         flat_base = req_flat_base[req_idx]
-        for pos in range(span_start, span_end):
+        # For a partially cached span only the tail is in this extend; the
+        # window's left edge may still point into the prefix (valid — those
+        # slots are guaranteed by the match validator).
+        for pos in range(max(span_start, req_prefix[req_idx]), span_end):
             left = pos - span_start
             win_start = max(0, pos - (swa_window - 1) - max(0, left - (swa_window - 1)))
             i = flat_base + pos
@@ -156,3 +181,26 @@ def image_span_aligned_extend_end(mm_input, extend_end: int) -> int:
             if span_start < extend_end < span_end:
                 extend_end = span_end
     return extend_end
+
+
+def image_span_cut_point(mm_input, position: int, swa_window: int) -> Optional[int]:
+    """Return the span start when a radix match of length ``position`` must be
+    truncated to that start, else None.
+
+    A match ending inside an image span is only a problem when it ends deeper
+    than ``swa_window`` into the span: the match validator guarantees the
+    trailing ``swa_window`` tokens of the prefix keep their raw SWA KV, so a
+    shallow mid-span match leaves the span's early KV readable and the
+    visible window can still be served (see _iter_visible_window_spans). A
+    deeper match must be re-issued capped to the span start, fully
+    re-prefilling the span.
+    """
+    if mm_input is None:
+        return None
+    for item in mm_input.mm_items:
+        if not item.is_image() or not item.offsets:
+            continue
+        for span_start, span_end_incl in item.offsets:
+            if span_start < position - swa_window and position <= span_end_incl:
+                return int(span_start)
+    return None

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -43,6 +43,18 @@ def _warn_degraded_span_once() -> None:
     _degraded_span_warned = True
 
 
+def _is_dsv4_sentinel_item(item) -> bool:
+    """True iff an mm item is a DeepSeek-V4 sentinel block.
+
+    Only the DSV4 mm processor emits these keys; other VLMs' items never
+    carry them, which makes the span machinery in this module a no-op for
+    every other model (they keep their previous chunked-prefill / radix
+    behavior).
+    """
+    data = item.model_specific_data
+    return data is not None and "perm" in data and "types" in data
+
+
 def _iter_visible_window_spans(
     mm_inputs,
     prefix_lens: Sequence[int],
@@ -75,6 +87,8 @@ def _iter_visible_window_spans(
         extend_end = prefix + int(extend_lens[req_idx])
         for item in mm_input.mm_items:
             if not item.is_image() or not item.offsets:
+                continue
+            if not _is_dsv4_sentinel_item(item):
                 continue
             for span_start, span_end_incl in item.offsets:
                 if span_start >= prefix and span_end_incl < extend_end:
@@ -178,6 +192,8 @@ def image_span_aligned_extend_end(mm_input, extend_end: int) -> int:
     for item in mm_input.mm_items:
         if not item.is_image() or not item.offsets:
             continue
+        if not _is_dsv4_sentinel_item(item):
+            continue
         for span_start, span_end_incl in item.offsets:
             span_end = span_end_incl + 1
             if span_start < extend_end < span_end:
@@ -202,6 +218,8 @@ def image_span_cut_point(mm_input, position: int, swa_window: int) -> Optional[i
         return None
     for item in mm_input.mm_items:
         if not item.is_image() or not item.offsets:
+            continue
+        if not _is_dsv4_sentinel_item(item):
             continue
         for span_start, span_end_incl in item.offsets:
             if span_start < position - (swa_window - 1) and position <= span_end_incl:

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -1,0 +1,131 @@
+"""Visible-window attention helpers for DeepSeek-V4 vision prefill.
+
+During prefill, tokens inside an image sentinel span attend over a "visible
+window" instead of the plain causal sliding window: the left edge is shifted
+further left so the whole span stays visible, and the right edge extends past
+the diagonal to the span end (bidirectional within the span):
+
+    window(i) = [max(0, i - (W-1) - max(0, left_i - (W-1))), span_end)
+
+where ``left_i`` is the distance of token ``i`` from the span start and ``W``
+is the SWA window (128). Tokens outside any span keep the causal window
+``[max(0, i - (W-1)), i]``.
+
+A span that is not fully contained in the current extend chunk (chunked
+prefill split or radix-cache hit in the middle of the span) degrades to the
+causal window, with a one-time warning (the supported deployment disables
+both, so this should never fire there).
+
+This module is deliberately torch-free so scheduler-side code (dp_attn vote,
+prefill cuda graph runner) can import it without pulling in the attention
+backend.
+"""
+
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_degraded_span_warned = False
+
+
+def _warn_degraded_span_once() -> None:
+    global _degraded_span_warned
+    if _degraded_span_warned:
+        return
+    logger.warning(
+        "DSV4 visible-window: an image span is not fully contained in this "
+        "extend chunk (chunked prefill or radix-cache hit); the span falls "
+        "back to the plain causal window."
+    )
+    _degraded_span_warned = True
+
+
+def _iter_fully_contained_image_spans(
+    mm_inputs,
+    prefix_lens: Sequence[int],
+    extend_lens: Sequence[int],
+):
+    """Yield (req_idx, span_start, span_end_exclusive) for each image sentinel
+    span fully contained in that request's extend range."""
+    for req_idx, mm_input in enumerate(mm_inputs or []):
+        if mm_input is None:
+            continue
+        prefix = int(prefix_lens[req_idx])
+        extend_end = prefix + int(extend_lens[req_idx])
+        for item in mm_input.mm_items:
+            if not item.is_image() or not item.offsets:
+                continue
+            for span_start, span_end_incl in item.offsets:
+                # Degrade to the causal window when the span is cut by this
+                # chunk (chunked prefill / radix-cache hit mid-span).
+                if span_start >= prefix and span_end_incl < extend_end:
+                    yield req_idx, int(span_start), int(span_end_incl) + 1
+                else:
+                    _warn_degraded_span_once()
+
+
+def has_fully_contained_image_span(
+    mm_inputs,
+    prefix_lens: Sequence[int],
+    extend_lens: Sequence[int],
+) -> bool:
+    """True iff any request's extend chunk fully contains an image span, i.e.
+    the batch needs per-token visible-window overrides and is ineligible for
+    fixed-shape prefill cuda graphs."""
+    return any(
+        True
+        for _ in _iter_fully_contained_image_spans(mm_inputs, prefix_lens, extend_lens)
+    )
+
+
+def compute_visible_window_overrides(
+    *,
+    mm_inputs,
+    extend_prefix_lens: Sequence[int],
+    extend_seq_lens: Sequence[int],
+    swa_window: int,
+    padded_num_tokens: int,
+) -> Optional[Tuple[List[int], List[int]]]:
+    """Per-token SWA window (start, length) for every extend token.
+
+    Defaults to the causal window ``[max(0, pos-(W-1)), pos]``; tokens inside
+    a fully contained image span get the visible window instead. Returns None
+    when no span is fully contained in this chunk (pure causal behavior).
+
+    The returned lists have length ``padded_num_tokens``; padding rows carry
+    the (start=0, len=1) values that match the padded causal metadata
+    (``seq_lens_casual == 1``).
+    """
+    spans = list(
+        _iter_fully_contained_image_spans(
+            mm_inputs, extend_prefix_lens, extend_seq_lens
+        )
+    )
+    if not spans:
+        return None
+
+    win_starts: List[int] = []
+    win_lens: List[int] = []
+    req_flat_base: List[int] = []
+    for prefix, extend_len in zip(extend_prefix_lens, extend_seq_lens):
+        prefix, extend_len = int(prefix), int(extend_len)
+        req_flat_base.append(len(win_starts) - prefix)
+        for pos in range(prefix, prefix + extend_len):
+            win_starts.append(max(pos - (swa_window - 1), 0))
+            win_lens.append(min(pos + 1, swa_window))
+
+    for req_idx, span_start, span_end in spans:
+        flat_base = req_flat_base[req_idx]
+        for pos in range(span_start, span_end):
+            left = pos - span_start
+            win_start = max(0, pos - (swa_window - 1) - max(0, left - (swa_window - 1)))
+            i = flat_base + pos
+            win_starts[i] = win_start
+            win_lens[i] = span_end - win_start
+
+    if padded_num_tokens > len(win_starts):
+        pad = padded_num_tokens - len(win_starts)
+        win_starts.extend([0] * pad)
+        win_lens.extend([1] * pad)
+    return win_starts, win_lens

--- a/python/sglang/srt/layers/attention/dsv4/visible_window.py
+++ b/python/sglang/srt/layers/attention/dsv4/visible_window.py
@@ -91,12 +91,18 @@ def _iter_visible_window_spans(
             if not _is_dsv4_sentinel_item(item):
                 continue
             for span_start, span_end_incl in item.offsets:
-                if span_start >= prefix and span_end_incl < extend_end:
-                    yield req_idx, int(span_start), int(span_end_incl) + 1
-                elif span_start < prefix <= span_end_incl and span_start >= prefix - (
+                # item.offsets start at the first compress-pad token, but the
+                # reference's bidirectional span starts at IMAGE_START. The
+                # compress pads (0-3 tokens) keep the plain causal window, so
+                # skip them here to avoid widening the span.
+                compress_pad = 3 - span_start % 4
+                image_start = span_start + compress_pad
+                if image_start >= prefix and span_end_incl < extend_end:
+                    yield req_idx, int(image_start), int(span_end_incl) + 1
+                elif image_start < prefix <= span_end_incl and image_start >= prefix - (
                     swa_window - 1
                 ):
-                    yield req_idx, int(span_start), int(span_end_incl) + 1
+                    yield req_idx, int(image_start), int(span_end_incl) + 1
                 elif span_start < extend_end and span_end_incl >= prefix:
                     _warn_degraded_span_once()
 

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.moe.topk import (
     remap_topk_for_per_rank_shared_slots,
 )
 from sglang.srt.layers.moe.utils import has_per_rank_fused_shared_slots
+from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
 from sglang.srt.runtime_context import get_exec
 from sglang.srt.utils import is_hip, is_npu, is_xpu
 
@@ -257,13 +258,7 @@ class HashTopK(nn.Module):
             and not skip_image_check
             and not torch.cuda.is_current_stream_capturing()
         ):
-            # The .any() below syncs, which is illegal under CUDA graph
-            # capture. Capture only sees dummy (pad-free) input_ids, and image
-            # batches never replay graphs (prefill-with-image runs eager;
-            # decode input_ids never contain pad sentinels), so skipping the
-            # check during capture is exact.
-            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
-
+            # CUDA graph capture uses pad-free inputs and cannot synchronize .any().
             image_mask = input_ids >= MM_PAD_SHIFT_VALUE
             if not image_mask.any():
                 image_mask = None

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -27,6 +27,8 @@ from sglang.srt.utils import is_hip, is_npu, is_xpu
 
 logger = logging.getLogger(__name__)
 
+_bias_vl_route_logged = [False]
+
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
@@ -50,7 +52,10 @@ class HashTopK(nn.Module):
         # DeepSeek-V4-Vision only: image tokens bypass the tid2eid hash table
         # and are selected by (scores + bias_vl). Reference to the gate's
         # parameter (not a submodule); None keeps text-only behavior exact.
-        self.bias_vl = bias_vl
+        # object.__setattr__ because plain assignment would auto-register the
+        # shared tensor as mlp.topk.bias_vl, duplicating mlp.gate.bias_vl in
+        # named_parameters and tripping name-based weight audits.
+        object.__setattr__(self, "bias_vl", bias_vl)
 
         self.enable_waterfill = (
             num_fused_shared_experts > 0 and get_exec().moe.enable_waterfill
@@ -260,6 +265,11 @@ class HashTopK(nn.Module):
         if image_mask is not None:
             # The fused kernels know nothing about bias_vl and their tid2eid
             # gather would index out of vocab on pad sentinels.
+            if not _bias_vl_route_logged[0]:
+                _bias_vl_route_logged[0] = True
+                logger.info(
+                    "DSV4-Vision: routing image tokens with gate bias_vl (hash layer)."
+                )
             topk_weights, topk_ids = self._forward_torch(
                 router_logits, input_ids, image_mask=image_mask
             )

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -244,13 +244,19 @@ class HashTopK(nn.Module):
         input_ids: torch.Tensor,
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+        image_mask: Optional[torch.Tensor] = None,
+        skip_image_check: bool = False,
     ):
         assert (
             input_ids.shape[0] == hidden_states.shape[0] == router_logits.shape[0]
         ), f"{input_ids.shape=} {hidden_states.shape=} {router_logits.shape=}"
 
-        image_mask = None
-        if self.bias_vl is not None and not torch.cuda.is_current_stream_capturing():
+        if (
+            image_mask is None
+            and self.bias_vl is not None
+            and not skip_image_check
+            and not torch.cuda.is_current_stream_capturing()
+        ):
             # The .any() below syncs, which is illegal under CUDA graph
             # capture. Capture only sees dummy (pad-free) input_ids, and image
             # batches never replay graphs (prefill-with-image runs eager;

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -43,9 +43,14 @@ class HashTopK(nn.Module):
         routed_scaling_factor=1.5,
         apply_routed_scaling_factor_on_output=False,
         layer_id: Optional[int] = None,
+        bias_vl: Optional[torch.Tensor] = None,
     ):
         super().__init__()
         self.layer_id = layer_id
+        # DeepSeek-V4-Vision only: image tokens bypass the tid2eid hash table
+        # and are selected by (scores + bias_vl). Reference to the gate's
+        # parameter (not a submodule); None keeps text-only behavior exact.
+        self.bias_vl = bias_vl
 
         self.enable_waterfill = (
             num_fused_shared_experts > 0 and get_exec().moe.enable_waterfill
@@ -134,7 +139,10 @@ class HashTopK(nn.Module):
         return self.waterfill_balancer.expand_topk(topk_output, num_tokens)
 
     def _forward_torch(
-        self, router_logits: torch.Tensor, input_ids: torch.Tensor
+        self,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor,
+        image_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.score_func == "softmax":
             scores = router_logits.softmax(dim=-1)
@@ -152,8 +160,22 @@ class HashTopK(nn.Module):
             (num_token, self.topk), dtype=scores.dtype, device=scores.device
         )
 
+        n_routed = self.tid2eid.shape[1]
+        vl_topk_ids = None
+        if image_mask is not None:
+            # Multimodal pad sentinels sit far out of vocab; clamp them to 0
+            # before the tid2eid gather. Image rows are overwritten below with
+            # the (scores + bias_vl) top-k, matching the reference gate.
+            input_ids = torch.where(image_mask, 0, input_ids)
+            vl_topk_ids = (
+                (scores + self.bias_vl).topk(n_routed, dim=-1).indices.to(torch.int32)
+            )
+        routed_ids = self.tid2eid[input_ids]
+        if vl_topk_ids is not None:
+            routed_ids = torch.where(image_mask.unsqueeze(1), vl_topk_ids, routed_ids)
+
         if self.num_fused_shared_experts == 1:
-            topk_ids[:, :-1] = self.tid2eid[input_ids]
+            topk_ids[:, :-1] = routed_ids
             topk_weights[:, :-1] = scores.gather(1, topk_ids[:, :-1])
 
             if self.score_func != "softmax":
@@ -171,7 +193,7 @@ class HashTopK(nn.Module):
                 topk_weights[:, :-1].sum(dim=-1) / self.routed_scaling_factor
             )
         else:
-            topk_ids[:, :] = self.tid2eid[input_ids]
+            topk_ids[:, :] = routed_ids
             topk_weights[:, :] = scores.gather(1, topk_ids[:, :])
             if self.score_func != "softmax":
                 topk_weights[:, :] /= topk_weights[:, :].sum(dim=-1, keepdim=True)
@@ -222,7 +244,26 @@ class HashTopK(nn.Module):
             input_ids.shape[0] == hidden_states.shape[0] == router_logits.shape[0]
         ), f"{input_ids.shape=} {hidden_states.shape=} {router_logits.shape=}"
 
-        if _is_xpu:
+        image_mask = None
+        if self.bias_vl is not None and not torch.cuda.is_current_stream_capturing():
+            # The .any() below syncs, which is illegal under CUDA graph
+            # capture. Capture only sees dummy (pad-free) input_ids, and image
+            # batches never replay graphs (prefill-with-image runs eager;
+            # decode input_ids never contain pad sentinels), so skipping the
+            # check during capture is exact.
+            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+
+            image_mask = input_ids >= MM_PAD_SHIFT_VALUE
+            if not image_mask.any():
+                image_mask = None
+
+        if image_mask is not None:
+            # The fused kernels know nothing about bias_vl and their tid2eid
+            # gather would index out of vocab on pad sentinels.
+            topk_weights, topk_ids = self._forward_torch(
+                router_logits, input_ids, image_mask=image_mask
+            )
+        elif _is_xpu:
             topk_weights, topk_ids = self._forward_xpu(router_logits, input_ids)
         elif envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.get():
             from sglang.kernels.ops.attention.dsv4 import hash_topk

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -195,9 +195,7 @@ def _run_mega_routed(
             router_logits,
             input_ids=input_ids_global,
             image_mask=(
-                getattr(forward_batch, "dsv4_image_mask", None)
-                if forward_batch is not None
-                else None
+                forward_batch.dsv4_image_mask if forward_batch is not None else None
             ),
             forward_batch=forward_batch,
             num_token_non_padded=(

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -194,6 +194,12 @@ def _run_mega_routed(
             hidden_states,
             router_logits,
             input_ids=input_ids_global,
+            image_mask=(
+                getattr(forward_batch, "dsv4_image_mask", None)
+                if forward_batch is not None
+                else None
+            ),
+            forward_batch=forward_batch,
             num_token_non_padded=(
                 forward_batch.num_token_non_padded
                 if forward_batch is not None

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -188,10 +188,12 @@ def _run_mega_routed(
 
     if num_tokens > 0:
         router_logits = moe.gate(hidden_states, forward_batch=forward_batch)
-        topk_kwargs = {"input_ids": input_ids_global} if moe.is_hash else {}
-        topk_output = moe.topk(
+        # _forward_topk passes input_ids to HashTopK for hash layers and
+        # handles the DeepSeek-V4-Vision per-token bias_vl fallback.
+        topk_output = moe._forward_topk(
             hidden_states,
             router_logits,
+            input_ids=input_ids_global,
             num_token_non_padded=(
                 forward_batch.num_token_non_padded
                 if forward_batch is not None
@@ -200,7 +202,6 @@ def _run_mega_routed(
             expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
                 layer_id=moe.layer_id,
             ),
-            **topk_kwargs,
         )
         topk_ids = topk_output.topk_ids
         topk_weights = topk_output.topk_weights

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -2526,6 +2526,115 @@ def select_experts(
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)
 
 
+def per_token_biased_topk(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    per_token_correction_bias: torch.Tensor,
+    topk_config: TopKConfig,
+    *,
+    layer_id: Optional[int] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+) -> StandardTopKOutput:
+    """select_experts variant whose selection bias varies per token.
+
+    DeepSeek-V4-Vision routes text tokens with ``e_score_correction_bias``
+    but image tokens with ``bias_vl``; the fused kernels accept a 1D bias
+    only, so batches containing image tokens take this eager torch path with
+    the per-token bias folded into ``scores_for_choice``. Selection mirrors
+    :func:`biased_topk_impl` (weights are gathered from the raw scores, so
+    the bias affects selection only) and the tail reuses the exact
+    post-processing of :func:`select_experts`.
+    """
+    assert hidden_states.shape[0] == router_logits.shape[0], "Number of tokens mismatch"
+
+    top_k = topk_config.top_k
+    num_fused_shared_experts = topk_config.num_fused_shared_experts
+    renormalize = topk_config.renormalize
+    scoring_func = topk_config.scoring_func
+    routed_scaling_factor = topk_config.routed_scaling_factor
+    apply_routed_scaling_factor_on_output = (
+        topk_config.apply_routed_scaling_factor_on_output
+    )
+
+    (
+        router_logits,
+        per_token_correction_bias,
+    ) = expert_location_dispatch.transform_select_experts_inputs(
+        router_logits=router_logits,
+        correction_bias=per_token_correction_bias,
+        info=expert_location_dispatch_info,
+    )
+
+    if scoring_func == "sigmoid":
+        scores = router_logits.sigmoid()
+    elif scoring_func == "sqrtsoftplus":
+        scores = torch.nn.functional.softplus(router_logits).sqrt()
+    else:
+        scores = router_logits.softmax(dim=-1)
+
+    num_token = scores.shape[0]
+    num_experts = scores.shape[1]
+
+    # Same effective arguments select_experts hands to biased_topk_*.
+    num_fused_shared_experts_for_gate = (
+        0
+        if has_per_rank_fused_shared_slots(num_fused_shared_experts)
+        else num_fused_shared_experts
+    )
+    topk = (top_k - num_fused_shared_experts) if _use_aiter else top_k
+
+    scores_for_choice = scores.view(num_token, -1) + per_token_correction_bias
+    _, topk_ids = torch.topk(
+        scores_for_choice,
+        k=topk,
+        dim=-1,
+        sorted=(True if num_fused_shared_experts_for_gate > 0 else False),
+    )
+    topk_weights = scores.gather(1, topk_ids)
+
+    if num_fused_shared_experts_for_gate:
+        topk_ids[:, -1] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts_for_gate,
+            size=(topk_ids.size(0),),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        if routed_scaling_factor is not None:
+            topk_weights[:, -1] = (
+                topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+            )
+
+    if renormalize:
+        # fp32 like the reference gate (see biased_topk_impl)
+        topk_weights_sum = (
+            topk_weights.sum(dim=-1, keepdim=True, dtype=torch.float32)
+            if num_fused_shared_experts_for_gate == 0
+            else topk_weights[:, :-1].sum(dim=-1, keepdim=True, dtype=torch.float32)
+        )
+        topk_weights = topk_weights / (topk_weights_sum + _RENORMALIZE_SUM_EPSILON)
+        if apply_routed_scaling_factor_on_output:
+            topk_weights *= routed_scaling_factor
+
+    topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+    topk_ids, topk_weights, recorder_topk_ids = _post_process_topk_ids(
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        topk_config=topk_config,
+        router_logits=router_logits,
+        layer_id=layer_id,
+        num_token_non_padded=num_token_non_padded,
+        expert_location_dispatch_info=expert_location_dispatch_info,
+    )
+
+    get_global_expert_distribution_recorder().on_select_experts(
+        topk_ids=recorder_topk_ids
+    )
+    return StandardTopKOutput(topk_weights, topk_ids, router_logits)
+
+
 def precomputed_topk_postprocess_is_noop(
     topk_config: TopKConfig,
     num_token_non_padded: Optional[torch.Tensor] = None,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1433,31 +1433,24 @@ class Req(ReqDllmMixin):
                 match_result = zero_match_result(
                     tree_cache, match_result, extra_key=self.extra_key
                 )
-            # DeepSeek-V4-Vision: a prefix match ending inside an image span
-            # would cut the span's atomic visible-window prefill — the span's
-            # early raw KV is not retained beyond the sliding window, so the
-            # re-prefilled tail could not read it. Re-match capped to the span
-            # start, which fully re-prefills the span in one extend.
-            # HiCache: the effective match after load-back is deeper than the
-            # device-resident anchor, so include the host-hit length —
-            # otherwise a deep host hit into a span would bypass the cut and
-            # silently degrade the span to a causal window.
-            cut_point = image_span_cut_point(
-                self.multimodal_inputs,
-                len(match_result.device_indices) + match_result.host_hit_length,
-                getattr(tree_cache, "sliding_window_size", None) or 128,
-            )
-            if cut_point is not None:
+            # Host hits become part of the prefix after HiCache load-back.
+            # Keep image blocks atomic at both tiers. Page rounding during a
+            # re-match may land inside an earlier block, so repeat until safe.
+            while (
+                cut_point := image_span_cut_point(
+                    self.multimodal_inputs,
+                    len(match_result.device_indices) + match_result.host_hit_length,
+                )
+            ) is not None:
+                key_limit = (
+                    cut_point if key_limit is None else min(key_limit, cut_point)
+                )
                 match_result = tree_cache.match_prefix(
                     MatchPrefixParams(
                         key=RadixKey(
                             token_ids=token_ids_to_match,
                             extra_key=self.extra_key,
-                            limit=(
-                                cut_point
-                                if key_limit is None
-                                else min(key_limit, cut_point)
-                            ),
+                            limit=key_limit,
                             cache_salt=self.cache_salt,
                         ),
                         req=self,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1438,9 +1438,13 @@ class Req(ReqDllmMixin):
             # early raw KV is not retained beyond the sliding window, so the
             # re-prefilled tail could not read it. Re-match capped to the span
             # start, which fully re-prefills the span in one extend.
+            # HiCache: the effective match after load-back is deeper than the
+            # device-resident anchor, so include the host-hit length —
+            # otherwise a deep host hit into a span would bypass the cut and
+            # silently degrade the span to a causal window.
             cut_point = image_span_cut_point(
                 self.multimodal_inputs,
-                len(match_result.device_indices),
+                len(match_result.device_indices) + match_result.host_hit_length,
                 getattr(tree_cache, "sliding_window_size", None) or 128,
             )
             if cut_point is not None:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.attention.dsv4.visible_window import image_span_cut_point
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
     get_disagg,
@@ -1431,6 +1432,33 @@ class Req(ReqDllmMixin):
             if envs.SGLANG_RADIX_FORCE_MISS.get():
                 match_result = zero_match_result(
                     tree_cache, match_result, extra_key=self.extra_key
+                )
+            # DeepSeek-V4-Vision: a prefix match ending inside an image span
+            # would cut the span's atomic visible-window prefill — the span's
+            # early raw KV is not retained beyond the sliding window, so the
+            # re-prefilled tail could not read it. Re-match capped to the span
+            # start, which fully re-prefills the span in one extend.
+            cut_point = image_span_cut_point(
+                self.multimodal_inputs,
+                len(match_result.device_indices),
+                getattr(tree_cache, "sliding_window_size", None) or 128,
+            )
+            if cut_point is not None:
+                match_result = tree_cache.match_prefix(
+                    MatchPrefixParams(
+                        key=RadixKey(
+                            token_ids=token_ids_to_match,
+                            extra_key=self.extra_key,
+                            limit=(
+                                cut_point
+                                if key_limit is None
+                                else min(key_limit, cut_point)
+                            ),
+                            cache_salt=self.cache_salt,
+                        ),
+                        req=self,
+                        cow_mamba=cow_mamba,
+                    )
                 )
             (
                 self.prefix_indices,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1024,6 +1024,16 @@ class PrefillAdder:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
 
+        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+            req.prefix_indices
+        )
+        new_len = min(cand_extend_input_len, _rem_tokens)
+        # Image blocks must fit entirely within this iteration's budget.
+        new_len = image_span_aligned_extend_end(
+            req.multimodal_inputs, len(req.prefix_indices) + new_len
+        ) - len(req.prefix_indices)
+        if new_len <= 0:
+            return req
         # A mid-chunk rank prefills this pass regardless of the delayer
         # verdict, so report prefillable=True and ignore the result.
         if self.prefill_delayer_single_pass is not None:
@@ -1035,15 +1045,6 @@ class PrefillAdder:
                 waiting_queue_len=self.waiting_queue_len,
             )
 
-        cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
-            req.prefix_indices
-        )
-        new_len = min(cand_extend_input_len, _rem_tokens)
-        # Never cut an image span: DeepSeek-V4-Vision needs each span in one
-        # extend (may overshoot the chunk budget by up to one span).
-        new_len = image_span_aligned_extend_end(
-            req.multimodal_inputs, len(req.prefix_indices) + new_len
-        ) - len(req.prefix_indices)
         truncated = cand_extend_input_len > new_len
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
@@ -1195,9 +1196,9 @@ class PrefillAdder:
 
             # Chunked prefill
             trunc_len = self.rem_chunk_tokens
-            # Never cut an image span: DeepSeek-V4-Vision needs each span in
-            # one extend (may overshoot the chunk budget by up to one span).
             trunc_len = image_span_aligned_extend_end(req.multimodal_inputs, trunc_len)
+            if trunc_len <= 0:
+                return AddReqResult.OTHER
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
@@ -1418,10 +1419,7 @@ class PrefillAdder:
                 now_input_len = now_input_len // self.page_size * self.page_size
                 trunc_len = now_input_len - len(req.prefix_indices)
 
-                # Never cut an image span: DeepSeek-V4-Vision needs each span
-                # in one extend. This may intentionally break the page
-                # alignment above when it would land inside a span (overshoots
-                # the chunk budget by up to one span).
+                # Shrink to the image block start without exceeding the KV budget.
                 trunc_len = image_span_aligned_extend_end(
                     req.multimodal_inputs, len(req.prefix_indices) + trunc_len
                 ) - len(req.prefix_indices)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -40,6 +40,9 @@ import torch
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
+from sglang.srt.layers.attention.dsv4.visible_window import (
+    image_span_aligned_extend_end,
+)
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.managers.schedule_batch import (
     Req,
@@ -1035,8 +1038,13 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
+        # Never cut an image span: DeepSeek-V4-Vision needs each span in one
+        # extend (may overshoot the chunk budget by up to one span).
+        new_len = image_span_aligned_extend_end(
+            req.multimodal_inputs, len(req.prefix_indices) + new_len
+        ) - len(req.prefix_indices)
+        truncated = cand_extend_input_len > new_len
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
@@ -1187,6 +1195,9 @@ class PrefillAdder:
 
             # Chunked prefill
             trunc_len = self.rem_chunk_tokens
+            # Never cut an image span: DeepSeek-V4-Vision needs each span in
+            # one extend (may overshoot the chunk budget by up to one span).
+            trunc_len = image_span_aligned_extend_end(req.multimodal_inputs, trunc_len)
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
@@ -1406,6 +1417,14 @@ class PrefillAdder:
                 now_input_len = trunc_len + len(req.prefix_indices)
                 now_input_len = now_input_len // self.page_size * self.page_size
                 trunc_len = now_input_len - len(req.prefix_indices)
+
+                # Never cut an image span: DeepSeek-V4-Vision needs each span
+                # in one extend. This may intentionally break the page
+                # alignment above when it would land inside a span (overshoots
+                # the chunk budget by up to one span).
+                trunc_len = image_span_aligned_extend_end(
+                    req.multimodal_inputs, len(req.prefix_indices) + trunc_len
+                ) - len(req.prefix_indices)
 
                 if trunc_len <= 0:
                     return AddReqResult.OTHER

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5018,10 +5018,16 @@ class Scheduler(
                     # The rebootstrap payload only carries token ids (see
                     # Req.build_rebootstrap_payload), so the prefill recompute
                     # would silently rebuild the prefix KV without the image.
-                    # Abort instead of serving silently-wrong output.
+                    # Abort with a client-visible error instead of serving
+                    # silently-wrong output.
                     req.set_finish_with_abort(
                         "Multimodal requests are not supported by PD "
                         "rebootstrap (retraction + weight update)."
+                    )
+                    # retract_all already released this request's KV; emit
+                    # the abort to the client directly (no re-run).
+                    self.ipc_channels.send_to_tokenizer.send_output(
+                        _make_abort_req(req), req
                     )
                     continue
                 if req.output_ids:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5014,6 +5014,16 @@ class Scheduler(
         self.running_batch.reqs = []
         for req in retract_reqs:
             if self.disaggregation_mode == DisaggregationMode.DECODE:
+                if req.multimodal_inputs is not None:
+                    # The rebootstrap payload only carries token ids (see
+                    # Req.build_rebootstrap_payload), so the prefill recompute
+                    # would silently rebuild the prefix KV without the image.
+                    # Abort instead of serving silently-wrong output.
+                    req.set_finish_with_abort(
+                        "Multimodal requests are not supported by PD "
+                        "rebootstrap (retraction + weight update)."
+                    )
+                    continue
                 if req.output_ids:
                     req.pd_rebootstrap_forced_output_id = req.output_ids.pop()
                 req.pd_rebootstrap_in_progress = True

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5025,9 +5025,11 @@ class Scheduler(
                         "rebootstrap (retraction + weight update)."
                     )
                     # retract_all already released this request's KV; emit
-                    # the abort to the client directly (no re-run).
+                    # the abort to the client directly (no re-run), with the
+                    # finish reason attached so the client gets a structured
+                    # 400 (BadRequestError) instead of a bare abort.
                     self.ipc_channels.send_to_tokenizer.send_output(
-                        _make_abort_req(req), req
+                        _make_abort_req(req, req.to_finish.to_json()), req
                     )
                     continue
                 if req.output_ids:

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -285,7 +285,6 @@ def _dsv4_batch_needs_visible_window(local_batch: ScheduleBatch, model_config) -
         local_batch.multimodal_inputs,
         local_batch.prefix_lens,
         local_batch.extend_lens,
-        getattr(model_config, "sliding_window_size", None) or 128,
     )
 
 

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -10,6 +10,7 @@ from sglang.srt.configs.model_config import ModelConfig, is_deepseek_v4
 from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsv4.visible_window import has_visible_window_span
 from sglang.srt.layers.cp.utils import get_cp_strategy
 from sglang.srt.layers.dp_attention import world_dp_gather_enabled
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
@@ -277,10 +278,6 @@ def _dsv4_batch_needs_visible_window(local_batch: ScheduleBatch, model_config) -
     per-token visible-window overrides (eager-only)."""
     if not is_deepseek_v4(model_config.hf_config):
         return False
-    from sglang.srt.layers.attention.dsv4.visible_window import (
-        has_visible_window_span,
-    )
-
     return has_visible_window_span(
         local_batch.multimodal_inputs,
         local_batch.prefix_lens,

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 import torch
 
 from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
-from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.configs.model_config import ModelConfig, is_deepseek_v4
 from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
@@ -272,6 +272,22 @@ def _local_decode_cuda_graph_vote(
     )
 
 
+def _dsv4_batch_needs_visible_window(local_batch: ScheduleBatch, model_config) -> bool:
+    """True iff a DSV4 batch's extend chunk fully contains an image span, i.e.
+    it needs per-token visible-window overrides (eager-only)."""
+    if not is_deepseek_v4(model_config.hf_config):
+        return False
+    from sglang.srt.layers.attention.dsv4.visible_window import (
+        has_fully_contained_image_span,
+    )
+
+    return has_fully_contained_image_span(
+        local_batch.multimodal_inputs,
+        local_batch.prefix_lens,
+        local_batch.extend_lens,
+    )
+
+
 def _local_prefill_cuda_graph_vote(
     *,
     local_batch: Optional[ScheduleBatch],
@@ -297,6 +313,11 @@ def _local_prefill_cuda_graph_vote(
         replace_embeds = local_batch.replace_embeds
         prefix_lens = local_batch.prefix_lens
         return_logprob = local_batch.return_logprob
+        if _dsv4_batch_needs_visible_window(local_batch, model_config):
+            # DSV4 image spans widen the SWA window per token, making the
+            # index shapes batch-dependent; prefill graphs capture fixed
+            # shapes, so such batches must run eagerly.
+            return False
     elif (
         mode.is_decode()
         # Conversion replays the breakable graphs only; full's fixed

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -273,18 +273,19 @@ def _local_decode_cuda_graph_vote(
 
 
 def _dsv4_batch_needs_visible_window(local_batch: ScheduleBatch, model_config) -> bool:
-    """True iff a DSV4 batch's extend chunk fully contains an image span, i.e.
-    it needs per-token visible-window overrides (eager-only)."""
+    """True iff a DSV4 batch's extend chunk contains an image span that needs
+    per-token visible-window overrides (eager-only)."""
     if not is_deepseek_v4(model_config.hf_config):
         return False
     from sglang.srt.layers.attention.dsv4.visible_window import (
-        has_fully_contained_image_span,
+        has_visible_window_span,
     )
 
-    return has_fully_contained_image_span(
+    return has_visible_window_span(
         local_batch.multimodal_inputs,
         local_batch.prefix_lens,
         local_batch.extend_lens,
+        getattr(model_config, "sliding_window_size", None) or 128,
     )
 
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -474,6 +474,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
     # For multimodal
     mm_inputs: Optional[List[MultimodalInputs]] = None
+    dsv4_routing_input_ids: Optional[torch.Tensor] = None
+    dsv4_image_mask: Optional[torch.Tensor] = None
+    dsv4_has_image_tokens: bool = False
 
     # Encoder-decoder host fields
     encoder_cached: Optional[List[bool]] = None

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -152,6 +152,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
     get_embedding_tp_kwargs,
 )
+from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
@@ -508,10 +509,7 @@ class MoEGate(nn.Module):
             self.e_score_correction_bias = nn.Parameter(correction_bias)
         else:
             self.e_score_correction_bias = None
-        # DeepSeek-V4-Vision: image tokens are selected with bias_vl instead
-        # of the (text) correction bias. The checkpoint carries it on every
-        # MoE layer (hash and non-hash). Text-only configs never set
-        # vision_n_layers, so nothing changes for them.
+        # The vision checkpoint provides a separate routing bias for image tokens.
         self.bias_vl = (
             nn.Parameter(torch.empty(config.n_routed_experts, dtype=torch.float32))
             if getattr(config, "vision_n_layers", 0) > 0
@@ -909,7 +907,7 @@ class DeepseekV2MoE(nn.Module):
             and getattr(self.experts, "use_flashinfer_trtllm_moe", False)
             and not self._enable_a2a_moe
             and not self._fuse_shared_experts_inside_sbo
-            and not getattr(self, "is_hash", False)
+            and not self.is_hash
             and not get_exec().moe.enable_eplb
         )
 
@@ -1013,9 +1011,7 @@ class DeepseekV2MoE(nn.Module):
                 router_logits,
                 input_ids=input_ids_global,
                 image_mask=(
-                    getattr(forward_batch, "dsv4_image_mask", None)
-                    if forward_batch is not None
-                    else None
+                    forward_batch.dsv4_image_mask if forward_batch is not None else None
                 ),
                 forward_batch=forward_batch,
                 expert_location_dispatch_info=dispatch_info,
@@ -1092,23 +1088,11 @@ class DeepseekV2MoE(nn.Module):
         forward_batch=None,
         **kwargs,
     ):
-        """self.topk(...) plus the DeepSeek-V4-Vision bias_vl fallback.
-
-        Hash layers route via HashTopK (image-aware when built with bias_vl).
-        Non-hash layers: image tokens must be selected with gate.bias_vl
-        instead of the 1D correction bias the fused kernels take, so a batch
-        containing image tokens falls back to an eager per-token-bias top-k.
-        Text-only batches and non-vision models keep the fused path
-        bit-identical.
-
-        The image check uses the host-side batch flag
-        (forward_batch.dsv4_has_image_tokens) when available, so text-only
-        batches pay no GPU->CPU sync per layer.
-        """
-        skip_image_check = forward_batch is not None and not getattr(
-            forward_batch, "dsv4_has_image_tokens", False
+        """Use per-token vision bias when the fused router cannot represent it."""
+        skip_image_check = (
+            forward_batch is not None and not forward_batch.dsv4_has_image_tokens
         )
-        if getattr(self, "is_hash", False):
+        if self.is_hash:
             return self.topk(
                 hidden_states,
                 router_logits,
@@ -1124,14 +1108,8 @@ class DeepseekV2MoE(nn.Module):
             and not skip_image_check
             and not torch.cuda.is_current_stream_capturing()
         ):
-            # The .any() below syncs, which is illegal under CUDA graph
-            # capture. Capture only sees dummy (pad-free) input_ids, and image
-            # batches never replay graphs (prefill-with-image runs eager;
-            # decode input_ids never contain pad sentinels), so skipping the
-            # check during capture is exact.
+            # CUDA graph capture uses pad-free inputs and cannot synchronize .any().
             if image_mask is None:
-                from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
-
                 image_mask = input_ids >= MM_PAD_SHIFT_VALUE
                 if not image_mask.any():
                     image_mask = None
@@ -1209,9 +1187,7 @@ class DeepseekV2MoE(nn.Module):
                 router_logits,
                 input_ids=input_ids_global,
                 image_mask=(
-                    getattr(forward_batch, "dsv4_image_mask", None)
-                    if forward_batch is not None
-                    else None
+                    forward_batch.dsv4_image_mask if forward_batch is not None else None
                 ),
                 forward_batch=forward_batch,
                 expert_location_dispatch_info=dispatch_info,
@@ -1398,7 +1374,7 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states,
                 router_logits,
                 input_ids=input_ids_global,
-                image_mask=getattr(forward_batch, "dsv4_image_mask", None),
+                image_mask=forward_batch.dsv4_image_mask,
                 forward_batch=forward_batch,
                 num_token_non_padded=forward_batch.num_token_non_padded,
                 expert_location_dispatch_info=(
@@ -1747,7 +1723,7 @@ class DeepseekV2MoE(nn.Module):
         # Prefer the pre-clamp snapshot: embed_mm_inputs clamps
         # forward_batch.input_ids in place, which would erase the mm pad
         # sentinels the bias_vl routing keys on (EP+TBO+image path).
-        routing_ids = getattr(state.forward_batch, "dsv4_routing_input_ids", None)
+        routing_ids = state.forward_batch.dsv4_routing_input_ids
         if routing_ids is not None:
             if routing_ids.shape[0] < hidden_states.shape[0]:
                 # The child batch may pad input_ids after the slice; pad with
@@ -1772,7 +1748,7 @@ class DeepseekV2MoE(nn.Module):
                         if routing_ids is not None
                         else state.forward_batch.input_ids
                     ),
-                    image_mask=getattr(state.forward_batch, "dsv4_image_mask", None),
+                    image_mask=state.forward_batch.dsv4_image_mask,
                     forward_batch=state.forward_batch,
                     num_token_non_padded=state.forward_batch.num_token_non_padded,
                     expert_location_dispatch_info=(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -952,6 +952,7 @@ class DeepseekV2MoE(nn.Module):
                     gemm_output_zero_allocator,
                     input_ids,
                     input_ids_global=input_ids_global,
+                    forward_batch=forward_batch,
                 )
             else:
                 return self.forward_normal(
@@ -960,6 +961,7 @@ class DeepseekV2MoE(nn.Module):
                     input_ids,
                     input_ids_global=input_ids_global,
                     skip_shared_experts=skip_shared_experts,
+                    forward_batch=forward_batch,
                 )
         else:
             return self.forward_deepep(
@@ -972,6 +974,7 @@ class DeepseekV2MoE(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
         # Note(kpham-sgl): issue order satisfies 3 constraints:
         # - no stream explosion: main (routed) issued before alt block -> capture reuses 1 alt stream;
@@ -1009,6 +1012,12 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states,
                 router_logits,
                 input_ids=input_ids_global,
+                image_mask=(
+                    getattr(forward_batch, "dsv4_image_mask", None)
+                    if forward_batch is not None
+                    else None
+                ),
+                forward_batch=forward_batch,
                 expert_location_dispatch_info=dispatch_info,
             )
         deferred_finalize = (
@@ -1079,6 +1088,8 @@ class DeepseekV2MoE(nn.Module):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: Optional[torch.Tensor] = None,
+        image_mask: Optional[torch.Tensor] = None,
+        forward_batch=None,
         **kwargs,
     ):
         """self.topk(...) plus the DeepSeek-V4-Vision bias_vl fallback.
@@ -1089,15 +1100,28 @@ class DeepseekV2MoE(nn.Module):
         containing image tokens falls back to an eager per-token-bias top-k.
         Text-only batches and non-vision models keep the fused path
         bit-identical.
+
+        The image check uses the host-side batch flag
+        (forward_batch.dsv4_has_image_tokens) when available, so text-only
+        batches pay no GPU->CPU sync per layer.
         """
+        skip_image_check = forward_batch is not None and not getattr(
+            forward_batch, "dsv4_has_image_tokens", False
+        )
         if getattr(self, "is_hash", False):
             return self.topk(
-                hidden_states, router_logits, input_ids=input_ids, **kwargs
+                hidden_states,
+                router_logits,
+                input_ids=input_ids,
+                image_mask=image_mask,
+                skip_image_check=skip_image_check,
+                **kwargs,
             )
         bias_vl = self.gate.bias_vl
         if (
             bias_vl is not None
             and input_ids is not None
+            and not skip_image_check
             and not torch.cuda.is_current_stream_capturing()
         ):
             # The .any() below syncs, which is illegal under CUDA graph
@@ -1105,10 +1129,13 @@ class DeepseekV2MoE(nn.Module):
             # batches never replay graphs (prefill-with-image runs eager;
             # decode input_ids never contain pad sentinels), so skipping the
             # check during capture is exact.
-            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+            if image_mask is None:
+                from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
 
-            image_mask = input_ids >= MM_PAD_SHIFT_VALUE
-            if image_mask.any():
+                image_mask = input_ids >= MM_PAD_SHIFT_VALUE
+                if not image_mask.any():
+                    image_mask = None
+            if image_mask is not None:
                 if not _bias_vl_route_logged[0]:
                     _bias_vl_route_logged[0] = True
                     logger.info(
@@ -1141,6 +1168,7 @@ class DeepseekV2MoE(nn.Module):
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
         skip_shared_experts: bool = False,
+        forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
@@ -1180,6 +1208,12 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states,
                 router_logits,
                 input_ids=input_ids_global,
+                image_mask=(
+                    getattr(forward_batch, "dsv4_image_mask", None)
+                    if forward_batch is not None
+                    else None
+                ),
+                forward_batch=forward_batch,
                 expert_location_dispatch_info=dispatch_info,
             )
         else:
@@ -1364,6 +1398,8 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states,
                 router_logits,
                 input_ids=input_ids_global,
+                image_mask=getattr(forward_batch, "dsv4_image_mask", None),
+                forward_batch=forward_batch,
                 num_token_non_padded=forward_batch.num_token_non_padded,
                 expert_location_dispatch_info=(
                     ExpertLocationDispatchInfo.init_new(
@@ -1721,7 +1757,9 @@ class DeepseekV2MoE(nn.Module):
                     (0, hidden_states.shape[0] - routing_ids.shape[0]),
                 )
             elif routing_ids.shape[0] > hidden_states.shape[0]:
-                routing_ids = None
+                # Symmetric with the pad above; never fall back to the
+                # (possibly clamped) batch ids.
+                routing_ids = routing_ids[: hidden_states.shape[0]]
         if router_logits is not None:
             with get_global_expert_distribution_recorder().with_current_layer(
                 self.layer_id
@@ -1734,6 +1772,8 @@ class DeepseekV2MoE(nn.Module):
                         if routing_ids is not None
                         else state.forward_batch.input_ids
                     ),
+                    image_mask=getattr(state.forward_batch, "dsv4_image_mask", None),
+                    forward_batch=state.forward_batch,
                     num_token_non_padded=state.forward_batch.num_token_non_padded,
                     expert_location_dispatch_info=(
                         ExpertLocationDispatchInfo.init_new(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -259,6 +259,8 @@ logger = logging.getLogger(__name__)
 # One-time SGLANG_OPT_MOE_QUANT_ONCE engagement log (see _moe_quant_once_enabled).
 _moe_quant_once_logged = False
 
+_bias_vl_route_logged = [False]
+
 _enable_pcg_dsv2_dual_stream = (
     _is_cuda and envs.SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM.get()
 )
@@ -1107,6 +1109,11 @@ class DeepseekV2MoE(nn.Module):
 
             image_mask = input_ids >= MM_PAD_SHIFT_VALUE
             if image_mask.any():
+                if not _bias_vl_route_logged[0]:
+                    _bias_vl_route_logged[0] = True
+                    logger.info(
+                        "DSV4-Vision: routing image tokens with gate bias_vl (MoE gate)."
+                    )
                 correction_bias = self.gate.e_score_correction_bias
                 text_bias = (
                     torch.zeros_like(bias_vl)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1708,6 +1708,20 @@ class DeepseekV2MoE(nn.Module):
         # on vision models). The per-ubatch forward_batch.input_ids is already
         # sliced+padded to match hidden_states rows (and equals the global ids
         # under EP dp-attention). No-op for non-hash models.
+        # Prefer the pre-clamp snapshot: embed_mm_inputs clamps
+        # forward_batch.input_ids in place, which would erase the mm pad
+        # sentinels the bias_vl routing keys on (EP+TBO+image path).
+        routing_ids = getattr(state.forward_batch, "dsv4_routing_input_ids", None)
+        if routing_ids is not None:
+            if routing_ids.shape[0] < hidden_states.shape[0]:
+                # The child batch may pad input_ids after the slice; pad with
+                # a plain token id so the image mask stays empty there.
+                routing_ids = torch.nn.functional.pad(
+                    routing_ids,
+                    (0, hidden_states.shape[0] - routing_ids.shape[0]),
+                )
+            elif routing_ids.shape[0] > hidden_states.shape[0]:
+                routing_ids = None
         if router_logits is not None:
             with get_global_expert_distribution_recorder().with_current_layer(
                 self.layer_id
@@ -1715,7 +1729,11 @@ class DeepseekV2MoE(nn.Module):
                 state.topk_output = self._forward_topk(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
-                    input_ids=state.forward_batch.input_ids,
+                    input_ids=(
+                        routing_ids
+                        if routing_ids is not None
+                        else state.forward_batch.input_ids
+                    ),
                     num_token_non_padded=state.forward_batch.num_token_non_padded,
                     expert_location_dispatch_info=(
                         ExpertLocationDispatchInfo.init_new(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -110,7 +110,12 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     CombineInput,
     DispatchOutput,
 )
-from sglang.srt.layers.moe.topk import BypassedTopKOutput, TopK, TopKOutputFormat
+from sglang.srt.layers.moe.topk import (
+    BypassedTopKOutput,
+    TopK,
+    TopKOutputFormat,
+    per_token_biased_topk,
+)
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -501,6 +506,15 @@ class MoEGate(nn.Module):
             self.e_score_correction_bias = nn.Parameter(correction_bias)
         else:
             self.e_score_correction_bias = None
+        # DeepSeek-V4-Vision: image tokens are selected with bias_vl instead
+        # of the (text) correction bias. The checkpoint carries it on every
+        # MoE layer (hash and non-hash). Text-only configs never set
+        # vision_n_layers, so nothing changes for them.
+        self.bias_vl = (
+            nn.Parameter(torch.empty(config.n_routed_experts, dtype=torch.float32))
+            if getattr(config, "vision_n_layers", 0) > 0
+            else None
+        )
         if _is_cpu and _is_cpu_amx_available:
             self.quant_method = PackWeightMethod(weight_names=["weight"])
         self.use_dsa = is_deepseek_dsa(config)
@@ -680,6 +694,7 @@ class DeepseekV2MoE(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
                 apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
                 layer_id=self.layer_id,
+                bias_vl=self.gate.bias_vl,
             )
         else:
             # Default: grouped noaux_tc top-k. Covers V3/V3.2/GLM-5/Glm4MoeLite.
@@ -988,16 +1003,11 @@ class DeepseekV2MoE(nn.Module):
                 topk_config=self.topk.topk_config,
             )
         else:
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._forward_topk(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
             )
         deferred_finalize = (
             has_shared_output
@@ -1062,6 +1072,61 @@ class DeepseekV2MoE(nn.Module):
             final_hidden_states += shared_output
         return final_hidden_states
 
+    def _forward_topk(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        """self.topk(...) plus the DeepSeek-V4-Vision bias_vl fallback.
+
+        Hash layers route via HashTopK (image-aware when built with bias_vl).
+        Non-hash layers: image tokens must be selected with gate.bias_vl
+        instead of the 1D correction bias the fused kernels take, so a batch
+        containing image tokens falls back to an eager per-token-bias top-k.
+        Text-only batches and non-vision models keep the fused path
+        bit-identical.
+        """
+        if getattr(self, "is_hash", False):
+            return self.topk(
+                hidden_states, router_logits, input_ids=input_ids, **kwargs
+            )
+        bias_vl = self.gate.bias_vl
+        if (
+            bias_vl is not None
+            and input_ids is not None
+            and not torch.cuda.is_current_stream_capturing()
+        ):
+            # The .any() below syncs, which is illegal under CUDA graph
+            # capture. Capture only sees dummy (pad-free) input_ids, and image
+            # batches never replay graphs (prefill-with-image runs eager;
+            # decode input_ids never contain pad sentinels), so skipping the
+            # check during capture is exact.
+            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+
+            image_mask = input_ids >= MM_PAD_SHIFT_VALUE
+            if image_mask.any():
+                correction_bias = self.gate.e_score_correction_bias
+                text_bias = (
+                    torch.zeros_like(bias_vl)
+                    if correction_bias is None
+                    else correction_bias.to(torch.float32)
+                )
+                per_token_bias = torch.where(
+                    image_mask.unsqueeze(1), bias_vl, text_bias
+                )
+                topk_output = per_token_biased_topk(
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                    per_token_correction_bias=per_token_bias,
+                    topk_config=self.topk.topk_config,
+                    layer_id=self.layer_id,
+                    **kwargs,
+                )
+                return self.topk._apply_waterfill(topk_output, hidden_states.shape[0])
+        return self.topk(hidden_states, router_logits, **kwargs)
+
     def forward_normal(
         self,
         hidden_states: torch.Tensor,
@@ -1104,16 +1169,11 @@ class DeepseekV2MoE(nn.Module):
                 )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._forward_topk(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
             )
         else:
             pre_quant_input = None
@@ -1293,14 +1353,10 @@ class DeepseekV2MoE(nn.Module):
                         torch.cuda.current_stream().wait_event(shared_event)
                 else:
                     shared_output = self._forward_shared_experts(hidden_states)
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._forward_topk(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 num_token_non_padded=forward_batch.num_token_non_padded,
                 expert_location_dispatch_info=(
                     ExpertLocationDispatchInfo.init_new(
@@ -1309,7 +1365,6 @@ class DeepseekV2MoE(nn.Module):
                     if not self.is_nextn
                     else None
                 ),
-                **topk_kwargs,
             )
         else:
             topk_output = self.topk.empty_topk_output(
@@ -1641,21 +1696,19 @@ class DeepseekV2MoE(nn.Module):
         router_logits = state.pop("router_logits")
         hidden_states = state.hidden_states_mlp_input
 
-        # Hash MoE layers (e.g. DeepSeek-V4) route on input_ids; forward_deepep
-        # passes them as a topk kwarg. The per-ubatch forward_batch.input_ids is
-        # already sliced+padded to match hidden_states rows (and equals the
-        # global ids under EP dp-attention). No-op for non-hash models.
-        topk_kwargs = {}
-        if getattr(self, "is_hash", False):
-            topk_kwargs["input_ids"] = state.forward_batch.input_ids
-
+        # Hash MoE layers (e.g. DeepSeek-V4) route on input_ids; _forward_topk
+        # passes them as a topk kwarg (and uses them for the bias_vl fallback
+        # on vision models). The per-ubatch forward_batch.input_ids is already
+        # sliced+padded to match hidden_states rows (and equals the global ids
+        # under EP dp-attention). No-op for non-hash models.
         if router_logits is not None:
             with get_global_expert_distribution_recorder().with_current_layer(
                 self.layer_id
             ):
-                state.topk_output = self.topk(
+                state.topk_output = self._forward_topk(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
+                    input_ids=state.forward_batch.input_ids,
                     num_token_non_padded=state.forward_batch.num_token_non_padded,
                     expert_location_dispatch_info=(
                         ExpertLocationDispatchInfo.init_new(
@@ -1664,7 +1717,6 @@ class DeepseekV2MoE(nn.Module):
                         if not self.is_nextn
                         else None
                     ),
-                    **topk_kwargs,
                 )
         else:
             state.topk_output = self.topk.empty_topk_output(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -110,6 +110,7 @@ from sglang.srt.layers.utils.cp_utils import (
     prepare_context_parallel_metadata,
 )
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
 from sglang.srt.mem_cache.memory_pool import RadixAttention
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -3072,7 +3073,7 @@ class DeepseekV4Model(nn.Module):
         # (max=vocab_size-1), which would erase the mm pad sentinels the
         # bias_vl routing keys on.
         if input_ids is None:
-            input_ids = getattr(forward_batch, "dsv4_routing_input_ids", None)
+            input_ids = forward_batch.dsv4_routing_input_ids
             if input_ids is None:
                 input_ids = forward_batch.input_ids
         # Note: the image-token mask + host flag for the bias_vl routing are
@@ -3118,8 +3119,6 @@ class DeepseekV4Model(nn.Module):
         # idle/text-only rank would skip the check while the gathered global
         # ids still contain a peer's mm pad sentinels, sending them into the
         # fused hash_topk kernel for an illegal access.)
-        from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
-
         if not torch.cuda.is_current_stream_capturing():
             image_mask = input_ids_global >= MM_PAD_SHIFT_VALUE
             if image_mask.any():
@@ -3372,7 +3371,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         if self.dsa_enable_prefill_cp:
             cp_input_ids = input_ids
             if cp_input_ids is None:
-                cp_input_ids = getattr(forward_batch, "dsv4_routing_input_ids", None)
+                cp_input_ids = forward_batch.dsv4_routing_input_ids
             if cp_input_ids is None:
                 cp_input_ids = forward_batch.input_ids
             if can_dsa_cp_split(len(cp_input_ids), self.cp_size, True, forward_batch):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2865,7 +2865,7 @@ class DeepseekV4Model(nn.Module):
             # TBO child batches drop mm metadata (the split sets mm_inputs=None),
             # which would silently degrade image-span visible-window attention
             # to causal. Fall back to the normal path for mm batches.
-            and not forward_batch.contains_mm_inputs()
+            and not forward_batch.dsv4_has_image_tokens
             and path_ok
             and self.pp_group.world_size == 1
         )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3063,9 +3063,14 @@ class DeepseekV4Model(nn.Module):
     ) -> Union[torch.Tensor, PPProxyTensors]:
         # Multimodal prefill embeds tokens outside and calls this with
         # input_ids=None; the hash-MoE routing and the dp gather below still
-        # need the real (padded) ids, which forward_batch always carries.
+        # need the real (padded) ids. Read the pre-embedding snapshot when
+        # present: embed_mm_inputs clamps forward_batch.input_ids in place
+        # (max=vocab_size-1), which would erase the mm pad sentinels the
+        # bias_vl routing keys on.
         if input_ids is None:
-            input_ids = forward_batch.input_ids
+            input_ids = getattr(forward_batch, "dsv4_routing_input_ids", None)
+            if input_ids is None:
+                input_ids = forward_batch.input_ids
         cp_v2_active = is_cp_v2_active(forward_batch)
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         if self.pp_group.is_first_rank:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3071,6 +3071,10 @@ class DeepseekV4Model(nn.Module):
             input_ids = getattr(forward_batch, "dsv4_routing_input_ids", None)
             if input_ids is None:
                 input_ids = forward_batch.input_ids
+        # Note: the image-token mask + host flag for the bias_vl routing are
+        # hoisted by the VL wrapper (deepseek_v4_vl.py) before the mm embed
+        # routine — by the time this forward runs, forward_batch.mm_inputs
+        # has been nulled by embed_mm_inputs.
         cp_v2_active = is_cp_v2_active(forward_batch)
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         if self.pp_group.is_first_rank:
@@ -3338,11 +3342,18 @@ class DeepseekV4ForCausalLM(nn.Module):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         # input_ids is None for multimodal prefill (tokens are embedded by
-        # the VL wrapper); CP metadata prep needs the length, so skip it then.
-        if self.dsa_enable_prefill_cp and input_ids is not None:
-            if can_dsa_cp_split(len(input_ids), self.cp_size, True, forward_batch):
+        # the VL wrapper); CP metadata prep only needs the length, so resolve
+        # the ids the same way DeepseekV4Model.forward does — the pre-clamp
+        # snapshot first, then the (possibly clamped) batch ids.
+        if self.dsa_enable_prefill_cp:
+            cp_input_ids = input_ids
+            if cp_input_ids is None:
+                cp_input_ids = getattr(forward_batch, "dsv4_routing_input_ids", None)
+            if cp_input_ids is None:
+                cp_input_ids = forward_batch.input_ids
+            if can_dsa_cp_split(len(cp_input_ids), self.cp_size, True, forward_batch):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
-                    len(input_ids),
+                    len(cp_input_ids),
                     self.cp_rank,
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2862,6 +2862,10 @@ class DeepseekV4Model(nn.Module):
             # MTP target-verify also reports is_extend(); only real prefill
             # should enter the prefill TBO strategy.
             and forward_batch.global_forward_mode.is_extend_without_speculative()
+            # TBO child batches drop mm metadata (the split sets mm_inputs=None),
+            # which would silently degrade image-span visible-window attention
+            # to causal. Fall back to the normal path for mm batches.
+            and not forward_batch.contains_mm_inputs()
             and path_ok
             and self.pp_group.world_size == 1
         )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3108,6 +3108,26 @@ class DeepseekV4Model(nn.Module):
         else:
             input_ids_global = input_ids
 
+        # Hoist the image-token mask + host flag for the bias_vl routing,
+        # computed from input_ids_global — the exact ids the MoE gate sees.
+        # (Computing from the local batch ids breaks under dp-attention: an
+        # idle/text-only rank would skip the check while the gathered global
+        # ids still contain a peer's mm pad sentinels, sending them into the
+        # fused hash_topk kernel for an illegal access.)
+        from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+
+        if not torch.cuda.is_current_stream_capturing():
+            image_mask = input_ids_global >= MM_PAD_SHIFT_VALUE
+            if image_mask.any():
+                forward_batch.dsv4_image_mask = image_mask
+                forward_batch.dsv4_has_image_tokens = True
+            else:
+                forward_batch.dsv4_image_mask = None
+                forward_batch.dsv4_has_image_tokens = False
+        else:
+            forward_batch.dsv4_image_mask = None
+            forward_batch.dsv4_has_image_tokens = False
+
         capture_dspark = self.dspark_layers_to_capture is not None
         dspark_aux_hidden_states: List[torch.Tensor] = []
         # DSpark aux capture needs the per-layer eager loop (TBO's overlapped

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3061,6 +3061,11 @@ class DeepseekV4Model(nn.Module):
         input_embeds: Optional[torch.Tensor],
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[torch.Tensor, PPProxyTensors]:
+        # Multimodal prefill embeds tokens outside and calls this with
+        # input_ids=None; the hash-MoE routing and the dp gather below still
+        # need the real (padded) ids, which forward_batch always carries.
+        if input_ids is None:
+            input_ids = forward_batch.input_ids
         cp_v2_active = is_cp_v2_active(forward_batch)
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         if self.pp_group.is_first_rank:
@@ -3327,7 +3332,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-        if self.dsa_enable_prefill_cp:
+        # input_ids is None for multimodal prefill (tokens are embedded by
+        # the VL wrapper); CP metadata prep needs the length, so skip it then.
+        if self.dsa_enable_prefill_cp and input_ids is not None:
             if can_dsa_cp_split(len(input_ids), self.cp_size, True, forward_batch):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
                     len(input_ids),
@@ -3479,7 +3486,10 @@ class DeepseekV4ForCausalLM(nn.Module):
             name = name.removesuffix(".scale") + ".weight_scale_inv"
 
         name = name.replace(".gate.tid2eid", ".topk.tid2eid")
-        name = name.replace(".gate.bias", ".gate.e_score_correction_bias")
+        # Suffix-exact match: a substring replace would also rewrite the
+        # vision model's ".gate.bias_vl" into ".gate.e_score_correction_bias_vl".
+        if name.endswith(".gate.bias"):
+            name = name.removesuffix(".gate.bias") + ".gate.e_score_correction_bias"
         name = name.replace(".w1.", ".gate_proj.")
         name = name.replace(".w2.", ".down_proj.")
         name = name.replace(".w3.", ".up_proj.")
@@ -3929,7 +3939,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         )
 
 
-EntryClass = [DeepseekV4ForCausalLM]
+# NOTE: EntryClass registration moved to deepseek_v4_vl.py, whose vision-capable
+# wrapper is also named DeepseekV4ForCausalLM (the HF arch string is identical
+# for text-only and vision checkpoints). Text-only checkpoints delegate to this
+# class unchanged. Do not re-add an EntryClass here — the model registry rejects
+# duplicate class names.
+# EntryClass = [DeepseekV4ForCausalLM]  # see deepseek_v4_vl.py
 
 
 def _dequant_fp8(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -1034,7 +1034,12 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         mapped_rest = mapped_rest.replace(".w2.", ".down_proj.")
         mapped_rest = mapped_rest.replace(".w3.", ".up_proj.")
         mapped_rest = mapped_rest.replace(".gate.tid2eid", ".topk.tid2eid")
-        mapped_rest = mapped_rest.replace(".gate.bias", ".gate.e_score_correction_bias")
+        # Suffix-exact match: a substring replace would also rewrite the
+        # vision model's ".gate.bias_vl" into ".gate.e_score_correction_bias_vl".
+        if mapped_rest.endswith(".gate.bias"):
+            mapped_rest = (
+                mapped_rest.removesuffix(".gate.bias") + ".gate.e_score_correction_bias"
+            )
         mapped_rest = mapped_rest.replace(".scale", ".weight_scale_inv")
         return f"stages.{stage_id}.{mapped_rest}"
 
@@ -1091,7 +1096,12 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         mapped_rest = mapped_rest.replace(".w2.", ".down_proj.")
         mapped_rest = mapped_rest.replace(".w3.", ".up_proj.")
         mapped_rest = mapped_rest.replace(".gate.tid2eid", ".topk.tid2eid")
-        mapped_rest = mapped_rest.replace(".gate.bias", ".gate.e_score_correction_bias")
+        # Suffix-exact match: a substring replace would also rewrite the
+        # vision model's ".gate.bias_vl" into ".gate.e_score_correction_bias_vl".
+        if mapped_rest.endswith(".gate.bias"):
+            mapped_rest = (
+                mapped_rest.removesuffix(".gate.bias") + ".gate.e_score_correction_bias"
+            )
         if mapped_rest.endswith(".scale"):
             mapped_rest = mapped_rest.removesuffix(".scale") + ".weight_scale_inv"
         return f"stages.{stage_id}.{mapped_rest}"

--- a/python/sglang/srt/models/deepseek_v4_vit.py
+++ b/python/sglang/srt/models/deepseek_v4_vit.py
@@ -1,25 +1,8 @@
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0
-"""Vision tower (ViT) and aligner for DeepSeek-V4-Flash-Vision-Exp.
-
-Ported from the reference implementation in the HuggingFace repo
-(deepseek-ai/DeepSeek-V4-Flash-Vision-Exp, inference/vision.py).
-
-The vision encoder is a plain bidirectional ViT with 2D RoPE:
-  - linear patch embedding (patch_size=14, no conv)
-  - pre-norm blocks: RMSNorm(fp32) -> full attention(2D RoPE) -> RMSNorm -> SwiGLU MLP
-  - final RMSNorm
-The aligner pixel-unshuffles the ViT grid by `vision_downsample_ratio` (3x3)
-and projects to the LLM hidden size with a 2-layer GELU MLP.
-
-Token-layout note: `encode_image` returns aligner outputs in row-major
-("N-layout") order. The caller (language model) is responsible for applying
-the `perm` reordering built by image_processor.build_image_block and for
-splicing in the learned sentinel embeddings (image_start / image_pad /
-image_newline / image_end), which live on the language-model side.
-
-The tower runs replicated (ReplicatedLinear) — it is small (32 layers,
-dim 1024) and is executed during multimodal embedding only.
+"""Replicated DeepSeek-V4 ViT and aligner, matching inference/vision.py in
+deepseek-ai/DeepSeek-V4-Flash-Vision-Exp. The wrapper applies the processor's
+permutation and inserts sentinel embeddings after alignment.
 """
 
 from functools import lru_cache

--- a/python/sglang/srt/models/deepseek_v4_vit.py
+++ b/python/sglang/srt/models/deepseek_v4_vit.py
@@ -1,0 +1,252 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Vision tower (ViT) and aligner for DeepSeek-V4-Flash-Vision-Exp.
+
+Ported from the reference implementation in the HuggingFace repo
+(deepseek-ai/DeepSeek-V4-Flash-Vision-Exp, inference/vision.py).
+
+The vision encoder is a plain bidirectional ViT with 2D RoPE:
+  - linear patch embedding (patch_size=14, no conv)
+  - pre-norm blocks: RMSNorm(fp32) -> full attention(2D RoPE) -> RMSNorm -> SwiGLU MLP
+  - final RMSNorm
+The aligner pixel-unshuffles the ViT grid by `vision_downsample_ratio` (3x3)
+and projects to the LLM hidden size with a 2-layer GELU MLP.
+
+Token-layout note: `encode_image` returns aligner outputs in row-major
+("N-layout") order. The caller (language model) is responsible for applying
+the `perm` reordering built by image_processor.build_image_block and for
+splicing in the learned sentinel embeddings (image_start / image_pad /
+image_newline / image_end), which live on the language-model side.
+
+The tower runs replicated (ReplicatedLinear) — it is small (32 layers,
+dim 1024) and is executed during multimodal embedding only.
+"""
+
+from functools import lru_cache
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.utils import add_prefix
+
+
+@lru_cache(16)
+def get_vision_cos_sin(
+    n_h: int, n_w: int, dim: int, theta: float, device: torch.device
+):
+    """2D RoPE cos/sin tables for an n_h x n_w patch grid, fp32."""
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    hpos = torch.arange(n_h).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    return freqs.cos().unsqueeze(1).to(device), freqs.sin().unsqueeze(1).to(device)
+
+
+def apply_vision_rotary(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+class DeepseekV4VisionRMSNorm(nn.Module):
+    """RMSNorm computed in fp32 with an fp32 weight, matching the reference."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class DeepseekV4VisionPatchEmbed(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        patch_size = config.vision_patch_size
+        self.proj = ReplicatedLinear(
+            3 * patch_size**2,
+            config.vision_dim,
+            bias=True,
+            quant_config=None,
+            prefix=add_prefix("proj", prefix),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [n_patches, 3, p, p] -> [n_patches, vision_dim]
+        out, _ = self.proj(x.flatten(1))
+        return out
+
+
+class DeepseekV4VisionAttention(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        dim = config.vision_dim
+        self.n_heads = config.vision_n_heads
+        self.head_dim = dim // self.n_heads
+        self.wqkv = ReplicatedLinear(
+            dim,
+            3 * dim,
+            bias=True,
+            quant_config=None,
+            prefix=add_prefix("wqkv", prefix),
+        )
+        self.wo = ReplicatedLinear(
+            dim, dim, bias=True, quant_config=None, prefix=add_prefix("wo", prefix)
+        )
+
+    def forward(
+        self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+    ) -> torch.Tensor:
+        n = x.size(0)
+        qkv, _ = self.wqkv(x)
+        q, k, v = (t.view(n, self.n_heads, self.head_dim) for t in qkv.chunk(3, dim=-1))
+        q = apply_vision_rotary(q, cos, sin)
+        k = apply_vision_rotary(k, cos, sin)
+        o = F.scaled_dot_product_attention(
+            q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1)
+        )
+        out, _ = self.wo(o.transpose(0, 1).reshape(n, -1))
+        return out
+
+
+class DeepseekV4VisionMLP(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        self.w1 = ReplicatedLinear(
+            config.vision_dim,
+            2 * config.vision_inter_dim,
+            bias=False,
+            quant_config=None,
+            prefix=add_prefix("w1", prefix),
+        )
+        self.w2 = ReplicatedLinear(
+            config.vision_inter_dim,
+            config.vision_dim,
+            bias=False,
+            quant_config=None,
+            prefix=add_prefix("w2", prefix),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.w1(x)
+        gate, up = gate_up.chunk(2, dim=-1)
+        out, _ = self.w2(F.silu(gate) * up)
+        return out
+
+
+class DeepseekV4VisionBlock(nn.Module):
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        dim = config.vision_dim
+        self.norm1 = DeepseekV4VisionRMSNorm(dim)
+        self.attn = DeepseekV4VisionAttention(config, prefix=add_prefix("attn", prefix))
+        self.norm2 = DeepseekV4VisionRMSNorm(dim)
+        self.mlp = DeepseekV4VisionMLP(config, prefix=add_prefix("mlp", prefix))
+
+    def forward(
+        self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class DeepseekV4VisionTower(nn.Module):
+    """DeepSeek-V4 ViT: full bidirectional attention over one image with 2D RoPE.
+
+    Maps to the `vision.*` weights in the HF checkpoint.
+    """
+
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        self.n_heads = config.vision_n_heads
+        self.rope_dim = config.vision_dim // config.vision_n_heads // 2
+        self.rope_theta = config.vision_rope_theta
+        self.patch_embed = DeepseekV4VisionPatchEmbed(
+            config, prefix=add_prefix("patch_embed", prefix)
+        )
+        self.blocks = nn.ModuleList(
+            DeepseekV4VisionBlock(config, prefix=add_prefix(f"blocks.{i}", prefix))
+            for i in range(config.vision_n_layers)
+        )
+        self.norm = DeepseekV4VisionRMSNorm(config.vision_dim)
+
+    def forward(self, patches: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        x = self.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(
+            n_h, n_w, self.rope_dim, self.rope_theta, x.device
+        )
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        return self.norm(x)
+
+
+class DeepseekV4VisionAligner(nn.Module):
+    """Pixel-unshuffle (3x3) + 2-layer GELU projector to the LLM hidden size.
+
+    Maps to the `aligner.*` weights in the HF checkpoint.
+    """
+
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        self.downsample_ratio = config.vision_downsample_ratio
+        in_dim = config.vision_dim * self.downsample_ratio**2
+        self.w1 = ReplicatedLinear(
+            in_dim,
+            config.hidden_size,
+            bias=True,
+            quant_config=None,
+            prefix=add_prefix("w1", prefix),
+        )
+        self.w2 = ReplicatedLinear(
+            config.hidden_size,
+            config.hidden_size,
+            bias=True,
+            quant_config=None,
+            prefix=add_prefix("w2", prefix),
+        )
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.downsample_ratio
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        h, _ = self.w1(x)
+        out, _ = self.w2(F.gelu(h))
+        return out
+
+
+class DeepseekV4VisionEncoder(nn.Module):
+    """Convenience wrapper: ViT + aligner, one call per image.
+
+    Returns aligner outputs in row-major grid order ([n_llm_tokens, hidden]).
+    The caller applies the `perm` reordering and merges with the learned
+    image sentinel embeddings on the language-model side.
+    """
+
+    def __init__(self, config: PretrainedConfig, prefix: str = ""):
+        super().__init__()
+        self.vision = DeepseekV4VisionTower(config, prefix=add_prefix("vision", prefix))
+        self.aligner = DeepseekV4VisionAligner(
+            config, prefix=add_prefix("aligner", prefix)
+        )
+
+    def forward(
+        self, patches: torch.Tensor, n_vit_h: int, n_vit_w: int
+    ) -> torch.Tensor:
+        return self.aligner(self.vision(patches, n_vit_h, n_vit_w), n_vit_h, n_vit_w)
+
+    # alias matching the reference model's naming
+    def encode_image(
+        self, patches: torch.Tensor, n_vit_h: int, n_vit_w: int
+    ) -> torch.Tensor:
+        return self.forward(patches, n_vit_h, n_vit_w)

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -1,18 +1,8 @@
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0
-"""DeepSeek-V4-Flash-Vision-Exp: vision-enabled wrapper for DeepseekV4.
+"""DeepSeek-V4 vision wrapper; text checkpoints use the same registry entry.
 
-The HF checkpoint of the vision model reports the same architecture string as
-the text-only model ("DeepseekV4ForCausalLM"), so — following the MiMo-V2
-precedent — this wrapper takes over the EntryClass registration from
-deepseek_v4.py and conditionally builds the vision modules when
-``config.vision_n_layers > 0``. Text-only checkpoints behave exactly as
-before: the wrapper delegates everything to the text model.
-
-Image-embedding layout (see multimodal/processors/deepseek_v4_vl.py):
-each image placeholder expands into a sentinel block of learned vectors
-(image_start / image_pad / image_newline / image_end) with ViT+aligner
-embeddings scattered into the IMAGE slots in N-layout order (via `perm`).
+The processor supplies sentinel types and the aligner permutation for each image.
 """
 
 from typing import Iterable, List, Optional, Tuple
@@ -126,13 +116,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         if forward_batch.contains_mm_inputs():
-            # embed_mm_inputs clamps forward_batch.input_ids in place
-            # (max=vocab_size-1) to embed the placeholder region. The MoE
-            # gate's bias_vl routing keys on the mm pad sentinels in those
-            # ids, so keep a pre-clamp snapshot for it to read. The
-            # image-token mask + host flag are hoisted later by
-            # DeepseekV4Model.forward from input_ids_global (the exact ids
-            # the gate sees — required for dp-attention).
+            # Preserve pad IDs for MoE routing before embedding clamps them.
             forward_batch.dsv4_routing_input_ids = forward_batch.input_ids.clone()
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
@@ -210,15 +194,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         return _DeepseekV4TextLM.get_model_config_for_expert_location(config)
 
     def __getattr__(self, name: str):
-        # The wrapper replaces the text model in the registry for every
-        # DeepseekV4 checkpoint, so it must expose the text model's full
-        # public surface (get_embed_and_head for EAGLE,
-        # routed_experts_weights_of_layer for EPLB, start/end_layer for PP,
-        # get_model_config_for_expert_location, ...). Delegate anything that
-        # is not the wrapper's own parameter/buffer/submodule/attribute.
-        # `language_model` itself is resolved through nn.Module machinery so
-        # a miss before __init__ assigns it raises AttributeError instead of
-        # recursing.
+        # Resolve registered modules first; delegate the text model's remaining API.
         try:
             return super().__getattr__(name)
         except AttributeError:

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -13,20 +13,8 @@ Image-embedding layout (see multimodal/processors/deepseek_v4_vl.py):
 each image placeholder expands into a sentinel block of learned vectors
 (image_start / image_pad / image_newline / image_end) with ViT+aligner
 embeddings scattered into the IMAGE slots in N-layout order (via `perm`).
-
-MoE gate ``bias_vl`` routing (phase 2, done): ``*.gate.bias_vl`` weights
-flow through the text model's load_weights onto ``MoEGate.bias_vl``. Hash
-layers select image tokens by ``(scores + bias_vl).topk`` instead of the
-tid2eid table; non-hash layers fall back to an eager per-token-bias top-k
-whenever a batch contains image tokens (see DeepseekV2MoE._forward_topk).
-
-NOT YET IMPLEMENTED (phase 2, required for correct outputs):
-- bidirectional / visible-window attention inside image spans during prefill
-  (reference: get_image_visible + get_window_topk_idxs_visible); needs
-  image-span-aware topk construction in layers/attention/deepseek_v4_backend.py.
 """
 
-import logging
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -50,8 +38,6 @@ from sglang.srt.models.deepseek_v4_vit import (
 )
 from sglang.srt.utils import add_prefix
 
-logger = logging.getLogger(__name__)
-
 # Sentinel type ids, matching the reference image_processor.py and
 # multimodal/processors/deepseek_v4_vl.py.
 IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
@@ -68,6 +54,7 @@ class DeepseekV4ForCausalLM(nn.Module):
     ) -> None:
         super().__init__()
         self.config = config
+        self._vision_weights_loaded = False
         self.is_multimodal = getattr(config, "vision_n_layers", 0) > 0
 
         self.language_model = _DeepseekV4TextLM(
@@ -86,9 +73,6 @@ class DeepseekV4ForCausalLM(nn.Module):
             self.image_newline = nn.Parameter(torch.empty(config.hidden_size))
             self.image_pad = nn.Parameter(torch.empty(config.hidden_size))
 
-    # ------------------------------------------------------------------
-    # multimodal interface
-    # ------------------------------------------------------------------
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
@@ -162,46 +146,41 @@ class DeepseekV4ForCausalLM(nn.Module):
         )
         return hidden_states
 
-    # ------------------------------------------------------------------
-    # weight loading
-    # ------------------------------------------------------------------
     _SENTINEL_NAMES = ("image_start", "image_end", "image_newline", "image_pad")
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
-        llm_weights = []
         loaded_vision_names = set()
-        for name, loaded_weight in weights:
-            if name.startswith(("vision.", "aligner.")):
-                param = params_dict[name]
-                default_weight_loader(param, loaded_weight)
-                loaded_vision_names.add(name)
-            elif name in self._SENTINEL_NAMES:
-                param = params_dict[name]
-                default_weight_loader(param, loaded_weight)
-                loaded_vision_names.add(name)
-            else:
-                llm_weights.append((name, loaded_weight))
-        self.language_model.load_weights(llm_weights)
-        if self.is_multimodal:
-            # The vision params are created with torch.empty; a checkpoint
-            # missing them would silently serve garbage, so audit loudly.
+
+        def llm_weights():
+            for name, loaded_weight in weights:
+                if (
+                    name.startswith(("vision.", "aligner."))
+                    or name in self._SENTINEL_NAMES
+                ):
+                    default_weight_loader(params_dict[name], loaded_weight)
+                    loaded_vision_names.add(name)
+                else:
+                    yield name, loaded_weight
+
+        self.language_model.load_weights(llm_weights())
+        if self.is_multimodal and not self._vision_weights_loaded:
+            # Check the complete checkpoint iterator, which can span many shards.
+            # Later updates may contain only language-model weights.
             expected_vision = {
-                n for n in params_dict if n.startswith(("vision.", "aligner."))
+                name
+                for name in params_dict
+                if name.startswith(("vision.", "aligner."))
+                or name in self._SENTINEL_NAMES
             }
             missing = sorted(expected_vision - loaded_vision_names)
-            missing += sorted(set(self._SENTINEL_NAMES) - loaded_vision_names)
             if missing:
-                logger.warning(
-                    "DeepSeek-V4-Vision checkpoint did not provide %d vision "
-                    "weights (e.g. %s); they hold uninitialized values.",
-                    len(missing),
-                    missing[:4],
+                raise ValueError(
+                    f"DeepSeek-V4-Vision checkpoint is missing {len(missing)} "
+                    f"required vision weights: {missing}"
                 )
+            self._vision_weights_loaded = True
 
-    # ------------------------------------------------------------------
-    # delegations expected by the framework / engine
-    # ------------------------------------------------------------------
     def get_input_embeddings(self) -> nn.Module:
         return self.language_model.get_input_embeddings()
 

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -194,6 +194,18 @@ class DeepseekV4ForCausalLM(nn.Module):
         # DSPARK aux-hidden capture is configured on the text model.
         self.language_model.set_dspark_layers_to_capture(layer_ids)
 
+    # Class-level probes (hasattr(model_class, ...)) bypass instance
+    # __getattr__, so these must exist on the wrapper class itself.
+    @classmethod
+    def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):
+        return _DeepseekV4TextLM.shared_experts_fusion_disable_reason(
+            hf_config, quant_config
+        )
+
+    @classmethod
+    def get_model_config_for_expert_location(cls, config):
+        return _DeepseekV4TextLM.get_model_config_for_expert_location(config)
+
     def __getattr__(self, name: str):
         # The wrapper replaces the text model in the registry for every
         # DeepseekV4 checkpoint, so it must expose the text model's full

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -145,18 +145,11 @@ class DeepseekV4ForCausalLM(nn.Module):
             # embed_mm_inputs clamps forward_batch.input_ids in place
             # (max=vocab_size-1) to embed the placeholder region. The MoE
             # gate's bias_vl routing keys on the mm pad sentinels in those
-            # ids, so keep a pre-clamp snapshot for it to read. Also hoist
-            # the image-token mask + host flag here: the routine nulls
-            # forward_batch.mm_inputs before the LM runs, so the mask must be
-            # computed now, and the flag lets MoE layers skip their per-layer
-            # GPU->CPU check on text-only batches.
-            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
-
-            routing_ids = forward_batch.input_ids.clone()
-            forward_batch.dsv4_routing_input_ids = routing_ids
-            image_mask = routing_ids >= MM_PAD_SHIFT_VALUE
-            forward_batch.dsv4_image_mask = image_mask
-            forward_batch.dsv4_has_image_tokens = bool(image_mask.any())
+            # ids, so keep a pre-clamp snapshot for it to read. The
+            # image-token mask + host flag are hoisted later by
+            # DeepseekV4Model.forward from input_ids_global (the exact ids
+            # the gate sees — required for dp-attention).
+            forward_batch.dsv4_routing_input_ids = forward_batch.input_ids.clone()
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -138,6 +138,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         **kwargs,
     ) -> torch.Tensor:
+        if forward_batch.contains_mm_inputs():
+            # embed_mm_inputs clamps forward_batch.input_ids in place
+            # (max=vocab_size-1) to embed the placeholder region. The MoE
+            # gate's bias_vl routing keys on the mm pad sentinels in those
+            # ids, so keep a pre-clamp snapshot for it to read.
+            forward_batch.dsv4_routing_input_ids = forward_batch.input_ids.clone()
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,
@@ -187,6 +193,22 @@ class DeepseekV4ForCausalLM(nn.Module):
     def set_dspark_layers_to_capture(self, layer_ids) -> None:
         # DSPARK aux-hidden capture is configured on the text model.
         self.language_model.set_dspark_layers_to_capture(layer_ids)
+
+    def __getattr__(self, name: str):
+        # The wrapper replaces the text model in the registry for every
+        # DeepseekV4 checkpoint, so it must expose the text model's full
+        # public surface (get_embed_and_head for EAGLE,
+        # routed_experts_weights_of_layer for EPLB, start/end_layer for PP,
+        # get_model_config_for_expert_location, ...). Delegate anything that
+        # is not the wrapper's own parameter/buffer/submodule/attribute.
+        # `language_model` itself is resolved through nn.Module machinery so
+        # a miss before __init__ assigns it raises AttributeError instead of
+        # recursing.
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            language_model = super().__getattr__("language_model")
+            return getattr(language_model, name)
 
 
 EntryClass = [DeepseekV4ForCausalLM]

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -179,5 +179,14 @@ class DeepseekV4ForCausalLM(nn.Module):
     def pp_group(self):
         return self.language_model.pp_group
 
+    @property
+    def lm_head(self):
+        # DSpark's draft worker attaches the target's lm_head to the draft.
+        return self.language_model.lm_head
+
+    def set_dspark_layers_to_capture(self, layer_ids) -> None:
+        # DSPARK aux-hidden capture is configured on the text model.
+        self.language_model.set_dspark_layers_to_capture(layer_ids)
+
 
 EntryClass = [DeepseekV4ForCausalLM]

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -1,0 +1,183 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""DeepSeek-V4-Flash-Vision-Exp: vision-enabled wrapper for DeepseekV4.
+
+The HF checkpoint of the vision model reports the same architecture string as
+the text-only model ("DeepseekV4ForCausalLM"), so — following the MiMo-V2
+precedent — this wrapper takes over the EntryClass registration from
+deepseek_v4.py and conditionally builds the vision modules when
+``config.vision_n_layers > 0``. Text-only checkpoints behave exactly as
+before: the wrapper delegates everything to the text model.
+
+Image-embedding layout (see multimodal/processors/deepseek_v4_vl.py):
+each image placeholder expands into a sentinel block of learned vectors
+(image_start / image_pad / image_newline / image_end) with ViT+aligner
+embeddings scattered into the IMAGE slots in N-layout order (via `perm`).
+
+MoE gate ``bias_vl`` routing (phase 2, done): ``*.gate.bias_vl`` weights
+flow through the text model's load_weights onto ``MoEGate.bias_vl``. Hash
+layers select image tokens by ``(scores + bias_vl).topk`` instead of the
+tid2eid table; non-hash layers fall back to an eager per-token-bias top-k
+whenever a batch contains image tokens (see DeepseekV2MoE._forward_topk).
+
+NOT YET IMPLEMENTED (phase 2, required for correct outputs):
+- bidirectional / visible-window attention inside image spans during prefill
+  (reference: get_image_visible + get_window_topk_idxs_visible); needs
+  image-span-aware topk construction in layers/attention/deepseek_v4_backend.py.
+"""
+
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+from torch import nn
+
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM as _DeepseekV4TextLM
+from sglang.srt.models.deepseek_v4_vit import (
+    DeepseekV4VisionAligner,
+    DeepseekV4VisionTower,
+)
+from sglang.srt.utils import add_prefix
+
+# Sentinel type ids, matching the reference image_processor.py and
+# multimodal/processors/deepseek_v4_vl.py.
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+
+
+class DeepseekV4ForCausalLM(nn.Module):
+    """Vision-capable DeepseekV4, registered for arch "DeepseekV4ForCausalLM"."""
+
+    def __init__(
+        self,
+        config,
+        quant_config=None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.is_multimodal = getattr(config, "vision_n_layers", 0) > 0
+
+        self.language_model = _DeepseekV4TextLM(
+            config, quant_config, prefix=add_prefix("language_model", prefix)
+        )
+
+        if self.is_multimodal:
+            self.vision = DeepseekV4VisionTower(
+                config, prefix=add_prefix("vision", prefix)
+            )
+            self.aligner = DeepseekV4VisionAligner(
+                config, prefix=add_prefix("aligner", prefix)
+            )
+            self.image_start = nn.Parameter(torch.empty(config.hidden_size))
+            self.image_end = nn.Parameter(torch.empty(config.hidden_size))
+            self.image_newline = nn.Parameter(torch.empty(config.hidden_size))
+            self.image_pad = nn.Parameter(torch.empty(config.hidden_size))
+
+    # ------------------------------------------------------------------
+    # multimodal interface
+    # ------------------------------------------------------------------
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        """ViT + aligner + sentinel block assembly, one block per image item.
+
+        Returns [sum(block_len), hidden] concatenated in item order, matching
+        the placeholder spans the scheduler padded into input_ids."""
+        assert self.is_multimodal
+        device = self.image_start.device
+        dtype = self.image_start.dtype
+        # Order matters: index i of this stack is sentinel type id i; the IMAGE
+        # slot (id 2) maps to image_pad and gets overwritten below.
+        sentinel = torch.stack(
+            [
+                self.image_start,
+                self.image_pad,
+                self.image_pad,
+                self.image_newline,
+                self.image_end,
+            ]
+        )
+        features = []
+        for item in items:
+            data = item.model_specific_data
+            n_vit_h, n_vit_w = data["n_vit_h"], data["n_vit_w"]
+            types = torch.tensor(data["types"], dtype=torch.int64, device=device)
+            perm = torch.tensor(data["perm"], dtype=torch.int64, device=device)
+            patches = item.feature.to(device=device, dtype=dtype)
+
+            embeds = self.aligner(
+                self.vision(patches, n_vit_h, n_vit_w), n_vit_h, n_vit_w
+            )[perm]
+            block = sentinel[types]
+            image_mask = types == IMAGE
+            assert embeds.size(0) == int(image_mask.sum()), (
+                f"aligner produced {embeds.size(0)} tokens but the block has "
+                f"{int(image_mask.sum())} IMAGE slots"
+            )
+            block[image_mask] = embeds
+            features.append(block)
+        return torch.cat(features, dim=0)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={
+                Modality.IMAGE: self.get_image_feature,
+            },
+            positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+        return hidden_states
+
+    # ------------------------------------------------------------------
+    # weight loading
+    # ------------------------------------------------------------------
+    _SENTINEL_NAMES = ("image_start", "image_end", "image_newline", "image_pad")
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        params_dict = dict(self.named_parameters())
+        llm_weights = []
+        for name, loaded_weight in weights:
+            if name.startswith(("vision.", "aligner.")):
+                param = params_dict[name]
+                default_weight_loader(param, loaded_weight)
+            elif name in self._SENTINEL_NAMES:
+                param = params_dict[name]
+                default_weight_loader(param, loaded_weight)
+            else:
+                llm_weights.append((name, loaded_weight))
+        self.language_model.load_weights(llm_weights)
+
+    # ------------------------------------------------------------------
+    # delegations expected by the framework / engine
+    # ------------------------------------------------------------------
+    def get_input_embeddings(self) -> nn.Module:
+        return self.language_model.get_input_embeddings()
+
+    @property
+    def pp_group(self):
+        return self.language_model.pp_group
+
+
+EntryClass = [DeepseekV4ForCausalLM]

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -26,6 +26,7 @@ NOT YET IMPLEMENTED (phase 2, required for correct outputs):
   image-span-aware topk construction in layers/attention/deepseek_v4_backend.py.
 """
 
+import logging
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -48,6 +49,8 @@ from sglang.srt.models.deepseek_v4_vit import (
     DeepseekV4VisionTower,
 )
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 # Sentinel type ids, matching the reference image_processor.py and
 # multimodal/processors/deepseek_v4_vl.py.
@@ -142,8 +145,18 @@ class DeepseekV4ForCausalLM(nn.Module):
             # embed_mm_inputs clamps forward_batch.input_ids in place
             # (max=vocab_size-1) to embed the placeholder region. The MoE
             # gate's bias_vl routing keys on the mm pad sentinels in those
-            # ids, so keep a pre-clamp snapshot for it to read.
-            forward_batch.dsv4_routing_input_ids = forward_batch.input_ids.clone()
+            # ids, so keep a pre-clamp snapshot for it to read. Also hoist
+            # the image-token mask + host flag here: the routine nulls
+            # forward_batch.mm_inputs before the LM runs, so the mask must be
+            # computed now, and the flag lets MoE layers skip their per-layer
+            # GPU->CPU check on text-only batches.
+            from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+
+            routing_ids = forward_batch.input_ids.clone()
+            forward_batch.dsv4_routing_input_ids = routing_ids
+            image_mask = routing_ids >= MM_PAD_SHIFT_VALUE
+            forward_batch.dsv4_image_mask = image_mask
+            forward_batch.dsv4_has_image_tokens = bool(image_mask.any())
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,
@@ -164,16 +177,34 @@ class DeepseekV4ForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         llm_weights = []
+        loaded_vision_names = set()
         for name, loaded_weight in weights:
             if name.startswith(("vision.", "aligner.")):
                 param = params_dict[name]
                 default_weight_loader(param, loaded_weight)
+                loaded_vision_names.add(name)
             elif name in self._SENTINEL_NAMES:
                 param = params_dict[name]
                 default_weight_loader(param, loaded_weight)
+                loaded_vision_names.add(name)
             else:
                 llm_weights.append((name, loaded_weight))
         self.language_model.load_weights(llm_weights)
+        if self.is_multimodal:
+            # The vision params are created with torch.empty; a checkpoint
+            # missing them would silently serve garbage, so audit loudly.
+            expected_vision = {
+                n for n in params_dict if n.startswith(("vision.", "aligner."))
+            }
+            missing = sorted(expected_vision - loaded_vision_names)
+            missing += sorted(set(self._SENTINEL_NAMES) - loaded_vision_names)
+            if missing:
+                logger.warning(
+                    "DeepSeek-V4-Vision checkpoint did not provide %d vision "
+                    "weights (e.g. %s); they hold uninitialized values.",
+                    len(missing),
+                    missing[:4],
+                )
 
     # ------------------------------------------------------------------
     # delegations expected by the framework / engine

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -1,22 +1,8 @@
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0
-"""Multimodal processor for DeepSeek-V4-Flash-Vision-Exp.
-
-Ports the reference preprocessing from the HuggingFace repo
-(deepseek-ai/DeepSeek-V4-Flash-Vision-Exp, inference/image_processor.py):
-
-- each `<｜deepseek_image｜>` placeholder expands into a *variable-length*
-  sentinel block: compress_pad (aligns the block start to COMPRESS_PAD_TO),
-  IMAGE_START, an N-layout grid of IMAGE tokens with one IMAGE_NEW_LINE per
-  row (rows padded to even), trailing pad, IMAGE_END;
-- the block layout (token `types`) and the aligner-row reordering (`perm`)
-  are computed here and passed to the model via
-  MultimodalDataItem.model_specific_data, so the model only needs to run
-  ViT + aligner and scatter the result.
-
-The expanded token count computed here MUST match the number of embeddings
-produced by DeepseekV4ForCausalLM.get_image_feature, or the scheduler's
-length accounting breaks.
+"""DeepSeek-V4 image preprocessing, matching inference/image_processor.py in
+deepseek-ai/DeepSeek-V4-Flash-Vision-Exp. Block lengths must match the wrapper's
+embeddings, including compression padding and sentinels.
 """
 
 import math

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -27,6 +27,7 @@ import numpy as np
 import torch
 from PIL import Image, ImageOps
 
+from sglang.srt.managers.mm_utils import hash_feature
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -262,6 +263,18 @@ class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
                 MultimodalDataItem(
                     modality=Modality.IMAGE,
                     feature=patches,
+                    # Grid and compression alignment determine types/perm for
+                    # this processor. Cached blocks include that layout as well
+                    # as pixels, even when two layouts have the same length.
+                    hash=hash_feature(
+                        [
+                            patches,
+                            torch.tensor(
+                                [n_vit_h, n_vit_w, start % COMPRESS_PAD_TO],
+                                dtype=torch.int64,
+                            ),
+                        ]
+                    ),
                     offsets=[(start, len(input_ids) - 1)],
                     model_specific_data={
                         "types": types,

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -1,0 +1,279 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Multimodal processor for DeepSeek-V4-Flash-Vision-Exp.
+
+Ports the reference preprocessing from the HuggingFace repo
+(deepseek-ai/DeepSeek-V4-Flash-Vision-Exp, inference/image_processor.py):
+
+- each `<｜deepseek_image｜>` placeholder expands into a *variable-length*
+  sentinel block: compress_pad (aligns the block start to COMPRESS_PAD_TO),
+  IMAGE_START, an N-layout grid of IMAGE tokens with one IMAGE_NEW_LINE per
+  row (rows padded to even), trailing pad, IMAGE_END;
+- the block layout (token `types`) and the aligner-row reordering (`perm`)
+  are computed here and passed to the model via
+  MultimodalDataItem.model_specific_data, so the model only needs to run
+  ViT + aligner and scatter the result.
+
+The expanded token count computed here MUST match the number of embeddings
+produced by DeepseekV4ForCausalLM.get_image_feature, or the scheduler's
+length accounting breaks.
+"""
+
+import math
+import re
+from typing import List, Union
+
+import numpy as np
+import torch
+from PIL import Image, ImageOps
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalProcessorOutput,
+)
+from sglang.srt.models.deepseek_v4_vl import DeepseekV4ForCausalLM
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+# Sentinel type ids, matching the reference image_processor.py.
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+COMPRESS_PAD_TO = 4
+
+
+def grid_tokens(best_height, best_width, patch_size, downsample_ratio):
+    """Number of LLM tokens the aligner grid occupies (N-layout, incl. row/align padding)."""
+    n_llm_h = math.ceil((best_height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((best_width // patch_size) / downsample_ratio)
+    num_tokens = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2 == 1:
+        num_tokens += n_llm_w + 1
+    num_tokens += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, num_tokens
+
+
+def solve_resize_ratio(height, width, patch_size, downsample_ratio, max_n_token):
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (max_n_token - 2) // (max_w + 1)
+        if max_h % 2 == 1:
+            max_h -= 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = ((max_n_token - 2) // max_h) - 1
+        assert max_w > 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    else:
+        max_w = math.floor(max_w_float)
+        max_h = math.floor(max_h_float)
+        if max_h % 2 == 1:
+            max_h -= 1
+        beta = min(
+            max_w * patch_size * downsample_ratio / width,
+            max_h * patch_size * downsample_ratio / height,
+        )
+        best_width = math.floor(width * beta / patch_size) * patch_size
+        best_height = math.floor(height * beta / patch_size) * patch_size
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    return n_llm_h, n_llm_w, best_height, best_width, num_tokens
+
+
+def safe_resize(
+    height,
+    width,
+    best_height,
+    best_width,
+    patch_size,
+    downsample_ratio,
+    max_n_token,
+):
+    max_n_token -= COMPRESS_PAD_TO - 1
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    budget = max_n_token
+    while num_tokens > max_n_token:
+        n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, budget
+        )
+        budget -= 1
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+def build_image_block(n_llm_h: int, n_llm_w: int, start_pos: int):
+    """Builds the N-layout token types (final order) and the aligner-row order
+    for IMAGE slots. Returns (types, perm) as python lists."""
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = rows // 2 * row_len % 2 * 2
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h
+        + [IMAGE_PAD] * (row_len * pad_h),
+        dtype=torch.int64,
+    )
+    order = (
+        torch.arange(rows * row_len)
+        .view(rows // 2, 2, row_len)
+        .transpose(1, 2)
+        .reshape(-1)
+    )
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.int64)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w
+    ).view(n_llm_h, n_llm_w)
+    perm = image_idx[order]
+    perm = perm[perm >= 0]
+    types = torch.cat(
+        [
+            torch.full((compress_pad,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_START]),
+            types[order],
+            torch.full((pad_last,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_END]),
+        ]
+    )
+    return types.tolist(), perm.tolist()
+
+
+class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
+    models = [DeepseekV4ForCausalLM]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        image_token_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+        if image_token_id is None or image_token_id == self._tokenizer.unk_token_id:
+            raise ValueError(f"Token not found in tokenizer: {IMAGE_PLACEHOLDER}")
+        self.image_token_id = image_token_id
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token=IMAGE_PLACEHOLDER,
+            image_token_id=image_token_id,
+        ).build(_processor)
+
+        # vision preprocessing hyperparameters from the HF config
+        self.patch_size = hf_config.vision_patch_size
+        self.downsample_ratio = hf_config.vision_downsample_ratio
+        self.max_n_token = hf_config.vision_max_n_token
+        self.min_pixels = hf_config.vision_min_pixels
+        self.max_wh_ratio = hf_config.vision_max_wh_ratio
+
+    def _load_image(self, image):
+        """One image -> (patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w).
+
+        Faithful port of image_processor.load_image, minus the byte loading
+        (load_mm_data already decoded the image)."""
+        p = self.patch_size
+        if not isinstance(image, Image.Image):
+            # Depending on the image backend / transport, load_mm_data may
+            # hand us a CHW uint8 tensor instead of a PIL image.
+            arr = torch.as_tensor(image)
+            if arr.dim() == 3 and arr.shape[0] in (1, 3, 4):
+                arr = arr.permute(1, 2, 0)
+            image = Image.fromarray(arr.cpu().numpy().astype(np.uint8))
+        image = image.convert("RGB")
+        width, height = image.size
+        if self.max_wh_ratio is not None and width > height * self.max_wh_ratio:
+            width = height * self.max_wh_ratio
+        if 0 < width * height < self.min_pixels:
+            ratio = (self.min_pixels / (width * height)) ** 0.5
+            width = int(width * ratio)
+            height = int(height * ratio)
+        best_width = math.ceil(width / p) * p
+        best_height = math.ceil(height / p) * p
+        n_llm_h, n_llm_w, best_height, best_width = safe_resize(
+            height,
+            width,
+            best_height,
+            best_width,
+            p,
+            self.downsample_ratio,
+            self.max_n_token,
+        )
+        n_vit_h, n_vit_w = best_height // p, best_width // p
+        if (
+            self.max_wh_ratio is not None
+            and image.width >= self.max_wh_ratio * image.height
+        ):
+            image = image.resize((best_width, best_height))
+        else:
+            image = ImageOps.pad(
+                image, (best_width, best_height), color=(127, 127, 127)
+            )
+        x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+        x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+        patches = (
+            x.reshape(3, n_vit_h, p, n_vit_w, p)
+            .permute(1, 3, 0, 2, 4)
+            .reshape(n_vit_h * n_vit_w, 3, p, p)
+        )
+        return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+    async def process_mm_data_async(
+        self,
+        image_data: List[Union[str, bytes]],
+        input_text,
+        request_obj,
+        max_req_input_len,
+        *args,
+        **kwargs,
+    ):
+        base_output = await self.load_mm_data(
+            input_text,
+            image_data=image_data,
+            multimodal_tokens=self.mm_tokens,
+        )
+        prompt = base_output.input_text
+        images = base_output.images
+
+        text_parts = re.split(re.escape(IMAGE_PLACEHOLDER), prompt)
+        if len(text_parts) - 1 != len(images):
+            raise ValueError(
+                f"Found {len(text_parts) - 1} image placeholders "
+                f"but got {len(images)} images"
+            )
+
+        input_ids: List[int] = []
+        mm_items: List[MultimodalDataItem] = []
+        for i, part in enumerate(text_parts):
+            if part:
+                input_ids.extend(self._tokenizer.encode(part))
+            if i >= len(images):
+                continue
+            patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = self._load_image(images[i])
+            # The block layout depends on the absolute position (compress-pad
+            # alignment), so it must be computed against the running length.
+            types, perm = build_image_block(n_llm_h, n_llm_w, len(input_ids))
+            start = len(input_ids)
+            input_ids.extend([self.image_token_id] * len(types))
+            mm_items.append(
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    feature=patches,
+                    offsets=[(start, len(input_ids) - 1)],
+                    model_specific_data={
+                        "types": types,
+                        "perm": perm,
+                        "n_vit_h": n_vit_h,
+                        "n_vit_w": n_vit_w,
+                    },
+                )
+            )
+
+        return MultimodalProcessorOutput(
+            mm_items=mm_items,
+            input_ids=input_ids,
+            im_token_id=self.image_token_id,
+        )

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -284,6 +284,17 @@ def get_processor(
                 revision=revision,
                 **kwargs,
             )
+        elif config.model_type == "deepseek_v4":
+            # DeepSeek-V4 (incl. the Vision variant) ships no HF processor;
+            # its mm processor only needs the tokenizer — image preprocessing
+            # is implemented inside sglang (multimodal/processors/deepseek_v4_vl.py).
+            processor = AutoTokenizer.from_pretrained(
+                tokenizer_name,
+                *args,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                **kwargs,
+            )
         else:
             if config.model_type in _CUSTOMIZED_MM_PROCESSOR:
                 processor = _CUSTOMIZED_MM_PROCESSOR[config.model_type].from_pretrained(

--- a/test/registered/unit/arg_groups/test_deepseek_v4_vision_args.py
+++ b/test/registered/unit/arg_groups/test_deepseek_v4_vision_args.py
@@ -1,0 +1,74 @@
+"""Configuration limits for atomic DeepSeek-V4 image prefill."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import sglang.srt.arg_groups.deepseek_v4_hook as vision_hook
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, stage="base-a", runner_config="cpu")
+
+
+class TestVisionConfiguration(CustomTestCase):
+    def validate(
+        self, *, chunk, page=256, cp=False, vision=True, dynamic=False, hip=False
+    ):
+        cfg = SimpleNamespace(
+            enable_prefill_cp=cp,
+            enable_dsa_prefill_context_parallel=False,
+            page_size=page,
+            chunked_prefill_size=chunk,
+            enable_dynamic_chunking=dynamic,
+        )
+        hf = SimpleNamespace(
+            architectures=["DeepseekV4ForCausalLM"],
+            vision_n_layers=int(vision),
+            vision_max_n_token=384,
+        )
+        with (
+            patch.object(vision_hook, "resolving_view", return_value=cfg),
+            patch.object(
+                vision_hook,
+                "model_config_of",
+                return_value=SimpleNamespace(hf_config=hf),
+            ),
+            patch.object(
+                vision_hook, "get_platform", return_value=SimpleNamespace(is_hip=hip)
+            ),
+        ):
+            vision_hook.validate_deepseek_v4_vision(object())
+
+    def test_minimum_chunk_accounts_for_page_alignment(self):
+        with self.assertRaisesRegex(ValueError, "at least 768"):
+            self.validate(chunk=512)
+        self.validate(chunk=768)
+        self.validate(chunk=-1)
+        self.validate(chunk=384, page=1)
+
+    def test_text_model_is_unaffected(self):
+        self.validate(chunk=16, cp=True, vision=False)
+
+    def test_dynamic_budget_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "dynamic chunk sizes"):
+            self.validate(chunk=1024, dynamic=True)
+
+    def test_unified_kv_storage_is_rejected(self):
+        with (
+            patch.object(
+                vision_hook.envs.SGLANG_HACK_FLASHMLA_BACKEND,
+                "get",
+                return_value="unified_kv_triton",
+            ),
+            self.assertRaisesRegex(ValueError, "complete image blocks"),
+        ):
+            self.validate(chunk=1024, hip=True)
+
+    def test_unsupported_cp_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "context parallelism"):
+            self.validate(chunk=1024, cp=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/batch_overlap/test_dsv4_vision_tbo.py
+++ b/test/registered/unit/batch_overlap/test_dsv4_vision_tbo.py
@@ -1,0 +1,61 @@
+"""Image prefill must veto TBO before multimodal metadata is discarded."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+import sglang.srt.batch_overlap.two_batch_overlap as tbo
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, stage="base-a", runner_config="cpu")
+
+
+class TestVisionTboVote(CustomTestCase):
+    def vote(self, image):
+        mode = Mock()
+        mode.resolve.return_value.is_low_latency.return_value = False
+        item = SimpleNamespace(
+            is_image=lambda: True,
+            offsets=[(10, 389)],
+            model_specific_data={"types": [], "perm": []},
+        )
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            spec_info=None,
+            extend_num_tokens=1024,
+            extend_lens=[512, 512],
+            is_extend_in_batch=True,
+            multimodal_inputs=[SimpleNamespace(mm_items=[item])] if image else None,
+        )
+        preparer = tbo.TboDPAttentionPreparer()
+        with (
+            patch.object(tbo, "is_tbo_enabled", return_value=True),
+            patch.object(tbo, "get_deepep_mode", return_value=mode),
+            patch.object(
+                tbo,
+                "get_moe_a2a_backend",
+                return_value=SimpleNamespace(is_none=lambda: True),
+            ),
+            patch.object(tbo, "compute_split_seq_index", return_value=1),
+        ):
+            vote, forward_mode = preparer.prepare_all_gather(batch)
+        return preparer, vote, forward_mode
+
+    def test_image_rank_vetoes_tbo_for_all_dp_ranks(self):
+        _, image_vote, mode = self.vote(True)
+        text_preparer, text_vote, _ = self.vote(False)
+        self.assertFalse(image_vote)
+        self.assertTrue(text_vote)
+        split, global_mode = text_preparer.compute_output(
+            torch.tensor([[int(image_vote), mode], [int(text_vote), mode]])
+        )
+        self.assertIsNone(split)
+        self.assertIsNone(global_mode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_dsv4_encoder_compat.py
+++ b/test/registered/unit/entrypoints/openai/test_dsv4_encoder_compat.py
@@ -1,0 +1,81 @@
+"""Preserve legacy effort keywords and normalized tool history encoding."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai import encoding_dsv4 as encoding
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, stage="base-a", runner_config="cpu")
+
+
+class TestDsv4EncoderCompatibility(CustomTestCase):
+    def test_legacy_profiles_match_flat_efforts(self):
+        messages = [{"role": "user", "content": "Solve this."}]
+        for profile, effort, flat in [
+            ("preview", None, "low"),
+            ("preview", "high", "low"),
+            ("preview", "max", "high"),
+            ("official", None, "low"),
+            ("official", "low", "low"),
+            ("official", "high", "high"),
+            ("official", "max", "max"),
+        ]:
+            with self.subTest(profile=profile, effort=effort):
+                actual = encoding.encode_messages(
+                    messages,
+                    thinking_mode="thinking",
+                    reasoning_effort=effort,
+                    reasoning_effort_profile=profile,
+                )
+                expected = encoding.encode_messages(
+                    messages,
+                    thinking_mode="thinking",
+                    reasoning_effort=flat,
+                )
+                self.assertEqual(actual, expected)
+
+    def test_invalid_legacy_profile_or_effort(self):
+        for profile, effort in [("invalid", "high"), ("preview", "low")]:
+            with self.subTest(profile=profile, effort=effort):
+                with self.assertRaises(ValueError):
+                    encoding.encode_messages(
+                        [{"role": "user", "content": "Hi"}],
+                        thinking_mode="thinking",
+                        reasoning_effort_profile=profile,
+                        reasoning_effort=effort,
+                    )
+
+    def test_replayed_tool_arguments_match_json_strings(self):
+        arguments = {"city": "Paris", "count": 2, "options": {"units": "metric"}}
+
+        def history(value):
+            return [
+                {"role": "user", "content": "Find the weather."},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": value},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "Sunny"},
+                {"role": "user", "content": "And tomorrow?"},
+            ]
+
+        actual = encoding.encode_messages(history(arguments), thinking_mode="chat")
+        expected = encoding.encode_messages(
+            history(json.dumps(arguments)), thinking_mode="chat"
+        )
+        self.assertEqual(actual, expected)
+        self.assertIn('parameter name="city"', actual)
+        self.assertNotIn('parameter name="arguments"', actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_dsv4_visible_window.py
+++ b/test/registered/unit/layers/test_dsv4_visible_window.py
@@ -1,0 +1,139 @@
+"""Atomic image boundaries shared by scheduling, cache matching and attention."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.layers.attention.dsv4.visible_window import (
+    compute_visible_window_overrides,
+    image_span_aligned_extend_end,
+    image_span_cut_point,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, stage="base-a", runner_config="cpu")
+
+
+def image_inputs(*spans):
+    return SimpleNamespace(
+        mm_items=[
+            SimpleNamespace(
+                is_image=lambda: True,
+                offsets=[(start, end - 1)],
+                model_specific_data={"types": [], "perm": []},
+            )
+            for start, end in spans
+        ]
+    )
+
+
+class TestImageBoundaries(CustomTestCase):
+    def test_all_cut_points(self):
+        spans = [(13, 393), (501, 1001), (1001, 1121)]
+        mm = image_inputs(*spans)
+        for position in range(1200):
+            expected = next(
+                (start for start, end in spans if start < position < end), position
+            )
+            self.assertEqual(image_span_aligned_extend_end(mm, position), expected)
+            self.assertEqual(
+                image_span_cut_point(mm, position),
+                expected if expected < position else None,
+            )
+
+    def test_shrink_respects_kv_budget(self):
+        mm = image_inputs((1100, 1480))
+        end = image_span_aligned_extend_end(mm, 1024 + 256)
+        self.assertEqual(end, 1100)
+        self.assertLessEqual(end - 1024, 256)
+
+    def test_chunking_makes_progress_for_every_start_alignment(self):
+        for start in range(512):
+            mm = image_inputs((start, start + 500), (start + 500, start + 880))
+            prefix = 0
+            chunks = []
+            while prefix < start + 1000:
+                end = image_span_aligned_extend_end(mm, min(prefix + 512, start + 1000))
+                self.assertGreater(end, prefix)
+                self.assertLessEqual(end - prefix, 512)
+                chunks.append((prefix, end))
+                prefix = end
+            self.assertLessEqual(len(chunks), 4)
+
+    def test_remaining_batch_budget_can_defer_image(self):
+        mm = image_inputs((100, 480))
+        self.assertEqual(image_span_aligned_extend_end(mm, 100 + 256), 100)
+        self.assertEqual(image_span_aligned_extend_end(mm, 100 + 512), 612)
+
+    def test_text_and_other_models_are_unchanged(self):
+        other_mm = SimpleNamespace(
+            mm_items=[
+                SimpleNamespace(
+                    is_image=lambda: True, offsets=[(0, 499)], model_specific_data={}
+                )
+            ]
+        )
+        for mm in (None, other_mm):
+            self.assertEqual(image_span_aligned_extend_end(mm, 128), 128)
+            self.assertIsNone(image_span_cut_point(mm, 128))
+
+    def test_host_match_uses_device_plus_host_length(self):
+        mm = image_inputs((100, 480), (520, 900))
+        for device, host, expected in [
+            (64, 64, 100),
+            (128, 256, 100),
+            (480, 64, 520),
+            (64, 416, None),
+        ]:
+            self.assertEqual(image_span_cut_point(mm, device + host), expected)
+
+
+class TestVisibleWindows(CustomTestCase):
+    def test_matches_reference_for_all_four_compression_alignments(self):
+        for start in range(128, 132):
+            end = start + 380
+            starts, lengths = compute_visible_window_overrides(
+                mm_inputs=[image_inputs((start, end))],
+                extend_prefix_lens=[64],
+                extend_seq_lens=[512],
+                swa_window=128,
+                padded_num_tokens=520,
+            )
+            image_start = start + 3 - start % 4
+            for row, pos in enumerate(range(64, 576)):
+                in_image = image_start <= pos < end
+                left = pos - image_start if in_image else 0
+                right = end - 1 - pos if in_image else 0
+                expected_start = max(0, pos - 127 - max(0, left - 127))
+                self.assertEqual(
+                    (starts[row], lengths[row]),
+                    (expected_start, pos + right - expected_start + 1),
+                )
+            self.assertEqual(starts[512:], [0] * 8)
+            self.assertEqual(lengths[512:], [1] * 8)
+
+    def test_rejects_partial_images_instead_of_changing_attention(self):
+        for prefix, end in [(0, 256), (101, 500), (256, 400)]:
+            with self.assertRaisesRegex(ValueError, "crosses the prefill range"):
+                compute_visible_window_overrides(
+                    mm_inputs=[image_inputs((100, 480))],
+                    extend_prefix_lens=[prefix],
+                    extend_seq_lens=[end - prefix],
+                    swa_window=128,
+                    padded_num_tokens=end - prefix,
+                )
+
+    def test_cached_images_do_not_change_following_text(self):
+        self.assertIsNone(
+            compute_visible_window_overrides(
+                mm_inputs=[image_inputs((100, 480))],
+                extend_prefix_lens=[480],
+                extend_seq_lens=[20],
+                swa_window=128,
+                padded_num_tokens=20,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_dsv4_image_prefix.py
+++ b/test/registered/unit/managers/test_dsv4_image_prefix.py
@@ -1,0 +1,97 @@
+"""Cache matches must not split bidirectional image blocks."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.base_prefix_cache import MatchResult
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, stage="base-a", runner_config="cpu")
+
+
+class TestImagePrefix(CustomTestCase):
+    def setUp(self):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def test_device_and_host_matches_are_capped_before_load_back(self):
+        for device, host in [(256, 0), (64, 192), (0, 256), (128, 128)]:
+            with self.subTest(device=device, host=host):
+                req = Req("image", "", array("q", range(800)), SamplingParams())
+                req.multimodal_inputs = SimpleNamespace(
+                    mm_items=[
+                        SimpleNamespace(
+                            is_image=lambda: True,
+                            offsets=[(100, 479)],
+                            model_specific_data={"types": [], "perm": []},
+                        )
+                    ]
+                )
+                cache = Mock()
+                cache.swa_reprefill_tail_tokens.return_value = 0
+                cache.supports_mamba.return_value = False
+                cache.match_prefix.side_effect = [
+                    MatchResult(
+                        last_device_node=None,
+                        last_host_node=None,
+                        best_match_node=None,
+                        device_indices=torch.arange(device),
+                        host_hit_length=host,
+                    ),
+                    MatchResult(
+                        last_device_node=None,
+                        last_host_node=None,
+                        best_match_node=None,
+                        device_indices=torch.arange(64),
+                        host_hit_length=0,
+                    ),
+                ]
+                req.init_next_round_input(cache)
+                self.assertEqual(len(req.prefix_indices), 64)
+                self.assertEqual(req.host_hit_length, 0)
+                self.assertEqual(cache.match_prefix.call_args.args[0].key.limit, 100)
+                self.assertEqual(cache.match_prefix.call_count, 2)
+
+    def test_page_rounded_rematch_can_cross_an_earlier_image(self):
+        """Re-matching must continue if page rounding lands in an earlier image."""
+        req = Req("images", "", array("q", range(800)), SamplingParams())
+        req.multimodal_inputs = SimpleNamespace(
+            mm_items=[
+                SimpleNamespace(
+                    is_image=lambda: True,
+                    offsets=[(100, 379), (400, 779)],
+                    model_specific_data={"types": [], "perm": []},
+                )
+            ]
+        )
+        cache = Mock()
+        cache.swa_reprefill_tail_tokens.return_value = 0
+        cache.supports_mamba.return_value = False
+        cache.match_prefix.side_effect = [
+            MatchResult(
+                last_device_node=None,
+                last_host_node=None,
+                best_match_node=None,
+                device_indices=torch.arange(length),
+                host_hit_length=0,
+            )
+            for length in (600, 256, 0)
+        ]
+        req.init_next_round_input(cache)
+        self.assertEqual(len(req.prefix_indices), 0)
+        self.assertEqual(cache.match_prefix.call_count, 3)
+        self.assertEqual(
+            [call.args[0].key.limit for call in cache.match_prefix.call_args_list[1:]],
+            [400, 100],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -94,6 +94,7 @@ class TestPrefillAdder(CustomTestCase):
         req.rid = str(rid)
         req.priority = priority
         req.prefix_indices = []
+        req.multimodal_inputs = None
         req.full_untruncated_fill_ids = []
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
@@ -474,6 +475,7 @@ class TestPrefillAdder(CustomTestCase):
 
         req = self.create_mock_req("chunked", priority=0, max_new_tokens=128)
         req.prefix_indices = []
+        req.multimodal_inputs = None
         req.full_untruncated_fill_ids = list(range(extend_input_len))
         # set_extend_range is the only writer of extend_range; the production
         # path reads req.extend_range.length right after calling it, so the mock
@@ -520,6 +522,49 @@ class TestPrefillAdder(CustomTestCase):
         self.assertIs(result, req)
         req.set_extend_range.assert_not_called()
         self.assertEqual(len(adder.can_run_list), 0)
+
+    @staticmethod
+    def _image_block(start, end):
+        return SimpleNamespace(
+            mm_items=[
+                SimpleNamespace(
+                    is_image=lambda: True,
+                    offsets=[(start, end - 1)],
+                    model_specific_data={"types": [], "perm": []},
+                )
+            ]
+        )
+
+    def test_image_chunk_shrinks_within_swa_budget(self):
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=64,
+            rem_swa=320,
+            rem_chunk=1024,
+            extend_input_len=1000,
+        )
+        req.multimodal_inputs = self._image_block(100, 480)
+        self.assertIs(adder.add_chunked_req(req), req)
+        req.set_extend_range.assert_called_once_with(0, 100)
+        self.assertEqual(adder.can_run_list, [req])
+
+    def test_image_chunk_defers_without_submitting_zero_tokens(self):
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=64,
+            rem_swa=320,
+            rem_chunk=1024,
+            extend_input_len=1000,
+        )
+        req.multimodal_inputs = self._image_block(0, 380)
+        delayer = _RecordingDelayer(allow=True)
+        adder.prefill_delayer_single_pass = delayer
+        self.assertIs(adder.add_chunked_req(req), req)
+        req.set_extend_range.assert_not_called()
+        self.assertEqual(adder.can_run_list, [])
+        self.assertEqual(delayer.calls, [])
+        # A fresh iteration with sufficient space must make progress.
+        self.mock_token_allocator.swa_available_size.return_value = 2048
+        self.assertIsNone(adder.add_chunked_req(req))
+        req.set_extend_range.assert_called_once_with(0, 1000)
 
     def test_swa_budget_for_req(self):
         # budget = max(alloc - window, 0) + min(extend + max_new, window) + page,

--- a/test/registered/unit/models/test_deepseek_v4_vl_weights.py
+++ b/test/registered/unit/models/test_deepseek_v4_vl_weights.py
@@ -1,0 +1,82 @@
+"""Streaming and completeness checks for DeepSeek-V4 vision weights."""
+
+import unittest
+from itertools import chain
+
+import torch
+from torch import nn
+
+from sglang.srt.models.deepseek_v4_vl import DeepseekV4ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, stage="base-a", runner_config="cpu")
+
+
+class RecordingLanguageModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.names = []
+
+    def load_weights(self, weights):
+        for name, _ in weights:
+            self.names.append(name)
+
+
+class TestDeepseekV4VisionWeights(CustomTestCase):
+    def make_model(self, multimodal=True):
+        model = DeepseekV4ForCausalLM.__new__(DeepseekV4ForCausalLM)
+        nn.Module.__init__(model)
+        model.is_multimodal = multimodal
+        model._vision_weights_loaded = False
+        model.language_model = RecordingLanguageModel()
+        if multimodal:
+            model.vision = nn.Linear(2, 2, bias=False)
+            model.aligner = nn.Linear(2, 2, bias=False)
+            for name in model._SENTINEL_NAMES:
+                model.register_parameter(name, nn.Parameter(torch.empty(2)))
+        return model
+
+    def vision_weights(self, model):
+        return [(name, torch.ones_like(p)) for name, p in model.named_parameters()]
+
+    def test_streams_language_weights_across_checkpoint_shards(self):
+        model = self.make_model()
+        vision = self.vision_weights(model)
+
+        def shards():
+            yield iter([("model.first", torch.zeros(1)), *vision[:2]])
+            self.assertEqual(model.language_model.names, ["model.first"])
+            yield iter([("model.second", torch.zeros(1)), *vision[2:]])
+
+        model.load_weights(chain.from_iterable(shards()))
+        self.assertEqual(model.language_model.names, ["model.first", "model.second"])
+        for _, param in model.named_parameters():
+            torch.testing.assert_close(param, torch.ones_like(param))
+
+    def test_missing_required_weights_fail(self):
+        for missing in ("vision.weight", "aligner.weight", "image_start"):
+            with self.subTest(missing=missing):
+                model = self.make_model()
+                weights = [
+                    (n, w) for n, w in self.vision_weights(model) if n != missing
+                ]
+                with self.assertRaisesRegex(ValueError, missing):
+                    model.load_weights(iter(weights))
+                self.assertFalse(model._vision_weights_loaded)
+
+    def test_text_only_checkpoint(self):
+        model = self.make_model(multimodal=False)
+        model.load_weights(iter([("model.weight", torch.zeros(1))]))
+        self.assertEqual(model.language_model.names, ["model.weight"])
+
+    def test_language_only_update_after_initial_load(self):
+        model = self.make_model()
+        model.load_weights(iter(self.vision_weights(model)))
+        model.load_weights(iter([("model.weight", torch.zeros(1))]))
+        self.assertEqual(model.language_model.names, ["model.weight"])
+        self.assertTrue(model._vision_weights_loaded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/multimodal/test_deepseek_v4_vl.py
+++ b/test/registered/unit/multimodal/test_deepseek_v4_vl.py
@@ -1,0 +1,154 @@
+"""Image layout and cache identity regressions for DeepSeek-V4 vision."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import torch
+from PIL import Image
+
+import sglang.srt.managers.mm_schedule as mm_schedule
+from sglang.srt.managers.mm_utils import hash_feature
+from sglang.srt.mem_cache.multimodal_cache import MultiModalStaticCache
+from sglang.srt.multimodal.processors.deepseek_v4_vl import (
+    IMAGE_PLACEHOLDER,
+    DeepseekV4VLImageProcessor,
+    build_image_block,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, stage="base-a", runner_config="cpu")
+
+
+class TestDeepseekV4Processor(CustomTestCase):
+    def process(self, text, *, grid=(12, 12), image=None):
+        processor = object.__new__(DeepseekV4VLImageProcessor)
+        processor.image_token_id = 100
+        processor.mm_tokens = None
+        processor._tokenizer = SimpleNamespace(
+            encode=Mock(side_effect=lambda s, **kw: [1] * len(s))
+        )
+        processor.load_mm_data = AsyncMock(
+            return_value=SimpleNamespace(
+                input_text=text, images=[image if image is not None else object()]
+            )
+        )
+        if image is None:
+            h, w = grid
+            processor._load_image = Mock(
+                return_value=(
+                    torch.zeros(h * w, 3, 14, 14, dtype=torch.bfloat16),
+                    h,
+                    w,
+                    (h + 2) // 3,
+                    (w + 2) // 3,
+                )
+            )
+        else:
+            processor.patch_size = 14
+            processor.downsample_ratio = 3
+            processor.max_n_token = 384
+            processor.min_pixels = 147456
+            processor.max_wh_ratio = 8
+        output = asyncio.run(processor.process_mm_data_async([], text, None, 8192))
+        return output
+
+    def test_compression_padding_changes_cache_identity(self):
+        a = self.process("a" + IMAGE_PLACEHOLDER)
+        b = self.process("ab" + IMAGE_PLACEHOLDER)
+        self.assertNotEqual(a.mm_items[0].hash, b.mm_items[0].hash)
+        self.assertEqual(
+            a.mm_items[0].hash, self.process("a" + IMAGE_PLACEHOLDER).mm_items[0].hash
+        )
+
+    def equal_length_layouts(self):
+        # Both inputs survive production preprocessing unchanged: 756 patches
+        # and 105 block tokens, but different 2D positions and newline layouts.
+        return [
+            self.process(IMAGE_PLACEHOLDER, image=Image.new("RGB", size, "red"))
+            for size in [(378, 392), (252, 588)]
+        ]
+
+    def test_equal_length_grids_have_distinct_cache_and_prefix_identity(self):
+        """Feature-only hashing aliases valid grids despite the length guard."""
+        a, b = self.equal_length_layouts()
+        x, y = a.mm_items[0], b.mm_items[0]
+        self.assertEqual(x.feature.shape, (756, 3, 14, 14))
+        self.assertTrue(torch.equal(x.feature, y.feature))
+        self.assertEqual(hash_feature(x.feature), hash_feature(y.feature))
+        self.assertEqual(len(a.input_ids), 105)
+        self.assertEqual(len(b.input_ids), 105)
+        self.assertNotEqual(
+            x.model_specific_data["types"], y.model_specific_data["types"]
+        )
+        for item in (x, y):
+            item.set_pad_value()
+        self.assertNotEqual(x.hash, y.hash)
+        # These pad values replace the image spans in radix-cache token keys.
+        self.assertNotEqual(x.pad_value, y.pad_value)
+
+    def test_equal_length_grids_do_not_share_embeddings(self):
+        """Both batch deduplication and warm-cache hits must distinguish grids."""
+        a, b = [out.mm_items[0] for out in self.equal_length_layouts()]
+        for item in (a, b):
+            item.set_pad_value()
+
+        def encode(items):
+            return torch.cat(
+                [
+                    torch.tensor(item.model_specific_data["types"]).float().unsqueeze(1)
+                    for item in items
+                ]
+            )
+
+        embedder = Mock(side_effect=encode)
+
+        def get(items):
+            lengths = [len(item.model_specific_data["types"]) for item in items]
+            ids = torch.cat(
+                [torch.full((n,), item.pad_value) for item, n in zip(items, lengths)]
+            )
+            return mm_schedule.get_embedding_and_mask(
+                data_embedding_func=embedder,
+                embedding_items=items,
+                placeholder_tensor=torch.tensor([item.pad_value for item in items]),
+                input_ids=ids,
+                items_size=list(range(len(items) + 1)),
+                prefix_length=[0] * len(items),
+                extend_length=lengths,
+                items_offset_list=[item.offsets for item in items],
+            )[0]
+
+        for batched in (False, True):
+            with self.subTest(batched=batched), patch.object(
+                mm_schedule, "embedding_cache", MultiModalStaticCache(1 << 20)
+            ):
+                embedder.reset_mock()
+                actual = get([a, b]) if batched else torch.cat([get([a]), get([b])])
+                torch.testing.assert_close(actual, encode([a, b]), atol=0, rtol=0)
+                calls = embedder.call_count
+                torch.testing.assert_close(get([b]), encode([b]), atol=0, rtol=0)
+                self.assertEqual(embedder.call_count, calls)
+
+    def test_offsets_cover_exactly_the_emitted_block(self):
+        out = self.process("abc" + IMAGE_PLACEHOLDER + "tail")
+        item = out.mm_items[0]
+        start, end = item.offsets[0]
+        self.assertEqual((start, end + 1), (3, len(out.input_ids) - 4))
+        self.assertEqual(end - start + 1, len(item.model_specific_data["types"]))
+
+    def test_layout_permutation_covers_every_patch_once(self):
+        for h in range(1, 12):
+            for w in range(1, 12):
+                for start in range(4):
+                    types, perm = build_image_block(h, w, start)
+                    self.assertEqual(sorted(perm), list(range(h * w)))
+                    self.assertEqual(types.count(2), h * w)
+                    self.assertEqual(types[3 - start], 0)
+                    self.assertEqual(types[-1], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add inference support for DeepSeek-V4-Flash-Vision-Exp.

## What

- ViT + aligner (`deepseek_v4_vit.py`) and an mm processor reproducing the reference image preprocessing and sentinel-block token layout.
- VL wrapper registered under the shared `DeepseekV4ForCausalLM` arch (MiMo-V2 style conditional vision); text-only checkpoints unaffected.
- Visible-window attention: image spans attend bidirectionally within the span during prefill (dsv4 backend, both flash_mla and sparse paths).
- MoE gate `bias_vl` routing for image tokens (hash and non-hash layers).
- Chat completions: updated vendored `encoding_dsv4` to the vision release with backward-compatible reasoning-effort profiles.

## Launch

```bash
python3 -m sglang.launch_server   --model-path deepseek-ai/DeepSeek-V4-Flash-Vision-Exp   --tp 8 --host 0.0.0.0 --port 30000 --mem-fraction-static 0.85
```

The engine auto-configures for this checkpoint: shared-experts fusion is auto-disabled with the flashinfer_mxfp4 MoE runner (HashTopK + fused scaling factor rejects fused shared experts).

Chunked prefill and radix cache both stay enabled, with span-safety handled by the scheduler:

- Chunked prefill truncation points are span-aligned (`image_span_aligned_extend_end`), so an image span is always prefilled within a single extend (the chunk budget may be overshot by at most one span, a few hundred tokens).
- A radix match ending deep inside an image span is re-issued capped to the span start (`image_span_cut_point`), fully re-prefilling the span — the span's early raw KV is not retained beyond the SWA window, so reusing it would read garbage. Shallow mid-span matches (within one window of the span start) are safe and reuse normally; the visible window then extends into the cached prefix.

## Known limitations

- A prefix match ending right at/inside a span start region hits an SWA tombstone and degrades to a full re-prefill (safe, no incorrect reuse). Retaining an extra SWA window around cached span starts is a possible follow-up.
- HIP/unified-KV falls back to causal windows inside image spans (the 128-slot SWA ring cannot hold a widened window).
- MTP/DSpark speculative decoding with image batches is unverified.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->