### PR TITLE
    [scheduler] fix: stop the queued-request limit from killing retracted requests[optional]

### DIFF
--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -153,6 +153,8 @@ def check_server_args(server_args: Any):
         raise ValueError(
             "--retraction-policy priority requires --enable-priority-scheduling"
         )
+    if cfg.max_retraction_count is not None and cfg.max_retraction_count < 0:
+        raise ValueError("--max-retraction-count must be non-negative")
 
     # Check hisparse
     # Moved to the resolution pipeline (arg_groups/overrides.py:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -447,6 +447,7 @@ class Scheduler(
         self.priority_scheduling_preemption_threshold = (
             get_schedule().priority_scheduling_preemption_threshold
         )
+        self.max_retraction_count = get_schedule().max_retraction_count
         self.enable_lora = get_lora().enable_lora
         self.enable_lora_overlap_loading = get_lora().enable_lora_overlap_loading
         self.max_loras_per_batch = get_lora().max_loras_per_batch
@@ -2897,12 +2898,26 @@ class Scheduler(
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
         if not self._set_or_validate_priority(req):
             return
+        if is_retracted and self._abort_on_retraction_limit(req):
+            return
         if self.disaggregation_mode == DisaggregationMode.NULL:
-            if self._abort_on_queued_limit(req):
+            # A retracted request is not a new arrival: it was already admitted and
+            # has already paid for a full prefill. Rejecting it here because other
+            # requests filled the queue would throw that work away and punish the
+            # victim of memory pressure it did not create. Retracted requests are
+            # therefore exempt from the cap; the resulting overflow is bounded by
+            # the running batch size (you can only retract what was running), so
+            # the queue can exceed max_queued_requests by at most
+            # max_running_requests. Churn is bounded separately by
+            # _abort_on_retraction_limit above.
+            if not is_retracted and self._abort_on_queued_limit(req):
                 return
             self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
-            req.time_stats.set_wait_queue_entry_time()
+            if is_retracted:
+                req.time_stats.set_retract_time()
+            else:
+                req.time_stats.set_wait_queue_entry_time()
         elif self.disaggregation_mode == DisaggregationMode.PREFILL:
             self._prefetch_kvcache(req)
             self.disagg_prefill_bootstrap_queue.add(
@@ -2941,6 +2956,49 @@ class Scheduler(
             req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
             self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
             return False
+        return True
+
+    def _abort_on_retraction_limit(self, req: Req) -> bool:
+        """Fail a request fast once it has been retracted too many times.
+
+        Retracted requests bypass the waiting-queue cap so that memory pressure
+        does not kill work that was already admitted and prefilled. That
+        exemption needs a bound: every retraction discards the request's KV
+        cache, so a request that keeps getting retracted keeps paying for a full
+        re-prefill and can livelock between the running batch and the waiting
+        queue while the GPU stays busy at zero goodput. Aborting explicitly is
+        strictly better for the client than hanging indefinitely.
+
+        Returns True if the request was aborted.
+        """
+        if (
+            self.max_retraction_count is None
+            or req.retraction_count <= self.max_retraction_count
+        ):
+            return False
+
+        message = (
+            f"The request was retracted {req.retraction_count} times, exceeding "
+            f"--max-retraction-count ({self.max_retraction_count}). The server is "
+            "memory-bound; retry later or reduce the input length."
+        )
+        logger.warning(
+            "Aborting req %s: retraction_count=%d > max_retraction_count=%d",
+            req.rid,
+            req.retraction_count,
+            self.max_retraction_count,
+        )
+        abort_req = _make_abort_req(
+            req,
+            finished_reason={
+                "type": "abort",
+                "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
+                "message": message,
+            },
+        )
+        req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
+        self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
+        self.beam_coordinator.retire_group(req)
         return True
 
     def _abort_on_queued_limit(self, recv_req: Req) -> bool:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -800,6 +800,18 @@ class ServerArgs:
         ),
         NS("schedule"),
     ] = "length"
+    max_retraction_count: A[
+        Optional[int],
+        (
+            "The maximum number of times a single request may be retracted and "
+            "re-queued before it is failed fast with HTTP 503. Retracting a request "
+            "discards its KV cache, so every retraction costs a full re-prefill; "
+            "without a bound, a request can livelock between the running batch and "
+            "the waiting queue while burning GPU on repeated prefills. "
+            "None (default) keeps the unlimited legacy behavior."
+        ),
+        NS("schedule")
+    ] = None
     schedule_conservativeness: A[
         float,
         "How conservative the schedule policy is. A larger value means more conservative scheduling. Use a larger value if you see requests being retracted frequently.",

--- a/test/registered/unit/managers/test_retracted_req_requeue.py
+++ b/test/registered/unit/managers/test_retracted_req_requeue.py
@@ -1,0 +1,170 @@
+"""Unit tests for how retracted requests are re-queued.
+
+A retracted request is not a new arrival: it was already admitted and has
+already paid for a full prefill. It must therefore not be rejected by the
+waiting-queue cap (`--max-queued-requests`), which exists to shed *incoming*
+load. Churn is bounded instead by `--max-retraction-count`.
+"""
+
+import unittest
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.utils import DisaggregationMode  # noqa: E402
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestRetractedReqRequeue(unittest.TestCase):
+    def setUp(self):
+        # _make_abort_req reads get_serving().weight_version from the
+        # published config, which does not exist for a __new__-built scheduler.
+        patcher = patch(
+            "sglang.srt.managers.scheduler.get_serving",
+            return_value=SimpleNamespace(weight_version="v0"),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _new_scheduler(
+        self,
+        max_queued_requests=None,
+        max_retraction_count=None,
+        queue_depth=0,
+    ) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.enable_priority_scheduling = False
+        scheduler.schedule_low_priority_values_first = False
+        scheduler.abort_on_priority_when_disabled = False
+        scheduler.enable_hicache_storage = False
+        scheduler.max_queued_requests = max_queued_requests
+        scheduler.max_retraction_count = max_retraction_count
+        scheduler.waiting_queue = [
+            self._new_req(rid=f"queued-{i}") for i in range(queue_depth)
+        ]
+        scheduler._prefetch_kvcache = MagicMock()
+        scheduler.model_config = SimpleNamespace(num_key_value_heads=8)
+        scheduler.ipc_channels = MagicMock()
+        scheduler.beam_coordinator = MagicMock()
+        scheduler.tree_cache = MagicMock()
+        return scheduler
+
+    def _new_req(self, rid="req", retraction_count=0, priority=None):
+        req = MagicMock()
+        req.rid = rid
+        req.priority = priority
+        req.retraction_count = retraction_count
+        req.output_ids = []
+        req.weight_version_events = []
+        req.time_stats = MagicMock()
+        req.time_stats.trace_ctx = MagicMock()
+        return req
+
+    def _sent_abort(self, scheduler):
+        """Return the finished_reason of the abort that was sent, or None."""
+        calls = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args_list
+        if not calls:
+            return None
+        return calls[-1].args[0].finished_reason
+
+    # --- queue cap must not kill retracted requests -----------------------
+
+    def test_retracted_req_bypasses_full_queue(self):
+        """The regression this branch fixes: a full queue used to 503 a
+        retracted request, discarding a prefill it had already paid for."""
+        scheduler = self._new_scheduler(max_queued_requests=1, queue_depth=1)
+        req = self._new_req(rid="retracted", retraction_count=1)
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertIn(req, scheduler.waiting_queue)
+        self.assertIsNone(self._sent_abort(scheduler))
+        req.time_stats.set_retract_time.assert_called_once()
+
+    def test_new_req_still_rejected_when_queue_full(self):
+        """The exemption must not weaken admission control for new arrivals."""
+        scheduler = self._new_scheduler(max_queued_requests=1, queue_depth=1)
+        req = self._new_req(rid="incoming")
+
+        scheduler._add_request_to_queue(req, is_retracted=False)
+
+        self.assertNotIn(req, scheduler.waiting_queue)
+        reason = self._sent_abort(scheduler)
+        self.assertIsNotNone(reason)
+        self.assertEqual(reason["status_code"], HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertIn("queue is full", reason["message"])
+
+    # --- retraction count bounds the churn --------------------------------
+
+    def test_retraction_count_over_limit_fails_fast(self):
+        scheduler = self._new_scheduler(max_queued_requests=8, max_retraction_count=3)
+        req = self._new_req(rid="thrashing", retraction_count=4)
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertNotIn(req, scheduler.waiting_queue)
+        reason = self._sent_abort(scheduler)
+        self.assertIsNotNone(reason)
+        self.assertEqual(reason["status_code"], HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertIn("max-retraction-count", reason["message"])
+
+    def test_retraction_count_at_limit_is_still_admitted(self):
+        scheduler = self._new_scheduler(max_queued_requests=8, max_retraction_count=3)
+        req = self._new_req(rid="borderline", retraction_count=3)
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertIn(req, scheduler.waiting_queue)
+        self.assertIsNone(self._sent_abort(scheduler))
+
+    def test_retraction_count_unlimited_by_default(self):
+        """Default (None) preserves the legacy unbounded behavior."""
+        scheduler = self._new_scheduler(max_queued_requests=8)
+        req = self._new_req(rid="veteran", retraction_count=9999)
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertIn(req, scheduler.waiting_queue)
+        self.assertIsNone(self._sent_abort(scheduler))
+
+    def test_retraction_limit_applies_before_queue_exemption(self):
+        """A request over the retraction limit is dropped even though the
+        exemption would otherwise let it into a full queue."""
+        scheduler = self._new_scheduler(
+            max_queued_requests=1, max_retraction_count=2, queue_depth=1
+        )
+        req = self._new_req(rid="thrashing", retraction_count=5)
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertNotIn(req, scheduler.waiting_queue)
+        self.assertEqual(len(scheduler.waiting_queue), 1)
+        reason = self._sent_abort(scheduler)
+        self.assertIn("max-retraction-count", reason["message"])
+
+    # --- overflow stays bounded -------------------------------------------
+
+    def test_retracted_overflow_is_bounded_by_running_batch(self):
+        """Exempting retracted requests can only overflow the queue by the
+        number of requests that were actually running."""
+        max_queued, max_running = 4, 3
+        scheduler = self._new_scheduler(
+            max_queued_requests=max_queued, queue_depth=max_queued
+        )
+
+        for i in range(max_running):
+            scheduler._add_request_to_queue(
+                self._new_req(rid=f"retracted-{i}", retraction_count=1),
+                is_retracted=True,
+            )
+
+        self.assertEqual(len(scheduler.waiting_queue), max_queued + max_running)
+        self.assertIsNone(self._sent_abort(scheduler))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

    A retracted request is re-queued through the same _add_request_to_queue
    entry point as a brand-new arrival, so it was subject to
    _abort_on_queued_limit. That meant a request which had already been
    admitted and had already paid for a full prefill could be answered with
    503 because *other* requests filled the waiting queue in the meantime.
    The victim of memory pressure was charged for pressure it did not create,
    and the prefill work was thrown away.

    Retracted requests are now exempt from max_queued_requests. The resulting
    overflow is bounded rather than open-ended: only requests that were in the
    running batch can be retracted, so the queue can exceed the cap by at most
    max_running_requests.

    The exemption needs a churn bound of its own. Retraction discards the
    request's KV cache (release_req only host-backs it in PD-disaggregated
    decode mode), so each retraction costs a full re-prefill, and an unbounded
    exemption lets a request livelock between the running batch and the
    waiting queue while the GPU stays busy at zero goodput. Add
    --max-retraction-count to fail such a request fast with 503 and a message
    pointing at memory pressure. The retraction_count field already existed
    but was observability-only; it now feeds the decision. Default None keeps
    the previous unlimited behavior.

    The retraction limit is checked before the queue-cap exemption, so an
    over-limit request cannot use the exemption to linger in the queue.
    Re-queued requests also now record set_retract_time instead of
    set_wait_queue_entry_time, which keeps the waiting-timeout sweep and the
    priority-eviction tiebreak reading a first-arrival timestamp.

## Motivation

A retracted request is re-queued through the same _add_request_to_queue entry point as a brand-new arrival, so it was subject to _abort_on_queued_limit. That meant a request which had already been admitted and had already paid for a full prefill could be answered with 503 simply because other requests filled the waiting queue in the meantime. The victim of memory pressure was charged for pressure it did not create, and the prefill work it had already completed was thrown away.The waiting-queue cap exists to shed incoming load, not to punish requests the server has already committed to serving.

## Modifications

- Retracted requests are now exempt from --max-queued-requests (scheduler.py:_add_request_to_queue). The resulting overflow is bounded rather than open-ended: only requests that were in the running batch can be retracted, so the waiting queue can exceed the cap by at most max_running_requests.
- New --max-retraction-count server argument (default None, preserving the previous unlimited behavior). The exemption above needs a churn bound of its own: retraction discards the request's KV cache (release_req only host-backs it in PD-disaggregated decode mode), so each retraction costs a full re-prefill, and an unbounded exemption lets a request livelock between the running batch and the waiting queue while the GPU stays busy at zero goodput. When the limit is exceeded, the - request fails fast with HTTP 503 and a message pointing at memory pressure.
- retraction_count now feeds the scheduling decision. The field already existed but was observability-only.
The retraction limit is checked before the queue-cap exemption, so an over-limit request cannot use the exemption to linger in the queue.
- Re-queued retracted requests now record set_retract_time instead of set_wait_queue_entry_time, so the waiting-timeout sweep and the priority-eviction tiebreak keep reading a first-arrival timestamp.
Validation: --max-retraction-count must be non-negative (arg_groups/validation_hook.py).
Unit tests (test/registered/unit/managers/test_retracted_req_requeue.py): 7 cases covering the regression (retracted request bypasses a full queue), admission control for new arrivals, the retraction-count boundary (over limit fails fast / at limit admitted / default unlimited), check ordering (limit before exemption), and bounded overflow.

## Accuracy Tests

This PR does not touch model forward code or any kernel; model outputs are unaffected.
Unit tests run locally:
```
pytest test/registered/unit/managers/test_retracted_req_requeue.py -v
======================== 7 passed in ~5s ========================
```

## Speed Tests and Profiling

No benchmarking was performed because this PR does not touch the inference hot path. The added logic is a single branch check in _add_request_to_queue, which runs only at enqueue time (new arrivals and retractions), not per token step.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33401886990](https://github.com/sgl-project/sglang/actions/runs/33401886990)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33401886792](https://github.com/sgl-project/sglang/actions/runs/33401886792)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33401886956](https://github.com/sgl-project/sglang/actions/runs/33401886956)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->