### PR TITLE
fix(epd): fail fast on bootstrap bind errors

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -58,6 +58,7 @@ from sglang.srt.utils.network import (
     NetworkAddress,
     get_local_ip_auto,
     get_zmq_socket_on_host,
+    try_bind_socket,
 )
 
 logger = logging.getLogger(__name__)
@@ -126,7 +127,6 @@ class EncoderBootstrapServer:
         self.port = port
         self._urls: List[str] = urls if urls is not None else []
         self._lock = threading.Lock()
-        self._server: Optional[uvicorn.Server] = None  # set in _run_server
         self._health_check_interval = (
             health_check_interval
             if health_check_interval is not None
@@ -196,6 +196,17 @@ class EncoderBootstrapServer:
         async def _list():
             return {"encoder_urls": self.list_urls()}
 
+        self._socket = try_bind_socket(self.host, self.port, listen=True)
+        self.port = self._socket.getsockname()[1]
+        config = uvicorn.Config(
+            self.app,
+            host=self.host,
+            port=self.port,
+            log_level="warning",
+            access_log=False,
+            loop="auto",
+        )
+        self._server = uvicorn.Server(config)
         self.thread = threading.Thread(
             target=self._run_server, daemon=True, name="EncoderBootstrap"
         )
@@ -330,31 +341,22 @@ class EncoderBootstrapServer:
     # Lifecycle                                                          #
     # ------------------------------------------------------------------ #
     def _run_server(self):
-
-        config = uvicorn.Config(
-            self.app,
-            host=self.host,
-            port=self.port,
-            log_level="warning",
-            access_log=False,
-            loop="auto",
-        )
-        self._server = uvicorn.Server(config)
         logger.info(
             f"EncoderBootstrapServer starting on {self.host}:{self.port} "
             f"(health_check every {self._health_check_interval}s, "
             f"timeout {self._health_check_timeout}s)"
         )
         try:
-            self._server.run()
+            self._server.run(sockets=[self._socket])
         except Exception as e:
             logger.error(f"EncoderBootstrapServer error: {e}", exc_info=True)
+        finally:
+            self._socket.close()
 
     def close(self):
-        if self._server is not None:
-            # uvicorn polls should_exit on its own event loop; thread-safe.
-            self._server.should_exit = True
-            logger.info("Stopping EncoderBootstrapServer...")
+        # uvicorn polls should_exit on its own event loop; thread-safe.
+        self._server.should_exit = True
+        logger.info("Stopping EncoderBootstrapServer...")
         if self.thread.is_alive():
             self.thread.join(timeout=5)
             logger.info("EncoderBootstrapServer thread stopped")

--- a/test/registered/unit/disaggregation/test_encode_receiver.py
+++ b/test/registered/unit/disaggregation/test_encode_receiver.py
@@ -1,6 +1,8 @@
 """Unit tests for the encode-disaggregation receiver."""
 
 import asyncio
+import http.client
+import socket
 import threading
 import time
 import unittest
@@ -10,6 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from sglang.srt.disaggregation.encoder.receiver import (
+    EncoderBootstrapServer,
     MMReceiverBase,
     WaitingMMRequestStatus,
     WaitingRDMARequest,
@@ -393,6 +396,39 @@ class TestEncodeReceiverRequestConstruction(CustomTestCase):
         self.assertTrue(waiting_req.released)
         self.assertTrue(waiting_req.closed)
         self.assertEqual(len(abort_reqs), 1)
+
+
+class TestEncoderBootstrapLifecycle(CustomTestCase):
+    def _server(self, port=0):
+        return EncoderBootstrapServer("127.0.0.1", port, health_check_interval=0)
+
+    def test_constructor_rejects_an_occupied_port(self):
+        with socket.create_server(("127.0.0.1", 0)) as occupied:
+            with self.assertRaisesRegex(OSError, "Could not bind port"):
+                self._server(occupied.getsockname()[1])
+
+    def test_publishes_served_port_and_releases_listener(self):
+        first = self._server()
+        port = first.port
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        try:
+            connection.request("GET", "/health")
+            response = connection.getresponse()
+            self.assertEqual((response.status, response.read()), (200, b"OK"))
+        finally:
+            connection.close()
+        first.close()
+
+        replacement = self._server(port)
+        replacement.close()
+
+    def test_close_releases_listener_for_restart(self):
+        first = self._server()
+        port = first.port
+        first.close()
+
+        replacement = self._server(port)
+        replacement.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`EncoderBootstrapServer` currently binds its port inside a background thread. An occupied port can therefore kill the thread after construction has already returned, leaving the caller with an apparently valid but dead bootstrap server. Port `0` also remains published as `0` instead of the actual served port.

## Modifications

- Bind and listen before starting the bootstrap thread.
- Publish the actual socket port when port `0` is requested.
- Pass the prebound socket to Uvicorn.
- Close the listener reliably when the server exits.
- Add focused coverage for synchronous bind failures, ephemeral port publication, shutdown, and rebinding.

## Accuracy Test

- Focused encoder receiver suite: 4 passed.
- Direct registered test execution: 4 passed.
- Changed-file pre-commit hooks: passed.

## Benchmark & Profiling

Pushed tip `4499c969d113ebfc2ee9b8c8a8f89ded72000d56` has the same stable patch ID as the tip validated with a two-GPU encoder and one-GPU prefill deployment on NVIDIA H200s. Both text requests and all six image requests returned HTTP 200. Health checks remained HTTP 200 before and after the workload, the bootstrap registry contained the encoder, and cleanup removed the owned process groups and selected GPU processes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34377553184](https://github.com/sgl-project/sglang/actions/runs/34377553184)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34377552334](https://github.com/sgl-project/sglang/actions/runs/34377552334)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34377552759](https://github.com/sgl-project/sglang/actions/runs/34377552759)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->