### PR TITLE
fix(memory): skip speculative Mamba verify budget on PD prefill

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -113,6 +113,13 @@ def _should_elide_dsa_index_k(*, is_draft_worker: bool) -> bool:
     )
 
 
+def _target_verify_num_draft_tokens() -> int | None:
+    """Return the draft width only for workers that can run target verify."""
+    if get_disagg().disaggregation_mode == "prefill":
+        return None
+    return max_speculative_num_draft_tokens()
+
+
 _is_hip = is_hip()
 
 
@@ -1117,14 +1124,8 @@ class KVCacheConfigurator:
             mamba_layer_ids=self._get_mamba_layer_ids_for_req_pool(),
             enable_mamba_extra_buffer=get_exec().mamba.enable_mamba_extra_buffer,
             enable_mamba_extra_buffer_lazy=get_exec().mamba.enable_mamba_extra_buffer_lazy,
-            # A PD prefill server never runs TARGET_VERIFY, so skip the
-            # verify-only per-draft-token state snapshots (see the draft-head
-            # case above: None => the pool skips SpeculativeState).
-            speculative_num_draft_tokens=(
-                None
-                if get_disagg().disaggregation_mode == "prefill"
-                else max_speculative_num_draft_tokens()
-            ),
+            # None skips verify-only per-draft-token state snapshots.
+            speculative_num_draft_tokens=_target_verify_num_draft_tokens(),
             speculative_eagle_topk=get_spec().speculative_eagle_topk,
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             start_layer=self.layer_info.start_layer,
@@ -2335,16 +2336,21 @@ class KVCacheConfigurator:
             config.mamba2_cache_params.mamba_cache_per_req * pp_layer_scale
         )
 
-        has_spec_dec = not self.spec_algorithm.is_none()
+        target_verify_num_draft_tokens = _target_verify_num_draft_tokens()
+        has_target_verify = target_verify_num_draft_tokens is not None
         # ReplaySSM drops the per-step intermediate_ssm scratch, so its mamba budget
         # no longer reserves the (1 + D/ratio) intermediate factor -- the whole
         # budget goes to persistent slots (K sized like non-spec), which is how the
         # freed ~9GB turns into higher max_running.
         # The ring is not part of mamba_cache_per_req. GDN replay is fixed-size
         # request scratch; KDA replay remains attached to each mamba slot.
