### PR TITLE
fix(epd): terminate encoder workers on shutdown

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/http_server.py
+++ b/python/sglang/srt/disaggregation/encoder/http_server.py
@@ -89,7 +89,10 @@ def is_health_check_request(rid: Optional[str]) -> bool:
 async def _lifespan(app: FastAPI):
     if dp_dispatcher is not None:
         dp_dispatcher.start()
-        yield
+        try:
+            yield
+        finally:
+            await dp_dispatcher.stop()
         return
     if local_runtime is not None:
         local_runtime.start()
@@ -232,7 +235,12 @@ def launch_server(server_args: ServerArgs):
         _register_encoder_url_with_bootstrap()
         atexit.register(_unregister_encoder_url_from_bootstrap)
 
-    uvicorn.run(app, host=get_serving().host, port=get_serving().port)
+    uvicorn.run(
+        app,
+        host=get_serving().host,
+        port=get_serving().port,
+        timeout_graceful_shutdown=5,
+    )
 
 
 def _summarise_dp_broadcast(results: List[dict]) -> Response:

--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -60,10 +60,24 @@ from sglang.srt.runtime_context import (
 )
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import configure_logger, random_uuid, set_prometheus_multiproc_dir
-from sglang.srt.utils.common import maybe_reindex_device_id
+from sglang.srt.utils.common import kill_process_tree, maybe_reindex_device_id
 from sglang.srt.utils.network import NetworkAddress, get_free_port, get_zmq_socket
 
 logger = logging.getLogger(__name__)
+
+
+def _terminate_worker_processes(processes: List[mp.Process]) -> None:
+    for process in processes:
+        if process.is_alive():
+            kill_process_tree(process.pid, wait_timeout=None)
+
+    alive = []
+    for process in processes:
+        process.join(timeout=5)
+        if process.is_alive():
+            alive.append(process.pid)
+    if alive:
+        raise RuntimeError(f"Encoder workers did not exit after SIGKILL: {alive}")
 
 
 class PendingRequest:
@@ -414,9 +428,10 @@ class EncoderRuntime:
         self.scheduler.start()
 
     async def stop(self) -> None:
-        # Preserve the existing lifecycle: Uvicorn stops the Scheduler, while
-        # daemon TP followers exit with their parent process.
-        await self.scheduler.stop()
+        try:
+            await self.scheduler.stop()
+        finally:
+            _terminate_worker_processes(self.tp_processes)
 
 
 class DPDispatcher:
@@ -502,6 +517,9 @@ class DPDispatcher:
             task = asyncio.create_task(coro)
             self.background_tasks.add(task)
             task.add_done_callback(self.background_tasks.discard)
+
+    async def stop(self) -> None:
+        _terminate_worker_processes(self.worker_processes)
 
     def _drop_pending_and_mapping(self, rank: int, req_id: str) -> None:
         # dispatch / broadcast failure: no follow-up /send expected.

--- a/test/registered/unit/disaggregation/test_encoder_health.py
+++ b/test/registered/unit/disaggregation/test_encoder_health.py
@@ -1,5 +1,7 @@
 import asyncio
 import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -165,6 +167,49 @@ def test_health_cleanup_failure_releases_dispatch_lock(monkeypatch):
         assert response.status_code == 503
         assert not encoder.encode_dispatch_lock.locked()
         assert len(encoder.released) == 1
