### PR TITLE
[AMD][MORI] Bump MoRI to 7c51d18 for ionic RoCE dmabuf fix (#509)

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -398,7 +398,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="12d1bc32d0c93dcd5062e74f4e0f772e36e1aac4"
+ARG MORI_COMMIT="7c51d18fda59457cc9238ed262bd93c8cad906c9"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).


### PR DESCRIPTION
## What

Bump MoRI from `12d1bc32` (#505) to `7c51d18` (#617). Picks up #509 (`rdma: fix dmabuf offset for
sub-allocated GPU buffers, LOC_PROT on ionic RoCE`), which the current pin is missing.

## Why

DSV4 HiSparse/HiCache PD over MoRI on ionic RoCE hits `ReadMessageHeader failed: EOF` during KV transfer with
the pinned MoRI; #509 fixes it. Validated end-to-end at 7c51d18 (DSV4-Pro 2-node 1P1D, GSM8K 0.95, 0 faults).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33427673313](https://github.com/sgl-project/sglang/actions/runs/33427673313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33427673137](https://github.com/sgl-project/sglang/actions/runs/33427673137)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33427673322](https://github.com/sgl-project/sglang/actions/runs/33427673322)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->