-        replayssm_active = get_exec().mamba.enable_linear_replayssm_spec and (
-            self.hybrid_gdn_config is not None
-            or kimi_linear_config(self.model_config) is not None
+        replayssm_active = (
+            has_target_verify
+            and get_exec().mamba.enable_linear_replayssm_spec
+            and (
+                self.hybrid_gdn_config is not None
+                or kimi_linear_config(self.model_config) is not None
+            )
         )
         if replayssm_active:
             record_len = get_exec().mamba.linear_replayssm_cache_len
@@ -2365,8 +2371,7 @@ class KVCacheConfigurator:
         else:
             replayssm_fixed_bytes = 0
             replayssm_ring_per_slot = replayssm_ring_per_req
-        if has_spec_dec:
-            assert get_spec().speculative_num_draft_tokens is not None
+        if has_target_verify:
             assert get_schedule().max_running_requests is not None
 
         if get_schedule().max_mamba_cache_size is not None:
@@ -2379,16 +2384,14 @@ class KVCacheConfigurator:
             # Reserve intermediate memory based on capped max_num_reqs (+1: the
             # pool's padding slot, see memory_pool.py). Skipped under replayssm
             # (no intermediate_ssm allocated).
-            if has_spec_dec and not replayssm_active:
+            if has_target_verify and not replayssm_active:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
                     get_schedule().max_running_requests // self.ps.attn_dp_size,
                     get_schedule().max_mamba_cache_size // ratio,
                 )
                 intermediate_size = (
-                    stage_per_req
-                    * (capped_reqs + 1)
-                    * get_spec().speculative_num_draft_tokens
+                    stage_per_req * (capped_reqs + 1) * target_verify_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         elif (
@@ -2403,11 +2406,11 @@ class KVCacheConfigurator:
             )
             # Reserve intermediate memory based on capped max_num_reqs (+1: the
             # pool's padding slot). Skipped under replayssm.
-            if has_spec_dec and not replayssm_active:
+            if has_target_verify and not replayssm_active:
                 intermediate_size = (
                     stage_per_req
                     * (get_schedule().max_mamba_cache_size + 1)
-                    * get_spec().speculative_num_draft_tokens
+                    * target_verify_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         else:
@@ -2425,9 +2428,9 @@ class KVCacheConfigurator:
             )
             mamba_budget_bytes = mamba_budget * (1 << 30)
 
-            if has_spec_dec and not replayssm_active:
+            if has_target_verify and not replayssm_active:
                 ratio = self._calculate_mamba_ratio()
-                D = get_spec().speculative_num_draft_tokens
+                D = target_verify_num_draft_tokens
                 # Joint solve: main_state + intermediate = mamba_budget
                 get_context().override(
                     "mamba_pool.memory_budget_spec",

--- a/test/registered/unit/mem_cache/test_pd_prefill_spec_mamba_budget.py
+++ b/test/registered/unit/mem_cache/test_pd_prefill_spec_mamba_budget.py
@@ -1,0 +1,176 @@
+"""CPU regressions for role-aware speculative Mamba-state sizing."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.srt.mem_cache import kv_cache_configurator as kvc
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+GB = 1 << 30
+PERSISTENT_BYTES_PER_SLOT = 1024
+REPLAY_RING_BYTES_PER_SLOT = 64
+DRAFT_TOKENS = 8
+MAX_RUNNING = 4
+
+
+class TestPDWorkerSpecMambaBudget(unittest.TestCase):
+    def _budgeted_verify_bytes(self, *, mode, draft_tokens, replay):
+        params = SimpleNamespace(
+            layers=[0],
+            mamba_cache_per_req=PERSISTENT_BYTES_PER_SLOT,
+            replayssm_ring_bytes_per_req=lambda *, record_len: (
+                REPLAY_RING_BYTES_PER_SLOT
+            ),
+        )
+        configurator = SimpleNamespace(
+            mambaish_config=SimpleNamespace(mamba2_cache_params=params),
+            ps=SimpleNamespace(pp_size=1, attn_dp_size=1),
+            hybrid_gdn_config=object(),
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(), num_hidden_layers=1
+            ),
+            _calculate_mamba_ratio=lambda: 1,
+        )
+        schedule = SimpleNamespace(
+            max_mamba_cache_size=MAX_RUNNING,
+            max_running_requests=MAX_RUNNING,
+        )
+        exec_config = SimpleNamespace(
+            mamba=SimpleNamespace(
+                enable_linear_replayssm_spec=replay,
+                linear_replayssm_cache_len=16,
+            )
+        )
+
+        with (
+            patch.object(
+                kvc,
+                "get_disagg",
+                return_value=SimpleNamespace(disaggregation_mode=mode),
+            ),
+            patch.object(
+                kvc, "max_speculative_num_draft_tokens", return_value=draft_tokens
+            ),
+            patch.object(kvc, "get_schedule", return_value=schedule),
+            patch.object(kvc, "get_exec", return_value=exec_config),
+            patch.object(
+                kvc,
+                "get_context",
+                return_value=SimpleNamespace(override=Mock()),
+            ),
+            patch.object(kvc, "kimi_linear_config", return_value=None),
+        ):
+            remaining_gb = kvc.KVCacheConfigurator._handle_max_mamba_cache(
+                configurator, 1.0
+            )
+
+        charged_bytes = round((1.0 - remaining_gb) * GB)
+        persistent_bytes = (MAX_RUNNING + 1) * PERSISTENT_BYTES_PER_SLOT
+        return charged_bytes - persistent_bytes
+
+    def test_role_and_replay_matrix(self):
+        snapshot_bytes = (MAX_RUNNING + 1) * DRAFT_TOKENS * PERSISTENT_BYTES_PER_SLOT
+        replay_ring_bytes = (MAX_RUNNING + 1) * REPLAY_RING_BYTES_PER_SLOT
+        cases = (
+            ("null", None, False, 0, "standalone without speculation"),
+            ("null", DRAFT_TOKENS, False, snapshot_bytes, "standalone snapshot"),
+            ("null", DRAFT_TOKENS, True, replay_ring_bytes, "standalone ReplaySSM"),
+            ("decode", DRAFT_TOKENS, False, snapshot_bytes, "PD decode snapshot"),
+            ("decode", DRAFT_TOKENS, True, replay_ring_bytes, "PD decode ReplaySSM"),
+            ("prefill", DRAFT_TOKENS, False, 0, "PD prefill snapshot config"),
+            ("prefill", DRAFT_TOKENS, True, 0, "PD prefill ReplaySSM config"),
+        )
+
+        for mode, draft_tokens, replay, expected, label in cases:
+            with self.subTest(label=label):
+                self.assertEqual(
+                    self._budgeted_verify_bytes(
+                        mode=mode, draft_tokens=draft_tokens, replay=replay
+                    ),
+                    expected,
+                )
+
+    def test_pdmux_keeps_target_verify_width(self):
+        with (
+            patch.object(
+                kvc,
+                "get_disagg",
+                return_value=SimpleNamespace(
+                    disaggregation_mode="null", enable_pdmux=True
+                ),
+            ),
+            patch.object(
+                kvc,
+                "max_speculative_num_draft_tokens",
+                return_value=DRAFT_TOKENS,
+            ),
+        ):
+            self.assertEqual(kvc._target_verify_num_draft_tokens(), DRAFT_TOKENS)
+
+    def test_pool_allocation_uses_the_same_worker_role_gate(self):
+        params = SimpleNamespace(layers=[0])
+        configurator = SimpleNamespace(
+            model_config=SimpleNamespace(context_len=8192),
+            device="cuda",
+            mambaish_config=SimpleNamespace(mamba2_cache_params=params),
+            layer_info=SimpleNamespace(start_layer=0, end_layer=1),
+            hybrid_gdn_config=object(),
+            _get_mamba_layer_ids_for_req_pool=lambda: [0],
+        )
+        schedule = SimpleNamespace(
+            max_mamba_cache_size=MAX_RUNNING, disable_overlap_schedule=False
+        )
+        exec_config = SimpleNamespace(
+            features=SimpleNamespace(enable_memory_saver=False),
+            mamba=SimpleNamespace(
+                enable_linear_replayssm=False,
+                linear_replayssm_cache_len=16,
+                enable_linear_replayssm_spec=False,
+                enable_mamba_extra_buffer=False,
+                enable_mamba_extra_buffer_lazy=False,
+            ),
+        )
+        memory = SimpleNamespace(enable_page_major_kv_layout=False)
+        spec = SimpleNamespace(speculative_algorithm="DFLASH", speculative_eagle_topk=1)
+
+        for mode, expected in (
+            ("prefill", None),
+            ("decode", DRAFT_TOKENS),
+            ("null", DRAFT_TOKENS),
+        ):
+            pool = Mock()
+            with (
+                self.subTest(mode=mode),
+                patch.object(
+                    kvc,
+                    "get_disagg",
+                    return_value=SimpleNamespace(disaggregation_mode=mode),
+                ),
+                patch.object(
+                    kvc,
+                    "max_speculative_num_draft_tokens",
+                    return_value=DRAFT_TOKENS,
+                ),
+                patch.object(kvc, "get_schedule", return_value=schedule),
+                patch.object(kvc, "get_exec", return_value=exec_config),
+                patch.object(kvc, "get_memory", return_value=memory),
+                patch.object(kvc, "get_spec", return_value=spec),
+                patch.object(kvc, "HybridReqToTokenPool", return_value=pool) as ctor,
+            ):
+                result = kvc.KVCacheConfigurator._build_hybrid_req_pool(
+                    configurator,
+                    max_num_reqs=MAX_RUNNING,
+                    extra_max_context_len=0,
+                )
+
+            self.assertIs(result, pool)
+            self.assertEqual(
+                ctor.call_args.kwargs["speculative_num_draft_tokens"], expected
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PD prefill workers do not execute `TARGET_VERIFY`. #34191 already made their
hybrid request pool skip verify-only per-draft Mamba/GDN state, but the memory
sizing path still charged that state whenever speculative decoding was enabled.

For Qwen3.8-27B-FP8 + DFlash2 with `max_running_requests=8` and draft width 8,
this phantom reservation is 11,083,972,608 bytes (10.322 GiB) on one rank. It can
consume the Target KV budget and prevent the Prefill worker from starting.

## Root Cause

`_build_hybrid_req_pool()` already passes `speculative_num_draft_tokens=None` on
`disaggregation_mode=prefill`, so `MambaPool` does not allocate the verify-only
state. `_handle_max_mamba_cache()`, however, used only the global speculative
algorithm as its gate and subtracted the full snapshot budget on the same worker.

The accounting predicate therefore did not match the allocation predicate.

## Modifications

- Add one helper that returns the maximum draft width only for workers that can
  execute Target Verify.
- Reuse that helper in the existing pool construction and Mamba memory sizing.
- Skip snapshot or ReplaySSM verify-only budget only on PD Prefill.
- Keep persistent Mamba/GDN state accounting unchanged for P-to-D handoff.
- Preserve existing accounting on standalone, PD Decode, and PDMux workers.

No scheduler, allocator implementation, transfer backend, model, or kernel logic
is changed.

## Correctness / Tests

CPU tests cover:

- standalone without speculation, snapshot state, and ReplaySSM;
- PD Decode snapshot state and ReplaySSM;
- PD Prefill with normal speculative and ReplaySSM configurations;
- PDMux retaining Target Verify width;
- the actual pool constructor receiving `None` only for PD Prefill.

Commands and results:

```text
pytest focused Mamba/accounting suite: 51 passed, 12 subtests passed
expanded related CPU suite:            80 passed, 14 subtests passed
pre-commit run --files <changed files>: passed
git diff --check upstream/main...HEAD: passed
```

An earlier correctness-qualified DFlash-PD run of the same accounting change
preserved 4/4 selected deterministic oracle cases exactly: token IDs, text,
finish reason/token count, acceptance length, and verify count all matched.

The current clean-main 12-case rerun could not reach model output because the
existing DFlash-PD decode path fails independently with `batch.spec_info is None`
in `spec_prepare_for_decode`. This PR does not alter or work around that path.

## GPU Reproduction Evidence

Hardware: GPU2=P and GPU3=D on RTX 4090, context 8192, FP32 GDN state, radix
disabled, DFlash block/draft width 8, `max_running_requests=8`, and identical
server arguments except for this patch.

Before:

- Target weights: 28.47 GB; Draft weights: 3.73 GB; 14.69 GB remained.
- Prefill failed before Target KV allocation with `Loaded weights leave no GPU
  memory for the KV cache`.
- Target KV capacity: 0.

After:

- Prefill allocated 8 persistent Mamba slots (1.27 GB).
- Prefill allocated 106,256 Target KV tokens and completed Prefill CUDA Graph
  capture, NIXL initialization, and server startup.
- Decode allocated 105,590 Target KV tokens, the FP32 ReplaySSM ring, and completed
  Target Verify and Draft CUDA Graph capture at MR8.

## Backend Independence

The incorrect subtraction happens during local KV/Mamba pool sizing, before NIXL
initialization or any P-to-D transfer. The fix depends only on whether the worker
can execute Target Verify. It does not inspect or modify NIXL, Mooncake, UCX,
transfer manifests, or Draft KV layout.

## Related Work

- Follow-up to #34191, which established the allocator-side PD Prefill semantics.
- #36995 changes compact DFlash Draft KV allocation/transfer and is orthogonal.
- No existing PR or commit was found that aligns `_handle_max_mamba_cache()` with
  the PD Prefill allocation gate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34223923400](https://github.com/sgl-project/sglang/actions/runs/34223923400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34223922862](https://github.com/sgl-project/sglang/actions/runs/34223922862)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34223923256](https://github.com/sgl-project/sglang/actions/runs/34223923256)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->