### PR TITLE
[ROCm] Optimize Hy4-preview graph inference on gfx942 and gfx950

### DIFF
--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -16,6 +16,22 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
+)
+
+
+@torch.compiler.disable
+def _retain_mhc_capture_owners(*tensors: torch.Tensor) -> None:
+    """Retain scratch tensors whose addresses a full graph capture records.
+
+    No-op outside an active full-graph capture scope. The compiler-disable
+    boundary keeps the retention side effect out of any enclosing Dynamo
+    graph, which would otherwise trace it away.
+    """
+    for tensor in tensors:
+        retain_full_cuda_graph_owner(tensor)
+
 
 logger = logging.getLogger(__name__)
 
@@ -844,6 +860,7 @@ def mhc_pre(
         gemm_out_sqrsum = torch.empty(
             n_splits, num_tokens, dtype=torch.float32, device=residual.device
         )
+        _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
 
         from sglang.srt.layers.deep_gemm_wrapper.entrypoint import tf32_hc_prenorm_gemm
 
@@ -885,6 +902,7 @@ def mhc_pre(
             partial_sqrsum = torch.empty(
                 n_splits_pre, num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(partial_out, partial_sqrsum)
             kernel_0(
                 residual_flat.view(num_tokens, hc_hidden_size),
                 fn_flat,
@@ -907,6 +925,7 @@ def mhc_pre(
             gemm_out_sqrsum = torch.empty(
                 n_splits, num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
             assert (
                 n_splits == 1
             ), "The simple TileLang version gemm_sqrsum doesn't support split-k"
@@ -933,6 +952,10 @@ def mhc_pre(
         )
         if not norm_weight_bf.is_contiguous():
             norm_weight_bf = norm_weight_bf.contiguous()
+        if norm_weight_bf is not norm_weight:
+            # Only a converted or contiguous copy has a dying owner; the
+            # caller's own parameter tensor outlives the graph already.
+            _retain_mhc_capture_owners(norm_weight_bf)
         mhc_pre_big_fuse_with_norm_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
@@ -1419,6 +1442,7 @@ def mhc_fused_post_pre(
     if num_tokens <= fma_token_threshold:
         # Small-batch path: one TileLang launch computes hc_post, the bf16
         # residual write, GEMM partials, and the RMS square-sum partials.
+        _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
         mhc_fused_post_pre_fma_tilelang(
             comb_res_mix.view(num_tokens, hc_mult, hc_mult),
             residual_flat,
@@ -1450,6 +1474,7 @@ def mhc_fused_post_pre(
         if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
             import deep_gemm
 
+            _retain_mhc_capture_owners(gemm_out_mul, gemm_out_sqrsum)
             deep_gemm.tf32_hc_prenorm_gemm(
                 residual_cur.view(num_tokens, hc_hidden_size),
                 fn,
@@ -1466,6 +1491,7 @@ def mhc_fused_post_pre(
             gemm_out_sqrsum_1d = torch.empty(
                 num_tokens, dtype=torch.float32, device=residual.device
             )
+            _retain_mhc_capture_owners(gemm_out_mul_2d, gemm_out_sqrsum_1d)
             mhc_pre_gemm_sqrsum_tilelang(
                 residual_cur.view(num_tokens, hc_hidden_size),
                 fn,
@@ -1512,6 +1538,10 @@ def mhc_fused_post_pre(
         )
         if not norm_weight_bf.is_contiguous():
             norm_weight_bf = norm_weight_bf.contiguous()
+        if norm_weight_bf is not norm_weight:
+            # Only a converted or contiguous copy has a dying owner; the
+            # caller's own parameter tensor outlives the graph already.
+            _retain_mhc_capture_owners(norm_weight_bf)
         mhc_pre_big_fuse_with_norm_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2041,7 +2041,10 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
     )
 
     if getattr(hf_config, "learnable_sink", False):
-        backend = "flashmla_sparse"
+        # FlashMLA consumes the sink natively on CUDA. ROCm uses AITER sparse
+        # MLA and reconstructs the virtual zero-value sink from the kernel's
+        # natural-log LSE, preserving the trained attention denominator.
+        backend = "aiter" if is_hip() else "flashmla_sparse"
         for field in ("dsa_prefill_backend", "dsa_decode_backend"):
             value = getattr(view, field)
             if value is not None and value != backend:

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -121,7 +121,7 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         """Precompute metadata for normal decode mode."""
         max_len = self.decode_cuda_graph_metadata[bs].page_table_1.shape[1]
 
-        if _is_cuda and not _is_hip:
+        if _is_cuda or _is_hip:
             from sglang.kernels.ops.attention.dsa_metadata import (
                 fused_dsa_decode_metadata,
             )
@@ -240,7 +240,7 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
         max_seqlen_k = self.decode_cuda_graph_metadata[bs].page_table_1.shape[1]
         seqlens_expanded_size = bs * self.speculative_num_draft_tokens
 
-        if _is_cuda and not _is_hip:
+        if _is_cuda or _is_hip:
             from sglang.kernels.ops.attention.dsa_metadata import (
                 fused_dsa_target_verify_metadata,
             )

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -132,15 +132,18 @@ if TYPE_CHECKING:
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
 
+if _is_cuda or _is_hip:
+    # Plain-torch graph helpers: usable wherever the split-op surface is.
+    from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
+        logits_head_gate_graph,
+        scale_head_gate_graph,
+    )
+
 if _is_cuda:
     from sglang.kernels.ops.attention.dsv4 import fused_q_indexer_rope_first_quant
     from sglang.kernels.ops.quantization.dsv32 import (
         fused_k_indexer_norm_rope,
         fused_k_indexer_norm_rope_store,
-    )
-    from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
-        logits_head_gate_graph,
-        scale_head_gate_graph,
     )
 
     @register_custom_op(mutates_args=["topk_indices"])

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -39,6 +39,9 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
+)
 from sglang.srt.runtime_context import (
     get_device,
     get_exec,
@@ -756,7 +759,18 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         target_heads = 32
         q_fp8 = torch.nn.functional.pad(q_fp8, (0, 0, 0, target_heads - num_heads))
         weights = torch.nn.functional.pad(weights, (0, target_heads - num_heads))
+        Indexer._retain_padded_head_capture_owners(q_fp8, weights)
         return q_fp8, weights, num_heads
+
+    @staticmethod
+    @torch.compiler.disable
+    def _retain_padded_head_capture_owners(
+        q_fp8: torch.Tensor, weights: torch.Tensor
+    ) -> None:
+        # The padded tensors, not their sources, are what the captured
+        # kernels record; no-op outside an active full-graph capture scope.
+        retain_full_cuda_graph_owner(q_fp8)
+        retain_full_cuda_graph_owner(weights)
 
     def _mask_init_and_local_tokens(
         self,
@@ -792,6 +806,21 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             logits.scatter_(dim=1, index=local_idxs, value=float("inf"))
         return logits
 
+    @torch.compiler.disable
+    def _retain_full_graph_capture_owner(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Retain a tensor whose address a full CUDA graph capture records.
+
+        CUDA graphs replay through raw device pointers, so every tensor a
+        captured kernel reads or writes must stay allocated for the graph's
+        lifetime. The retain call is a no-op outside an active full-graph
+        capture scope; during capture the backend stores the owner with the
+        captured shape and releases it on recapture or cleanup. The
+        ``torch.compiler.disable`` boundary keeps the Python side effect out
+        of any enclosing Dynamo graph, which would otherwise trace it away.
+        """
+        retain_full_cuda_graph_owner(tensor)
+        return tensor
+
     def _get_topk_paged(
         self,
         forward_batch: ForwardBatch,
@@ -803,6 +832,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
+        weights = self._retain_full_graph_capture_owner(weights)
         page_size = get_token_to_kv_pool().page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
         if _is_hip:
@@ -951,6 +981,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
             )
 
+        logits = self._retain_full_graph_capture_owner(logits)
         # NOTE(dark): logits should be cleaned in topk_transform
         self._mask_init_and_local_tokens(logits, seqlens_32)
         topk_result = metadata.topk_transform(logits, self.index_topk)
@@ -1032,6 +1063,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
+        weights = self._retain_full_graph_capture_owner(weights)
         assert forward_batch.forward_mode.is_extend_without_speculative()
 
         page_size = get_token_to_kv_pool().page_size
@@ -1141,6 +1173,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
+            logits = self._retain_full_graph_capture_owner(logits)
             self._mask_init_and_local_tokens(logits, seq_lens_expanded, ks)
             raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
             topk_result[:q_offset] = raw_topk_result
@@ -1210,6 +1243,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 cu_seqlens_q_chunk = cu_seqlens_q_full[start:end]
                 batch_idx_chunk = token_to_batch_idx[start:end]
 
+            logits_chunk = self._retain_full_graph_capture_owner(logits_chunk)
             raw_topk_chunk = metadata.topk_transform(
                 logits_chunk,
                 self.index_topk,
@@ -1301,6 +1335,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             dtype=torch.float32,
             device=x_meta.device,
         )
+        dummy_logits = self._retain_full_graph_capture_owner(dummy_logits)
         raw_topk_result = metadata.topk_transform(dummy_logits, self.index_topk)
         if topk_result is not None:
             # PCG/BCG: fill the valid prefix of the padded static buffer and
@@ -1324,6 +1359,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             "DSA context parallel (_get_topk_ragged_with_cp) not supported under "
             "piecewise/breakable CUDA graph"
         )
+        weights = self._retain_full_graph_capture_owner(weights)
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
 
@@ -1404,6 +1440,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     ke,
                     clean_logits=False,
                 )
+            logits = self._retain_full_graph_capture_owner(logits)
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -1454,6 +1491,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
+            logits = self._retain_full_graph_capture_owner(logits)
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,

--- a/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
@@ -14,10 +14,11 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_hip
 from sglang.srt.utils.custom_op import register_custom_op
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 
 GRAPH_WEIGHTS_PROJ_LORA_ERROR = (
     "DSA indexer weights_proj LoRA is incompatible with "
@@ -31,7 +32,7 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
     return is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph()
 
 
-if _is_cuda:
+if _is_cuda or _is_hip:
 
     def _scale_head_gate_graph_fake_impl(
         weights_raw: torch.Tensor,
@@ -103,7 +104,9 @@ def pcg_dsa_indexer_prefill_split(
     # call site pre-allocates it at a static, padded shape and a downstream
     # captured graph reads it at a fixed address; eager code instead allocates
     # and returns a fresh, naturally-sized tensor each call.
-    assert _is_cuda, "Internal error: DSA graph dispatch is only supported on CUDA"
+    assert (
+        _is_cuda or _is_hip
+    ), "Internal error: DSA graph dispatch is only supported on CUDA/HIP"
     from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 
     forward_context = get_tc_piecewise_forward_context()

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -140,7 +140,7 @@ def is_dsa_prefill_cp_round_robin_split():
 # site (e.g. the indexer also excludes DSA prefill context parallelism).
 def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
-        is_cuda()
+        (is_cuda() or is_hip())
         and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
         and forward_batch.forward_mode.is_extend_without_speculative()
     )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1447,7 +1447,7 @@ class DeepseekSparseAttnBackend(
             # Normal Decode
             max_len = self._graph_page_table_width(metadata)
 
-            if is_cuda() and not _is_hip:
+            if is_cuda() or _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_decode_metadata,
                 )
@@ -1489,7 +1489,7 @@ class DeepseekSparseAttnBackend(
         elif forward_mode.is_target_verify():
             max_seqlen_k = self._graph_page_table_width(metadata)
 
-            if is_cuda() and not _is_hip:
+            if is_cuda() or _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_target_verify_metadata,
                 )
@@ -1587,7 +1587,7 @@ class DeepseekSparseAttnBackend(
                 device=self.device,
             )
 
-            if is_cuda() and not _is_hip:
+            if is_cuda() or _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_draft_extend_metadata,
                 )
@@ -1956,7 +1956,6 @@ class DeepseekSparseAttnBackend(
             )
 
         # Do absorbed multi-latent attention (MLA path)
-        assert q_rope is not None
         kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
 
         if q_rope is not None:
@@ -1964,6 +1963,7 @@ class DeepseekSparseAttnBackend(
             q_rope = q_rope.view(
                 -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
             )
+            q_all = None
         else:
             q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
             q_nope = q_all[:, :, : layer.v_head_dim]
@@ -2044,7 +2044,11 @@ class DeepseekSparseAttnBackend(
                         sm_scale=layer.scaling,
                         d_v=layer.v_head_dim,
                     )
-                q_all = concat_mla_absorb_q_general(q_nope, q_rope)
+                # Cat-skip, as in forward_decode: q_rope=None means the caller
+                # already handed us the concatenated form and q_all is a
+                # zero-copy view of it. `not _is_hip` keeps CUDA byte-identical.
+                if q_all is None or not _is_hip:
+                    q_all = concat_mla_absorb_q_general(q_nope, q_rope)
             return self._forward_tilelang(
                 q_all=q_all,
                 kv_cache=kv_cache,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -90,6 +90,35 @@ from sglang.srt.utils import (
 _DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
 _IS_GFX95 = is_gfx95_supported()
 
+
+def apply_aiter_attention_sink(
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    attn_sink: torch.Tensor,
+) -> torch.Tensor:
+    """Apply HYV4's zero-valued attention sink to AITER MLA output.
+
+    AITER returns the sink-free normalized output and natural-log softmax
+    denominator. Appending a virtual key with score ``attn_sink`` and value
+    zero therefore only rescales the output by
+    ``exp(lse) / (exp(lse) + exp(attn_sink))``.
+    """
+    if output.ndim != 3:
+        raise ValueError(f"AITER MLA output must be 3D, got {output.shape}.")
+    if lse.shape != output.shape[:2]:
+        raise ValueError(
+            "AITER MLA LSE must match the output token/head dimensions, "
+            f"got lse={lse.shape}, output={output.shape}."
+        )
+    if attn_sink.ndim != 1 or attn_sink.shape[0] != output.shape[1]:
+        raise ValueError(
+            "Attention sink must contain one value per local attention head, "
+            f"got sink={attn_sink.shape}, output={output.shape}."
+        )
+    factor = torch.sigmoid(lse.float() - attn_sink.float().unsqueeze(0))
+    return (output.float() * factor.unsqueeze(-1)).to(output.dtype)
+
+
 if is_cuda():
     import deep_gemm
 
@@ -1901,9 +1930,10 @@ class DeepseekSparseAttnBackend(
             )
             else self.dsa_prefill_impl
         )
-        if attn_sink is not None and dsa_impl != "flashmla_sparse":
+        if attn_sink is not None and dsa_impl not in ("flashmla_sparse", "aiter"):
             raise RuntimeError(
-                f"Learnable attention sinks require flashmla_sparse, got {dsa_impl}"
+                "Learnable attention sinks require flashmla_sparse or aiter, "
+                f"got {dsa_impl}"
             )
 
         if dsa_impl == "trtllm" and not self.use_mha:
@@ -2185,6 +2215,7 @@ class DeepseekSparseAttnBackend(
                 kv_cache=kv_cache,
                 page_table_1=page_table_1,
                 layer=layer,
+                attn_sink=attn_sink,
             )
         else:
             raise ValueError(
@@ -2213,9 +2244,12 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
-        if attn_sink is not None and self.dsa_decode_impl != "flashmla_sparse":
+        if attn_sink is not None and self.dsa_decode_impl not in (
+            "flashmla_sparse",
+            "aiter",
+        ):
             raise RuntimeError(
-                "Learnable attention sinks require flashmla_sparse, got "
+                "Learnable attention sinks require flashmla_sparse or aiter, got "
                 f"{self.dsa_decode_impl}"
             )
 
@@ -2364,6 +2398,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 bs=forward_batch.batch_size,
+                attn_sink=attn_sink,
             )
 
         else:
@@ -2978,6 +3013,7 @@ class DeepseekSparseAttnBackend(
         layer: RadixAttention,
         metadata: DSAMetadata,
         bs: int,
+        attn_sink: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
 
@@ -3028,7 +3064,7 @@ class DeepseekSparseAttnBackend(
             )
             kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
 
-        mla_decode_fwd(
+        aiter_args = (
             q_kernel,
             kv_cache.view(-1, 1, 1, layer.head_dim),
             o_kernel,
@@ -3037,15 +3073,32 @@ class DeepseekSparseAttnBackend(
             kv_indices,
             kv_last_page_lens,
             metadata.max_seq_len_q,
+        )
+        aiter_kwargs = dict(
             sm_scale=layer.scaling,
             logit_cap=layer.logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
             **aiter_persistent_kwargs,
         )
+        lse = None
+        if attn_sink is None:
+            mla_decode_fwd(*aiter_args, **aiter_kwargs)
+        else:
+            _, lse = mla_decode_fwd(*aiter_args, return_lse=True, **aiter_kwargs)
+            if lse is None:
+                raise RuntimeError("AITER MLA did not return LSE for attention sinks.")
 
         if self.need_pad_heads:
             o = o_kernel[:, :: self.head_repeat_factor, :]
+            if lse is not None:
+                lse = lse[:, :: self.head_repeat_factor]
+
+        if attn_sink is not None:
+            assert lse is not None
+            output = o if self.need_pad_heads else o_kernel
+            output = apply_aiter_attention_sink(output, lse, attn_sink)
+            o = output if self.need_pad_heads else output.reshape_as(o)
 
         return o
 
@@ -3055,6 +3108,7 @@ class DeepseekSparseAttnBackend(
         kv_cache: torch.Tensor,
         page_table_1: torch.Tensor,
         layer: RadixAttention,
+        attn_sink: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         num_tokens = q_all.shape[0]
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
@@ -3117,7 +3171,7 @@ class DeepseekSparseAttnBackend(
             kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
 
         # TODO support more forward_mode
-        mla_decode_fwd(
+        aiter_args = (
             q_kernel,
             kv_cache.view(-1, 1, 1, layer.head_dim),
             o_kernel,
@@ -3126,15 +3180,32 @@ class DeepseekSparseAttnBackend(
             kv_indices,
             kv_last_page_lens,
             1,  # max_seq_len_q = 1 for per-token attention
+        )
+        aiter_kwargs = dict(
             sm_scale=layer.scaling,
             logit_cap=layer.logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
             **aiter_persistent_kwargs,
         )
+        lse = None
+        if attn_sink is None:
+            mla_decode_fwd(*aiter_args, **aiter_kwargs)
+        else:
+            _, lse = mla_decode_fwd(*aiter_args, return_lse=True, **aiter_kwargs)
+            if lse is None:
+                raise RuntimeError("AITER MLA did not return LSE for attention sinks.")
 
         if self.need_pad_heads:
             o = o_kernel[:, :: self.head_repeat_factor, :]
+            if lse is not None:
+                lse = lse[:, :: self.head_repeat_factor]
+
+        if attn_sink is not None:
+            assert lse is not None
+            output = o if self.need_pad_heads else o_kernel
+            output = apply_aiter_attention_sink(output, lse, attn_sink)
+            o = output if self.need_pad_heads else output.reshape_as(o)
 
         return o
 

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -378,6 +378,13 @@ def _swiglu_silu_clamp_mul(x, gemm1_limit):
     return gate * up
 
 
+def _apply_swiglu_limit_inplace(x: torch.Tensor, swiglu_limit: float) -> None:
+    """Apply the DeepSeek-V4/HYV4 SwiGLU clamp before activation."""
+    gate, up = x.chunk(2, dim=-1)
+    gate.clamp_(max=swiglu_limit)
+    up.clamp_(min=-swiglu_limit, max=swiglu_limit)
+
+
 @torch.compile
 def swiglu_gpt_oss_sigmoid_alpha(x, gemm1_alpha, gemm1_limit):
     # NOTE: This variant uses gemm1_alpha, unlike _swiglu_silu_clamp_mul.
@@ -694,9 +701,6 @@ def _fused_moe_kernel_sequence(
             )
         elif swiglu_limit is not None:
             # DeepSeek V4: swiglu clamp before silu_and_mul.
-            # Two paths gated by SGLANG_OPT_SWIGLU_CLAMP_FUSION:
-            #   fusion=True: clamp fused into act_and_mul_triton or silu_and_mul_clamp
-            #   fusion=False: explicit clamp_ on intermediate_cache1 (path checker)
             assert swiglu_limit == 10
             assert intermediate_cache1.shape == (total_tokens, N)
             assert (
@@ -708,10 +712,17 @@ def _fused_moe_kernel_sequence(
 
             if filter_expert:
                 swiglu_limit_for_triton = swiglu_limit
+            elif _is_hip:
+                # The fused DSV4 clamp kernel is CUDA/XPU-only. Keep ROCm on
+                # the same graph-captured Triton MoE path by applying the exact
+                # gate/up clamps in place before the ROCm sgl-kernel SiLU.
+                _apply_swiglu_limit_inplace(
+                    intermediate_cache1.view(-1, N), swiglu_limit
+                )
             else:
                 assert (
                     _is_cuda or _is_xpu
-                ), "fused silu_and_mul_clamp kernel is CUDA/XPU only; HIP must disable SWIGLU_CLAMP_FUSION"
+                ), "fused silu_and_mul_clamp kernel is CUDA/XPU only"
                 swiglu_limit_for_silu_and_mul_clamp = swiglu_limit
 
             if not filter_expert:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -97,7 +97,6 @@ from sglang.srt.utils import (
     is_sm120_supported,
     is_xpu,
     log_info_on_rank0,
-    mxfp8_block_convert_required,
     print_warning_once,
     set_weight_attrs,
     use_intel_amx_backend,
@@ -117,15 +116,11 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
-# gfx942 (MI300) has no MX matmul HW; MXFP8 checkpoints are converted to
-# block-fp8 [128,128] at load and run through the native block-fp8 kernels.
-# SGLANG_FORCE_MXFP8_BLOCK_CONVERT=1 opts into that same block-fp8 path on
-# gfx950 (MI35x): it routes the fp8 GEMMs / fused MoE through the mature aiter
-# block-scale kernels instead of the native MX dot_scaled path (measured +20%
-# throughput at equal accuracy on MiniMax-M3, GSM8K 0.9719 vs 0.9689).
-_mxfp8_to_block_fp8_required = mxfp8_block_convert_required() or get_bool_env_var(
-    "SGLANG_FORCE_MXFP8_BLOCK_CONVERT"
-)
+# Keep the opt-in block-FP8 conversion separate from the correctness fallback.
+# When ROCm has no native MXFP8 dense kernel but AITER is available, convert the
+# checkpoint once and use AITER block-FP8 GEMMs. Otherwise retain the exact BF16
+# emulation fallback. Devices with a native MX kernel retain that path.
+_force_mxfp8_to_block_fp8 = get_bool_env_var("SGLANG_FORCE_MXFP8_BLOCK_CONVERT")
 _use_hip_int4 = get_bool_env_var("SGLANG_INT4_WEIGHT") and _is_hip
 _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
@@ -153,6 +148,17 @@ if _use_aiter:
 ACTIVATION_SCHEMES = ["static", "dynamic"]
 
 logger = logging.getLogger(__name__)
+
+
+def _mxfp8_bf16_fallback_required() -> bool:
+    """Whether ROCm lacks a native MXFP8 kernel for checkpoint weights."""
+    return _is_hip and resolve_mxfp8_dense_gemm_backend().is_unsupported()
+
+
+def _mxfp8_block_fp8_fallback_available() -> bool:
+    """Whether AITER block-FP8 can replace unsupported native MXFP8 GEMMs."""
+    return _mxfp8_bf16_fallback_required() and _use_aiter
+
 
 DSV4_DEQUANT_FP4_TABLE = torch.tensor(
     [
@@ -293,7 +299,7 @@ class Fp8Config(QuantizationConfig):
             return 31
         if self.use_mxfp8 and _is_hip and _is_gfx95_supported:
             return 95
-        if self.use_mxfp8 and _mxfp8_to_block_fp8_required:
+        if self.use_mxfp8 and _mxfp8_bf16_fallback_required():
             return 94
 
         return 100 if self.use_mxfp8 else 80
@@ -465,15 +471,26 @@ class Fp8LinearMethod(LinearMethodBase):
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
-        self.convert_mxfp8_to_block = self.use_mxfp8 and _mxfp8_to_block_fp8_required
+        self.convert_mxfp8_to_block = self.use_mxfp8 and (
+            _force_mxfp8_to_block_fp8 or _mxfp8_block_fp8_fallback_available()
+        )
+        self.emulate_mxfp8 = (
+            self.use_mxfp8
+            and _mxfp8_bf16_fallback_required()
+            and not self.convert_mxfp8_to_block
+        )
         self.weight_block_size = self.quant_config.weight_block_size
         self.w8a8_block_fp8_linear = None
         self.w8a8_mxfp8_linear = None
         self.mxfp8_dense_backend = None
-        if self.use_mxfp8 and not self.convert_mxfp8_to_block:
+        if (
+            self.use_mxfp8
+            and not self.emulate_mxfp8
+            and not self.convert_mxfp8_to_block
+        ):
             self.mxfp8_dense_backend = resolve_mxfp8_dense_gemm_backend()
             self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
-        else:
+        elif not self.emulate_mxfp8:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
         self.is_checkpoint_fp8_serialized = (
             self.quant_config.is_checkpoint_fp8_serialized
@@ -653,6 +670,17 @@ class Fp8LinearMethod(LinearMethodBase):
         )
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        if getattr(self, "emulate_mxfp8", False):
+            layer.weight.requires_grad_(False)
+            layer.weight_scale_inv.requires_grad_(False)
+            layer.weight_scale_inv.format_ue8m0 = True
+            layer.input_scale = None
+            logger.info_once(
+                "Using graph-capturable MXFP8 dense emulation because no native "
+                "ROCm MXFP8 GEMM is available. Weights remain MXFP8-resident and "
+                "are dequantized to BF16 inside each forward."
+            )
+            return
         if self.convert_mxfp8_to_block:
             from sglang.srt.layers.quantization.mxfp8_block_convert import (
                 convert_mxfp8_weight_to_block_fp8,
@@ -960,6 +988,20 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if getattr(self, "emulate_mxfp8", False):
+            if isinstance(x, tuple):
+                raise RuntimeError(
+                    "MXFP8 emulation requires unquantized linear inputs."
+                )
+            from sglang.srt.layers.quantization.mxfp8_block_convert import (
+                dequant_mxfp8_to_bf16,
+            )
+
+            weight = dequant_mxfp8_to_bf16(layer.weight, layer.weight_scale_inv).to(
+                x.dtype
+            )
+            return F.linear(x, weight, bias).to(x.dtype)
+
         if self.use_marlin:
             return torch.ops.sglang.apply_fp8_marlin_linear(
                 input=x,
@@ -1080,7 +1122,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
-        self.convert_mxfp8_to_block = self.use_mxfp8 and _mxfp8_to_block_fp8_required
+        self.convert_mxfp8_to_block = self.use_mxfp8 and (
+            _force_mxfp8_to_block_fp8 or _mxfp8_bf16_fallback_required()
+        )
         self.weight_block_size = self.quant_config.weight_block_size
         self.is_fp4_expert = self.quant_config.is_fp4_experts
         self.dequant_fp4_to_fp8 = self.quant_config.dequant_fp4_to_fp8
@@ -2350,6 +2394,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 moe_runner_backend = MoeRunnerBackend.AITER
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
+
+        # AITER consumes block-FP8 weights rather than checkpoint-native MXFP8.
+        # Devices with native MXFP8 use AITER after a one-time conversion.
+        if self.use_mxfp8 and _use_aiter and moe_runner_backend.is_aiter():
+            self.convert_mxfp8_to_block = True
+
+        # AITER's block-FP8 two-stage path applies router weights in stage 2.
+        # Other backends fall back to graph-capturable Triton when native MXFP8
+        # is unavailable.
+        if (
+            self.use_mxfp8
+            and _mxfp8_bf16_fallback_required()
+            and not (_use_aiter and moe_runner_backend.is_aiter())
+        ):
+            if not moe_runner_backend.is_triton():
+                logger.warning_once(
+                    "Selecting the Triton block-FP8 MoE runner because this device "
+                    "does not provide a native MXFP8 MoE path."
+                )
+            moe_runner_backend = MoeRunnerBackend.TRITON
 
         if (
             moe_runner_backend.is_deep_gemm()

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1185,7 +1185,10 @@ def aiter_w8a8_block_fp8_linear(
             _ck_safe_m is not None and input_2d.shape[0] > _ck_safe_m
         )
     else:
-        use_triton = True
+        # Let AITER's public block-scale dispatcher choose the native CK path on
+        # supported ROCm devices without native MX instructions. It falls back to its
+        # Triton implementation itself when no matching HIP code object exists.
+        use_triton = False
 
     # if input_scale not None, input is quanted
     if input_scale is not None:

--- a/python/sglang/srt/layers/quantization/mxfp8_block_convert.py
+++ b/python/sglang/srt/layers/quantization/mxfp8_block_convert.py
@@ -1,13 +1,13 @@
-"""Convert MXFP8 weights to block-fp8 [128,128] for AMD gfx942 (CDNA3 / MI300).
+"""MXFP8 conversion helpers.
 
-gfx942 has no hardware MX-scaled matmul: Triton's ``tl.dot_scaled`` fails to
-lower and the gfx950 ``mfma_scale`` intrinsics are unavailable. So MXFP8
-checkpoints (e4m3fn weights + 1x32 UE8M0 scales) are converted at load time to
-block-wise FP8 [128,128] (e4m3fn + fp32 scales), which runs through SGLang's
-native DeepSeek-V3 block-fp8 kernels (aiter / triton). The conversion is:
+MXFP8 checkpoints store e4m3fn weights with 1x32 UE8M0 scales. Platforms
+without native MX-scaled matmul can dequantize those weights exactly to BF16
+inside a graph-captured forward without permanently expanding model storage.
+An optional compatibility/performance path can instead requantize the BF16
+values to block-wise FP8 [128,128] at load time. The conversion is:
 
     bf16 = e4m3.to(f32) * exp2(ue8m0_scale.to(f32) - 127.0)   # dequant 1x32
-    block-fp8 = per-128x128-block quantize(bf16)              # requant 128x128
+    block-fp8 = per-128x128-block quantize(bf16)              # optional requant
 """
 
 from __future__ import annotations
@@ -24,17 +24,40 @@ def _ue8m0_to_fp32(scale_u8: torch.Tensor) -> torch.Tensor:
     return (scale_u8.to(torch.int32) << 23).view(torch.float32)
 
 
+def dequant_mxfp8_to_bf16(weight: torch.Tensor, scale_u8: torch.Tensor) -> torch.Tensor:
+    """Dequant an MXFP8 tensor to BF16 along its final dimension.
+
+    ``weight`` has shape ``[..., K]`` and ``scale_u8`` has shape
+    ``[..., K // 32]``. Supporting arbitrary leading dimensions lets dense
+    linears and all experts in an MoE layer share the same exact conversion.
+    """
+    k = weight.shape[-1]
+    if k % MXFP8_BLOCK_SIZE != 0:
+        raise ValueError(f"MXFP8 weight K={k} must be divisible by {MXFP8_BLOCK_SIZE}.")
+    expected_scale_shape = (*weight.shape[:-1], k // MXFP8_BLOCK_SIZE)
+    if tuple(scale_u8.shape) != expected_scale_shape:
+        raise ValueError(
+            "MXFP8 scale shape must match weight leading dimensions and have "
+            f"K/{MXFP8_BLOCK_SIZE} columns: expected {expected_scale_shape}, "
+            f"got {tuple(scale_u8.shape)}."
+        )
+
+    descale = _ue8m0_to_fp32(scale_u8).unsqueeze(-1)
+    deq = weight.to(torch.float32).view(
+        *weight.shape[:-1], k // MXFP8_BLOCK_SIZE, MXFP8_BLOCK_SIZE
+    )
+    return (deq * descale).view_as(weight).to(torch.bfloat16)
+
+
 def dequant_mxfp8_2d_to_bf16(
     weight: torch.Tensor, scale_u8: torch.Tensor
 ) -> torch.Tensor:
-    """Dequant a 2D MXFP8 tensor (e4m3fn + 1x32 UE8M0 scales) to bf16.
-
-    weight: [N, K] float8_e4m3fn; scale_u8: [N, K//32] uint8.
-    """
-    n, k = weight.shape
-    descale = _ue8m0_to_fp32(scale_u8).unsqueeze(-1)  # [N, K//32, 1]
-    deq = weight.to(torch.float32).view(n, k // MXFP8_BLOCK_SIZE, MXFP8_BLOCK_SIZE)
-    return (deq * descale).view(n, k).to(torch.bfloat16)
+    """Backward-compatible 2D wrapper around :func:`dequant_mxfp8_to_bf16`."""
+    if weight.ndim != 2 or scale_u8.ndim != 2:
+        raise ValueError(
+            "dequant_mxfp8_2d_to_bf16 requires 2D weight and scale tensors."
+        )
+    return dequant_mxfp8_to_bf16(weight, scale_u8)
 
 
 def bf16_to_block_fp8_128(

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -30,6 +30,9 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.model_executor.runner_backend.base_cuda_graph_backend import (
     BaseCudaGraphBackend,
 )
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
 from sglang.srt.model_executor.runner_utils.pool import (
     get_or_create_global_graph_memory_pool,
     graph_pool_capture_scope,
@@ -59,6 +62,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
     ) -> None:
         self._graphs: Dict[Any, torch.cuda.CUDAGraph] = {}
         self._outputs: Dict[Any, Any] = {}
+        self._capture_owners: Dict[Any, tuple[Any, ...]] = {}
         self._pool = None
         self._cuda_graph_runner = cuda_graph_runner
         self._device_module = cuda_graph_runner.device_module
@@ -128,6 +132,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx = self._device_module.graph
 
         with (
+            collect_full_cuda_graph_owners() as capture_owners,
             graph_pool_capture_scope(),
             graph_ctx(cuda_graph=graph, pool=self._pool, stream=self._capture_stream),
         ):
@@ -138,6 +143,9 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
 
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = out
+        if capture_inputs is not None:
+            capture_owners.append(capture_inputs)
+        self._capture_owners[shape_key] = tuple(capture_owners)
 
     def can_run(self, forward_batch: ForwardBatch, shape_key: ShapeKey) -> bool:
         return shape_key in self._graphs
@@ -159,4 +167,5 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
     def cleanup(self) -> None:
         self._graphs.clear()
         self._outputs.clear()
+        self._capture_owners.clear()
         self._pool = None

--- a/python/sglang/srt/model_executor/runner_utils/capture_owner.py
+++ b/python/sglang/srt/model_executor/runner_utils/capture_owner.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator, Optional
+
+_full_cuda_graph_owners: ContextVar[Optional[list[Any]]] = ContextVar(
+    "full_cuda_graph_owners", default=None
+)
+
+
+@contextmanager
+def collect_full_cuda_graph_owners() -> Iterator[list[Any]]:
+    """Collect tensor owners whose addresses are recorded by one full graph."""
+
+    owners: list[Any] = []
+    token = _full_cuda_graph_owners.set(owners)
+    try:
+        yield owners
+    finally:
+        _full_cuda_graph_owners.reset(token)
+
+
+def retain_full_cuda_graph_owner(owner: Any) -> bool:
+    """Retain ``owner`` when called from an active full-graph capture."""
+
+    owners = _full_cuda_graph_owners.get()
+    if owners is None:
+        return False
+    owners.append(owner)
+    return True

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -348,7 +348,6 @@ def _fused_rope_cat_and_cache(
 
 
 class DeepseekMLARocmForwardMixin:
-
     def forward_absorb_rocm_prepare(
         self: DeepseekV2AttentionMLA,
         positions: torch.Tensor,
@@ -359,6 +358,12 @@ class DeepseekMLARocmForwardMixin:
         prev_topk_indices: Optional[torch.Tensor] = None,
     ):
         from sglang.srt.model_executor.runner import get_is_capture_mode
+
+        attention_output_gate = (
+            self.prepare_attention_output_gate(hidden_states)
+            if hasattr(self, "prepare_attention_output_gate")
+            else None
+        )
 
         q_replicate_active = (
             get_parallel().dcp_replicate_q_proj
@@ -649,6 +654,11 @@ class DeepseekMLARocmForwardMixin:
             positions,
             topk_indices,
             llama_4_scaling,
+            *(
+                (attention_output_gate,)
+                if hasattr(self, "prepare_attention_output_gate")
+                else ()
+            ),
         )
 
     def forward_absorb_rocm_core(
@@ -662,6 +672,7 @@ class DeepseekMLARocmForwardMixin:
         positions,
         topk_indices,
         llama_4_scaling,
+        attention_output_gate: Optional[torch.Tensor] = None,
     ):
         save_kv_cache = True
 
@@ -726,12 +737,14 @@ class DeepseekMLARocmForwardMixin:
                     )
             else:
                 extra_args = {}
+                if getattr(self, "learnable_sink_param", None) is not None:
+                    extra_args["attn_sink"] = self.learnable_sink_param
                 if self._fuse_rope_for_trtllm_mla(forward_batch):
-                    extra_args = {
-                        "cos_sin_cache": self.rotary_emb.cos_sin_cache,
-                        "is_neox": self.rotary_emb.is_neox_style,
-                        "llama_4_scaling": llama_4_scaling,
-                    }
+                    extra_args.update(
+                        cos_sin_cache=self.rotary_emb.cos_sin_cache,
+                        is_neox=self.rotary_emb.is_neox_style,
+                        llama_4_scaling=llama_4_scaling,
+                    )
                 if is_dcp_mla_decode_phase(forward_batch):
                     # set return_lse=True to correct attn_output
                     attn_output, lse = self.attn_mqa_for_dcp_decode(
@@ -877,6 +890,16 @@ class DeepseekMLARocmForwardMixin:
             attn_bmm_output = apply_kv_b_lora_v_correction(
                 self, attn_output, attn_bmm_output
             )
+        if attention_output_gate is not None:
+            apply_gate = getattr(self, "apply_attention_output_gate", None)
+            if apply_gate is not None:
+                attn_bmm_output = apply_gate(attn_bmm_output, attention_output_gate)
+            elif hasattr(self, "_apply_gated"):
+                attn_bmm_output = self._apply_gated(
+                    attn_bmm_output, attention_output_gate
+                )
+            else:
+                attn_bmm_output = attn_bmm_output * torch.sigmoid(attention_output_gate)
         output, _ = self.o_proj(attn_bmm_output)
 
         if self.next_skip_topk is None:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -47,6 +47,9 @@ from sglang.srt.lora.deepseek_mla_correction import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    is_in_tc_piecewise_cuda_graph,
+)
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla import (
     _select_local_dcp_heads_for_autotune,
     is_dcp_mla_decode_phase,
@@ -125,6 +128,17 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
 
 
+def _absorb_weight_bf16(w: torch.Tensor, w_scale) -> torch.Tensor:
+    """Dequantize an absorbed MLA weight, skipping the pass when it is a no-op."""
+    if (
+        w.dtype == torch.bfloat16
+        and isinstance(w_scale, (int, float))
+        and w_scale == 1.0
+    ):
+        return w
+    return w.to(torch.bfloat16) * w_scale
+
+
 def rocm_absorb_q_bmm(
     attn: DeepseekV2AttentionMLA,
     q_nope: torch.Tensor,
@@ -170,7 +184,7 @@ def rocm_absorb_q_bmm(
         else:
             q_nope_out = torch.bmm(
                 q_nope.to(torch.bfloat16).transpose(0, 1),
-                attn.w_kc.to(torch.bfloat16) * attn.w_scale,
+                _absorb_weight_bf16(attn.w_kc, attn.w_scale),
             )
     return q_nope_out
 
@@ -224,10 +238,26 @@ def rocm_absorb_v_bmm(
                 transpose_bm_in=True,
                 dtype=torch.bfloat16,
             )
+        elif not is_in_tc_piecewise_cuda_graph():
+            # Same (batch, heads, dim) layout as the quantized paths above, so the
+            # post-GEMM flatten is a view. Skipped under piecewise: torch dynamo
+            # rejects out= with a non-contiguous output tensor.
+            _bmm_buf = torch.empty(
+                attn_output.shape[0],
+                attn.num_local_heads,
+                attn.w_vc.shape[2],
+                device=attn_output.device,
+                dtype=torch.bfloat16,
+            )
+            torch.bmm(
+                attn_output.to(torch.bfloat16).transpose(0, 1),
+                _absorb_weight_bf16(attn.w_vc, attn.w_scale),
+                out=_bmm_buf.transpose(0, 1),
+            )
         else:
             attn_bmm_output = torch.bmm(
                 attn_output.to(torch.bfloat16).transpose(0, 1),
-                attn.w_vc.to(torch.bfloat16) * attn.w_scale,
+                _absorb_weight_bf16(attn.w_vc, attn.w_scale),
             )
 
     if _bmm_buf is not None:
@@ -647,17 +677,16 @@ class DeepseekMLARocmForwardMixin:
                     forward_batch.out_cache_loc,
                 )
                 save_kv_cache = False
-                # On decode, pass q_cat directly to attn_mqa with q_rope=None so
-                # dsa_backend.forward_decode reuses q_cat as a zero-copy view
-                # (`q.contiguous().view(...)` fast-path) instead of running the
-                # redundant `concat_mla_absorb_q_general(q_nope_fused, q_pe_fused)`
-                # that would otherwise rebuild a tensor byte-identical to q_cat.
-                # On ROCm tilelang decode, this eliminates the
-                # `CatArrayBatchedCopy<OpaqueType<1u>, ...>` kernel that used to
-                # fire once per layer per decode step (~2.6 us / layer saved).
-                # Prefill keeps the split form because dsa_backend.forward_extend
-                # asserts `q_rope is not None`.
-                if forward_batch.forward_mode.is_decode_or_idle():
+                # Pass q_cat straight to attn_mqa with q_rope=None so the backend
+                # reuses it as a zero-copy view instead of rebuilding a tensor
+                # byte-identical to it -- one `CatArrayBatchedCopy` per layer per
+                # step. Target-verify is the same absorbed shape as decode, just
+                # more rows; real prefill keeps the split form because the Triton
+                # sparse-MLA kernel reads q_nope/q_rope separately.
+                if (
+                    forward_batch.forward_mode.is_decode_or_idle()
+                    or forward_batch.forward_mode.is_target_verify()
+                ):
                     if llama_4_scaling is not None:
                         # llama_4_scaling applies only to the q_nope portion;
                         # mutate in place via the slice view of q_cat.

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -78,6 +78,22 @@ def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
+def _is_ue8m0_scale(tensor: torch.Tensor) -> bool:
+    """Return whether a scale tensor carries the optional UE8M0 marker."""
+    return bool(getattr(tensor, "format_ue8m0", False))
+
+
+def _get_effective_weight_block_size(
+    layer: nn.Module, quant_config: Optional[QuantizationConfig]
+) -> Optional[List[int]]:
+    """Prefer a layer-local block size after load-time format conversion."""
+    quant_method = getattr(layer, "quant_method", None)
+    layer_block_size = getattr(quant_method, "weight_block_size", None)
+    if layer_block_size is not None:
+        return layer_block_size
+    return quant_config.weight_block_size if quant_config is not None else None
+
+
 def _get_indexer_weight_block_size(
     quant_config: Optional[QuantizationConfig],
 ) -> List[int]:
@@ -605,95 +621,117 @@ class DeepseekV2WeightLoaderMixin:
                 torch.float8_e4m3fn,
                 torch.float8_e4m3fnuz,
             ):
+                kv_b_quant_method = getattr(self_attn.kv_b_proj, "quant_method", None)
+                exact_mxfp8_fallback = bool(
+                    getattr(kv_b_quant_method, "use_mxfp8", False)
+                    and (
+                        getattr(kv_b_quant_method, "emulate_mxfp8", False)
+                        or getattr(kv_b_quant_method, "convert_mxfp8_to_block", False)
+                    )
+                )
+
+                if exact_mxfp8_fallback:
+                    if not hasattr(self_attn.kv_b_proj, "weight_scale_inv"):
+                        raise ValueError(
+                            "MXFP8 kv_b_proj fallback requires weight_scale_inv."
+                        )
+
+                    from sglang.srt.layers.quantization.mxfp8_block_convert import (
+                        dequant_mxfp8_to_bf16,
+                    )
+
+                    # kv_b_proj is absorbed into w_kc/w_vc below and therefore
+                    # never reaches Fp8LinearMethod.apply.  Dequantize its native
+                    # group-32 MXFP8 representation exactly before the split,
+                    # instead of normalizing to fnuz and requantizing it to a
+                    # lossy per-tensor FP8 representation.
+                    w = dequant_mxfp8_to_bf16(w, self_attn.kv_b_proj.weight_scale_inv)
+                    self_attn.w_scale = 1.0
+
                 # For mixed quantization (experts int4, linear fp8), use linear_fp8_config
-                selected_quant_config = getattr(
-                    self.quant_config, "linear_fp8_config", None
-                )
-                if selected_quant_config is None:
-                    selected_quant_config = self.quant_config
-                weight_block_size = (
-                    selected_quant_config.weight_block_size
-                    if selected_quant_config is not None
-                    else None
-                )
-                if weight_block_size is not None:
-                    assert hasattr(self_attn.kv_b_proj, "weight_scale_inv") or hasattr(
-                        self_attn.kv_b_proj, "weight_scale"
-                    )
-                    weight_scale = (
-                        self_attn.kv_b_proj.weight_scale
-                        if hasattr(self_attn.kv_b_proj, "weight_scale")
-                        else self_attn.kv_b_proj.weight_scale_inv
-                    )
-                    if _is_fp8_fnuz:
-                        weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
-                            weight=w,
-                            weight_scale=weight_scale,
-                            input_scale=None,
-                        )
-                    else:
-                        weight = w
-
-                    # In multiple weight loading scenarios (e.g. RL), we need to inverse the scale of the weights after the requantization happened at the first loading.
-                    if weight_scale.format_ue8m0 and weight_scale.dtype == torch.uint8:
-                        weight_scale = (weight_scale.to(torch.int32) << 23).view(
-                            torch.float32
-                        )
-                    elif (
-                        should_deepgemm_weight_requant_ue8m0(
-                            weight_block_size=(
-                                self.quant_config.weight_block_size
-                                if self.quant_config is not None
-                                else None
-                            )
-                        )
-                        and weight_scale.format_ue8m0
-                    ):
-                        weight_scale = inverse_transform_scale_ue8m0(
-                            weight_scale, mn=weight.shape[-2]
-                        )
-
-                    if (
-                        (_is_cuda or _is_musa or _is_xpu)
-                        and weight_block_size[0] == 128
-                        and weight_block_size[1] == 128
-                    ):
-                        if (
-                            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                            and not deep_gemm_wrapper.DEEPGEMM_BLACKWELL
-                            and get_bool_env_var("SGL_USE_DEEPGEMM_BMM", "false")
-                        ):
-                            block_scale = weight_scale
-                            use_deep_gemm_bmm = True
-                        else:
-                            w = block_quant_dequant(
-                                weight,
-                                weight_scale,
-                                weight_block_size,
-                                torch.bfloat16,
-                            )
-                    else:
-                        w, scale = block_quant_to_tensor_quant(
-                            weight, weight_scale, weight_block_size
-                        )
-                        self_attn.w_scale = scale
                 else:
-                    if _is_fp8_fnuz:
-                        weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
-                            weight=w,
-                            weight_scale=self_attn.kv_b_proj.weight_scale,
-                            input_scale=None,
+                    selected_quant_config = getattr(
+                        self.quant_config, "linear_fp8_config", None
+                    )
+                    if selected_quant_config is None:
+                        selected_quant_config = self.quant_config
+                    weight_block_size = _get_effective_weight_block_size(
+                        self_attn.kv_b_proj, selected_quant_config
+                    )
+                    if weight_block_size is not None:
+                        assert hasattr(
+                            self_attn.kv_b_proj, "weight_scale_inv"
+                        ) or hasattr(self_attn.kv_b_proj, "weight_scale")
+                        weight_scale = (
+                            self_attn.kv_b_proj.weight_scale
+                            if hasattr(self_attn.kv_b_proj, "weight_scale")
+                            else self_attn.kv_b_proj.weight_scale_inv
                         )
-                    else:
-                        weight = w
-                        weight_scale = self_attn.kv_b_proj.weight_scale
-                        # Per-channel scale is 1D [out]; reshape to [out, 1] so it
-                        # broadcasts correctly against weight [out, in].
-                        if weight_scale.dim() == 1:
-                            weight_scale = weight_scale.view(-1, 1)
+                        if _is_fp8_fnuz:
+                            weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                                weight=w,
+                                weight_scale=weight_scale,
+                                input_scale=None,
+                            )
+                        else:
+                            weight = w
 
-                    w, scale = channel_quant_to_tensor_quant(weight, weight_scale)
-                    self_attn.w_scale = scale
+                        # In multiple weight loading scenarios (e.g. RL), we need to inverse the scale of the weights after the requantization happened at the first loading.
+                        if (
+                            _is_ue8m0_scale(weight_scale)
+                            and weight_scale.dtype == torch.uint8
+                        ):
+                            weight_scale = (weight_scale.to(torch.int32) << 23).view(
+                                torch.float32
+                            )
+                        elif should_deepgemm_weight_requant_ue8m0(
+                            weight_block_size=weight_block_size
+                        ) and _is_ue8m0_scale(weight_scale):
+                            weight_scale = inverse_transform_scale_ue8m0(
+                                weight_scale, mn=weight.shape[-2]
+                            )
+
+                        if (
+                            (_is_cuda or _is_musa or _is_xpu)
+                            and weight_block_size[0] == 128
+                            and weight_block_size[1] == 128
+                        ):
+                            if (
+                                deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+                                and not deep_gemm_wrapper.DEEPGEMM_BLACKWELL
+                                and get_bool_env_var("SGL_USE_DEEPGEMM_BMM", "false")
+                            ):
+                                block_scale = weight_scale
+                                use_deep_gemm_bmm = True
+                            else:
+                                w = block_quant_dequant(
+                                    weight,
+                                    weight_scale,
+                                    weight_block_size,
+                                    torch.bfloat16,
+                                )
+                        else:
+                            w, scale = block_quant_to_tensor_quant(
+                                weight, weight_scale, weight_block_size
+                            )
+                            self_attn.w_scale = scale
+                    else:
+                        if _is_fp8_fnuz:
+                            weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                                weight=w,
+                                weight_scale=self_attn.kv_b_proj.weight_scale,
+                                input_scale=None,
+                            )
+                        else:
+                            weight = w
+                            weight_scale = self_attn.kv_b_proj.weight_scale
+                            # Per-channel scale is 1D [out]; reshape to [out, 1] so it
+                            # broadcasts correctly against weight [out, in].
+                            if weight_scale.dim() == 1:
+                                weight_scale = weight_scale.view(-1, 1)
+
+                        w, scale = channel_quant_to_tensor_quant(weight, weight_scale)
+                        self_attn.w_scale = scale
 
             if w.dtype == torch.int8:
                 weight_block_size = (

--- a/python/sglang/srt/models/hunyuan_v4.py
+++ b/python/sglang/srt/models/hunyuan_v4.py
@@ -505,7 +505,7 @@ class HYV4Attention(DeepseekV2AttentionMLA):
         if hasattr(backend, "use_mha") and backend.use_mha is not False:
             backend.use_mha = False
         method = super().dispatch_attn_forward_method(forward_batch)
-        if method != AttnForwardMethod.MLA:
+        if method not in (AttnForwardMethod.MLA, AttnForwardMethod.MLA_ROCM):
             raise RuntimeError("HYV4 requires the sparse MLA attention path")
         return method
 

--- a/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
+++ b/test/registered/kernels/ops/layernorm/test_mhc_kernels.py
@@ -5,6 +5,9 @@ import torch
 
 import sglang.kernels.ops.layernorm.mhc as mhc
 from sglang.kernels.ops.layernorm.mhc import mhc_fused_post_pre, mhc_post, mhc_pre
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
@@ -19,6 +22,11 @@ def test_mhc_fused_post_pre_matches_unfused(
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for TileLang mHC kernels")
 
+    # This SM120 regression exercises the same TileLang prenorm fallback used
+    # by the GLM serving profile. Server-argument normalization disables the
+    # optional DeepGEMM path before model loading; the standalone kernel test
+    # must establish that profile explicitly.
+    monkeypatch.setenv("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "0")
     monkeypatch.setattr(mhc, "is_dsa_prefill_cp_round_robin_split", lambda: False)
     # This is a single-process kernel unit test with no TP group initialized.
     # mhc_pre / mhc_fused_post_pre allocate the MoE input in the symmetric-memory
@@ -78,25 +86,27 @@ def test_mhc_fused_post_pre_matches_unfused(
             norm_weight=norm_weight,
             norm_eps=norm_eps,
         )
-    residual_out, post_out, comb_out, layer_out = mhc_fused_post_pre(
-        x,
-        residual,
-        post_prev,
-        comb_prev,
-        fn,
-        hc_scale,
-        hc_base,
-        rms_eps,
-        hc_eps,
-        hc_eps,
-        2.0,
-        sinkhorn_repeat,
-        norm_weight=norm_weight,
-        norm_eps=norm_eps,
-    )
+    with collect_full_cuda_graph_owners() as capture_owners:
+        residual_out, post_out, comb_out, layer_out = mhc_fused_post_pre(
+            x,
+            residual,
+            post_prev,
+            comb_prev,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_eps,
+            hc_eps,
+            2.0,
+            sinkhorn_repeat,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+        )
 
     torch.cuda.synchronize()
     if num_tokens == 0:
+        assert capture_owners == []
         assert residual_out.shape == residual.shape
         assert post_out.shape == (0, hc_mult, 1)
         assert comb_out.shape == (0, hc_mult, hc_mult)
@@ -106,6 +116,25 @@ def test_mhc_fused_post_pre_matches_unfused(
         assert comb_out.dtype == torch.float32
         assert layer_out.dtype == torch.bfloat16
         return
+
+    assert len(capture_owners) == 2
+    gemm_out_mul_owner, gemm_out_sqrsum_owner = capture_owners
+    assert gemm_out_mul_owner.dtype == torch.float32
+    assert gemm_out_sqrsum_owner.dtype == torch.float32
+    if num_tokens <= 32:
+        # Small-batch path: the split-K pair is the kernel operand set.
+        assert gemm_out_mul_owner.ndim == 3
+        assert gemm_out_mul_owner.shape[1:] == (num_tokens, hc_mult3)
+        assert gemm_out_sqrsum_owner.ndim == 2
+        assert gemm_out_sqrsum_owner.shape == gemm_out_mul_owner.shape[:2]
+    else:
+        # Large-batch TileLang fallback (DeepGEMM prenorm disabled): the
+        # reallocated 2-D/1-D pair is the real kernel operand set and must
+        # be the retained owners, not the discarded split-K allocations.
+        assert gemm_out_mul_owner.ndim == 2
+        assert gemm_out_mul_owner.shape == (num_tokens, hc_mult3)
+        assert gemm_out_sqrsum_owner.ndim == 1
+        assert gemm_out_sqrsum_owner.shape == (num_tokens,)
 
     assert residual_ref is not None
     assert post_ref is not None
@@ -122,6 +151,65 @@ def test_mhc_fused_post_pre_matches_unfused(
     layer_atol = 2e-2 if use_norm else 2e-3
     layer_rtol = 2e-2 if use_norm else 2e-3
     torch.testing.assert_close(layer_out, layer_ref, atol=layer_atol, rtol=layer_rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fused_norm_weight_conversion_copy_is_retained(monkeypatch):
+    monkeypatch.setenv("SGLANG_OPT_DEEPGEMM_HC_PRENORM", "0")
+    monkeypatch.setattr(mhc, "is_dsa_prefill_cp_round_robin_split", lambda: False)
+    monkeypatch.setattr(mhc, "use_symmetric_memory", lambda *a, **kw: nullcontext())
+    monkeypatch.setattr(mhc, "is_allocation_symmetric", lambda: False)
+    monkeypatch.setattr(mhc, "get_tp_group", lambda: None)
+    torch.manual_seed(20260830)
+    device = torch.device("cuda")
+    hc_mult, hidden_size, num_tokens = 4, 4096, 8
+    hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+    hc_hidden_size = hc_mult * hidden_size
+
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16) * 0.1
+    residual = (
+        torch.randn(
+            num_tokens, hc_mult, hidden_size, device=device, dtype=torch.bfloat16
+        )
+        * 0.1
+    )
+    post_prev = torch.rand(num_tokens, hc_mult, 1, device=device, dtype=torch.float32)
+    comb_prev = (
+        torch.rand(num_tokens, hc_mult, hc_mult, device=device, dtype=torch.float32)
+        * 0.25
+    )
+    fn = (
+        torch.randn(hc_mult3, hc_hidden_size, device=device, dtype=torch.float32) * 0.01
+    )
+    hc_scale = torch.tensor([0.5, 0.25, 0.25], device=device, dtype=torch.float32)
+    hc_base = torch.zeros(hc_mult3, device=device, dtype=torch.float32)
+    # A float32 norm weight forces the bf16 conversion copy inside the kernel.
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.float32)
+
+    with collect_full_cuda_graph_owners() as capture_owners:
+        mhc_fused_post_pre(
+            x,
+            residual,
+            post_prev,
+            comb_prev,
+            fn,
+            hc_scale,
+            hc_base,
+            1e-6,
+            1e-4,
+            1e-4,
+            2.0,
+            2,
+            norm_weight=norm_weight,
+            norm_eps=1e-6,
+        )
+    torch.cuda.synchronize()
+
+    assert len(capture_owners) == 3
+    converted = capture_owners[-1]
+    assert converted.dtype == torch.bfloat16
+    assert converted.shape == (hidden_size,)
+    assert converted is not norm_weight
 
 
 if __name__ == "__main__":

--- a/test/registered/layers/attention/test_dsa_capture_owner_cuda.py
+++ b/test/registered/layers/attention/test_dsa_capture_owner_cuda.py
@@ -1,0 +1,200 @@
+import pytest
+import torch
+
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.layers.attention.dsa.utils import fp8_mqa_logits_make_fused_kv
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_outer_torch_compile_preserves_capture_owner():
+    torch.manual_seed(48)
+    indexer = object.__new__(Indexer)
+    values = torch.randn(16, 32, device="cuda")
+
+    def outer(value):
+        produced = value.float().square()
+        produced = indexer._retain_full_graph_capture_owner(produced)
+        return produced.to(torch.int32)
+
+    compiled_outer = torch.compile(
+        outer, mode="max-autotune-no-cudagraphs", dynamic=False
+    )
+    compiled_outer(values)
+    torch.cuda.synchronize()
+
+    with collect_full_cuda_graph_owners() as owners:
+        output = compiled_outer(values)
+    torch.cuda.synchronize()
+
+    assert output.dtype == torch.int32
+    assert len(owners) == 1
+    assert owners[0].dtype == torch.float32
+    expected_replay = values.float().square()
+    torch.testing.assert_close(owners[0], expected_replay)
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        compiled_outer(values)
+        compiled_outer(values)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with collect_full_cuda_graph_owners() as capture_owners:
+        with torch.cuda.graph(graph, stream=capture_stream):
+            captured_output = compiled_outer(values)
+
+    del captured_output
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert len(capture_owners) == 1
+    torch.testing.assert_close(capture_owners[0], expected_replay)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_deepgemm_paged_logits_owner_survives_shared_pool_capture():
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("DeepGEMM paged MQA requires SM90 or newer")
+    deep_gemm = pytest.importorskip("deep_gemm")
+
+    torch.manual_seed(52)
+    torch._dynamo.reset()
+    batch_size = 24
+    max_context_len = 2240
+    block_size = 64
+    num_heads = 32
+    head_dim = 128
+    num_blocks = max_context_len // block_size
+
+    q_fp8 = torch.randn(batch_size, 1, num_heads, head_dim, device="cuda").to(
+        torch.float8_e4m3fn
+    )
+    kv_fp8 = torch.randn(num_blocks, block_size, head_dim, device="cuda").to(
+        torch.float8_e4m3fn
+    )
+    kv_scales = torch.ones(num_blocks, block_size, device="cuda")
+    kv_fused = fp8_mqa_logits_make_fused_kv(kv_fp8, kv_scales, block_size, head_dim)
+    weights = torch.randn(batch_size, num_heads, device="cuda")
+    context_lens = torch.full(
+        (batch_size, 1), max_context_len, dtype=torch.int32, device="cuda"
+    )
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device="cuda").repeat(
+        batch_size, 1
+    )
+    schedule = deep_gemm.get_paged_mqa_logits_metadata(
+        context_lens, block_size, deep_gemm.get_num_sms()
+    )
+    indexer = object.__new__(Indexer)
+
+    def outer(query):
+        logits = deep_gemm.fp8_paged_mqa_logits(
+            query,
+            kv_fused,
+            weights,
+            context_lens,
+            block_table,
+            schedule,
+            max_context_len,
+            clean_logits=False,
+        )
+        logits = indexer._retain_full_graph_capture_owner(logits)
+        return logits[:, :1]
+
+    compiled_outer = torch.compile(
+        outer, mode="max-autotune-no-cudagraphs", dynamic=False
+    )
+    expected = compiled_outer(q_fp8).detach().clone()
+    torch.cuda.synchronize()
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        compiled_outer(q_fp8)
+        compiled_outer(q_fp8)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+
+    pool = torch.cuda.graph_pool_handle()
+    graph = torch.cuda.CUDAGraph()
+    with collect_full_cuda_graph_owners() as capture_owners:
+        with torch.cuda.graph(graph, pool=pool, stream=capture_stream):
+            captured_output = compiled_outer(q_fp8)
+
+    assert len(capture_owners) == 1
+    owner = capture_owners[0]
+    assert owner.shape == (batch_size, max_context_len)
+    assert owner.dtype == torch.float32
+    assert (
+        owner.untyped_storage().data_ptr()
+        == captured_output.untyped_storage().data_ptr()
+    )
+
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(owner[:, :1], expected)
+    del captured_output
+    expected_owner = owner.detach().clone()
+
+    # A second capture sharing the pool must not receive the retained
+    # owner's storage; without retention the freed block is reusable and
+    # replaying the first graph would overwrite the second graph's tensor.
+    other_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(other_graph, pool=pool, stream=capture_stream):
+        other = torch.empty_like(owner)
+        other.fill_(17.0)
+    owner_start = owner.untyped_storage().data_ptr()
+    owner_end = owner_start + owner.untyped_storage().nbytes()
+    other_start = other.untyped_storage().data_ptr()
+    other_end = other_start + other.untyped_storage().nbytes()
+    assert owner_end <= other_start or other_end <= owner_start
+    del other
+
+    other_graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(owner, expected_owner)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_backend_stores_helper_retained_owner_with_the_shape():
+    from unittest import mock
+
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    indexer = object.__new__(Indexer)
+    runner = mock.Mock()
+    runner.device_module = torch.cuda
+    runner.model_runner.tp_group.barrier = lambda: None
+    runner.enable_profile_cuda_graph = False
+    backend = FullCudaGraphBackend(runner)
+
+    values = torch.randn(8, device="cuda")
+    produced = {}
+
+    def forward_fn():
+        tensor = values.float().square()
+        produced["tensor"] = indexer._retain_full_graph_capture_owner(tensor)
+        return object()
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with backend.capture_session(stream):
+        backend.capture_one("shape", forward_fn)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    assert produced["tensor"] in backend._capture_owners["shape"]
+    backend.cleanup()
+    assert backend._capture_owners == {}
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/unit/layers/attention/test_dsa_capture_owner.py
+++ b/test/registered/unit/layers/attention/test_dsa_capture_owner.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer as indexer_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    collect_full_cuda_graph_owners,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestRetainFullGraphCaptureOwner(unittest.TestCase):
+    def test_noop_outside_capture_scope(self):
+        indexer = object.__new__(Indexer)
+        tensor = torch.empty(4)
+        result = indexer._retain_full_graph_capture_owner(tensor)
+        self.assertIs(result, tensor)
+
+    def test_records_owner_inside_capture_scope(self):
+        indexer = object.__new__(Indexer)
+        tensor = torch.empty(4)
+        with collect_full_cuda_graph_owners() as owners:
+            result = indexer._retain_full_graph_capture_owner(tensor)
+        self.assertIs(result, tensor)
+        self.assertEqual(owners, [tensor])
+
+    def test_retention_survives_enclosing_torch_compile(self):
+        # Dynamo traces away plain Python side effects; the helper's
+        # torch.compiler.disable boundary must force it to execute.
+        indexer = object.__new__(Indexer)
+
+        def outer(value):
+            produced = value.float().square()
+            produced = indexer._retain_full_graph_capture_owner(produced)
+            return produced.to(torch.int32)
+
+        compiled_outer = torch.compile(outer, dynamic=False)
+        values = torch.randn(8)
+        compiled_outer(values)
+
+        with collect_full_cuda_graph_owners() as owners:
+            output = compiled_outer(values)
+
+        self.assertEqual(output.dtype, torch.int32)
+        self.assertEqual(len(owners), 1)
+        self.assertEqual(owners[0].dtype, torch.float32)
+        torch.testing.assert_close(owners[0], values.float().square())
+
+    def test_paged_path_retains_weights_and_logits_before_consumers(self):
+        indexer = object.__new__(Indexer)
+        indexer.sm_count = 1
+        indexer.index_topk = 2048
+        indexer.paged_mqa_logits_backend = mock.Mock()
+        indexer.paged_mqa_logits_backend.is_cutedsl.return_value = False
+        indexer.paged_mqa_logits_backend.is_aiter.return_value = False
+        indexer._get_index_k_read_buffer = mock.Mock(
+            return_value=torch.empty(1, 64 * 132)
+        )
+        indexer._mask_init_and_local_tokens = mock.Mock(
+            side_effect=lambda logits, seqlens: events.append(("mask", logits))
+        )
+
+        q_fp8 = torch.empty(24, 32, 128)
+        weights = torch.empty(24, 32, 1)
+        seqlens = torch.full((24,), 2240, dtype=torch.int32)
+        block_tables = torch.zeros(24, 35, dtype=torch.int32)
+        logits = torch.empty(24, 2240)
+        topk = torch.empty(24, 2051, dtype=torch.int32)
+        events = []
+
+        forward_batch = mock.Mock()
+        forward_batch.forward_mode.is_target_verify.return_value = True
+        forward_batch.forward_mode.is_draft_extend_v2.return_value = False
+        metadata = mock.Mock()
+        metadata.get_page_table_64.return_value = block_tables
+        metadata.get_seqlens_expanded.return_value = seqlens
+        metadata.get_seqlens_int32.return_value = seqlens
+        metadata.get_dsa_extend_len_cpu.return_value = [1] * 24
+        metadata.paged_mqa_schedule_metadata = torch.empty(1, dtype=torch.int32)
+
+        def topk_transform(candidate, topk_count):
+            events.append(("topk", candidate))
+            return topk
+
+        metadata.topk_transform.side_effect = topk_transform
+
+        def retain(candidate):
+            events.append(("retain", candidate))
+            return candidate
+
+        def produce_logits(*args, **kwargs):
+            events.append(("produce", args[3]))
+            return logits
+
+        indexer._retain_full_graph_capture_owner = retain
+        pool = mock.Mock(page_size=64)
+        with (
+            mock.patch.object(
+                indexer_module, "get_token_to_kv_pool", return_value=pool
+            ),
+            mock.patch.object(indexer_module, "_is_hip", False),
+            mock.patch.object(indexer_module, "_is_cuda", True),
+            mock.patch.object(indexer_module, "deep_gemm", mock.Mock(), create=True),
+            mock.patch.object(
+                indexer_module,
+                "deepgemm_paged_mqa_logits_split",
+                side_effect=produce_logits,
+            ),
+        ):
+            result = indexer._get_topk_paged(forward_batch, 0, q_fp8, weights, metadata)
+
+        self.assertIs(result, topk)
+        kinds = [kind for kind, _ in events]
+        self.assertEqual(kinds, ["retain", "produce", "retain", "mask", "topk"])
+        self.assertIs(events[0][1], weights)
+        # The producer receives the squeezed view of the retained owner.
+        self.assertEqual(events[1][1].shape, (24, 32))
+        self.assertEqual(
+            events[1][1].untyped_storage().data_ptr(),
+            weights.untyped_storage().data_ptr(),
+        )
+        self.assertIs(events[2][1], logits)
+        self.assertIs(events[3][1], logits)
+        self.assertIs(events[4][1], logits)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_head_gate_guard.py
+++ b/test/registered/unit/layers/attention/test_dsa_head_gate_guard.py
@@ -1,0 +1,42 @@
+import unittest
+
+from sglang.srt.utils import is_cuda, is_hip
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+HELPERS = ("logits_head_gate_graph", "scale_head_gate_graph")
+
+
+class TestDsaHeadGateGuard(CustomTestCase):
+    """The head-gate helpers are defined in one module and imported in another.
+
+    Both sides carry their own platform condition, so the two can drift: widen
+    the import without widening the definition and every DSA model fails to
+    import on the platform in between. That is a startup failure far from its
+    cause, and no CUDA runner can see it.
+    """
+
+    def test_definition_and_import_agree(self):
+        from sglang.srt.layers.attention.dsa import dsa_indexer, dsa_prefill_cuda_graph
+
+        for name in HELPERS:
+            with self.subTest(helper=name):
+                self.assertEqual(
+                    hasattr(dsa_prefill_cuda_graph, name),
+                    hasattr(dsa_indexer, name),
+                    f"{name} is defined on one side of the guard but not the other",
+                )
+
+    def test_helpers_exist_on_cuda_and_hip(self):
+        from sglang.srt.layers.attention.dsa import dsa_prefill_cuda_graph
+
+        expected = is_cuda() or is_hip()
+        for name in HELPERS:
+            with self.subTest(helper=name):
+                self.assertEqual(hasattr(dsa_prefill_cuda_graph, name), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_deepgemm_ue8m0_requant.py
+++ b/test/registered/unit/layers/quantization/test_deepgemm_ue8m0_requant.py
@@ -5,6 +5,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import call, patch
 
 import torch
@@ -15,6 +16,10 @@ from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.quantization import fp8 as fp8_quant
 from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import (
     CompressedTensorsW8A8Fp8,
+)
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    _get_effective_weight_block_size,
+    _is_ue8m0_scale,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -29,6 +34,23 @@ def _make_params(n: int = 64, k: int = 128):
 
 
 class TestDeepGemmUE8M0Requant(CustomTestCase):
+    def test_optional_ue8m0_marker_defaults_to_false(self):
+        weight_scale = torch.ones((1, 1), dtype=torch.float32)
+
+        self.assertFalse(_is_ue8m0_scale(weight_scale))
+        weight_scale.format_ue8m0 = True
+        self.assertTrue(_is_ue8m0_scale(weight_scale))
+
+    def test_layer_block_size_wins_after_mxfp8_conversion(self):
+        layer = SimpleNamespace(
+            quant_method=SimpleNamespace(weight_block_size=[128, 128])
+        )
+        quant_config = SimpleNamespace(weight_block_size=[1, 32])
+
+        self.assertEqual(
+            _get_effective_weight_block_size(layer, quant_config), [128, 128]
+        )
+
     def _enabled_deepgemm_ue8m0(self):
         return patch.multiple(
             deep_gemm_wrapper,

--- a/test/registered/unit/layers/quantization/test_fp8_moe_aiter_quant_type.py
+++ b/test/registered/unit/layers/quantization/test_fp8_moe_aiter_quant_type.py
@@ -1,0 +1,151 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import sglang.srt.layers.quantization.fp8 as fp8_quant
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.aiter import AiterQuantType
+from sglang.srt.layers.quantization import mxfp8_block_convert
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+def _method(*, use_mxfp8: bool, is_fp4_expert: bool = False):
+    method = object.__new__(fp8_quant.Fp8MoEMethod)
+    method.block_quant = True
+    method.use_mxfp8 = use_mxfp8
+    method.is_fp4_expert = is_fp4_expert
+    method.moe_runner_config = SimpleNamespace(swiglu_limit=None)
+    return method
+
+
+def _layer():
+    return SimpleNamespace(
+        w13_weight=torch.empty((2, 8, 32), dtype=torch.float8_e4m3fn),
+        w2_weight=torch.empty((2, 4, 32), dtype=torch.float8_e4m3fn),
+        w13_weight_scale_inv=torch.empty((2, 8, 1), dtype=torch.uint8),
+        w2_weight_scale_inv=torch.empty((2, 4, 1), dtype=torch.uint8),
+        dispatcher=SimpleNamespace(expert_mask_gpu=None),
+    )
+
+
+def test_block_fp8_keeps_aiter_128x128_quant_type(monkeypatch):
+    monkeypatch.setattr(fp8_quant, "_use_aiter", True)
+    monkeypatch.setattr(fp8_quant, "_use_hip_int4", False)
+
+    quant_info = _method(use_mxfp8=False).maybe_get_hip_aiter_quant_info(_layer())
+
+    assert quant_info is not None
+    assert quant_info.quant_type == AiterQuantType.PER_128X128
+
+
+def test_mxfp8_block_fallback_uses_aiter_stage2_runner(monkeypatch):
+    method = _method(use_mxfp8=True)
+    method.convert_mxfp8_to_block = True
+    monkeypatch.setattr(fp8_quant, "_use_aiter", True)
+    monkeypatch.setattr(fp8_quant, "_mxfp8_bf16_fallback_required", lambda: True)
+    monkeypatch.setattr(
+        fp8_quant, "get_moe_runner_backend", lambda: MoeRunnerBackend.AITER
+    )
+    monkeypatch.setattr(
+        fp8_quant,
+        "MoeRunner",
+        lambda backend, config: SimpleNamespace(runner_backend=backend),
+    )
+
+    method.create_moe_runner(SimpleNamespace(), MoeRunnerConfig())
+
+    assert method.convert_mxfp8_to_block is True
+    assert method.runner.runner_backend == MoeRunnerBackend.AITER
+
+
+def test_mxfp8_block_fallback_forces_triton_without_aiter(monkeypatch):
+    method = _method(use_mxfp8=True)
+    method.convert_mxfp8_to_block = True
+    monkeypatch.setattr(fp8_quant, "_use_aiter", False)
+    monkeypatch.setattr(fp8_quant, "_mxfp8_bf16_fallback_required", lambda: True)
+    monkeypatch.setattr(
+        fp8_quant, "get_moe_runner_backend", lambda: MoeRunnerBackend.AITER
+    )
+    monkeypatch.setattr(
+        fp8_quant,
+        "MoeRunner",
+        lambda backend, config: SimpleNamespace(runner_backend=backend),
+    )
+
+    method.create_moe_runner(SimpleNamespace(), MoeRunnerConfig())
+
+    assert method.convert_mxfp8_to_block is True
+    assert method.runner.runner_backend == MoeRunnerBackend.TRITON
+
+
+def test_mxfp8_block_fallback_builds_triton_quant_info(monkeypatch):
+    method = _method(use_mxfp8=True)
+    method.convert_mxfp8_to_block = True
+    method.weight_block_size = [1, 32]
+    method.runner = SimpleNamespace(runner_backend=MoeRunnerBackend.TRITON)
+    layer = _layer()
+    layer.w13_input_scale = None
+    layer.w2_input_scale = None
+
+    def convert(weight, scale, block=128):
+        assert scale.dtype == torch.uint8
+        return weight.clone(), torch.ones(
+            ((weight.shape[0] + block - 1) // block, 1), dtype=torch.float32
+        )
+
+    monkeypatch.setattr(
+        mxfp8_block_convert, "convert_mxfp8_weight_to_block_fp8", convert
+    )
+    monkeypatch.setattr(fp8_quant, "_is_fp8_fnuz", False)
+
+    method.process_weights_after_loading_block_quant(layer)
+    quant_info = method.get_triton_quant_info(layer)
+
+    assert method.use_mxfp8 is False
+    assert method.weight_block_size == [128, 128]
+    assert quant_info.use_mxfp8 is False
+    assert quant_info.use_fp8_w8a8 is True
+    assert quant_info.block_shape == [128, 128]
+    assert quant_info.w13_scale.dtype == torch.float32
+    assert quant_info.w2_scale.dtype == torch.float32
+
+
+def test_mxfp8_uses_aiter_after_load_time_block_conversion(monkeypatch):
+    method = _method(use_mxfp8=True)
+    method.convert_mxfp8_to_block = False
+    monkeypatch.setattr(fp8_quant, "_use_aiter", True)
+    monkeypatch.setattr(fp8_quant, "_mxfp8_bf16_fallback_required", lambda: False)
+    monkeypatch.setattr(
+        fp8_quant, "get_moe_runner_backend", lambda: MoeRunnerBackend.AITER
+    )
+    monkeypatch.setattr(
+        fp8_quant,
+        "MoeRunner",
+        lambda backend, config: SimpleNamespace(runner_backend=backend),
+    )
+
+    method.create_moe_runner(SimpleNamespace(), MoeRunnerConfig())
+
+    assert method.convert_mxfp8_to_block is True
+    assert method.runner.runner_backend == MoeRunnerBackend.AITER
+
+
+def test_aiter_block_fp8_keeps_stage2_router_weighting(monkeypatch):
+    method = _method(use_mxfp8=False)
+    monkeypatch.setattr(fp8_quant, "_use_aiter", True)
+    monkeypatch.setattr(fp8_quant, "_use_hip_int4", False)
+
+    quant_info = method.maybe_get_hip_aiter_quant_info(_layer())
+
+    assert quant_info is not None
+    assert quant_info.quant_type == AiterQuantType.PER_128X128
+    assert quant_info.doweight_stage1 is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/quantization/test_mxfp8_bf16_fallback.py
+++ b/test/registered/unit/layers/quantization/test_mxfp8_bf16_fallback.py
@@ -1,0 +1,179 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import sglang.srt.layers.quantization.fp8 as fp8_quant
+from sglang.srt.layers.quantization.mxfp8_block_convert import (
+    dequant_mxfp8_to_bf16,
+)
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    DeepseekV2WeightLoaderMixin,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=45, suite="stage-b-test-1-gpu-small-amd")
+register_amd_ci(est_time=45, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+def _mxfp8_values(shape):
+    values = torch.linspace(-2, 2, torch.tensor(shape).prod().item()).reshape(shape)
+    return values.to(torch.float8_e4m3fn)
+
+
+def test_dequant_mxfp8_supports_dense_and_expert_shapes():
+    dense_weight = _mxfp8_values((3, 64))
+    dense_scale = torch.tensor([[127, 128], [126, 127], [128, 126]], dtype=torch.uint8)
+    dense = dequant_mxfp8_to_bf16(dense_weight, dense_scale)
+
+    expert_weight = dense_weight.reshape(1, 3, 64).expand(2, -1, -1).contiguous()
+    expert_scale = dense_scale.reshape(1, 3, 2).expand(2, -1, -1).contiguous()
+    experts = dequant_mxfp8_to_bf16(expert_weight, expert_scale)
+
+    assert dense.dtype == torch.bfloat16
+    assert experts.dtype == torch.bfloat16
+    torch.testing.assert_close(experts[0], dense, rtol=0, atol=0)
+    torch.testing.assert_close(experts[1], dense, rtol=0, atol=0)
+
+
+def test_dense_uses_aiter_block_fp8_when_native_mxfp8_is_unavailable(monkeypatch):
+    block_linear = object()
+    monkeypatch.setattr(fp8_quant, "_is_hip", True)
+    monkeypatch.setattr(fp8_quant, "_is_cuda", False)
+    monkeypatch.setattr(fp8_quant, "_use_aiter", True)
+    monkeypatch.setattr(fp8_quant, "cutlass_fp8_supported", lambda: False)
+    monkeypatch.setattr(
+        fp8_quant,
+        "resolve_mxfp8_dense_gemm_backend",
+        lambda: SimpleNamespace(is_unsupported=lambda: True),
+    )
+    monkeypatch.setattr(
+        fp8_quant, "dispatch_w8a8_block_fp8_linear", lambda: block_linear
+    )
+
+    method = fp8_quant.Fp8LinearMethod(
+        SimpleNamespace(
+            use_mxfp8=True,
+            weight_block_size=[1, 32],
+            is_checkpoint_fp8_serialized=True,
+        )
+    )
+
+    assert method.convert_mxfp8_to_block is True
+    assert method.emulate_mxfp8 is False
+    assert method.w8a8_block_fp8_linear is block_linear
+
+
+def test_dense_emulation_preserves_mxfp8_storage_and_dequantizes_in_forward():
+    method = object.__new__(fp8_quant.Fp8LinearMethod)
+    method.emulate_mxfp8 = True
+    method.convert_mxfp8_to_block = False
+    method.use_mxfp8 = True
+    method.block_quant = True
+
+    weight = _mxfp8_values((4, 64))
+    scale = torch.full((4, 2), 127, dtype=torch.uint8)
+    expected_weight = dequant_mxfp8_to_bf16(weight, scale)
+    layer = SimpleNamespace(
+        weight=torch.nn.Parameter(weight, requires_grad=False),
+        weight_scale_inv=torch.nn.Parameter(scale, requires_grad=False),
+        input_scale=None,
+    )
+
+    method.process_weights_after_loading_block_quant(layer)
+
+    assert method.use_mxfp8 is True
+    assert method.block_quant is True
+    assert layer.weight.dtype == torch.float8_e4m3fn
+    assert layer.weight_scale_inv.dtype == torch.uint8
+
+    x = torch.randn(2, 64, dtype=torch.bfloat16)
+    torch.testing.assert_close(
+        method.apply(layer, x),
+        torch.nn.functional.linear(x, expected_weight),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _test_absorbed_kv_b_proj_uses_exact_mxfp8_dequant_before_split(
+    *, emulate_mxfp8: bool, convert_mxfp8_to_block: bool
+):
+    qk_nope_head_dim = 4
+    v_head_dim = 2
+    num_heads = 2
+    weight = _mxfp8_values((num_heads * (qk_nope_head_dim + v_head_dim), 64))
+    scale = torch.tensor(
+        [[126 + (row % 3), 127 + (row % 2)] for row in range(weight.shape[0])],
+        dtype=torch.uint8,
+    )
+    expected = dequant_mxfp8_to_bf16(weight, scale)
+    expected_kc, expected_vc = expected.unflatten(
+        0, (-1, qk_nope_head_dim + v_head_dim)
+    ).split([qk_nope_head_dim, v_head_dim], dim=1)
+
+    kv_b_proj = SimpleNamespace(
+        weight=torch.nn.Parameter(weight, requires_grad=False),
+        weight_scale_inv=torch.nn.Parameter(scale, requires_grad=False),
+        quant_method=SimpleNamespace(
+            use_mxfp8=True,
+            emulate_mxfp8=emulate_mxfp8,
+            convert_mxfp8_to_block=convert_mxfp8_to_block,
+        ),
+    )
+    self_attn = SimpleNamespace(
+        kv_b_proj=kv_b_proj,
+        qk_nope_head_dim=qk_nope_head_dim,
+        v_head_dim=v_head_dim,
+        w_scale=99.0,
+        w_kc=None,
+        w_vc=None,
+    )
+    loader = DeepseekV2WeightLoaderMixin.__new__(DeepseekV2WeightLoaderMixin)
+    loader.config = SimpleNamespace(
+        num_hidden_layers=1,
+        architectures=["HunyuanV4ForCausalLM"],
+    )
+    loader.quant_config = SimpleNamespace(
+        weight_block_size=[1, 32], get_name=lambda: "mxfp8"
+    )
+    loader.model = SimpleNamespace(
+        start_layer=0,
+        end_layer=1,
+        layers=[SimpleNamespace(self_attn=self_attn)],
+    )
+
+    loader.post_load_weights(weight_names=["model.layers.0.self_attn.kv_b_proj.weight"])
+
+    assert self_attn.w_scale == 1.0
+    assert self_attn.w_kc.dtype == torch.bfloat16
+    assert self_attn.w_vc.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        self_attn.w_kc,
+        expected_kc.transpose(1, 2).contiguous().transpose(1, 2),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        self_attn.w_vc,
+        expected_vc.contiguous().transpose(1, 2),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_absorbed_kv_b_proj_uses_exact_mxfp8_dequant_for_emulation():
+    _test_absorbed_kv_b_proj_uses_exact_mxfp8_dequant_before_split(
+        emulate_mxfp8=True, convert_mxfp8_to_block=False
+    )
+
+
+def test_absorbed_kv_b_proj_uses_exact_mxfp8_dequant_for_block_conversion():
+    _test_absorbed_kv_b_proj_uses_exact_mxfp8_dequant_before_split(
+        emulate_mxfp8=False, convert_mxfp8_to_block=True
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
+++ b/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
@@ -20,13 +20,18 @@ profiler stepping) is pure-Python and runs on CPU.
 """
 
 import contextlib
+import gc
 import unittest
+import weakref
 from types import SimpleNamespace
 from unittest import mock
 
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
     FullCudaGraphBackend,
+)
+from sglang.srt.model_executor.runner_utils.capture_owner import (
+    retain_full_cuda_graph_owner,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -54,6 +59,7 @@ def _make_backend(runner):
     backend = FullCudaGraphBackend.__new__(FullCudaGraphBackend)
     backend._graphs = {}
     backend._outputs = {}
+    backend._capture_owners = {}
     backend._pool = None
     backend._capture_stream = None
     backend._memory_saver_adapter = None
@@ -103,6 +109,57 @@ class TestCaptureOneNoProfiling(CustomTestCase):
         # Graph + output are recorded against the shape key.
         self.assertEqual(backend._graphs[shape_key], "GRAPH")
         self.assertIs(backend._outputs[shape_key], sentinel_out)
+
+    def test_retains_only_capture_owners_and_releases_on_replacement(self):
+        runner = _make_runner(enable_profile=False, profiler=None)
+        backend = _make_backend(runner)
+        shape_key = ShapeKey(size=4)
+        captured_refs = []
+
+        class Owner:
+            pass
+
+        def forward_fn():
+            owner = Owner()
+            if retain_full_cuda_graph_owner(owner):
+                captured_refs.append(weakref.ref(owner))
+            return object()
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH-1"):
+            backend.capture_one(shape_key, forward_fn)
+
+        self.assertEqual(len(captured_refs), 1)
+        self.assertIsNotNone(captured_refs[0]())
+        self.assertEqual(len(backend._capture_owners[shape_key]), 1)
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH-2"):
+            backend.capture_one(shape_key, forward_fn)
+        gc.collect()
+
+        self.assertEqual(len(captured_refs), 2)
+        self.assertIsNone(captured_refs[0]())
+        self.assertIsNotNone(captured_refs[1]())
+        self.assertEqual(len(backend._capture_owners[shape_key]), 1)
+
+        backend.cleanup()
+        gc.collect()
+        self.assertIsNone(captured_refs[1]())
+        self.assertEqual(backend._capture_owners, {})
+
+    def test_capture_inputs_are_retained_with_the_shape(self):
+        runner = _make_runner(enable_profile=False, profiler=None)
+        backend = _make_backend(runner)
+        shape_key = ShapeKey(size=2)
+        capture_inputs = object()
+
+        with mock.patch("torch.cuda.CUDAGraph", return_value="GRAPH"):
+            backend.capture_one(
+                shape_key, lambda: object(), capture_inputs=capture_inputs
+            )
+
+        self.assertIn(capture_inputs, backend._capture_owners[shape_key])
+        backend.cleanup()
+        self.assertEqual(backend._capture_owners, {})
 
     def test_enable_flag_set_but_no_profiler_attr_does_not_step(self):
         # The runner advertises the flag but never created a profiler; the

--- a/test/registered/unit/models/test_hunyuan_v4.py
+++ b/test/registered/unit/models/test_hunyuan_v4.py
@@ -6,10 +6,31 @@ import torch
 from torch import nn
 
 from sglang.srt.models import hunyuan_v4, hunyuan_v4_nextn
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla_rocm,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
+)
 from sglang.srt.runtime_context import get_context, get_flags, reset_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize("method", (AttnForwardMethod.MLA, AttnForwardMethod.MLA_ROCM))
+def test_attention_accepts_sparse_mla_platform_variants(monkeypatch, method):
+    backend = SimpleNamespace(use_mha=True)
+    monkeypatch.setattr(hunyuan_v4, "get_attn_backend", lambda: backend)
+    monkeypatch.setattr(
+        hunyuan_v4.DeepseekV2AttentionMLA,
+        "dispatch_attn_forward_method",
+        lambda self, forward_batch: method,
+    )
+
+    attention = object.__new__(hunyuan_v4.HYV4Attention)
+    assert attention.dispatch_attn_forward_method(SimpleNamespace()) == method
+    assert backend.use_mha is False
 
 
 @pytest.mark.parametrize("attn_tp_size", [1, 2, 4, 8, 16, 32, 64])
@@ -60,6 +81,68 @@ def test_attention_gate_uses_attention_tp(monkeypatch, attn_tp_size):
     assert captured["tp_size"] == parallel.attn_tp_size
     assert attention.local_gate_width == (64 // attn_tp_size) * 256
     assert attention.linear_gate.output_size_per_partition == attention.local_gate_width
+
+
+def test_rocm_mla_applies_attention_output_gate_before_o_proj(monkeypatch):
+    events = []
+    ungated = torch.tensor([[4.0, 8.0]])
+    gate = torch.tensor([[0.25, 0.25]])
+    attention_sink = torch.tensor([0.5])
+
+    def attn_mqa(*args, **kwargs):
+        events.append("attn_mqa")
+        assert kwargs["attn_sink"] is attention_sink
+        return torch.tensor([[[1.0, 2.0]]])
+
+    def apply_attention_output_gate(attn_output, prepared_gate):
+        events.append("gate")
+        assert torch.equal(attn_output, ungated)
+        assert prepared_gate is gate
+        return attn_output * prepared_gate
+
+    def o_proj(attn_output):
+        events.append("o_proj")
+        assert torch.equal(attn_output, torch.tensor([[1.0, 2.0]]))
+        return attn_output, None
+
+    attention = SimpleNamespace(
+        current_attention_backend=next(
+            iter(forward_mla_rocm.FORWARD_ABSORB_CORE_ATTENTION_BACKENDS)
+        ),
+        num_local_heads=1,
+        kv_lora_rank=2,
+        use_deep_gemm_bmm=False,
+        next_skip_topk=None,
+        learnable_sink_param=attention_sink,
+        _skip_rope_for_dsa_tilelang_fused=lambda: False,
+        _fuse_rope_for_trtllm_mla=lambda forward_batch: False,
+        attn_mqa=attn_mqa,
+        apply_attention_output_gate=apply_attention_output_gate,
+        o_proj=o_proj,
+    )
+    forward_batch = SimpleNamespace()
+
+    monkeypatch.setattr(forward_mla_rocm, "is_dcp_mla_decode_phase", lambda _: False)
+    monkeypatch.setattr(forward_mla_rocm, "rocm_absorb_v_bmm", lambda *_: ungated)
+    monkeypatch.setattr(forward_mla_rocm, "is_kv_b_lora_active", lambda _: False)
+    monkeypatch.setattr(forward_mla_rocm, "_SGLANG_EXPERIMENTAL_LORA_OPTI", False)
+
+    output = forward_mla_rocm.DeepseekMLARocmForwardMixin.forward_absorb_rocm_core(
+        attention,
+        q_pe=None,
+        k_pe=None,
+        q_nope_out=None,
+        k_nope=None,
+        forward_batch=forward_batch,
+        zero_allocator=None,
+        positions=None,
+        topk_indices=None,
+        llama_4_scaling=None,
+        attention_output_gate=gate,
+    )
+
+    assert events == ["attn_mqa", "gate", "o_proj"]
+    assert torch.equal(output, torch.tensor([[1.0, 2.0]]))
 
 
 def test_attention_gate_rejects_mismatched_local_width(monkeypatch):

--- a/test/registered/unit/test_dsa_aiter_sink.py
+++ b/test/registered/unit/test_dsa_aiter_sink.py
@@ -1,0 +1,117 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention import dsa_backend
+from sglang.srt.layers.attention.dsa import utils as dsa_utils
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+@pytest.mark.parametrize("cuda,hip", [(True, False), (False, True)])
+def test_graph_dsa_split_surface_supports_cuda_and_hip(
+    monkeypatch: pytest.MonkeyPatch, cuda: bool, hip: bool
+) -> None:
+    monkeypatch.setattr(dsa_utils, "is_cuda", lambda: cuda)
+    monkeypatch.setattr(dsa_utils, "is_hip", lambda: hip)
+    monkeypatch.setattr(dsa_utils, "is_in_tc_piecewise_cuda_graph", lambda: False)
+    monkeypatch.setattr(dsa_utils, "is_in_breakable_cuda_graph", lambda: True)
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend_without_speculative=lambda: True)
+    )
+
+    assert dsa_utils.is_graph_dsa_split_op_surface(forward_batch)
+
+
+def test_apply_aiter_attention_sink_matches_explicit_denominator() -> None:
+    output = torch.tensor([[[2.0, -4.0], [3.0, 5.0]]], dtype=torch.bfloat16)
+    lse = torch.tensor([[1.25, -0.5]], dtype=torch.float32)
+    sinks = torch.tensor([0.75, 0.25], dtype=torch.float32)
+
+    actual = dsa_backend.apply_aiter_attention_sink(output, lse, sinks)
+    expected = output.float() * (
+        torch.exp(lse) / (torch.exp(lse) + torch.exp(sinks))
+    ).unsqueeze(-1)
+
+    torch.testing.assert_close(actual.float(), expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("method_name", ["_forward_aiter", "_forward_aiter_extend"])
+def test_aiter_sparse_mla_requests_lse_and_applies_sink(
+    monkeypatch: pytest.MonkeyPatch, method_name: str
+) -> None:
+    backend = object.__new__(dsa_backend.DeepseekSparseAttnBackend)
+    backend.device = torch.device("cpu")
+    backend.need_pad_heads = True
+    backend.head_repeat_factor = 2
+    backend.kv_indptr = torch.zeros(2, dtype=torch.int32)
+    backend.kv_indices = torch.zeros(4, dtype=torch.int32)
+
+    layer = SimpleNamespace(
+        tp_q_head_num=8,
+        head_dim=6,
+        v_head_dim=4,
+        scaling=0.5,
+        logit_cap=0.0,
+    )
+    q_all = torch.zeros((1, 8, 6), dtype=torch.bfloat16)
+    kv_cache = torch.zeros((4, 1, 6), dtype=torch.bfloat16)
+    page_table = torch.tensor([[0, 1, -1, -1]], dtype=torch.int32)
+    sinks = torch.linspace(-0.5, 0.5, 8, dtype=torch.float32)
+
+    monkeypatch.setattr(dsa_backend, "fp8_dtype", torch.float8_e4m3fn, raising=False)
+    monkeypatch.setattr(
+        dsa_backend,
+        "get_valid_kv_indices",
+        lambda page_table, kv_indptr, kv_indices, batch_size: None,
+        raising=False,
+    )
+
+    seen = {}
+
+    def fake_mla_decode_fwd(q, kv, out, *args, **kwargs):
+        seen["return_lse"] = kwargs.get("return_lse")
+        out.fill_(2.0)
+        lse = torch.full(q.shape[:2], 1.25, dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setattr(
+        dsa_backend, "mla_decode_fwd", fake_mla_decode_fwd, raising=False
+    )
+
+    if method_name == "_forward_aiter":
+        metadata = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+            max_seq_len_q=1,
+        )
+        actual = backend._forward_aiter(
+            q_all,
+            kv_cache,
+            page_table,
+            layer,
+            metadata,
+            bs=1,
+            attn_sink=sinks,
+        )
+    else:
+        actual = backend._forward_aiter_extend(
+            q_all,
+            kv_cache,
+            page_table,
+            layer,
+            attn_sink=sinks,
+        )
+
+    expected_factor = torch.sigmoid(torch.full((1, 8), 1.25) - sinks)
+    expected = 2.0 * expected_factor.unsqueeze(-1).expand(1, 8, 4)
+    assert seen["return_lse"] is True
+    assert actual.shape == (1, 8, 4)
+    torch.testing.assert_close(actual.float(), expected, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1721,6 +1721,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             patch.object(overrides_module, "is_npu", return_value=False),
             patch.object(overrides_module, "is_xpu", return_value=False),
             patch.object(overrides_module, "is_hip", return_value=False),
+            patch("sglang.srt.arg_groups.hisparse_hook._is_hip", return_value=False),
             patch("torch.cuda.get_device_capability", return_value=(9, 0)),
         ):
             # Hopper FP8 -> flashmla_kv both
@@ -1809,6 +1810,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             patch.object(overrides_module, "is_npu", return_value=False),
             patch.object(overrides_module, "is_xpu", return_value=False),
             patch.object(overrides_module, "is_hip", return_value=True),
+            patch("sglang.srt.arg_groups.hisparse_hook._is_hip", return_value=True),
             patch("torch.cuda.get_device_capability", return_value=(9, 4)),
         ):
             # ROCm with both unset -> tilelang
@@ -1819,6 +1821,34 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "dsa_decode_backend": "tilelang",
                 },
             )
+            for arch in ("HYV4ForCausalLM", "HYV4ForCausalLMNextN"):
+                with self.subTest(arch=arch, backends="rocm-default"):
+                    self.assertEqual(
+                        _dsa_split_backend_resolution(
+                            _view(
+                                arch=arch,
+                                learnable_sink=True,
+                                kv_cache_dtype="bfloat16",
+                            )
+                        ),
+                        {
+                            "dsa_prefill_backend": "aiter",
+                            "dsa_decode_backend": "aiter",
+                        },
+                    )
+                with self.subTest(arch=arch, backends="rocm-explicit"):
+                    self.assertEqual(
+                        _dsa_split_backend_resolution(
+                            _view(
+                                arch=arch,
+                                learnable_sink=True,
+                                kv_cache_dtype="bfloat16",
+                                dsa_prefill_backend="aiter",
+                                dsa_decode_backend="aiter",
+                            )
+                        ),
+                        {},
+                    )
 
     def test_flashinfer_allreduce_fusion_passes(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
# [ROCm] Optimize Hy4-preview graph inference on gfx942 and gfx950

## Motivation

This PR is stacked on #36805 and adds the ROCm graph-mode performance and
correctness work needed to serve Hy4-preview on gfx942 and gfx950. #36805 is
the only active SGLang Hy4-preview implementation PR found, so this change
extends that branch rather than duplicating model support.

This draft includes patch-equivalent versions of #37118, #37124, and #37168
on top of #36805. It also overlaps generic ROCm infrastructure work in #35279
(DSA prefill graphs), #33022 (AITER sparse MLA), and #36574/#32516
(MXFP8/block-FP8 dispatch). Those common pieces need an agreed landing/rebase
order before this PR is ready to merge. The coordination note is posted on
#36805: https://github.com/sgl-project/sglang/pull/36805#issuecomment-5480724178.

#32506 and the broader MiniMax-specific #34014 touch the same quantization
helpers with different gfx950 A8W8/MXFP8 strategies; those paths are not copied
here. CUDA SM100 NVFP4 DSA work in #35237 overlaps generic override/backend
files but remains platform-disjoint and must be preserved through rebase.

#37114 and #33059 carry independent AITER DSA allocation and HIP-padding
correctness changes in files touched by this stack. They are not reimplemented
here and must be preserved when the final branch is rebased.

#30575 directly overlaps the DSA overrides, backend, and ROCm forward path but
adds an explicit Triton DSA implementation. This candidate uses AITER DSA with
attention-sink reconstruction. The two routes must remain separately
selectable and be compared after rebase rather than textually combined.

All new runtime branches are gated by HIP/ROCm detection, native-MX
capability, or explicit backend availability. No AMD product name or gfx
identifier is used for runtime dispatch, and existing CUDA branches retain
their original behavior.

AI assistance was used to investigate, implement, test, and prepare this
change. Before submission, the human submitter reviewed the complete patch,
confirmed the test and model-evaluation evidence below, and approved the DCO
signoff and draft publication.

## Modifications

- Add AITER DSA attention-sink handling for prefill and decode.
- Extend the DSA graph split surface to HIP while keeping CUDA dispatch on its
  existing path.
- Select MXFP8 execution by capability: native MX for dense layers where
  supported, one-time block-FP8 conversion for AITER MoE, and graph-capturable
  fallbacks when the optimized backend is unavailable.
- Preserve MXFP8 scale semantics in the absorbed MLA weight loader and select
  compatible target/NEXTN MoE runners.
- Add focused tests for sink math, graph dispatch, MXFP8 conversion/fallback,
  AITER quantization, model overrides, and Hy4 model behavior.

## Accuracy Tests

Focused commands:

```bash
pre-commit run --files \
  $(git diff --name-only 08f00d486aa6ac7161a54c89d06cd88ef25d629b..HEAD)

python -m pytest -q \
  test/registered/unit/layers/quantization/test_deepgemm_ue8m0_requant.py \
  test/registered/unit/layers/quantization/test_fp8_moe_aiter_quant_type.py \
  test/registered/unit/layers/quantization/test_mxfp8_bf16_fallback.py \
  test/registered/unit/models/test_hunyuan_v4.py \
  test/registered/unit/test_dsa_aiter_sink.py \
  test/registered/unit/test_model_overrides.py::TestGoldenModelOverrides::test_dsa_split_backend_resolution_pass
```

Results:

- Pre-commit on every touched file: passed.
- gfx942: 49 passed, 1 skipped, 16 subtests passed.
- gfx950: 49 passed, 1 skipped, 16 subtests passed.

The broader inherited `test_model_overrides.py` file still has unrelated
ROCm/platform-assumption failures; the focused command above selects and
claims only the modified resolution behavior.

Full graph-mode GSM8K settings: all 1,319 samples, temperature 0.9, top-p 1.0,
seed 0, and four request threads.

| Architecture | Health | Graph | NEXTN smoke | Full GSM8K | Length truncations |
| --- | --- | --- | --- | --- | --- |
| gfx942 | 200 before / 200 after | Target prefill/verify and draft decode/extend captured; live prefill/decode reported `cuda graph: True` | Native NEXTN, 3 steps / 4 draft tokens; 2/2 smoke requests returned 200 | 1,238/1,319 = 93.8590%; stop-only 1,219/1,242 = 98.1481%; 44 missing predictions | 77 total; 19 correct |
| gfx950 | 200 before / 200 after | Target prefill/verify and draft decode/extend captured; live decode reported `cuda graph: True` | Native NEXTN, 3 steps / 4 draft tokens; 2/2 smoke requests returned 200; acceptance telemetry observed during GSM8K | 1,223/1,319 = 92.7218%; stop-only 1,195/1,218 = 98.1117%; 61 missing predictions | 101 total; 28 correct |

HY V4 often emits long reasoning traces. Samples ending with
`finish_reason=length` are reported separately because output truncation can
materially lower GSM8K accuracy without indicating a serving error.

## Speed Tests and Profiling

Exact source and runtime:

- Signed publication commit: `df2205691628989589c934e694ffa5ce649bd716`
- Hardware-validated pre-signoff commit:
  `69168ff9ad0d8e9409ff7e19c577887f9e493473`
- Both commits have the identical tree
  `e70db691216b349f748a485a57b6a26005bbf1c2`; the rewrite added DCO trailers
  only.
- Tree: `e70db691216b349f748a485a57b6a26005bbf1c2`
- Base: `08f00d486aa6ac7161a54c89d06cd88ef25d629b` (#36805)
- Model revision: `4215ec29de873a998e849cee902654490c7ff4d1`
- gfx942 image: `rocm/sgl-dev:v0.5.18-rocm720-mi30x-20260826`
  (`sha256:894dcf014de3f50561c8f992b48e237a744aa14998ca3b88e3ff654edbd564a7`)
- gfx950 image: `lmsysorg/sglang@sha256:6d68cd19206716cb3f1e31e2ad89cd0852d7ae614a792773c30a4277f8955c72`
- gfx942 AITER commit: `c16d44b93a528b2a4bfd6d8d3409116d465872a9`
- gfx950 AITER commit: `d9e5ef7ce08ee7045d583aed768cff41aa9210fe`
- GSM8K dataset SHA-256: `67e9046d913470477dfb321814d4e3240240a397cfc19c6c610af02dd2cb6456`
- `sgl-eval` package commit:
  `a231b7a439b235090ff7baa30778fa2b514309ae`
- Vendored NeMo-Skills grader commit reported by `metrics.json`:
  `645cf567ff08c0ae9cc3fc8e1edbb975b3067816`
- The final gfx942 bundle records the architecture-matched image's native
  extension provenance; the older locally rebuilt extension is diagnostic
  evidence only. The image's AITER checkout includes one tracked PyTorch stream
  compatibility edit in `csrc/cpp_itfs/torch_utils.py` with patch SHA-256
  `0fade401f1b5915e8f30e51dbd226483f1bc12123b083fab62f2449191bf43b7`;
  its MoE selector and block-FP8 kernel sources are unmodified, and no AITER
  patch is included in this PR.

Both lanes use AITER DSA prefill/decode, AITER's two-stage block-FP8 MoE with
router weighting in stage 2, native NEXTN with three speculative steps and
four draft tokens, page size 64, breakable prefill graphs, and full decode
graphs. gfx942 converts unsupported MXFP8 dense and MoE weights once to block
FP8. gfx950 retains native MX for dense layers and converts routed-expert
weights once for AITER MoE.

No AITER source patch is part of this contribution. The exact gfx942 image
state described above was checked with real Hy4 expert weights at decode token
counts 1, 2, and 4. It selected available native CK two-stage or tuned
one-stage block-FP8 kernels, produced finite graph-replayed output, and matched
the exact MXFP8-to-BF16 reference with cosine similarity from 0.9980887 to
0.9985164. The older validation-only selector experiment is retained only as
diagnostic history.

| Architecture | Evaluator output throughput |
| --- | --- |
| gfx942 | 314.91 output tokens/s; 2,086,986 completion tokens in 6,627.24 seconds |
| gfx950 | 277.23 output tokens/s; 2,161,686 completion tokens in 7,797.47 seconds |

Each completed artifact is fail-closed on 1,319 unique rows, evaluator exit 0,
health 200 before/after, graph and NEXTN evidence, an empty runtime-error audit,
eight idle GPUs postflight, and an empty kernel-fault delta since server start.

## Checklist

- [x] Format the code with pre-commit.
- [x] Add and run focused unit tests.
- [x] Documentation is owned by the parent Hy4-preview support PR; this stacked
  performance PR adds no separate user-facing surface.
- [x] Provide full accuracy and evaluator-throughput results on gfx942/gfx950.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33410005823](https://github.com/sgl-project/sglang/actions/runs/33410005823)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33410005460](https://github.com/sgl-project/sglang/actions/runs/33410005460)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33410005777](https://github.com/sgl-project/sglang/actions/runs/33410005777)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->