### PR TITLE
[Bug] Honor prompt_cache_key on /v1/responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1629,6 +1629,12 @@ class ResponsesRequest(BaseModel):
     cache_salt: Optional[str] = Field(
         default=None, description="Cache salt for request caching"
     )
+    prompt_cache_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "OpenAI prompt cache key. Applied as cache_salt when cache_salt is unset."
+        ),
+    )
 
     # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.
     frequency_penalty: float = 0.0

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -455,7 +455,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         rid=request.request_id,
                         session_id=request.session_id,
                         extra_key=request.extra_key,
-                        cache_salt=request.cache_salt,
+                        cache_salt=request.cache_salt or request.prompt_cache_key,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
                         require_reasoning=require_reasoning,

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -422,6 +422,5 @@ class PromptCacheKeyTestCase(CustomTestCase):
         self.assertEqual(request.prompt_cache_key, "task-a")
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -406,5 +406,22 @@ class ToolChoiceObjectFormTestCase(CustomTestCase):
             )
 
 
+class PromptCacheKeyTestCase(CustomTestCase):
+    def test_prompt_cache_key_is_accepted(self):
+        request = ResponsesRequest(input="hello", prompt_cache_key="task-a")
+        self.assertEqual(request.prompt_cache_key, "task-a")
+        self.assertIsNone(request.cache_salt)
+
+    def test_cache_salt_wins_when_both_set(self):
+        request = ResponsesRequest(
+            input="hello",
+            cache_salt="native",
+            prompt_cache_key="task-a",
+        )
+        self.assertEqual(request.cache_salt, "native")
+        self.assertEqual(request.prompt_cache_key, "task-a")
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1060,6 +1060,5 @@ class PromptCacheKeyForwardingTestCase(CustomTestCase):
         self.assertEqual(adapted.cache_salt, "native")
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -989,5 +989,77 @@ class StreamingLogprobsRejectionTestCase(CustomTestCase):
         self.assertIn("streaming mode", body["error"]["message"])
 
 
+class PromptCacheKeyForwardingTestCase(CustomTestCase):
+    def _capture_adapted(self, request):
+        serving = make_serving()
+        rendered = MessageProcessingResult(
+            prompt="prompt",
+            prompt_ids=[1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=None,
+            modalities=[],
+            stop=[],
+        )
+        captured = {}
+
+        async def fake_generate(
+            request_id,
+            request_prompt,
+            adapted_request,
+            sampling_params,
+            context,
+            **kwargs,
+        ):
+            captured["adapted_request"] = adapted_request
+            context.append_output(
+                {
+                    "text": "done",
+                    "meta_info": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 1,
+                        "cached_tokens": 0,
+                    },
+                }
+            )
+            yield context
+
+        serving._generate_with_builtin_tools = fake_generate
+        with (
+            patch.object(
+                serving, "_apply_conversation_template", return_value=rendered
+            ),
+            patch(
+                "sglang.srt.entrypoints.openai.serving_responses.ReasoningParser"
+            ) as parser_cls,
+        ):
+            parser_cls.return_value.parse_non_stream.return_value = (None, "done")
+            response = asyncio.run(serving.create_responses(request))
+        self.assertEqual(response.status, "completed")
+        return captured["adapted_request"]
+
+    def test_prompt_cache_key_maps_to_cache_salt(self):
+        request = ResponsesRequest(
+            model="x",
+            input="hello",
+            prompt_cache_key="task-a",
+            store=False,
+        )
+        adapted = self._capture_adapted(request)
+        self.assertEqual(adapted.cache_salt, "task-a")
+
+    def test_native_cache_salt_wins_over_prompt_cache_key(self):
+        request = ResponsesRequest(
+            model="x",
+            input="hello",
+            cache_salt="native",
+            prompt_cache_key="task-a",
+            store=False,
+        )
+        adapted = self._capture_adapted(request)
+        self.assertEqual(adapted.cache_salt, "native")
+
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #37263.

`/v1/responses` was silently dropping OpenAI's `prompt_cache_key`. `ResponsesRequest` did not declare the field, so Pydantic ignored it and `GenerateReqInput.cache_salt` stayed `None`. Callers that send a stable key (for example Codex task IDs) then shared the global radix-cache namespace instead of isolating by key.

I added `prompt_cache_key` on `ResponsesRequest` and map it into `GenerateReqInput.cache_salt` when native `cache_salt` is unset. An explicit `cache_salt` still wins if both are set. I only changed the HTTP-model construction site; the later tool-loop site already copies `adapted_request.cache_salt`.

## Test plan

- [x] Schema-level reproduction from the issue:
  `ResponsesRequest(input="hello", prompt_cache_key="task-a")` now keeps `prompt_cache_key == "task-a"`.
- [x] Native `cache_salt` still wins when both fields are set.
- [x] Serving maps `prompt_cache_key` into `GenerateReqInput.cache_salt`.

```bash
python -m pytest test/registered/unit/entrypoints/openai/test_responses_protocol.py test/registered/unit/entrypoints/openai/test_serving_responses.py -q
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33651925273](https://github.com/sgl-project/sglang/actions/runs/33651925273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33651925195](https://github.com/sgl-project/sglang/actions/runs/33651925195)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33651925194](https://github.com/sgl-project/sglang/actions/runs/33651925194)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->