### PR TITLE
Support deterministic inference for DeepSeek-V4

### DIFF
--- a/docs/docs/advanced_features/deterministic_inference.mdx
+++ b/docs/docs/advanced_features/deterministic_inference.mdx
@@ -25,7 +25,7 @@ Building on [Thinking Machines Lab's batch-invariant operators](https://github.c
 
 Deterministic inference is only supported with the following three attention backends: **FlashInfer**, **FlashAttention 3 (FA3)**, and **Triton**.
 
-DeepSeek-V4 is the exception: it can only run on its own **dsv4** backend, which its config-time overrides select for you, so `--enable-deterministic-inference` is supported there without picking an attention backend. Deterministic inference on the dsv4 backend requires SM90 or SM100; SM120 is rejected at startup.
+DeepSeek-V4 is the exception: it can only run on its own **dsv4** backend, which its config-time overrides select for you, so `--enable-deterministic-inference` is supported there without picking an attention backend. Deterministic inference on the dsv4 backend requires SM90 or SM100; SM120 is rejected at startup. The DSA indexer top-k is resolved from the default `sgl-kernel` backend to `flashinfer`, whose ordered selection is the only one that stays bit-stable once a sequence holds more than `index_topk` candidates.
 
 The following table shows feature compatibility for deterministic inference across different attention backends:
 

--- a/docs/docs/advanced_features/deterministic_inference.mdx
+++ b/docs/docs/advanced_features/deterministic_inference.mdx
@@ -25,6 +25,8 @@ Building on [Thinking Machines Lab's batch-invariant operators](https://github.c
 
 Deterministic inference is only supported with the following three attention backends: **FlashInfer**, **FlashAttention 3 (FA3)**, and **Triton**.
 
+DeepSeek-V4 is the exception: it can only run on its own **dsv4** backend, which its config-time overrides select for you, so `--enable-deterministic-inference` is supported there without picking an attention backend. Deterministic inference on the dsv4 backend requires SM90 or SM100; SM120 is rejected at startup.
+
 The following table shows feature compatibility for deterministic inference across different attention backends:
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
@@ -61,6 +63,13 @@ The following table shows feature compatibility for deterministic inference acro
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**Triton**</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ Yes</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅ Yes</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ Yes</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅ Yes</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**dsv4** (DeepSeek-V4 only)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ Yes</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅ Yes</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ Yes</td>

--- a/python/sglang/kernels/ops/attention/dsv4/gemm.py
+++ b/python/sglang/kernels/ops/attention/dsv4/gemm.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.environ import envs
 from sglang.srt.utils import get_bool_env_var, is_hip
 
@@ -147,6 +148,11 @@ def linear_bf16_fp32(
     *,
     hpc_kernel_min_m: Optional[int] = None,
 ) -> torch.Tensor:
+    if is_batch_invariant_mode_enabled():
+        # cuBLAS goes through torch.mm, which the batch-invariant library
+        # overrides. The aiter, HPC-Ops and DeepGEMM paths do not, and the
+        # HPC-Ops one additionally dispatches on the row count.
+        return _linear_bf16_fp32_cublas(x, y)
     if _use_aiter and y.dtype == torch.bfloat16:
         return tgemm.mm(x, y, otype=x.dtype).float()
     elif hpc_kernel_min_m is not None:

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.jit.utils import is_arch_support_pdl
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
@@ -711,13 +712,23 @@ def mhc_pre_gemm_sqrsum_splitk_kernel(
 
 
 def _compute_num_split_for_mhc_pre(num_tokens: int, hc_hidden_size: int) -> int:
-    block_m, block_k = 64, 64
-    grid_size = (num_tokens + block_m - 1) // block_m
-    num_block_k = (hc_hidden_size + block_k - 1) // block_k
+    """Split-K count for the mHC pre-norm GEMM.
 
+    ``n_splits`` is how many partial sums the K reduction is later folded from,
+    so it fixes the summation order. Deterministic inference therefore drops the
+    token-count term and keeps the widest split the K extent allows -- the value
+    a single-tile batch would pick anyway.
+    """
+    block_m, block_k = 64, 64
+    num_block_k = (hc_hidden_size + block_k - 1) // block_k
+    max_splits = max(1, num_block_k // 4)
+    if is_batch_invariant_mode_enabled():
+        return max_splits
+
+    grid_size = (num_tokens + block_m - 1) // block_m
     n_sms = torch.cuda.get_device_properties(0).multi_processor_count
 
-    return max(1, min(n_sms // max(grid_size, 1), num_block_k // 4))
+    return max(1, min(n_sms // max(grid_size, 1), max_splits))
 
 
 def get_mhc_pre_token_count_representatives(
@@ -1028,7 +1039,9 @@ def mhc_pre(
         gemm_last_dim = hc_mult3
         big_fuse_n_splits = n_splits
     else:
-        if num_tokens <= 2048:
+        # The token-count threshold selects a different kernel and split-K, so
+        # deterministic inference pins the token-independent split-K stage.
+        if num_tokens <= 2048 or is_batch_invariant_mode_enabled():
             assert n_splits == 1
             if hc_hidden_size == 16384:
                 hidden_block = 256
@@ -1565,8 +1578,12 @@ def mhc_fused_post_pre(
 
     # The scalar-FMA kernel wins only for small batches where launch
     # overhead dominates; beyond the threshold DeepGEMM's tensor-core path wins.
-    fma_token_threshold = 32
-    if num_tokens <= fma_token_threshold:
+    # Deterministic inference stays on the DeepGEMM path: the FMA kernel's
+    # split-K follows the token count, which would tie a token's output to the
+    # batch it arrived in.
+    fma_token_threshold = 0 if is_batch_invariant_mode_enabled() else 32
+    use_fma = num_tokens <= fma_token_threshold
+    if use_fma:
         tile_n = 2 if num_tokens < 8 else 3
         n_splits = 8 if (num_tokens < 8 and hidden_size <= 4096) else 4
     else:
@@ -1587,7 +1604,7 @@ def mhc_fused_post_pre(
     )
     residual_cur = torch.empty_like(residual_flat)
 
-    if num_tokens <= fma_token_threshold:
+    if use_fma:
         # Small-batch path: one TileLang launch computes hc_post, the bf16
         # residual write, GEMM partials, and the RMS square-sum partials.
         mhc_fused_post_pre_fma_tilelang(

--- a/python/sglang/srt/arg_groups/attention_hook.py
+++ b/python/sglang/srt/arg_groups/attention_hook.py
@@ -15,6 +15,7 @@ from sglang.srt.arg_groups.overrides import (
     _cutedsl_prefill_backend_fill,
     _deterministic_allreduce_fusion_disable,
     _deterministic_attention_backend,
+    _deterministic_dsa_topk_backend,
     _deterministic_sampling_backend,
     _fa4_page_constraint,
     _intel_xpu_page_constraint,
@@ -553,6 +554,7 @@ def handle_deterministic_inference(server_args: Any):
         # (arg_groups/overrides.py), invoked at their legacy slots.
 
         run_post_process_pass(server_args, _deterministic_sampling_backend)
+        run_post_process_pass(server_args, _deterministic_dsa_topk_backend)
         is_deepseek_model = False
         if parse_connector_type(cfg.model_path) != ConnectorType.INSTANCE:
             try:

--- a/python/sglang/srt/arg_groups/attention_hook.py
+++ b/python/sglang/srt/arg_groups/attention_hook.py
@@ -587,6 +587,14 @@ def handle_deterministic_inference(server_args: Any):
                     "implements on those archs."
                 )
 
+        if attention_backend == "dsv4" and get_platform().is_sm120:
+            raise ValueError(
+                "Deterministic inference on the dsv4 attention backend requires "
+                "SM90 or SM100: the SM120 kernel is an autotuned Triton kernel "
+                "whose tile size, and with it the softmax rescaling order, is "
+                "picked from measured timings."
+            )
+
         if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:
             # Currently, only certain backends support radix cache. Support for other backends is in progress
             declare_resolution(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1037,6 +1037,23 @@ def _deterministic_sampling_backend(view: Any) -> dict:
     return {}
 
 
+def _deterministic_dsa_topk_backend(view: Any) -> dict:
+    """sgl-kernel's radix-select top-k admits tied candidates in the threshold
+    bin first-come-first-served, so once the indexer holds more than index_topk
+    candidates its index set is not repeatable; FlashInfer's ordered path is."""
+    if not view.enable_deterministic_inference:
+        return {}
+    resolved = {}
+    if view.dsa_topk_backend == "sgl-kernel":
+        logger.warning(
+            "DSA top-k backend is set to flashinfer for deterministic inference."
+        )
+        resolved["dsa_topk_backend"] = "flashinfer"
+    if view.speculative_dsa_topk_backend == "sgl-kernel":
+        resolved["speculative_dsa_topk_backend"] = "flashinfer"
+    return resolved
+
+
 def _deterministic_is_deepseek_model(view: Any) -> bool:
     """Faithful copy of the deterministic handler's arch probe (pure read;
     the handler keeps its own copy for the later deepseek validation)."""

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -39,6 +39,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     BuildDsparkSwaPageIndices,
     ComputeDsparkWindowGather,
 )
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import (
     AttentionBackend,
@@ -1380,11 +1381,7 @@ class DeepseekV4AttnBackend(
             return
 
         assert isinstance(metadata, DSV4Metadata)
-        use_sparse_prefill = not get_platform().is_sm120 and (
-            num_qo_tokens > _LARGE_INDEXER_QUERY_THRESHOLD
-            or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
-        )
-        if use_sparse_prefill:
+        if self._use_sparse_prefill(num_qo_tokens):
             metadata.sparse_prefill_cache = self._build_sparse_prefill_chunk_cache(
                 forward_batch, num_qo_tokens=num_qo_tokens
             )
@@ -1665,6 +1662,94 @@ class DeepseekV4AttnBackend(
             cache_k=swa_k,
         )
 
+    def _use_sparse_prefill(self, num_qo_tokens: int) -> bool:
+        """Whether an extend runs through ``flash_mla_sparse_fwd``.
+
+        sparse_prefill_fwd does not support SM120. Deterministic inference
+        pins the choice: the token-count threshold otherwise makes a prompt's
+        output follow the batch it was prefilled in.
+        """
+        if get_platform().is_sm120:
+            return False
+        if is_batch_invariant_mode_enabled():
+            return True
+        return (
+            num_qo_tokens > _LARGE_INDEXER_QUERY_THRESHOLD
+            or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+        )
+
+    def _forward_flashmla_kvcache(
+        self,
+        *,
+        q: torch.Tensor,
+        swa_k_cache: torch.Tensor,
+        swa_page_indices: torch.Tensor,
+        swa_topk_lengths: torch.Tensor,
+        attn_sink: torch.Tensor,
+        extra_k_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        flashmla_metadata: FlashMLASchedMeta,
+    ) -> torch.Tensor:
+        """Sparse MLA attention over the paged SWA window plus the
+        compressed cache, via ``flash_mla_with_kvcache``."""
+        if _is_xpu:
+            from sgl_kernel import flash_mla_with_kvcache
+        else:
+            from sgl_kernel.flash_mla import flash_mla_with_kvcache
+
+        def run(q, indices, topk_lengths, ex_indices, ex_topk_lengths, sched_meta):
+            return flash_mla_with_kvcache(
+                q=q,
+                k_cache=swa_k_cache,
+                head_dim_v=self.head_dim_v,
+                block_table=None,
+                cache_seqlens=None,
+                tile_scheduler_metadata=sched_meta,
+                softmax_scale=self.softmax_scale,
+                is_fp8_kvcache=True,
+                indices=indices,
+                topk_length=topk_lengths,
+                attn_sink=attn_sink,
+                extra_k_cache=extra_k_cache,
+                extra_indices_in_kvcache=ex_indices,
+                extra_topk_length=ex_topk_lengths,
+            )[0]
+
+        if not is_batch_invariant_mode_enabled():
+            return run(
+                q,
+                swa_page_indices,
+                swa_topk_lengths,
+                extra_indices,
+                extra_topk_lengths,
+                flashmla_metadata,
+            )
+
+        # FlashMLA's tile scheduler cuts each request's KV range at boundaries
+        # derived from the whole batch's block count, so which partial sums a
+        # request's output is combined from -- and with it the last bits of
+        # that output -- follow whatever it was co-batched with. One launch per
+        # request makes the schedule a function of that request alone, at the
+        # cost of one kernel launch per request per layer.
+        def row(x: Optional[torch.Tensor], i: int) -> Optional[torch.Tensor]:
+            return None if x is None else x[i : i + 1]
+
+        return torch.cat(
+            [
+                run(
+                    q[i : i + 1],
+                    swa_page_indices[i : i + 1],
+                    swa_topk_lengths[i : i + 1],
+                    row(extra_indices, i),
+                    row(extra_topk_lengths, i),
+                    _create_flashmla_metadata(),
+                )
+                for i in range(q.shape[0])
+            ],
+            dim=0,
+        )
+
     def forward(
         self,
         q: torch.Tensor,
@@ -1758,14 +1843,9 @@ class DeepseekV4AttnBackend(
                     extra_indices.shape[-1] % 64 == 0
                 ), f"{extra_indices.shape=}'s last dimension is not aligned to 64"
 
-            # sparse_prefill_fwd does not support SM120.
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
-                and not get_platform().is_sm120
-                and (
-                    q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
-                    or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
-                )
+                and self._use_sparse_prefill(q.shape[0])
             ):
                 if use_dsv4_q8kv8_sparse_prefill(self.dsv4_prefill_backend):
                     return self._forward_prefill_sparse_q8kv8(
@@ -1805,27 +1885,17 @@ class DeepseekV4AttnBackend(
                     extra_topk_length=extra_topk_lengths,
                 )[0]
             else:
-                if _is_xpu:
-                    from sgl_kernel import flash_mla_with_kvcache
-                else:
-                    from sgl_kernel.flash_mla import flash_mla_with_kvcache
-
-                o = flash_mla_with_kvcache(
+                o = self._forward_flashmla_kvcache(
                     q=q,
-                    k_cache=swa_k_cache,
-                    head_dim_v=self.head_dim_v,
-                    block_table=None,
-                    cache_seqlens=None,
-                    tile_scheduler_metadata=flashmla_metadata,
-                    softmax_scale=self.softmax_scale,
-                    is_fp8_kvcache=True,
-                    indices=swa_page_indices,
-                    topk_length=swa_topk_lengths,
+                    swa_k_cache=swa_k_cache,
+                    swa_page_indices=swa_page_indices,
+                    swa_topk_lengths=swa_topk_lengths,
                     attn_sink=attn_sink,
                     extra_k_cache=extra_k_cache,
-                    extra_indices_in_kvcache=extra_indices,
-                    extra_topk_length=extra_topk_lengths,
-                )[0]
+                    extra_indices=extra_indices,
+                    extra_topk_lengths=extra_topk_lengths,
+                    flashmla_metadata=flashmla_metadata,
+                )
 
             o = o.squeeze(1)
             return o

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1667,8 +1667,12 @@ class DeepseekV4AttnBackend(
 
         sparse_prefill_fwd does not support SM120. Deterministic inference
         pins the choice: the token-count threshold otherwise makes a prompt's
-        output follow the batch it was prefilled in.
+        output follow the batch it was prefilled in. ``flashmla_kv`` is an
+        explicit correctness/debug mode that keeps prefill and decode on the
+        same paged KV-cache attention kernel.
         """
+        if self.dsv4_prefill_backend == "flashmla_kv":
+            return False
         if get_platform().is_sm120:
             return False
         if is_batch_invariant_mode_enabled():

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_exec, get_spec
 
@@ -83,7 +84,7 @@ class DSATopKBackend(Enum):
                 topk_op=flashinfer.top_k,
                 topk_op_kwargs={
                     "sorted": False,
-                    "deterministic": envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+                    "deterministic": _flashinfer_topk_deterministic(),
                     "tie_break": _flashinfer_tie_break_value(),
                     "dsa_graph_safe": True,
                 },
@@ -206,7 +207,7 @@ class DSATopKBackend(Enum):
                     lengths.contiguous(),
                     topk,
                     row_to_batch=row_to_batch,
-                    deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+                    deterministic=_flashinfer_topk_deterministic(),
                     tie_break=_flashinfer_tie_break_value(),
                     dsa_graph_safe=True,
                     row_starts=row_starts,
@@ -223,7 +224,7 @@ class DSATopKBackend(Enum):
                     topk_indices_offset.contiguous(),
                     lengths.contiguous(),
                     topk,
-                    deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+                    deterministic=_flashinfer_topk_deterministic(),
                     tie_break=_flashinfer_tie_break_value(),
                     dsa_graph_safe=True,
                     row_starts=row_starts,
@@ -424,6 +425,18 @@ def _build_flashinfer_paged_args(
         )
 
     return row_to_batch, page_table_row_starts
+
+
+def _flashinfer_topk_deterministic() -> bool:
+    """Whether FlashInfer's top-k must select a batch-independent index set.
+
+    Its fast path resolves ties by whichever candidate a race lands on, so
+    deterministic inference always takes the ordered path.
+    """
+    return (
+        envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get()
+        or is_batch_invariant_mode_enabled()
+    )
 
 
 def _flashinfer_tie_break_value() -> int:

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -23,6 +23,7 @@ from sglang.kernels.ops.attention.dsv4 import (
     topk_transform_paged_v2,
 )
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
@@ -384,6 +385,7 @@ def topk_transform_flashinfer_unfused(
 
     from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
         _flashinfer_tie_break_value,
+        _flashinfer_topk_deterministic,
     )
 
     _topk_transform_vectorized(
@@ -396,7 +398,7 @@ def topk_transform_flashinfer_unfused(
         topk_op=flashinfer.top_k,
         topk_op_kwargs={
             "sorted": False,
-            "deterministic": envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+            "deterministic": _flashinfer_topk_deterministic(),
             "tie_break": _flashinfer_tie_break_value(),
             "dsa_graph_safe": True,
         },
@@ -416,6 +418,7 @@ def topk_transform_flashinfer_fused(
 
     from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
         _flashinfer_tie_break_value,
+        _flashinfer_topk_deterministic,
     )
 
     flashinfer.top_k_page_table_transform(
@@ -423,7 +426,7 @@ def topk_transform_flashinfer_fused(
         page_tables.contiguous(),
         seq_lens.contiguous(),
         out_page_indices.shape[1],
-        deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+        deterministic=_flashinfer_topk_deterministic(),
         tie_break=_flashinfer_tie_break_value(),
         dsa_graph_safe=True,
         page_size=page_size,
@@ -520,6 +523,11 @@ class C4IndexerBackendMixin:
         indexer_metadata: PagedIndexerMetadata,
     ) -> bool:
         if not envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER.get():
+            return False
+        # This path is taken only for single-request extends above a token
+        # threshold, so leaving it on would make a prompt's indexer logits
+        # depend on the batch it arrived in.
+        if is_batch_invariant_mode_enabled():
             return False
         # This path calls CUDA DeepGEMM and assumes the CUDA FP8+FP32 packed
         # indexer cache layout. Explicitly reject HIP, NPU, and other devices.

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -524,7 +524,8 @@ class MoEGate(nn.Module):
                 True,  # is_vnni
             )
 
-        if get_exec().deterministic.enable_deterministic_inference:
+        deterministic = get_exec().deterministic.enable_deterministic_inference
+        if deterministic and not self.is_deepseek_v4:
             return F.linear(hidden_states, self.weight, None)
 
         if (
@@ -541,7 +542,13 @@ class MoEGate(nn.Module):
                 return linear_bf16_fp32(hidden_states, self.weight)
             return F.linear(hidden_states, self.weight, None)
         else:
-            if hidden_states.shape[0] <= self.tiny_router_gemm_max_tokens:
+            if (
+                # The token-count threshold selects a different GEMM, so under
+                # deterministic inference the router logits -- and with them the
+                # expert choice -- would follow the batch a token arrived in.
+                not deterministic
+                and hidden_states.shape[0] <= self.tiny_router_gemm_max_tokens
+            ):
                 logits = tiny_gemm_bf16(
                     hidden_states,
                     self.weight,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -32,6 +32,7 @@ from sglang.kernels.ops.attention.dsv4 import (
 from sglang.kernels.ops.quantization.fp8_kernel import (
     sglang_per_token_group_quant_fp8,
 )
+from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.distributed import (
@@ -240,9 +241,15 @@ def _cuda_sm_count() -> int:
 
 def _flashinfer_mhc_pre_num_splits(num_tokens: int, hc_hidden_size: int) -> int:
     block_m = block_k = 64
-    grid_m = (num_tokens + block_m - 1) // block_m
     num_block_k = (hc_hidden_size + block_k - 1) // block_k
-    raw = max(1, min(_cuda_sm_count() // max(grid_m, 1), num_block_k // 4))
+    max_splits = max(1, num_block_k // 4)
+    if is_batch_invariant_mode_enabled():
+        # The split count fixes the K summation order; see
+        # _compute_num_split_for_mhc_pre.
+        raw = max_splits
+    else:
+        grid_m = (num_tokens + block_m - 1) // block_m
+        raw = max(1, min(_cuda_sm_count() // max(grid_m, 1), max_splits))
     best = 1
     for split in _FLASHINFER_MHC_PRE_SPLITS:
         if split <= raw:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -233,6 +233,7 @@ add_chunked_prefix_cache_attention_backend = (
 
 DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [
     "ascend",
+    "dsv4",
     "fa3",
     "fa4",
     "flashinfer",
@@ -243,7 +244,13 @@ add_deterministic_attention_backend_choices = (
     DETERMINISTIC_ATTENTION_BACKEND_CHOICES.extend
 )
 
-RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = ["ascend", "fa3", "fa4", "triton"]
+RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = [
+    "ascend",
+    "dsv4",
+    "fa3",
+    "fa4",
+    "triton",
+]
 add_radix_supported_deterministic_attention_backend_choices = (
     RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND.extend
 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1785,11 +1785,17 @@ class ServerArgs:
         str,
         Arg(
             help=(
-                "DeepSeek-V4 sparse prefill backend. 'auto' and "
+                "DeepSeek-V4 prefill attention backend. 'auto' and "
                 "'flashmla_sparse' use the existing BF16 sparse prefill path; "
-                "'flashmla_sparse_q8' enables the Q8KV8 sparse prefill path."
+                "'flashmla_sparse_q8' enables the Q8KV8 sparse prefill path; "
+                "'flashmla_kv' uses the paged KV-cache kernel for prefill."
             ),
-            choices=["auto", "flashmla_sparse", "flashmla_sparse_q8"],
+            choices=[
+                "auto",
+                "flashmla_sparse",
+                "flashmla_sparse_q8",
+                "flashmla_kv",
+            ],
         ),
         NS("exec.kernel"),
     ] = "auto"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1829,8 +1829,9 @@ class ServerArgs:
     dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false. Deterministic inference resolves 'sgl-kernel' to 'flashinfer'.",
             choices=["sgl-kernel", "torch", "flashinfer"],
+            resolvable=True,
         ),
         NS("exec.kernel"),
     ] = "sgl-kernel"
@@ -2199,8 +2200,9 @@ class ServerArgs:
     speculative_dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend for speculative draft workers. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            help="DSA indexer top-k backend for speculative draft workers. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false. Deterministic inference resolves 'sgl-kernel' to 'flashinfer'.",
             choices=["sgl-kernel", "torch", "flashinfer"],
+            resolvable=True,
         ),
         NS("spec"),
     ] = "sgl-kernel"

--- a/python/sglang/test/kl_test_utils.py
+++ b/python/sglang/test/kl_test_utils.py
@@ -195,14 +195,15 @@ def _extract_output_logprobs(result):
     return [x[0] for x in result["meta_info"]["output_token_logprobs"]]
 
 
-def test_input_output_logprobs_match_helper(
+def _collect_decode_and_prefill_logprobs(
     base_url,
-    ACC_THRESHOLDS,
     model_name,
     max_samples=None,
     max_new_tokens=16000,
     trust_remote_code=False,
 ):
+    """Decode the prompts, then prefill-replay prompt + output; returns the
+    (prefill, decode) logprobs of the same selected tokens."""
     num_samples = DEFAULT_NUM_SAMPLES
     if max_samples is not None and max_samples > num_samples:
         num_samples = max_samples
@@ -213,7 +214,7 @@ def test_input_output_logprobs_match_helper(
     )
     if max_samples is not None:
         input_ids = input_ids[:max_samples]
-    print(f"Running test_input_output_logprobs_match with {len(input_ids)} prompts")
+    print(f"Running decode-vs-prefill replay with {len(input_ids)} prompts")
 
     print("Flush Cache and Running generation to get output logprobs ...")
     _flush_cache(base_url)
@@ -228,13 +229,63 @@ def test_input_output_logprobs_match_helper(
 
     print("Running prefill to get input logprobs ...")
     input_logprobs = _get_input_logprobs(base_url, new_input_ids, output_logprobs)
+    return input_logprobs, output_logprobs
 
+
+def test_input_output_logprobs_match_helper(
+    base_url,
+    ACC_THRESHOLDS,
+    model_name,
+    max_samples=None,
+    max_new_tokens=16000,
+    trust_remote_code=False,
+):
+    input_logprobs, output_logprobs = _collect_decode_and_prefill_logprobs(
+        base_url,
+        model_name,
+        max_samples=max_samples,
+        max_new_tokens=max_new_tokens,
+        trust_remote_code=trust_remote_code,
+    )
     compare_kl_divergence(
         input_logprobs,
         output_logprobs,
         ACC_THRESHOLDS,
         model_name,
         inspect.currentframe().f_code.co_name,
+    )
+
+
+def test_input_output_logprobs_bitexact_helper(
+    base_url,
+    model_name,
+    max_samples=None,
+    max_new_tokens=16000,
+    trust_remote_code=False,
+):
+    """Every selected-token logprob must match bit for bit between decode and
+    its prefill replay, so the KL is exactly 0 rather than under a floor."""
+    input_logprobs, output_logprobs = _collect_decode_and_prefill_logprobs(
+        base_url,
+        model_name,
+        max_samples=max_samples,
+        max_new_tokens=max_new_tokens,
+        trust_remote_code=trust_remote_code,
+    )
+    mismatches = []
+    total = 0
+    for sample, (prefill, decode) in enumerate(
+        zip(input_logprobs, output_logprobs, strict=True)
+    ):
+        assert len(prefill) == len(decode)
+        total += len(decode)
+        for pos, (p, d) in enumerate(zip(prefill, decode)):
+            if p != d:
+                mismatches.append((sample, pos, p, d))
+    print(f"bitexact: {total - len(mismatches)}/{total} logprobs match")
+    assert not mismatches, (
+        f"{len(mismatches)}/{total} logprobs differ between decode and prefill; "
+        f"first (sample, pos, prefill, decode): {mismatches[:5]}"
     )
 
 

--- a/python/sglang/test/test_deterministic_utils.py
+++ b/python/sglang/test/test_deterministic_utils.py
@@ -28,6 +28,10 @@ class TestDeterministicBase(CustomTestCase):
         return DEFAULT_MODEL
 
     @classmethod
+    def get_launch_timeout(cls):
+        return DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+    @classmethod
     def setUpClass(cls):
         cls.model = cls.get_model()
         cls.base_url = DEFAULT_URL_FOR_TEST
@@ -39,7 +43,7 @@ class TestDeterministicBase(CustomTestCase):
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            timeout=cls.get_launch_timeout(),
             other_args=cls.get_server_args(),
         )
 

--- a/test/registered/attention/test_deepseek_v4_deterministic.py
+++ b/test/registered/attention/test_deepseek_v4_deterministic.py
@@ -1,0 +1,43 @@
+"""
+Usage:
+cd test/registered/attention
+python3 -m unittest test_deepseek_v4_deterministic.TestDeepseekV4Deterministic
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_deterministic_utils import (
+    COMMON_SERVER_ARGS,
+    TestDeterministicBase,
+)
+
+register_cuda_ci(est_time=1200, stage="weekly", runner_config="4-gpu-h100")
+
+DEEPSEEK_V4_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
+DEEPSEEK_V4_LAUNCH_TIMEOUT = 3600
+
+
+class TestDeepseekV4Deterministic(TestDeterministicBase):
+    """DeepSeek-V4 on its own dsv4 attention backend.
+
+    The backend is forced by the model's config-time overrides, so this covers
+    the one attention backend DeepSeek-V4 can run on rather than a choice
+    between several.
+    """
+
+    @classmethod
+    def get_model(cls):
+        return DEEPSEEK_V4_MODEL
+
+    @classmethod
+    def get_launch_timeout(cls):
+        return DEEPSEEK_V4_LAUNCH_TIMEOUT
+
+    @classmethod
+    def get_server_args(cls):
+        return COMMON_SERVER_ARGS + ["--tp", "4"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/test_deepseek_v4_deterministic.py
+++ b/test/registered/attention/test_deepseek_v4_deterministic.py
@@ -5,22 +5,14 @@ python3 -m unittest test_deepseek_v4_deterministic.TestDeepseekV4Deterministic
 """
 
 import unittest
-from urllib.parse import urlparse
 
 from sglang.test.ci.ci_register import register_cuda_ci
-from sglang.test.test_deterministic import BenchArgs, test_deterministic
 from sglang.test.test_deterministic_utils import (
     COMMON_SERVER_ARGS,
     TestDeterministicBase,
 )
-from sglang.test.test_utils import (
-    DEFAULT_URL_FOR_TEST,
-    CustomTestCase,
-    popen_launch_server,
-    terminate_and_kill_process_tree,
-)
 
-register_cuda_ci(est_time=2400, stage="weekly", runner_config="4-gpu-h100")
+register_cuda_ci(est_time=1200, stage="weekly", runner_config="4-gpu-h100")
 
 DEEPSEEK_V4_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DEEPSEEK_V4_LAUNCH_TIMEOUT = 3600
@@ -45,53 +37,6 @@ class TestDeepseekV4Deterministic(TestDeterministicBase):
     @classmethod
     def get_server_args(cls):
         return COMMON_SERVER_ARGS + ["--tp", "4"]
-
-
-class TestDeepseekV4SameKernelPD(CustomTestCase):
-    """Exact prefill-vs-decode parity with both modes on FlashMLA KV-cache.
-
-    Exact selected-token logprob equality implies zero K3 KL for every token.
-    This isolates KV-cache state and metadata correctness from numerical drift
-    between the production sparse-prefill and KV-cache attention kernels.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            DEEPSEEK_V4_MODEL,
-            cls.base_url,
-            timeout=DEEPSEEK_V4_LAUNCH_TIMEOUT,
-            other_args=[
-                "--trust-remote-code",
-                "--cuda-graph-max-bs-decode",
-                "4",
-                "--enable-deterministic-inference",
-                "--tp",
-                "4",
-                "--max-running-requests",
-                "4",
-                "--dsv4-prefill-backend",
-                "flashmla_kv",
-            ],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
-
-    def test_prefill_decode_logprobs_are_bitexact(self):
-        url = urlparse(self.base_url)
-        args = BenchArgs(
-            host=url.hostname,
-            port=url.port,
-            test_mode="p_vs_d",
-            n_trials=4,
-            max_new_tokens=100,
-        )
-        results = test_deterministic(args)
-        self.assertTrue(all(result == 1 for result in results), results)
-        print("Same-kernel P/D logprobs are bit-exact; K3 KL=0.")
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/test_deepseek_v4_deterministic.py
+++ b/test/registered/attention/test_deepseek_v4_deterministic.py
@@ -5,14 +5,22 @@ python3 -m unittest test_deepseek_v4_deterministic.TestDeepseekV4Deterministic
 """
 
 import unittest
+from urllib.parse import urlparse
 
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_deterministic import BenchArgs, test_deterministic
 from sglang.test.test_deterministic_utils import (
     COMMON_SERVER_ARGS,
     TestDeterministicBase,
 )
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    terminate_and_kill_process_tree,
+)
 
-register_cuda_ci(est_time=1200, stage="weekly", runner_config="4-gpu-h100")
+register_cuda_ci(est_time=2400, stage="weekly", runner_config="4-gpu-h100")
 
 DEEPSEEK_V4_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DEEPSEEK_V4_LAUNCH_TIMEOUT = 3600
@@ -37,6 +45,53 @@ class TestDeepseekV4Deterministic(TestDeterministicBase):
     @classmethod
     def get_server_args(cls):
         return COMMON_SERVER_ARGS + ["--tp", "4"]
+
+
+class TestDeepseekV4SameKernelPD(CustomTestCase):
+    """Exact prefill-vs-decode parity with both modes on FlashMLA KV-cache.
+
+    Exact selected-token logprob equality implies zero K3 KL for every token.
+    This isolates KV-cache state and metadata correctness from numerical drift
+    between the production sparse-prefill and KV-cache attention kernels.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            DEEPSEEK_V4_MODEL,
+            cls.base_url,
+            timeout=DEEPSEEK_V4_LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--cuda-graph-max-bs-decode",
+                "4",
+                "--enable-deterministic-inference",
+                "--tp",
+                "4",
+                "--max-running-requests",
+                "4",
+                "--dsv4-prefill-backend",
+                "flashmla_kv",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
+
+    def test_prefill_decode_logprobs_are_bitexact(self):
+        url = urlparse(self.base_url)
+        args = BenchArgs(
+            host=url.hostname,
+            port=url.port,
+            test_mode="p_vs_d",
+            n_trials=4,
+            max_new_tokens=100,
+        )
+        results = test_deterministic(args)
+        self.assertTrue(all(result == 1 for result in results), results)
+        print("Same-kernel P/D logprobs are bit-exact; K3 KL=0.")
 
 
 if __name__ == "__main__":

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
@@ -12,6 +12,9 @@ from sglang.test.kits.unified_radix_cache_kit import (
     UnifiedRadixTreeTestMixin,
 )
 from sglang.test.kl_multiturn_utils import get_input_ids
+from sglang.test.kl_test_utils import (
+    test_input_output_logprobs_bitexact_helper as assert_logprobs_bitexact,
+)
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
@@ -25,7 +28,7 @@ DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DSV4_DSPARK_MODEL = "deepseek-ai/DeepSeek-V4-Flash-DSpark"
 DSV4_FLASH_LAUNCH_TIMEOUT = 3600
 
-register_cuda_ci(est_time=4800, stage="extra-b", runner_config="4-gpu-h100")
+register_cuda_ci(est_time=5400, stage="extra-b", runner_config="4-gpu-h100")
 
 
 def _assert_dsv4_decode_cached_tokens(result, history_len, output_len, label):
@@ -121,6 +124,63 @@ class TestUnifiedDeepSeekV4FlashHiCachePageFirstDirect(
 
     hicache_io_backend = "kernel"
     hicache_mem_layout = "layer_first"
+
+
+# ─── DeepSeek V4 Flash deterministic same-kernel prefill/decode parity ───
+
+
+class TestUnifiedDeepSeekV4FlashSameKernelBitExact(CustomTestCase):
+    """Decode and its prefill replay must score every token identically.
+
+    Deterministic inference makes each kernel batch-invariant and ``flashmla_kv``
+    runs prefill on the decode KV-cache kernel, so both paths compute the same
+    function; a nonzero KL is KV-cache state or metadata corruption, not drift
+    between the sparse-prefill and KV-cache attention kernels.
+    """
+
+    tree_core_backend = "python"
+    max_running_requests = 4
+    max_samples = 8
+    max_new_tokens = 256
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DSV4_FLASH_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DSV4_FLASH_LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "4",
+                "--enable-deterministic-inference",
+                "--dsv4-prefill-backend",
+                "flashmla_kv",
+                "--cuda-graph-max-bs-decode",
+                str(cls.max_running_requests),
+                "--max-running-requests",
+                str(cls.max_running_requests),
+            ],
+            env=unified_radix_tree_server_env(
+                cls.tree_core_backend,
+                SGLANG_DSV4_FP4_EXPERTS="0",
+            ),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
+
+    def test_logprobs_bitexact(self):
+        assert_logprobs_bitexact(
+            self.base_url,
+            self.model,
+            max_samples=self.max_samples,
+            max_new_tokens=self.max_new_tokens,
+            trust_remote_code=True,
+        )
 
 
 # ─── DeepSeek V4 Flash + HiCache L3 (file backend) ──────────────────────

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2332,6 +2332,26 @@ class TestDeepEPv2Args(CustomTestCase):
         )
         handle_a2a_moe(args)
 
+    def test_deterministic_inference_resolves_dsa_topk_backend(self):
+        """The default sgl-kernel DSA top-k picks tied candidates by thread
+        order, so a DSA model past index_topk tokens is not repeatable on it."""
+        args = self._args(enable_deterministic_inference=True)
+        handle_deterministic_inference(args)
+        self.assertEqual(resolution_result(args, "dsa_topk_backend"), "flashinfer")
+        self.assertEqual(
+            resolution_result(args, "speculative_dsa_topk_backend"), "flashinfer"
+        )
+
+        explicit = self._args(
+            enable_deterministic_inference=True, dsa_topk_backend="torch"
+        )
+        handle_deterministic_inference(explicit)
+        self.assertEqual(resolution_result(explicit, "dsa_topk_backend"), "torch")
+
+        default = self._args()
+        handle_deterministic_inference(default)
+        self.assertEqual(resolution_result(default, "dsa_topk_backend"), "sgl-kernel")
+
     def test_runner_restored_by_declaration_fails_fast(self):
         # Validate the declaration-resolved runner rather than the raw field.
         args = self._args(moe_runner_backend="auto")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -176,8 +176,15 @@ class TestPrepareServerArgs(CustomTestCase):
         )
         self.assertEqual(q8_args.dsv4_prefill_backend, "flashmla_sparse_q8")
 
+        kv_args = parser.parse_args(
+            base_args + ["--dsv4-prefill-backend", "flashmla_kv"]
+        )
+        self.assertEqual(kv_args.dsv4_prefill_backend, "flashmla_kv")
+
         with self.assertRaises(SystemExit):
-            parser.parse_args(base_args + ["--dsv4-prefill-backend", "flashmla_kv"])
+            parser.parse_args(
+                base_args + ["--dsv4-prefill-backend", "not_a_prefill_backend"]
+            )
 
     def test_return_hidden_states_mode_configuration(self):
         def _resolved(**kwargs):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -94,6 +94,8 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "kv_cache_dtype",
                     "dsa_prefill_backend",
                     "dsa_decode_backend",
+                    "dsa_topk_backend",
+                    "speculative_dsa_topk_backend",
                     "prefill_attention_backend",
                     "decode_attention_backend",
                     "flashinfer_allreduce_fusion_backend",


### PR DESCRIPTION
## Motivation

Closes #36174.

`--enable-deterministic-inference` rejects DeepSeek-V4 at startup, and because the
model's config-time overrides pin `--attention-backend dsv4`, there is no backend to
fall back to — the flag is unusable on V4 in every configuration:

```
ValueError: Currently only ['ascend', 'fa3', 'fa4', 'flashinfer', 'intel_xpu', 'triton']
attention backends are supported for deterministic inference, but you explicitly
specified 'dsv4'.
```

Allowlisting the backend alone is not enough: with it allowlisted but nothing else
changed, DeepSeek-V4-Flash-FP8 still produces 3 distinct outputs over 20 batch sizes.
The V4 path has four separate dispatches that key off the token count.

## Modifications

Each site below picks a kernel, a tile size, or a split-K count from the number of
tokens in the batch, which is exactly what deterministic inference must not do.

1. **mHC pre-norm split-K** — `_compute_num_split_for_mhc_pre` derives `n_splits`
   from `n_sms // ceil(num_tokens / 64)`, and `n_splits` is the number of partial
   sums the K reduction is folded from, so it fixes the summation order. This is the
   first op of every layer, so a prompt prefilled alongside two others differs from
   the same prompt prefilled alone in *every* token's logprob by ~1e-2. Pinned to the
   token-independent `num_block_k // 4`. `mhc_fused_post_pre` carries the same term
   plus a `num_tokens <= 32` FMA-kernel switch, and
   `_flashinfer_mhc_pre_num_splits` is a third copy.
2. **FlashMLA sparse decode tile scheduler** — `sparse_attn_decode_interface`
   computes `payload = ceil(total_num_blocks / num_sm_parts)` over the whole batch,
   so where a request's KV range is cut depends on its co-batched requests.
   Deterministic mode issues one launch per request, which makes the schedule a
   function of that request alone.
3. **Non-paged indexer** — taken only when `batch_size == 1 and query_rows >= 8192`.
4. **Router GEMM** — `MoEGate` switches to `dsv3_router_gemm` at
   `hidden_states.shape[0] <= 16`, and `linear_bf16_fp32`'s HPC-Ops path at `M >= 8`.
   Fixing the first also fixes a startup crash: the deterministic branch of `MoEGate`
   returned bf16 router logits, and V4's fused `hash_topk` kernel requires fp32
   (`Dtype value [bfloat16] not in the allowed options: [float32]`).

Also probed and ruled out on H200, so left alone: the DeepGEMM fp8 block GEMM is
M-invariant at every V4 shape, `flash_mla_sparse_fwd` (prefill) is s_q-invariant,
and the MoE runner choice makes no difference.

Deterministic inference on `dsv4` is rejected on SM120, whose attention kernel is an
autotuned Triton kernel that picks its tile size — and with it the softmax rescaling
order — from measured timings.

Everything above is gated: with the flag off, the only changes are an extracted
`_use_sparse_prefill` predicate, two algebraically identical `max_splits` locals and
a `use_fma` local. Verified below.

## Accuracy Tests

DeepSeek-V4-Flash-FP8, 4xH200, TP=4.

**The feature.** Distinct outputs over 32 batch sizes,
`sglang.test.test_deterministic --test-mode single`:

| | distinct outputs / 32 |
| --- | --- |
| without the flag | 6 |
| with `--enable-deterministic-inference` | **1** |

All three harness modes pass with radix cache and CUDA graphs on: `single` (n=32),
`prefix` + logprobs (temperature 0.5, shared prefixes of 1 / 511 / 2048 / 4097), and
`radix_cache`. Chunked prefill was checked separately at
`--chunked-prefill-size 512` over 4097-token prompts.

**No regression with the flag off.** Same box, arms run back to back, benchmark client always from `main` so only the
server tree varies.

The strongest check pins the batch at one request, which removes batch-composition
noise entirely: 150 GSM8K completions issued serially are **150/150 byte-identical**
between `main` and this branch, as are 8/8 fixed greedy prompts.

GSM8K, 400 questions, 5-shot, greedy, `--parallel 64`:

| tree | runs |
| --- | --- |
| `main` | 0.965, 0.965, 0.968, 0.968, 0.968 |
| this branch | 0.960, 0.963, 0.970, 0.960 |

Repeats within one warm server span 0.960-0.970 on this branch, bracketing every
`main` number; at 400 questions the harness cannot resolve better than about +/-4
questions. That spread is DeepSeek-V4's own batch-composition non-determinism -- the
thing the new flag removes.

## Speed Tests and Profiling

**With the flag off** — `sglang.benchmark.serving`, random 1024/512, 200 prompts,
concurrency 32: 

| order | tree | output tok/s | total tok/s | mean TPOT |
| --- | --- | --- | --- | --- |
| 1st | `main` | 1849.80 | 5549.39 | 14.01 ms |
| 2nd | this branch | 1919.93 | 5759.80 | 13.99 ms |
| 3rd | `main` | 1919.67 | 5759.01 | 13.99 ms |

This branch lands within 0.01% of the warm `main` run. The first run is the cold
outlier (JIT and autotune caches), and that cold-start effect (+3.8%) is far larger
than anything between the trees. `MHC prenorm prewarm: 21 n_splits buckets` is logged
by both trees with the flag off, i.e. the split-K schedule is untouched there.

**With the flag on**, decode throughput (fixed batch, 128 output tokens, best of 3):

| | bs=1 | bs=16 | bs=32 |
| --- | --- | --- | --- |
| no flag | 131 | 1611 | 3045 tok/s |
| deterministic | 50 | 354 | 444 tok/s |

Deterministic inference costs ~2.1-2.5x on its own (batch-invariant matmul/rmsnorm,
pytorch sampling, NCCL tree with pinned channels, pinned MoE and mHC split-K), flat
in batch size. The per-request FlashMLA launch adds a further 2.3x at bs=16 and 3.2x
at bs=32, and is free at bs=1. It is not optional: an ablation that keeps the single
batched launch and everything else is still non-deterministic (2 distinct outputs
over 32 batch sizes).

That ablation is also the opening for a follow-up. `sparse_decode_fwd` accepts
`tile_scheduler_metadata` and `num_splits` as inputs and only computes them when
absent, so a supplied no-split schedule would recover the single launch. This PR
takes the loop instead: it is 15 lines, obviously correct, and carries no coupling to
a pinned third-party struct layout — and its bit-exact output is the oracle a
schedule builder would be validated against.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33838023064](https://github.com/sgl-project/sglang/actions/runs/33838023064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33838022909](https://github.com/sgl-project/sglang/actions/runs/33838022909)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33838022979](https://github.com/sgl-project/sglang/actions/runs/33838022979)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->