### PR TITLE
[Benchmark] Add a lightweight online stress suite

### DIFF
--- a/benchmark/stress_suite/README.md
+++ b/benchmark/stress_suite/README.md
@@ -1,0 +1,107 @@
+# Continuous online stress suite
+
+`sglang.benchmark.stress_suite` creates one timestamped workload and runs it
+through the canonical `sglang.benchmark.serving` entrypoint. All phases share
+one client process and one time line, so QPS and token lengths change without a
+warmup or process gap between corner cases.
+
+```bash
+python -m sglang.benchmark.stress_suite \
+  --base-url http://127.0.0.1:30000 \
+  --profile standard \
+  --baseline-qps 2 \
+  --peak-qps 8 \
+  --output-dir stress_results/standard
+```
+
+Profiles:
+
+- `quick`: smoke, steady, burst, and recovery.
+- `standard`: ramp, length boundaries, and generated shared-prefix traffic.
+- `edge`: zigzag, microburst, connection churn, tool schema, 32K/80K context
+  boundaries, and high concurrency.
+- `all`: every phase once.
+- `soak`: continuously repeat all non-smoke phases for 20 hours. Smoke runs
+  only once at the beginning.
+
+Use repeated `--scenario` options to select phases. `--total-duration-sec`
+repeats the selected workload to an exact planned duration and truncates only
+the final phase. For example, a 20-hour custom run is:
+
+```bash
+python -m sglang.benchmark.stress_suite \
+  --base-url http://127.0.0.1:30000 \
+  --profile standard \
+  --total-duration-sec 72000 \
+  --baseline-qps 2 \
+  --peak-qps 8 \
+  --output-dir stress_results/standard-20h
+```
+
+`--arrival-pattern constant` gives deterministic spacing. Use
+`--arrival-pattern poisson` for reproducible Poisson arrivals. Every run writes
+`workload.json`, the normal serving `result.jsonl`, `benchmark.log`,
+`phases.jsonl`, `health.jsonl`, `progress.json`, `summary.json`, and
+`summary.md`. `phases.jsonl` is flushed as each phase completes, so a partial
+run retains completed-phase evidence. `progress.json` stays small and contains
+only current progress plus an aggregate health status.
+
+While the serving process runs, the suite checks `/health` every 60 seconds and
+atomically updates `progress.json`. The final health check is always recorded
+and any failure fails the suite by default. Use `--health-check-interval-sec`
+to change the interval, or `--max-health-failures` to tolerate a bounded number
+of transient failures. `--max-pending-requests` bounds live asyncio tasks; a
+positive scheduling backlog is reported as phase-level mean/p99 schedule lag
+and actual dispatch QPS instead of being hidden.
+
+The suite queries `/server_info` and `/model_info` when available. Phases that
+exceed the advertised context length or require an explicitly unavailable tool
+parser are recorded as `SKIP`. Use `--context-length` when a compatible server
+does not expose these endpoints, or `--disable-capability-check` to exercise
+server-side rejection behavior deliberately. Skipped intervals remain in the
+timeline, so a 72,000-second soak does not silently become shorter.
+
+Add `--cache-report` for phase-level cached-token totals and cache-hit ratios.
+Add `--prometheus` to snapshot selected `/metrics` series at phase completion;
+repeat `--prometheus-metric` to add series. HTTP status, 429/4xx/5xx, timeout,
+connection/protocol failures, finish reasons, missing usage, and incomplete SSE
+streams are summarized per phase. Headers, authorization fields, cookies, and
+token-like fields are redacted from printed and persisted commands.
+
+Generating a 20-hour plan or completing a short validation is not a substitute
+for a 20-hour acceptance run. Run `soak` against a dedicated service, retain the
+entire output directory, and verify the final health, phase count, failure
+taxonomy, server log, and post-run inference before declaring long-run PASS.
+
+## Test data
+
+The default `--dataset-source random-ids` generates synthetic prompts locally
+with the existing SGLang random dataset generator. No dataset is downloaded.
+Eight prompts are generated for each length/source combination and reused
+across the timestamped request sequence. Change this with `--prompt-pool-size`.
+
+Two existing open-source benchmark generators are also supported:
+
+- `--dataset-source sharegpt` uses the community ShareGPT sampler. Pass
+  `--dataset-path` to use a local copy; otherwise the existing serving dataset
+  loader downloads its public source at runtime.
+- `generated-shared-prefix` is used automatically by the `shared_prefix`
+  phase and generates synthetic prefix-sharing requests locally.
+
+The repository contains only six hand-authored examples in
+`data/synthetic_trace.jsonl`. Never commit production requests, transformed
+production data, customer data, or private dataset metadata.
+
+For a short validation against an existing service:
+
+```bash
+python -m sglang.benchmark.stress_suite \
+  --base-url http://127.0.0.1:8000 \
+  --profile quick \
+  --duration-scale 0.1 \
+  --context-length 4096 \
+  --max-pending-requests 256 \
+  --cache-report \
+  --prometheus \
+  --output-dir /tmp/sglang-stress-quick
+```

--- a/benchmark/stress_suite/data/.gitignore
+++ b/benchmark/stress_suite/data/.gitignore
@@ -1,0 +1,5 @@
+# Keep this directory limited to the reviewed, hand-authored fixture.
+*
+!.gitignore
+!README.md
+!synthetic_trace.jsonl

--- a/benchmark/stress_suite/data/README.md
+++ b/benchmark/stress_suite/data/README.md
@@ -1,0 +1,9 @@
+# Synthetic trace fixture
+
+`synthetic_trace.jsonl` is hand-authored test data in the existing custom
+dataset format. Every prompt and answer is fictional and exists only to exercise
+the benchmark harness.
+
+Do not add production requests, transformed production requests, customer data,
+or private dataset metadata to this directory. Private traces must remain outside
+the repository and be passed to the benchmark by local path.

--- a/benchmark/stress_suite/data/synthetic_trace.jsonl
+++ b/benchmark/stress_suite/data/synthetic_trace.jsonl
@@ -1,0 +1,6 @@
+{"conversations":[{"from":"human","value":"Reply with the single word amber."},{"from":"assistant","value":"amber"}]}
+{"conversations":[{"from":"human","value":"List the first three prime numbers."},{"from":"assistant","value":"2, 3, 5"}]}
+{"conversations":[{"from":"human","value":"Rewrite this in uppercase: synthetic clouds drift."},{"from":"assistant","value":"SYNTHETIC CLOUDS DRIFT."}]}
+{"conversations":[{"from":"human","value":"A fictional box has two blue tokens and three green tokens. How many tokens are there?"},{"from":"assistant","value":"There are five tokens."}]}
+{"conversations":[{"from":"human","value":"Translate the synthetic phrase hello benchmark into Chinese."},{"from":"assistant","value":"你好，基准测试。"}]}
+{"conversations":[{"from":"human","value":"Count from one to five using comma-separated English words."},{"from":"assistant","value":"one, two, three, four, five"}]}

--- a/python/sglang/benchmark/datasets/__init__.py
+++ b/python/sglang/benchmark/datasets/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from sglang.benchmark.datasets.agentic_trace import AgenticTraceDataset
 from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
 from sglang.benchmark.datasets.custom import CustomDataset
+from sglang.benchmark.datasets.dynamic import DynamicDataset
 from sglang.benchmark.datasets.generated_shared_prefix import (
     GeneratedSharedPrefixDataset,
 )
