### PR TITLE
[Kernel] Fix shared-memory reuse race in CuTe DSL DSV3 fused-A GEMM

### DIFF
--- a/python/sglang/kernels/ops/gemm/cutedsl_dsv3_fused_a_gemm.py
+++ b/python/sglang/kernels/ops/gemm/cutedsl_dsv3_fused_a_gemm.py
@@ -246,6 +246,10 @@ def _dsv3_fused_a_gemm_kernel(
                         acc[nb][i] = cutlass.Float32(d[i])
             cute.arch.mbarrier_arrive(empty + buf)
             ph = (ph ^ 1) if buf == nstage - 1 else ph
+
+        # All compute warps must finish reading sA/sB before any of them reuses
+        # that shared memory for the split-K partial accumulators in sC.
+        cute.arch.barrier(barrier_id=1, number_of_threads=COMPUTE_THREADS)
         for nb in cutlass.range_constexpr(NB):
             for i in cutlass.range_constexpr(4):
                 m = r0 + (8 if i >= 2 else 0)


### PR DESCRIPTION
## Motivation

The kernel reuses its A/B pipeline shared memory for split-K partial
accumulators: `sC` aliases `sA` stage 0. Its existing barrier protects the
reduction after `sC` stores, but does not ensure every compute warp has
finished reading `sA` before another warp overwrites it through `sC`. This
can produce incorrect output.

The original CUDA implementation has both pre-store and post-store barriers;
the CuTe DSL port omitted the pre-store barrier.

## Modifications

Add a compute-warp barrier immediately before the first `sC` store:

```python
cute.arch.barrier(barrier_id=1, number_of_threads=COMPUTE_THREADS)
```

This orders all `sA`/`sB` reads before the aliased `sC` writes. Loader warps
remain excluded, and tiling and output format are unchanged.

## Accuracy Tests

- B200: `tokens=16, hd_in=6144, hd_out=2112` matched the BF16 reference.
- B300: 256 configurations across token counts and fused-A dimensions passed
  against the reference.
- `pytest -v test/registered/kernels/ops/gemm/test_cutedsl_dsv3_fused_a_gemm.py`

Tested with SGLang's pinned `nvidia-cutlass-dsl==4.6.2`.

## Speed Tests and Profiling

Interleaved B300 A/B, 2 runs × 5 rounds × 50 launches:

| Shape | Before | After | Delta |
| --- | ---: | ---: | ---: |
| tokens=1, 6144→2112 | 0.0600 ms | 0.0612 ms | +2.0% |
| tokens=16, 7168→2624 | 0.0605 ms | 0.0598 ms | -1.2% |

Round distributions overlap; no systematic regression was measured.

## Checklist

- [x] Run pre-commit checks on the changed file.
- [x] Run focused accuracy and performance tests.
- [x] Documentation is not applicable.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35636625833](https://github.com/sgl-project/sglang/actions/runs/35636625833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35636625711](https://github.com/sgl-project/sglang/actions/runs/35636625711)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35636625764](https://github.com/sgl-project/sglang/actions/runs/35636625764)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->