+
+    asyncio.run(run_test())
+
+
+def test_launch_server_bounds_graceful_shutdown(monkeypatch):
+    serving = SimpleNamespace(host="127.0.0.1", port=30000)
+    uvicorn_run = MagicMock()
+    monkeypatch.setattr(http_server, "dp_dispatcher", None)
+    monkeypatch.setattr(http_server, "configure_logger", MagicMock())
+    monkeypatch.setattr(http_server, "publish", MagicMock())
+    monkeypatch.setattr(http_server, "get_parallel", lambda: SimpleNamespace(dp_size=2))
+    monkeypatch.setattr(http_server, "launch_dp_runtime", MagicMock())
+    monkeypatch.setattr(
+        http_server, "get_observability", lambda: SimpleNamespace(enable_metrics=False)
+    )
+    monkeypatch.setattr(
+        http_server,
+        "get_disagg",
+        lambda: SimpleNamespace(encoder_register_urls=[]),
+    )
+    monkeypatch.setattr(http_server, "get_serving", lambda: serving)
+    monkeypatch.setattr(http_server.uvicorn, "run", uvicorn_run)
+
+    http_server.launch_server(SimpleNamespace())
+
+    uvicorn_run.assert_called_once_with(
+        http_server.app,
+        host=serving.host,
+        port=serving.port,
+        timeout_graceful_shutdown=5,
+    )
+
+
+def test_dp_lifespan_stops_dispatcher(monkeypatch):
+    async def run_test():
+        dispatcher = SimpleNamespace(start=MagicMock(), stop=AsyncMock())
+        monkeypatch.setattr(http_server, "dp_dispatcher", dispatcher)
+        monkeypatch.setattr(http_server, "local_runtime", None)
+
+        async with http_server._lifespan(http_server.app):
+            dispatcher.stop.assert_not_awaited()
+
+        dispatcher.stop.assert_awaited_once_with()
 
     asyncio.run(run_test())
 

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -1,11 +1,14 @@
 import asyncio
 import sys
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+import sglang.srt.disaggregation.encoder.runtime as runtime_module
 from sglang.srt.disaggregation.encoder.runtime import (
+    DPDispatcher,
+    EncoderRuntime,
     EncoderScheduler,
     PendingRequest,
     _resolve_encoder_batch_policy,
@@ -230,6 +233,41 @@ def test_video_request_is_validated_before_tp_broadcast():
 )
 def test_resolve_encoder_batch_policy(model_type, configured, explicit, expected):
     assert _resolve_encoder_batch_policy(model_type, configured, explicit) == expected
+
+
+def test_encoder_runtime_reaps_tp_workers_when_scheduler_stop_fails():
+    async def run_test():
+        process = SimpleNamespace(pid=123)
+        runtime = EncoderRuntime(
+            encoder=None,
+            scheduler=SimpleNamespace(
+                stop=AsyncMock(side_effect=RuntimeError("scheduler stop failed"))
+            ),
+            send_sockets=[],
+            zmq_context=None,
+            tp_processes=[process],
+        )
+
+        with patch.object(runtime_module, "_terminate_worker_processes") as terminate:
+            with pytest.raises(RuntimeError, match="scheduler stop failed"):
+                await runtime.stop()
+
+        terminate.assert_called_once_with([process])
+
+    asyncio.run(run_test())
+
+
+def test_dp_dispatcher_stop_reaps_workers():
+    async def run_test():
+        process = SimpleNamespace(pid=456)
+        dispatcher = DPDispatcher(1, [], [], None, [process])
+
+        with patch.object(runtime_module, "_terminate_worker_processes") as terminate:
+            await dispatcher.stop()
+
+        terminate.assert_called_once_with([process])
+
+    asyncio.run(run_test())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

A parent-only SIGTERM could stop the EPD HTTP server while leaving TP followers, DP workers, and their GPU allocations alive. Cleanup depended on outer launcher control flow that Uvicorn signal handling could bypass.

## Modifications

- Terminate and join each encoder worker process tree during runtime shutdown.
- Reap TP workers even if scheduler shutdown raises.
- Stop DP workers from the FastAPI lifespan.
- Bound Uvicorn graceful shutdown at five seconds.

## Accuracy Test

- Focused encoder health and scheduler suites: 13 passed.
- Changed-file pre-commit hooks: passed.

## Benchmark & Profiling

The production code, unchanged by the final test-only trim, was validated under active load with TP2 and DP2 serving on NVIDIA H200 GPUs. After SIGTERM, the parent exited in 4.85 seconds for TP2 and 1.80 seconds for DP2. At the 15-second snapshot, both runs had no remaining process-group members, resource trackers, compile workers, or GPU processes. Cleanup confirmed that the server ports were no longer connectable. A control without the five-second Uvicorn bound did not exit within 15 seconds.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34377548949](https://github.com/sgl-project/sglang/actions/runs/34377548949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34377548705](https://github.com/sgl-project/sglang/actions/runs/34377548705)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34377548901](https://github.com/sgl-project/sglang/actions/runs/34377548901)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->