### PR TITLE
[Bug] Enforce Responses max_tool_calls for built-in tools

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1874,6 +1874,7 @@ class ResponsesResponse(BaseModel):
     incomplete_details: Optional[dict] = None  # TODO(v) support this input
     instructions: Optional[str] = None
     max_output_tokens: Optional[int] = None
+    max_tool_calls: Optional[int] = None
     previous_response_id: Optional[str] = None
     reasoning: Optional[dict] = (
         # Unused. No model supports this. For GPT-oss, system prompt sets
@@ -1986,6 +1987,7 @@ class ResponsesResponse(BaseModel):
             ),
             instructions=request.instructions,
             max_output_tokens=request.max_output_tokens,
+            max_tool_calls=request.max_tool_calls,
             previous_response_id=request.previous_response_id,  # TODO(v): ensure this is propagated if retrieved from store
             reasoning={
                 "effort": (

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -469,6 +469,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         context,
                         raw_request=raw_request,
                         priority=request.priority,
+                        max_tool_calls=request.max_tool_calls,
                     )
                     generators.append(generator)
             except ValueError as e:
@@ -2537,10 +2538,12 @@ class OpenAIServingResponses(OpenAIServingChat):
         context: ConversationContext,
         raw_request: Optional[Request] = None,
         priority: Optional[int] = None,
+        max_tool_calls: Optional[int] = None,
         **kwargs,
     ) -> AsyncGenerator[Any, None]:
         """Generate with builtin tool support for harmony-based models."""
         orig_priority = priority or 0
+        tool_call_count = 0
 
         while True:
             # Generate using SGLang's tokenizer manager
@@ -2556,9 +2559,12 @@ class OpenAIServingResponses(OpenAIServingChat):
             if not context.need_builtin_tool_call():
                 # The model did not ask for a tool call, so we're done.
                 break
+            if max_tool_calls is not None and tool_call_count >= max_tool_calls:
+                break
 
             # Call the tool and update the context with the result.
             tool_output = await context.call_tool()
+            tool_call_count += 1
             context.append_output(tool_output)
 
             # Prepare for the next generation turn

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -267,6 +267,39 @@ class ResponsesResponseFromRequestTestCase(CustomTestCase):
         )
         self.assertFalse(response.parallel_tool_calls)
 
+    def test_max_tool_calls_preserved(self):
+        import openai.types.responses as ort
+
+        for max_tool_calls in (None, 0, 3):
+            with self.subTest(max_tool_calls=max_tool_calls):
+                request = ResponsesRequest(
+                    model="x",
+                    input="hi",
+                    max_tool_calls=max_tool_calls,
+                    store=False,
+                )
+                response = ResponsesResponse.from_request(
+                    request,
+                    sampling_params={},
+                    model_name="x",
+                    created_time=0,
+                    output=[],
+                    status="completed",
+                    usage=UsageInfo(
+                        prompt_tokens=1, completion_tokens=1, total_tokens=2
+                    ),
+                )
+
+                self.assertEqual(response.max_tool_calls, max_tool_calls)
+                self.assertEqual(
+                    response.model_dump()["max_tool_calls"], max_tool_calls
+                )
+                ort.ResponseCreatedEvent(
+                    type="response.created",
+                    sequence_number=0,
+                    response=response.model_dump(),
+                )
+
     def test_incomplete_status_sets_incomplete_details(self):
         request = ResponsesRequest(model="x", input="hi", store=False)
         incomplete = ResponsesResponse.from_request(

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -22,6 +22,7 @@ from sglang.srt.entrypoints.openai.serving_responses import (
     _should_emit_normal_text_as_message,
 )
 from sglang.srt.function_call.core_types import ToolCallItem
+from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -438,6 +439,96 @@ class InputItemNormalizationTestCase(CustomTestCase):
             OpenAIServingResponses._normalize_response_message_for_chat(
                 {"type": "web_search_call", "id": "ws_1"}
             )
+
+
+class _BuiltinToolSequenceContext:
+    def __init__(self, requested_tools):
+        self.requested_tools = requested_tools
+        self.generation_turns = 0
+        self.executed_tools = []
+
+    def append_output(self, output):
+        if isinstance(output, dict) and "engine_turn" in output:
+            self.generation_turns += 1
+
+    def need_builtin_tool_call(self):
+        return self.generation_turns <= len(self.requested_tools)
+
+    async def call_tool(self):
+        tool = self.requested_tools[self.generation_turns - 1]
+        self.executed_tools.append(tool)
+        return [{"tool": tool}]
+
+    def render_for_completion(self):
+        return [1, 2, 3]
+
+
+class BuiltinToolCallLimitTestCase(CustomTestCase):
+    def _run_tool_sequence(self, requested_tools, max_tool_calls, stream):
+        serving = make_serving()
+        context = _BuiltinToolSequenceContext(requested_tools)
+        engine_requests = []
+
+        async def generate(adapted_request, _raw_request):
+            engine_requests.append(adapted_request)
+            yield {"engine_turn": len(engine_requests)}
+
+        serving.tokenizer_manager.generate_request.side_effect = generate
+        adapted_request = GenerateReqInput(
+            input_ids=[1],
+            sampling_params={},
+            stream=stream,
+            rid="resp_tool_limit",
+        )
+
+        async def consume():
+            async for _ in serving._generate_with_builtin_tools(
+                "resp_tool_limit",
+                [1],
+                adapted_request,
+                {},
+                context,
+                max_tool_calls=max_tool_calls,
+            ):
+                pass
+
+        asyncio.run(consume())
+        return context, engine_requests
+
+    def test_builtin_tool_limit_matrix(self):
+        cases = (
+            ("zero", ["browser.search"], 0, [], 1),
+            ("one_shared", ["browser.search", "python"], 1, ["browser.search"], 2),
+            (
+                "exact_boundary",
+                ["browser.search", "python"],
+                2,
+                ["browser.search", "python"],
+                3,
+            ),
+            (
+                "unlimited",
+                ["browser.search", "python"],
+                None,
+                ["browser.search", "python"],
+                3,
+            ),
+            ("no_tool", [], 1, [], 1),
+        )
+
+        for stream in (False, True):
+            for name, tools, limit, expected_tools, expected_turns in cases:
+                with self.subTest(name=name, stream=stream):
+                    context, engine_requests = self._run_tool_sequence(
+                        tools, limit, stream
+                    )
+
+                    self.assertEqual(context.executed_tools, expected_tools)
+                    self.assertEqual(context.generation_turns, expected_turns)
+                    self.assertEqual(len(engine_requests), expected_turns)
+                    self.assertTrue(
+                        all(request.stream is stream for request in engine_requests)
+                    )
 
 
 class FullResponseUsageTestCase(CustomTestCase):
@@ -864,6 +955,7 @@ class EnginePassthroughTestCase(CustomTestCase):
         ):
             captured["adapted_request"] = adapted_request
             captured["sampling_params"] = sampling_params
