### PR TITLE
[Kernel] Fix cross-iteration shared-memory WAR races in Blackwell GDN prefill

### DIFF
--- a/python/sglang/kernels/ops/attention/linear/gdn_blackwell/kernel_kkt_inv_uw.py
+++ b/python/sglang/kernels/ops/attention/linear/gdn_blackwell/kernel_kkt_inv_uw.py
@@ -677,6 +677,10 @@ class Sm100ChunkUWKernel:
                 if stage_id == 0:
                     parity ^= 1
 
+                # Order this iteration's phase-4 s_beta/s_g_cu_exp loads before the
+                # next iteration's phase-1 stores (cross-iteration WAR).
+                cute.arch.barrier(barrier_id=1, number_of_threads=128)
+
         elif warp_id < 4:
             # epi warps
             stage_id = 0

--- a/python/sglang/kernels/ops/attention/linear/gdn_blackwell/kernel_o.py
+++ b/python/sglang/kernels/ops/attention/linear/gdn_blackwell/kernel_o.py
@@ -415,6 +415,10 @@ class Sm100ChunkOKernel:
 
                 parity ^= 1
 
+                # Order this iteration's s_g_cu loads before the next
+                # iteration's loop-top s_g_cu stores (cross-iteration WAR).
+                cute.arch.barrier(barrier_id=1, number_of_threads=128)
+
         else:
             # epilogue warps
             # for ldmatrix layout later


### PR DESCRIPTION
## Motivation

Two GDN CuTe DSL kernels overwrite shared-memory buffers at the start of
chunk iteration i+1 without ensuring all warps finished reading iteration i:

- `kernel_kkt_inv_uw.py`: `s_beta` and gating cumulative-sum buffers.
- `kernel_o.py`: `s_g_cu`, used to construct the exponential gating mask.

A lagging warp can therefore read values from two iterations. The
`kernel_o.py` path can amplify corrupted input through `exp()`.

## Modifications

Add a 128-thread named barrier at the end of each affected loop:

```python
cute.arch.barrier(barrier_id=1, number_of_threads=128)
```

The barriers execute every iteration and order the final shared-memory reads
before the next iteration's stores.

## Accuracy Tests

The patched GDN prefill pipeline passes `test_gdn_prefill_cutedsl.py` on
B300 with output-error tolerance `2e-3`. Tested with SGLang's pinned
`nvidia-cutlass-dsl==4.6.2`.

## Speed Tests and Profiling

The full GDN prefill pipeline at 32k tokens measured 0.2296 ms before and
0.2302 ms after (+0.3%), within the approximately ±1.5% B300 measurement
noise. This A/B also includes the companion `kernel_h` TMEM-load fix.

## Checklist

- [x] Run pre-commit checks on the changed files.
- [x] Run focused accuracy and performance tests.
- [x] Documentation is not applicable.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35636630986](https://github.com/sgl-project/sglang/actions/runs/35636630986)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35636630782](https://github.com/sgl-project/sglang/actions/runs/35636630782)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35636630869](https://github.com/sgl-project/sglang/actions/runs/35636630869)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->