### PR TITLE
fix(function_call): skip non-object entries in parse_base_json

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -81,6 +81,11 @@ class BaseFormatDetector(ABC):
 
         results = []
         for act in action:
+            if not isinstance(act, dict):
+                # Without this, act.get() raises AttributeError and the whole
+                # batch is lost, valid calls included; /parse_function_call 500s.
+                logger.warning(f"Skipping non-object tool call entry: {act!r}")
+                continue
             name = act.get("name")
             if not (name and name in tool_indices):
                 logger.warning(f"Model attempted to call undefined function: {name}")

--- a/test/registered/unit/function_call/test_malformed_tool_call_payloads.py
+++ b/test/registered/unit/function_call/test_malformed_tool_call_payloads.py
@@ -1,0 +1,69 @@
+"""Tool-call payloads that are valid JSON but not objects."""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# Parsers that reach the shared BaseFormatDetector.parse_base_json without an
+# exception guard of their own.
+PARSERS = ["qwen25", "llama3", "mistral", "trinity"]
+
+# Of those, the ones whose payload between the markers is itself a JSON array, so
+# a malformed sibling can sit next to a valid call. llama3 separates calls with
+# ";" and mistral's "[" is part of its bot_token, so neither takes an array here.
+ARRAY_PAYLOAD_PARSERS = ["qwen25", "trinity"]
+
+# Valid JSON, but the array elements are not tool-call objects.
+NON_OBJECT_PAYLOADS = ["[1, 2]", '["x"]', "[null]", "[[]]"]
+
+
+def _tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="test tool",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            ),
+        )
+    ]
+
+
+def _wrap(parser: FunctionCallParser, payload: str) -> str:
+    """Wrap a payload in the parser's own tool-call markers."""
+    detector = parser.detector
+    return (detector.bot_token or "") + payload + (detector.eot_token or "")
+
+
+class TestMalformedToolCallPayloads(unittest.TestCase):
+    def test_non_object_array_entries_are_skipped(self):
+        """A tool-call array whose entries are not objects must parse to no calls
+        rather than raising, so /parse_function_call cannot be made to return 500.
+        """
+        for name in PARSERS:
+            parser = FunctionCallParser(tools=_tools(), tool_call_parser=name)
+            for payload in NON_OBJECT_PAYLOADS:
+                with self.subTest(parser=name, payload=payload):
+                    _, calls = parser.parse_non_stream(_wrap(parser, payload))
+                    self.assertEqual(calls, [])
+
+    def test_valid_call_survives_a_malformed_sibling(self):
+        """One non-object entry must not discard the valid calls beside it."""
+        payload = '[{"name": "get_weather", "arguments": {"city": "Paris"}}, "junk"]'
+        for name in ARRAY_PAYLOAD_PARSERS:
+            parser = FunctionCallParser(tools=_tools(), tool_call_parser=name)
+            with self.subTest(parser=name):
+                _, calls = parser.parse_non_stream(_wrap(parser, payload))
+                self.assertEqual([c.name for c in calls], ["get_weather"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37283 

A tool-call array entry that is valid JSON but not an object makes
`BaseFormatDetector.parse_base_json` call `act.get("name")` on it, raising
`AttributeError` (`python/sglang/srt/function_call/base_format_detector.py:83`):

```python
results = []
for act in action:
    name = act.get("name")
```

```
[1, 2]   -> AttributeError: 'int' object has no attribute 'get'
["x"]    -> AttributeError: 'str' object has no attribute 'get'
[null]   -> AttributeError: 'NoneType' object has no attribute 'get'
[[]]     -> AttributeError: 'list' object has no attribute 'get'
```

The user-visible effect is that a malformed entry discards the *valid* calls
beside it. `serving_chat.py:2145` catches the exception and returns
`ToolCallProcessingResult(None, ...)`, dropping every call in the response:

```
[{"name": "get_weather", "arguments": {"city": "Paris"}}, "junk"]
  -> no tool calls at all, though the first entry is well-formed
```

No crafted input is needed, only a model emitting a slightly malformed array.

Secondarily the same exception reaches the HTTP layer uncaught:
`/parse_function_call` (`http_server.py:1632`) passes `obj.text` straight from
the request body into `parse_non_stream` with no `try/except`, and the only
registered handlers are for `HTTPException` / `RequestValidationError`, so a
request body can produce a 500.

Note the nearby guards do not cover this: `qwen25_detector.py:65` wraps the call
in `try/except json.JSONDecodeError`, but `[1, 2]` is *valid* JSON of the wrong
shape, so the `AttributeError` escapes it.

## Modifications

Skip a non-object entry and continue, exactly as the unknown-tool-name branch a
few lines below already does:

```python
for act in action:
    if not isinstance(act, dict):
        logger.warning(f"Skipping non-object tool call entry: {act!r}")
        continue
    name = act.get("name")
```

No behaviour change for well-formed payloads.

Adds `test/registered/unit/function_call/test_malformed_tool_call_payloads.py`:

- `test_non_object_array_entries_are_skipped` — the four parsers that reach
  `parse_base_json` unguarded (`qwen25`, `llama3`, `mistral`, `trinity`) return no
  calls instead of raising.
- `test_valid_call_survives_a_malformed_sibling` — for the parsers whose payload
  between the markers is itself a JSON array (`qwen25`, `trinity`), the valid call
  is still returned. `llama3` separates calls with `;` and mistral's `[` is part of
  its `bot_token`, so neither takes an array there.

Verified pre- and post-fix on a GCE `g2-standard-8` (NVIDIA L4, Ubuntu 22.04),
sglang from source:

```
before: 18 failed, 2 passed
after:  2 passed, 18 subtests passed
```

Neighbouring `function_call` suites unaffected (`test_unknown_tool_name`,
`test_parallel_tool_calls`, `test_hermes_detector`, `test_mistral_detector`,
`test_llama32_detector`): 48 passed.

## Accuracy Tests

Not applicable — request-path parsing only; no kernel, model forward, or sampling
code is touched, so model outputs are unchanged.

## Speed Tests and Profiling

Not applicable — one `isinstance` check per tool-call entry, on a path that
already does JSON decoding and `json.dumps` per entry.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a, no user-facing behaviour or flag change
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — n/a, see above
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33430806149](https://github.com/sgl-project/sglang/actions/runs/33430806149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33430805646](https://github.com/sgl-project/sglang/actions/runs/33430805646)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33430805956](https://github.com/sgl-project/sglang/actions/runs/33430805956)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->