+            captured["generator_kwargs"] = kwargs
             context.append_output(
                 {
                     "text": "ok",
@@ -946,6 +1038,16 @@ class EnginePassthroughTestCase(CustomTestCase):
         )
 
         self.assertFalse(captured["sampling_params"]["skip_special_tokens"])
+
+    def test_max_tool_calls_forwarded_to_builtin_loop(self):
+        serving = make_serving()
+
+        captured = self._capture(
+            serving,
+            ResponsesRequest(model="x", input="hi", max_tool_calls=3, store=False),
+        )
+
+        self.assertEqual(captured["generator_kwargs"]["max_tool_calls"], 3)
 
 
 class CancelIdempotencyTestCase(CustomTestCase):


### PR DESCRIPTION
## Motivation

ResponsesRequest accepts max_tool_calls, but the Harmony built-in tool loop does not currently enforce it. On current main, a request with max_tool_calls=1 still executes two consecutive built-in tool calls.

## Modifications

- Forward max_tool_calls into the built-in tool generation loop.
- Track successful built-in executions per response, shared across browser and Python tools, and stop before dispatching an attempt beyond the limit.
- Preserve unlimited behavior when the field is omitted and leave custom function calls and response completion status unchanged.
- Echo max_tool_calls in Responses objects, including typed streaming event payloads.
- Add regression coverage for zero, one, exact-boundary, unlimited, no-tool, streaming, non-streaming, request forwarding, response serialization, and OpenAI SDK event validation.

## Accuracy Tests

This changes Responses API control flow, not model or kernel numerics.

- 57 focused tests passed, with 13 boundary subtests.
- The complete OpenAI entrypoint unit suite passed: 328 tests and 131 subtests.
- Both modified test files pass through their repository CI unittest entry points (35 and 22 tests).
- All configured pre-commit hooks passed on the exact committed SHA.
- Three mutation checks independently confirmed that the regressions fail if enforcement, request forwarding, or response echoing is removed.

## Speed Tests and Profiling

Not applicable. The runtime change is one response-local counter and one comparison at a built-in tool-call boundary.

## Checklist

- [x] Format your code according to the Format code with pre-commit guidance.
- [x] Add unit tests according to the Run and add unit tests guidance.
- [x] Documentation is not required because this fixes enforcement of an existing request field without changing syntax.
- [x] Accuracy and speed benchmarks are not applicable to this API control-flow fix; relevant unit and mutation tests are reported above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33408369829](https://github.com/sgl-project/sglang/actions/runs/33408369829)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33408369544](https://github.com/sgl-project/sglang/actions/runs/33408369544)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33408369789](https://github.com/sgl-project/sglang/actions/runs/33408369789)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->