### PR TITLE
Use world rank as bootstrap key for remote instance weight transport …

### DIFF
--- a/python/sglang/srt/entrypoints/engine_info_bootstrap_server.py
+++ b/python/sglang/srt/entrypoints/engine_info_bootstrap_server.py
@@ -38,7 +38,8 @@ class EngineInfoBootstrapServer:
         self.host = host
         self.port = port
 
-        # Storage: {tp_rank: (session_id, weights_info_dict)}
+        # Storage: {rank: (session_id, weights_info_dict)}, keyed by world rank
+        # so pipeline-parallel workers with the same tp_rank don't collide.
         self.transfer_engine_info: Dict[int, Tuple] = {}
         self.lock = threading.Lock()
 
@@ -51,19 +52,19 @@ class EngineInfoBootstrapServer:
         @app.put("/register_transfer_engine_info")
         def register_transfer_engine_info(data: dict):
             try:
-                tp_rank = data["tp_rank"]
+                rank = data["rank"]
                 info = data["transfer_engine_info"]
                 session_id = info["session_id"]
                 weights_info_dict = info["weights_info_dict"]
 
                 with self.lock:
-                    self.transfer_engine_info[tp_rank] = (
+                    self.transfer_engine_info[rank] = (
                         session_id,
                         weights_info_dict,
                     )
 
                 logger.info(
-                    f"Registered transfer engine info for tp_rank={tp_rank}, "
+                    f"Registered transfer engine info for rank={rank}, "
                     f"session_id={session_id}"
                 )
                 return PlainTextResponse("OK")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -33,7 +33,7 @@ from sglang.srt.configs.model_config import (
 )
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
 from sglang.srt.debug_utils.dumper import dumper
-from sglang.srt.distributed import bootstrap
+from sglang.srt.distributed import bootstrap, get_world_rank
 from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
     maybe_init_shared_mooncake_transfer_engine,
 )
@@ -580,7 +580,7 @@ class ModelRunner:
     def init_remote_instance_weight_transporter(self):
         self.remote_instance_weight_transporter = RemoteInstanceWeightTransporter(
             get_model=lambda: self.model,
-            tp_rank=self.ps.tp_rank,
+            rank=get_world_rank(),
             gpu_id=self.gpu_id,
         )
 

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 @dataclass(slots=True, kw_only=True)
 class RemoteInstanceWeightTransporter:
     get_model: Callable[[], torch.nn.Module]
-    tp_rank: int
+    rank: int
     gpu_id: int
     engine: Optional[Any] = None
     session_id: str = ""
@@ -91,8 +91,11 @@ class RemoteInstanceWeightTransporter:
         bootstrap_na = NetworkAddress(bootstrap_host, bootstrap_port)
         url = f"{bootstrap_na.to_url()}/register_transfer_engine_info"
 
+        # The bootstrap server keys transfer engine info by world rank so two
+        # pipeline-parallel workers with the same tp_rank don't clobber each
+        # other's entries.
         payload = {
-            "tp_rank": self.tp_rank,
+            "rank": self.rank,
             "transfer_engine_info": {
                 "session_id": self.session_id,
                 "weights_info_dict": self.weight_info,
@@ -103,15 +106,15 @@ class RemoteInstanceWeightTransporter:
             resp = http_requests.put(url, json=payload, timeout=5)
             if resp.status_code == 200:
                 logger.info(
-                    f"Registered transfer engine info for tp_rank={self.tp_rank} "
+                    f"Registered transfer engine info for rank={self.rank} "
                     f"with bootstrap server at {bootstrap_na}"
                 )
             else:
                 logger.error(
-                    f"Failed to register transfer engine info for tp_rank={self.tp_rank}: "
+                    f"Failed to register transfer engine info for rank={self.rank}: "
                     f"{resp.status_code}, {resp.text}"
                 )
         except Exception as e:
             logger.error(
-                f"Failed to register transfer engine info for tp_rank={self.tp_rank}: {e}"
+                f"Failed to register transfer engine info for rank={self.rank}: {e}"
             )

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -81,6 +81,7 @@ from sglang.srt.connector import (
 )
 from sglang.srt.connector.utils import parse_model_name
 from sglang.srt.distributed import (
+    get_world_rank,
     model_parallel_is_initialized,
 )
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
@@ -3323,7 +3324,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                 model,
                 load_config.remote_instance_weight_loader_transfer_engine,
                 f"http://{load_config.remote_instance_weight_loader_seed_instance_ip}:{load_config.remote_instance_weight_loader_seed_instance_service_port}",
-                load_config.tp_rank,
+                get_world_rank(),
             )
             if not success:
                 raise RuntimeError(
@@ -3402,11 +3403,11 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         current_platform.empty_cache()
 
     def load_model_from_remote_instance_by_transfer_engine(
-        self, model, transfer_engine, seed_url, tp_rank
+        self, model, transfer_engine, seed_url, rank
     ) -> bool:
         # get remote weights metadata from source instance
         seed_transfer_engine_session_id, seed_transfer_engine_weight_info = (
-            get_remote_instance_transfer_engine_info_per_rank(seed_url, tp_rank)
+            get_remote_instance_transfer_engine_info_per_rank(seed_url, rank)
         )
         if (
             seed_transfer_engine_session_id is None


### PR DESCRIPTION
…to support pipeline parallelism

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

##Motivation
Fixes #37216.

When launching with pp_size > 1, multiple pipeline-parallel workers can share the same tp_rank. The remote-instance weight transfer engine registers its metadata (session id + weight buffer info) with the EngineInfoBootstrapServer keyed by tp_rank, so the second pp worker's PUT overwrites the first's entry. On lookup, every pp worker with that tp_rank retrieves the same (wrong) transfer engine info, breaking remote-instance weight loading under pipeline parallelism.

The key must be globally unique across both TP and PP dimensions.

##Modifications
Keyed transfer engine bootstrap info by world rank instead of tp_rank, end-to-end across the register / store / lookup path:

remote_instance_weight_transporter.py: renamed the tp_rank field to rank; the registration payload now sends "rank": self.rank. Removed the in-method get_world_rank() call (the value is now injected at construction).
model_runner.py: init_remote_instance_weight_transporter now passes rank=get_world_rank() instead of tp_rank=self.ps.tp_rank.
engine_info_bootstrap_server.py: the PUT /register_transfer_engine_info endpoint reads data["rank"] and stores under that key. The GET endpoint already accepted rank and is unchanged.
loader.py: the transfer-engine weight-loading path now looks up the source instance by get_world_rank() (renamed the method's tp_rank parameter to rank to match its new meaning). The NCCL path and load_config.tp_rank-based port indexing are intentionally left untouched — those are per-TP-rank by design.

##Accuracy Tests
This change affects weight-loading bookkeeping (the registry key), not model forward or kernel code. Weight tensor contents and sharding are unchanged, so model outputs are unaffected. The existing manual integration test test/manual/test_cross_node_scheduler_info_sync.py (which queries /get_remote_instance_transfer_engine_info per rank) continues to pass: all its cases use pp_size=1, where world_rank == tp_rank, so the enumerated ranks correctly hit the now-world-rank-keyed entries.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33401496207](https://github.com/sgl-project/sglang/actions/runs/33401496207)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #33401495968](https://github.com/sgl-project/sglang/actions/runs/33401495968)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33401495999](https://github.com/sgl-project/sglang/actions/runs/33401495999)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->