### PR TITLE
[DSV4] Support DeepSeek-V4-Flash-Vision-Exp

### DIFF
--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -1111,7 +1111,9 @@ sgl-eval run aime25 \\
     // ====================================================================
     // Flash Vision is multimodal: the vision tower runs replicated on every
     // rank outside the CUDA graph, and images are prefilled with bidirectional
-    // attention inside each image's token block.
+    // attention inside each image's token block. DSPARK is validated with the
+    // tower; EAGLE/MTP is not (the draft head routes image tokens with the text
+    // bias). Prefill context parallelism is refused with the tower.
     {
       match: { hw: "gb300", variant: "flash-vision", quant: "fp4", strategy: "low-latency", nodes: "single" },
       verified: false,

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -156,6 +156,8 @@ sgl-eval run aime25 \\
   defaultAccuracy: {
     flash: { gpqa_pct: 88.1, aime25_pct: 95,   gsm8k_pct: 96.13 },
     pro:   { gpqa_pct: 90.1, aime25_pct: 97.5, gsm8k_pct: 96.13 },
+    // Only GSM8K has been measured for the vision checkpoint so far.
+    "flash-vision": { gsm8k_pct: 96.36 },
   },
 
   // The eval set rendered in the benchmark card + "⚡ Reproduce" (the engine
@@ -1116,7 +1118,7 @@ sgl-eval run aime25 \\
     // bias). Prefill context parallelism is refused with the tower.
     {
       match: { hw: "gb300", variant: "flash-vision", quant: "fp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -25,6 +25,7 @@ export const config = {
   variants: [
     { id: "flash", label: "Flash", subtitle: "284B" },
     { id: "flash-official", label: "Flash Official", subtitle: "284B · 0731" },
+    { id: "flash-vision", label: "Flash Vision", subtitle: "284B · multimodal" },
     { id: "pro",   label: "Pro",   subtitle: "1.6T" },
     { id: "pro-official", label: "Pro Official", subtitle: "1.6T · 0813" },
   ],
@@ -49,6 +50,7 @@ export const config = {
     "flash|fp8": "deepseek-ai/DeepSeek-V4-Flash",
     "flash|nvfp4": "nvidia/DeepSeek-V4-Flash-NVFP4",
     "flash-official|fp4": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "flash-vision|fp4": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
     "pro|fp4":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|fp8":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|nvfp4": "nvidia/DeepSeek-V4-Pro-NVFP4",
@@ -1107,6 +1109,57 @@ sgl-eval run aime25 \\
     // ====================================================================
     // GB300 + FP4
     // ====================================================================
+    // Flash Vision is multimodal: the vision tower runs replicated on every
+    // rank outside the CUDA graph, and images are prefilled with bidirectional
+    // attention inside each image's token block.
+    {
+      match: { hw: "gb300", variant: "flash-vision", quant: "fp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_mxfp4",
+        "--speculative-algorithm DSPARK",
+        "--mem-fraction-static 0.90",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "flash-vision", quant: "fp4", strategy: "balanced", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_mxfp4",
+        "--mem-fraction-static 0.85",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "flash-vision", quant: "fp4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [
+        "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320",
+      ],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--dp 4",
+        "--enable-dp-attention",
+        "--moe-a2a-backend megamoe",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
     {
       match: { hw: "gb300", variant: "flash-official", quant: "fp4", strategy: "low-latency", nodes: "single" },
       verified: true,

--- a/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import msgspec
 import torch
@@ -461,6 +461,214 @@ def build_causal_swa_page_indices(
     return torch.nn.functional.pad(
         swa_indices, (0, padded_width - swa_window), value=-1
     )
+
+
+def compute_image_visible_spans(
+    *,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    vocab_size: int,
+    compress_pad_to: int,
+    max_image_tokens: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-token visible counts inside each image block, for both directions.
+
+    DeepSeek-V4-Flash-Vision attends bidirectionally within one image's span --
+    the ``[IMAGE_START, IMAGE_END]`` range of its token block -- while the rest
+    of the sequence stays causal. This returns, per query token, how many tokens
+    of its own span sit to its left and to its right; both are 0 for a token
+    outside any span, which leaves it on the plain sliding window.
+
+    A block is a maximal run of multimodal placeholder tokens (their ids are pad
+    sentinels above ``vocab_size``) inside one request. Its leading
+    ``compress_pad_to`` alignment padding is *not* part of the span: the block
+    is laid out as ``pad* IMAGE_START ... IMAGE_END``, with the pad count fixed
+    by the block's own start position, so the span starts at a computable offset
+    into the run.
+
+    Both tensors are ``int32[num_tokens]``.
+    """
+    device = input_ids.device
+    num_tokens = input_ids.shape[0]
+    idx = torch.arange(num_tokens, dtype=torch.int32, device=device)
+    positions = positions.to(torch.int32)
+    is_image = input_ids >= vocab_size
+
+    # A run breaks on a non-image token and at a request boundary, which shows
+    # up as a position that does not continue the previous token's.
+    prev_is_image = torch.cat(
+        [torch.zeros(1, dtype=torch.bool, device=device), is_image[:-1]]
+    )
+    prev_pos = torch.cat([positions.new_zeros(1), positions[:-1]])
+    starts_run = is_image & (~prev_is_image | (positions != prev_pos + 1))
+    next_is_image = torch.cat(
+        [is_image[1:], torch.zeros(1, dtype=torch.bool, device=device)]
+    )
+    next_pos = torch.cat([positions[1:], positions.new_zeros(1)])
+    ends_run = is_image & (~next_is_image | (next_pos != positions + 1))
+
+    run_start = torch.where(starts_run, idx, idx.new_full((), -1)).cummax(0)[0]
+    run_end = (
+        torch.where(ends_run, idx, idx.new_full((), num_tokens))
+        .flip(0)
+        .cummin(0)[0]
+        .flip(0)
+    )
+
+    block_start_pos = positions[run_start.clamp(min=0).to(torch.long)]
+    compress_pad = compress_pad_to - 1 - block_start_pos % compress_pad_to
+    span_start = run_start + compress_pad
+    in_span = is_image & (idx >= span_start)
+
+    left = torch.where(in_span, idx - span_start, idx.new_zeros(()))
+    right = torch.where(in_span, run_end - idx, idx.new_zeros(()))
+    return (
+        left.clamp_(min=0, max=max_image_tokens - 1),
+        right.clamp_(min=0, max=max_image_tokens),
+    )
+
+
+class BuildVisionSwaPageIndices:
+    """The sliding-window gather, widened where an image span is visible.
+
+    Same contract as :class:`BuildCausalSwaPageIndices` -- a per-query list of
+    SWA-pool slots plus the number of leading entries that are valid -- except
+    that a query inside an image span reaches back to the span's start and
+    forward to its end. The gathered range stays contiguous in position, so the
+    valid entries stay packed at the front.
+    """
+
+    @classmethod
+    def execute(cls, *args, **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
+        if _inputs_on_cuda(*args, **kwargs):
+            return cls.triton(*args, **kwargs)
+        return cls.torch(*args, **kwargs)
+
+    @classmethod
+    def torch(cls, **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
+        return build_vision_swa_page_indices(**kwargs)
+
+    @classmethod
+    def triton(cls, **kwargs) -> Tuple[torch.Tensor, torch.Tensor]:
+        return build_vision_swa_page_indices_triton(**kwargs)
+
+
+def _vision_window_extent(
+    seq_lens_casual: torch.Tensor,
+    visible_left: torch.Tensor,
+    visible_right: torch.Tensor,
+    swa_window: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """First visible position per query, and how many positions are visible."""
+    pos = seq_lens_casual.to(torch.int32) - 1
+    back = torch.clamp(visible_left, min=swa_window - 1)
+    back = torch.minimum(back, pos)
+    return pos - back, back + 1 + visible_right
+
+
+def build_vision_swa_page_indices(
+    *,
+    req_to_token: torch.Tensor,
+    full_to_swa_mapping: torch.Tensor,
+    req_pool_indices_repeated: torch.Tensor,
+    seq_lens_casual: torch.Tensor,
+    visible_left: torch.Tensor,
+    visible_right: torch.Tensor,
+    swa_window: int,
+    width: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    device = seq_lens_casual.device
+    first_pos, lengths = _vision_window_extent(
+        seq_lens_casual, visible_left, visible_right, swa_window
+    )
+    offsets = first_pos.unsqueeze(1) + torch.arange(
+        width, dtype=torch.int32, device=device
+    ).unsqueeze(0)
+    valid = torch.arange(width, dtype=torch.int32, device=device).unsqueeze(
+        0
+    ) < lengths.unsqueeze(1)
+    raw_indices = req_to_token[
+        req_pool_indices_repeated[:, None].to(torch.long),
+        torch.where(valid, offsets, offsets.new_zeros(())).to(torch.long),
+    ]
+    swa_indices = full_to_swa_mapping[raw_indices.to(torch.long)].to(torch.int32)
+    # -1 past topk_length, matching the triton path: the sentinel the attention
+    # kernel's index contract documents, rather than whatever the mapping holds
+    # for the slot the masked gather happened to read.
+    swa_indices = torch.where(valid, swa_indices, swa_indices.new_full((), -1))
+    return swa_indices, lengths
+
+
+@triton.jit
+def _vision_swa_page_indices_kernel(
+    req_to_token_ptr,
+    full_to_swa_ptr,
+    req_pool_ptr,
+    seq_lens_ptr,
+    visible_left_ptr,
+    visible_right_ptr,
+    out_ptr,
+    lengths_ptr,
+    rt_stride,
+    swa_window,
+    width,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    pos = tl.load(seq_lens_ptr + row).to(tl.int64) - 1
+    left = tl.load(visible_left_ptr + row).to(tl.int64)
+    right = tl.load(visible_right_ptr + row).to(tl.int64)
+    back = tl.minimum(tl.maximum(left, swa_window - 1), pos)
+    first_pos = pos - back
+    length = back + 1 + right
+    tl.store(lengths_ptr + row, length.to(tl.int32))
+
+    rp = tl.load(req_pool_ptr + row).to(tl.int64)
+    base = req_to_token_ptr + rp * rt_stride
+    out_base = out_ptr + row.to(tl.int64) * width
+
+    for k0 in range(0, width, BLOCK_K):
+        k = k0 + tl.arange(0, BLOCK_K)
+        kmask = k < width
+        off = first_pos + k.to(tl.int64)
+        valid = (k.to(tl.int64) < length) & kmask
+        full_loc = tl.load(base + tl.where(valid, off, 0), mask=valid, other=-1).to(
+            tl.int64
+        )
+        swa = tl.load(full_to_swa_ptr + full_loc, mask=valid, other=-1).to(tl.int32)
+        tl.store(out_base + k, tl.where(valid, swa, -1), mask=kmask)
+
+
+def build_vision_swa_page_indices_triton(
+    *,
+    req_to_token: torch.Tensor,
+    full_to_swa_mapping: torch.Tensor,
+    req_pool_indices_repeated: torch.Tensor,
+    seq_lens_casual: torch.Tensor,
+    visible_left: torch.Tensor,
+    visible_right: torch.Tensor,
+    swa_window: int,
+    width: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_qo_tokens = seq_lens_casual.size(0)
+    device = seq_lens_casual.device
+    out = torch.empty((num_qo_tokens, width), dtype=torch.int32, device=device)
+    lengths = torch.empty(num_qo_tokens, dtype=torch.int32, device=device)
+    _vision_swa_page_indices_kernel[(num_qo_tokens,)](
+        req_to_token,
+        full_to_swa_mapping,
+        req_pool_indices_repeated,
+        seq_lens_casual,
+        visible_left,
+        visible_right,
+        out,
+        lengths,
+        req_to_token.stride(0),
+        swa_window,
+        width,
+        BLOCK_K=256,
+    )
+    return out, lengths
 
 
 @triton.jit

--- a/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import msgspec
 import torch
@@ -463,68 +463,58 @@ def build_causal_swa_page_indices(
     )
 
 
-def compute_image_visible_spans(
+class ImageSpan(msgspec.Struct, frozen=True):
+    """One image block's bidirectionally-visible extent, in flat-batch rows.
+
+    ``left_origin`` is the row that ``visible_left`` counts from. It is below
+    ``row_start`` when the span opened in an earlier prefill chunk, and equal to
+    it when the span opens in this one.
+    """
+
+    row_start: int
+    row_end: int
+    left_origin: int
+
+
+def build_image_visible_spans(
     *,
-    input_ids: torch.Tensor,
-    positions: torch.Tensor,
-    vocab_size: int,
-    compress_pad_to: int,
+    spans: List[ImageSpan],
+    num_tokens: int,
     max_image_tokens: int,
+    device: torch.device,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Per-token visible counts inside each image block, for both directions.
+    """Per-token visible counts inside each image span, for both directions.
 
     DeepSeek-V4-Flash-Vision attends bidirectionally within one image's span --
     the ``[IMAGE_START, IMAGE_END]`` range of its token block -- while the rest
     of the sequence stays causal. This returns, per query token, how many tokens
     of its own span sit to its left and to its right; both are 0 for a token
-    outside any span, which leaves it on the plain sliding window.
+    outside every span, which leaves it on the plain sliding window.
 
-    A block is a maximal run of multimodal placeholder tokens (their ids are pad
-    sentinels above ``vocab_size``) inside one request. Its leading
-    ``compress_pad_to`` alignment padding is *not* part of the span: the block
-    is laid out as ``pad* IMAGE_START ... IMAGE_END``, with the pad count fixed
-    by the block's own start position, so the span starts at a computable offset
-    into the run.
+    Spans arrive already resolved and clipped by the caller. Deliberately not
+    inferred from runs of placeholder ids in ``input_ids``: two images whose
+    blocks land next to each other form one run, and so do two requests whose
+    positions happen to be contiguous across a batch boundary -- either merge
+    would let one image attend into the next and push the gather length past the
+    indices row it addresses.
 
     Both tensors are ``int32[num_tokens]``.
     """
-    device = input_ids.device
-    num_tokens = input_ids.shape[0]
-    idx = torch.arange(num_tokens, dtype=torch.int32, device=device)
-    positions = positions.to(torch.int32)
-    is_image = input_ids >= vocab_size
-
-    # A run breaks on a non-image token and at a request boundary, which shows
-    # up as a position that does not continue the previous token's.
-    prev_is_image = torch.cat(
-        [torch.zeros(1, dtype=torch.bool, device=device), is_image[:-1]]
-    )
-    prev_pos = torch.cat([positions.new_zeros(1), positions[:-1]])
-    starts_run = is_image & (~prev_is_image | (positions != prev_pos + 1))
-    next_is_image = torch.cat(
-        [is_image[1:], torch.zeros(1, dtype=torch.bool, device=device)]
-    )
-    next_pos = torch.cat([positions[1:], positions.new_zeros(1)])
-    ends_run = is_image & (~next_is_image | (next_pos != positions + 1))
-
-    run_start = torch.where(starts_run, idx, idx.new_full((), -1)).cummax(0)[0]
-    run_end = (
-        torch.where(ends_run, idx, idx.new_full((), num_tokens))
-        .flip(0)
-        .cummin(0)[0]
-        .flip(0)
-    )
-
-    block_start_pos = positions[run_start.clamp(min=0).to(torch.long)]
-    compress_pad = compress_pad_to - 1 - block_start_pos % compress_pad_to
-    span_start = run_start + compress_pad
-    in_span = is_image & (idx >= span_start)
-
-    left = torch.where(in_span, idx - span_start, idx.new_zeros(()))
-    right = torch.where(in_span, run_end - idx, idx.new_zeros(()))
+    visible_left = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    visible_right = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    for span in spans:
+        width = span.row_end - span.row_start + 1
+        rows = slice(span.row_start, span.row_end + 1)
+        first_left = span.row_start - span.left_origin
+        visible_left[rows] = torch.arange(
+            first_left, first_left + width, dtype=torch.int32, device=device
+        )
+        visible_right[rows] = torch.arange(
+            width - 1, -1, -1, dtype=torch.int32, device=device
+        )
     return (
-        left.clamp_(min=0, max=max_image_tokens - 1),
-        right.clamp_(min=0, max=max_image_tokens),
+        visible_left.clamp_(max=max_image_tokens - 1),
+        visible_right.clamp_(max=max_image_tokens),
     )
 
 
@@ -558,12 +548,27 @@ def _vision_window_extent(
     visible_left: torch.Tensor,
     visible_right: torch.Tensor,
     swa_window: int,
+    width: int,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """First visible position per query, and how many positions are visible."""
+    """First visible position per query, and how many positions are visible.
+
+    ``visible_right`` must already be clipped so that ``pos + right`` stays
+    inside the query's own request -- the caller does that when it resolves the
+    spans, and only the caller knows where the request ends. Reaching past it
+    would gather ``req_to_token`` columns the request never wrote.
+
+    An exact span also keeps ``left + right`` inside one block, which bounds the
+    result by ``swa_window + max_image_tokens`` -- the gather's own width. The
+    clamp is the backstop for that one: a layout that broke the bound would
+    otherwise hand the attention kernel a topk_length past the end of its
+    indices row, and losing the far end of an image's forward reach beats
+    reading out of bounds.
+    """
     pos = seq_lens_casual.to(torch.int32) - 1
     back = torch.clamp(visible_left, min=swa_window - 1)
     back = torch.minimum(back, pos)
-    return pos - back, back + 1 + visible_right
+    lengths = (back + 1 + visible_right).clamp_(max=width)
+    return pos - back, lengths
 
 
 def build_vision_swa_page_indices(
@@ -579,7 +584,7 @@ def build_vision_swa_page_indices(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     device = seq_lens_casual.device
     first_pos, lengths = _vision_window_extent(
-        seq_lens_casual, visible_left, visible_right, swa_window
+        seq_lens_casual, visible_left, visible_right, swa_window, width
     )
     offsets = first_pos.unsqueeze(1) + torch.arange(
         width, dtype=torch.int32, device=device
@@ -620,7 +625,8 @@ def _vision_swa_page_indices_kernel(
     right = tl.load(visible_right_ptr + row).to(tl.int64)
     back = tl.minimum(tl.maximum(left, swa_window - 1), pos)
     first_pos = pos - back
-    length = back + 1 + right
+    # Same backstop as the torch path: never address past the indices row.
+    length = tl.minimum(back + 1 + right, width)
     tl.store(lengths_ptr + row, length.to(tl.int32))
 
     rp = tl.load(req_pool_ptr + row).to(tl.int64)

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sglang.srt.arg_groups.model_override_base import model_config_of
 from sglang.srt.arg_groups.overrides import (
     _deepseek_v4_kv_cache_dtype,
     declare_resolution,
     resolving_view,
     run_post_process_pass,
 )
+from sglang.srt.configs.model_config import is_deepseek_v4_vision
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
 
@@ -160,6 +162,18 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
     if not cfg.enable_prefill_cp:
         return
+
+    hf_config = model_config_of(server_args).hf_config
+    if is_deepseek_v4_vision(hf_config):
+        # CP round-robins tokens across ranks and reindexes the attention
+        # metadata afterwards, which the per-token image-span counts cannot
+        # follow. Serving anyway would put every image on the plain causal
+        # window with no diagnostic.
+        raise ValueError(
+            "DeepSeek-V4-Flash-Vision does not support prefill context "
+            "parallelism: image spans would silently lose their bidirectional "
+            "attention. Drop --enable-prefill-cp."
+        )
 
     if cfg.cp_strategy != "interleave":
         raise ValueError(

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -133,6 +133,7 @@ def handle_model_specific_adjustments(server_args: Any):
 
     if model_arch in [
         "DeepseekV4ForCausalLM",
+        "DeepseekV4VLForCausalLM",
     ]:
         from sglang.srt.arg_groups.deepseek_v4_hook import (
             apply_deepseek_v4_defaults,
@@ -323,6 +324,7 @@ def handle_model_specific_adjustments(server_args: Any):
 
     elif model_arch in [
         "DeepseekV4ForCausalLM",
+        "DeepseekV4VLForCausalLM",
     ]:
         from sglang.srt.arg_groups.deepseek_v4_hook import (
             validate_deepseek_v4_cp,

--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v4.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v4.py
@@ -1,6 +1,6 @@
 """Config-time override declarations for deepseek_v4.
 
-Architectures: DeepseekV4ForCausalLM.
+Architectures: DeepseekV4ForCausalLM, DeepseekV4VLForCausalLM.
 """
 
 import logging
@@ -17,7 +17,7 @@ from sglang.srt.runtime_context import get_platform
 logger = logging.getLogger(__name__)
 
 
-@_register_for("DeepseekV4ForCausalLM")
+@_register_for("DeepseekV4ForCausalLM", "DeepseekV4VLForCausalLM")
 def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
     """DeepSeek V4 attention/page/window/MoE-runner defaults (from
     arg_groups/deepseek_v4_hook.py). The kv-cache dtype and NPU split-backend

--- a/python/sglang/srt/arg_groups/moe_hook.py
+++ b/python/sglang/srt/arg_groups/moe_hook.py
@@ -436,6 +436,7 @@ def validate_deepep_v2_model_architecture(server_args: Any) -> None:
     validated_architectures = (
         "DeepseekV3ForCausalLM",
         "DeepseekV4ForCausalLM",
+        "DeepseekV4VLForCausalLM",
         "Qwen3MoeForCausalLM",
     )
     if architecture not in validated_architectures:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -910,7 +910,7 @@ def _deepseek_v4_kv_cache_dtype(view: Any) -> dict:
     result. The NPU split-backend writes stay in the hook."""
     hf_config = model_config_of(view).hf_config
     model_arch = hf_config.architectures[0]
-    if model_arch != "DeepseekV4ForCausalLM":
+    if model_arch not in ("DeepseekV4ForCausalLM", "DeepseekV4VLForCausalLM"):
         return {}
 
     kv_cache_dtype = view.kv_cache_dtype
@@ -946,6 +946,7 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
         "DeepseekV4ForCausalLM",
+        "DeepseekV4VLForCausalLM",
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -704,6 +704,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         "DeepseekV32ForCausalLM",
         "DeepseekV3ForCausalLM",
         "DeepseekV4ForCausalLM",
+        "DeepseekV4VLForCausalLM",
         "Glm4MoeForCausalLM",
         "Glm4MoeLiteForCausalLM",
         "GlmMoeDsaForCausalLM",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -464,9 +464,10 @@ class ModelConfig:
             # arch lists and the processor registry all agree. Draft
             # architectures are already resolved by _config_draft_model above
             # and carry no tower of their own.
-            if is_deepseek_v4_vision(self.hf_config) and self.hf_config.architectures[
-                0
-            ] == ("DeepseekV4ForCausalLM"):
+            arch = self.hf_config.architectures[0]
+            if arch == "DeepseekV4ForCausalLM" and is_deepseek_v4_vision(
+                self.hf_config
+            ):
                 self.hf_config.architectures[0] = "DeepseekV4VLForCausalLM"
                 logger.info(
                     "Detected the DeepSeek-V4 vision tower; loading arch "

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -159,12 +159,29 @@ def is_qwen3_5(config) -> bool:
     )
 
 
+DEEPSEEK_V4_MODEL_ARCHS = (
+    "DeepseekV4ForCausalLM",
+    "DeepseekV4VLForCausalLM",
+    "DeepseekV4ForCausalLMNextN",
+    "DeepseekV4ForCausalLMDSpark",
+)
+
+
 def is_deepseek_v4(config) -> bool:
-    return _hf_arch(config) in (
-        "DeepseekV4ForCausalLM",
-        "DeepseekV4ForCausalLMNextN",
-        "DeepseekV4ForCausalLMDSpark",
-    )
+    return _hf_arch(config) in DEEPSEEK_V4_MODEL_ARCHS
+
+
+def is_deepseek_v4_vision(config) -> bool:
+    """A DeepSeek-V4 checkpoint that also carries the vision tower.
+
+    Checked on the config rather than the architecture string, because the
+    checkpoint declares plain ``DeepseekV4ForCausalLM`` and only the
+    ``vision_*`` fields distinguish it. ``ModelConfig`` rewrites the
+    architecture to ``DeepseekV4VLForCausalLM`` once, on this test, and then
+    backfills ``vision_n_layers=0`` on the checkpoints that lack it -- so the
+    default here is only for the one call that runs before that backfill.
+    """
+    return is_deepseek_v4(config) and getattr(config, "vision_n_layers", 0) > 0
 
 
 def get_dsa_index_head_dim(config: PretrainedConfig) -> int:
@@ -441,6 +458,25 @@ class ModelConfig:
             if n_group is not None:
                 self.hf_config.topk_group = n_group
 
+            # DeepSeek-V4-Flash-Vision ships as plain "DeepseekV4ForCausalLM"
+            # and is told apart only by its vision_* fields. Rewrite the
+            # architecture once, here, so the model registry, the multimodal
+            # arch lists and the processor registry all agree. Draft
+            # architectures are already resolved by _config_draft_model above
+            # and carry no tower of their own.
+            if is_deepseek_v4_vision(self.hf_config) and self.hf_config.architectures[
+                0
+            ] == ("DeepseekV4ForCausalLM"):
+                self.hf_config.architectures[0] = "DeepseekV4VLForCausalLM"
+                logger.info(
+                    "Detected the DeepSeek-V4 vision tower; loading arch "
+                    "DeepseekV4VLForCausalLM."
+                )
+            # Give every DeepSeek-V4 config the field, so downstream code can
+            # read it directly whether or not the checkpoint has a tower.
+            if not hasattr(self.hf_config, "vision_n_layers"):
+                self.hf_config.vision_n_layers = 0
+
         # Handle hybrid NVFP4 moe (nvidia/DeepSeek-V4-Pro-NVFP4)
         self.nvfp4_moe_meta: Optional[dict] = None
         hybrid_quant_cfg = _quant_config_to_dict(
@@ -503,9 +539,11 @@ class ModelConfig:
         # vision_config to None, which presence alone would read as image-capable
         # (MuseGlimmerConfig's text-only layouts are one such case).
         # TODO: requires further polishing
-        self.is_image_understandable_model = (
-            self.is_multimodal
-            and getattr(self.hf_config, "vision_config", None) is not None
+        self.is_image_understandable_model = self.is_multimodal and (
+            getattr(self.hf_config, "vision_config", None) is not None
+            # DeepSeek-V4-Vision keeps its tower's fields flat in config.json
+            # rather than under a vision_config sub-config.
+            or is_deepseek_v4_vision(self.hf_config)
         )
 
         # Models expose audio_config at different nesting levels:
@@ -798,13 +836,7 @@ class ModelConfig:
             logger.debug(f"Hybrid swa model: {self.hf_config.architectures=}")
 
             self.is_deepseek_v4_arch = any(
-                arch
-                in [
-                    "DeepseekV4ForCausalLM",
-                    "DeepseekV4ForCausalLMNextN",
-                    "DeepseekV4ForCausalLMDSpark",
-                ]
-                for arch in self.hf_config.architectures
+                arch in DEEPSEEK_V4_MODEL_ARCHS for arch in self.hf_config.architectures
             )
 
             if not self.is_deepseek_v4_arch:
@@ -963,10 +995,8 @@ class ModelConfig:
             )
             # In transformers v5, rope_scaling is just rope_parameters.
             self._init_mla_scaling(self.hf_text_config.rope_scaling)
-        elif (
-            "DeepseekV4ForCausalLM" in self.hf_config.architectures
-            or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
-            or "DeepseekV4ForCausalLMDSpark" in self.hf_config.architectures
+        elif any(
+            arch in DEEPSEEK_V4_MODEL_ARCHS for arch in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
             self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
@@ -1886,6 +1916,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
 multimodal_model_archs = [
     "CLIPModel",
     "Cohere2VisionForConditionalGeneration",
+    "DeepseekV4VLForCausalLM",
     "DeepseekVL2ForCausalLM",
     "Ernie4_5_VLMoeForConditionalGeneration",
     "MiniMaxM3SparseForConditionalGeneration",
@@ -1958,9 +1989,7 @@ multimodal_model_archs = [
 ]
 
 piecewise_cuda_graph_disabled_model_archs = [
-    "DeepseekV4ForCausalLM",
-    "DeepseekV4ForCausalLMNextN",
-    "DeepseekV4ForCausalLMDSpark",
+    *DEEPSEEK_V4_MODEL_ARCHS,
     "Qwen3NextForCausalLM",
     "BailingMoeV2_5ForCausalLM",
     "LLaDAModelLM",
@@ -2119,9 +2148,7 @@ def is_hybrid_swa_model(
 
     hybrid_swa_archs = {
         "Llama4ForConditionalGeneration",
-        "DeepseekV4ForCausalLM",
-        "DeepseekV4ForCausalLMNextN",
-        "DeepseekV4ForCausalLMDSpark",
+        *DEEPSEEK_V4_MODEL_ARCHS,
         *SWA_SINK_ARCHS,
         *MIMO_V2_MODEL_ARCHS,
         "MiMoV2MTP",

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -24,6 +24,9 @@ dsml_token: str = "｜DSML｜"
 USER_SP_TOKEN = "<｜User｜>"
 ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
 LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+# One of these stands in for each image in the prompt; the multimodal processor
+# expands it into that image's block of placeholder tokens.
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
 
 # Task special tokens for internal classification tasks
 DS_TASK_SP_TOKENS = {
@@ -362,6 +365,8 @@ def render_message(
                 block_type = block.get("type")
                 if block_type == "text":
                     parts.append(block.get("text", ""))
+                elif block_type == "image":
+                    parts.append(IMAGE_PLACEHOLDER)
                 elif block_type == "tool_result":
                     tool_content = block.get("content", "")
                     if isinstance(tool_content, list):
@@ -369,6 +374,8 @@ def render_message(
                         for b in tool_content:
                             if b.get("type") == "text":
                                 text_parts.append(b.get("text", ""))
+                            elif b.get("type") == "image":
+                                text_parts.append(IMAGE_PLACEHOLDER)
                             else:
                                 text_parts.append(f"[Unsupported {b.get('type')}]")
                         tool_content = "\n\n".join(text_parts)
@@ -528,24 +535,22 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     }
                 )
         elif role == "user":
-            text_block = {"type": "text", "text": msg.get("content", "")}
+            # A multimodal turn arrives as content blocks; a text-only turn is
+            # wrapped into the one block shape the renderer consumes.
+            content_blocks = msg.get("content_blocks")
+            if content_blocks is None:
+                content_blocks = [{"type": "text", "text": msg.get("content", "")}]
             if (
                 merged
                 and merged[-1].get("role") == "user"
                 and "content_blocks" in merged[-1]
                 and merged[-1].get("task") is None
             ):
-                merged[-1]["content_blocks"].append(text_block)
+                merged[-1]["content_blocks"].extend(content_blocks)
             else:
-                new_msg = {
-                    "role": "user",
-                    "content": msg.get("content", ""),
-                    "content_blocks": [text_block],
-                }
-                # Preserve extra fields (task, wo_eos, mask, etc.)
-                for key in ("task", "wo_eos", "mask"):
-                    if key in msg:
-                        new_msg[key] = msg[key]
+                # Keep every message-level field (task, wo_eos, mask, tools, ...).
+                new_msg = msg
+                new_msg["content_blocks"] = content_blocks
                 merged.append(new_msg)
         else:
             merged.append(msg)
@@ -597,6 +602,86 @@ def sort_tool_results_by_call_order(
                 msg["content_blocks"] = new_blocks
 
     return messages
+
+
+# ============================================================
+# Multimodal Preprocessing
+# ============================================================
+
+
+def _replace_image_blocks(blocks: List[Any]) -> Tuple[List[Any], int]:
+    """Turn each image block into a placeholder text block, counting them.
+
+    The payloads are already out: ``serving_chat`` collected them into the
+    request's ``image_data`` and left ``{"type": "image"}`` markers behind, in
+    prompt order. Nested ``tool_result`` content is walked so an image returned
+    by a tool keeps its place in the prompt.
+    """
+    new_blocks: List[Any] = []
+    count = 0
+    for block in blocks:
+        if not isinstance(block, dict):
+            new_blocks.append(block)
+            continue
+        block_type = block.get("type")
+        if block_type in ("image", "image_url", "input_image"):
+            new_blocks.append({"type": "text", "text": IMAGE_PLACEHOLDER})
+            count += 1
+        elif block_type == "tool_result" and isinstance(block.get("content"), list):
+            block = copy.copy(block)
+            block["content"], nested = _replace_image_blocks(block["content"])
+            new_blocks.append(block)
+            count += nested
+        elif block_type == "text":
+            text = block.get("text") or ""
+            if IMAGE_PLACEHOLDER in text:
+                raise ValueError(
+                    f"Text content contains the image placeholder token "
+                    f"{IMAGE_PLACEHOLDER}; pass images as image content blocks."
+                )
+            new_blocks.append(block)
+        else:
+            new_blocks.append(block)
+    return new_blocks, count
+
+
+def process_image_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Normalize image-carrying messages for the text renderer.
+
+    Returns the rewritten messages and the number of images they reference, so
+    the caller can check that against the request's image payloads.
+    """
+    processed: List[Dict[str, Any]] = []
+    total = 0
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        for field in ("content", "reasoning_content"):
+            value = msg.get(field)
+            if isinstance(value, str) and IMAGE_PLACEHOLDER in value:
+                raise ValueError(
+                    f"Message {field} contains the image placeholder token "
+                    f"{IMAGE_PLACEHOLDER}; pass images as image content blocks."
+                )
+
+        if isinstance(msg.get("content"), list) and "content_blocks" not in msg:
+            msg["content_blocks"] = msg.pop("content")
+
+        if msg.get("content_blocks"):
+            msg["content_blocks"], count = _replace_image_blocks(msg["content_blocks"])
+            total += count
+            if not isinstance(msg.get("content"), str):
+                # Roles the renderer reads as a flat string (system, assistant,
+                # developer) still need the placeholders inline.
+                msg["content"] = "\n\n".join(
+                    block.get("text", "")
+                    for block in msg["content_blocks"]
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+
+        processed.append(msg)
+    return processed, total
 
 
 # ============================================================

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -548,9 +548,15 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             ):
                 merged[-1]["content_blocks"].extend(content_blocks)
             else:
-                # Keep every message-level field (task, wo_eos, mask, tools, ...).
-                new_msg = msg
-                new_msg["content_blocks"] = content_blocks
+                new_msg = {
+                    "role": "user",
+                    "content": msg.get("content") or "",
+                    "content_blocks": content_blocks,
+                }
+                # Preserve extra fields (task, wo_eos, mask, etc.)
+                for key in ("task", "wo_eos", "mask"):
+                    if key in msg:
+                        new_msg[key] = msg[key]
                 merged.append(new_msg)
         else:
             merged.append(msg)

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1018,12 +1018,12 @@ class OpenAIServingChat(OpenAIServingBase):
             prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
         elif is_multimodal:
             # Standard VLMs render a text prompt (with placeholder strings) for the MM
-            # processor to tokenize. Inkling's custom encoder instead produces pre-rendered
-            # input_ids with single placeholders; pass those through so the MM processor
-            # expands them rather than re-tokenizing an empty prompt. Gated on the Inkling
-            # encoding spec so every other model keeps the standard text path.
+            # processor to tokenize. The Inkling and DeepSeek-V4 encoders instead produce
+            # pre-rendered input_ids with single placeholders; pass those through so the MM
+            # processor expands them rather than re-tokenizing an empty prompt. Gated on
+            # the encoding spec so every other model keeps the standard text path.
             if (
-                self.chat_encoding_spec == "inkling"
+                self.chat_encoding_spec in ("inkling", "dsv4")
                 and isinstance(processed_messages.prompt_ids, list)
                 and processed_messages.prompt_ids
             ):
@@ -1258,17 +1258,29 @@ class OpenAIServingChat(OpenAIServingBase):
             # dsv4/dsv32 encoding path
             messages = copy.deepcopy(messages)
 
-            # dsv4/dsv32 are text-only and consume string content; flatten
-            # OpenAI parts-list content here so the encoder sees a plain string.
+            # dsv32, and dsv4 without a vision tower, consume string content;
+            # flatten OpenAI parts-list content so the encoder sees a plain
+            # string. DeepSeek-V4-Vision instead keeps the parts list, so its
+            # encoder can put an image placeholder where each image was.
+            dsv4_multimodal = self.chat_encoding_spec == "dsv4" and is_multimodal
             for i, msg in enumerate(messages):
                 if isinstance(msg.get("content"), list):
                     messages[i] = process_content_for_template_format(
-                        msg, "string", [], [], [], []
+                        msg,
+                        "openai" if dsv4_multimodal else "string",
+                        image_data if dsv4_multimodal else [],
+                        video_data if dsv4_multimodal else [],
+                        audio_data if dsv4_multimodal else [],
+                        modalities if dsv4_multimodal else [],
                     )
 
             for msg in messages:
                 if msg.get("content") is None:
                     msg["content"] = ""
+                if dsv4_multimodal:
+                    # Already normalized above; a second pass would double-count
+                    # the images.
+                    continue
                 processed_msg = process_content_for_template_format(
                     msg,
                     template_content_format,
@@ -1310,6 +1322,16 @@ class OpenAIServingChat(OpenAIServingBase):
                     encoding_dsv4.attach_task_to_last_user_message(
                         messages, request.task
                     )
+                if dsv4_multimodal:
+                    messages, num_images = encoding_dsv4.process_image_messages(
+                        messages
+                    )
+                    if num_images != len(image_data):
+                        raise ValueError(
+                            f"Found {num_images} image content block(s) but "
+                            f"{len(image_data)} image payload(s); they must "
+                            "correspond one to one."
+                        )
                 real_input = encoding_dsv4.encode_messages(
                     messages,
                     thinking_mode=thinking_mode,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -34,7 +35,8 @@ from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     BuildPageTablePositions,
     BuildVisionSwaPageIndices,
     ExpandPrefillCausally,
-    compute_image_visible_spans,
+    ImageSpan,
+    build_image_visible_spans,
 )
 from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     BuildBlockSeqLensCausal,
@@ -70,9 +72,9 @@ from sglang.srt.layers.attention.verify_mask import (
     maybe_create_verify_mask,
 )
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.managers.schedule_batch import Modality, MultimodalInputs
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.multimodal.deepseek_v4_vl_image_processing import COMPRESS_PAD_TO
 from sglang.srt.runtime_context import (
     get_parallel,
     get_platform,
@@ -145,6 +147,65 @@ def _round_up(value: int, multiples_of: int) -> int:
     return -(-value // multiples_of) * multiples_of
 
 
+def collect_image_spans(
+    *,
+    mm_inputs: List[Optional[MultimodalInputs]],
+    extend_prefix_lens: Sequence[int],
+    extend_seq_lens: Sequence[int],
+    swa_window: int,
+) -> List[ImageSpan]:
+    """Each image block's bidirectional extent, clipped to what this chunk sees.
+
+    Block extents come from the multimodal items' own offsets, which are
+    absolute in the request's token sequence -- the same coordinate as
+    ``positions``, and kept there across a session prefix by
+    ``SessionController.adjust_mm_offsets``. The block's leading
+    alignment padding sits outside the span, so the span opens
+    ``compress_pad`` tokens into the block.
+
+    Two clips keep the gather inside KV that exists:
+
+    * forward, to this chunk's last token -- later tokens have no KV yet;
+    * backward, to the oldest SWA-resident token. The pool holds
+      ``extend_len + SWA_WINDOW - 1`` tokens back from the chunk's end (see
+      ``_build_sparse_prefill_chunk_cache``), so a span that opened in an
+      earlier chunk may no longer be reachable all the way to its start.
+    """
+    spans: List[ImageSpan] = []
+    row = 0
+    for index, mm_input in enumerate(mm_inputs):
+        prefix_len = extend_prefix_lens[index]
+        extend_len = extend_seq_lens[index]
+        if extend_len <= 0:
+            continue
+        if mm_input is None:
+            row += extend_len
+            continue
+        chunk_last = prefix_len + extend_len - 1
+        resident_first = max(0, prefix_len - (swa_window - 1))
+        for item in mm_input.mm_items:
+            if not item.is_modality(Modality.IMAGE) or item.offsets is None:
+                continue
+            compress_pad = int(item.compress_pad)
+            for block_start, block_end in item.offsets:
+                span_start = block_start + compress_pad
+                first = max(span_start, prefix_len)
+                last = min(block_end, chunk_last)
+                if first > last:
+                    continue
+                spans.append(
+                    ImageSpan(
+                        row_start=row + first - prefix_len,
+                        row_end=row + last - prefix_len,
+                        left_origin=(
+                            row + max(span_start, resident_first) - prefix_len
+                        ),
+                    )
+                )
+        row += extend_len
+    return spans
+
+
 def _pad_last_dim(x: T, multiples_of: int = PAGE_INDEX_ALIGNED_SIZE) -> T:
     if x is None:
         return None
@@ -199,6 +260,12 @@ class DSV4AttnMetadata:
     c128_out_loc: Optional[torch.Tensor] = None
     c128_page_indices: Optional[torch.Tensor] = None
     c128_topk_lengths_clamp1: Optional[torch.Tensor] = None
+
+    # This chunk's SWA gather was widened for DeepSeek-V4-Flash-Vision image
+    # spans. Host-side and set at construction; the sparse-prefill path reads it
+    # to route such a chunk elsewhere, since that path rebuilds its own
+    # per-request SWA gather and cannot express a per-token widening.
+    uses_vision_window: bool = False
 
     c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
@@ -766,33 +833,33 @@ class DeepseekV4AttnBackend(
         when the batch actually carries image tokens.
 
         Context parallelism is excluded: it round-robins tokens across ranks and
-        the metadata is reindexed afterwards, which would not line up with a
-        per-token mask derived from this rank's token order.
+        reindexes the metadata afterwards, which would not line up with
+        per-token counts derived from this rank's token order. ServerArgs
+        rejects the combination up front, so this is a second line of defence.
         """
         if not self.vision_max_image_tokens or forward_batch is None:
             return None
-        if forward_batch.input_ids is None or is_cp_v2_active(forward_batch):
-            return None
-        if not forward_batch.contains_mm_inputs():
+        if is_cp_v2_active(forward_batch) or not forward_batch.contains_mm_inputs():
             return None
 
-        input_ids = forward_batch.input_ids[:num_tokens]
-        positions = forward_batch.positions[:num_tokens]
-        visible_left, visible_right = compute_image_visible_spans(
-            input_ids=input_ids,
-            positions=positions,
-            vocab_size=self.model_runner.model_config.vocab_size,
-            compress_pad_to=COMPRESS_PAD_TO,
-            max_image_tokens=self.vision_max_image_tokens,
+        spans = collect_image_spans(
+            mm_inputs=forward_batch.mm_inputs,
+            extend_prefix_lens=forward_batch.extend_prefix_lens_cpu,
+            extend_seq_lens=forward_batch.extend_seq_lens_cpu,
+            swa_window=SWA_WINDOW,
         )
-        if padded_num_tokens > num_tokens:
-            visible_left = _pad_tensor_to_size(visible_left, padded_num_tokens)
-            visible_right = _pad_tensor_to_size(visible_right, padded_num_tokens)
+        if not spans:
+            return None
         print_info_once(
             "DeepSeek-V4 vision attention: widening the sliding-window gather to "
             f"{self.vision_swa_width} so image spans attend bidirectionally."
         )
-        return visible_left, visible_right
+        return build_image_visible_spans(
+            spans=spans,
+            num_tokens=max(padded_num_tokens, num_tokens),
+            max_image_tokens=self.vision_max_image_tokens,
+            device=self.device,
+        )
 
     def init_forward_metadata_prefill(
         self,
@@ -1829,7 +1896,7 @@ class DeepseekV4AttnBackend(
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
                 and not get_platform().is_sm120
-                and not self._uses_vision_window(core_attn_metadata)
+                and not core_attn_metadata.uses_vision_window
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
@@ -1899,20 +1966,6 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
-
-    def _uses_vision_window(self, core_attn_metadata: DSV4AttnMetadata) -> bool:
-        """Whether this chunk's SWA gather was widened for image spans.
-
-        The widened builder is the only one that emits exactly
-        ``vision_swa_width`` columns. The sparse-prefill path rebuilds its own
-        SWA gather from per-request geometry and so cannot express a per-token
-        widening; such a chunk takes flash_mla_with_kvcache, which consumes
-        swa_page_indices as built.
-        """
-        return (
-            self.vision_swa_width > 0
-            and core_attn_metadata.swa_page_indices.shape[-1] == self.vision_swa_width
-        )
 
     def _forward_prefill_sparse(
         self,
@@ -2309,7 +2362,12 @@ class DeepseekV4AttnBackend(
                 block_size=dspark_block_size,
             )
         elif image_visible is not None:
-            visible_left, visible_right = image_visible
+            # The gather runs one program per row of seq_lens_casual and reads
+            # the visible counts by that row, so they must cover it exactly.
+            num_queries = seq_lens_casual.shape[0]
+            visible_left, visible_right = (
+                _fit_tensor_to_size(tensor, num_queries) for tensor in image_visible
+            )
             swa_page_indices, swa_topk_lengths = BuildVisionSwaPageIndices.execute(
                 req_to_token=self.req_to_token,
                 full_to_swa_mapping=self.token_to_kv_pool.full_to_swa_index_mapping,
@@ -2334,6 +2392,7 @@ class DeepseekV4AttnBackend(
         page_table = prep.page_table
 
         core_attn_metadata = DSV4AttnMetadata(
+            uses_vision_window=image_visible is not None,
             page_size=self.page_size,
             raw_out_loc=out_loc,
             seq_lens_casual=seq_lens_casual,
@@ -2492,6 +2551,15 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
     def on_after_cuda_graph_warmup(self):
         for backend in self.attn_backends:
             backend.on_after_cuda_graph_warmup()
+
+
+def _fit_tensor_to_size(tensor: torch.Tensor, size: int) -> torch.Tensor:
+    """Zero-pad or truncate ``tensor``'s leading dim to exactly ``size``."""
+    if tensor.shape[0] == size:
+        return tensor
+    if tensor.shape[0] > size:
+        return tensor[:size]
+    return _pad_tensor_to_size(tensor, size)
 
 
 def _pad_tensor_to_size(tensor: torch.Tensor, size: int, *, value: int = 0):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -312,6 +312,9 @@ class DSV4AttnMetadata:
                 "c4_sparse_raw_indices",
             ],
             assign_fields=[
+                # Host-side; a graph-captured metadata is always built from a
+                # batch with no image spans, so this is False on both sides.
+                "uses_vision_window",
                 # Recomputed by the recorded init_forward_metadata_in_graph op
                 # each forward; not copied across replays.
                 "swa_out_cache_loc",
@@ -337,6 +340,7 @@ class DSV4AttnMetadata:
             "c4_sparse_topk_lengths",
         ]
         reference_assign_fields = [
+            "uses_vision_window",
             "page_table",
             "swa_page_indices",
             "swa_topk_lengths",

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -32,13 +32,16 @@ from sglang.kernels.ops.attention.dsv4.online_c128_mtp import OnlineC128MTPContr
 from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     BuildCausalSwaPageIndices,
     BuildPageTablePositions,
+    BuildVisionSwaPageIndices,
     ExpandPrefillCausally,
+    compute_image_visible_spans,
 )
 from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     BuildBlockSeqLensCausal,
     BuildDsparkSwaPageIndices,
     ComputeDsparkWindowGather,
 )
+from sglang.srt.configs.model_config import is_deepseek_v4_vision
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import (
     AttentionBackend,
@@ -69,6 +72,7 @@ from sglang.srt.layers.attention.verify_mask import (
 from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.multimodal.deepseek_v4_vl_image_processing import COMPRESS_PAD_TO
 from sglang.srt.runtime_context import (
     get_parallel,
     get_platform,
@@ -82,7 +86,7 @@ from sglang.srt.speculative.ragged_verify import (
     read_ragged_verify_mode,
     resolve_ragged_verify_layout,
 )
-from sglang.srt.utils import ceil_align, is_cuda, is_xpu
+from sglang.srt.utils import ceil_align, is_cuda, is_xpu, print_info_once
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -135,6 +139,10 @@ def _get_target_verify_bs(forward_batch: ForwardBatch) -> int:
 
 
 T = TypeVar("T", bound=Optional[torch.Tensor])
+
+
+def _round_up(value: int, multiples_of: int) -> int:
+    return -(-value // multiples_of) * multiples_of
 
 
 def _pad_last_dim(x: T, multiples_of: int = PAGE_INDEX_ALIGNED_SIZE) -> T:
@@ -618,6 +626,21 @@ class DeepseekV4AttnBackend(
             not _is_cuda or self.online_c128_mtp.enabled()
         )
 
+        # DeepSeek-V4-Flash-Vision attends bidirectionally inside an image's
+        # token block, so a query there gathers the plain window plus at most a
+        # whole block. 0 disables the widened path for text-only checkpoints.
+        hf_config = model_runner.model_config.hf_config
+        self.vision_max_image_tokens: int = (
+            hf_config.vision_max_n_token if is_deepseek_v4_vision(hf_config) else 0
+        )
+        self.vision_swa_width: int = (
+            _round_up(
+                SWA_WINDOW + self.vision_max_image_tokens, PAGE_INDEX_ALIGNED_SIZE
+            )
+            if self.vision_max_image_tokens
+            else 0
+        )
+
         self.is_dspark_draft = model_runner.is_draft_worker and spec_alg.is_dspark()
         self.is_draft_runner = model_runner.is_draft_worker
         self._verify_mask = None
@@ -729,6 +752,48 @@ class DeepseekV4AttnBackend(
             out_cache_loc=out_cache_loc,
         )
 
+    def _image_visible_spans(
+        self,
+        forward_batch: Optional[ForwardBatch],
+        num_tokens: int,
+        padded_num_tokens: int,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+        """Per-token image-span visibility for this prefill, or None.
+
+        None keeps the plain causal sliding window, which is what every
+        text-only batch wants. Returning spans widens the gather to
+        ``vision_swa_width`` for the whole batch, so it is worth paying only
+        when the batch actually carries image tokens.
+
+        Context parallelism is excluded: it round-robins tokens across ranks and
+        the metadata is reindexed afterwards, which would not line up with a
+        per-token mask derived from this rank's token order.
+        """
+        if not self.vision_max_image_tokens or forward_batch is None:
+            return None
+        if forward_batch.input_ids is None or is_cp_v2_active(forward_batch):
+            return None
+        if not forward_batch.contains_mm_inputs():
+            return None
+
+        input_ids = forward_batch.input_ids[:num_tokens]
+        positions = forward_batch.positions[:num_tokens]
+        visible_left, visible_right = compute_image_visible_spans(
+            input_ids=input_ids,
+            positions=positions,
+            vocab_size=self.model_runner.model_config.vocab_size,
+            compress_pad_to=COMPRESS_PAD_TO,
+            max_image_tokens=self.vision_max_image_tokens,
+        )
+        if padded_num_tokens > num_tokens:
+            visible_left = _pad_tensor_to_size(visible_left, padded_num_tokens)
+            visible_right = _pad_tensor_to_size(visible_right, padded_num_tokens)
+        print_info_once(
+            "DeepSeek-V4 vision attention: widening the sliding-window gather to "
+            f"{self.vision_swa_width} so image spans attend bidirectionally."
+        )
+        return visible_left, visible_right
+
     def init_forward_metadata_prefill(
         self,
         max_seq_len: int,
@@ -773,6 +838,9 @@ class DeepseekV4AttnBackend(
             is_prefill=True,
             dspark_block_size=dspark_block_size,
             num_tokens=num_tokens if cp_v2_active else None,
+            image_visible=self._image_visible_spans(
+                forward_batch, num_tokens, padded_num_tokens
+            ),
         )
         if cp_v2_active:
             core_attn_metadata.apply_cp_reindex(num_tokens=num_tokens)
@@ -1761,6 +1829,7 @@ class DeepseekV4AttnBackend(
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
                 and not get_platform().is_sm120
+                and not self._uses_vision_window(core_attn_metadata)
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
@@ -1830,6 +1899,20 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _uses_vision_window(self, core_attn_metadata: DSV4AttnMetadata) -> bool:
+        """Whether this chunk's SWA gather was widened for image spans.
+
+        The widened builder is the only one that emits exactly
+        ``vision_swa_width`` columns. The sparse-prefill path rebuilds its own
+        SWA gather from per-request geometry and so cannot express a per-token
+        widening; such a chunk takes flash_mla_with_kvcache, which consumes
+        swa_page_indices as built.
+        """
+        return (
+            self.vision_swa_width > 0
+            and core_attn_metadata.swa_page_indices.shape[-1] == self.vision_swa_width
+        )
 
     def _forward_prefill_sparse(
         self,
@@ -2194,6 +2277,7 @@ class DeepseekV4AttnBackend(
         is_prefill: bool = False,
         dspark_block_size: Optional[int] = None,
         num_tokens: Optional[int] = None,
+        image_visible: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> DSV4AttnMetadata:
         assert self.swa_page_size == SWA_WINDOW
 
@@ -2223,6 +2307,18 @@ class DeepseekV4AttnBackend(
                 req_pool_indices_repeated=req_pool_indices_repeated,
                 out_loc=out_loc,
                 block_size=dspark_block_size,
+            )
+        elif image_visible is not None:
+            visible_left, visible_right = image_visible
+            swa_page_indices, swa_topk_lengths = BuildVisionSwaPageIndices.execute(
+                req_to_token=self.req_to_token,
+                full_to_swa_mapping=self.token_to_kv_pool.full_to_swa_index_mapping,
+                req_pool_indices_repeated=req_pool_indices_repeated,
+                seq_lens_casual=seq_lens_casual,
+                visible_left=visible_left,
+                visible_right=visible_right,
+                swa_window=SWA_WINDOW,
+                width=self.vision_swa_width,
             )
         else:
             swa_page_indices = BuildCausalSwaPageIndices.execute(

--- a/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
+++ b/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 CP_DECODE_ATTN_TP_SUPPORTED_ARCHS: Tuple[str, ...] = (
     # DeepSeek-V4
     "DeepseekV4ForCausalLM",
+    "DeepseekV4VLForCausalLM",
     "DeepseekV4ForCausalLMNextN",
     "DeepseekV4ForCausalLMDSpark",
     # GLM-5.x (inherits DeepseekV2 attention; DSA path)

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -142,13 +142,7 @@ class HashTopK(nn.Module):
     def _forward_torch(
         self, router_logits: torch.Tensor, input_ids: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.score_func == "softmax":
-            scores = router_logits.softmax(dim=-1)
-        elif self.score_func == "sigmoid":
-            scores = router_logits.sigmoid()
-        else:
-            scores = torch.nn.functional.softplus(router_logits).sqrt()
-
+        scores = self._scores(router_logits)
         num_token = scores.shape[0]
 
         topk_ids = torch.zeros(

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -43,9 +43,15 @@ class HashTopK(nn.Module):
         routed_scaling_factor=1.5,
         apply_routed_scaling_factor_on_output=False,
         layer_id: Optional[int] = None,
+        correction_bias_vl: Optional[torch.Tensor] = None,
     ):
         super().__init__()
         self.layer_id = layer_id
+        # DeepSeek-V4-Vision: image tokens do not hash-route at all -- they take
+        # the top-k of scores biased by this second routed-expert bias. Held as a
+        # plain attribute (not a submodule parameter) the way TopK holds the text
+        # bias: the owner is the gate.
+        self.correction_bias_vl = correction_bias_vl
 
         self.enable_waterfill = (
             num_fused_shared_experts > 0 and get_exec().moe.enable_waterfill
@@ -210,6 +216,46 @@ class HashTopK(nn.Module):
         else:
             return self._forward_torch(router_logits, input_ids)
 
+    def _scores(self, router_logits: torch.Tensor) -> torch.Tensor:
+        if self.score_func == "softmax":
+            return router_logits.softmax(dim=-1)
+        if self.score_func == "sigmoid":
+            return router_logits.sigmoid()
+        return torch.nn.functional.softplus(router_logits).sqrt()
+
+    def _route_image_tokens(
+        self,
+        router_logits: torch.Tensor,
+        image_mask: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ):
+        """Replace the hash routing of image-token rows with vision-biased top-k.
+
+        Only the routed columns are replaced. A fused shared-expert column, when
+        present, holds ``1 / routed_scaling_factor`` for every row once the
+        routed weights are renormalized, so it needs no per-row fixup.
+        """
+        assert self.correction_bias_vl is not None
+        scores = self._scores(router_logits)
+        num_routed = self.topk - self.num_fused_shared_experts
+        vl_ids = (scores + self.correction_bias_vl.to(scores.dtype)).topk(
+            num_routed, dim=-1, sorted=False
+        )[1]
+        vl_weights = scores.gather(1, vl_ids)
+        if self.score_func != "softmax":
+            vl_weights = vl_weights / vl_weights.sum(dim=-1, keepdim=True)
+
+        mask = image_mask.unsqueeze(-1)
+        routed = slice(None, num_routed)
+        topk_ids[:, routed] = torch.where(
+            mask, vl_ids.to(topk_ids.dtype), topk_ids[:, routed]
+        )
+        topk_weights[:, routed] = torch.where(
+            mask, vl_weights.to(topk_weights.dtype), topk_weights[:, routed]
+        )
+        return topk_weights, topk_ids
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -217,10 +263,18 @@ class HashTopK(nn.Module):
         input_ids: torch.Tensor,
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+        image_mask: Optional[torch.Tensor] = None,
     ):
         assert (
             input_ids.shape[0] == hidden_states.shape[0] == router_logits.shape[0]
         ), f"{input_ids.shape=} {hidden_states.shape=} {router_logits.shape=}"
+
+        if image_mask is not None:
+            # Image-token ids are multimodal pad sentinels far above the
+            # vocabulary; the table lookup would read out of bounds. Their rows
+            # are overwritten by _route_image_tokens below, so any in-range
+            # index will do.
+            input_ids = torch.where(image_mask, 0, input_ids)
 
         if _is_xpu:
             topk_weights, topk_ids = self._forward_xpu(router_logits, input_ids)
@@ -237,6 +291,10 @@ class HashTopK(nn.Module):
             )
         else:
             topk_weights, topk_ids = self._forward_torch(router_logits, input_ids)
+        if image_mask is not None:
+            topk_weights, topk_ids = self._route_image_tokens(
+                router_logits, image_mask, topk_weights, topk_ids
+            )
         if _is_hip or _is_npu:
             topk_weights = topk_weights.to(torch.float32)
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -691,9 +691,11 @@ class TopK(BaseFusedOp):
         """Route with a ``[num_tokens, num_experts]`` bias instead of the layer's.
 
         DeepSeek-V4-Vision picks between two routed-expert biases per token. No
-        fused top-k kernel accepts a per-token bias, so this forces the torch
-        selection path and its STANDARD output; the caller reaches for it only
-        on batches that carry image tokens.
+        fused top-k kernel accepts a per-token bias, so select_experts routes a
+        2-D one to biased_topk_per_token_bias_impl; pinning the output format
+        keeps a runner that would otherwise route internally from a single
+        bias off the BYPASSED path. The caller reaches for this only on batches
+        that carry image tokens.
         """
         assert correction_bias.dim() == 2, correction_bias.shape
         topk_output = select_experts(

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import math
 from dataclasses import dataclass
@@ -678,6 +679,38 @@ class TopK(BaseFusedOp):
                 )
         return self._apply_waterfill(topk_output, hidden_states.shape[0])
 
+    def forward_per_token_correction_bias(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        correction_bias: torch.Tensor,
+        *,
+        num_token_non_padded: Optional[torch.Tensor] = None,
+        expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    ) -> TopKOutput:
+        """Route with a ``[num_tokens, num_experts]`` bias instead of the layer's.
+
+        DeepSeek-V4-Vision picks between two routed-expert biases per token. No
+        fused top-k kernel accepts a per-token bias, so this forces the torch
+        selection path and its STANDARD output; the caller reaches for it only
+        on batches that carry image tokens.
+        """
+        assert correction_bias.dim() == 2, correction_bias.shape
+        topk_output = select_experts(
+            hidden_states=hidden_states,
+            layer_id=self.layer_id,
+            router_logits=router_logits,
+            topk_config=dataclasses.replace(
+                self.topk_config,
+                correction_bias=correction_bias,
+                output_format=TopKOutputFormat.STANDARD,
+                torch_native=False,
+            ),
+            num_token_non_padded=num_token_non_padded,
+            expert_location_dispatch_info=expert_location_dispatch_info,
+        )
+        return self._apply_waterfill(topk_output, hidden_states.shape[0])
+
     def forward_cpu(
         self,
         hidden_states: torch.Tensor,
@@ -1270,6 +1303,71 @@ def kimi_k2_biased_topk_impl(
 
     topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
     return topk_weights, topk_ids
+
+
+@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+def biased_topk_per_token_bias_impl(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    scoring_func: str = "sqrtsoftplus",
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+):
+    """Biased top-k where ``correction_bias`` is per token, ``[num_tokens, E]``.
+
+    DeepSeek-V4-Vision carries two routed-expert biases and picks between them
+    per token (image tokens take ``e_score_correction_bias_vl``). Every fused
+    biased-topk kernel takes a single ``[E]`` bias, so batches that actually
+    contain image tokens come through here; text-only batches keep the fused
+    path. Otherwise identical to :func:`biased_topk_impl`, including that the
+    bias shifts selection only while the weights come from unbiased scores.
+    """
+    if scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    elif scoring_func == "sqrtsoftplus":
+        scores = torch.nn.functional.softplus(gating_output).sqrt()
+    else:
+        raise ValueError(
+            f"per-token correction bias does not support scoring_func={scoring_func!r}"
+        )
+
+    num_token, num_experts = scores.shape
+    scores_for_choice = scores + correction_bias
+    _, topk_ids = torch.topk(
+        scores_for_choice,
+        k=topk,
+        dim=-1,
+        sorted=(True if num_fused_shared_experts > 0 else False),
+    )
+    topk_weights = scores.gather(1, topk_ids)
+
+    if num_fused_shared_experts:
+        topk_ids[:, -1] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(num_token,),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        if routed_scaling_factor is not None:
+            topk_weights[:, -1] = (
+                topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+            )
+
+    if renormalize:
+        topk_weights_sum = (
+            topk_weights.sum(dim=-1, keepdim=True, dtype=torch.float32)
+            if num_fused_shared_experts == 0
+            else topk_weights[:, :-1].sum(dim=-1, keepdim=True, dtype=torch.float32)
+        )
+        topk_weights = topk_weights / (topk_weights_sum + _RENORMALIZE_SUM_EPSILON)
+        if apply_routed_scaling_factor_on_output:
+            topk_weights *= routed_scaling_factor
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
 @torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
@@ -2329,7 +2427,23 @@ def select_experts(
         if has_per_rank_fused_shared_slots(num_fused_shared_experts)
         else num_fused_shared_experts
     )
-    if use_grouped_topk:
+    if correction_bias is not None and correction_bias.dim() == 2:
+        # Per-token routing bias: DeepSeek-V4-Vision only, and only on batches
+        # that carry image tokens.
+        assert (
+            not use_grouped_topk and custom_routing_function is None
+        ), "a per-token correction bias is only supported on the ungrouped top-k path"
+        topk_weights, topk_ids = biased_topk_per_token_bias_impl(
+            gating_output=router_logits,
+            correction_bias=correction_bias,
+            topk=num_routed_topk if _use_aiter else top_k,
+            renormalize=renormalize,
+            scoring_func=scoring_func,
+            num_fused_shared_experts=num_fused_shared_experts_for_gate,
+            routed_scaling_factor=routed_scaling_factor,
+            apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+        )
+    elif use_grouped_topk:
         assert topk_group is not None
         assert num_expert_group is not None
         if correction_bias is None:

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -624,6 +624,21 @@ def _embed_mm_inputs_with_split(
     return input_embeds, other_info
 
 
+def has_mm_inputs_to_embed(forward_batch: ForwardBatch) -> bool:
+    """Whether this forward has multimodal inputs that still need embedding.
+
+    A request keeps its ``multimodal_inputs`` until it finishes, so
+    ``contains_mm_inputs()`` alone stays true for every decode and
+    target-verify step after the prompt is embedded. Callers that key work off
+    "this batch carries image tokens" want this narrower test.
+    """
+    return (
+        not forward_batch.forward_mode.is_decode()
+        and not forward_batch.forward_mode.is_target_verify()
+        and forward_batch.contains_mm_inputs()
+    )
+
+
 def compute_mm_input_embeds(
     input_ids: torch.Tensor,
     forward_batch: ForwardBatch,
@@ -648,11 +663,7 @@ def compute_mm_input_embeds(
     Returns ``(input_embeds, extra_language_model_kwargs)``.
     """
     extra_kwargs: Dict[str, Any] = {}
-    if (
-        not forward_batch.forward_mode.is_decode()
-        and not forward_batch.forward_mode.is_target_verify()
-        and forward_batch.contains_mm_inputs()
-    ):
+    if has_mm_inputs_to_embed(forward_batch):
         mm_inputs_list = [
             mm_input for mm_input in forward_batch.mm_inputs if mm_input is not None
         ]

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -624,6 +624,123 @@ def _embed_mm_inputs_with_split(
     return input_embeds, other_info
 
 
+def compute_mm_input_embeds(
+    input_ids: torch.Tensor,
+    forward_batch: ForwardBatch,
+    embed_tokens: nn.Module,
+    multimodal_model: Optional[nn.Module] = None,
+    data_embedding_funcs: Dict[Modality, DataEmbeddingFunc] = None,
+    placeholder_tokens: Optional[dict[Modality, List[int]]] = None,
+    use_deepstack: Dict[Modality, bool] = {},
+) -> Tuple[torch.Tensor, Dict[str, Any]]:
+    """Build the language model's input embeddings for a (possibly) mm batch.
+
+    The embedding half of :func:`general_mm_embed_routine`, split out for models
+    whose language-model call needs more than ``(input_embeds, forward_batch)``
+    -- DeepSeek-V4's hash-routed MoE layers, for instance, also route on
+    ``input_ids``, so they cannot go through the routine's ``input_ids=None``
+    language-model call.
+
+    ``input_ids`` is clamped in place at multimodal positions (they hold pad
+    hashes far above the vocabulary); pass a copy if the caller still needs the
+    sentinels afterwards.
+
+    Returns ``(input_embeds, extra_language_model_kwargs)``.
+    """
+    extra_kwargs: Dict[str, Any] = {}
+    if (
+        not forward_batch.forward_mode.is_decode()
+        and not forward_batch.forward_mode.is_target_verify()
+        and forward_batch.contains_mm_inputs()
+    ):
+        mm_inputs_list = [
+            mm_input for mm_input in forward_batch.mm_inputs if mm_input is not None
+        ]
+        extend_prefix_lens = [
+            prefix_len
+            for i, prefix_len in enumerate(forward_batch.extend_prefix_lens_cpu)
+            if forward_batch.mm_inputs[i] is not None
+        ]
+        extend_seq_lens = [
+            seq_len
+            for i, seq_len in enumerate(forward_batch.extend_seq_lens_cpu)
+            if forward_batch.mm_inputs[i] is not None
+        ]
+        server_args = get_server_args()
+        # Makes VLM profiles directly attributable: this range includes
+        # encoder/ViT execution and multimodal feature placement, while
+        # the language model range below excludes both.
+        with torch.profiler.record_function("sglang.vlm.mm_embedding"):
+            if server_args and get_disagg().enable_adaptive_dispatch_to_encoder:
+                # Split by precomputed vs non-precomputed so get_embedding_and_mask only sees uniform batches
+                input_embeds, other_info = _embed_mm_inputs_with_split(
+                    mm_inputs_list=mm_inputs_list,
+                    extend_prefix_lens=extend_prefix_lens,
+                    extend_seq_lens=extend_seq_lens,
+                    input_ids=input_ids,
+                    forward_batch=forward_batch,
+                    input_embedding=embed_tokens,
+                    multimodal_model=multimodal_model,
+                    data_embedding_func_mapping=data_embedding_funcs,
+                    placeholder_tokens=placeholder_tokens,
+                    use_deepstack=use_deepstack,
+                )
+            else:
+                input_embeds, other_info = embed_mm_inputs(
+                    mm_inputs_list=mm_inputs_list,
+                    extend_prefix_lens=extend_prefix_lens,
+                    extend_seq_lens=extend_seq_lens,
+                    input_ids=input_ids,
+                    input_embedding=embed_tokens,
+                    multimodal_model=multimodal_model,
+                    data_embedding_func_mapping=data_embedding_funcs,
+                    placeholder_tokens=placeholder_tokens,
+                    use_deepstack=use_deepstack,
+                )
+
+        # add for qwen3_vl deepstack
+        if use_deepstack:
+            extra_kwargs["input_deepstack_embeds"] = other_info[
+                "input_deepstack_embeds"
+            ]
+        # Offload GPU features to CPU instead of discarding them to balance memory
+        # efficiency and data persistence.
+        # In chunked-prefill, a request is processed across multiple batches, and
+        # the original multimodal data must remain accessible until the entire
+        # prefill phase is complete. Since the multimodal embedding cache is
+        # best-effort, offloading to CPU ensures we have a reliable fallback
+        # if a cache miss occurs in subsequent chunks, while still freeing up
+        # critical GPU memory.
+        if mm_inputs_list:
+            for mm_input_obj in mm_inputs_list:
+                if mm_input_obj and hasattr(mm_input_obj, "mm_items"):
+                    for mm_item in mm_input_obj.mm_items:
+                        feature = getattr(mm_item, "feature", None)
+                        if isinstance(feature, torch.Tensor) and feature.is_cuda:
+                            mm_item.feature = feature.to("cpu", non_blocking=True)
+                        if get_disagg().language_only:
+                            precomputed_embeddings = getattr(
+                                mm_item, "precomputed_embeddings", None
+                            )
+                            if (
+                                isinstance(precomputed_embeddings, torch.Tensor)
+                                and precomputed_embeddings.is_cuda
+                                and not mm_item.keep_device_embedding
+                            ):
+                                mm_item.precomputed_embeddings = (
+                                    precomputed_embeddings.to("cpu", non_blocking=True)
+                                )
+        forward_batch.mm_inputs = None
+        forward_batch.mm_input_embeds = input_embeds
+    else:
+        input_embeds = embed_tokens(input_ids)
+    # Copy to pre-allocated buffer if available (for CUDA graph address stability)
+    if forward_batch.input_embeds is not None:
+        forward_batch.input_embeds.copy_(input_embeds)
+        input_embeds = forward_batch.input_embeds
+    return input_embeds, extra_kwargs
+
+
 def general_mm_embed_routine(
     input_ids: torch.Tensor,
     forward_batch: ForwardBatch,
@@ -652,96 +769,16 @@ def general_mm_embed_routine(
     assert hasattr(language_model, "get_input_embeddings")
     embed_tokens = language_model.get_input_embeddings()
     if not hasattr(language_model, "pp_group") or language_model.pp_group.is_first_rank:
-        if (
-            not forward_batch.forward_mode.is_decode()
-            and not forward_batch.forward_mode.is_target_verify()
-            and forward_batch.contains_mm_inputs()
-        ):
-            mm_inputs_list = [
-                mm_input for mm_input in forward_batch.mm_inputs if mm_input is not None
-            ]
-            extend_prefix_lens = [
-                prefix_len
-                for i, prefix_len in enumerate(forward_batch.extend_prefix_lens_cpu)
-                if forward_batch.mm_inputs[i] is not None
-            ]
-            extend_seq_lens = [
-                seq_len
-                for i, seq_len in enumerate(forward_batch.extend_seq_lens_cpu)
-                if forward_batch.mm_inputs[i] is not None
-            ]
-            server_args = get_server_args()
-            # Makes VLM profiles directly attributable: this range includes
-            # encoder/ViT execution and multimodal feature placement, while
-            # the language model range below excludes both.
-            with torch.profiler.record_function("sglang.vlm.mm_embedding"):
-                if server_args and get_disagg().enable_adaptive_dispatch_to_encoder:
-                    # Split by precomputed vs non-precomputed so get_embedding_and_mask only sees uniform batches
-                    input_embeds, other_info = _embed_mm_inputs_with_split(
-                        mm_inputs_list=mm_inputs_list,
-                        extend_prefix_lens=extend_prefix_lens,
-                        extend_seq_lens=extend_seq_lens,
-                        input_ids=input_ids,
-                        forward_batch=forward_batch,
-                        input_embedding=embed_tokens,
-                        multimodal_model=multimodal_model,
-                        data_embedding_func_mapping=data_embedding_funcs,
-                        placeholder_tokens=placeholder_tokens,
-                        use_deepstack=use_deepstack,
-                    )
-                else:
-                    input_embeds, other_info = embed_mm_inputs(
-                        mm_inputs_list=mm_inputs_list,
-                        extend_prefix_lens=extend_prefix_lens,
-                        extend_seq_lens=extend_seq_lens,
-                        input_ids=input_ids,
-                        input_embedding=embed_tokens,
-                        multimodal_model=multimodal_model,
-                        data_embedding_func_mapping=data_embedding_funcs,
-                        placeholder_tokens=placeholder_tokens,
-                        use_deepstack=use_deepstack,
-                    )
-
-            # add for qwen3_vl deepstack
-            if use_deepstack:
-                kwargs["input_deepstack_embeds"] = other_info["input_deepstack_embeds"]
-            # Offload GPU features to CPU instead of discarding them to balance memory
-            # efficiency and data persistence.
-            # In chunked-prefill, a request is processed across multiple batches, and
-            # the original multimodal data must remain accessible until the entire
-            # prefill phase is complete. Since the multimodal embedding cache is
-            # best-effort, offloading to CPU ensures we have a reliable fallback
-            # if a cache miss occurs in subsequent chunks, while still freeing up
-            # critical GPU memory.
-            if mm_inputs_list:
-                for mm_input_obj in mm_inputs_list:
-                    if mm_input_obj and hasattr(mm_input_obj, "mm_items"):
-                        for mm_item in mm_input_obj.mm_items:
-                            feature = getattr(mm_item, "feature", None)
-                            if isinstance(feature, torch.Tensor) and feature.is_cuda:
-                                mm_item.feature = feature.to("cpu", non_blocking=True)
-                            if get_disagg().language_only:
-                                precomputed_embeddings = getattr(
-                                    mm_item, "precomputed_embeddings", None
-                                )
-                                if (
-                                    isinstance(precomputed_embeddings, torch.Tensor)
-                                    and precomputed_embeddings.is_cuda
-                                    and not mm_item.keep_device_embedding
-                                ):
-                                    mm_item.precomputed_embeddings = (
-                                        precomputed_embeddings.to(
-                                            "cpu", non_blocking=True
-                                        )
-                                    )
-            forward_batch.mm_inputs = None
-            forward_batch.mm_input_embeds = input_embeds
-        else:
-            input_embeds = embed_tokens(input_ids)
-        # Copy to pre-allocated buffer if available (for CUDA graph address stability)
-        if forward_batch.input_embeds is not None:
-            forward_batch.input_embeds.copy_(input_embeds)
-            input_embeds = forward_batch.input_embeds
+        input_embeds, extra_kwargs = compute_mm_input_embeds(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            embed_tokens=embed_tokens,
+            multimodal_model=multimodal_model,
+            data_embedding_funcs=data_embedding_funcs,
+            placeholder_tokens=placeholder_tokens,
+            use_deepstack=use_deepstack,
+        )
+        kwargs.update(extra_kwargs)
     else:
         input_embeds = None
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -48,6 +48,7 @@ from sglang.srt.configs.model_config import (
     get_dsa_index_n_heads,
     get_dsa_index_topk,
     is_deepseek_dsa,
+    is_deepseek_v4_vision,
 )
 from sglang.srt.distributed import (
     divide,
@@ -510,7 +511,7 @@ class MoEGate(nn.Module):
         # checkpoint carries both biases on every layer -- including the
         # hash-routed ones, where the text bias goes unused because text tokens
         # there route by token-id lookup rather than by score.
-        vision_routing = getattr(config, "vision_n_layers", 0) > 0
+        vision_routing = is_deepseek_v4_vision(config)
         if config.topk_method == "noaux_tc" and (not is_hash_moe or vision_routing):
             self.e_score_correction_bias = _new_correction_bias()
         else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -110,7 +110,12 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     CombineInput,
     DispatchOutput,
 )
-from sglang.srt.layers.moe.topk import BypassedTopKOutput, TopK, TopKOutputFormat
+from sglang.srt.layers.moe.topk import (
+    BypassedTopKOutput,
+    TopK,
+    TopKOutput,
+    TopKOutputFormat,
+)
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -484,23 +489,35 @@ class MoEGate(nn.Module):
             torch.empty((config.n_routed_experts, config.hidden_size))
         )
 
-        if config.topk_method == "noaux_tc" and not is_hash_moe:
-            correction_bias_dtype = torch.float32
-            if quant_config is not None:
-                if _use_aiter and quant_config.get_name() in (
-                    "fp8",
-                    "compressed_tensors",
-                    "quark",
-                ):
-                    correction_bias_dtype = torch.bfloat16
+        correction_bias_dtype = torch.float32
+        if quant_config is not None:
+            if _use_aiter and quant_config.get_name() in (
+                "fp8",
+                "compressed_tensors",
+                "quark",
+            ):
+                correction_bias_dtype = torch.bfloat16
+
+        def _new_correction_bias() -> nn.Parameter:
             correction_bias = torch.empty(
                 (config.n_routed_experts), dtype=correction_bias_dtype
             )
             if quant_config is not None and quant_config.get_name() == "expert_pack":
                 correction_bias.zero_()
-            self.e_score_correction_bias = nn.Parameter(correction_bias)
+            return nn.Parameter(correction_bias)
+
+        # DeepSeek-V4-Vision routes image tokens with a second bias, and its
+        # checkpoint carries both biases on every layer -- including the
+        # hash-routed ones, where the text bias goes unused because text tokens
+        # there route by token-id lookup rather than by score.
+        vision_routing = getattr(config, "vision_n_layers", 0) > 0
+        if config.topk_method == "noaux_tc" and (not is_hash_moe or vision_routing):
+            self.e_score_correction_bias = _new_correction_bias()
         else:
             self.e_score_correction_bias = None
+        self.e_score_correction_bias_vl = (
+            _new_correction_bias() if vision_routing else None
+        )
         if _is_cpu and _is_cpu_amx_available:
             self.quant_method = PackWeightMethod(weight_names=["weight"])
         self.use_dsa = is_deepseek_dsa(config)
@@ -680,6 +697,7 @@ class DeepseekV2MoE(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
                 apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
                 layer_id=self.layer_id,
+                correction_bias_vl=self.gate.e_score_correction_bias_vl,
             )
         else:
             # Default: grouped noaux_tc top-k. Covers V3/V3.2/GLM-5/Glm4MoeLite.
@@ -949,6 +967,64 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states, forward_batch, input_ids_global=input_ids_global
             )
 
+    def _image_token_mask(
+        self, input_ids: Optional[torch.Tensor]
+    ) -> Optional[torch.Tensor]:
+        """Rows that belong to an image block, or None when routing is uniform.
+
+        DeepSeek-V4-Vision expands each image into a block of placeholder tokens
+        whose ids are multimodal pad sentinels, far above the vocabulary -- so
+        this is the same test the reference gate makes. The host-side
+        ``vision_expert_routing`` flag keeps text-only batches on the fused
+        single-bias top-k without a device sync on the mask.
+        """
+        if self.gate.e_score_correction_bias_vl is None or input_ids is None:
+            return None
+        if not get_forward().vision_expert_routing:
+            return None
+        return input_ids >= self.config.vocab_size
+
+    def _select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        *,
+        input_ids: Optional[torch.Tensor] = None,
+        num_token_non_padded: Optional[torch.Tensor] = None,
+        expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    ) -> TopKOutput:
+        image_mask = self._image_token_mask(input_ids)
+        if self.is_hash:
+            return self.topk(
+                hidden_states,
+                router_logits,
+                input_ids=input_ids,
+                num_token_non_padded=num_token_non_padded,
+                expert_location_dispatch_info=expert_location_dispatch_info,
+                image_mask=image_mask,
+            )
+        if image_mask is None:
+            return self.topk(
+                hidden_states,
+                router_logits,
+                num_token_non_padded=num_token_non_padded,
+                expert_location_dispatch_info=expert_location_dispatch_info,
+            )
+        # Image and text tokens take different routed-expert biases, so the
+        # selection needs a per-token one.
+        per_token_bias = torch.where(
+            image_mask.unsqueeze(-1),
+            self.gate.e_score_correction_bias_vl,
+            self.gate.e_score_correction_bias,
+        )
+        return self.topk.forward_per_token_correction_bias(
+            hidden_states,
+            router_logits,
+            per_token_bias,
+            num_token_non_padded=num_token_non_padded,
+            expert_location_dispatch_info=expert_location_dispatch_info,
+        )
+
     def forward_normal_dual_stream(
         self,
         hidden_states: torch.Tensor,
@@ -988,16 +1064,11 @@ class DeepseekV2MoE(nn.Module):
                 topk_config=self.topk.topk_config,
             )
         else:
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._select_experts(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
             )
         deferred_finalize = (
             has_shared_output
@@ -1104,16 +1175,11 @@ class DeepseekV2MoE(nn.Module):
                 )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._select_experts(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
             )
         else:
             pre_quant_input = None
@@ -1293,14 +1359,10 @@ class DeepseekV2MoE(nn.Module):
                         torch.cuda.current_stream().wait_event(shared_event)
                 else:
                     shared_output = self._forward_shared_experts(hidden_states)
-            topk_kwargs = (
-                {"input_ids": input_ids_global}
-                if getattr(self, "is_hash", False)
-                else {}
-            )
-            topk_output = self.topk(
+            topk_output = self._select_experts(
                 hidden_states,
                 router_logits,
+                input_ids=input_ids_global,
                 num_token_non_padded=forward_batch.num_token_non_padded,
                 expert_location_dispatch_info=(
                     ExpertLocationDispatchInfo.init_new(
@@ -1309,7 +1371,6 @@ class DeepseekV2MoE(nn.Module):
                     if not self.is_nextn
                     else None
                 ),
-                **topk_kwargs,
             )
         else:
             topk_output = self.topk.empty_topk_output(
@@ -1641,21 +1702,18 @@ class DeepseekV2MoE(nn.Module):
         router_logits = state.pop("router_logits")
         hidden_states = state.hidden_states_mlp_input
 
-        # Hash MoE layers (e.g. DeepSeek-V4) route on input_ids; forward_deepep
-        # passes them as a topk kwarg. The per-ubatch forward_batch.input_ids is
-        # already sliced+padded to match hidden_states rows (and equals the
-        # global ids under EP dp-attention). No-op for non-hash models.
-        topk_kwargs = {}
-        if getattr(self, "is_hash", False):
-            topk_kwargs["input_ids"] = state.forward_batch.input_ids
-
+        # Hash MoE layers (e.g. DeepSeek-V4) route on input_ids, and its vision
+        # variant also reads them for the image-token mask. The per-ubatch
+        # forward_batch.input_ids is already sliced+padded to match
+        # hidden_states rows (and equals the global ids under EP dp-attention).
         if router_logits is not None:
             with get_global_expert_distribution_recorder().with_current_layer(
                 self.layer_id
             ):
-                state.topk_output = self.topk(
-                    hidden_states=hidden_states,
-                    router_logits=router_logits,
+                state.topk_output = self._select_experts(
+                    hidden_states,
+                    router_logits,
+                    input_ids=state.forward_batch.input_ids,
                     num_token_non_padded=state.forward_batch.num_token_non_padded,
                     expert_location_dispatch_info=(
                         ExpertLocationDispatchInfo.init_new(
@@ -1664,7 +1722,6 @@ class DeepseekV2MoE(nn.Module):
                         if not self.is_nextn
                         else None
                     ),
-                    **topk_kwargs,
                 )
         else:
             state.topk_output = self.topk.empty_topk_output(

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -147,7 +147,13 @@ class DeepseekV4ModelNextN(nn.Module):
         cp_v2_active = is_cp_v2_active(forward_batch)
         use_prefill_cp = dsa_use_prefill_cp(forward_batch)
         if input_embeds is None:
-            hidden_states = self.embed_tokens(input_ids)
+            # Multimodal pad sentinels (MM_PAD_SHIFT_VALUE + hash) sit out of
+            # vocab; clamp so the gather stays in range. The draft gets an
+            # image's semantics from the target's hidden_states, so the
+            # embedding at those positions only shapes the proposal.
+            hidden_states = self.embed_tokens(
+                input_ids.clamp(min=0, max=self.config.vocab_size - 1)
+            )
         else:
             hidden_states = input_embeds
 

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -1,0 +1,413 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""DeepSeek-V4-Flash-Vision: the DeepSeek-V4 language model plus a vision tower.
+
+The checkpoint (``deepseek-ai/DeepSeek-V4-Flash-Vision-Exp``) is
+DeepSeek-V4-Flash with three additions, all of which live here:
+
+*   a 32-layer ViT with 2D RoPE and an aligner MLP that folds each
+    ``downsample_ratio``-squared block of ViT patches into one LLM token,
+    plus four learned framing embeddings (``image_start``, ``image_pad``,
+    ``image_newline``, ``image_end``);
+*   a second routed-expert bias, ``e_score_correction_bias_vl``, used for image
+    tokens in place of the text bias -- and, on the hash-routed layers, in place
+    of hash routing entirely; and
+*   bidirectional attention inside each image's token block.
+
+The vision tower is replicated on every rank: the checkpoint does not shard it,
+and at ~0.4B parameters it is negligible next to the 284B language model.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    compute_mm_input_embeds,
+)
+from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+from sglang.srt.multimodal.deepseek_v4_vl_image_processing import (
+    IMAGE,
+    IMAGE_END,
+    IMAGE_NEW_LINE,
+    IMAGE_PAD,
+    IMAGE_START,
+    NUM_IMAGE_SLOT_KINDS,
+)
+from sglang.srt.runtime_context import get_forward
+
+logger = logging.getLogger(__name__)
+
+
+def vision_rope_cos_sin(
+    n_h: int, n_w: int, dim: int, theta: float, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """2D RoPE tables for one ``n_h x n_w`` patch grid, row-major.
+
+    Each head's ``2 * dim`` rotary channels split in half: the first ``dim / 2``
+    frequencies encode the patch row, the second ``dim / 2`` the patch column.
+    Shapes are ``[n_h * n_w, 1, dim]`` so they broadcast over heads.
+    """
+    inv_freq = 1.0 / (
+        theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device).div_(dim))
+    )
+    hpos = torch.arange(n_h, device=device).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w, device=device).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+
+
+def _apply_vision_rope(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+class DeepseekV4VisionRMSNorm(nn.Module):
+    """The tower's own RMSNorm: fp32 weight and fp32 math, eps 1e-6.
+
+    Deliberately not :class:`sglang.srt.layers.layernorm.RMSNorm`; the tower's
+    eps is 1e-6 while the language model's ``rms_norm_eps`` is 1e-20, and the
+    checkpoint's reference implementation keeps this weight in fp32.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class DeepseekV4VisionPatchEmbed(nn.Module):
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.proj = nn.Linear(3 * config.vision_patch_size**2, config.vision_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x.flatten(1))
+
+
+class DeepseekV4VisionAttention(nn.Module):
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.n_heads = config.vision_n_heads
+        self.head_dim = config.vision_dim // config.vision_n_heads
+        self.wqkv = nn.Linear(config.vision_dim, 3 * config.vision_dim)
+        self.wo = nn.Linear(config.vision_dim, config.vision_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        seqlens: List[int],
+    ) -> torch.Tensor:
+        n = x.size(0)
+        q, k, v = (
+            t.view(n, self.n_heads, self.head_dim)
+            for t in self.wqkv(x).chunk(3, dim=-1)
+        )
+        q = _apply_vision_rope(q, cos, sin)
+        k = _apply_vision_rope(k, cos, sin)
+        # Attention is unmasked within an image and must not cross images, so it
+        # runs per image while every projection above and below stays batched
+        # across the whole request (that is where the tower's FLOPs are).
+        if len(seqlens) == 1:
+            o = F.scaled_dot_product_attention(
+                q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1)
+            ).transpose(0, 1)
+        else:
+            outs = []
+            offset = 0
+            for seqlen in seqlens:
+                sl = slice(offset, offset + seqlen)
+                outs.append(
+                    F.scaled_dot_product_attention(
+                        q[sl].transpose(0, 1),
+                        k[sl].transpose(0, 1),
+                        v[sl].transpose(0, 1),
+                    ).transpose(0, 1)
+                )
+                offset += seqlen
+            o = torch.cat(outs)
+        return self.wo(o.reshape(n, -1))
+
+
+class DeepseekV4VisionMLP(nn.Module):
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        # w1 emits the gate and up halves in one matmul.
+        self.w1 = nn.Linear(
+            config.vision_dim,
+            2 * config.vision_inter_dim,
+            bias=False,
+        )
+        self.w2 = nn.Linear(
+            config.vision_inter_dim,
+            config.vision_dim,
+            bias=False,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate, up = self.w1(x).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class DeepseekV4VisionBlock(nn.Module):
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.norm1 = DeepseekV4VisionRMSNorm(config.vision_dim)
+        self.attn = DeepseekV4VisionAttention(config)
+        self.norm2 = DeepseekV4VisionRMSNorm(config.vision_dim)
+        self.mlp = DeepseekV4VisionMLP(config)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        seqlens: List[int],
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin, seqlens)
+        return x + self.mlp(self.norm2(x))
+
+
+class DeepseekV4ViT(nn.Module):
+    """Full bidirectional attention over one image's patches, with 2D RoPE."""
+
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.rope_dim = config.vision_dim // config.vision_n_heads // 2
+        self.rope_theta = config.vision_rope_theta
+        self.patch_embed = DeepseekV4VisionPatchEmbed(config)
+        self.blocks = nn.ModuleList(
+            [DeepseekV4VisionBlock(config) for _ in range(config.vision_n_layers)]
+        )
+        self.norm = DeepseekV4VisionRMSNorm(config.vision_dim)
+
+    def forward(
+        self, patches: torch.Tensor, grids: List[Tuple[int, int]]
+    ) -> torch.Tensor:
+        """``patches`` is every image's patches concatenated; ``grids`` their dims."""
+        device = patches.device
+        tables = [
+            vision_rope_cos_sin(n_h, n_w, self.rope_dim, self.rope_theta, device)
+            for n_h, n_w in grids
+        ]
+        if len(tables) == 1:
+            cos, sin = tables[0]
+        else:
+            cos = torch.cat([t[0] for t in tables])
+            sin = torch.cat([t[1] for t in tables])
+        seqlens = [n_h * n_w for n_h, n_w in grids]
+
+        x = self.patch_embed(patches)
+        for block in self.blocks:
+            x = block(x, cos, sin, seqlens)
+        return self.norm(x)
+
+
+class DeepseekV4Aligner(nn.Module):
+    """Folds a ``r x r`` block of ViT patch features into one LLM-width token."""
+
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.downsample_ratio = config.vision_downsample_ratio
+        in_dim = config.vision_dim * self.downsample_ratio**2
+        self.w1 = nn.Linear(in_dim, config.hidden_size)
+        self.w2 = nn.Linear(config.hidden_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.downsample_ratio
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        # Pad right/bottom so the grid divides evenly; unfold then walks the
+        # r x r blocks row-major, matching the aligner's training layout.
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(x)))
+
+
+class DeepseekV4VisionModel(nn.Module):
+    """The tower, the aligner, and the four learned block-framing embeddings."""
+
+    def __init__(self, config: DeepSeekV4Config):
+        super().__init__()
+        self.config = config
+        self.vision = DeepseekV4ViT(config)
+        self.aligner = DeepseekV4Aligner(config)
+        self.image_start = nn.Parameter(torch.empty(config.hidden_size))
+        self.image_end = nn.Parameter(torch.empty(config.hidden_size))
+        self.image_newline = nn.Parameter(torch.empty(config.hidden_size))
+        self.image_pad = nn.Parameter(torch.empty(config.hidden_size))
+
+    def _slot_embeddings(self) -> torch.Tensor:
+        """The learned embedding per slot kind, indexable by slot type id.
+
+        The ``IMAGE`` row is filler -- every ``IMAGE`` slot is overwritten with
+        an aligner output -- but keeping it in the table lets the block be built
+        with a single gather.
+        """
+        table = [None] * NUM_IMAGE_SLOT_KINDS
+        table[IMAGE_START] = self.image_start
+        table[IMAGE_PAD] = self.image_pad
+        table[IMAGE] = self.image_pad
+        table[IMAGE_NEW_LINE] = self.image_newline
+        table[IMAGE_END] = self.image_end
+        return torch.stack(table)
+
+    def forward(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        """Embeddings for every slot of every item's image block, concatenated.
+
+        The returned rows cover the *whole* block -- framing, newline and
+        alignment-padding slots included -- because all of them are placeholder
+        positions in ``input_ids`` and must be filled by the scatter.
+        """
+        device = self.image_start.device
+        patches, grids = [], []
+        for item in items:
+            feature = item.feature
+            if not isinstance(feature, torch.Tensor):
+                feature = torch.as_tensor(feature)
+            patches.append(feature.to(device=device))
+            grids.append((int(item.n_vit_h), int(item.n_vit_w)))
+
+        patch_features = self.vision(
+            torch.cat(patches) if len(patches) > 1 else patches[0], grids
+        )
+
+        table = self._slot_embeddings()
+        blocks = []
+        offset = 0
+        for item, (n_vit_h, n_vit_w) in zip(items, grids):
+            num_patches = n_vit_h * n_vit_w
+            embeds = self.aligner(
+                patch_features[offset : offset + num_patches], n_vit_h, n_vit_w
+            )
+            offset += num_patches
+            types = torch.as_tensor(item.slot_types, device=device)
+            perm = torch.as_tensor(item.aligner_perm, device=device)
+            block = table[types]
+            block[types == IMAGE] = embeds[perm]
+            blocks.append(block)
+        return torch.cat(blocks) if len(blocks) > 1 else blocks[0]
+
+
+class DeepseekV4VLForCausalLM(DeepseekV4ForCausalLM):
+    """DeepSeek-V4 with the vision tower wired into the embedding path."""
+
+    def __init__(
+        self,
+        config: DeepSeekV4Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, quant_config=quant_config, prefix=prefix)
+        # The tower only lives on the rank that owns the embedding table, since
+        # that is the only rank whose input embeddings it contributes to.
+        if self.pp_group.is_first_rank:
+            self.vision_model = DeepseekV4VisionModel(config)
+        else:
+            self.vision_model = None
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        return self.vision_model(items)
+
+    def pad_input_ids(
+        self, input_ids: List[int], mm_inputs: MultimodalInputs
+    ) -> List[int]:
+        """Stamp each image block's per-image pad value over its placeholders.
+
+        The block is one contiguous placeholder run, so the whole span --
+        framing and alignment padding included -- takes the item's pad value.
+        Both the MoE's image-token mask and the attention backend's image spans
+        then read those out-of-vocabulary sentinels straight out of input_ids,
+        the same test the checkpoint's reference implementation makes.
+        """
+        return MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
+            input_ids, mm_inputs
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        # Read before embedding: compute_mm_input_embeds clears mm_inputs.
+        vision_routing = forward_batch.contains_mm_inputs()
+        if input_embeds is None and self.pp_group.is_first_rank:
+            # Embed here rather than through general_mm_embed_routine: the
+            # hash-routed MoE layers route on input_ids, so the language model
+            # cannot be called with input_ids=None. Feed the embedder a copy --
+            # it clamps multimodal pad sentinels in place, and both the MoE
+            # image mask and the attention backend's image spans read them.
+            input_embeds, _ = compute_mm_input_embeds(
+                input_ids=input_ids.clone(),
+                forward_batch=forward_batch,
+                embed_tokens=self.get_input_embeddings(),
+                multimodal_model=self,
+            )
+        with get_forward().scoped(vision_expert_routing=vision_routing):
+            return super().forward(
+                input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
+            )
+
+    def load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn: bool = False
+    ):
+        if self.vision_model is None:
+            # Only the first pipeline rank owns the tower.
+            weights = (
+                (name, weight)
+                for name, weight in weights
+                if not name.startswith(("vision.", "aligner.", "image_"))
+            )
+        return super().load_weights(weights, is_nextn=is_nextn)
+
+    @staticmethod
+    def remap_weight_name_to_dpsk_hf_format(
+        name: str,
+        is_nextn: bool = False,
+        num_hidden_layers: Optional[int] = None,
+    ) -> str:
+        if name.startswith(("vision.", "aligner.", "image_")):
+            # Keep the checkpoint's own names for the tower; the base remapper
+            # would rewrite .w1./.w2. into MLP projection names.
+            return "vision_model." + name
+        return DeepseekV4ForCausalLM.remap_weight_name_to_dpsk_hf_format(
+            name, is_nextn=is_nextn, num_hidden_layers=num_hidden_layers
+        )
+
+
+EntryClass = [DeepseekV4VLForCausalLM]

--- a/python/sglang/srt/models/deepseek_v4_vl.py
+++ b/python/sglang/srt/models/deepseek_v4_vl.py
@@ -27,6 +27,15 @@ DeepSeek-V4-Flash with three additions, all of which live here:
 
 The vision tower is replicated on every rank: the checkpoint does not shard it,
 and at ~0.4B parameters it is negligible next to the 284B language model.
+
+Speculative decoding: DSPARK is validated with the tower. EAGLE/MTP is not --
+the NextN draft head clamps the multimodal pad sentinels so it cannot fault, but
+it routes image tokens with the text bias and nothing exercises the combination,
+so its acceptance rate at image positions is unmeasured.
+
+Not supported with the tower: prefill context parallelism, which ServerArgs
+refuses -- it round-robins tokens and reindexes the attention metadata, which
+the per-token image-span counts cannot follow.
 """
 
 from __future__ import annotations
@@ -43,6 +52,7 @@ from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     compute_mm_input_embeds,
+    has_mm_inputs_to_embed,
 )
 from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
@@ -364,8 +374,13 @@ class DeepseekV4VLForCausalLM(DeepseekV4ForCausalLM):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-        # Read before embedding: compute_mm_input_embeds clears mm_inputs.
-        vision_routing = forward_batch.contains_mm_inputs()
+        # Read before embedding: compute_mm_input_embeds clears mm_inputs. The
+        # predicate is the embedding path's, so the two cannot drift: a request
+        # keeps its mm_inputs until it finishes, and every decode and
+        # target-verify step of one that once carried an image would otherwise
+        # drag the whole batch onto the unfused per-token-bias top-k for a mask
+        # that is uniformly false there.
+        vision_routing = has_mm_inputs_to_embed(forward_batch)
         if input_embeds is None and self.pp_group.is_first_rank:
             # Embed here rather than through general_mm_embed_routine: the
             # hash-routed MoE layers route on input_ids, so the language model

--- a/python/sglang/srt/multimodal/deepseek_v4_vl_image_processing.py
+++ b/python/sglang/srt/multimodal/deepseek_v4_vl_image_processing.py
@@ -1,0 +1,251 @@
+"""Image preprocessing for DeepSeek-V4-Flash-Vision.
+
+A faithful port of ``inference/image_processor.py`` from the
+``deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`` checkpoint. Kept free of any
+SGLang runtime imports so it can be unit-tested against the reference.
+
+Two things happen here:
+
+1.  **Resize solving.** The ViT sees ``patch_size``-aligned pixels; the aligner
+    then folds every ``downsample_ratio``-squared block of ViT patches into one
+    LLM token. ``solve_resize_ratio`` picks the largest aspect-preserving size
+    whose resulting LLM-token block fits ``vision_max_n_token``.
+
+2.  **Block layout.** One image does not occupy ``n_llm_h * n_llm_w`` contiguous
+    LLM tokens. It occupies a longer block, in a row-pair-interleaved order the
+    checkpoint calls the N-layout, framed by learned ``image_start`` /
+    ``image_end`` embeddings, with a learned ``image_newline`` closing every grid
+    row and learned ``image_pad`` filler for row/alignment padding.
+    ``build_image_block`` returns the per-slot ``types`` in final sequence order
+    plus ``perm``, which reorders the aligner's row-major output into the order
+    its ``IMAGE`` slots appear in that block.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+import msgspec
+import numpy as np
+import torch
+from PIL import Image, ImageOps
+
+# Slot kinds inside one image block, in final sequence order.
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+NUM_IMAGE_SLOT_KINDS = 5
+
+# Every image block starts on a multiple of this many tokens, so an image never
+# straddles a C4 compression group. Achieved with leading IMAGE_PAD slots.
+COMPRESS_PAD_TO = 4
+
+
+class DeepseekV4VisionParams(msgspec.Struct, frozen=True):
+    """The ``vision_*`` fields of the checkpoint's ``config.json``."""
+
+    patch_size: int = 14
+    downsample_ratio: int = 3
+    max_n_token: int = 384
+    min_pixels: int = 147456
+    # None disables the wide-image squash entirely.
+    max_wh_ratio: Optional[int] = 8
+
+    @classmethod
+    def from_hf_config(cls, hf_config) -> DeepseekV4VisionParams:
+        return cls(
+            patch_size=hf_config.vision_patch_size,
+            downsample_ratio=hf_config.vision_downsample_ratio,
+            max_n_token=hf_config.vision_max_n_token,
+            min_pixels=hf_config.vision_min_pixels,
+            max_wh_ratio=hf_config.vision_max_wh_ratio,
+        )
+
+
+def grid_tokens(
+    best_height: int, best_width: int, patch_size: int, downsample_ratio: int
+) -> Tuple[int, int, int]:
+    """LLM tokens an aligner grid occupies (N-layout, incl. row/align padding)."""
+    n_llm_h = math.ceil((best_height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((best_width // patch_size) / downsample_ratio)
+    num_tokens = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2 == 1:
+        num_tokens += n_llm_w + 1
+    num_tokens += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, num_tokens
+
+
+def solve_resize_ratio(
+    height: int,
+    width: int,
+    patch_size: int,
+    downsample_ratio: int,
+    max_n_token: int,
+) -> Tuple[int, int, int, int, int]:
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (max_n_token - 2) // (max_w + 1)
+        if max_h % 2 == 1:
+            max_h -= 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = ((max_n_token - 2) // max_h) - 1
+        assert max_w > 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    else:
+        max_w = math.floor(max_w_float)
+        max_h = math.floor(max_h_float)
+        if max_h % 2 == 1:
+            max_h -= 1
+        beta = min(
+            max_w * patch_size * downsample_ratio / width,
+            max_h * patch_size * downsample_ratio / height,
+        )
+        best_width = math.floor(width * beta / patch_size) * patch_size
+        best_height = math.floor(height * beta / patch_size) * patch_size
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    return n_llm_h, n_llm_w, best_height, best_width, num_tokens
+
+
+def safe_resize(
+    height: int,
+    width: int,
+    best_height: int,
+    best_width: int,
+    patch_size: int,
+    downsample_ratio: int,
+    max_n_token: int,
+) -> Tuple[int, int, int, int]:
+    # Reserve room for the worst-case leading COMPRESS_PAD_TO alignment padding
+    # so the whole block still fits the per-image token budget.
+    max_n_token -= COMPRESS_PAD_TO - 1
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    budget = max_n_token
+    while num_tokens > max_n_token:
+        n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, budget
+        )
+        budget -= 1
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+def _contain_size(size: Tuple[int, int], target: Tuple[int, int]) -> Tuple[int, int]:
+    """The size ``PIL.ImageOps.contain`` would resize ``size`` to (may be 0)."""
+    width, height = size
+    target_width, target_height = target
+    if width == 0 or height == 0:
+        return 0, 0
+    if target_width / width < target_height / height:
+        return target_width, round(height * target_width / width)
+    return round(width * target_height / height), target_height
+
+
+def preprocess_image(
+    image: Image.Image, params: DeepseekV4VisionParams
+) -> Tuple[torch.Tensor, int, int, int, int]:
+    """Transform one PIL image into ViT patches plus its ViT and LLM grid dims.
+
+    Returns ``(patches[n_vit_h * n_vit_w, 3, p, p] bf16, n_vit_h, n_vit_w,
+    n_llm_h, n_llm_w)``.
+    """
+    p = params.patch_size
+    image = image.convert("RGB")
+    width, height = image.size
+    if params.max_wh_ratio is not None and width > height * params.max_wh_ratio:
+        width = height * params.max_wh_ratio
+    if 0 < width * height < params.min_pixels:
+        ratio = (params.min_pixels / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / p) * p
+    best_height = math.ceil(height / p) * p
+    n_llm_h, n_llm_w, best_height, best_width = safe_resize(
+        height,
+        width,
+        best_height,
+        best_width,
+        p,
+        params.downsample_ratio,
+        params.max_n_token,
+    )
+    n_vit_h, n_vit_w = best_height // p, best_width // p
+    if (
+        params.max_wh_ratio is not None
+        and image.width >= params.max_wh_ratio * image.height
+    ):
+        # Extreme panoramas are squashed rather than letterboxed: padding one to
+        # the solved box would leave almost nothing but gray.
+        image = image.resize((best_width, best_height))
+    elif min(_contain_size(image.size, (best_width, best_height))) == 0:
+        # Only max_wh_ratio-wide images are squashed above, so an extremely tall
+        # one still reaches ImageOps.pad, where aspect-preserving containment
+        # rounds its width to 0 and PIL raises. Squash it like a panorama rather
+        # than fail the request (the reference implementation raises here).
+        image = image.resize((best_width, best_height))
+    else:
+        image = ImageOps.pad(image, (best_width, best_height), color=(127, 127, 127))
+    x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+    patches = (
+        x.reshape(3, n_vit_h, p, n_vit_w, p)
+        .permute(1, 3, 0, 2, 4)
+        .reshape(n_vit_h * n_vit_w, 3, p, p)
+    )
+    return patches.contiguous(), n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+def build_image_block(
+    n_llm_h: int, n_llm_w: int, start_pos: int
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
+    """Slot kinds in final sequence order, plus the aligner reorder and lead pad.
+
+    ``start_pos`` is the absolute token index the block begins at; it only
+    decides how many leading ``IMAGE_PAD`` slots align the block to
+    ``COMPRESS_PAD_TO``.
+
+    Returns ``(types[block_len], perm[n_llm_h * n_llm_w], compress_pad)`` where
+    ``types == IMAGE`` marks the slots fed from the aligner and ``perm`` maps
+    aligner row-major rows onto those slots in order.
+    """
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = rows // 2 * row_len % 2 * 2
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h
+        + [IMAGE_PAD] * (row_len * pad_h),
+        dtype=torch.int64,
+    )
+    # N-layout: walk the grid in row pairs, column-major inside each pair.
+    order = (
+        torch.arange(rows * row_len)
+        .view(rows // 2, 2, row_len)
+        .transpose(1, 2)
+        .reshape(-1)
+    )
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.int64)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w
+    ).view(n_llm_h, n_llm_w)
+    perm = image_idx[order]
+    perm = perm[perm >= 0]
+    types = torch.cat(
+        [
+            torch.full((compress_pad,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_START]),
+            types[order],
+            torch.full((pad_last,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_END]),
+        ]
+    )
+    return types, perm, compress_pad

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -107,7 +107,7 @@ class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
             next_image += 1
             # The block's own start position fixes how much leading alignment
             # padding it carries, so the expansion has to walk left to right.
-            slot_types, aligner_perm, _ = build_image_block(
+            slot_types, aligner_perm, compress_pad = build_image_block(
                 image["n_llm_h"], image["n_llm_w"], len(expanded)
             )
             start = len(expanded)
@@ -122,6 +122,11 @@ class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
                         "n_vit_w": image["n_vit_w"],
                         "slot_types": slot_types,
                         "aligner_perm": aligner_perm,
+                        # How far into the block the bidirectional span opens:
+                        # the leading alignment padding sits outside it. A
+                        # length, not a position, so it stays correct when a
+                        # session prefix shifts `offsets`.
+                        "compress_pad": compress_pad,
                     },
                 )
             )

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -1,0 +1,166 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Multimodal processor for DeepSeek-V4-Flash-Vision.
+
+The prompt arrives already tokenized -- DeepSeek-V4 renders chat through
+``entrypoints/openai/encoding_dsv4.py``, not a Jinja template -- with one
+``<|deepseek_image|>`` token per image. Each of those expands into that image's
+block of placeholder tokens, whose length depends both on the image's solved
+grid and on where the block starts (it is aligned to ``COMPRESS_PAD_TO``), so
+the expansion walks the token list left to right.
+
+Every slot of the block is a placeholder, framing and padding included: the
+model fills the whole block from :class:`DeepseekV4VisionModel`, which writes
+its learned ``image_start`` / ``image_pad`` / ``image_newline`` / ``image_end``
+embeddings into the non-content slots.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalProcessorOutput,
+)
+from sglang.srt.models.deepseek_v4_vl import DeepseekV4VLForCausalLM
+from sglang.srt.multimodal.deepseek_v4_vl_image_processing import (
+    DeepseekV4VisionParams,
+    build_image_block,
+    preprocess_image,
+)
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+logger = logging.getLogger(__name__)
+
+IMAGE_TOKEN = "<｜deepseek_image｜>"
+
+
+class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
+    models = [DeepseekV4VLForCausalLM]
+    prefer_tokenized_input = True
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.vision_params = DeepseekV4VisionParams.from_hf_config(hf_config)
+        image_token_id = self._tokenizer.convert_tokens_to_ids(IMAGE_TOKEN)
+        if image_token_id is None or image_token_id == self._tokenizer.unk_token_id:
+            raise ValueError(
+                f"{IMAGE_TOKEN} is missing from the tokenizer of "
+                f"{server_args.model_path}; this is not a DeepSeek-V4 vision "
+                "checkpoint."
+            )
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token=IMAGE_TOKEN, image_token_id=image_token_id
+        ).build(_processor)
+
+    def _preprocess_one(self, image) -> Dict[str, Any]:
+        patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = preprocess_image(
+            image, self.vision_params
+        )
+        return {
+            "patches": patches,
+            "n_vit_h": n_vit_h,
+            "n_vit_w": n_vit_w,
+            "n_llm_h": n_llm_h,
+            "n_llm_w": n_llm_w,
+        }
+
+    def build_items(
+        self, input_ids: List[int], preprocessed: List[Dict[str, Any]]
+    ) -> Tuple[List[int], List[MultimodalDataItem]]:
+        """Expand each image placeholder into its block; return ids and items."""
+        image_token_id = self.mm_tokens.image_token_id
+        num_placeholders = sum(1 for token in input_ids if token == image_token_id)
+        if num_placeholders != len(preprocessed):
+            raise ValueError(
+                f"prompt carries {num_placeholders} image placeholder token(s) "
+                f"but {len(preprocessed)} image(s) were provided; they must "
+                "correspond one to one."
+            )
+
+        expanded: List[int] = []
+        items: List[MultimodalDataItem] = []
+        next_image = 0
+        for token in input_ids:
+            if token != image_token_id:
+                expanded.append(token)
+                continue
+            image = preprocessed[next_image]
+            next_image += 1
+            # The block's own start position fixes how much leading alignment
+            # padding it carries, so the expansion has to walk left to right.
+            slot_types, aligner_perm, _ = build_image_block(
+                image["n_llm_h"], image["n_llm_w"], len(expanded)
+            )
+            start = len(expanded)
+            expanded.extend([image_token_id] * len(slot_types))
+            items.append(
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    feature=image["patches"],
+                    offsets=[(start, len(expanded) - 1)],
+                    model_specific_data={
+                        "n_vit_h": image["n_vit_h"],
+                        "n_vit_w": image["n_vit_w"],
+                        "slot_types": slot_types,
+                        "aligner_perm": aligner_perm,
+                    },
+                )
+            )
+        return expanded, items
+
+    async def process_mm_data_async(
+        self,
+        image_data: List[Union[str, bytes, Dict]],
+        input_text,
+        request_obj,
+        *args,
+        **kwargs,
+    ) -> Optional[MultimodalProcessorOutput]:
+        if request_obj.video_data or kwargs.get("audio_data"):
+            raise ValueError("DeepSeek-V4-Flash-Vision supports image input only")
+
+        input_ids = input_text
+        if not isinstance(input_ids, list):
+            input_ids = self._tokenizer.encode(input_ids)
+
+        base_output = await self.fast_load_mm_data(
+            prompt="",
+            multimodal_tokens=self.mm_tokens,
+            image_data=image_data,
+            return_text=False,
+            input_ids=input_ids,
+        )
+
+        loop = asyncio.get_running_loop()
+        preprocessed = await asyncio.gather(
+            *(
+                loop.run_in_executor(self.io_executor, self._preprocess_one, image)
+                for image in base_output.images
+            )
+        )
+
+        expanded_ids, items = self.build_items(list(input_ids), list(preprocessed))
+        return MultimodalProcessorOutput(
+            input_ids=expanded_ids,
+            mm_items=items,
+            im_token_id=self.mm_tokens.image_token_id,
+        )

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -606,6 +606,11 @@ class ForwardFlags:
         "fuse_mlp_allreduce": False,
         "mlp_reduce_scatter": False,
         "flashinfer_trtllm_bypass": False,
+        # This forward's token batch may contain image tokens, which route to
+        # routed experts through a second bias (DeepSeek-V4-Vision). Host-side
+        # so the MoE can keep its fused single-bias top-k for text-only batches
+        # without a device sync on the mask.
+        "vision_expert_routing": False,
     }
 
     # Read/written inside compiled graphs (vocab embedding, communicator,
@@ -620,6 +625,7 @@ class ForwardFlags:
             "fuse_mlp_allreduce",
             "mlp_reduce_scatter",
             "flashinfer_trtllm_bypass",
+            "vision_expert_routing",
         }
     )
 

--- a/test/manual/dsv4/test_dsv4_flash_vision_tp4.py
+++ b/test/manual/dsv4/test_dsv4_flash_vision_tp4.py
@@ -1,0 +1,172 @@
+"""DSV4-Flash-Vision 4-GPU server sanity (TP4): image understanding + text.
+
+Not CI-registered: the checkpoint is ~168 GB and the config below targets a
+single 4x GB300 node. Run it by hand after touching the vision tower, the
+image processor, the DeepSeek-V4 prompt encoder, or the vision attention
+window.
+"""
+
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+DSV4_FLASH_VISION_MODEL_PATH = "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp"
+
+# Test images with unambiguous, different subjects, so a single generation is
+# enough to tell "the tower ran and its output landed in the right tokens" from
+# "the model is describing noise", and to tell the two blocks apart.
+PHOTO_IMAGE_URL = (
+    "https://raw.githubusercontent.com/sgl-project/sgl-test-files"
+    "/refs/heads/main/images/man_ironing_on_back_of_suv.png"
+)
+TEXT_IMAGE_URL = (
+    "https://raw.githubusercontent.com/sgl-project/sgl-test-files"
+    "/refs/heads/main/images/ocr-text.png"
+)
+
+
+class TestDSV4FlashVisionTP4(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            DSV4_FLASH_VISION_MODEL_PATH,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--moe-runner-backend",
+                "flashinfer_mxfp4",
+                "--mem-fraction-static",
+                "0.85",
+                "--swa-full-tokens-ratio",
+                "0.1",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _chat(self, content, max_tokens=192):
+        response = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": DSV4_FLASH_VISION_MODEL_PATH,
+                "messages": [{"role": "user", "content": content}],
+                "max_tokens": max_tokens,
+                "temperature": 0.0,
+            },
+            timeout=600,
+        )
+        response.raise_for_status()
+        return response.json()["choices"][0]["message"]["content"]
+
+    def test_model_info_advertises_image_understanding(self):
+        info = requests.get(f"{self.base_url}/model_info", timeout=30).json()
+        self.assertEqual(info["architectures"], ["DeepseekV4VLForCausalLM"])
+        self.assertTrue(info["has_image_understanding"])
+
+    def test_text_only_request_still_works(self):
+        text = self._chat("What is the capital of France? Answer in one word.")
+        self.assertIn("paris", text.lower())
+
+    def test_single_image(self):
+        text = self._chat(
+            [
+                {"type": "image_url", "image_url": {"url": PHOTO_IMAGE_URL}},
+                {
+                    "type": "text",
+                    "text": "What vehicle is in this image? Answer with one word.",
+                },
+            ]
+        )
+        print(f"single image -> {text!r}")
+        self.assertIn("taxi", text.lower())
+
+    def test_two_images_in_one_prompt(self):
+        """Exercises multi-block expansion and per-block alignment padding.
+
+        Each block's leading padding depends on where the block starts, so a
+        second image is the first thing that can expose an expansion that only
+        happens to work at offset zero.
+        """
+        text = self._chat(
+            [
+                {"type": "text", "text": "First image:"},
+                {"type": "image_url", "image_url": {"url": PHOTO_IMAGE_URL}},
+                {"type": "text", "text": "Second image:"},
+                {"type": "image_url", "image_url": {"url": TEXT_IMAGE_URL}},
+                {
+                    "type": "text",
+                    "text": (
+                        "Which image is mostly text rather than a photograph? "
+                        "Answer 'first' or 'second'."
+                    ),
+                },
+            ]
+        )
+        print(f"two images -> {text!r}")
+        self.assertIn("second", text.lower())
+
+    def test_image_survives_a_long_text_prompt(self):
+        """An image inside a prompt long enough to be prefilled in chunks."""
+        filler = "The quick brown fox jumps over the lazy dog. " * 400
+        text = self._chat(
+            [
+                {"type": "text", "text": filler},
+                {"type": "image_url", "image_url": {"url": PHOTO_IMAGE_URL}},
+                {"type": "text", "text": filler},
+                {
+                    "type": "text",
+                    "text": (
+                        "Ignoring the filler text, what vehicle is in the image? "
+                        "Answer with one word."
+                    ),
+                },
+            ]
+        )
+        print(f"long prompt -> {text!r}")
+        self.assertIn("taxi", text.lower())
+
+    def test_image_prompt_is_stable_across_a_cache_hit(self):
+        """The second call hits the prefix cache and must still see the image.
+
+        Not an exact-string check: DeepSeek-V4's attention is not
+        batch-invariant, so a cached prefix can pick a different token among
+        near-ties even at temperature 0.
+        """
+        content = [
+            {"type": "image_url", "image_url": {"url": PHOTO_IMAGE_URL}},
+            {"type": "text", "text": "What vehicle is in this image? One word."},
+        ]
+        for _ in range(2):
+            self.assertIn("taxi", self._chat(content).lower())
+
+    def test_an_injected_image_placeholder_is_rejected(self):
+        response = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": DSV4_FLASH_VISION_MODEL_PATH,
+                "messages": [
+                    {"role": "user", "content": "<｜deepseek_image｜> describe"}
+                ],
+                "max_tokens": 8,
+            },
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
+++ b/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
@@ -8,6 +8,9 @@ the causal builder when no image tokens are present, its triton and torch paths
 agree, and a token in a span really does reach past the 128-token window.
 """
 
+import dataclasses
+import inspect
+import re
 import unittest
 
 import torch
@@ -20,6 +23,7 @@ from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     build_vision_swa_page_indices,
     build_vision_swa_page_indices_triton,
 )
+from sglang.srt.layers.attention.deepseek_v4_backend import DSV4AttnMetadata
 from sglang.srt.multimodal.deepseek_v4_vl_image_processing import COMPRESS_PAD_TO
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -148,6 +152,21 @@ class TestDeepseekV4VisionSwaGather(CustomTestCase):
             tail = indices[row, length:]
             if tail.numel():
                 self.assertEqual(int(tail.max()), -1, f"row {row} tail")
+
+    def test_copy_field_lists_cover_every_metadata_field(self):
+        """DSV4AttnMetadata.copy_ must name every field of the struct.
+
+        copy_metadata asserts that its three field lists partition the struct,
+        so a field added without being listed raises only on the CUDA-graph
+        replay path -- reachable with speculative decoding and easy to miss
+        otherwise. Checking the lists here fails at import cost instead.
+        """
+        all_fields = {field.name for field in dataclasses.fields(DSV4AttnMetadata)}
+        named = set(
+            re.findall(r'"([a-z0-9_]+)"', inspect.getsource(DSV4AttnMetadata.copy_))
+        )
+        self.assertEqual(all_fields - named, set(), "field(s) missing from copy_")
+        self.assertEqual(named - all_fields, set(), "copy_ names a non-field")
 
     def test_topk_length_never_exceeds_the_indices_row(self):
         """The clamp is what stands between a bad span and an out-of-bounds read.

--- a/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
+++ b/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
@@ -13,11 +13,12 @@ import unittest
 import torch
 
 from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
+    ImageSpan,
     _vision_window_extent,
     build_causal_swa_page_indices_triton,
+    build_image_visible_spans,
     build_vision_swa_page_indices,
     build_vision_swa_page_indices_triton,
-    compute_image_visible_spans,
 )
 from sglang.srt.multimodal.deepseek_v4_vl_image_processing import COMPRESS_PAD_TO
 from sglang.srt.utils import get_device
@@ -30,10 +31,6 @@ SWA_WINDOW = 128
 MAX_IMAGE_TOKENS = 384
 WIDTH = SWA_WINDOW + MAX_IMAGE_TOKENS
 PAGE_INDEX_ALIGNED_SIZE = 64
-VOCAB_SIZE = 129280
-# What MultimodalDataItem.pad_value looks like: MM_PAD_SHIFT_VALUE + a hash.
-PAD_SENTINEL = 1_000_000 + 5
-
 NUM_REQS, MAX_LEN, NUM_SLOTS = 8, 4096, 40000
 
 
@@ -62,31 +59,29 @@ class TestDeepseekV4VisionSwaGather(CustomTestCase):
         )
 
     def _image_batch(self, span_lens):
-        """One request: text, an image block per span length, text. Returns the
-        flat input_ids / positions plus each span's index range."""
-        input_ids, spans = [], []
-        for span_len in span_lens:
-            input_ids.extend((11, 12, 13))
-            compress_pad = COMPRESS_PAD_TO - 1 - len(input_ids) % COMPRESS_PAD_TO
-            start = len(input_ids) + compress_pad
-            input_ids.extend([PAD_SENTINEL] * (compress_pad + span_len))
-            spans.append((start, start + span_len - 1))
-            input_ids.extend((14, 15))
-        positions = torch.arange(len(input_ids), dtype=torch.int32, device=self.device)
-        return (
-            torch.tensor(input_ids, device=self.device),
-            positions,
-            spans,
-        )
+        """One request: text, then one image block per span length, then text.
 
-    def _spans(self, input_ids, positions):
-        return compute_image_visible_spans(
-            input_ids=input_ids,
-            positions=positions,
-            vocab_size=VOCAB_SIZE,
-            compress_pad_to=COMPRESS_PAD_TO,
+        Returns the flat-batch positions plus the visible counts the backend
+        would resolve from the items' offsets.
+        """
+        spans, cursor = [], 0
+        for span_len in span_lens:
+            cursor += 3  # leading text
+            compress_pad = COMPRESS_PAD_TO - 1 - cursor % COMPRESS_PAD_TO
+            row_start = cursor + compress_pad
+            row_end = row_start + span_len - 1
+            spans.append(
+                ImageSpan(row_start=row_start, row_end=row_end, left_origin=row_start)
+            )
+            cursor = row_end + 1 + 2  # trailing text
+        positions = torch.arange(cursor, dtype=torch.int32, device=self.device)
+        left, right = build_image_visible_spans(
+            spans=spans,
+            num_tokens=cursor,
             max_image_tokens=MAX_IMAGE_TOKENS,
+            device=self.device,
         )
+        return positions, left, right, spans
 
     def test_degenerates_to_the_causal_window_without_images(self):
         seq_lens = torch.randint(1, 2000, (600,), dtype=torch.int32, device=self.device)
@@ -116,8 +111,7 @@ class TestDeepseekV4VisionSwaGather(CustomTestCase):
             )
 
     def test_triton_matches_torch(self):
-        input_ids, positions, _ = self._image_batch((37, 200, 381, 5))
-        left, right = self._spans(input_ids, positions)
+        positions, left, right, _ = self._image_batch((37, 200, 381, 5))
         seq_lens = positions + 1
         reqs = torch.zeros_like(seq_lens)
         torch_indices, torch_lengths = self._vision(
@@ -130,16 +124,17 @@ class TestDeepseekV4VisionSwaGather(CustomTestCase):
         self.assertTrue(torch.equal(torch_indices, triton_indices))
 
     def test_gathered_slots_are_the_visible_positions(self):
-        input_ids, positions, _ = self._image_batch((37, 200))
-        left, right = self._spans(input_ids, positions)
+        positions, left, right, _ = self._image_batch((37, 200))
         seq_lens = positions + 1
         reqs = torch.zeros_like(seq_lens)
         indices, lengths = self._vision(
             build_vision_swa_page_indices_triton, seq_lens, reqs, left, right
         )
-        first_pos, extents = _vision_window_extent(seq_lens, left, right, SWA_WINDOW)
+        first_pos, extents = _vision_window_extent(
+            seq_lens, left, right, SWA_WINDOW, WIDTH
+        )
         self.assertTrue(torch.equal(lengths, extents))
-        for row in range(input_ids.numel()):
+        for row in range(positions.numel()):
             length = int(extents[row])
             wanted = torch.arange(
                 int(first_pos[row]),
@@ -154,16 +149,48 @@ class TestDeepseekV4VisionSwaGather(CustomTestCase):
             if tail.numel():
                 self.assertEqual(int(tail.max()), -1, f"row {row} tail")
 
+    def test_topk_length_never_exceeds_the_indices_row(self):
+        """The clamp is what stands between a bad span and an out-of-bounds read.
+
+        flash_mla_with_kvcache reads ``indices[0:topk_length]`` with no bound of
+        its own, so both builders must cap the length at the gather width even
+        when handed visible counts a correct span layout could not produce.
+        """
+        rows = 64
+        # Positions far enough in that the backward reach stays inside the
+        # request, and far enough from the end that the forward reach does too:
+        # clipping the reach to the sequence is the collector's job, and this
+        # test is about the width bound alone.
+        seq_lens = torch.full((rows,), 1200, dtype=torch.int32, device=self.device)
+        reqs = torch.zeros_like(seq_lens)
+        # Deliberately impossible for a real span: both directions maxed at once,
+        # so left + right exceeds one block.
+        left = torch.full(
+            (rows,), MAX_IMAGE_TOKENS - 1, dtype=torch.int32, device=self.device
+        )
+        right = torch.full(
+            (rows,), MAX_IMAGE_TOKENS, dtype=torch.int32, device=self.device
+        )
+        _, unclamped = _vision_window_extent(seq_lens, left, right, SWA_WINDOW, 1 << 30)
+        self.assertGreater(int(unclamped.max()), WIDTH)
+        for builder in (
+            build_vision_swa_page_indices,
+            build_vision_swa_page_indices_triton,
+        ):
+            with self.subTest(builder=builder.__name__):
+                indices, lengths = self._vision(builder, seq_lens, reqs, left, right)
+                self.assertEqual(indices.shape[-1], WIDTH)
+                self.assertLessEqual(int(lengths.max()), indices.shape[-1])
+
     def test_a_span_is_visible_in_both_directions(self):
         span_len = 381
         # The leading span puts the span under test past position SWA_WINDOW, so
         # its backward reach is the window rather than the start of the sequence.
-        input_ids, positions, spans = self._image_batch((200, span_len))
-        left, right = self._spans(input_ids, positions)
+        positions, left, right, spans = self._image_batch((200, span_len))
         first_pos, extents = _vision_window_extent(
-            positions + 1, left, right, SWA_WINDOW
+            positions + 1, left, right, SWA_WINDOW, WIDTH
         )
-        start, end = spans[1]
+        start, end = spans[1].row_start, spans[1].row_end
         self.assertGreater(start, SWA_WINDOW)
         # Backward reach is unchanged at the span's first token, but it now sees
         # forward all the way to IMAGE_END.

--- a/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
+++ b/test/registered/attention/test_deepseek_v4_vision_swa_gather.py
@@ -1,0 +1,180 @@
+"""The DeepSeek-V4-Flash-Vision sliding-window gather, widened over image spans.
+
+A query inside an image's ``[IMAGE_START, IMAGE_END]`` span attends across the
+whole span in both directions; everywhere else the window stays causal. The
+gather that expresses this feeds ``flash_mla_with_kvcache``'s ``indices`` /
+``topk_length``, so the properties worth pinning are: it degenerates exactly to
+the causal builder when no image tokens are present, its triton and torch paths
+agree, and a token in a span really does reach past the 128-token window.
+"""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
+    _vision_window_extent,
+    build_causal_swa_page_indices_triton,
+    build_vision_swa_page_indices,
+    build_vision_swa_page_indices_triton,
+    compute_image_visible_spans,
+)
+from sglang.srt.multimodal.deepseek_v4_vl_image_processing import COMPRESS_PAD_TO
+from sglang.srt.utils import get_device
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+SWA_WINDOW = 128
+MAX_IMAGE_TOKENS = 384
+WIDTH = SWA_WINDOW + MAX_IMAGE_TOKENS
+PAGE_INDEX_ALIGNED_SIZE = 64
+VOCAB_SIZE = 129280
+# What MultimodalDataItem.pad_value looks like: MM_PAD_SHIFT_VALUE + a hash.
+PAD_SENTINEL = 1_000_000 + 5
+
+NUM_REQS, MAX_LEN, NUM_SLOTS = 8, 4096, 40000
+
+
+class TestDeepseekV4VisionSwaGather(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = get_device()
+        torch.manual_seed(0)
+        cls.req_to_token = torch.randint(
+            0, NUM_SLOTS, (NUM_REQS, MAX_LEN), dtype=torch.int32, device=cls.device
+        )
+        cls.full_to_swa = torch.randint(
+            0, 9999, (NUM_SLOTS + 1,), dtype=torch.int32, device=cls.device
+        )
+
+    def _vision(self, builder, seq_lens, reqs, left, right):
+        return builder(
+            req_to_token=self.req_to_token,
+            full_to_swa_mapping=self.full_to_swa,
+            req_pool_indices_repeated=reqs,
+            seq_lens_casual=seq_lens,
+            visible_left=left,
+            visible_right=right,
+            swa_window=SWA_WINDOW,
+            width=WIDTH,
+        )
+
+    def _image_batch(self, span_lens):
+        """One request: text, an image block per span length, text. Returns the
+        flat input_ids / positions plus each span's index range."""
+        input_ids, spans = [], []
+        for span_len in span_lens:
+            input_ids.extend((11, 12, 13))
+            compress_pad = COMPRESS_PAD_TO - 1 - len(input_ids) % COMPRESS_PAD_TO
+            start = len(input_ids) + compress_pad
+            input_ids.extend([PAD_SENTINEL] * (compress_pad + span_len))
+            spans.append((start, start + span_len - 1))
+            input_ids.extend((14, 15))
+        positions = torch.arange(len(input_ids), dtype=torch.int32, device=self.device)
+        return (
+            torch.tensor(input_ids, device=self.device),
+            positions,
+            spans,
+        )
+
+    def _spans(self, input_ids, positions):
+        return compute_image_visible_spans(
+            input_ids=input_ids,
+            positions=positions,
+            vocab_size=VOCAB_SIZE,
+            compress_pad_to=COMPRESS_PAD_TO,
+            max_image_tokens=MAX_IMAGE_TOKENS,
+        )
+
+    def test_degenerates_to_the_causal_window_without_images(self):
+        seq_lens = torch.randint(1, 2000, (600,), dtype=torch.int32, device=self.device)
+        reqs = torch.randint(0, NUM_REQS, (600,), dtype=torch.int32, device=self.device)
+        zeros = torch.zeros_like(seq_lens)
+        causal = build_causal_swa_page_indices_triton(
+            req_to_token=self.req_to_token,
+            full_to_swa_mapping=self.full_to_swa,
+            req_pool_indices_repeated=reqs,
+            seq_lens_casual=seq_lens,
+            swa_window=SWA_WINDOW,
+            page_index_aligned_size=PAGE_INDEX_ALIGNED_SIZE,
+        )
+        causal_lengths = torch.clamp(seq_lens, max=SWA_WINDOW)
+        indices, lengths = self._vision(
+            build_vision_swa_page_indices_triton, seq_lens, reqs, zeros, zeros
+        )
+        self.assertTrue(torch.equal(lengths, causal_lengths))
+        for row in range(seq_lens.numel()):
+            length = int(causal_lengths[row])
+            # The causal builder walks the window newest-first and the widened
+            # one oldest-first, so compare the visible KV set, not its order.
+            self.assertEqual(
+                sorted(causal[row, :length].tolist()),
+                sorted(indices[row, :length].tolist()),
+                f"row {row}",
+            )
+
+    def test_triton_matches_torch(self):
+        input_ids, positions, _ = self._image_batch((37, 200, 381, 5))
+        left, right = self._spans(input_ids, positions)
+        seq_lens = positions + 1
+        reqs = torch.zeros_like(seq_lens)
+        torch_indices, torch_lengths = self._vision(
+            build_vision_swa_page_indices, seq_lens, reqs, left, right
+        )
+        triton_indices, triton_lengths = self._vision(
+            build_vision_swa_page_indices_triton, seq_lens, reqs, left, right
+        )
+        self.assertTrue(torch.equal(torch_lengths, triton_lengths))
+        self.assertTrue(torch.equal(torch_indices, triton_indices))
+
+    def test_gathered_slots_are_the_visible_positions(self):
+        input_ids, positions, _ = self._image_batch((37, 200))
+        left, right = self._spans(input_ids, positions)
+        seq_lens = positions + 1
+        reqs = torch.zeros_like(seq_lens)
+        indices, lengths = self._vision(
+            build_vision_swa_page_indices_triton, seq_lens, reqs, left, right
+        )
+        first_pos, extents = _vision_window_extent(seq_lens, left, right, SWA_WINDOW)
+        self.assertTrue(torch.equal(lengths, extents))
+        for row in range(input_ids.numel()):
+            length = int(extents[row])
+            wanted = torch.arange(
+                int(first_pos[row]),
+                int(first_pos[row]) + length,
+                device=self.device,
+            )
+            expected = self.full_to_swa[self.req_to_token[0, wanted].to(torch.long)].to(
+                torch.int32
+            )
+            self.assertTrue(torch.equal(indices[row, :length], expected), f"row {row}")
+            tail = indices[row, length:]
+            if tail.numel():
+                self.assertEqual(int(tail.max()), -1, f"row {row} tail")
+
+    def test_a_span_is_visible_in_both_directions(self):
+        span_len = 381
+        # The leading span puts the span under test past position SWA_WINDOW, so
+        # its backward reach is the window rather than the start of the sequence.
+        input_ids, positions, spans = self._image_batch((200, span_len))
+        left, right = self._spans(input_ids, positions)
+        first_pos, extents = _vision_window_extent(
+            positions + 1, left, right, SWA_WINDOW
+        )
+        start, end = spans[1]
+        self.assertGreater(start, SWA_WINDOW)
+        # Backward reach is unchanged at the span's first token, but it now sees
+        # forward all the way to IMAGE_END.
+        self.assertEqual(int(first_pos[start]), start - (SWA_WINDOW - 1))
+        self.assertEqual(int(first_pos[start]) + int(extents[start]) - 1, end)
+        # The span's last token reaches back over the whole span, past the window.
+        self.assertEqual(int(extents[end]), span_len)
+        self.assertGreater(int(extents[end]), SWA_WINDOW)
+        # And the gather still fits the widened width.
+        self.assertLessEqual(int(extents.max()), WIDTH)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_v4_vl_preprocessing.py
+++ b/test/registered/unit/models/test_deepseek_v4_vl_preprocessing.py
@@ -1,0 +1,392 @@
+"""Unit tests for DeepSeek-V4-Flash-Vision prompt and image preprocessing.
+
+Everything checked here has a counterpart in the checkpoint's own reference
+implementation (``inference/image_processor.py``, ``inference/model.py``,
+``encoding/encoding_dsv4.py``), so the assertions are written against the
+reference's formulas rather than against this implementation's output.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+from PIL import Image
+
+from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
+    _vision_window_extent,
+    compute_image_visible_spans,
+)
+from sglang.srt.entrypoints.openai import encoding_dsv4
+from sglang.srt.models.deepseek_v4_vl import DeepseekV4VisionModel
+from sglang.srt.multimodal.deepseek_v4_vl_image_processing import (
+    COMPRESS_PAD_TO,
+    IMAGE,
+    IMAGE_END,
+    IMAGE_NEW_LINE,
+    IMAGE_PAD,
+    IMAGE_START,
+    DeepseekV4VisionParams,
+    build_image_block,
+    grid_tokens,
+    preprocess_image,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+PARAMS = DeepseekV4VisionParams(
+    patch_size=14,
+    downsample_ratio=3,
+    max_n_token=384,
+    min_pixels=147456,
+    max_wh_ratio=8,
+)
+VOCAB_SIZE = 129280
+# What MultimodalDataItem.pad_value looks like: MM_PAD_SHIFT_VALUE + a hash.
+PAD_SENTINEL = 1_000_000 + 12345
+
+
+class TestDeepseekV4VLImagePreprocessing(CustomTestCase):
+    def test_block_fits_the_per_image_token_budget(self):
+        """Every solved grid must fit max_n_token including its lead padding."""
+        sizes = [(1, 1), (64, 64), (1920, 1080), (1080, 1920), (333, 777), (4000, 30)]
+        sizes += [(w, h) for w in (17, 128, 512, 2001) for h in (23, 256, 900)]
+        for width, height in sizes:
+            with self.subTest(size=(width, height)):
+                _, n_vit_h, n_vit_w, n_llm_h, n_llm_w = preprocess_image(
+                    Image.new("RGB", (width, height)), PARAMS
+                )
+                for start_pos in range(COMPRESS_PAD_TO):
+                    types, _, _ = build_image_block(n_llm_h, n_llm_w, start_pos)
+                    self.assertLessEqual(len(types), PARAMS.max_n_token)
+
+    def test_patches_match_the_solved_grid(self):
+        patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = preprocess_image(
+            Image.new("RGB", (1920, 1080)), PARAMS
+        )
+        self.assertEqual(patches.shape, (n_vit_h * n_vit_w, 3, 14, 14))
+        self.assertEqual(patches.dtype, torch.bfloat16)
+        # The aligner folds each 3x3 block of ViT patches into one LLM token.
+        self.assertEqual(n_llm_h, -(-n_vit_h // PARAMS.downsample_ratio))
+        self.assertEqual(n_llm_w, -(-n_vit_w // PARAMS.downsample_ratio))
+
+    def test_extreme_aspect_ratios_do_not_raise(self):
+        """The reference raises inside PIL on very tall images; we squash instead."""
+        for size in ((2, 50000), (1, 900), (50000, 2)):
+            with self.subTest(size=size):
+                patches, *_ = preprocess_image(Image.new("RGB", size), PARAMS)
+                self.assertGreater(patches.shape[0], 0)
+
+    def test_block_layout_matches_the_reference_formulas(self):
+        for n_llm_h, n_llm_w in ((8, 12), (14, 21), (1, 1), (3, 7), (2, 2)):
+            for start_pos in range(8):
+                with self.subTest(grid=(n_llm_h, n_llm_w), start_pos=start_pos):
+                    types, perm, compress_pad = build_image_block(
+                        n_llm_h, n_llm_w, start_pos
+                    )
+                    self.assertEqual(
+                        compress_pad,
+                        COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO,
+                    )
+                    # grid_tokens counts the block without the lead padding.
+                    _, _, num_tokens = grid_tokens(
+                        n_llm_h * PARAMS.downsample_ratio * PARAMS.patch_size,
+                        n_llm_w * PARAMS.downsample_ratio * PARAMS.patch_size,
+                        PARAMS.patch_size,
+                        PARAMS.downsample_ratio,
+                    )
+                    self.assertEqual(len(types), num_tokens + compress_pad)
+
+                    # One aligner output per IMAGE slot, and perm is a bijection.
+                    self.assertEqual(int((types == IMAGE).sum()), n_llm_h * n_llm_w)
+                    self.assertEqual(len(perm), n_llm_h * n_llm_w)
+                    self.assertEqual(
+                        sorted(perm.tolist()), list(range(n_llm_h * n_llm_w))
+                    )
+
+                    # Framing: exactly one START at the end of the lead padding
+                    # and one END last, and nothing else outside the grid kinds.
+                    self.assertEqual(types[compress_pad].item(), IMAGE_START)
+                    self.assertEqual(types[-1].item(), IMAGE_END)
+                    self.assertEqual(int((types == IMAGE_START).sum()), 1)
+                    self.assertEqual(int((types == IMAGE_END).sum()), 1)
+                    self.assertEqual(
+                        int((types == IMAGE_NEW_LINE).sum()),
+                        # one row terminator per real grid row
+                        n_llm_h,
+                    )
+                    self.assertTrue(
+                        bool(
+                            (types[:compress_pad] == IMAGE_PAD).all()
+                            if compress_pad
+                            else True
+                        )
+                    )
+
+                    # The grid content starts on a compression-group boundary.
+                    self.assertEqual(
+                        (start_pos + compress_pad + 1) % COMPRESS_PAD_TO, 0
+                    )
+
+
+class TestDeepseekV4VisionModelBlock(CustomTestCase):
+    """The tower must return one row per block slot, framing included.
+
+    Those rows are scattered onto the block's placeholder positions in
+    input_ids, so a row-count or ordering mistake here shows up as a
+    device-side assert deep inside the multimodal scatter rather than as a
+    wrong answer. A tiny config exercises the layout on CPU.
+    """
+
+    @staticmethod
+    def _config():
+        return SimpleNamespace(
+            hidden_size=32,
+            vision_n_layers=2,
+            vision_dim=16,
+            vision_n_heads=2,
+            vision_inter_dim=24,
+            vision_patch_size=PARAMS.patch_size,
+            vision_rope_theta=10000.0,
+            vision_downsample_ratio=PARAMS.downsample_ratio,
+        )
+
+    def test_block_rows_and_framing_slots(self):
+        torch.manual_seed(0)
+        config = self._config()
+        model = DeepseekV4VisionModel(config).to(torch.float32)
+
+        items, expected_rows = [], 0
+        start_pos = 0
+        for n_vit_h, n_vit_w in ((4, 7), (9, 9)):
+            n_llm_h = -(-n_vit_h // config.vision_downsample_ratio)
+            n_llm_w = -(-n_vit_w // config.vision_downsample_ratio)
+            slot_types, aligner_perm, _ = build_image_block(n_llm_h, n_llm_w, start_pos)
+            start_pos += len(slot_types)
+            expected_rows += len(slot_types)
+            items.append(
+                SimpleNamespace(
+                    feature=torch.randn(
+                        n_vit_h * n_vit_w,
+                        3,
+                        config.vision_patch_size,
+                        config.vision_patch_size,
+                    ),
+                    n_vit_h=n_vit_h,
+                    n_vit_w=n_vit_w,
+                    slot_types=slot_types,
+                    aligner_perm=aligner_perm,
+                )
+            )
+
+        with torch.no_grad():
+            out = model(items)
+        self.assertEqual(out.shape, (expected_rows, config.hidden_size))
+
+        # Each non-IMAGE slot must carry its learned framing embedding verbatim.
+        learned = {
+            IMAGE_START: model.image_start,
+            IMAGE_PAD: model.image_pad,
+            IMAGE_NEW_LINE: model.image_newline,
+            IMAGE_END: model.image_end,
+        }
+        row = 0
+        for item in items:
+            for kind in item.slot_types.tolist():
+                if kind != IMAGE:
+                    self.assertTrue(
+                        torch.equal(out[row], learned[kind].detach()),
+                        f"row {row} kind {kind}",
+                    )
+                row += 1
+        self.assertEqual(row, expected_rows)
+
+
+class TestDeepseekV4VLPromptEncoding(CustomTestCase):
+    """The encoder must place one placeholder per image, in prompt order."""
+
+    @staticmethod
+    def _encode(messages):
+        messages, num_images = encoding_dsv4.process_image_messages(messages)
+        return (
+            encoding_dsv4.encode_messages(messages, thinking_mode="chat"),
+            num_images,
+        )
+
+    def test_image_between_text_parts(self):
+        prompt, num_images = self._encode(
+            [
+                {"role": "system", "content": ""},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "before"},
+                        {"type": "image"},
+                        {"type": "text", "text": "after"},
+                    ],
+                },
+            ]
+        )
+        self.assertEqual(num_images, 1)
+        self.assertEqual(
+            prompt,
+            "<｜begin▁of▁sentence｜><｜User｜>before\n\n"
+            f"{encoding_dsv4.IMAGE_PLACEHOLDER}\n\nafter"
+            "<｜Assistant｜></think>",
+        )
+
+    def test_multiple_images_keep_prompt_order(self):
+        prompt, num_images = self._encode(
+            [
+                {"role": "system", "content": ""},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "middle"},
+                        {"type": "image"},
+                    ],
+                },
+            ]
+        )
+        self.assertEqual(num_images, 2)
+        self.assertEqual(prompt.count(encoding_dsv4.IMAGE_PLACEHOLDER), 2)
+
+    def test_image_returned_by_a_tool_keeps_its_place(self):
+        prompt, num_images = self._encode(
+            [
+                {"role": "system", "content": ""},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "inspect", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "c1",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "tool image"},
+                    ],
+                },
+            ]
+        )
+        self.assertEqual(num_images, 1)
+        self.assertIn(
+            f"<tool_result>{encoding_dsv4.IMAGE_PLACEHOLDER}\n\ntool image</tool_result>",
+            prompt,
+        )
+
+    def test_text_only_prompt_is_unchanged(self):
+        prompt, num_images = self._encode(
+            [{"role": "system", "content": ""}, {"role": "user", "content": "hello"}]
+        )
+        self.assertEqual(num_images, 0)
+        self.assertEqual(
+            prompt,
+            "<｜begin▁of▁sentence｜><｜User｜>hello<｜Assistant｜></think>",
+        )
+
+    def test_a_placeholder_in_user_text_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "image placeholder token"):
+            self._encode(
+                [
+                    {
+                        "role": "user",
+                        "content": encoding_dsv4.IMAGE_PLACEHOLDER,
+                    }
+                ]
+            )
+
+
+class TestDeepseekV4VLImageVisibleSpans(CustomTestCase):
+    """Bidirectional visibility must cover exactly [IMAGE_START, IMAGE_END]."""
+
+    WINDOW = 128
+
+    @staticmethod
+    def _batch(spans, leading_text=3, trailing_text=2, first_position=0):
+        """One request: text, then one block per span length, then text."""
+        input_ids, expected = [], []
+        for span_len in spans:
+            input_ids.extend(range(100, 100 + leading_text))
+            compress_pad = COMPRESS_PAD_TO - 1 - len(input_ids) % COMPRESS_PAD_TO
+            span_start = len(input_ids) + compress_pad
+            input_ids.extend([PAD_SENTINEL] * (compress_pad + span_len))
+            expected.append((span_start, span_start + span_len - 1))
+            input_ids.extend(range(200, 200 + trailing_text))
+        positions = torch.arange(
+            first_position, first_position + len(input_ids), dtype=torch.int32
+        )
+        return torch.tensor(input_ids), positions, expected
+
+    def _spans(self, input_ids, positions):
+        return compute_image_visible_spans(
+            input_ids=input_ids,
+            positions=positions,
+            vocab_size=VOCAB_SIZE,
+            compress_pad_to=COMPRESS_PAD_TO,
+            max_image_tokens=PARAMS.max_n_token,
+        )
+
+    def test_visibility_covers_the_span_and_nothing_else(self):
+        input_ids, positions, expected = self._batch([37, 200])
+        left, right = self._spans(input_ids, positions)
+        inside = torch.zeros(len(input_ids), dtype=torch.bool)
+        for start, end in expected:
+            inside[start : end + 1] = True
+            self.assertTrue(
+                torch.equal(left[start : end + 1].long(), torch.arange(end - start + 1))
+            )
+            self.assertTrue(
+                torch.equal(
+                    right[start : end + 1].long(),
+                    torch.arange(end - start, -1, -1),
+                )
+            )
+        # Text and the block's lead padding stay on the plain causal window.
+        self.assertEqual(int(left[~inside].max()), 0)
+        self.assertEqual(int(right[~inside].max()), 0)
+
+    def test_runs_do_not_merge_across_requests(self):
+        """A flat batch concatenates requests; positions restart at each one."""
+        ids_a, pos_a, expected_a = self._batch([16])
+        ids_b, pos_b, expected_b = self._batch([16])
+        offset = len(ids_a)
+        input_ids = torch.cat([ids_a, ids_b])
+        positions = torch.cat([pos_a, pos_b])
+        left, right = self._spans(input_ids, positions)
+        for start, end in expected_a:
+            self.assertEqual(int(left[end]), end - start)
+        for start, end in expected_b:
+            self.assertEqual(int(left[offset + end]), end - start)
+
+    def test_gather_stays_within_the_widened_window(self):
+        max_span = PARAMS.max_n_token - (COMPRESS_PAD_TO - 1)
+        input_ids, positions, _ = self._batch([max_span])
+        left, right = self._spans(input_ids, positions)
+        _, lengths = _vision_window_extent(positions + 1, left, right, self.WINDOW)
+        self.assertLessEqual(int(lengths.max()), self.WINDOW + PARAMS.max_n_token)
+
+    def test_window_extent_matches_the_reference_formula(self):
+        input_ids, positions, _ = self._batch([37, 200])
+        left, right = self._spans(input_ids, positions)
+        first_pos, lengths = _vision_window_extent(
+            positions + 1, left, right, self.WINDOW
+        )
+        for i, position in enumerate(positions.tolist()):
+            # Reference: start = idx - max(window - 1, left), end = idx + right.
+            back = min(position, max(self.WINDOW - 1, int(left[i])))
+            self.assertEqual(int(first_pos[i]), position - back)
+            self.assertEqual(int(lengths[i]), back + 1 + int(right[i]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_v4_vl_preprocessing.py
+++ b/test/registered/unit/models/test_deepseek_v4_vl_preprocessing.py
@@ -14,9 +14,15 @@ from PIL import Image
 
 from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     _vision_window_extent,
-    compute_image_visible_spans,
+    build_image_visible_spans,
 )
 from sglang.srt.entrypoints.openai import encoding_dsv4
+from sglang.srt.layers.attention.deepseek_v4_backend import collect_image_spans
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
 from sglang.srt.models.deepseek_v4_vl import DeepseekV4VisionModel
 from sglang.srt.multimodal.deepseek_v4_vl_image_processing import (
     COMPRESS_PAD_TO,
@@ -42,9 +48,8 @@ PARAMS = DeepseekV4VisionParams(
     min_pixels=147456,
     max_wh_ratio=8,
 )
-VOCAB_SIZE = 129280
-# What MultimodalDataItem.pad_value looks like: MM_PAD_SHIFT_VALUE + a hash.
-PAD_SENTINEL = 1_000_000 + 12345
+# The widened gather's width: the plain window plus at most one whole block.
+WIDTH = 128 + PARAMS.max_n_token
 
 
 class TestDeepseekV4VLImagePreprocessing(CustomTestCase):
@@ -306,80 +311,188 @@ class TestDeepseekV4VLPromptEncoding(CustomTestCase):
             )
 
 
-class TestDeepseekV4VLImageVisibleSpans(CustomTestCase):
-    """Bidirectional visibility must cover exactly [IMAGE_START, IMAGE_END]."""
+class TestDeepseekV4VLImageSpanCollection(CustomTestCase):
+    """Span extents come from the items' offsets, not from placeholder runs.
+
+    Each case below is a layout where inferring "one image block in one
+    request" from a maximal run of out-of-vocabulary ids at contiguous
+    positions gives the wrong answer.
+    """
 
     WINDOW = 128
 
     @staticmethod
-    def _batch(spans, leading_text=3, trailing_text=2, first_position=0):
-        """One request: text, then one block per span length, then text."""
-        input_ids, expected = [], []
-        for span_len in spans:
-            input_ids.extend(range(100, 100 + leading_text))
-            compress_pad = COMPRESS_PAD_TO - 1 - len(input_ids) % COMPRESS_PAD_TO
-            span_start = len(input_ids) + compress_pad
-            input_ids.extend([PAD_SENTINEL] * (compress_pad + span_len))
-            expected.append((span_start, span_start + span_len - 1))
-            input_ids.extend(range(200, 200 + trailing_text))
-        positions = torch.arange(
-            first_position, first_position + len(input_ids), dtype=torch.int32
+    def _item(block_start, span_len):
+        """One image whose block starts at ``block_start`` in its request."""
+        compress_pad = COMPRESS_PAD_TO - 1 - block_start % COMPRESS_PAD_TO
+        block_end = block_start + compress_pad + span_len - 1
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            feature=torch.zeros(1, 3, PARAMS.patch_size, PARAMS.patch_size),
+            offsets=[(block_start, block_end)],
+            model_specific_data={"compress_pad": compress_pad},
         )
-        return torch.tensor(input_ids), positions, expected
+        return item, block_start + compress_pad, block_end
 
-    def _spans(self, input_ids, positions):
-        return compute_image_visible_spans(
-            input_ids=input_ids,
-            positions=positions,
-            vocab_size=VOCAB_SIZE,
-            compress_pad_to=COMPRESS_PAD_TO,
-            max_image_tokens=PARAMS.max_n_token,
+    def _collect(self, mm_items_per_req, prefix_lens, extend_lens):
+        mm_inputs = [
+            None if items is None else MultimodalInputs(mm_items=items)
+            for items in mm_items_per_req
+        ]
+        return collect_image_spans(
+            mm_inputs=mm_inputs,
+            extend_prefix_lens=prefix_lens,
+            extend_seq_lens=extend_lens,
+            swa_window=self.WINDOW,
         )
+
+    def _visible(self, spans, num_tokens):
+        return build_image_visible_spans(
+            spans=spans,
+            num_tokens=num_tokens,
+            max_image_tokens=PARAMS.max_n_token,
+            device="cpu",
+        )
+
+    def test_adjacent_blocks_stay_separate(self):
+        """Two images can land back to back; they are two spans, not one.
+
+        Merging them would let the first image attend into the second and, at
+        full block size, push the gather length past the indices row it
+        addresses.
+        """
+        span_len = PARAMS.max_n_token - (COMPRESS_PAD_TO - 1)
+        first, first_start, first_end = self._item(0, span_len)
+        second, second_start, second_end = self._item(first_end + 1, span_len)
+        total = second_end + 1
+
+        spans = self._collect([[first, second]], [0], [total])
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(
+            [(s.row_start, s.row_end) for s in spans],
+            [(first_start, first_end), (second_start, second_end)],
+        )
+
+        left, right = self._visible(spans, total)
+        # The first block's last token sees nothing forward: its span ends there.
+        self.assertEqual(int(right[first_end]), 0)
+        self.assertEqual(int(left[second_start]), 0)
+        _, lengths = _vision_window_extent(
+            torch.arange(1, total + 1, dtype=torch.int32),
+            left,
+            right,
+            self.WINDOW,
+            WIDTH,
+        )
+        self.assertLessEqual(int(lengths.max()), WIDTH)
+
+    def test_requests_with_contiguous_positions_stay_separate(self):
+        """Request B's prefix can continue A's positions across the batch.
+
+        A merge there would give A's tokens a forward reach past their own
+        sequence end, into req_to_token slots A never wrote.
+        """
+        first, _, first_end = self._item(3, 16)
+        len_a = first_end + 1 + 2
+        second, _, second_end = self._item(0, 30)
+        len_b = second_end + 1
+
+        spans = self._collect([[first], [second]], [0, len_a], [len_a, len_b])
+        self.assertEqual(len(spans), 2)
+        left, right = self._visible(spans, len_a + len_b)
+
+        # A's span ends inside A, and A's trailing text is on the plain window.
+        self.assertEqual(spans[0].row_end, first_end)
+        self.assertEqual(int(right[first_end]), 0)
+        self.assertEqual(int(left[first_end + 1 : len_a].max()), 0)
+        self.assertEqual(int(right[first_end + 1 : len_a].max()), 0)
+        # B's span lives entirely in B's rows.
+        self.assertGreaterEqual(spans[1].row_start, len_a)
+
+    def test_a_split_block_keeps_its_true_start_and_stops_at_the_chunk(self):
+        """A chunk opening mid-block must not re-anchor the span to the chunk.
+
+        Backward reach is clipped to the oldest SWA-resident token rather than
+        to the chunk start, and forward reach stops at the chunk's last token,
+        whose KV is the newest that exists.
+        """
+        block_start, span_len = 100, 300
+        item, span_start, block_end = self._item(block_start, span_len)
+        prefix_len, extend_len = 250, 200
+        chunk_last = prefix_len + extend_len - 1
+        resident_first = max(0, prefix_len - (self.WINDOW - 1))
+
+        spans = self._collect([[item]], [prefix_len], [extend_len])
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        # The span opened before this chunk, so left counts from before row 0.
+        self.assertLess(span.left_origin, span.row_start)
+        self.assertEqual(span.row_start, 0)
+        self.assertEqual(span.row_end, min(block_end, chunk_last) - prefix_len)
+
+        left, right = self._visible(spans, extend_len)
+        self.assertEqual(
+            int(left[span.row_start]), prefix_len - max(span_start, resident_first)
+        )
+        self.assertEqual(int(right[span.row_end]), 0)
+        _, lengths = _vision_window_extent(
+            torch.arange(
+                prefix_len + 1, prefix_len + extend_len + 1, dtype=torch.int32
+            ),
+            left,
+            right,
+            self.WINDOW,
+            WIDTH,
+        )
+        self.assertLessEqual(int(lengths.max()), WIDTH)
+
+    def test_a_chunk_before_the_block_yields_no_span(self):
+        item, _, _ = self._item(4000, 100)
+        self.assertEqual(self._collect([[item]], [0], [512]), [])
+
+    def test_text_only_requests_shift_the_row_cursor(self):
+        """A text-only request between two image ones must still advance rows."""
+        first, _, first_end = self._item(0, 8)
+        second, _, second_end = self._item(0, 8)
+        len_a, len_text, len_b = first_end + 1, 17, second_end + 1
+        spans = self._collect(
+            [[first], None, [second]], [0, 0, 0], [len_a, len_text, len_b]
+        )
+        self.assertEqual(len(spans), 2)
+        # Identical geometry, so the second span sits at the same offset inside
+        # its own request's rows as the first does inside its own.
+        third_req_row = len_a + len_text
+        self.assertEqual(spans[1].row_start - third_req_row, spans[0].row_start)
+        self.assertLess(spans[1].row_end, third_req_row + len_b)
 
     def test_visibility_covers_the_span_and_nothing_else(self):
-        input_ids, positions, expected = self._batch([37, 200])
-        left, right = self._spans(input_ids, positions)
-        inside = torch.zeros(len(input_ids), dtype=torch.bool)
-        for start, end in expected:
-            inside[start : end + 1] = True
-            self.assertTrue(
-                torch.equal(left[start : end + 1].long(), torch.arange(end - start + 1))
+        item, span_start, block_end = self._item(3, 37)
+        total = block_end + 1 + 5
+        spans = self._collect([[item]], [0], [total])
+        left, right = self._visible(spans, total)
+        span_len = block_end - span_start + 1
+        self.assertTrue(
+            torch.equal(left[span_start : block_end + 1].long(), torch.arange(span_len))
+        )
+        self.assertTrue(
+            torch.equal(
+                right[span_start : block_end + 1].long(),
+                torch.arange(span_len - 1, -1, -1),
             )
-            self.assertTrue(
-                torch.equal(
-                    right[start : end + 1].long(),
-                    torch.arange(end - start, -1, -1),
-                )
-            )
-        # Text and the block's lead padding stay on the plain causal window.
-        self.assertEqual(int(left[~inside].max()), 0)
-        self.assertEqual(int(right[~inside].max()), 0)
-
-    def test_runs_do_not_merge_across_requests(self):
-        """A flat batch concatenates requests; positions restart at each one."""
-        ids_a, pos_a, expected_a = self._batch([16])
-        ids_b, pos_b, expected_b = self._batch([16])
-        offset = len(ids_a)
-        input_ids = torch.cat([ids_a, ids_b])
-        positions = torch.cat([pos_a, pos_b])
-        left, right = self._spans(input_ids, positions)
-        for start, end in expected_a:
-            self.assertEqual(int(left[end]), end - start)
-        for start, end in expected_b:
-            self.assertEqual(int(left[offset + end]), end - start)
-
-    def test_gather_stays_within_the_widened_window(self):
-        max_span = PARAMS.max_n_token - (COMPRESS_PAD_TO - 1)
-        input_ids, positions, _ = self._batch([max_span])
-        left, right = self._spans(input_ids, positions)
-        _, lengths = _vision_window_extent(positions + 1, left, right, self.WINDOW)
-        self.assertLessEqual(int(lengths.max()), self.WINDOW + PARAMS.max_n_token)
+        )
+        outside = torch.ones(total, dtype=torch.bool)
+        outside[span_start : block_end + 1] = False
+        self.assertEqual(int(left[outside].max()), 0)
+        self.assertEqual(int(right[outside].max()), 0)
 
     def test_window_extent_matches_the_reference_formula(self):
-        input_ids, positions, _ = self._batch([37, 200])
-        left, right = self._spans(input_ids, positions)
+        item, _, block_end = self._item(3, 200)
+        total = block_end + 1
+        spans = self._collect([[item]], [0], [total])
+        left, right = self._visible(spans, total)
+        positions = torch.arange(total, dtype=torch.int32)
         first_pos, lengths = _vision_window_extent(
-            positions + 1, left, right, self.WINDOW
+            positions + 1, left, right, self.WINDOW, WIDTH
         )
         for i, position in enumerate(positions.tolist()):
             # Reference: start = idx - max(window - 1, left), end = idx + right.


### PR DESCRIPTION
## Motivation

Support `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`.

## Modifications

```
$ git diff --stat 771e613d96..HEAD | tail -1
 25 files changed, 2824 insertions(+), 185 deletions(-)
```

## Accuracy Tests

### Launch

```
$ python3 -m sglang.launch_server \
    --trust-remote-code \
    --model-path deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
    --tp 4 \
    --moe-runner-backend flashinfer_mxfp4 \
    --speculative-algorithm DSPARK \
    --mem-fraction-static 0.90 \
    --swa-full-tokens-ratio 0.1 \
    --host 0.0.0.0 --port 30000

[2026-08-31 13:17:47 TP0] Auto-detected DSV4 routed-expert layout: is_fp4_experts=True
[2026-08-31 13:17:47 TP0] Detected the DeepSeek-V4 vision tower; loading arch DeepseekV4VLForCausalLM.
[2026-08-31 13:18:34 TP1] Load weight end. elapsed=38.86 s, type=DeepseekV4VLForCausalLM, quant=fp8, fmt=e4m3, avail mem=234.90 GB, mem usage=39.50 GB.
[2026-08-31 13:19:04 TP0] max_total_num_tokens=23131904, chunked_prefill_size=16384, max_prefill_tokens=16384, max_running_requests=256, context_len=1048576

# on the first image request:
[2026-08-31 13:19:59 TP0] DeepSeek-V4 vision attention: widening the sliding-window gather to 512 so image spans attend bidirectionally.
[2026-08-31 13:19:59 TP1] DeepSeek-V4 vision attention: widening the sliding-window gather to 512 so image spans attend bidirectionally.
[2026-08-31 13:19:59 TP2] DeepSeek-V4 vision attention: widening the sliding-window gather to 512 so image spans attend bidirectionally.
[2026-08-31 13:19:59 TP3] DeepSeek-V4 vision attention: widening the sliding-window gather to 512 so image spans attend bidirectionally.
```

```
$ curl -s localhost:30000/model_info
{
    "is_generation": true,
    "has_image_understanding": true,
    "has_audio_understanding": false,
    "model_type": "deepseek_v4",
    "architectures": ["DeepseekV4VLForCausalLM"]
}
```

### GSM8K

```
$ sgl-eval run gsm8k --base-url http://127.0.0.1:30000/v1 --num-threads 256

== gsm8k ==
1319 examples (single-shot)  |  33.6s  |  4274 tok/s  |  144K tokens

* score           =  96.36%
  stop_rate       =  100.00%
  truncated_rate  =  0.00%
  error_rate      =  0.00%
```

| | this PR (Flash-Vision-Exp) | published (Flash-0731) |
| --- | --- | --- |
| GSM8K (1-shot) | 96.36 % | 97.04 % |

### Image requests

```
$ # single image
prompt_tokens=126 -> 'Corn'
prompt_tokens=330 -> 'Carrots'

$ # two images interleaved with text, order preserved
prompt_tokens=452 -> 'first: carrots, second: corn'

$ # image inside an 8k-token prompt
prompt_tokens=8131 -> 'Corn'

$ # thinking mode
content="...4. **Verify the count:** I can see 4 distinct orange carrot bodies with green stems....</think>4"

$ # injected placeholder token is rejected
status: 400 {"message":"Message content contains the image placeholder token <deepseek_image>; pass images as image content blocks.","type":"BadRequest","code":400}

$ # 8-way concurrency, mixed images
  req0: prompt_tokens=328 -> 'Carrots' OK      req4: prompt_tokens=328 -> 'Carrots' OK
  req1: prompt_tokens=124 -> 'Corn'    OK      req5: prompt_tokens=124 -> 'Corn'    OK
  req2: prompt_tokens=328 -> 'Carrots' OK      req6: prompt_tokens=328 -> 'Carrots' OK
  req3: prompt_tokens=124 -> 'Corn'    OK      req7: prompt_tokens=124 -> 'Corn'    OK
```

```
$ # two ADJACENT image blocks (no separator token), via /generate
prompt_tokens=434 -> 'Based on the images provided, the foods are:
  1. **Carrots** (the first image shows a pile of orange carrots with green tops).
  2. **Corn** (the second image shows ears of corn, with one'

$ # three adjacent blocks
prompt_tokens=544 -> '3'
```

```
$ # image block straddling a chunk boundary: --chunked-prefill-size 512
  filler=   0 words  prompt_tokens=  326 -> 'Carrots'  OK
  filler=  80 words  prompt_tokens=  406 -> 'Carrots'  OK
  filler= 118 words  prompt_tokens=  446 -> 'carrots'  OK
  filler= 126 words  prompt_tokens=  454 -> 'carrots'  OK
  filler= 200 words  prompt_tokens=  526 -> 'Carrots'  OK
  two images across several chunks: prompt_tokens=738 -> '1. **Carrots**  2. **Corn**'
```

## Speed Tests and Profiling

```
$ python3 -m sglang.bench_serving --backend sglang --host localhost --port 30000 \
    --model deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
    --dataset-name random --random-input-len 8192 --random-output-len 1024 \
    --random-range-ratio 1.0 --num-prompts 32 --max-concurrency 1 \
    --warmup-requests 64 --flush-cache

Max request concurrency:                 1
Successful requests:                     32
Benchmark duration (s):                  48.67
Total input tokens:                      262144
Total generated tokens:                  32768
Request throughput (req/s):              0.66
Output token throughput (tok/s):         673.20
Total token throughput (tok/s):          6058.84
Concurrency:                             1.00
Accept length:                           5.26
Median TTFT (ms):                        231.13
Median TPOT (ms):                        1.25
Median ITL (ms):                         1.10
```

```
$ python3 -m sglang.bench_serving --backend sglang --host localhost --port 30000 \
    --model deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
    --dataset-name random --random-input-len 8192 --random-output-len 1024 \
    --random-range-ratio 1.0 --num-prompts 32 --max-concurrency 16 \
    --warmup-requests 64 --flush-cache

Max request concurrency:                 16
Successful requests:                     32
Benchmark duration (s):                  9.93
Total input tokens:                      262144
Total generated tokens:                  32768
Request throughput (req/s):              3.22
Output token throughput (tok/s):         3299.71
Total token throughput (tok/s):          29697.36
Concurrency:                             14.91
Accept length:                           5.24
Median TTFT (ms):                        780.18
Median TPOT (ms):                        3.57
Median ITL (ms):                         2.01
```

random, in/out=8192/1024, P50. `throughput per gpu = (input+output)/elapsed/4`,
`interactivity = 1000/TPOT`.

| | this PR, conc=1 | published 0731, conc=1 | this PR, conc=16 | published 0731, conc=16 |
| --- | --- | --- | --- | --- |
| TTFT (P50) | 231.13 ms | 468.93 ms | 780.18 ms | 726.81 ms |
| TPOT (P50) | 1.25 ms | 1.31 ms | 3.57 ms | 8.84 ms |
| throughput per gpu | 1515 tok/s | 930 tok/s | 7425 tok/s | 2711 tok/s |
| interactivity | 800.0 tok/s/user | 763.4 tok/s/user | 280.1 tok/s/user | 113.1 tok/s/user |

Different checkpoint (Flash-Vision-Exp vs Flash-0731) and newer SGLang
(0.5.19.dev732 vs 0.5.16) than the published column.

## Not covered

- EAGLE / MTP with the vision tower.
- Prefill context parallelism: refused at startup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33398320458](https://github.com/sgl-project/sglang/actions/runs/33398320458)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33398320023](https://github.com/sgl-project/sglang/actions/runs/33398320023)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33398320361](https://github.com/sgl-project/sglang/actions/runs/33398320361)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->