@@ -19,6 +20,7 @@ DATASET_MAPPING: Dict[str, Type[BaseDataset]] = {
     "agentic-trace": AgenticTraceDataset,
     "sharegpt": ShareGPTDataset,
     "custom": CustomDataset,
+    "dynamic": DynamicDataset,
     "openai": OpenAIDataset,
     # TODO: "random" vs "random-ids" should be a flag (e.g. --random-source=sharegpt|integers),
     # not two separate dataset names sharing the same class.

--- a/python/sglang/benchmark/datasets/common.py
+++ b/python/sglang/benchmark/datasets/common.py
@@ -29,6 +29,10 @@ class DatasetRow:
     timestamp: Optional[float] = None
     routing_key: Optional[str] = None
     extra_request_body: Optional[Dict[str, Any]] = None  # Per-request API parameters
+    phase: Optional[str] = None
+    phase_duration: Optional[float] = None
+    phase_request_rate: Optional[float] = None
+    phase_max_concurrency: Optional[int] = None
 
     def __post_init__(self):
         if self.text_prompt_len is None:

--- a/python/sglang/benchmark/datasets/dynamic.py
+++ b/python/sglang/benchmark/datasets/dynamic.py
@@ -1,0 +1,261 @@
+import json
+import math
+import random
+from argparse import Namespace
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, List, Optional
+
+import numpy as np
+
+from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
+from sglang.benchmark.datasets.generated_shared_prefix import (
+    sample_generated_shared_prefix_requests,
+)
+from sglang.benchmark.datasets.random import sample_random_requests
+
+SOURCES = ("random-ids", "sharegpt", "generated-shared-prefix")
+ARRIVAL_PATTERNS = ("constant", "poisson")
+
+
+def _positive_number(value: Any, field: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{field} must be a number")
+    value = float(value)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{field} must be finite and positive")
+    return value
+
+
+def _positive_int(value: Any, field: str) -> int:
+    number = _positive_number(value, field)
+    if not number.is_integer():
+        raise ValueError(f"{field} must be an integer")
+    return int(number)
+
+
+def load_workload_plan(path: str) -> dict:
+    plan_path = Path(path)
+    try:
+        plan = json.loads(plan_path.read_text())
+    except FileNotFoundError as exc:
+        raise ValueError(f"dynamic workload does not exist: {plan_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid dynamic workload JSON: {exc}") from exc
+
+    if not isinstance(plan, dict) or not isinstance(plan.get("phases"), list):
+        raise ValueError("dynamic workload must contain a phases list")
+    if not plan["phases"]:
+        raise ValueError("dynamic workload must contain at least one phase")
+    if plan.get("prompt_pool_size") is not None:
+        _positive_int(plan["prompt_pool_size"], "prompt_pool_size")
+
+    names = set()
+    for index, phase in enumerate(plan["phases"]):
+        prefix = f"phases[{index}]"
+        if not isinstance(phase, dict):
+            raise ValueError(f"{prefix} must be an object")
+        name = phase.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{prefix}.name must be a non-empty string")
+        if name in names:
+            raise ValueError(f"duplicate dynamic workload phase: {name}")
+        names.add(name)
+        _positive_number(phase.get("duration"), f"{prefix}.duration")
+        _positive_number(phase.get("request_rate"), f"{prefix}.request_rate")
+        _positive_int(phase.get("input_len"), f"{prefix}.input_len")
+        _positive_int(phase.get("output_len"), f"{prefix}.output_len")
+        if phase.get("max_concurrency") is not None:
+            _positive_int(phase.get("max_concurrency"), f"{prefix}.max_concurrency")
+        range_ratio = phase.get("range_ratio", 1.0)
+        _positive_number(range_ratio, f"{prefix}.range_ratio")
+        if range_ratio > 1:
+            raise ValueError(f"{prefix}.range_ratio must be at most 1")
+        if phase.get("extra_request_body") is not None and not isinstance(
+            phase["extra_request_body"], dict
+        ):
+            raise ValueError(f"{prefix}.extra_request_body must be an object")
+        source = phase.get("source", plan.get("source", "random-ids"))
+        if source not in SOURCES:
+            raise ValueError(f"{prefix}.source must be one of {SOURCES}")
+        pattern = phase.get("arrival_pattern", plan.get("arrival_pattern", "constant"))
+        if pattern not in ARRIVAL_PATTERNS:
+            raise ValueError(
+                f"{prefix}.arrival_pattern must be one of {ARRIVAL_PATTERNS}"
+            )
+    return plan
+
+
+def generate_arrival_offsets(
+    duration: float,
+    request_rate: float,
+    pattern: str,
+    rng: np.random.Generator,
+) -> List[float]:
+    if pattern == "constant":
+        count = max(1, math.ceil(duration * request_rate))
+        return [
+            index / request_rate
+            for index in range(count)
+            if index / request_rate < duration
+        ]
+
+    offsets = [0.0]
+    elapsed = 0.0
+    while True:
+        elapsed += float(rng.exponential(1.0 / request_rate))
+        if elapsed >= duration:
+            break
+        offsets.append(elapsed)
+    return offsets
+
+
+def _generate_requests(
+    *,
+    source: str,
+    input_len: int,
+    output_len: int,
+    count: int,
+    range_ratio: float,
+    tokenizer: Any,
+    dataset_path: str,
+    seed: int,
+) -> List[DatasetRow]:
+    if source in ("random-ids", "sharegpt"):
+        return sample_random_requests(
+            input_len=input_len,
+            output_len=output_len,
+            num_prompts=count,
+            range_ratio=range_ratio,
+            tokenizer=tokenizer,
+            dataset_path=dataset_path,
+            random_sample=source == "sharegpt",
+            return_text=True,
+        )
+
+    num_groups = min(4, count)
+    prompts_per_group = math.ceil(count / num_groups)
+    # Leave room for decode/encode drift and the separator inserted by the
+    # existing shared-prefix generator.
+    prompt_budget = max(2, input_len * 9 // 10)
+    system_prompt_len = max(1, prompt_budget * 3 // 4)
+    question_len = max(1, prompt_budget - system_prompt_len)
+    requests = sample_generated_shared_prefix_requests(
+        num_groups=num_groups,
+        prompts_per_group=prompts_per_group,
+        system_prompt_len=system_prompt_len,
+        question_len=question_len,
+        output_len=output_len,
+        range_ratio=range_ratio,
+        tokenizer=tokenizer,
+        seed=seed,
+        ordered=True,
+    )
+    return requests[:count]
+
+
+def _encode(tokenizer: Any, prompt: str, *, add_special_tokens: bool) -> list[int]:
+    try:
+        return tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
+    except TypeError:
+        return tokenizer.encode(prompt)
+
+
+def fit_prompt_length(tokenizer: Any, prompt: str, target: int) -> tuple[str, int]:
+    """Best-effort text round-trip with an exact tokenizer-visible length."""
+    special_tokens = int(tokenizer.num_special_tokens_to_add())
+    target_content = max(1, target - special_tokens)
+    token_ids = _encode(tokenizer, prompt, add_special_tokens=False)
+    if not token_ids:
+        token_ids = [next(iter(tokenizer.get_vocab().values()))]
+    while len(token_ids) < target_content:
+        token_ids.extend(token_ids[: target_content - len(token_ids)])
+    token_ids = token_ids[:target_content]
+
+    for _ in range(8):
+        prompt = tokenizer.decode(token_ids)
+        actual = len(_encode(tokenizer, prompt, add_special_tokens=True))
+        if actual == target:
+            return prompt, actual
+        target_content = max(1, target_content + target - actual)
+        while len(token_ids) < target_content:
+            token_ids.extend(token_ids[: target_content - len(token_ids)])
+        token_ids = token_ids[:target_content]
+    return prompt, actual
+
+
+@dataclass
+class DynamicDataset(BaseDataset):
+    workload_path: str
+    dataset_path: str
+    seed: int
+
+    @classmethod
+    def from_args(cls, args: Namespace) -> "DynamicDataset":
+        return cls(
+            workload_path=args.dynamic_workload_path,
+            dataset_path=args.dataset_path,
+            seed=args.seed,
+        )
+
+    def load(self, tokenizer: Any, model_id: Optional[str] = None) -> List[DatasetRow]:
+        del model_id
+        plan = load_workload_plan(self.workload_path)
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        rng = np.random.default_rng(self.seed)
+        phase_start = 0.0
+        requests = []
+        request_pools = {}
+        prompt_pool_size = int(plan.get("prompt_pool_size", 8))
+
+        for index, phase in enumerate(plan["phases"]):
+            duration = float(phase["duration"])
+            request_rate = float(phase["request_rate"])
+            source = phase.get("source", plan.get("source", "random-ids"))
+            pattern = phase.get(
+                "arrival_pattern", plan.get("arrival_pattern", "constant")
+            )
+            offsets = generate_arrival_offsets(duration, request_rate, pattern, rng)
+            input_len = int(phase["input_len"])
+            output_len = int(phase["output_len"])
+            range_ratio = float(phase.get("range_ratio", 1.0))
+            pool_key = (source, input_len, output_len, range_ratio)
+            pool = request_pools.get(pool_key)
+            if pool is None:
+                pool = _generate_requests(
+                    source=source,
+                    input_len=input_len,
+                    output_len=output_len,
+                    count=prompt_pool_size,
+                    range_ratio=range_ratio,
+                    tokenizer=tokenizer,
+                    dataset_path=self.dataset_path,
+                    seed=self.seed + index,
+                )
+                for request in pool:
+                    target_len = (
+                        input_len
+                        if range_ratio == 1
+                        else request.prompt_len
+                        + int(tokenizer.num_special_tokens_to_add())
+                    )
+                    request.prompt, request.prompt_len = fit_prompt_length(
+                        tokenizer, request.prompt, target_len
+                    )
+                    request.text_prompt_len = request.prompt_len
+                request_pools[pool_key] = pool
+            for request_index, offset in enumerate(offsets):
+                request = replace(pool[request_index % len(pool)])
+                request.timestamp = (phase_start + offset) * 1000
+                request.phase = phase["name"]
+                request.phase_duration = duration
+                request.phase_request_rate = request_rate
+                request.phase_max_concurrency = phase.get("max_concurrency")
+                request.extra_request_body = dict(
+                    phase.get("extra_request_body") or request.extra_request_body
+                )
+                requests.append(request)
+            phase_start += duration
+
+        return requests

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -20,6 +20,7 @@ import json
 import math
 import os
 import random
+import re
 import shutil
 import sys
 import time
@@ -27,6 +28,7 @@ import traceback
 import uuid
 import warnings
 from argparse import ArgumentParser
+from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -48,7 +50,6 @@ from sglang.benchmark.utils import (
     remove_prefix,
     set_ulimit,
 )
-from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 from sglang.srt.utils.network import resolve_base_url, resolve_host_port
 
 _ROUTING_KEY_HEADER = "X-SMG-Routing-Key"
@@ -93,6 +94,8 @@ class RequestFuncInput:
     extra_request_body: Dict[str, Any]
     timestamp: Optional[float] = None
     routing_key: Optional[str] = None
+    scheduled_offset_ms: Optional[float] = None
+    benchmark_start_time: Optional[float] = None
 
 
 @dataclass
@@ -114,11 +117,22 @@ class RequestFuncOutput:
     spec_cap_length: float = 0.0
     spec_block_accept_length: float = 0.0
     spec_cap_lens_histogram: List[int] = field(default_factory=list)
+    status_code: Optional[int] = None
+    finish_reason: Optional[str] = None
+    usage_present: bool = False
+    stream_complete: bool = False
+    scheduled_offset_ms: Optional[float] = None
+    dispatch_offset_ms: Optional[float] = None
 
     @staticmethod
     def init_new(request_func_input: RequestFuncInput):
         output = RequestFuncOutput()
         output.prompt_len = request_func_input.prompt_len
+        output.scheduled_offset_ms = request_func_input.scheduled_offset_ms
+        if request_func_input.benchmark_start_time is not None:
+            output.dispatch_offset_ms = (
+                time.perf_counter() - request_func_input.benchmark_start_time
+            ) * 1000
         return output
 
 
@@ -201,6 +215,7 @@ async def async_request_trt_llm(
         most_recent_timestamp = st
         try:
             async with session.post(url=api_url, json=payload) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -225,6 +240,7 @@ async def async_request_trt_llm(
 
                     output.latency = most_recent_timestamp - st
                     output.success = True
+                    output.stream_complete = True
                     output.output_len = request_func_input.output_len
 
                 else:
@@ -315,6 +331,7 @@ async def async_request_openai_completions(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -324,9 +341,11 @@ async def async_request_openai_completions(
                         chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
                         latency = time.perf_counter() - st
                         if chunk == "[DONE]":
-                            pass
+                            output.stream_complete = True
                         else:
                             data = json.loads(chunk)
+                            usage = data.get("usage") or {}
+                            output.usage_present = output.usage_present or bool(usage)
 
                             if getattr(args, "cache_report", False):
                                 _extract_cache_from_sglext(data, output)
@@ -334,7 +353,14 @@ async def async_request_openai_completions(
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
                             # want to check a token was generated
-                            if data["choices"][0]["text"]:
+                            choices = data.get("choices") or []
+                            if not choices:
+                                continue
+                            choice = choices[0]
+                            output.finish_reason = (
+                                choice.get("finish_reason") or output.finish_reason
+                            )
+                            if choice.get("text"):
                                 timestamp = time.perf_counter()
                                 # First token
                                 if ttft == 0.0:
@@ -343,19 +369,19 @@ async def async_request_openai_completions(
 
                                 # Decoding phase
                                 else:
-                                    output.text_chunks.append(
-                                        data["choices"][0]["text"]
-                                    )
+                                    output.text_chunks.append(choice["text"])
                                     output.itl.append(timestamp - most_recent_timestamp)
 
                                 most_recent_timestamp = timestamp
-                                generated_text += data["choices"][0]["text"]
+                                generated_text += choice["text"]
                                 output_len = (data.get("usage") or {}).get(
                                     "completion_tokens", output_len
                                 )
 
                     output.generated_text = generated_text
                     output.success = True
+                    if args.disable_stream:
+                        output.stream_complete = True
                     output.latency = latency
                     output.output_len = output_len
                 else:
@@ -470,6 +496,7 @@ async def async_request_openai_chat_completions(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     if args.disable_stream:
                         # Non-streaming response
@@ -484,6 +511,11 @@ async def async_request_openai_chat_completions(
                         output.output_len = response_json.get("usage", {}).get(
                             "completion_tokens", output_len
                         )
+                        output.usage_present = bool(response_json.get("usage"))
+                        output.finish_reason = response_json["choices"][0].get(
+                            "finish_reason"
+                        )
+                        output.stream_complete = True
                         _meta_info = response_json["choices"][0].get("meta_info") or {}
                         output.spec_accept_length = (
                             _meta_info.get("spec_accept_length", 0.0) or 0.0
@@ -509,13 +541,16 @@ async def async_request_openai_chat_completions(
                             chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
                             latency = time.perf_counter() - st
                             if chunk == "[DONE]":
-                                pass
+                                output.stream_complete = True
                             else:
                                 data = json.loads(chunk)
                                 # Check for usage info in final chunks. OpenAI-compatible
                                 # servers may emit usage-only chunks with choices=[].
                                 output_len = (data.get("usage") or {}).get(
                                     "completion_tokens", output_len
+                                )
+                                output.usage_present = output.usage_present or bool(
+                                    data.get("usage")
                                 )
 
                                 if getattr(args, "cache_report", False):
@@ -524,6 +559,10 @@ async def async_request_openai_chat_completions(
                                 choices = data.get("choices") or []
                                 if not choices:
                                     continue
+                                output.finish_reason = (
+                                    choices[0].get("finish_reason")
+                                    or output.finish_reason
+                                )
 
                                 # Reasoning models stream thoughts via
                                 # `reasoning_content`; count them like content.
@@ -606,6 +645,7 @@ async def async_request_truss(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -615,7 +655,7 @@ async def async_request_truss(
                         chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
                         latency = time.perf_counter() - st
                         if chunk == "[DONE]":
-                            pass
+                            output.stream_complete = True
                         else:
                             data = json.loads(chunk)
 
@@ -706,6 +746,7 @@ async def async_request_sglang_generate(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -721,7 +762,7 @@ async def async_request_sglang_generate(
                         )
                         latency = time.perf_counter() - st
                         if sse_data == b"[DONE]":
-                            pass
+                            output.stream_complete = True
                         else:
                             data = orjson.loads(sse_data)
 
@@ -813,10 +854,12 @@ async def async_request_openai_embeddings(
             async with session.post(
                 url=api_url, json=payload, headers=headers
             ) as response:
+                output.status_code = response.status
                 if response.status == 200:
                     await response.json()
                     output.latency = time.perf_counter() - st
                     output.success = True
+                    output.stream_complete = True
                     output.output_len = 0
                 else:
                     output.error = (
@@ -1093,6 +1136,13 @@ async def get_request(
             await asyncio.sleep(interval)
 
 
+async def _async_enumerate(generator):
+    index = 0
+    async for item in generator:
+        yield index, item
+        index += 1
+
+
 def calculate_metrics(
     input_requests: Optional[List[DatasetRow]],
     outputs: List[RequestFuncOutput],
@@ -1274,6 +1324,211 @@ def calculate_metrics(
     return metrics, output_lens
 
 
+def classify_failure(output: RequestFuncOutput) -> str:
+    if output.success:
+        return "success"
+    if output.status_code == 429:
+        return "http_429"
+    if output.status_code is not None and 400 <= output.status_code < 500:
+        return "http_4xx"
+    if output.status_code is not None and output.status_code >= 500:
+        return "http_5xx"
+    error = output.error.lower()
+    if "timeout" in error or "timed out" in error:
+        return "timeout"
+    if any(
+        value in error
+        for value in ("connection reset", "connection refused", "disconnect")
+    ):
+        return "connection"
+    if error:
+        return "client_or_protocol"
+    return "unknown"
+
+
+def _redact_error(error: str) -> str:
+    error = re.sub(r"(?i)(bearer\s+)[^\s,;]+", r"\1<redacted>", error)
+    return re.sub(
+        r'(?i)(api[_-]?key|authorization|cookie|token)(["\s:=]+)[^\s,;}]+',
+        r"\1\2<redacted>",
+        error,
+    )
+
+
+def calculate_phase_metrics(
+    input_requests: List[DatasetRow], outputs: List[RequestFuncOutput]
+) -> List[Dict[str, Any]]:
+    """Summarize timestamped workload phases without changing request transport."""
+    phases: Dict[str, Dict[str, Any]] = {}
+    for request, output in zip(input_requests, outputs):
+        if request.phase is None:
+            continue
+        phase = phases.setdefault(
+            request.phase,
+            {
+                "name": request.phase,
+                "duration": request.phase_duration,
+                "request_rate": request.phase_request_rate,
+                "max_concurrency": request.phase_max_concurrency,
+                "input_len": request.prompt_len,
+                "output_len": request.output_len,
+                "planned": 0,
+                "completed": 0,
+                "ttfts": [],
+                "e2e_latencies": [],
+                "dispatch_offsets": [],
+                "schedule_lags": [],
+                "errors": [],
+                "failure_categories": Counter(),
+                "status_codes": Counter(),
+                "finish_reasons": Counter(),
+                "missing_usage": 0,
+                "incomplete_streams": 0,
+                "total_prompt_tokens": 0,
+                "cached_tokens": 0,
+                "device_cached_tokens": 0,
+                "host_cached_tokens": 0,
+                "storage_cached_tokens": 0,
+            },
+        )
+        phase["planned"] += 1
+        if output.status_code is not None:
+            phase["status_codes"][str(output.status_code)] += 1
+        if output.finish_reason:
+            phase["finish_reasons"][output.finish_reason] += 1
+        if not output.usage_present:
+            phase["missing_usage"] += 1
+        if output.success and not output.stream_complete:
+            phase["incomplete_streams"] += 1
+            phase["failure_categories"]["sse_incomplete"] += 1
+        if output.dispatch_offset_ms is not None:
+            phase["dispatch_offsets"].append(output.dispatch_offset_ms)
+        if (
+            output.dispatch_offset_ms is not None
+            and output.scheduled_offset_ms is not None
+        ):
+            phase["schedule_lags"].append(
+                max(0.0, output.dispatch_offset_ms - output.scheduled_offset_ms)
+            )
+        if output.success:
+            phase["completed"] += 1
+            phase["ttfts"].append(output.ttft * 1000)
+            phase["e2e_latencies"].append(output.latency * 1000)
+            phase["total_prompt_tokens"] += output.prompt_len
+            phase["cached_tokens"] += output.cached_tokens
+            details = output.cached_tokens_details or {}
+            phase["device_cached_tokens"] += details.get("device") or 0
+            phase["host_cached_tokens"] += details.get("host") or 0
+            phase["storage_cached_tokens"] += details.get("storage") or 0
+        elif len(phase["errors"]) < 3:
+            phase["failure_categories"][classify_failure(output)] += 1
+            phase["errors"].append(_redact_error(output.error)[:500])
+        elif not output.success:
+            phase["failure_categories"][classify_failure(output)] += 1
+
+    summaries = []
+    for phase in phases.values():
+        ttfts = phase.pop("ttfts")
+        e2e_latencies = phase.pop("e2e_latencies")
+        dispatch_offsets = phase.pop("dispatch_offsets")
+        schedule_lags = phase.pop("schedule_lags")
+        phase["failure_categories"] = dict(phase["failure_categories"])
+        phase["status_codes"] = dict(phase["status_codes"])
+        phase["finish_reasons"] = dict(phase["finish_reasons"])
+        phase["mean_ttft_ms"] = float(np.mean(ttfts)) if ttfts else None
+        phase["p99_ttft_ms"] = float(np.percentile(ttfts, 99)) if ttfts else None
+        phase["mean_e2e_latency_ms"] = (
+            float(np.mean(e2e_latencies)) if e2e_latencies else None
+        )
+        phase["p99_e2e_latency_ms"] = (
+            float(np.percentile(e2e_latencies, 99)) if e2e_latencies else None
+        )
+        phase["actual_dispatch_qps"] = (
+            (len(dispatch_offsets) - 1)
+            / ((max(dispatch_offsets) - min(dispatch_offsets)) / 1000)
+            if len(dispatch_offsets) > 1
+            and max(dispatch_offsets) > min(dispatch_offsets)
+            else None
+        )
+        phase["mean_schedule_lag_ms"] = (
+            float(np.mean(schedule_lags)) if schedule_lags else None
+        )
+        phase["p99_schedule_lag_ms"] = (
+            float(np.percentile(schedule_lags, 99)) if schedule_lags else None
+        )
+        phase["cache_hit_rate_pct"] = (
+            phase["cached_tokens"] / phase["total_prompt_tokens"] * 100
+            if phase["total_prompt_tokens"]
+            else 0.0
+        )
+        summaries.append(phase)
+    return summaries
+
+
+def _prometheus_snapshot(
+    base_url: Optional[str], metric_names: List[str]
+) -> Optional[Dict[str, float]]:
+    if not base_url or not metric_names:
+        return None
+    try:
+        response = requests.get(
+            base_url.rstrip("/") + "/metrics", headers=get_auth_headers(), timeout=5
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        return None
+    samples: Dict[str, float] = {}
+    for line in response.text.splitlines():
+        match = re.match(r"([^\s{]+)(?:\{[^}]*\})?\s+([^\s]+)", line)
+        if not match or match.group(1) not in metric_names:
+            continue
+        try:
+            samples[match.group(1)] = samples.get(match.group(1), 0.0) + float(
+                match.group(2)
+            )
+        except ValueError:
+            continue
+    return samples
+
+
+class PhaseResultWriter:
+    """Write a phase as soon as all of its requests have completed."""
+
+    def __init__(
+        self,
+        requests: List[DatasetRow],
+        output_file: Optional[str],
+        base_url: Optional[str] = None,
+        prometheus_metrics: Optional[List[str]] = None,
+    ):
+        self.output_file = output_file
+        self.base_url = base_url
+        self.prometheus_metrics = prometheus_metrics or []
+        self.remaining = Counter(row.phase for row in requests if row.phase is not None)
+        self.requests: Dict[str, List[DatasetRow]] = {}
+        self.outputs: Dict[str, List[RequestFuncOutput]] = {}
+
+    def record(self, request: DatasetRow, output: RequestFuncOutput) -> None:
+        if request.phase is None or not self.output_file:
+            return
+        self.requests.setdefault(request.phase, []).append(request)
+        self.outputs.setdefault(request.phase, []).append(output)
+        self.remaining[request.phase] -= 1
+        if self.remaining[request.phase] == 0:
+            summary = calculate_phase_metrics(
+                self.requests.pop(request.phase), self.outputs.pop(request.phase)
+            )[0]
+            snapshot = _prometheus_snapshot(self.base_url, self.prometheus_metrics)
+            if snapshot is not None:
+                summary["prometheus_snapshot"] = snapshot
+            elif self.prometheus_metrics:
+                # Avoid paying the timeout once per phase when /metrics is absent.
+                self.prometheus_metrics = []
+            with open(self.output_file, "a") as file:
+                file.write(json.dumps(summary) + "\n")
+                file.flush()
+
+
 MULTI_TURN_BACKENDS = {"sglang-oai-chat", "vllm-chat", "lmdeploy-chat"}
 
 
@@ -1359,6 +1614,9 @@ async def benchmark(
     mooncake_num_rounds=1,
     profile_prefill_url: Optional[List[str]] = None,
     profile_decode_url: Optional[List[str]] = None,
+    max_pending_requests: Optional[int] = None,
+    phase_output_file: Optional[str] = None,
+    prometheus_metrics: Optional[List[str]] = None,
 ):
     if backend in ASYNC_REQUEST_FUNCS:
         request_func = ASYNC_REQUEST_FUNCS[backend]
@@ -1385,12 +1643,23 @@ async def benchmark(
     # Limit concurrency
     # From https://github.com/vllm-project/vllm/pull/9390
     semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
+    phase_semaphores: Dict[str, asyncio.Semaphore] = {}
 
-    async def limited_request_func(request_func_input, pbar):
+    async def limited_request_func(request_func_input, pbar, phase_semaphore=None):
+        async def run_request():
+            if phase_semaphore is None:
+                return await request_func(
+                    request_func_input=request_func_input, pbar=pbar
+                )
+            async with phase_semaphore:
+                return await request_func(
+                    request_func_input=request_func_input, pbar=pbar
+                )
+
         if semaphore is None:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await run_request()
         async with semaphore:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await run_request()
 
     # Warmup
     print(f"Starting warmup with {warmup_requests} sequences...")
@@ -1497,7 +1766,11 @@ async def benchmark(
 
     # Run all requests
     benchmark_start_time = time.perf_counter()
-    tasks: List[asyncio.Task] = []
+    pending: set[asyncio.Task] = set()
+    outputs: List[Optional[RequestFuncOutput]] = [None] * len(input_requests)
+    phase_writer = PhaseResultWriter(
+        input_requests, phase_output_file, base_url, prometheus_metrics
+    )
     pbar_total = len(input_requests)
     if (
         backend == "sglang" and is_mooncake
@@ -1511,7 +1784,11 @@ async def benchmark(
         )
         pbar_total *= args.mooncake_num_rounds
     else:
-        request_generator = get_request(input_requests, request_rate)
+        request_generator = get_request(
+            input_requests,
+            request_rate,
+            use_trace_timestamps=use_trace_timestamps,
+        )
 
     # Prepare LoRA request distribution parameters
     if lora_request_distribution == "distinct":
@@ -1525,8 +1802,33 @@ async def benchmark(
 
     pbar = None if disable_tqdm else tqdm(total=pbar_total)
     benchmark_requests: List[DatasetRow] = []
-    async for request in request_generator:
+
+    async def run_indexed(index, request, request_func_input, phase_semaphore):
+        output = await limited_request_func(
+            request_func_input=request_func_input,
+            pbar=pbar,
+            phase_semaphore=phase_semaphore,
+        )
+        return index, request, output
+
+    async def collect(done):
+        for task in done:
+            index, request, output = await task
+            outputs[index] = output
+            if not is_multi_turn:
+                phase_writer.record(request, output)
+
+    trace_origin_ms = (
+        input_requests[0].timestamp
+        if use_trace_timestamps
+        and input_requests
+        and input_requests[0].timestamp is not None
+        else 0.0
+    )
+    async for request_index, request in _async_enumerate(request_generator):
         benchmark_requests.append(request)
+        if request_index == len(outputs):
+            outputs.append(None)
         if lora_names is not None and len(lora_names) != 0:
             if lora_request_distribution == "uniform":
                 lora_name = random.choice(lora_names)
@@ -1557,14 +1859,33 @@ async def benchmark(
             extra_request_body=merged_extra_body,
             timestamp=request.timestamp,
             routing_key=request.routing_key,
+            scheduled_offset_ms=(
+                request.timestamp - trace_origin_ms
+                if use_trace_timestamps and request.timestamp is not None
+                else None
+            ),
+            benchmark_start_time=benchmark_start_time,
         )
 
-        tasks.append(
+        phase_semaphore = None
+        if request.phase is not None and request.phase_max_concurrency is not None:
+            phase_semaphore = phase_semaphores.setdefault(
+                request.phase, asyncio.Semaphore(request.phase_max_concurrency)
+            )
+        pending.add(
             asyncio.create_task(
-                limited_request_func(request_func_input=request_func_input, pbar=pbar)
+                run_indexed(request_index, request, request_func_input, phase_semaphore)
             )
         )
-    outputs: List[RequestFuncOutput] = await asyncio.gather(*tasks)
+        if max_pending_requests and len(pending) >= max_pending_requests:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            await collect(done)
+    if pending:
+        done, _ = await asyncio.wait(pending)
+        await collect(done)
+    outputs = [output for output in outputs if output is not None]
     if is_multi_turn:
         outputs = [x for output in outputs for x in output]
 
@@ -1858,6 +2179,9 @@ async def benchmark(
                 "storage_cached_tokens": (total_storage if total_storage > 0 else None),
                 "storage_backend": storage_backend_name,
             }
+        phase_metrics = calculate_phase_metrics(benchmark_requests, outputs)
+        if phase_metrics:
+            result["phase_metrics"] = phase_metrics
     else:
         print(f"Error running benchmark for request rate: {request_rate}")
         print("-" * 30)
@@ -1921,6 +2245,50 @@ def set_global_args(args_: argparse.Namespace):
     args = args_
 
 
+def _redacted_args(args_: argparse.Namespace) -> argparse.Namespace:
+    def redact(value):
+        if isinstance(value, dict):
+            return {
+                key: (
+                    "<redacted>"
+                    if any(
+                        name in key.lower()
+                        for name in (
+                            "authorization",
+                            "api_key",
+                            "api-key",
+                            "cookie",
+                            "token",
+                        )
+                    )
+                    else redact(item)
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        return value
+
+    values = vars(args_).copy()
+    if values.get("base_url"):
+        scheme, separator, remainder = values["base_url"].partition("://")
+        if separator and "@" in remainder:
+            values["base_url"] = (
+                f"{scheme}{separator}<redacted>@{remainder.split('@', 1)[1]}"
+            )
+    if values.get("header"):
+        values["header"] = [
+            f"{value.partition('=')[0]}=<redacted>" for value in values["header"]
+        ]
+    if values.get("extra_request_body"):
+        try:
+            body = redact(json.loads(values["extra_request_body"]))
+            values["extra_request_body"] = json.dumps(body, separators=(",", ":"))
+        except (TypeError, json.JSONDecodeError):
+            values["extra_request_body"] = "<redacted>"
+    return argparse.Namespace(**values)
+
+
 def run_benchmark(args_: argparse.Namespace):
     global args
     args = args_
@@ -1976,7 +2344,7 @@ def run_benchmark(args_: argparse.Namespace):
     if getattr(args, "print_requests", False):
         assert args.backend == "sglang-oai-chat"  # only support this now
 
-    print(f"benchmark_args={args}")
+    print(f"benchmark_args={_redacted_args(args)}")
 
     # Set global environments
     set_ulimit()
@@ -1996,6 +2364,8 @@ def run_benchmark(args_: argparse.Namespace):
 
     # Inject bootstrap fields for fake decode benchmarking
     if getattr(args, "fake_prefill", False):
+        from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+
         extra_request_body["bootstrap_host"] = FAKE_BOOTSTRAP_HOST
         extra_request_body["bootstrap_room"] = 0
 
@@ -2092,7 +2462,7 @@ def run_benchmark(args_: argparse.Namespace):
         f"Got invalid value for --lora-zipf-alpha of {args.lora_zipf_alpha}. It must be greater than 1."
     )
 
-    print(f"{args}\n")
+    print(f"{_redacted_args(args)}\n")
 
     # Read dataset
     backend = args.backend
@@ -2156,6 +2526,9 @@ def run_benchmark(args_: argparse.Namespace):
             mooncake_num_rounds=args.mooncake_num_rounds,
             profile_prefill_url=getattr(args, "profile_prefill_url", None),
             profile_decode_url=getattr(args, "profile_decode_url", None),
+            max_pending_requests=getattr(args, "max_pending_requests", None),
+            phase_output_file=getattr(args, "phase_output_file", None),
+            prometheus_metrics=getattr(args, "prometheus_metric", None),
         )
     )
 
@@ -2242,6 +2615,7 @@ def cli_main():
             "agentic-trace",
             "sharegpt",
             "custom",
+            "dynamic",
             "openai",
             "random",
             "random-ids",
@@ -2256,6 +2630,12 @@ def cli_main():
     )
     parser.add_argument(
         "--dataset-path", type=str, default="", help="Path to the dataset."
+    )
+    parser.add_argument(
+        "--dynamic-workload-path",
+        type=str,
+        default="",
+        help="JSON workload plan used by the dynamic dataset.",
     )
     parser.add_argument(
         "--dataset-offset",
@@ -2382,7 +2762,7 @@ def cli_main():
     parser.add_argument(
         "--use-trace-timestamps",
         action="store_true",
-        help="Use timestamps from the trace file for request scheduling. Only valid for 'mooncake' dataset.",
+        help="Schedule requests by DatasetRow timestamps instead of a fixed request rate.",
     )
     parser.add_argument(
         "--max-concurrency",
@@ -2398,6 +2778,22 @@ def cli_main():
         "if the server is not processing requests fast enough to keep up.",
     )
     parser.add_argument("--output-file", type=str, help="Output JSONL file name.")
+    parser.add_argument(
+        "--phase-output-file",
+        type=str,
+        help="Append each completed dynamic phase as one JSONL record.",
+    )
+    parser.add_argument(
+        "--max-pending-requests",
+        type=int,
+        help="Bound pending request tasks for long-running benchmarks.",
+    )
+    parser.add_argument(
+        "--prometheus-metric",
+        action="append",
+        default=[],
+        help="Prometheus metric to snapshot when a dynamic phase completes.",
+    )
     parser.add_argument(
         "--output-details", action="store_true", help="Output details of benchmarking."
     )
@@ -2754,6 +3150,10 @@ def cli_main():
     )
     args = parser.parse_args()
     _validate_parsed_gsp_args(parser, args)
+    if args.dataset_name == "dynamic" and not args.dynamic_workload_path:
+        parser.error("--dataset-name dynamic requires --dynamic-workload-path")
+    if args.max_pending_requests is not None and args.max_pending_requests <= 0:
+        parser.error("--max-pending-requests must be positive")
     run_benchmark(args)
 
 

--- a/python/sglang/benchmark/stress_suite.py
+++ b/python/sglang/benchmark/stress_suite.py
@@ -1,0 +1,1034 @@
+"""Run continuous, dynamically changing online serving workloads.
+
+The suite builds one timestamped workload and delegates request generation,
+transport, token accounting, and latency metrics to ``sglang.benchmark.serving``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shlex
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_SOAK_DURATION_SEC = 20 * 60 * 60
+DEFAULT_PROMETHEUS_METRICS = (
+    "sglang:cache_hit_rate",
+    "sglang:cached_tokens_total",
+    "sglang:prompt_tokens_total",
+    "sglang:generation_tokens_total",
+    "sglang:num_running_reqs",
+    "sglang:num_queue_reqs",
+    "sglang:num_used_tokens",
+)
+SENSITIVE_NAMES = ("authorization", "api-key", "api_key", "cookie", "token")
+TOOL_REQUEST_BODY = {
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_weather",
+                "description": "Return synthetic weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+}
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    description: str
+    input_len: int
+    output_len: int
+    duration: float
+    max_concurrency: int
+    qps_source: str = "baseline"
+    qps_scale: float = 1.0
+    fixed_qps: float | None = None
+    scale_duration: bool = True
+    source: str | None = None
+    extra_request_body: dict | None = None
+
+
+SCENARIOS = {
+    scenario.name: scenario
+    for scenario in (
+        Scenario(
+            "smoke",
+            "Low-rate correctness check before pressure.",
+            input_len=32,
+            output_len=8,
+            duration=3,
+            max_concurrency=8,
+            fixed_qps=1,
+            scale_duration=False,
+        ),
+        Scenario(
+            "steady",
+            "Baseline traffic.",
+            input_len=512,
+            output_len=64,
+            duration=20,
+            max_concurrency=256,
+        ),
+        Scenario(
+            "ramp_low",
+            "First ramp step at 25% of peak QPS.",
+            input_len=512,
+            output_len=64,
+            duration=10,
+            max_concurrency=256,
+            qps_source="peak",
+            qps_scale=0.25,
+        ),
+        Scenario(
+            "ramp_mid",
+            "Second ramp step at 50% of peak QPS.",
+            input_len=512,
+            output_len=64,
+            duration=10,
+            max_concurrency=256,
+            qps_source="peak",
+            qps_scale=0.5,
+        ),
+        Scenario(
+            "burst",
+            "Peak-rate burst.",
+            input_len=512,
+            output_len=64,
+            duration=10,
+            max_concurrency=512,
+            qps_source="peak",
+        ),
+        Scenario(
+            "recovery",
+            "Low-rate recovery after pressure.",
+            input_len=256,
+            output_len=32,
+            duration=10,
+            max_concurrency=128,
+            qps_scale=0.5,
+        ),
+        Scenario(
+            "zigzag_low",
+            "Low half of an alternating load pair.",
+            input_len=256,
+            output_len=64,
+            duration=5,
+            max_concurrency=256,
+            qps_scale=0.5,
+        ),
+        Scenario(
+            "zigzag_high",
+            "High half of an alternating load pair.",
+            input_len=256,
+            output_len=64,
+            duration=5,
+            max_concurrency=512,
+            qps_source="peak",
+        ),
+        Scenario(
+            "microburst",
+            "Brief overload at twice the peak QPS.",
+            input_len=256,
+            output_len=32,
+            duration=3,
+            max_concurrency=1024,
+            qps_source="peak",
+            qps_scale=2,
+        ),
+        Scenario(
+            "connection_churn",
+            "Peak traffic through serving's per-request client sessions.",
+            input_len=64,
+            output_len=16,
+            duration=5,
+            max_concurrency=512,
+            qps_source="peak",
+        ),
+        Scenario(
+            "tool_rich",
+            "Chat requests carrying a synthetic function schema.",
+            input_len=256,
+            output_len=128,
+            duration=5,
+            max_concurrency=128,
+            extra_request_body=TOOL_REQUEST_BODY,
+        ),
+        Scenario(
+            "tiny_input",
+            "Minimal input and single-token output boundary.",
+            input_len=4,
+            output_len=1,
+            duration=5,
+            max_concurrency=128,
+        ),
+        Scenario(
+            "long_prefill",
+            "Long-context prefill pressure.",
+            input_len=8192,
+            output_len=32,
+            duration=10,
+            max_concurrency=64,
+            qps_scale=0.25,
+        ),
+        Scenario(
+            "long_decode",
+            "Long decode pressure.",
+            input_len=128,
+            output_len=512,
+            duration=10,
+            max_concurrency=128,
+            qps_scale=0.5,
+        ),
+        Scenario(
+            "long_context_32k",
+            "32K input context boundary.",
+            input_len=32768,
+            output_len=16,
+            duration=5,
+            max_concurrency=16,
+            qps_scale=0.1,
+        ),
+        Scenario(
+            "long_context_80k",
+            "80K input context boundary.",
+            input_len=81920,
+            output_len=16,
+            duration=5,
+            max_concurrency=8,
+            qps_scale=0.05,
+        ),
+        Scenario(
+            "shared_prefix",
+            "Generated shared-prefix traffic for cache behavior.",
+            input_len=2048,
+            output_len=64,
+            duration=10,
+            max_concurrency=256,
+            source="generated-shared-prefix",
+        ),
+        Scenario(
+            "high_concurrency",
+            "Peak traffic with a large concurrency window.",
+            input_len=256,
+            output_len=64,
+            duration=10,
+            max_concurrency=1024,
+            qps_source="peak",
+        ),
+    )
+}
+
+PROFILES = {
+    "quick": ("smoke", "steady", "burst", "recovery"),
+    "standard": (
+        "smoke",
+        "steady",
+        "ramp_low",
+        "ramp_mid",
+        "burst",
+        "recovery",
+        "tiny_input",
+        "long_prefill",
+        "long_decode",
+        "shared_prefix",
+    ),
+    "edge": (
+        "smoke",
+        "zigzag_low",
+        "zigzag_high",
+        "microburst",
+        "recovery",
+        "connection_churn",
+        "tool_rich",
+        "tiny_input",
+        "long_prefill",
+        "long_decode",
+        "long_context_32k",
+        "long_context_80k",
+        "high_concurrency",
+    ),
+    "all": tuple(SCENARIOS),
+    "soak": tuple(SCENARIOS),
+}
+
+RESULT_KEYS = (
+    "duration",
+    "completed",
+    "request_throughput",
+    "input_throughput",
+    "output_throughput",
+    "mean_ttft_ms",
+    "p99_ttft_ms",
+    "mean_e2e_latency_ms",
+    "p99_e2e_latency_ms",
+    "concurrency",
+    "max_concurrent_requests",
+    "cache_report",
+)
+
+
+def resolve_scenarios(profile: str, names: Sequence[str]) -> list[Scenario]:
+    selected = names or PROFILES[profile]
+    return [SCENARIOS[name] for name in dict.fromkeys(selected)]
+
+
+def target_qps(args: argparse.Namespace, scenario: Scenario) -> float:
+    if scenario.fixed_qps is not None:
+        return scenario.fixed_qps
+    base = args.peak_qps if scenario.qps_source == "peak" else args.baseline_qps
+    return base * scenario.qps_scale
+
+
+def scenario_duration(args: argparse.Namespace, scenario: Scenario) -> float:
+    return scenario.duration * (args.duration_scale if scenario.scale_duration else 1)
+
+
+def _target_duration(args: argparse.Namespace) -> float | None:
+    if args.total_duration_sec is not None:
+        return args.total_duration_sec
+    if args.profile == "soak" and not args.scenario:
+        return DEFAULT_SOAK_DURATION_SEC
+    return None
+
+
+def build_workload(args: argparse.Namespace) -> dict:
+    scenarios = resolve_scenarios(args.profile, args.scenario)
+    target_duration = _target_duration(args)
+    phases = []
+    elapsed = 0.0
+    cycle = 1
+
+    while True:
+        repeatable_scenarios = [
+            scenario for scenario in scenarios if scenario.name != "smoke"
+        ]
+        cycle_scenarios = (
+            scenarios if cycle == 1 else (repeatable_scenarios or scenarios)
+        )
+        if not cycle_scenarios:
+            break
+        for scenario in cycle_scenarios:
+            duration = scenario_duration(args, scenario)
+            if target_duration is not None:
+                remaining = target_duration - elapsed
+                if remaining <= 0:
+                    break
+                duration = min(duration, remaining)
+            name = scenario.name if cycle == 1 else f"{scenario.name}-c{cycle:03d}"
+            phases.append(
+                {
+                    "name": name,
+                    "scenario": scenario.name,
+                    "description": scenario.description,
+                    "start_time": elapsed,
+                    "duration": duration,
+                    "request_rate": target_qps(args, scenario),
+                    "input_len": scenario.input_len,
+                    "output_len": scenario.output_len,
+                    "max_concurrency": scenario.max_concurrency,
+                    "source": scenario.source or args.dataset_source,
+                    "arrival_pattern": args.arrival_pattern,
+                    "range_ratio": args.random_range_ratio,
+                    **(
+                        {"extra_request_body": scenario.extra_request_body}
+                        if scenario.extra_request_body
+                        else {}
+                    ),
+                }
+            )
+            elapsed += duration
+            if target_duration is not None and elapsed >= target_duration:
+                break
+        if target_duration is None or elapsed >= target_duration:
+            break
+        cycle += 1
+
+    return {
+        "version": 1,
+        "seed": args.seed,
+        "source": args.dataset_source,
+        "arrival_pattern": args.arrival_pattern,
+        "prompt_pool_size": args.prompt_pool_size,
+        "duration": elapsed,
+        "phases": phases,
+    }
+
+
+def _get_json(url: str, headers: dict[str, str]) -> dict | None:
+    try:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=5) as response:
+            if response.status == 200:
+                value = json.load(response)
+                return value if isinstance(value, dict) else None
+    except (OSError, ValueError, urllib.error.URLError):
+        pass
+    return None
+
+
+def detect_capabilities(args: argparse.Namespace) -> dict:
+    """Best-effort discovery used only to skip unsupported scenarios."""
+    headers = _request_headers(args.header)
+    server_info = _get_json(args.base_url.rstrip("/") + "/server_info", headers) or {}
+    model_info = _get_json(args.base_url.rstrip("/") + "/model_info", headers) or {}
+    context_length = args.context_length
+    if context_length is None:
+        for key in ("context_length", "max_model_len", "max_seq_len"):
+            value = server_info.get(key)
+            if isinstance(value, int) and value > 0:
+                context_length = value
+                break
+    parser_advertised = (
+        "tool_call_parser" in model_info or "tool_call_parser" in server_info
+    )
+    tool_parser = model_info.get(
+        "tool_call_parser", server_info.get("tool_call_parser")
+    )
+    return {
+        "context_length": context_length,
+        "tool_call_parser": tool_parser,
+        "tool_support": bool(tool_parser) if parser_advertised else None,
+        "source": (
+            "explicit"
+            if args.context_length is not None
+            else "server"
+            if server_info or model_info
+            else "unavailable"
+        ),
+    }
+
+
+def apply_capabilities(workload: dict, capabilities: dict) -> list[dict]:
+    """Remove unsupported phases and return explicit SKIP records."""
+    runnable = []
+    skipped = []
+    context_length = capabilities.get("context_length")
+    tool_support = capabilities.get("tool_support")
+    for phase in workload["phases"]:
+        reason = None
+        if context_length and phase["input_len"] + phase["output_len"] > context_length:
+            reason = (
+                f"requires {phase['input_len'] + phase['output_len']} tokens, "
+                f"server context length is {context_length}"
+            )
+        elif phase.get("scenario") == "tool_rich" and tool_support is False:
+            reason = "server does not advertise a tool-call parser"
+        if reason:
+            skipped.append({**phase, "verdict": "SKIP", "reason": reason})
+            continue
+        runnable.append(phase)
+    workload["phases"] = runnable
+    return skipped
+
+
+def estimated_requests(workload: dict) -> int:
+    return sum(
+        max(1, math.ceil(phase["duration"] * phase["request_rate"]))
+        for phase in workload["phases"]
+    )
+
+
+def build_command(
+    args: argparse.Namespace,
+    workload_file: Path,
+    result_file: Path,
+    workload: dict,
+) -> list[str]:
+    max_concurrency = args.max_concurrency or max(
+        phase["max_concurrency"] for phase in workload["phases"]
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "sglang.benchmark.serving",
+        "--backend",
+        args.backend,
+        "--base-url",
+        args.base_url.rstrip("/"),
+        "--dataset-name",
+        "dynamic",
+        "--dynamic-workload-path",
+        str(workload_file),
+        "--use-trace-timestamps",
+        "--num-prompts",
+        str(estimated_requests(workload)),
+        "--request-rate",
+        "1",
+        "--max-concurrency",
+        str(max_concurrency),
+        "--seed",
+        str(args.seed),
+        "--warmup-requests",
+        str(args.warmup_requests),
+        "--ready-check-timeout-sec",
+        str(args.ready_check_timeout_sec),
+        "--output-file",
+        str(result_file),
+        "--tag",
+        args.profile,
+        "--disable-tqdm",
+        "--max-pending-requests",
+        str(args.max_pending_requests),
+        "--phase-output-file",
+        str(result_file.with_name("phases.jsonl")),
+    ]
+    if args.dataset_path:
+        command.extend(("--dataset-path", args.dataset_path))
+    if args.model:
+        command.extend(("--model", args.model))
+    if args.tokenizer:
+        command.extend(("--tokenizer", args.tokenizer))
+    if args.extra_request_body:
+        command.extend(("--extra-request-body", args.extra_request_body))
+    if args.header:
+        command.extend(("--header", *args.header))
+    if args.flush_cache:
+        command.append("--flush-cache")
+    if args.cache_report:
+        command.append("--cache-report")
+    if args.prometheus:
+        for metric in args.prometheus_metric:
+            command.extend(("--prometheus-metric", metric))
+    return command
+
+
+def redact_value(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                "<redacted>"
+                if any(name in key.lower() for name in SENSITIVE_NAMES)
+                else redact_value(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    return value
+
+
+def redact_url(value: str) -> str:
+    scheme, separator, remainder = value.partition("://")
+    if separator and "@" in remainder:
+        return f"{scheme}{separator}<redacted>@{remainder.split('@', 1)[1]}"
+    return value
+
+
+def redact_command(command: Sequence[str]) -> list[str]:
+    redacted = list(command)
+    index = 0
+    while index < len(redacted):
+        option = redacted[index]
+        if option == "--base-url" and index + 1 < len(redacted):
+            redacted[index + 1] = redact_url(redacted[index + 1])
+            index += 2
+            continue
+        if option == "--header" and index + 1 < len(redacted):
+            index += 1
+            while index < len(redacted) and not redacted[index].startswith("--"):
+                key, separator, _ = redacted[index].partition("=")
+                redacted[index] = f"{key}=<redacted>" if separator else "<redacted>"
+                index += 1
+            continue
+        if option == "--extra-request-body" and index + 1 < len(redacted):
+            try:
+                redacted[index + 1] = json.dumps(
+                    redact_value(json.loads(redacted[index + 1])), separators=(",", ":")
+                )
+            except json.JSONDecodeError:
+                redacted[index + 1] = "<redacted>"
+            index += 2
+            continue
+        index += 1
+    return redacted
+
+
+def load_result(path: Path) -> dict:
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    if not rows:
+        raise ValueError(f"benchmark produced no result: {path}")
+    return rows[-1]
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def count_jsonl(path: Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open() as file:
+        return sum(bool(line.strip()) for line in file)
+
+
+def write_json_atomic(path: Path, payload: dict) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def append_jsonl(path: Path, payload: dict) -> None:
+    with path.open("a") as file:
+        file.write(json.dumps(payload, sort_keys=True) + "\n")
+        file.flush()
+
+
+def health_summary(checks: Sequence[dict]) -> dict:
+    return {
+        "total": len(checks),
+        "failed": sum(not check["ok"] for check in checks),
+        "latest": checks[-1] if checks else None,
+    }
+
+
+def check_health(base_url: str, headers: dict[str, str] | None = None) -> dict:
+    started = time.perf_counter()
+    status = None
+    error = ""
+    try:
+        request = urllib.request.Request(
+            base_url.rstrip("/") + "/health", headers=headers or {}
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        error = str(exc)
+    except (OSError, urllib.error.URLError) as exc:
+        error = str(exc)
+    error = error.replace(base_url, redact_url(base_url))
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "ok": status == 200,
+        "latency_ms": round((time.perf_counter() - started) * 1000, 3),
+        "error": error,
+    }
+
+
+def monitor_health(
+    stop: threading.Event,
+    *,
+    base_url: str,
+    interval: float,
+    progress_file: Path,
+    health_file: Path,
+    phase_file: Path,
+    workload: dict,
+    checks: list[dict],
+    headers: dict[str, str],
+    started_at: str,
+) -> None:
+    started = time.monotonic()
+    while True:
+        check = check_health(base_url, headers)
+        checks.append(check)
+        append_jsonl(health_file, check)
+        elapsed = time.monotonic() - started
+        phase = next(
+            (
+                item
+                for item in reversed(workload["phases"])
+                if item["start_time"] <= elapsed < item["start_time"] + item["duration"]
+            ),
+            None,
+        )
+        write_json_atomic(
+            progress_file,
+            {
+                "status": "running",
+                "started_at": started_at,
+                "elapsed_sec": round(elapsed, 3),
+                "planned_duration_sec": workload["duration"],
+                "current_phase": phase["name"] if phase else None,
+                "completed_phases": count_jsonl(phase_file),
+                "health": health_summary(checks),
+            },
+        )
+        if stop.wait(interval):
+            return
+
+
+def _request_headers(values: Sequence[str]) -> dict[str, str]:
+    headers = {}
+    for value in values:
+        key, separator, header_value = value.partition("=")
+        if separator and key and header_value:
+            headers[key] = header_value
+    return headers
+
+
+def judge_phase(args: argparse.Namespace, phase: dict) -> tuple[str, str]:
+    reasons = []
+    completed = int(phase.get("completed", 0))
+    planned = int(phase.get("planned", 0))
+    if completed != planned:
+        reasons.append(f"completed {completed}/{planned} requests")
+    if incomplete := int(phase.get("incomplete_streams", 0)):
+        reasons.append(f"{incomplete} streams ended without a completion marker")
+    for option, key, label in (
+        (args.max_ttft_p99_ms, "p99_ttft_ms", "TTFT"),
+        (args.max_e2e_p99_ms, "p99_e2e_latency_ms", "E2E"),
+    ):
+        value = phase.get(key)
+        if option is not None and value is not None and value > option:
+            reasons.append(f"{label} p99 {value:.2f} ms exceeds {option:.2f} ms")
+    return ("FAIL", "; ".join(reasons)) if reasons else ("PASS", "")
+
+
+def judge_health(checks: Sequence[dict], allowed_failures: int) -> str:
+    failures = sum(not check["ok"] for check in checks)
+    if failures > allowed_failures:
+        return f"health failed {failures} times (allowed {allowed_failures})"
+    return ""
+
+
+def write_summary(summary: dict, output_dir: Path) -> None:
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+    rows = [
+        "# SGLang continuous stress suite",
+        "",
+        f"Overall: **{summary['verdict']}**",
+        "",
+        f"Planned duration: {summary['planned_duration_sec']:.1f} seconds",
+        "",
+        "| Phase | Target QPS | Dispatch QPS | Lag p99 (ms) | Cache hit | Verdict | Completed | TTFT p99 (ms) | E2E p99 (ms) |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for run in summary["runs"]:
+        rows.append(
+            f"| {run['name']} | {run.get('request_rate', '-')} | "
+            f"{run.get('actual_dispatch_qps', '-')} | "
+            f"{run.get('p99_schedule_lag_ms', '-')} | "
+            f"{run.get('cache_hit_rate_pct', '-')} | {run['verdict']} | "
+            f"{run.get('completed', '-')} / "
+            f"{run.get('planned', '-')} | {run.get('p99_ttft_ms', '-')} | "
+            f"{run.get('p99_e2e_latency_ms', '-')} |"
+        )
+    (output_dir / "summary.md").write_text("\n".join(rows) + "\n")
+
+
+def run_suite(args: argparse.Namespace) -> int:
+    workload = build_workload(args)
+    phase_order = {
+        phase["name"]: index for index, phase in enumerate(workload["phases"])
+    }
+    capabilities = {}
+    skipped = []
+    if not args.disable_capability_check and not args.dry_run:
+        capabilities = detect_capabilities(args)
+        skipped = apply_capabilities(workload, capabilities)
+    if args.dry_run:
+        workload_file = Path("workload.json")
+        result_file = Path("result.jsonl")
+        print(json.dumps(workload, indent=2))
+        print(
+            shlex.join(
+                redact_command(
+                    build_command(args, workload_file, result_file, workload)
+                )
+            )
+        )
+        return 0
+
+    output_dir = args.output_dir or Path(
+        "stress_results", time.strftime("%Y%m%d-%H%M%S")
+    )
+    output_dir = output_dir.resolve()
+    if output_dir.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"output directory exists: {output_dir}")
+        if output_dir in (Path("/"), Path.home()):
+            raise ValueError(f"refusing to overwrite broad path: {output_dir}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    workload_file = output_dir / "workload.json"
+    result_file = output_dir / "result.jsonl"
+    phase_file = output_dir / "phases.jsonl"
+    progress_file = output_dir / "progress.json"
+    health_file = output_dir / "health.jsonl"
+    workload_file.write_text(json.dumps(workload, indent=2) + "\n")
+    if not workload["phases"]:
+        summary = {
+            "verdict": "SKIP",
+            "reason": "all selected phases are unsupported by the target server",
+            "profile": args.profile,
+            "base_url": redact_url(args.base_url),
+            "baseline_qps": args.baseline_qps,
+            "peak_qps": args.peak_qps,
+            "planned_duration_sec": workload["duration"],
+            "estimated_requests": 0,
+            "health": health_summary([]),
+            "capabilities": capabilities,
+            "command": None,
+            "metrics": None,
+            "runs": skipped,
+        }
+        write_json_atomic(progress_file, {"status": "skipped", "completed_phases": 0})
+        write_summary(summary, output_dir)
+        print(f"SKIP: {summary['reason']}")
+        return 0
+    command = build_command(args, workload_file, result_file, workload)
+    safe_command = redact_command(command)
+    print(shlex.join(safe_command), flush=True)
+    health_checks = []
+    monitor_stop = threading.Event()
+    started_at = datetime.now(timezone.utc).isoformat()
+    monitor = None
+    if args.health_check_interval_sec > 0:
+        monitor = threading.Thread(
+            target=monitor_health,
+            kwargs={
+                "stop": monitor_stop,
+                "base_url": args.base_url,
+                "interval": args.health_check_interval_sec,
+                "progress_file": progress_file,
+                "health_file": health_file,
+                "phase_file": phase_file,
+                "workload": workload,
+                "checks": health_checks,
+                "headers": _request_headers(args.header),
+                "started_at": started_at,
+            },
+            daemon=True,
+        )
+        monitor.start()
+    try:
+        with (output_dir / "benchmark.log").open("w") as log:
+            completed = subprocess.run(
+                command,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+    finally:
+        monitor_stop.set()
+        if monitor is not None:
+            monitor.join()
+    final_health = check_health(args.base_url, _request_headers(args.header))
+    health_checks.append(final_health)
+    append_jsonl(health_file, final_health)
+
+    try:
+        result = load_result(result_file)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError):
+        result = None
+
+    phase_config = {phase["name"]: phase for phase in workload["phases"]}
+    incremental_metrics = load_jsonl(phase_file)
+    incremental_by_name = {item["name"]: item for item in incremental_metrics}
+    phase_metrics = (result or {}).get("phase_metrics") or incremental_metrics
+    phase_metrics = [
+        {
+            **metrics,
+            **(
+                {
+                    "prometheus_snapshot": incremental_by_name[metrics["name"]][
+                        "prometheus_snapshot"
+                    ]
+                }
+                if incremental_by_name.get(metrics["name"], {}).get(
+                    "prometheus_snapshot"
+                )
+                else {}
+            ),
+        }
+        for metrics in phase_metrics
+    ]
+    runs = list(skipped)
+    for metrics in phase_metrics:
+        verdict, reason = judge_phase(args, metrics)
+        runs.append(
+            {
+                **phase_config.get(metrics["name"], {}),
+                **metrics,
+                "verdict": verdict,
+                "reason": reason,
+            }
+        )
+    runs.sort(key=lambda run: phase_order.get(run["name"], len(phase_order)))
+
+    reasons = []
+    if completed.returncode != 0:
+        reasons.append(f"serving benchmark exited {completed.returncode}")
+    if result is None:
+        reasons.append("serving benchmark produced no result")
+    elif len(runs) - len(skipped) != len(workload["phases"]):
+        reasons.append(
+            f"reported {len(runs) - len(skipped)}/{len(workload['phases'])} phases"
+        )
+    if any(run["verdict"] == "FAIL" for run in runs):
+        reasons.append("one or more phases failed")
+    if health_reason := judge_health(health_checks, args.max_health_failures):
+        reasons.append(health_reason)
+
+    summary = {
+        "verdict": "FAIL" if reasons else "PASS",
+        "reason": "; ".join(reasons),
+        "profile": args.profile,
+        "base_url": redact_url(args.base_url),
+        "baseline_qps": args.baseline_qps,
+        "peak_qps": args.peak_qps,
+        "planned_duration_sec": workload["duration"],
+        "estimated_requests": estimated_requests(workload),
+        "health": health_summary(health_checks),
+        "capabilities": capabilities,
+        "command": shlex.join(safe_command),
+        "metrics": (
+            {key: result[key] for key in RESULT_KEYS if key in result}
+            if result
+            else None
+        ),
+        "runs": runs,
+    }
+    write_summary(summary, output_dir)
+    write_json_atomic(
+        progress_file,
+        {
+            "status": "completed" if summary["verdict"] == "PASS" else "failed",
+            "verdict": summary["verdict"],
+            "started_at": started_at,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "return_code": completed.returncode,
+            "planned_duration_sec": workload["duration"],
+            "completed_phases": count_jsonl(phase_file),
+            "health": health_summary(health_checks),
+        },
+    )
+    print(f"{summary['verdict']}: {summary['reason']}" if reasons else "PASS")
+    print(output_dir / "summary.md")
+    return 1 if reasons else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url")
+    parser.add_argument(
+        "--backend",
+        choices=("sglang", "sglang-oai", "sglang-oai-chat"),
+        default="sglang-oai-chat",
+    )
+    parser.add_argument("--model")
+    parser.add_argument("--tokenizer")
+    parser.add_argument("--profile", choices=PROFILES, default="standard")
+    parser.add_argument("--scenario", action="append", choices=SCENARIOS, default=[])
+    parser.add_argument("--list-scenarios", action="store_true")
+    parser.add_argument("--baseline-qps", type=float, default=1)
+    parser.add_argument("--peak-qps", type=float, default=4)
+    parser.add_argument("--duration-scale", type=float, default=1)
+    parser.add_argument("--total-duration-sec", type=float)
+    parser.add_argument(
+        "--dataset-source",
+        choices=("random-ids", "sharegpt", "generated-shared-prefix"),
+        default="random-ids",
+    )
+    parser.add_argument("--dataset-path")
+    parser.add_argument(
+        "--arrival-pattern", choices=("constant", "poisson"), default="constant"
+    )
+    parser.add_argument("--random-range-ratio", type=float, default=1)
+    parser.add_argument("--prompt-pool-size", type=int, default=8)
+    parser.add_argument("--max-concurrency", type=int)
+    parser.add_argument("--max-pending-requests", type=int, default=4096)
+    parser.add_argument("--warmup-requests", type=int, default=1)
+    parser.add_argument("--ready-check-timeout-sec", type=int, default=60)
+    parser.add_argument("--health-check-interval-sec", type=float, default=60)
+    parser.add_argument("--max-health-failures", type=int, default=0)
+    parser.add_argument("--context-length", type=int)
+    parser.add_argument("--disable-capability-check", action="store_true")
+    parser.add_argument("--prometheus", action="store_true")
+    parser.add_argument(
+        "--prometheus-metric",
+        action="append",
+        default=list(DEFAULT_PROMETHEUS_METRICS),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--extra-request-body")
+    parser.add_argument("--header", action="append", default=[])
+    parser.add_argument("--flush-cache", action="store_true")
+    parser.add_argument("--cache-report", action="store_true")
+    parser.add_argument("--max-ttft-p99-ms", type=float)
+    parser.add_argument("--max-e2e-p99-ms", type=float)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.list_scenarios:
+        return
+    if not args.base_url:
+        parser.error("--base-url is required")
+    if args.baseline_qps <= 0 or args.peak_qps <= 0:
+        parser.error("--baseline-qps and --peak-qps must be positive")
+    if args.peak_qps < args.baseline_qps:
+        parser.error("--peak-qps must be greater than or equal to --baseline-qps")
+    if args.duration_scale <= 0:
+        parser.error("--duration-scale must be positive")
+    if args.total_duration_sec is not None and args.total_duration_sec <= 0:
+        parser.error("--total-duration-sec must be positive")
+    if not 0 < args.random_range_ratio <= 1:
+        parser.error("--random-range-ratio must be in (0, 1]")
+    if args.max_concurrency is not None and args.max_concurrency <= 0:
+        parser.error("--max-concurrency must be positive")
+    if args.max_pending_requests <= 0:
+        parser.error("--max-pending-requests must be positive")
+    if args.context_length is not None and args.context_length <= 0:
+        parser.error("--context-length must be positive")
+    if args.prompt_pool_size <= 0:
+        parser.error("--prompt-pool-size must be positive")
+    if args.warmup_requests < 0:
+        parser.error("--warmup-requests cannot be negative")
+    if args.health_check_interval_sec < 0:
+        parser.error("--health-check-interval-sec cannot be negative")
+    if args.max_health_failures < 0:
+        parser.error("--max-health-failures cannot be negative")
+    if args.extra_request_body:
+        try:
+            value = json.loads(args.extra_request_body)
+        except json.JSONDecodeError as exc:
+            parser.error(f"--extra-request-body is not valid JSON: {exc}")
+        if not isinstance(value, dict):
+            parser.error("--extra-request-body must be a JSON object")
+
+
+def cli_main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    validate_args(parser, args)
+    if args.list_scenarios:
+        for scenario in SCENARIOS.values():
+            print(f"{scenario.name:18} {scenario.description}")
+        return
+    raise SystemExit(run_suite(args))
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/test/registered/bench_fn/test_stress_suite.py
+++ b/test/registered/bench_fn/test_stress_suite.py
@@ -1,0 +1,556 @@
+import json
+import math
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from sglang.benchmark import stress_suite
+from sglang.benchmark.datasets.common import DatasetRow
+from sglang.benchmark.datasets.dynamic import (
+    DynamicDataset,
+    fit_prompt_length,
+    generate_arrival_offsets,
+    load_workload_plan,
+)
+from sglang.benchmark.serving import (
+    PhaseResultWriter,
+    RequestFuncOutput,
+    calculate_phase_metrics,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class DummyTokenizer:
+    vocab_size = 128
+    all_special_ids = []
+
+    def decode(self, token_ids):
+        return " ".join(str(token_id) for token_id in token_ids)
+
+    def num_special_tokens_to_add(self):
+        return 0
+
+    def get_vocab(self):
+        return {str(token_id): token_id for token_id in range(self.vocab_size)}
+
+    def encode(self, text):
+        return text.split()
+
+
+class TestStressSuite(unittest.TestCase):
+    def args(self, *extra):
+        parser = stress_suite.build_parser()
+        args = parser.parse_args(["--base-url", "http://127.0.0.1:30000", *extra])
+        stress_suite.validate_args(parser, args)
+        return args
+
+    def test_profile_resolution_is_ordered_and_deduplicated(self):
+        scenarios = stress_suite.resolve_scenarios(
+            "standard", ["burst", "smoke", "burst"]
+        )
+        self.assertEqual([scenario.name for scenario in scenarios], ["burst", "smoke"])
+        self.assertEqual(
+            [scenario.name for scenario in stress_suite.resolve_scenarios("quick", [])],
+            ["smoke", "steady", "burst", "recovery"],
+        )
+
+    def test_workload_has_contiguous_dynamic_phases(self):
+        workload = stress_suite.build_workload(
+            self.args("--profile", "quick", "--baseline-qps", "2", "--peak-qps", "8")
+        )
+        phases = workload["phases"]
+
+        self.assertEqual([phase["request_rate"] for phase in phases], [1, 2, 8, 1])
+        self.assertEqual(
+            [phase["start_time"] for phase in phases],
+            [0, 3, 23, 33],
+        )
+        for left, right in zip(phases, phases[1:]):
+            self.assertEqual(left["start_time"] + left["duration"], right["start_time"])
+
+    def test_total_duration_repeats_without_repeating_smoke(self):
+        workload = stress_suite.build_workload(
+            self.args("--profile", "quick", "--total-duration-sec", "50")
+        )
+
+        self.assertEqual(workload["duration"], 50)
+        self.assertEqual(
+            [phase["scenario"] for phase in workload["phases"]].count("smoke"), 1
+        )
+        self.assertEqual(workload["phases"][-1]["name"], "steady-c002")
+        self.assertEqual(workload["phases"][-1]["duration"], 7)
+
+    def test_explicit_smoke_can_fill_a_target_duration(self):
+        workload = stress_suite.build_workload(
+            self.args("--scenario", "smoke", "--total-duration-sec", "5")
+        )
+        self.assertEqual(workload["duration"], 5)
+        self.assertEqual([phase["duration"] for phase in workload["phases"]], [3, 2])
+
+    def test_soak_defaults_to_twenty_hours(self):
+        workload = stress_suite.build_workload(self.args("--profile", "soak"))
+        self.assertEqual(workload["duration"], 20 * 60 * 60)
+        self.assertGreater(len(workload["phases"]), len(stress_suite.SCENARIOS))
+        self.assertEqual(
+            [phase["scenario"] for phase in workload["phases"]].count("smoke"), 1
+        )
+
+    def test_command_uses_one_timestamped_serving_run(self):
+        args = self.args("--profile", "quick")
+        workload = stress_suite.build_workload(args)
+        command = stress_suite.build_command(
+            args, Path("workload.json"), Path("result.jsonl"), workload
+        )
+
+        self.assertEqual(
+            command[:3], [stress_suite.sys.executable, "-m", "sglang.benchmark.serving"]
+        )
+        self.assertEqual(command[command.index("--dataset-name") + 1], "dynamic")
+        self.assertIn("--use-trace-timestamps", command)
+        self.assertIn("--max-pending-requests", command)
+        self.assertIn("--phase-output-file", command)
+        self.assertEqual(command.count("sglang.benchmark.serving"), 1)
+
+    def test_command_redacts_headers_and_nested_secrets(self):
+        command = [
+            "python",
+            "--header",
+            "Authorization=Bearer secret",
+            "Cookie=session-secret",
+            "--base-url",
+            "https://user:password@example.com",
+            "--extra-request-body",
+            '{"metadata":{"api_key":"secret"},"temperature":0}',
+        ]
+        rendered = " ".join(stress_suite.redact_command(command))
+        self.assertNotIn("session-secret", rendered)
+        self.assertNotIn('"secret"', rendered)
+        self.assertNotIn("password", rendered)
+        self.assertIn("temperature", rendered)
+
+    def test_capabilities_skip_unsupported_phases(self):
+        workload = stress_suite.build_workload(self.args("--profile", "edge"))
+        skipped = stress_suite.apply_capabilities(
+            workload,
+            {"context_length": 4096, "tool_support": False},
+        )
+        skipped_scenarios = {phase["scenario"] for phase in skipped}
+        self.assertIn("tool_rich", skipped_scenarios)
+        self.assertIn("long_context_32k", skipped_scenarios)
+        self.assertNotIn("steady", skipped_scenarios)
+        self.assertEqual(workload["duration"], 81)
+
+    def test_suite_reports_skip_when_every_phase_is_unsupported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory) / "result"
+            args = self.args(
+                "--scenario",
+                "long_context_80k",
+                "--context-length",
+                "4096",
+                "--output-dir",
+                str(output_dir),
+            )
+            with (
+                patch.object(
+                    stress_suite,
+                    "detect_capabilities",
+                    return_value={"context_length": 4096, "tool_support": None},
+                ),
+                patch.object(stress_suite.subprocess, "run") as run,
+            ):
+                self.assertEqual(stress_suite.run_suite(args), 0)
+            self.assertFalse(run.called)
+            summary = json.loads((output_dir / "summary.json").read_text())
+        self.assertEqual(summary["verdict"], "SKIP")
+
+    def test_phase_judgement_checks_completion_and_slo(self):
+        args = self.args("--max-ttft-p99-ms", "100")
+        self.assertEqual(
+            stress_suite.judge_phase(
+                args,
+                {"planned": 3, "completed": 3, "p99_ttft_ms": 90},
+            ),
+            ("PASS", ""),
+        )
+        verdict, reason = stress_suite.judge_phase(
+            args,
+            {"planned": 3, "completed": 2, "p99_ttft_ms": 120},
+        )
+        self.assertEqual(verdict, "FAIL")
+        self.assertIn("completed 2/3", reason)
+        self.assertIn("TTFT p99", reason)
+
+    def test_health_judgement_enforces_failure_budget(self):
+        checks = [{"ok": True}, {"ok": False}, {"ok": False}]
+        self.assertEqual(
+            stress_suite.judge_health(checks, 1),
+            "health failed 2 times (allowed 1)",
+        )
+        self.assertEqual(stress_suite.judge_health(checks, 2), "")
+
+    def test_suite_runs_all_phases_in_one_subprocess(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory) / "result"
+            args = self.args(
+                "--profile",
+                "quick",
+                "--duration-scale",
+                "0.1",
+                "--output-dir",
+                str(output_dir),
+                "--health-check-interval-sec",
+                "0",
+            )
+
+            def fake_run(command, **kwargs):
+                workload_path = Path(
+                    command[command.index("--dynamic-workload-path") + 1]
+                )
+                workload = json.loads(workload_path.read_text())
+                phase_metrics = []
+                for phase in workload["phases"]:
+                    planned = math.ceil(phase["duration"] * phase["request_rate"])
+                    phase_metrics.append(
+                        {
+                            "name": phase["name"],
+                            "planned": planned,
+                            "completed": planned,
+                            "request_rate": phase["request_rate"],
+                            "input_len": phase["input_len"],
+                            "output_len": phase["output_len"],
+                            "p99_ttft_ms": 10,
+                            "p99_e2e_latency_ms": 20,
+                        }
+                    )
+                result_file = Path(command[command.index("--output-file") + 1])
+                result_file.write_text(
+                    json.dumps(
+                        {
+                            "completed": sum(
+                                phase["completed"] for phase in phase_metrics
+                            ),
+                            "p99_ttft_ms": 10,
+                            "p99_e2e_latency_ms": 20,
+                            "phase_metrics": phase_metrics,
+                        }
+                    )
+                    + "\n"
+                )
+                return subprocess.CompletedProcess(command, 0)
+
+            healthy = {
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "status": 200,
+                "ok": True,
+                "latency_ms": 1,
+                "error": "",
+            }
+            with (
+                patch.object(
+                    stress_suite.subprocess, "run", side_effect=fake_run
+                ) as run,
+                patch.object(stress_suite, "check_health", return_value=healthy),
+            ):
+                self.assertEqual(stress_suite.run_suite(args), 0)
+
+            self.assertEqual(run.call_count, 1)
+            summary = json.loads((output_dir / "summary.json").read_text())
+            self.assertEqual(summary["verdict"], "PASS")
+            self.assertEqual(len(summary["runs"]), 4)
+            self.assertEqual(summary["health"]["total"], 1)
+            progress = json.loads((output_dir / "progress.json").read_text())
+            self.assertEqual(progress["status"], "completed")
+            self.assertEqual(
+                stress_suite.load_jsonl(output_dir / "health.jsonl"), [healthy]
+            )
+
+    def test_health_monitor_writes_atomic_progress(self):
+        with tempfile.TemporaryDirectory() as directory:
+            progress_file = Path(directory) / "progress.json"
+            health_file = Path(directory) / "health.jsonl"
+            phase_file = Path(directory) / "phases.jsonl"
+            stop = threading.Event()
+            stop.set()
+            checks = []
+            healthy = {
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "status": 200,
+                "ok": True,
+                "latency_ms": 1,
+                "error": "",
+            }
+            with patch.object(stress_suite, "check_health", return_value=healthy):
+                stress_suite.monitor_health(
+                    stop,
+                    base_url="http://127.0.0.1:30000",
+                    interval=1,
+                    progress_file=progress_file,
+                    health_file=health_file,
+                    phase_file=phase_file,
+                    workload={"duration": 20, "phases": []},
+                    checks=checks,
+                    headers={},
+                    started_at="2026-01-01T00:00:00+00:00",
+                )
+
+            progress = json.loads(progress_file.read_text())
+            self.assertEqual(progress["status"], "running")
+            self.assertEqual(progress["health"]["latest"], healthy)
+            self.assertEqual(stress_suite.load_jsonl(health_file), [healthy])
+            self.assertFalse(progress_file.with_suffix(".json.tmp").exists())
+
+    def test_dynamic_dataset_generates_timestamped_synthetic_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "workload.json"
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "source": "random-ids",
+                        "arrival_pattern": "constant",
+                        "phases": [
+                            {
+                                "name": "small",
+                                "duration": 1,
+                                "request_rate": 2,
+                                "input_len": 8,
+                                "output_len": 2,
+                                "extra_request_body": {"temperature": 0.2},
+                            },
+                            {
+                                "name": "large",
+                                "duration": 1,
+                                "request_rate": 1,
+                                "input_len": 16,
+                                "output_len": 4,
+                            },
+                        ],
+                    }
+                )
+            )
+            dataset = DynamicDataset(str(plan_path), "", seed=7)
+            rows = dataset.load(DummyTokenizer())
+
+        self.assertEqual([row.phase for row in rows], ["small", "small", "large"])
+        self.assertEqual([row.timestamp for row in rows], [0, 500, 1000])
+        self.assertEqual([row.prompt_len for row in rows], [8, 8, 16])
+        self.assertEqual(rows[0].extra_request_body, {"temperature": 0.2})
+        self.assertEqual(rows[2].extra_request_body, {})
+
+    def test_prompt_length_is_calibrated_after_text_round_trip(self):
+        prompt, length = fit_prompt_length(DummyTokenizer(), "1 2", 8)
+        self.assertEqual(length, 8)
+        self.assertEqual(len(DummyTokenizer().encode(prompt)), 8)
+
+    def test_dynamic_plan_validation_and_poisson_schedule(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "invalid.json"
+            plan_path.write_text(json.dumps({"phases": []}))
+            with self.assertRaisesRegex(ValueError, "at least one phase"):
+                load_workload_plan(str(plan_path))
+
+        offsets = generate_arrival_offsets(
+            duration=2,
+            request_rate=2,
+            pattern="poisson",
+            rng=np.random.default_rng(1),
+        )
+        self.assertEqual(offsets[0], 0)
+        self.assertTrue(all(left < right for left, right in zip(offsets, offsets[1:])))
+        self.assertLess(offsets[-1], 2)
+
+    def test_dynamic_dataset_reuses_shared_prefix_generator(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "workload.json"
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "source": "generated-shared-prefix",
+                        "prompt_pool_size": 2,
+                        "phases": [
+                            {
+                                "name": "prefix",
+                                "duration": 1,
+                                "request_rate": 2,
+                                "input_len": 8,
+                                "output_len": 2,
+                                "range_ratio": 0.9,
+                            }
+                        ],
+                    }
+                )
+            )
+            rows = DynamicDataset(str(plan_path), "", seed=7).load(DummyTokenizer())
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row.phase for row in rows}, {"prefix"})
+        self.assertTrue(all(row.prompt for row in rows))
+
+    def test_dynamic_dataset_reuses_sharegpt_sampler(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dataset_path = root / "sharegpt.json"
+            dataset_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "conversations": [
+                                {"value": "synthetic question one"},
+                                {"value": "synthetic answer one"},
+                            ]
+                        },
+                        {
+                            "conversations": [
+                                {"value": "synthetic question two"},
+                                {"value": "synthetic answer two"},
+                            ]
+                        },
+                    ]
+                )
+            )
+            plan_path = root / "workload.json"
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "source": "sharegpt",
+                        "prompt_pool_size": 2,
+                        "phases": [
+                            {
+                                "name": "open_source",
+                                "duration": 1,
+                                "request_rate": 1,
+                                "input_len": 8,
+                                "output_len": 2,
+                            }
+                        ],
+                    }
+                )
+            )
+            rows = DynamicDataset(str(plan_path), str(dataset_path), seed=7).load(
+                DummyTokenizer()
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].phase, "open_source")
+        self.assertTrue(rows[0].prompt)
+
+    def test_serving_reports_metrics_for_each_phase(self):
+        requests = [
+            DatasetRow(
+                prompt="a",
+                prompt_len=1,
+                output_len=2,
+                phase="low",
+                phase_duration=1,
+                phase_request_rate=1,
+                phase_max_concurrency=2,
+            ),
+            DatasetRow(
+                prompt="b",
+                prompt_len=1,
+                output_len=2,
+                phase="high",
+                phase_duration=1,
+                phase_request_rate=4,
+                phase_max_concurrency=8,
+            ),
+        ]
+        outputs = [
+            RequestFuncOutput(
+                success=True,
+                latency=0.2,
+                ttft=0.1,
+                prompt_len=1,
+                cached_tokens=1,
+                stream_complete=True,
+                scheduled_offset_ms=0,
+                dispatch_offset_ms=10,
+                status_code=200,
+                finish_reason="stop",
+                usage_present=True,
+            ),
+            RequestFuncOutput(
+                success=False,
+                error="overloaded",
+                status_code=429,
+                scheduled_offset_ms=1000,
+                dispatch_offset_ms=1020,
+            ),
+        ]
+
+        phases = calculate_phase_metrics(requests, outputs)
+        self.assertEqual(phases[0]["completed"], 1)
+        self.assertEqual(phases[0]["p99_ttft_ms"], 100)
+        self.assertEqual(phases[1]["completed"], 0)
+        self.assertEqual(phases[1]["errors"], ["overloaded"])
+        self.assertEqual(phases[1]["failure_categories"], {"http_429": 1})
+        self.assertEqual(phases[0]["cache_hit_rate_pct"], 100)
+        self.assertEqual(phases[0]["mean_schedule_lag_ms"], 10)
+        self.assertEqual(phases[1]["max_concurrency"], 8)
+
+    def test_phase_writer_checkpoints_completed_phase(self):
+        requests = [
+            DatasetRow(prompt="a", prompt_len=1, output_len=1, phase="one"),
+            DatasetRow(prompt="b", prompt_len=1, output_len=1, phase="one"),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "phases.jsonl"
+            writer = PhaseResultWriter(requests, str(path))
+            writer.record(requests[0], RequestFuncOutput(success=True))
+            self.assertFalse(path.exists())
+            writer.record(requests[1], RequestFuncOutput(success=True))
+            rows = stress_suite.load_jsonl(path)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["planned"], 2)
+
+    def test_phase_writer_snapshots_selected_prometheus_metrics(self):
+        request = DatasetRow(prompt="a", prompt_len=1, output_len=1, phase="one")
+        response = type(
+            "Response",
+            (),
+            {
+                "text": (
+                    'sglang:num_queue_reqs{model="m",rank="0"} 2\n'
+                    'sglang:num_queue_reqs{model="m",rank="1"} 3\n'
+                    "unrelated_metric 9\n"
+                ),
+                "raise_for_status": lambda self: None,
+            },
+        )()
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch("sglang.benchmark.serving.requests.get", return_value=response),
+        ):
+            path = Path(directory) / "phases.jsonl"
+            writer = PhaseResultWriter(
+                [request],
+                str(path),
+                "http://127.0.0.1:30000",
+                ["sglang:num_queue_reqs"],
+            )
+            writer.record(request, RequestFuncOutput(success=True))
+            row = stress_suite.load_jsonl(path)[0]
+        self.assertEqual(row["prometheus_snapshot"], {"sglang:num_queue_reqs": 5.0})
+
+    def test_repository_fixture_is_synthetic_custom_data(self):
+        fixture = (
+            Path(__file__).resolve().parents[3]
+            / "benchmark"
+            / "stress_suite"
+            / "data"
+            / "synthetic_trace.jsonl"
+        )
+        rows = [json.loads(line) for line in fixture.read_text().splitlines() if line]
+        self.assertEqual(len(rows), 6)
+        self.assertTrue(all(len(row["conversations"]) == 2 for row in rows))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add a reproducible online stress suite without introducing another HTTP client, dataset loader, or metrics implementation.

The suite reuses the canonical `sglang.benchmark.serving` entrypoint and keeps private production datasets outside the repository. Only a small hand-authored synthetic fixture is included.

## Modifications

- Add `python -m sglang.benchmark.stress_suite` as the benchmark entrypoint.
- Add predefined traffic profiles:
  - `quick`: smoke and steady traffic.
  - `standard`: quick plus burst, long-prefill, and long-decode scenarios.
  - `edge`: boundary cases and a high-concurrency scenario.
  - `all`: all available scenarios.
- Support selecting individual scenarios with repeated `--scenario` arguments.
- Support configurable baseline/peak QPS, duration scaling, concurrency, warmup, SLO thresholds, headers, and extra request bodies.
- Reuse `sglang.benchmark.serving` for request generation, tokenization, transport, and metrics.
- Write the canonical serving JSONL results plus concise `summary.json` and `summary.md` reports.
- Add documentation and six hand-authored synthetic samples. No production or transformed private data is included.
- Add six CPU unit tests covering profile resolution, command generation, duration scaling, SLO evaluation, summary generation, and the synthetic fixture.
- Defer the server-only disaggregation import in `serving.py`, so normal remote benchmark clients do not require server-side quantization dependencies such as `gguf`.
- Fix the `PretrainedConfig` class name in `Cohere2MoeConfig`.

Example:

```bash
python -m sglang.benchmark.stress_suite \
  --base-url http://127.0.0.1:30000 \
  --profile standard \
  --baseline-qps 2 \
  --peak-qps 8 \
  --output-dir stress_results/standard
```

## Accuracy Tests

Not applicable. This PR does not modify model execution, kernels, sampling, or model outputs.
The benchmark request path was functionally validated against an existing TinyLlama OpenAI-compatible service:
- Health check: HTTP 200
- Model discovery: HTTP 200
- Chat completion: HTTP 200
- Stress suite:
  - smoke: 3/3 requests completed
  - steady: 2/2 requests completed
  - Overall verdict: PASS
- No traceback, OOM, fatal error, or HTTP 5xx was found in the service log after the run.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33780781189](https://github.com/sgl-project/sglang/actions/runs/33780781189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33780774675](https://github.com/sgl-project/sglang/actions/runs/33780774675)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33780774988](https://github.com/sgl-project/sglang/actions/runs/33780774988)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->