### PR TITLE
[Kernel] Fix cross-iteration s_beta WAR race in Blackwell KDA prefill

### DIFF
--- a/python/sglang/kernels/ops/attention/linear/kda_blackwell/kernel_kkt_inv_uw.py
+++ b/python/sglang/kernels/ops/attention/linear/kda_blackwell/kernel_kkt_inv_uw.py
@@ -612,6 +612,10 @@ class Sm100KdaChunkUWKernel:
                 if stage_id == 0:
                     parity ^= 1
 
+                # Order this iteration's phase-4 s_beta loads before the next
+                # iteration's phase-1 s_beta stores (cross-iteration WAR).
+                cute.arch.barrier(barrier_id=1, number_of_threads=128)
+
         elif warp_id < 4:
             # epi warps (store U, W) -- VERBATIM from GDN
             stage_id = 0


### PR DESCRIPTION
## Motivation

In the KDA CuTe DSL inverse kernel, warps store the current chunk's beta to
`s_beta` near the top of the loop and read it again in phase 4. No barrier
crosses the loop back edge, so the next iteration can overwrite `s_beta`
while a lagging warp still reads it.

## Modifications

Add a 128-thread named barrier at the end of the inverse-warp chunk loop:

```python
cute.arch.barrier(barrier_id=1, number_of_threads=128)
```

It executes every iteration and orders phase-4 reads before the next
iteration's stores. The sibling GDN kernels are handled separately.

## Accuracy Tests

The patched KDA prefill pipeline passes `test_kda_prefill_cutedsl.py` on
B300, including the 257-token multi-chunk case. Tested with SGLang's pinned
`nvidia-cutlass-dsl==4.6.2`.

## Speed Tests and Profiling

The full KDA prefill pipeline at 32k tokens measured 0.9891 ms before and
0.9860 ms after (-0.3%), within the approximately ±1.5% B300 measurement
noise. This A/B also includes the companion `kernel_h` TMEM-load fix.

## Checklist

- [x] Run pre-commit checks on the changed file.
- [x] Run focused accuracy and performance tests.
- [x] Documentation is not applicable.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35636635179](https://github.com/sgl-project/sglang/actions/runs/35636635179)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35636635081](https://github.com/sgl-project/sglang/actions/runs/35636635081)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35636635395](https://github.com/sgl-project/sglang/actions/runs/35636635395)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->