### PR TITLE
fix: initialize Inkling safely on ROCm

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -92,7 +92,7 @@ env:
   # default times out on a cold cache.
   HF_HUB_DOWNLOAD_TIMEOUT: 300
   HF_HUB_ETAG_TIMEOUT: 300
-  SKIP_PR_TEST_HEALTH_CHECK: ${{ (fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (inputs.scheduled || fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
 

--- a/docs/docs/advanced_features/sglang_for_rl.mdx
+++ b/docs/docs/advanced_features/sglang_for_rl.mdx
@@ -578,6 +578,20 @@ Training workers gather weights (typically on TP rank 0), broadcast them to the 
 - `engine.update_weights_from_distributed(names, dtypes, shapes, ...)`
 - `engine.destroy_weights_update_group(group_name)`
 
+### Per-Token Weight Version Attribution
+
+A request can outlive a version change: the RL flow retracts it with `pause_generation`, refits, and continues it, or `POST /update_weight_version` relabels while it is still generating. `meta_info` then reports which tokens came from which weights:
+
+```json Output
+"weight_version": "42",
+"weight_versions": [
+    {"version": "41", "start": 0, "end": 57},
+    {"version": "42", "start": 57, "end": 128}
+]
+```
+
+- Ranges are half-open `[start, end)` over output-token indices, prompt excluded. The usual case is a single span.
+
 ## Easy To Postpone Generation
 
 Multi-turn RL rollouts often suffer from long-tail requests that block the entire batch. A small number of slow interactions can stall all GPUs, and the long-tail behavior makes profiling and monitoring difficult.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,8 +89,8 @@ dependencies = [
   "uvloop",
   "watchfiles",
   "xgrammar==0.2.1",
-  "xxhash",
-  "zstandard",
+  "xxhash",  # /pull_weights delta checksum
+  "zstandard",  # /pull_weights delta codec
 ]
 
 [[tool.uv.index]]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -133,7 +133,7 @@ diffusion-qvg = [
 ]
 
 ray = [
-  "ray[default]>=2.55.1",
+  "ray[default]>=2.56.0",
 ]
 
 tracing = [

--- a/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
+++ b/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
@@ -6,10 +6,26 @@
 
 #include <sgl_kernel/utils.cuh>
 
+#ifndef USE_ROCM
 #include <cub/cub.cuh>
+#else
+#include <hipcub/hipcub.hpp>
+#endif
 #include <tvm/ffi/container/tensor.h>
 
 #include <algorithm>
+#include <bit>
+
+#ifdef USE_ROCM
+// The JIT build does not run hipify, so this file maps the CUDA spellings it
+// uses onto HIP itself. Deliberately local rather than in utils.cuh: that
+// header sits in nearly every kernel's dependency closure, which the build
+// cache is keyed on, so editing it rebuilds every JIT module.
+namespace cub = hipcub;
+#define cudaDevAttrMaxSharedMemoryPerBlockOptin hipDeviceAttributeSharedMemPerBlockOptin
+#define cudaFuncSetAttribute hipFuncSetAttribute
+#define cudaFuncAttributeMaxDynamicSharedMemorySize hipFuncAttributeMaxDynamicSharedMemorySize
+#endif
 
 #ifndef WARP_SIZE
 #define WARP_SIZE 32
@@ -529,7 +545,8 @@ struct MoeLoraAlignBlockSizeKernel {
 
       dim3 blockDim(num_thread + fill_threads);
       auto kernel = moe::moe_lora_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads>;
-      RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
+      const auto fptr = std::bit_cast<const void*>(kernel);
+      RuntimeDeviceCheck(cudaFuncSetAttribute(fptr, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
 
       LaunchKernel(dim3(max_loras), blockDim, stream, shared_mem)(
           kernel,

--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -1944,6 +1944,7 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     k,
     K_SCALE_BLOCK_SIZE: tl.constexpr,
     K_BLOCK_SIZE: tl.constexpr,
+    HAS_K_TAIL: tl.constexpr,
 ):
     pid_k, pid_m, pid_e = (
         tl.program_id(axis=0),
@@ -1959,6 +1960,11 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
         return
     output_scale_val_inv = 1.0 / tl.load(output_scale_ptr).to(tl.float32)
     k_offsets = pid_k * K_BLOCK_SIZE + tl.arange(0, K_BLOCK_SIZE)
+    # k only has to be a multiple of the 128-wide scale group (e.g. 3584), so the
+    # last k block can be partial.  Specialize on it: hidden sizes that fill
+    # every block keep the unmasked loads, and their codegen is unchanged.
+    if HAS_K_TAIL:
+        k_mask = k_offsets < k
     scale_offsets = (k_offsets // K_SCALE_BLOCK_SIZE) * x_scale_stride2
 
     x_ptrs = x_ptr + pid_e * m * k + k_offsets
@@ -1966,10 +1972,22 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     x_scale_ptrs = x_scale_ptr + pid_e * x_scale_stride0 + scale_offsets
 
     for tok_idx in tl.range(token_id, last_effective_id, pid_m_dim):
-        hidden = tl.load(x_ptrs + tok_idx * k).to(tl.float32)
-        scale_fp32 = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1).to(tl.float32)
+        if HAS_K_TAIL:
+            hidden = tl.load(x_ptrs + tok_idx * k, mask=k_mask, other=0.0)
+            x_scale = tl.load(
+                x_scale_ptrs + tok_idx * x_scale_stride1, mask=k_mask, other=0.0
+            )
+        else:
+            hidden = tl.load(x_ptrs + tok_idx * k)
+            x_scale = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1)
+        hidden = hidden.to(tl.float32)
+        scale_fp32 = x_scale.to(tl.float32)
         hidden = hidden * scale_fp32 * output_scale_val_inv
-        tl.store(output_ptrs + tok_idx * k, hidden.to(output_ptr.dtype.element_ty))
+        quantized = hidden.to(output_ptr.dtype.element_ty)
+        if HAS_K_TAIL:
+            tl.store(output_ptrs + tok_idx * k, quantized, mask=k_mask)
+        else:
+            tl.store(output_ptrs + tok_idx * k, quantized)
 
 
 def fp8_per_token_to_per_tensor_quant_triton(
@@ -1986,8 +2004,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
     assert output_scale.numel() == 1
 
     K_BLOCK_SIZE = 1024
-    assert x.size(2) % K_BLOCK_SIZE == 0
-    grid = (x.size(2) // K_BLOCK_SIZE, 32, x.size(0))
+    grid = (triton.cdiv(x.size(2), K_BLOCK_SIZE), 32, x.size(0))
     _fp8_per_token_quant_to_per_tensor_quant_kernel[grid](
         x,
         x_scale,
@@ -1999,6 +2016,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
         x.size(2),
         K_SCALE_BLOCK_SIZE=K_SCALE_BLOCK_SIZE,
         K_BLOCK_SIZE=K_BLOCK_SIZE,
+        HAS_K_TAIL=x.size(2) % K_BLOCK_SIZE != 0,
         num_warps=8,
     )
 

--- a/python/sglang/kernels/ops/moe/virtual_experts.py
+++ b/python/sglang/kernels/ops/moe/virtual_experts.py
@@ -517,7 +517,7 @@ def _merged_experts_fused_moe_lora_add_impl(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor,
+    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -526,13 +526,30 @@ def _merged_experts_fused_moe_lora_add_impl(
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
 ) -> None:
+    """Fused virtual-experts LoRA delta add.
+
+    ``lora_b`` accepts either a single tensor or a sequence of tensors stacked
+    along the output dim. Length-2 is the gate_up case where A has rank ``2*r``
+    (gate's A and up's A concatenated along rank) and each B has rank ``r``.
+    The shrink runs once over the full ``2*r`` rank; the expand runs once per
+    B, each reading its half of the intermediate and writing to its slice of
+    ``output``.
     """
-    1. Prepare virtual expert routing metadata from topk_ids + token_lora_mapping * num_experts.
-    2. Flatten LoRA weights from [max_loras, num_experts, ...] to [max_loras * num_experts, ...].
-    3. Run regular SGLang fused-MoE kernels for LoRA A and LoRA B.
-    4. Mask out tokens with token_lora_mapping == -1 on the add path.
-    """
+    lora_b_list: list[torch.Tensor] = (
+        list(lora_b) if isinstance(lora_b, (list, tuple)) else [lora_b]
+    )
+    n_b = len(lora_b_list)
+    assert n_b in (1, 2), f"lora_b must be length 1 or 2, got {n_b}"
+    b_rank = lora_b_list[0].shape[3]
+    for b in lora_b_list[1:]:
+        assert (
+            b.shape == lora_b_list[0].shape
+        ), f"all lora_b tensors must share shape; got {[tuple(t.shape) for t in lora_b_list]}"
+
     max_loras, _, max_lora_rank, _ = lora_a.shape
+    assert (
+        max_lora_rank == n_b * b_rank
+    ), f"lora_a rank {max_lora_rank} != n_b ({n_b}) * lora_b rank {b_rank}"
     input_top_k = 1 if hidden_states.shape[0] == topk_ids.numel() else topk_ids.shape[1]
 
     def _merge_lora_expert_weight(t: torch.Tensor) -> torch.Tensor:
@@ -616,16 +633,18 @@ def _merged_experts_fused_moe_lora_add_impl(
             block_size=block_size,
             num_experts=virtual_num_experts,
         )
-        # _align_block_size uses a worst-case padded allocation. Trim the routing buffers
-        # to a tighter upper bound so we keep the real routed work but drop unused padding
-        num_tokens = topk_ids.numel()
-        max_nonempty = min(num_tokens, virtual_num_experts)
-        tight_padded = (
-            triton.cdiv(num_tokens + max_nonempty * (block_size - 1), block_size)
-            * block_size
-        )
-        sorted_token_ids = sorted_token_ids[:tight_padded]
-        expert_ids = expert_ids[: tight_padded // block_size]
+        # NOTE: do NOT trim sorted_token_ids / expert_ids to a tighter upper bound here.
+        # The downstream kernels (_moe_lora_shrink_splitk_kernel, fused_moe_kernel) read
+        # sorted_token_ids[pid_m*BLOCK : +BLOCK] and expert_ids[pid_m] WITHOUT a bounds mask
+        # for every block up to num_tokens_post_padded (a GPU-side count loaded at run time).
+        # num_tokens_post_padded comes from _align_block_size with `virtual_num_experts` buckets
+        # and can exceed a tighter `numel + min(numel,virtual_num_experts)*(block-1)` bound
+        # (most so for shared-outer, where virtual_num_experts = max_loras is small), so trimming
+        # made those unmasked reads land PAST the view. In eager mode the slack still lives inside
+        # the same _align_block_size allocation (garbage, masked out downstream) so it worked; under
+        # CUDA-graph capture/replay the graph mempool packs tensors tightly and that slack may belong
+        # to another pooled tensor / lie past a page -> cudaErrorIllegalInstruction during capture.
+        # Keep the full worst-case-allocated buffers so every unmasked read stays in-allocation.
         expert_ids = fused_sanitize_expert_ids(expert_ids, virtual_num_experts)
         result = (
             sorted_token_ids,
@@ -644,12 +663,22 @@ def _merged_experts_fused_moe_lora_add_impl(
     )
 
     lora_a_virtual = _merge_lora_expert_weight(lora_a)
-    lora_b_virtual = _merge_lora_expert_weight(lora_b)
+    lora_b_virtuals = [_merge_lora_expert_weight(b) for b in lora_b_list]
     num_experts_a = lora_a.shape[1]
-    num_experts_b = lora_b.shape[1]
+    num_experts_b = lora_b_list[0].shape[1]
+    half_out = lora_b_list[0].shape[2]
 
+    # The kernels index token_lora_mapping / intermediate by token ids up to
+    # topk_ids.shape[0] (the DP-gathered token count under --enable-dp-attention). An
+    # under-sized mapping means unmasked OOB reads/writes that surface as a sticky,
+    # hard-to-attribute CUDA IMA — fail loudly on the host instead.
+    assert token_lora_mapping.shape[0] >= topk_ids.shape[0], (
+        f"token_lora_mapping covers {token_lora_mapping.shape[0]} tokens but the MoE runs on "
+        f"{topk_ids.shape[0]} (DP-gathered?) tokens; mapping was sized before the dp gather "
+        f"length was known (see get_gathered_moe_num_tokens)"
+    )
     intermediate = torch.zeros(
-        [token_lora_mapping.shape[0], topk_ids.shape[1], max_lora_rank],
+        [topk_ids.shape[0], topk_ids.shape[1], max_lora_rank],
         dtype=hidden_states.dtype,
         device=hidden_states.device,
     )
@@ -680,7 +709,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         a_stage_config,
     )
 
-    b_stage_config = _get_stage_config(lora_b_virtual, 1)
+    b_stage_config = _get_stage_config(lora_b_virtuals[0], 1)
     (
         sorted_token_ids,
         expert_ids,
@@ -694,33 +723,53 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    invoke_fused_moe_kernel(
-        intermediate.view(-1, max_lora_rank),
-        lora_b_virtual,
-        None,
-        output,
-        None,
-        None,
-        None,
-        topk_weights,
-        topk_ids,
-        sorted_token_ids,
-        expert_ids,
-        num_tokens_post_padded,
-        mul_routed_weight,
-        1,
-        b_stage_config,
-        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-        False,
-        False,
-        False,
-        False,
-        False,
-        None,
-        fuse_add_to_output=True,
-        add_output_mask=token_lora_mask,
-        router_topk=topk_ids.shape[1],
-    )
+    # n_b expands. For len 1: K=b_rank covers full intermediate, write full output.
+    # For len 2 (gate_up): split intermediate along rank into [gate, up] halves
+    # (each contiguous, K=b_rank=r) and output along last dim into [gate, up]
+    # halves (each of width half_out). Each B in lora_b_virtuals is its own
+    # half's weight tensor, naturally K=b_rank.
+    for b_idx, b_virtual in enumerate(lora_b_virtuals):
+        if n_b == 1:
+            inter_arg = intermediate.view(-1, b_rank)
+            out_arg = output
+        else:
+            inter_arg = (
+                intermediate[..., b_idx * b_rank : (b_idx + 1) * b_rank]
+                .contiguous()
+                .view(-1, b_rank)
+            )
+            out_arg = output[
+                ..., b_idx * half_out : (b_idx + 1) * half_out
+            ].contiguous()
+        invoke_fused_moe_kernel(
+            inter_arg,
+            b_virtual,
+            None,
+            out_arg,
+            None,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            1,
+            b_stage_config,
+            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+            fuse_add_to_output=True,
+            add_output_mask=token_lora_mask,
+            router_topk=topk_ids.shape[1],
+        )
+        if n_b != 1:
+            output[..., b_idx * half_out : (b_idx + 1) * half_out].copy_(out_arg)
 
 
 def _merged_experts_fused_moe_lora_add_op(
@@ -763,7 +812,7 @@ def merged_experts_fused_moe_lora_add(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor,
+    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -772,7 +821,12 @@ def merged_experts_fused_moe_lora_add(
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
 ) -> None:
-    """Public API: wraps the registered op with routing_cache support."""
+    """Public API: wraps the registered op with routing_cache support.
+
+    ``lora_b`` accepts a sequence of length 2 for the gate_up case (each B
+    holds one half of the stacked output, rank ``r``, with A's rank ``2*r``);
+    a single tensor is used for the down case.
+    """
     _merged_experts_fused_moe_lora_add_impl(
         output,
         hidden_states,

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2400,7 +2400,12 @@ def _page_size_default(view: Any) -> dict:
 @register_post_process
 def _data_parallelism_defaults(view: Any) -> dict:
     if view.dp_size == 1 and view.ep_join_mode != "scale":
-        return {"enable_dp_attention": False, "enable_dp_lm_head": False}
+        overrides = {"enable_dp_attention": False}
+        # Keep the dp LM head when attention context parallelism is enabled,
+        # even without data parallelism (context-parallel LM head).
+        if not (view.enable_dp_lm_head and view.attn_cp_size > 1):
+            overrides["enable_dp_lm_head"] = False
+        return overrides
     return {}
 
 
@@ -2433,9 +2438,10 @@ def _dp_lm_head_validation(view: Any) -> dict:
     dp LM head and the TP LM-head all-to-all path. Reads the mid-resolution
     values through the view."""
     if view.enable_dp_lm_head:
-        assert (
-            view.enable_dp_attention
-        ), "Please enable dp attention when setting enable_dp_lm_head. "
+        assert view.enable_dp_attention or view.attn_cp_size > 1, (
+            "Please enable dp attention when setting enable_dp_lm_head, "
+            "unless attention context parallelism is enabled."
+        )
     if view.enable_tp_lm_head_all_to_all:
         assert view.enable_dp_attention, (
             "Please enable dp attention when setting " "enable_tp_lm_head_all_to_all."

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1960,7 +1960,8 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
-        "DeepseekV4ForCausalLM",
+        # DeepseekV4 is absent on purpose: under EP + NextN its workspace
+        # creation barriers against the cuda-graph capture loop's own barrier.
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -229,7 +229,10 @@ def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
 
 
 def get_dsa_index_n_heads(config: PretrainedConfig) -> int:
-    assert is_deepseek_dsa(config)
+    # Permit both DSA (V3.2-family) and V4: both carry the indexer (index_n_heads) and this must
+    # match get_dsa_index_head_dim's contract, else LoRA buffer init for indexer.wq_b /
+    # indexer.weights_proj on a V4 model asserts here while indexer.wk (which uses head_dim) succeeds.
+    assert is_deepseek_dsa(config) or is_deepseek_v4(config)
     return config.index_n_heads
 
 

--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """The base class of a backend for grammar-guided constrained decoding."""
 
+import json
 import logging
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -158,6 +159,35 @@ class GrammarMask(NamedTuple):
         self.grammar.apply_vocab_mask(logits=logits, vocab_mask=self.vocab_mask)
 
 
+def _grammar_key_contains_nul(key_type: str, key_string: str) -> bool:
+    """A NUL in a spec segfaults xgrammar's regex converter, which a JSON schema
+    also reaches through `pattern` (possibly escaped). Drop once the upstream fix
+    https://github.com/mlc-ai/xgrammar/pull/850 is in our pinned version.
+    """
+    if "\x00" in key_string:
+        return True
+    if key_type not in ("json", "structural_tag"):
+        return False
+    try:
+        decoded = json.loads(key_string)
+    except ValueError:
+        # Malformed JSON: the backend's own parse reports it as a normal error.
+        return False
+
+    stack = [decoded]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            if "\x00" in node:
+                return True
+        elif isinstance(node, dict):
+            stack.extend(node.keys())
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return False
+
+
 class InvalidGrammarObject(BaseGrammarObject):
     """Represents a grammar that failed to compile, carrying the original error message."""
 
@@ -231,6 +261,11 @@ class BaseGrammarBackend:
     ) -> BaseGrammarObject:
         s = time.perf_counter()
         key_type, key_string = key
+        if _grammar_key_contains_nul(key_type, key_string):
+            logger.error(f"Rejecting {key_type} grammar containing a NUL byte")
+            return InvalidGrammarObject(
+                f"Invalid {key_type}: NUL bytes (\\u0000) are not allowed"
+            )
         if key_type == "json":
             grammar = self.dispatch_json(key_string)
         elif key_type == "regex":

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -881,9 +881,11 @@ class SchedulerDisaggregationPrefillMixin:
                 # todo: set Transferring correctly in backend
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
+                if req.return_routed_experts:
+                    self.batch_result_processor._maybe_collect_routed_experts(req)
+                release_kv_cache(req, self.tree_cache)  # unlock the tree
                 if not isinstance(req.finished_reason, FINISH_ABORT):
                     req.finished_reason = FINISH_LENGTH(length=0)
-                release_kv_cache(req, self.tree_cache)  # unlock the tree
                 # FIXME: clean up req's data in transfer engine
                 req.disagg_kv_sender.clear()
                 done_reqs.append(req)

--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -20,6 +20,7 @@ from sglang.srt.distributed import (
     set_mscclpp_all_reduce,
     set_torch_symm_mem_all_reduce,
 )
+from sglang.srt.distributed.gated_launch import maybe_wait_for_gated_launch
 from sglang.srt.distributed.parallel_state import (
     _tag_groups_for_flashinfer_allreduce_only,
 )
@@ -128,6 +129,10 @@ def init_torch_distributed(
             and ps.tp_size > 1
         ):
             _prewarm_tp_lm_head_all_to_all()
+
+    maybe_wait_for_gated_launch(
+        host=server_args.host, port=server_args.gated_launch_port
+    )
 
     pre_model_load_memory = get_available_gpu_memory(
         device,

--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 import torch.distributed
 
+from sglang.srt.tp_invariant_ops import tree_all_reduce_sum
+from sglang.srt.true_on_policy import should_use_tp_invariant_tree_all_reduce
+
 from .parallel_state import (
     get_attn_tp_group,
     get_moe_ep_group,
@@ -17,6 +20,8 @@ from .parallel_state import (
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
+    if should_use_tp_invariant_tree_all_reduce():
+        return tree_all_reduce_sum(input_, device_group=get_tp_group().device_group)
     return get_tp_group().all_reduce(input_)
 
 
@@ -87,6 +92,10 @@ def broadcast_tensor_dict(
 
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
+    if should_use_tp_invariant_tree_all_reduce():
+        return tree_all_reduce_sum(
+            input_, device_group=get_attn_tp_group().device_group
+        )
     return get_attn_tp_group().all_reduce(input_)
 
 

--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -16,6 +16,8 @@ import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
 
+from sglang.srt.environ import envs
+
 logger = logging.getLogger(__name__)
 
 # Each thread moves _NUMEL_PER_THREAD bf16 via one 128-bit multimem op; the
@@ -460,6 +462,8 @@ class MultimemAllGatherer:
     ):
         self._max_tokens = int(max_tokens)
         self._skip_entry_sync = skip_entry_sync
+        if envs.SGLANG_DISABLE_MULTIMEM_AG.get():
+            enabled = False
         # None => always NCCL; _UNINIT => build on first eager call.
         self._state = self._UNINIT if enabled else None
         if self._state is self._UNINIT:

--- a/python/sglang/srt/distributed/gated_launch.py
+++ b/python/sglang/srt/distributed/gated_launch.py
@@ -1,0 +1,96 @@
+import logging
+import threading
+import time
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+from sglang.srt.distributed import get_world_group
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECONDS = 1.0
+LOG_INTERVAL_SECONDS = 10.0
+
+_instance: Optional["_GatedLaunchServer"] = None
+
+
+def maybe_wait_for_gated_launch(*, host: str, port: Optional[int]) -> None:
+    global _instance
+
+    if port is None or _instance is not None:
+        return
+
+    world_group = get_world_group()
+
+    _instance = _GatedLaunchServer()
+    if world_group.rank_in_group == 0:
+        _instance.serve(host=host, port=port)
+
+    logger.info(f"Gated launch waiting for activation. rank={world_group.rank}")
+    tic = time.perf_counter()
+    _wait_until_activated(world_group=world_group, server=_instance)
+    logger.info(f"Gated launch activated. elapsed={time.perf_counter() - tic:.2f} s")
+
+
+def _wait_until_activated(*, world_group, server: "_GatedLaunchServer") -> None:
+    activated = torch.zeros(1, dtype=torch.int32)
+    started_at = time.perf_counter()
+    next_log_at = started_at + LOG_INTERVAL_SECONDS
+
+    while True:
+        activated[0] = int(server.activated)
+
+        if world_group.world_size > 1:
+            dist.broadcast(
+                activated,
+                src=world_group.ranks[0],
+                group=world_group.cpu_group,
+            )
+
+        if bool(activated[0]):
+            return
+
+        if (now := time.perf_counter()) >= next_log_at:
+            logger.info(
+                f"Gated launch still waiting for activation. "
+                f"rank={world_group.rank} elapsed={now - started_at:.0f} s"
+            )
+            next_log_at = now + LOG_INTERVAL_SECONDS
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+class _GatedLaunchServer:
+    def __init__(self):
+        self.activated = False
+        self._server: Optional[uvicorn.Server] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def serve(self, *, host: str, port: int) -> None:
+        config = uvicorn.Config(
+            _build_app(self), host=host, port=port, log_level="warning"
+        )
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+        logger.info(f"Gated launch control server started on {host}:{port}")
+
+
+def _build_app(server: _GatedLaunchServer) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    def health():
+        return PlainTextResponse("OK")
+
+    @app.post("/gate/activate")
+    def activate():
+        server.activated = True
+        return PlainTextResponse("OK")
+
+    return app

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -3161,15 +3161,12 @@ class RankParallelismConfig:
         tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank()
 
-        # Import dp_attention lazily to avoid circular imports
-        from sglang.srt.layers.dp_attention import (
-            get_attention_cp_rank,
-            get_attention_cp_size,
-            get_attention_dp_rank,
-            get_attention_dp_size,
-            get_attention_tp_rank,
-            get_attention_tp_size,
-        )
+        # v0.5.16 retired the get_attention_{tp,dp,cp}_* helpers from dp_attention;
+        # the attention-side ranks/sizes now live on the runtime ParallelState.
+        # Imported lazily to avoid a circular import.
+        from sglang.srt.runtime_context import get_parallel
+
+        ps = get_parallel()
 
         return cls(
             tp_size=tp_size,
@@ -3180,12 +3177,12 @@ class RankParallelismConfig:
             ep_rank=get_moe_expert_parallel_rank(),
             moe_tp_size=get_moe_tensor_parallel_world_size(),
             moe_tp_rank=get_moe_tensor_parallel_rank(),
-            attn_tp_size=get_attention_tp_size(),
-            attn_tp_rank=get_attention_tp_rank(),
-            attn_dp_size=get_attention_dp_size(),
-            attn_dp_rank=get_attention_dp_rank(),
-            attn_cp_size=get_attention_cp_size(),
-            attn_cp_rank=get_attention_cp_rank(),
+            attn_tp_size=ps.attn_tp_size,
+            attn_tp_rank=ps.attn_tp_rank,
+            attn_dp_size=ps.attn_dp_size,
+            attn_dp_rank=ps.attn_dp_rank,
+            attn_cp_size=ps.attn_cp_size,
+            attn_cp_rank=ps.attn_cp_rank,
             moe_dp_size=get_moe_data_parallel_world_size(),
             moe_dp_rank=get_moe_data_parallel_rank(),
             world_size=(
@@ -3204,8 +3201,10 @@ class RankParallelismConfig:
 
 # Globals on parallel_state module to save/restore
 _PS_GLOBALS = ("_TP", "_PP", "_MOE_EP", "_MOE_TP", "_ATTN_TP", "_ATTN_CP", "_MOE_DP")
-# Globals on dp_attention module to save/restore
-_DA_GLOBALS = ("_ATTN_DP_RANK", "_ATTN_DP_SIZE", "_ENABLE_DP_ATTENTION_FLAG")
+# Globals on dp_attention module to save/restore. v0.5.16 moved the dp-attention
+# enable flag out of this module onto the runtime flags (get_flags().dp.enabled),
+# so it is saved/restored separately below rather than as a module attribute.
+_DA_GLOBALS = ("_ATTN_DP_RANK", "_ATTN_DP_SIZE")
 
 
 class ParallelismContext:
@@ -3244,6 +3243,7 @@ class ParallelismContext:
 
         from sglang.srt.distributed import parallel_state
         from sglang.srt.layers import dp_attention
+        from sglang.srt.runtime_context import get_flags
 
         # Save original globals
         for name in _PS_GLOBALS:
@@ -3267,7 +3267,10 @@ class ParallelismContext:
         # Set dp_attention scalar globals
         dp_attention._ATTN_DP_RANK = conf.attn_dp_rank
         dp_attention._ATTN_DP_SIZE = conf.attn_dp_size
-        dp_attention._ENABLE_DP_ATTENTION_FLAG = conf.attn_dp_size > 1
+        # is_dp_attention_enabled() reads this, not a dp_attention module global.
+        dp_flags = get_flags().dp
+        self._original_dp_enabled = dp_flags.enabled
+        dp_flags.enabled = conf.attn_dp_size > 1
 
         logger.info(f"[ParallelismContext] Activated: {conf}")
         return self
@@ -3275,12 +3278,14 @@ class ParallelismContext:
     def __exit__(self, *args):
         from sglang.srt.distributed import parallel_state
         from sglang.srt.layers import dp_attention
+        from sglang.srt.runtime_context import get_flags
 
         # Restore original globals
         for name in _PS_GLOBALS:
             setattr(parallel_state, name, self._original_globals.get(name))
         for name in _DA_GLOBALS:
             setattr(dp_attention, name, self._original_globals.get(name))
+        get_flags().dp.enabled = self._original_dp_enabled
 
         logger.info("[ParallelismContext] Deactivated")
         return False

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2848,7 +2848,10 @@ def get_dcp_rank():
 
 def get_tensor_model_parallel_rank():
     """Return my rank for the tensor model parallel group."""
-    return get_tp_group().rank_in_group
+    try:
+        return get_tp_group().rank_in_group
+    except Exception:
+        return 0
 
 
 # ATTN_TP

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -32,11 +32,11 @@ import pickle
 import weakref
 from collections import namedtuple
 from contextlib import contextmanager, nullcontext
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import timedelta
 from multiprocessing import shared_memory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.distributed
@@ -3108,3 +3108,179 @@ def monkey_patch_vllm_parallel_state(reverse: bool = False):
         setattr(vllm_parallel_state, "get_pp_group", get_pp_group)
         setattr(vllm_parallel_state, "get_tp_group", get_tp_group)
         setattr(vllm_parallel_state, "get_world_group", get_world_group)
+
+
+@dataclass
+class RankParallelismConfig:
+    """
+    Complete parallelism configuration for a single inference rank.
+
+    This configuration captures all the parallelism settings needed to recreate
+    a model shard outside of sglang. It supports:
+    - TP/PP/EP for model parallelism
+    - MoE-TP/Attn-TP/Attn-DP for MoE and DP attention.
+    """
+
+    tp_size: int = 1
+    tp_rank: int = 0
+    pp_size: int = 1
+    pp_rank: int = 0
+    ep_size: int = 1
+    ep_rank: int = 0
+    moe_tp_size: int = 1
+    moe_tp_rank: int = 0
+    attn_tp_size: int = 1
+    attn_tp_rank: int = 0
+    attn_dp_size: int = 1
+    attn_dp_rank: int = 0
+    attn_cp_size: int = 1
+    attn_cp_rank: int = 0
+    moe_dp_size: int = 1
+    moe_dp_rank: int = 0
+
+    world_size: int = 1
+    global_rank: int = 0
+    local_rank: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RankParallelismConfig":
+        """Create from dictionary, filtering unknown fields."""
+        import dataclasses
+
+        valid_fields = {f.name for f in dataclasses.fields(cls)}
+        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered_data)
+
+    @classmethod
+    def from_parallel_state(cls, local_rank: int = 0) -> "RankParallelismConfig":
+        """Extract current parallelism settings from the global parallel state."""
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+
+        # Import dp_attention lazily to avoid circular imports
+        from sglang.srt.layers.dp_attention import (
+            get_attention_cp_rank,
+            get_attention_cp_size,
+            get_attention_dp_rank,
+            get_attention_dp_size,
+            get_attention_tp_rank,
+            get_attention_tp_size,
+        )
+
+        return cls(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            pp_size=get_pipeline_model_parallel_world_size(),
+            pp_rank=get_pipeline_model_parallel_rank(),
+            ep_size=get_moe_expert_parallel_world_size(),
+            ep_rank=get_moe_expert_parallel_rank(),
+            moe_tp_size=get_moe_tensor_parallel_world_size(),
+            moe_tp_rank=get_moe_tensor_parallel_rank(),
+            attn_tp_size=get_attention_tp_size(),
+            attn_tp_rank=get_attention_tp_rank(),
+            attn_dp_size=get_attention_dp_size(),
+            attn_dp_rank=get_attention_dp_rank(),
+            attn_cp_size=get_attention_cp_size(),
+            attn_cp_rank=get_attention_cp_rank(),
+            moe_dp_size=get_moe_data_parallel_world_size(),
+            moe_dp_rank=get_moe_data_parallel_rank(),
+            world_size=(
+                torch.distributed.get_world_size()
+                if torch.distributed.is_initialized()
+                else 1
+            ),
+            global_rank=(
+                torch.distributed.get_rank()
+                if torch.distributed.is_initialized()
+                else 0
+            ),
+            local_rank=local_rank,
+        )
+
+
+# Globals on parallel_state module to save/restore
+_PS_GLOBALS = ("_TP", "_PP", "_MOE_EP", "_MOE_TP", "_ATTN_TP", "_ATTN_CP", "_MOE_DP")
+# Globals on dp_attention module to save/restore
+_DA_GLOBALS = ("_ATTN_DP_RANK", "_ATTN_DP_SIZE", "_ENABLE_DP_ATTENTION_FLAG")
+
+
+class ParallelismContext:
+    """
+    Context manager for creating model replicas with specific parallelism settings.
+
+    Temporarily sets global variables to allow creating model shards outside of a
+    real distributed environment.
+    Usage:
+        with ParallelismContext(RankParallelismConfig.from_dict(parallelism_info)):
+            model = get_model(...)
+    """
+
+    def __init__(self, parallelism_config: RankParallelismConfig):
+        self.config = parallelism_config
+        self._original_globals: Dict[str, Any] = {}
+
+    def _create_mock_group(self, world_size: int, rank_in_group: int):
+        """Create a mock group coordinator with all necessary properties."""
+        mock_group = MagicMock()
+        mock_group.world_size = world_size
+        mock_group.rank_in_group = rank_in_group
+        mock_group.rank = rank_in_group
+        mock_group.local_rank = rank_in_group
+        mock_group.ranks = list(range(world_size))
+        mock_group.first_rank = 0
+        mock_group.last_rank = world_size - 1
+        mock_group.is_first_rank = rank_in_group == 0
+        mock_group.is_last_rank = rank_in_group == world_size - 1
+        mock_group.next_rank = mock_group.ranks[(rank_in_group + 1) % world_size]
+        mock_group.prev_rank = mock_group.ranks[(rank_in_group - 1) % world_size]
+        return mock_group
+
+    def __enter__(self):
+        conf = self.config
+
+        from sglang.srt.distributed import parallel_state
+        from sglang.srt.layers import dp_attention
+
+        # Save original globals
+        for name in _PS_GLOBALS:
+            self._original_globals[name] = getattr(parallel_state, name, None)
+        for name in _DA_GLOBALS:
+            self._original_globals[name] = getattr(dp_attention, name, None)
+
+        # Build and set mock group objects on parallel_state
+        _ps_new_values = {
+            "_TP": self._create_mock_group(conf.tp_size, conf.tp_rank),
+            "_PP": self._create_mock_group(conf.pp_size, conf.pp_rank),
+            "_MOE_EP": self._create_mock_group(conf.ep_size, conf.ep_rank),
+            "_MOE_TP": self._create_mock_group(conf.moe_tp_size, conf.moe_tp_rank),
+            "_ATTN_TP": self._create_mock_group(conf.attn_tp_size, conf.attn_tp_rank),
+            "_ATTN_CP": self._create_mock_group(conf.attn_cp_size, conf.attn_cp_rank),
+            "_MOE_DP": self._create_mock_group(conf.moe_dp_size, conf.moe_dp_rank),
+        }
+        for name, value in _ps_new_values.items():
+            setattr(parallel_state, name, value)
+
+        # Set dp_attention scalar globals
+        dp_attention._ATTN_DP_RANK = conf.attn_dp_rank
+        dp_attention._ATTN_DP_SIZE = conf.attn_dp_size
+        dp_attention._ENABLE_DP_ATTENTION_FLAG = conf.attn_dp_size > 1
+
+        logger.info(f"[ParallelismContext] Activated: {conf}")
+        return self
+
+    def __exit__(self, *args):
+        from sglang.srt.distributed import parallel_state
+        from sglang.srt.layers import dp_attention
+
+        # Restore original globals
+        for name in _PS_GLOBALS:
+            setattr(parallel_state, name, self._original_globals.get(name))
+        for name in _DA_GLOBALS:
+            setattr(dp_attention, name, self._original_globals.get(name))
+
+        logger.info("[ParallelismContext] Deactivated")
+        return False

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Optional, Union
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -181,6 +181,582 @@ def _scrub_error_message(message: str, status_code: int) -> str:
     return cleaned or "Request failed"
 
 
+def convert_to_chat_completion_request(
+    anthropic_request: AnthropicMessagesRequest,
+    *,
+    merge_inline_system: bool,
+    wrap_reasoning_history: Optional[Callable[[str], str]] = None,
+    apply_reasoning_enabled: Optional[
+        Callable[[ChatCompletionRequest, bool], None]
+    ] = None,
+) -> ChatCompletionRequest:
+    """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
+    openai_messages = []
+
+    def _convert_anthropic_image_source_to_openai_part(
+        source: Any,
+    ) -> Optional[dict]:
+        # Source may arrive as a Pydantic model (typed ImageBlock.source)
+        # or as a raw dict when parsed from a nested tool_result payload.
+        if isinstance(source, BaseModel):
+            source = source.model_dump(exclude_none=True)
+        if not isinstance(source, dict):
+            return None
+
+        source_type = source.get("type")
+        if source_type == "base64":
+            media_type = source.get("media_type", "image/png")
+            data = source.get("data", "")
+            if not data:
+                return None
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{media_type};base64,{data}",
+                },
+            }
+
+        url = source.get("url")
+        if url:
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": url,
+                },
+            }
+
+        return None
+
+    def _text_from_search_result(item: dict[str, Any]) -> str:
+        search_parts = []
+        title = item.get("title")
+        if title:
+            search_parts.append(f"Title: {title}")
+
+        source = item.get("source")
+        if isinstance(source, dict):
+            source_text = source.get("url") or source.get("text")
+            if source_text:
+                search_parts.append(f"Source: {source_text}")
+        elif source:
+            search_parts.append(f"Source: {source}")
+
+        content = item.get("content")
+        content_parts = []
+        if isinstance(content, str):
+            content_parts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "text" and part.get("text"):
+                    content_parts.append(part["text"])
+        if content_parts:
+            search_parts.append("Content: " + "\n".join(content_parts))
+
+        return "\n".join(search_parts)
+
+    def _convert_tool_result_content(
+        content: Any,
+    ) -> tuple[list[Union[str, list[dict]]], str]:
+        if isinstance(content, list):
+            tool_content_parts = []
+            tool_text_parts = []
+
+            for raw_item in content:
+                # Items may be typed Pydantic blocks (after request
+                # validation) or raw dicts (from legacy callers). Coerce
+                # to dict so the existing key-based logic still works.
+                if isinstance(raw_item, BaseModel):
+                    item = raw_item.model_dump(exclude_none=True)
+                elif isinstance(raw_item, dict):
+                    item = raw_item
+                else:
+                    continue
+
+                item_type = item.get("type")
+                if item_type == "text":
+                    text = item.get("text", "")
+                    if text:
+                        tool_text_parts.append(text)
+                        tool_content_parts.append({"type": "text", "text": text})
+                elif item_type == "image":
+                    image_part = _convert_anthropic_image_source_to_openai_part(
+                        item.get("source")
+                    )
+                    if image_part is not None:
+                        tool_content_parts.append(image_part)
+                elif item_type == "tool_reference":
+                    # Anthropic uses `tool_name`; the SGLang chat template
+                    # matches on `name`. Translate at the boundary.
+                    ref_name = item.get("tool_name") or item.get("name")
+                    if ref_name:
+                        tool_content_parts.append(
+                            {"type": "tool_reference", "name": ref_name}
+                        )
+                elif item_type == "search_result":
+                    search_text = _text_from_search_result(item)
+                    if search_text:
+                        tool_text_parts.append(search_text)
+                        tool_content_parts.append({"type": "text", "text": search_text})
+
+            tool_text = "\n".join(tool_text_parts)
+            # GLM templates expand references only at the start of a tool
+            # message, so isolate reference runs without changing part order.
+            tool_content_groups: list[list[dict]] = []
+            for part in tool_content_parts:
+                is_reference = part["type"] == "tool_reference"
+                if (
+                    not tool_content_groups
+                    or (tool_content_groups[-1][0]["type"] == "tool_reference")
+                    != is_reference
+                ):
+                    tool_content_groups.append([])
+                tool_content_groups[-1].append(part)
+
+            tool_contents: list[Union[str, list[dict]]] = []
+            for group in tool_content_groups:
+                if len(group) == 1 and group[0]["type"] == "text":
+                    tool_contents.append(group[0]["text"])
+                else:
+                    tool_contents.append(group)
+            return tool_contents or [""], tool_text
+
+        tool_text = str(content) if content else ""
+        return [tool_text], tool_text
+
+    def _convert_assistant_thinking_blocks(
+        blocks: list[AnthropicContentBlock],
+    ) -> Optional[str]:
+        """Re-wrap prior-turn thinking blocks in the parser's own tokens.
+
+        ``redacted_thinking`` carries encrypted bytes that no local
+        parser can interpret, so we raise rather than silently drop it.
+        On non-reasoning models (no detector configured) the rewrap is
+        best-effort: we log a warning and drop the thinking text so a
+        history echo doesn't 400 the whole request — the prior thinking
+        is opaque context the model didn't need anyway.
+        """
+        if any(block.type == "redacted_thinking" for block in blocks):
+            raise ValueError("Anthropic redacted_thinking history is not supported")
+
+        thinking_parts = [
+            block.thinking
+            for block in blocks
+            if block.type == "thinking" and block.thinking
+        ]
+        if not thinking_parts:
+            return None
+
+        if wrap_reasoning_history is None:
+            raise ValueError(
+                "Cannot convert thinking history without a reasoning adapter"
+            )
+        try:
+            return wrap_reasoning_history("\n".join(thinking_parts))
+        except ValueError as e:
+            logger.warning(
+                "Dropping prior-turn thinking history (%d blocks): %s",
+                len(thinking_parts),
+                e,
+            )
+            return None
+
+    system_parts: list[str] = []
+    if anthropic_request.system:
+        if isinstance(anthropic_request.system, str):
+            if anthropic_request.system.strip():
+                system_parts.append(anthropic_request.system)
+        else:
+            for block in anthropic_request.system:
+                if block.type == "text" and block.text:
+                    system_parts.append(block.text)
+
+    if merge_inline_system:
+        for msg in anthropic_request.messages:
+            if msg.role != "system":
+                continue
+            text = _extract_system_text(msg.content)
+            if text:
+                system_parts.append(text)
+
+    if system_parts:
+        openai_messages.append({"role": "system", "content": "\n".join(system_parts)})
+
+    def _emit_user_message(parts: list[dict]) -> None:
+        """Append accumulated parts as a user message, then clear them.
+
+        Used to flush content collected BEFORE a tool_result so the
+        wire order stays user(pre) → tool → user(post). Without this
+        flush, text/image parts that appeared before a tool_result
+        block would be moved AFTER the tool message at end of loop.
+        """
+        if not parts:
+            return
+        if len(parts) == 1 and parts[0]["type"] == "text":
+            openai_messages.append({"role": "user", "content": parts[0]["text"]})
+        else:
+            openai_messages.append({"role": "user", "content": list(parts)})
+        parts.clear()
+
+    # Convert messages
+    for msg in anthropic_request.messages:
+        if msg.role == "system" and merge_inline_system:
+            continue
+        if isinstance(msg.content, str):
+            openai_messages.append({"role": msg.role, "content": msg.content})
+            continue
+
+        # Complex content with blocks
+        openai_msg = {"role": msg.role}
+        content_parts: list[dict] = []
+        tool_calls: list[dict] = []
+
+        if msg.role == "assistant":
+            reasoning_history = _convert_assistant_thinking_blocks(msg.content)
+            if reasoning_history is not None:
+                content_parts.append({"type": "text", "text": reasoning_history})
+
+        for block in msg.content:
+            # ``thinking``/``redacted_thinking`` blocks are surfaced via
+            # the reasoning-history reconstruction above; skip them here
+            # to avoid double-injecting their text into the prompt.
+            if block.type in ("thinking", "redacted_thinking"):
+                continue
+
+            # ``is not None`` (not truthy) so an empty-string text block
+            # still produces a placeholder text part — without it, an
+            # assistant turn whose only content is "" vanishes and
+            # subsequent user→user pairs trip strict chat templates.
+            if block.type == "text" and block.text is not None:
+                content_parts.append({"type": "text", "text": block.text})
+
+            elif block.type == "image" and block.source:
+                image_part = _convert_anthropic_image_source_to_openai_part(
+                    block.source
+                )
+                if image_part is not None:
+                    content_parts.append(image_part)
+
+            elif block.type == "search_result":
+                search_text = _text_from_search_result(block.model_dump())
+                if search_text:
+                    content_parts.append({"type": "text", "text": search_text})
+
+            elif block.type == "tool_use":
+                tool_call = {
+                    "id": block.id or f"call_{uuid.uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": block.name or "",
+                        "arguments": json.dumps(block.input or {}),
+                    },
+                }
+                tool_calls.append(tool_call)
+
+            elif block.type == "tool_result":
+                tool_contents, tool_text = _convert_tool_result_content(block.content)
+
+                # Use tool_use_id (per spec) with fallback to id
+                tool_call_id = block.tool_use_id or block.id or ""
+
+                # Tool results from user become separate tool messages.
+                # Flush any pending text/image first so the wire order
+                # is preserved (a tool_result that arrived AFTER a text
+                # block must come AFTER that text in OpenAI form too).
+                if msg.role == "user":
+                    _emit_user_message(content_parts)
+                    for tool_content in tool_contents:
+                        openai_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tool_call_id,
+                                "content": tool_content,
+                            }
+                        )
+                else:
+                    content_parts.append(
+                        {
+                            "type": "text",
+                            "text": f"Tool result: {tool_text}",
+                        }
+                    )
+
+        # Attach tool calls to assistant messages
+        if tool_calls:
+            openai_msg["tool_calls"] = tool_calls
+
+        # Attach content
+        if content_parts:
+            if len(content_parts) == 1 and content_parts[0]["type"] == "text":
+                openai_msg["content"] = content_parts[0]["text"]
+            else:
+                openai_msg["content"] = content_parts
+            openai_messages.append(openai_msg)
+        elif tool_calls:
+            openai_messages.append(openai_msg)
+        elif msg.role == "user":
+            # User turn that was entirely tool_results — the tool
+            # messages were already emitted above, nothing left.
+            continue
+        else:
+            # Assistant turn with no content and no tool_calls: emit
+            # an empty-string placeholder so strict templates still
+            # see a valid role-alternation sequence.
+            openai_msg["content"] = ""
+            openai_messages.append(openai_msg)
+
+    # Build ChatCompletionRequest
+    request_data = {
+        "messages": openai_messages,
+        "model": anthropic_request.model,
+        "max_tokens": anthropic_request.max_tokens,
+        "stream": anthropic_request.stream or False,
+    }
+
+    if anthropic_request.temperature is not None:
+        request_data["temperature"] = anthropic_request.temperature
+    if anthropic_request.top_p is not None:
+        request_data["top_p"] = anthropic_request.top_p
+    if anthropic_request.top_k is not None:
+        request_data["top_k"] = anthropic_request.top_k
+    if anthropic_request.stop_sequences is not None:
+        request_data["stop"] = anthropic_request.stop_sequences
+
+    # Enable usage in stream so we can report it
+    if anthropic_request.stream:
+        request_data["stream_options"] = StreamOptions(
+            include_usage=True,
+            continuous_usage_stats=True,
+        )
+
+    chat_request = ChatCompletionRequest(**request_data)
+
+    if anthropic_request.thinking is not None:
+        # The protocol layer already enforces SDK shape:
+        #   enabled  -> budget_tokens required (>=1024), display optional
+        #   disabled -> neither budget_tokens nor display allowed
+        #   adaptive -> budget_tokens forbidden, display optional
+        # So by the time we get here ``budget_tokens`` can only be
+        # set on ``enabled``. The local backend has no equivalent
+        # hard-cap knob, so we log a WARNING instead of rejecting —
+        # the Anthropic SDK would have accepted the request and we
+        # mirror that. Operators see the unenforced budget in logs.
+        if anthropic_request.thinking.budget_tokens is not None:
+            logger.warning(
+                "Anthropic thinking.budget_tokens=%d is accepted for "
+                "SDK compatibility but the local backend has no "
+                "equivalent hard-cap knob — the budget is not enforced",
+                anthropic_request.thinking.budget_tokens,
+            )
+        # Claude 4.7's ``adaptive`` is treated identically to ``enabled``
+        # because the local backend has no auto-throttle equivalent.
+        # Anything other than ``disabled`` enables reasoning.
+        enabled = anthropic_request.thinking.type != "disabled"
+        if anthropic_request.thinking.display == "omitted":
+            # Anthropic 4.7 spec: keep reasoning ON but hide reasoning
+            # text from the client. The OpenAI streaming pipeline has
+            # no equivalent suppress knob — log so operators can see
+            # the request, then proceed with normal reasoning emission.
+            logger.warning(
+                "Anthropic thinking.display='omitted' is accepted for "
+                "SDK compatibility but reasoning text will still be "
+                "emitted to the client"
+            )
+        if apply_reasoning_enabled is None:
+            raise ValueError(
+                "Cannot convert Anthropic thinking without a reasoning adapter"
+            )
+        apply_reasoning_enabled(chat_request, enabled)
+
+    # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
+    # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because
+    # the OpenAI Literal does not include the Anthropic-only ``xhigh``.
+    # ``task_budget`` is a soft hint forwarded as a custom param so the
+    # model can see it without it becoming a hard cap (``max_tokens``
+    # is still the hard cap).
+    if anthropic_request.output_config is not None:
+        oc = anthropic_request.output_config
+        if oc.effort is not None:
+            chat_request.reasoning_effort = "max" if oc.effort == "xhigh" else oc.effort
+        if oc.task_budget is not None:
+            # Custom params are silently ignored by backends that
+            # don't recognise them; logging it makes the propagation
+            # visible.
+            logger.info(
+                "Anthropic output_config.task_budget hint: %d %s",
+                oc.task_budget.total,
+                oc.task_budget.type,
+            )
+
+    # ``betas`` is the Anthropic SDK's opt-in feature list (e.g.
+    # ``["thinking-2025-08-04"]``). The local backend has no
+    # equivalent beta system; accept-and-log so requests don't 400.
+    if anthropic_request.betas:
+        logger.info(
+            "Anthropic request opted into betas %s — no-op locally",
+            anthropic_request.betas,
+        )
+
+    # Convert tools. Deferred tools stay in the list with defer_loading=True;
+    # the chat template hides them from the initial <tools> block and renders
+    # them on demand when a tool_reference block names them.
+    if anthropic_request.tools:
+        converted_tools = []
+        for tool in anthropic_request.tools:
+            if is_server_tool(tool):
+                # Anthropic server-side tools (web_search_*, computer_*,
+                # bash_*, text_editor_*) have no client-side input_schema
+                # because Anthropic provides the implementation. We can't
+                # forward them to the OpenAI tools array (which requires a
+                # schema), so skip with a visible log.
+                logger.info(
+                    "Skipping built-in Anthropic server tool %r (type=%r): "
+                    "no native support in the OpenAI-compatible backend",
+                    tool.name,
+                    tool.type,
+                )
+                continue
+
+            # Custom tools always have a validated input_schema
+            # (enforced at Pydantic parse time).
+            converted_tools.append(
+                Tool(
+                    type="function",
+                    defer_loading=tool.defer_loading,
+                    function={
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": tool.input_schema,
+                    },
+                )
+            )
+
+        if converted_tools:
+            chat_request.tools = converted_tools
+
+    # Convert tool choice. ``any``/``tool`` express a hard requirement
+    # ("the model MUST call a tool"); if every requested tool was a
+    # server-side Anthropic built-in that we just skipped, there is
+    # no tool the model could call. Silently downgrading to "no tool"
+    # would deceive the caller, so raise an explicit 400.
+    if anthropic_request.tool_choice is not None:
+        tc_type = anthropic_request.tool_choice.type
+        if tc_type == "none":
+            chat_request.tool_choice = "none"
+        elif chat_request.tools:
+            if tc_type == "auto":
+                chat_request.tool_choice = "auto"
+            elif tc_type == "any":
+                chat_request.tool_choice = "required"
+            elif tc_type == "tool":
+                tool_name = anthropic_request.tool_choice.name
+                # ``Tool.function`` is a ``Function`` Pydantic model, not
+                # a dict — access by attribute. A dict ``.get`` would
+                # AttributeError and surface as a 500 instead of the
+                # intended 400 / happy path.
+                if not any(t.function.name == tool_name for t in chat_request.tools):
+                    raise ValueError(
+                        f"tool_choice references tool {tool_name!r} but it "
+                        f"is not in the forwarded tools list "
+                        f"(server-side Anthropic tools cannot be selected)"
+                    )
+                chat_request.tool_choice = ToolChoice(
+                    type="function",
+                    function=ToolChoiceFuncName(name=tool_name),
+                )
+        elif tc_type in ("any", "tool"):
+            raise ValueError(
+                f"tool_choice={tc_type!r} requires at least one custom "
+                f"tool; all supplied tools were server-side Anthropic "
+                f"built-ins which the OpenAI-compatible backend cannot "
+                f"invoke"
+            )
+    elif chat_request.tools:
+        chat_request.tool_choice = "auto"
+
+    return chat_request
+
+
+def convert_response(
+    response: ChatCompletionResponse,
+) -> AnthropicMessagesResponse:
+    """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages response."""
+    if not response.choices:
+        return AnthropicMessagesResponse(
+            content=[TextBlock(text="")],
+            model=response.model,
+            stop_reason="end_turn",
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        )
+
+    choice = response.choices[0]
+    content: list[AnthropicContentBlock] = []
+
+    # Add reasoning content as a thinking block. signature is omitted
+    # entirely when the backend doesn't provide one — empty strings
+    # would fail downstream Anthropic signature verifiers.
+    if choice.message.reasoning_content:
+        content.append(ThinkingBlock(thinking=choice.message.reasoning_content))
+
+    # Add text content
+    if choice.message.content:
+        content.append(TextBlock(text=choice.message.content))
+
+    # Add tool calls
+    if choice.message.tool_calls:
+        for tool_call in choice.message.tool_calls:
+            raw_args = tool_call.function.arguments
+            try:
+                tool_input = json.loads(raw_args)
+            except (json.JSONDecodeError, TypeError):
+                # Surface invalid tool arguments so an empty-dict
+                # tool call is never indistinguishable from a real
+                # one when something downstream goes wrong.
+                logger.warning(
+                    "Tool %r emitted invalid JSON arguments: %r — "
+                    "defaulting to empty input",
+                    tool_call.function.name,
+                    (raw_args or "")[:200],
+                )
+                tool_input = {}
+
+            content.append(
+                ToolUseBlock(
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    input=tool_input,
+                )
+            )
+
+    # Map stop reason
+    finish_reason = choice.finish_reason or "stop"
+    if finish_reason not in STOP_REASON_MAP:
+        logger.warning(
+            "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
+            finish_reason,
+        )
+    stop_reason = STOP_REASON_MAP.get(finish_reason, "end_turn")
+
+    # Anthropic requires ``content`` to contain at least one block.
+    # Empty string completions (max_tokens=1 stop, content filter, etc.)
+    # would otherwise ship ``content=[]`` and break strict SDK parsers.
+    if not content:
+        content.append(TextBlock(text=""))
+
+    return AnthropicMessagesResponse(
+        id=f"msg_{uuid.uuid4().hex}",
+        content=content,
+        model=response.model,
+        stop_reason=stop_reason,
+        usage=_anthropic_usage_from_openai(
+            response.usage,
+            include_input=True,
+            include_output=True,
+        ),
+    )
+
+
 class AnthropicServing:
     """Handler for Anthropic Messages API requests.
 
@@ -229,496 +805,16 @@ class AnthropicServing:
     def _convert_to_chat_completion_request(
         self, anthropic_request: AnthropicMessagesRequest
     ) -> ChatCompletionRequest:
-        """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
-        openai_messages = []
-
-        def _convert_anthropic_image_source_to_openai_part(
-            source: Any,
-        ) -> Optional[dict]:
-            # Source may arrive as a Pydantic model (typed ImageBlock.source)
-            # or as a raw dict when parsed from a nested tool_result payload.
-            if isinstance(source, BaseModel):
-                source = source.model_dump(exclude_none=True)
-            if not isinstance(source, dict):
-                return None
-
-            source_type = source.get("type")
-            if source_type == "base64":
-                media_type = source.get("media_type", "image/png")
-                data = source.get("data", "")
-                if not data:
-                    return None
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{media_type};base64,{data}",
-                    },
-                }
-
-            url = source.get("url")
-            if url:
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": url,
-                    },
-                }
-
-            return None
-
-        def _text_from_search_result(item: dict[str, Any]) -> str:
-            search_parts = []
-            title = item.get("title")
-            if title:
-                search_parts.append(f"Title: {title}")
-
-            source = item.get("source")
-            if isinstance(source, dict):
-                source_text = source.get("url") or source.get("text")
-                if source_text:
-                    search_parts.append(f"Source: {source_text}")
-            elif source:
-                search_parts.append(f"Source: {source}")
-
-            content = item.get("content")
-            content_parts = []
-            if isinstance(content, str):
-                content_parts.append(content)
-            elif isinstance(content, list):
-                for part in content:
-                    if not isinstance(part, dict):
-                        continue
-                    if part.get("type") == "text" and part.get("text"):
-                        content_parts.append(part["text"])
-            if content_parts:
-                search_parts.append("Content: " + "\n".join(content_parts))
-
-            return "\n".join(search_parts)
-
-        def _convert_tool_result_content(
-            content: Any,
-        ) -> tuple[list[Union[str, list[dict]]], str]:
-            if isinstance(content, list):
-                tool_content_parts = []
-                tool_text_parts = []
-
-                for raw_item in content:
-                    # Items may be typed Pydantic blocks (after request
-                    # validation) or raw dicts (from legacy callers). Coerce
-                    # to dict so the existing key-based logic still works.
-                    if isinstance(raw_item, BaseModel):
-                        item = raw_item.model_dump(exclude_none=True)
-                    elif isinstance(raw_item, dict):
-                        item = raw_item
-                    else:
-                        continue
-
-                    item_type = item.get("type")
-                    if item_type == "text":
-                        text = item.get("text", "")
-                        if text:
-                            tool_text_parts.append(text)
-                            tool_content_parts.append({"type": "text", "text": text})
-                    elif item_type == "image":
-                        image_part = _convert_anthropic_image_source_to_openai_part(
-                            item.get("source")
-                        )
-                        if image_part is not None:
-                            tool_content_parts.append(image_part)
-                    elif item_type == "tool_reference":
-                        # Anthropic uses `tool_name`; the SGLang chat template
-                        # matches on `name`. Translate at the boundary.
-                        ref_name = item.get("tool_name") or item.get("name")
-                        if ref_name:
-                            tool_content_parts.append(
-                                {"type": "tool_reference", "name": ref_name}
-                            )
-                    elif item_type == "search_result":
-                        search_text = _text_from_search_result(item)
-                        if search_text:
-                            tool_text_parts.append(search_text)
-                            tool_content_parts.append(
-                                {"type": "text", "text": search_text}
-                            )
-
-                tool_text = "\n".join(tool_text_parts)
-                # GLM templates expand references only at the start of a tool
-                # message, so isolate reference runs without changing part order.
-                tool_content_groups: list[list[dict]] = []
-                for part in tool_content_parts:
-                    is_reference = part["type"] == "tool_reference"
-                    if (
-                        not tool_content_groups
-                        or (tool_content_groups[-1][0]["type"] == "tool_reference")
-                        != is_reference
-                    ):
-                        tool_content_groups.append([])
-                    tool_content_groups[-1].append(part)
-
-                tool_contents: list[Union[str, list[dict]]] = []
-                for group in tool_content_groups:
-                    if len(group) == 1 and group[0]["type"] == "text":
-                        tool_contents.append(group[0]["text"])
-                    else:
-                        tool_contents.append(group)
-                return tool_contents or [""], tool_text
-
-            tool_text = str(content) if content else ""
-            return [tool_text], tool_text
-
-        def _convert_assistant_thinking_blocks(
-            blocks: list[AnthropicContentBlock],
-        ) -> Optional[str]:
-            """Re-wrap prior-turn thinking blocks in the parser's own tokens.
-
-            ``redacted_thinking`` carries encrypted bytes that no local
-            parser can interpret, so we raise rather than silently drop it.
-            On non-reasoning models (no detector configured) the rewrap is
-            best-effort: we log a warning and drop the thinking text so a
-            history echo doesn't 400 the whole request — the prior thinking
-            is opaque context the model didn't need anyway.
-            """
-            if any(block.type == "redacted_thinking" for block in blocks):
-                raise ValueError("Anthropic redacted_thinking history is not supported")
-
-            thinking_parts = [
-                block.thinking
-                for block in blocks
-                if block.type == "thinking" and block.thinking
-            ]
-            if not thinking_parts:
-                return None
-
-            try:
-                return self.openai_serving_chat.wrap_reasoning_history(
-                    "\n".join(thinking_parts)
-                )
-            except ValueError as e:
-                logger.warning(
-                    "Dropping prior-turn thinking history (%d blocks): %s",
-                    len(thinking_parts),
-                    e,
-                )
-                return None
-
-        system_parts: list[str] = []
-        if anthropic_request.system:
-            if isinstance(anthropic_request.system, str):
-                if anthropic_request.system.strip():
-                    system_parts.append(anthropic_request.system)
-            else:
-                for block in anthropic_request.system:
-                    if block.type == "text" and block.text:
-                        system_parts.append(block.text)
-
-        if self._merge_inline_system:
-            for msg in anthropic_request.messages:
-                if msg.role != "system":
-                    continue
-                text = _extract_system_text(msg.content)
-                if text:
-                    system_parts.append(text)
-
-        if system_parts:
-            openai_messages.append(
-                {"role": "system", "content": "\n".join(system_parts)}
-            )
-
-        def _emit_user_message(parts: list[dict]) -> None:
-            """Append accumulated parts as a user message, then clear them.
-
-            Used to flush content collected BEFORE a tool_result so the
-            wire order stays user(pre) → tool → user(post). Without this
-            flush, text/image parts that appeared before a tool_result
-            block would be moved AFTER the tool message at end of loop.
-            """
-            if not parts:
-                return
-            if len(parts) == 1 and parts[0]["type"] == "text":
-                openai_messages.append({"role": "user", "content": parts[0]["text"]})
-            else:
-                openai_messages.append({"role": "user", "content": list(parts)})
-            parts.clear()
-
-        # Convert messages
-        for msg in anthropic_request.messages:
-            if msg.role == "system" and self._merge_inline_system:
-                continue
-            if isinstance(msg.content, str):
-                openai_messages.append({"role": msg.role, "content": msg.content})
-                continue
-
-            # Complex content with blocks
-            openai_msg = {"role": msg.role}
-            content_parts: list[dict] = []
-            tool_calls: list[dict] = []
-
-            if msg.role == "assistant":
-                reasoning_history = _convert_assistant_thinking_blocks(msg.content)
-                if reasoning_history is not None:
-                    content_parts.append({"type": "text", "text": reasoning_history})
-
-            for block in msg.content:
-                # ``thinking``/``redacted_thinking`` blocks are surfaced via
-                # the reasoning-history reconstruction above; skip them here
-                # to avoid double-injecting their text into the prompt.
-                if block.type in ("thinking", "redacted_thinking"):
-                    continue
-
-                # ``is not None`` (not truthy) so an empty-string text block
-                # still produces a placeholder text part — without it, an
-                # assistant turn whose only content is "" vanishes and
-                # subsequent user→user pairs trip strict chat templates.
-                if block.type == "text" and block.text is not None:
-                    content_parts.append({"type": "text", "text": block.text})
-
-                elif block.type == "image" and block.source:
-                    image_part = _convert_anthropic_image_source_to_openai_part(
-                        block.source
-                    )
-                    if image_part is not None:
-                        content_parts.append(image_part)
-
-                elif block.type == "search_result":
-                    search_text = _text_from_search_result(block.model_dump())
-                    if search_text:
-                        content_parts.append({"type": "text", "text": search_text})
-
-                elif block.type == "tool_use":
-                    tool_call = {
-                        "id": block.id or f"call_{uuid.uuid4().hex}",
-                        "type": "function",
-                        "function": {
-                            "name": block.name or "",
-                            "arguments": json.dumps(block.input or {}),
-                        },
-                    }
-                    tool_calls.append(tool_call)
-
-                elif block.type == "tool_result":
-                    tool_contents, tool_text = _convert_tool_result_content(
-                        block.content
-                    )
-
-                    # Use tool_use_id (per spec) with fallback to id
-                    tool_call_id = block.tool_use_id or block.id or ""
-
-                    # Tool results from user become separate tool messages.
-                    # Flush any pending text/image first so the wire order
-                    # is preserved (a tool_result that arrived AFTER a text
-                    # block must come AFTER that text in OpenAI form too).
-                    if msg.role == "user":
-                        _emit_user_message(content_parts)
-                        for tool_content in tool_contents:
-                            openai_messages.append(
-                                {
-                                    "role": "tool",
-                                    "tool_call_id": tool_call_id,
-                                    "content": tool_content,
-                                }
-                            )
-                    else:
-                        content_parts.append(
-                            {
-                                "type": "text",
-                                "text": f"Tool result: {tool_text}",
-                            }
-                        )
-
-            # Attach tool calls to assistant messages
-            if tool_calls:
-                openai_msg["tool_calls"] = tool_calls
-
-            # Attach content
-            if content_parts:
-                if len(content_parts) == 1 and content_parts[0]["type"] == "text":
-                    openai_msg["content"] = content_parts[0]["text"]
-                else:
-                    openai_msg["content"] = content_parts
-                openai_messages.append(openai_msg)
-            elif tool_calls:
-                openai_messages.append(openai_msg)
-            elif msg.role == "user":
-                # User turn that was entirely tool_results — the tool
-                # messages were already emitted above, nothing left.
-                continue
-            else:
-                # Assistant turn with no content and no tool_calls: emit
-                # an empty-string placeholder so strict templates still
-                # see a valid role-alternation sequence.
-                openai_msg["content"] = ""
-                openai_messages.append(openai_msg)
-
-        # Build ChatCompletionRequest
-        request_data = {
-            "messages": openai_messages,
-            "model": anthropic_request.model,
-            "max_tokens": anthropic_request.max_tokens,
-            "stream": anthropic_request.stream or False,
-        }
-
-        if anthropic_request.temperature is not None:
-            request_data["temperature"] = anthropic_request.temperature
-        if anthropic_request.top_p is not None:
-            request_data["top_p"] = anthropic_request.top_p
-        if anthropic_request.top_k is not None:
-            request_data["top_k"] = anthropic_request.top_k
-        if anthropic_request.stop_sequences is not None:
-            request_data["stop"] = anthropic_request.stop_sequences
-
-        # Enable usage in stream so we can report it
-        if anthropic_request.stream:
-            request_data["stream_options"] = StreamOptions(
-                include_usage=True,
-                continuous_usage_stats=True,
-            )
-
-        chat_request = ChatCompletionRequest(**request_data)
-
-        if anthropic_request.thinking is not None:
-            # The protocol layer already enforces SDK shape:
-            #   enabled  -> budget_tokens required (>=1024), display optional
-            #   disabled -> neither budget_tokens nor display allowed
-            #   adaptive -> budget_tokens forbidden, display optional
-            # So by the time we get here ``budget_tokens`` can only be
-            # set on ``enabled``. The local backend has no equivalent
-            # hard-cap knob, so we log a WARNING instead of rejecting —
-            # the Anthropic SDK would have accepted the request and we
-            # mirror that. Operators see the unenforced budget in logs.
-            if anthropic_request.thinking.budget_tokens is not None:
-                logger.warning(
-                    "Anthropic thinking.budget_tokens=%d is accepted for "
-                    "SDK compatibility but the local backend has no "
-                    "equivalent hard-cap knob — the budget is not enforced",
-                    anthropic_request.thinking.budget_tokens,
-                )
-            # Claude 4.7's ``adaptive`` is treated identically to ``enabled``
-            # because the local backend has no auto-throttle equivalent.
-            # Anything other than ``disabled`` enables reasoning.
-            enabled = anthropic_request.thinking.type != "disabled"
-            if anthropic_request.thinking.display == "omitted":
-                # Anthropic 4.7 spec: keep reasoning ON but hide reasoning
-                # text from the client. The OpenAI streaming pipeline has
-                # no equivalent suppress knob — log so operators can see
-                # the request, then proceed with normal reasoning emission.
-                logger.warning(
-                    "Anthropic thinking.display='omitted' is accepted for "
-                    "SDK compatibility but reasoning text will still be "
-                    "emitted to the client"
-                )
-            self.openai_serving_chat.apply_reasoning_enabled(chat_request, enabled)
-
-        # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
-        # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because
-        # the OpenAI Literal does not include the Anthropic-only ``xhigh``.
-        # ``task_budget`` is a soft hint forwarded as a custom param so the
-        # model can see it without it becoming a hard cap (``max_tokens``
-        # is still the hard cap).
-        if anthropic_request.output_config is not None:
-            oc = anthropic_request.output_config
-            if oc.effort is not None:
-                chat_request.reasoning_effort = (
-                    "max" if oc.effort == "xhigh" else oc.effort
-                )
-            if oc.task_budget is not None:
-                # Custom params are silently ignored by backends that
-                # don't recognise them; logging it makes the propagation
-                # visible.
-                logger.info(
-                    "Anthropic output_config.task_budget hint: %d %s",
-                    oc.task_budget.total,
-                    oc.task_budget.type,
-                )
-
-        # ``betas`` is the Anthropic SDK's opt-in feature list (e.g.
-        # ``["thinking-2025-08-04"]``). The local backend has no
-        # equivalent beta system; accept-and-log so requests don't 400.
-        if anthropic_request.betas:
-            logger.info(
-                "Anthropic request opted into betas %s — no-op locally",
-                anthropic_request.betas,
-            )
-
-        # Convert tools. Deferred tools stay in the list with defer_loading=True;
-        # the chat template hides them from the initial <tools> block and renders
-        # them on demand when a tool_reference block names them.
-        if anthropic_request.tools:
-            converted_tools = []
-            for tool in anthropic_request.tools:
-                if is_server_tool(tool):
-                    # Anthropic server-side tools (web_search_*, computer_*,
-                    # bash_*, text_editor_*) have no client-side input_schema
-                    # because Anthropic provides the implementation. We can't
-                    # forward them to the OpenAI tools array (which requires a
-                    # schema), so skip with a visible log.
-                    logger.info(
-                        "Skipping built-in Anthropic server tool %r (type=%r): "
-                        "no native support in the OpenAI-compatible backend",
-                        tool.name,
-                        tool.type,
-                    )
-                    continue
-
-                # Custom tools always have a validated input_schema
-                # (enforced at Pydantic parse time).
-                converted_tools.append(
-                    Tool(
-                        type="function",
-                        defer_loading=tool.defer_loading,
-                        function={
-                            "name": tool.name,
-                            "description": tool.description or "",
-                            "parameters": tool.input_schema,
-                        },
-                    )
-                )
-
-            if converted_tools:
-                chat_request.tools = converted_tools
-
-        # Convert tool choice. ``any``/``tool`` express a hard requirement
-        # ("the model MUST call a tool"); if every requested tool was a
-        # server-side Anthropic built-in that we just skipped, there is
-        # no tool the model could call. Silently downgrading to "no tool"
-        # would deceive the caller, so raise an explicit 400.
-        if anthropic_request.tool_choice is not None:
-            tc_type = anthropic_request.tool_choice.type
-            if tc_type == "none":
-                chat_request.tool_choice = "none"
-            elif chat_request.tools:
-                if tc_type == "auto":
-                    chat_request.tool_choice = "auto"
-                elif tc_type == "any":
-                    chat_request.tool_choice = "required"
-                elif tc_type == "tool":
-                    tool_name = anthropic_request.tool_choice.name
-                    # ``Tool.function`` is a ``Function`` Pydantic model, not
-                    # a dict — access by attribute. A dict ``.get`` would
-                    # AttributeError and surface as a 500 instead of the
-                    # intended 400 / happy path.
-                    if not any(
-                        t.function.name == tool_name for t in chat_request.tools
-                    ):
-                        raise ValueError(
-                            f"tool_choice references tool {tool_name!r} but it "
-                            f"is not in the forwarded tools list "
-                            f"(server-side Anthropic tools cannot be selected)"
-                        )
-                    chat_request.tool_choice = ToolChoice(
-                        type="function",
-                        function=ToolChoiceFuncName(name=tool_name),
-                    )
-            elif tc_type in ("any", "tool"):
-                raise ValueError(
-                    f"tool_choice={tc_type!r} requires at least one custom "
-                    f"tool; all supplied tools were server-side Anthropic "
-                    f"built-ins which the OpenAI-compatible backend cannot "
-                    f"invoke"
-                )
-        elif chat_request.tools:
-            chat_request.tool_choice = "auto"
-
-        return chat_request
+        return convert_to_chat_completion_request(
+            anthropic_request,
+            merge_inline_system=self._merge_inline_system,
+            wrap_reasoning_history=lambda reasoning_text: self.openai_serving_chat.wrap_reasoning_history(
+                reasoning_text
+            ),
+            apply_reasoning_enabled=lambda request, enabled: self.openai_serving_chat.apply_reasoning_enabled(
+                request, enabled
+            ),
+        )
 
     async def _handle_non_streaming(
         self,
@@ -1247,80 +1343,7 @@ class AnthropicServing:
     def _convert_response(
         self, response: ChatCompletionResponse
     ) -> AnthropicMessagesResponse:
-        """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages response."""
-        if not response.choices:
-            return AnthropicMessagesResponse(
-                content=[TextBlock(text="")],
-                model=response.model,
-                stop_reason="end_turn",
-                usage=AnthropicUsage(input_tokens=0, output_tokens=0),
-            )
-
-        choice = response.choices[0]
-        content: list[AnthropicContentBlock] = []
-
-        # Add reasoning content as a thinking block. signature is omitted
-        # entirely when the backend doesn't provide one — empty strings
-        # would fail downstream Anthropic signature verifiers.
-        if choice.message.reasoning_content:
-            content.append(ThinkingBlock(thinking=choice.message.reasoning_content))
-
-        # Add text content
-        if choice.message.content:
-            content.append(TextBlock(text=choice.message.content))
-
-        # Add tool calls
-        if choice.message.tool_calls:
-            for tool_call in choice.message.tool_calls:
-                raw_args = tool_call.function.arguments
-                try:
-                    tool_input = json.loads(raw_args)
-                except (json.JSONDecodeError, TypeError):
-                    # Surface invalid tool arguments so an empty-dict
-                    # tool call is never indistinguishable from a real
-                    # one when something downstream goes wrong.
-                    logger.warning(
-                        "Tool %r emitted invalid JSON arguments: %r — "
-                        "defaulting to empty input",
-                        tool_call.function.name,
-                        (raw_args or "")[:200],
-                    )
-                    tool_input = {}
-
-                content.append(
-                    ToolUseBlock(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        input=tool_input,
-                    )
-                )
-
-        # Map stop reason
-        finish_reason = choice.finish_reason or "stop"
-        if finish_reason not in STOP_REASON_MAP:
-            logger.warning(
-                "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
-                finish_reason,
-            )
-        stop_reason = STOP_REASON_MAP.get(finish_reason, "end_turn")
-
-        # Anthropic requires ``content`` to contain at least one block.
-        # Empty string completions (max_tokens=1 stop, content filter, etc.)
-        # would otherwise ship ``content=[]`` and break strict SDK parsers.
-        if not content:
-            content.append(TextBlock(text=""))
-
-        return AnthropicMessagesResponse(
-            id=f"msg_{uuid.uuid4().hex}",
-            content=content,
-            model=response.model,
-            stop_reason=stop_reason,
-            usage=_anthropic_usage_from_openai(
-                response.usage,
-                include_input=True,
-                include_output=True,
-            ),
-        )
+        return convert_response(response)
 
     def _convert_openai_error_response(self, response) -> JSONResponse:
         """Forward an upstream OpenAI-handler error as an Anthropic error.

--- a/python/sglang/srt/entrypoints/anthropic/utils.py
+++ b/python/sglang/srt/entrypoints/anthropic/utils.py
@@ -1,0 +1,219 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Anthropic error conversion and fake-SSE response helpers.
+
+Request and response format conversion lives in serving.py as public,
+runtime-independent functions. This module contains the two adaptations used
+by external frontends: an Anthropic error DTO and an eager event sequence for
+an already-complete OpenAI response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Callable, Optional
+
+from sglang.srt.entrypoints.anthropic.protocol import (
+    AnthropicError,
+    AnthropicErrorResponse,
+    AnthropicMessageEndDelta,
+    AnthropicMessagesResponse,
+    AnthropicStreamEvent,
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    InputJsonDelta,
+    MessageDeltaEvent,
+    MessageStartEvent,
+    MessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolUseBlock,
+)
+from sglang.srt.entrypoints.anthropic.serving import (
+    ERROR_TYPE_MAP as _SERVING_ERROR_TYPE_MAP,
+)
+from sglang.srt.entrypoints.anthropic.serving import (
+    STOP_REASON_MAP,
+    _anthropic_usage_from_openai,
+    _scrub_error_message,
+)
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
+
+logger = logging.getLogger(__name__)
+
+# ``serving.py``'s map plus the two statuses the HTTP layer maps in its
+# ``/v1/messages`` exception handler (``http_server.py``): FastAPI raises
+# 413/422 before ``AnthropicServing`` runs, so ``serving.py`` never needed
+# them. Unlisted statuses fall through to ``api_error`` in both sources.
+ERROR_TYPE_MAP = {
+    **_SERVING_ERROR_TYPE_MAP,
+    413: "request_too_large",
+    422: "invalid_request_error",
+}
+
+
+def _anthropic_message_id() -> str:
+    """Message-ID factory with the same format the server generates."""
+    return f"msg_{uuid.uuid4().hex}"
+
+
+def to_anthropic_error(status_code: int, body: bytes) -> AnthropicErrorResponse:
+    """Map an upstream error status and body to an Anthropic error envelope.
+
+    Same payload parsing and scrub policy as ``serving.py``'s
+    ``_convert_openai_error_response``, but against the composite
+    ``ERROR_TYPE_MAP`` above and returning the envelope DTO — HTTP response
+    construction stays with the caller. 4xx keeps a sanitized upstream
+    message and honors an upstream ``error.type``; 5xx is always the
+    generic scrubbed message.
+    """
+    body = body or b""
+    error_type = ERROR_TYPE_MAP.get(status_code, "api_error")
+
+    upstream_message: Optional[str] = None
+    try:
+        payload = json.loads(body.decode("utf-8")) if body else None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Non-JSON body (HTML gateway error, plain text, ...). Use a bounded
+        # slice of the raw body so the client still has a useful hint.
+        upstream_message = body.decode("utf-8", errors="replace")[:500]
+    else:
+        if isinstance(payload, dict):
+            error_payload = payload.get("error", payload)
+            if isinstance(error_payload, dict):
+                upstream_message = error_payload.get("message") or payload.get(
+                    "message"
+                )
+                # Honor the upstream error.type only for 4xx; 5xx is
+                # normalized by the scrub below.
+                if status_code < 500:
+                    upstream_type = error_payload.get("type")
+                    if isinstance(upstream_type, str) and upstream_type:
+                        error_type = upstream_type
+            elif isinstance(error_payload, str):
+                upstream_message = error_payload
+            elif isinstance(payload.get("message"), str):
+                upstream_message = payload["message"]
+
+    message = _scrub_error_message(upstream_message or "", status_code)
+    return AnthropicErrorResponse(
+        error=AnthropicError(type=error_type, message=message)
+    )
+
+
+def to_anthropic_fake_sse_events(
+    response: ChatCompletionResponse,
+    *,
+    model: str,
+    id_factory: Callable[[], str] = _anthropic_message_id,
+) -> tuple[AnthropicStreamEvent, ...]:
+    """Eagerly synthesize the Anthropic SSE event sequence from one complete
+    OpenAI response.
+
+    Event schema, block ordering (thinking → text → tool_use), index
+    accounting, usage split (input on ``message_start``, output on
+    ``message_delta``) and stop-reason mapping follow the server's live
+    stream; collapsing each block into a single delta is the documented
+    difference. ``model`` must be the original Anthropic request model, not
+    the backend's possibly-aliased response model.
+    """
+    events: list[AnthropicStreamEvent] = [
+        MessageStartEvent(
+            message=AnthropicMessagesResponse(
+                id=id_factory(),
+                content=[],
+                model=model,
+                usage=_anthropic_usage_from_openai(
+                    response.usage,
+                    include_input=True,
+                    include_output=True,
+                    force_zero_output=True,
+                ),
+            )
+        )
+    ]
+
+    message = response.choices[0].message if response.choices else None
+    index = 0
+
+    if message is not None and message.reasoning_content:
+        events.append(
+            ContentBlockStartEvent(
+                index=index, content_block=ThinkingBlock(thinking="")
+            )
+        )
+        events.append(
+            ContentBlockDeltaEvent(
+                index=index, delta=ThinkingDelta(thinking=message.reasoning_content)
+            )
+        )
+        events.append(ContentBlockStopEvent(index=index))
+        index += 1
+
+    if message is not None and message.content:
+        events.append(
+            ContentBlockStartEvent(index=index, content_block=TextBlock(text=""))
+        )
+        events.append(
+            ContentBlockDeltaEvent(index=index, delta=TextDelta(text=message.content))
+        )
+        events.append(ContentBlockStopEvent(index=index))
+        index += 1
+
+    if message is not None and message.tool_calls:
+        for tool_call in message.tool_calls:
+            events.append(
+                ContentBlockStartEvent(
+                    index=index,
+                    content_block=ToolUseBlock(
+                        id=tool_call.id or f"toolu_{uuid.uuid4().hex}",
+                        name=tool_call.function.name,
+                        input={},
+                    ),
+                )
+            )
+            if tool_call.function.arguments:
+                events.append(
+                    ContentBlockDeltaEvent(
+                        index=index,
+                        delta=InputJsonDelta(partial_json=tool_call.function.arguments),
+                    )
+                )
+            events.append(ContentBlockStopEvent(index=index))
+            index += 1
+
+    finish_reason = (
+        (response.choices[0].finish_reason or "stop") if response.choices else "stop"
+    )
+    if finish_reason not in STOP_REASON_MAP:
+        logger.warning(
+            "Unmapped OpenAI finish_reason %r; defaulting to end_turn", finish_reason
+        )
+    events.append(
+        MessageDeltaEvent(
+            delta=AnthropicMessageEndDelta(
+                stop_reason=STOP_REASON_MAP.get(finish_reason, "end_turn")
+            ),
+            usage=_anthropic_usage_from_openai(
+                response.usage, include_input=False, include_output=True
+            ),
+        )
+    )
+    events.append(MessageStopEvent())
+    return tuple(events)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -228,10 +228,6 @@ class Engine(EngineScoreMixin, EngineBase):
     run_scheduler_process_func: Callable = staticmethod(run_scheduler_process)
     run_detokenizer_process_func: Callable = staticmethod(run_detokenizer_process)
 
-    # Backend-specific launch handle: the Ray engine schedules its actors onto a
-    # placement group. Not config — a live cluster object.
-    _placement_group = None
-
     def __init__(self, **kwargs):
         """
         The arguments of this function is the same as `sglang/srt/server_args.py::ServerArgs`.
@@ -283,7 +279,6 @@ class Engine(EngineScoreMixin, EngineBase):
             init_tokenizer_manager_func=self.init_tokenizer_manager_func,
             run_scheduler_process_func=self.run_scheduler_process_func,
             run_detokenizer_process_func=self.run_detokenizer_process_func,
-            placement_group=self._placement_group,
         )
         self.tokenizer_manager = tokenizer_manager
         self.template_manager = template_manager
@@ -861,8 +856,6 @@ class Engine(EngineScoreMixin, EngineBase):
         server_args: ServerArgs,
         port_args: PortArgs,
         run_scheduler_process_func: Callable,
-        *,
-        placement_group=None,
     ) -> Tuple[SchedulerInitResult, Optional[List]]:
         """Launch scheduler processes using multiprocessing.
         Override in subclasses for different backends (e.g. Ray).
@@ -1067,7 +1060,6 @@ class Engine(EngineScoreMixin, EngineBase):
         run_scheduler_process_func: Callable,
         run_detokenizer_process_func: Callable,
         port_args: Optional[PortArgs] = None,
-        placement_group=None,
     ) -> Tuple[
         TokenizerManager,
         TemplateManager,
@@ -1099,10 +1091,7 @@ class Engine(EngineScoreMixin, EngineBase):
 
         # Start the engine info bootstrap server if per-rank info is needed.
         engine_info_bootstrap_server = None
-        if (
-            server_args.remote_instance_weight_loader_start_seed_via_transfer_engine
-            and server_args.node_rank == 0
-        ):
+        if server_args.needs_engine_info_bootstrap() and server_args.node_rank == 0:
             bootstrap_port = server_args.engine_info_bootstrap_port
             if not is_port_available(bootstrap_port):
                 raise RuntimeError(
@@ -1132,13 +1121,8 @@ class Engine(EngineScoreMixin, EngineBase):
             weight_cache_daemon_procs = cls._launch_weight_cache_daemons(server_args)
 
         # Launch scheduler processes
-        # Passed only when there is one: this hook is an override point, and a
-        # subclass written against the three-argument signature must keep working.
-        launch_kwargs = (
-            {"placement_group": placement_group} if placement_group is not None else {}
-        )
         scheduler_init_result, scheduler_procs = cls._launch_scheduler_processes(
-            server_args, port_args, run_scheduler_process_func, **launch_kwargs
+            server_args, port_args, run_scheduler_process_func
         )
         scheduler_init_result.engine_info_bootstrap_server = (
             engine_info_bootstrap_server

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -63,9 +63,11 @@ from sglang.srt.managers.data_parallel_controller import (
 )
 from sglang.srt.managers.detokenizer_manager import run_detokenizer_process
 from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
     CloseSessionReqInput,
     DestroyWeightsUpdateGroupReqInput,
     EmbeddingReqInput,
+    EndWeightUpdateReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsUpdateGroupReqInput,
@@ -1426,6 +1428,23 @@ class Engine(EngineScoreMixin, EngineBase):
         )
         return self.loop.run_until_complete(
             self.tokenizer_manager.destroy_weights_update_group(obj, None)
+        )
+
+    def begin_weight_update(self, selector: str = "all"):
+        """Open a weight-update session: unpack in-place-quantized weights on the
+        selected runners so update_weights_from_{distributed,tensor} can load into
+        them. Must be closed with end_weight_update()."""
+        obj = BeginWeightUpdateReqInput(selector=selector)
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.begin_weight_update(obj, None)
+        )
+
+    def end_weight_update(self):
+        """Close the session opened by begin_weight_update() and finalize quantized
+        weights into kernel layout."""
+        obj = EndWeightUpdateReqInput()
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.end_weight_update(obj, None)
         )
 
     def update_weights_from_distributed(

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -69,6 +69,7 @@ from sglang.srt.managers.io_struct import (
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsUpdateGroupReqInput,
+    LoadLoRAAdapterFromDistributedReqInput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterReqInput,
     MultimodalDataInputFormat,
@@ -1549,6 +1550,34 @@ class Engine(EngineScoreMixin, EngineBase):
         )
         return self.loop.run_until_complete(
             self.tokenizer_manager.load_lora_adapter_from_tensors(lora_req, None)
+        )
+
+    def load_lora_adapter_from_distributed(
+        self,
+        lora_name: str,
+        config_dict: Dict,
+        names: list[str],
+        dtypes: list[str],
+        shapes: list[list[int]],
+        group_name: str = "weight_update_group",
+        pinned: bool = False,
+        added_tokens_config: Optional[Dict] = None,
+    ):
+        """Load a new LoRA adapter whose weights are broadcast over
+        a process group. The weight-update group must already be
+        initialized via `init_weights_update_group`."""
+        lora_req = LoadLoRAAdapterFromDistributedReqInput(
+            lora_name=lora_name,
+            config_dict=config_dict,
+            names=names,
+            dtypes=dtypes,
+            shapes=shapes,
+            group_name=group_name,
+            pinned=pinned,
+            added_tokens_config=added_tokens_config,
+        )
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.load_lora_adapter_from_distributed(lora_req, None)
         )
 
     def load_lora_adapter(self, lora_name: str, lora_path: str, pinned: bool = False):

--- a/python/sglang/srt/entrypoints/engine_info_bootstrap_server.py
+++ b/python/sglang/srt/entrypoints/engine_info_bootstrap_server.py
@@ -31,7 +31,8 @@ class EngineInfoBootstrapServer:
     accesses the collected info directly in-process; external consumers can
     query via HTTP GET.
 
-    Currently supports transfer engine memory registration info.
+    Currently supports transfer engine memory registration info and
+    per-rank parallelism configuration.
     """
 
     def __init__(self, host: str, port: int):
@@ -40,6 +41,8 @@ class EngineInfoBootstrapServer:
 
         # Storage: {tp_rank: (session_id, weights_info_dict)}
         self.transfer_engine_info: Dict[int, Tuple] = {}
+        # Storage: {tp_rank: parallelism_config_dict}
+        self.parallelism_config: Dict[int, dict] = {}
         self.lock = threading.Lock()
 
         app = FastAPI()
@@ -89,6 +92,38 @@ class EngineInfoBootstrapServer:
 
         config = uvicorn.Config(app, host=host, port=port, log_level="warning")
         self._server = uvicorn.Server(config)
+
+        @app.put("/register_parallelism_config")
+        def register_parallelism_config(data: dict):
+            try:
+                tp_rank = data["tp_rank"]
+                config = data["parallelism_config"]
+
+                with self.lock:
+                    self.parallelism_config[tp_rank] = config
+
+                logger.info(f"Registered parallelism config for tp_rank={tp_rank}")
+                return PlainTextResponse("OK")
+            except Exception as e:
+                logger.error(f"Failed to register parallelism config: {e}")
+                raise HTTPException(status_code=400, detail=str(e))
+
+        @app.get("/get_parallelism_config")
+        def get_parallelism_config(rank: int):
+            if rank < 0:
+                raise HTTPException(status_code=400, detail="Invalid rank parameter")
+
+            with self.lock:
+                config = self.parallelism_config.get(rank)
+
+            if config is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No parallelism config for rank {rank}",
+                )
+
+            return config
+
         self._thread = threading.Thread(
             target=self._server.run,
             daemon=True,
@@ -103,3 +138,7 @@ class EngineInfoBootstrapServer:
     def get_transfer_engine_info(self, rank: int) -> Optional[Tuple]:
         """Direct in-process access for co-located HTTP server (no HTTP round-trip)."""
         return self.transfer_engine_info.get(rank)
+
+    def get_parallelism_config_info(self, rank: int) -> Optional[dict]:
+        """Direct in-process access for parallelism config (no HTTP round-trip)."""
+        return self.parallelism_config.get(rank)

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -419,6 +419,9 @@ class RuntimeHandle:
     def get_server_info(self) -> str:
         result: Dict[str, Any] = dataclasses.asdict(self.tokenizer_manager.server_args)
         result.update(self.scheduler_info)
+        result["kv_events"] = (
+            self.tokenizer_manager.server_args.describe_kv_events_publisher()
+        )
         return json.dumps(msgspec_to_builtins(result), default=str)
 
     def health_check(self) -> bool:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1621,6 +1621,7 @@ async def load_lora_adapter(
 
 
 @app.api_route("/load_lora_adapter_from_tensors", methods=["POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def load_lora_adapter_from_tensors(
     obj: Annotated[LoadLoRAAdapterFromTensorsReqInput, Body()], request: Request
 ):
@@ -1633,6 +1634,7 @@ async def load_lora_adapter_from_tensors(
 
 
 @app.api_route("/load_lora_adapter_from_distributed", methods=["POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def load_lora_adapter_from_distributed(
     obj: Annotated[LoadLoRAAdapterFromDistributedReqInput, Body()], request: Request
 ):

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1695,7 +1695,7 @@ async def abort_request(obj: Annotated[AbortReq, Body()], request: Request):
     """Abort a request."""
     try:
         _global_state.tokenizer_manager.abort_request(
-            rid=obj.rid, abort_all=obj.abort_all
+            rid=obj.rid, abort_all=obj.abort_all, prefix=obj.prefix
         )
         return Response(status_code=200)
     except Exception as e:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -136,6 +136,7 @@ from sglang.srt.managers.io_struct import (
     ParseFunctionCallReq,
     PauseGenerationReqInput,
     ProfileReq,
+    PullWeightsReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
     SendWeightsToRemoteInstanceReqInput,
@@ -1262,6 +1263,19 @@ async def update_weights_from_disk(
             content,
             status_code=HTTPStatus.BAD_REQUEST,
         )
+
+
+@app.post("/pull_weights")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def pull_weights(obj: Annotated[PullWeightsReqInput, Body()], request: Request):
+    """Have every host of this deployment pull published weight deltas into its
+    local checkpoint (materialized from the model path on first use)."""
+    success, message = await _global_state.tokenizer_manager.pull_weights(obj, request)
+
+    content = {"success": success, "message": message}
+    return ORJSONResponse(
+        content, status_code=HTTPStatus.OK if success else HTTPStatus.BAD_REQUEST
+    )
 
 
 @app.post("/init_weights_send_group_for_remote_instance")

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -127,6 +127,7 @@ from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqInput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
     InitWeightsUpdateGroupReqInput,
+    LoadLoRAAdapterFromDistributedReqInput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterReqInput,
     OpenSessionReqInput,
@@ -1553,6 +1554,18 @@ async def load_lora_adapter_from_tensors(
 ):
     """Load a new LoRA adapter from tensors without re-launching the server."""
     result = await _global_state.tokenizer_manager.load_lora_adapter_from_tensors(
+        obj, request
+    )
+    status_code = HTTPStatus.OK if result.success else HTTPStatus.BAD_REQUEST
+    return ORJSONResponse(msgspec_to_builtins(result), status_code=status_code)
+
+
+@app.api_route("/load_lora_adapter_from_distributed", methods=["POST"])
+async def load_lora_adapter_from_distributed(
+    obj: Annotated[LoadLoRAAdapterFromDistributedReqInput, Body()], request: Request
+):
+    """Load a new LoRA adapter broadcast over a process group without re-launching the server."""
+    result = await _global_state.tokenizer_manager.load_lora_adapter_from_distributed(
         obj, request
     )
     status_code = HTTPStatus.OK if result.success else HTTPStatus.BAD_REQUEST

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -116,6 +116,7 @@ from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.managers.io_struct import (
     AbortReq,
     AttachHiCacheStorageReqInput,
+    BeginWeightUpdateReqInput,
     CheckWeightsReqInput,
     CloseSessionReqInput,
     ConfigureLoggingReq,
@@ -123,6 +124,7 @@ from sglang.srt.managers.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
     DumperControlReqInput,
     EmbeddingReqInput,
+    EndWeightUpdateReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -1414,6 +1416,36 @@ async def update_weights_from_tensor(
     content = {"success": success, "message": message}
     return ORJSONResponse(
         content, status_code=200 if success else HTTPStatus.BAD_REQUEST
+    )
+
+
+@app.post("/begin_weight_update")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def begin_weight_update(
+    obj: Annotated[BeginWeightUpdateReqInput, Body()], request: Request
+):
+    """Open a weight-update session so in-place-quantized weights become loadable."""
+    success, message = await _global_state.tokenizer_manager.begin_weight_update(
+        obj, request
+    )
+    return ORJSONResponse(
+        {"success": success, "message": message},
+        status_code=HTTPStatus.OK if success else HTTPStatus.BAD_REQUEST,
+    )
+
+
+@app.post("/end_weight_update")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def end_weight_update(
+    obj: Annotated[EndWeightUpdateReqInput, Body()], request: Request
+):
+    """Close the weight-update session and finalize quantized weights."""
+    success, message = await _global_state.tokenizer_manager.end_weight_update(
+        obj, request
+    )
+    return ORJSONResponse(
+        {"success": success, "message": message},
+        status_code=HTTPStatus.OK if success else HTTPStatus.BAD_REQUEST,
     )
 
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1337,6 +1337,32 @@ async def remote_instance_transfer_engine_info(rank: int = None):
     )
 
 
+@app.get("/parallelism_config")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def parallelism_config(rank: int = None):
+    """Get per-rank parallelism config from the bootstrap server."""
+    if rank is None or rank < 0:
+        return ORJSONResponse(
+            {"error": {"message": "Missing or invalid rank parameter"}},
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    server_args = _global_state.tokenizer_manager.server_args
+    try:
+
+        resp = requests.get(
+            f"{server_args.engine_info_bootstrap_url}/get_parallelism_config",
+            params={"rank": rank},
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+
+    return Response(status_code=HTTPStatus.BAD_REQUEST)
+
+
 @app.post("/init_weights_update_group")
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def init_weights_update_group(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1514,9 +1514,7 @@ async def update_weight_version(
     # Use a simple approach without the complex lock mechanism for now
     # since weight_version update is a simple operation that doesn't affect model weights
     try:
-        _global_state.tokenizer_manager.record_config_updates(
-            "http.update_weight_version", weight_version=obj.new_version
-        )
+        await _global_state.tokenizer_manager.update_weight_version(obj)
 
         return ORJSONResponse(
             {

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1081,6 +1081,14 @@ class ChatCompletionRequest(BaseModel):
         )
 
         if tool_call_constraint and has_existing_constraints:
+            if self.tool_choice == "required" or isinstance(
+                self.tool_choice, ToolChoice
+            ):
+                raise ValueError(
+                    "tool_choice 'required' or a named tool cannot be combined with "
+                    "response_format, regex, or ebnf: the tool-call constraint and the "
+                    "output constraint cannot both be honored."
+                )
             logger.warning("Constrained decoding is not compatible with tool calls.")
         elif tool_call_constraint:
             constraint_type, constraint_value = tool_call_constraint

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1975,6 +1975,15 @@ class OpenAIServingChat(OpenAIServingBase):
         """Process for generating a new and unique `tool_call_id`"""
         if self.tool_call_parser == "kimi_k3":
             return f"{call_item.name}:{history_tool_calls_cnt + call_item.tool_index}"
+        if self.tool_call_parser == "kimi_k2_raw_id":
+            # RL training needs the model-emitted tool_call_id round-tripped verbatim,
+            # so we skip the history-based renumbering below and return whatever the
+            # detector captured. Fall back to the canonical Kimi-K2 reconstruction
+            # (without history offset) if for any reason the detector did not record
+            # a raw id — the raw id field is best-effort but the format is stable.
+            if call_item.tool_call_id:
+                return call_item.tool_call_id
+            return f"functions.{call_item.name}:{call_item.tool_index}"
         if self.tool_call_parser != "kimi_k2":
             # A simple uuid is sufficient for all models except for Kimi-K2.
             tool_call_id = f"call_{uuid.uuid4().hex[:24]}"

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2007,15 +2007,25 @@ class OpenAIServingChat(OpenAIServingBase):
             parser = FunctionCallParser(
                 tools, self.tool_call_parser, tokenizer=self.tokenizer_manager.tokenizer
             )
-            should_try_parser = (
-                not is_required
-                or parser.detector.supports_structural_tag()
+            detector_owns_format = (
+                parser.detector.supports_structural_tag()
                 or parser.detector.parses_required_natively()
             )
+            should_try_parser = not is_required or detector_owns_format
             if should_try_parser and parser.has_tool_call(text):
                 try:
                     text, call_info_list = parser.parse_non_stream(text)
                     if not call_info_list:
+                        logger.warning(
+                            "Tool call marker present but no complete call parsed "
+                            "from %s output; dropping the incomplete call",
+                            self.tool_call_parser,
+                        )
+                        logger.debug(
+                            "Unparsed tool call output (%d chars): %r",
+                            len(text),
+                            text[:2000],
+                        )
                         return ToolCallProcessingResult(None, text, finish_reason)
 
                     tool_calls = []
@@ -2041,6 +2051,15 @@ class OpenAIServingChat(OpenAIServingBase):
                     logger.error(f"Tool call parsing error: {e}")
                     return ToolCallProcessingResult(None, text, finish_reason)
 
+            if is_required and detector_owns_format:
+                logger.warning(
+                    "Required tool call missing from %s output (%d chars)",
+                    self.tool_call_parser,
+                    len(text),
+                )
+                logger.debug("Unparsed required tool call output: %r", text[:2000])
+                return ToolCallProcessingResult(None, text, finish_reason)
+
         # json_schema constraint → JSON array output for required/named
         if is_required:
             original_finish_type = finish_reason["type"]
@@ -2049,12 +2068,28 @@ class OpenAIServingChat(OpenAIServingBase):
                 finish_reason["matched"] = None
             try:
                 tool_call_data = orjson.loads(text)
+                if isinstance(tool_call_data, dict):
+                    tool_call_data = [tool_call_data]
+                if not isinstance(tool_call_data, list):
+                    raise ValueError(
+                        "expected a JSON array of tool calls, got "
+                        f"{type(tool_call_data).__name__}"
+                    )
+                if not all(
+                    isinstance(tool, dict) and "name" in tool for tool in tool_call_data
+                ):
+                    raise ValueError(
+                        "every tool call must be a JSON object with a 'name'"
+                    )
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
+                    parameters = json.dumps(
+                        tool.get("parameters", {}), ensure_ascii=False
+                    )
                     call_info = ToolCallItem(
                         tool_index=i,
                         name=tool["name"],
-                        parameters=json.dumps(tool["parameters"], ensure_ascii=False),
+                        parameters=parameters,
                     )
                     tool_id = self._process_tool_call_id(
                         call_info, history_tool_calls_cnt
@@ -2065,15 +2100,14 @@ class OpenAIServingChat(OpenAIServingBase):
                             index=i,
                             function=FunctionResponse(
                                 name=tool["name"],
-                                arguments=json.dumps(
-                                    tool["parameters"], ensure_ascii=False
-                                ),
+                                arguments=parameters,
                             ),
                         )
                     )
                 return ToolCallProcessingResult(tool_calls, "", finish_reason)
             except Exception as e:
                 logger.error(f"Tool call parsing error: {e}")
+                logger.debug("Unparsed required tool call output: %r", text[:2000])
                 finish_reason["type"] = original_finish_type
                 return ToolCallProcessingResult(None, text, finish_reason)
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -74,6 +74,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.utils.weight_versions import build_endpoint_weight_version_metadata
 
 if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
@@ -1911,7 +1912,7 @@ class OpenAIServingChat(OpenAIServingBase):
             model=request.model,
             choices=choices,
             usage=usage,
-            metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            metadata=build_endpoint_weight_version_metadata(ret[0]["meta_info"]),
             sglext=response_sglext,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -32,6 +32,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.code_completion_parser import (
     generate_completion_prompt_from_request,
 )
+from sglang.srt.utils.weight_versions import build_endpoint_weight_version_metadata
 from sglang.utils import convert_json_schema_to_str
 
 if TYPE_CHECKING:
@@ -592,7 +593,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             created=created,
             choices=choices,
             usage=usage,
-            metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            metadata=build_endpoint_weight_version_metadata(ret[0]["meta_info"]),
             sglext=response_sglext,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -859,6 +859,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         is_required = request.tool_choice == "required"
         tool_call_items: list[ResponseFunctionToolCall] = []
         parsed_via_native = False
+        detector_owns_format = False
         if (
             content
             and chat_tools
@@ -870,9 +871,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                 self.tool_call_parser,
                 tokenizer=self.tokenizer_manager.tokenizer,
             )
-            should_try_native = (
-                not is_required or parser.detector.supports_structural_tag()
+            detector_owns_format = (
+                parser.detector.supports_structural_tag()
+                or parser.detector.parses_required_natively()
             )
+            should_try_native = not is_required or detector_owns_format
             if should_try_native and parser.has_tool_call(content):
                 try:
                     content, call_info_list = parser.parse_non_stream(content)
@@ -891,7 +894,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                 except Exception as e:
                     logger.error("Tool call parsing error: %s", e)
 
-        if content and chat_tools and is_required and not parsed_via_native:
+        if (
+            content
+            and chat_tools
+            and is_required
+            and not parsed_via_native
+            and not detector_owns_format
+        ):
             try:
                 tool_call_data = orjson.loads(content)
                 if isinstance(tool_call_data, dict):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1472,6 +1472,7 @@ class Envs:
     # ===================================================================
     SGLANG_SYMM_MEM_PREALLOC_GB_SIZE = EnvInt(-1)
     SGLANG_DEBUG_SYMM_MEM = EnvBool(False)
+    SGLANG_DISABLE_MULTIMEM_AG = EnvBool(False)
 
     # ===================================================================
     # Plugin system

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1,3 +1,4 @@
+import base64
 import functools
 import json
 import os
@@ -24,6 +25,9 @@ def _default_hip() -> bool:
         return False
 
 
+_NON_UTF8_PREFIX = "base64:"
+
+
 def _default_cache_subdir(name: str) -> str:
     """A directory under SGLANG_CACHE_DIR, for env defaults that track it.
 
@@ -36,11 +40,12 @@ def _default_cache_subdir(name: str) -> str:
 class EnvField:
     _allow_set_name = True
 
-    def __init__(self, default: Any):
+    def __init__(self, default: Any, secret: bool = False):
         self.default = default
         # NOTE: environ can only accept str values, so we need a flag to indicate
         # whether the env var is explicitly set to None.
         self._set_to_none = False
+        self.secret = secret
 
     def __set_name__(self, owner, name):
         assert EnvField._allow_set_name, "Usage like `a = envs.A` is not allowed"
@@ -156,8 +161,8 @@ class _DeprecatedEnvFallback:
         SGLANG_DSA_FUSE_TOPK = EnvBoolWithAlias(True, deprecated_name="SGLANG_NSA_FUSE_TOPK")
     """
 
-    def __init__(self, default: Any, deprecated_name: str):
-        super().__init__(default)
+    def __init__(self, default: Any, deprecated_name: str, secret: bool = False):
+        super().__init__(default, secret=secret)
         self.deprecated_name = deprecated_name
 
     def get(self) -> Any:
@@ -317,6 +322,7 @@ class Envs:
     # too short when many workers cold-start and load tokenizers in parallel.
     SGLANG_UVICORN_WORKER_HEALTHCHECK_TIMEOUT = EnvInt(10)
     SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION = EnvBool(True)
+    SGLANG_EXPOSE_OWN_ENV_VARS = EnvBool(False)
 
     # ===================================================================
     # Logging
@@ -649,7 +655,7 @@ class Envs:
     # Native web search (Exa). EXA_API_KEY is the vendor BYOK credential
     # (kept as-is, not renamed to SGLANG_*); the SGLANG_EXA_* knobs tune the
     # request defaults for the built-in GPT-OSS web_search tool.
-    EXA_API_KEY = EnvStr(None)
+    EXA_API_KEY = EnvStr(None, secret=True)
     SGLANG_EXA_NUM_RESULTS = EnvInt(10)
     SGLANG_EXA_SEARCH_TYPE = EnvStr("auto")
     SGLANG_EXA_INCLUDE_HIGHLIGHTS = EnvBool(True)
@@ -1511,6 +1517,28 @@ class Envs:
 
 envs = Envs()
 EnvField._allow_set_name = False
+
+
+def exportable_env_vars() -> dict[str, str]:
+    return {
+        field.name: _exportable_value(os.environ[field.name])
+        for field in sorted(
+            (value for value in vars(Envs).values() if isinstance(value, EnvField)),
+            key=lambda field: field.name,
+        )
+        if not field.secret and field.name in os.environ
+    }
+
+
+def _exportable_value(value: str) -> str:
+    try:
+        value.encode()
+    except UnicodeEncodeError:
+        return (
+            _NON_UTF8_PREFIX
+            + base64.b64encode(value.encode(errors="surrogateescape")).decode()
+        )
+    return value
 
 
 class _DeprecatedEnv:

--- a/python/sglang/srt/function_call/core_types.py
+++ b/python/sglang/srt/function_call/core_types.py
@@ -10,6 +10,12 @@ class ToolCallItem(BaseModel):
     tool_index: int
     name: Optional[str] = None
     parameters: str  # JSON string
+    # The tool_call_id string emitted by the model, captured verbatim.
+    # Only populated by detectors whose downstream consumers need the exact
+    # model-emitted id (e.g. RL training trajectories). Existing detectors
+    # leave this as None and the serving layer falls back to its usual id
+    # generation strategy.
+    tool_call_id: Optional[str] = None
 
 
 class StreamingParseResult(BaseModel):

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -28,7 +28,10 @@ from sglang.srt.function_call.hermes_detector import HermesDetector
 from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
 from sglang.srt.function_call.inkling_detector import InklingDetector
 from sglang.srt.function_call.internlm_detector import InternlmDetector
-from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+from sglang.srt.function_call.kimik2_detector import (
+    KimiK2Detector,
+    KimiK2RawIdDetector,
+)
 from sglang.srt.function_call.kimik3_detector import KimiK3Detector
 from sglang.srt.function_call.lfm2_detector import Lfm2Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
@@ -74,6 +77,7 @@ class FunctionCallParser:
         "gpt-oss": GptOssDetector,
         "kimi_k2": KimiK2Detector,
         "kimi_k3": KimiK3Detector,
+        "kimi_k2_raw_id": KimiK2RawIdDetector,
         "lfm2": Lfm2Detector,
         "llama3": Llama32Detector,
         "mimo": MiMoDetector,

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -197,6 +197,7 @@ class KimiK2Detector(BaseFormatDetector):
                         tool_index=local_tool_index,
                         name=function_name,
                         parameters=function_args,
+                        tool_call_id=function_id,
                     )
                 )
                 local_tool_index += 1
@@ -328,6 +329,9 @@ class KimiK2Detector(BaseFormatDetector):
                                 else None
                             ),
                             parameters=argument_diff,
+                            # Capture the model-emitted id on the name-carrying
+                            # delta so kimi_k2_raw_id can round-trip it (RL).
+                            tool_call_id=function_id if name_just_resolved else None,
                         )
                     )
                     if argument_diff:
@@ -471,3 +475,23 @@ class KimiK2Detector(BaseFormatDetector):
 
     def get_structural_tag_name(self) -> str:
         return "kimi"
+
+
+class KimiK2RawIdDetector(KimiK2Detector):
+    """
+    Variant of KimiK2Detector that preserves the model-emitted tool_call_id verbatim.
+
+    The default kimi_k2 path renumbers ids via `history_tool_calls_cnt + tool_index`
+    in the serving layer so that multi-turn conversations get globally unique,
+    monotonically increasing ids (see PR #10600). That is the right behavior for
+    chat use cases.
+
+    RL training has the opposite requirement: the trajectory must round-trip the
+    exact tool_call_id the model produced (e.g. `functions.foo:5`), so that the
+    follow-up tool result turn references the same id the policy emitted. This
+    subclass exists purely as a marker so the serving layer can branch on the
+    parser name and use `ToolCallItem.tool_call_id` directly. Parsing logic
+    is identical to KimiK2Detector.
+    """
+
+    pass

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -19,6 +19,7 @@ from sglang.srt.function_call.kimik3_format import (
     TOOLS_CLOSE,
     TOOLS_OPEN,
     partial_suffix_len,
+    strip_partial_marker_suffix,
     strip_response_wrappers,
 )
 from sglang.srt.function_call.kimik3_structural_tag import (
@@ -216,6 +217,20 @@ class KimiK3Detector(BaseFormatDetector):
             self._buffer = ""
             self._sent_normal_idx = 0
             return StreamingParseResult()
+
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        open_idx = self._buffer.find(self.bot_token)
+        if open_idx != -1:
+            section = self._buffer[open_idx + len(self.bot_token) :]
+            if not self._parse_calls(section):
+                logger.warning(
+                    "Kimi K3 tools section ended with no complete tool call; "
+                    "dropping %d buffered chars",
+                    len(section),
+                )
+            return StreamingParseResult()
+        pending = self._emit_normal_text(limit=len(self._buffer))
+        return StreamingParseResult(normal_text=strip_partial_marker_suffix(pending))
 
     def _emit_normal_text(self, limit: int | None = None) -> str:
         if limit is None:

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -33,7 +33,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
@@ -130,7 +131,7 @@ logger = logging.getLogger(__name__)
 class SiluAndMul(BaseFusedOp):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if is_true_on_policy_enabled():
             self._forward_method = self.forward_native
         elif _use_aiter and envs.SGLANG_OPT_USE_AITER_SILU_MUL.get():
             self._forward_method = self.forward_aiter

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -88,6 +88,7 @@ else:
     pick_dsl_expand = None
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
@@ -109,13 +110,20 @@ if _is_cuda:
 if _use_aiter:
     from aiter.ops.cache import indexer_k_quant_and_cache
 
+if _is_npu:
+    import torch_npu
+
+    from sglang.srt.hardware_backend.npu.utils import get_indexer_weight_stream
+
 from sglang.srt.distributed import (
     get_attn_tp_group,
 )
 from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.communicator import ScatterMode
 from sglang.srt.layers.cp.base import get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -126,6 +134,12 @@ from sglang.srt.model_executor.forward_context import (
     get_token_to_kv_pool,
 )
 from sglang.srt.model_executor.runner import get_is_capture_mode
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+)
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    get_tc_piecewise_forward_context,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -47,6 +47,7 @@ from sglang.srt.runtime_context import (
     get_schedule,
 )
 from sglang.srt.state_capturer.indexer_topk import (
+    get_global_indexer_capturer,
     maybe_capture_indexer_topk,
 )
 from sglang.srt.utils import (
@@ -942,7 +943,14 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         # NOTE(dark): logits should be cleaned in topk_transform
         self._mask_init_and_local_tokens(logits, seqlens_32)
-        topk_result = metadata.topk_transform(logits, self.index_topk)
+        capture = get_global_indexer_capturer() is not None
+        if capture:
+            topk_result, raw_result = metadata.topk_transform(
+                logits, self.index_topk, return_raw_indices=True
+            )
+        else:
+            topk_result = metadata.topk_transform(logits, self.index_topk)
+            raw_result = None
         # Restore possible padding exist in the hidden states.
         if not _is_hip and q_offset < q_fp8.shape[0]:
             pad_len = q_fp8.shape[0] - q_offset
@@ -953,7 +961,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 device=topk_result.device,
             )
             topk_result = torch.cat([topk_result, padding], dim=0)
-        return topk_result
+            if capture:
+                raw_result = torch.cat([raw_result, padding], dim=0)
+        return topk_result, raw_result
 
     def _get_mqa_logits_budget_bytes(self, device_index: int) -> int:
         free_mem_fraction = self._mqa_logits_free_mem_fraction()
@@ -1063,8 +1073,10 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             topk_result = torch.full(
                 (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
             )
+        capture = get_global_indexer_capturer() is not None
+        raw_result = torch.full_like(topk_result, -1) if capture else None
         if batch_size == 0:
-            return topk_result
+            return topk_result, raw_result
 
         ks, ke = metadata.get_indexer_kvcache_range()
 
@@ -1131,9 +1143,17 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             assert logits.shape[1] == k_offset
 
             self._mask_init_and_local_tokens(logits, seq_lens_expanded, ks)
-            raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
-            topk_result[:q_offset] = raw_topk_result
-            return topk_result
+            if capture:
+                transformed, raw = metadata.topk_transform(
+                    logits, self.index_topk, ks=ks, return_raw_indices=True
+                )
+                topk_result[:q_offset] = transformed
+                raw_result[:q_offset] = raw
+            else:
+                topk_result[:q_offset] = metadata.topk_transform(
+                    logits, self.index_topk, ks=ks
+                )
+            return topk_result, raw_result
 
         bytes_per_row = k_offset * self._MQA_LOGITS_BYTES_PER_ELEM
         max_rows = max(1, int(logits_budget_bytes // max(bytes_per_row, 1)))
@@ -1199,19 +1219,32 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 cu_seqlens_q_chunk = cu_seqlens_q_full[start:end]
                 batch_idx_chunk = token_to_batch_idx[start:end]
 
-            raw_topk_chunk = metadata.topk_transform(
-                logits_chunk,
-                self.index_topk,
-                ks=ks[start:end],
-                cu_seqlens_q=cu_seqlens_q_chunk,
-                ke_offset=lengths_chunk,
-                batch_idx_list=batch_idx_chunk,
-                topk_indices_offset_override=topk_offset_chunk,
-            )
-            topk_result[start:end] = raw_topk_chunk
+            if capture:
+                transformed, raw = metadata.topk_transform(
+                    logits_chunk,
+                    self.index_topk,
+                    ks=ks[start:end],
+                    cu_seqlens_q=cu_seqlens_q_chunk,
+                    ke_offset=lengths_chunk,
+                    batch_idx_list=batch_idx_chunk,
+                    topk_indices_offset_override=topk_offset_chunk,
+                    return_raw_indices=True,
+                )
+                topk_result[start:end] = transformed
+                raw_result[start:end] = raw
+            else:
+                topk_result[start:end] = metadata.topk_transform(
+                    logits_chunk,
+                    self.index_topk,
+                    ks=ks[start:end],
+                    cu_seqlens_q=cu_seqlens_q_chunk,
+                    ke_offset=lengths_chunk,
+                    batch_idx_list=batch_idx_chunk,
+                    topk_indices_offset_override=topk_offset_chunk,
+                )
             start = end
 
-        return topk_result
+        return topk_result, raw_result
 
     def _forward_cuda_k_only(
         self,
@@ -1279,7 +1312,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         # MHA doesn't need topk_indices
         if not return_indices:
-            return None
+            return None, None
 
         # MLA: use dummy logits with topk kernel's fast path to generate indices
         # When length <= 2048, naive_topk_cuda directly generates [0,1,...,length-1,-1,...]
@@ -1290,13 +1323,19 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             dtype=torch.float32,
             device=x_meta.device,
         )
-        raw_topk_result = metadata.topk_transform(dummy_logits, self.index_topk)
+        if get_global_indexer_capturer() is not None:
+            raw_topk_result, raw_result = metadata.topk_transform(
+                dummy_logits, self.index_topk, return_raw_indices=True
+            )
+        else:
+            raw_topk_result = metadata.topk_transform(dummy_logits, self.index_topk)
+            raw_result = None
         if topk_result is not None:
             # PCG/BCG: fill the valid prefix of the padded static buffer and
             # leave padded rows at the -1 sentinel.
             topk_result[: raw_topk_result.shape[0]] = raw_topk_result
-            return None
-        return raw_topk_result
+            return None, raw_result
+        return raw_topk_result, raw_result
 
     def _get_topk_ragged_with_cp(
         self,
@@ -1320,6 +1359,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         assert page_size == 64, "only support page size 64"
         assert len(weights.shape) == 3
         weights = weights.squeeze(-1)
+        capture = get_global_indexer_capturer() is not None
+        raw_result = None
         k_fp8_list = []
         k_scale_list = []
         ks_list = []
@@ -1393,14 +1434,25 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     ke,
                     clean_logits=False,
                 )
-            topk_result = metadata.topk_transform(
-                logits,
-                self.index_topk,
-                ks=ks,
-                cu_seqlens_q=actual_seq_q,
-                ke_offset=ke_offset,
-                batch_idx_list=batch_idx_list,
-            )
+            if capture:
+                topk_result, raw_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    batch_idx_list=batch_idx_list,
+                    return_raw_indices=True,
+                )
+            else:
+                topk_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    batch_idx_list=batch_idx_list,
+                )
         else:
             kv_len = (
                 forward_batch.seq_lens_cpu[0].item()
@@ -1443,15 +1495,25 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )
-            topk_result = metadata.topk_transform(
-                logits,
-                self.index_topk,
-                ks=ks,
-                cu_seqlens_q=actual_seq_q,
-                ke_offset=ke_offset,
-            )
+            if capture:
+                topk_result, raw_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                    return_raw_indices=True,
+                )
+            else:
+                topk_result = metadata.topk_transform(
+                    logits,
+                    self.index_topk,
+                    ks=ks,
+                    cu_seqlens_q=actual_seq_q,
+                    ke_offset=ke_offset,
+                )
 
-        return topk_result
+        return topk_result, raw_result
 
     def _store_index_k_cache(
         self,
@@ -1553,6 +1615,15 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             x, q_lora, positions, forward_batch, layer_id, return_indices
         )
 
+    def _capture_and_return(self, layer_id, topk_result, raw_result):
+        # Capture the model's natural (sequence-relative) topk for rollout R3
+        # replay; the attention kernel still receives the transformed
+        # (paged/ragged kv-cache) indices in topk_result.
+        maybe_capture_indexer_topk(
+            layer_id, raw_result if raw_result is not None else topk_result
+        )
+        return topk_result
+
     def forward_cuda(
         self,
         x: torch.Tensor,
@@ -1606,7 +1677,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         # Optimization: fast path when skipping topk computation
         if skip_logits_computation and (not self.dsa_enable_prefill_cp):
-            topk_result = self._forward_cuda_k_only(
+            topk_result, raw_result = self._forward_cuda_k_only(
                 x,
                 positions,
                 forward_batch,
@@ -1616,7 +1687,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 return_indices,
             )
             topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
-            return maybe_capture_indexer_topk(layer_id, topk_result)
+            return self._capture_and_return(layer_id, topk_result, raw_result)
 
         # When weights_proj is LoRA-wrapped, use an eager module call so the
         # wrapper owns base+delta and no LoRA kernel runs under torch.compile.
@@ -1800,6 +1871,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             else:
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
+        raw_result = None
         if _is_cuda or _is_hip:
             # In piecewise/breakable CUDA graph, any access to seq_lens_cpu
             # creates a Dynamo shape guard. These graph modes never have empty
@@ -1818,14 +1890,14 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                         device=x_meta.device,
                     )
                     topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
-                    return maybe_capture_indexer_topk(layer_id, topk_result)
+                    return self._capture_and_return(layer_id, topk_result, None)
 
             if (
                 forward_batch.forward_mode.is_decode_or_idle()
                 or forward_batch.forward_mode.is_target_verify()
                 or forward_batch.forward_mode.is_draft_extend_v2()
             ):
-                topk_result = self._get_topk_paged(
+                topk_result, raw_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata
                 )
             else:
@@ -1852,7 +1924,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     weights_prev, weights_next = torch.split(
                         weights, (weights.shape[0] + 1) // 2, dim=0
                     )
-                    topk_result_prev = self._get_topk_ragged_with_cp(
+                    topk_result_prev, raw_prev = self._get_topk_ragged_with_cp(
                         forward_batch,
                         layer_id,
                         q_fp8_prev,
@@ -1862,7 +1934,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                         actual_seq_q_prev,
                     )
 
-                    topk_result_next = self._get_topk_ragged_with_cp(
+                    topk_result_next, raw_next = self._get_topk_ragged_with_cp(
                         forward_batch,
                         layer_id,
                         q_fp8_next,
@@ -1872,8 +1944,13 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                         actual_seq_q_next,
                     )
                     topk_result = torch.cat([topk_result_prev, topk_result_next], dim=0)
+                    raw_result = (
+                        torch.cat([raw_prev, raw_next], dim=0)
+                        if raw_prev is not None
+                        else None
+                    )
                     topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
-                    return maybe_capture_indexer_topk(layer_id, topk_result)
+                    return self._capture_and_return(layer_id, topk_result, raw_result)
                 else:
                     # In-graph (PCG/BCG) non-CP prefill is handled earlier by the
                     # graph DSA split-op dispatch, so only the eager path reaches
@@ -1882,7 +1959,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                         "Internal error: in-graph DSA prefill must go through the "
                         "graph DSA split-op dispatch"
                     )
-                    topk_result = self._get_topk_ragged(
+                    topk_result, raw_result = self._get_topk_ragged(
                         enable_dual_stream,
                         forward_batch,
                         layer_id,
@@ -1893,4 +1970,458 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         else:
             raise NotImplementedError("DSA indexer only supports CUDA, HIP, and NPU")
         topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
-        return maybe_capture_indexer_topk(layer_id, topk_result)
+        return self._capture_and_return(layer_id, topk_result, raw_result)
+
+    def forward_npu(
+        self,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        layer_scatter_modes=None,
+        dynamic_scale: torch.Tensor = None,
+    ) -> torch.Tensor:
+        if get_attn_backend().forward_metadata.seq_lens_cpu_int is None:
+            actual_seq_lengths_kv = get_attn_backend().forward_metadata.seq_lens
+        else:
+            actual_seq_lengths_kv = get_attn_backend().forward_metadata.seq_lens_cpu_int
+        is_prefill = (
+            forward_batch.forward_mode.is_extend()
+            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and not forward_batch.forward_mode.is_target_verify()
+        )
+
+        bs = q_lora.shape[0]
+
+        if self.rotary_emb.is_neox_style:
+            if not hasattr(forward_batch, "npu_indexer_sin_cos_cache"):
+                cos_sin = self.rotary_emb.cos_sin_cache[positions]
+                cos, sin = cos_sin.chunk(2, dim=-1)
+                cos = cos.repeat(1, 2).view(-1, 1, 1, self.rope_head_dim)
+                sin = sin.repeat(1, 2).view(-1, 1, 1, self.rope_head_dim)
+                forward_batch.npu_indexer_sin_cos_cache = (sin, cos)
+            else:
+                sin, cos = forward_batch.npu_indexer_sin_cos_cache
+
+            if self.alt_stream is not None:
+                self.alt_stream.wait_stream(torch.npu.current_stream())
+                with torch.npu.stream(self.alt_stream):
+                    q_lora = (
+                        (q_lora, dynamic_scale) if dynamic_scale is not None else q_lora
+                    )
+                    q = self.wq_b(q_lora)[
+                        0
+                    ]  # [bs, 1536] @ [1536, 64 * 128] = [bs, 64 * 128]
+                    wq_b_event = self.alt_stream.record_event()
+                    q = q.view(bs, self.n_heads, self.head_dim)  # [bs, 64, 128]
+                    q_pe, q_nope = torch.split(
+                        q,
+                        [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                        dim=-1,
+                    )  # [bs, 64, 64 + 64]
+                    q_pe = q_pe.view(bs, self.n_heads, 1, self.rope_head_dim)
+                    q_pe = torch_npu.npu_rotary_mul(q_pe, cos, sin).view(
+                        bs, self.n_heads, self.rope_head_dim
+                    )  # [bs, n, d]
+                    q = torch.cat([q_pe, q_nope], dim=-1)
+                    q.record_stream(self.alt_stream)
+                    q_rope_event = self.alt_stream.record_event()
+            else:
+                q_lora = (
+                    (q_lora, dynamic_scale) if dynamic_scale is not None else q_lora
+                )
+                q = self.wq_b(q_lora)[
+                    0
+                ]  # [bs, 1536] @ [1536, 64 * 128] = [bs, 64 * 128]
+                q = q.view(bs, self.n_heads, self.head_dim)  # [bs, 64, 128]
+                q_pe, q_nope = torch.split(
+                    q,
+                    [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                    dim=-1,
+                )  # [bs, 64, 64 + 64]
+                q_pe = q_pe.view(bs, self.n_heads, 1, self.rope_head_dim)
+                q_pe = torch_npu.npu_rotary_mul(q_pe, cos, sin).view(
+                    bs, self.n_heads, self.rope_head_dim
+                )  # [bs, n, d]
+                q = torch.cat([q_pe, q_nope], dim=-1)
+
+            if envs.SGLANG_NPU_USE_MULTI_STREAM.get():
+                indexer_weight_stream = get_indexer_weight_stream()
+                indexer_weight_stream.wait_stream(torch.npu.current_stream())
+                with torch.npu.stream(indexer_weight_stream):
+                    x = x.view(-1, self.hidden_size)
+                    weights = self.weights_proj(x.float())[0].to(torch.bfloat16)
+                    weights.record_stream(indexer_weight_stream)
+                    weights_event = indexer_weight_stream.record_event()
+            else:
+                x = x.view(-1, self.hidden_size)
+                weights = self.weights_proj(x.float())[0].to(torch.bfloat16)
+
+            k_proj = self.wk(x)[0]  # [b, s, 7168] @ [7168, 128] = [b, s, 128]
+            k = self.k_norm(k_proj)
+            if (
+                _use_ag_after_qlora
+                and layer_scatter_modes.layer_input_mode == ScatterMode.SCATTERED
+                and layer_scatter_modes.attn_mode == ScatterMode.TP_ATTN_FULL
+            ):
+                k = scattered_to_tp_attn_full(k, forward_batch)
+            k_pe, k_nope = torch.split(
+                k,
+                [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                dim=-1,
+            )  # [bs, 64 + 64]
+
+            k_pe = k_pe.view(-1, 1, 1, self.rope_head_dim)
+            k_pe = torch.ops.npu.npu_rotary_mul(k_pe, cos, sin).view(
+                bs, 1, self.rope_head_dim
+            )  # [bs, 1, d]
+            k = torch.cat([k_pe, k_nope.unsqueeze(1)], dim=-1)  # [bs, 1, 128]
+
+        else:
+            if envs.SGLANG_NPU_USE_MULTI_STREAM.get():
+                indexer_weight_stream = get_indexer_weight_stream()
+                indexer_weight_stream.wait_stream(torch.npu.current_stream())
+                with torch.npu.stream(indexer_weight_stream):
+                    x = x.view(-1, self.hidden_size)
+                    weights = self.weights_proj(x.float())[0].to(torch.bfloat16)
+                    weights.record_stream(indexer_weight_stream)
+                    weights_event = indexer_weight_stream.record_event()
+            else:
+                x = x.view(-1, self.hidden_size)
+                weights = self.weights_proj(x.float())[0].to(torch.bfloat16)
+
+            q_lora = (q_lora, dynamic_scale) if dynamic_scale is not None else q_lora
+            q = self.wq_b(q_lora)[0]  # [bs, 1536] @ [1536, 64 * 128] = [bs, 64 * 128]
+            q = q.view(bs, self.n_heads, self.head_dim)  # [bs, 64, 128]
+            q_pe, q_nope = torch.split(
+                q,
+                [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                dim=-1,
+            )  # [bs, 64, 64 + 64]
+
+            k_proj = self.wk(x)[0]  # [b, s, 7168] @ [7168, 128] = [b, s, 128]
+            k = self.k_norm(k_proj)
+            k_pe, k_nope = torch.split(
+                k,
+                [self.rope_head_dim, self.head_dim - self.rope_head_dim],
+                dim=-1,
+            )  # [bs, 64 + 64]
+
+            k_pe = k_pe.unsqueeze(1)
+
+            if layer_id == 0:
+                self.rotary_emb.sin_cos_cache = (
+                    self.rotary_emb.cos_sin_cache.index_select(0, positions)
+                )
+
+            q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
+            k_pe = k_pe.squeeze(1)
+            q = torch.cat([q_pe, q_nope], dim=-1)
+            k = torch.cat([k_pe, k_nope], dim=-1)
+
+        if (
+            is_prefill
+            and self.dsa_enable_prefill_cp
+            and forward_batch.attn_cp_metadata is not None
+        ):
+            k = cp_all_gather_rerange_output(
+                k.contiguous().view(-1, self.head_dim),
+                self.cp_size,
+                forward_batch,
+                torch.npu.current_stream(),
+            )
+
+        get_token_to_kv_pool().set_index_k_buffer(
+            layer_id, forward_batch.out_cache_loc, k
+        )
+        if is_prefill:
+            if (
+                self.dsa_enable_prefill_cp
+                and forward_batch.attn_cp_metadata is not None
+            ):
+                get_attn_backend().forward_metadata.actual_seq_lengths_q = (
+                    forward_batch.attn_cp_metadata.actual_seq_q_prev_tensor,
+                    forward_batch.attn_cp_metadata.actual_seq_q_next_tensor,
+                )
+                if sum(forward_batch.extend_prefix_lens_cpu) > 0:
+                    total_kv_len_prev_tensor = (
+                        forward_batch.attn_cp_metadata.kv_len_prev_tensor
+                        + forward_batch.extend_prefix_lens.squeeze()
+                    )
+                    total_kv_len_next_tensor = (
+                        forward_batch.attn_cp_metadata.kv_len_next_tensor
+                        + forward_batch.extend_prefix_lens.squeeze()
+                    )
+                    get_attn_backend().forward_metadata.actual_seq_lengths_kv = (
+                        total_kv_len_prev_tensor,
+                        total_kv_len_next_tensor,
+                    )
+                else:
+                    get_attn_backend().forward_metadata.actual_seq_lengths_kv = (
+                        forward_batch.attn_cp_metadata.kv_len_prev_tensor,
+                        forward_batch.attn_cp_metadata.kv_len_next_tensor,
+                    )
+                actual_seq_lengths_q = (
+                    get_attn_backend().forward_metadata.actual_seq_lengths_q
+                )
+                actual_seq_lengths_kv = (
+                    get_attn_backend().forward_metadata.actual_seq_lengths_kv
+                )
+            else:
+                actual_seq_lengths_kv = forward_batch.seq_lens
+                actual_seq_lengths_q = forward_batch.extend_seq_lens.cumsum(dim=0)
+        else:
+            if get_attn_backend().forward_metadata.actual_seq_lengths_q is None:
+                if (
+                    forward_batch.forward_mode.is_draft_extend_v2()
+                    or forward_batch.forward_mode.is_target_verify()
+                ):
+                    num_draft_tokens = get_attn_backend().speculative_num_draft_tokens
+                    actual_seq_lengths_q = torch.arange(
+                        num_draft_tokens,
+                        num_draft_tokens + bs,
+                        num_draft_tokens,
+                        dtype=torch.int32,
+                        device=k.device,
+                    )
+                else:
+                    actual_seq_lengths_q = torch.tensor(
+                        [1 + i * 1 for i in range(bs)],
+                        dtype=torch.int32,
+                        device=k.device,
+                    )
+            else:
+                actual_seq_lengths_q = (
+                    get_attn_backend().forward_metadata.actual_seq_lengths_q
+                )
+
+        past_key_states = get_token_to_kv_pool().get_index_k_buffer(layer_id)
+
+        if self.rotary_emb.is_neox_style and self.alt_stream is not None:
+            torch.npu.current_stream().wait_event(q_rope_event)
+        if envs.SGLANG_NPU_USE_MULTI_STREAM.get():
+            torch.npu.current_stream().wait_event(weights_event)
+        if (
+            _use_ag_after_qlora
+            and layer_scatter_modes.layer_input_mode == ScatterMode.SCATTERED
+            and layer_scatter_modes.attn_mode == ScatterMode.TP_ATTN_FULL
+        ):
+            weights = scattered_to_tp_attn_full(weights, forward_batch)
+        block_table = get_attn_backend().forward_metadata.block_tables
+        if (
+            is_prefill
+            and self.dsa_enable_prefill_cp
+            and forward_batch.attn_cp_metadata is not None
+        ):
+            block_table = block_table[: actual_seq_lengths_q[0].numel()]
+            topk_indices = self.do_npu_cp_balance_indexer(
+                q.view(-1, self.n_heads, self.head_dim),
+                past_key_states,
+                weights,
+                actual_seq_lengths_q,
+                actual_seq_lengths_kv,
+                block_table,
+            )
+            return topk_indices
+        else:
+            block_table = (
+                block_table[: actual_seq_lengths_q.size()[0]]
+                if is_prefill
+                else block_table
+            )
+
+            topk_indices = torch_npu.npu_lightning_indexer(
+                query=q.view(-1, self.n_heads, self.head_dim),
+                key=past_key_states,
+                weights=weights,
+                actual_seq_lengths_query=actual_seq_lengths_q.to(torch.int32),
+                actual_seq_lengths_key=actual_seq_lengths_kv.to(k.device).to(
+                    torch.int32
+                ),
+                block_table=block_table,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=self.index_topk,
+                sparse_mode=3,
+            )
+            # Keep DSA top-k as [T, K]; NPU attention expands it when needed.
+            return topk_indices[0].squeeze(1)
+
+    def do_npu_cp_balance_indexer(
+        self,
+        q,
+        past_key_states,
+        indexer_weights,
+        actual_seq_lengths_q,
+        actual_seq_lengths_kv,
+        block_table,
+    ):
+        q_prev, q_next = torch.split(q, (q.size(0) + 1) // 2, dim=0)
+        weights_prev, weights_next = None, None
+        if indexer_weights is not None:
+            weights_prev, weights_next = torch.split(
+                indexer_weights, (indexer_weights.size(0) + 1) // 2, dim=0
+            )
+            weights_prev = weights_prev.contiguous().view(-1, weights_prev.shape[-1])
+            weights_next = weights_next.contiguous().view(-1, weights_next.shape[-1])
+
+        actual_seq_lengths_q_prev, actual_seq_lengths_q_next = actual_seq_lengths_q
+        actual_seq_lengths_kv_prev, actual_seq_lengths_kv_next = actual_seq_lengths_kv
+
+        topk_indices_prev = torch_npu.npu_lightning_indexer(
+            query=q_prev,
+            key=past_key_states,
+            weights=weights_prev,
+            actual_seq_lengths_query=actual_seq_lengths_q_prev.to(
+                device=q.device, dtype=torch.int32
+            ),
+            actual_seq_lengths_key=actual_seq_lengths_kv_prev.to(
+                device=q.device, dtype=torch.int32
+            ),
+            block_table=block_table,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            sparse_count=self.index_topk,
+            sparse_mode=3,
+        )
+        topk_indices_next = torch_npu.npu_lightning_indexer(
+            query=q_next,
+            key=past_key_states,
+            weights=weights_next,
+            actual_seq_lengths_query=actual_seq_lengths_q_next.to(
+                device=q.device, dtype=torch.int32
+            ),
+            actual_seq_lengths_key=actual_seq_lengths_kv_next.to(
+                device=q.device, dtype=torch.int32
+            ),
+            block_table=block_table,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            sparse_count=self.index_topk,
+            sparse_mode=3,
+        )
+        return topk_indices_prev[0], topk_indices_next[0]
+
+
+@register_custom_op(mutates_args=["topk_result"])
+@register_split_op()
+def pcg_dsa_indexer_prefill_split(
+    layer_id: int,
+    x: torch.Tensor,
+    q_lora: torch.Tensor,
+    positions: torch.Tensor,
+    topk_result: torch.Tensor,
+) -> None:
+    # Default in-graph indexer path for non-CP prefill: runs the whole indexer
+    # (q/k proj, head gate, k-cache store, topk) as one eager split op. PCG calls
+    # this as a split op; BCG uses the explicit eager wrapper below.
+    #
+    # Output contract (differs from the eager `forward` path): a split op returns
+    # None, so results are delivered only by mutating `topk_result` in place. The
+    # call site pre-allocates it at a static, padded shape and a downstream
+    # captured graph reads it at a fixed address; eager code instead allocates
+    # and returns a fresh, naturally-sized tensor each call.
+    assert _is_cuda, "Internal error: DSA graph dispatch is only supported on CUDA"
+    from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
+
+    forward_context = get_tc_piecewise_forward_context()
+    forward_batch = forward_context.forward_batch
+    indexer = forward_context.dsa_indexers[layer_id]
+    metadata = get_attn_backend().get_indexer_metadata(layer_id, forward_batch)
+
+    extend_num_tokens = forward_batch.extend_num_tokens
+    # Empty buffer encodes return_indices=False for graph dispatch.
+    return_indices = topk_result.numel() != 0
+    k_only = not return_indices or (
+        indexer._should_skip_logits_computation(forward_batch)
+        and not indexer.dsa_enable_prefill_cp
+    )
+    if k_only:
+        indexer._forward_cuda_k_only(
+            x,
+            positions,
+            forward_batch,
+            layer_id,
+            act_quant,
+            enable_dual_stream=False,
+            metadata=metadata,
+            return_indices=return_indices,
+            num_tokens=extend_num_tokens,
+            topk_result=topk_result,
+        )
+        return
+
+    # Fused path stores K (no-Hadamard) and computes q_fp8 + head gate in the
+    # fused kernels, sliced to the unpadded count. Single stream: the split op is
+    # captured, so the dual-stream overlap is disabled.
+    if indexer.use_dsa_indexer_fusion:
+        q_fp8, weights = indexer._fused_q_prepare_and_store(
+            x,
+            q_lora,
+            positions,
+            forward_batch,
+            layer_id,
+            act_quant,
+            num_tokens=extend_num_tokens,
+            enable_dual_stream=False,
+        )
+        indexer._get_topk_ragged(
+            False,
+            forward_batch,
+            layer_id,
+            q_fp8,
+            weights,
+            metadata,
+            topk_result,
+        )
+        return
+
+    query, key, _ = indexer._get_q_k_bf16(
+        q_lora,
+        x,
+        positions,
+        enable_dual_stream=False,
+        forward_batch=forward_batch,
+    )
+    q_fp8, q_scale = act_quant(query, indexer.block_size, indexer.scale_fmt)
+    # Reuse the compiled head-gate util shared with the eager path.
+    weights = indexer._get_logits_head_gate(x, q_scale)
+    # Store K cache + ragged top-k, sliced to the unpadded count and writing into
+    # the static padded topk_result buffer (the graph contract). Mirrors the eager
+    # path's store + _get_topk_ragged.
+    indexer._store_index_k_cache(
+        forward_batch=forward_batch,
+        layer_id=layer_id,
+        key=key[:extend_num_tokens],
+        act_quant=act_quant,
+        out_cache_loc=forward_batch.out_cache_loc[:extend_num_tokens],
+    )
+    indexer._get_topk_ragged(
+        False,
+        forward_batch,
+        layer_id,
+        q_fp8[:extend_num_tokens],
+        weights,
+        metadata,
+        topk_result,
+    )
+
+
+bcg_dsa_indexer_prefill_split = eager_on_graph(True)(pcg_dsa_indexer_prefill_split)
+
+
+def scattered_to_tp_attn_full(
+    hidden_states: torch.Tensor,
+    forward_batch,
+) -> torch.Tensor:
+    hidden_states, local_hidden_states = (
+        torch.empty(
+            (forward_batch.input_ids.shape[0], hidden_states.shape[1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        ),
+        hidden_states,
+    )
+    attn_tp_all_gather_into_tensor(hidden_states, local_hidden_states.contiguous())
+    return hidden_states

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -87,9 +87,21 @@ class DSATopKBackend(Enum):
         row_starts: Optional[torch.Tensor] = None,
         batch_idx_list: Optional[List[int]] = None,
         force_unfused_topk: bool = False,
+        return_raw_indices: bool = False,
     ) -> torch.Tensor:
         if not envs.SGLANG_DSA_FUSE_TOPK.get() or force_unfused_topk:
-            return self.topk_func(logits, lengths, topk, row_starts=row_starts)
+            result = self.topk_func(logits, lengths, topk, row_starts=row_starts)
+            return (result, result) if return_raw_indices else result
+
+        # Sequence-relative selection, before the kv-cache coordinate remap done
+        # by the fused transform below. Rollout R3 replay compares against the
+        # model's natural (sequence-relative) topk, so capture must use these raw
+        # indices rather than the transformed (paged/ragged) result.
+        raw_indices = (
+            self.topk_func(logits, lengths, topk, row_starts=row_starts)
+            if return_raw_indices
+            else None
+        )
 
         # Decode-shaped PAGED top-k for the SGL backend (plain decode AND spec
         # verify / draft-extend, whose expanded rows match the same shape) routes
@@ -112,7 +124,8 @@ class DSATopKBackend(Enum):
             == logits.shape[0]
             == attn_metadata.real_page_table.shape[0]
         ):
-            return _topk_transform_v2_paged(logits, lengths, topk, attn_metadata)
+            result = _topk_transform_v2_paged(logits, lengths, topk, attn_metadata)
+            return (result, raw_indices) if return_raw_indices else result
 
         # The legacy transforms below read attn_metadata.page_table_1 (page_size=1),
         # which is always present here: the fold only drops it for the decode case
@@ -131,7 +144,7 @@ class DSATopKBackend(Enum):
                     if batch_idx_list is not None
                     else attn_metadata.page_table_1
                 )
-                return fast_topk_transform_fused(
+                result = fast_topk_transform_fused(
                     score=logits,
                     lengths=lengths,
                     page_table_size_1=page_table_size_1,
@@ -139,22 +152,22 @@ class DSATopKBackend(Enum):
                     topk=topk,
                     row_starts=row_starts,
                 )
-            if topk_transform_method == TopkTransformMethod.RAGGED:
+            elif topk_transform_method == TopkTransformMethod.RAGGED:
                 if topk_indices_offset is None:
                     raise RuntimeError(
                         "RAGGED topk_transform requires topk_indices_offset; "
                         "expected extend-without-speculative metadata."
                     )
-                return fast_topk_transform_ragged_fused(
+                result = fast_topk_transform_ragged_fused(
                     score=logits,
                     lengths=lengths,
                     topk_indices_offset=topk_indices_offset,
                     topk=topk,
                     row_starts=row_starts,
                 )
-            raise RuntimeError(f"Unsupported {topk_transform_method = }.")
-
-        if self.is_flashinfer():
+            else:
+                raise RuntimeError(f"Unsupported {topk_transform_method = }.")
+        elif self.is_flashinfer():
             import flashinfer
 
             if topk_transform_method == TopkTransformMethod.PAGED:
@@ -166,7 +179,7 @@ class DSATopKBackend(Enum):
                     device=logits.device,
                     num_rows=logits.shape[0],
                 )
-                return flashinfer.top_k_page_table_transform(
+                result = flashinfer.top_k_page_table_transform(
                     logits.contiguous(),
                     attn_metadata.page_table_1.contiguous(),
                     lengths.contiguous(),
@@ -178,13 +191,13 @@ class DSATopKBackend(Enum):
                     row_starts=row_starts,
                     page_table_row_starts=page_table_row_starts,
                 )
-            if topk_transform_method == TopkTransformMethod.RAGGED:
+            elif topk_transform_method == TopkTransformMethod.RAGGED:
                 if topk_indices_offset is None:
                     raise RuntimeError(
                         "RAGGED topk_transform requires topk_indices_offset; "
                         "expected extend-without-speculative metadata."
                     )
-                return flashinfer.top_k_ragged_transform(
+                result = flashinfer.top_k_ragged_transform(
                     logits.contiguous(),
                     topk_indices_offset.contiguous(),
                     lengths.contiguous(),
@@ -194,9 +207,12 @@ class DSATopKBackend(Enum):
                     dsa_graph_safe=True,
                     row_starts=row_starts,
                 )
-            raise RuntimeError(f"Unsupported {topk_transform_method = }.")
+            else:
+                raise RuntimeError(f"Unsupported {topk_transform_method = }.")
+        else:
+            raise RuntimeError(f"Unsupported {self = } for SGLANG_DSA_FUSE_TOPK.")
 
-        raise RuntimeError(f"Unsupported {self = } for SGLANG_DSA_FUSE_TOPK.")
+        return (result, raw_indices) if return_raw_indices else result
 
 
 def _topk_unfused(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -15,6 +16,7 @@ from typing import (
 import torch
 
 from sglang.srt.configs.model_config import get_dsa_index_topk, is_deepseek_dsa
+from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH
 from sglang.srt.runtime_context import get_parallel, get_spec
 
 logger = logging.getLogger(__name__)
@@ -78,6 +80,7 @@ from sglang.srt.utils import (
     is_sm100_supported,
     print_warning_once,
 )
+from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 # Opt-in (default off): route the fp8 sparse-MLA prefill path through the Triton
 # per-query flash kernel instead of TileLang. Validated on gfx950 (GLM-5.1 @
@@ -400,6 +403,7 @@ class DeepseekSparseAttnBackend(
         )
         self.dsa_index_topk = get_dsa_index_topk(model_runner.model_config.hf_config)
         self.max_context_len = model_runner.model_config.context_len
+        self.enable_memory_saver = model_runner.server_args.enable_memory_saver
         self.num_q_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         )
@@ -1236,6 +1240,16 @@ class DeepseekSparseAttnBackend(
             token_to_batch_idx = split_per_token(token_to_batch_idx)
         return (ks, ke), token_to_batch_idx
 
+    def _cuda_graph_memory_region(self):
+        """Region whose tensors are released while the engine is paused."""
+        adapter = TorchMemorySaverAdapter.create(
+            enable=self.enable_memory_saver
+            and envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
+        )
+        if not adapter.enabled:
+            return nullcontext()
+        return adapter.region(tag=GPU_MEMORY_TYPE_CUDA_GRAPH)
+
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Initialize CUDA graph state for the attention backend.
 
@@ -1271,6 +1285,31 @@ class DeepseekSparseAttnBackend(
         )
 
         max_ctx_len = self.req_to_token.shape[1]
+        # The wide page_table (max_num_tokens x max_ctx_len int32) and the
+        # flashmla metadata are rewritten in full before every replay, so they
+        # can live in the pausable cuda-graph region. The others are written
+        # once at init and would come back zeroed after a resume.
+        with self._cuda_graph_memory_region():
+            page_table = (
+                None
+                if self.dsa_drop_wide_page_table
+                else torch.zeros(
+                    max_num_tokens,
+                    max_ctx_len,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+            )
+            flashmla_metadata = (
+                self._compute_flashmla_metadata(
+                    cache_seqlens=torch.ones(
+                        max_num_tokens, dtype=torch.int32, device=self.device
+                    ),
+                    seq_len_q=1,
+                )
+                if self.dsa_decode_impl == "flashmla_kv"
+                else None
+            )
         self.decode_cuda_graph_metadata: Dict = {
             "cache_seqlens": torch.ones(
                 max_num_tokens, dtype=torch.int32, device=self.device
@@ -1297,26 +1336,8 @@ class DeepseekSparseAttnBackend(
                 if self.dsa_drop_wide_page_table
                 else None
             ),
-            "page_table": (
-                None
-                if self.dsa_drop_wide_page_table
-                else torch.zeros(
-                    max_num_tokens,
-                    max_ctx_len,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
-            ),
-            "flashmla_metadata": (
-                self._compute_flashmla_metadata(
-                    cache_seqlens=torch.ones(
-                        max_num_tokens, dtype=torch.int32, device=self.device
-                    ),
-                    seq_len_q=1,
-                )
-                if self.dsa_decode_impl == "flashmla_kv"
-                else None
-            ),
+            "page_table": page_table,
+            "flashmla_metadata": flashmla_metadata,
         }
 
     def _build_forward_metadata_cuda_graph(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -17,6 +17,7 @@ import torch
 
 from sglang.srt.configs.model_config import get_dsa_index_topk, is_deepseek_dsa
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH
+from sglang.srt.layers.attention.dsa.dsa_indexer import BaseIndexerMetadata
 from sglang.srt.runtime_context import get_parallel, get_spec
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -271,6 +271,88 @@ def _cat(tensors: list[torch.Tensor], dim: int = -1) -> torch.Tensor:
     return _compiled_cat([qk_nope, qk_rope], dim=dim)
 
 
+@dataclass(frozen=True)
+class DSAIndexerMetadata(BaseIndexerMetadata):
+    attn_metadata: DSAMetadata
+    topk_transform_method: TopkTransformMethod
+    topk_backend: DSATopKBackend = DSATopKBackend.SGL_KERNEL
+    paged_mqa_schedule_metadata: Optional[torch.Tensor] = None
+    paged_mqa_ctx_lens_2d: Optional[torch.Tensor] = None
+    force_unfused_topk: bool = False
+
+    def get_seqlens_int32(self) -> torch.Tensor:
+        return self.attn_metadata.cache_seqlens_int32
+
+    def get_page_table_64(self) -> torch.Tensor:
+        return self.attn_metadata.real_page_table
+
+    def get_page_table_1(self) -> torch.Tensor:
+        return self.attn_metadata.page_table_1
+
+    def get_seqlens_expanded(self) -> torch.Tensor:
+        return self.attn_metadata.dsa_seqlens_expanded
+
+    def get_cu_seqlens_k(self) -> torch.Tensor:
+        return self.attn_metadata.cu_seqlens_k
+
+    def get_indexer_kvcache_range(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.attn_metadata.indexer_k_start_end
+
+    def get_indexer_seq_len(self) -> torch.Tensor:
+        return self.attn_metadata.indexer_seq_lens
+
+    def get_indexer_seq_len_cpu(self) -> torch.Tensor:
+        return self.attn_metadata.indexer_seq_lens_cpu
+
+    def get_dsa_extend_len_cpu(self) -> List[int]:
+        return self.attn_metadata.dsa_extend_seq_lens_list
+
+    def get_token_to_batch_idx(self) -> torch.Tensor:
+        return self.attn_metadata.token_to_batch_idx
+
+    def topk_transform(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        ks: Optional[torch.Tensor] = None,
+        cu_seqlens_q: Optional[torch.Tensor] = None,
+        ke_offset: Optional[torch.Tensor] = None,
+        batch_idx_list: Optional[List[int]] = None,
+        topk_indices_offset_override: Optional[torch.Tensor] = None,
+        return_raw_indices: bool = False,
+    ) -> torch.Tensor:
+        if topk_indices_offset_override is not None:
+            cu_topk_indices_offset = topk_indices_offset_override
+            cu_seqlens_q_topk = None
+        elif cu_seqlens_q is not None:
+            cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+            cu_seqlens_q_topk = compute_cu_seqlens(cu_seqlens_q)
+            cu_topk_indices_offset = torch.repeat_interleave(
+                cu_seqlens_q_topk[:-1],
+                cu_seqlens_q,
+            )
+        else:
+            cu_seqlens_q_topk = self.attn_metadata.cu_seqlens_q
+            cu_topk_indices_offset = self.attn_metadata.topk_indices_offset
+        if ke_offset is not None:
+            seq_lens_topk = ke_offset
+        else:
+            seq_lens_topk = self.get_seqlens_expanded()
+        return self.topk_backend.topk_transform(
+            logits=logits,
+            lengths=seq_lens_topk,
+            topk=topk,
+            topk_transform_method=self.topk_transform_method,
+            attn_metadata=self.attn_metadata,
+            cu_seqlens_q_topk=cu_seqlens_q_topk,
+            topk_indices_offset=cu_topk_indices_offset,
+            row_starts=ks,
+            batch_idx_list=batch_idx_list,
+            force_unfused_topk=self.force_unfused_topk,
+            return_raw_indices=return_raw_indices,
+        )
+
+
 _DSA_IMPL_T: TypeAlias = Literal[
     "flashmla_sparse",
     "flashmla_sparse_q8",

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -237,10 +237,16 @@ class Mamba2Metadata(ForwardMetadata):
             num_prefill_tokens = int(sum(extend_seq_lens_cpu))
         else:
             num_prefill_tokens = int(forward_batch.extend_num_tokens)
-        batch_size = getattr(forward_batch, "_original_batch_size", None)
-        if batch_size is None:
-            batch_size = len(forward_batch.seq_lens)
-        num_decodes = max(0, batch_size - num_prefills)
+        if forward_batch._original_forward_mode is not None:
+            # mlp-sync converted the whole batch to EXTEND, so there are no decode
+            # rows; on an idle rank _original_batch_size is 0 and subtracting here
+            # would go negative.
+            num_decodes = 0
+        else:
+            batch_size = forward_batch._original_batch_size
+            if batch_size is None:
+                batch_size = len(forward_batch.seq_lens)
+            num_decodes = batch_size - num_prefills
         context_lens_tensor = forward_batch.extend_prefix_lens
         assert context_lens_tensor is not None
         has_initial_states = context_lens_tensor > 0

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -17,7 +17,7 @@ from sglang.kernels.ops.layernorm.norm import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.models.utils import apply_qk_norm
-from sglang.srt.runtime_context import get_context, get_exec, get_mm, get_parallel
+from sglang.srt.runtime_context import get_context, get_mm, get_parallel
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -18,6 +18,7 @@ from sglang.kernels.ops.layernorm.norm import (
 from sglang.srt.environ import envs
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.runtime_context import get_context, get_exec, get_mm, get_parallel
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
@@ -1185,7 +1186,7 @@ class VisionAttention(nn.Module):
                 weight_dtype=torch.float32,
                 cast_x_before_out_mul=True,
             )
-            if get_exec().deterministic.rl_on_policy_target is not None
+            if is_true_on_policy_enabled()
             else {}
         )
         q_norm = RMSNorm(
@@ -1327,10 +1328,7 @@ class VisionAttention(nn.Module):
         if x.dim() == 2:
             x = x.unsqueeze(0)
         assert x.dim() == 3, x.shape
-        if (
-            get_exec().deterministic.rl_on_policy_target is not None
-            and position_embeddings is not None
-        ):
+        if is_true_on_policy_enabled() and position_embeddings is not None:
             assert isinstance(position_embeddings, tuple), (
                 "expected position_embeddings to be a tuple of two tensors,\n"
                 f"but got {type(position_embeddings)}, change if needed"

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -75,6 +75,10 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.true_on_policy import (
+    should_disable_mlp_allreduce_fusion_for_on_policy,
+    should_disable_reduce_scatter_for_on_policy,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,
@@ -789,6 +793,9 @@ class LayerCommunicator:
         )
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
+        if should_disable_reduce_scatter_for_on_policy():
+            return False
+
         if not self.allow_reduce_scatter:
             return False
         if (
@@ -809,6 +816,9 @@ class LayerCommunicator:
     def should_fuse_mlp_allreduce_with_next_layer(
         self, forward_batch: ForwardBatch
     ) -> bool:
+        if should_disable_mlp_allreduce_fusion_for_on_policy():
+            return False
+
         # When MOE_FULL is active (moe_cp allgather), fusion must be disabled because
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -37,7 +37,13 @@ _FAST_WARMUP = envs.SGLANG_JIT_DEEPGEMM_FAST_WARMUP.get()
 
 # Force redirect deep_gemm cache_dir. Defaults under SGLANG_CACHE_DIR so it
 # sits with the other compiled-kernel caches; SGLANG_DG_CACHE_DIR still wins.
-os.environ["DG_JIT_CACHE_DIR"] = envs.SGLANG_DG_CACHE_DIR.get()
+_dg_cache_dir = envs.SGLANG_DG_CACHE_DIR.get()
+if os.getenv("SGLANG_DG_CACHE_DIR_PER_PROCESS", "0").lower() in ("1", "true", "yes"):
+    # Colocated RL engines share a host; a per-process dir keeps their JIT caches
+    # from racing on the same files.
+    _dg_cache_dir = os.path.join(_dg_cache_dir, f"pid_{os.getpid()}")
+os.makedirs(_dg_cache_dir, exist_ok=True)
+os.environ["DG_JIT_CACHE_DIR"] = _dg_cache_dir
 
 # Refer to https://github.com/deepseek-ai/DeepGEMM/commit/d75b218b7b8f4a5dd5406ac87905039ead3ae42f
 # NVRTC may have performance loss with some cases.

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -436,16 +436,21 @@ def get_dp_local_slice_cpu(
     can_run_graph: bool,
     cuda_graph_batch: Optional[int],
 ) -> Tuple[int, int]:
-    # CPU (start, length) slice for DP-local data in a rank-padded buffer.
-    # Returns Python ints (no D2H sync) and handles the cuda-graph-padded layout.
+    # CPU (start, length) slice for this rank's real rows, no D2H sync. A graph
+    # forward strides by the replayed graph's padded size, not by
+    # max(global_num_tokens): a prefill graph pads 300 tokens to a 320 capture.
+    # The length excludes that padding -- every pad row holds the routing of a
+    # zero hidden state, and its out_cache_loc entry points at a live token.
     global_num_tokens = forward_batch.global_num_tokens_cpu
     dp_rank = get_attention_dp_rank()
-    local_num_tokens = global_num_tokens[dp_rank]
     if can_run_graph:
+        assert cuda_graph_batch is not None, "graph forward without its size"
         local_start_pos = dp_rank * cuda_graph_batch
     else:
         local_start_pos = sum(global_num_tokens[:dp_rank])
-    return local_start_pos, local_num_tokens
+    original = forward_batch.original_global_num_tokens_cpu
+    counts = original if original is not None else global_num_tokens
+    return local_start_pos, counts[dp_rank]
 
 
 from sglang.kernels.ops.memory.memcpy_triton import memcpy_triton

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -32,7 +32,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.true_on_policy import (
     get_on_policy_rms_norm_kwargs,
     is_true_on_policy_enabled,

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -32,7 +32,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.true_on_policy import (
+    get_on_policy_rms_norm_kwargs,
+    is_true_on_policy_enabled,
+)
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
@@ -216,7 +220,7 @@ def _forward_with_allreduce_fusion(
 
         if world_size > 1:
             if post_residual_addition is not None:
-                residual = residual + post_residual_addition
+                x = x + post_residual_addition
 
             # Prefer AITER fused AR+RMSNorm when enabled on AMD.
             if _use_aiter:
@@ -427,13 +431,32 @@ class RMSNorm(BaseFusedOp):
         eps: float = 1e-6,
         var_hidden_size: Optional[int] = None,
         cast_x_before_out_mul: bool = False,
-        fp32_residual: bool = False,
+        fp32_residual: bool = True,
         has_weight: bool = True,
-        weight_dtype: Optional = None,
-        override_orig_dtype: Optional = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        override_orig_dtype: Optional[torch.dtype] = None,
         x_pad_to_multiple: int = 0,
+        true_on_policy_weight_dtype: Optional[torch.dtype] = None,
+        true_on_policy_override_orig_dtype: Optional[torch.dtype] = None,
+        true_on_policy_fp32_residual: bool = False,
     ) -> None:
         super().__init__()
+        true_on_policy_kwargs = get_on_policy_rms_norm_kwargs(
+            weight_dtype=true_on_policy_weight_dtype,
+            override_orig_dtype=true_on_policy_override_orig_dtype,
+            fp32_residual=true_on_policy_fp32_residual,
+        )
+        if not cast_x_before_out_mul:
+            cast_x_before_out_mul = true_on_policy_kwargs.get(
+                "cast_x_before_out_mul", cast_x_before_out_mul
+            )
+        fp32_residual = true_on_policy_kwargs.get("fp32_residual", fp32_residual)
+        if weight_dtype is None:
+            weight_dtype = true_on_policy_kwargs.get("weight_dtype", weight_dtype)
+        if override_orig_dtype is None:
+            override_orig_dtype = true_on_policy_kwargs.get(
+                "override_orig_dtype", override_orig_dtype
+            )
         self.has_weight = has_weight
         self.cast_x_before_out_mul = cast_x_before_out_mul
         self.fp32_residual = fp32_residual
@@ -488,11 +511,17 @@ class RMSNorm(BaseFusedOp):
             x = x.contiguous().reshape(-1, original_shape[-1])
         if self.variance_size_override is not None:
             return self.forward_native(x, residual, post_residual_addition)
+        if (
+            self.weight.dtype != x.dtype
+            or self.cast_x_before_out_mul
+            or self.override_orig_dtype is not None
+        ):
+            return self.forward_native(x, residual, post_residual_addition)
         if is_batch_invariant_mode_enabled():
             if (
                 residual is not None
                 or self.cast_x_before_out_mul
-                or get_exec().deterministic.rl_on_policy_target == "fsdp"
+                or is_true_on_policy_enabled()
             ):
                 return self.forward_native(x, residual, post_residual_addition)
             out = rms_norm_batch_invariant(
@@ -644,10 +673,10 @@ class RMSNorm(BaseFusedOp):
                 self.x_pad_to_multiple,
             )
         if residual is not None:
-            residual_out = torch.empty_like(x)
-            output = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
+            residual_out = torch.empty_like(x)
+            output = torch.empty_like(x)
             fused_add_rms_norm(
                 output,
                 x,
@@ -690,10 +719,10 @@ class RMSNorm(BaseFusedOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
+            out = torch.empty_like(x)
+            residual_out = torch.empty_like(x)
             fused_add_rms_norm(
                 out, x, residual_out, residual, self.weight.data, self.variance_epsilon
             )
@@ -736,15 +765,18 @@ class RMSNorm(BaseFusedOp):
         if not x.is_contiguous():
             x = x.contiguous()
         orig_dtype = self.override_orig_dtype or x.dtype
+
+        if residual is not None and not self.fp32_residual:
+            x = x + residual
+            if post_residual_addition is not None:
+                x = x + post_residual_addition
+            residual = x.clone()
         x = x.to(torch.float32)
-        if residual is not None:
+        if residual is not None and self.fp32_residual:
             x = x + residual.to(torch.float32)
             if post_residual_addition is not None:
                 x = x + post_residual_addition.to(torch.float32)
-            if self.fp32_residual:
-                residual = x.clone()
-            else:
-                residual = x.to(orig_dtype)
+            residual = x.to(orig_dtype)
 
         hidden_size = x.shape[-1]
         if hidden_size != self.hidden_size:
@@ -1055,7 +1087,7 @@ class GemmaRMSNorm(BaseFusedOp):
         orig_dtype = x.dtype
         if residual is not None:
             if post_residual_addition is not None:
-                residual = residual + post_residual_addition
+                x = x + post_residual_addition
             x = x + residual
             residual = x
 

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1653,11 +1653,22 @@ class RowParallelLinear(LinearBase):
                 get_tp_group(), disabled=not is_allocation_symmetric()
             )
         with symm_ctx:
-            if should_use_tp_invariant_row_linear(input_parallel.shape[-1]):
+            from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+
+            is_tuple = isinstance(input_parallel, tuple)
+            is_fp8 = isinstance(self.quant_method, Fp8LinearMethod)
+            k_size = (
+                input_parallel[0].shape[-1] if is_tuple else input_parallel.shape[-1]
+            )
+            if should_use_tp_invariant_row_linear(k_size):
                 if output_tensor is not None:
                     raise RuntimeError(
                         "tp-invariant row linear cannot write into a caller-owned "
                         "output tensor"
+                    )
+                if is_fp8:
+                    raise NotImplementedError(
+                        "FP8 tp-invariant row-linear not yet supported"
                     )
                 output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
                     input_parallel, self.weight.t(), bias_

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -39,7 +39,7 @@ from sglang.srt.layers.parameter import (
     _ColumnvLLMParameter,
 )
 from sglang.srt.layers.utils import pad_or_narrow_weight
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.true_on_policy import should_use_tp_invariant_row_linear
 from sglang.srt.utils import get_bool_env_var, is_cpu, is_hip, is_npu, set_weight_attrs
 

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -39,7 +39,8 @@ from sglang.srt.layers.parameter import (
     _ColumnvLLMParameter,
 )
 from sglang.srt.layers.utils import pad_or_narrow_weight
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.true_on_policy import should_use_tp_invariant_row_linear
 from sglang.srt.utils import get_bool_env_var, is_cpu, is_hip, is_npu, set_weight_attrs
 
 if TYPE_CHECKING:
@@ -1620,7 +1621,16 @@ class RowParallelLinear(LinearBase):
                 get_tp_group(), disabled=not is_allocation_symmetric()
             )
         with symm_ctx:
-            if output_tensor is None:
+            if should_use_tp_invariant_row_linear(input_parallel.shape[-1]):
+                if output_tensor is not None:
+                    raise RuntimeError(
+                        "tp-invariant row linear cannot write into a caller-owned "
+                        "output tensor"
+                    )
+                output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
+                    input_parallel, self.weight.t(), bias_
+                )
+            elif output_tensor is None:
                 output_parallel = self.quant_method.apply(
                     self, input_parallel, bias=bias_
                 )

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1572,6 +1572,15 @@ class RowParallelLinear(LinearBase):
             assert loaded_weight.numel() == 1
             loaded_weight = loaded_weight.reshape(1)
 
+        if (
+            isinstance(param, BlockQuantScaleParameter)
+            and getattr(param, "format_ue8m0", False)
+            and loaded_weight.dtype == torch.int32
+            and not self.use_presharded_weights
+        ):
+            self._load_ue8m0_packed_scale(param, loaded_weight)
+            return
+
         if isinstance(param, RowvLLMParameter):
             # This `BasevLLMParameter` is defined in sglang/srt/layers/parameter.py,
             # It supports additional parameters like tp_rank and use_presharded_weights.
@@ -1593,6 +1602,29 @@ class RowParallelLinear(LinearBase):
             except TypeError:
                 # Fallback for parameters that don't accept additional args
                 param.load_row_parallel_weight(loaded_weight)
+
+    def _load_ue8m0_packed_scale(
+        self, param: BlockQuantScaleParameter, loaded_weight: torch.Tensor
+    ):
+        # TODO: This is hacky, better to have a more stable solution
+        # The loaded scale is a full-size DeepGEMM UE8M0 packed tensor (int32,
+        # mn-major, 4 scale columns per word; see transform_scale_ue8m0). The
+        # input-dim shard boundary sits at sub-word granularity whenever
+        # (k_local / block_k) % 4 != 0, so the packed form cannot be narrowed
+        # directly: unpack to fp32, narrow in scale-column units, then repack.
+        from sglang.srt.layers.quantization.fp8_utils import (
+            inverse_transform_scale_ue8m0,
+            transform_scale_ue8m0,
+        )
+
+        block_k = self.quant_method.quant_config.weight_block_size[1]
+        mn = param.data.shape[0]
+        sf_fp32 = inverse_transform_scale_ue8m0(loaded_weight, mn=mn)
+        shard_size = (self.input_size_per_partition + block_k - 1) // block_k
+        sf_local = sf_fp32.narrow(1, self.tp_rank * shard_size, shard_size).contiguous()
+        packed = transform_scale_ue8m0(sf_local, mn=mn)
+        assert param.data.shape == packed.shape, f"{param.data.shape=} {packed.shape=}"
+        param.data.copy_(packed)
 
     def forward(
         self,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -52,7 +52,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.true_on_policy import should_force_bfloat16_lm_head
 from sglang.srt.utils.common import (
     is_cpu,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -52,7 +52,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.true_on_policy import should_force_bfloat16_lm_head
 from sglang.srt.utils.common import (
     is_cpu,
     is_npu,
@@ -733,17 +734,17 @@ class LogitsProcessor(nn.Module):
                         hidden_states.to(torch.float32),
                         lm_head.weight.to(torch.float32).T,
                     )
+            elif should_force_bfloat16_lm_head(use_fp32_lm_head=self.use_fp32_lm_head):
+                logits = torch.matmul(
+                    hidden_states.to(torch.bfloat16),
+                    lm_head.weight.to(torch.bfloat16).T,
+                ).to(torch.bfloat16)
             elif use_intel_amx_backend(lm_head):
                 logits = torch.ops.sgl_kernel.weight_packed_linear(
                     hidden_states.to(lm_head.weight.dtype),
                     lm_head.weight,
                     None,  # bias
                     True,  # is_vnni
-                )
-            elif self.rl_on_policy_target is not None:
-                # Due to tie-weight, we may not be able to change lm_head's weight dtype
-                logits = torch.matmul(
-                    hidden_states.bfloat16(), lm_head.weight.T.bfloat16()
                 )
             else:
                 logits = torch.matmul(
@@ -884,6 +885,8 @@ class LogitsProcessor(nn.Module):
             assert logits_buffer.dtype == torch.float
             logits_buffer.copy_(logits)
             logits = logits_buffer
+        elif should_force_bfloat16_lm_head(use_fp32_lm_head=self.use_fp32_lm_head):
+            logits = logits[:, : self.vocab_size].to(torch.bfloat16)
         else:
             logits = logits.float()
         return logits

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -517,6 +517,7 @@ def _compute_g1_scale_c(
     g1_alphas: torch.Tensor,
     g1_alphas_up: torch.Tensor,
     is_gated: bool,
+    activation: Optional[str] = None,
 ) -> torch.Tensor:
     """TRT-LLM GEMM1-output scale for the up (w3) half.
 
@@ -526,6 +527,11 @@ def _compute_g1_scale_c(
     scale passes g1_alphas as g1_alphas_up and recovers the single-scale value;
     non-gated (Relu2) has no gate half, so it is just 1/a2_scale per expert.
     """
+    if activation == "situ":
+        # SiTU consumes both GEMM1 scales before tanh; scale_c carries only
+        # the GEMM2 input requantization factor.
+        num_experts = g1_alphas.shape[0]
+        return w2_input_scale_quant.to(torch.float32).expand(num_experts).contiguous()
     if is_gated:
         return (w2_input_scale_quant * g1_alphas_up).to(torch.float32)
     num_experts = g1_alphas.shape[0]
@@ -596,7 +602,11 @@ def align_fp4_moe_weights_for_flashinfer_trtllm(layer: Module) -> None:
     g1_alphas = cast(torch.Tensor, layer.g1_alphas)
     g1_alphas_up = cast(torch.Tensor, getattr(layer, "g1_alphas_up", g1_alphas))
     g1_scale_c = _compute_g1_scale_c(
-        w2_input_scale_quant, g1_alphas, g1_alphas_up, layer.moe_runner_config.is_gated
+        w2_input_scale_quant,
+        g1_alphas,
+        g1_alphas_up,
+        layer.moe_runner_config.is_gated,
+        activation=layer.moe_runner_config.activation,
     )
     copy_or_rebind_param(layer, "g1_scale_c", g1_scale_c)
 
@@ -612,6 +622,7 @@ def get_activation_type(activation: str, is_gated: bool = True) -> int:
         _ACTIVATION_STR_TO_TYPE = {
             "silu": ActivationType.Swiglu,
             "gelu": ActivationType.Geglu,
+            "situ": ActivationType.Situ,
         }
     else:
         _ACTIVATION_STR_TO_TYPE = {
@@ -956,7 +967,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     from sglang.srt.layers.moe.topk import TopKOutputChecker
     from sglang.srt.layers.moe.utils import RoutingMethodType
 
-    _SUPPORTED_FP4_ACTIVATIONS = {"silu", "relu2", "gelu"}
+    _SUPPORTED_FP4_ACTIVATIONS = {"silu", "relu2", "gelu", "situ"}
     assert runner_config.activation in _SUPPORTED_FP4_ACTIVATIONS, (
         f"Only {_SUPPORTED_FP4_ACTIVATIONS} are supported for FP4 MoE, "
         f"got '{runner_config.activation}'."

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -100,7 +100,7 @@ def _use_moe_sum_reduce_torch_compile(num_tokens: int) -> bool:
     return (
         num_tokens <= 32
         and not is_batch_invariant_mode_enabled()
-        and not get_server_args().enable_deterministic_inference
+        and not get_exec().deterministic.enable_deterministic_inference
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -97,7 +97,11 @@ logger = logging.getLogger(__name__)
 
 
 def _use_moe_sum_reduce_torch_compile(num_tokens: int) -> bool:
-    return num_tokens <= 32 and not is_batch_invariant_mode_enabled()
+    return (
+        num_tokens <= 32
+        and not is_batch_invariant_mode_enabled()
+        and not get_server_args().enable_deterministic_inference
+    )
 
 
 @register_custom_op(mutates_args=["hidden_states"])

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1900,19 +1900,31 @@ def capture_routed_experts_if_allowed(
     topk_config: TopKConfig,
     layer_id: Optional[int],
     topk_ids: torch.Tensor,
+    num_token_non_padded: Optional[torch.Tensor] = None,
 ) -> None:
     """Single capture site for every backend, gated by the per-config opt-out.
 
     Routing all backends through here keeps the draft-side opt-out from being
     bypassed by an inlined capturer call.
+
+    Rows at or past ``num_token_non_padded`` still hold whatever the router left
+    there; ``_post_process_topk_ids`` masks them only further down, and on ROCm it
+    masks them to 0, a valid expert id. Capture runs ahead of both, so mask a copy
+    here: replay consumers skip -1 rows, and treating a padded row as a real
+    selection makes a whole padded region replay one stale routing row.
     """
     if not topk_config.allow_routed_experts_capture:
         return
-    if (cap := get_global_experts_capturer()) is not None:
-        cap.capture(
-            layer_id=layer_id,
-            topk_indices=topk_ids,
-        )
+    cap = get_global_experts_capturer()
+    if cap is None:
+        return
+    if num_token_non_padded is not None:
+        topk_ids = topk_ids.clone()
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    cap.capture(
+        layer_id=layer_id,
+        topk_indices=topk_ids,
+    )
 
 
 def _post_process_topk_ids(
@@ -1931,7 +1943,9 @@ def _post_process_topk_ids(
     fused_shared_experts_scaling_factor = (
         topk_config.fused_shared_experts_scaling_factor
     )
-    capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
+    capture_routed_experts_if_allowed(
+        topk_config, layer_id, topk_ids, num_token_non_padded
+    )
     recorder_topk_ids = None
     if _is_cuda:
         # LP path: solve LP outside torch.compile (the solver contains an

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1907,11 +1907,9 @@ def capture_routed_experts_if_allowed(
     Routing all backends through here keeps the draft-side opt-out from being
     bypassed by an inlined capturer call.
 
-    Rows at or past ``num_token_non_padded`` still hold whatever the router left
-    there; ``_post_process_topk_ids`` masks them only further down, and on ROCm it
-    masks them to 0, a valid expert id. Capture runs ahead of both, so mask a copy
-    here: replay consumers skip -1 rows, and treating a padded row as a real
-    selection makes a whole padded region replay one stale routing row.
+    Capture runs ahead of every padded-region mask in ``_post_process_topk_ids``
+    (and ROCm's masks to 0, a valid expert id), so mask a copy here: replay skips
+    -1 rows but reads a padded one as a real selection.
     """
     if not topk_config.allow_routed_experts_capture:
         return

--- a/python/sglang/srt/layers/on_policy_utils.py
+++ b/python/sglang/srt/layers/on_policy_utils.py
@@ -1,0 +1,6 @@
+"""Compatibility imports for SGLang true-on-policy helpers.
+
+New code should import from :mod:`sglang.srt.true_on_policy`.
+"""
+
+from sglang.srt.true_on_policy import *  # noqa: F403

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1075,6 +1075,10 @@ class CompressedTensorsFusedMoEMethod(FusedMoEMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.scheme.process_weights_after_loading(layer)
 
+    def restore_weights_before_loading(self, layer: torch.nn.Module) -> None:
+        if hasattr(layer.scheme, "restore_weights_before_loading"):
+            layer.scheme.restore_weights_before_loading(layer)
+
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -510,11 +510,19 @@ class Fp8LinearMethod(LinearMethodBase):
                         f"{input_size_per_partition} is not divisible by "
                         f"weight quantization block_k = {block_k}."
                     )
-            # Required by column parallel or enabling merged weights
-            if (
+            # Required by column parallel or enabling merged weights.
+            is_tp_split = (
                 tp_size > 1 and output_size // output_size_per_partition == tp_size
-            ) or len(output_partition_sizes) > 1:
-                for output_partition_size in output_partition_sizes:
+            )
+            is_merged_gemm = len(output_partition_sizes) > 1
+            if is_tp_split or is_merged_gemm:
+                sizes_to_check = output_partition_sizes
+                if not is_tp_split and is_merged_gemm:
+                    # Match validate_fp8_block_shape: merged weights may have a
+                    # ragged final logical matrix, and scale tensors are already
+                    # allocated with ceil-divided block counts.
+                    sizes_to_check = output_partition_sizes[:-1]
+                for output_partition_size in sizes_to_check:
                     if output_partition_size % block_n != 0:
                         raise ValueError(
                             f"Weight output_partition_size = "

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -736,6 +736,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]],
         quantized_layers: Dict[str, Dict[str, Any]],
         fp8_config: ModelOptFp8Config,
+        fp8_pb_wo_config: Fp8Config,
         nvfp4_config: ModelOptFp4Config,
         nvfp4a16_config: ModelOptFp4Config,
         mxfp8_config: Fp8Config,
@@ -743,6 +744,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         super().__init__(kv_cache_quant_algo, exclude_modules, packed_modules_mapping)
         self.quantized_layers = quantized_layers
         self.fp8_config = fp8_config
+        self.fp8_pb_wo_config = fp8_pb_wo_config
         self.mxfp8_config = mxfp8_config
         self.nvfp4_config = nvfp4_config
         self.nvfp4a16_config = nvfp4a16_config
@@ -827,6 +829,12 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             exclude_modules=[],
             packed_modules_mapping=packed_modules_mapping,
         )
+        fp8_pb_wo_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            packed_modules_mapping=packed_modules_mapping,
+        )
         mxfp8_config = Fp8Config(
             is_checkpoint_fp8_serialized=True,
             activation_scheme="dynamic",
@@ -856,6 +864,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             packed_modules_mapping=packed_modules_mapping,
             quantized_layers=quantized_layers,
             fp8_config=fp8_config,
+            fp8_pb_wo_config=fp8_pb_wo_config,
             mxfp8_config=mxfp8_config,
             nvfp4_config=nvfp4_config,
             nvfp4a16_config=nvfp4a16_config,
@@ -937,6 +946,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "FP8_PB_WO":
+                return Fp8LinearMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
             if quant_algo == "NVFP4":
@@ -2471,9 +2482,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         )
 
         if layer.moe_runner_config.is_gated and self.enable_flashinfer_trtllm_moe:
+            runner_config = layer.moe_runner_config
+            is_situ = runner_config.activation == "situ"
             gemm1_clamp_limit = (
-                layer.moe_runner_config.gemm1_clamp_limit
-                or layer.moe_runner_config.swiglu_limit
+                None
+                if is_situ
+                else (runner_config.gemm1_clamp_limit or runner_config.swiglu_limit)
             )
             if gemm1_clamp_limit is not None:
                 copy_or_rebind_param(
@@ -2482,21 +2496,26 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                     (gemm1_clamp_limit / layer.g1_alphas).to(torch.float32),
                 )
 
-            if layer.moe_runner_config.gemm1_alpha is not None:
+            if runner_config.gemm1_alpha is not None:
                 copy_or_rebind_param(
                     layer,
                     "gemm1_alpha",
                     torch.full_like(
                         layer.g1_alphas,
-                        layer.moe_runner_config.gemm1_alpha,
+                        runner_config.gemm1_alpha,
                         dtype=torch.float32,
                     ),
                 )
-                copy_or_rebind_param(
-                    layer,
-                    "gemm1_beta",
-                    (1.0 / layer.g1_alphas).to(torch.float32),
+                gemm1_beta = (
+                    torch.full_like(
+                        layer.g1_alphas,
+                        runner_config.gemm1_clamp_limit,
+                        dtype=torch.float32,
+                    )
+                    if is_situ
+                    else (1.0 / layer.g1_alphas).to(torch.float32)
                 )
+                copy_or_rebind_param(layer, "gemm1_beta", gemm1_beta)
 
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         use_dispatch_fp4 = not self.quant_config.use_per_token_activation and (
@@ -2762,9 +2781,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self, "_moe_runner_backend", get_moe_runner_backend()
         )
 
-        assert (
-            activation in _SUPPORTED_ACT_STRS
-        ), f"{activation=} not in supported {_SUPPORTED_ACT_STRS}"
+        assert activation in _SUPPORTED_ACT_STRS or (
+            activation == "situ" and moe_runner_backend.is_flashinfer_trtllm()
+        ), f"{activation=} is unsupported by {moe_runner_backend}"
         moe_runner_config = self.moe_runner_config
 
         if moe_runner_backend.is_marlin():

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -11,7 +11,6 @@ from sglang.kernels.fused_op import BaseFusedOp
 from sglang.srt.environ import envs
 from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_exec
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -12,6 +12,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_exec
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
@@ -129,12 +130,8 @@ class RotaryEmbedding(BaseFusedOp):
         self._apply_rotary_emb_wrapped = apply_rotary_emb
 
         # XXX (MUSA): Implement sgl_kernel.rotary_embedding support for MUSA backend
-        if get_exec().deterministic.rl_on_policy_target is not None or _is_musa:
+        if is_true_on_policy_enabled() or _is_musa:
             self._forward_method = self.forward_native
-            self._apply_rotary_emb_wrapped = torch.compile(
-                dynamic=True,
-                disable=_is_npu,
-            )(apply_rotary_emb)
         self.position_cos, self.position_sin = None, None
 
     def _match_cos_sin_cache_dtype(self, query: torch.Tensor) -> None:
@@ -152,9 +149,7 @@ class RotaryEmbedding(BaseFusedOp):
         # use CPU to compute the cache and then move it to GPU. However, we
         # create the cache on GPU for faster initialization. This may cause
         # a slight numerical difference between the HF implementation and ours.
-        init_device = (
-            "cpu" if get_exec().deterministic.rl_on_policy_target is not None else None
-        )
+        init_device = "cpu" if is_true_on_policy_enabled() else None
         inv_freq = 1.0 / (
             base
             ** (
@@ -164,7 +159,7 @@ class RotaryEmbedding(BaseFusedOp):
                 / self.rotary_dim
             )
         )
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if is_true_on_policy_enabled():
             inv_freq = inv_freq.cuda()
         return inv_freq
 

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.rotary_embedding.yarn import (
     yarn_get_mscale_simple,
     yarn_linear_ramp_mask,
 )
-from sglang.srt.runtime_context import attention_backends, get_exec, get_server_args
+from sglang.srt.runtime_context import attention_backends
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -18,7 +18,8 @@ from sglang.srt.layers.rotary_embedding.yarn import (
     yarn_get_mscale_simple,
     yarn_linear_ramp_mask,
 )
-from sglang.srt.runtime_context import attention_backends, get_exec
+from sglang.srt.runtime_context import attention_backends, get_exec, get_server_args
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
@@ -131,7 +132,7 @@ class MRotaryEmbedding(RotaryEmbedding):
             self.register_buffer("axis_map", axis_map, persistent=False)
         else:
             self.axis_map = None
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if is_true_on_policy_enabled():
             self._forward_method = self.forward_native
 
     def get_cos_sin_with_position(self, positions):

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.logprob_processor import (
 from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.srt.true_on_policy import resolve_true_on_policy_runtime_policy
 from sglang.srt.utils.async_probe import sanitize_nan_logits
 from sglang.srt.utils.common import (
     get_bool_env_var,
@@ -75,13 +76,13 @@ class Sampler(nn.Module):
         if is_dp_attention_enabled():
             self.tp_sync_group = get_parallel().attn_tp_group.device_group
 
-        self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
+        true_on_policy = resolve_true_on_policy_runtime_policy(get_server_args())
         # In RL on-policy mode, deterministic inference is automatically enabled.
         self.enable_deterministic = (
             get_exec().deterministic.enable_deterministic_inference
         )
         # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
-        self.use_log_softmax_logprob = self.rl_on_policy_target is not None
+        self.use_log_softmax_logprob = true_on_policy.enabled
         self.use_ascend_backend = get_exec().kernel.sampling_backend == "ascend"
 
         self.output_logprob_processor = OutputLogprobProcessor()
@@ -154,17 +155,13 @@ class Sampler(nn.Module):
             if return_logprob and SGLANG_RETURN_ORIGINAL_LOGPROB:
                 original_logprobs = torch.log_softmax(logits, dim=-1)
 
+            # Post process logits
+            logits.div_(sampling_info.temperatures)
+
             # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
             logprobs_via_logsoftmax_kernel = None
-            if self.rl_on_policy_target is not None:
-                # TODO: use more inplace ops to save memory
-                logits_div_temperature = (
-                    logits.bfloat16().div(sampling_info.temperatures).bfloat16()
-                )
-                logprobs_via_logsoftmax_kernel = torch.log_softmax(
-                    logits_div_temperature, dim=-1
-                )
-                del logits_div_temperature
+            if self.use_log_softmax_logprob:
+                logprobs_via_logsoftmax_kernel = torch.log_softmax(logits, dim=-1)
 
             if self.use_ascend_backend:
                 # Ascend backend: sample from logits directly.
@@ -190,8 +187,6 @@ class Sampler(nn.Module):
                     logprobs = logprobs_via_logsoftmax_kernel
             else:
                 # Standard path: do softmax and sample from probs.
-                logits.div_(sampling_info.temperatures)
-
                 # Deterministic inference must derive the returned logprobs
                 # from F.log_softmax — the same kernel prefill rescoring uses —
                 # not log(softmax(x)) below: the two disagree at ~1e-6 despite
@@ -479,13 +474,13 @@ class Sampler(nn.Module):
         """Handle the full Ascend backend sampling path.
 
         Ascend backend has fused kernels that handle softmax internally,
-        so we sample directly from temperature-scaled logits.
+        so we sample directly from temperature-scaled logits. Temperature
+        scaling is already applied by the caller before branch dispatch.
 
         Returns:
             A tuple of (batch_next_token_ids, logprobs). logprobs is None
             when return_logprob is False or SGLANG_RETURN_ORIGINAL_LOGPROB is set.
         """
-        logits.div_(sampling_info.temperatures)
         batch_next_token_ids = self._sample_from_logits(
             logits, sampling_info, simple_sampling_case, positions
         )

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -27,12 +27,13 @@ def get_gathered_moe_num_tokens(forward_batch: ForwardBatch, num_tokens: int) ->
     global_num_tokens = getattr(forward_batch, "global_num_tokens_cpu", None)
     if not global_num_tokens:
         return num_tokens
-    from sglang.srt.layers.dp_attention import get_attention_tp_size
+    # Local import: a module-level cp import here is circular (see forward_batch_info).
+    # v0.5.16 moved this helper layers.utils.cp_utils -> layers.cp.padding.
+    from sglang.srt.layers.cp.padding import get_cp_padding_align_size
+    from sglang.srt.runtime_context import get_parallel
 
-    # Local import: a module-level cp_utils import here is circular (see forward_batch_info).
-    from sglang.srt.layers.utils.cp_utils import get_cp_padding_align_size
-
-    attn_tp_size = get_attention_tp_size()
+    # v0.5.16 retired dp_attention.get_attention_tp_size(); it lives on ParallelState now.
+    attn_tp_size = get_parallel().attn_tp_size
     cp_align_size = get_cp_padding_align_size()
     upper = max(
         ceil_align(ceil_align(t, attn_tp_size), cp_align_size)

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -7,6 +7,38 @@ import triton.language as tl
 from sglang.srt.lora.backend.lmhead_mixing import LoRABackendLmHeadMixing
 from sglang.srt.lora.utils import LoRABatchInfo, MoELoRABatchInfo
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.utils.common import ceil_align
+
+
+def get_gathered_moe_num_tokens(forward_batch: ForwardBatch, num_tokens: int) -> int:
+    """Token count the MoE-LoRA mapping must cover: gathered under --enable-dp-attention, else per-rank.
+
+    In the eager path prepare_lora_batch runs from ForwardBatch.init_new, BEFORE
+    prepare_mlp_sync_batch assigns forward_batch.global_dp_buffer_len (only the cuda-graph
+    capture path pre-sets it), so that field alone under-sizes the MoE-LoRA token mapping to the
+    per-rank length and the MoE-LoRA kernels index past it (sticky CUDA IMA). When it is unset,
+    derive an upper bound of the gathered length from global_num_tokens_cpu (assigned in
+    init_new before prepare_lora_batch runs), mirroring prepare_mlp_sync_batch's attn-tp/cp
+    alignment; max*n covers both SUM_LEN and MAX_LEN padding modes. Over-allocation is harmless:
+    the kernels index at most the actual gathered length.
+    """
+    if forward_batch.global_dp_buffer_len is not None:
+        return max(forward_batch.global_dp_buffer_len, num_tokens)
+    global_num_tokens = getattr(forward_batch, "global_num_tokens_cpu", None)
+    if not global_num_tokens:
+        return num_tokens
+    from sglang.srt.layers.dp_attention import get_attention_tp_size
+
+    # Local import: a module-level cp_utils import here is circular (see forward_batch_info).
+    from sglang.srt.layers.utils.cp_utils import get_cp_padding_align_size
+
+    attn_tp_size = get_attention_tp_size()
+    cp_align_size = get_cp_padding_align_size()
+    upper = max(
+        ceil_align(ceil_align(t, attn_tp_size), cp_align_size)
+        for t in global_num_tokens
+    ) * len(global_num_tokens)
+    return max(upper, num_tokens)
 
 
 class BaseLoRABackend(LoRABackendLmHeadMixing):
@@ -218,15 +250,30 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         """
         base = moe_layer.base_layer
         top_k = base.top_k
-        qinfo = moe_layer._quant_info
-        E, N, _ = qinfo.w13_weight.shape
-        hidden_dim = qinfo.w2_weight.shape[1]
-        device = qinfo.w13_weight.device
+        # Derive dims from the base FusedMoE rather than quant-specific tensors,
+        # so this works for any scheme (FP, WNA16, Marlin-packed, etc.).
+        E = base.num_local_experts
+        hidden_dim = base.hidden_size
+        N = 2 * base.intermediate_size_per_partition
+        device = next(base.parameters()).device
         dtype = compute_dtype
         num_experts = base.num_experts
 
+        # Under --enable-dp-attention the MoE runs on DP-GATHERED tokens (the global DP buffer of
+        # length up to max_bs * attn_dp_size), not the per-rank batch. The per-token LoRA routing
+        # buffers below are indexed by that gathered token count, so size them for the gathered
+        # maximum; otherwise the MoE-LoRA kernels read token_lora_mapping / sorted_token_ids past a
+        # per-rank-sized buffer -> cudaErrorIllegalInstruction during cuda-graph capture. Expert- and
+        # adapter-indexed buffers (cumsum_buffer, adapter_enabled, lora_ids) are unaffected.
+        from sglang.srt.layers.dp_attention import get_attention_dp_size
+
+        dp_size = max(1, get_attention_dp_size())
+        max_moe_tokens = max_bs * dp_size
+
         block_size_m = 64
-        max_num_tokens_padded = max_bs * top_k + num_experts * (block_size_m - 1)
+        max_num_tokens_padded = max_moe_tokens * top_k + num_experts * (
+            block_size_m - 1
+        )
         max_num_tokens_padded = (
             (max_num_tokens_padded + block_size_m - 1) // block_size_m
         ) * block_size_m
@@ -263,7 +310,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             # LongTensor.  weight_indices itself must stay int32 because the
             # CUDA moe_lora_align kernel casts it to int32_t*.
             "weight_indices_long": torch.zeros(
-                max_bs, dtype=torch.int64, device=device
+                max_moe_tokens, dtype=torch.int64, device=device
             ),
             "lora_ids": torch.arange(max_loras, dtype=torch.int32, device=device),
             "cumsum_buffer": torch.zeros(
@@ -272,14 +319,14 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
                 device=device,
             ),
             "token_mask": torch.empty(
-                (max_loras * max_bs * top_k,),
+                (max_loras * max_moe_tokens * top_k,),
                 dtype=torch.int32,
                 device=device,
             ),
             "max_num_tokens_padded": max_num_tokens_padded,
             "max_num_m_blocks": max_num_m_blocks,
             "token_lora_mapping": torch.full(
-                (max_bs,), -1, dtype=torch.int32, device=device
+                (max_moe_tokens,), -1, dtype=torch.int32, device=device
             ),
         }
 
@@ -321,6 +368,19 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             seg_indptr = batch_info.seg_indptr[: num_moe_segments + 1]
             req_to_lora = batch_info.weight_indices[:num_moe_segments]
 
+        # --enable-dp-attention all-gathers tokens into the MoE, so the MoE-LoRA kernels index
+        # token_lora_mapping by the GATHERED token count, not the per-rank num_tokens. Size the
+        # mapping to (an upper bound of) the gathered count so those reads stay in-bounds — see
+        # get_gathered_moe_num_tokens for why global_dp_buffer_len alone is NOT enough in the
+        # eager path (the per-rank segments still fill only [0, num_tokens); the tail stays -1).
+        moe_num_tokens = get_gathered_moe_num_tokens(forward_batch, num_tokens)
+        if batch_info.use_cuda_graph:
+            # Static capture buffers hold max_bs*dp tokens; a REAL replay's gathered length never
+            # exceeds that (the captured graph could not address it), so cap the upper bound at
+            # the buffer size. Batches whose gathered bound exceeds it are demoted to the eager
+            # prep path in LoRAManager.prepare_lora_batch before we get here.
+            moe_num_tokens = min(moe_num_tokens, token_lora_mapping.shape[0])
+
         adapter_enabled, token_lora_mapping = _compute_moe_lora_info(
             num_tokens,
             seg_indptr,
@@ -329,7 +389,33 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             adapter_enabled,
             token_lora_mapping,
             max_len=max_len,
+            mapping_len=moe_num_tokens,
         )
+
+        # Tier-1 (colocate RL, exactly one adapter loaded): the DP-gathered tail
+        # [num_tokens, moe_num_tokens) covers OTHER dp ranks' tokens, which under colocate RL all
+        # use that single adapter. The per-rank fill above only wrote [0, num_tokens), leaving the
+        # tail -1 (adapter-disabled) -> cross-rank gathered tokens would miss the LoRA delta on
+        # this rank's local experts. The stamps below are ARMED BY LoRAManager.prepare_lora_batch
+        # (policy lives there; both are host ints, no GPU sync -> cuda-graph safe, written each
+        # batch in the eager prep path):
+        #   * _single_loaded_buffer_id: armed only when exactly one adapter is loaded AND this
+        #     rank's local requests actively use it -> stamp the tail with that adapter.
+        #   * _idle_rank_active_buffer_id: armed only on a true idle rank (num_tokens == 0) ->
+        #     _compute_moe_lora_info left the whole mapping -1 / adapter_enabled all-0, so stamp
+        #     the whole gathered buffer and enable the adapter.
+        # Multi-adapter batches and base-only local batches arm neither stamp and keep the -1
+        # tail: foreign tokens get base rather than a delta this rank cannot attribute.
+        if moe_num_tokens > num_tokens:
+            if num_tokens > 0:
+                single_bid = getattr(self, "_single_loaded_buffer_id", None)
+                if single_bid is not None:
+                    token_lora_mapping[num_tokens:moe_num_tokens].fill_(single_bid)
+            else:
+                idle_bid = getattr(self, "_idle_rank_active_buffer_id", None)
+                if idle_bid is not None:
+                    token_lora_mapping.fill_(idle_bid)
+                    adapter_enabled[idle_bid] = 1
 
         batch_info.moe_lora_info = MoELoRABatchInfo(
             seg_indptr=seg_indptr,
@@ -397,16 +483,28 @@ def _compute_moe_lora_info(
     adapter_enabled: torch.Tensor | None,
     token_lora_mapping: torch.Tensor | None,
     max_len: int,
+    mapping_len: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # ``num_tokens`` is the PER-RANK fill count (segments cover this rank's tokens). ``mapping_len``
+    # is the length of the token_lora_mapping the MoE-LoRA kernels actually index -- under
+    # --enable-dp-attention the MoE runs on DP-GATHERED tokens (mapping_len = global_dp_buffer_len
+    # >= num_tokens), so the returned mapping must span the gathered count to keep those kernels
+    # in-bounds. The DP-gathered tail [num_tokens, mapping_len) defaults to -1 (adapter-disabled).
+    if mapping_len is None:
+        mapping_len = num_tokens
+    assert mapping_len >= num_tokens
     if token_lora_mapping is not None:
         assert (
-            num_tokens <= token_lora_mapping.shape[0]
-        ), "num_tokens must be less than or equal to the shape of token_lora_mapping"
-        token_lora_mapping = token_lora_mapping[:num_tokens]
+            mapping_len <= token_lora_mapping.shape[0]
+        ), "mapping_len must be less than or equal to the shape of token_lora_mapping"
+        token_lora_mapping = token_lora_mapping[:mapping_len]
     else:
         token_lora_mapping = torch.empty(
-            (num_tokens,), dtype=torch.int32, device=seg_indptr.device
+            (mapping_len,), dtype=torch.int32, device=seg_indptr.device
         )
+    if mapping_len > num_tokens:
+        # clean the gathered tail before the per-rank fill writes [0, num_tokens)
+        token_lora_mapping.fill_(-1)
 
     if adapter_enabled is not None:
         assert (
@@ -464,8 +562,12 @@ def _compute_moe_lora_info(
         torch.searchsorted(seg_indptr.to(torch.int32), token_positions, right=True) - 1
     )
 
-    token_lora_mapping = torch.index_select(
-        weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping
+    # Fill only the per-rank prefix [0, num_tokens); the gathered tail keeps the -1 set above.
+    torch.index_select(
+        weight_indices.to(torch.int32),
+        0,
+        req_indices,
+        out=token_lora_mapping[:num_tokens],
     )
 
     return adapter_enabled, token_lora_mapping

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -51,6 +51,13 @@ class BaseLayerWithLoRA(nn.Module):
         # LoRA-wrapped.
         if hasattr(self.base_layer, "reduce_results"):
             self.reduce_results = self.base_layer.reduce_results
+        # Alias remaining base-layer parameters onto the wrapper so
+        # `named_parameters(remove_duplicate=True)` yields them at the outer
+        # path — weight loaders (e.g. FusedMoE's `w13_weight_packed`) lookup
+        # names without the `.base_layer.` segment.
+        for _name, _param in base_layer.named_parameters(recurse=False):
+            if not hasattr(self, _name):
+                setattr(self, _name, _param)
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)
@@ -952,6 +959,13 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         self.experts_shared_outer_loras: bool = False
         self.lora_use_virtual_experts: bool = False
+        # Forward for the model's own forward-path dispatch — the outer model
+        # reads several FusedMoE attributes (e.g. `self.experts.moe_runner_config`,
+        # `self.experts.dispatcher`, `self.experts.num_local_experts`,
+        # `self.experts.quant_method`) directly on the wrapper. Quant
+        # post-processing iterators skip LoRA wrappers via
+        # `isinstance(module, BaseLayerWithLoRA)` so the packed params on the
+        # inner FusedMoE get processed there, not here.
         self.quant_method = base_layer.quant_method
         self.moe_runner_config = base_layer.moe_runner_config
         # Don't let the MoE runner overwrite hidden_states with its output:
@@ -964,6 +978,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.should_fuse_routed_scaling_factor_in_topk = (
             base_layer.should_fuse_routed_scaling_factor_in_topk
         )
+        if hasattr(base_layer, "scheme"):
+            self.scheme = base_layer.scheme
 
         self.tp_size = getattr(base_layer, "moe_tp_size", 1)
         self.tp_rank = getattr(base_layer, "moe_tp_rank", 0)
@@ -988,6 +1004,12 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             and base_layer.quant_method.runner is not None
         ):
             runner_backend = base_layer.quant_method.runner.runner_backend
+        elif (
+            hasattr(base_layer, "scheme")
+            and hasattr(base_layer.scheme, "runner")
+            and base_layer.scheme.runner is not None
+        ):
+            runner_backend = base_layer.scheme.runner.runner_backend
         else:
             runner_backend = MoeRunnerBackend.TRITON
 
@@ -1150,6 +1172,9 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
+        quant_info.expert_map = getattr(
+            base_layer.dispatcher, "local_expert_mapping", None
+        )
 
         # ===== TO BE REFACTORED ====
         if self._lora_runner_backend.is_experimental_sgl_trtllm():

--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -210,6 +210,8 @@ class LoRAAdapter(nn.Module):
             self._normalize_in_proj(layer.weights)
             # Stack in_proj_q + in_proj_k + in_proj_v + in_proj_z → in_proj_qkvz for GDN layers
             self._normalize_in_proj_qkvz(layer.weights)
+            # Stack in_proj_b + in_proj_a → in_proj_ba for GDN layers
+            self._normalize_in_proj_ba(layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_gate_up_proj(weight_names, layer.weights)
             weight_names = list(layer.weights.keys())
@@ -450,6 +452,25 @@ class LoRAAdapter(nn.Module):
                 weights.pop(k_name)
                 weights.pop(v_name)
                 weights.pop(z_name)
+            elif "in_proj_qkv." in weight_name:
+                # 2-way split (Megatron-Bridge adapter export): in_proj_qkv
+                # covers the q|k|v rows and in_proj_z the z rows, with one
+                # shared lora_A. The stacked buffer expects one A block per
+                # slice, so repeat the qkv A block 3x (q, k, v) before
+                # appending the z block; B rows concatenate directly.
+                z_name = weight_name.replace("in_proj_qkv.", "in_proj_z.")
+                if z_name not in weights:
+                    continue
+                qkvz_name = weight_name.replace("in_proj_qkv.", "in_proj_qkvz.")
+                cat_dim = weights[weight_name].dim() - 2
+                qkv_w = weights[weight_name]
+                if "lora_A" in weight_name:
+                    repeat_dims = [1] * qkv_w.dim()
+                    repeat_dims[cat_dim] = 3
+                    qkv_w = qkv_w.repeat(*repeat_dims)
+                weights[qkvz_name] = torch.cat((qkv_w, weights[z_name]), cat_dim)
+                weights.pop(weight_name)
+                weights.pop(z_name)
             elif "in_proj_qkvz" in weight_name and "lora_A" in weight_name:
                 # Already-merged adapter: replicate the shared A across the 4
                 # stacked slots the buffer expects (q, k, v, z).
@@ -458,6 +479,45 @@ class LoRAAdapter(nn.Module):
                 repeat_dims[ndim - 2] = 4
                 weights[weight_name] = weights[weight_name].repeat(*repeat_dims)
             # else (in_proj_qkvz lora_B, or unrelated): no-op.
+
+    def _normalize_in_proj_ba(self, weights: Dict[str, torch.Tensor]):
+        """Normalize in_proj_ba weights for GDN (GatedDeltaNet) layers like
+        Qwen3.5.
+
+        Two adapter formats are handled:
+
+        1. Split: ``in_proj_b + in_proj_a`` (HF checkpoint naming, also the
+           Megatron-Bridge adapter export) are present as separate weights →
+           concatenate them into ``in_proj_ba`` (B rows b|a; A blocks b, a).
+
+        2. Already-merged: the adapter has a single ``in_proj_ba`` weight
+           (PEFT trained against SGLang's fused Linear). The stacked buffer
+           expects two per-slice ``A`` blocks, so repeat ``lora_A`` 2x along
+           the rank dim. ``lora_B`` is already full-output-dim and matches
+           the buffer directly.
+        """
+        for weight_name in list(weights.keys()):
+            # NB: match with the trailing dot so the merged "in_proj_ba."
+            # names don't take the split branch.
+            if "in_proj_b." in weight_name:
+                a_name = weight_name.replace("in_proj_b.", "in_proj_a.")
+                if a_name not in weights:
+                    continue
+                ba_name = weight_name.replace("in_proj_b.", "in_proj_ba.")
+                cat_dim = weights[weight_name].dim() - 2
+                weights[ba_name] = torch.cat(
+                    (weights[weight_name], weights[a_name]), cat_dim
+                )
+                weights.pop(weight_name)
+                weights.pop(a_name)
+            elif "in_proj_ba" in weight_name and "lora_A" in weight_name:
+                # Already-merged adapter: replicate the shared A across the 2
+                # stacked slots the buffer expects (b, a).
+                ndim = weights[weight_name].dim()
+                repeat_dims = [1] * ndim
+                repeat_dims[ndim - 2] = 2
+                weights[weight_name] = weights[weight_name].repeat(*repeat_dims)
+            # else (in_proj_ba lora_B, or unrelated): no-op.
 
     def normalize_gate_up_proj(
         self, weight_names: List[str], weights: Dict[str, torch.Tensor]

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -1050,6 +1050,8 @@ class LoRAManager:
 
         self.embed_tokens_module: Optional[BaseLayerWithLoRA] = None
         self.lm_head_module: Optional[BaseLayerWithLoRA] = None
+        # One MoE layer's worth of warning is enough; the condition is model-wide.
+        warned_one_sided_moe_targets = False
 
         # When tie_word_embeddings=True, lm_head is the same Python object as
         # embed_tokens. PyTorch's named_modules() deduplicates by object identity,
@@ -1141,9 +1143,36 @@ class LoRAManager:
                 )
                 continue
 
-            if isinstance(module, (FusedMoE, InklingBatchDenseMLP)) and all(
-                x in self.target_modules for x in ["gate_up_proj", "down_proj"]
-            ):
+            if isinstance(module, (FusedMoE, InklingBatchDenseMLP)):
+                expert_projections = ("gate_up_proj", "down_proj")
+                missing = [
+                    x for x in expert_projections if x not in self.target_modules
+                ]
+                if len(missing) == 1 and not warned_one_sided_moe_targets:
+                    warned_one_sided_moe_targets = True
+                    # The MoE-LoRA hooks inject a delta after gate_up and after
+                    # down together, so wrapping for only one of them is not
+                    # implemented and the layer stays unwrapped. Adapters that only
+                    # train the dense/shared MLP still work, but one that carries
+                    # expert weights for the targeted projection has them loaded
+                    # into the pool and never applied. Warn once -- silently
+                    # dropping part of an adapter reads as a serving/training
+                    # mismatch with no symptom.
+                    present = next(x for x in expert_projections if x != missing[0])
+                    logger.warning(
+                        "LoRA target modules include %r but not %r, so MoE expert layers "
+                        "(e.g. %s) get no adapter at all: expert LoRA needs both projections. "
+                        "Any %r expert weights in a loaded adapter will be ignored. Add %r to "
+                        "the target modules to enable expert LoRA -- an adapter that does not "
+                        "train it keeps zero-filled buffers and contributes no delta.",
+                        present,
+                        missing[0],
+                        module_name,
+                        present,
+                        missing[0],
+                    )
+                if missing:
+                    continue
                 layer_id = get_layer_id(module_name)
                 if layer_id is None:
                     if module_name.startswith("model.meta_mlp."):

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -271,9 +271,19 @@ class LoRAManager:
 
         return self.create_lora_update_result(success=True)
 
-    def validate_new_adapter(self, lora_config: LoRAConfig, lora_ref: LoRARef):
+    def validate_new_adapter(
+        self,
+        lora_config: LoRAConfig,
+        lora_ref: LoRARef,
+        is_update: bool = False,
+        old_ref: Optional[LoRARef] = None,
+    ):
         """
         Validate if an adapter can be loaded into the current LoRA memory pool and generate error if it is incompatible.
+
+        For an in-place refresh (``is_update``), pass the currently-loaded ref as
+        ``old_ref`` so checks that count loaded adapters exclude the adapter's
+        own current state.
         """
         if lora_config.lora_added_tokens_size > 0:
             raise ValueError(
@@ -285,18 +295,19 @@ class LoRAManager:
                 f"Failed to load {lora_ref.lora_name} because LoRA serving currently doesn't support DoRA adapters"
             )
 
-        # Check if this LoRA adapter is already loaded
-        for existing_lora_ref in self.lora_refs.values():
-            if lora_ref.lora_name == existing_lora_ref.lora_name:
-                raise ValueError(
-                    f"Failed to load LoRA adapter {lora_ref.lora_name} because it is already loaded"
-                )
+        # Reject duplicates unless refreshing an existing adapter in place.
+        if not is_update:
+            for existing_lora_ref in self.lora_refs.values():
+                if lora_ref.lora_name == existing_lora_ref.lora_name:
+                    raise ValueError(
+                        f"Failed to load LoRA adapter {lora_ref.lora_name} because it is already loaded"
+                    )
 
-            if lora_ref.lora_path == existing_lora_ref.lora_path:
-                logger.warning(
-                    f"{lora_ref.lora_path} is already loaded with name: {existing_lora_ref.lora_name}, "
-                    f"but another copy is being loaded with name: {lora_ref.lora_name}"
-                )
+                if lora_ref.lora_path == existing_lora_ref.lora_path:
+                    logger.warning(
+                        f"{lora_ref.lora_path} is already loaded with name: {existing_lora_ref.lora_name}, "
+                        f"but another copy is being loaded with name: {lora_ref.lora_name}"
+                    )
 
         # Check if the LoRA adapter shape is compatible with the current LoRA memory pool configuration.
         memory_pool = getattr(self, "memory_pool", None)
@@ -309,7 +320,13 @@ class LoRAManager:
             )
 
         # Ensure pinned LoRA adapters does not exceed maximal limit or cause starvation.
-        if lora_ref.pinned and self.num_pinned_loras >= self.max_loras_per_batch - 1:
+        # On an in-place refresh the adapter's own pin is already counted in
+        # num_pinned_loras; refreshing occupies no additional pinned slot, so
+        # exclude it or a pinned adapter at the limit could never be refreshed.
+        num_other_pinned_loras = self.num_pinned_loras
+        if is_update and old_ref is not None:
+            num_other_pinned_loras -= int(bool(old_ref.pinned))
+        if lora_ref.pinned and num_other_pinned_loras >= self.max_loras_per_batch - 1:
             raise ValueError(
                 f"Failed to load LoRA adapter {lora_ref.lora_name} as a pinned adapter. It is not allowed to pin all slots "
                 "in the LoRA memory pool to avoid starvation for unpinned adapters and base models. Please increase your "
@@ -856,16 +873,25 @@ class LoRAManager:
         """
         Load the weights of a LoRA adapter from tensors to CPU memory.
         """
+        self.loras[lora_ref.lora_id] = self._create_lora_adapter_from_tensors(
+            lora_ref, self.configs[lora_ref.lora_id], tensors
+        )
+
+    def _create_lora_adapter_from_tensors(
+        self, lora_ref: LoRARef, config: LoRAConfig, tensors: Dict[str, torch.Tensor]
+    ) -> LoRAAdapter:
+        """Build and initialize a LoRAAdapter without touching served state,
+        so callers can stage it and commit only after every fallible step."""
         lora_adapter = LoRAAdapter(
             lora_ref.lora_id,
-            self.configs[lora_ref.lora_id],
+            config,
             self.base_hf_config,
             self.load_config,
             self.lora_backend,
             base_model=self.base_model,
         )
         lora_adapter.initialize_weights_from_tensors(tensors)
-        self.loras[lora_ref.lora_id] = lora_adapter
+        return lora_adapter
 
     def load_lora_adapter_from_tensors(
         self,
@@ -873,10 +899,11 @@ class LoRAManager:
         tensors: Dict[str, torch.Tensor],
         config_dict: Dict,
         added_tokens_config: Optional[Dict] = None,
+        upsert: bool = False,
     ) -> LoRAUpdateOutput:
         logger.info(f"LoRA adapter loading from tensors starts: {lora_ref}.")
         result = self._load_lora_adapter_from_tensors(
-            lora_ref, tensors, config_dict, added_tokens_config
+            lora_ref, tensors, config_dict, added_tokens_config, upsert=upsert
         )
         logger.info(f"LoRA adapter loading from tensors completes: {lora_ref}.")
         return result
@@ -887,35 +914,103 @@ class LoRAManager:
         tensors: Dict[str, torch.Tensor],
         config_dict: Dict,
         added_tokens_config: Optional[Dict] = None,
+        upsert: bool = False,
     ) -> LoRAUpdateOutput:
         """
         Load a single LoRA adapter from tensors and config dict.
+
+        With ``upsert``, an already-loaded adapter has its weights refreshed in
+        place (reusing its lora_id); otherwise the adapter must not be loaded yet.
         """
         assert (
             lora_ref.lora_name is not None and lora_ref.lora_path is not None
         ), "LoRARef must have both lora_name and lora_path set for loading."
-        assert (
-            lora_ref.lora_id not in self.loras
-        ), f"LoRA adapter with ID {lora_ref.lora_id} is already loaded. This should have been verified before request is sent to the backend."
+        is_update = upsert and (lora_ref.lora_id in self.loras)
+        if not is_update:
+            assert (
+                lora_ref.lora_id not in self.loras
+            ), f"LoRA adapter with ID {lora_ref.lora_id} is already loaded. This should have been verified before request is sent to the backend."
 
+        uid = lora_ref.lora_id
+        old_config = self.configs.get(uid)
+        old_lora = self.loras.get(uid)
+        old_ref = self.lora_refs.get(uid)
+
+        # Stage every fallible step before mutating served state: a failed
+        # request must not leave a live adapter with new metadata over old
+        # weights (or leak unreachable entries on a fresh insert).
         try:
-            new_adapter = LoRAConfig.from_dict(
+            new_config = LoRAConfig.from_dict(
                 config_dict,
                 added_tokens_config,
                 base_vocab_size=self.base_hf_config.vocab_size,
             )
-            self.validate_new_adapter(new_adapter, lora_ref)
-            self.configs[lora_ref.lora_id] = new_adapter
-
-            self.load_lora_weights_from_tensors(lora_ref, tensors)
-
-            self.lora_refs[lora_ref.lora_id] = lora_ref
-            self.num_pinned_loras += int(lora_ref.pinned)
+            self.validate_new_adapter(
+                new_config, lora_ref, is_update=is_update, old_ref=old_ref
+            )
+            new_lora = self._create_lora_adapter_from_tensors(
+                lora_ref, new_config, tensors
+            )
         except Exception as e:
             return self.create_lora_update_result(
                 success=False,
                 error_message=str(e),
             )
+
+        self.configs[uid] = new_config
+        self.loras[uid] = new_lora
+
+        if (
+            is_update
+            and getattr(self, "memory_pool", None) is not None
+            and uid in self.memory_pool.uid_to_buffer_id
+        ):
+            buffer_id = self.memory_pool.uid_to_buffer_id[uid]
+            try:
+                # The served buffer slot is rewritten in place. Wait for
+                # already-launched kernels first: under overlap scheduling /
+                # CUDA-graph replay a forward pass can still be executing on
+                # another stream, and it must not read a half-rewritten slot.
+                if self.device.type == "cuda":
+                    torch.cuda.synchronize(self.device)
+                self.memory_pool.load_lora_weight_to_buffer(
+                    uid,
+                    buffer_id,
+                    new_lora,
+                    self.lora_modules,
+                    self.embed_tokens_module,
+                    self.lm_head_module,
+                )
+            except Exception as e:
+                # Roll back so the adapter keeps serving its previous weights
+                # instead of a torn half-old/half-new buffer.
+                self.configs[uid] = old_config
+                self.loras[uid] = old_lora
+                try:
+                    self.memory_pool.load_lora_weight_to_buffer(
+                        uid,
+                        buffer_id,
+                        old_lora,
+                        self.lora_modules,
+                        self.embed_tokens_module,
+                        self.lm_head_module,
+                    )
+                except Exception:
+                    logger.exception(
+                        f"Failed to restore previous weights for LoRA adapter "
+                        f"{lora_ref.lora_name} (buffer slot {buffer_id}) after a "
+                        "failed upsert; the served buffer may be corrupted."
+                    )
+                return self.create_lora_update_result(
+                    success=False,
+                    error_message=str(e),
+                )
+
+        self.lora_refs[uid] = lora_ref
+        # An upsert may change ``pinned``; track the delta against the replaced
+        # ref so the counter stays consistent with lora_refs.
+        old_pinned = int(bool(old_ref.pinned)) if is_update else 0
+        self.num_pinned_loras += int(bool(lora_ref.pinned)) - old_pinned
 
         return self.create_lora_update_result(success=True)
 

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -438,6 +438,23 @@ class LoRAManager:
             and bs <= self.max_bs_in_cuda_graph
             and forward_batch.forward_mode.is_cuda_graph()
         )
+        if use_cuda_graph and self.lora_backend.is_moe_lora:
+            # This flag is a HEURISTIC computed before the runner's real replay decision. Under
+            # --enable-dp-attention a batch that is graph-eligible on THIS rank (small local bs)
+            # can still have a DP-gathered token count exceeding the static MoE capture buffers
+            # (max_bs*dp) when other ranks carry more tokens — such a batch cannot replay the
+            # captured graph and runs eager, so prep the eager (freshly sized) buffers for it
+            # instead of an under-sized static mapping.
+            from sglang.srt.lora.backend.base_backend import get_gathered_moe_num_tokens
+
+            moe_cg_buffers = getattr(self.lora_backend, "moe_cg_buffers", None)
+            if (
+                moe_cg_buffers is not None
+                and get_gathered_moe_num_tokens(forward_batch, bs)
+                > moe_cg_buffers["token_lora_mapping"].shape[0]
+            ):
+                use_cuda_graph = False
+
         # Eligible extend batches refresh the static prefill batch info in
         # place so captured kernels read current values at replay.
         use_prefill_cuda_graph = not use_cuda_graph and self.can_use_prefill_cuda_graph(
@@ -455,6 +472,55 @@ class LoRAManager:
                 lora = self.loras[uid]
                 lora_ranks[weight_indices[i]] = lora.config.r
                 scalings[weight_indices[i]] = lora.scaling
+
+        local_active = any(lora_ranks[wi] > 0 for wi in weight_indices)
+
+        # MoE-expert LoRA under --enable-dp-attention: the MoE runs on DP-GATHERED tokens, so this
+        # rank's local experts also process OTHER ranks' tokens, whose adapter identity is not known
+        # host-side. Under Tier-1 (exactly one adapter loaded — the colocate RL case) the gathered
+        # tail can be attributed to that single adapter. Two mutually-exclusive stamps, both armed
+        # here (policy) and mechanically applied by the backend in _add_moe_lora_info:
+        #   * idle rank (forward_mode.is_idle(), zero local tokens): inject the adapter into
+        #     lora_ranks/scalings (nothing else carries them into the batch tensors) and record its
+        #     buffer id so the backend stamps the WHOLE gathered mapping and enables the adapter —
+        #     otherwise foreign tokens routed to this rank's experts silently lose the LoRA delta.
+        #   * active rank (local requests DO use the adapter): record the buffer id so the backend
+        #     stamps the gathered tail [num_tokens, moe_num_tokens) with it instead of copying an
+        #     arbitrary local token's slot. Base-only local batches (local_active False) and
+        #     multi-adapter batches arm NOTHING: the tail stays -1 (adapter-disabled), foreign
+        #     tokens get base — never a delta this rank cannot attribute.
+        # Buffer ids are host ints (no GPU sync -> cuda-graph safe). NOTE: gate on
+        # global_num_tokens_cpu too, not just global_dp_buffer_len — the eager path runs
+        # prepare_lora_batch from ForwardBatch.init_new BEFORE prepare_mlp_sync_batch assigns
+        # global_dp_buffer_len (only cuda-graph capture pre-sets it).
+        idle_rank_active_buffer_id = None
+        single_active_buffer_id = None
+        if self.lora_backend.is_moe_lora and (
+            getattr(forward_batch, "global_dp_buffer_len", None) is not None
+            or len(getattr(forward_batch, "global_num_tokens_cpu", None) or []) > 1
+        ):
+            loaded = [
+                (uid, bid)
+                for uid, bid in self.memory_pool.uid_to_buffer_id.items()
+                if uid is not None
+                and uid in self.loras
+                and self.loras[uid].config.r > 0
+            ]
+            if len(loaded) == 1:
+                uid, bid = loaded[0]
+                if forward_batch.forward_mode.is_idle():
+                    lora = self.loras[uid]
+                    lora_ranks[bid] = lora.config.r
+                    scalings[bid] = lora.scaling
+                    idle_rank_active_buffer_id = bid
+                elif local_active:
+                    single_active_buffer_id = bid
+
+        # Pass the stamps to the backend (read in _add_moe_lora_info); reset each batch so a
+        # previous batch's stamp never leaks into a later one.
+        self.lora_backend._idle_rank_active_buffer_id = idle_rank_active_buffer_id
+        self.lora_backend._single_loaded_buffer_id = single_active_buffer_id
+
         # Do in-place updates when CUDA graph is enabled and the batch forward mode
         # could use CUDA graph.
         self.lora_backend.prepare_lora_batch(
@@ -465,8 +531,8 @@ class LoRAManager:
             use_cuda_graph=use_cuda_graph,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
         )
-        self.lora_backend.batch_info.has_active_lora = any(
-            lora_ranks[wi] > 0 for wi in weight_indices
+        self.lora_backend.batch_info.has_active_lora = local_active or (
+            idle_rank_active_buffer_id is not None
         )
 
     def update_lora_info(self):

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -328,7 +328,6 @@ def _add_lora_gate_up_delta(
     r = lora_info.max_lora_rank
     gate_up_a = lora_info.gate_up_lora_a_weights
     gate_up_b = lora_info.gate_up_lora_b_weights
-
     if lora_info.experts_shared_outer_loras and not lora_info.lora_use_virtual_experts:
         gate_up_a = gate_up_a.expand(-1, lora_info.num_experts, -1, -1)
 
@@ -338,6 +337,8 @@ def _add_lora_gate_up_delta(
     if is_gated:
         inter_size = gate_up_b.shape[2] // 2
         lora_a_stacked = [gate_up_a[:, :, :r, :], gate_up_a[:, :, r : 2 * r, :]]
+        # B halves are also the tuple form the virtual-experts kernel wants
+        # (one shrink at K=2*r, two expands at K=r each).
         lora_b_stacked = [
             gate_up_b[:, :, :inter_size, :],
             gate_up_b[:, :, inter_size:, :],
@@ -351,7 +352,7 @@ def _add_lora_gate_up_delta(
             output=intermediate_cache,
             hidden_states=hidden_states,
             lora_a=gate_up_a,
-            lora_b=gate_up_b,
+            lora_b=tuple(lora_b_stacked) if is_gated else gate_up_b,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             token_lora_mapping=token_lora_mapping,
@@ -418,6 +419,8 @@ def _add_lora_down_delta(
     down_lora_a = lora_info.down_lora_a_weights
     down_lora_b = lora_info.down_lora_b_weights
     if lora_info.experts_shared_outer_loras and not lora_info.lora_use_virtual_experts:
+        # fused_moe_lora requires B's expert_dim to match A's; expand the
+        # shared B view.
         down_lora_b = down_lora_b.expand(-1, lora_info.num_experts, -1, -1)
 
     if lora_info.fully_sharded and lora_info.tp_size > 1:

--- a/python/sglang/srt/lora/lora_registry.py
+++ b/python/sglang/srt/lora/lora_registry.py
@@ -15,11 +15,11 @@
 
 import asyncio
 from collections import OrderedDict
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import msgspec
-from msgspec.structs import fields
+from msgspec.structs import fields, replace
 
 from sglang.srt.utils import ConcurrentCounter
 from sglang.srt.utils.aio_rwlock import RWLock
@@ -122,6 +122,48 @@ class LoRARegistry:
             del self._registry[lora_name]
 
         return lora_ref.lora_id
+
+    async def get_lora_id(self, lora_name: str) -> Optional[str]:
+        """Return the ``lora_id`` of a registered adapter, or ``None``."""
+        async with self._registry_lock.reader_lock:
+            lora_ref = self._registry.get(lora_name, None)
+            return lora_ref.lora_id if lora_ref is not None else None
+
+    async def register_or_reuse(
+        self, lora_ref: LoRARef, upsert: bool = False
+    ) -> Tuple[LoRARef, bool]:
+        """Resolve which identity a load request should use.
+
+        Returns ``(ref, reused)``. With ``upsert`` and a same-name adapter
+        already registered, the returned ref adopts the existing ``lora_id``
+        (``reused=True``) so the backend refreshes that adapter in place;
+        otherwise ``lora_ref`` is returned unchanged (``reused=False``).
+        Nothing is registered here: the caller commits the resolved ref with
+        ``register`` / ``refresh`` once the backend load succeeded, keeping
+        failed loads invisible to the registry.
+        """
+        if not upsert:
+            return lora_ref, False
+        async with self._registry_lock.reader_lock:
+            existing = self._registry.get(lora_ref.lora_name, None)
+        if existing is None:
+            return lora_ref, False
+        return replace(lora_ref, lora_id=existing.lora_id), True
+
+    async def refresh(self, lora_ref: LoRARef):
+        """Replace a registered adapter's ref after a successful upsert.
+
+        Keeps the id (asserted) while adopting the new path/pinned metadata,
+        and counts as a use for LRU ordering.
+        """
+        async with self._registry_lock.writer_lock:
+            existing = self._registry.get(lora_ref.lora_name, None)
+            assert existing is not None and existing.lora_id == lora_ref.lora_id, (
+                f"refresh() must target a registered adapter with the same lora_id; "
+                f"got {lora_ref}, registered: {existing}"
+            )
+            self._registry[lora_ref.lora_name] = lora_ref
+            self._registry.move_to_end(lora_ref.lora_name)
 
     async def acquire(self, lora_name: Union[str, List[str]]) -> Union[str, List[str]]:
         """

--- a/python/sglang/srt/lora/lora_registry.py
+++ b/python/sglang/srt/lora/lora_registry.py
@@ -38,6 +38,12 @@ class LoRARef(msgspec.Struct, frozen=True, array_like=True):
     lora_name: Optional[str] = None
     lora_path: Optional[str] = None
     pinned: Optional[bool] = None
+    # False for adapters whose weights arrived over the wire (lora_path
+    # "__distributed__" / "__tensor__"): there is no disk artifact to reload
+    # from, so they must never be LRU-evicted nor implicitly reloaded.
+    # Trailing field with a default keeps the array_like wire format
+    # compatible with refs encoded before this field existed.
+    reloadable: bool = True
 
     def __post_init__(self):
         if self.lora_id is None:
@@ -184,24 +190,28 @@ class LoRARegistry:
             self._registry.move_to_end(name)
             return lora_ref.lora_id
 
+        # Lookup and increment must be one atomic admission step under the
+        # writer lock: with the increment outside, an unload can slip between
+        # them — unregister the adapter, observe the counter at zero, delete
+        # the counter — leaving this request to KeyError or to run on an
+        # adapter that is already gone. wait_for_unload never awaits inside
+        # this lock, so holding it across the increment cannot deadlock.
         if isinstance(lora_name, str):
             async with self._registry_lock.writer_lock:
                 lora_id = _lookup(lora_name)
-
-            await self._counters[lora_id].increment(notify_all=False)
+                await self._counters[lora_id].increment(notify_all=False)
             return lora_id
         elif isinstance(lora_name, list):
             async with self._registry_lock.writer_lock:
                 lora_ids = [_lookup(name) for name in lora_name]
-
-            # Increment the counters only after all IDs are looked up.
-            await asyncio.gather(
-                *[
-                    self._counters[id].increment(notify_all=False)
-                    for id in lora_ids
-                    if id is not None
-                ]
-            )
+                # Increment the counters only after all IDs are looked up.
+                await asyncio.gather(
+                    *[
+                        self._counters[id].increment(notify_all=False)
+                        for id in lora_ids
+                        if id is not None
+                    ]
+                )
             return lora_ids
         else:
             raise TypeError("lora_name must be either a string or a list of strings.")
@@ -266,14 +276,15 @@ class LoRARegistry:
         If exclude_pinned is True, then return the LRU LoRA adapter that isn't pinned.
         """
         async with self._registry_lock.reader_lock:
-            if not exclude_pinned:
-                return next(iter(self._registry), None)
-
             for lora_name, lora_ref in self._registry.items():
-                if not lora_ref.pinned:
-                    return lora_name
-            else:
-                return None
+                # Evicting a non-reloadable (wire-loaded) adapter is always
+                # destructive: there is no artifact to reload it from.
+                if not lora_ref.reloadable:
+                    continue
+                if exclude_pinned and lora_ref.pinned:
+                    continue
+                return lora_name
+            return None
 
     def _register_adapter(self, lora_ref: LoRARef):
         """

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -375,6 +375,157 @@ class LoRAMemoryPool:
             f"Expected dict or 3D torch.Tensor, got {type(weights).__name__}."
         )
 
+    def _row_parallel_shard_tp(
+        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
+    ) -> int:
+        """Shard count for a non-MoE row-parallel module's activation axis.
+
+        Probes the base module's ``input_size // input_size_per_partition`` so
+        the LoRA buffer matches the actual shard regardless of which TP group
+        owns it — covers DP-attention (``o_proj`` uses ``attn_tp_size``) and
+        shared-expert dense-vs-MoE per-layer-TP differences. Falls back to
+        ``self.tp_size``. Cached per ``(module_name, layer_idx)``.
+
+        MoE-internal names go through ``self.moe_tp_size`` upstream.
+        """
+        cache = getattr(self, "_row_parallel_tp_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_row_parallel_tp_cache", cache)
+        key = (module_name, layer_idx)
+        if key in cache:
+            return cache[key]
+
+        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
+
+        def _probe(m):
+            in_size = getattr(m, "input_size", None)
+            per_part = getattr(m, "input_size_per_partition", None)
+            if in_size is not None and per_part is not None and per_part > 0:
+                return max(1, in_size // per_part)
+            inner = getattr(m, "base_layer", None)
+            if inner is not None and inner is not m:
+                return _probe(inner)
+            return None
+
+        suffix = f".{module_name}"
+        found = None
+        for _name, module in base_model.named_modules():
+            if not _name.endswith(suffix):
+                continue
+            if not any(marker in _name for marker in layer_markers):
+                continue
+            r = _probe(module)
+            if r is not None:
+                found = r
+                break
+
+        out = found if found is not None else self.tp_size
+        cache[key] = out
+        return out
+
+    def _column_parallel_shard_tp(
+        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
+    ) -> int:
+        """Shard count for a non-MoE column-parallel module's output axis.
+
+        Probes the base module's ``output_size // output_size_per_partition``.
+        The input-axis probe used for row-parallel modules is poisoned here:
+        quantized linear methods (e.g. ``Fp8LinearMethod.create_weights``)
+        stamp ``input_size_per_partition == input_size`` on column-parallel
+        layers (whose input is never sharded), which reports a shard count of
+        1 and leaves the LoRA-B buffer at the full output dim while the base
+        stays TP-sharded -- ``set_lora_info`` then fails with "LoRA B output
+        dim != base partition prefix dim" (e.g. blockwise-fp8 GLM-5.2
+        ``shared_experts.gate_up_proj``). The output-axis ratio is
+        quantization-independent: ``output_size_per_partition`` is set in
+        ``ColumnParallelLinear.__init__`` before the quant method runs. Falls
+        back to ``self.tp_size``. Cached per ``(module_name, layer_idx)``.
+        """
+        cache = getattr(self, "_col_parallel_tp_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_col_parallel_tp_cache", cache)
+        key = (module_name, layer_idx)
+        if key in cache:
+            return cache[key]
+
+        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
+
+        def _probe(m):
+            out_size = getattr(m, "output_size", None)
+            per_part = getattr(m, "output_size_per_partition", None)
+            if out_size is not None and per_part is not None and per_part > 0:
+                return max(1, out_size // per_part)
+            inner = getattr(m, "base_layer", None)
+            if inner is not None and inner is not m:
+                return _probe(inner)
+            return None
+
+        suffix = f".{module_name}"
+        found = None
+        for _name, module in base_model.named_modules():
+            if not _name.endswith(suffix):
+                continue
+            if not any(marker in _name for marker in layer_markers):
+                continue
+            r = _probe(module)
+            if r is not None:
+                found = r
+                break
+
+        out = found if found is not None else self.tp_size
+        cache[key] = out
+        return out
+
+    def _column_parallel_out_partition(
+        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
+    ):
+        """Actual per-rank output dim of a non-MoE column-parallel base module.
+
+        Reads ``output_size_per_partition`` from the matching base linear -- the
+        ground truth that ``set_lora_info`` validates against. Critically handles
+        the dense MLP ``gate_up_proj`` that is fully REPLICATED under
+        ``--moe-dense-tp-size 1`` (``output_size_per_partition == output_size``),
+        where dividing ``get_hidden_dim``'s output by the global ``tp_size``
+        undersizes LoRA-B and raises "LoRA B output dim != base partition prefix
+        dim". Returns ``None`` if no base module is found. Cached per
+        ``(module_name, layer_idx)``.
+        """
+        cache = getattr(self, "_col_parallel_out_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_col_parallel_out_cache", cache)
+        key = (module_name, layer_idx)
+        if key in cache:
+            return cache[key]
+
+        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
+
+        def _probe(m):
+            ops = getattr(m, "output_size_per_partition", None)
+            if ops is not None and ops > 0:
+                return ops
+            inner = getattr(m, "base_layer", None)
+            if inner is not None and inner is not m:
+                return _probe(inner)
+            return None
+
+        suffix = f".{module_name}"
+        found = None
+        for _name, module in base_model.named_modules():
+            if not _name.endswith(suffix):
+                continue
+            if not any(marker in _name for marker in layer_markers):
+                continue
+            r = _probe(module)
+            if r is not None:
+                found = r
+                break
+
+        cache[key] = found
+        return found
+
     def _get_standard_shape(
         self,
         module_name: str,
@@ -387,8 +538,12 @@ class LoRAMemoryPool:
             module_name, self.base_hf_config, base_model, layer_idx
         )
         c = get_stacked_multiply(module_name, base_model)
-        if self.tp_size > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
-            input_dim = divide(input_dim, self.tp_size)
+        # Non-MoE row-parallel modules: probe the actual shard size so o_proj /
+        # down_proj match attn_tp under DP-attention and the shared-experts
+        # dense-vs-MoE per-layer-TP differences.
+        row_tp = self._row_parallel_shard_tp(module_name, base_model, layer_idx)
+        if row_tp > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
+            input_dim = divide(input_dim, row_tp)
         return (self.max_loras_per_batch, max_lora_dim * c, input_dim)
 
     def get_lora_A_shape(
@@ -513,9 +668,25 @@ class LoRAMemoryPool:
             and module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
             and module_name not in REPLICATED_LINEAR_LORA_NAMES
         ):
-            output_dim = self._column_parallel_lora_b_per_rank_dim(
-                module_name, output_dim, effective_tp_size
+            # If the base column-parallel module is fully REPLICATED (its actual
+            # output_size_per_partition still equals the full output_dim -- e.g. the
+            # dense MLP gate_up under --moe-dense-tp-size 1), its output is NOT
+            # sharded, so keep LoRA-B at the full output dim. Dividing by the global
+            # tp_size here undersizes B and crashes set_lora_info ("LoRA B output dim
+            # != base partition prefix dim"). Non-MoE only; MoE shards by moe_tp_size.
+            probed_out = (
+                None
+                if self.is_moe_module(module_name)
+                else self._column_parallel_out_partition(
+                    module_name, base_model, layer_idx
+                )
             )
+            if probed_out is not None and probed_out == output_dim:
+                pass  # replicated base: keep full B output dim
+            else:
+                output_dim = self._column_parallel_lora_b_per_rank_dim(
+                    module_name, output_dim, effective_tp_size
+                )
 
         # Check if MoE module and return appropriate shape
         if self.is_moe_module(module_name):
@@ -974,19 +1145,45 @@ class LoRAMemoryPool:
                         temp_B_buffer[target_module] = weights
                         temp_B_cache_keys[target_module] = name
                 elif expert_match:
-                    # Per-expert MoE weight — 2D tensors, one per expert
+                    # Per-expert MoE weight — 2D tensors, one per expert.
+                    # Init A and B INDEPENDENTLY (both buffer and cache_keys). Under
+                    # ``experts_shared_outer_loras`` one side of a projection is a
+                    # shared 3D Tensor (set by the dim()==3 branch below) and the
+                    # other is this per-expert dict: fc1 = shared A + per-expert B,
+                    # fc2 = the opposite. The old coupled init keyed every dict off
+                    # ``temp_A_buffer is None``, which either left the per-expert
+                    # side's cache_keys as None (-> TypeError at
+                    # ``[expert_id] = name``) or clobbered the shared side the 3D
+                    # branch already populated. So each side now guards its own
+                    # buffer + cache_keys and never touches the other side.
                     target_module = target_module + "_moe"
-                    if temp_A_buffer[target_module] is None:
-                        temp_A_buffer[target_module] = {}
-                        temp_B_buffer[target_module] = {}
-                        temp_A_cache_keys[target_module] = {}
-                        temp_B_cache_keys[target_module] = {}
-
                     expert_id = int(expert_match.group(1))
                     if "lora_A" in name:
+                        assert not isinstance(
+                            temp_A_buffer[target_module], torch.Tensor
+                        ), (
+                            f"{target_module} lora_A already holds a shared-outer 3D "
+                            f"tensor but also got per-expert weight '{name}'; a "
+                            f"projection side must use one layout, not both."
+                        )
+                        if temp_A_buffer[target_module] is None:
+                            temp_A_buffer[target_module] = {}
+                        if temp_A_cache_keys[target_module] is None:
+                            temp_A_cache_keys[target_module] = {}
                         temp_A_buffer[target_module][expert_id] = weights
                         temp_A_cache_keys[target_module][expert_id] = name
                     else:
+                        assert not isinstance(
+                            temp_B_buffer[target_module], torch.Tensor
+                        ), (
+                            f"{target_module} lora_B already holds a shared-outer 3D "
+                            f"tensor but also got per-expert weight '{name}'; a "
+                            f"projection side must use one layout, not both."
+                        )
+                        if temp_B_buffer[target_module] is None:
+                            temp_B_buffer[target_module] = {}
+                        if temp_B_cache_keys[target_module] is None:
+                            temp_B_cache_keys[target_module] = {}
                         temp_B_buffer[target_module][expert_id] = weights
                         temp_B_cache_keys[target_module][expert_id] = name
                 elif "experts" in name and weights.dim() == 3:

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -261,6 +261,8 @@ def get_normalized_target_modules(
         "v_proj": "qkv_proj",
         "gate_proj": "gate_up_proj",
         "up_proj": "gate_up_proj",
+        "in_proj_b": "in_proj_ba",
+        "in_proj_a": "in_proj_ba",
         "out_proj": "out_proj",
         "embed_tokens": "embed_tokens",
         "vocab_emb": "embed_tokens",
@@ -299,6 +301,7 @@ def get_stacked_multiply(
     stacked_rank = {
         "qkv_proj": 3,
         "in_proj_qkvz": 4,  # GDN packed input projection
+        "in_proj_ba": 2,  # GDN packed b/a input projection
         "gate_up_proj": 2,
         "gate_up_proj_moe": 2,
         "gate_up_proj_shared_moe": 2,
@@ -378,6 +381,7 @@ _KNOWN_LORA_TARGET_MODULES = frozenset(
         "out_proj",
         "in_proj",
         "in_proj_qkvz",
+        "in_proj_ba",
         "up_proj",
         "gate_up_proj",
         "down_proj",

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -478,6 +478,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             output_hidden_states=recv_obj.output_hidden_states,
             routed_experts=routed_experts,
             indexer_topk=indexer_topk,
+            indexer_topk_num_layers=recv_obj.indexer_topk_num_layers,
             customized_info=recv_obj.customized_info,
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -483,6 +483,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             retraction_counts=recv_obj.retraction_counts,
+            weight_versions=recv_obj.weight_versions,
             token_steps=recv_obj.token_steps,
             dp_ranks=recv_obj.dp_ranks,
             time_stats=recv_obj.time_stats,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2061,6 +2061,13 @@ class AbortReq(BaseReq, kw_only=True):
     # The finished reason data (from BaseFinishReason.to_json())
     finished_reason: Optional[FinishReasonDict] = None
     abort_message: Optional[str] = None
+    # Treat ``rid`` as a namespace prefix. Note this only relaxes the
+    # tokenizer-side gate (which otherwise requires an exact live rid, with a
+    # single tokenizer worker): once the request reaches the scheduler,
+    # matching is prefix-based (``rid.startswith``) regardless of this flag,
+    # because batch requests derive child rids as ``f"{rid}_{i}"`` and an
+    # abort for the parent rid must cover them.
+    prefix: bool = False
 
     def __post_init__(self):
         # FIXME: This is a hack to keep the same with the old code

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2023,6 +2023,9 @@ class CheckWeightsReqInput(BaseReq, kw_only=True):
 # sglang.srt.utils.weight_checker. Not array_like: the payload is read by field
 # name and re-serialized to JSON, so it must stay a {field: value} map.
 class ParallelismInfo(msgspec.Struct, kw_only=True):
+    # Which runner this describes: "target", or a draft role such as "draft" /
+    # "draft_step_0". One entry per runner the checksum covers.
+    role: str
     tp_rank: int
     tp_size: int
     dp_rank: int
@@ -2036,7 +2039,10 @@ class ParallelismInfo(msgspec.Struct, kw_only=True):
 class ChecksumInfo(msgspec.Struct, kw_only=True):
     checksums: Dict[str, str]
     per_gpu_checksum: str
-    parallelism_info: ParallelismInfo
+    # One entry per role the checksum covers: the target model plus, under
+    # speculative decoding, each draft runner. All roles on a rank share the GPU
+    # rank; consumers key off it to merge the shards.
+    parallelism_info: List[ParallelismInfo]
 
 
 class CheckWeightsReqOutput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1779,6 +1779,22 @@ class UpdateWeightFromDiskReqOutput(BaseReq, kw_only=True):
     num_paused_requests: int = 0
 
 
+class PullWeightsReqInput(BaseReq, kw_only=True):
+    # Host-local checkpoint dir the pulled weights land in; seeded from the
+    # server's model path when the published stream has no full version.
+    local_checkpoint_dir: str
+    # Shared dir the publisher writes weight_v{N:06d}/ version dirs under; each
+    # version is a full HF checkpoint or a delta against the previous version.
+    source_dir: str
+    # The version to bring the local checkpoint up to.
+    target_version: int
+
+
+class PullWeightsReqOutput(BaseReq, kw_only=True):
+    success: bool
+    message: str
+
+
 class UpdateWeightsFromDistributedReqInput(BaseReq, kw_only=True):
     names: List[str]
     dtypes: List[str]

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2254,6 +2254,8 @@ class LoadLoRAAdapterFromTensorsReqInput(BaseReq, kw_only=True):
     added_tokens_config: Optional[Dict[str, int]] = None
     lora_id: Optional[str] = None
     load_format: Optional[str] = None
+    # If already loaded, refresh weights in place instead of failing.
+    upsert: bool = False
     expected_checksums: Optional[Dict[str, str]] = None
 
     def to_ref(self) -> LoRARef:
@@ -2261,6 +2263,28 @@ class LoadLoRAAdapterFromTensorsReqInput(BaseReq, kw_only=True):
             lora_id=self.lora_id,
             lora_name=self.lora_name,
             lora_path="__tensor__",
+            pinned=self.pinned,
+        )
+
+
+class LoadLoRAAdapterFromDistributedReqInput(BaseReq, kw_only=True):
+    lora_name: str
+    config_dict: Dict[str, Any]
+    names: List[str]
+    dtypes: List[str]
+    shapes: List[List[int]]
+    group_name: str = "weight_update_group"
+    pinned: bool = False
+    added_tokens_config: Optional[Dict[str, Any]] = None
+    lora_id: Optional[str] = None
+    # If already loaded, refresh weights in place instead of failing.
+    upsert: bool = False
+
+    def to_ref(self) -> LoRARef:
+        return LoRARef(
+            lora_id=self.lora_id,
+            lora_name=self.lora_name,
+            lora_path="__distributed__",
             pinned=self.pinned,
         )
 
@@ -2273,7 +2297,7 @@ class LoRAUpdateOutput(BaseReq, kw_only=True):
 
 LoadLoRAAdapterReqOutput = UnloadLoRAAdapterReqOutput = (
     LoadLoRAAdapterFromTensorsReqOutput
-) = LoRAUpdateOutput
+) = LoadLoRAAdapterFromDistributedReqOutput = LoRAUpdateOutput
 
 
 class BlockReqType(Enum):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1476,6 +1476,10 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # Pickled Optional[List[SchedulerReqTimeStats]]
     time_stats: Optional[PickleWrapper] = None
 
+    # Number of indexer layers, set when indexer_topk is non-empty. The
+    # rollout-indexer-replay consumer needs the layer count to reshape the
+    # flattened per-token topk back into (token, layer, topk).
+    indexer_topk_num_layers: Optional[int] = None
     # Multimodal prompt token counts (image/audio/video). None when not applicable.
     image_tokens: Optional[List[int]] = None
     audio_tokens: Optional[List[int]] = None
@@ -1567,6 +1571,9 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     # Pickled Optional[List[SchedulerReqTimeStats]]
     time_stats: Optional[PickleWrapper] = None
 
+    # Number of indexer layers, set when indexer_topk is non-empty (see
+    # BatchTokenIDOutput.indexer_topk_num_layers).
+    indexer_topk_num_layers: Optional[int] = None
     # Multimodal prompt token counts (image/audio/video). None when not applicable.
     image_tokens: Optional[List[int]] = None
     audio_tokens: Optional[List[int]] = None

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1793,6 +1793,9 @@ class UpdateWeightsFromDistributedReqInput(BaseReq, kw_only=True):
     weight_version: Optional[str] = None
     # Optional format specification for loading
     load_format: Optional[str] = None
+    # Which model runners to update: "target" (target model only), "draft" (draft
+    # worker(s) only), or "all" (default).
+    selector: Literal["target", "draft", "all"] = "all"
     # Whether to call torch.cuda.empty_cache() during flush
     torch_empty_cache: bool = False
 
@@ -1819,8 +1822,9 @@ class UpdateWeightsFromTensorReqInput(BaseReq, kw_only=True):
     abort_all_requests: bool = False
     # Optional: Update weight version along with weights
     weight_version: Optional[str] = None
-    # Optional: Determine whether to disable updating the draft model
-    disable_draft_model: Optional[bool] = None
+    # Which model runners to update: "target" (target model only), "draft" (draft
+    # worker(s) only), or "all" (default).
+    selector: Literal["target", "draft", "all"] = "all"
     # Whether to call torch.cuda.empty_cache() during flush
     torch_empty_cache: bool = False
 
@@ -1968,9 +1972,35 @@ class ResumeMemoryOccupationReqOutput(BaseReq, kw_only=True):
     pass
 
 
+class BeginWeightUpdateReqInput(BaseReq, kw_only=True):
+    """Open a weight-update session: unpack in-place-quantized weights on the
+    selected runners so fresh weights can be loaded into them."""
+
+    selector: Literal["target", "draft", "all"] = "all"
+
+
+class BeginWeightUpdateReqOutput(BaseReq, kw_only=True):
+    success: bool
+    message: str
+
+
+class EndWeightUpdateReqInput(BaseReq, kw_only=True):
+    """Close the weight-update session opened by BeginWeightUpdateReqInput."""
+
+
+class EndWeightUpdateReqOutput(BaseReq, kw_only=True):
+    success: bool
+    message: str
+
+
 class CheckWeightsReqInput(BaseReq, kw_only=True):
     action: str = "checksum"
     allow_quant_error: bool = False
+    # Substrings of tensor names to exclude from reset/compare/checksum.
+    skip_tensor_list: Optional[List[str]] = None
+    # Which model runners to update: "target" (target model only), "draft" (draft
+    # worker(s) only), or "all" (default).
+    selector: Literal["target", "draft", "all"] = "all"
 
 
 # Wire versions of the pydantic ParallelismInfo/ChecksumInfo in

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -66,6 +66,7 @@ from sglang.srt.utils.msgspec_utils import (
     Base64Bytes,
     msgspec_struct_pydantic_core_schema,
 )
+from sglang.srt.utils.weight_versions import WeightVersionSpans
 
 # Handle serialization of Image for pydantic
 if TYPE_CHECKING:
@@ -1462,6 +1463,8 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # Number of times each request was retracted.
     retraction_counts: Optional[List[int]] = None
 
+    weight_versions: Optional[List[Optional[WeightVersionSpans]]] = None
+
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
@@ -1556,6 +1559,8 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
 
     # Number of times each request was retracted.
     retraction_counts: Optional[List[int]] = None
+
+    weight_versions: Optional[List[Optional[WeightVersionSpans]]] = None
 
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
@@ -1957,6 +1962,10 @@ class UpdateWeightVersionReqInput(BaseReq, kw_only=True):
     abort_all_requests: bool = True
 
 
+class UpdateWeightVersionReqOutput(BaseReq, kw_only=True):
+    pass
+
+
 class GetWeightsByNameReqInput(BaseReq, kw_only=True):
     name: str
     truncate_size: int = 100
@@ -2074,6 +2083,7 @@ class AbortReq(BaseReq, kw_only=True):
     # because batch requests derive child rids as ``f"{rid}_{i}"`` and an
     # abort for the parent rid must cover them.
     prefix: bool = False
+    weight_versions: Optional[WeightVersionSpans] = None
 
     def __post_init__(self):
         # FIXME: This is a hack to keep the same with the old code

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -256,6 +256,7 @@ def _handle_output_by_index(output, i):
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
             ),
+            indexer_topk_num_layers=getattr(output, "indexer_topk_num_layers", None),
             retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
@@ -373,6 +374,7 @@ def _handle_output_by_index(output, i):
             indexer_topk=_extract_field_by_index(
                 output, "indexer_topk", i, check_length=False
             ),
+            indexer_topk_num_layers=getattr(output, "indexer_topk_num_layers", None),
             customized_info=_extract_field_by_index(
                 output, "customized_info", i, check_length=False
             ),

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -258,6 +258,7 @@ def _handle_output_by_index(output, i):
             ),
             indexer_topk_num_layers=getattr(output, "indexer_topk_num_layers", None),
             retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
+            weight_versions=_extract_field_by_index(output, "weight_versions", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             token_steps=_extract_field_by_index(
@@ -382,6 +383,7 @@ def _handle_output_by_index(output, i):
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
+            weight_versions=_extract_field_by_index(output, "weight_versions", i),
             token_steps=_extract_field_by_index(
                 output, "token_steps", i, check_length=False
             ),

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2824,8 +2824,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         while first_iter or (
             not self.check_decode_mem(selected_indices=sorted_indices)
         ):
-            if len(sorted_indices) == 1:
-                # Always keep at least one request
+            # We should allow all requests to be retracted in decode disaggregation mode
+            # because there can be prealloc prefill requests.
+            num_minimum_reqs = 0 if server_args.disaggregation_mode == "decode" else 1
+            if len(sorted_indices) == num_minimum_reqs:
                 break
 
             first_iter = False

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -19,6 +19,10 @@ from sglang.srt.utils.common import (
     flatten_arrays_to_pinned_cpu,
     is_pin_memory_available,
 )
+from sglang.srt.utils.weight_versions import (
+    WeightVersionEvent,
+    truncate_weight_version_events,
+)
 
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1025,6 +1029,8 @@ class Req(ReqDllmMixin):
         # Indicates if the req has ever been retracted.
         self.retracted_stain = False
 
+        self.weight_version_events: List[WeightVersionEvent] = []
+
         # Incremental streamining
         self.send_token_offset: int = 0
         self.send_decode_id_offset: int = 0
@@ -1710,6 +1716,9 @@ class Req(ReqDllmMixin):
         # to ensure shape consistency in KV cache.
         if self.input_embeds is not None:
             self.output_ids = array("q")
+            self.weight_version_events = truncate_weight_version_events(
+                self.weight_version_events, num_kept_tokens=self.send_token_offset
+            )
 
     def offload_kv_cache(self, req_to_token_pool, token_to_kv_pool_allocator):
         token_indices = req_to_token_pool.req_to_token[

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -157,6 +157,7 @@ from sglang.srt.managers.io_struct import (
     OpenSessionReqInput,
     PauseGenerationReqInput,
     ProfileReq,
+    PullWeightsReqInput,
     ReleaseMemoryOccupationReqInput,
     RemoveExternalCorpusReqInput,
     RemoveExternalCorpusReqOutput,
@@ -1603,6 +1604,10 @@ class Scheduler(
                 (
                     CheckWeightsReqInput,
                     self.weight_updater.check_weights,
+                ),
+                (
+                    PullWeightsReqInput,
+                    self.weight_updater.pull_weights,
                 ),
                 (SlowDownReqInput, self.slow_down),
                 (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4105,7 +4105,7 @@ class Scheduler(
         # sleep until next event
         self.maybe_sleep_on_idle()
 
-    def is_fully_idle(self, for_health_check=False) -> bool:
+    def is_fully_idle(self, for_health_check=False, ignore_waiting=False) -> bool:
         # Health check piggybacks on running requests in process_output.
         # Only running_batch + waiting_queue guarantee active GPU processing;
         # disagg queues (bootstrap/prealloc/transfer) may have items without
@@ -4122,7 +4122,8 @@ class Scheduler(
         )
 
         # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
-        idle &= len(self.waiting_queue) == 0
+        if not ignore_waiting:
+            idle &= len(self.waiting_queue) == 0
 
         if (
             for_health_check
@@ -4275,7 +4276,7 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
-        if self.is_fully_idle():
+        if self.is_fully_idle(ignore_waiting=self._engine_paused):
             self.cur_batch_for_debug = None
             self.last_batch = None
             self.tree_cache.reset()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -121,6 +121,7 @@ from sglang.srt.managers.io_struct import (
     AttachHiCacheStorageReqOutput,
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
+    BeginWeightUpdateReqInput,
     CheckWeightsReqInput,
     ClearHiCacheReqInput,
     ClearHiCacheReqOutput,
@@ -132,6 +133,7 @@ from sglang.srt.managers.io_struct import (
     DetachHiCacheStorageReqOutput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EndWeightUpdateReqInput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -1565,6 +1567,14 @@ class Scheduler(
                 (
                     SendWeightsToRemoteInstanceReqInput,
                     self.send_weights_to_remote_instance,
+                ),
+                (
+                    BeginWeightUpdateReqInput,
+                    self.weight_updater.begin_weight_update,
+                ),
+                (
+                    EndWeightUpdateReqInput,
+                    self.weight_updater.end_weight_update,
                 ),
                 (
                     UpdateWeightsFromDistributedReqInput,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4587,6 +4587,20 @@ class Scheduler(
 
     def pause_generation(self, recv_req: PauseGenerationReqInput):
         assert recv_req.mode in ("in_place", "retract")
+        # PD disaggregation: `retract` has no decode-to-prefill rebootstrap path,
+        # so retracted decode-side requests cannot be re-prefilled under new
+        # weights. Fail fast before mutating any scheduler state to avoid
+        # leaving the engine in a half-paused / inconsistent state that later
+        # crashes inside radix-cache cleanup on flush_cache.
+        assert not (
+            recv_req.mode == "retract"
+            and self.disaggregation_mode != DisaggregationMode.NULL
+        ), (
+            "pause_generation(mode='retract') is not supported in PD "
+            "disaggregation mode yet. Decode-side retracted requests need "
+            "a rebootstrap path back to prefill."
+        )
+
         self._engine_paused = True
 
         if recv_req.mode == "in_place":

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -146,6 +146,8 @@ from sglang.srt.managers.io_struct import (
     InitWeightsUpdateGroupReqInput,
     ListExternalCorporaReqInput,
     ListExternalCorporaReqOutput,
+    LoadLoRAAdapterFromDistributedReqInput,
+    LoadLoRAAdapterFromDistributedReqOutput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterFromTensorsReqOutput,
     LoadLoRAAdapterReqInput,
@@ -1607,6 +1609,10 @@ class Scheduler(
                 (
                     LoadLoRAAdapterFromTensorsReqInput,
                     self.load_lora_adapter_from_tensors,
+                ),
+                (
+                    LoadLoRAAdapterFromDistributedReqInput,
+                    self.load_lora_adapter_from_distributed,
                 ),
                 (UnloadLoRAAdapterReqInput, self.unload_lora_adapter),
                 (PauseGenerationReqInput, self.pause_generation),
@@ -4804,6 +4810,14 @@ class Scheduler(
         """In-place loading a new lora adapter from serialized tensors."""
 
         result = self.tp_worker.load_lora_adapter_from_tensors(recv_req)
+        return result
+
+    def load_lora_adapter_from_distributed(
+        self, recv_req: LoadLoRAAdapterFromDistributedReqInput
+    ) -> LoadLoRAAdapterFromDistributedReqOutput:
+        """In-place loading a new lora adapter broadcast over a process group."""
+
+        result = self.tp_worker.load_lora_adapter_from_distributed(recv_req)
         return result
 
     def unload_lora_adapter(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -786,6 +786,7 @@ class Scheduler(
                     self.ipc_channels.recv_from_tokenizer,
                     self.ipc_channels.recv_from_rpc,
                 ],
+                can_empty_cache=lambda: not self._engine_paused,
             )
         else:
             self.idle_sleeper = None
@@ -2007,7 +2008,9 @@ class Scheduler(
         # drains its request ring (rust_server_mode) instead of a zmq socket.
         self.recv_from_tokenizer = rust_server
         # Park the idle loop on the request ring within the rank-0 rust-server
-        self.idle_sleeper = RustServerIdleSleeper(rust_server)
+        self.idle_sleeper = RustServerIdleSleeper(
+            rust_server, can_empty_cache=lambda: not self._engine_paused
+        )
 
     def init_request_receiver(self) -> None:
         self.request_receiver = SchedulerRequestReceiver(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2143,6 +2143,7 @@ class Scheduler(
             ps=self.ps,
             server_args=self.server_args,
             is_generation=self.is_generation,
+            is_multimodal_gen=getattr(self.model_config, "is_multimodal_gen", False),
             spec_algorithm=self.spec_algorithm,
             disaggregation_mode=self.disaggregation_mode,
             enable_hicache_storage=lambda: self.enable_hicache_storage,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -43,6 +43,7 @@ from sglang.srt.runtime_context import (
     get_observability,
     get_parallel,
     get_schedule,
+    get_server_args,
     get_serving,
     get_spec,
 )
@@ -101,7 +102,7 @@ from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
-from sglang.srt.environ import envs
+from sglang.srt.environ import envs, exportable_env_vars
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
@@ -137,6 +138,7 @@ from sglang.srt.managers.io_struct import (
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
+    FinishReasonDict,
     FlushCacheReqInput,
     FreezeGCReq,
     GetInternalStateReq,
@@ -181,6 +183,8 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
+    UpdateWeightVersionReqInput,
+    UpdateWeightVersionReqOutput,
     sock_send,
 )
 from sglang.srt.managers.load_snapshot import create_load_snapshot_writer
@@ -296,7 +300,7 @@ from sglang.srt.plugins import load_plugins
 from sglang.srt.runtime_context import get_context, publish
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
-from sglang.srt.server_args import PortArgs, ServerArgs
+from sglang.srt.server_args import PortArgs, ServerArgs, compute_world_size
 from sglang.srt.session.session_controller import SessionController
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_utils import validate_dflash_request
@@ -332,6 +336,10 @@ from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+from sglang.srt.utils.weight_versions import (
+    compute_weight_version_spans,
+    record_weight_version_events,
+)
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 if is_mps():
@@ -1590,6 +1598,10 @@ class Scheduler(
                     self.weight_updater.update_weights_from_ipc,
                 ),
                 (
+                    UpdateWeightVersionReqInput,
+                    self.handle_update_weight_version,
+                ),
+                (
                     GetWeightsByNameReqInput,
                     self.weight_updater.get_weights_by_name,
                 ),
@@ -2776,13 +2788,13 @@ class Scheduler(
             and req.priority is not None
             and self.abort_on_priority_when_disabled
         ):
-            abort_req = AbortReq(
+            abort_req = _make_abort_req(
+                req,
                 finished_reason={
                     "type": "abort",
                     "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                     "message": "Using priority is disabled for this server. Please send a new request without a priority.",
                 },
-                rid=req.rid,
             )
             req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
             self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
@@ -2825,13 +2837,13 @@ class Scheduler(
                 message = "The request is aborted by a higher priority request."
 
         self.ipc_channels.send_to_tokenizer.send_output(
-            AbortReq(
+            _make_abort_req(
+                req_to_abort,
                 finished_reason={
                     "type": "abort",
                     "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                     "message": message,
                 },
-                rid=req_to_abort.rid,
             ),
             req_to_abort,
         )
@@ -2851,13 +2863,13 @@ class Scheduler(
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
-                    AbortReq(
+                    _make_abort_req(
+                        req,
                         finished_reason={
                             "type": "abort",
                             "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                             "message": "Request waiting timeout reached.",
                         },
-                        rid=req.rid,
                     ),
                     req,
                 )
@@ -2990,7 +3002,7 @@ class Scheduler(
 
         self.chunked_req = None
         self._pending_chunked_abort_req = None
-        self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+        self.ipc_channels.send_to_tokenizer.send_output(_make_abort_req(req), req)
         logger.debug(f"Abort chunked prefill request. {req.rid=}")
 
     def _build_hisparse_decode_batch(self, reqs):
@@ -3552,10 +3564,7 @@ class Scheduler(
             for req in reqs_to_abort:
                 abort_reason: FINISH_ABORT = req.to_finish
                 self.ipc_channels.send_to_tokenizer.send_output(
-                    AbortReq(
-                        finished_reason=abort_reason.to_json(),
-                        rid=req.rid,
-                    ),
+                    _make_abort_req(req, finished_reason=abort_reason.to_json()),
                     req,
                 )
 
@@ -4308,6 +4317,7 @@ class Scheduler(
         # Resolved config (pristine server_args + post-publish overrides) so a
         # readback reflects values changed via /set_internal_state, not startup.
         ret = get_context().resolved_server_args_dict()
+        ret["world_size"] = compute_world_size(get_server_args())
         ret["last_gen_throughput"] = self.metrics_reporter.last_gen_throughput
         draft_graph_memory_usage = (
             None if self.draft_worker is None else self.draft_worker.graph_memory_usage
@@ -4349,6 +4359,9 @@ class Scheduler(
             info_record = self.draft_worker.dump_info_records()
             if info_record is not None:
                 ret["dspark_info_record"] = info_record
+
+        if envs.SGLANG_EXPOSE_OWN_ENV_VARS.get():
+            ret["env_vars"] = exportable_env_vars()
 
         # These fields are not msgpack-serializable (a config object and a bound
         # signal handler); no reader consumes them.
@@ -4465,6 +4478,42 @@ class Scheduler(
         barrier(group=self.tp_group.cpu_group)
         return RpcReqOutput(success=success, message="" if not exec else str(exec))
 
+    def handle_update_weight_version(
+        self, recv_req: UpdateWeightVersionReqInput
+    ) -> UpdateWeightVersionReqOutput:
+        self.record_weight_version_change(new_version=recv_req.new_version)
+        return UpdateWeightVersionReqOutput()
+
+    def record_weight_version_change(self, new_version: Optional[str]) -> None:
+        if new_version is None or new_version == get_serving().weight_version:
+            return
+
+        old_version = get_serving().weight_version
+        get_context().override("scheduler.weight_version", weight_version=new_version)
+
+        live_reqs = {
+            *self.collect_inflight_reqs(),
+            *self.waiting_queue,
+            *([self.chunked_req] if self.chunked_req is not None else []),
+        }
+        if self.hisparse_coordinator is not None:
+            live_reqs.update(
+                act.req for act in self.hisparse_coordinator.ack_staging_queue
+            )
+        num_recorded = record_weight_version_events(live_reqs, old_version=old_version)
+        logger.info(
+            f"Weight version changed. {old_version=} {new_version=} {num_recorded=}"
+        )
+
+    def collect_inflight_reqs(self) -> Set[Req]:
+        if self.ps.pp_size == 1:
+            inflight_batches = [self.running_batch, self.last_batch]
+        else:
+            inflight_batches = [*self.running_mbs, *self.mbs]
+        return {
+            req for batch in inflight_batches if batch is not None for req in batch.reqs
+        }
+
     def abort_request(self, recv_req: AbortReq):
         if (chunked_req := self.chunked_req) is not None:
             if recv_req.abort_all or chunked_req.rid.startswith(recv_req.rid):
@@ -4486,7 +4535,7 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
-            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            self.ipc_channels.send_to_tokenizer.send_output(_make_abort_req(req), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 release_kv_cache(req, self.tree_cache)
@@ -4519,7 +4568,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
-                    AbortReq(rid=req.rid), req
+                    _make_abort_req(req), req
                 )
                 if (
                     req.req_pool_idx is not None
@@ -4581,20 +4630,14 @@ class Scheduler(
                             get_disagg().disaggregation_decode_retraction_backup,
                         )
                         self.ipc_channels.send_to_tokenizer.send_output(
-                            AbortReq(rid=decode_req.rid), decode_req
+                            _make_abort_req(decode_req), decode_req
                         )
                     else:
                         remaining_retracted.append(decode_req)
                 self.disagg_decode_prealloc_queue.retracted_queue = remaining_retracted
 
         # Delete requests in the running batch
-        if self.ps.pp_size == 1:
-            inflight_batches = [self.running_batch, self.last_batch]
-        else:
-            inflight_batches = [*self.running_mbs, *self.mbs]
-
-        inflight_reqs = {r for b in inflight_batches if b is not None for r in b.reqs}
-        for req in inflight_reqs:
+        for req in self.collect_inflight_reqs():
             if not req.finished() and (
                 recv_req.abort_all or req.rid.startswith(recv_req.rid)
             ):
@@ -5131,3 +5174,17 @@ def run_scheduler_process(
             # and the synchronize() in destroy() could itself hang.
             if scheduler.gracefully_exit:
                 scheduler.release_host_resources()
+
+
+def _make_abort_req(
+    req: Req, finished_reason: Optional[FinishReasonDict] = None
+) -> AbortReq:
+    return AbortReq(
+        rid=req.rid,
+        finished_reason=finished_reason,
+        weight_versions=compute_weight_version_spans(
+            req.weight_version_events,
+            current_version=get_serving().weight_version,
+            num_output_tokens=len(req.output_ids),
+        ),
+    )

--- a/python/sglang/srt/managers/scheduler_components/idle_sleeper.py
+++ b/python/sglang/srt/managers/scheduler_components/idle_sleeper.py
@@ -24,9 +24,10 @@ class IdleSleeper:
     data that needs handling immediately.
     """
 
-    def __init__(self, sockets):
+    def __init__(self, sockets, can_empty_cache=None):
         self.poller = zmq.Poller()
         self.last_empty_time = real_time()
+        self.can_empty_cache = can_empty_cache
         for s in sockets:
             self.poller.register(s, zmq.POLLIN)
 
@@ -39,7 +40,8 @@ class IdleSleeper:
             and real_time() - self.last_empty_time > self.empty_cache_interval
         ):
             self.last_empty_time = real_time()
-            current_platform.empty_cache()
+            if self.can_empty_cache is None or self.can_empty_cache():
+                current_platform.empty_cache()
 
 
 class RustServerIdleSleeper:
@@ -52,10 +54,13 @@ class RustServerIdleSleeper:
     requests — or the timeout elapses.
     """
 
-    def __init__(self, rust_server: RustServer, timeout_ms: int = 1000):
+    def __init__(
+        self, rust_server: RustServer, timeout_ms: int = 1000, can_empty_cache=None
+    ):
         self.rust_server = rust_server
         self.timeout_ms = timeout_ms
         self.last_empty_time = real_time()
+        self.can_empty_cache = can_empty_cache
         self.empty_cache_interval = envs.SGLANG_EMPTY_CACHE_INTERVAL.get()
 
     def maybe_sleep(self):
@@ -65,4 +70,5 @@ class RustServerIdleSleeper:
             and real_time() - self.last_empty_time > self.empty_cache_interval
         ):
             self.last_empty_time = real_time()
-            current_platform.empty_cache()
+            if self.can_empty_cache is None or self.can_empty_cache():
+                current_platform.empty_cache()

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -615,6 +615,15 @@ class _GenerationStreamAccumulator:
         if not (self.rids or is_idle_batch):
             return None
         dp_ranks = [dp_rank] * len(self.rids) if self.rids else None
+        indexer_topk_num_layers = None
+        if self.return_indexer_topk:
+            from sglang.srt.state_capturer.indexer_topk import (
+                get_global_indexer_capturer,
+            )
+
+            _idx_cap = get_global_indexer_capturer()
+            if _idx_cap is not None:
+                indexer_topk_num_layers = _idx_cap.num_indexer_layers
         return BatchTokenIDOutput(
             rids=self.rids,
             http_worker_ipcs=self.http_worker_ipcs,
@@ -676,6 +685,7 @@ class _GenerationStreamAccumulator:
             output_hidden_states=self.output_hidden_states,
             routed_experts=self.routed_experts,
             indexer_topk=self.indexer_topk,
+            indexer_topk_num_layers=indexer_topk_num_layers,
             customized_info=(
                 wrap_as_pickle(self.customized_info) if self.customized_info else None
             ),

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -48,6 +48,7 @@ class SchedulerOutputStreamer:
     ps: ParallelState
     server_args: ServerArgs
     is_generation: bool
+    is_multimodal_gen: bool
     spec_algorithm: SpeculativeAlgorithm
     disaggregation_mode: DisaggregationMode
     enable_hicache_storage: Callable[[], bool]
@@ -171,6 +172,8 @@ class SchedulerOutputStreamer:
             self._maybe_log_time_stats(req=req)
 
         # Send to detokenizer
+        if self.is_multimodal_gen:
+            return
         payload = acc.to_payload(
             dp_rank=self.ps.dp_rank,
             is_idle_batch=is_idle_batch,

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -30,6 +30,7 @@ from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.runtime_context import get_observability, get_serving
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils.weight_versions import compute_weight_version_spans
 
 if TYPE_CHECKING:
     from sglang.srt.managers.rust_server import RustServer
@@ -159,6 +160,7 @@ class SchedulerOutputStreamer:
             default_force_stream_interval=DEFAULT_FORCE_STREAM_INTERVAL,
             get_cached_tokens_details=self.get_cached_tokens_details,
             rust_server_mode=self.rust_server is not None,
+            current_weight_version=get_serving().weight_version,
         )
         for req in reqs:
             if req is skip_req:
@@ -277,6 +279,7 @@ class _GenerationStreamAccumulator:
     default_stream_interval: int
     default_force_stream_interval: int
     get_cached_tokens_details: Callable[[Req], Optional[CachedTokensDetails]]
+    current_weight_version: Optional[str]
     rids: list = field(default_factory=list)
     http_worker_ipcs: list = field(default_factory=list)
     finished_reasons: list = field(default_factory=list)
@@ -304,6 +307,7 @@ class _GenerationStreamAccumulator:
     spec_correct_drafts_histogram: list = field(default_factory=list)
     spec_cap_lens_histogram: list = field(default_factory=list)
     retraction_counts: list = field(default_factory=list)
+    weight_versions: list = field(default_factory=list)
     output_hidden_states: Optional[list] = None
     routed_experts: Optional[list] = None
     indexer_topk: Optional[list] = None
@@ -448,6 +452,16 @@ class _GenerationStreamAccumulator:
         self.video_tokens.append(video_t)
 
         self.retraction_counts.append(req.retraction_count)
+        if req.finished():
+            self.weight_versions.append(
+                compute_weight_version_spans(
+                    req.weight_version_events,
+                    current_version=self.current_weight_version,
+                    num_output_tokens=len(output_ids_),
+                )
+            )
+        else:
+            self.weight_versions.append(None)
 
         self.time_stats.append(req.time_stats)
 
@@ -692,5 +706,8 @@ class _GenerationStreamAccumulator:
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             retraction_counts=self.retraction_counts,
+            weight_versions=(
+                self.weight_versions if any(self.weight_versions) else None
+            ),
             dp_ranks=dp_ranks,
         )

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -31,6 +31,8 @@ from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqOutput,
     InitWeightsUpdateGroupReqInput,
     InitWeightsUpdateGroupReqOutput,
+    PullWeightsReqInput,
+    PullWeightsReqOutput,
     ReleaseMemoryOccupationReqInput,
     ReleaseMemoryOccupationReqOutput,
     ResumeMemoryOccupationReqInput,
@@ -134,6 +136,44 @@ class SchedulerWeightUpdaterManager:
             return UpdateWeightFromDiskReqOutput(
                 success=success, message=message, num_paused_requests=0
             )
+
+    def pull_weights(self, recv_req: PullWeightsReqInput):
+        """Sync this host's local checkpoint up to recv_req.target_version.
+
+        Every rank runs the pull; a per-host file lock collapses co-located
+        ranks to one pull. Success is gathered across the TP group (all nodes),
+        so the reply only reports success once every host holds a verified
+        checkpoint.
+        """
+        from sglang.srt.weight_sync import local_checkpoint
+
+        server_args = self.tp_worker.model_runner.server_args
+        try:
+            local_checkpoint.pull(
+                local_checkpoint_dir=recv_req.local_checkpoint_dir,
+                base_dir=server_args.model_path,
+                source_dir=recv_req.source_dir,
+                target_version=recv_req.target_version,
+                pre_read_hook=server_args.custom_pull_weights_pre_read_hook,
+            )
+            success, message = True, "Success."
+        except Exception:
+            success, message = False, traceback.format_exc()
+            logger.error(message)
+
+        tp_size = (
+            torch.distributed.get_world_size(group=self.tp_cpu_group)
+            if torch.distributed.is_initialized()
+            else 1
+        )
+        if tp_size > 1:
+            results = [None] * tp_size
+            torch.distributed.all_gather_object(
+                results, (success, message), group=self.tp_cpu_group
+            )
+            success = all(ok for ok, _ in results)
+            message = "; ".join(msg for ok, msg in results if not ok) or message
+        return PullWeightsReqOutput(success=success, message=message)
 
     def init_weights_update_group(self, recv_req: InitWeightsUpdateGroupReqInput):
         """Initialize the online model parameter update group."""

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -341,8 +341,9 @@ class SchedulerWeightUpdaterManager:
         return EndWeightUpdateReqOutput(success=True, message="Success")
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
-        assert (
-            self.is_fully_idle()
+        scheduler = self.scheduler
+        assert self.is_fully_idle(
+            ignore_waiting=scheduler is not None and scheduler._engine_paused
         ), "release_memory_occupation should be called only when server is idle."
 
         tags = recv_req.tags
@@ -354,7 +355,6 @@ class SchedulerWeightUpdaterManager:
             self.offload_tags.add(tag)
 
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
-            scheduler = self.scheduler
             if scheduler is not None:
                 if scheduler.disaggregation_mode == DisaggregationMode.DECODE:
                     for queue_name in (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -122,6 +122,9 @@ class SchedulerWeightUpdaterManager:
             )
             assert flush_cache_success, "Cache flush failed after updating weights"
 
+    def record_weight_version_after_update(self, weight_version: Optional[str]) -> None:
+        self.scheduler.record_weight_version_change(new_version=weight_version)
+
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         """In-place update of the weights from disk."""
         with self._observe_weight_load("disk"):
@@ -131,7 +134,9 @@ class SchedulerWeightUpdaterManager:
                 success, message = self.draft_worker.update_weights_from_disk(recv_req)
             if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
-            if not success:
+            if success:
+                self.record_weight_version_after_update(recv_req.weight_version)
+            else:
                 logger.error(message)
             return UpdateWeightFromDiskReqOutput(
                 success=success, message=message, num_paused_requests=0
@@ -244,6 +249,7 @@ class SchedulerWeightUpdaterManager:
             if success:
                 self._weight_update_loaded = True
                 self.flush_cache_after_weight_update(recv_req)
+                self.record_weight_version_after_update(recv_req.weight_version)
             return UpdateWeightsFromDistributedReqOutput(
                 success=success, message=message
             )
@@ -271,6 +277,7 @@ class SchedulerWeightUpdaterManager:
                 self._weight_update_loaded = True
             if success:
                 self.flush_cache_after_weight_update(recv_req)
+                self.record_weight_version_after_update(recv_req.weight_version)
             else:
                 logger.error(message)
             torch.distributed.barrier(group=self.tp_cpu_group)
@@ -285,7 +292,9 @@ class SchedulerWeightUpdaterManager:
                 success, message = self.draft_worker.update_weights_from_ipc(recv_req)
             if tp_success:
                 self.flush_cache_after_weight_update(recv_req)
-            if not success:
+            if success:
+                self.record_weight_version_after_update(recv_req.weight_version)
+            else:
                 logger.error(message)
             torch.distributed.barrier(group=self.tp_cpu_group)
             return UpdateWeightsFromIPCReqOutput(success=success, message=message)

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import logging
 import time
 import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterator, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
 
 import msgspec
 import torch
@@ -19,11 +18,15 @@ from sglang.srt.constants import (
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
+    BeginWeightUpdateReqOutput,
     ChecksumInfo,
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
     DestroyWeightsUpdateGroupReqInput,
     DestroyWeightsUpdateGroupReqOutput,
+    EndWeightUpdateReqInput,
+    EndWeightUpdateReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
     InitWeightsUpdateGroupReqInput,
@@ -41,35 +44,40 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
+from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
+from sglang.srt.utils.weight_checker import overall_checksum
 
 logger = logging.getLogger(__name__)
 
 
-def _get_draft_model_runner(draft_worker):
-    # DFlash / FrozenKVMTP workers expose draft_model_runner directly
-    runner = getattr(draft_worker, "draft_model_runner", None)
-    if runner is not None:
-        return runner
-    # EAGLEWorkerV2: _draft_worker.draft_runner
-    inner = getattr(draft_worker, "_draft_worker", None)
-    if inner is not None:
-        runner = getattr(inner, "draft_runner", None)
-        if runner is not None:
-            return runner
-    return None
+def _merge_checksum_payloads(role_payloads: List[Tuple[str, Dict]]) -> Dict:
+    merged: Dict[str, str] = {}
+    parallelism_infos = []
+    for role, p in role_payloads:
+        for name, chk in p["checksums"].items():
+            # Only non-target roles are prefixed, so target keys stay stable.
+            key = name if role == "" else f"{role}.{name}"
+            if key in merged:
+                raise ValueError(f"checksum key collision: {key}")
+            merged[key] = chk
+        parallelism_infos.append({"role": role or "target", **p["parallelism_info"]})
+    return {
+        "checksums": merged,
+        "per_gpu_checksum": overall_checksum(merged),
+        "parallelism_info": parallelism_infos,
+    }
 
 
-def _merge_checksum_payloads(target: Dict, draft: Dict) -> Dict:
-    merged_checksums = dict(target["checksums"])
-    for name, chk in draft["checksums"].items():
-        merged_checksums[f"draft.{name}"] = chk
-    h = hashlib.sha256()
-    for name in sorted(merged_checksums):
-        h.update(name.encode())
-        h.update(merged_checksums[name].encode())
-    target["checksums"] = merged_checksums
-    target["per_gpu_checksum"] = h.hexdigest()
-    return target
+def _parse_runner_selector(selector: str) -> Set[str]:
+    """Map a {target, draft, all} weight-op selector to the set of roles it covers."""
+    if selector == "all":
+        return {"target", "draft"}
+    if selector in ("target", "draft"):
+        return {selector}
+    raise ValueError(
+        f"invalid selector {selector!r}; expected 'target', 'draft', or 'all'"
+    )
 
 
 @dataclass(kw_only=True, slots=True)
@@ -84,6 +92,11 @@ class SchedulerWeightUpdaterManager:
     metrics_collector: Optional[Any] = None
     offload_tags: set = field(default_factory=set)
     stashed_model_static_state: Any = None
+    _weight_update_in_progress: bool = False
+    _weight_update_loaded: bool = False
+    # Runner selector for the open session, recorded at begin_weight_update and
+    # reused by end_weight_update so the same set is restored and finalized.
+    _weight_update_selector: str = "all"
 
     @contextmanager
     def _observe_weight_load(self, source: str) -> Iterator[None]:
@@ -135,29 +148,87 @@ class SchedulerWeightUpdaterManager:
         success, message = self.tp_worker.destroy_weights_update_group(recv_req)
         return DestroyWeightsUpdateGroupReqOutput(success=success, message=message)
 
+    def iter_weight_update_workers(
+        self, selector: str = "all"
+    ) -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, worker) pairs, target
+        first. This is the worker-level inclusion decision; each worker then
+        contributes its own runners via iter_runners()."""
+        parsed = _parse_runner_selector(selector)
+        workers: List[Tuple[str, Any]] = []
+        if "target" in parsed:
+            workers.append(("target", self.tp_worker))
+        if "draft" in parsed and self.draft_worker is not None:
+            workers.append(("draft", self.draft_worker))
+        return workers
+
+    def get_model_runners(self, selector: str = "all") -> List[Tuple[str, Any]]:
+        """Resolve a {target, draft, all} selector to (role, ModelRunner) pairs,
+        target first. Role is "" for the target runner; draft roles come from the
+        draft worker's iter_runners()."""
+        runners: List[Tuple[str, Any]] = []
+        for _, worker in self.iter_weight_update_workers(selector):
+            runners += worker.iter_runners()
+        return runners
+
     def update_weights_from_distributed(
         self,
         recv_req: UpdateWeightsFromDistributedReqInput,
     ) -> Tuple[bool, str]:
-        """Update the online model parameter."""
+        """Update the online model parameter, fanning out to the selected runners."""
+        assert (
+            self._weight_update_in_progress
+        ), "update_weights_from_distributed requires an open begin_weight_update session"
         with self._observe_weight_load("distributed"):
-            success, message = self.tp_worker.update_weights_from_distributed(recv_req)
-            if success:
-                self.flush_cache_after_weight_update(recv_req)
-            else:
+            # Only the target (main) model joined this process's update group, so it
+            # receives the broadcast once; the received weights are then loaded into
+            # each selected runner locally. Draft runners never join the group.
+            try:
+                weights = self.tp_worker.model_runner.weight_updater.receive_weights_from_distributed(
+                    recv_req.names,
+                    recv_req.dtypes,
+                    recv_req.shapes,
+                    recv_req.group_name,
+                    recv_req.load_format,
+                )
+                for _, runner in self.get_model_runners(recv_req.selector):
+                    runner.weight_updater.load_weights(weights)
+                success, message = True, "Succeeded to update parameter online."
+            except Exception as e:
+                success = False
+                message = (
+                    f"Failed to update parameter online: {e}. The full weights of the "
+                    "ModelRunner are partially updated. Please discard the whole weights."
+                )
                 logger.error(message)
+            if success:
+                self._weight_update_loaded = True
+                self.flush_cache_after_weight_update(recv_req)
             return UpdateWeightsFromDistributedReqOutput(
                 success=success, message=message
             )
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-        """Update the online model parameter from tensors."""
+        """Update the online model parameter from tensors, fanning out to the
+        selected runners."""
+        assert (
+            self._weight_update_in_progress
+        ), "update_weights_from_tensor requires an open begin_weight_update session"
         with self._observe_weight_load("tensor"):
-            if recv_req.disable_draft_model:
-                worker = self.tp_worker
-            else:
-                worker = self.draft_worker or self.tp_worker
-            success, message = worker.update_weights_from_tensor(recv_req)
+            monkey_patch_torch_reductions()
+            named_tensors = MultiprocessingSerializer.deserialize(
+                recv_req.serialized_named_tensors[self.tp_worker.ps.tp_rank]
+            )
+            success, message = True, "Success"
+            for _, runner in self.get_model_runners(recv_req.selector):
+                success, message = runner.weight_updater.update_weights_from_tensor(
+                    named_tensors=named_tensors,
+                    load_format=recv_req.load_format,
+                )
+                if not success:
+                    break
+            if success:
+                self._weight_update_loaded = True
             if success:
                 self.flush_cache_after_weight_update(recv_req)
             else:
@@ -198,6 +269,36 @@ class SchedulerWeightUpdaterManager:
                 f"corrupt the daemon's master copy and every co-attached engine. "
                 f"Restart with --weight-cache-mode off to use this operation."
             )
+
+    def begin_weight_update(self, recv_req: BeginWeightUpdateReqInput):
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state on the selected runners (target and/or draft), so the draft
+        model is prepared identically to the target. The selector is recorded and
+        reused by end_weight_update so the same set is finalized."""
+        assert (
+            not self._weight_update_in_progress
+        ), "begin_weight_update called while a weight-update session is already open"
+        self._weight_update_selector = recv_req.selector
+        for _, runner in self.get_model_runners(recv_req.selector):
+            runner.begin_weight_update()
+        self._weight_update_in_progress = True
+        self._weight_update_loaded = False
+        torch.distributed.barrier(group=self.tp_cpu_group)
+        return BeginWeightUpdateReqOutput(success=True, message="Success")
+
+    def end_weight_update(self, recv_req: EndWeightUpdateReqInput):
+        """End the weight-update session on the runners begin_weight_update opened
+        (its recorded selector): quant finalize on each, plus model.post_load_weights
+        only when load_weights was bypassed this session (e.g. P2P/RDMA)."""
+        assert (
+            self._weight_update_in_progress
+        ), "end_weight_update called without begin_weight_update"
+        run_post_load = not self._weight_update_loaded
+        for _, runner in self.get_model_runners(self._weight_update_selector):
+            runner.end_weight_update(run_post_load=run_post_load)
+        self._weight_update_in_progress = False
+        torch.distributed.barrier(group=self.tp_cpu_group)
+        return EndWeightUpdateReqOutput(success=True, message="Success")
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         assert (
@@ -288,19 +389,16 @@ class SchedulerWeightUpdaterManager:
 
     def check_weights(self, recv_req: CheckWeightsReqInput):
         try:
-            payload = self.tp_worker.model_runner.check_weights(
-                action=recv_req.action, allow_quant_error=recv_req.allow_quant_error
-            )
-
-            if self.draft_worker is not None:
-                draft_runner = _get_draft_model_runner(self.draft_worker)
-                if draft_runner is not None:
-                    draft_payload = draft_runner.check_weights(
-                        action=recv_req.action,
-                        allow_quant_error=recv_req.allow_quant_error,
-                    )
-                    if payload is not None and draft_payload is not None:
-                        payload = _merge_checksum_payloads(payload, draft_payload)
+            role_payloads = []
+            for role, runner in self.get_model_runners(recv_req.selector):
+                p = runner.check_weights(
+                    action=recv_req.action,
+                    allow_quant_error=recv_req.allow_quant_error,
+                    skip_tensor_list=recv_req.skip_tensor_list,
+                )
+                if p is not None:
+                    role_payloads.append((role, p))
+            payload = _merge_checksum_payloads(role_payloads) if role_payloads else None
 
             tp_size = torch.distributed.get_world_size(group=self.tp_cpu_group)
             if tp_size > 1 and payload is not None:

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -57,6 +57,8 @@ from sglang.srt.managers.io_struct import (
     ProfileReq,
     ProfileReqOutput,
     ProfileReqType,
+    PullWeightsReqInput,
+    PullWeightsReqOutput,
     ReleaseMemoryOccupationReqInput,
     ReleaseMemoryOccupationReqOutput,
     RemoveExternalCorpusReqInput,
@@ -112,6 +114,7 @@ _COMMUNICATOR_SPECS = [
     ("release_memory_occupation", ReleaseMemoryOccupationReqOutput),
     ("resume_memory_occupation", ResumeMemoryOccupationReqOutput),
     ("check_weights", CheckWeightsReqOutput),
+    ("pull_weights", PullWeightsReqOutput),
     ("slow_down", SlowDownReqOutput),
     ("flush_cache", FlushCacheReqOutput),
     ("add_external_corpus", AddExternalCorpusReqOutput),
@@ -956,6 +959,15 @@ class TokenizerControlMixin:
     ):
         self.auto_create_handle_loop()
         await self.resume_memory_occupation_communicator(obj)
+
+    async def pull_weights(
+        self: TokenizerManager,
+        obj: PullWeightsReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Tuple[bool, str]:
+        self.auto_create_handle_loop()
+        results = await self.pull_weights_communicator(obj)
+        return FanOutCommunicator.merge_results(results)
 
     async def check_weights(
         self: TokenizerManager,

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -774,6 +774,7 @@ class TokenizerControlMixin:
                     lora_name=obj.lora_name,
                     lora_path="__tensor__",
                     pinned=obj.pinned,
+                    reloadable=False,
                 )
                 obj.lora_id = new_adapter.lora_id
                 result = _merge_lora_update_results(
@@ -852,6 +853,7 @@ class TokenizerControlMixin:
                         lora_name=obj.lora_name,
                         lora_path="__distributed__",
                         pinned=obj.pinned,
+                        reloadable=False,
                     ),
                     upsert=obj.upsert,
                 )
@@ -927,7 +929,14 @@ class TokenizerControlMixin:
             )
 
             async with self.lora_update_lock:
-                return await self._unload_lora_adapter_locked(obj)
+                result = await self._unload_lora_adapter_locked(obj)
+                # Explicit unload is a DELETE: drop the reload-catalog entry too.
+                # The max_loaded_loras LRU loop calls _unload_lora_adapter_locked
+                # directly — an EVICT — and must keep the entry so disk-backed
+                # adapters can be implicitly reloaded later.
+                if result.success:
+                    self.lora_ref_cache.pop(obj.lora_name, None)
+                return result
         except ValueError as e:
             return UnloadLoRAAdapterReqOutput(success=False, error_message=str(e))
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -15,6 +15,8 @@ from sglang.srt.managers.io_struct import (
     AddExternalCorpusReqOutput,
     AttachHiCacheStorageReqInput,
     AttachHiCacheStorageReqOutput,
+    BeginWeightUpdateReqInput,
+    BeginWeightUpdateReqOutput,
     ChecksumInfo,
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
@@ -27,6 +29,8 @@ from sglang.srt.managers.io_struct import (
     DetachHiCacheStorageReqOutput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EndWeightUpdateReqInput,
+    EndWeightUpdateReqOutput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -120,6 +124,8 @@ _COMMUNICATOR_SPECS = [
     ("get_internal_state", GetInternalStateReqOutput),
     ("set_internal_state", SetInternalStateReqOutput),
     ("expert_distribution", ExpertDistributionReqOutput),
+    ("begin_weight_update", BeginWeightUpdateReqOutput),
+    ("end_weight_update", EndWeightUpdateReqOutput),
     ("update_lora_adapter", LoRAUpdateOutput),
     ("dumper_control", DumperControlReqOutput),
     ("scale_elastic_ep", ScaleElasticEPReqOutput),
@@ -441,6 +447,40 @@ class TokenizerControlMixin:
 
         results = await self.destroy_weights_update_group_communicator(obj)
         return FanOutCommunicator.merge_results(results)
+
+    async def _weight_update_session_call(
+        self: TokenizerManager, communicator, obj
+    ) -> Tuple[bool, str]:
+        """Run one weight-update session RPC under the same pause-aware locking as
+        update_weights_from_distributed: while the engine is paused the writer lock
+        is already held by whoever paused it, so taking it again would deadlock."""
+        self.auto_create_handle_loop()
+        async with self.is_pause_cond:
+            is_paused = self.is_pause
+            if is_paused:
+                results = await communicator(obj)
+        if not is_paused:
+            async with self.model_update_lock.writer_lock:
+                results = await communicator(obj)
+        return FanOutCommunicator.merge_results(results)
+
+    async def begin_weight_update(
+        self: TokenizerManager,
+        obj: BeginWeightUpdateReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Tuple[bool, str]:
+        return await self._weight_update_session_call(
+            self.begin_weight_update_communicator, obj
+        )
+
+    async def end_weight_update(
+        self: TokenizerManager,
+        obj: EndWeightUpdateReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Tuple[bool, str]:
+        return await self._weight_update_session_call(
+            self.end_weight_update_communicator, obj
+        )
 
     async def update_weights_from_distributed(
         self: TokenizerManager,

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -42,6 +42,8 @@ from sglang.srt.managers.io_struct import (
     InitWeightsUpdateGroupReqOutput,
     ListExternalCorporaReqInput,
     ListExternalCorporaReqOutput,
+    LoadLoRAAdapterFromDistributedReqInput,
+    LoadLoRAAdapterFromDistributedReqOutput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterFromTensorsReqOutput,
     LoadLoRAAdapterReqInput,
@@ -672,6 +674,24 @@ class TokenizerControlMixin:
                 error_message=str(e),
             )
 
+    def _validate_lora_upsert_supported(
+        self: TokenizerManager,
+        obj: LoadLoRAAdapterFromDistributedReqInput,
+    ) -> None:
+        """Upsert resolves lora_name -> lora_id through this process's registry.
+
+        With multiple tokenizer workers each HTTP worker process holds its own
+        registry, so the resolution depends on which worker the router picks:
+        a worker that never served the original load would mint a fresh id and
+        die on the backend duplicate check. Fail loudly instead.
+        """
+        if obj.upsert and self.server_args.tokenizer_worker_num > 1:
+            raise ValueError(
+                "LoRA upsert is not supported with tokenizer_worker_num > 1: "
+                "each HTTP worker resolves lora_name against its own registry, "
+                "making upsert nondeterministic across workers."
+            )
+
     async def load_lora_adapter_from_tensors(
         self: TokenizerManager,
         obj: LoadLoRAAdapterFromTensorsReqInput,
@@ -688,6 +708,15 @@ class TokenizerControlMixin:
             assert (
                 get_parallel().dp_size == 1 or get_parallel().enable_dp_attention
             ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
+            if obj.upsert:
+                # In-place refresh is only wired up on the from_distributed
+                # route (the disaggregated RL weight-sync path). Reject
+                # explicitly instead of dying later on the duplicate check
+                # with a fresh uuid.
+                raise ValueError(
+                    "upsert is not supported on the from_tensors route; use "
+                    "/load_lora_adapter_from_distributed to refresh an adapter in place."
+                )
             logger.info(
                 "Start load Lora adapter from tensors. Lora name=%s",
                 obj.lora_name,
@@ -744,6 +773,87 @@ class TokenizerControlMixin:
                 return result
         except ValueError as e:
             return LoadLoRAAdapterFromTensorsReqOutput(
+                success=False,
+                error_message=str(e),
+            )
+
+    async def load_lora_adapter_from_distributed(
+        self: TokenizerManager,
+        obj: LoadLoRAAdapterFromDistributedReqInput,
+        _: Optional[fastapi.Request] = None,
+    ) -> LoadLoRAAdapterFromDistributedReqOutput:
+        self.auto_create_handle_loop()
+
+        try:
+            if not self.server_args.enable_lora:
+                raise ValueError(
+                    "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
+                )
+
+            assert (
+                self.server_args.dp_size == 1
+            ), "dp_size must be 1 for dynamic lora loading"
+            logger.info(
+                "Start load Lora adapter from distributed. Lora name=%s, group=%s",
+                obj.lora_name,
+                obj.group_name,
+            )
+
+            async with self.lora_update_lock:
+                self._validate_lora_upsert_supported(obj)
+                # With upsert, a same-name adapter keeps its lora_id so the
+                # backend refreshes it in place instead of failing the
+                # duplicate check; otherwise this resolves to a fresh ref.
+                new_adapter, reused = await self.lora_registry.register_or_reuse(
+                    LoRARef(
+                        lora_name=obj.lora_name,
+                        lora_path="__distributed__",
+                        pinned=obj.pinned,
+                    ),
+                    upsert=obj.upsert,
+                )
+                obj.lora_id = new_adapter.lora_id
+                result = (await self.update_lora_adapter_communicator(obj))[0]
+
+                if result.success:
+                    if reused:
+                        await self.lora_registry.refresh(new_adapter)
+                    else:
+                        await self.lora_registry.register(new_adapter)
+                    self.lora_ref_cache[obj.lora_name] = new_adapter
+                if self.server_args.max_loaded_loras is not None:
+                    while (
+                        self.lora_registry.num_registered_loras
+                        > self.server_args.max_loaded_loras
+                    ):
+                        lru_lora_name = await self.lora_registry.lru_lora_name(
+                            exclude_pinned=True
+                        )
+                        if lru_lora_name is None:
+                            raise ValueError(
+                                "Didn't find any LoRA adapters when trying to evict LRU LoRA adapter. "
+                                f"LoRA registry is: {self.lora_registry._registry}"
+                            )
+
+                        logger.info(
+                            f"Unloading least recently used LoRA adapter '{lru_lora_name}' "
+                            f"(current number of adapters: {self.lora_registry.num_registered_loras}, "
+                            f"max allowed: {self.server_args.max_loaded_loras})"
+                        )
+
+                        unload_result = await self._unload_lora_adapter_locked(
+                            UnloadLoRAAdapterReqInput(lora_name=lru_lora_name)
+                        )
+                        if not unload_result.success:
+                            raise ValueError(
+                                f"Error while unloading LRU LoRA adapter '{lru_lora_name}': "
+                                f"{unload_result.error_message}"
+                            )
+                        del result.loaded_adapters[lru_lora_name]
+
+                return result
+        except ValueError as e:
+            return LoadLoRAAdapterFromDistributedReqOutput(
                 success=False,
                 error_message=str(e),
             )

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -80,6 +80,8 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromIPCReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
+    UpdateWeightVersionReqInput,
+    UpdateWeightVersionReqOutput,
 )
 from sglang.srt.managers.load_snapshot import LoadSnapshot
 from sglang.srt.runtime_context import get_parallel
@@ -110,6 +112,7 @@ _COMMUNICATOR_SPECS = [
     ("send_weights_to_remote_instance", SendWeightsToRemoteInstanceReqOutput),
     ("update_weights_from_tensor", UpdateWeightsFromTensorReqOutput),
     ("update_weights_from_ipc", UpdateWeightsFromIPCReqOutput),
+    ("update_weight_version", UpdateWeightVersionReqOutput),
     ("get_weights_by_name", GetWeightsByNameReqOutput),
     ("release_memory_occupation", ReleaseMemoryOccupationReqOutput),
     ("resume_memory_occupation", ResumeMemoryOccupationReqOutput),
@@ -1095,6 +1098,13 @@ class TokenizerControlMixin:
         request: Optional[fastapi.Request] = None,
     ):
         await self._async_dispatch_to_scheduler(obj)
+
+    async def update_weight_version(
+        self: TokenizerManager, obj: UpdateWeightVersionReqInput
+    ) -> None:
+        self.auto_create_handle_loop()
+        await self.update_weight_version_communicator(obj)
+        self._update_weight_version_if_provided(obj.new_version)
 
     def _update_weight_version_if_provided(
         self: TokenizerManager, weight_version: Optional[str]

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -231,6 +231,13 @@ class ReqState:
     # request as aborted instead of sending it.
     abort_before_dispatch: bool = False
 
+    # The LoRA lease for this request has already been released. Every terminal
+    # path funnels through TokenizerManager._finalize_lora_lease, which uses
+    # this flag to stay idempotent: a leaked release hangs unload's
+    # wait_for_zero forever, and a double release drives the ConcurrentCounter
+    # negative, which hangs it just the same (it waits for exactly zero).
+    lora_lease_released: bool = False
+
     # For streaming output
     last_output_offset: int = 0
 
@@ -1727,6 +1734,25 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             out["meta_info"] = meta_info
         return out
 
+    def _finalize_lora_lease(self, state: Optional[ReqState]) -> None:
+        """Release the request's LoRA lease exactly once, however it terminates:
+        normal finish, scheduler abort echo (queued / tokenizer-held / disagg),
+        status-code abort, or a failed dispatch. A request whose LoRA was never
+        acquired (pre-acquire failure leaves lora_id unset) has no lease to
+        release."""
+        if state is None or state.lora_lease_released:
+            return
+        # lora_path / lora_id are declared on both input structs with default
+        # None (= base model / lease never acquired), so plain None checks are
+        # the contract. State-derived checks come first: a request without a
+        # lease has nothing to release, whatever the server config says.
+        if state.obj.lora_path is None or state.obj.lora_id is None:
+            return
+        if not self.enable_lora:
+            return
+        state.lora_lease_released = True
+        asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+
     async def _handle_abort_finish_reason(
         self,
         out: dict,
@@ -1759,9 +1785,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             if state.obj.rid in self.rid_to_state:
                 del self.rid_to_state[state.obj.rid]
 
-            # Mark ongoing LoRA request as finished.
-            if self.enable_lora and state.obj.lora_path:
-                await self.lora_registry.release(state.obj.lora_id)
+            # Status-code aborts also arrive through _handle_batch_output, which
+            # already released the lease and deleted the state — the finalizer's
+            # idempotency is what prevents the counter from going negative here.
+            self._finalize_lora_lease(state)
             if not is_stream:
                 raise fastapi.HTTPException(
                     status_code=finish_reason["status_code"],
@@ -2538,8 +2565,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 del self.rid_to_state[rid]
 
                 # Mark ongoing LoRA request as finished.
-                if self.enable_lora and state.obj.lora_path:
-                    asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+                self._finalize_lora_lease(state)
 
             if out_dict is not None:
                 state.out_list.append(out_dict)
@@ -3271,6 +3297,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "output_ids": output_ids,
             "meta_info": meta_info,
         }
+        # This abort echo is the scheduler-side terminal ACK for queued,
+        # tokenizer-held, and disagg-retracted requests — none of them reach
+        # _handle_batch_output, so this is their only lease-release point.
+        self._finalize_lora_lease(self.rid_to_state.get(recv_obj.rid))
         del self.rid_to_state[recv_obj.rid]
 
         state.out_list.append(out)
@@ -3402,8 +3432,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"All loaded adapters: {self.lora_ref_cache.keys()}."
                 )
 
-            logger.info(f"Reloading evicted adapter: {lora_path}")
             new_lora_ref = self.lora_ref_cache[lora_path]
+            if not new_lora_ref.reloadable:
+                raise ValueError(
+                    f"LoRA adapter '{lora_path}' was loaded over the wire "
+                    f"(lora_path={new_lora_ref.lora_path!r}) and has no disk "
+                    "artifact to reload from; it must be re-pushed by the "
+                    "trainer instead of implicitly reloaded."
+                )
+            logger.info(f"Reloading evicted adapter: {lora_path}")
             load_result = await self.load_lora_adapter(
                 LoadLoRAAdapterReqInput(
                     lora_name=new_lora_ref.lora_name,
@@ -3484,6 +3521,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             rids = obj.rid
         for rid in rids:
+            # A failed/partial dispatch may never produce a scheduler terminal for
+            # this rid, and once the state is dropped a late terminal has no release
+            # point either — so release the LoRA lease here.
+            self._finalize_lora_lease(self.rid_to_state.get(rid))
             self.rid_to_state.pop(rid, None)
 
     def _should_dispatch_to_encoder(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -225,6 +225,12 @@ class ReqState:
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
+    # An abort matched this rid while the request was still tokenizer-held
+    # (parked at the pause gate / model-update lock / tokenization). The
+    # scheduler never saw the rid, so the dispatch path must resolve the
+    # request as aborted instead of sending it.
+    abort_before_dispatch: bool = False
+
     # For streaming output
     last_output_offset: int = 0
 
@@ -1594,10 +1600,35 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
         )
 
+    def _abort_instead_of_dispatch(
+        self,
+        tokenized_obj: Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput],
+    ) -> bool:
+        """Resolve a request whose rid an abort matched while it was still
+        tokenizer-held (see abort_request): the scheduler never saw the rid, so
+        it must be finished here instead of dispatched. Returns True if the
+        request was aborted."""
+        state = self.rid_to_state.get(tokenized_obj.rid)
+        if (
+            state is None
+            or not state.abort_before_dispatch
+            or is_health_check_generate_req(tokenized_obj)
+        ):
+            return False
+        self._handle_abort_req(
+            AbortReq(
+                rid=tokenized_obj.rid,
+                abort_message="Aborted by AbortReq before dispatch to scheduler",
+            )
+        )
+        return True
+
     def _send_one_request(
         self,
         tokenized_obj: Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput],
     ):
+        if self._abort_instead_of_dispatch(tokenized_obj):
+            return
         prepared_mm_items = []
         dispatched = False
         try:
@@ -1610,6 +1641,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             tokenized_obj.wrap_pickle_fields()
             self._dispatch_to_scheduler(tokenized_obj)
             dispatched = True
+            state = self.rid_to_state.get(tokenized_obj.rid)
+            if state is not None:
+                state.dispatched = True
             tokenized_obj.time_stats = time_stats
             tokenized_obj.time_stats.set_api_server_dispatch_finish_time()
         finally:
@@ -1623,6 +1657,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         ],
     ):
         """Send a batch of tokenized requests as a single batched request to the scheduler."""
+        tokenized_objs = [
+            tokenized_obj
+            for tokenized_obj in tokenized_objs
+            if not self._abort_instead_of_dispatch(tokenized_obj)
+        ]
+        if not tokenized_objs:
+            return
         prepared_mm_items = []
         dispatched = False
         try:
@@ -1988,18 +2029,32 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 return_exceptions=True,
             )
 
-    def abort_request(self, rid: str = "", abort_all: bool = False):
+    def abort_request(
+        self, rid: str = "", abort_all: bool = False, prefix: bool = False
+    ):
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        if (
-            not abort_all
-            and self.server_args.tokenizer_worker_num == 1
-            and rid not in self.rid_to_state
-        ):
-            return
-        req = AbortReq(rid=rid, abort_all=abort_all)
+        if not abort_all and self.server_args.tokenizer_worker_num == 1:
+            if prefix:
+                if not any(r.startswith(rid) for r in self.rid_to_state):
+                    return
+            elif rid not in self.rid_to_state:
+                return
+        # A matching request can still be tokenizer-held: rid_to_state is
+        # populated in _init_req_state, several awaits (pause gate,
+        # model_update_lock, tokenization) before the scheduler learns the rid
+        # in _send_one_request. The scheduler-side abort cannot match those, so
+        # flag them here; the dispatch path resolves flagged requests as
+        # aborted instead of sending them. Already-dispatched requests are
+        # unaffected (the flag is only read at dispatch).
+        for tracked_rid, state in self.rid_to_state.items():
+            if abort_all or (
+                tracked_rid.startswith(rid) if prefix else tracked_rid == rid
+            ):
+                state.abort_before_dispatch = True
+        req = AbortReq(rid=rid, abort_all=abort_all, prefix=prefix)
         self._dispatch_to_scheduler(req)
         if self.enable_metrics:
             # TODO: also use custom_labels from the request

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2336,6 +2336,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     if isinstance(val, torch.Tensor):
                         val = pybase64.b64encode(val.numpy().tobytes()).decode("utf-8")
                     meta_info["indexer_topk"] = val
+                    n = getattr(recv_obj, "indexer_topk_num_layers", None)
+                    if n is not None:
+                        meta_info["indexer_topk_num_layers"] = n
             if getattr(recv_obj, "dp_ranks", None):
                 meta_info["dp_rank"] = recv_obj.dp_ranks[i]
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -163,6 +163,7 @@ from sglang.srt.utils.hf_transformers_utils import (
 from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.request_logger import RequestLogger
 from sglang.srt.utils.watchdog import Watchdog
+from sglang.srt.utils.weight_versions import add_weight_versions_to_meta_info
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -2373,6 +2374,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         "cached_tokens": recv_obj.cached_tokens[i],
                     }
                 )
+                if (
+                    recv_obj.weight_versions is not None
+                    and (spans := recv_obj.weight_versions[i]) is not None
+                ):
+                    add_weight_versions_to_meta_info(
+                        meta_info,
+                        spans,
+                        num_output_tokens=recv_obj.completion_tokens[i],
+                    )
                 # Add detailed cache breakdown if available
                 if (
                     hasattr(recv_obj, "cached_tokens_details")
@@ -3277,6 +3287,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "weight_version": self.config_value("weight_version"),
             "e2e_latency": state.time_stats.get_e2e_latency(),
         }
+        if recv_obj.weight_versions is not None:
+            add_weight_versions_to_meta_info(
+                meta_info,
+                recv_obj.weight_versions,
+                num_output_tokens=len(state.output_ids),
+            )
         is_stream = getattr(state.obj, "stream", False)
         if getattr(state.obj, "return_logprob", False):
             self.add_logprob_to_meta_info(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -29,6 +29,7 @@ from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqInput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
     InitWeightsUpdateGroupReqInput,
+    LoadLoRAAdapterFromDistributedReqInput,
     LoadLoRAAdapterFromTensorsReqInput,
     LoadLoRAAdapterReqInput,
     SendWeightsToRemoteInstanceReqInput,
@@ -283,6 +284,22 @@ class BaseTpWorker(ABC):
             tensors,
             recv_req.config_dict,
             recv_req.added_tokens_config,
+            upsert=recv_req.upsert,
+        )
+        return result
+
+    def load_lora_adapter_from_distributed(
+        self, recv_req: LoadLoRAAdapterFromDistributedReqInput
+    ):
+        result = self.model_runner.load_lora_adapter_from_distributed(
+            recv_req.to_ref(),
+            recv_req.names,
+            recv_req.dtypes,
+            recv_req.shapes,
+            recv_req.config_dict,
+            recv_req.group_name,
+            recv_req.added_tokens_config,
+            upsert=recv_req.upsert,
         )
         return result
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -35,9 +35,7 @@ from sglang.srt.managers.io_struct import (
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
-    UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
-    UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -183,20 +181,6 @@ class BaseTpWorker(ABC):
         )
         return success, message
 
-    def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
-    ):
-        success, message = (
-            self.model_runner.weight_updater.update_weights_from_distributed(
-                recv_req.names,
-                recv_req.dtypes,
-                recv_req.shapes,
-                recv_req.group_name,
-                recv_req.load_format,
-            )
-        )
-        return success, message
-
     def _deserialize_own_rank(self, serialized_named_tensors):
         """Each rank deserializes only its own payload (index ps.tp_rank);
         deserializing another rank's copy would break producer-side CUDA-IPC
@@ -205,13 +189,6 @@ class BaseTpWorker(ABC):
         return MultiprocessingSerializer.deserialize(
             serialized_named_tensors[self.ps.tp_rank]
         )
-
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-        success, message = self.model_runner.weight_updater.update_weights_from_tensor(
-            named_tensors=self._deserialize_own_rank(recv_req.serialized_named_tensors),
-            load_format=recv_req.load_format,
-        )
-        return success, message
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
         """Update weights from IPC for checkpoint-engine integration."""
@@ -528,6 +505,11 @@ class TpModelWorker(BaseTpWorker):
     @property
     def model_runner(self) -> ModelRunner:
         return self._model_runner
+
+    def iter_runners(self) -> List[Tuple[str, ModelRunner]]:
+        """(role, runner) pairs this worker owns for weight ops. The target worker
+        owns one runner and uses the empty role so its checksum keys stay unprefixed."""
+        return [("", self._model_runner)]
 
     def register_hicache_layer_transfer_counter(self, counter: LayerDoneCounter):
         self.hicache_layer_transfer_counter = counter

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1007,9 +1007,11 @@ def build_full_draft_pools(
     controller = tree_cache.cache_controller
     host_pool_group = controller.mem_pool_host
 
+    # Note(kpham-sgl): DCP x DSpark draft KV is replicated and spans the virtual
+    # loc space, so match the target host's logical_size instead of physical size.
     draft_host_pool = _build_mha_mla_host_pool(
         pool=pool,
-        host_to_device_ratio=host_pool_group.size / pool.size,
+        host_to_device_ratio=host_pool_group.logical_size / pool.size,
         page_size=controller.page_size,
         layout=server_args.hicache_mem_layout,
         allocator_type=_get_allocator_type(server_args),

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -117,7 +117,7 @@ def _register_legacy_hicache_draft(
     # so that host indices stay 1-to-1 between target and draft KV caches.
     primary_host_pool = tree_cache.cache_controller.mem_pool_host
     host_pool_kwargs = dict(
-        host_to_device_ratio=primary_host_pool.size / pool.size,
+        host_to_device_ratio=primary_host_pool.logical_size / pool.size,
         host_size=0,
         page_size=page_size,
         layout=server_args.hicache_mem_layout,

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -160,6 +160,15 @@ class SWAKVPool(BaseSWAKVPool):
         else:
             return self.full_kv_pool.get_value_buffer(layer_id_pool)
 
+    def get_v_head_dim(self):
+        # Read off the full-attention sub-pool: TritonAttnBackend asks for this on
+        # the mambaish path, where a global layer id is not guaranteed to be a
+        # full-attention layer. Uses start_layer for pipeline parallelism, matching
+        # HybridLinearKVPool.
+        return self.full_kv_pool.get_value_buffer(self.full_kv_pool.start_layer).shape[
+            -1
+        ]
+
     def get_kv_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)
         layer_id_pool, is_swa_layer = self.layers_mapping[layer_id]

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -161,13 +161,7 @@ class SWAKVPool(BaseSWAKVPool):
             return self.full_kv_pool.get_value_buffer(layer_id_pool)
 
     def get_v_head_dim(self):
-        # Read off the full-attention sub-pool: TritonAttnBackend asks for this on
-        # the mambaish path, where a global layer id is not guaranteed to be a
-        # full-attention layer. Uses start_layer for pipeline parallelism, matching
-        # HybridLinearKVPool.
-        return self.full_kv_pool.get_value_buffer(self.full_kv_pool.start_layer).shape[
-            -1
-        ]
+        return self.full_kv_pool.get_v_head_dim()
 
     def get_kv_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -51,7 +51,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     is_cuda,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -844,8 +844,18 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         if ret.forward_mode.is_idle():
             ret.positions = torch.empty((0,), dtype=torch.int64, device=device)
+            # Under --enable-dp-attention an IDLE rank still runs its local experts over
+            # the DP-GATHERED tokens of the other ranks, so MoE-LoRA batch info has to be
+            # re-prepared for THIS batch — sized to the gathered length and stamped via the
+            # idle-rank path — rather than cleared: clearing leaves those experts reading the
+            # previous batch's token_lora_mapping, which is undersized (OOB in the MoE-LoRA
+            # kernels) and points foreign tokens at the wrong adapter. Non-MoE LoRA does no
+            # such cross-rank work on an idle rank, so it takes the base path.
             if model_runner.server_args.enable_lora:
-                model_runner.lora_manager.reset_lora_batch()
+                if model_runner.lora_manager.lora_backend.is_moe_lora:
+                    model_runner.lora_manager.prepare_lora_batch(ret)
+                else:
+                    model_runner.lora_manager.reset_lora_batch()
             return ret
 
         # Override the positions with diffusion LLM or spec_info

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -51,7 +51,8 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     is_cuda,
     is_hip,
@@ -1164,7 +1165,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         )
         has_multimodal_input = any(mm is not None for mm in mm_inputs)
 
-        if rl_on_policy_target is not None or not has_multimodal_input:
+        if (
+            rl_on_policy_target is not None
+            or is_true_on_policy_enabled()
+            or not has_multimodal_input
+        ):
             # Text-only
             positions_1d = seq_lens_int64 - 1
             self.mrope_positions = positions_1d.unsqueeze(0).repeat(3, 1)
@@ -1225,7 +1230,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             mm_input = mm_inputs[batch_idx]
             extend_seq_len = extend_lens[batch_idx]
             extend_prefix_len = prefix_lens[batch_idx]
-            if mm_input is None or rl_on_policy_target is not None:
+            if (
+                mm_input is None
+                or rl_on_policy_target is not None
+                or is_true_on_policy_enabled()
+            ):
                 # text only
                 mrope_positions = (
                     torch.arange(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1634,14 +1634,14 @@ class ModelRunner:
         output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
         no_copy_to_cpu = not get_schedule().disable_overlap_schedule
-        # In speculative decoding, num_tokens_per_bs > 1, so pass the actual
-        # number of tokens per DP rank in CUDA graph, not the batch size.
+        # In speculative decoding more than one token is captured per request, so
+        # pass the actual number of tokens per DP rank in CUDA graph, not the batch
+        # size — the width is captured_req_width.
+
         cuda_graph_num_tokens = None
-        if getattr(self.decode_cuda_graph_runner, "bs", None):
-            cuda_graph_num_tokens = (
-                self.decode_cuda_graph_runner.bs
-                * self.decode_cuda_graph_runner.num_tokens_per_bs
-            )
+        runner = self.decode_cuda_graph_runner
+        if getattr(runner, "bs", None):
+            cuda_graph_num_tokens = runner.bs * runner.captured_req_width
 
         if (
             not self.is_draft_worker

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1302,8 +1302,10 @@ class ModelRunner:
         """Load a new lora adapter whose weights are broadcast over the
         `_model_update_group` process group (no CUDA IPC).
         """
-        assert group_name in self._model_update_group, (
-            f"Group {group_name} not in {list(self._model_update_group.keys())}. "
+        # v0.5.16 moved the update-group registry onto the WeightUpdater component.
+        update_groups = self.weight_updater._model_update_group
+        assert group_name in update_groups, (
+            f"Group {group_name} not in {list(update_groups.keys())}. "
             "Please call `init_weights_update_group` first."
         )
 
@@ -1320,7 +1322,7 @@ class ModelRunner:
                     torch.distributed.broadcast(
                         weight,
                         src=0,
-                        group=self._model_update_group[group_name],
+                        group=update_groups[group_name],
                         async_op=True,
                     )
                 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -564,6 +564,7 @@ class ModelRunner:
 
     def init_remote_instance_weight_transporter(self):
         self.remote_instance_weight_transporter = RemoteInstanceWeightTransporter(
+            server_args=self.server_args,
             get_model=lambda: self.model,
             tp_rank=self.ps.tp_rank,
             gpu_id=self.gpu_id,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -83,6 +83,7 @@ from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
 from sglang.srt.lora.lora_manager import LoRAManager, init_lora_cuda_graph_moe_buffers
 from sglang.srt.lora.lora_registry import LoRARef
+from sglang.srt.managers.io_struct import LoRAUpdateOutput
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache import kv_cache_dtype
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -1264,11 +1265,77 @@ class ModelRunner:
         return self.lora_manager.load_lora_adapter(lora_ref)
 
     def load_lora_adapter_from_tensors(
-        self, lora_ref: LoRARef, tensors, config_dict, added_tokens_config=None
+        self,
+        lora_ref: LoRARef,
+        tensors,
+        config_dict,
+        added_tokens_config=None,
+        upsert: bool = False,
     ):
-        return self.lora_manager.load_lora_adapter_from_tensors(
-            lora_ref, tensors, config_dict, added_tokens_config
+        logger.info(f"LoRA adapter loading from tensors starts: {lora_ref}.")
+        result = self.lora_manager.load_lora_adapter_from_tensors(
+            lora_ref,
+            tensors,
+            config_dict,
+            added_tokens_config,
+            upsert=upsert,
         )
+        logger.info(f"LoRA adapter loading from tensors completes: {lora_ref}.")
+        return result
+
+    def load_lora_adapter_from_distributed(
+        self,
+        lora_ref: LoRARef,
+        names,
+        dtypes,
+        shapes,
+        config_dict,
+        group_name,
+        added_tokens_config=None,
+        upsert: bool = False,
+    ):
+        """Load a new lora adapter whose weights are broadcast over the
+        `_model_update_group` process group (no CUDA IPC).
+        """
+        assert group_name in self._model_update_group, (
+            f"Group {group_name} not in {list(self._model_update_group.keys())}. "
+            "Please call `init_weights_update_group` first."
+        )
+
+        logger.info(f"LoRA adapter loading from distributed starts: {lora_ref}.")
+        try:
+            tensors = {}
+            handles = []
+            for name, dtype, shape in zip(names, dtypes, shapes):
+                target_dtype = (
+                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+                )
+                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
+                handles.append(
+                    torch.distributed.broadcast(
+                        weight,
+                        src=0,
+                        group=self._model_update_group[group_name],
+                        async_op=True,
+                    )
+                )
+                tensors[name] = weight
+            for handle in handles:
+                handle.wait()
+        except Exception as e:
+            error_msg = f"Failed to receive LoRA adapter weights from distributed: {e}."
+            logger.error(error_msg)
+            return LoRAUpdateOutput(success=False, error_message=error_msg)
+
+        result = self.lora_manager.load_lora_adapter_from_tensors(
+            lora_ref,
+            tensors,
+            config_dict,
+            added_tokens_config,
+            upsert=upsert,
+        )
+        logger.info(f"LoRA adapter loading from distributed completes: {lora_ref}.")
+        return result
 
     def unload_lora_adapter(self, lora_ref: LoRARef):
         """Unload a lora adapter that was previously loaded during initialization or dynamic loading."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -676,6 +676,7 @@ class ModelRunner:
     def maybe_init_remote_instance_transfer_engine(self):
         if remote_instance_transfer_engine_enabled(load_format=self.draft_load_format):
             self.remote_instance_weight_transporter.init_engine()
+        self.remote_instance_weight_transporter.maybe_init_parallelism_config()
 
     def maybe_init_expert_location_metadata(self):
         if self.is_draft_worker:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -203,6 +203,7 @@ from sglang.srt.state_capturer.routed_experts import (
     get_global_experts_capturer,
     set_global_experts_capturer,
 )
+from sglang.srt.true_on_policy import is_tp_invariant_target
 from sglang.srt.utils import (
     cpu_has_amx_support,
     enable_show_time_cost,
@@ -759,6 +760,10 @@ class ModelRunner:
             from sglang.srt.batch_invariant_ops import enable_batch_invariant_mode
 
             enable_batch_invariant_mode()
+        if is_tp_invariant_target():
+            from sglang.srt.tp_invariant_ops import enable_tp_invariant_mode
+
+            enable_tp_invariant_mode()
 
     def get_pp_proxy_topk_size(self) -> Optional[int]:
         return misc_utils.resolve_pp_proxy_topk_size(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -20,7 +20,7 @@ import inspect
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -166,6 +166,11 @@ from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.model_executor.runner import (
     EagerRunner,
     get_batch_sizes_to_capture,
+)
+from sglang.srt.model_loader.loader import (
+    post_load_weights,
+    postprocess_weight,
+    restore_weight,
 )
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
@@ -1904,9 +1909,29 @@ class ModelRunner:
             forward_batch.token_ids_logprobs,
         )
 
-    def check_weights(self, action: str, allow_quant_error: bool = False):
+    def begin_weight_update(self) -> None:
+        """Begin a weight-update session: restore in-place-packed weights to a
+        loadable state (no-op for schemes that don't repack)."""
+        restore_weight(self.model, torch.device(self.device))
+
+    def end_weight_update(self, run_post_load: bool) -> None:
+        """End the weight-update session: optionally run model.post_load_weights
+        (when load_weights was bypassed this session, e.g. P2P/RDMA), then finalize
+        quantized weights into kernel layout."""
+        if run_post_load:
+            post_load_weights(self.model)
+        postprocess_weight(self.model, torch.device(self.device))
+
+    def check_weights(
+        self,
+        action: str,
+        allow_quant_error: bool = False,
+        skip_tensor_list: Optional[List[str]] = None,
+    ):
         return self._weight_checker.handle(
-            action=action, allow_quant_error=allow_quant_error
+            action=action,
+            allow_quant_error=allow_quant_error,
+            skip_tensor_list=skip_tensor_list,
         )
 
     def _expand_eplb_metadata_for_scale(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -841,7 +841,8 @@ class ModelRunner:
 
         self.maybe_init_hisparse_coordinator()
 
-        self.init_routed_experts_capturer()
+        if not self.is_draft_worker:
+            self.init_routed_experts_capturer()
         self.init_indexer_capturer()
 
         self.graph_shared_output = None
@@ -1561,6 +1562,15 @@ class ModelRunner:
         output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
         no_copy_to_cpu = not get_schedule().disable_overlap_schedule
+        # In speculative decoding, num_tokens_per_bs > 1, so pass the actual
+        # number of tokens per DP rank in CUDA graph, not the batch size.
+        cuda_graph_num_tokens = None
+        if getattr(self.decode_cuda_graph_runner, "bs", None):
+            cuda_graph_num_tokens = (
+                self.decode_cuda_graph_runner.bs
+                * self.decode_cuda_graph_runner.num_tokens_per_bs
+            )
+
         if (
             not self.is_draft_worker
             and (experts_capturer := get_global_experts_capturer()) is not None
@@ -1568,7 +1578,7 @@ class ModelRunner:
             output.routed_experts_output = experts_capturer.on_forward_end(
                 forward_batch=forward_batch,
                 can_run_graph=output.can_run_graph,
-                cuda_graph_batch=getattr(self.decode_cuda_graph_runner, "bs", None),
+                cuda_graph_batch=cuda_graph_num_tokens,
                 no_copy_to_cpu=no_copy_to_cpu,
             )
 
@@ -1576,7 +1586,7 @@ class ModelRunner:
             output.indexer_topk_output = indexer_capturer.on_forward_end(
                 forward_batch=forward_batch,
                 can_run_graph=output.can_run_graph,
-                cuda_graph_batch=getattr(self.decode_cuda_graph_runner, "bs", None),
+                cuda_graph_batch=cuda_graph_num_tokens,
                 no_copy_to_cpu=no_copy_to_cpu,
             )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -265,6 +265,9 @@ def _prefill_cuda_graph_allows_context_parallel(
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
     can_run_graph: bool
+    # Per-rank padded size of the graph this forward replayed (None for eager);
+    # the dp-gathered buffer is strided by it.
+    graph_num_tokens: Optional[int] = None
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
     routed_experts_output: Optional[TopkCaptureOutput] = None
     indexer_topk_output: Optional[TopkCaptureOutput] = None
@@ -1642,10 +1645,9 @@ class ModelRunner:
         # pass the actual number of tokens per DP rank in CUDA graph, not the batch
         # size — the width is captured_req_width.
 
-        cuda_graph_num_tokens = None
-        runner = self.decode_cuda_graph_runner
-        if getattr(runner, "bs", None):
-            cuda_graph_num_tokens = runner.bs * runner.captured_req_width
+        # From the runner that ran this forward: the decode runner's own bs is
+        # another graph's stride once a prefill graph replays.
+        cuda_graph_num_tokens = output.graph_num_tokens
 
         if (
             not self.is_draft_worker
@@ -1760,13 +1762,20 @@ class ModelRunner:
                 self.hisparse_coordinator.wait_for_pending_backup()
                 self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
+            graph_num_tokens = None
+
             # Replay cuda graph if applicable
             if can_run_graph:
                 ret = self.decode_cuda_graph_runner.execute(
                     forward_batch,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
-                return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+                return ModelRunnerOutput(
+                    logits_output=ret,
+                    can_run_graph=can_run_graph,
+                    graph_num_tokens=self.decode_cuda_graph_runner.bs
+                    * self.decode_cuda_graph_runner.captured_req_width,
+                )
 
             # DP / MLP-sync padding + attn-tp normalization. Only the decode
             # cuda-graph path above pre-pads its static buffers and returns
@@ -1815,6 +1824,7 @@ class ModelRunner:
                         forward_batch, **kwargs
                     )
                 can_run_graph = True
+                graph_num_tokens = self.prefill_cuda_graph_runner.last_replay_num_tokens
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.
                 ret = self.eager_runner.execute(
@@ -1827,7 +1837,11 @@ class ModelRunner:
             ):
                 forward_batch.post_forward_mlp_sync_batch(ret)
 
-            return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+            return ModelRunnerOutput(
+                logits_output=ret,
+                can_run_graph=can_run_graph,
+                graph_num_tokens=graph_num_tokens,
+            )
 
     def _preprocess_logits(
         self, logits_output: LogitsProcessorOutput, sampling_info: SamplingBatchInfo

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 
 import torch
 
+from sglang.srt.distributed.parallel_state import RankParallelismConfig
 from sglang.srt.environ import envs
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
@@ -29,6 +30,7 @@ class RemoteInstanceWeightTransporter:
     engine: Optional[Any] = None
     session_id: str = ""
     weight_info: Optional[dict[str, tuple[int, int, int]]] = None
+    parallelism_config: Optional[RankParallelismConfig] = None
     _nixl_manager: Optional[Any] = None
 
     @property
@@ -54,6 +56,9 @@ class RemoteInstanceWeightTransporter:
         self.session_id = NetworkAddress(
             local_ip, self.engine.get_rpc_port()
         ).to_host_port_str()
+        self.parallelism_config = RankParallelismConfig.from_parallel_state(
+            self.tp_rank
+        )
 
     def maybe_register_and_publish_weight_info(self) -> None:
         if (
@@ -69,6 +74,51 @@ class RemoteInstanceWeightTransporter:
             # Register memory and upstream the transfer engine info to the bootstrap server
             self.weight_info = register_memory_region(self.model, self.engine)
             self._register_to_engine_info_bootstrap()
+
+        # The P2P weight-update client needs each rank's parallelism layout to
+        # map training-side parameters onto this rank's shards.
+        if (
+            self.server_args.remote_instance_weight_loader_use_transfer_engine()
+            and self.parallelism_config is not None
+        ):
+            self._register_parallelism_config_to_bootstrap()
+
+    def _bootstrap_url(self) -> str:
+        if self.server_args.dist_init_addr:
+            bootstrap_host = (
+                NetworkAddress.parse(self.server_args.dist_init_addr).resolved().host
+            )
+        else:
+            bootstrap_host = "127.0.0.1"
+        bootstrap_port = self.server_args.engine_info_bootstrap_port
+        return NetworkAddress(bootstrap_host, bootstrap_port).to_url()
+
+    def _register_parallelism_config_to_bootstrap(self) -> None:
+        """Register this rank's parallelism config with the EngineInfoBootstrapServer."""
+        import requests as http_requests
+
+        bootstrap_url = self._bootstrap_url()
+        url = f"{bootstrap_url}/register_parallelism_config"
+        payload = {
+            "tp_rank": self.tp_rank,
+            "parallelism_config": self.parallelism_config.to_dict(),
+        }
+        try:
+            resp = http_requests.put(url, json=payload, timeout=5)
+            if resp.status_code == 200:
+                logger.info(
+                    f"Registered parallelism config for tp_rank={self.tp_rank} "
+                    f"with bootstrap server at {bootstrap_url}"
+                )
+            else:
+                logger.error(
+                    f"Failed to register parallelism config for tp_rank={self.tp_rank}: "
+                    f"{resp.status_code}, {resp.text}"
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to register parallelism config for tp_rank={self.tp_rank}: {e}"
+            )
 
     def _register_to_engine_info_bootstrap(self: RemoteInstanceWeightTransporter):
         """Register transfer engine info with the EngineInfoBootstrapServer via HTTP PUT.

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -56,9 +56,12 @@ class RemoteInstanceWeightTransporter:
         self.session_id = NetworkAddress(
             local_ip, self.engine.get_rpc_port()
         ).to_host_port_str()
-        self.parallelism_config = RankParallelismConfig.from_parallel_state(
-            self.tp_rank
-        )
+
+    def maybe_init_parallelism_config(self) -> None:
+        if self.server_args.registers_parallelism_config():
+            self.parallelism_config = RankParallelismConfig.from_parallel_state(
+                self.tp_rank
+            )
 
     def maybe_register_and_publish_weight_info(self) -> None:
         if (
@@ -78,7 +81,7 @@ class RemoteInstanceWeightTransporter:
         # The P2P weight-update client needs each rank's parallelism layout to
         # map training-side parameters onto this rank's shards.
         if (
-            self.server_args.remote_instance_weight_loader_use_transfer_engine()
+            self.server_args.registers_parallelism_config()
             and self.parallelism_config is not None
         ):
             self._register_parallelism_config_to_bootstrap()

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -17,6 +17,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     remote_instance_transfer_engine_enabled,
 )
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True, kw_only=True)
 class RemoteInstanceWeightTransporter:
+    server_args: ServerArgs
     get_model: Callable[[], torch.nn.Module]
     tp_rank: int
     gpu_id: int

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -335,6 +335,40 @@ class WeightUpdater:
             logger.error(error_msg)
             return False, error_msg
 
+    def _update_bucketed_weights_from_distributed(
+        self: WeightUpdater, names, dtypes, shapes, group_name
+    ):
+        try:
+            named_tensors = []
+            for name, dtype, shape in zip(names, dtypes, shapes):
+                target_dtype = (
+                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+                )
+                named_tensors.append(
+                    (
+                        name,
+                        torch.empty(shape, dtype=target_dtype, device=self.device),
+                    )
+                )
+            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            flattened_tensor = bucket.get_flattened_tensor()
+            torch.distributed.broadcast(
+                flattened_tensor,
+                src=0,
+                group=self._model_update_group[group_name],
+            )
+            reconstructed_tensors = bucket.reconstruct_tensors()
+            self.get_model().load_weights(reconstructed_tensors)
+            return True, f"Succeeded to update parameter online."
+        except Exception as e:
+            error_msg = (
+                f"Failed to update parameter online: {e}. "
+                f"The full weights of the ModelRunner are partially updated. "
+                f"Please discard the whole weights."
+            )
+            logger.error(error_msg)
+            return False, error_msg
+
     def update_weights_from_tensor(
         self: WeightUpdater,
         named_tensors: List[Tuple[str, Union[torch.Tensor, LocalSerializedTensor]]],

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -219,6 +219,75 @@ class WeightUpdater:
         logger.info("Update weights end.")
         return True, "Succeeded to update model weights."
 
+    def load_weights(self: WeightUpdater, weights) -> None:
+        """Load an in-memory list of (name, tensor) weights into this runner's model."""
+        self.get_model().load_weights(weights)
+
+    def receive_weights_from_distributed(
+        self: WeightUpdater,
+        names,
+        dtypes,
+        shapes,
+        group_name,
+        load_format: Optional[str] = None,
+    ):
+        """Receive one weight broadcast from the training engine over this runner's
+        `_model_update_group` and return the named tensors WITHOUT loading them.
+
+        Only the runner that joined the group (the target / main model) can receive;
+        the caller loads the result into each runner it wants updated. Speculative
+        draft runners never join the group, so they are fed from here.
+        """
+        assert group_name in self._model_update_group, (
+            f"Group {group_name} not in {list(self._model_update_group.keys())}. "
+            "Please call `init_weights_update_group` first."
+        )
+
+        if load_format == "flattened_bucket":
+            return self._receive_bucketed_weights_from_distributed(
+                names, dtypes, shapes, group_name
+            )
+
+        weights = []
+        handles = []
+        for name, dtype, shape in zip(names, dtypes, shapes):
+            target_dtype = (
+                dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+            )
+            weight = torch.empty(shape, dtype=target_dtype, device=self.device)
+            handles.append(
+                torch.distributed.broadcast(
+                    weight,
+                    src=0,
+                    group=self._model_update_group[group_name],
+                    async_op=True,
+                )
+            )
+            weights.append((name, weight))
+        for handle in handles:
+            handle.wait()
+        return weights
+
+    def _receive_bucketed_weights_from_distributed(
+        self: WeightUpdater, names, dtypes, shapes, group_name
+    ):
+        named_tensors = []
+        for name, dtype, shape in zip(names, dtypes, shapes):
+            target_dtype = (
+                dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+            )
+            named_tensors.append(
+                (name, torch.empty(shape, dtype=target_dtype, device=self.device))
+            )
+        bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+        flattened_tensor = bucket.get_flattened_tensor()
+        torch.distributed.broadcast(
+            flattened_tensor,
+            src=0,
+            group=self._model_update_group[group_name],
+        )
+        return bucket.reconstruct_tensors()
+
     def update_weights_from_distributed(
         self: WeightUpdater,
         names,
@@ -251,62 +320,12 @@ class WeightUpdater:
                 names, dtypes, shapes, group_name
             )
         try:
-            weights = []
-            handles = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
-                handles.append(
-                    torch.distributed.broadcast(
-                        weight,
-                        src=0,
-                        group=self._model_update_group[group_name],
-                        async_op=True,
-                    )
-                )
-                weights.append((name, weight))
-            for handle in handles:
-                handle.wait()
-
-            self.get_model().load_weights(weights)
+            weights = self.receive_weights_from_distributed(
+                names, dtypes, shapes, group_name, load_format
+            )
+            self.load_weights(weights)
             return True, "Succeeded to update parameter online."
 
-        except Exception as e:
-            error_msg = (
-                f"Failed to update parameter online: {e}. "
-                f"The full weights of the ModelRunner are partially updated. "
-                f"Please discard the whole weights."
-            )
-            logger.error(error_msg)
-            return False, error_msg
-
-    def _update_bucketed_weights_from_distributed(
-        self: WeightUpdater, names, dtypes, shapes, group_name
-    ):
-        try:
-            named_tensors = []
-            for name, dtype, shape in zip(names, dtypes, shapes):
-                target_dtype = (
-                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
-                )
-                named_tensors.append(
-                    (
-                        name,
-                        torch.empty(shape, dtype=target_dtype, device=self.device),
-                    )
-                )
-            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
-            flattened_tensor = bucket.get_flattened_tensor()
-            torch.distributed.broadcast(
-                flattened_tensor,
-                src=0,
-                group=self._model_update_group[group_name],
-            )
-            reconstructed_tensors = bucket.reconstruct_tensors()
-            self.get_model().load_weights(reconstructed_tensors)
-            return True, f"Succeeded to update parameter online."
         except Exception as e:
             error_msg = (
                 f"Failed to update parameter online: {e}. "

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -101,6 +101,9 @@ from sglang.srt.model_executor.runner_utils.shared_read_event import make_extern
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
 from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
+from sglang.srt.true_on_policy import (
+    patch_prefill_only_deterministic_inference_for_cuda_graph,
+)
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -1032,22 +1035,32 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
-        with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
-            if not self.enable_pdmux:
-                with graph_capture() as graph_capture_context, profile_context as prof:
-                    self.stream = graph_capture_context.stream
-                    with self.backend.capture_session(self.stream):
-                        self._capture_one_stream()
-            else:
-                set_pdmux_status(False)
-                for i, sg in enumerate(self.stream_groups):
+        with patch_prefill_only_deterministic_inference_for_cuda_graph(
+            self.model_runner.server_args,
+            attn_backend=getattr(self.model_runner, "attn_backend", None),
+            dvr_target_verify_cuda_graph=getattr(
+                self.model_runner, "enable_dvr_target_verify_cuda_graph", False
+            ),
+        ):
+            with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
+                if not self.enable_pdmux:
                     with (
-                        graph_capture(stream=sg[1]) as graph_capture_context,
+                        graph_capture() as graph_capture_context,
                         profile_context as prof,
                     ):
                         self.stream = graph_capture_context.stream
                         with self.backend.capture_session(self.stream):
-                            self._capture_one_stream(i)
+                            self._capture_one_stream()
+                else:
+                    set_pdmux_status(False)
+                    for i, sg in enumerate(self.stream_groups):
+                        with (
+                            graph_capture(stream=sg[1]) as graph_capture_context,
+                            profile_context as prof,
+                        ):
+                            self.stream = graph_capture_context.stream
+                            with self.backend.capture_session(self.stream):
+                                self._capture_one_stream(i)
 
         if self.enable_profile_cuda_graph:
             self._post_process_after_profile(prof)

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1778,6 +1778,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
             static_num_tokens = len(static_forward_batch.input_ids)
+            # Stride of the dp-gathered buffer for this replay; surfaced through
+            # ModelRunnerOutput.graph_num_tokens.
+            self.last_replay_num_tokens = static_num_tokens
             raw_num_tokens = self.raw_num_tokens
             shape_key = self._shape_key(static_num_tokens, forward_batch)
             # The only variants this runner records are chunked-prefix ones.

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -121,6 +121,10 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx = partial(
                 self._memory_saver_adapter.cuda_graph,
                 tag=GPU_MEMORY_TYPE_CUDA_GRAPH,
+                # The pool holds capture-time-initialized device state that replays
+                # read but never rewrite, so pausing must preserve the pool contents
+                # instead of discarding them.
+                enable_cpu_backup=True,
             )
         else:
             graph_ctx = self._device_module.graph

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -384,6 +384,15 @@ def postprocess_weight(model: nn.Module, target_device) -> None:
     _apply_quant_method_hook(model, target_device, "process_weights_after_loading")
 
 
+def _post_load_weights(model: nn.Module) -> None:
+    # Loaders that bypass `model.load_weights()` (dummy / sharded state / remote instance /
+    # remote fs) must trigger the model's post-load fixup explicitly; `model.load_weights()`
+    # would normally do it internally. NextN subclasses override the method to fill in
+    # `is_nextn=True`, so the loader doesn't need to know.
+    if hasattr(model, "post_load_weights"):
+        model.post_load_weights()
+
+
 class BaseModelLoader(ABC):
     """Base class for model loaders."""
 

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -345,13 +345,43 @@ def _initialize_model(
     return model_class(**kwargs)
 
 
-def _post_load_weights(model: nn.Module) -> None:
+def post_load_weights(model: nn.Module) -> None:
     # Loaders that bypass `model.load_weights()` (dummy / sharded state / remote instance /
     # remote fs) must trigger the model's post-load fixup explicitly; `model.load_weights()`
     # would normally do it internally. NextN subclasses override the method to fill in
     # `is_nextn=True`, so the loader doesn't need to know.
     if hasattr(model, "post_load_weights"):
         model.post_load_weights()
+
+
+def _apply_quant_method_hook(model: nn.Module, target_device, hook_name: str) -> None:
+    """Run a quant_method hook (restore/process) on every quantized module.
+
+    LoRA wrappers forward `quant_method` for forward-path dispatch but don't own
+    the packed params; skip them so the inner base layer (yielded separately by
+    `named_modules`) handles it.
+    """
+    from sglang.srt.lora.layers import BaseLayerWithLoRA
+
+    for _, module in model.named_modules():
+        if isinstance(module, BaseLayerWithLoRA):
+            continue
+        quant_method = getattr(module, "quant_method", None)
+        if quant_method is not None and hasattr(quant_method, hook_name):
+            with device_loading_context(module, target_device):
+                getattr(quant_method, hook_name)(module)
+
+
+def restore_weight(model: nn.Module, target_device) -> None:
+    """Undo in-place quant packing so fresh weights can be loaded
+    (no-op for schemes that don't repack, e.g. plain fp8)."""
+    _apply_quant_method_hook(model, target_device, "restore_weights_before_loading")
+
+
+def postprocess_weight(model: nn.Module, target_device) -> None:
+    """Finalize quantized weights into kernel layout (Marlin repack, UE8M0 requant,
+    transpose, ...)."""
+    _apply_quant_method_hook(model, target_device, "process_weights_after_loading")
 
 
 class BaseModelLoader(ABC):
@@ -1639,7 +1669,7 @@ class DummyModelLoader(BaseModelLoader):
             # random values to the weights.
             initialize_dummy_weights(model)
 
-            _post_load_weights(model)
+            post_load_weights(model)
 
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)
@@ -1800,7 +1830,7 @@ class ShardedStateLoader(BaseModelLoader):
             if state_dict:
                 raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
-            _post_load_weights(model)
+            post_load_weights(model)
 
         return model.eval()
 
@@ -3407,7 +3437,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                 )
             current_platform.synchronize()
 
-            _post_load_weights(model)
+            post_load_weights(model)
         end_get_weights_tic = time.time()
         logger.debug(
             f"finish getting all weights from remote instance, time used: {(end_get_weights_tic - start_get_weights_tic):.4f}s"
@@ -3470,7 +3500,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             logger.error(f"batch transfer failed, error: {ret}")
             return False
 
-        _post_load_weights(model)
+        post_load_weights(model)
 
         return True
 
@@ -3560,7 +3590,7 @@ class RemoteModelLoader(BaseModelLoader):
         if state_dict:
             raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
-        _post_load_weights(model)
+        post_load_weights(model)
 
     def _load_model_from_remote_fs(
         self, model, client, model_config: ModelConfig, device_config: DeviceConfig

--- a/python/sglang/srt/model_loader/parameter_mapper.py
+++ b/python/sglang/srt/model_loader/parameter_mapper.py
@@ -1,0 +1,261 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Parameter mapping from HuggingFace checkpoint names to SGLang model parameters.
+
+This module provides utilities for translating weight names between HuggingFace
+checkpoint format and SGLang's internal parameter naming, handling:
+
+1. Stacked Parameter Fusion
+   - gate_proj + up_proj → gate_up_proj (num_shards=2)
+   - q_proj + k_proj + v_proj → qkv_proj (num_shards=3)
+   - q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa (DeepSeek MLA)
+
+2. Expert Parameter Sharding (MoE models)
+   - experts.{id}.gate_proj + experts.{id}.up_proj → experts.w13_weight (num_shards=2)
+   - experts.{id}.down_proj → experts.w2_weight (num_shards=1)
+   - Handles expert parallelism: num_local_experts = n_routed // ep_size + shared
+
+3. Scale Remapping (Quantized models)
+   - k_proj.k_scale → attn.k_scale
+   - v_proj.v_scale → attn.v_scale
+   - Quark-specific: output_scale → per-component scales
+
+Supported Models:
+    Dense: Llama, Qwen2, Qwen3, GLM4
+    MoE:   DeepSeekV2/V3/R1, Qwen3-MoE, GLM4-MoE, GLM4-MoE-Lite (GLM-4.7)
+
+Example:
+    >>> mapper = ParameterMapper.from_model(model)
+    >>> result = mapper.map("model.layers.0.mlp.gate_proj.weight")
+    >>> result.sglang_name  # "model.layers.0.mlp.gate_up_proj.weight"
+    >>> result.shard_id     # 0
+    >>> result.num_shards   # 2
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+StackedParamsEntry = Tuple[str, str, Union[int, str]]
+ExpertParamsEntry = Tuple[str, str, int, Union[int, str]]
+
+
+@dataclass
+class MappingResult:
+    """Result of mapping a HuggingFace checkpoint weight name to SGLang parameter."""
+
+    sglang_name: str
+    shard_id: Optional[Union[int, str]]
+    num_shards: int
+    expert_id: Optional[int]
+    num_local_experts: Optional[int]
+
+
+# Standard FP8 scale remapping patterns
+_SCALE_REMAP_PATTERNS: List[Tuple[str, str, str]] = [
+    (".k_scale", ".self_attn.k_proj.k_scale", ".self_attn.attn.k_scale"),
+    (".v_scale", ".self_attn.v_proj.v_scale", ".self_attn.attn.v_scale"),
+    (".k_scale", ".k_scale", ".attn.k_scale"),
+    (".v_scale", ".v_scale", ".attn.v_scale"),
+]
+
+# Quark quantization scale remapping
+_QUARK_SCALE_REMAP: Dict[str, str] = {
+    ".q_proj.output_scale": ".attn.q_scale",
+    ".k_proj.output_scale": ".attn.k_scale",
+    ".v_proj.output_scale": ".attn.v_scale",
+    "self_attn.prob_output_scale": ".attn.prob_scale",
+}
+
+
+class ParameterMapper:
+    """Maps HuggingFace checkpoint weight names to SGLang model parameters.
+
+    This class pre-computes lookup tables at initialization for efficient
+    repeated mapping. It handles:
+    - Stacked/fused parameter mapping (gate_up_proj, qkv_proj, etc.)
+    - Expert parameter mapping with shard information
+    - Scale remapping for quantized models
+    - Model-specific weight name mutations
+    """
+
+    def __init__(
+        self,
+        stacked_params_mapping: List[StackedParamsEntry],
+        expert_params_mapping: List[ExpertParamsEntry],
+        num_local_experts: int = 0,
+        mutate_weight_preload: Optional[Callable[[str], str]] = None,
+        custom_scale_remap: Optional[Callable[[str], str]] = None,
+    ):
+        """Initialize the parameter mapper with model-specific configuration.
+
+        Args:
+            stacked_params_mapping: List of (sglang_name, hf_name, shard_id) tuples.
+                Example: [("gate_up_proj", "gate_proj", 0), ("gate_up_proj", "up_proj", 1)]
+            expert_params_mapping: List of (sglang_name, hf_name, expert_id, shard_id) tuples.
+                Example: [("w13_weight", "experts.0.gate_proj.weight", 0, 0), ...]
+            num_local_experts: Number of experts in the current model rank.
+                For EP=1: num_local_experts = n_routed_experts + num_fused_shared_experts
+                For EP>1: num_local_experts = n_routed_experts // ep_size + num_fused_shared_experts
+            mutate_weight_preload: Optional function to transform weight names before mapping.
+                Used for shared expert fusion in DeepSeek (shared_experts → experts.{n_routed}).
+            custom_scale_remap: Optional function for model-specific scale remapping.
+                Used for DeepSeek k_proj/v_proj → attn_mqa scale mapping.
+        """
+        self.num_local_experts = num_local_experts
+        self._mutate_weight_preload = mutate_weight_preload
+        self._custom_scale_remap = custom_scale_remap
+
+        self._stacked_lookup, self._stacked_num_shards = self._build_stacked_lookup(
+            stacked_params_mapping
+        )
+        self._expert_lookup, self._expert_num_shards = self._build_expert_lookup(
+            expert_params_mapping
+        )
+
+    @staticmethod
+    def _build_stacked_lookup(
+        mapping: List[StackedParamsEntry],
+    ) -> Tuple[Dict[str, Tuple[str, Union[int, str]]], Dict[str, int]]:
+        """Build lookup table and num_shards from stacked params mapping."""
+        lookup: Dict[str, Tuple[str, Union[int, str]]] = {}
+        shard_counts: Dict[str, int] = {}
+
+        for sglang_name, hf_name, shard_id in mapping:
+            lookup[hf_name] = (sglang_name, shard_id)
+            shard_counts[sglang_name] = shard_counts.get(sglang_name, 0) + 1
+
+        return lookup, shard_counts
+
+    @staticmethod
+    def _build_expert_lookup(
+        mapping: List[ExpertParamsEntry],
+    ) -> Tuple[Dict[str, Tuple[str, int, Union[int, str]]], Dict[str, int]]:
+        """Build lookup table and num_shards from expert params mapping."""
+        lookup: Dict[str, Tuple[str, int, Union[int, str]]] = {}
+        shard_counts: Dict[str, int] = {}
+
+        for sglang_name, hf_name, expert_id, shard_id in mapping:
+            lookup[hf_name] = (sglang_name, expert_id, shard_id)
+
+        for sglang_name, _, _, shard_id in mapping:
+            key = sglang_name
+            if key not in shard_counts:
+                unique_shards = set(
+                    s_id for s_name, _, _, s_id in mapping if s_name == sglang_name
+                )
+                shard_counts[key] = len(unique_shards)
+
+        return lookup, shard_counts
+
+    def _apply_scale_remap(self, name: str) -> str:
+        """Apply standard and Quark scale remapping patterns."""
+        for suffix, pattern, replacement in _SCALE_REMAP_PATTERNS:
+            if name.endswith(suffix) and pattern in name:
+                return name.replace(pattern, replacement)
+
+        for quark_suffix, replacement in _QUARK_SCALE_REMAP.items():
+            if name.endswith(quark_suffix):
+                return name.replace(quark_suffix, replacement)
+
+        return name
+
+    def map(self, hf_weight_name: str) -> MappingResult:
+        """Map a HuggingFace checkpoint weight name to SGLang parameter info.
+
+        Args:
+            hf_weight_name: The weight name from HuggingFace checkpoint.
+
+        Returns:
+            MappingResult with mapped name and sharding information.
+        """
+        name = hf_weight_name
+
+        if self._mutate_weight_preload is not None:
+            name = self._mutate_weight_preload(name)
+
+        if "scale" in name:
+            if self._custom_scale_remap is not None:
+                remapped = self._custom_scale_remap(name)
+                if remapped != name:
+                    name = remapped
+                else:
+                    name = self._apply_scale_remap(name)
+            else:
+                name = self._apply_scale_remap(name)
+
+        for hf_pattern, (
+            sglang_name,
+            expert_id,
+            shard_id,
+        ) in self._expert_lookup.items():
+            if hf_pattern in name:
+                mapped_name = name.replace(hf_pattern, sglang_name)
+                return MappingResult(
+                    sglang_name=mapped_name,
+                    shard_id=shard_id,
+                    num_shards=self._expert_num_shards.get(sglang_name, 1),
+                    expert_id=expert_id,
+                    num_local_experts=self.num_local_experts,
+                )
+
+        for hf_pattern, (sglang_name, shard_id) in self._stacked_lookup.items():
+            if hf_pattern in name:
+                mapped_name = name.replace(hf_pattern, sglang_name)
+                return MappingResult(
+                    sglang_name=mapped_name,
+                    shard_id=shard_id,
+                    num_shards=self._stacked_num_shards.get(sglang_name, 1),
+                    expert_id=None,
+                    num_local_experts=None,
+                )
+
+        return MappingResult(
+            sglang_name=name,
+            shard_id=None,
+            num_shards=1,
+            expert_id=None,
+            num_local_experts=None,
+        )
+
+    @classmethod
+    def from_model(cls, model) -> "ParameterMapper":
+        """Create a ParameterMapper from a model instance; currently supports
+        DeepseekV2ForCausalLM, Glm4ForCausalLM, Glm4MoeForCausalLM,
+        Glm4MoeLiteForCausalLM, LlamaForCausalLM, Qwen2ForCausalLM,
+        Qwen3ForCausalLM, Qwen3MoeForCausalLM."""
+        stacked_mapping = list(getattr(model, "stacked_params_mapping", []) or [])
+        expert_mapping = list(getattr(model, "expert_params_mapping", []) or [])
+
+        num_local_experts = 0
+        if hasattr(model, "num_local_experts"):
+            num_local_experts = model.num_local_experts
+        elif expert_mapping:
+            expert_ids = set(entry[2] for entry in expert_mapping)
+            num_local_experts = len(expert_ids)
+
+        mutate_fn = None
+        if hasattr(model, "mutate_weight_preload"):
+            mutate_fn = model.mutate_weight_preload
+
+        scale_fn = None
+        if hasattr(model, "custom_scale_remap"):
+            scale_fn = model.custom_scale_remap
+
+        return cls(
+            stacked_params_mapping=stacked_mapping,
+            expert_params_mapping=expert_mapping,
+            num_local_experts=num_local_experts,
+            mutate_weight_preload=mutate_fn,
+            custom_scale_remap=scale_fn,
+        )

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -25,7 +25,6 @@ from transformers import PretrainedConfig
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
-from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
@@ -59,7 +58,6 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_gfx95,
     awq_dequantize_func,
     enable_nextn_moe_bf16_cast_to_fp8,
-    is_wint4afp8_or_wint4a16_config,
 )
 from sglang.srt.utils import bind_or_assign, get_bool_env_var, log_info_on_rank0
 
@@ -149,6 +147,18 @@ class DeepseekV2WeightLoaderMixin:
     quant_config: Optional[QuantizationConfig]
     pp_group: GroupCoordinator
     num_fused_shared_experts: int
+    # Weight mapping relationships determined at model initialization time.
+    fuse_qkv_a_proj: bool
+    stacked_params_mapping: List[Tuple[str, str, int]]
+    expert_params_mapping: List[Tuple[str, str, int, int]]
+
+    def mutate_weight_preload(self, name: str) -> str:
+        """Override in subclass for model-specific weight name mutations."""
+        return name
+
+    def custom_scale_remap(self, name: str) -> str:
+        """Override in subclass for model-specific scale remapping."""
+        return name
 
     def do_load_weights(
         self,
@@ -167,33 +177,7 @@ class DeepseekV2WeightLoaderMixin:
             weights, NVFP4_CKPT_FP8_ATTN_QUANT_MODULES, nextn_conf
         )
 
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-
-        # Params for weights, fp8 weight scales, fp8 activation scales
-        # (param_name, weight_name, expert_id, shard_id)
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
-        )
-        # Params for special naming rules in mixed-precision models, for example:
-        # model.layers.xx.mlp.experts.xx.w1.input_scale. For details,
-        # see https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8/blob/main.
-        if is_wint4afp8_or_wint4a16_config(self.quant_config):
-            expert_params_mapping += FusedMoE.make_expert_input_scale_params_mapping(
-                num_experts=self.config.n_routed_experts
-            )
-
-        # Fuse q_a_proj and kv_a_proj_with_mqa along output dimension when q_lora_rank is not None
-        fuse_qkv_a_proj = hasattr(self.config, "q_lora_rank") and (
-            self.config.q_lora_rank is not None
-        )
-        cached_a_proj = {} if fuse_qkv_a_proj else None
+        cached_a_proj = {} if self.fuse_qkv_a_proj else None
 
         pending_indexer_wk: Dict[str, Dict[str, torch.Tensor]] = {}
 
@@ -221,11 +205,7 @@ class DeepseekV2WeightLoaderMixin:
                     )
                 ):
                     continue
-                if self.num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
-                    name = name.replace(
-                        "mlp.shared_experts",
-                        f"mlp.experts.{self.config.n_routed_experts}",
-                    )
+                name = self.mutate_weight_preload(name)
 
                 weight_names.append(name)
 
@@ -279,7 +259,7 @@ class DeepseekV2WeightLoaderMixin:
                 ):
                     continue
 
-                for param_name, weight_name, shard_id in stacked_params_mapping:
+                for param_name, weight_name, shard_id in self.stacked_params_mapping:
                     # Skip non-stacked layers and experts (experts handled below).
                     if weight_name not in name:
                         continue
@@ -292,6 +272,10 @@ class DeepseekV2WeightLoaderMixin:
                     # will then be updated below in expert_params_mapping
                     # for mlp.experts[0].gate_gate_up_proj, which breaks load.
                     if ("mlp.experts." in name) and name not in params_dict:
+                        continue
+                    # q_a_proj / kv_a_proj_with_mqa must bypass stacked loading
+                    # and use the cache+concat fused A-proj path below.
+                    if param_name == "fused_qkv_a_proj_with_mqa":
                         continue
                     name = name.replace(weight_name, param_name)
                     # Skip loading extra bias for GPTQ models.
@@ -308,7 +292,7 @@ class DeepseekV2WeightLoaderMixin:
                     )
                     break
                 else:
-                    for mapping in expert_params_mapping:
+                    for mapping in self.expert_params_mapping:
                         param_name, weight_name, expert_id, shard_id = mapping
                         if weight_name not in name:
                             continue
@@ -345,7 +329,7 @@ class DeepseekV2WeightLoaderMixin:
                         # Skip loading norm if not last rank in pipeline parallelism
                         if ".norm." in name and not self.pp_group.is_last_rank:
                             continue
-                        if fuse_qkv_a_proj and (
+                        if self.fuse_qkv_a_proj and (
                             "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                         ):
                             cached_a_proj[name] = _clone_if_runai_streamed_tensor(
@@ -415,13 +399,7 @@ class DeepseekV2WeightLoaderMixin:
                             if (
                                 "k_scale" in name or "v_scale" in name
                             ) and name not in params_dict:
-                                # modelopt attn kv scale is named differently
-                                for scale in ["k_scale", "v_scale"]:
-                                    if scale in name:
-                                        name = name.replace(
-                                            f"{scale[0]}_proj", "attn_mqa"
-                                        )
-                                        break
+                                name = self.custom_scale_remap(name)
                             if name not in params_dict:
                                 # modelopt ckpt contains not needed weights for MTP module:
                                 # model.decoder.self_attn.attn_mqa.v_scale and

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -346,6 +346,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         # if not set, model load will be broken in DeepseekV3ForCausalLM load_weights()
         self.pp_group = get_pp_group()
         self.determine_num_fused_shared_experts()
+        self.init_unified_loader_mappings()
         self.use_dsa = is_deepseek_dsa(config)
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = is_mla_prefill_cp_enabled() and not self.use_dsa

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3069,11 +3069,11 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 )
             )
 
-    def determine_num_fused_shared_experts(
-        self, architecture: str = "DeepseekV3ForCausalLM"
-    ):
-        self.num_fused_shared_experts = 0
-        server_args = get_server_args()
+    def determine_num_fused_shared_experts(self):
+        # The decision was installed by the loader; this only reads it.
+        self.num_fused_shared_experts = (
+            0 if is_shared_experts_fusion_disabled() else self.config.n_shared_experts
+        )
 
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2981,36 +2981,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config)
 
-        # Stacked params mapping for unified weight loading API
-        self.stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-        # Add A-proj fusion mapping when q_lora_rank is enabled
-        # q_a_proj + kv_a_proj_with_mqa -> fused_qkv_a_proj_with_mqa
-        if self.fuse_qkv_a_proj:
-            self.stacked_params_mapping.extend(
-                [
-                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
-                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
-                ]
-            )
-        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
-        )
-        # Params for special naming rules in mixed-precision models, for example:
-        # model.layers.xx.mlp.experts.xx.w1.input_scale. For details,
-        # see https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8/blob/main.
-        if is_wint4afp8_or_wint4a16_config(self.quant_config):
-            self.expert_params_mapping += (
-                FusedMoE.make_expert_input_scale_params_mapping(
-                    num_experts=self.config.n_routed_experts
-                )
-            )
+        self.init_unified_loader_mappings()
 
         self._routed_experts_weights_of_layer = LazyValue(
             lambda: {
@@ -3058,6 +3029,51 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     # checkpoint reports a different name (the NextN drafts, GLM's DSA variant)
     # overrides it.
     fused_shared_experts_architecture = "DeepseekV3ForCausalLM"
+
+    def init_unified_loader_mappings(self):
+        """Mappings the unified weight loading API reads off the model.
+
+        Call after determine_num_fused_shared_experts(); subclasses that build
+        their own __init__ must call this or weight loading fails on the
+        missing attributes.
+        """
+        self.fuse_qkv_a_proj = (
+            hasattr(self.config, "q_lora_rank") and self.config.q_lora_rank is not None
+        )
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        # q_a_proj + kv_a_proj_with_mqa -> fused_qkv_a_proj_with_mqa
+        if self.fuse_qkv_a_proj:
+            self.stacked_params_mapping.extend(
+                [
+                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
+                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
+                ]
+            )
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
+        )
+        # Params for special naming rules in mixed-precision models, for example:
+        # model.layers.xx.mlp.experts.xx.w1.input_scale. For details,
+        # see https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8/blob/main.
+        if is_wint4afp8_or_wint4a16_config(self.quant_config):
+            self.expert_params_mapping += (
+                FusedMoE.make_expert_input_scale_params_mapping(
+                    num_experts=self.config.n_routed_experts
+                )
+            )
+
+    def determine_num_fused_shared_experts(
+        self, architecture: str = "DeepseekV3ForCausalLM"
+    ):
+        self.num_fused_shared_experts = 0
+        server_args = get_server_args()
 
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2977,6 +2977,37 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config)
 
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        # Add A-proj fusion mapping when q_lora_rank is enabled
+        # q_a_proj + kv_a_proj_with_mqa -> fused_qkv_a_proj_with_mqa
+        if self.fuse_qkv_a_proj:
+            self.stacked_params_mapping.extend(
+                [
+                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
+                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
+                ]
+            )
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
+        )
+        # Params for special naming rules in mixed-precision models, for example:
+        # model.layers.xx.mlp.experts.xx.w1.input_scale. For details,
+        # see https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8/blob/main.
+        if is_wint4afp8_or_wint4a16_config(self.quant_config):
+            self.expert_params_mapping += (
+                FusedMoE.make_expert_input_scale_params_mapping(
+                    num_experts=self.config.n_routed_experts
+                )
+            )
+
         self._routed_experts_weights_of_layer = LazyValue(
             lambda: {
                 layer_id: self.model.layers[layer_id].mlp.get_moe_weights()
@@ -2998,6 +3029,22 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
 
         q_lora_rank = config.q_lora_rank if hasattr(config, "q_lora_rank") else None
         get_attn_tp_context().init_context(q_lora_rank, is_deepseek_dsa(config))
+
+    def mutate_weight_preload(self, name: str) -> str:
+        """DeepSeek V2: shared expert fusion."""
+        if self.num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
+            return name.replace(
+                "mlp.shared_experts",
+                f"mlp.experts.{self.config.n_routed_experts}",
+            )
+        return name
+
+    def custom_scale_remap(self, name: str) -> str:
+        """DeepSeek V2: k_proj -> attn_mqa when k_scale in name, v_proj -> attn_mqa when v_scale in name."""
+        for scale in ["k_scale", "v_scale"]:
+            if scale in name:
+                return name.replace(f"{scale[0]}_proj", "attn_mqa")
+        return name
 
     @property
     def routed_experts_weights_of_layer(self):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1846,7 +1846,10 @@ class DeepseekV2AttentionMLA(
                     config=config,
                 )
 
-            if self.skip_topk:
+            # A skip-topk layer only owns an indexer when it is also nextn; the
+            # others reuse the previous layer's topk and build none, so there are
+            # no weights to exempt.
+            if self.skip_topk and self.indexer is not None:
                 for p in self.indexer.parameters():
                     p._skip_weight_check = True
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1846,6 +1846,10 @@ class DeepseekV2AttentionMLA(
                     config=config,
                 )
 
+            if self.skip_topk:
+                for p in self.indexer.parameters():
+                    p._skip_weight_check = True
+
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import functools
 import logging
 import time
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -58,6 +58,7 @@ from sglang.srt.layers.communicator_dsa_cp import (
     dsa_cp_gather_hidden_states,
     dsa_cp_reduce_scatter_hidden_states,
 )
+from sglang.srt.layers.cp.cp_decode_attn_tp import get_cp_decode_attn_tp_ctx
 from sglang.srt.layers.cp.utils import (
     cp_materialize_global_token_order,
     cp_round_robin_input_ids_v2,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import functools
 import logging
 import time
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -58,7 +58,6 @@ from sglang.srt.layers.communicator_dsa_cp import (
     dsa_cp_gather_hidden_states,
     dsa_cp_reduce_scatter_hidden_states,
 )
-from sglang.srt.layers.cp.cp_decode_attn_tp import get_cp_decode_attn_tp_ctx
 from sglang.srt.layers.cp.utils import (
     cp_materialize_global_token_order,
     cp_round_robin_input_ids_v2,
@@ -1524,7 +1523,7 @@ class MQALayer(MqaAttentionBase):
                     o,
                     self.attn_mqa.layer_id,
                     self.compress_ratio,
-                    attn_sink,
+                    self._attn_sink_local,
                     save_kv_cache,
                 )
             else:
@@ -1535,7 +1534,7 @@ class MQALayer(MqaAttentionBase):
                     layer=self.attn_mqa,
                     forward_batch=forward_batch,
                     compress_ratio=self.compress_ratio,
-                    attn_sink=attn_sink,
+                    attn_sink=self._attn_sink_local,
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -544,7 +544,15 @@ class MqaAttentionBase(nn.Module):
         self.fuse_wqa_wkv = fuse
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
-        self._attn_sink_local: Optional[torch.Tensor] = None
+        # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
+        # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
+        # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
+        # this rank and padded to match.
+        self.padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
+        self._attn_sink_local: Optional[torch.Tensor] = (
+            self.attn_sink if self.attn_tp_size == 1 else None
+        )
+
         if fuse:
             self.wqkv_a = ReplicatedLinear(
                 self.hidden_size,
@@ -642,17 +650,25 @@ class MqaAttentionBase(nn.Module):
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
         self.freqs_cis: torch.Tensor
 
-    def _local_attn_sink(self) -> torch.Tensor:
-        if self.attn_tp_size == 1:
-            return self.attn_sink
+    def _attn_sink_pad_width(self) -> int:
+        """Width of the per-rank attn_sink buffer; subclasses that pad q differently
+        override this so the sink matches their q layout."""
+        return self.padded_num_heads
+
+    def refresh_attn_sink_cache(self):
+        if self._attn_sink_local is self.attn_sink:
+            return
         if self._attn_sink_local is None:
-            rank = self.attn_tp_rank
-            num_heads = self.n_local_heads
-            padded_num_heads = 64 if num_heads <= 64 else self.n_heads
-            sink = self.attn_sink.new_zeros(padded_num_heads)
-            sink[:num_heads] = self.attn_sink[rank * num_heads : (rank + 1) * num_heads]
-            self._attn_sink_local = sink
-        return self._attn_sink_local
+            self._attn_sink_local = self.attn_sink.new_zeros(
+                self._attn_sink_pad_width()
+            )
+        self._attn_sink_local[: self.n_local_heads].copy_(
+            self.attn_sink[
+                self.attn_tp_rank
+                * self.n_local_heads : (self.attn_tp_rank + 1)
+                * self.n_local_heads
+            ]
+        )
 
     @contextmanager
     def maybe_use_decode_attn_tp(self, forward_batch: ForwardBatch):
@@ -1421,23 +1437,18 @@ class MQALayer(MqaAttentionBase):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        if self.attn_tp_size > 1:
-            # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
-            # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
-            # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
-            # this rank and padded to match.
-            padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
+        if self.tp_size > 1:
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init
             # there; other archs tolerate new_empty and skip the per-forward
             # memset.
             if _is_gfx942_supported:
-                q_padded = x.new_zeros(x.shape[0], padded_num_heads, self.head_dim)
+                q_padded = x.new_zeros(x.shape[0], self.padded_num_heads, self.head_dim)
             else:
-                q_padded = x.new_empty(x.shape[0], padded_num_heads, self.head_dim)
+                q_padded = x.new_empty(x.shape[0], self.padded_num_heads, self.head_dim)
             tp_slice = slice(0, self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]
-        attn_sink = self._local_attn_sink()
+            assert self._attn_sink_local is not None
 
         if enable_multi_stream:
             # Multi-stream path always fuses cache write into the K kernel,
@@ -3145,6 +3156,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             ):
                 self_attn.indexer.compressor.apply_ape_hotfix()
             layer.refresh_mhc_norm_weight_cache()
+            self_attn.refresh_attn_sink_cache()
 
     @staticmethod
     def remap_weight_name_to_dpsk_hf_format(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3616,7 +3616,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         }
         if unloaded_params:
             logger.warning(
-                f"Some weights are not initialized from checkpoints: {unloaded_params}"
+                "Some weights are not initialized from checkpoints: "
+                f"count={len(unloaded_params)}. "
+                "Ignore this message for RL weight update."
             )
 
         self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1437,7 +1437,9 @@ class MQALayer(MqaAttentionBase):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        if self.tp_size > 1:
+        # attn_tp_size: the head counts indexed below derive from it, and
+        # MqaAttentionBase never sets tp_size.
+        if self.attn_tp_size > 1:
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init
             # there; other archs tolerate new_empty and skip the per-forward

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -142,6 +142,18 @@ class DSparkAttention(MqaAttentionBase):
         kv, _ = self.wkv(x)
         return kv
 
+    def _attn_sink_pad_width(self) -> int:
+        # DSpark pads q to _PAD_NUM_HEADS only when the rank has fewer heads than
+        # that, so the sink follows the same width rather than padded_num_heads.
+        return max(self.n_local_heads, _PAD_NUM_HEADS)
+
+    def _local_attn_sink(self) -> torch.Tensor:
+        if self.attn_tp_size == 1:
+            return self.attn_sink
+        if self._attn_sink_local is None:
+            self.refresh_attn_sink_cache()
+        return self._attn_sink_local
+
     def _store_block_kv(
         self,
         *,
@@ -979,6 +991,14 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self._assert_confidence_head_loaded(
             params_dict=params_dict, loaded_params=loaded_params
         )
+
+    def post_load_weights(self):
+        # The per-rank attn_sink slice is cached on first use; an RL weight update
+        # rewrites attn_sink in place, so re-slice it here or decode keeps serving
+        # the pre-update sink.
+        for module in self.modules():
+            if isinstance(module, DSparkAttention):
+                module.refresh_attn_sink_cache()
 
     def _assert_confidence_head_loaded(
         self, *, params_dict: dict, loaded_params: set

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -295,6 +295,7 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
 
     def post_load_weights(self, is_nextn=False, weight_names=None):
         super().post_load_weights(is_nextn=True, weight_names=weight_names)
+        self.model.decoder.self_attn.refresh_attn_sink_cache()
 
 
 EntryClass = [DeepseekV4ForCausalLMNextN]

--- a/python/sglang/srt/models/glm4.py
+++ b/python/sglang/srt/models/glm4.py
@@ -458,6 +458,17 @@ class Glm4ForCausalLM(nn.Module):
 
         self.logits_processor = LogitsProcessor(config)
         self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
 
@@ -552,14 +563,7 @@ class Glm4ForCausalLM(nn.Module):
         return self.model.end_layer
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-            (".gate_up_proj", ".up_proj", 1),
-            (".gate_up_proj", ".gate_proj", 0),
-        ]
+        stacked_params_mapping = self.stacked_params_mapping
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -15,7 +15,6 @@
 """Inference-only GLM-4.5, GLM-4.6 and GLM-4.7 model compatible with HuggingFace weights"""
 
 import logging
-import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -1167,8 +1166,42 @@ class Glm4MoeForCausalLM(nn.Module):
         )
         self.logits_processor = LogitsProcessor(config)
 
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
+        )
+
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
+
+    def mutate_weight_preload(self, name: str) -> str:
+        """GLM4-MoE: shared expert fusion."""
+        if self.num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
+            return name.replace(
+                "mlp.shared_experts",
+                f"mlp.experts.{self.config.n_routed_experts}",
+            )
+        return name
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.model.embed_tokens
+
+    def determine_num_fused_shared_experts(self):
+        if get_exec().moe.disable_shared_experts_fusion:
+            return
+
+        disable_reason = None
 
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):
@@ -1250,43 +1283,8 @@ class Glm4MoeForCausalLM(nn.Module):
             else:
                 raise ValueError("num_nextn_predict_layers is not in the config")
 
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-
-        if self.num_fused_shared_experts > 0:
-            assert self.num_fused_shared_experts == 1
-
-            def iter_weights_with_fused_shared_experts(
-                weights: Iterable[Tuple[str, torch.Tensor]],
-            ) -> Iterable[Tuple[str, torch.Tensor]]:
-
-                pattern = re.compile(
-                    r"^model\.layers\.(\d+)\.mlp\.shared_experts\.(.+)$"
-                )
-                for name, weight in weights:
-                    match = pattern.match(name)
-                    if match:
-                        layer_id = int(match.group(1))
-                        suffix = match.group(2)
-                        name = f"model.layers.{layer_id}.mlp.experts.{self.config.n_routed_experts}.{suffix}"
-                    yield name, weight
-
-            weights = iter_weights_with_fused_shared_experts(weights)
-
-        # Params for weights, fp8 weight scales, fp8 activation scales
-        # (param_name, weight_name, expert_id, shard_id)
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
-        )
+        stacked_params_mapping = self.stacked_params_mapping
+        expert_params_mapping = self.expert_params_mapping
 
         if is_nextn:
             nextn_layer_prefix = f"model.layers.{nextn_layer_id}"
@@ -1306,6 +1304,8 @@ class Glm4MoeForCausalLM(nn.Module):
         weight_names = []
         for name, loaded_weight in weights:
             weight_names.append(name)
+
+            name = self.mutate_weight_preload(name)
 
             if not is_nextn:
                 if hasattr(self.config, "num_nextn_predict_layers"):

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -249,6 +249,11 @@ class Glm4MoeLiteSparseMoeBlock(nn.Module):
         if config.n_shared_experts is not None and self.num_fused_shared_experts == 0:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
             # disable tp for shared experts when enable deepep moe, or with fp4 allgather
+            _shared_expert_use_tp1 = (
+                get_moe_a2a_backend().is_deepep()
+                or get_moe_a2a_backend().is_mooncake()
+                or should_use_flashinfer_cutlass_moe_fp4_allgather()
+            )
             self.shared_experts = Glm4MoeLiteMLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=intermediate_size,
@@ -256,14 +261,9 @@ class Glm4MoeLiteSparseMoeBlock(nn.Module):
                 quant_config=quant_config,
                 reduce_results=False,
                 prefix=add_prefix("shared_experts", prefix),
-                **(
-                    dict(tp_rank=0, tp_size=1)
-                    if get_moe_a2a_backend().is_deepep()
-                    or get_moe_a2a_backend().is_mooncake()
-                    or should_use_flashinfer_cutlass_moe_fp4_allgather()
-                    else {}
-                ),
+                **(dict(tp_rank=0, tp_size=1) if _shared_expert_use_tp1 else {}),
             )
+            self._shared_expert_tp1 = _shared_expert_use_tp1
             is_packed_weight = hasattr(
                 self.shared_experts.gate_up_proj.quant_method, "quant_config"
             )

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -918,6 +918,33 @@ class Glm4MoeLiteForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         )
         self.capture_aux_hidden_states = False
 
+        # Weight loading mappings for ParameterMapper compatibility
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        # Add A-proj fusion mapping when q_lora_rank is enabled (MLA)
+        self.fuse_qkv_a_proj = hasattr(config, "q_lora_rank") and (
+            config.q_lora_rank is not None
+        )
+        if self.fuse_qkv_a_proj:
+            self.stacked_params_mapping.extend(
+                [
+                    ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
+                    ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
+                ]
+            )
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=config.n_routed_experts + self.num_fused_shared_experts,
+        )
+
     @property
     def routed_experts_weights_of_layer(self):
         return self._routed_experts_weights_of_layer.value
@@ -1029,6 +1056,22 @@ class Glm4MoeLiteForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
 
         self.capture_aux_hidden_states = True
         self.model.layers_to_capture = [val + 1 for val in layer_ids]
+
+    def mutate_weight_preload(self, name: str) -> str:
+        """GLM4-MoE-Lite: shared expert fusion."""
+        if self.num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
+            return name.replace(
+                "mlp.shared_experts",
+                f"mlp.experts.{self.config.n_routed_experts}",
+            )
+        return name
+
+    def custom_scale_remap(self, name: str) -> str:
+        """GLM4-MoE-Lite: k_proj/v_proj -> attn_mqa for MLA kv scale."""
+        for s in ["k_scale", "v_scale"]:
+            if s in name:
+                return name.replace(f"{s[0]}_proj", "attn_mqa")
+        return name
 
     def load_weights(
         self,

--- a/python/sglang/srt/models/glm4_moe_nextn.py
+++ b/python/sglang/srt/models/glm4_moe_nextn.py
@@ -33,7 +33,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.glm4_moe import Glm4MoeDecoderLayer, Glm4MoeForCausalLM
-from sglang.srt.runtime_context import get_parallel, get_spec
+from sglang.srt.runtime_context import get_exec, get_parallel, get_spec
 from sglang.srt.utils import add_prefix, is_npu
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/models/glm4_moe_nextn.py
+++ b/python/sglang/srt/models/glm4_moe_nextn.py
@@ -25,6 +25,7 @@ from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_r
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -147,6 +148,26 @@ class Glm4MoeForCausalLMNextN(Glm4MoeForCausalLM):
             use_attn_tp_group=get_parallel().enable_dp_lm_head,
         )
         self.logits_processor = LogitsProcessor(config)
+
+        self.num_fused_shared_experts = (
+            0 if get_exec().moe.disable_shared_experts_fusion else 1
+        )
+
+        # Weight loading mappings (must match parent for load_weights to work)
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts + self.num_fused_shared_experts,
+        )
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/inkling_common/attn.py
+++ b/python/sglang/srt/models/inkling_common/attn.py
@@ -6,9 +6,6 @@ from functools import cache
 import torch
 from torch import nn
 
-from sglang.kernels.ops.attention.flash_attn.cute.batch_invariance import (
-    is_batch_invariant,
-)
 from sglang.kernels.ops.attention.inkling_rel_proj import rel_proj_small_t
 from sglang.kernels.ops.attention.inkling_row_scale import row_compact_bf16
 from sglang.kernels.ops.attention.log_scaling_tau import (
@@ -45,10 +42,14 @@ try:
     import cutlass.cute as cute
     from cutlass.cute import Float32
 
+    from sglang.kernels.ops.attention.flash_attn.cute.batch_invariance import (
+        is_batch_invariant,
+    )
     from sglang.kernels.ops.attention.flash_attn.cute.seqlen_info import SeqlenInfoQK
 except Exception as _import_error:
     cute = None
     Float32 = None
+    is_batch_invariant = None
     SeqlenInfoQK = None
     _cute_import_error = _import_error
 else:
@@ -953,6 +954,7 @@ class InklingAttention(nn.Module):
         if (
             envs.SGLANG_OPT_USE_INKLING_SHEARED_BIAS.get()
             and fa4
+            and is_batch_invariant is not None
             and not is_batch_invariant()
         ):
             # FA4 sheared-bias kernel: pass rel_logits directly; the kernel shears

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -73,6 +73,7 @@ from sglang.srt.layers.moe.utils import (
     get_moe_runner_backend,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import (
@@ -140,6 +141,35 @@ _k3_dense_mlp_attn_tp = envs.SGLANG_K3_DENSE_MLP_ATTN_TP.get()
 
 def _cdiv(a: int, b: int) -> int:
     return (a + b - 1) // b
+
+
+def _uses_modelopt_fp8_pb_wo(
+    quant_config: Optional[QuantizationConfig], prefix: str
+) -> bool:
+    resolver = getattr(quant_config, "_resolve_quant_algo", None)
+    return resolver is not None and resolver(prefix) == "FP8_PB_WO"
+
+
+def _maybe_map_fp8_pb_scale_name(name: str, params_dict: dict) -> str:
+    """Map ModelOpt FP8_PB_WO scale keys to SGLang block-FP8 params."""
+    if name.endswith(".weight_scale"):
+        candidate = name.removesuffix(".weight_scale") + ".weight_scale_inv"
+        if candidate in params_dict:
+            return candidate
+    return name
+
+
+def _get_k3_dense_weight(module: nn.Module) -> torch.Tensor:
+    """Return a dense weight with serialized block-FP8 scales applied."""
+    weight = module.weight.data
+    if not hasattr(module, "weight_scale_inv"):
+        return weight
+    return block_quant_dequant(
+        weight,
+        module.weight_scale_inv,
+        module.quant_method.weight_block_size,
+        module.params_dtype,
+    )
 
 
 def _k3_bf16_gemm(
@@ -457,17 +487,17 @@ class KimiK3MoE(nn.Module):
             quant_config=quant_config,
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
-            # flashinfer_mxfp4 + situ consumes precomputed routing
-            # (PackedPrecomputed): keep the radix router in the TopK layer
-            # and hand its ids/weights to the MoE op. Other quantized paths
-            # keep the runner-resolved format (marlin -> standard anyway,
-            # bypassed only for the public logits-routing path).
+            # TRT-LLM cannot consume fused-front's row-strided router logits;
+            # keep K3's FP32 router and pass precomputed top-k instead.
             output_format=(
                 TopKOutputFormat.STANDARD
                 if quant_config is None
                 or (
                     config.hidden_act == "situ"
-                    and get_moe_runner_backend().is_flashinfer_mxfp4()
+                    and (
+                        get_moe_runner_backend().is_flashinfer_mxfp4()
+                        or get_moe_runner_backend().is_flashinfer_trtllm()
+                    )
                 )
                 # mega pre-dispatch consumes raw topk_ids/topk_weights
                 or get_moe_a2a_backend().is_megamoe()
@@ -1385,11 +1415,12 @@ class KimiK3DeltaAttention(nn.Module):
         self.use_full_rank_gate = config.linear_attn_config.get(
             "use_full_rank_gate", False
         )
+        self._bfa_uses_block_fp8 = self.use_full_rank_gate and _uses_modelopt_fp8_pb_wo(
+            quant_config, f"{prefix}.b_proj"
+        )
 
         # The fused path hardcodes tp_size sharding, so require attn_tp == tp.
-        # For the full-rank gate (K3) the checkpoint quantizes only the MoE
-        # experts; attention linears resolve to UnquantizedLinearMethod, so a
-        # non-None quant_config is fine for the merged projection.
+        # Full-rank K3 also fuses mixed block-FP8 attention projections.
         self.do_fuse_qkvbfg = self.attn_tp_size == self.tp_size and (
             quant_config is None or self.use_full_rank_gate
         )
@@ -1425,6 +1456,8 @@ class KimiK3DeltaAttention(nn.Module):
                 tp_rank=self.attn_tp_rank,
                 tp_size=self.attn_tp_size,
                 prefix=f"{prefix}.b_proj",
+                # TP8 shards K3's 96 beta rows below the 128-row FP8 block.
+                skip_block_quant_check=self._bfa_uses_block_fp8,
             )
             self.f_a_proj = ReplicatedLinear(
                 self.hidden_size,
@@ -1445,6 +1478,7 @@ class KimiK3DeltaAttention(nn.Module):
             # Merged [f_a | b] weight, built after weight loading by
             # _merge_bfa_weights().
             self._bfa_w: Optional[torch.Tensor] = None
+            self._bfa_f_b_w: Optional[torch.Tensor] = None
         elif self.do_fuse_qkvbfg:
             self.qkvb_sizes = [
                 projection_size,
@@ -1661,15 +1695,24 @@ class KimiK3DeltaAttention(nn.Module):
         and the width is padded to a multiple of 8 so every fused-output row
         stays 16-byte aligned for vectorized consumers (tiny-GEMM on f_b).
 
-        Called once from load_weights (after all weights are loaded, before
-        cuda graph capture)."""
+        Called once after weight loading. Block-FP8 inputs are dequantized into
+        the BF16 tiny-GEMM buffers here."""
         if not self.use_full_rank_gate:
             return
         if _is_npu:
             return
-        self._bfa_w, sizes = _merge_weights_as_views(
-            [self.f_a_proj, self.b_proj], pad_rows_to=8
-        )
+        mods = [self.f_a_proj, self.b_proj]
+        if self._bfa_uses_block_fp8:
+            weights = [_get_k3_dense_weight(mod) for mod in mods]
+            sizes = [weight.shape[0] for weight in weights]
+            pad = (-sum(sizes)) % 8
+            if pad:
+                weights.append(weights[0].new_zeros((pad, weights[0].shape[1])))
+            self._bfa_w = torch.cat(weights, dim=0).contiguous()
+            self._bfa_f_b_w = _get_k3_dense_weight(self.f_b_proj).contiguous()
+        else:
+            self._bfa_w, sizes = _merge_weights_as_views(mods, pad_rows_to=8)
+            self._bfa_f_b_w = self.f_b_proj.weight
         self._bfa_fa_size, self._bfa_b_size = sizes
 
     def _prepare_fused_decode(self) -> None:
@@ -1748,7 +1791,7 @@ class KimiK3DeltaAttention(nn.Module):
                     alt.wait_stream(cur)
                     with torch.cuda.stream(alt):
                         bfa = gemm(hidden_states, w)
-                        forget_gate = gemm(bfa[..., :n_fa], self.f_b_proj.weight)
+                        forget_gate = gemm(bfa[..., :n_fa], self._bfa_f_b_w)
                         beta = bfa[..., n_fa : n_fa + n_b]
                     fused_states, _ = self.fused_qkvg_proj(hidden_states)
                     qkv, g_proj_states = torch.split(
@@ -1760,7 +1803,7 @@ class KimiK3DeltaAttention(nn.Module):
                 fused_states, _ = self.fused_qkvg_proj(hidden_states)
                 qkv, g_proj_states = torch.split(fused_states, self.split_sizes, dim=-1)
                 bfa = gemm(hidden_states, w)
-                forget_gate = gemm(bfa[..., :n_fa], self.f_b_proj.weight)
+                forget_gate = gemm(bfa[..., :n_fa], self._bfa_f_b_w)
                 beta = bfa[..., n_fa : n_fa + n_b]
             else:
                 fused_states, _ = self.fused_qkvg_proj(hidden_states)
@@ -2883,6 +2926,8 @@ class KimiK3LinearForCausalLM(nn.Module):
         for args in weights:
             name, loaded_weight = args[:2]
             kwargs = args[2] if len(args) > 2 else {}
+            if name.endswith(".weight_scale") and loaded_weight.ndim == 4:
+                loaded_weight = loaded_weight[:, 0, :, 0]
 
             layer_id = get_layer_id(name)
             if layer_id is not None and (
@@ -2904,13 +2949,20 @@ class KimiK3LinearForCausalLM(nn.Module):
 
             # MLA: fuse q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa
             if ".q_a_proj." in name or ".kv_a_proj_with_mqa." in name:
+                is_q_a = ".q_a_proj." in name
                 fused_name = name.replace(".q_a_proj.", ".fused_qkv_a_proj_with_mqa.")
                 fused_name = fused_name.replace(
                     ".kv_a_proj_with_mqa.", ".fused_qkv_a_proj_with_mqa."
                 )
+                fused_name = _maybe_map_fp8_pb_scale_name(fused_name, params_dict)
                 if fused_name in params_dict:
                     param = params_dict[fused_name]
-                    if ".q_a_proj." in name:
+                    if fused_name.endswith(".weight_scale_inv"):
+                        offset = 0 if is_q_a else _cdiv(self.config.q_lora_rank, 128)
+                        param.data[offset : offset + loaded_weight.shape[0]].copy_(
+                            loaded_weight
+                        )
+                    elif is_q_a:
                         param.data[: loaded_weight.shape[0]].copy_(loaded_weight)
                     else:
                         q_lora_rank = self.config.q_lora_rank or 0
@@ -2947,6 +2999,7 @@ class KimiK3LinearForCausalLM(nn.Module):
                 name = name.replace(weight_name, param_name)
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+                name = _maybe_map_fp8_pb_scale_name(name, params_dict)
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -2983,13 +3036,18 @@ class KimiK3LinearForCausalLM(nn.Module):
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:
                         continue
+                    name = _maybe_map_fp8_pb_scale_name(name, params_dict)
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
-                    weight_loader = getattr(
-                        param, "weight_loader", default_weight_loader
-                    )
-                    weight_loader(param, loaded_weight, **kwargs)
+                    if name.endswith(".b_proj.weight_scale_inv"):
+                        # All TP ranks share K3's single beta output-scale block.
+                        param.data.copy_(loaded_weight)
+                    else:
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        weight_loader(param, loaded_weight, **kwargs)
             loaded_params.add(name)
 
         self.post_load_weights()
@@ -3007,7 +3065,8 @@ class KimiK3LinearForCausalLM(nn.Module):
             if isinstance(layer, PPMissingLayer):
                 continue
             self_attn = layer.self_attn
-            w_kc, w_vc = self_attn.kv_b_proj.weight.unflatten(
+            kv_b_weight = _get_k3_dense_weight(self_attn.kv_b_proj)
+            w_kc, w_vc = kv_b_weight.unflatten(
                 0, (-1, self_attn.qk_nope_head_dim + self_attn.v_head_dim)
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
             self_attn.w_kc = w_kc.transpose(1, 2).contiguous().transpose(1, 2)
@@ -3065,7 +3124,7 @@ class KimiK3LinearForCausalLM(nn.Module):
 
             if precompile_k3_recompute_w_u_kernel(
                 num_heads=layer.self_attn.local_num_heads,
-                dtype=layer.self_attn.o_proj.weight.dtype,
+                dtype=layer.self_attn.o_proj.params_dtype,
                 device=layer.self_attn.dt_bias.device,
             ):
                 rank0_log("Precompiled the Kimi-K3 KDA prefill kernel.")

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -548,8 +548,20 @@ class LlamaForCausalLM(nn.Module):
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
         ]
+        # Llama-specific scale remapping patterns (suffix, pattern, replacement)
+        self._llama_scale_remap_patterns = [
+            (".activation_scale", ".activation_scale", ".input_scale"),
+            (".weight_scale_inv", ".weight_scale_inv", ".weight_scale"),
+        ]
 
         self.capture_aux_hidden_states = False
+
+    def custom_scale_remap(self, name: str) -> str:
+        """Llama: activation_scale->input_scale, weight_scale_inv->weight_scale."""
+        for suffix, pattern, replacement in self._llama_scale_remap_patterns:
+            if name.endswith(suffix) and pattern in name:
+                return name.replace(pattern, replacement)
+        return name
 
     def _init_model(
         self,
@@ -668,23 +680,11 @@ class LlamaForCausalLM(nn.Module):
         return self._legacy_load_weights(weights)
 
     def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-            (".gate_up_proj", ".gate_proj", 0),
-            (".gate_up_proj", ".up_proj", 1),
-        ]
 
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
-            if name.endswith(".activation_scale"):
-                name = name.replace(".activation_scale", ".input_scale")
-            if name.endswith(".weight_scale_inv"):
-                name = name.replace(".weight_scale_inv", ".weight_scale")
-
+            name = self.custom_scale_remap(name)
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None
@@ -711,7 +711,7 @@ class LlamaForCausalLM(nn.Module):
                 if name is None:
                     continue
 
-            for param_name, weight_name, shard_id in stacked_params_mapping:
+            for param_name, weight_name, shard_id in self.stacked_params_mapping:
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -50,7 +50,7 @@ from sglang.srt.model_loader.weight_utils import (
     kv_cache_scales_loader,
 )
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.true_on_policy import (
     get_on_policy_rms_norm_kwargs,
     is_true_on_policy_enabled,

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -514,6 +514,17 @@ class Qwen2ForCausalLM(nn.Module):
 
         self.logits_processor = LogitsProcessor(config)
         self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
 
@@ -615,14 +626,7 @@ class Qwen2ForCausalLM(nn.Module):
         return self._legacy_load_weights(weights)
 
     def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
+        stacked_params_mapping = self.stacked_params_mapping
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -51,6 +51,11 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.true_on_policy import (
+    get_on_policy_rms_norm_kwargs,
+    is_true_on_policy_enabled,
+    should_force_bfloat16_dense_tensor_math,
+)
 from sglang.srt.utils import add_prefix, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
@@ -96,9 +101,11 @@ class Qwen2MLP(nn.Module):
         x: torch.Tensor,
         forward_batch: ForwardBatch = None,
     ) -> torch.Tensor:
-        if get_exec().deterministic.rl_on_policy_target is not None:
-            x = x.bfloat16()
-
+        if (
+            should_force_bfloat16_dense_tensor_math()
+            or x.dtype != self.gate_up_proj.weight.dtype
+        ):
+            x = x.to(self.gate_up_proj.weight.dtype)
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x, forward_batch=forward_batch)
@@ -334,11 +341,7 @@ class Qwen2Model(nn.Module):
                 quant_config=quant_config,
                 use_attn_tp_group=is_dp_attention_enabled(),
                 prefix=add_prefix("embed_tokens", prefix),
-                params_dtype=(
-                    torch.float32
-                    if get_exec().deterministic.rl_on_policy_target is not None
-                    else None
-                ),
+                params_dtype=(torch.float32 if is_true_on_policy_enabled() else None),
             )
         else:
             self.embed_tokens = PPMissingLayer()
@@ -365,16 +368,7 @@ class Qwen2Model(nn.Module):
             prefix=add_prefix("layers", prefix),
         )
         if self.pp_group.is_last_rank:
-            norm_kwargs = (
-                dict(
-                    weight_dtype=torch.float32,
-                    cast_x_before_out_mul=True,
-                    override_orig_dtype=torch.float32,
-                    fp32_residual=True,
-                )
-                if get_exec().deterministic.rl_on_policy_target is not None
-                else {}
-            )
+            norm_kwargs = get_on_policy_rms_norm_kwargs()
             self.norm = RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
             )

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -92,7 +92,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_parallel,
+)
 from sglang.srt.true_on_policy import get_on_policy_rms_norm_kwargs
 from sglang.srt.utils import (
     add_prefix,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -92,7 +92,8 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel
+from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_server_args
+from sglang.srt.true_on_policy import get_on_policy_rms_norm_kwargs
 from sglang.srt.utils import (
     add_prefix,
     cpu_has_amx_support,
@@ -916,7 +917,10 @@ class Qwen2MoeModel(nn.Module):
             prefix=add_prefix("layers", prefix),
         )
         if self.pp_group.is_last_rank:
-            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            norm_kwargs = get_on_policy_rms_norm_kwargs(fp32_residual=False)
+            self.norm = RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+            )
         else:
             self.norm = PPMissingLayer(return_tuple=True)
 

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -34,9 +34,7 @@ from sglang.srt.models.qwen2 import Qwen2MLP as Qwen3MLP
 from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.runtime_context import (
-    get_exec,
     get_parallel,
-    get_server_args,
     get_stream,
 )
 from sglang.srt.true_on_policy import (

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -33,7 +33,16 @@ from sglang.srt.model_loader.weight_utils import (
 from sglang.srt.models.qwen2 import Qwen2MLP as Qwen3MLP
 from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import apply_qk_norm
-from sglang.srt.runtime_context import get_exec, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_parallel,
+    get_server_args,
+    get_stream,
+)
+from sglang.srt.true_on_policy import (
+    should_disable_fused_qk_norm_mrope,
+    should_force_bfloat16_dense_tensor_math,
+)
 from sglang.srt.utils import add_prefix, get_bool_env_var, is_cuda, is_hip, is_npu
 
 Qwen3Config = None
@@ -106,16 +115,16 @@ class Qwen3Attention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.tp_rank = get_parallel().tp_rank
 
-        norm_kwargs = (
-            dict(
-                weight_dtype=torch.float32,
-                cast_x_before_out_mul=True,
-            )
-            if get_exec().deterministic.rl_on_policy_target is not None
-            else {}
+        self.q_norm = RMSNorm(
+            self.head_dim,
+            eps=rms_norm_eps,
+            true_on_policy_weight_dtype=torch.float32,
         )
-        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
-        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
+        self.k_norm = RMSNorm(
+            self.head_dim,
+            eps=rms_norm_eps,
+            true_on_policy_weight_dtype=torch.float32,
+        )
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size,
@@ -271,14 +280,20 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        if get_exec().deterministic.rl_on_policy_target is not None:
-            hidden_states = hidden_states.bfloat16()
+        if (
+            should_force_bfloat16_dense_tensor_math()
+            or hidden_states.dtype != self.qkv_proj.weight.dtype
+        ):
+            # True-on-policy RMSNorm can produce fp32 activations while dense
+            # projections remain bf16, including during cuda-graph capture when
+            # the global on-policy flag is temporarily cleared.
+            hidden_states = hidden_states.to(self.qkv_proj.weight.dtype)
 
         save_kv_cache = True
         use_aiter_fused = (
             self.use_fused_qk_norm_mrope
             and forward_batch.forward_mode.is_decode()
-            and get_exec().deterministic.rl_on_policy_target is None
+            and not should_disable_fused_qk_norm_mrope()
         )
 
         if use_aiter_fused:
@@ -298,9 +313,9 @@ class Qwen3Attention(nn.Module):
                 forward_batch=forward_batch,
             )
 
-        if get_exec().deterministic.rl_on_policy_target is not None:
-            q = q.to(torch.bfloat16)
-            k = k.to(torch.bfloat16)
+        if should_force_bfloat16_dense_tensor_math() or q.dtype != v.dtype:
+            q = q.to(v.dtype)
+            k = k.to(v.dtype)
 
         attn_output = self.attn(q, k, v, forward_batch, save_kv_cache=save_kv_cache)
         output, _ = self.o_proj(attn_output)
@@ -355,21 +370,19 @@ class Qwen3DecoderLayer(nn.Module):
             prefix=add_prefix("mlp", prefix),
         )
 
-        norm_kwargs = (
-            dict(
-                weight_dtype=torch.float32,
-                cast_x_before_out_mul=True,
-                override_orig_dtype=torch.float32,
-                fp32_residual=True,
-            )
-            if get_exec().deterministic.rl_on_policy_target is not None
-            else {}
-        )
         self.input_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            true_on_policy_weight_dtype=torch.float32,
+            true_on_policy_override_orig_dtype=torch.float32,
+            true_on_policy_fp32_residual=True,
         )
         self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+            true_on_policy_weight_dtype=torch.float32,
+            true_on_policy_override_orig_dtype=torch.float32,
+            true_on_policy_fp32_residual=True,
         )
 
         self.layer_scatter_modes = LayerScatterModes.init_new(

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -44,6 +44,7 @@ from sglang.srt.true_on_policy import (
     should_force_bfloat16_dense_tensor_math,
 )
 from sglang.srt.utils import add_prefix, get_bool_env_var, is_cuda, is_hip, is_npu
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 Qwen3Config = None
 
@@ -334,16 +335,7 @@ class Qwen3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        if (
-            hasattr(config, "rope_parameters")
-            and config.rope_parameters
-            and "rope_theta" in config.rope_parameters
-        ):
-            rope_theta = config.rope_parameters["rope_theta"]
-            rope_scaling = config.rope_parameters
-        else:
-            rope_theta = getattr(config, "rope_theta", 1000000)
-            rope_scaling = getattr(config, "rope_scaling", None)
+        rope_theta, rope_scaling = get_rope_config(config)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
         self.self_attn = Qwen3Attention(
@@ -496,6 +488,16 @@ class Qwen3ForCausalLM(nn.Module):
             config, quant_config=quant_config, prefix=add_prefix("model", prefix)
         )
 
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
         # handle the lm head on different pp ranks
         if self.pp_group.is_last_rank:
             if self.pp_group.world_size == 1 and config.tie_word_embeddings:
@@ -607,15 +609,7 @@ class Qwen3ForCausalLM(nn.Module):
         return self.model.end_layer
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-
+        stacked_params_mapping = self.stacked_params_mapping
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
             if not name.startswith("model.") and (

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1280,6 +1280,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         "o_proj",
         "out_proj",
         "in_proj_qkvz",
+        "in_proj_ba",
         "gate_up_proj",
         "down_proj",
         "lm_head",
@@ -1305,6 +1306,9 @@ class Qwen3_5ForCausalLM(nn.Module):
             key_dim = config.linear_key_head_dim * config.linear_num_key_heads
             value_dim = config.linear_value_head_dim * config.linear_num_value_heads
             return config.hidden_size, key_dim * 2 + value_dim * 2
+        elif module_name == "in_proj_ba":
+            # b + a projections: one scalar per linear-attention value head each
+            return config.hidden_size, config.linear_num_value_heads * 2
         elif module_name == "gate_up_proj":
             # MoE: shared expert uses shared_expert_intermediate_size
             # Dense: regular MLP uses intermediate_size

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -78,7 +78,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
-    get_server_args,
     get_stream,
 )
 from sglang.srt.true_on_policy import (

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -22,6 +22,7 @@ import math
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -48,7 +49,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.topk import StandardTopKOutput, TopK
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -73,7 +74,18 @@ from sglang.srt.models.utils import (
     create_fused_set_kv_buffer_arg,
     enable_fused_set_kv_buffer,
 )
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_parallel,
+    get_server_args,
+    get_stream,
+)
+from sglang.srt.true_on_policy import (
+    get_on_policy_rms_norm_kwargs,
+    is_true_on_policy_enabled,
+    should_disable_fused_qk_norm_mrope,
+)
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
@@ -326,7 +338,20 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        if is_true_on_policy_enabled():
+            routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+            routing_weights, selected_experts = torch.topk(
+                routing_weights, self.top_k, dim=-1
+            )
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+            routing_weights = routing_weights.to(hidden_states.dtype)
+            topk_output = StandardTopKOutput(
+                topk_weights=routing_weights,
+                topk_ids=selected_experts,
+                router_logits=router_logits,
+            )
+        else:
+            topk_output = self.topk(hidden_states, router_logits)
         final_hidden_states = self.experts(hidden_states, topk_output)
 
         if self.ep_size > 1 and not should_skip_post_experts_all_reduce(
@@ -514,7 +539,7 @@ class Qwen3MoeAttention(nn.Module):
         )
         self.compatible_with_fused_kv_buffer = (
             False if isinstance(self.rotary_emb, MRotaryEmbedding) else True
-        )
+        ) and not is_true_on_policy_enabled()
         self.compatible_with_fused_qk_norm_rope = not isinstance(
             self.rotary_emb, MRotaryEmbedding
         ) and self.head_dim in (64, 128, 256)
@@ -529,6 +554,7 @@ class Qwen3MoeAttention(nn.Module):
                 torch.bfloat16,
                 _yarn_factor != 1.0,
             )
+            and not should_disable_fused_qk_norm_mrope()
         )
         self._used_fused_qk_norm_rope_last_call = False
 
@@ -541,8 +567,9 @@ class Qwen3MoeAttention(nn.Module):
             prefix=add_prefix("attn", prefix),
         )
 
-        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        norm_kwargs = get_on_policy_rms_norm_kwargs(fp32_residual=False)
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
         self.alt_stream = alt_stream
 
     def op_prepare(self, state):
@@ -785,9 +812,12 @@ class Qwen3MoeDecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("mlp", prefix),
             )
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        norm_kwargs = get_on_policy_rms_norm_kwargs(fp32_residual=False)
+        self.input_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+        )
         self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
+            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
         )
 
         self.layer_communicator = LayerCommunicator(

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -994,6 +994,23 @@ class Qwen3MoeForCausalLM(nn.Module):
             use_attn_tp_group=get_parallel().enable_dp_lm_head,
         )
         self.logits_processor = LogitsProcessor(config)
+
+        # Stacked params mapping for unified weight loading API
+        self.stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        self.expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_experts,
+        )
+
         self.capture_aux_hidden_states = False
         # IPC loading bypasses load_weights(), so initialize the EPLB descriptor here.
         self.routed_experts_weights_of_layer = LazyValue(
@@ -1141,21 +1158,8 @@ class Qwen3MoeForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.num_experts,
-        )
+        stacked_params_mapping = self.stacked_params_mapping
+        expert_params_mapping = self.expert_params_mapping
 
         # Pre-define `params_dict` to avoid repeated expensive traversal of model parameters.
         params_dict = dict(self.named_parameters())

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -458,75 +458,73 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
         return cos_combined, sin_combined
 
-    def _get_interpolation_indices(self, dim_size: int) -> torch.Tensor:
-        """
-        Compute continuous interpolation indices for a single dimension.
+    def fast_pos_embed_interpolate(self, grid_thw):
+        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
+        num_grid_per_side = int(self.num_position_embeddings**0.5)
+        device = self.pos_embed.weight.device
 
-        Returns continuous indices.
-        """
-        if self.align_corners:
-            indices = np.linspace(
-                0, self.num_grid_per_side - 1, dim_size, dtype=np.float32
-            )
-        else:
-            indices = (np.arange(dim_size, dtype=np.float32) + 0.5) * (
-                self.num_grid_per_side / dim_size
-            ) - 0.5
-            indices = np.clip(indices, 0, self.num_grid_per_side - 1)
-        return indices
+        idx_list = [[] for _ in range(4)]
+        weight_list = [[] for _ in range(4)]
 
-    def _calculate_indices_and_weights(self, h_idxs, w_idxs):
-        """
-        Compute bilinear interpolation indices and weights.
+        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
+            h_idxs = torch.linspace(0, num_grid_per_side - 1, h)
+            w_idxs = torch.linspace(0, num_grid_per_side - 1, w)
 
-        Returns tuple of (indices, weights), each as 4 numpy arrays for the 4 corner points.
-        """
-        h_f = np.floor(h_idxs).astype(np.int64)
-        h_c = np.clip(h_f + 1, 0, self.num_grid_per_side - 1)
-        dh = h_idxs - h_f
+            h_idxs_floor = h_idxs.int()
+            w_idxs_floor = w_idxs.int()
+            h_idxs_ceil = (h_idxs.int() + 1).clip(max=num_grid_per_side - 1)
+            w_idxs_ceil = (w_idxs.int() + 1).clip(max=num_grid_per_side - 1)
 
-        w_f = np.floor(w_idxs).astype(np.int64)
-        w_c = np.clip(w_f + 1, 0, self.num_grid_per_side - 1)
-        dw = w_idxs - w_f
+            dh = h_idxs - h_idxs_floor
+            dw = w_idxs - w_idxs_floor
 
-        side = self.num_grid_per_side
+            base_h = h_idxs_floor * num_grid_per_side
+            base_h_ceil = h_idxs_ceil * num_grid_per_side
 
-        indices = [
-            (h_f[:, None] * side + w_f).flatten(),
-            (h_f[:, None] * side + w_c).flatten(),
-            (h_c[:, None] * side + w_f).flatten(),
-            (h_c[:, None] * side + w_c).flatten(),
-        ]
-        weights = [
-            ((1 - dh)[:, None] * (1 - dw)).flatten(),
-            ((1 - dh)[:, None] * dw).flatten(),
-            (dh[:, None] * (1 - dw)).flatten(),
-            (dh[:, None] * dw).flatten(),
-        ]
-        return indices, weights
+            indices = [
+                (base_h[None].T + w_idxs_floor[None]).flatten(),
+                (base_h[None].T + w_idxs_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+            ]
 
-    def _get_position_embedding(self, patch_pos_embeds, grid_ts, grid_hs, grid_ws):
-        """
-        Tile and reorganize position embeddings to align with the token sequence.
-        """
-        result_parts = []
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+
+        idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(
+            weight_list, dtype=self.pos_embed.weight.dtype, device=device
+        )
+        pos_embeds = self.pos_embed(idx_tensor).to(device) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+
+        patch_pos_embeds = patch_pos_embeds.split(
+            [h * w for h, w in zip(grid_hs, grid_ws)]
+        )
+
+        patch_pos_embeds_permute = []
         merge_size = self.spatial_merge_size
-
         for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
             pos_embed = pos_embed.repeat(t, 1)
-
-            h_merge = h // merge_size
-            w_merge = w // merge_size
-
             pos_embed = (
-                pos_embed.view(t, h_merge, merge_size, w_merge, merge_size, -1)
+                pos_embed.view(
+                    t, h // merge_size, merge_size, w // merge_size, merge_size, -1
+                )
                 .permute(0, 1, 3, 2, 4, 5)
                 .flatten(0, 4)
             )
 
-            result_parts.append(pos_embed)
+            patch_pos_embeds_permute.append(pos_embed)
 
-        return torch.cat(result_parts, dim=0)
+        return torch.cat(patch_pos_embeds_permute)
 
     def _torch_interp_indices(
         self, dim_size: int, device: torch.device
@@ -757,61 +755,6 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             # For large sequences (> max bucket), round up to a multiple of
             # the largest bucket to avoid under-estimation.
             round_up(real_max_seqlen, FLASHINFER_MAX_SEQLEN_BUCKETS[-1]),
-        )
-
-    def fast_pos_embed_interpolate(self, grid_thw):
-        """Interpolate position embeddings for (batch, 3) size input dimensions.
-
-        Performs bilinear interpolation on spatial dimensions (height, width) and replicates
-        along temporal dimension. The result is reorganized according to spatial_merge_size.
-
-        Args:
-            grid_thw: Tensor of shape [batch_size, 3] with (temporal, height, width) dimensions
-                     in patches for each sample.
-
-        Returns:
-            Interpolated position embeddings tensor.
-        """
-        grid_thw_cpu = grid_thw.cpu().numpy()
-
-        # transfer data to CPU before loop
-        temporal_dims = grid_thw_cpu[:, 0].tolist()
-        height_dims = grid_thw_cpu[:, 1].tolist()
-        width_dims = grid_thw_cpu[:, 2].tolist()
-
-        device = self.pos_embed.weight.device
-        dtype = self.pos_embed.weight.dtype
-
-        patches_size = [h * w for h, w in zip(height_dims, width_dims)]
-        total_patches = sum(patches_size)
-        all_indices_np = np.zeros((4, total_patches), dtype=np.int64)
-        all_weights_np = np.zeros((4, total_patches), dtype=np.float32)
-
-        current_idx = 0
-
-        # calculate indices and weights on CPU
-        for t, h, w in zip(temporal_dims, height_dims, width_dims):
-            h_idxs = self._get_interpolation_indices(h)
-            w_idxs = self._get_interpolation_indices(w)
-
-            indices, weights = self._calculate_indices_and_weights(h_idxs, w_idxs)
-
-            end_idx = current_idx + h * w
-            for i in range(4):
-                all_indices_np[i, current_idx:end_idx] = indices[i]
-                all_weights_np[i, current_idx:end_idx] = weights[i]
-            current_idx = end_idx
-
-        idx_tensor = torch.from_numpy(all_indices_np).to(device)
-        weight_tensor = torch.from_numpy(all_weights_np).to(dtype=dtype, device=device)
-
-        # calculate interpolation
-        pos_embeds = self.pos_embed(idx_tensor.view(-1))
-        pos_embeds = pos_embeds.view(4, total_patches, -1)
-        patch_pos_embeds = (pos_embeds * weight_tensor.unsqueeze(-1)).sum(dim=0)
-        patch_pos_embeds = patch_pos_embeds.split(patches_size)
-        return self._get_position_embedding(
-            patch_pos_embeds, temporal_dims, height_dims, width_dims
         )
 
     def compute_flashinfer_batch_offsets_packed(
@@ -1166,14 +1109,19 @@ class Qwen3LLMModel(Qwen3Model):
                     hidden_states + residual if residual is not None else hidden_states
                 )
 
+            deepstack_embeds = None
+            if input_deepstack_embeds is not None:
+                prev_layer_idx = layer_idx - 1
+                if prev_layer_idx in self.deepstack_embed_to_decoder_layer:
+                    sep = self.hidden_size * prev_layer_idx
+                    deepstack_embeds = input_deepstack_embeds[
+                        :, sep : sep + self.hidden_size
+                    ]
+
             # SGLang applies residual at the START of the next layer, not at the END like HuggingFace.
             # See: https://github.com/huggingface/transformers/blob/v5.0.0rc0/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L549
             # To match HF behavior, deepstack must be added AFTER residual: (hidden_states + residual) + deepstack
             # The order matters because addition with different tensors is not associative in practice.
-            # Deepstack for prev_layer is applied at the start of current layer via post_residual_addition.
-            deepstack_embeds = self.get_deepstack_embeds(
-                layer_idx - 1, input_deepstack_embeds
-            )
             hidden_states, residual = layer(
                 positions,
                 hidden_states,

--- a/python/sglang/srt/models/sdar.py
+++ b/python/sglang/srt/models/sdar.py
@@ -42,10 +42,8 @@ from sglang.srt.models.utils import (
     enable_fused_set_kv_buffer,
 )
 from sglang.srt.runtime_context import (
-    get_exec,
     get_forward,
     get_parallel,
-    get_server_args,
     get_stream,
 )
 from sglang.srt.true_on_policy import (

--- a/python/sglang/srt/models/sdar.py
+++ b/python/sglang/srt/models/sdar.py
@@ -41,7 +41,17 @@ from sglang.srt.models.utils import (
     create_fused_set_kv_buffer_arg,
     enable_fused_set_kv_buffer,
 )
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_parallel,
+    get_server_args,
+    get_stream,
+)
+from sglang.srt.true_on_policy import (
+    get_on_policy_rms_norm_kwargs,
+    should_force_bfloat16_dense_tensor_math,
+)
 from sglang.srt.utils import add_prefix, is_cuda, make_layers
 
 logger = logging.getLogger(__name__)
@@ -202,7 +212,7 @@ class SDARAttention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if should_force_bfloat16_dense_tensor_math():
             hidden_states = hidden_states.bfloat16()
 
         qkv, _ = self.qkv_proj(hidden_states)
@@ -230,7 +240,7 @@ class SDARAttention(nn.Module):
             ),
         )
 
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if should_force_bfloat16_dense_tensor_math():
             q = q.to(torch.bfloat16)
             k = k.to(torch.bfloat16)
 
@@ -258,15 +268,10 @@ class SDARBlock(nn.Module):
         self.hidden_size = config.hidden_size
         self.layer_id = layer_id
 
-        norm_kwargs = (
-            dict(
-                weight_dtype=torch.float32,
-                cast_x_before_out_mul=True,
-                override_orig_dtype=torch.float32,
-                fp32_residual=True,
-            )
-            if get_exec().deterministic.rl_on_policy_target is not None
-            else {}
+        norm_kwargs = get_on_policy_rms_norm_kwargs(
+            weight_dtype=torch.float32,
+            override_orig_dtype=torch.float32,
+            fp32_residual=True,
         )
         self.input_layernorm = RMSNorm(
             self.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
@@ -383,15 +388,10 @@ class SDARModel(nn.Module):
             prefix=add_prefix("layers", prefix),
         )
         if self.pp_group.is_last_rank:
-            norm_kwargs = (
-                dict(
-                    weight_dtype=torch.float32,
-                    cast_x_before_out_mul=True,
-                    override_orig_dtype=torch.float32,
-                    fp32_residual=True,
-                )
-                if get_exec().deterministic.rl_on_policy_target is not None
-                else {}
+            norm_kwargs = get_on_policy_rms_norm_kwargs(
+                weight_dtype=torch.float32,
+                override_orig_dtype=torch.float32,
+                fp32_residual=True,
             )
             self.norm = RMSNorm(self.embed_dim, eps=config.rms_norm_eps, **norm_kwargs)
         else:

--- a/python/sglang/srt/models/sdar_moe.py
+++ b/python/sglang/srt/models/sdar_moe.py
@@ -61,7 +61,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
-    get_server_args,
     get_stream,
 )
 from sglang.srt.true_on_policy import (

--- a/python/sglang/srt/models/sdar_moe.py
+++ b/python/sglang/srt/models/sdar_moe.py
@@ -57,7 +57,17 @@ from sglang.srt.models.utils import (
     create_fused_set_kv_buffer_arg,
     enable_fused_set_kv_buffer,
 )
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_parallel,
+    get_server_args,
+    get_stream,
+)
+from sglang.srt.true_on_policy import (
+    get_on_policy_rms_norm_kwargs,
+    should_force_bfloat16_dense_tensor_math,
+)
 from sglang.srt.utils import LazyValue, add_prefix, is_cuda, make_layers
 
 logger = logging.getLogger(__name__)
@@ -269,7 +279,7 @@ class SDARMoeAttention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if should_force_bfloat16_dense_tensor_math():
             hidden_states = hidden_states.bfloat16()
 
         qkv, _ = self.qkv_proj(hidden_states)
@@ -297,7 +307,7 @@ class SDARMoeAttention(nn.Module):
             ),
         )
 
-        if get_exec().deterministic.rl_on_policy_target is not None:
+        if should_force_bfloat16_dense_tensor_math():
             q = q.to(torch.bfloat16)
             k = k.to(torch.bfloat16)
 
@@ -326,15 +336,10 @@ class SDARMoeBlock(nn.Module):
         self.hidden_size = config.hidden_size
         self.layer_id = layer_id
 
-        norm_kwargs = (
-            dict(
-                weight_dtype=torch.float32,
-                cast_x_before_out_mul=True,
-                override_orig_dtype=torch.float32,
-                fp32_residual=True,
-            )
-            if get_exec().deterministic.rl_on_policy_target is not None
-            else {}
+        norm_kwargs = get_on_policy_rms_norm_kwargs(
+            weight_dtype=torch.float32,
+            override_orig_dtype=torch.float32,
+            fp32_residual=True,
         )
         self.input_layernorm = RMSNorm(
             self.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
@@ -466,15 +471,10 @@ class SDARMoeModel(nn.Module):
         )
 
         if self.pp_group.is_last_rank:
-            norm_kwargs = (
-                dict(
-                    weight_dtype=torch.float32,
-                    cast_x_before_out_mul=True,
-                    override_orig_dtype=torch.float32,
-                    fp32_residual=True,
-                )
-                if get_exec().deterministic.rl_on_policy_target is not None
-                else {}
+            norm_kwargs = get_on_policy_rms_norm_kwargs(
+                weight_dtype=torch.float32,
+                override_orig_dtype=torch.float32,
+                fp32_residual=True,
             )
             self.norm = RMSNorm(self.embed_dim, eps=config.rms_norm_eps, **norm_kwargs)
         else:

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -50,7 +50,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
-    get_server_args,
     get_stream,
 )
 from sglang.srt.true_on_policy import is_true_on_policy_enabled

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -46,7 +46,14 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_parallel,
+    get_server_args,
+    get_stream,
+)
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import add_prefix, is_cuda, is_non_idle_and_non_empty, make_layers
 
 Step3p5Config = None
@@ -669,11 +676,7 @@ class Step3p5Model(nn.Module):
                 quant_config=quant_config,
                 enable_tp=not is_dp_attention_enabled(),
                 prefix=add_prefix("embed_tokens", prefix),
-                params_dtype=(
-                    torch.float32
-                    if get_exec().deterministic.rl_on_policy_target is not None
-                    else None
-                ),
+                params_dtype=torch.float32 if is_true_on_policy_enabled() else None,
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -487,6 +487,8 @@ def apply_qk_norm(
         _is_cuda  # TODO(dark): have not tested on ROCm or other backends
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
+        and q_norm.weight.dtype == q.dtype
+        and k_norm.weight.dtype == k.dtype
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
         and get_exec().graph.cuda_graph_config.prefill.tc_compiler
         != "inductor"  # let inductor fuse QK norm

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -39,7 +39,7 @@ from sglang.srt.multimodal.transport.cuda_ipc import (
     MmItemMemoryPool,
     get_mm_feature_pool_size_per_worker,
 )
-from sglang.srt.runtime_context import get_mm, get_server_args
+from sglang.srt.runtime_context import get_mm
 from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -39,7 +39,8 @@ from sglang.srt.multimodal.transport.cuda_ipc import (
     MmItemMemoryPool,
     get_mm_feature_pool_size_per_worker,
 )
-from sglang.srt.runtime_context import get_mm
+from sglang.srt.runtime_context import get_mm, get_server_args
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,
     configure_media_url_security,
@@ -602,7 +603,11 @@ class BaseMultimodalProcessor(ABC):
         tokenizer process each carry their own ``base_gpu_id``.
         """
         server_args = self.server_args
-        if _is_cpu or server_args.rl_on_policy_target is not None:
+        if (
+            _is_cpu
+            or server_args.rl_on_policy_target is not None
+            or is_true_on_policy_enabled()
+        ):
             return "cpu"
         if _is_xpu:
             return "xpu"

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -732,7 +732,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         **kwargs,
     ):
         entry_time = time.perf_counter()
-        base_output = await self.load_mm_data(
+        base_output = await self.legacy_load_mm_data(
             prompt=input_text,
             image_data=image_data,
             video_data=request_obj.video_data,

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -542,6 +542,12 @@ class KimiK3Detector(BaseReasoningFormatDetector):
         open_idx = text.find(self.think_start_token)
         start = open_idx + len(self.think_start_token) if open_idx != -1 else 0
         close_idx = text.find(self.think_end_token, start)
+        tools_idx = text.find(self.tool_start_token, start)
+        if close_idx != -1 and tools_idx != -1 and tools_idx < close_idx:
+            return StreamingParseResult(
+                reasoning_text=strip_partial_marker_suffix(text[start:tools_idx]),
+                normal_text=self._clean_content(text[tools_idx:]),
+            )
         if close_idx == -1:
             channel_idx = self._next_channel_idx(text, start)
             if channel_idx != -1:
@@ -583,7 +589,8 @@ class KimiK3Detector(BaseReasoningFormatDetector):
                     self.stripped_think_start = True
 
             close_idx = buf.find(self.think_end_token)
-            if close_idx != -1:
+            tools_idx = buf.find(self.tool_start_token)
+            if close_idx != -1 and not (tools_idx != -1 and tools_idx < close_idx):
                 reasoning_text = buf[:close_idx]
                 self._buffer = buf[close_idx + len(self.think_end_token) :]
                 self._in_reasoning = False

--- a/python/sglang/srt/ray/__init__.py
+++ b/python/sglang/srt/ray/__init__.py
@@ -1,3 +1,4 @@
 from sglang.srt.ray.engine import RayEngine
+from sglang.srt.ray.http_server import launch_engine, launch_server, serve_http
 
-__all__ = ["RayEngine"]
+__all__ = ["RayEngine", "launch_engine", "launch_server", "serve_http"]

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -15,9 +15,11 @@
 
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import logging
 import threading
+from contextlib import contextmanager
 from typing import Callable, List, Optional
 
 import ray
@@ -36,6 +38,20 @@ from sglang.srt.runtime_context import configured_pp_size, get_parallel
 from sglang.srt.server_args import PortArgs, ServerArgs
 
 logger = logging.getLogger(__name__)
+
+_caller_placement_group: contextvars.ContextVar[Optional[PlacementGroup]] = (
+    contextvars.ContextVar("sglang_ray_caller_placement_group", default=None)
+)
+
+
+@contextmanager
+def _placement_group_context(placement_group: Optional[PlacementGroup]):
+    """Expose launch-only state while Engine synchronously starts schedulers."""
+    token = _caller_placement_group.set(placement_group)
+    try:
+        yield
+    finally:
+        _caller_placement_group.reset(token)
 
 
 @dataclasses.dataclass
@@ -176,6 +192,22 @@ def _validate_custom_placement_group(pg: PlacementGroup, world_size: int) -> Non
         )
 
 
+def get_scheduler_actor_name(
+    *,
+    rank0_node_ip: str,
+    dp_rank: int,
+    pp_rank: int,
+    tp_rank: int,
+    pg_id_hex: str,
+    bundle_idx: int,
+) -> str:
+    return (
+        f"sglang_scheduler_node{rank0_node_ip}"
+        f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
+        f"_pg{pg_id_hex}_bundle{bundle_idx}"
+    )
+
+
 def _create_scheduler_actor(
     pg: PlacementGroup,
     bundle_idx: int,
@@ -201,14 +233,25 @@ def _create_scheduler_actor(
         server_args, tp_rank
     )
 
+    rdt = server_args.enable_rdt_weight_sync
+
     return SchedulerActor.options(
         num_cpus=0,
         num_gpus=1,
-        name=(
-            f"sglang_scheduler_node{rank0_node_ip}"
-            f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-            f"_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+        # run_event_loop() blocks one thread for the actor's lifetime; leave a spare
+        # for pull_weights, which the trainer calls while generation is paused.
+        max_concurrency=2 if rdt else 1,
+        name=get_scheduler_actor_name(
+            rank0_node_ip=rank0_node_ip,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
+            tp_rank=tp_rank,
+            pg_id_hex=pg.id.hex()[:8],
+            bundle_idx=bundle_idx,
         ),
+        # SchedulerActor calls set_device() with the absolute id from
+        # get_accelerator_ids(), which is only valid if Ray leaves the mask alone.
+        runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"}},
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,
             placement_group_bundle_index=bundle_idx,
@@ -228,15 +271,19 @@ def _create_scheduler_actor(
 
 
 class RayEngine(Engine):
-    """Engine using Ray actors for scheduler processes."""
+    """Engine using Ray actors for scheduler processes.
 
-    def __init__(self, **kwargs):
-        # Set before super().__init__(): it launches the subprocesses, which need
-        # the group to schedule the scheduler actors onto.
-        self._placement_group = kwargs.pop("placement_group", None)
+    Same constructor kwargs as :class:`Engine`, plus ``placement_group`` (a Ray
+    PlacementGroup handle, not a ServerArgs field).
+    """
+
+    def __init__(self, *, placement_group: Optional[PlacementGroup] = None, **kwargs):
         if "log_level" not in kwargs:
             kwargs["log_level"] = "error"
-        super().__init__(server_args=ServerArgs(**kwargs))
+        # The context is read while super().__init__() launches the subprocesses,
+        # which need the group to schedule the scheduler actors onto.
+        with _placement_group_context(placement_group):
+            super().__init__(server_args=ServerArgs(**kwargs))
 
     def shutdown(self):
         """Shutdown the engine — kill Ray scheduler actors then local processes."""
@@ -253,8 +300,6 @@ class RayEngine(Engine):
         server_args: ServerArgs,
         port_args: PortArgs,
         run_scheduler_process_func: Callable,
-        *,
-        placement_group=None,
     ) -> tuple[SchedulerInitResult, None]:
         """Launch schedulers as Ray actors.
 
@@ -262,6 +307,7 @@ class RayEngine(Engine):
             Tuple of (RaySchedulerInitResult, None).
             scheduler_procs is None since Ray uses actors instead of mp.Process.
         """
+        placement_group = _caller_placement_group.get()
         pg = placement_group or ray.util.get_current_placement_group()
         if pg is None:
             from ray.util.placement_group import (

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -15,12 +15,70 @@
 
 from typing import Callable, Optional
 
+from ray.util.placement_group import PlacementGroup
+
 from sglang.srt.entrypoints.engine import (
     init_tokenizer_manager,
     run_detokenizer_process,
     run_scheduler_process,
 )
 from sglang.srt.server_args import ServerArgs
+
+
+def launch_engine(
+    server_args: ServerArgs,
+    init_tokenizer_manager_func: Callable = init_tokenizer_manager,
+    run_scheduler_process_func: Callable = run_scheduler_process,
+    run_detokenizer_process_func: Callable = run_detokenizer_process,
+    *,
+    placement_group: Optional[PlacementGroup] = None,
+):
+    """Create RayEngine subprocesses / SchedulerActors."""
+    from sglang.srt.ray.engine import RayEngine, _placement_group_context
+
+    with _placement_group_context(placement_group):
+        return RayEngine._launch_subprocesses(
+            server_args,
+            init_tokenizer_manager_func=init_tokenizer_manager_func,
+            run_scheduler_process_func=run_scheduler_process_func,
+            run_detokenizer_process_func=run_detokenizer_process_func,
+        )
+
+
+def serve_http(
+    engine,
+    server_args: ServerArgs,
+    execute_warmup_func: Optional[Callable] = None,
+    launch_callback: Optional[Callable[[], None]] = None,
+):
+    """Block in uvicorn. ``engine`` is the tuple from ``launch_engine``."""
+    from sglang.srt.entrypoints.http_server import (
+        _execute_server_warmup,
+        _setup_and_run_http_server,
+    )
+
+    if execute_warmup_func is None:
+        execute_warmup_func = _execute_server_warmup
+
+    (
+        tokenizer_manager,
+        template_manager,
+        port_args,
+        scheduler_init_result,
+        subprocess_watchdog,
+        _weight_cache_daemon_procs,
+    ) = engine
+
+    _setup_and_run_http_server(
+        server_args,
+        tokenizer_manager,
+        template_manager,
+        port_args,
+        scheduler_init_result.scheduler_infos,
+        subprocess_watchdog,
+        execute_warmup_func=execute_warmup_func,
+        launch_callback=launch_callback,
+    )
 
 
 def launch_server(
@@ -35,36 +93,14 @@ def launch_server(
 
     Mirrors http_server.launch_server() but uses RayEngine for scheduler launching.
     """
-    from sglang.srt.entrypoints.http_server import (
-        _execute_server_warmup,
-        _setup_and_run_http_server,
-    )
-    from sglang.srt.ray.engine import RayEngine
-
-    if execute_warmup_func is None:
-        execute_warmup_func = _execute_server_warmup
-
-    (
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result,
-        subprocess_watchdog,
-        _weight_cache_daemon_procs,
-    ) = RayEngine._launch_subprocesses(
+    serve_http(
+        launch_engine(
+            server_args,
+            init_tokenizer_manager_func=init_tokenizer_manager_func,
+            run_scheduler_process_func=run_scheduler_process_func,
+            run_detokenizer_process_func=run_detokenizer_process_func,
+        ),
         server_args,
-        init_tokenizer_manager_func=init_tokenizer_manager_func,
-        run_scheduler_process_func=run_scheduler_process_func,
-        run_detokenizer_process_func=run_detokenizer_process_func,
-    )
-
-    _setup_and_run_http_server(
-        server_args,
-        tokenizer_manager,
-        template_manager,
-        port_args,
-        scheduler_init_result.scheduler_infos,
-        subprocess_watchdog,
         execute_warmup_func=execute_warmup_func,
         launch_callback=launch_callback,
     )

--- a/python/sglang/srt/ray/scheduler_actor.py
+++ b/python/sglang/srt/ray/scheduler_actor.py
@@ -16,9 +16,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import ray
+from ray import ObjectRef
 
 from sglang.srt.runtime_context import publish
 from sglang.srt.server_args import PortArgs, ServerArgs
@@ -122,6 +123,38 @@ class SchedulerActor:
     def get_info(self) -> Dict[str, Any]:
         """Return scheduler initialization info for handshake."""
         return self.scheduler.get_init_info()
+
+    def register_weight_for_rdt(self) -> None:
+        """Pin model parameters with NIXL for repeated RDT pulls."""
+        if self.scheduler.server_args.enable_memory_saver:
+            return
+
+        import torch
+        from ray.experimental import register_nixl_memory
+
+        torch.cuda.set_device(self.scheduler.ps.gpu_id)
+        model = self.scheduler.tp_worker.model_runner.model
+        for _, param in model.named_parameters():
+            register_nixl_memory(param.data)
+
+    def pull_weights(
+        self, weights_refs: List[ObjectRef], param_names: List[str]
+    ) -> None:
+        """Pull a pre-sharded weight bucket from the trainer via RDT zero-copy.
+
+        ``weights_refs`` is a list so Ray does not resolve the ref on call.
+        """
+        import torch
+        from ray.experimental import set_target_for_ref
+
+        # Runs on a different thread than run_event_loop, which owns the device binding.
+        torch.cuda.set_device(self.scheduler.ps.gpu_id)
+
+        model = self.scheduler.tp_worker.model_runner.model
+        params_dict = dict(model.named_parameters())
+        target_buffers = [params_dict[name].data for name in param_names]
+        set_target_for_ref(weights_refs[0], target_buffers)
+        ray.get(weights_refs[0])
 
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop. Blocks until shutdown."""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3250,6 +3250,10 @@ class ServerArgs:
         ),
         NS("model"),
     ] = None
+    custom_pull_weights_pre_read_hook: A[
+        Optional[str],
+        "Import path of a hook(source_dir, target_version) that /pull_weights calls before reading the published weights. POSIX shared filesystems need no hook; object-store-backed mounts often lack cross-host read-after-write consistency, so another host's writes only become visible after an explicit refresh.",
+    ] = None
     weight_loader_disable_mmap: A[
         bool, "Disable mmap while loading weight using safetensors.", NS("model")
     ] = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7405,11 +7405,11 @@ class ServerArgs:
                 "backup and the storage keys must become dcp_rank-aware "
                 "first. Run HiCache+DCP with L1/L2 only."
             )
-        if self.speculative_algorithm is not None:
+        if self.speculative_algorithm not in (None, "DSPARK"):
             raise NotImplementedError(
-                "HiCache with --dcp-size > 1 does not support speculative "
-                "decoding yet (the draft-model host pool has no DCP index "
-                "translation)."
+                "HiCache with --dcp-size > 1 only supports DSPARK speculative "
+                "decoding; other draft-model host pools have no DCP index "
+                "translation."
             )
         if self.enable_lmcache:
             raise NotImplementedError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1916,6 +1916,11 @@ class ServerArgs:
         NS("exec.graph"),
     ] = False
     disable_cuda_graph: A[bool, Arg(no_cli=True), NS("exec.graph")] = False
+    disable_draft_cuda_graph: A[
+        bool,
+        "Disable cuda graph for draft model in speculative decoding.",
+        NS("exec.graph"),
+    ] = False
     disable_cuda_graph_padding: A[
         bool,
         "Disable cuda graph when padding is needed. Still uses cuda graph when padding is not needed.",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3300,6 +3300,14 @@ class ServerArgs:
         "Start seed server via transfer engine backend for remote instance weight loader.",
         NS("model"),
     ] = False
+    enable_engine_info_bootstrap: A[
+        bool,
+        "Start the EngineInfoBootstrapServer and register per-rank parallelism config, without the mooncake/verbs P2P transfer-engine seeding.",
+    ] = False
+    enable_rdt_weight_sync: A[
+        bool,
+        "Expose SchedulerActor.pull_weights for RDT (Ray Direct Transport / NIXL) weight sync. Requires --use-ray; implies --enable-engine-info-bootstrap.",
+    ] = False
     engine_info_bootstrap_port: A[
         int,
         "Port for the engine info bootstrap server. Default is 6789. Must be set explicitly when running multiple instances on the same node.",
@@ -3641,6 +3649,8 @@ class ServerArgs:
         self._handle_return_hidden_states_mode()
         self._handle_media_url_security()
         self._handle_hicache_ratio_default()
+        self._handle_rdt_weight_sync()
+
         if self.model_path.lower() in ["none", "dummy"]:
             return
 
@@ -3994,6 +4004,14 @@ class ServerArgs:
             ):
                 ObjectStorageModel.download_and_get_path(model_path)
                 seen_paths.add(model_path)
+
+    def _handle_rdt_weight_sync(self):
+        if not self.enable_rdt_weight_sync:
+            return
+        assert (
+            self.use_ray
+        ), "--enable-rdt-weight-sync requires --use-ray: the trainer pulls weights through SchedulerActors."
+        self.enable_engine_info_bootstrap = True
 
     def _handle_pd_disaggregation(self):
         from sglang.srt.arg_groups.pd_disaggregation_hook import (
@@ -9660,6 +9678,20 @@ class ServerArgs:
         ``page_size * dcp_size`` (``mem_cache/kv_cache_builder.py``).
         """
         return self.page_size * self.dcp_size
+
+    def needs_engine_info_bootstrap(self) -> bool:
+        """Whether this node (rank 0) hosts the EngineInfoBootstrapServer."""
+        return (
+            self.remote_instance_weight_loader_start_seed_via_transfer_engine
+            or self.enable_engine_info_bootstrap
+        )
+
+    def registers_parallelism_config(self) -> bool:
+        """Whether this rank publishes its parallelism config to the bootstrap server."""
+        return (
+            self.remote_instance_weight_loader_use_transfer_engine()
+            or self.enable_engine_info_bootstrap
+        )
 
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9608,6 +9608,13 @@ class ServerArgs:
         ``--speculative-draft-load-format`` needs its own transfer engine."""
         return remote_instance_transfer_engine_of(self, load_format)
 
+    @property
+    def kv_event_block_size(self) -> int:
+        """Width KV events are emitted at: under DCP the radix tree pages at
+        ``page_size * dcp_size`` (``mem_cache/kv_cache_builder.py``).
+        """
+        return self.page_size * self.dcp_size
+
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event
         publisher, or `None` if publishing is disabled / misconfigured.
@@ -9633,10 +9640,13 @@ class ServerArgs:
                 "topic": "",                      # ZMQ topic prefix on the
                                                   # SUB filter (empty =
                                                   # subscribe-all)
-                "block_size": <page_size>,        # subscribers MUST hash
-                                                  # prompts at this size
-                "dp_size": <dp_size>,             # number of SUB sockets
-                                                  # to open
+                "block_size": <kv_event_block_size>,  # subscribers MUST
+                                                  # hash prompts at this size
+                "dp_size": <dp_size>,             # number of SUB sockets to
+                                                  # open; not DCP-scaled, as
+                                                  # DCP shards within a rank
+                                                  # rather than adding
+                                                  # publishers
             }
 
         Returns None (i.e. "no publisher to describe") when any of:
@@ -9691,7 +9701,7 @@ class ServerArgs:
             "endpoint_host": host,
             "endpoint_port_base": port,
             "topic": cfg.topic,
-            "block_size": page_size,
+            "block_size": self.kv_event_block_size,
             "dp_size": self.dp_size,
         }
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -67,6 +67,10 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.platforms import current_platform
 from sglang.srt.speculative.decoupled_spec_io import DecoupledSpecIpcConfig
+from sglang.srt.true_on_policy.contracts import (
+    resolve_true_on_policy_runtime_policy,
+    validate_true_on_policy_contract,
+)
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
@@ -317,7 +321,7 @@ BF16_GEMM_BACKEND_CHOICES = ["auto", "cutedsl", "torch"]
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 RETRACTION_POLICY_CHOICES = ["length", "priority"]
 
-RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
+RL_ON_POLICY_TARGET_CHOICES = ["fsdp", "fsdp_tp"]
 
 LORA_BACKEND_CHOICES = ["triton", "csgmv", "ascend", "torch_native"]
 
@@ -3399,6 +3403,15 @@ class ServerArgs:
         "Enable deterministic inference mode with batch invariant ops.",
         NS("exec.deterministic"),
     ] = False
+    enable_prefill_only_deterministic_inference: A[
+        bool,
+        "Enable prefill-only deterministic inference mode with batch invariant ops.",
+    ] = False
+    true_on_policy_contract: A[
+        Optional[str],
+        "Internal true-on-policy parity contract selected by the launcher. "
+        "Normal users should prefer the Miles true_on_policy switch.",
+    ] = None
     rl_on_policy_target: A[
         Optional[str],
         Arg(
@@ -8175,16 +8188,40 @@ class ServerArgs:
             raise ValueError("--swa-full-tokens-ratio should be in range (0, 1.0].")
 
     def _handle_deterministic_inference(self):
+        validate_true_on_policy_contract(self)
+
+        if self.enable_prefill_only_deterministic_inference:
+            self.enable_deterministic_inference = True
+
         if self.rl_on_policy_target is not None:
             logger.warning(
-                "Enable deterministic inference because of rl_on_policy_target."
+                "Enable deterministic inference because of legacy rl_on_policy_target."
+            )
+            self.enable_deterministic_inference = True
+
+        if self.true_on_policy_contract is not None:
+            logger.warning(
+                "Enable deterministic inference because of true_on_policy_contract."
             )
             self.enable_deterministic_inference = True
 
             # For VLM
             envs.SGLANG_VLM_CACHE_SIZE_MB.set(0)
-            # TODO remove this environment variable as a whole
-            envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.set(True)
+
+            if (
+                resolve_true_on_policy_runtime_policy(
+                    self
+                ).disable_flashinfer_allreduce_fusion
+                and self.enable_flashinfer_allreduce_fusion
+            ):
+                self.enable_flashinfer_allreduce_fusion = False
+                logger.warning(
+                    "Disable flashinfer allreduce fusion because of "
+                    "true_on_policy_contract with TP rollout."
+                )
+
+        if self.enable_deterministic_inference:
+            envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.set("1")
 
         if self.enable_deterministic_inference:
             if self.enable_aiter_allreduce_fusion:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1009,6 +1009,11 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = None
+    gated_launch_port: A[
+        Optional[int],
+        "The port of the gated launch control server. When set, every rank blocks right after the distributed environment is initialized, before any sizable GPU allocation, until `POST /gate/activate` is sent to this port on the host of the first rank. This lets an external orchestrator defer the memory hungry part of startup to a safe window. Defaults to None, which disables the gate.",
+        NS("parallel"),
+    ] = None
     nnodes: A[int, "The number of nodes.", NS("parallel")] = 1
     node_rank: A[int, "The node rank.", NS("parallel")] = 0
     tp_size: A[
@@ -9791,6 +9796,15 @@ class ServerArgs:
 
     def should_export_expert_balancedness_to_prometheus(self) -> bool:
         return self.expert_balancedness_report_mode in ("prometheus", "both")
+
+
+def compute_world_size(server_args: ServerArgs) -> int:
+    """Return the total GPU count across all data-parallel replicas."""
+    return (
+        (1 if server_args.enable_dp_attention else server_args.dp_size)
+        * server_args.tp_size
+        * server_args.pp_size
+    )
 
 
 def m3_fp8_attn_gemm_enabled(args) -> bool:

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from dataclasses import replace
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
@@ -62,6 +62,9 @@ from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
 
 _is_npu = is_npu()
 
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +174,9 @@ class DFlashWorkerV2(BaseSpecWorker):
     Drives both overlap and non-overlap scheduling, same as EAGLE: the
     scheduler runs it synchronously when overlap is disabled.
     """
+
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        return [("draft", self.draft_model_runner)]
 
     def __init__(
         self,

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -564,8 +564,10 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.seq_lens,
             forward_batch.out_cache_loc,
             forward_batch.positions,
-            forward_batch.spec_info.topk_p,
-            forward_batch.spec_info.topk_index,
+            forward_batch.spec_info.topk_p.clamp(0, 1),
+            forward_batch.spec_info.topk_index.clamp(
+                0, self.model_runner.model_config.vocab_size - 1
+            ),
             forward_batch.req_pool_indices,
         ]
         if buffers.rids_int is not None and forward_batch.rids_int is not None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1014,7 +1014,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
 class EAGLEWorkerV2(BaseSpecWorker):
     def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
-        return [("draft", self.draft_runner)]
+        return [("draft", self.draft_worker.draft_runner)]
 
     def __init__(
         self,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import time
 from dataclasses import replace
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
@@ -30,7 +30,6 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_a2a_backend_context,
     speculative_moe_backend_context,
 )
-from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -101,7 +100,6 @@ from sglang.srt.utils.async_probe import (
     maybe_detect_oob,
 )
 from sglang.srt.utils.common import (
-    MultiprocessingSerializer,
     empty_context,
     fast_topk,
     get_available_gpu_memory,
@@ -113,7 +111,6 @@ from sglang.srt.utils.common import (
     is_xpu,
     log_info_on_rank0,
 )
-from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
@@ -122,6 +119,9 @@ _is_musa = is_musa()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
 
@@ -1013,6 +1013,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
 
 class EAGLEWorkerV2(BaseSpecWorker):
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        return [("draft", self.draft_runner)]
+
     def __init__(
         self,
         server_args: ServerArgs,
@@ -1516,25 +1519,3 @@ class EAGLEWorkerV2(BaseSpecWorker):
             finalize_tree_path=True,
             grammar_barrier=grammar_barrier,
         )
-
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-        monkey_patch_torch_reductions()
-        named_tensors = MultiprocessingSerializer.deserialize(
-            recv_req.serialized_named_tensors[self.ps.tp_rank]
-        )
-        success, message = (
-            self.draft_worker.draft_runner.weight_updater.update_weights_from_tensor(
-                named_tensors=named_tensors,
-                load_format=recv_req.load_format,
-            )
-        )
-        if not success:
-            return success, message
-
-        success, message = (
-            self.target_worker.model_runner.weight_updater.update_weights_from_tensor(
-                named_tensors=named_tensors,
-                load_format=recv_req.load_format,
-            )
-        )
-        return success, message

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -348,7 +348,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.cuda_graph_runner = None
         self.cuda_graph_runner_for_draft_extend = None
 
-        if _is_cpu or check_cuda_graph_backend(Phase.DECODE, Backend.DISABLED):
+        if (
+            _is_cpu
+            or check_cuda_graph_backend(Phase.DECODE, Backend.DISABLED)
+            or self.server_args.disable_draft_cuda_graph
+        ):
             return
 
         if get_model().model_impl == "mindspore":

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -917,7 +917,10 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
 
 class MultiLayerEagleWorkerV2(BaseSpecWorker):
     def iter_runners(self) -> List[Tuple[str, ModelRunner]]:
-        return [(f"draft_step_{i}", r) for i, r in enumerate(self.draft_runner_list)]
+        return [
+            (f"draft_step_{i}", r)
+            for i, r in enumerate(self.draft_worker.draft_runner_list)
+        ]
 
     def __init__(
         self,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import replace
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Tuple
 
 import torch
 
@@ -916,6 +916,9 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
 
 
 class MultiLayerEagleWorkerV2(BaseSpecWorker):
+    def iter_runners(self) -> List[Tuple[str, ModelRunner]]:
+        return [(f"draft_step_{i}", r) for i, r in enumerate(self.draft_runner_list)]
+
     def __init__(
         self,
         server_args: ServerArgs,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -33,6 +33,9 @@ from sglang.srt.utils import is_cpu
 from sglang.srt.utils.async_probe import maybe_detect_inf, maybe_detect_nan
 
 _is_cpu = is_cpu()
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +72,11 @@ def _derive_tree_links(
 
 
 class NGRAMWorker(BaseSpecWorker):
+    def iter_runners(self) -> List[Tuple[str, "ModelRunner"]]:
+        # NGRAM shares the target's model_runner -- no independent draft weights
+        # (the n-gram corpus is a CPU lookup structure built from token streams).
+        return []
+
     def alloc_memory_pool(self, **kwargs):
         # The target memory pool does not exist yet when __init__ runs.
         self.req_to_token_pool, self.token_to_kv_pool_allocator = (
@@ -147,15 +155,6 @@ class NGRAMWorker(BaseSpecWorker):
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
         self._prev_decode_rids = set()
-
-    def update_weights_from_tensor(self, recv_req):
-        # NGRAM has no draft weights of its own — the n-gram corpus is a CPU
-        # lookup structure built from request token streams — and its
-        # `model_runner` is shared with the target worker. The scheduler
-        # mixin dispatches via `self.draft_worker or self.tp_worker`, so
-        # without this method any caller of `update_weights_from_tensor`
-        # under `--speculative-algorithm NGRAM` raises AttributeError.
-        return self.target_worker.update_weights_from_tensor(recv_req)
 
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:
         return self.ngram_corpus.load_external_corpus_named(corpus_id, token_chunks)

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -178,10 +178,10 @@ class BaseTopkCapturer:
         if no_copy_to_cpu:
             # Clone before the next overlapping forward reuses these buffers.
             return TopkCaptureOutput(
-                out_cache_loc=forward_batch.out_cache_loc.clone(),
+                out_cache_loc=forward_batch.out_cache_loc[: slice_gpu.shape[0]].clone(),
                 topk=slice_gpu.clone(),
                 host_cache=self.host_cache,
             )
-        out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
+        out_cache_loc_cpu = forward_batch.out_cache_loc[: slice_gpu.shape[0]].cpu()
         self.host_cache.buffer[out_cache_loc_cpu] = slice_gpu.cpu()
         return None

--- a/python/sglang/srt/tp_invariant_ops/__init__.py
+++ b/python/sglang/srt/tp_invariant_ops/__init__.py
@@ -1,0 +1,23 @@
+from .tp_invariant_ops import (
+    disable_tp_invariant_mode,
+    enable_tp_invariant_mode,
+    is_tp_invariant_mode_enabled,
+    matmul_tp_inv,
+    matmul_tp_persistent,
+    moe_sum_tree_reduce,
+    set_tp_invariant_mode,
+    tree_all_reduce_sum,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "matmul_tp_persistent",
+    "matmul_tp_inv",
+    "moe_sum_tree_reduce",
+    "tree_all_reduce_sum",
+    "set_tp_invariant_mode",
+    "is_tp_invariant_mode_enabled",
+    "disable_tp_invariant_mode",
+    "enable_tp_invariant_mode",
+]

--- a/python/sglang/srt/tp_invariant_ops/tp_invariant_ops.py
+++ b/python/sglang/srt/tp_invariant_ops/tp_invariant_ops.py
@@ -1,0 +1,1941 @@
+import contextlib
+import math
+import os
+import sys
+from typing import Any, Callable, Dict
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+
+# Triton's constexpr tree unrolling causes deep AST recursion in the JIT
+# compiler.  The two-level tree (v2) bounds compilation depth to
+# max(log2(SUBTREE), log2(E/SUBTREE)) instead of log2(E), but we still
+# need headroom for the per-level AST visitor overhead.
+if sys.getrecursionlimit() < 16384:
+    sys.setrecursionlimit(16384)
+
+
+def _matmul_launch_metadata(
+    grid: Callable[..., Any], kernel: Any, args: Dict[str, Any]
+) -> Dict[str, Any]:
+    ret = {}
+    m, n, k = args["M"], args["N"], args["K"]
+    ret["name"] = f"{kernel.name} [M={m}, N={n}, K={k}]"
+    if "tiles_per_update" in args:
+        ret["name"] = (
+            f"{kernel.name} [M={m}, N={n}, K={k}, tiles_per_update={args['tiles_per_update']:02}]"
+        )
+    if "c_ptr" in args:
+        bytes_per_elem = args["c_ptr"].element_size()
+    else:
+        bytes_per_elem = 1 if args["FP8_OUTPUT"] else 2
+    ret[f"flops{bytes_per_elem * 8}"] = 2.0 * m * n * k
+    ret["bytes"] = bytes_per_elem * (m * k + n * k + m * n)
+    return ret
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+def _get_tl_dtype(dtype):
+    if dtype == torch.float32:
+        return tl.float32
+    elif dtype == torch.float16:
+        return tl.float16
+    elif dtype == torch.bfloat16:
+        return tl.bfloat16
+
+
+# ---- kernel ----
+@triton.jit(launch_metadata=_matmul_launch_metadata)
+def matmul_kernel_tp_persistent(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    LEVEL_K: tl.constexpr,
+    TILE_K: tl.constexpr,
+    FIRST_LEVEL_BLOCK: tl.constexpr,
+    NEXT_POWER_OF_LEVEL: tl.constexpr,
+    NEXT_POWER_OF_REMAIN_LEVEL: tl.constexpr,
+    ACC_DTYPE: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+    A_LARGE: tl.constexpr,
+    B_LARGE: tl.constexpr,
+    C_LARGE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = num_pid_m * num_pid_n
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    manual_acc = 3
+    acc1 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc2 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc3 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+
+    S = tl.zeros((NEXT_POWER_OF_REMAIN_LEVEL, BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+
+    S_mask = tl.arange(0, NEXT_POWER_OF_REMAIN_LEVEL)[:, None, None]
+    level_ids = tl.arange(0, NEXT_POWER_OF_LEVEL)
+
+    base_offs_m = tl.arange(0, BLOCK_M)
+    base_offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    offs_k = tl.max_contiguous(tl.multiple_of(offs_k, BLOCK_K), BLOCK_K)
+
+    for tile_id in tl.range(pid, num_tiles, NUM_SMS, flatten=False):
+        pid_m, pid_n = _compute_pid(
+            tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS
+        )
+
+        start_m = pid_m * BLOCK_M
+        start_n = pid_n * BLOCK_N
+
+        offs_am = start_m + base_offs_m
+        if A_LARGE:
+            offs_am = offs_am.to(tl.int64)
+        offs_am = tl.where(offs_am < M, offs_am, 0)
+
+        offs_bn = start_n + base_offs_n
+        if B_LARGE:
+            offs_bn = offs_bn.to(tl.int64)
+        offs_bn = tl.where(offs_bn < N, offs_bn, 0)
+
+        offs_am = tl.max_contiguous(tl.multiple_of(offs_am, BLOCK_M), BLOCK_M)
+        offs_bn = tl.max_contiguous(tl.multiple_of(offs_bn, BLOCK_N), BLOCK_N)
+
+        a_ptrs = A_ptr + offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+        b_ptrs = B_ptr + offs_bn[None, :] * stride_bn + offs_k[:, None] * stride_bk
+
+        count = tl.zeros((NEXT_POWER_OF_LEVEL,), dtype=tl.int32)
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+        for s_tile_idx in range(0, TILE_K):
+            k0 = s_tile_idx * BLOCK_K
+            a = tl.load(
+                a_ptrs,
+                mask=(offs_am[:, None] < M) & ((k0 + offs_k)[None, :] < K),
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=((k0 + offs_k)[:, None] < K) & (offs_bn[None, :] < N),
+                other=0.0,
+            )
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+
+            acc = tl.dot(a, b).to(ACC_DTYPE)
+
+            break_flag = 0
+            for level in range(LEVEL_K):
+                if break_flag == 0:
+                    idx_mask = level_ids == level
+
+                    count_value_added = tl.sum(count * idx_mask) + 1
+
+                    table_value = FIRST_LEVEL_BLOCK if level == 0 else 2
+
+                    carry_over = (table_value == count_value_added).to(tl.int1)
+
+                    if count_value_added > 1:
+                        if level == 0:
+                            acc = acc1 + acc
+                        elif level == 1:
+                            acc = acc2 + acc
+                        elif level == 2:
+                            acc = acc3 + acc
+                        else:
+                            tmp_acc_mask = S_mask == (level - manual_acc)
+                            acc = (
+                                tl.sum(S * tmp_acc_mask, axis=0, dtype=ACC_DTYPE) + acc
+                            )
+
+                    count = tl.where(
+                        idx_mask, count_value_added * (1 - carry_over), count
+                    )
+                    if not carry_over:
+                        break_flag = 1
+                        if level == 0:
+                            acc1 = acc
+                        elif level == 1:
+                            acc2 = acc
+                        elif level == 2:
+                            acc3 = acc
+                        else:
+                            tmp_acc_mask = S_mask == (level - manual_acc)
+                            S = tl.where(tmp_acc_mask, acc[None, :, :], S)
+
+        c_ptr = C_ptr + (offs_am[:, None] * stride_cm + offs_bn[None, :] * stride_cn)
+        offs_cm = start_m + base_offs_m
+        offs_cn = start_n + base_offs_n
+        if C_LARGE:
+            offs_cm = offs_cm.to(tl.int64)
+            offs_cn = offs_cn.to(tl.int64)
+        offs_cm = tl.where(offs_cm < M, offs_cm, 0)
+        offs_cn = tl.where(offs_cn < N, offs_cn, 0)
+        offs_cm = tl.max_contiguous(tl.multiple_of(offs_cm, BLOCK_M), BLOCK_M)
+        offs_cn = tl.max_contiguous(tl.multiple_of(offs_cn, BLOCK_N), BLOCK_N)
+        mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        tl.store(c_ptr, acc.to(OUT_DTYPE), mask=mask_c)
+
+
+@triton.jit(launch_metadata=_matmul_launch_metadata)
+def matmul_kernel_tp_persistent_optim(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    LEVEL_K: tl.constexpr,
+    TILE_K: tl.constexpr,
+    FIRST_LEVEL_BLOCK: tl.constexpr,
+    NEXT_POWER_OF_LEVEL: tl.constexpr,
+    NEXT_POWER_OF_REMAIN_LEVEL: tl.constexpr,
+    ACC_DTYPE: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+    A_LARGE: tl.constexpr,
+    B_LARGE: tl.constexpr,
+    C_LARGE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = num_pid_m * num_pid_n
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Flat loop (same structure as original) with inlined level-0 handling.
+    # Level-0 uses scalar counter; tree merge (levels 1+) only on carry.
+    # Accumulators are conditionally allocated based on LEVEL_K (constexpr)
+    # to minimize register pressure and maximize occupancy.
+    acc1 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc2 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc3 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc4 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    acc5 = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+
+    S = tl.zeros((NEXT_POWER_OF_REMAIN_LEVEL, BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+    S_mask = tl.arange(0, NEXT_POWER_OF_REMAIN_LEVEL)[:, None, None]
+    level_ids = tl.arange(0, NEXT_POWER_OF_LEVEL)
+
+    offs_k = tl.arange(0, BLOCK_K)
+    offs_k = tl.max_contiguous(tl.multiple_of(offs_k, BLOCK_K), BLOCK_K)
+
+    for tile_id in tl.range(pid, num_tiles, NUM_SMS, flatten=False):
+        pid_m, pid_n = _compute_pid(
+            tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS
+        )
+
+        start_m = pid_m * BLOCK_M
+        start_n = pid_n * BLOCK_N
+
+        offs_am = start_m + tl.arange(0, BLOCK_M)
+        mask_m = offs_am < M
+        if A_LARGE:
+            offs_am = offs_am.to(tl.int64)
+        offs_am = tl.where(mask_m, offs_am, 0)
+
+        offs_bn = start_n + tl.arange(0, BLOCK_N)
+        mask_n = offs_bn < N
+        if B_LARGE:
+            offs_bn = offs_bn.to(tl.int64)
+        offs_bn = tl.where(mask_n, offs_bn, 0)
+
+        offs_am = tl.max_contiguous(tl.multiple_of(offs_am, BLOCK_M), BLOCK_M)
+        offs_bn = tl.max_contiguous(tl.multiple_of(offs_bn, BLOCK_N), BLOCK_N)
+        mask_m_bc = mask_m[:, None]
+        mask_n_bc = mask_n[None, :]
+
+        a_ptrs = A_ptr + offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+        b_ptrs = B_ptr + offs_bn[None, :] * stride_bn + offs_k[:, None] * stride_bk
+
+        c0 = 0
+        c1 = 0
+        c2 = 0
+        c3 = 0
+        c4 = 0
+        count = tl.zeros((NEXT_POWER_OF_LEVEL,), dtype=tl.int32)
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_DTYPE)
+        for _ in range(0, TILE_K):
+            a = tl.load(a_ptrs, mask=mask_m_bc, other=0.0)
+            b = tl.load(b_ptrs, mask=mask_n_bc, other=0.0)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+
+            acc = tl.dot(a, b).to(ACC_DTYPE)
+
+            c0 += 1
+            if c0 > 1:
+                acc = acc1 + acc
+            if c0 < FIRST_LEVEL_BLOCK:
+                acc1 = acc
+            else:
+                c0 = 0
+                break_flag = 0
+                for level in range(1, LEVEL_K):
+                    if break_flag == 0:
+                        if level == 1:
+                            c1 += 1
+                            if c1 > 1:
+                                acc = acc2 + acc
+                            if c1 == 2:
+                                c1 = 0
+                            else:
+                                acc2 = acc
+                                break_flag = 1
+                        elif level == 2:
+                            c2 += 1
+                            if c2 > 1:
+                                acc = acc3 + acc
+                            if c2 == 2:
+                                c2 = 0
+                            else:
+                                acc3 = acc
+                                break_flag = 1
+                        elif level == 3:
+                            c3 += 1
+                            if c3 > 1:
+                                acc = acc4 + acc
+                            if c3 == 2:
+                                c3 = 0
+                            else:
+                                acc4 = acc
+                                break_flag = 1
+                        elif level == 4:
+                            c4 += 1
+                            if c4 > 1:
+                                acc = acc5 + acc
+                            if c4 == 2:
+                                c4 = 0
+                            else:
+                                acc5 = acc
+                                break_flag = 1
+                        else:
+                            idx_mask = level_ids == level
+                            count_value_added = tl.sum(count * idx_mask) + 1
+                            carry_over = (2 == count_value_added).to(tl.int1)
+                            if count_value_added > 1:
+                                tmp_acc_mask = S_mask == (level - 5)
+                                acc = (
+                                    tl.sum(S * tmp_acc_mask, axis=0, dtype=ACC_DTYPE)
+                                    + acc
+                                )
+                            count = tl.where(
+                                idx_mask, count_value_added * (1 - carry_over), count
+                            )
+                            if not carry_over:
+                                break_flag = 1
+                                tmp_acc_mask = S_mask == (level - 5)
+                                S = tl.where(tmp_acc_mask, acc[None, :, :], S)
+
+        offs_cm = start_m + tl.arange(0, BLOCK_M)
+        offs_cn = start_n + tl.arange(0, BLOCK_N)
+        if C_LARGE:
+            offs_cm = offs_cm.to(tl.int64)
+            offs_cn = offs_cn.to(tl.int64)
+        offs_cm = tl.where(mask_m, offs_cm, 0)
+        offs_cn = tl.where(mask_n, offs_cn, 0)
+        offs_cm = tl.max_contiguous(tl.multiple_of(offs_cm, BLOCK_M), BLOCK_M)
+        offs_cn = tl.max_contiguous(tl.multiple_of(offs_cn, BLOCK_N), BLOCK_N)
+        c_ptr = C_ptr + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
+        mask_c = mask_m_bc & mask_n_bc
+        tl.store(c_ptr, acc.to(OUT_DTYPE), mask=mask_c)
+
+
+def _matmul_tp_persistent_impl(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    bias: torch.Tensor = None,
+    fp32_accum: bool = False,
+    use_optim_kernel: bool = False,
+):
+    assert A.shape[-1] == B.shape[-2], "Dim doesn't match"
+
+    out_dtype = A.dtype
+    acc_dtype = torch.float32 if fp32_accum else A.dtype
+
+    NUM_SMS = torch.cuda.get_device_properties(A.device).multi_processor_count
+
+    # 1D launch kernel where each block gets its own program.
+    def grid(META):
+        return (
+            min(
+                NUM_SMS,
+                triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+            ),
+        )
+
+    base_configs = {
+        torch.bfloat16: {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 8,
+            "num_stages": 2,
+            "num_warps": 8,
+        },
+        torch.float16: {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 8,
+            "num_stages": 2,
+            "num_warps": 8,
+        },
+        torch.float32: {
+            "BLOCK_SIZE_M": 32,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 8,
+            "num_stages": 2,
+            "num_warps": 8,
+        },
+    }
+
+    configs = base_configs
+    BLOCK_M = configs[out_dtype]["BLOCK_SIZE_M"]
+    BLOCK_N = configs[out_dtype]["BLOCK_SIZE_N"]
+    BLOCK_K = configs[out_dtype]["BLOCK_SIZE_K"]
+    GROUP_SIZE_M = configs[out_dtype]["GROUP_SIZE_M"]
+    num_stages = configs[out_dtype]["num_stages"]
+    num_warps = configs[out_dtype]["num_warps"]
+
+    M, K = A.shape
+    _, N = B.shape
+    assert (
+        K % BLOCK_K == 0
+    ), f"Dimension K should be divisible by BLOCK_K. Got K={K}, BLOCK_K={BLOCK_K}."
+    T = K // BLOCK_K
+    FIRST_LEVEL_BLOCK = T
+
+    if use_optim_kernel:
+        num_n_tiles = triton.cdiv(N, BLOCK_N)
+        total_tiles = triton.cdiv(M, BLOCK_M) * num_n_tiles
+
+        if total_tiles * 4 <= NUM_SMS:
+            while BLOCK_M > 16 and triton.cdiv(M, BLOCK_M) * num_n_tiles < NUM_SMS:
+                BLOCK_M //= 2
+        elif total_tiles * 2 <= NUM_SMS:
+            while BLOCK_M > 32 and triton.cdiv(M, BLOCK_M) * num_n_tiles < NUM_SMS:
+                BLOCK_M //= 2
+
+        if out_dtype in (torch.bfloat16, torch.float16):
+            num_warps = 4 if BLOCK_M <= 16 else 8
+            num_stages = 3 if K >= 1024 else 2
+
+    LEVEL_K = 1
+    while FIRST_LEVEL_BLOCK > 2 and FIRST_LEVEL_BLOCK % 2 == 0:
+        FIRST_LEVEL_BLOCK //= 2
+        LEVEL_K += 1
+
+    C = torch.empty((M, N), device=A.device, dtype=out_dtype)
+
+    # Original kernel manually handles levels 0-2 (3 accumulators);
+    # optim kernel handles levels 0-4 (5 register accumulators),
+    # so S tensor is smaller / unused for common LEVEL_K <= 5.
+    manual_acc = 5 if use_optim_kernel else 3
+
+    NEXT_POWER_OF_LEVEL = 2 ** math.ceil(math.log2(LEVEL_K))
+    NEXT_POWER_OF_REMAIN_LEVEL = (
+        2 ** math.ceil(math.log2(LEVEL_K - manual_acc)) if LEVEL_K > manual_acc else 1
+    )
+
+    kernel = (
+        matmul_kernel_tp_persistent_optim
+        if use_optim_kernel
+        else matmul_kernel_tp_persistent
+    )
+    kernel[grid](
+        A,
+        B,
+        C,
+        M,
+        N,
+        K,
+        *A.stride(),
+        *B.stride(),
+        *C.stride(),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_SMS=NUM_SMS,
+        NEXT_POWER_OF_REMAIN_LEVEL=NEXT_POWER_OF_REMAIN_LEVEL,
+        LEVEL_K=LEVEL_K,
+        TILE_K=T,
+        FIRST_LEVEL_BLOCK=FIRST_LEVEL_BLOCK,
+        NEXT_POWER_OF_LEVEL=NEXT_POWER_OF_LEVEL,
+        ACC_DTYPE=_get_tl_dtype(acc_dtype),
+        OUT_DTYPE=_get_tl_dtype(out_dtype),
+        A_LARGE=A.numel() > 2**31,
+        B_LARGE=B.numel() > 2**31,
+        C_LARGE=C.numel() > 2**31,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    if bias is not None:
+        C += bias
+    return C
+
+
+def matmul_tp_persistent(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    bias: torch.Tensor = None,
+    fp32_accum: bool = False,
+):
+    return _matmul_tp_persistent_impl(
+        A=A,
+        B=B,
+        bias=bias,
+        fp32_accum=fp32_accum,
+        use_optim_kernel=False,
+    )
+
+
+def matmul_tp_inv(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    bias: torch.Tensor = None,
+    fp32_accum: bool = False,
+):
+    return matmul_tp_persistent(A, B, bias=bias, fp32_accum=fp32_accum)
+
+
+def matmul_tp_persistent_optim(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    bias: torch.Tensor = None,
+    fp32_accum: bool = False,
+):
+    return _matmul_tp_persistent_impl(
+        A=A,
+        B=B,
+        bias=bias,
+        fp32_accum=fp32_accum,
+        use_optim_kernel=True,
+    )
+
+
+def tree_all_reduce_sum(x: torch.Tensor, device_group=None) -> torch.Tensor:
+    rank = dist.get_rank(device_group)
+    world_size = dist.get_world_size(device_group)
+
+    if world_size & (world_size - 1) != 0:
+        raise ValueError(
+            "world_size must be a power of 2 in order to use all_reduce_sum."
+        )
+
+    result = [torch.zeros_like(x) for _ in range(world_size)]
+    dist.all_gather(result, x, group=device_group)
+
+    for level in range(1, world_size.bit_length()):
+        for left in range(0, world_size, 1 << level):
+            right = left + (1 << (level - 1))
+            result[left] += result[right]
+
+    return result[0]
+
+
+def tree_all_reduce_sum_optim(x: torch.Tensor, device_group=None) -> torch.Tensor:
+    if not x.is_cuda:
+        raise ValueError("x must be a CUDA tensor.")
+    if not x.is_contiguous():
+        raise ValueError(
+            "x must be contiguous. Call x = x.contiguous() OUTSIDE graph capture."
+        )
+
+    world_size = dist.get_world_size(device_group)
+    if world_size & (world_size - 1) != 0:
+        raise ValueError("world_size must be a power of 2.")
+
+    # cache
+    if not hasattr(tree_all_reduce_sum, "_cache"):
+        tree_all_reduce_sum._cache = {}
+
+    key = (id(device_group), x.device.index, tuple(x.shape), x.dtype, world_size)
+    st = tree_all_reduce_sum._cache.get(key)
+    if st is None:
+        gather = torch.empty(
+            (world_size,) + tuple(x.shape), device=x.device, dtype=x.dtype
+        )
+        out = torch.empty_like(x)
+        st = tree_all_reduce_sum._cache[key] = (gather, out)
+
+    gather, out = st
+
+    # 1) all_gather into one contiguous buffer
+    dist.all_gather_into_tensor(gather, x, group=device_group)
+
+    # 2) deterministic tree pairing EXACTLY like your original:
+    # for level in range(1, bit_length):
+    #   for left in range(0, world_size, 1<<level):
+    #       right = left + (1<<(level-1))
+    #       gather[left] += gather[right]
+    #
+    # vectorized form: left indices are 0:step: , right are half:step:
+    levels = world_size.bit_length()
+    for level in range(1, levels):
+        step = 1 << level
+        half = step >> 1
+        # Views only (no alloc); one add_ kernel per level
+        gather[0:world_size:step].add_(gather[half:world_size:step])
+
+    out.copy_(gather[0])
+    tree_all_reduce_sum._cache.clear()
+    return out
+
+
+_tp_inv_MODE = False
+
+try:
+    def_lib = torch.library.Library("tp_inv_ops", "DEF")
+    def_lib.define("matmul_tp_inv(Tensor a, Tensor b, Tensor? bias=None) -> Tensor")
+except RuntimeError:
+    pass
+
+try:
+    impl = torch.library.Library("tp_inv_ops", "IMPL")
+
+    impl.impl("matmul_tp_inv", matmul_tp_persistent, "CUDA")
+except RuntimeError:
+    pass
+
+
+def is_tp_invariant_mode_enabled():
+    return _tp_inv_MODE
+
+
+def enable_tp_invariant_mode():
+    global _tp_inv_MODE
+
+    if _tp_inv_MODE:
+        return
+
+    _tp_inv_MODE = True
+
+
+def disable_tp_invariant_mode():
+    global _tp_inv_MODE
+
+    _tp_inv_MODE = False
+
+
+@contextlib.contextmanager
+def set_tp_invariant_mode(enabled=True):
+    global _tp_inv_MODE
+
+    old_state = _tp_inv_MODE
+
+    if enabled:
+        enable_tp_invariant_mode()
+    else:
+        disable_tp_invariant_mode()
+
+    try:
+        yield
+    finally:
+        _tp_inv_MODE = old_state
+
+
+def scatter_input_by_local_expert(
+    topk: torch.Tensor, input: torch.Tensor, E: int
+) -> torch.Tensor:
+    """
+    Args:
+        topk: [M, topk], long, -1 means remote expert
+        input: [M, topk, hidden_size], float
+        E: int, number of local experts (expert ids in [0, E))
+    Returns:
+        output: [M, E, hidden_size]
+    """
+    M, _, hidden_size = input.shape
+
+    # Mask out remote experts in output
+    valid = (topk != -1).unsqueeze(-1)  # [M, topk, 1]
+    output_masked = input * valid.to(input.dtype)  # [M, topk, hidden_size]
+
+    # Replace -1 with 0 for safe indexing (value doesn't matter because output is zero)
+    topk_index = topk.clamp(min=0)  # turns -1 into 0, leaves others unchanged
+
+    # Expand index to match output
+    index = topk_index.unsqueeze(-1).expand(
+        -1, -1, hidden_size
+    )  # [M, topk, hidden_size]
+
+    # Initialize result
+    output = torch.zeros(M, E, hidden_size, device=input.device, dtype=input.dtype)
+
+    # Scatter add
+    output.scatter_add_(1, index, output_masked)
+
+    return output
+
+
+@triton.jit
+def _load_expert_tile(
+    input_ptr,
+    input_base,
+    input_stride_1,
+    topk_ids_base,
+    topk_ids_stride_1,
+    zero_ptrs,
+    offs_dim,
+    mask,
+    mask_token,
+    e: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """Load tile for expert e: search topk_ids for slot, redirect to zero_buf if remote."""
+    found_slot = tl.full([BLOCK_M], -1, dtype=tl.int32)
+    for k in range(TOPK):
+        kid = tl.load(
+            topk_ids_base + k * topk_ids_stride_1,
+            mask=mask_token,
+            other=-1,
+        ).to(tl.int32)
+        match = (kid == e) & (found_slot == -1)
+        found_slot = tl.where(match, k, found_slot)
+
+    is_valid = found_slot != -1
+    slot_safe = tl.maximum(found_slot, 0)
+    input_ptrs = input_base + slot_safe[:, None] * input_stride_1 + offs_dim[None, :]
+    load_ptrs = tl.where(is_valid[:, None], input_ptrs, zero_ptrs)
+    return tl.load(load_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+
+@triton.jit
+def _tree_reduce_pair(
+    input_ptr,
+    input_base,
+    input_stride_1,
+    topk_ids_base,
+    topk_ids_stride_1,
+    zero_ptrs,
+    offs_dim,
+    mask,
+    mask_token,
+    start: tl.constexpr,
+    size: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """
+    Recursively compute binary-tree sum over experts [start, start+size).
+    Returns a fp32 tile [BLOCK_M, BLOCK_DIM].
+
+    Tree structure (e.g. size=4, start=0):
+      _tree_reduce_pair(0, 4)
+        = _tree_reduce_pair(0, 2) + _tree_reduce_pair(2, 2)
+        = (_tree_reduce_pair(0,1) + _tree_reduce_pair(1,1))
+          + (_tree_reduce_pair(2,1) + _tree_reduce_pair(3,1))
+        = (load(e0) + load(e1)) + (load(e2) + load(e3))
+
+    Since size is constexpr and always a power of 2, Triton fully unrolls this
+    into a fixed sequence of loads and adds with no dynamic branching.
+    Max register depth = log2(E) tiles, e.g. E=64 -> 6 tiles.
+    """
+    if size == 1:
+        return _load_expert_tile(
+            input_ptr,
+            input_base,
+            input_stride_1,
+            topk_ids_base,
+            topk_ids_stride_1,
+            zero_ptrs,
+            offs_dim,
+            mask,
+            mask_token,
+            start,
+            TOPK,
+            BLOCK_M,
+        )
+    else:
+        half: tl.constexpr = size // 2
+        left = _tree_reduce_pair(
+            input_ptr,
+            input_base,
+            input_stride_1,
+            topk_ids_base,
+            topk_ids_stride_1,
+            zero_ptrs,
+            offs_dim,
+            mask,
+            mask_token,
+            start,
+            half,
+            TOPK,
+            BLOCK_M,
+        )
+        right = _tree_reduce_pair(
+            input_ptr,
+            input_base,
+            input_stride_1,
+            topk_ids_base,
+            topk_ids_stride_1,
+            zero_ptrs,
+            offs_dim,
+            mask,
+            mask_token,
+            start + half,
+            half,
+            TOPK,
+            BLOCK_M,
+        )
+        return left + right
+
+
+@triton.jit
+def _fused_tree_reduce_kernel(
+    # input: [M, topk, hidden_dim], contiguous
+    input_ptr,
+    input_stride_0,
+    input_stride_1,
+    # topk_ids: [M, topk], -1 means remote
+    topk_ids_ptr,
+    topk_ids_stride_0,
+    topk_ids_stride_1,
+    # zero_buf: [hidden_dim], all zeros
+    zero_buf_ptr,
+    # output: [M, hidden_dim]
+    output_ptr,
+    output_stride_0,
+    # scalars
+    token_num,
+    hidden_dim,
+    routed_scaling_factor,
+    # constexpr
+    E: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """
+    Fused scatter + binary-tree reduce in a single kernel.
+    Zero extra memory: all intermediate results live in registers.
+
+    For each token block, loads expert tiles on-the-fly (with zero-buf redirect
+    for remote experts), and reduces them in binary-tree order using recursive
+    constexpr unrolling. The tree structure is:
+      result = tree_sum(0, E)
+      tree_sum(s, n) = tree_sum(s, n/2) + tree_sum(s+n/2, n/2)   if n > 1
+      tree_sum(s, 1) = load_expert(s)                              base case
+
+    Register pressure: log2(E) tiles of [BLOCK_M, BLOCK_DIM] fp32.
+    E.g. E=64, BLOCK_M=1, BLOCK_DIM=2048 -> 6 * 8KB = 48KB, well within limits.
+    """
+    input_stride_0 = tl.cast(input_stride_0, dtype=tl.int64)
+    input_stride_1 = tl.cast(input_stride_1, dtype=tl.int64)
+    topk_ids_stride_0 = tl.cast(topk_ids_stride_0, dtype=tl.int64)
+    topk_ids_stride_1 = tl.cast(topk_ids_stride_1, dtype=tl.int64)
+    output_stride_0 = tl.cast(output_stride_0, dtype=tl.int64)
+
+    token_block_id = tl.program_id(0)
+    dim_block_id = tl.program_id(1)
+
+    offs_token = token_block_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_dim = dim_block_id * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+
+    mask_token = offs_token < token_num
+    mask_dim = offs_dim < hidden_dim
+    mask = mask_token[:, None] & mask_dim[None, :]
+
+    zero_ptrs = zero_buf_ptr + offs_dim[None, :]
+    input_base = input_ptr + offs_token[:, None] * input_stride_0
+    topk_ids_base = topk_ids_ptr + offs_token * topk_ids_stride_0
+
+    # Binary tree reduce over all E experts, entirely in registers.
+    result = _tree_reduce_pair(
+        input_ptr,
+        input_base,
+        input_stride_1,
+        topk_ids_base,
+        topk_ids_stride_1,
+        zero_ptrs,
+        offs_dim,
+        mask,
+        mask_token,
+        0,
+        E,
+        TOPK,
+        BLOCK_M,
+    )
+
+    result *= routed_scaling_factor
+
+    store_ptrs = output_ptr + offs_token[:, None] * output_stride_0 + offs_dim[None, :]
+    tl.store(store_ptrs, result.to(input_ptr.dtype.element_ty), mask=mask)
+
+
+# Persistent zero buffer: only [hidden_dim] elements, negligible memory.
+# Allocated once on first call, never freed.
+_zero_buf_cache: torch.Tensor | None = None
+
+
+def moe_sum_tree_reduce_v1(
+    input: torch.Tensor,  # [M, topk, hidden_dim]
+    output: torch.Tensor,  # [M, hidden_dim]
+    curr_topk_ids: torch.Tensor,  # [M, topk], -1 means remote
+    routed_scaling_factor: float,
+    E: int,
+):
+    """
+    Fused MoE tree reduce: zero extra memory, CUDA Graph safe.
+
+    Single kernel: loads expert tiles on-the-fly with zero-buf pointer redirect
+    for remote experts (L1 cache hit), reduces in binary-tree order entirely
+    in registers. No scratch buffer needed.
+
+    Invariant guarantee: binary tree reduce order is fixed by expert id,
+    identical across all EP ranks regardless of which experts are local.
+
+    Memory overhead: only a single [hidden_dim] zero buffer (~14KB for H=7168 bf16).
+    """
+    assert input.is_contiguous()
+    assert output.is_contiguous()
+
+    token_num, topk, hidden_dim = input.shape
+    assert output.shape[0] == token_num and output.shape[1] == hidden_dim
+    assert (E & (E - 1)) == 0, f"E must be power of 2, got {E}"
+
+    # Fast path for the dominant K=8 case: avoids generic expert-tree loads/scans.
+    if topk == 8:
+        _moe_sum_tree_reduce_k8_fast_path(
+            input=input,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=routed_scaling_factor,
+            E=E,
+        )
+        return
+
+    # Zero buffer: [hidden_dim], allocated once, reused forever
+    global _zero_buf_cache
+    if (
+        _zero_buf_cache is None
+        or _zero_buf_cache.device != input.device
+        or _zero_buf_cache.dtype != input.dtype
+        or _zero_buf_cache.numel() < hidden_dim
+    ):
+        _zero_buf_cache = torch.zeros(
+            hidden_dim, device=input.device, dtype=input.dtype
+        )
+    zero_buf = _zero_buf_cache
+
+    BLOCK_M = 1
+    BLOCK_DIM = 2048
+    num_warps = 16
+
+    grid = (
+        triton.cdiv(token_num, BLOCK_M),
+        triton.cdiv(hidden_dim, BLOCK_DIM),
+    )
+
+    _fused_tree_reduce_kernel[grid](
+        input,
+        input.stride(0),
+        input.stride(1),
+        curr_topk_ids,
+        curr_topk_ids.stride(0),
+        curr_topk_ids.stride(1),
+        zero_buf,
+        output,
+        output.stride(0),
+        token_num=token_num,
+        hidden_dim=hidden_dim,
+        routed_scaling_factor=routed_scaling_factor,
+        E=E,
+        TOPK=topk,
+        BLOCK_M=BLOCK_M,
+        BLOCK_DIM=BLOCK_DIM,
+        num_warps=num_warps,
+    )
+    return
+
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _moe_sum_tree_reduce_k8_fused_kernel_opt2d(
+    x_ptr,
+    ids_ptr,
+    out_ptr,
+    sx_m: tl.constexpr,
+    sx_k: tl.constexpr,
+    sx_h: tl.constexpr,  # x: [M,8,H]
+    sid_m: tl.constexpr,
+    sid_k: tl.constexpr,  # ids: [M,8]
+    so_m: tl.constexpr,
+    so_h: tl.constexpr,  # out: [M,H]
+    M,
+    H,  # runtime OK
+    E_LEVEL,  # runtime int (log2(E))
+    routed_scaling_factor,  # runtime scalar
+    BLOCK_M: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+
+    mask_m = m < M
+    mask_h = h < H
+    mask_mh = mask_m[:, None] & mask_h[None, :]
+
+    # ---- load ids (int32), -1 means remote ----
+    ids0 = tl.load(ids_ptr + m * sid_m + 0 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids1 = tl.load(ids_ptr + m * sid_m + 1 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids2 = tl.load(ids_ptr + m * sid_m + 2 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids3 = tl.load(ids_ptr + m * sid_m + 3 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids4 = tl.load(ids_ptr + m * sid_m + 4 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids5 = tl.load(ids_ptr + m * sid_m + 5 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids6 = tl.load(ids_ptr + m * sid_m + 6 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids7 = tl.load(ids_ptr + m * sid_m + 7 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+
+    # h comes from tl.arange and can be annotated for alignment.
+    tl.multiple_of(h, 8)
+    tl.max_contiguous(h, BLOCK_H)
+
+    # m is also a tensor.
+    tl.multiple_of(m, BLOCK_M)
+
+    # ---- load values: remote handled by mask->other=0 (NO zero_tile / NO tl.where big tiles) ----
+    m0 = mask_mh & (ids0 != -1)[:, None]
+    m1 = mask_mh & (ids1 != -1)[:, None]
+    m2 = mask_mh & (ids2 != -1)[:, None]
+    m3 = mask_mh & (ids3 != -1)[:, None]
+    m4 = mask_mh & (ids4 != -1)[:, None]
+    m5 = mask_mh & (ids5 != -1)[:, None]
+    m6 = mask_mh & (ids6 != -1)[:, None]
+    m7 = mask_mh & (ids7 != -1)[:, None]
+
+    v0 = tl.load(
+        x_ptr + m[:, None] * sx_m + 0 * sx_k + h[None, :] * sx_h, mask=m0, other=0.0
+    )
+    v1 = tl.load(
+        x_ptr + m[:, None] * sx_m + 1 * sx_k + h[None, :] * sx_h, mask=m1, other=0.0
+    )
+    v2 = tl.load(
+        x_ptr + m[:, None] * sx_m + 2 * sx_k + h[None, :] * sx_h, mask=m2, other=0.0
+    )
+    v3 = tl.load(
+        x_ptr + m[:, None] * sx_m + 3 * sx_k + h[None, :] * sx_h, mask=m3, other=0.0
+    )
+    v4 = tl.load(
+        x_ptr + m[:, None] * sx_m + 4 * sx_k + h[None, :] * sx_h, mask=m4, other=0.0
+    )
+    v5 = tl.load(
+        x_ptr + m[:, None] * sx_m + 5 * sx_k + h[None, :] * sx_h, mask=m5, other=0.0
+    )
+    v6 = tl.load(
+        x_ptr + m[:, None] * sx_m + 6 * sx_k + h[None, :] * sx_h, mask=m6, other=0.0
+    )
+    v7 = tl.load(
+        x_ptr + m[:, None] * sx_m + 7 * sx_k + h[None, :] * sx_h, mask=m7, other=0.0
+    )
+
+    x_dtype = x_ptr.dtype.element_ty
+
+    # ---- deterministic dense-tree-equivalent reduce (same order concept as baseline) ----
+    # Remote entries have already been masked to 0.0 at load time (m0..m7).
+
+    for bit in tl.range(0, E_LEVEL):
+        bitmask = 1 << bit
+
+        # ========== lane0 as source ==========
+        cond = (ids0 != -1) & ((ids0 & bitmask) != 0)
+        target = ids0 ^ bitmask
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm1 | mm2 | mm3 | mm4 | mm5 | mm6 | mm7
+
+        src = v0.to(tl.float32)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v0 = tl.where(hit[:, None], 0.0, v0)
+        ids0 = tl.where(hit, -1, ids0)
+        ids0 = tl.where(cond & (~hit), target, ids0)
+
+        # ========== lane1 as source ==========
+        cond = (ids1 != -1) & ((ids1 & bitmask) != 0)
+        target = ids1 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm2 | mm3 | mm4 | mm5 | mm6 | mm7
+
+        src = v1.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v1 = tl.where(hit[:, None], 0.0, v1)
+        ids1 = tl.where(hit, -1, ids1)
+        ids1 = tl.where(cond & (~hit), target, ids1)
+
+        # ========== lane2 as source ==========
+        cond = (ids2 != -1) & ((ids2 & bitmask) != 0)
+        target = ids2 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm1 | mm3 | mm4 | mm5 | mm6 | mm7
+
+        src = v2.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v2 = tl.where(hit[:, None], 0.0, v2)
+        ids2 = tl.where(hit, -1, ids2)
+        ids2 = tl.where(cond & (~hit), target, ids2)
+
+        # ========== lane3 as source ==========
+        cond = (ids3 != -1) & ((ids3 & bitmask) != 0)
+        target = ids3 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm1 | mm2 | mm4 | mm5 | mm6 | mm7
+
+        src = v3.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v3 = tl.where(hit[:, None], 0.0, v3)
+        ids3 = tl.where(hit, -1, ids3)
+        ids3 = tl.where(cond & (~hit), target, ids3)
+
+        # ========== lane4 as source ==========
+        cond = (ids4 != -1) & ((ids4 & bitmask) != 0)
+        target = ids4 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm1 | mm2 | mm3 | mm5 | mm6 | mm7
+
+        src = v4.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v4 = tl.where(hit[:, None], 0.0, v4)
+        ids4 = tl.where(hit, -1, ids4)
+        ids4 = tl.where(cond & (~hit), target, ids4)
+
+        # ========== lane5 as source ==========
+        cond = (ids5 != -1) & ((ids5 & bitmask) != 0)
+        target = ids5 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm6 = cond & (ids6 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm1 | mm2 | mm3 | mm4 | mm6 | mm7
+
+        src = v5.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v5 = tl.where(hit[:, None], 0.0, v5)
+        ids5 = tl.where(hit, -1, ids5)
+        ids5 = tl.where(cond & (~hit), target, ids5)
+
+        # ========== lane6 as source ==========
+        cond = (ids6 != -1) & ((ids6 & bitmask) != 0)
+        target = ids6 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm7 = cond & (ids7 == target)
+        hit = mm0 | mm1 | mm2 | mm3 | mm4 | mm5 | mm7
+
+        src = v6.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v7 = tl.where(mm7[:, None], (v7.to(tl.float32) + src).to(x_dtype), v7)
+
+        v6 = tl.where(hit[:, None], 0.0, v6)
+        ids6 = tl.where(hit, -1, ids6)
+        ids6 = tl.where(cond & (~hit), target, ids6)
+
+        # ========== lane7 as source ==========
+        cond = (ids7 != -1) & ((ids7 & bitmask) != 0)
+        target = ids7 ^ bitmask
+        mm0 = cond & (ids0 == target)
+        mm1 = cond & (ids1 == target)
+        mm2 = cond & (ids2 == target)
+        mm3 = cond & (ids3 == target)
+        mm4 = cond & (ids4 == target)
+        mm5 = cond & (ids5 == target)
+        mm6 = cond & (ids6 == target)
+        hit = mm0 | mm1 | mm2 | mm3 | mm4 | mm5 | mm6
+
+        src = v7.to(tl.float32)
+        v0 = tl.where(mm0[:, None], (v0.to(tl.float32) + src).to(x_dtype), v0)
+        v1 = tl.where(mm1[:, None], (v1.to(tl.float32) + src).to(x_dtype), v1)
+        v2 = tl.where(mm2[:, None], (v2.to(tl.float32) + src).to(x_dtype), v2)
+        v3 = tl.where(mm3[:, None], (v3.to(tl.float32) + src).to(x_dtype), v3)
+        v4 = tl.where(mm4[:, None], (v4.to(tl.float32) + src).to(x_dtype), v4)
+        v5 = tl.where(mm5[:, None], (v5.to(tl.float32) + src).to(x_dtype), v5)
+        v6 = tl.where(mm6[:, None], (v6.to(tl.float32) + src).to(x_dtype), v6)
+
+        v7 = tl.where(hit[:, None], 0.0, v7)
+        ids7 = tl.where(hit, -1, ids7)
+        ids7 = tl.where(cond & (~hit), target, ids7)
+
+    # ---- final: since ids unique per token, bucket0 is unique; compute directly in fp32 (no out_tile chain) ----
+    acc = tl.zeros((BLOCK_M, BLOCK_H), dtype=tl.float32)
+    acc += tl.where((ids0 == 0)[:, None], v0.to(tl.float32), 0.0)
+    acc += tl.where((ids1 == 0)[:, None], v1.to(tl.float32), 0.0)
+    acc += tl.where((ids2 == 0)[:, None], v2.to(tl.float32), 0.0)
+    acc += tl.where((ids3 == 0)[:, None], v3.to(tl.float32), 0.0)
+    acc += tl.where((ids4 == 0)[:, None], v4.to(tl.float32), 0.0)
+    acc += tl.where((ids5 == 0)[:, None], v5.to(tl.float32), 0.0)
+    acc += tl.where((ids6 == 0)[:, None], v6.to(tl.float32), 0.0)
+    acc += tl.where((ids7 == 0)[:, None], v7.to(tl.float32), 0.0)
+
+    acc *= routed_scaling_factor
+
+    out_ptrs = out_ptr + m[:, None] * so_m + h[None, :] * so_h
+    tl.store(out_ptrs, acc.to(out_ptr.dtype.element_ty), mask=mask_mh)
+
+
+def _moe_sum_tree_reduce_k8_fast_path(
+    input: torch.Tensor,  # [M, 8, H]
+    output: torch.Tensor,  # [M, H]
+    curr_topk_ids: torch.Tensor,  # [M, 8], -1 means remote
+    routed_scaling_factor: float,
+    E: int,
+):
+    assert input.is_contiguous()
+    assert output.is_contiguous()
+    assert curr_topk_ids.is_contiguous()
+    M, K, H = input.shape
+    assert K == 8
+    assert output.shape == (M, H)
+    assert (E & (E - 1)) == 0
+
+    E_LEVEL = int(math.log2(E))
+
+    # K=8 specialization: use wider H tiles for better memory throughput.
+    if H >= 4096:
+        BLOCK_M = 8
+        BLOCK_H = 128
+        num_warps = 4
+    elif H >= 2048:
+        BLOCK_M = 8
+        BLOCK_H = 256
+        num_warps = 8
+    else:
+        BLOCK_M = 8
+        BLOCK_H = 128
+        num_warps = 4
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(H, BLOCK_H))
+    _moe_sum_tree_reduce_k8_fused_kernel_opt2d[grid](
+        input,
+        curr_topk_ids,
+        output,
+        input.stride(0),
+        input.stride(1),
+        input.stride(2),
+        curr_topk_ids.stride(0),
+        curr_topk_ids.stride(1),
+        output.stride(0),
+        output.stride(1),
+        M,
+        H,
+        E_LEVEL,
+        routed_scaling_factor,
+        BLOCK_M=BLOCK_M,
+        BLOCK_H=BLOCK_H,
+        num_warps=num_warps,
+    )
+    return output
+
+
+@triton.jit
+def _moe_sum_tree_reduce_topk16_sparse_kernel(
+    x_ptr,
+    ids_ptr,
+    out_ptr,
+    sx_m,
+    sx_k,
+    sx_h,  # x: [M, K, H]
+    sid_m,
+    sid_k,  # ids: [M, K]
+    so_m,
+    so_h,  # out: [M, H]
+    M,
+    K,
+    H,  # runtime
+    E_LEVEL,  # log2(E)
+    routed_scaling_factor,
+    BLOCK_H: tl.constexpr,
+    MAX_TOPK: tl.constexpr,  # fixed compile-time capacity, e.g. 16
+):
+    # One program handles one token + one hidden tile.
+    pid_m = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    m = pid_m
+    h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+
+    mask_m = m < M
+    mask_h = h < H
+    mask_mh = mask_m & mask_h
+
+    slot = tl.arange(0, MAX_TOPK)
+    in_k = slot < K
+
+    ids = tl.load(
+        ids_ptr + m * sid_m + slot * sid_k, mask=(mask_m & in_k), other=-1
+    ).to(tl.int32)
+    valid = (ids != -1) & in_k & mask_m
+
+    vals = tl.zeros((MAX_TOPK, BLOCK_H), dtype=tl.float32)
+    for s in range(MAX_TOPK):
+        vmask = mask_h & valid[s]
+        v = tl.load(
+            x_ptr + m * sx_m + s * sx_k + h * sx_h,
+            mask=vmask,
+            other=0.0,
+        ).to(tl.float32)
+        vals = tl.where((slot == s)[:, None], v[None, :], vals)
+
+    idx = tl.arange(0, MAX_TOPK)
+    for bit in tl.range(0, E_LEVEL):
+        bitmask = 1 << bit
+
+        for s in range(MAX_TOPK):
+            id_s = ids[s]
+            cond = (id_s != -1) & ((id_s & bitmask) != 0)
+            target = id_s ^ bitmask
+
+            match = (ids == target) & (idx != s)
+            # 1-based index; 0 means no match.
+            match_pos1 = tl.max(tl.where(match, idx + 1, 0))
+            has = match_pos1 > 0
+            j = match_pos1 - 1
+
+            src = vals[s, :]
+            hit_mask = idx == j
+            vals = vals + tl.where(hit_mask[:, None] & has, src[None, :], 0.0)
+            vals = tl.where((idx == s)[:, None] & has, 0.0, vals)
+            ids = tl.where((idx == s) & has, -1, ids)
+
+            # No partner found at this level: update bucket id only.
+            ids = tl.where((idx == s) & cond & (~has), target, ids)
+
+    acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    for s in range(MAX_TOPK):
+        acc += tl.where(ids[s] == 0, vals[s, :], 0.0)
+
+    acc *= routed_scaling_factor
+    tl.store(
+        out_ptr + m * so_m + h * so_h, acc.to(out_ptr.dtype.element_ty), mask=mask_mh
+    )
+
+
+def moe_sum_tree_reduce_v1_topk_sparse16(
+    input: torch.Tensor,  # [M, K, H]
+    output: torch.Tensor,  # [M, H]
+    curr_topk_ids: torch.Tensor,  # [M, K], -1 means remote
+    routed_scaling_factor: float,
+    E: int,
+    max_topk: int = 16,
+):
+    """
+    Supplemental kernel path for topk != 8:
+    - optimized for small topk (<=16)
+    - keeps deterministic tree-equivalent reduction semantics
+    - does not replace existing v1 entrypoint automatically
+    """
+    assert input.is_contiguous()
+    assert output.is_contiguous()
+    assert curr_topk_ids.is_contiguous()
+    M, K, H = input.shape
+    assert output.shape == (M, H)
+    assert K <= max_topk, f"K={K} > max_topk={max_topk}"
+    assert (E & (E - 1)) == 0, "E must be power of 2"
+
+    E_LEVEL = int(math.log2(E))
+    BLOCK_H = 128 if H >= 4096 else 256
+    num_warps = 4 if BLOCK_H == 128 else 8
+
+    grid = (M, triton.cdiv(H, BLOCK_H))
+    _moe_sum_tree_reduce_topk16_sparse_kernel[grid](
+        input,
+        curr_topk_ids,
+        output,
+        input.stride(0),
+        input.stride(1),
+        input.stride(2),
+        curr_topk_ids.stride(0),
+        curr_topk_ids.stride(1),
+        output.stride(0),
+        output.stride(1),
+        M,
+        K,
+        H,
+        E_LEVEL,
+        routed_scaling_factor,
+        BLOCK_H=BLOCK_H,
+        MAX_TOPK=max_topk,
+        num_warps=num_warps,
+    )
+    return output
+
+
+def moe_sum_tree_reduce_v0(
+    input: torch.Tensor,  # [M, 8, H]
+    output: torch.Tensor,  # [M, H]
+    curr_topk_ids: torch.Tensor,  # [M, 8], -1 means remote
+    routed_scaling_factor: float,
+    E: int,
+):
+    # Backward-compatible alias.
+    return _moe_sum_tree_reduce_k8_fast_path(
+        input=input,
+        output=output,
+        curr_topk_ids=curr_topk_ids,
+        routed_scaling_factor=routed_scaling_factor,
+        E=E,
+    )
+
+
+@triton.jit
+def _moe_tree_reduce_sparse_k8_kernel(
+    x_ptr,
+    ids_ptr,
+    out_ptr,
+    sx_m: tl.constexpr,
+    sx_k: tl.constexpr,
+    sx_h: tl.constexpr,
+    sid_m: tl.constexpr,
+    sid_k: tl.constexpr,
+    so_m: tl.constexpr,
+    so_h: tl.constexpr,
+    M,
+    H,
+    routed_scaling_factor,
+    LOGE,  # runtime: tl.range does not unroll
+    CAST_MODE: tl.constexpr,  # 0: per-level bf16 round, 1: no intermediate cast
+    BLOCK_M: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+
+    tl.multiple_of(m, BLOCK_M)
+    tl.multiple_of(h, 8)
+    tl.max_contiguous(h, BLOCK_H)
+
+    mask_m = m < M
+    mask_h = h < H
+    mask_mh = mask_m[:, None] & mask_h[None, :]
+
+    x_ty = x_ptr.dtype.element_ty
+    NEG2 = -2  # sentinel: topk_ids cannot be -2
+
+    # ---- ids ----
+    ids0 = tl.load(ids_ptr + m * sid_m + 0 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids1 = tl.load(ids_ptr + m * sid_m + 1 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids2 = tl.load(ids_ptr + m * sid_m + 2 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids3 = tl.load(ids_ptr + m * sid_m + 3 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids4 = tl.load(ids_ptr + m * sid_m + 4 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids5 = tl.load(ids_ptr + m * sid_m + 5 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids6 = tl.load(ids_ptr + m * sid_m + 6 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+    ids7 = tl.load(ids_ptr + m * sid_m + 7 * sid_k, mask=mask_m, other=-1).to(tl.int32)
+
+    # ---- vals: load -> fp32 ----
+    f0 = tl.load(
+        x_ptr + m[:, None] * sx_m + 0 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids0 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f1 = tl.load(
+        x_ptr + m[:, None] * sx_m + 1 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids1 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f2 = tl.load(
+        x_ptr + m[:, None] * sx_m + 2 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids2 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f3 = tl.load(
+        x_ptr + m[:, None] * sx_m + 3 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids3 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f4 = tl.load(
+        x_ptr + m[:, None] * sx_m + 4 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids4 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f5 = tl.load(
+        x_ptr + m[:, None] * sx_m + 5 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids5 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f6 = tl.load(
+        x_ptr + m[:, None] * sx_m + 6 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids6 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    f7 = tl.load(
+        x_ptr + m[:, None] * sx_m + 7 * sx_k + h[None, :] * sx_h,
+        mask=mask_mh & (ids7 != -1)[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    # ---- main: runtime loop ----
+    for bit in tl.range(0, LOGE):
+        bitmask = 1 << bit
+
+        # snapshot ids for matching (critical!)
+        a0, a1, a2, a3, a4, a5, a6, a7 = ids0, ids1, ids2, ids3, ids4, ids5, ids6, ids7
+
+        # ---------------- s0 ----------------
+        c0 = (a0 != -1) & ((a0 & bitmask) != 0)
+        t0 = tl.where(c0, a0 ^ bitmask, NEG2)
+        m01 = a1 == t0
+        m02 = a2 == t0
+        m03 = a3 == t0
+        m04 = a4 == t0
+        m05 = a5 == t0
+        m06 = a6 == t0
+        m07 = a7 == t0
+        hit0 = m01 | m02 | m03 | m04 | m05 | m06 | m07
+        src = f0
+        f1 = tl.where(m01[:, None], f1 + src, f1)
+        f2 = tl.where(m02[:, None], f2 + src, f2)
+        f3 = tl.where(m03[:, None], f3 + src, f3)
+        f4 = tl.where(m04[:, None], f4 + src, f4)
+        f5 = tl.where(m05[:, None], f5 + src, f5)
+        f6 = tl.where(m06[:, None], f6 + src, f6)
+        f7 = tl.where(m07[:, None], f7 + src, f7)
+        f0 = tl.where(hit0[:, None], 0.0, f0)
+        ids0 = tl.where(c0, tl.where(hit0, -1, t0), ids0)
+
+        # ---------------- s1 ----------------
+        c1 = (a1 != -1) & ((a1 & bitmask) != 0)
+        t1 = tl.where(c1, a1 ^ bitmask, NEG2)
+        m10 = a0 == t1
+        m12 = a2 == t1
+        m13 = a3 == t1
+        m14 = a4 == t1
+        m15 = a5 == t1
+        m16 = a6 == t1
+        m17 = a7 == t1
+        hit1 = m10 | m12 | m13 | m14 | m15 | m16 | m17
+        src = f1
+        f0 = tl.where(m10[:, None], f0 + src, f0)
+        f2 = tl.where(m12[:, None], f2 + src, f2)
+        f3 = tl.where(m13[:, None], f3 + src, f3)
+        f4 = tl.where(m14[:, None], f4 + src, f4)
+        f5 = tl.where(m15[:, None], f5 + src, f5)
+        f6 = tl.where(m16[:, None], f6 + src, f6)
+        f7 = tl.where(m17[:, None], f7 + src, f7)
+        f1 = tl.where(hit1[:, None], 0.0, f1)
+        ids1 = tl.where(c1, tl.where(hit1, -1, t1), ids1)
+
+        # ---------------- s2 ----------------
+        c2 = (a2 != -1) & ((a2 & bitmask) != 0)
+        t2 = tl.where(c2, a2 ^ bitmask, NEG2)
+        m20 = a0 == t2
+        m21 = a1 == t2
+        m23 = a3 == t2
+        m24 = a4 == t2
+        m25 = a5 == t2
+        m26 = a6 == t2
+        m27 = a7 == t2
+        hit2 = m20 | m21 | m23 | m24 | m25 | m26 | m27
+        src = f2
+        f0 = tl.where(m20[:, None], f0 + src, f0)
+        f1 = tl.where(m21[:, None], f1 + src, f1)
+        f3 = tl.where(m23[:, None], f3 + src, f3)
+        f4 = tl.where(m24[:, None], f4 + src, f4)
+        f5 = tl.where(m25[:, None], f5 + src, f5)
+        f6 = tl.where(m26[:, None], f6 + src, f6)
+        f7 = tl.where(m27[:, None], f7 + src, f7)
+        f2 = tl.where(hit2[:, None], 0.0, f2)
+        ids2 = tl.where(c2, tl.where(hit2, -1, t2), ids2)
+
+        # ---------------- s3 ----------------
+        c3 = (a3 != -1) & ((a3 & bitmask) != 0)
+        t3 = tl.where(c3, a3 ^ bitmask, NEG2)
+        m30 = a0 == t3
+        m31 = a1 == t3
+        m32 = a2 == t3
+        m34 = a4 == t3
+        m35 = a5 == t3
+        m36 = a6 == t3
+        m37 = a7 == t3
+        hit3 = m30 | m31 | m32 | m34 | m35 | m36 | m37
+        src = f3
+        f0 = tl.where(m30[:, None], f0 + src, f0)
+        f1 = tl.where(m31[:, None], f1 + src, f1)
+        f2 = tl.where(m32[:, None], f2 + src, f2)
+        f4 = tl.where(m34[:, None], f4 + src, f4)
+        f5 = tl.where(m35[:, None], f5 + src, f5)
+        f6 = tl.where(m36[:, None], f6 + src, f6)
+        f7 = tl.where(m37[:, None], f7 + src, f7)
+        f3 = tl.where(hit3[:, None], 0.0, f3)
+        ids3 = tl.where(c3, tl.where(hit3, -1, t3), ids3)
+
+        # ---------------- s4 ----------------
+        c4 = (a4 != -1) & ((a4 & bitmask) != 0)
+        t4 = tl.where(c4, a4 ^ bitmask, NEG2)
+        m40 = a0 == t4
+        m41 = a1 == t4
+        m42 = a2 == t4
+        m43 = a3 == t4
+        m45 = a5 == t4
+        m46 = a6 == t4
+        m47 = a7 == t4
+        hit4 = m40 | m41 | m42 | m43 | m45 | m46 | m47
+        src = f4
+        f0 = tl.where(m40[:, None], f0 + src, f0)
+        f1 = tl.where(m41[:, None], f1 + src, f1)
+        f2 = tl.where(m42[:, None], f2 + src, f2)
+        f3 = tl.where(m43[:, None], f3 + src, f3)
+        f5 = tl.where(m45[:, None], f5 + src, f5)
+        f6 = tl.where(m46[:, None], f6 + src, f6)
+        f7 = tl.where(m47[:, None], f7 + src, f7)
+        f4 = tl.where(hit4[:, None], 0.0, f4)
+        ids4 = tl.where(c4, tl.where(hit4, -1, t4), ids4)
+
+        # ---------------- s5 ----------------
+        c5 = (a5 != -1) & ((a5 & bitmask) != 0)
+        t5 = tl.where(c5, a5 ^ bitmask, NEG2)
+        m50 = a0 == t5
+        m51 = a1 == t5
+        m52 = a2 == t5
+        m53 = a3 == t5
+        m54 = a4 == t5
+        m56 = a6 == t5
+        m57 = a7 == t5
+        hit5 = m50 | m51 | m52 | m53 | m54 | m56 | m57
+        src = f5
+        f0 = tl.where(m50[:, None], f0 + src, f0)
+        f1 = tl.where(m51[:, None], f1 + src, f1)
+        f2 = tl.where(m52[:, None], f2 + src, f2)
+        f3 = tl.where(m53[:, None], f3 + src, f3)
+        f4 = tl.where(m54[:, None], f4 + src, f4)
+        f6 = tl.where(m56[:, None], f6 + src, f6)
+        f7 = tl.where(m57[:, None], f7 + src, f7)
+        f5 = tl.where(hit5[:, None], 0.0, f5)
+        ids5 = tl.where(c5, tl.where(hit5, -1, t5), ids5)
+
+        # ---------------- s6 ----------------
+        c6 = (a6 != -1) & ((a6 & bitmask) != 0)
+        t6 = tl.where(c6, a6 ^ bitmask, NEG2)
+        m60 = a0 == t6
+        m61 = a1 == t6
+        m62 = a2 == t6
+        m63 = a3 == t6
+        m64 = a4 == t6
+        m65 = a5 == t6
+        m67 = a7 == t6
+        hit6 = m60 | m61 | m62 | m63 | m64 | m65 | m67
+        src = f6
+        f0 = tl.where(m60[:, None], f0 + src, f0)
+        f1 = tl.where(m61[:, None], f1 + src, f1)
+        f2 = tl.where(m62[:, None], f2 + src, f2)
+        f3 = tl.where(m63[:, None], f3 + src, f3)
+        f4 = tl.where(m64[:, None], f4 + src, f4)
+        f5 = tl.where(m65[:, None], f5 + src, f5)
+        f7 = tl.where(m67[:, None], f7 + src, f7)
+        f6 = tl.where(hit6[:, None], 0.0, f6)
+        ids6 = tl.where(c6, tl.where(hit6, -1, t6), ids6)
+
+        # ---------------- s7 ----------------
+        c7 = (a7 != -1) & ((a7 & bitmask) != 0)
+        t7 = tl.where(c7, a7 ^ bitmask, NEG2)
+        m70 = a0 == t7
+        m71 = a1 == t7
+        m72 = a2 == t7
+        m73 = a3 == t7
+        m74 = a4 == t7
+        m75 = a5 == t7
+        m76 = a6 == t7
+        hit7 = m70 | m71 | m72 | m73 | m74 | m75 | m76
+        src = f7
+        f0 = tl.where(m70[:, None], f0 + src, f0)
+        f1 = tl.where(m71[:, None], f1 + src, f1)
+        f2 = tl.where(m72[:, None], f2 + src, f2)
+        f3 = tl.where(m73[:, None], f3 + src, f3)
+        f4 = tl.where(m74[:, None], f4 + src, f4)
+        f5 = tl.where(m75[:, None], f5 + src, f5)
+        f6 = tl.where(m76[:, None], f6 + src, f6)
+        f7 = tl.where(hit7[:, None], 0.0, f7)
+        ids7 = tl.where(c7, tl.where(hit7, -1, t7), ids7)
+
+        # ---- per-level bf16 rounding (optional) ----
+        if CAST_MODE == 0:
+            # emulate "store bf16 per level then reload": round once per level
+            f0 = f0.to(x_ty).to(tl.float32)
+            f1 = f1.to(x_ty).to(tl.float32)
+            f2 = f2.to(x_ty).to(tl.float32)
+            f3 = f3.to(x_ty).to(tl.float32)
+            f4 = f4.to(x_ty).to(tl.float32)
+            f5 = f5.to(x_ty).to(tl.float32)
+            f6 = f6.to(x_ty).to(tl.float32)
+            f7 = f7.to(x_ty).to(tl.float32)
+
+    # ---- gather root (id==0) ----
+    acc = tl.zeros((BLOCK_M, BLOCK_H), dtype=tl.float32)
+    acc += tl.where((ids0 == 0)[:, None], f0, 0.0)
+    acc += tl.where((ids1 == 0)[:, None], f1, 0.0)
+    acc += tl.where((ids2 == 0)[:, None], f2, 0.0)
+    acc += tl.where((ids3 == 0)[:, None], f3, 0.0)
+    acc += tl.where((ids4 == 0)[:, None], f4, 0.0)
+    acc += tl.where((ids5 == 0)[:, None], f5, 0.0)
+    acc += tl.where((ids6 == 0)[:, None], f6, 0.0)
+    acc += tl.where((ids7 == 0)[:, None], f7, 0.0)
+
+    acc *= routed_scaling_factor
+
+    out_ptrs = out_ptr + m[:, None] * so_m + h[None, :] * so_h
+    tl.store(out_ptrs, acc.to(out_ptr.dtype.element_ty), mask=mask_mh)
+
+
+def _launch_sparse_tree_k8_k10(
+    input: torch.Tensor,  # [M, K, H], bf16 contiguous
+    output: torch.Tensor,  # [M, H], bf16 contiguous
+    curr_topk_ids: torch.Tensor,  # [M, K], int32/int64 contiguous, -1 remote
+    routed_scaling_factor: float,
+    E: int,
+    cast_mode: int = 1,  # <-- you asked for "last cast" version, so default = 1
+):
+    assert (
+        input.is_contiguous()
+        and output.is_contiguous()
+        and curr_topk_ids.is_contiguous()
+    )
+    M, K, H = input.shape
+    assert output.shape == (M, H)
+    assert K in (8, 10)
+    assert (E & (E - 1)) == 0
+    LOGE = int(math.log2(E))
+
+    # stable params for CUDA Graph
+    BLOCK_M = 8
+    BLOCK_H = 256
+    num_warps = 8
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(H, BLOCK_H))
+
+    # NOTE: for strict CUDA Graph safety, avoid dtype conversion here.
+    # Please ensure curr_topk_ids is int32 upstream.
+    assert (
+        curr_topk_ids.dtype == torch.int32
+    ), "make ids int32 upstream for CUDA Graph stability"
+
+    if K == 8:
+        _moe_tree_reduce_sparse_k8_kernel[grid](
+            input,
+            curr_topk_ids,
+            output,
+            input.stride(0),
+            input.stride(1),
+            input.stride(2),
+            curr_topk_ids.stride(0),
+            curr_topk_ids.stride(1),
+            output.stride(0),
+            output.stride(1),
+            M,
+            H,
+            routed_scaling_factor,
+            LOGE=LOGE,
+            CAST_MODE=cast_mode,
+            BLOCK_M=BLOCK_M,
+            BLOCK_H=BLOCK_H,
+            num_warps=num_warps,
+        )
+
+
+def moe_sum_tree_reduce_v2(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    curr_topk_ids: torch.Tensor,
+    routed_scaling_factor: float,
+    E: int,
+    *,
+    cast_mode: int = 0,  # default to "last cast" as requested
+):
+    assert (
+        input.is_contiguous()
+        and output.is_contiguous()
+        and curr_topk_ids.is_contiguous()
+    )
+    M, K, H = input.shape
+    if M == 0:
+        return output
+    if K in (8, 10):
+        _launch_sparse_tree_k8_k10(
+            input=input,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=routed_scaling_factor,
+            E=E,
+            cast_mode=cast_mode,
+        )
+        return output
+
+    # fallback: keep your existing generic path here
+    return output
+
+
+def moe_sum_tree_reduce(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    curr_topk_ids: torch.Tensor,
+    routed_scaling_factor: float,
+    E: int,
+):
+    curr_topk_ids = curr_topk_ids.to(torch.int32)
+    if os.environ.get("SGLANG_MOE_TREE_REDUCE_USE_V2", "0") == "1":
+        return moe_sum_tree_reduce_v2(
+            input=input,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=routed_scaling_factor,
+            E=E,
+        )
+
+    if input.shape[1] == 8:
+        return moe_sum_tree_reduce_v0(
+            input=input,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=routed_scaling_factor,
+            E=E,
+        )
+    return moe_sum_tree_reduce_v1(
+        input=input,
+        output=output,
+        curr_topk_ids=curr_topk_ids,
+        routed_scaling_factor=routed_scaling_factor,
+        E=E,
+    )
+
+
+# if os.getenv("MOE_SUM_OPTIM", "0") == "1":
+#     moe_sum_tree_reduce = moe_sum_tree_reduce_optim
+#     print("using optimized moe_sum_tree_reduce_optim")
+# else:
+#     print("using original moe_sum_tree_reduce_original")
+
+if os.getenv("TREE_ALL_REDUCE_OPTIM", "0") == "1":
+    tree_all_reduce_sum = tree_all_reduce_sum_optim

--- a/python/sglang/srt/true_on_policy/__init__.py
+++ b/python/sglang/srt/true_on_policy/__init__.py
@@ -1,0 +1,49 @@
+"""True-on-policy runtime contract helpers."""
+
+from .config import (
+    ROW_LINEAR_INV_BLOCK_K,
+    get_on_policy_rms_norm_kwargs,
+    get_rl_on_policy_target,
+    is_tp_invariant_target,
+    is_true_on_policy_enabled,
+    patch_prefill_only_deterministic_inference_for_cuda_graph,
+    should_disable_flashinfer_allreduce_fusion,
+    should_disable_fused_qk_norm_mrope,
+    should_disable_mlp_allreduce_fusion_for_on_policy,
+    should_disable_reduce_scatter_for_on_policy,
+    should_force_bfloat16_dense_tensor_math,
+    should_force_bfloat16_lm_head,
+    should_use_tp_invariant_row_linear,
+    should_use_tp_invariant_tree_all_reduce,
+)
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    SGLangTrueOnPolicyContract,
+    SGLangTrueOnPolicyRuntimePolicy,
+    get_true_on_policy_contract,
+    resolve_true_on_policy_runtime_policy,
+    validate_true_on_policy_contract,
+)
+
+__all__ = [
+    "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "ROW_LINEAR_INV_BLOCK_K",
+    "SGLangTrueOnPolicyContract",
+    "SGLangTrueOnPolicyRuntimePolicy",
+    "get_true_on_policy_contract",
+    "get_on_policy_rms_norm_kwargs",
+    "get_rl_on_policy_target",
+    "is_tp_invariant_target",
+    "is_true_on_policy_enabled",
+    "patch_prefill_only_deterministic_inference_for_cuda_graph",
+    "resolve_true_on_policy_runtime_policy",
+    "validate_true_on_policy_contract",
+    "should_disable_flashinfer_allreduce_fusion",
+    "should_disable_fused_qk_norm_mrope",
+    "should_disable_mlp_allreduce_fusion_for_on_policy",
+    "should_disable_reduce_scatter_for_on_policy",
+    "should_force_bfloat16_dense_tensor_math",
+    "should_force_bfloat16_lm_head",
+    "should_use_tp_invariant_row_linear",
+    "should_use_tp_invariant_tree_all_reduce",
+]

--- a/python/sglang/srt/true_on_policy/config.py
+++ b/python/sglang/srt/true_on_policy/config.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterator, Optional
+
+import torch
+
+from sglang.srt.true_on_policy.contracts import resolve_true_on_policy_runtime_policy
+
+ROW_LINEAR_INV_BLOCK_K = 128
+
+
+def _get_global_server_args() -> Any:
+    from sglang.srt.runtime_context import get_server_args
+
+    return get_server_args()
+
+
+def get_rl_on_policy_target() -> Optional[str]:
+    return getattr(_get_global_server_args(), "rl_on_policy_target", None)
+
+
+def is_true_on_policy_enabled() -> bool:
+    return resolve_true_on_policy_runtime_policy(_get_global_server_args()).enabled
+
+
+def is_tp_invariant_target() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).tp_invariant_row_linear
+
+
+def should_disable_reduce_scatter_for_on_policy() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).disable_reduce_scatter
+
+
+def should_disable_mlp_allreduce_fusion_for_on_policy() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).disable_mlp_allreduce_fusion
+
+
+def should_disable_flashinfer_allreduce_fusion() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).disable_flashinfer_allreduce_fusion
+
+
+def should_force_bfloat16_dense_tensor_math() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).force_bfloat16_dense_tensor_math
+
+
+def should_force_bfloat16_lm_head(
+    *,
+    use_fp32_lm_head: bool = False,
+) -> bool:
+    return (
+        resolve_true_on_policy_runtime_policy(
+            _get_global_server_args()
+        ).force_bfloat16_lm_head
+        and not use_fp32_lm_head
+    )
+
+
+def should_disable_fused_qk_norm_mrope() -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).disable_fused_qk_norm_mrope
+
+
+def get_on_policy_rms_norm_kwargs(
+    *,
+    weight_dtype: Optional[torch.dtype] = None,
+    override_orig_dtype: Optional[torch.dtype] = None,
+    fp32_residual: bool = False,
+) -> dict[str, Any]:
+    if not is_true_on_policy_enabled():
+        return {}
+
+    kwargs: dict[str, Any] = {
+        "cast_x_before_out_mul": True,
+        "fp32_residual": fp32_residual,
+    }
+    if weight_dtype is not None:
+        kwargs["weight_dtype"] = weight_dtype
+    if override_orig_dtype is not None:
+        kwargs["override_orig_dtype"] = override_orig_dtype
+    return kwargs
+
+
+def should_use_tp_invariant_row_linear(
+    k_size: int,
+    row_linear_enable_inv: Optional[bool] = None,
+) -> bool:
+    policy_enabled = resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).tp_invariant_row_linear
+    if row_linear_enable_inv is not None:
+        policy_enabled = policy_enabled and row_linear_enable_inv
+
+    return (
+        policy_enabled
+        and k_size >= ROW_LINEAR_INV_BLOCK_K
+        and k_size % ROW_LINEAR_INV_BLOCK_K == 0
+    )
+
+
+def should_use_tp_invariant_tree_all_reduce(
+    accl_binary_tree_enabled: Optional[bool] = None,
+) -> bool:
+    policy_enabled = resolve_true_on_policy_runtime_policy(
+        _get_global_server_args()
+    ).deterministic_tree_all_reduce
+    if accl_binary_tree_enabled is not None:
+        policy_enabled = policy_enabled and not accl_binary_tree_enabled
+
+    return policy_enabled
+
+
+@contextlib.contextmanager
+def patch_prefill_only_deterministic_inference_for_cuda_graph(
+    server_args: Any,
+    *,
+    attn_backend: Optional[Any] = None,
+    dvr_target_verify_cuda_graph: bool = False,
+) -> Iterator[bool]:
+    enabled = (
+        getattr(server_args, "enable_prefill_only_deterministic_inference", False)
+        and not dvr_target_verify_cuda_graph
+    )
+    if not enabled:
+        yield False
+        return
+
+    saved_num_splits = None
+    if attn_backend is not None and hasattr(attn_backend, "num_splits"):
+        saved_num_splits = attn_backend.num_splits
+
+    try:
+        if attn_backend is not None and hasattr(attn_backend, "num_splits"):
+            attn_backend.num_splits = 0
+
+        yield True
+    finally:
+        if attn_backend is not None and hasattr(attn_backend, "num_splits"):
+            attn_backend.num_splits = saved_num_splits

--- a/python/sglang/srt/true_on_policy/contracts.py
+++ b/python/sglang/srt/true_on_policy/contracts.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from sglang.srt.true_on_policy.schema import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+    TrueOnPolicyContractName,
+    TrueOnPolicyContractSchema,
+)
+
+QWEN3_DENSE_TRUE_ON_POLICY_V1 = QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA.name
+
+
+@dataclass(frozen=True)
+class SGLangTrueOnPolicyRuntimePolicy:
+    """SGLang-local behavior implied by a true-on-policy parity contract."""
+
+    contract_name: Optional[str]
+    enabled: bool
+    force_bfloat16_dense_tensor_math: bool
+    force_bfloat16_lm_head: bool
+    disable_reduce_scatter: bool
+    disable_mlp_allreduce_fusion: bool
+    disable_flashinfer_allreduce_fusion: bool
+    tp_invariant_row_linear: bool
+    deterministic_tree_all_reduce: bool
+    disable_fused_qk_norm_mrope: bool
+
+
+DEFAULT_RUNTIME_POLICY = SGLangTrueOnPolicyRuntimePolicy(
+    contract_name=None,
+    enabled=False,
+    force_bfloat16_dense_tensor_math=False,
+    force_bfloat16_lm_head=False,
+    disable_reduce_scatter=False,
+    disable_mlp_allreduce_fusion=False,
+    disable_flashinfer_allreduce_fusion=False,
+    tp_invariant_row_linear=False,
+    deterministic_tree_all_reduce=False,
+    disable_fused_qk_norm_mrope=False,
+)
+
+
+@dataclass(frozen=True)
+class SGLangTrueOnPolicyContract:
+    """SGLang-local adapter from a shared contract schema to runtime policy."""
+
+    schema: TrueOnPolicyContractSchema
+
+    @property
+    def name(self) -> TrueOnPolicyContractName:
+        return self.schema.name
+
+    def policy_for(self, server_args: Any) -> SGLangTrueOnPolicyRuntimePolicy:
+        uses_tp_invariant_rollout = getattr(server_args, "tp_size", 1) > 1
+        return SGLangTrueOnPolicyRuntimePolicy(
+            contract_name=self.name,
+            enabled=True,
+            force_bfloat16_dense_tensor_math=True,
+            force_bfloat16_lm_head=True,
+            disable_reduce_scatter=True,
+            disable_mlp_allreduce_fusion=True,
+            disable_flashinfer_allreduce_fusion=uses_tp_invariant_rollout,
+            tp_invariant_row_linear=uses_tp_invariant_rollout,
+            deterministic_tree_all_reduce=uses_tp_invariant_rollout,
+            disable_fused_qk_norm_mrope=True,
+        )
+
+
+QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT = SGLangTrueOnPolicyContract(
+    schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+)
+
+
+_CONTRACT_BY_NAME = {
+    QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT.name: QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT,
+}
+
+
+def get_true_on_policy_contract(contract_name: str) -> SGLangTrueOnPolicyContract:
+    try:
+        return _CONTRACT_BY_NAME[contract_name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_CONTRACT_BY_NAME))
+        raise ValueError(
+            f"Unsupported SGLang true-on-policy contract {contract_name!r}. "
+            f"Supported contracts: {supported}"
+        ) from exc
+
+
+def _contract_name_for(server_args: Any) -> Optional[str]:
+    return getattr(server_args, "true_on_policy_contract", None)
+
+
+def validate_true_on_policy_contract(server_args: Any) -> None:
+    contract_name = getattr(server_args, "true_on_policy_contract", None)
+    if contract_name is None:
+        return
+    get_true_on_policy_contract(contract_name)
+
+
+def resolve_true_on_policy_runtime_policy(
+    server_args: Any,
+) -> SGLangTrueOnPolicyRuntimePolicy:
+    contract_name = _contract_name_for(server_args)
+    if contract_name is None:
+        return DEFAULT_RUNTIME_POLICY
+
+    validate_true_on_policy_contract(server_args)
+    return get_true_on_policy_contract(contract_name).policy_for(server_args)

--- a/python/sglang/srt/true_on_policy/schema.py
+++ b/python/sglang/srt/true_on_policy/schema.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
+ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
+KernelContract = Literal["qwen3_dense_sglang_math"]
+LogprobContract = Literal["sglang_prefill"]
+
+
+@dataclass(frozen=True)
+class TrueOnPolicyContractSchema:
+    """Declarative cross-repo identity for a true-on-policy parity contract."""
+
+    name: TrueOnPolicyContractName
+    model_family: ModelFamily
+    required_kernel_contracts: tuple[KernelContract, ...]
+    logprob_contract: LogprobContract
+    sglang_attention_backend: str
+    fsdp_attention_implementation: str
+    disable_megatron_sequence_parallel: bool
+
+
+QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="qwen3_dense_true_on_policy_v1",
+    model_family="qwen3_dense",
+    required_kernel_contracts=("qwen3_dense_sglang_math",),
+    logprob_contract="sglang_prefill",
+    sglang_attention_backend="fa3",
+    fsdp_attention_implementation="flash_attention_3",
+    disable_megatron_sequence_parallel=True,
+)

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -323,7 +323,11 @@ def _build_check_entries(
             continue  # compared via its weight's comparable
         if name in quantized_set:
             qw = quantized_set[name]
-            yield CheckEntry(name, True, qw.comparable_cls(tensor, raw[qw.scale_name]))
+            yield CheckEntry(
+                name,
+                name not in skip_compare_names,
+                qw.comparable_cls(tensor, raw[qw.scale_name]),
+            )
         else:
             should_compare = name not in skip_compare_names and (
                 not _is_non_persistent_buffer_name(name)

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import time
-from typing import Any, Callable, Dict, Iterable, NamedTuple, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set
 
 import torch
 import torch.distributed as dist
@@ -64,24 +64,50 @@ def _is_non_persistent_buffer_name(name: str) -> bool:
     return any(pat in name for pat in _NON_PERSISTENT_BUFFER_PATTERNS)
 
 
+def _is_skip_weight_check(name, param, skip_tensor_list=None) -> bool:
+    # One skip group shared by reset / compare / checksum; the _skip_weight_check
+    # flag is set on kv-cache k/v_scale and process_weights_after_loading placeholders.
+    return (
+        _is_non_persistent_buffer_name(name)
+        or getattr(param, "_skip_weight_check", False)
+        or any(pat in name for pat in (skip_tensor_list or ()))
+    )
+
+
+def overall_checksum(checksums: Dict[str, str]) -> str:
+    h = hashlib.sha256()
+    for name in sorted(checksums):
+        h.update(name.encode())
+        h.update(checksums[name].encode())
+    return h.hexdigest()
+
+
 class WeightChecker:
     def __init__(self, *, get_model: Callable[[], Any], ps: Any):
         self._get_model = get_model
         self._ps = ps
         self._snapshot_tensors = None
 
-    def handle(self, action: str, allow_quant_error: bool = False) -> Optional[Dict]:
+    def handle(
+        self,
+        action: str,
+        allow_quant_error: bool = False,
+        skip_tensor_list: Optional[List[str]] = None,
+    ) -> Optional[Dict]:
         logger.info(
-            f"[WeightChecker] handle action={action} allow_quant_error={allow_quant_error}"
+            f"[WeightChecker] handle action={action} "
+            f"allow_quant_error={allow_quant_error} skip_tensor_list={skip_tensor_list}"
         )
         if action == "snapshot":
             return self._snapshot()
         elif action == "reset_tensors":
-            return self._reset_tensors()
+            return self._reset_tensors(skip_tensor_list)
         elif action == "compare":
-            return self._compare(allow_quant_error=allow_quant_error)
+            return self._compare(
+                allow_quant_error=allow_quant_error, skip_tensor_list=skip_tensor_list
+            )
         elif action == "checksum":
-            return self._compute_checksum()
+            return self._compute_checksum(skip_tensor_list)
         else:
             raise Exception(f"Unsupported {action=}")
 
@@ -94,21 +120,32 @@ class WeightChecker:
             named_tensors
         ), f"should not have duplicated tensor name"
 
-    def _reset_tensors(self):
+    def _skip_compare_names(
+        self, skip_tensor_list: Optional[List[str]] = None
+    ) -> Set[str]:
+        return {
+            name
+            for name, param in self._model_state()
+            if _is_skip_weight_check(name, param, skip_tensor_list)
+        }
+
+    def _reset_tensors(self, skip_tensor_list: Optional[List[str]] = None):
         for name, param in self._model_state():
-            if _is_non_persistent_buffer_name(name):
+            # Skip exactly what compare/checksum skip, so reset only poisons
+            # tensors compare will verify.
+            if _is_skip_weight_check(name, param, skip_tensor_list):
                 continue
             param.copy_(_random_like(param))
 
-    def _compare(self, allow_quant_error: bool = False):
+    def _compare(
+        self,
+        allow_quant_error: bool = False,
+        skip_tensor_list: Optional[List[str]] = None,
+    ):
         assert self._snapshot_tensors is not None
 
         quantized_set = _build_quantized_set(self._get_model())
-        skip_compare_names = {
-            name
-            for name, param in self._model_state()
-            if getattr(param, "_skip_weight_check", False)
-        }
+        skip_compare_names = self._skip_compare_names(skip_tensor_list)
         _check_tensors(
             expect_tensors=_build_check_entries(
                 self._snapshot_tensors, skip_compare_names, quantized_set
@@ -119,16 +156,12 @@ class WeightChecker:
             allow_quant_error=allow_quant_error,
         )
 
-    def _compute_checksum(self) -> Dict:
+    def _compute_checksum(self, skip_tensor_list: Optional[List[str]] = None) -> Dict:
         torch.cuda.synchronize()
         start = time.perf_counter()
 
         quantized_set = _build_quantized_set(self._get_model())
-        skip_compare_names = {
-            name
-            for name, param in self._model_state()
-            if getattr(param, "_skip_weight_check", False)
-        }
+        skip_compare_names = self._skip_compare_names(skip_tensor_list)
 
         # Hash the dequantized weight so two (qweight, scale) pairs with the same
         # bf16 hash equal.
@@ -139,11 +172,7 @@ class WeightChecker:
             if should_compare:
                 checksums[name] = _hash_tensor(comparable.dequantize().data)
 
-        h = hashlib.sha256()
-        for name in sorted(checksums):
-            h.update(name.encode())
-            h.update(checksums[name].encode())
-        overall = h.hexdigest()
+        overall = overall_checksum(checksums)
 
         torch.cuda.synchronize()
         elapsed = time.perf_counter() - start

--- a/python/sglang/srt/utils/weight_versions.py
+++ b/python/sglang/srt/utils/weight_versions.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List
+
+import msgspec
+
+from sglang.srt.utils.msgspec_utils import msgspec_struct_pydantic_core_schema
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+
+
+# ======================================================================
+# Shared types
+# ======================================================================
+class WeightVersionSpan(msgspec.Struct, kw_only=True, array_like=True):
+    version: str
+    start: int
+    end: int
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+WeightVersionSpans = List[WeightVersionSpan]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class WeightVersionEvent:
+    old_version: str
+    num_output_tokens: int
+
+
+# ======================================================================
+# Scheduler process
+# ======================================================================
+def record_weight_version_events(reqs: Iterable[Req], old_version: str) -> int:
+    num_recorded = 0
+    for req in reqs:
+        if req.output_ids:
+            req.weight_version_events.append(
+                WeightVersionEvent(
+                    old_version=old_version,
+                    num_output_tokens=len(req.output_ids),
+                )
+            )
+            num_recorded += 1
+    return num_recorded
+
+
+def truncate_weight_version_events(
+    events: List[WeightVersionEvent], num_kept_tokens: int
+) -> List[WeightVersionEvent]:
+    truncated = [
+        WeightVersionEvent(
+            old_version=event.old_version,
+            num_output_tokens=min(event.num_output_tokens, num_kept_tokens),
+        )
+        for event in events
+    ]
+    return [event for event in truncated if event.num_output_tokens > 0]
+
+
+def compute_weight_version_spans(
+    events: List[WeightVersionEvent],
+    current_version: str,
+    num_output_tokens: int,
+) -> WeightVersionSpans:
+    changes = [(event.old_version, event.num_output_tokens) for event in events]
+    changes.append((current_version, num_output_tokens))
+
+    spans: WeightVersionSpans = []
+    for version, end in changes:
+        end = min(end, num_output_tokens)
+        if spans and end <= spans[-1].end:
+            continue
+        if spans and version == spans[-1].version:
+            spans[-1].end = end
+            continue
+        start = spans[-1].end if spans else 0
+        spans.append(WeightVersionSpan(version=version, start=start, end=end))
+    return spans
+
+
+# ======================================================================
+# TokenizerManager
+# ======================================================================
+def add_weight_versions_to_meta_info(
+    meta_info: Dict[str, Any],
+    spans: WeightVersionSpans,
+    num_output_tokens: int,
+) -> None:
+    visible = [
+        span for span in spans if span.start < num_output_tokens or span.start == 0
+    ]
+
+    meta_info["weight_versions"] = [
+        {
+            "version": span.version,
+            "start": span.start,
+            "end": min(span.end, num_output_tokens),
+        }
+        for span in visible
+    ]
+    meta_info["weight_version"] = visible[-1].version
+
+
+# ======================================================================
+# OpenAI-compatible endpoints
+# ======================================================================
+def build_endpoint_weight_version_metadata(meta_info: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = {"weight_version": meta_info["weight_version"]}
+    if "weight_versions" in meta_info:
+        metadata["weight_versions"] = meta_info["weight_versions"]
+    return metadata

--- a/python/sglang/srt/weight_sync/local_checkpoint.py
+++ b/python/sglang/srt/weight_sync/local_checkpoint.py
@@ -1,0 +1,350 @@
+"""Host-local pull of published weights (the /pull_weights endpoint).
+
+A trainer publishes each weight sync as a version directory ``weight_v{N:06d}/``
+under a shared ``source_dir``. Each version is a canonical HF checkpoint
+directory of one of two kinds, distinguished by its index metadata:
+
+- **full**: an ordinary checkpoint. Pulling it copies it into the host-local
+  ``local_checkpoint_dir``, replacing whatever is there — no history needed.
+- **delta** (index metadata carries ``delta_encoding``): safetensors files
+  holding zstd-compressed per-tensor diffs against version N-1, plus per-tensor
+  checksums of the new state. Pulling it patches the local checkpoint in place.
+
+Version 0 is the engine's own base checkpoint (``model_path``). Every host of a
+(possibly multi-node) deployment runs the same pull; the engine then reloads the
+local checkpoint through the ordinary ``update_weights_from_disk`` path.
+
+``pull()`` is safe to call concurrently from every scheduler rank on a host: a
+per-host file lock serializes the work and an applied-version marker makes the
+extra calls no-ops.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import glob
+import importlib
+import json
+import logging
+import mmap
+import os
+import shutil
+import struct
+import threading
+import zlib
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from typing import Optional
+
+import numpy as np
+import zstandard
+
+logger = logging.getLogger(__name__)
+
+# The delta-apply phases (decompress, XOR/scatter, checksum) are memory-bandwidth
+# bound and release the GIL, so a thread pool over tensors recovers the
+# bandwidth one thread leaves idle.
+NUM_WORKERS = min(32, (os.cpu_count() or 8))
+
+# Per-checkpoint dir holding the applied-version marker and the pull lock.
+SYNC_DIR = ".weight_sync"
+
+
+def pull(
+    local_checkpoint_dir: str,
+    base_dir: str,
+    source_dir: str,
+    target_version: int,
+    pre_read_hook: Optional[str] = None,
+) -> None:
+    """Bring the host-local checkpoint up to ``target_version``.
+
+    Seeds from the newest full checkpoint at or below the target — the engine's
+    own base (``base_dir``) for a pure-delta stream, a published full version
+    otherwise — then applies the remaining deltas in order. A local checkpoint
+    already past the seed point just continues its delta chain. Raises on any
+    per-tensor checksum mismatch (fail loud, never serve bad weights).
+    """
+    # Object-store-backed shared filesystems lack cross-host read-after-write
+    # consistency: the publisher's files only appear here after an explicit
+    # refresh, which the deployment supplies as this hook. POSIX shared
+    # filesystems (NFS, Lustre, ...) need none.
+    if target_version > 0 and pre_read_hook:
+        _load_hook(pre_read_hook)(source_dir, target_version)
+    with _pull_lock(local_checkpoint_dir):
+        applied = _read_applied_version(local_checkpoint_dir)  # None on a fresh host
+        # Scan back from the target for the newest full version. Stop at the
+        # local state — below it a reset can never be needed (or, on a fresh
+        # host, at 0 = the engine's base).
+        floor = applied if applied is not None else 0
+        start = target_version
+        while start > floor and _is_delta(_version_dir(source_dir, start)):
+            start -= 1
+        if applied is None or start > applied:
+            seed_dir = base_dir if start == 0 else _version_dir(source_dir, start)
+            _reset_checkpoint(seed_dir, local_checkpoint_dir, start)
+        else:
+            start = applied
+        for version in range(start + 1, target_version + 1):
+            _apply_delta(local_checkpoint_dir, _version_dir(source_dir, version))
+
+
+def _load_hook(path: str):
+    module_path, _, name = path.rpartition(".")
+    return getattr(importlib.import_module(module_path), name)
+
+
+def _version_dir(source_dir: str, version: int) -> str:
+    return os.path.join(source_dir, f"weight_v{version:06d}")
+
+
+def _is_delta(version_dir: str) -> bool:
+    """A version is a delta iff its index metadata declares an encoding; an
+    ordinary HF checkpoint (with or without an index) is a full version."""
+    if not os.path.isdir(version_dir):
+        raise FileNotFoundError(f"published weight version missing: {version_dir}")
+    try:
+        with open(os.path.join(version_dir, "model.safetensors.index.json")) as f:
+            return "delta_encoding" in json.load(f).get("metadata", {})
+    except FileNotFoundError:
+        return False
+
+
+class _Adler32:
+    """adler32 behind the incremental .update / .hexdigest interface the hash objects expose."""
+
+    def __init__(self):
+        self._value = 1
+
+    def update(self, data) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def hexdigest(self) -> str:
+        return f"{self._value:08x}"
+
+
+def _new_hasher(algorithm: str):
+    if algorithm == "xxh3-128":
+        import xxhash
+
+        return xxhash.xxh3_128()
+    if algorithm == "blake3":
+        import blake3
+
+        return blake3.blake3()
+    if algorithm == "adler32":
+        return _Adler32()
+    raise KeyError(f"unknown checksum algorithm {algorithm!r}")
+
+
+def _checksum(algorithm: str, buf) -> str:
+    hasher = _new_hasher(algorithm)
+    hasher.update(buf)
+    return hasher.hexdigest()
+
+
+@contextmanager
+def _pull_lock(local_checkpoint_dir: str):
+    sync = os.path.join(local_checkpoint_dir, SYNC_DIR)
+    os.makedirs(sync, exist_ok=True)
+    with open(os.path.join(sync, "lock"), "w") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def _read_applied_version(local_checkpoint_dir: str) -> Optional[int]:
+    try:
+        with open(os.path.join(local_checkpoint_dir, SYNC_DIR, "state.json")) as f:
+            return int(json.load(f)["version"])
+    except FileNotFoundError:
+        return None
+
+
+def _write_applied_version(local_checkpoint_dir: str, version: int) -> None:
+    path = os.path.join(local_checkpoint_dir, SYNC_DIR, "state.json")
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump({"version": f"{version:06d}"}, f)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def _drop_page_cache(path: str) -> None:
+    """Evict a file from the page cache (POSIX_FADV_DONTNEED)."""
+    if not hasattr(os, "posix_fadvise"):  # POSIX-only (absent on macOS/Windows)
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
+def _reset_checkpoint(src_dir: str, local_checkpoint_dir: str, version: int) -> None:
+    """Make local_checkpoint_dir an exact copy of the full checkpoint in src_dir
+    (files the new checkpoint doesn't have — e.g. differently-sharded old ones —
+    are pruned). Later deltas chain on top of this state."""
+    logger.info(
+        "Pulling full checkpoint v%d %s -> %s", version, src_dir, local_checkpoint_dir
+    )
+    os.makedirs(local_checkpoint_dir, exist_ok=True)
+    src_files = [entry for entry in os.scandir(src_dir) if entry.is_file()]
+    for entry in src_files:
+        shutil.copy2(entry.path, os.path.join(local_checkpoint_dir, entry.name))
+        # don't let the source evict the local copy we keep resident
+        _drop_page_cache(entry.path)
+    names = {entry.name for entry in src_files}
+    for entry in os.scandir(local_checkpoint_dir):
+        if entry.is_file() and entry.name not in names:
+            os.remove(entry.path)
+    # a truncated copy (e.g. an object-store mount surfacing metadata before
+    # bytes) must fail loud, not serve bad weights
+    for entry in src_files:
+        copied = os.path.getsize(os.path.join(local_checkpoint_dir, entry.name))
+        if copied != entry.stat().st_size:
+            raise RuntimeError(
+                f"size mismatch copying {entry.name}: src {entry.stat().st_size} != local {copied}"
+            )
+    _write_applied_version(local_checkpoint_dir, version)
+
+
+def _tensor_locations(ckpt_dir: str) -> dict:
+    """Map each tensor name to (file, byte offset, nbytes) by reading every safetensors header."""
+    locations = {}
+    for path in glob.glob(os.path.join(ckpt_dir, "*.safetensors")):
+        with open(path, "rb") as f:
+            (header_len,) = struct.unpack("<Q", f.read(8))
+            header = json.loads(f.read(header_len))
+        for name, info in header.items():
+            if name == "__metadata__":
+                continue
+            begin, end = info["data_offsets"]
+            locations[name] = (path, 8 + header_len + begin, end - begin)
+    return locations
+
+
+def _apply_delta(local_checkpoint_dir: str, version_dir: str) -> None:
+    """Apply one version's delta in place: decompress + apply + checksum each tensor across a thread
+    pool (each writes a distinct mmap region, so the writes don't conflict). Any mismatch raises.
+    """
+    with open(os.path.join(version_dir, "model.safetensors.index.json")) as f:
+        meta = json.load(f)["metadata"]
+    applied = _read_applied_version(local_checkpoint_dir)
+    if applied == int(meta["version"]):
+        return
+    if applied != int(meta["base_version"]):
+        raise RuntimeError(
+            f"out-of-order delta: local at {applied}, delta builds on {meta['base_version']}"
+        )
+    if meta["compression_format"] != "zstd":
+        raise NotImplementedError(
+            f"compression {meta['compression_format']!r} not supported"
+        )
+    encoding = meta["delta_encoding"]
+    algorithm = meta["checksum_format"]
+    locations = _tensor_locations(local_checkpoint_dir)
+    open_mmaps = {}
+    mismatches = []
+    lock = threading.Lock()
+    file_bytes = []  # keep alive: items hold zero-copy views into these
+    items = []  # (name, compressed_view, path, offset, nbytes, want_checksum)
+    try:
+        for delta_file in sorted(glob.glob(os.path.join(version_dir, "*.safetensors"))):
+            with open(delta_file, "rb") as f:
+                blob = f.read()
+            file_bytes.append(blob)
+            (header_len,) = struct.unpack("<Q", blob[:8])
+            header = json.loads(blob[8 : 8 + header_len])
+            want_checksums = header.get("__metadata__", {})
+            view = memoryview(blob)
+            for name, info in header.items():
+                if name == "__metadata__":
+                    continue
+                begin, end = info["data_offsets"]
+                path, offset, nbytes = locations[name]
+                if path not in open_mmaps:
+                    fh = open(path, "r+b")
+                    open_mmaps[path] = (fh, mmap.mmap(fh.fileno(), 0))
+                data_start = 8 + header_len
+                items.append(
+                    (
+                        name,
+                        view[data_start + begin : data_start + end],
+                        path,
+                        offset,
+                        nbytes,
+                        want_checksums.get(name),
+                    )
+                )
+
+        # prefetch into page cache (evicted during the rollout) so the apply
+        # doesn't fault from cold storage
+        for _, mm in open_mmaps.values():
+            try:
+                mm.madvise(mmap.MADV_WILLNEED)
+            except (OSError, AttributeError, ValueError):
+                pass
+
+        def apply_xor(item) -> None:
+            name, compressed, path, offset, nbytes, want = item
+            region = np.ndarray(
+                (nbytes,), dtype=np.uint8, buffer=open_mmaps[path][1], offset=offset
+            )
+            hasher = _new_hasher(algorithm)
+            reader = zstandard.ZstdDecompressor().stream_reader(compressed)
+            pos = 0
+            # 2 MB chunks stay L2-resident across decompress -> XOR -> checksum
+            while pos < nbytes:
+                block = reader.read(min(2 << 20, nbytes - pos))
+                if not block:
+                    break
+                chunk = np.frombuffer(block, dtype=np.uint8)
+                region[pos : pos + chunk.size] ^= chunk
+                hasher.update(region[pos : pos + chunk.size])
+                pos += chunk.size
+            if hasher.hexdigest() != want:
+                with lock:
+                    mismatches.append(name)
+
+        def apply_overwrite(item) -> None:
+            name, compressed, path, offset, nbytes, want = item
+            delta = np.frombuffer(
+                zstandard.ZstdDecompressor().decompress(compressed), dtype=np.uint8
+            )
+            region = np.ndarray(
+                (nbytes,), dtype=np.uint8, buffer=open_mmaps[path][1], offset=offset
+            )
+            count = int.from_bytes(delta[:4], "little")
+            positions = np.frombuffer(delta[4 : 4 + 4 * count], dtype="<u4")
+            region[positions] = delta[4 + 4 * count :]
+            if _checksum(algorithm, region) != want:
+                with lock:
+                    mismatches.append(name)
+
+        if encoding == "xor":
+            apply_tensor = apply_xor
+        elif encoding == "overwrite":
+            apply_tensor = apply_overwrite
+        else:
+            raise NotImplementedError(f"delta encoding {encoding!r} not supported")
+        with ThreadPoolExecutor(max_workers=NUM_WORKERS) as pool:
+            list(pool.map(apply_tensor, items))
+        # no msync: the engine reads these pages via the shared cache; durability
+        # isn't needed (a host that loses the cache rebuilds from base)
+    finally:
+        for fh, mm in open_mmaps.values():
+            mm.close()
+            fh.close()
+    if mismatches:
+        raise RuntimeError(
+            f"checksum mismatch for {len(mismatches)} tensors after applying {version_dir}: "
+            f"{sorted(mismatches)[:20]}"
+        )
+    _write_applied_version(local_checkpoint_dir, int(meta["version"]))

--- a/sgl-model-gateway/bindings/python/pyproject.toml
+++ b/sgl-model-gateway/bindings/python/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "setproctitle",
     "aiohttp",
     "orjson",
+    "pybase64",
     "uvicorn",
     "fastapi",
 ]

--- a/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import aiohttp
 import orjson
+import pybase64
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
@@ -32,6 +33,44 @@ def maybe_wrap_ipv6_address(address: str) -> str:
         return f"[{address}]"
     except ValueError:
         return address
+
+
+def _merge_routed_experts(prefill: dict, decode: dict):
+    if "routed_experts" not in prefill or "routed_experts" not in decode:
+        return False
+
+    prefill_bytes = pybase64.b64decode(prefill["routed_experts"], validate=True)
+    decode_bytes = pybase64.b64decode(decode["routed_experts"], validate=True)
+    decode["routed_experts"] = pybase64.b64encode(
+        prefill_bytes + decode_bytes[len(prefill_bytes) :]
+    ).decode("utf-8")
+    return True
+
+
+def _merge_input_token_logprobs(prefill_meta: dict, decode_meta: dict):
+    if (
+        "input_token_logprobs" not in prefill_meta
+        or "input_token_logprobs" not in decode_meta
+    ):
+        return
+
+    decode_meta["input_token_logprobs"] = (
+        prefill_meta["input_token_logprobs"] + decode_meta["input_token_logprobs"]
+    )
+
+
+def _merge_prefill_json(prefill_json, decode_json):
+    if "meta_info" in prefill_json and "meta_info" in decode_json:
+        prefill_meta = prefill_json["meta_info"]
+        decode_meta = decode_json["meta_info"]
+        _merge_input_token_logprobs(prefill_meta, decode_meta)
+        _merge_routed_experts(prefill_meta, decode_meta)
+
+    if "sglext" not in prefill_json:
+        return
+
+    if "sglext" in decode_json:
+        _merge_routed_experts(prefill_json["sglext"], decode_json["sglext"])
 
 
 class MiniLoadBalancer:
@@ -140,18 +179,13 @@ class MiniLoadBalancer:
             # Wait for both responses to complete. Prefill should end first.
             prefill_response, decode_response = await asyncio.gather(*tasks)
 
-            if "return_logprob" in modified_request:
-
+            if (
+                "return_logprob" in modified_request
+                or "return_routed_experts" in modified_request
+            ):
                 prefill_json = await prefill_response.json()
                 ret_json = await decode_response.json()
-
-                # merge `meta_info.input_token_logprobs` from prefill to decode
-                if "meta_info" in ret_json:
-                    if "input_token_logprobs" in ret_json["meta_info"]:
-                        ret_json["meta_info"]["input_token_logprobs"] = (
-                            prefill_json["meta_info"]["input_token_logprobs"]
-                            + ret_json["meta_info"]["input_token_logprobs"]
-                        )
+                _merge_prefill_json(prefill_json, ret_json)
             else:
                 ret_json = await decode_response.json()
 

--- a/test/manual/layers/test_layernorm.py
+++ b/test/manual/layers/test_layernorm.py
@@ -56,6 +56,26 @@ class TestRMSNorm(CustomTestCase):
             ):
                 self._run_rms_norm_test(*params)
 
+    def test_rms_norm_cuda_uses_native_for_fp32_weight(self):
+        torch.manual_seed(0)
+
+        hidden_size = 256
+        layer = RMSNorm(
+            hidden_size,
+            cast_x_before_out_mul=True,
+            weight_dtype=torch.float32,
+            override_orig_dtype=torch.float32,
+        )
+        layer.weight.data.normal_(mean=1.0, std=0.1)
+        x = torch.randn(17, hidden_size, dtype=torch.bfloat16) / hidden_size
+
+        with torch.inference_mode():
+            ref_out = layer.forward_native(x)
+            out = layer(x)
+
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertTrue(torch.equal(out, ref_out))
+
 
 class TestGemmaRMSNorm(CustomTestCase):
     DTYPES = [torch.half, torch.bfloat16]

--- a/test/registered/core/test_dense_deterministic_math.py
+++ b/test/registered/core/test_dense_deterministic_math.py
@@ -1,0 +1,338 @@
+import json
+import os
+import subprocess
+import textwrap
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.true_on_policy import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    get_on_policy_rms_norm_kwargs,
+    should_force_bfloat16_dense_tensor_math,
+    should_force_bfloat16_lm_head,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=12, suite="stage-a-test-cpu")
+
+
+def _run_dense_math_script(script_body: str) -> dict[str, object]:
+    stubbed_imports = textwrap.dedent("""
+        import importlib.machinery
+        import json
+        import sys
+        import types
+        from pydantic import BaseModel
+
+        def install_openai_stubs():
+            openai_mod = types.ModuleType("openai")
+            openai_types_mod = types.ModuleType("openai.types")
+            openai_responses_mod = types.ModuleType("openai.types.responses")
+            openai_response_mod = types.ModuleType("openai.types.responses.response")
+            openai_tool_mod = types.ModuleType("openai.types.responses.tool")
+
+            openai_mod.__spec__ = importlib.machinery.ModuleSpec("openai", loader=None)
+            openai_types_mod.__spec__ = importlib.machinery.ModuleSpec("openai.types", loader=None)
+            openai_responses_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses", loader=None
+            )
+            openai_response_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses.response", loader=None
+            )
+            openai_tool_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses.tool", loader=None
+            )
+
+            for name in [
+                "ResponseFunctionToolCall",
+                "ResponseInputItemParam",
+                "ResponseOutputItem",
+                "ResponseOutputMessage",
+                "ResponseOutputText",
+                "ResponseReasoningItem",
+            ]:
+                setattr(openai_responses_mod, name, type(name, (BaseModel,), {}))
+
+            openai_response_mod.ToolChoice = type("ToolChoice", (BaseModel,), {})
+            openai_tool_mod.Tool = type("Tool", (BaseModel,), {})
+
+            sys.modules.setdefault("openai", openai_mod)
+            sys.modules.setdefault("openai.types", openai_types_mod)
+            sys.modules.setdefault("openai.types.responses", openai_responses_mod)
+            sys.modules.setdefault("openai.types.responses.response", openai_response_mod)
+            sys.modules.setdefault("openai.types.responses.tool", openai_tool_mod)
+
+        install_openai_stubs()
+
+        hf_utils_mod = types.ModuleType("sglang.srt.utils.hf_transformers_utils")
+        hf_utils_mod.__spec__ = importlib.machinery.ModuleSpec(
+            "sglang.srt.utils.hf_transformers_utils", loader=None
+        )
+        hf_utils_mod.check_gguf_file = lambda *args, **kwargs: False
+        hf_utils_mod.get_rope_config = lambda config: (
+            getattr(config, "rope_theta", 1000000),
+            getattr(config, "rope_scaling", None),
+        )
+        sys.modules.setdefault("sglang.srt.utils.hf_transformers_utils", hf_utils_mod)
+
+        gguf_mod = types.ModuleType("gguf")
+        gguf_mod.__spec__ = importlib.machinery.ModuleSpec("gguf", loader=None)
+        gguf_mod.GGMLQuantizationType = type(
+            "GGMLQuantizationType",
+            (),
+            {
+                "F32": 0,
+                "F16": 1,
+                "BF16": 2,
+                "Q4_0": 3,
+                "Q4_1": 4,
+                "Q5_0": 5,
+                "Q5_1": 6,
+                "Q8_0": 7,
+                "Q8_1": 8,
+                "Q2_K": 9,
+                "Q3_K": 10,
+                "Q4_K": 11,
+                "Q5_K": 12,
+                "Q6_K": 13,
+                "IQ1_S": 14,
+                "IQ1_M": 15,
+                "IQ2_XXS": 16,
+                "IQ2_XS": 17,
+                "IQ2_S": 18,
+                "IQ3_XXS": 19,
+                "IQ3_S": 20,
+                "IQ4_NL": 21,
+                "IQ4_XS": 22,
+            },
+        )
+        sys.modules.setdefault("gguf", gguf_mod)
+        """)
+
+    env = dict(os.environ)
+    pythonpath = env.get("PYTHONPATH")
+    repo_python = "python"
+    env["PYTHONPATH"] = (
+        f"{repo_python}{os.pathsep}{pythonpath}" if pythonpath else repo_python
+    )
+    script = f"{stubbed_imports}\n{script_body}"
+    completed = subprocess.run(
+        ["python", "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
+class TestDenseOnPolicyHelpers(unittest.TestCase):
+    def test_default_dense_math_helpers_are_inactive(self):
+        server_args = SimpleNamespace(
+            true_on_policy_contract=None,
+            tp_size=1,
+        )
+
+        self.assertFalse(should_force_bfloat16_dense_tensor_math(server_args))
+        self.assertFalse(
+            should_force_bfloat16_lm_head(
+                server_args=server_args,
+                use_fp32_lm_head=False,
+            )
+        )
+        self.assertEqual(get_on_policy_rms_norm_kwargs(server_args), {})
+
+    def test_on_policy_dense_math_helpers_enable_bfloat16_and_rms_norm_kwargs(self):
+        server_args = SimpleNamespace(
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+            tp_size=1,
+        )
+
+        kwargs = get_on_policy_rms_norm_kwargs(
+            server_args,
+            weight_dtype=torch.float32,
+            override_orig_dtype=torch.float32,
+            fp32_residual=True,
+        )
+
+        self.assertTrue(should_force_bfloat16_dense_tensor_math(server_args))
+        self.assertTrue(
+            should_force_bfloat16_lm_head(
+                server_args=server_args,
+                use_fp32_lm_head=False,
+            )
+        )
+        self.assertFalse(
+            should_force_bfloat16_lm_head(
+                server_args=server_args,
+                use_fp32_lm_head=True,
+            )
+        )
+        self.assertEqual(kwargs["weight_dtype"], torch.float32)
+        self.assertEqual(kwargs["override_orig_dtype"], torch.float32)
+        self.assertTrue(kwargs["cast_x_before_out_mul"])
+        self.assertTrue(kwargs["fp32_residual"])
+
+
+class TestDenseOnPolicyContracts(unittest.TestCase):
+    def test_qwen3_style_rms_norm_keeps_fp32_weight_output_and_residual(self):
+        result = _run_dense_math_script(textwrap.dedent("""
+                import json
+                from types import SimpleNamespace
+
+                import torch
+
+                from sglang.srt.layers.layernorm import RMSNorm
+                from sglang.srt.true_on_policy import get_on_policy_rms_norm_kwargs
+
+                from sglang.srt.true_on_policy import QWEN3_DENSE_TRUE_ON_POLICY_V1
+
+                server_args = SimpleNamespace(
+                    true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+                    tp_size=1,
+                )
+                norm = RMSNorm(
+                    4,
+                    eps=1e-6,
+                    **get_on_policy_rms_norm_kwargs(
+                        server_args,
+                        weight_dtype=torch.float32,
+                        override_orig_dtype=torch.float32,
+                        fp32_residual=True,
+                    ),
+                )
+                x = torch.randn(2, 4, dtype=torch.bfloat16)
+                residual = torch.randn(2, 4, dtype=torch.bfloat16)
+                out, residual_out = norm.forward_native(x, residual)
+                print(
+                    json.dumps(
+                        {
+                            "weight_dtype": str(norm.weight.dtype),
+                            "out_dtype": str(out.dtype),
+                            "residual_dtype": str(residual_out.dtype),
+                        }
+                    )
+                )
+                """))
+
+        self.assertEqual(result["weight_dtype"], "torch.float32")
+        self.assertEqual(result["out_dtype"], "torch.float32")
+        self.assertEqual(result["residual_dtype"], "torch.float32")
+
+    def test_rms_norm_can_self_configure_from_true_on_policy_role_hints(self):
+        result = _run_dense_math_script(textwrap.dedent("""
+                import json
+
+                import torch
+
+                from sglang.srt.layers.layernorm import RMSNorm
+                from sglang.srt.server_args import (
+                    ServerArgs,
+                    get_global_server_args,
+                    set_global_server_args_for_scheduler,
+                )
+                from sglang.srt.true_on_policy import QWEN3_DENSE_TRUE_ON_POLICY_V1
+
+                set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+                server_args = get_global_server_args()
+                server_args.true_on_policy_contract = QWEN3_DENSE_TRUE_ON_POLICY_V1
+                server_args.tp_size = 1
+                norm = RMSNorm(
+                    4,
+                    eps=1e-6,
+                    true_on_policy_weight_dtype=torch.float32,
+                    true_on_policy_override_orig_dtype=torch.float32,
+                    true_on_policy_fp32_residual=True,
+                )
+                print(
+                    json.dumps(
+                        {
+                            "weight_dtype": str(norm.weight.dtype),
+                            "cast_x_before_out_mul": norm.cast_x_before_out_mul,
+                            "fp32_residual": norm.fp32_residual,
+                            "override_orig_dtype": str(norm.override_orig_dtype),
+                        }
+                    )
+                )
+                """))
+
+        self.assertEqual(result["weight_dtype"], "torch.float32")
+        self.assertTrue(result["cast_x_before_out_mul"])
+        self.assertTrue(result["fp32_residual"])
+        self.assertEqual(result["override_orig_dtype"], "torch.float32")
+
+    def test_on_policy_lm_head_forces_bfloat16_matmul_inputs(self):
+        result = _run_dense_math_script(textwrap.dedent("""
+                import json
+                from types import SimpleNamespace
+                from unittest.mock import patch
+
+                import torch
+                import torch.nn as nn
+
+                from sglang.srt.layers.logits_processor import LogitsProcessor
+                from sglang.srt.server_args import (
+                    ServerArgs,
+                    get_global_server_args,
+                    set_global_server_args_for_scheduler,
+                )
+                from sglang.srt.true_on_policy import QWEN3_DENSE_TRUE_ON_POLICY_V1
+
+                class DummyMeta:
+                    gathered_buffer = None
+                    next_token_logits_buffer = None
+
+                    def compute_dp_attention_metadata(self):
+                        return None
+
+                class LMHeadStub(nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.weight = nn.Parameter(torch.randn(8, 4, dtype=torch.float32))
+
+                set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+                get_global_server_args().enable_dp_lm_head = False
+                get_global_server_args().enable_fp32_lm_head = False
+                get_global_server_args().true_on_policy_contract = QWEN3_DENSE_TRUE_ON_POLICY_V1
+                get_global_server_args().tp_size = 1
+
+                processor = LogitsProcessor(
+                    SimpleNamespace(vocab_size=8, final_logit_softcapping=None),
+                    skip_all_gather=True,
+                    logit_scale=None,
+                )
+                hidden_states = torch.randn(2, 4, dtype=torch.float32)
+                head = LMHeadStub()
+                captured = {}
+
+                original_matmul = torch.matmul
+
+                def probe_matmul(a, b, *args, **kwargs):
+                    if not captured:
+                        captured["a_dtype"] = str(a.dtype)
+                        captured["b_dtype"] = str(b.dtype)
+                    return original_matmul(a, b, *args, **kwargs)
+
+                with patch("torch.matmul", new=probe_matmul):
+                    logits = processor._get_logits(hidden_states, head, DummyMeta())
+
+                print(
+                    json.dumps(
+                        {
+                            "a_dtype": captured["a_dtype"],
+                            "b_dtype": captured["b_dtype"],
+                            "logits_dtype": str(logits.dtype),
+                        }
+                    )
+                )
+                """))
+
+        self.assertEqual(result["a_dtype"], "torch.bfloat16")
+        self.assertEqual(result["b_dtype"], "torch.bfloat16")
+        self.assertEqual(result["logits_dtype"], "torch.bfloat16")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/core/test_gated_launch.py
+++ b/test/registered/core/test_gated_launch.py
@@ -1,0 +1,124 @@
+import os
+import subprocess
+import time
+import unittest
+
+import psutil
+import requests
+
+from sglang.srt.utils.common import kill_process_tree
+from sglang.srt.utils.network import get_open_port
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+)
+
+register_cuda_ci(
+    est_time=180, stage="nightly", runner_config="1-gpu-large", nightly=True
+)
+
+MEM_FRACTION_STATIC = 0.6
+GATED_MEMORY_CEILING_MB = 8 * 1024
+SERVING_MEMORY_FLOOR_MB = 8 * 1024
+
+
+class TestGatedLaunch(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        _, host, port = cls.base_url.split(":")
+        cls.gate_port = get_open_port()
+        cls.gate_url = f"http:{host}:{cls.gate_port}"
+
+        command = [
+            "sglang",
+            "serve",
+            "--model-path",
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            "--host",
+            host[2:],
+            "--port",
+            port,
+            "--gated-launch-port",
+            str(cls.gate_port),
+            "--mem-fraction-static",
+            str(MEM_FRACTION_STATIC),
+        ]
+        cls.process = subprocess.Popen(command, env=os.environ.copy())
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gated_launch_defers_startup_until_activated(self):
+        """The engine holds off every sizable allocation until it is activated."""
+        self._wait_for_health(self.gate_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH)
+
+        with self.assertRaises(requests.exceptions.RequestException):
+            requests.get(f"{self.base_url}/health", timeout=5)
+
+        gated_memory_mb = self._device_memory_mb()
+        self.assertLess(gated_memory_mb, GATED_MEMORY_CEILING_MB)
+
+        for _ in range(2):
+            response = requests.post(f"{self.gate_url}/gate/activate", timeout=5)
+            self.assertEqual(response.status_code, 200)
+
+        self._wait_for_health(self.base_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH)
+
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"max_new_tokens": 8, "temperature": 0},
+            },
+            timeout=60,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["text"])
+
+        self.assertGreater(self._device_memory_mb(), SERVING_MEMORY_FLOOR_MB)
+
+    def _wait_for_health(self, url: str, timeout: float) -> None:
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline:
+            self.assertIsNone(
+                self.process.poll(), msg=f"server died while waiting for {url}"
+            )
+            try:
+                if requests.get(f"{url}/health", timeout=5).status_code == 200:
+                    return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(1)
+        self.fail(f"{url} did not become healthy within {timeout}s")
+
+    def _device_memory_mb(self) -> int:
+        parent = psutil.Process(self.process.pid)
+        pids = {parent.pid} | {child.pid for child in parent.children(recursive=True)}
+
+        output = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        )
+
+        total_mb = 0
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            pid, used_mb = (field.strip() for field in line.split(","))
+            if int(pid) in pids:
+                total_mb += int(used_mb)
+        return total_mb
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/core/test_on_policy_wiring.py
+++ b/test/registered/core/test_on_policy_wiring.py
@@ -1,0 +1,606 @@
+import json
+import os
+import subprocess
+import textwrap
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.true_on_policy import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    get_rl_on_policy_target,
+    get_true_on_policy_contract,
+    is_tp_invariant_target,
+    is_true_on_policy_enabled,
+    patch_prefill_only_deterministic_inference_for_cuda_graph,
+    resolve_true_on_policy_runtime_policy,
+    should_disable_flashinfer_allreduce_fusion,
+    should_disable_fused_qk_norm_mrope,
+    should_disable_mlp_allreduce_fusion_for_on_policy,
+    should_disable_reduce_scatter_for_on_policy,
+    should_use_tp_invariant_row_linear,
+    should_use_tp_invariant_tree_all_reduce,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=12, suite="stage-a-test-cpu")
+
+_PATCH_TARGET = "sglang.srt.server_args.get_global_server_args"
+
+
+def _run_server_args_script(argv: list[str]) -> dict[str, object]:
+    stubbed_imports = textwrap.dedent("""
+        import argparse
+        import importlib.machinery
+        import json
+        import sys
+        import types
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from pydantic import BaseModel
+
+        def install_openai_stubs():
+            openai_mod = types.ModuleType("openai")
+            openai_types_mod = types.ModuleType("openai.types")
+            openai_responses_mod = types.ModuleType("openai.types.responses")
+            openai_response_mod = types.ModuleType("openai.types.responses.response")
+            openai_tool_mod = types.ModuleType("openai.types.responses.tool")
+
+            openai_mod.__spec__ = importlib.machinery.ModuleSpec("openai", loader=None)
+            openai_types_mod.__spec__ = importlib.machinery.ModuleSpec("openai.types", loader=None)
+            openai_responses_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses", loader=None
+            )
+            openai_response_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses.response", loader=None
+            )
+            openai_tool_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "openai.types.responses.tool", loader=None
+            )
+
+            for name in [
+                "ResponseFunctionToolCall",
+                "ResponseInputItemParam",
+                "ResponseOutputItem",
+                "ResponseOutputMessage",
+                "ResponseOutputText",
+                "ResponseReasoningItem",
+            ]:
+                setattr(openai_responses_mod, name, type(name, (BaseModel,), {}))
+
+            openai_response_mod.ToolChoice = type("ToolChoice", (BaseModel,), {})
+            openai_tool_mod.Tool = type("Tool", (BaseModel,), {})
+
+            sys.modules.setdefault("openai", openai_mod)
+            sys.modules.setdefault("openai.types", openai_types_mod)
+            sys.modules.setdefault("openai.types.responses", openai_responses_mod)
+            sys.modules.setdefault("openai.types.responses.response", openai_response_mod)
+            sys.modules.setdefault("openai.types.responses.tool", openai_tool_mod)
+
+        install_openai_stubs()
+
+        hf_utils_mod = types.ModuleType("sglang.srt.utils.hf_transformers_utils")
+        hf_utils_mod.__spec__ = importlib.machinery.ModuleSpec(
+            "sglang.srt.utils.hf_transformers_utils", loader=None
+        )
+        hf_utils_mod.check_gguf_file = lambda *args, **kwargs: False
+        sys.modules.setdefault("sglang.srt.utils.hf_transformers_utils", hf_utils_mod)
+
+        from sglang.srt.server_args import ServerArgs
+
+        def _mock_model_config():
+            return SimpleNamespace(
+                hf_config=SimpleNamespace(architectures=["Qwen2ForCausalLM"])
+            )
+
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        cli_args = parser.parse_args(ARGV)
+
+        with patch("sglang.srt.server_args.get_device", return_value="cuda"), patch.object(
+            ServerArgs, "get_model_config", return_value=_mock_model_config()
+        ):
+            server_args = ServerArgs.from_cli_args(cli_args)
+            server_args._handle_deterministic_inference()
+
+        print(
+            json.dumps(
+                {
+                    "enable_deterministic_inference": server_args.enable_deterministic_inference,
+                    "enable_prefill_only_deterministic_inference": server_args.enable_prefill_only_deterministic_inference,
+                    "enable_flashinfer_allreduce_fusion": server_args.enable_flashinfer_allreduce_fusion,
+                    "rl_on_policy_target": server_args.rl_on_policy_target,
+                    "true_on_policy_contract": server_args.true_on_policy_contract,
+                    "sampling_backend": server_args.sampling_backend,
+                }
+            )
+        )
+        """)
+
+    env = dict(os.environ)
+    pythonpath = env.get("PYTHONPATH")
+    repo_python = "python"
+    env["PYTHONPATH"] = (
+        f"{repo_python}{os.pathsep}{pythonpath}" if pythonpath else repo_python
+    )
+    script = f"ARGV = {argv!r}\n{stubbed_imports}"
+    completed = subprocess.run(
+        ["python", "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
+class TestOnPolicyServerArgs(unittest.TestCase):
+    def test_cli_parses_prefill_only_deterministic_flag(self):
+        result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--enable-prefill-only-deterministic-inference",
+            ]
+        )
+
+        self.assertTrue(result["enable_prefill_only_deterministic_inference"])
+        self.assertTrue(result["enable_deterministic_inference"])
+        self.assertIsNone(result["rl_on_policy_target"])
+        self.assertEqual(result["sampling_backend"], "pytorch")
+
+    def test_cli_accepts_fsdp_and_fsdp_tp_targets(self):
+        fsdp_tp_result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--rl-on-policy-target",
+                "fsdp_tp",
+            ]
+        )
+        self.assertEqual(fsdp_tp_result["rl_on_policy_target"], "fsdp_tp")
+        self.assertIsNone(fsdp_tp_result["true_on_policy_contract"])
+        self.assertTrue(fsdp_tp_result["enable_deterministic_inference"])
+
+        fsdp_result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--rl-on-policy-target",
+                "fsdp",
+            ]
+        )
+        self.assertEqual(fsdp_result["rl_on_policy_target"], "fsdp")
+        self.assertIsNone(fsdp_result["true_on_policy_contract"])
+        self.assertTrue(fsdp_result["enable_deterministic_inference"])
+
+    def test_cli_accepts_explicit_true_on_policy_contract(self):
+        result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--true-on-policy-contract",
+                QWEN3_DENSE_TRUE_ON_POLICY_V1,
+            ]
+        )
+
+        self.assertIsNone(result["rl_on_policy_target"])
+        self.assertEqual(
+            result["true_on_policy_contract"], QWEN3_DENSE_TRUE_ON_POLICY_V1
+        )
+        self.assertTrue(result["enable_deterministic_inference"])
+
+    def test_contract_tp_rollout_disables_flashinfer_allreduce_fusion(self):
+        result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--tensor-parallel-size",
+                "2",
+                "--true-on-policy-contract",
+                QWEN3_DENSE_TRUE_ON_POLICY_V1,
+                "--enable-flashinfer-allreduce-fusion",
+            ]
+        )
+        self.assertFalse(result["enable_flashinfer_allreduce_fusion"])
+
+    def test_legacy_target_keeps_flashinfer_allreduce_fusion_available(self):
+        result = _run_server_args_script(
+            [
+                "--model-path",
+                "dummy",
+                "--attention-backend",
+                "triton",
+                "--rl-on-policy-target",
+                "fsdp_tp",
+                "--enable-flashinfer-allreduce-fusion",
+            ]
+        )
+        self.assertTrue(result["enable_flashinfer_allreduce_fusion"])
+
+
+def _mock_args(**kwargs):
+    defaults = dict(
+        rl_on_policy_target=None,
+        true_on_policy_contract=None,
+        tp_size=1,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _contract_args(*, tp_size: int = 1):
+    return _mock_args(
+        true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+        tp_size=tp_size,
+    )
+
+
+class TestDefaultPathUnchanged(unittest.TestCase):
+    """Default serving must not enter true-on-policy policy paths."""
+
+    def setUp(self):
+        self.default_args = _mock_args()
+
+    def test_default_args_no_on_policy(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertIsNone(get_rl_on_policy_target())
+            self.assertFalse(is_true_on_policy_enabled())
+            self.assertFalse(is_tp_invariant_target())
+
+    def test_default_args_row_linear_uses_quant_method(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(
+                    256,
+                    row_linear_enable_inv=True,
+                )
+            )
+
+    def test_default_args_tree_allreduce_not_selected(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertFalse(
+                should_use_tp_invariant_tree_all_reduce(
+                    accl_binary_tree_enabled=False,
+                )
+            )
+
+    def test_default_args_reduce_scatter_available(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertFalse(should_disable_reduce_scatter_for_on_policy())
+
+    def test_default_args_mlp_fusion_available(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertFalse(should_disable_mlp_allreduce_fusion_for_on_policy())
+
+    def test_default_args_flashinfer_fusion_available(self):
+        with patch(_PATCH_TARGET, return_value=self.default_args):
+            self.assertFalse(should_disable_flashinfer_allreduce_fusion())
+
+    def test_default_server_args_cli_no_on_policy_flags(self):
+        result = _run_server_args_script(
+            ["--model-path", "dummy", "--attention-backend", "triton"]
+        )
+        self.assertIsNone(result["rl_on_policy_target"])
+        self.assertFalse(result["enable_deterministic_inference"])
+        self.assertFalse(result["enable_prefill_only_deterministic_inference"])
+
+
+class TestOnPolicyHelpers(unittest.TestCase):
+    def test_tp_invariant_row_linear_selection(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(
+                should_use_tp_invariant_row_linear(
+                    256,
+                    row_linear_enable_inv=True,
+                )
+            )
+
+    def test_tp_invariant_row_linear_selection_is_contract_owned(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            with patch.dict(os.environ, {"ROW_LINEAR_ENABLE_INV": "0"}):
+                self.assertTrue(should_use_tp_invariant_row_linear(256))
+
+    def test_contract_resolver_ignores_legacy_target_without_contract(self):
+        policy = resolve_true_on_policy_runtime_policy(
+            _mock_args(rl_on_policy_target="fsdp_tp", tp_size=2)
+        )
+
+        self.assertIsNone(policy.contract_name)
+        self.assertFalse(policy.enabled)
+        self.assertFalse(policy.tp_invariant_row_linear)
+        self.assertFalse(policy.deterministic_tree_all_reduce)
+
+    def test_contract_resolver_accepts_explicit_qwen3_dense_contract(self):
+        args_tp1 = _contract_args(tp_size=1)
+        policy = resolve_true_on_policy_runtime_policy(args_tp1)
+
+        self.assertTrue(policy.enabled)
+        self.assertTrue(policy.force_bfloat16_dense_tensor_math)
+        self.assertFalse(policy.tp_invariant_row_linear)
+        with patch(_PATCH_TARGET, return_value=args_tp1):
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(
+                    96,
+                    row_linear_enable_inv=True,
+                )
+            )
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(
+                    256,
+                    row_linear_enable_inv=True,
+                )
+            )
+
+    def test_contract_object_owns_sglang_runtime_policy_values(self):
+        contract = get_true_on_policy_contract(QWEN3_DENSE_TRUE_ON_POLICY_V1)
+
+        policy = contract.policy_for(_contract_args(tp_size=2))
+
+        self.assertEqual(contract.schema.name, QWEN3_DENSE_TRUE_ON_POLICY_V1)
+        self.assertEqual(contract.schema.model_family, "qwen3_dense")
+        self.assertEqual(policy.contract_name, QWEN3_DENSE_TRUE_ON_POLICY_V1)
+        self.assertTrue(policy.enabled)
+        self.assertTrue(policy.force_bfloat16_dense_tensor_math)
+        self.assertTrue(policy.force_bfloat16_lm_head)
+        self.assertTrue(policy.disable_reduce_scatter)
+        self.assertTrue(policy.disable_mlp_allreduce_fusion)
+        self.assertTrue(policy.disable_flashinfer_allreduce_fusion)
+        self.assertTrue(policy.tp_invariant_row_linear)
+        self.assertTrue(policy.deterministic_tree_all_reduce)
+        self.assertTrue(policy.disable_fused_qk_norm_mrope)
+
+    def test_reduce_scatter_and_fusion_are_disabled_for_contract(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertTrue(should_disable_reduce_scatter_for_on_policy())
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(should_disable_mlp_allreduce_fusion_for_on_policy())
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertFalse(should_disable_reduce_scatter_for_on_policy())
+
+    def test_tree_all_reduce_selection_requires_tp_rollout_and_no_accl(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(
+                should_use_tp_invariant_tree_all_reduce(
+                    accl_binary_tree_enabled=False,
+                )
+            )
+            self.assertFalse(
+                should_use_tp_invariant_tree_all_reduce(
+                    accl_binary_tree_enabled=True,
+                )
+            )
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertFalse(
+                should_use_tp_invariant_tree_all_reduce(
+                    accl_binary_tree_enabled=False,
+                )
+            )
+
+    def test_tree_all_reduce_selection_is_contract_owned(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            with patch.dict(os.environ, {"ACCL_BINARY_TREE_ENABLE": "1"}):
+                self.assertTrue(should_use_tp_invariant_tree_all_reduce())
+
+    def test_attention_handoff_tree_reduce_uses_attention_tp_group(self):
+        from sglang.srt.layers.communicator import (
+            CommunicateWithAllReduceAndLayerNormFn,
+        )
+
+        hidden_states = torch.ones(2, 4)
+        residual = torch.full((2, 4), 3.0)
+
+        class FakeNorm:
+            def __call__(self, x, residual):
+                return x + residual, residual
+
+        with (
+            patch(
+                "sglang.srt.layers.communicator.get_attn_tp_context",
+                return_value=SimpleNamespace(input_scattered=False),
+            ),
+            patch(
+                "sglang.srt.layers.communicator.apply_aiter_all_reduce_fusion",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.communicator.apply_flashinfer_allreduce_fusion",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.communicator.attention_tensor_model_parallel_all_reduce",
+                side_effect=lambda x: x + 10.0,
+            ) as attn_tree_reduce,
+        ):
+            output, output_residual = (
+                CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual(
+                    hidden_states,
+                    residual,
+                    forward_batch=None,
+                    layernorm=FakeNorm(),
+                    context=SimpleNamespace(attn_dp_size=1, cache=None),
+                    residual_input_mode=None,
+                )
+            )
+
+        attn_tree_reduce.assert_called_once()
+        torch.testing.assert_close(output, hidden_states + 10.0 + residual)
+        torch.testing.assert_close(output_residual, residual)
+
+    def test_prefill_only_cuda_graph_patch_only_scopes_attention_splits(self):
+        server_args = SimpleNamespace(
+            enable_prefill_only_deterministic_inference=True,
+            enable_deterministic_inference=True,
+            enable_flashinfer_allreduce_fusion=False,
+            rl_on_policy_target="fsdp_tp",
+            true_on_policy_contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
+            disable_custom_all_reduce=True,
+        )
+        attn_backend = SimpleNamespace(num_splits=1)
+
+        with patch.dict(
+            os.environ,
+            {
+                "SGLANG_ENABLE_DETERMINISTIC_INFERENCE": "1",
+                "SGLANG_DISABLE_CUSTOM_ALL_REDUCE": "1",
+                "NCCL_ALGO": "allreduce:tree",
+            },
+            clear=False,
+        ):
+            with patch_prefill_only_deterministic_inference_for_cuda_graph(
+                server_args,
+                attn_backend=attn_backend,
+            ) as patched:
+                self.assertTrue(patched)
+                self.assertTrue(server_args.enable_deterministic_inference)
+                self.assertFalse(server_args.enable_flashinfer_allreduce_fusion)
+                self.assertEqual(server_args.rl_on_policy_target, "fsdp_tp")
+                self.assertEqual(
+                    server_args.true_on_policy_contract,
+                    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+                )
+                self.assertEqual(attn_backend.num_splits, 0)
+                self.assertEqual(
+                    os.environ["SGLANG_ENABLE_DETERMINISTIC_INFERENCE"], "1"
+                )
+                self.assertEqual(os.environ["SGLANG_DISABLE_CUSTOM_ALL_REDUCE"], "1")
+                self.assertEqual(os.environ["NCCL_ALGO"], "allreduce:tree")
+
+            self.assertTrue(server_args.enable_deterministic_inference)
+            self.assertFalse(server_args.enable_flashinfer_allreduce_fusion)
+            self.assertEqual(server_args.rl_on_policy_target, "fsdp_tp")
+            self.assertEqual(
+                server_args.true_on_policy_contract,
+                QWEN3_DENSE_TRUE_ON_POLICY_V1,
+            )
+            self.assertTrue(server_args.disable_custom_all_reduce)
+            self.assertEqual(attn_backend.num_splits, 1)
+            self.assertEqual(os.environ["SGLANG_ENABLE_DETERMINISTIC_INFERENCE"], "1")
+            self.assertEqual(os.environ["SGLANG_DISABLE_CUSTOM_ALL_REDUCE"], "1")
+            self.assertEqual(os.environ["NCCL_ALGO"], "allreduce:tree")
+
+    def test_row_linear_k_alignment_edge_cases(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(64, row_linear_enable_inv=True),
+            )
+            self.assertTrue(
+                should_use_tp_invariant_row_linear(128, row_linear_enable_inv=True),
+            )
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(300, row_linear_enable_inv=True),
+            )
+            self.assertTrue(
+                should_use_tp_invariant_row_linear(3584, row_linear_enable_inv=True),
+            )
+
+    def test_row_linear_explicit_override_can_disable(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertFalse(
+                should_use_tp_invariant_row_linear(256, row_linear_enable_inv=False)
+            )
+
+    def test_flashinfer_allreduce_fusion_helpers(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(should_disable_flashinfer_allreduce_fusion())
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertFalse(should_disable_flashinfer_allreduce_fusion())
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertFalse(should_disable_flashinfer_allreduce_fusion())
+
+    def test_fused_qk_norm_mrope_helper_follows_true_on_policy_contract(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertTrue(should_disable_fused_qk_norm_mrope())
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertFalse(should_disable_fused_qk_norm_mrope())
+
+    def test_get_rl_on_policy_target_returns_correct_value(self):
+        with patch(
+            _PATCH_TARGET, return_value=_mock_args(rl_on_policy_target="fsdp_tp")
+        ):
+            self.assertEqual(get_rl_on_policy_target(), "fsdp_tp")
+        with patch(_PATCH_TARGET, return_value=_mock_args(rl_on_policy_target="fsdp")):
+            self.assertEqual(get_rl_on_policy_target(), "fsdp")
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertIsNone(get_rl_on_policy_target())
+
+    def test_is_true_on_policy_enabled_for_both_targets(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertTrue(is_true_on_policy_enabled())
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(is_true_on_policy_enabled())
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertFalse(is_true_on_policy_enabled())
+
+    def test_is_tp_invariant_target_only_fsdp_tp(self):
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=2)):
+            self.assertTrue(is_tp_invariant_target())
+        with patch(_PATCH_TARGET, return_value=_contract_args(tp_size=1)):
+            self.assertFalse(is_tp_invariant_target())
+        with patch(_PATCH_TARGET, return_value=_mock_args()):
+            self.assertFalse(is_tp_invariant_target())
+
+    def test_cuda_graph_patch_noop_when_disabled(self):
+        server_args = SimpleNamespace(
+            enable_prefill_only_deterministic_inference=False,
+            enable_deterministic_inference=True,
+            rl_on_policy_target="fsdp_tp",
+        )
+        with patch_prefill_only_deterministic_inference_for_cuda_graph(
+            server_args,
+        ) as patched:
+            self.assertFalse(patched)
+            self.assertTrue(server_args.enable_deterministic_inference)
+            self.assertEqual(server_args.rl_on_policy_target, "fsdp_tp")
+
+    def test_cuda_graph_patch_noop_when_dvr_verify(self):
+        server_args = SimpleNamespace(
+            enable_prefill_only_deterministic_inference=True,
+            enable_deterministic_inference=True,
+            enable_flashinfer_allreduce_fusion=False,
+            rl_on_policy_target="fsdp_tp",
+            disable_custom_all_reduce=True,
+        )
+        with patch_prefill_only_deterministic_inference_for_cuda_graph(
+            server_args,
+            dvr_target_verify_cuda_graph=True,
+        ) as patched:
+            self.assertFalse(patched)
+            self.assertTrue(server_args.enable_deterministic_inference)
+            self.assertEqual(server_args.rl_on_policy_target, "fsdp_tp")
+
+    def test_tp_invariant_ops_import_is_available(self):
+        import sglang.srt.tp_invariant_ops as tp_invariant_ops
+
+        self.assertTrue(hasattr(tp_invariant_ops, "matmul_tp_inv"))
+
+    def test_legacy_on_policy_utils_import_matches_true_on_policy_namespace(self):
+        from sglang.srt import true_on_policy
+        from sglang.srt.layers import on_policy_utils as legacy
+
+        self.assertIs(
+            legacy.should_use_tp_invariant_row_linear,
+            true_on_policy.should_use_tp_invariant_row_linear,
+        )
+        self.assertIs(
+            legacy.patch_prefill_only_deterministic_inference_for_cuda_graph,
+            true_on_policy.patch_prefill_only_deterministic_inference_for_cuda_graph,
+        )
+        self.assertTrue(hasattr(torch.ops, "tp_inv_ops"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/core/test_tp_invariant_ops.py
+++ b/test/registered/core/test_tp_invariant_ops.py
@@ -1,0 +1,866 @@
+"""Tests for TP-invariant kernels (PR1).
+
+TP-invariance property:
+    Given the same TP degree and the same input data, matmul_tp_persistent
+    plus tree_all_reduce_sum produces bitwise identical results across runs.
+    When K/BLOCK_K is divisible by tp_size AND each shard yields a power-of-two
+    block count, TP=1 and TP=N also agree (isomorphic tree structure).
+
+    For production K values (e.g. 3584, 5120) where block counts per shard are
+    not power-of-two, the tree structure differs between TP degrees. The
+    invariance guarantee is *determinism for a fixed TP degree*.
+
+All bitwise assertions use torch.equal, never approximate tolerances.
+"""
+
+import os
+import random
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.tp_invariant_ops import (
+    disable_tp_invariant_mode,
+    enable_tp_invariant_mode,
+    is_tp_invariant_mode_enabled,
+    matmul_tp_inv,
+    matmul_tp_persistent,
+    moe_sum_tree_reduce,
+    set_tp_invariant_mode,
+    tree_all_reduce_sum,
+)
+from sglang.srt.tp_invariant_ops.tp_invariant_ops import (
+    _MATMUL_K_BLOCK,
+    _fixed_tree_sum_tensors,
+    _is_power_of_two,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+
+register_cpu_ci(est_time=12, suite="stage-a-test-cpu")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
+
+BLOCK_K = _MATMUL_K_BLOCK  # 128
+
+
+def _simulate_tp_matmul(A, B, tp_size, **kwargs):
+    """Simulate what production TP does: each rank runs matmul_tp_persistent
+    on its K-shard, then tree_all_reduce_sum gathers and tree-sums."""
+    K = A.shape[1]
+    shard = K // tp_size
+    partials = []
+    for r in range(tp_size):
+        start = r * shard
+        end = start + shard
+        partials.append(
+            matmul_tp_persistent(A[:, start:end], B[start:end, :], **kwargs)
+        )
+    return _fixed_tree_sum_tensors(partials)
+
+
+# ---------------------------------------------------------------------------
+# Mode flag
+# ---------------------------------------------------------------------------
+class TestTPInvariantMode(unittest.TestCase):
+    def tearDown(self):
+        disable_tp_invariant_mode()
+
+    def test_mode_context_restores_previous_state(self):
+        disable_tp_invariant_mode()
+        self.assertFalse(is_tp_invariant_mode_enabled())
+
+        with set_tp_invariant_mode(True):
+            self.assertTrue(is_tp_invariant_mode_enabled())
+        self.assertFalse(is_tp_invariant_mode_enabled())
+
+        enable_tp_invariant_mode()
+        with set_tp_invariant_mode(False):
+            self.assertFalse(is_tp_invariant_mode_enabled())
+        self.assertTrue(is_tp_invariant_mode_enabled())
+
+    def test_enable_is_idempotent(self):
+        enable_tp_invariant_mode()
+        enable_tp_invariant_mode()
+        self.assertTrue(is_tp_invariant_mode_enabled())
+        disable_tp_invariant_mode()
+        self.assertFalse(is_tp_invariant_mode_enabled())
+
+    def test_context_restores_after_exception(self):
+        disable_tp_invariant_mode()
+        try:
+            with set_tp_invariant_mode(True):
+                raise RuntimeError("deliberate")
+        except RuntimeError:
+            pass
+        self.assertFalse(is_tp_invariant_mode_enabled())
+
+
+# ---------------------------------------------------------------------------
+# Reference ops: correctness
+# ---------------------------------------------------------------------------
+class TestTPInvariantReferenceOps(unittest.TestCase):
+    def test_fixed_tree_sum_order_is_stable(self):
+        values = [
+            torch.tensor([1.0e20], dtype=torch.float32),
+            torch.tensor([1.0], dtype=torch.float32),
+            torch.tensor([-1.0e20], dtype=torch.float32),
+            torch.tensor([3.0], dtype=torch.float32),
+        ]
+        tree_result = _fixed_tree_sum_tensors(values)
+        sequential_result = values[0] + values[1] + values[2] + values[3]
+
+        self.assertEqual(tree_result.item(), 0.0)
+        self.assertEqual(sequential_result.item(), 3.0)
+
+    def test_matmul_tp_persistent_matches_torch_matmul_fp32(self):
+        torch.manual_seed(0)
+        A = torch.randn(5, 257, dtype=torch.float32)
+        B = torch.randn(257, 7, dtype=torch.float32)
+        bias = torch.randn(7, dtype=torch.float32)
+
+        actual = matmul_tp_persistent(A, B, bias=bias)
+        expected = A @ B + bias
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+    def test_matmul_tp_persistent_bf16_approximate_to_torch(self):
+        """BF16 block-tree matmul vs native torch matmul. Different accumulation
+        order means results differ by up to a few BF16 ULPs; this test only
+        checks that the magnitude is in the same ballpark, not bitwise equality."""
+        torch.manual_seed(0)
+        A = torch.randn(6, 256, dtype=torch.bfloat16)
+        B = torch.randn(256, 10, dtype=torch.bfloat16)
+        bias = torch.randn(10, dtype=torch.bfloat16)
+
+        actual = matmul_tp_persistent(A, B, bias=bias)
+        expected = A @ B + bias
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-1)
+
+    def test_torch_custom_op_dispatches_to_matmul(self):
+        A = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        B = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+
+        actual = torch.ops.tp_inv_ops.matmul_tp_inv(A, B)
+        expected = A @ B
+        torch.testing.assert_close(actual, expected)
+
+    def test_torch_custom_op_dispatches_with_bias(self):
+        torch.manual_seed(99)
+        A = torch.randn(4, 128, dtype=torch.float32)
+        B = torch.randn(128, 8, dtype=torch.float32)
+        bias = torch.randn(8, dtype=torch.float32)
+
+        actual = torch.ops.tp_inv_ops.matmul_tp_inv(A, B, bias)
+        expected = matmul_tp_persistent(A, B, bias=bias)
+        self.assertTrue(torch.equal(actual, expected))
+
+    def test_matmul_tp_inv_matches_persistent(self):
+        torch.manual_seed(11)
+        A = torch.randn(4, 256, dtype=torch.bfloat16)
+        B = torch.randn(256, 16, dtype=torch.bfloat16)
+        self.assertTrue(torch.equal(matmul_tp_inv(A, B), matmul_tp_persistent(A, B)))
+
+    def test_moe_sum_tree_reduce_matches_expert_order_reference(self):
+        input_tensor = torch.tensor(
+            [
+                [
+                    [1.0e20, 1.0],
+                    [1.0, 2.0],
+                    [-1.0e20, 4.0],
+                    [3.0, 8.0],
+                ],
+                [
+                    [5.0, 7.0],
+                    [11.0, 13.0],
+                    [17.0, 19.0],
+                    [23.0, 29.0],
+                ],
+            ],
+            dtype=torch.float32,
+        )
+        curr_topk_ids = torch.tensor(
+            [[0, 1, 2, 3], [3, -1, 1, 0]],
+            dtype=torch.int64,
+        )
+        output = torch.empty(2, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=0.5,
+            E=4,
+        )
+
+        expected = torch.tensor([[0.0, 7.5], [22.5, 27.5]], dtype=torch.float32)
+        torch.testing.assert_close(output, expected)
+
+    def test_moe_sum_tree_reduce_rejects_non_power_of_two_expert_count(self):
+        with self.assertRaisesRegex(ValueError, "power of two"):
+            moe_sum_tree_reduce(
+                input=torch.zeros(1, 1, 2),
+                output=torch.zeros(1, 2),
+                curr_topk_ids=torch.zeros(1, 1, dtype=torch.int64),
+                routed_scaling_factor=1.0,
+                E=3,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Matmul TP invariance: the core contract
+#
+# Two classes of tests:
+#   1. Cross-TP: TP=1 == TP=N, requires isomorphic tree (K/BLOCK_K power-of-two
+#      multiple of tp_size). Uses torch.equal.
+#   2. Determinism: same TP degree, two runs == bitwise identical. Works for
+#      any valid K alignment.
+# ---------------------------------------------------------------------------
+class TestTPInvarianceCrossTP(unittest.TestCase):
+    """TP=1 == TP=N when the binary tree structure is isomorphic."""
+
+    def test_fp32_cross_tp_k512(self):
+        torch.manual_seed(42)
+        A = torch.randn(8, 512, dtype=torch.float32)
+        B = torch.randn(512, 16, dtype=torch.float32)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        result_tp2 = _simulate_tp_matmul(A, B, tp_size=2)
+        result_tp4 = _simulate_tp_matmul(A, B, tp_size=4)
+
+        self.assertTrue(torch.equal(result_tp1, result_tp2))
+        self.assertTrue(torch.equal(result_tp1, result_tp4))
+
+    def test_bf16_cross_tp_k512(self):
+        torch.manual_seed(42)
+        A = torch.randn(8, 512, dtype=torch.bfloat16)
+        B = torch.randn(512, 16, dtype=torch.bfloat16)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        result_tp2 = _simulate_tp_matmul(A, B, tp_size=2)
+        result_tp4 = _simulate_tp_matmul(A, B, tp_size=4)
+
+        self.assertTrue(torch.equal(result_tp1, result_tp2))
+        self.assertTrue(torch.equal(result_tp1, result_tp4))
+
+    def test_bf16_cross_tp_k1024(self):
+        torch.manual_seed(7)
+        A = torch.randn(4, 1024, dtype=torch.bfloat16)
+        B = torch.randn(1024, 32, dtype=torch.bfloat16)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        result_tp2 = _simulate_tp_matmul(A, B, tp_size=2)
+        result_tp4 = _simulate_tp_matmul(A, B, tp_size=4)
+        result_tp8 = _simulate_tp_matmul(A, B, tp_size=8)
+
+        self.assertTrue(torch.equal(result_tp1, result_tp2))
+        self.assertTrue(torch.equal(result_tp1, result_tp4))
+        self.assertTrue(torch.equal(result_tp1, result_tp8))
+
+    def test_bf16_cross_tp_k2048_all_sizes(self):
+        """K=2048: 16 blocks. TP={1,2,4,8,16} all produce isomorphic trees."""
+        torch.manual_seed(102)
+        A = torch.randn(4, 2048, dtype=torch.bfloat16)
+        B = torch.randn(2048, 16, dtype=torch.bfloat16)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        for tp_size in [2, 4, 8, 16]:
+            result_tpN = _simulate_tp_matmul(A, B, tp_size=tp_size)
+            self.assertTrue(
+                torch.equal(result_tp1, result_tpN),
+                f"TP=1 != TP={tp_size} for K=2048",
+            )
+
+    def test_bf16_cross_tp_k4096(self):
+        """K=4096: 32 blocks."""
+        torch.manual_seed(103)
+        A = torch.randn(2, 4096, dtype=torch.bfloat16)
+        B = torch.randn(4096, 8, dtype=torch.bfloat16)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        for tp_size in [2, 4, 8]:
+            result_tpN = _simulate_tp_matmul(A, B, tp_size=tp_size)
+            self.assertTrue(
+                torch.equal(result_tp1, result_tpN),
+                f"TP=1 != TP={tp_size} for K=4096",
+            )
+
+    def test_fp16_cross_tp_k512(self):
+        torch.manual_seed(500)
+        A = torch.randn(4, 512, dtype=torch.float16)
+        B = torch.randn(512, 16, dtype=torch.float16)
+
+        result_tp1 = matmul_tp_persistent(A, B)
+        result_tp4 = _simulate_tp_matmul(A, B, tp_size=4)
+
+        self.assertTrue(torch.equal(result_tp1, result_tp4))
+
+    def test_torch_ops_dispatch_bf16_cross_tp(self):
+        """torch.ops.tp_inv_ops.matmul_tp_inv dispatch preserves cross-TP invariance."""
+        torch.manual_seed(400)
+        A = torch.randn(4, 512, dtype=torch.bfloat16)
+        B = torch.randn(512, 16, dtype=torch.bfloat16)
+
+        result_full = torch.ops.tp_inv_ops.matmul_tp_inv(A, B)
+
+        K = A.shape[1]
+        shard = K // 4
+        partials = []
+        for r in range(4):
+            s, e = r * shard, (r + 1) * shard
+            partials.append(torch.ops.tp_inv_ops.matmul_tp_inv(A[:, s:e], B[s:e, :]))
+        result_tp4 = _fixed_tree_sum_tensors(partials)
+
+        self.assertTrue(torch.equal(result_full, result_tp4))
+
+
+class TestTPInvarianceDeterminism(unittest.TestCase):
+    """Same TP degree, two runs -> bitwise identical. Works for all production K."""
+
+    def _assert_deterministic(self, K, tp_size, dtype=torch.bfloat16):
+        torch.manual_seed(42)
+        A = torch.randn(4, K, dtype=dtype)
+        B = torch.randn(K, 16, dtype=dtype)
+
+        result_a = _simulate_tp_matmul(A, B, tp_size=tp_size)
+        result_b = _simulate_tp_matmul(A, B, tp_size=tp_size)
+        self.assertTrue(
+            torch.equal(result_a, result_b),
+            f"K={K} TP={tp_size} dtype={dtype} not deterministic",
+        )
+
+    def test_bf16_k3584_tp2(self):
+        """Qwen3-4B hidden_size. 3584/2=1792 -> 14 blocks per shard."""
+        self._assert_deterministic(3584, tp_size=2)
+
+    def test_bf16_k3584_tp4(self):
+        self._assert_deterministic(3584, tp_size=4)
+
+    def test_bf16_k5120_tp4(self):
+        """Qwen3-30B hidden_size. 5120/4=1280 -> 10 blocks per shard."""
+        self._assert_deterministic(5120, tp_size=4)
+
+    def test_bf16_k5120_tp8(self):
+        self._assert_deterministic(5120, tp_size=8)
+
+    def test_bf16_k4096_tp8(self):
+        self._assert_deterministic(4096, tp_size=8)
+
+    def test_fp32_k3584_tp2(self):
+        self._assert_deterministic(3584, tp_size=2, dtype=torch.float32)
+
+    def test_fp32_accum_deterministic(self):
+        """fp32_accum=True is deterministic for a fixed TP degree."""
+        torch.manual_seed(200)
+        A = torch.randn(4, 512, dtype=torch.bfloat16)
+        B = torch.randn(512, 16, dtype=torch.bfloat16)
+
+        result_a = _simulate_tp_matmul(A, B, tp_size=2, fp32_accum=True)
+        result_b = _simulate_tp_matmul(A, B, tp_size=2, fp32_accum=True)
+        self.assertTrue(torch.equal(result_a, result_b))
+
+    def test_fp32_accum_output_dtype_is_input_dtype(self):
+        torch.manual_seed(300)
+        A = torch.randn(4, 512, dtype=torch.bfloat16)
+        B = torch.randn(512, 16, dtype=torch.bfloat16)
+
+        result = matmul_tp_persistent(A, B, fp32_accum=True)
+        self.assertEqual(result.dtype, torch.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# BFloat16 ops: approximate correctness vs torch
+# ---------------------------------------------------------------------------
+class TestBFloat16Ops(unittest.TestCase):
+    def test_moe_sum_tree_reduce_bf16(self):
+        input_tensor = torch.tensor(
+            [[[1.0, 2.0], [3.0, 4.0]]],
+            dtype=torch.bfloat16,
+        )
+        curr_topk_ids = torch.tensor([[0, 1]], dtype=torch.int64)
+        output = torch.empty(1, 2, dtype=torch.bfloat16)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=1.0,
+            E=2,
+        )
+
+        expected = torch.tensor([[4.0, 6.0]], dtype=torch.bfloat16)
+        torch.testing.assert_close(output, expected)
+
+
+# ---------------------------------------------------------------------------
+# MoE tree reduce: EP/slot invariance
+# ---------------------------------------------------------------------------
+class TestMoeReduceSlotInvariance(unittest.TestCase):
+    """moe_sum_tree_reduce must produce bitwise identical results regardless
+    of which topk slot an expert appears in. This is the EP invariance
+    property: different EP ranks may route the same experts to different
+    slot positions, but the tree-reduce result must be bitwise identical."""
+
+    def _run_moe_reduce(self, input_tensor, topk_ids, E, scaling=1.0):
+        output = torch.zeros(
+            input_tensor.shape[0], input_tensor.shape[2], dtype=input_tensor.dtype
+        )
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=topk_ids,
+            routed_scaling_factor=scaling,
+            E=E,
+        )
+        return output
+
+    def _permute_slots(self, values, ids_src, ids_dst, topk):
+        """Rearrange values so that each expert's data moves to its new slot."""
+        tokens = values.shape[0]
+        result = torch.zeros_like(values)
+        for t in range(tokens):
+            for slot_dst in range(topk):
+                eid = ids_dst[t, slot_dst].item()
+                if eid == -1:
+                    continue
+                slot_src = (ids_src[t] == eid).nonzero(as_tuple=True)[0].item()
+                result[t, slot_dst] = values[t, slot_src]
+        return result
+
+    def test_slot_permutation_gives_identical_result_fp32(self):
+        torch.manual_seed(10)
+        H = 64
+        values = torch.randn(1, 4, H, dtype=torch.float32)
+
+        ids_a = torch.tensor([[0, 1, 2, 3]], dtype=torch.int64)
+        ids_b = torch.tensor([[2, 0, 3, 1]], dtype=torch.int64)
+
+        input_b = self._permute_slots(values, ids_a, ids_b, topk=4)
+
+        result_a = self._run_moe_reduce(values, ids_a, E=4)
+        result_b = self._run_moe_reduce(input_b, ids_b, E=4)
+        self.assertTrue(torch.equal(result_a, result_b))
+
+    def test_slot_permutation_gives_identical_result_bf16(self):
+        torch.manual_seed(20)
+        H = 128
+        values = torch.randn(2, 8, H, dtype=torch.bfloat16)
+
+        expert_ids = list(range(8))
+        rng = random.Random(42)
+        shuffled = expert_ids.copy()
+        rng.shuffle(shuffled)
+
+        ids_a = torch.tensor([expert_ids, expert_ids], dtype=torch.int64)
+        ids_b = torch.tensor([shuffled, shuffled], dtype=torch.int64)
+
+        input_b = self._permute_slots(values, ids_a, ids_b, topk=8)
+
+        result_a = self._run_moe_reduce(values, ids_a, E=8)
+        result_b = self._run_moe_reduce(input_b, ids_b, E=8)
+        self.assertTrue(torch.equal(result_a, result_b))
+
+    def test_slot_invariance_with_remote_experts(self):
+        """Remote experts (-1) in different positions must not change the result."""
+        torch.manual_seed(30)
+        H = 32
+        values_a = torch.randn(1, 4, H, dtype=torch.float32)
+
+        ids_a = torch.tensor([[0, -1, 2, -1]], dtype=torch.int64)
+        ids_b = torch.tensor([[-1, 2, -1, 0]], dtype=torch.int64)
+
+        values_b = torch.randn(1, 4, H, dtype=torch.float32)
+        for slot_b in range(4):
+            eid = ids_b[0, slot_b].item()
+            if eid == -1:
+                continue
+            slot_a = (ids_a[0] == eid).nonzero(as_tuple=True)[0].item()
+            values_b[0, slot_b] = values_a[0, slot_a]
+
+        result_a = self._run_moe_reduce(values_a, ids_a, E=4)
+        result_b = self._run_moe_reduce(values_b, ids_b, E=4)
+        self.assertTrue(torch.equal(result_a, result_b))
+
+    def test_moe_bf16_large_hidden_invariance(self):
+        """Production-scale hidden dim (H=7168) with E=64 in BF16."""
+        torch.manual_seed(40)
+        H = 7168
+        topk = 8
+        E = 64
+        tokens = 2
+
+        expert_ids = torch.zeros(tokens, topk, dtype=torch.int64)
+        for t in range(tokens):
+            chosen = torch.randperm(E)[:topk]
+            expert_ids[t] = chosen
+
+        values = torch.randn(tokens, topk, H, dtype=torch.bfloat16)
+
+        output_a = torch.zeros(tokens, H, dtype=torch.bfloat16)
+        moe_sum_tree_reduce(
+            input=values,
+            output=output_a,
+            curr_topk_ids=expert_ids,
+            routed_scaling_factor=0.25,
+            E=E,
+        )
+
+        perm = torch.randperm(topk)
+        values_b = values[:, perm, :]
+        ids_b = expert_ids[:, perm]
+
+        output_b = torch.zeros(tokens, H, dtype=torch.bfloat16)
+        moe_sum_tree_reduce(
+            input=values_b,
+            output=output_b,
+            curr_topk_ids=ids_b,
+            routed_scaling_factor=0.25,
+            E=E,
+        )
+
+        self.assertTrue(torch.equal(output_a, output_b))
+
+    def test_moe_deterministic_two_runs(self):
+        """Same input, two calls -> bitwise identical."""
+        torch.manual_seed(50)
+        values = torch.randn(4, 4, 256, dtype=torch.bfloat16)
+        ids = torch.tensor(
+            [[0, 1, 2, 3], [3, 2, 1, 0], [0, 0, 1, 1], [2, 3, 0, 1]],
+            dtype=torch.int64,
+        )
+
+        out_a = torch.zeros(4, 256, dtype=torch.bfloat16)
+        moe_sum_tree_reduce(
+            input=values,
+            output=out_a,
+            curr_topk_ids=ids,
+            routed_scaling_factor=0.5,
+            E=4,
+        )
+
+        out_b = torch.zeros(4, 256, dtype=torch.bfloat16)
+        moe_sum_tree_reduce(
+            input=values,
+            output=out_b,
+            curr_topk_ids=ids,
+            routed_scaling_factor=0.5,
+            E=4,
+        )
+
+        self.assertTrue(torch.equal(out_a, out_b))
+
+
+# ---------------------------------------------------------------------------
+# tree_all_reduce_sum: non-distributed
+# ---------------------------------------------------------------------------
+class TestTreeAllReduceNonDistributed(unittest.TestCase):
+    def test_returns_clone_when_dist_not_initialized(self):
+        if dist.is_initialized():
+            self.skipTest("dist already initialized")
+        x = torch.tensor([1.0, 2.0, 3.0])
+        result = tree_all_reduce_sum(x)
+        self.assertTrue(torch.equal(x, result))
+        self.assertFalse(x.data_ptr() == result.data_ptr())
+
+    def test_fixed_tree_sum_is_order_deterministic(self):
+        torch.manual_seed(50)
+        world_size = 8
+        shards = [torch.randn(16, dtype=torch.bfloat16) for _ in range(world_size)]
+
+        result_a = _fixed_tree_sum_tensors(shards)
+        result_b = _fixed_tree_sum_tensors(list(shards))
+        self.assertTrue(torch.equal(result_a, result_b))
+
+    def test_tree_sum_power_of_two_sizes(self):
+        for n in [1, 2, 4, 8, 16]:
+            shards = [torch.tensor([float(i + 1)]) for i in range(n)]
+            result = _fixed_tree_sum_tensors(shards)
+            self.assertAlmostEqual(result.item(), n * (n + 1) / 2, places=5)
+
+
+# ---------------------------------------------------------------------------
+# MoE reduce: order-matters proof
+# ---------------------------------------------------------------------------
+class TestMoeReduceOrderMatters(unittest.TestCase):
+    def test_expert_order_differs_from_slot_order(self):
+        input_tensor = torch.tensor(
+            [[[1.0e16, 0.0], [1.0, 0.0], [-1.0e16, 0.0], [2.0, 0.0]]],
+            dtype=torch.float32,
+        )
+        curr_topk_ids = torch.tensor([[2, 0, 3, 1]], dtype=torch.int64)
+        output = torch.empty(1, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=1.0,
+            E=4,
+        )
+
+        slot_order_sum = (
+            input_tensor[0, 0]
+            + input_tensor[0, 1]
+            + input_tensor[0, 2]
+            + input_tensor[0, 3]
+        )
+        self.assertNotEqual(output[0, 0].item(), slot_order_sum[0].item())
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+class TestEdgeCases(unittest.TestCase):
+    def test_fixed_tree_sum_single_tensor(self):
+        t = torch.tensor([5.0])
+        result = _fixed_tree_sum_tensors([t])
+        self.assertEqual(result.item(), 5.0)
+
+    def test_fixed_tree_sum_odd_count(self):
+        values = [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])]
+        result = _fixed_tree_sum_tensors(values)
+        self.assertEqual(result.item(), 6.0)
+
+    def test_fixed_tree_sum_empty_raises(self):
+        with self.assertRaises(ValueError):
+            _fixed_tree_sum_tensors([])
+
+    def test_matmul_tp_persistent_k_less_than_block(self):
+        torch.manual_seed(0)
+        A = torch.randn(3, 64, dtype=torch.float32)
+        B = torch.randn(64, 5, dtype=torch.float32)
+        actual = matmul_tp_persistent(A, B)
+        expected = A @ B
+        torch.testing.assert_close(actual, expected)
+
+    def test_matmul_tp_persistent_k_equals_block(self):
+        torch.manual_seed(0)
+        A = torch.randn(3, 128, dtype=torch.float32)
+        B = torch.randn(128, 5, dtype=torch.float32)
+        actual = matmul_tp_persistent(A, B)
+        expected = A @ B
+        torch.testing.assert_close(actual, expected)
+
+    def test_matmul_tp_persistent_k_multi_block_non_aligned(self):
+        """K not divisible by BLOCK_K: reference handles remainder gracefully."""
+        torch.manual_seed(0)
+        A = torch.randn(3, 300, dtype=torch.float32)
+        B = torch.randn(300, 5, dtype=torch.float32)
+        actual = matmul_tp_persistent(A, B)
+        expected = A @ B
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+    def test_moe_sum_tree_reduce_single_expert(self):
+        input_tensor = torch.tensor([[[1.0, 2.0]]], dtype=torch.float32)
+        curr_topk_ids = torch.tensor([[0]], dtype=torch.int64)
+        output = torch.empty(1, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=1.0,
+            E=1,
+        )
+        expected = torch.tensor([[1.0, 2.0]], dtype=torch.float32)
+        torch.testing.assert_close(output, expected)
+
+    def test_moe_sum_tree_reduce_single_topk(self):
+        input_tensor = torch.tensor(
+            [[[10.0, 20.0]], [[30.0, 40.0]]],
+            dtype=torch.float32,
+        )
+        curr_topk_ids = torch.tensor([[1], [0]], dtype=torch.int64)
+        output = torch.empty(2, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=0.5,
+            E=2,
+        )
+        expected = torch.tensor([[5.0, 10.0], [15.0, 20.0]], dtype=torch.float32)
+        torch.testing.assert_close(output, expected)
+
+    def test_moe_sum_tree_reduce_all_remote(self):
+        input_tensor = torch.tensor(
+            [[[99.0, 99.0], [99.0, 99.0]]],
+            dtype=torch.float32,
+        )
+        curr_topk_ids = torch.tensor([[-1, -1]], dtype=torch.int64)
+        output = torch.empty(1, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=1.0,
+            E=2,
+        )
+        expected = torch.zeros(1, 2, dtype=torch.float32)
+        torch.testing.assert_close(output, expected)
+
+    def test_moe_sum_tree_reduce_duplicate_expert_ids(self):
+        """Same expert in multiple slots: both contributions must be summed."""
+        input_tensor = torch.tensor(
+            [[[10.0, 20.0], [30.0, 40.0]]],
+            dtype=torch.float32,
+        )
+        curr_topk_ids = torch.tensor([[0, 0]], dtype=torch.int64)
+        output = torch.empty(1, 2, dtype=torch.float32)
+
+        moe_sum_tree_reduce(
+            input=input_tensor,
+            output=output,
+            curr_topk_ids=curr_topk_ids,
+            routed_scaling_factor=1.0,
+            E=2,
+        )
+        expected = torch.tensor([[40.0, 60.0]], dtype=torch.float32)
+        torch.testing.assert_close(output, expected)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+class TestInputValidation(unittest.TestCase):
+    def test_matmul_rejects_non_2d_inputs(self):
+        with self.assertRaisesRegex(ValueError, "expected 2D"):
+            matmul_tp_persistent(torch.randn(2, 3, 4), torch.randn(4, 5))
+        with self.assertRaisesRegex(ValueError, "expected 2D"):
+            matmul_tp_persistent(torch.randn(2, 3), torch.randn(3))
+
+    def test_matmul_rejects_dimension_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "dimension mismatch"):
+            matmul_tp_persistent(torch.randn(2, 3), torch.randn(4, 5))
+
+    def test_moe_rejects_wrong_input_dims(self):
+        with self.assertRaisesRegex(ValueError, "tokens, topk, hidden"):
+            moe_sum_tree_reduce(
+                input=torch.zeros(4, 8),
+                output=torch.zeros(4, 8),
+                curr_topk_ids=torch.zeros(4, 2, dtype=torch.int64),
+                routed_scaling_factor=1.0,
+                E=2,
+            )
+
+    def test_moe_rejects_wrong_topk_ids_dims(self):
+        with self.assertRaisesRegex(ValueError, "tokens, topk"):
+            moe_sum_tree_reduce(
+                input=torch.zeros(4, 2, 8),
+                output=torch.zeros(4, 8),
+                curr_topk_ids=torch.zeros(4, dtype=torch.int64),
+                routed_scaling_factor=1.0,
+                E=2,
+            )
+
+    def test_moe_rejects_shape_mismatch_between_input_and_ids(self):
+        with self.assertRaisesRegex(ValueError, "must match"):
+            moe_sum_tree_reduce(
+                input=torch.zeros(4, 2, 8),
+                output=torch.zeros(4, 8),
+                curr_topk_ids=torch.zeros(4, 3, dtype=torch.int64),
+                routed_scaling_factor=1.0,
+                E=2,
+            )
+
+    def test_moe_rejects_wrong_output_shape(self):
+        with self.assertRaisesRegex(ValueError, "output must have shape"):
+            moe_sum_tree_reduce(
+                input=torch.zeros(4, 2, 8),
+                output=torch.zeros(4, 4),
+                curr_topk_ids=torch.zeros(4, 2, dtype=torch.int64),
+                routed_scaling_factor=1.0,
+                E=2,
+            )
+
+    def test_is_power_of_two_helper(self):
+        self.assertTrue(_is_power_of_two(1))
+        self.assertTrue(_is_power_of_two(2))
+        self.assertTrue(_is_power_of_two(64))
+        self.assertFalse(_is_power_of_two(0))
+        self.assertFalse(_is_power_of_two(3))
+        self.assertFalse(_is_power_of_two(6))
+
+
+# ---------------------------------------------------------------------------
+# Distributed tree all-reduce (multi-GPU only)
+# ---------------------------------------------------------------------------
+class TestDistributedTreeAllReduce(unittest.TestCase):
+    @unittest.skipUnless(
+        int(os.environ.get("WORLD_SIZE", "1")) > 1,
+        "requires torchrun with WORLD_SIZE > 1",
+    )
+    def test_tree_all_reduce_sum_distributed(self):
+        own_pg = False
+        if not dist.is_initialized():
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+            dist.init_process_group(backend=backend)
+            own_pg = True
+
+        try:
+            world_size = dist.get_world_size()
+            if world_size & (world_size - 1) != 0:
+                self.skipTest("requires power-of-two world size")
+
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+            if torch.cuda.is_available():
+                torch.cuda.set_device(local_rank)
+                device = torch.device("cuda", local_rank)
+            else:
+                device = torch.device("cpu")
+
+            rank = dist.get_rank()
+            value = torch.full((4,), float(rank + 1), device=device)
+            actual = tree_all_reduce_sum(value)
+            expected = torch.full(
+                (4,),
+                float(world_size * (world_size + 1) // 2),
+                device=device,
+            )
+
+            torch.testing.assert_close(actual, expected)
+            dist.barrier()
+        finally:
+            if own_pg:
+                dist.destroy_process_group()
+
+    @unittest.skipUnless(
+        int(os.environ.get("WORLD_SIZE", "1")) > 1,
+        "requires torchrun with WORLD_SIZE > 1",
+    )
+    def test_tree_all_reduce_bf16_bitwise_deterministic(self):
+        """Run tree all-reduce twice with same inputs, verify bitwise identical."""
+        own_pg = False
+        if not dist.is_initialized():
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+            dist.init_process_group(backend=backend)
+            own_pg = True
+
+        try:
+            world_size = dist.get_world_size()
+            if world_size & (world_size - 1) != 0:
+                self.skipTest("requires power-of-two world size")
+
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+            if torch.cuda.is_available():
+                torch.cuda.set_device(local_rank)
+                device = torch.device("cuda", local_rank)
+            else:
+                device = torch.device("cpu")
+
+            rank = dist.get_rank()
+            torch.manual_seed(rank * 1000 + 777)
+            value = torch.randn(256, device=device, dtype=torch.bfloat16)
+
+            result_a = tree_all_reduce_sum(value)
+            result_b = tree_all_reduce_sum(value)
+
+            self.assertTrue(torch.equal(result_a, result_b))
+            dist.barrier()
+        finally:
+            if own_pg:
+                dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/disaggregation/test_parallelism_context_integration.py
+++ b/test/registered/disaggregation/test_parallelism_context_integration.py
@@ -1,0 +1,275 @@
+"""
+Integration tests for ParallelismContext with real sglang servers.
+
+Tests that ParallelismContext can instantiate models with correct tensor parallel
+sharding by comparing parameter names and sizes against a running sglang server.
+
+Run with:
+    pytest test/registered/distributed/test_parallelism_context_integration.py -v
+
+Full test suite (non-CI):
+    - TP=2 small model (Qwem2.5-1.5B-Instruct)
+    - EP=2 small MOE model (DeepSeek-Coder-V2-Lite-Instruct)
+    - MLA model with hybrid dp attention (DeepSeek-Coder-V2-Lite-Instruct)
+
+CI test (reduced):
+    - TP=2 small model only
+"""
+
+import dataclasses
+import gc
+from typing import Dict, List, Tuple
+
+import pytest
+import requests
+import torch
+
+from sglang.srt.distributed.parallel_state import RankParallelismConfig
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+)
+from sglang.utils import terminate_process
+
+register_cuda_ci(est_time=145, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=72, suite="stage-b-test-2-gpu-large-amd")
+
+
+def get_transfer_engine_info(url: str, rank: int) -> Dict:
+    """Get transfer engine info (parameter names and sizes) for a rank."""
+    response = requests.get(
+        f"{url}/remote_instance_transfer_engine_info",
+        params={"rank": rank},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_parallelism_config(url: str, rank: int) -> Dict:
+    """Get parallelism config for a rank."""
+    response = requests.get(f"{url}/parallelism_config", params={"rank": rank})
+    response.raise_for_status()
+    return response.json()
+
+
+def get_server_info(url: str) -> Dict:
+    """Get server info."""
+    response = requests.get(f"{url}/server_info")
+    response.raise_for_status()
+    return response.json()
+
+
+def verify_model_params_match_for_rank(
+    url: str,
+    rank: int,
+    server_info: Dict,
+    test_gpu_id: int,
+):
+    """Verify model parameters match for a specific rank by recreating a model shard."""
+    transfer_info = get_transfer_engine_info(url, rank)
+    server_weights_info = transfer_info["remote_instance_transfer_engine_info"][1]
+
+    # Get parallelism config from running server
+    parallelism_config_data = get_parallelism_config(url, rank)
+    parallelism_config = RankParallelismConfig.from_dict(parallelism_config_data)
+    # Get server args from server info
+    from sglang.srt.server_args import ServerArgs
+
+    valid_fields = {f.name for f in dataclasses.fields(ServerArgs)}
+    filtered_info = {k: v for k, v in server_info.items() if k in valid_fields}
+    filtered_info.pop("model_config", None)
+    server_args = ServerArgs(**filtered_info)
+
+    from sglang.srt import server_args as server_args_module
+    from sglang.srt.distributed.parallel_state import ParallelismContext
+
+    original_global_server_args = server_args_module._global_server_args
+
+    try:
+        # In a Mock ParallelismContext, instantiate the model for this rank.
+        # Use a separate GPU (test_gpu_id) to avoid memory conflicts with the running server.
+        server_args_module._global_server_args = server_args
+        with ParallelismContext(parallelism_config):
+            from sglang.srt.configs.device_config import DeviceConfig
+            from sglang.srt.configs.load_config import LoadConfig
+            from sglang.srt.configs.model_config import ModelConfig
+            from sglang.srt.model_loader import get_model
+
+            model_config = ModelConfig.from_server_args(server_args)
+            load_config = LoadConfig(load_format="dummy")
+            device_config = DeviceConfig(device="cuda", gpu_id=test_gpu_id)
+
+            torch.cuda.set_device(test_gpu_id)
+            model = get_model(
+                model_config=model_config,
+                load_config=load_config,
+                device_config=device_config,
+            )
+            model_params = {}
+            for name, param in model.named_parameters():
+                model_params[name] = param.numel() * param.element_size()
+
+            # Verify all server parameters exist in model with same size
+            mismatches = []
+            missing = []
+            for param_name, (ptr, numel, elem_size) in server_weights_info.items():
+                expected_size = numel * elem_size
+                if param_name not in model_params:
+                    missing.append(param_name)
+                elif model_params[param_name] != expected_size:
+                    mismatches.append(
+                        f"{param_name}: model={model_params[param_name]}, server={expected_size}"
+                    )
+
+            assert not missing, f"Rank {rank}: Missing parameters: {missing}"
+            assert not mismatches, f"Rank {rank}: Size mismatches: {mismatches}"
+            del model
+            torch.cuda.empty_cache()
+
+    finally:
+        server_args_module._global_server_args = original_global_server_args
+
+
+TEST_CONFIGS: List[Tuple[str, str, int, List[str], int]] = [
+    # Basic TP=2 test (CI only)
+    (
+        "tp2_small",
+        DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+        2,
+        [],
+        2,
+    ),
+    # EP=2: MoE experts split across 2 groups, moe_tp=1 per group
+    (
+        "mla_ep2",
+        DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+        2,
+        ["--ep-size", "2"],
+        2,
+    ),
+    (
+        "mla_dp2_tp4",
+        DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+        4,
+        ["--enable-dp-attention", "--dp", "2"],
+        4,
+    ),
+    (
+        "mla_dp2_ep2_tp4",
+        DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+        4,
+        ["--enable-dp-attention", "--dp", "2", "--ep-size", "2"],
+        4,
+    ),
+    (
+        "mla_dp2_ep4_tp4",
+        DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+        4,
+        ["--enable-dp-attention", "--dp", "2", "--ep-size", "4"],
+        4,
+    ),
+    (
+        "mla_dp4_ep2_tp4",
+        DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+        4,
+        ["--enable-dp-attention", "--dp", "4", "--ep-size", "2"],
+        4,
+    ),
+]
+
+
+def get_test_configs():
+    if is_in_ci():
+        return [TEST_CONFIGS[0]]
+    else:
+        return TEST_CONFIGS
+
+
+def _get_test_params():
+    """Generate pytest parameters based on test configs."""
+    configs = get_test_configs()
+    params = []
+    ids = []
+    for (
+        test_id,
+        model_name,
+        tp_size,
+        extra_args,
+        min_gpus,
+    ) in configs:
+        params.append(
+            pytest.param(
+                (model_name, tp_size, extra_args, min_gpus),
+                id=test_id,
+            )
+        )
+    return params
+
+
+class TestParallelismContextIntegration:
+    """
+    Test that ParallelismContext can instantiate models with the same
+    parameter names and sizes as the sglang server engine.
+    """
+
+    @pytest.mark.parametrize("config", _get_test_params())
+    def test_model_instantiation_matches_server(self, config):
+        """
+        Test that a model instantiated with ParallelismContext has the same
+        parameter names and sizes as the model in the sglang server.
+
+        This test:
+        1. Starts a server with specified parallelism config
+        2. Gets transfer_engine_info for all ranks (contains param names and sizes)
+        3. Gets parallelism_config and server_info
+        4. Uses ParallelismContext to instantiate a model for each rank
+        5. Compares the parameter names and sizes
+        """
+        model_name, tp_size, extra_args, min_gpus = config
+        url = DEFAULT_URL_FOR_TEST
+
+        # Need min_gpus for server + 1 extra GPU for test model instantiation
+        required_gpus = min_gpus + 1
+        if torch.cuda.device_count() < required_gpus:
+            pytest.skip(
+                f"Need at least {required_gpus} GPUs (server={min_gpus} + test=1), have {torch.cuda.device_count()}"
+            )
+        test_gpu_id = min_gpus  # e.g., if server uses 0-1, test uses 2
+
+        # Build server args
+        other_args = [
+            "--tp-size",
+            str(tp_size),
+            "--remote-instance-weight-loader-start-seed-via-transfer-engine",
+            "--trust-remote-code",
+        ]
+        other_args.extend(extra_args)
+
+        process = None
+        try:
+            process = popen_launch_server(
+                model_name,
+                url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=other_args,
+            )
+            server_info = get_server_info(url)
+
+            for rank in range(tp_size):
+                verify_model_params_match_for_rank(url, rank, server_info, test_gpu_id)
+
+        finally:
+            if process is not None:
+                terminate_process(process)
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/registered/disaggregation/test_parallelism_context_integration.py
+++ b/test/registered/disaggregation/test_parallelism_context_integration.py
@@ -18,6 +18,7 @@ CI test (reduced):
 
 import dataclasses
 import gc
+import sys
 from typing import Dict, List, Tuple
 
 import pytest
@@ -272,4 +273,4 @@ class TestParallelismContextIntegration:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -208,6 +208,38 @@ def test_streaming_bookkeeping_for_serving_layer() -> None:
     assert json.loads(detector.streamed_args_for_tool[0]) == {"code": "a"}
 
 
+def test_stream_end_reports_truncated_tools_section(caplog) -> None:
+    """A tools section cut off before its closing tag used to vanish at
+    end-of-stream: no call, no text, no log. It must at least be reported."""
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    truncated = TOOLS_OPEN + '<|open|>call tool="python" index="1"<|sep|>'
+    text, calls = _stream(detector, _chunks(truncated, 7), tools)
+    assert calls == []
+    with caplog.at_level("WARNING", logger="sglang.srt.function_call.kimik3_detector"):
+        result = detector.finish(tools)
+    assert result.calls == []
+    assert TOOLS_OPEN not in (result.normal_text or "")
+    assert "no complete tool call" in caplog.text
+
+
+def test_stream_end_releases_held_back_text() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text, _ = _stream(detector, ["all done", "<"], tools)
+    assert text == "all done"
+    result = detector.finish(tools)
+    assert text + (result.normal_text or "") == "all done<"
+
+
+def test_stream_end_drops_truncated_marker() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text, _ = _stream(detector, ["all done", "<|open|>"], tools)
+    result = detector.finish(tools)
+    assert text + (result.normal_text or "") == "all done"
+
+
 def test_detector_capabilities_and_registration() -> None:
     detector = KimiK3Detector()
     assert detector.supports_structural_tag()

--- a/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
+++ b/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
@@ -1,0 +1,82 @@
+"""Unit test for ``fp8_per_token_to_per_tensor_quant_triton`` across hidden sizes.
+
+W4AFP8 DeepEP low-latency requantizes the fp8 dispatch payload with this kernel
+before the first CUTLASS grouped GEMM.  The payload's hidden size is only
+guaranteed to be a multiple of the fp8 scale-group size (128) -- e.g. 3584 for
+Kimi-K3 -- so the kernel must handle a ``k`` tail that does not fill a whole
+``K_BLOCK_SIZE`` (1024) block, and must still leave the rows past ``masked_m``
+untouched.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (
+    fp8_per_token_to_per_tensor_quant_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+dev = "cuda"
+FP8 = torch.float8_e4m3fn
+K_SCALE_BLOCK_SIZE = 128
+# Every value the kernel can produce below is a multiple of 0.25, so this
+# sentinel cannot be matched by a kernel that wrongly writes a padding row.
+SENTINEL = 0.375
+OUTPUT_SCALE = 2.0
+
+
+def _build(num_experts, m, k, seed):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    # Integers in [-8, 8] with power-of-two per-token-group scales keep every
+    # intermediate exactly representable in e4m3, so the reference below matches
+    # bit-for-bit regardless of the rounding mode of the final cast.
+    x = torch.randint(-8, 9, (num_experts, m, k), generator=g).float()
+    exps = torch.randint(-1, 2, (num_experts, m, k // K_SCALE_BLOCK_SIZE), generator=g)
+    x_scale = torch.pow(2.0, exps.float())
+    return x.to(dev).to(FP8), x_scale.to(dev)
+
+
+def _ref(x, x_scale):
+    dequant = x.float() * x_scale.repeat_interleave(K_SCALE_BLOCK_SIZE, dim=2)
+    return (dequant * (1.0 / OUTPUT_SCALE)).to(FP8)
+
+
+# 7168: exact multiple of K_BLOCK_SIZE (the DeepSeek-V3 hidden size).
+# 3584 / 1152: only 128-aligned, so the last k block is partially masked.
+@pytest.mark.parametrize("k", [7168, 3584, 1152])
+def test_masked_rows_and_k_tail(k):
+    num_experts, m = 4, 48
+    masked = [0, 1, 17, m]
+
+    x, x_scale = _build(num_experts, m, k, seed=k)
+    masked_m = torch.tensor(masked, dtype=torch.int32, device=dev)
+    output_scale = torch.tensor([OUTPUT_SCALE], dtype=torch.float32, device=dev)
+    output = torch.full((num_experts, m, k), SENTINEL, device=dev).to(FP8)
+
+    fp8_per_token_to_per_tensor_quant_triton(
+        x=x,
+        x_scale=x_scale,
+        masked_m=masked_m,
+        output_scale=output_scale,
+        output=output,
+    )
+
+    ref = _ref(x, x_scale)
+    for e, valid in enumerate(masked):
+        torch.testing.assert_close(
+            output[e, :valid].float(), ref[e, :valid].float(), rtol=0, atol=0
+        )
+        # Padding rows are not part of any expert's GEMM problem size and must
+        # stay as the caller left them.
+        padding = output[e, valid:].float()
+        torch.testing.assert_close(
+            padding, torch.full_like(padding, SENTINEL), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py
+++ b/test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py
@@ -9,9 +9,10 @@ import torch
 # IMPORT PREBUILT KERNEL
 # ---------------------------------------------------------
 from sglang.kernels.ops.moe.moe_lora_align import moe_lora_align_block_size
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 
 
 def round_up(x, base):

--- a/test/registered/rl/test_distributed_weight_update_spec_worker.py
+++ b/test/registered/rl/test_distributed_weight_update_spec_worker.py
@@ -1,0 +1,225 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+from sglang.srt.managers.io_struct import (
+    BeginWeightUpdateReqInput,
+    EndWeightUpdateReqInput,
+    UpdateWeightsFromDistributedReqInput,
+)
+from sglang.srt.managers.scheduler_components.weight_updater import (
+    SchedulerWeightUpdaterManager,
+)
+
+
+def _distributed_req(selector="all"):
+    return UpdateWeightsFromDistributedReqInput(
+        names=["model.layers.0.weight"],
+        dtypes=["float32"],
+        shapes=[[1]],
+        group_name="weight_update_group",
+        flush_cache=False,
+        selector=selector,
+    )
+
+
+def _manager(tp_worker, draft_worker):
+    # metrics_collector defaults to None, so _observe_weight_load is a no-op; the
+    # reqs below set flush_cache=False so flush_cache is never called either.
+    manager = SchedulerWeightUpdaterManager(
+        tp_worker=tp_worker,
+        draft_worker=draft_worker,
+        tp_cpu_group=object(),
+        memory_saver_adapter=Mock(),
+        flush_cache=Mock(return_value=True),
+        is_fully_idle=Mock(return_value=True),
+    )
+    # update_weights_from_* assert an open begin_weight_update session.
+    manager._weight_update_in_progress = True
+    return manager
+
+
+def test_scheduler_distributed_update_receives_once_on_target_loads_into_each():
+    # Default selector ("all"): only the target (main model) owns the update group,
+    # so it receives the broadcast once; that single weights object is then loaded
+    # into every selected runner — receive once on the target, load into each.
+    weights = object()
+    target_runner = Mock()
+    target_runner.weight_updater.receive_weights_from_distributed.return_value = weights
+    draft_runner = Mock()
+    manager = _manager(
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
+        ),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
+    )
+
+    output = manager.update_weights_from_distributed(_distributed_req())
+
+    assert output.success is True
+    target_runner.weight_updater.receive_weights_from_distributed.assert_called_once_with(
+        ["model.layers.0.weight"],
+        ["float32"],
+        [[1]],
+        "weight_update_group",
+        None,
+    )
+    # The single received weights object is loaded into every selected runner.
+    target_runner.weight_updater.load_weights.assert_called_once_with(weights)
+    draft_runner.weight_updater.load_weights.assert_called_once_with(weights)
+
+
+def test_scheduler_distributed_update_target_only_selector_skips_draft():
+    # selector="target": the target still receives once, but the draft worker is
+    # never enumerated and no draft runner is loaded.
+    weights = object()
+    target_runner = Mock()
+    target_runner.weight_updater.receive_weights_from_distributed.return_value = weights
+    draft_worker = Mock()
+    manager = _manager(
+        tp_worker=SimpleNamespace(
+            model_runner=target_runner,
+            iter_runners=lambda: [("", target_runner)],
+        ),
+        draft_worker=draft_worker,
+    )
+
+    output = manager.update_weights_from_distributed(
+        _distributed_req(selector="target")
+    )
+
+    assert output.success is True
+    target_runner.weight_updater.receive_weights_from_distributed.assert_called_once()
+    target_runner.weight_updater.load_weights.assert_called_once_with(weights)
+    draft_worker.iter_runners.assert_not_called()
+
+
+def _session_manager(target_runner, draft_runner):
+    return _manager(
+        tp_worker=SimpleNamespace(iter_runners=lambda: [("", target_runner)]),
+        draft_worker=SimpleNamespace(iter_runners=lambda: [("draft", draft_runner)]),
+    )
+
+
+def test_begin_weight_update_restores_target_and_draft():
+    # The session begins on every runner (target + draft): the draft model is
+    # restored to a loadable state identically to the target.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.begin_weight_update(BeginWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.begin_weight_update.assert_called_once_with()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_in_progress is True
+    assert manager._weight_update_loaded is False
+
+
+def test_end_weight_update_runs_post_load_on_both_when_load_was_bypassed():
+    # No load_weights happened this session (e.g. P2P/RDMA), so end runs
+    # post_load_weights then quant finalize on BOTH target and draft.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = False
+
+    with patch("torch.distributed.barrier"):
+        output = manager.end_weight_update(EndWeightUpdateReqInput())
+
+    assert output.success is True
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=True)
+    assert manager._weight_update_in_progress is False
+
+
+def test_end_weight_update_skips_post_load_on_both_when_weights_loaded():
+    # A distributed/tensor load happened this session, so post_load is skipped on
+    # both runners; only quant finalize runs.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_loaded = True
+
+    with patch("torch.distributed.barrier"):
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+    draft_runner.end_weight_update.assert_called_once_with(run_post_load=False)
+
+
+def test_model_runner_begin_end_wire_to_loader_hooks():
+    # ModelRunner.begin/end delegate to the loader: begin restores; end runs
+    # post_load only when requested, always finalizes quant layout.
+    import sglang.srt.model_executor.model_runner as mr
+
+    runner = SimpleNamespace(model=object(), device="cpu")
+
+    with patch.object(mr, "restore_weight") as restore:
+        mr.ModelRunner.begin_weight_update(runner)
+    restore.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=True)
+    post_load.assert_called_once()
+    postprocess.assert_called_once()
+
+    with patch.object(mr, "post_load_weights") as post_load, patch.object(
+        mr, "postprocess_weight"
+    ) as postprocess:
+        mr.ModelRunner.end_weight_update(runner, run_post_load=False)
+    post_load.assert_not_called()
+    postprocess.assert_called_once()
+
+
+def test_begin_weight_update_selector_restores_only_selected_and_is_recorded():
+    # begin(selector="draft") opens the session on the draft only; the target is
+    # untouched, and the selector is recorded for end to reuse.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+
+    target_runner.begin_weight_update.assert_not_called()
+    draft_runner.begin_weight_update.assert_called_once_with()
+    assert manager._weight_update_selector == "draft"
+
+
+def test_end_weight_update_reuses_session_selector_from_begin():
+    # end has no selector of its own; it finalizes exactly the set begin opened.
+    target_runner = Mock()
+    draft_runner = Mock()
+    manager = _session_manager(target_runner, draft_runner)
+    manager._weight_update_in_progress = False
+
+    with patch("torch.distributed.barrier"):
+        manager.begin_weight_update(BeginWeightUpdateReqInput(selector="draft"))
+        manager.end_weight_update(EndWeightUpdateReqInput())
+
+    target_runner.end_weight_update.assert_not_called()
+    draft_runner.end_weight_update.assert_called_once()
+
+
+def test_begin_weight_update_rejects_reentry():
+    # A second begin while a session is open would leave the first session's
+    # restored runners unfinalized — reject it loudly.
+    manager = _session_manager(Mock(), Mock())
+    manager._weight_update_in_progress = True
+
+    with patch("torch.distributed.barrier"):
+        with pytest.raises(AssertionError, match="already open"):
+            manager.begin_weight_update(BeginWeightUpdateReqInput())

--- a/test/registered/rl/test_weight_checker_e2e.py
+++ b/test/registered/rl/test_weight_checker_e2e.py
@@ -160,7 +160,12 @@ class TestWeightCheckerE2E(CustomTestCase):
         self.assertIn("checksums", first)
         self.assertIn("parallelism_info", first)
 
-        info = first["parallelism_info"]
+        parallelism_info = first["parallelism_info"]
+        self.assertIsInstance(parallelism_info, list)
+        self.assertGreaterEqual(len(parallelism_info), 1)
+
+        info = parallelism_info[0]
+        self.assertEqual(info["role"], "target")
         for key in (
             "tp_rank",
             "tp_size",

--- a/test/registered/rl/test_weight_version_spans.py
+++ b/test/registered/rl/test_weight_version_spans.py
@@ -1,0 +1,590 @@
+import json
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(
+    est_time=180, stage="nightly", runner_config="2-gpu-large", nightly=True
+)
+
+_REQUEST_TIMEOUT = 180
+
+
+def _assert_spans_contiguous(test, meta_info):
+    spans = meta_info["weight_versions"]
+    test.assertGreater(len(spans), 0)
+    test.assertEqual(spans[0]["start"], 0)
+    for prev, cur in zip(spans, spans[1:]):
+        test.assertEqual(prev["end"], cur["start"])
+        test.assertNotEqual(prev["version"], cur["version"])
+    test.assertEqual(meta_info["weight_version"], spans[-1]["version"])
+    return spans
+
+
+class TestWeightVersionSpans(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            base_url=cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--weight-version",
+                "base-v0",
+                "--trust-remote-code",
+                "--tp-size",
+                "2",
+                "--dp-size",
+                "2",
+                "--enable-dp-attention",
+                "--speculative-algorithm",
+                "EAGLE",
+                "--speculative-draft-model-path",
+                DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+                "--speculative-num-steps",
+                "2",
+                "--speculative-eagle-topk",
+                "3",
+                "--speculative-num-draft-tokens",
+                "3",
+                "--cuda-graph-max-bs-decode",
+                "32",
+                "--max-running-requests",
+                "8",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _generate(self, max_new_tokens: int, prompt: str = "The capital of France is"):
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0.8,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def _current_version(self):
+        response = requests.get(f"{self.base_url}/get_model_info", timeout=30)
+        self.assertEqual(response.status_code, 200)
+        return response.json()["weight_version"]
+
+    def _pause(self, mode: str):
+        requests.post(
+            f"{self.base_url}/pause_generation",
+            json={"mode": mode},
+            timeout=30,
+        ).raise_for_status()
+
+    def _continue(self):
+        requests.post(
+            f"{self.base_url}/continue_generation",
+            json={},
+            timeout=30,
+        ).raise_for_status()
+
+    def _set_weight_version(self, new_version: str, abort_all_requests: bool = False):
+        response = requests.post(
+            f"{self.base_url}/update_weight_version",
+            json={
+                "new_version": new_version,
+                "abort_all_requests": abort_all_requests,
+            },
+            timeout=30,
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    def _update_weights_from_disk(self, **fields) -> None:
+        response = requests.post(
+            f"{self.base_url}/update_weights_from_disk",
+            json={"model_path": self.model, "flush_cache": False, **fields},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+
+    def _run_while_paused(
+        self,
+        num_requests: int,
+        while_paused,
+        mode: str = "retract",
+        max_new_tokens: int = 1024,
+    ):
+        with ThreadPoolExecutor(max_workers=num_requests) as executor:
+            futures = [
+                executor.submit(
+                    self._generate,
+                    max_new_tokens=max_new_tokens - 16 * i,
+                    prompt=f"Write a long story about the number {i}.",
+                )
+                for i in range(num_requests)
+            ]
+
+            time.sleep(2)
+            self._pause(mode)
+            try:
+                while_paused()
+            finally:
+                self._continue()
+
+            return [future.result() for future in futures]
+
+    def test_01_single_span_without_update(self):
+        """A request untouched by updates reports one span covering all output tokens."""
+        data = self._generate(max_new_tokens=8)
+
+        meta_info = data["meta_info"]
+        spans = _assert_spans_contiguous(self, meta_info)
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0]["version"], "base-v0")
+        self.assertEqual(spans[0]["end"], meta_info["completion_tokens"])
+        self.assertEqual(meta_info["weight_version"], "base-v0")
+
+    def test_02_update_weight_version_endpoint_applies_to_new_requests(self):
+        """The endpoint returns only once every scheduler stamps new requests with the new version."""
+        self._set_weight_version("endpoint-v1")
+        self.assertEqual(self._current_version(), "endpoint-v1")
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [
+                executor.submit(self._generate, max_new_tokens=8) for _ in range(4)
+            ]
+            results = [future.result() for future in futures]
+
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(spans[0]["version"], "endpoint-v1")
+
+    def test_03_spans_split_across_pause_update_continue(self):
+        """Requests spanning pause -> update_weights_from_disk -> continue report one span per version."""
+        base_version = self._current_version()
+
+        results = self._run_while_paused(
+            num_requests=4,
+            while_paused=lambda: self._update_weights_from_disk(
+                weight_version="disk-v2"
+            ),
+        )
+
+        multi_span_count = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            versions = [span["version"] for span in spans]
+            self.assertEqual(versions[0], base_version)
+            self.assertIn(versions[-1], (base_version, "disk-v2"))
+            if len(spans) > 1:
+                multi_span_count += 1
+                self.assertEqual(versions, [base_version, "disk-v2"])
+                self.assertGreater(spans[0]["end"], 0)
+
+        self.assertGreater(
+            multi_span_count,
+            0,
+            "No request spanned the weight update -- no boundary was recorded.",
+        )
+
+    def test_04_openai_metadata_contains_weight_versions(self):
+        """OpenAI-compatible responses surface the spans under response metadata."""
+        response = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 8,
+                "temperature": 0.0,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        metadata = data["metadata"]
+        self.assertIn("weight_versions", metadata)
+        spans = metadata["weight_versions"]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0]["version"], metadata["weight_version"])
+        self.assertEqual(metadata["weight_version"], self._current_version())
+        self.assertEqual(spans[0]["start"], 0)
+        self.assertEqual(spans[0]["end"], data["usage"]["completion_tokens"])
+
+    def test_04b_openai_metadata_reports_the_first_choice_when_n_is_greater_than_one(
+        self,
+    ):
+        """With n > 1 the single metadata block describes the first choice instead of going missing."""
+        response = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 8,
+                "temperature": 0.8,
+                "n": 2,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data["choices"]), 2)
+        metadata = data["metadata"]
+        spans = metadata["weight_versions"]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0]["version"], metadata["weight_version"])
+        self.assertEqual(metadata["weight_version"], self._current_version())
+        self.assertEqual(spans[0]["start"], 0)
+
+    def test_05_aborted_retracted_requests_report_spans(self):
+        """Requests aborted while retracted in the waiting queue still report their spans."""
+
+        def abort_all():
+            requests.post(
+                f"{self.base_url}/abort_request",
+                json={"abort_all": True},
+                timeout=30,
+            ).raise_for_status()
+
+        results = self._run_while_paused(num_requests=4, while_paused=abort_all)
+
+        aborted_with_spans = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            if meta_info["finish_reason"]["type"] != "abort":
+                continue
+            if "weight_versions" not in meta_info:
+                continue
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            aborted_with_spans += 1
+
+        self.assertGreater(
+            aborted_with_spans,
+            0,
+            "No aborted request carried weight_versions -- the AbortReq path lost the spans.",
+        )
+
+    def test_06_running_requests_split_without_abort(self):
+        """A version bump with abort_all_requests=False splits requests still in the running batch."""
+        previous_version = self._current_version()
+
+        results = self._run_while_paused(
+            num_requests=4,
+            while_paused=lambda: self._set_weight_version("inplace-v3"),
+            mode="in_place",
+            max_new_tokens=1024,
+        )
+        self.assertEqual(self._current_version(), "inplace-v3")
+
+        split_count = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            self.assertNotEqual(meta_info["finish_reason"]["type"], "abort")
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            self.assertEqual(spans[0]["version"], previous_version)
+            if len(spans) > 1:
+                split_count += 1
+                self.assertEqual(
+                    [span["version"] for span in spans],
+                    [previous_version, "inplace-v3"],
+                )
+                self.assertGreater(spans[0]["end"], 0)
+
+        self.assertGreater(
+            split_count,
+            0,
+            "No running request was split -- the running batch was not visited.",
+        )
+
+    def test_07_update_without_weight_version_does_not_split(self):
+        """A refit that carries no weight_version leaves attribution untouched."""
+        version = self._current_version()
+
+        results = self._run_while_paused(
+            num_requests=4, while_paused=self._update_weights_from_disk
+        )
+        self.assertEqual(self._current_version(), version)
+
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(spans[0]["version"], version)
+            self.assertEqual(spans[0]["end"], meta_info["completion_tokens"])
+
+    def test_08_reannouncing_current_version_is_a_noop(self):
+        """Re-announcing the version the server already has must not split anything."""
+        version = self._current_version()
+
+        results = self._run_while_paused(
+            num_requests=4,
+            while_paused=lambda: self._set_weight_version(version),
+            mode="in_place",
+            max_new_tokens=128,
+        )
+        self.assertEqual(self._current_version(), version)
+
+        for data in results:
+            spans = _assert_spans_contiguous(self, data["meta_info"])
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(spans[0]["version"], version)
+
+    def test_09_three_spans_across_two_updates(self):
+        """Two updates during one request produce three ordered, non-empty spans."""
+        first_version = self._current_version()
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [
+                executor.submit(
+                    self._generate,
+                    max_new_tokens=2048,
+                    prompt=f"Write a long story about the number {i}.",
+                )
+                for i in range(4)
+            ]
+
+            for new_version in ("multi-a", "multi-b"):
+                time.sleep(2)
+                self._pause("in_place")
+                try:
+                    self._set_weight_version(new_version)
+                finally:
+                    self._continue()
+
+            results = [future.result() for future in futures]
+
+        expected = [first_version, "multi-a", "multi-b"]
+        three_span_count = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            versions = [span["version"] for span in spans]
+            self.assertEqual(versions, expected[: len(versions)])
+            for span in spans:
+                self.assertGreater(span["end"], span["start"])
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            if len(spans) == 3:
+                three_span_count += 1
+
+        self.assertGreater(
+            three_span_count,
+            0,
+            "No request spanned both updates -- multi-event accumulation was not exercised.",
+        )
+
+    def test_10_abort_before_first_token_reports_empty_span(self):
+        """A request aborted before producing a token still reports a well-formed span."""
+        version = self._current_version()
+
+        def abort_all():
+            requests.post(
+                f"{self.base_url}/abort_request",
+                json={"abort_all": True},
+                timeout=30,
+            ).raise_for_status()
+
+        results = self._run_while_paused(
+            num_requests=16,
+            while_paused=abort_all,
+        )
+
+        empty_aborts = [
+            data["meta_info"]
+            for data in results
+            if data["meta_info"]["finish_reason"]["type"] == "abort"
+            and data["meta_info"]["completion_tokens"] == 0
+        ]
+        self.assertGreater(len(empty_aborts), 0)
+        for meta_info in empty_aborts:
+            self.assertEqual(
+                meta_info["weight_versions"],
+                [{"version": version, "start": 0, "end": 0}],
+            )
+            self.assertEqual(meta_info["weight_version"], version)
+
+    def test_11_streaming_reports_spans_only_on_the_final_chunk(self):
+        """Intermediate stream chunks carry no spans; the finishing chunk carries them all."""
+        max_new_tokens = 32
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0.8,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+                "stream": True,
+            },
+            stream=True,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        chunks = []
+        for line in response.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            chunks.append(json.loads(payload))
+
+        version = self._current_version()
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks[:-1]:
+            self.assertNotIn("weight_versions", chunk["meta_info"])
+            self.assertEqual(chunk["meta_info"]["weight_version"], version)
+
+        meta_info = chunks[-1]["meta_info"]
+        spans = _assert_spans_contiguous(self, meta_info)
+        self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+        self.assertEqual(spans[-1]["end"], max_new_tokens)
+
+    def test_12_completions_endpoint_reports_metadata(self):
+        """/v1/completions surfaces the spans the same way /v1/chat/completions does."""
+        response = requests.post(
+            f"{self.base_url}/v1/completions",
+            json={
+                "model": self.model,
+                "prompt": "The capital of France is",
+                "max_tokens": 8,
+                "temperature": 0.0,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        metadata = data["metadata"]
+        self.assertEqual(metadata["weight_version"], self._current_version())
+        spans = metadata["weight_versions"]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0]["version"], metadata["weight_version"])
+        self.assertEqual(spans[0]["start"], 0)
+        self.assertEqual(spans[0]["end"], data["usage"]["completion_tokens"])
+
+    def test_13_new_requests_after_the_endpoint_returns_see_the_new_version(self):
+        """Once the endpoint returns, every concurrently admitted request stamps the new version."""
+        self._set_weight_version("dp-v1")
+        self.assertEqual(self._current_version(), "dp-v1")
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [
+                executor.submit(self._generate, max_new_tokens=8) for _ in range(8)
+            ]
+            results = [future.result() for future in futures]
+
+        for data in results:
+            spans = _assert_spans_contiguous(self, data["meta_info"])
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(spans[0]["version"], "dp-v1")
+
+    def test_14_all_inflight_requests_are_swept(self):
+        """A version change must split every in-flight request, not just the one the sweep happens to reach first."""
+        previous_version = self._current_version()
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [
+                executor.submit(
+                    self._generate,
+                    max_new_tokens=1024 - 16 * i,
+                    prompt=f"Write a long story about the number {i}.",
+                )
+                for i in range(8)
+            ]
+            time.sleep(2)
+            self._set_weight_version("dp-v2")
+            results = [future.result() for future in futures]
+
+        split_count = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            self.assertEqual(spans[0]["version"], previous_version)
+            if len(spans) > 1:
+                split_count += 1
+                self.assertEqual(
+                    [span["version"] for span in spans],
+                    [previous_version, "dp-v2"],
+                )
+                self.assertGreater(spans[0]["end"], 0)
+
+        self.assertGreater(
+            split_count,
+            1,
+            "At most one in-flight request was split -- an attention-DP rank was "
+            "likely missed by the weight version sweep.",
+        )
+
+    def test_15_single_span_covers_all_accepted_tokens(self):
+        """Draft-token overshoot must not leak past the reported completion length."""
+        data = self._generate(max_new_tokens=32)
+
+        meta_info = data["meta_info"]
+        spans = _assert_spans_contiguous(self, meta_info)
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0]["version"], self._current_version())
+        self.assertEqual(spans[0]["end"], meta_info["completion_tokens"])
+
+    def test_16_retract_update_continue_keeps_exact_boundaries(self):
+        """Spans stay contiguous and clamped when a retract-paused update lands mid-speculation."""
+        previous_version = self._current_version()
+        results = self._run_while_paused(
+            num_requests=4,
+            while_paused=lambda: self._set_weight_version("spec-v1"),
+        )
+
+        split_count = 0
+        for data in results:
+            meta_info = data["meta_info"]
+            spans = _assert_spans_contiguous(self, meta_info)
+            self.assertEqual(spans[-1]["end"], meta_info["completion_tokens"])
+            self.assertEqual(spans[0]["version"], previous_version)
+            if len(spans) > 1:
+                split_count += 1
+                self.assertEqual(
+                    [span["version"] for span in spans],
+                    [previous_version, "spec-v1"],
+                )
+                self.assertGreater(spans[0]["end"], 0)
+
+        self.assertGreater(
+            split_count,
+            0,
+            "No request spanned the update -- the retract boundary under "
+            "speculative decoding was not recorded.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/constrained/test_base_grammar_backend.py
+++ b/test/registered/unit/constrained/test_base_grammar_backend.py
@@ -15,6 +15,7 @@ Usage:
     python -m pytest test_base_grammar_backend.py -v
 """
 
+import json
 import unittest
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
@@ -249,7 +250,7 @@ class TestCreateGrammarBackend(unittest.TestCase):
         backend="none",
         reasoning_parser=None,
         enable_strict_thinking=False,
-        **fields
+        **fields,
     ):
         published = {
             "grammar_backend": backend,
@@ -464,6 +465,63 @@ class TestLlguidanceStructuralTagTriggerPairing(unittest.TestCase):
         )
         result = backend.dispatch_structural_tag(key)
         self.assertNotIsInstance(result, InvalidGrammarObject)
+
+
+class TestNulByteGrammarRejection(unittest.TestCase):
+    def setUp(self):
+        self.backend = BaseGrammarBackend()
+
+    def tearDown(self):
+        self.backend.executor.shutdown(wait=True)
+
+    def test_nul_payload_never_reaches_backend(self):
+        cases = [
+            ("regex", "\x00\x01\x02\x1f"),
+            ("regex", "\x00"),
+            # a non-leading NUL truncates the pattern instead of crashing; pinned
+            # so the guard cannot be narrowed to startswith()
+            ("regex", "a\x00b"),
+            ("ebnf", "root ::= \x00"),
+            ("structural_tag", '{"triggers": ["\x00"]}'),
+            # escaped forms: no raw NUL byte anywhere in the key string
+            ("json", '{"type":"string","pattern":"\\u0000"}'),
+            (
+                "json",
+                '{"type":"object","properties":'
+                '{"f":{"type":"string","pattern":"\\u0000x"}}}',
+            ),
+            ("structural_tag", '{"format":{"pattern":"\\u0000"}}'),
+        ]
+        for key_type, key_string in cases:
+            with self.subTest(key_type=key_type, key_string=repr(key_string)):
+                dispatch = MagicMock()
+                setattr(self.backend, f"dispatch_{key_type}", dispatch)
+
+                result = self.backend._init_value_dispatch(
+                    (key_type, key_string), False
+                )
+
+                self.assertIsInstance(result, InvalidGrammarObject)
+                dispatch.assert_not_called()
+
+    def test_nul_free_payload_still_dispatches(self):
+        cases = [
+            ("regex", "[0-9]+"),
+            ("regex", r"\x00"),  # escaped in the pattern text, not a raw NUL byte
+            ("regex", "\x01\x02\x1f"),  # other control bytes are not the trigger
+            ("json", json.dumps({"type": "string", "pattern": "[0-9]+"})),
+            # malformed json must reach the backend and get its normal error,
+            # not be swallowed by the NUL scan's decode failure
+            ("json", "{not valid json"),
+        ]
+        for key_type, key_string in cases:
+            with self.subTest(key_type=key_type, key_string=repr(key_string)):
+                dispatch = MagicMock(return_value=BaseGrammarObject())
+                setattr(self.backend, f"dispatch_{key_type}", dispatch)
+
+                self.backend._init_value_dispatch((key_type, key_string), False)
+
+                dispatch.assert_called_once_with(key_string)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/distributed/test_gated_launch.py
+++ b/test/registered/unit/distributed/test_gated_launch.py
@@ -1,0 +1,197 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+import multiprocessing
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import requests
+import torch.distributed as dist
+
+from sglang.srt.distributed import gated_launch
+from sglang.srt.distributed.gated_launch import (
+    POLL_INTERVAL_SECONDS,
+    _GatedLaunchServer,
+    _wait_until_activated,
+    maybe_wait_for_gated_launch,
+)
+from sglang.srt.utils.network import get_open_port
+from sglang.test.test_utils import CustomTestCase
+
+_JOIN_TIMEOUT_SECONDS = 120
+
+
+def _fake_world_group(*, rank: int, world_size: int, cpu_group=None):
+    return SimpleNamespace(
+        rank=rank,
+        rank_in_group=rank,
+        ranks=list(range(world_size)),
+        world_size=world_size,
+        cpu_group=cpu_group,
+    )
+
+
+def _activate_over_http(base_url: str, delay: float):
+    time.sleep(delay)
+    deadline = time.perf_counter() + 30
+    while time.perf_counter() < deadline:
+        try:
+            if requests.post(f"{base_url}/gate/activate", timeout=1).status_code == 200:
+                return
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(0.1)
+
+
+def _gated_launch_worker(
+    rank: int, dist_port: int, gate_port: int, activate_after: float, out
+):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{dist_port}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        if rank == 0:
+            threading.Thread(
+                target=_activate_over_http,
+                args=(f"http://127.0.0.1:{gate_port}", activate_after),
+                daemon=True,
+            ).start()
+
+        world_group = _fake_world_group(
+            rank=rank, world_size=2, cpu_group=dist.group.WORLD
+        )
+        started_at = time.perf_counter()
+        with patch.object(gated_launch, "get_world_group", return_value=world_group):
+            maybe_wait_for_gated_launch(host="127.0.0.1", port=gate_port)
+        out.put((rank, time.perf_counter() - started_at))
+    finally:
+        dist.destroy_process_group()
+
+
+class TestGatedLaunchServer(CustomTestCase):
+    def setUp(self):
+        self.server = _GatedLaunchServer()
+        self.port = get_open_port()
+        self.server.serve(host="127.0.0.1", port=self.port)
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self._wait_until_listening()
+
+    def _wait_until_listening(self):
+        deadline = time.perf_counter() + 30
+        while time.perf_counter() < deadline:
+            try:
+                requests.get(f"{self.base_url}/health", timeout=1)
+                return
+            except requests.exceptions.RequestException:
+                time.sleep(0.1)
+        self.fail(f"control server did not start listening on port {self.port}")
+
+    def test_health_is_served_while_the_gate_is_still_closed(self):
+        """The control port answers before activation so a caller can find it."""
+        response = requests.get(f"{self.base_url}/health", timeout=5)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(self.server.activated)
+
+    def test_activate_flips_the_flag_and_stays_successful_when_repeated(self):
+        """A retried activation still succeeds instead of erroring or toggling back."""
+        first = requests.post(f"{self.base_url}/gate/activate", timeout=5)
+        self.assertEqual(first.status_code, 200)
+        self.assertTrue(self.server.activated)
+
+        second = requests.post(f"{self.base_url}/gate/activate", timeout=5)
+        self.assertEqual(second.status_code, 200)
+        self.assertTrue(self.server.activated)
+
+    def test_activating_one_server_leaves_another_one_closed(self):
+        """The route acts on its own server instead of process wide state."""
+        other = _GatedLaunchServer()
+        other_port = get_open_port()
+        other.serve(host="127.0.0.1", port=other_port)
+
+        requests.post(f"{self.base_url}/gate/activate", timeout=5)
+
+        self.assertTrue(self.server.activated)
+        self.assertFalse(other.activated)
+
+
+class TestWaitUntilActivated(CustomTestCase):
+    def test_single_rank_keeps_polling_until_the_flag_is_set(self):
+        """A lone rank leaves the gate only after its own flag flips."""
+        server = _GatedLaunchServer()
+        activate_after = 2 * POLL_INTERVAL_SECONDS
+        threading.Timer(
+            activate_after, lambda: setattr(server, "activated", True)
+        ).start()
+
+        started_at = time.perf_counter()
+        _wait_until_activated(
+            world_group=_fake_world_group(rank=0, world_size=1), server=server
+        )
+        elapsed = time.perf_counter() - started_at
+
+        self.assertGreaterEqual(elapsed, activate_after)
+
+    def test_second_rank_learns_about_activation_through_the_cpu_group(self):
+        """Driven through maybe_wait_for_gated_launch: the rank without the control server is released by the gloo broadcast."""
+        context = multiprocessing.get_context("spawn")
+        out = context.Queue()
+        dist_port = get_open_port()
+        gate_port = get_open_port()
+        activate_after = 2 * POLL_INTERVAL_SECONDS
+
+        processes = [
+            context.Process(
+                target=_gated_launch_worker,
+                args=(rank, dist_port, gate_port, activate_after, out),
+            )
+            for rank in range(2)
+        ]
+        for process in processes:
+            process.start()
+
+        elapsed_by_rank = {}
+        for _ in processes:
+            rank, elapsed = out.get(timeout=_JOIN_TIMEOUT_SECONDS)
+            elapsed_by_rank[rank] = elapsed
+
+        for process in processes:
+            process.join(timeout=_JOIN_TIMEOUT_SECONDS)
+        for process in processes:
+            self.assertEqual(process.exitcode, 0)
+        self.assertEqual(sorted(elapsed_by_rank), [0, 1])
+        self.assertGreaterEqual(elapsed_by_rank[1], activate_after)
+
+
+class TestMaybeWaitForGatedLaunch(CustomTestCase):
+    def setUp(self):
+        self.addCleanup(setattr, gated_launch, "_instance", None)
+        gated_launch._instance = None
+
+    def test_an_unset_port_leaves_the_startup_path_untouched(self):
+        """Without the flag the gate never reaches the distributed environment."""
+        with patch.object(gated_launch, "get_world_group") as get_world_group:
+            maybe_wait_for_gated_launch(host="127.0.0.1", port=None)
+
+        get_world_group.assert_not_called()
+        self.assertIsNone(gated_launch._instance)
+
+    def test_a_second_call_in_the_same_process_does_not_gate_again(self):
+        """A draft worker re-entering the init path must not wait a second time."""
+        gated_launch._instance = _GatedLaunchServer()
+
+        with patch.object(gated_launch, "get_world_group") as get_world_group:
+            maybe_wait_for_gated_launch(host="127.0.0.1", port=get_open_port())
+
+        get_world_group.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/anthropic/test_utils.py
+++ b/test/registered/unit/entrypoints/anthropic/test_utils.py
@@ -1,0 +1,793 @@
+"""Tests for the Anthropic conversion seams used by external frontends.
+
+Request and response goldens call the public runtime-independent functions in
+serving.py directly. The utils-specific tests cover the composite error DTO,
+eager fake-SSE synthesis, and message-ID generation.
+"""
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
+
+from sglang.srt.entrypoints.anthropic import utils  # noqa: E402
+from sglang.srt.entrypoints.anthropic.protocol import (  # noqa: E402
+    AnthropicMessagesRequest,
+)
+from sglang.srt.entrypoints.anthropic.serving import (  # noqa: E402
+    AnthropicServing,
+    convert_response,
+    convert_to_chat_completion_request,
+)
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+class _FakeOpenAIServingChat:
+    """Just enough of OpenAIServingChat for ``AnthropicServing.__init__``."""
+
+    def __init__(self, chat_template=None):
+        self.tokenizer_manager = SimpleNamespace(
+            tokenizer=SimpleNamespace(chat_template=chat_template)
+        )
+
+
+def _real_serving(merge_inline_system: bool) -> AnthropicServing:
+    """A normally constructed AnthropicServing with a forced policy.
+
+    The matrix must cover both policy values regardless of what the fake's
+    (absent) chat template probes to; template detection itself is covered
+    by ``test_serving.py``.
+    """
+    serving = AnthropicServing(_FakeOpenAIServingChat())
+    serving._merge_inline_system = merge_inline_system
+    return serving
+
+
+def _payload(messages, **extra) -> dict:
+    return {"model": "claude-test", "max_tokens": 64, "messages": messages, **extra}
+
+
+def _convert(payload: dict, merge_inline_system: bool = True) -> dict:
+    request = AnthropicMessagesRequest.model_validate(payload)
+    openai_request = convert_to_chat_completion_request(
+        request, merge_inline_system=merge_inline_system
+    )
+    return openai_request.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+
+_TOOLS = [
+    {
+        "name": "get_weather",
+        "description": "w",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+]
+
+_REQUEST_CASES = {
+    "text_system_sampling": _payload(
+        [{"role": "user", "content": "hello"}],
+        system="be brief",
+        temperature=0.5,
+        top_k=20,
+        top_p=0.9,
+        stop_sequences=["END", "STOP"],
+    ),
+    "system_blocks_and_inline_system": _payload(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": [{"type": "text", "text": " inline "}]},
+        ],
+        system=[{"type": "text", "text": "s1"}, {"type": "text", "text": "s2"}],
+    ),
+    "stream_with_options": _payload([{"role": "user", "content": "hi"}], stream=True),
+    "tool_roundtrip": _payload(
+        [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "get_weather",
+                        "input": {"city": "Paris"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "pre"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "sunny",
+                        "is_error": True,
+                    },
+                    {"type": "text", "text": "post"},
+                ],
+            },
+        ],
+        tools=_TOOLS,
+        tool_choice={"type": "auto"},
+    ),
+    "empty_placeholders": _payload(
+        [
+            {"role": "assistant", "content": [{"type": "text", "text": ""}]},
+            {"role": "assistant", "content": []},
+            {"role": "user", "content": "q"},
+        ]
+    ),
+    "images": _payload(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": "eA==",
+                        },
+                    },
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://x/y.png"},
+                    },
+                ],
+            }
+        ]
+    ),
+    "search_result_block": _payload(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "search_result",
+                        "title": "T",
+                        "source": "https://s",
+                        "content": [{"type": "text", "text": "C"}],
+                    }
+                ],
+            }
+        ]
+    ),
+    "server_tools_skipped": _payload(
+        [{"role": "user", "content": "q"}],
+        tools=[{"type": "web_search_20250305", "name": "web_search"}, *_TOOLS],
+    ),
+}
+
+
+def _chat_response(
+    message: dict, finish_reason: str = "stop", usage: dict = None
+) -> ChatCompletionResponse:
+    return ChatCompletionResponse.model_validate(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "served-alias",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", **message},
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": usage
+            or {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+    )
+
+
+_RESPONSE_CASES = {
+    "reasoning_and_tools": (
+        {
+            "content": "text",
+            "reasoning_content": "thought",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"a": 1}'},
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "g", "arguments": "not json"},
+                },
+            ],
+        },
+        "tool_calls",
+        None,
+    ),
+}
+
+
+class TestRequestGoldens(unittest.TestCase):
+    """Absolute value pins for the public request converter."""
+
+    def test_sampling_params_and_system(self):
+        dump = _convert(_REQUEST_CASES["text_system_sampling"])
+        self.assertEqual(
+            (dump["temperature"], dump["top_k"], dump["top_p"], dump["stop"]),
+            (0.5, 20, 0.9, ["END", "STOP"]),
+        )
+        self.assertEqual(dump["max_tokens"], 64)
+        self.assertIs(dump["stream"], False)
+        self.assertNotIn("stream_options", dump)
+        self.assertEqual(
+            dump["messages"],
+            [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hello"},
+            ],
+        )
+
+    def test_stream_true_sets_stream_options(self):
+        dump = _convert(_REQUEST_CASES["stream_with_options"])
+        self.assertIs(dump["stream"], True)
+        self.assertEqual(
+            dump["stream_options"],
+            {"include_usage": True, "continuous_usage_stats": True},
+        )
+
+    def test_system_blocks_and_inline_system_merge(self):
+        payload = _REQUEST_CASES["system_blocks_and_inline_system"]
+        merged = _convert(payload, merge_inline_system=True)
+        self.assertEqual(
+            merged["messages"][0], {"role": "system", "content": "s1\ns2\ninline"}
+        )
+        self.assertEqual([m["role"] for m in merged["messages"]], ["system", "user"])
+
+        unmerged = _convert(payload, merge_inline_system=False)
+        self.assertEqual(
+            unmerged["messages"][0], {"role": "system", "content": "s1\ns2"}
+        )
+        self.assertEqual(
+            [m["role"] for m in unmerged["messages"]], ["system", "user", "system"]
+        )
+
+    def test_tool_use_roundtrip_and_wire_order(self):
+        dump = _convert(_REQUEST_CASES["tool_roundtrip"])
+        self.assertEqual(
+            dump["messages"][1],
+            {
+                "role": "assistant",
+                "content": "checking",
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                    }
+                ],
+            },
+        )
+        # Wire order preserved: user(pre) -> tool -> user(post); is_error is
+        # dropped from the OpenAI tool message.
+        self.assertEqual(dump["messages"][2], {"role": "user", "content": "pre"})
+        self.assertEqual(
+            dump["messages"][3],
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "sunny"},
+        )
+        self.assertEqual(dump["messages"][4], {"role": "user", "content": "post"})
+        self.assertEqual(dump["tools"][0]["function"]["name"], "get_weather")
+
+    def test_tool_result_variants(self):
+        dump = _convert(
+            _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "id": "legacy_id", "content": None}
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t2",
+                                "content": "inner",
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t3",
+                                "content": [
+                                    {"type": "text", "text": "a"},
+                                    {"type": "text", "text": "b"},
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        # None content -> ""; legacy ``id`` used as tool_call_id fallback.
+        self.assertEqual(
+            dump["messages"][0],
+            {"role": "tool", "tool_call_id": "legacy_id", "content": ""},
+        )
+        # Assistant-role tool_result folds into text.
+        self.assertEqual(
+            dump["messages"][1], {"role": "assistant", "content": "Tool result: inner"}
+        )
+        # Multi-text list keeps the parts list.
+        self.assertEqual(
+            dump["messages"][2]["content"],
+            [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+        )
+
+    def test_tool_choice_mappings(self):
+        msgs = [{"role": "user", "content": "q"}]
+        self.assertEqual(
+            _convert(_payload(msgs, tools=_TOOLS, tool_choice={"type": "any"}))[
+                "tool_choice"
+            ],
+            "required",
+        )
+        self.assertEqual(
+            _convert(_payload(msgs, tools=_TOOLS, tool_choice={"type": "none"}))[
+                "tool_choice"
+            ],
+            "none",
+        )
+        self.assertEqual(
+            _convert(
+                _payload(
+                    msgs,
+                    tools=_TOOLS,
+                    tool_choice={"type": "tool", "name": "get_weather"},
+                )
+            )["tool_choice"],
+            {"type": "function", "function": {"name": "get_weather"}},
+        )
+        self.assertEqual(_convert(_payload(msgs, tools=_TOOLS))["tool_choice"], "auto")
+        with self.assertRaisesRegex(ValueError, "not in the forwarded tools list"):
+            _convert(
+                _payload(
+                    msgs, tools=_TOOLS, tool_choice={"type": "tool", "name": "missing"}
+                )
+            )
+        with self.assertRaisesRegex(ValueError, "requires at least one custom"):
+            _convert(_payload(msgs, tool_choice={"type": "any"}))
+
+    def test_empty_text_and_empty_assistant_placeholders(self):
+        dump = _convert(_REQUEST_CASES["empty_placeholders"])
+        self.assertEqual(dump["messages"][0], {"role": "assistant", "content": ""})
+        self.assertEqual(dump["messages"][1], {"role": "assistant", "content": ""})
+
+
+class TestResponseGoldens(unittest.TestCase):
+    """Absolute value pins for the public response converter."""
+
+    def test_default_id_factory_keeps_wire_format(self):
+        result = convert_response(_chat_response({"content": "hi"}))
+        self.assertRegex(result.id, r"^msg_[0-9a-f]{32}$")
+
+    def test_empty_choices_response(self):
+        no_choices = ChatCompletionResponse.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            }
+        )
+        result = convert_response(no_choices)
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual([b.type for b in result.content], ["text"])
+        self.assertEqual(result.content[0].text, "")
+        self.assertEqual(
+            (result.usage.input_tokens, result.usage.output_tokens), (0, 0)
+        )
+
+    def test_block_order_and_invalid_json_tool_arguments(self):
+        message, finish_reason, _ = _RESPONSE_CASES["reasoning_and_tools"]
+        result = convert_response(_chat_response(message, finish_reason))
+        types = [(b.type, getattr(b, "name", None)) for b in result.content]
+        self.assertEqual(
+            types,
+            [("thinking", None), ("text", None), ("tool_use", "f"), ("tool_use", "g")],
+        )
+        self.assertEqual(result.content[2].input, {"a": 1})
+        self.assertEqual(result.content[3].input, {})
+        self.assertEqual(result.stop_reason, "tool_use")
+
+    def test_stop_reason_mapping(self):
+        length = convert_response(_chat_response({"content": "x"}, "length"))
+        self.assertEqual(length.stop_reason, "max_tokens")
+        unmapped = convert_response(_chat_response({"content": "x"}, "content_filter"))
+        self.assertEqual(unmapped.stop_reason, "end_turn")
+
+
+class TestExtendedRequestGoldens(unittest.TestCase):
+    def test_unknown_extra_keys_keep_pydantic_ignore_behavior(self):
+        payload = _payload(
+            [{"role": "user", "content": "hi", "unknown_msg_key": 1}],
+            unknown_top_key="x",
+        )
+        request = AnthropicMessagesRequest.model_validate(payload)
+        self.assertEqual(request.model, "claude-test")
+        self.assertFalse(hasattr(request, "unknown_top_key"))
+
+    def test_image_conversion(self):
+        dump = _convert(_REQUEST_CASES["images"])
+        parts = dump["messages"][0]["content"]
+        self.assertEqual([p["type"] for p in parts], ["text", "image_url", "image_url"])
+        self.assertEqual(parts[1]["image_url"]["url"], "data:image/jpeg;base64,eA==")
+        self.assertEqual(parts[2]["image_url"]["url"], "https://x/y.png")
+
+    def test_output_config_effort_mapping(self):
+        msgs = [{"role": "user", "content": "q"}]
+        high = _convert(_payload(msgs, output_config={"effort": "high"}))
+        xhigh = _convert(_payload(msgs, output_config={"effort": "xhigh"}))
+        self.assertEqual(high["reasoning_effort"], "high")
+        self.assertEqual(xhigh["reasoning_effort"], "max")
+
+    def test_server_tools_are_skipped_not_forwarded(self):
+        dump = _convert(_REQUEST_CASES["server_tools_skipped"])
+        self.assertEqual(
+            [tool["function"]["name"] for tool in dump["tools"]], ["get_weather"]
+        )
+
+    def test_search_result_flattening(self):
+        dump = _convert(_REQUEST_CASES["search_result_block"])
+        self.assertEqual(
+            dump["messages"][0],
+            {"role": "user", "content": "Title: T\nSource: https://s\nContent: C"},
+        )
+
+    def test_nested_tool_reference_translation(self):
+        dump = _convert(
+            _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t",
+                                "content": [
+                                    {
+                                        "type": "tool_reference",
+                                        "tool_name": "deferred_fn",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+        self.assertEqual(
+            dump["messages"][0]["content"],
+            [{"type": "tool_reference", "name": "deferred_fn"}],
+        )
+
+
+_ERROR_BODIES = [
+    b'{"error": "boom"}',
+    b'{"error": {"message": "m", "type": "custom_type"}}',
+    b'{"message": "top-level"}',
+    b"<html>gateway</html>",
+    b"",
+]
+
+
+class TestErrorConversion(unittest.TestCase):
+    def test_matches_serving_for_shared_statuses(self):
+        # Statuses present in serving.py's own ERROR_TYPE_MAP; 413/422 are
+        # composite additions with no serving.py equivalent (below).
+        for status in (400, 401, 403, 404, 408, 429, 500, 502, 503, 504):
+            for body in _ERROR_BODIES:
+                with self.subTest(status=status, body=body):
+                    serving_response = _real_serving(
+                        True
+                    )._convert_openai_error_response(
+                        SimpleNamespace(status_code=status, body=body)
+                    )
+                    self.assertEqual(serving_response.status_code, status)
+                    envelope = utils.to_anthropic_error(status, body)
+                    self.assertEqual(
+                        envelope.model_dump(), json.loads(bytes(serving_response.body))
+                    )
+
+    def test_composite_statuses_follow_http_layer_policy(self):
+        self.assertEqual(utils.ERROR_TYPE_MAP[413], "request_too_large")
+        self.assertEqual(utils.ERROR_TYPE_MAP[422], "invalid_request_error")
+        env_413 = utils.to_anthropic_error(413, b'{"error": "big"}')
+        self.assertEqual(
+            (env_413.error.type, env_413.error.message), ("request_too_large", "big")
+        )
+        env_422 = utils.to_anthropic_error(422, b'{"error": "bad"}')
+        self.assertEqual(
+            (env_422.error.type, env_422.error.message),
+            ("invalid_request_error", "bad"),
+        )
+        # The composite statuses share the full message policy: custom
+        # error.type honored for 4xx, empty body -> "Request failed".
+        custom = utils.to_anthropic_error(
+            413, b'{"error": {"message": "m", "type": "custom_type"}}'
+        )
+        self.assertEqual(
+            (custom.error.type, custom.error.message), ("custom_type", "m")
+        )
+        self.assertEqual(
+            utils.to_anthropic_error(422, b"").error.message, "Request failed"
+        )
+        # Unlisted statuses fall through to api_error in both sources.
+        self.assertEqual(
+            utils.to_anthropic_error(409, b'{"error": "conflict"}').error.type,
+            "api_error",
+        )
+
+    def test_message_policy_goldens(self):
+        """Absolute pins for the envelope message policy (see
+        TestRequestGoldens for why value pins accompany the delegation
+        matrix)."""
+        # 4xx keeps the parsed upstream message; custom error.type honored.
+        env = utils.to_anthropic_error(
+            400, b'{"error": {"message": "m", "type": "custom_type"}}'
+        )
+        self.assertEqual((env.error.type, env.error.message), ("custom_type", "m"))
+        # 5xx never echoes upstream detail or type.
+        env = utils.to_anthropic_error(
+            500, b'{"error": {"message": "secret", "type": "custom_type"}}'
+        )
+        self.assertEqual(
+            (env.error.type, env.error.message), ("api_error", "Internal server error")
+        )
+        # Empty-body fallbacks.
+        self.assertEqual(
+            utils.to_anthropic_error(400, b"").error.message, "Request failed"
+        )
+        self.assertEqual(
+            utils.to_anthropic_error(502, b"").error.message, "Internal server error"
+        )
+        # Non-JSON 4xx body passes through as a bounded hint.
+        self.assertEqual(
+            utils.to_anthropic_error(400, b"<html>gateway</html>").error.message,
+            "<html>gateway</html>",
+        )
+
+    def test_composite_map_matches_http_server_source(self):
+        """413/422 are a copy of the inline status->type dict in
+        ``http_server.py``'s ``/v1/messages`` exception handler, which is not
+        importable without loading the server app. Parse the source so a
+        policy change there fails loudly here instead of silently diverging
+        every external frontend."""
+        origin = importlib.util.find_spec("sglang.srt.entrypoints.http_server").origin
+        tree = ast.parse(Path(origin).read_text())
+        handler_maps = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict) or not node.keys:
+                continue
+            if not all(
+                key is not None
+                and isinstance(key, ast.Constant)
+                and isinstance(key.value, int)
+                for key in node.keys
+            ):
+                continue
+            mapping = {
+                key.value: value.value
+                for key, value in zip(node.keys, node.values)
+                if isinstance(value, ast.Constant)
+            }
+            if 413 in mapping and 422 in mapping:
+                handler_maps.append(mapping)
+        self.assertTrue(
+            handler_maps, "no status->type dict with 413/422 found in http_server.py"
+        )
+        for mapping in handler_maps:
+            for status, error_type in mapping.items():
+                self.assertEqual(
+                    utils.ERROR_TYPE_MAP.get(status, "api_error"),
+                    error_type,
+                    f"status {status} diverged from http_server.py policy",
+                )
+
+    def test_4xx_scrub_strips_traceback_lines_and_truncates(self):
+        upstream = "\n".join(
+            [
+                "Traceback (most recent call last):",
+                '  File "/app/handler.py", line 3, in run',
+                "real cause: " + "x" * 600,
+            ]
+        )
+        body = json.dumps({"error": {"message": upstream}}).encode()
+        message = utils.to_anthropic_error(400, body).error.message
+        self.assertNotIn("Traceback", message)
+        self.assertNotIn('File "/', message)
+        self.assertTrue(message.startswith("real cause: "))
+        self.assertEqual(len(message), 501)
+        self.assertTrue(message.endswith("…"))
+
+
+class TestFakeSse(unittest.TestCase):
+    def test_default_id_factory_keeps_wire_format(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response({"content": "hello"}), model="claude-test"
+        )
+        self.assertRegex(events[0].message.id, r"^msg_[0-9a-f]{32}$")
+
+    def test_text_event_sequence_uses_request_model(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response({"content": "hello"}),
+            model="claude-test",
+            id_factory=lambda: "msg_fixed",
+        )
+        self.assertEqual(
+            [e.type for e in events],
+            [
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ],
+        )
+        start = events[0].message
+        # Model comes from the Anthropic request, not the backend alias.
+        self.assertEqual(start.model, "claude-test")
+        self.assertEqual(start.id, "msg_fixed")
+        self.assertEqual(start.content, [])
+        self.assertEqual(start.usage.input_tokens, 10)
+        self.assertEqual(start.usage.output_tokens, 0)
+        self.assertEqual(events[2].delta.text, "hello")
+        self.assertEqual(events[4].delta.stop_reason, "end_turn")
+        self.assertIsNone(events[4].usage.input_tokens)
+        self.assertEqual(events[4].usage.output_tokens, 5)
+
+    def test_multi_block_index_accounting(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response(
+                {
+                    "content": "txt",
+                    "reasoning_content": "think",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a": 1}'},
+                        },
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {"name": "g", "arguments": ""},
+                        },
+                    ],
+                },
+                finish_reason="tool_calls",
+            ),
+            model="claude-test",
+            id_factory=lambda: "m",
+        )
+        starts = [e for e in events if e.type == "content_block_start"]
+        self.assertEqual(
+            [(e.index, e.content_block.type) for e in starts],
+            [(0, "thinking"), (1, "text"), (2, "tool_use"), (3, "tool_use")],
+        )
+        deltas = [e for e in events if e.type == "content_block_delta"]
+        # A zero-argument tool call emits no input_json_delta (live stream
+        # behavior).
+        self.assertEqual(
+            [(e.index, e.delta.type) for e in deltas],
+            [(0, "thinking_delta"), (1, "text_delta"), (2, "input_json_delta")],
+        )
+        self.assertEqual(deltas[2].delta.partial_json, '{"a": 1}')
+        stops = [e.index for e in events if e.type == "content_block_stop"]
+        self.assertEqual(stops, [0, 1, 2, 3])
+        self.assertEqual(events[-2].delta.stop_reason, "tool_use")
+        self.assertEqual(events[-1].type, "message_stop")
+
+    def test_unmapped_finish_reason_and_cached_usage(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response(
+                {"content": "x"},
+                finish_reason="content_filter",
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 4},
+                },
+            ),
+            model="claude-test",
+            id_factory=lambda: "m",
+        )
+        start_usage = events[0].message.usage
+        self.assertEqual(
+            (
+                start_usage.input_tokens,
+                start_usage.cache_read_input_tokens,
+                start_usage.output_tokens,
+            ),
+            (6, 4, 0),
+        )
+        message_delta = next(e for e in events if e.type == "message_delta")
+        # content_filter is unmapped and falls through to end_turn.
+        self.assertEqual(message_delta.delta.stop_reason, "end_turn")
+        self.assertIsNone(message_delta.usage.cache_read_input_tokens)
+        self.assertEqual(message_delta.usage.output_tokens, 5)
+
+
+class TestFakeSseEdgeCases(unittest.TestCase):
+    def test_empty_choices_emits_bare_envelope(self):
+        no_choices = ChatCompletionResponse.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            }
+        )
+        events = utils.to_anthropic_fake_sse_events(
+            no_choices, model="claude-test", id_factory=lambda: "m"
+        )
+        self.assertEqual(
+            [e.type for e in events], ["message_start", "message_delta", "message_stop"]
+        )
+        self.assertEqual(events[1].delta.stop_reason, "end_turn")
+
+
+class TestImportHygiene(unittest.TestCase):
+    def test_utils_import_loads_no_serving_runtime(self):
+        # External frontends import this module without a serving runtime;
+        # it must not pull the OpenAI serving chat, tokenizer manager, or
+        # engine (serving.py keeps OpenAIServingChat under TYPE_CHECKING).
+        code = (
+            "import sys\n"
+            "import sglang.srt.entrypoints.anthropic.utils\n"
+            "banned = ('sglang.srt.entrypoints.openai.serving_chat',\n"
+            "          'sglang.srt.managers.tokenizer_manager',\n"
+            "          'sglang.srt.entrypoints.engine')\n"
+            "loaded = [m for m in sys.modules for b in banned "
+            "if m == b or m.startswith(b + '.')]\n"
+            "assert not loaded, loaded\n"
+        )
+        subprocess.run([sys.executable, "-c", code], check=True, timeout=300)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -27,13 +27,15 @@ from sglang.srt.entrypoints.openai.chat_encoding import (
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     MessageProcessingResult,
+    ToolChoice,
+    ToolChoiceFuncName,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
     normalize_tool_content,
 )
 from sglang.srt.environ import envs
-from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE
+from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE, TOOLS_OPEN
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.srt.utils import get_or_create_event_loop
@@ -1568,6 +1570,191 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertEqual(tool_calls[0].function.name, "get_weather")
             self.assertEqual(tool_calls[1].id, "functions.get_weather:2")
             self.assertEqual(tool_calls[1].function.name, "get_weather")
+
+    def test_required_tool_choice_skips_json_fallback_for_native_parser(self):
+        """A structural-tag parser owns the output format, so a missing tool
+        call must not be pushed through the json_schema array fallback."""
+        self.chat.tool_call_parser = "kimi_k3"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        texts = {
+            "prose": "<|open|>response<|sep|>I'll check that.<|close|>response<|sep|>",
+            "empty": "",
+            "json_object": '{"name": "get_weather", "parameters": {"city": "Paris"}}',
+        }
+        for choice in (
+            "required",
+            ToolChoice(function=ToolChoiceFuncName(name="get_weather")),
+        ):
+            for label, text in texts.items():
+                with self.subTest(tool_choice=choice, payload=label):
+                    finish_reason = {"type": "stop", "matched": None}
+                    with self.assertLogs(
+                        "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+                    ) as logs:
+                        tool_calls, remaining, finish_reason = (
+                            self.chat._process_tool_calls(
+                                text=text,
+                                tools=tools,
+                                finish_reason=finish_reason,
+                                tool_choice=choice,
+                            )
+                        )
+                    self.assertIsNone(tool_calls)
+                    self.assertEqual(remaining, text)
+                    self.assertEqual(finish_reason["type"], "stop")
+                    self.assertNotIn("Tool call parsing error", "\n".join(logs.output))
+
+    def test_truncated_native_tool_call_logs_and_drops(self):
+        """A tools section cut off before its closing tag parses to zero calls
+        without raising; the sync path used to drop it with no log at all."""
+        self.chat.tool_call_parser = "kimi_k3"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        truncated = TOOLS_OPEN + '<|open|>call tool="get_weather" index="1"<|sep|>'
+        for choice in ("auto", "required"):
+            with self.subTest(tool_choice=choice):
+                finish_reason = {"type": "stop", "matched": None}
+                with self.assertLogs(
+                    "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+                ) as logs:
+                    tool_calls, remaining, finish_reason = (
+                        self.chat._process_tool_calls(
+                            text=truncated,
+                            tools=tools,
+                            finish_reason=finish_reason,
+                            tool_choice=choice,
+                        )
+                    )
+                self.assertIsNone(tool_calls)
+                self.assertEqual(remaining, "")
+                self.assertEqual(finish_reason["type"], "stop")
+                self.assertIn("no complete call", "\n".join(logs.output))
+
+    def test_required_tool_choice_json_fallback_tolerates_odd_shapes(self):
+        """Parsers without a structural tag keep the JSON array fallback, but a
+        non-array payload degrades instead of raising an opaque TypeError."""
+        self.chat.tool_call_parser = "glm45"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        cases = [
+            (
+                '[{"name": "get_weather", "parameters": {"city": "Paris"}}]',
+                '{"city": "Paris"}',
+            ),
+            (
+                '{"name": "get_weather", "parameters": {"city": "Paris"}}',
+                '{"city": "Paris"}',
+            ),
+            ('{"name": "get_weather"}', "{}"),
+        ]
+        for text, expected_args in cases:
+            with self.subTest(text=text):
+                tool_calls, _, finish_reason = self.chat._process_tool_calls(
+                    text=text,
+                    tools=tools,
+                    finish_reason={"type": "stop", "matched": None},
+                    tool_choice="required",
+                )
+                self.assertEqual(len(tool_calls), 1)
+                self.assertEqual(tool_calls[0].function.name, "get_weather")
+                self.assertEqual(tool_calls[0].function.arguments, expected_args)
+                self.assertEqual(finish_reason["type"], "tool_calls")
+
+        finish_reason = {"type": "stop", "matched": None}
+        with self.assertLogs(
+            "sglang.srt.entrypoints.openai.serving_chat", level="ERROR"
+        ):
+            tool_calls, remaining, finish_reason = self.chat._process_tool_calls(
+                text='["get_weather"]',
+                tools=tools,
+                finish_reason=finish_reason,
+                tool_choice="required",
+            )
+        self.assertIsNone(tool_calls)
+        self.assertEqual(remaining, '["get_weather"]')
+        self.assertEqual(finish_reason["type"], "stop")
+
+    def test_required_tool_choice_rejects_conflicting_output_constraint(self):
+        """response_format and a forced tool call cannot both be honored: the
+        tool-call constraint was dropped with only a warning, so the model was
+        constrained to a shape that can never contain a tool call."""
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        constraint = ("structural_tag", None)
+        conflicting = [
+            {"type": "json_object"},
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "a", "schema": {"type": "object"}},
+            },
+        ]
+        for tool_choice in (
+            "required",
+            ToolChoice(function=ToolChoiceFuncName(name="get_weather")),
+        ):
+            for response_format in conflicting:
+                with self.subTest(tool_choice=tool_choice, rf=response_format["type"]):
+                    request = ChatCompletionRequest(
+                        model="x",
+                        messages=[{"role": "user", "content": "hi"}],
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        response_format=response_format,
+                    )
+                    with self.assertRaises(ValueError) as ctx:
+                        request.to_sampling_params(
+                            stop=[],
+                            model_generation_config={},
+                            tool_call_constraint=constraint,
+                        )
+                    self.assertIn("cannot be combined", str(ctx.exception))
+
+    def test_auto_tool_choice_keeps_response_format_without_raising(self):
+        """ "auto" means the model need not call a tool, so dropping the
+        tool-call constraint still leaves a satisfiable request."""
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            tool_choice="auto",
+            response_format={"type": "json_object"},
+        )
+        sampling_params = request.to_sampling_params(
+            stop=[],
+            model_generation_config={},
+            tool_call_constraint=("structural_tag", None),
+        )
+        self.assertEqual(sampling_params["json_schema"], '{"type": "object"}')
 
     def test_kimi_k2_streaming_tool_call_id_with_history(self):
         """Ensure streaming first chunk tool_call.id increase with tool calls history for kimi_k2 parser."""

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -691,6 +691,44 @@ class OutputItemsTestCase(CustomTestCase):
             [],
         )
 
+    def test_required_tool_choice_skips_json_fallback_for_native_parser(self):
+        """muse reports parses_required_natively, so required output must not
+        be pushed through the orjson JSON-array fallback (mirrors chat)."""
+        serving = self.serving
+        serving.tool_call_parser = "muse"
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            tool_choice="required",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            store=False,
+        )
+        raw = '[{"name": "get_weather", "parameters": {"city": "Beijing"}}]'
+
+        output_items = serving._make_response_output_items(
+            request, raw, tokenizer=Mock(), require_reasoning=False
+        )
+
+        self.assertEqual(
+            [
+                item
+                for item in output_items
+                if isinstance(item, ResponseFunctionToolCall)
+            ],
+            [],
+        )
+        message_items = [
+            item for item in output_items if isinstance(item, ResponseOutputMessage)
+        ]
+        self.assertEqual(len(message_items), 1)
+        self.assertEqual(message_items[0].content[0].text, raw)
+
     def test_no_tool_call_extraction_when_tool_choice_none(self):
         serving = self.serving
         request = ResponsesRequest(

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
@@ -291,6 +291,26 @@ class TestG1ScaleC(CustomTestCase):
         self.assertTrue(g1_scale_c.is_contiguous())
         torch.testing.assert_close(g1_scale_c, torch.full((num_experts,), 20.0))
 
+    def test_situ_keeps_both_dequant_scales_inside_activation(self):
+        # SiTU keeps both GEMM1 scales before tanh; scale_c contains only the
+        # GEMM2 input requantization.
+        num_experts = GATED_CONFIGS[0][1]
+        w2_input_scale_quant = torch.tensor(20.0)
+        gate = _global_scales(num_experts, 1, seed=8)
+        up = _global_scales(num_experts, 1, seed=9)
+
+        g1_scale_c = _compute_g1_scale_c(
+            w2_input_scale_quant,
+            gate,
+            up,
+            is_gated=True,
+            activation="situ",
+        )
+
+        self.assertEqual(g1_scale_c.shape, (num_experts,))
+        self.assertTrue(g1_scale_c.is_contiguous())
+        torch.testing.assert_close(g1_scale_c, torch.full((num_experts,), 20.0))
+
     def test_scale_c_is_float32(self):
         # Lower-precision inputs are upcast to fp32 for the kernel.
         num_experts = GATED_CONFIGS[0][1]

--- a/test/registered/unit/lora/test_lora_lease.py
+++ b/test/registered/unit/lora/test_lora_lease.py
@@ -1,0 +1,233 @@
+"""Unit tests for the exactly-once LoRA lease lifecycle.
+
+A leaked lease leaves the adapter's in-flight counter above zero forever, so
+unload's wait_for_zero never returns; a double release drives the counter
+negative, which hangs it just the same (it waits for exactly zero). Covers:
+
+  * TokenizerManager._finalize_lora_lease is the single, idempotent release
+    owner for every terminal path
+  * pre-acquire failures (lora_id never set) release nothing
+  * LoRARegistry.acquire: lookup + counter increment are one atomic admission
+    step under the writer lock, so acquire racing an unload fails cleanly
+    instead of touching a deleted counter
+  * LoRARegistry.lru_lora_name never picks non-reloadable (wire-loaded) refs
+  * explicit unload drops the lora_ref_cache entry (DELETE) while the locked
+    helper alone (the max_loaded_loras EVICT path) keeps it
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
+from sglang.srt.managers.io_struct import UnloadLoRAAdapterReqInput
+from sglang.srt.managers.tokenizer_manager import ReqState, TokenizerManager
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tm(enable_lora: bool = True) -> TokenizerManager:
+    """TokenizerManager with only the fields the lease path reads."""
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.enable_lora = enable_lora
+    tm.lora_registry = MagicMock()
+    tm.lora_registry.release = AsyncMock()
+    return tm
+
+
+def _make_state(lora_path="adapter-a", lora_id="id-1") -> ReqState:
+    obj = SimpleNamespace(lora_path=lora_path, lora_id=lora_id, rid="rid-1")
+    return ReqState([], False, asyncio.Event(), obj, Mock())
+
+
+class TestFinalizeLoraLease(CustomTestCase):
+    def _finalize(self, tm, state, times=1):
+        async def run():
+            for _ in range(times):
+                tm._finalize_lora_lease(state)
+            # Let the create_task'd release coroutines run.
+            await asyncio.sleep(0)
+
+        asyncio.run(run())
+
+    def test_release_exactly_once_on_double_finalize(self):
+        tm = _make_tm()
+        state = _make_state()
+        self._finalize(tm, state, times=3)
+        tm.lora_registry.release.assert_awaited_once_with("id-1")
+        self.assertTrue(state.lora_lease_released)
+
+    def test_pre_acquire_failure_releases_nothing(self):
+        # _init_req_state runs before the LoRA acquire; a failure in between
+        # leaves lora_id unset and there is no lease to release.
+        tm = _make_tm()
+        state = _make_state(lora_id=None)
+        self._finalize(tm, state)
+        tm.lora_registry.release.assert_not_awaited()
+        self.assertFalse(state.lora_lease_released)
+
+    def test_no_lora_path_is_noop(self):
+        tm = _make_tm()
+        state = _make_state(lora_path=None)
+        self._finalize(tm, state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_lora_disabled_is_noop(self):
+        tm = _make_tm(enable_lora=False)
+        state = _make_state()
+        self._finalize(tm, state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_none_state_is_noop(self):
+        tm = _make_tm()
+
+        async def run():
+            tm._finalize_lora_lease(None)
+
+        asyncio.run(run())
+        tm.lora_registry.release.assert_not_awaited()
+
+
+class TestAcquireAtomicity(CustomTestCase):
+    def test_acquire_after_unregister_raises_value_error(self):
+        async def run():
+            registry = LoRARegistry()
+            ref = LoRARef(lora_name="a", lora_path="/x")
+            await registry.register(ref)
+            await registry.unregister("a")
+            with self.assertRaises(ValueError):
+                await registry.acquire("a")
+
+        asyncio.run(run())
+
+    def test_unload_waits_for_inflight_lease_then_completes(self):
+        async def run():
+            registry = LoRARegistry()
+            ref = LoRARef(lora_name="a", lora_path="/x")
+            await registry.register(ref)
+            lora_id = await registry.acquire("a")
+            await registry.unregister("a")
+
+            wait_task = asyncio.create_task(registry.wait_for_unload(lora_id))
+            await asyncio.sleep(0.01)
+            self.assertFalse(wait_task.done(), "unload must wait for the lease")
+
+            await registry.release(lora_id)
+            await asyncio.wait_for(wait_task, timeout=2)
+
+        asyncio.run(run())
+
+    def test_batch_acquire_release_roundtrip(self):
+        async def run():
+            registry = LoRARegistry()
+            for name in ("a", "b"):
+                await registry.register(LoRARef(lora_name=name, lora_path=f"/{name}"))
+            lora_ids = await registry.acquire(["a", "b", None])
+            self.assertEqual(len(lora_ids), 3)
+            self.assertIsNone(lora_ids[2])
+            await registry.release([i for i in lora_ids if i is not None])
+            for name in ("a", "b"):
+                await registry.unregister(name)
+
+        asyncio.run(run())
+
+
+class TestLruSkipsNonReloadable(CustomTestCase):
+    def test_lru_prefers_reloadable_even_if_older_entry_is_wire_loaded(self):
+        async def run():
+            registry = LoRARegistry()
+            # Registration order = LRU order; the wire-loaded ref is oldest.
+            await registry.register(
+                LoRARef(lora_name="wire", lora_path="__distributed__", reloadable=False)
+            )
+            await registry.register(LoRARef(lora_name="disk", lora_path="/d"))
+            self.assertEqual(await registry.lru_lora_name(), "disk")
+
+        asyncio.run(run())
+
+    def test_all_non_reloadable_yields_no_victim(self):
+        async def run():
+            registry = LoRARegistry()
+            await registry.register(
+                LoRARef(lora_name="w1", lora_path="__tensor__", reloadable=False)
+            )
+            await registry.register(
+                LoRARef(lora_name="w2", lora_path="__distributed__", reloadable=False)
+            )
+            self.assertIsNone(await registry.lru_lora_name())
+            self.assertIsNone(await registry.lru_lora_name(exclude_pinned=True))
+
+        asyncio.run(run())
+
+    def test_exclude_pinned_still_respected(self):
+        async def run():
+            registry = LoRARegistry()
+            await registry.register(
+                LoRARef(lora_name="pinned-disk", lora_path="/p", pinned=True)
+            )
+            await registry.register(LoRARef(lora_name="plain-disk", lora_path="/q"))
+            self.assertEqual(
+                await registry.lru_lora_name(exclude_pinned=True), "plain-disk"
+            )
+            self.assertEqual(await registry.lru_lora_name(), "pinned-disk")
+
+        asyncio.run(run())
+
+
+class TestUnloadRefCacheCleanup(CustomTestCase):
+    def _make_unload_tm(self, success: bool) -> TokenizerManager:
+        tm = TokenizerManager.__new__(TokenizerManager)
+        tm.auto_create_handle_loop = Mock()
+        tm.server_args = MagicMock()
+        tm.server_args.enable_lora = True
+        tm.server_args.dp_size = 1
+        tm.lora_update_lock = asyncio.Lock()
+        tm._unload_lora_adapter_locked = AsyncMock(
+            return_value=SimpleNamespace(success=success)
+        )
+        tm.lora_ref_cache = {"a": LoRARef(lora_name="a", lora_path="/x")}
+        return tm
+
+    def test_explicit_unload_drops_ref_cache_entry(self):
+        tm = self._make_unload_tm(success=True)
+        asyncio.run(tm.unload_lora_adapter(UnloadLoRAAdapterReqInput(lora_name="a")))
+        self.assertNotIn("a", tm.lora_ref_cache)
+
+    def test_failed_unload_keeps_ref_cache_entry(self):
+        tm = self._make_unload_tm(success=False)
+        asyncio.run(tm.unload_lora_adapter(UnloadLoRAAdapterReqInput(lora_name="a")))
+        self.assertIn("a", tm.lora_ref_cache)
+
+    def test_locked_helper_alone_keeps_ref_cache_entry(self):
+        # The max_loaded_loras LRU loop calls _unload_lora_adapter_locked
+        # directly — an EVICT — and a disk-backed adapter must keep its
+        # reload-catalog entry or it can never be implicitly reloaded.
+        tm = TokenizerManager.__new__(TokenizerManager)
+        tm.lora_update_lock = asyncio.Lock()
+        tm.lora_registry = MagicMock()
+        tm.lora_registry.unregister = AsyncMock(return_value="id-a")
+        tm.lora_registry.wait_for_unload = AsyncMock()
+        tm.update_lora_adapter_communicator = AsyncMock(
+            return_value=[SimpleNamespace(success=True)]
+        )
+        tm.lora_ref_cache = {"a": LoRARef(lora_name="a", lora_path="/x")}
+
+        async def run():
+            async with tm.lora_update_lock:
+                return await tm._unload_lora_adapter_locked(
+                    UnloadLoRAAdapterReqInput(lora_name="a")
+                )
+
+        result = asyncio.run(run())
+        self.assertTrue(result.success)
+        self.assertIn("a", tm.lora_ref_cache)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_lora_upsert.py
+++ b/test/registered/unit/lora/test_lora_upsert.py
@@ -1,0 +1,537 @@
+"""Unit tests for the LoRA upsert (in-place refresh) path.
+
+With upsert=True, loading an adapter that is already registered refreshes
+its weights in place, reusing the existing lora_id and memory-pool slot
+instead of failing with a duplicate error. Covers:
+
+  * LoRARegistry.get_lora_id / register_or_reuse / refresh
+  * LoRAManager.load_lora_adapter_from_tensors upsert semantics
+  * failed-upsert rollback (no half-updated live adapter)
+  * num_pinned_loras consistency across pinned flips
+  * LoRAManager.validate_new_adapter duplicate-name / starvation checks
+  * TokenizerControlMixin from_distributed id reuse; the from_tensors route
+    rejects upsert explicitly (only from_distributed supports in-place refresh)
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.lora.lora_manager import LoRAManager
+from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
+from sglang.srt.managers.io_struct import (
+    LoadLoRAAdapterFromDistributedReqInput,
+    LoadLoRAAdapterFromTensorsReqInput,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+CONFIG_DICT = {"target_modules": ["q_proj"], "r": 8, "lora_alpha": 16}
+
+
+class TestLoRARegistryGetLoraId(CustomTestCase):
+    def test_returns_id_for_registered_adapter(self):
+        registry = LoRARegistry()
+        ref = LoRARef(lora_name="a", lora_path="/x")
+        asyncio.run(registry.register(ref))
+
+        self.assertEqual(asyncio.run(registry.get_lora_id("a")), ref.lora_id)
+
+    def test_returns_none_for_unregistered_adapter(self):
+        registry = LoRARegistry()
+        self.assertIsNone(asyncio.run(registry.get_lora_id("missing")))
+
+
+def _make_manager() -> LoRAManager:
+    """Create a LoRAManager via __new__ with only the fields the load path reads."""
+    manager = LoRAManager.__new__(LoRAManager)
+    manager.configs = {}
+    manager.loras = {}
+    manager.lora_refs = {}
+    manager.num_pinned_loras = 0
+    manager.max_loras_per_batch = 4
+    manager.base_hf_config = MagicMock(vocab_size=32000)
+    manager.lora_modules = []
+    manager.embed_tokens_module = None
+    manager.lm_head_module = None
+    manager.device = torch.device("cpu")
+    manager.memory_pool = MagicMock()
+    manager.memory_pool.can_support.return_value = True
+    manager.memory_pool.uid_to_buffer_id = {}
+    # Weight loading needs a real base model / backend; just build a stub.
+    manager._create_lora_adapter_from_tensors = Mock(
+        side_effect=lambda ref, config, tensors: MagicMock()
+    )
+    return manager
+
+
+class TestLoRAManagerUpsert(CustomTestCase):
+    def test_fresh_load_registers_adapter(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__", pinned=True)
+
+        result = manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+
+        self.assertTrue(result.success)
+        self.assertIn(ref.lora_id, manager.loras)
+        self.assertIs(manager.lora_refs[ref.lora_id], ref)
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+    def test_duplicate_load_without_upsert_asserts(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__")
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+
+        with self.assertRaises(AssertionError):
+            manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+
+    def test_upsert_refreshes_loaded_adapter_in_place(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__", pinned=True)
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+        # Simulate the adapter occupying a memory-pool buffer slot.
+        manager.memory_pool.uid_to_buffer_id = {ref.lora_id: 3}
+
+        new_config = dict(CONFIG_DICT, lora_alpha=32)
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, new_config, upsert=True
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(manager.configs[ref.lora_id].lora_alpha, 32)
+        # Weights are re-copied into the existing buffer slot.
+        manager.memory_pool.load_lora_weight_to_buffer.assert_called_once()
+        call = manager.memory_pool.load_lora_weight_to_buffer.call_args
+        self.assertEqual(call.args[0], ref.lora_id)
+        self.assertEqual(call.args[1], 3)
+        # The pinned slot is not double-counted.
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+    def test_upsert_skips_pool_copy_when_not_resident(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__")
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, CONFIG_DICT, upsert=True
+        )
+
+        self.assertTrue(result.success)
+        manager.memory_pool.load_lora_weight_to_buffer.assert_not_called()
+
+    def test_upsert_falls_back_to_register_when_not_loaded(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__", pinned=True)
+
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, CONFIG_DICT, upsert=True
+        )
+
+        self.assertTrue(result.success)
+        self.assertIn(ref.lora_id, manager.loras)
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+
+class TestLoRARegistryRegisterOrReuse(CustomTestCase):
+    def test_upsert_reuses_id_of_registered_adapter(self):
+        registry = LoRARegistry()
+        existing = LoRARef(lora_name="a", lora_path="/x", pinned=False)
+        asyncio.run(registry.register(existing))
+
+        candidate = LoRARef(lora_name="a", lora_path="__tensor__", pinned=True)
+        resolved, reused = asyncio.run(registry.register_or_reuse(candidate, True))
+
+        self.assertTrue(reused)
+        self.assertEqual(resolved.lora_id, existing.lora_id)
+        self.assertEqual(resolved.lora_path, "__tensor__")
+        self.assertTrue(resolved.pinned)
+
+    def test_upsert_without_registered_adapter_keeps_fresh_id(self):
+        registry = LoRARegistry()
+        candidate = LoRARef(lora_name="a", lora_path="__tensor__")
+
+        resolved, reused = asyncio.run(registry.register_or_reuse(candidate, True))
+
+        self.assertFalse(reused)
+        self.assertIs(resolved, candidate)
+
+    def test_non_upsert_never_reuses(self):
+        registry = LoRARegistry()
+        asyncio.run(registry.register(LoRARef(lora_name="a", lora_path="/x")))
+
+        candidate = LoRARef(lora_name="a", lora_path="/x")
+        resolved, reused = asyncio.run(registry.register_or_reuse(candidate, False))
+
+        self.assertFalse(reused)
+        self.assertIs(resolved, candidate)
+
+    def test_refresh_replaces_ref_in_place(self):
+        registry = LoRARegistry()
+        existing = LoRARef(lora_name="a", lora_path="/x", pinned=False)
+        asyncio.run(registry.register(existing))
+
+        refreshed = LoRARef(
+            lora_id=existing.lora_id,
+            lora_name="a",
+            lora_path="__tensor__",
+            pinned=True,
+        )
+        asyncio.run(registry.refresh(refreshed))
+
+        self.assertEqual(registry.get_all_adapters()["a"].pinned, True)
+        self.assertEqual(asyncio.run(registry.get_lora_id("a")), existing.lora_id)
+
+    def test_refresh_rejects_id_mismatch(self):
+        registry = LoRARegistry()
+        asyncio.run(registry.register(LoRARef(lora_name="a", lora_path="/x")))
+
+        with self.assertRaises(AssertionError):
+            asyncio.run(
+                registry.refresh(LoRARef(lora_name="a", lora_path="__tensor__"))
+            )
+
+
+class TestUpsertRollback(CustomTestCase):
+    """A failed load/upsert must not leave a live adapter half-updated."""
+
+    def test_failed_fresh_load_leaves_no_state(self):
+        manager = _make_manager()
+        manager._create_lora_adapter_from_tensors = Mock(
+            side_effect=ValueError("bad tensors")
+        )
+        ref = LoRARef(lora_name="a", lora_path="__tensor__")
+
+        result = manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+
+        self.assertFalse(result.success)
+        self.assertIn("bad tensors", result.error_message)
+        self.assertEqual(manager.configs, {})
+        self.assertEqual(manager.loras, {})
+        self.assertEqual(manager.lora_refs, {})
+
+    def test_failed_upsert_staging_keeps_old_adapter_serving(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__")
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+        old_config = manager.configs[ref.lora_id]
+        old_lora = manager.loras[ref.lora_id]
+
+        manager._create_lora_adapter_from_tensors = Mock(
+            side_effect=ValueError("rank mismatch")
+        )
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, CONFIG_DICT, upsert=True
+        )
+
+        self.assertFalse(result.success)
+        self.assertIs(manager.configs[ref.lora_id], old_config)
+        self.assertIs(manager.loras[ref.lora_id], old_lora)
+        manager.memory_pool.load_lora_weight_to_buffer.assert_not_called()
+
+    def test_failed_buffer_rewrite_restores_old_weights(self):
+        manager = _make_manager()
+        ref = LoRARef(lora_name="a", lora_path="__tensor__")
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+        old_config = manager.configs[ref.lora_id]
+        old_lora = manager.loras[ref.lora_id]
+        manager.memory_pool.uid_to_buffer_id = {ref.lora_id: 3}
+        manager.memory_pool.load_lora_weight_to_buffer.side_effect = [
+            RuntimeError("copy failed at layer k"),
+            None,  # the restore pass
+        ]
+
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, CONFIG_DICT, upsert=True
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("copy failed", result.error_message)
+        # CPU-side state rolled back...
+        self.assertIs(manager.configs[ref.lora_id], old_config)
+        self.assertIs(manager.loras[ref.lora_id], old_lora)
+        # ...and the served buffer was rewritten back from the old adapter.
+        calls = manager.memory_pool.load_lora_weight_to_buffer.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertIs(calls[1].args[2], old_lora)
+
+
+class TestUpsertPinnedAccounting(CustomTestCase):
+    def test_pinned_flip_updates_counter_both_ways(self):
+        manager = _make_manager()
+        unpinned = LoRARef(lora_name="a", lora_path="__tensor__", pinned=False)
+        manager.load_lora_adapter_from_tensors(unpinned, {}, CONFIG_DICT)
+        self.assertEqual(manager.num_pinned_loras, 0)
+
+        pinned = LoRARef(
+            lora_id=unpinned.lora_id,
+            lora_name="a",
+            lora_path="__tensor__",
+            pinned=True,
+        )
+        manager.load_lora_adapter_from_tensors(pinned, {}, CONFIG_DICT, upsert=True)
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+        manager.load_lora_adapter_from_tensors(unpinned, {}, CONFIG_DICT, upsert=True)
+        self.assertEqual(manager.num_pinned_loras, 0)
+
+    def test_unload_after_pinned_flip_keeps_counter_consistent(self):
+        manager = _make_manager()
+        unpinned = LoRARef(lora_name="a", lora_path="__tensor__", pinned=False)
+        manager.load_lora_adapter_from_tensors(unpinned, {}, CONFIG_DICT)
+        pinned = LoRARef(
+            lora_id=unpinned.lora_id,
+            lora_name="a",
+            lora_path="__tensor__",
+            pinned=True,
+        )
+        manager.load_lora_adapter_from_tensors(pinned, {}, CONFIG_DICT, upsert=True)
+
+        result = manager.unload_lora_adapter(pinned)
+
+        self.assertTrue(result.success)
+        self.assertEqual(manager.num_pinned_loras, 0)
+
+    def test_pinned_refresh_allowed_at_pin_limit(self):
+        """Refreshing a pinned adapter adds no pinned slot; rejecting it would
+        freeze RL serving on the step-1 weights."""
+        manager = _make_manager()
+        manager.max_loras_per_batch = 2
+        ref = LoRARef(lora_name="a", lora_path="__tensor__", pinned=True)
+        manager.load_lora_adapter_from_tensors(ref, {}, CONFIG_DICT)
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+        result = manager.load_lora_adapter_from_tensors(
+            ref, {}, CONFIG_DICT, upsert=True
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(manager.num_pinned_loras, 1)
+
+    def test_fresh_pinned_load_still_rejected_at_pin_limit(self):
+        manager = _make_manager()
+        manager.max_loras_per_batch = 2
+        manager.load_lora_adapter_from_tensors(
+            LoRARef(lora_name="a", lora_path="__tensor__", pinned=True),
+            {},
+            CONFIG_DICT,
+        )
+
+        result = manager.load_lora_adapter_from_tensors(
+            LoRARef(lora_name="b", lora_path="__tensor__", pinned=True),
+            {},
+            CONFIG_DICT,
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("not allowed to pin all slots", result.error_message)
+
+
+class TestValidateNewAdapterDuplicates(CustomTestCase):
+    def test_duplicate_name_rejected_without_update(self):
+        manager = _make_manager()
+        existing = LoRARef(lora_name="a", lora_path="/x")
+        manager.lora_refs[existing.lora_id] = existing
+        config = MagicMock(lora_added_tokens_size=0, use_dora=False)
+
+        with self.assertRaisesRegex(ValueError, "already loaded"):
+            manager.validate_new_adapter(config, LoRARef(lora_name="a", lora_path="/y"))
+
+    def test_duplicate_name_allowed_for_update(self):
+        manager = _make_manager()
+        existing = LoRARef(lora_name="a", lora_path="/x")
+        manager.lora_refs[existing.lora_id] = existing
+        config = MagicMock(lora_added_tokens_size=0, use_dora=False)
+
+        manager.validate_new_adapter(config, existing, is_update=True)
+
+
+def _make_tokenizer_manager(tokenizer_worker_num: int = 1) -> TokenizerManager:
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.server_args = MagicMock()
+    tm.server_args.enable_lora = True
+    tm.server_args.dp_size = 1
+    tm.server_args.max_loaded_loras = None
+    tm.server_args.tokenizer_worker_num = tokenizer_worker_num
+    tm.auto_create_handle_loop = Mock()
+    tm.lora_update_lock = asyncio.Lock()
+    tm.lora_registry = LoRARegistry()
+    tm.lora_ref_cache = {}
+    tm.update_lora_adapter_communicator = AsyncMock(
+        return_value=[MagicMock(success=True)]
+    )
+    return tm
+
+
+def _make_distributed_req(upsert: bool) -> LoadLoRAAdapterFromDistributedReqInput:
+    return LoadLoRAAdapterFromDistributedReqInput(
+        lora_name="a",
+        config_dict=CONFIG_DICT,
+        names=[],
+        dtypes=[],
+        shapes=[],
+        upsert=upsert,
+    )
+
+
+def _make_tensors_req(
+    upsert: bool, pinned: bool = False
+) -> LoadLoRAAdapterFromTensorsReqInput:
+    return LoadLoRAAdapterFromTensorsReqInput(
+        lora_name="a",
+        config_dict=CONFIG_DICT,
+        serialized_named_tensors=[],
+        pinned=pinned,
+        upsert=upsert,
+    )
+
+
+class TestLoadFromDistributedUpsert(CustomTestCase):
+    def test_upsert_reuses_existing_lora_id(self):
+        tm = _make_tokenizer_manager()
+        existing = LoRARef(lora_name="a", lora_path="__distributed__")
+        asyncio.run(tm.lora_registry.register(existing))
+
+        obj = _make_distributed_req(upsert=True)
+        result = asyncio.run(tm.load_lora_adapter_from_distributed(obj))
+
+        self.assertTrue(result.success)
+        self.assertEqual(obj.lora_id, existing.lora_id)
+        tm.update_lora_adapter_communicator.assert_awaited_once_with(obj)
+        # Not re-registered: still exactly one adapter with the original id.
+        self.assertEqual(tm.lora_registry.num_registered_loras, 1)
+        self.assertEqual(
+            asyncio.run(tm.lora_registry.get_lora_id("a")), existing.lora_id
+        )
+        self.assertEqual(tm.lora_ref_cache["a"].lora_id, existing.lora_id)
+
+    def test_upsert_registers_when_missing(self):
+        tm = _make_tokenizer_manager()
+
+        obj = _make_distributed_req(upsert=True)
+        result = asyncio.run(tm.load_lora_adapter_from_distributed(obj))
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(obj.lora_id)
+        self.assertEqual(asyncio.run(tm.lora_registry.get_lora_id("a")), obj.lora_id)
+
+    def test_non_upsert_duplicate_fails(self):
+        tm = _make_tokenizer_manager()
+        asyncio.run(
+            tm.lora_registry.register(
+                LoRARef(lora_name="a", lora_path="__distributed__")
+            )
+        )
+
+        obj = _make_distributed_req(upsert=False)
+        result = asyncio.run(tm.load_lora_adapter_from_distributed(obj))
+
+        self.assertFalse(result.success)
+        self.assertIn("already exists", result.error_message)
+
+    def test_upsert_refreshes_registered_ref(self):
+        # The registry ref (not just lora_ref_cache) must adopt the new
+        # metadata: LRU eviction reads ``pinned`` from the registry.
+        tm = _make_tokenizer_manager()
+        existing = LoRARef(lora_name="a", lora_path="__distributed__", pinned=False)
+        asyncio.run(tm.lora_registry.register(existing))
+
+        obj = _make_distributed_req(upsert=True)
+        obj.pinned = True
+        result = asyncio.run(tm.load_lora_adapter_from_distributed(obj))
+
+        self.assertTrue(result.success)
+        registered = tm.lora_registry.get_all_adapters()["a"]
+        self.assertEqual(registered.lora_id, existing.lora_id)
+        self.assertTrue(registered.pinned)
+
+    def test_failed_backend_load_keeps_registry_untouched(self):
+        tm = _make_tokenizer_manager()
+        existing = LoRARef(lora_name="a", lora_path="__distributed__", pinned=False)
+        asyncio.run(tm.lora_registry.register(existing))
+        tm.update_lora_adapter_communicator = AsyncMock(
+            return_value=[MagicMock(success=False, error_message="boom")]
+        )
+
+        obj = _make_distributed_req(upsert=True)
+        obj.pinned = True
+        result = asyncio.run(tm.load_lora_adapter_from_distributed(obj))
+
+        self.assertFalse(result.success)
+        self.assertIs(tm.lora_registry.get_all_adapters()["a"], existing)
+        self.assertNotIn("a", tm.lora_ref_cache)
+
+
+class TestLoadFromTensorsUpsertUnsupported(CustomTestCase):
+    """Only the from_distributed route supports in-place refresh; the
+    from_tensors route must reject upsert explicitly instead of minting a
+    fresh uuid and dying later on the backend duplicate check."""
+
+    def test_upsert_rejected_explicitly(self):
+        tm = _make_tokenizer_manager()
+        asyncio.run(
+            tm.lora_registry.register(LoRARef(lora_name="a", lora_path="__tensor__"))
+        )
+
+        obj = _make_tensors_req(upsert=True)
+        result = asyncio.run(tm.load_lora_adapter_from_tensors(obj))
+
+        self.assertFalse(result.success)
+        self.assertIn("not supported on the from_tensors route", result.error_message)
+        tm.update_lora_adapter_communicator.assert_not_awaited()
+
+    def test_non_upsert_load_still_works(self):
+        tm = _make_tokenizer_manager()
+
+        obj = _make_tensors_req(upsert=False)
+        result = asyncio.run(tm.load_lora_adapter_from_tensors(obj))
+
+        self.assertTrue(result.success)
+        self.assertEqual(asyncio.run(tm.lora_registry.get_lora_id("a")), obj.lora_id)
+
+    def test_non_upsert_duplicate_fails(self):
+        tm = _make_tokenizer_manager()
+        asyncio.run(
+            tm.lora_registry.register(LoRARef(lora_name="a", lora_path="__tensor__"))
+        )
+
+        obj = _make_tensors_req(upsert=False)
+        result = asyncio.run(tm.load_lora_adapter_from_tensors(obj))
+
+        self.assertFalse(result.success)
+        self.assertIn("already exists", result.error_message)
+
+
+class TestUpsertMultiTokenizerWorkerGuard(CustomTestCase):
+    """Upsert resolves names against a per-process registry; with >1 tokenizer
+    workers that resolution is nondeterministic, so it must fail loudly."""
+
+    def test_distributed_upsert_rejected_with_multiple_workers(self):
+        tm = _make_tokenizer_manager(tokenizer_worker_num=2)
+
+        result = asyncio.run(
+            tm.load_lora_adapter_from_distributed(_make_distributed_req(True))
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("tokenizer_worker_num", result.error_message)
+
+    def test_non_upsert_load_unaffected_by_multiple_workers(self):
+        tm = _make_tokenizer_manager(tokenizer_worker_num=2)
+
+        result = asyncio.run(
+            tm.load_lora_adapter_from_tensors(_make_tensors_req(False))
+        )
+
+        self.assertTrue(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/lora/test_moe_lora_tail_stamp.py
+++ b/test/registered/unit/lora/test_moe_lora_tail_stamp.py
@@ -1,0 +1,134 @@
+"""Unit tests for the MoE-LoRA DP-gathered tail stamping in _add_moe_lora_info.
+
+Under --enable-dp-attention the MoE runs on DP-GATHERED tokens, so the per-token
+LoRA mapping must cover [0, moe_num_tokens) while the per-rank segments only fill
+[0, num_tokens). These tests pin the Tier-1 (single loaded adapter) semantics of
+the gathered tail [num_tokens, moe_num_tokens):
+
+  * active rank (local requests use the single adapter, ``_single_loaded_buffer_id``
+    armed): tail stamped with that adapter's buffer id;
+  * true idle rank (num_tokens == 0, ``_idle_rank_active_buffer_id`` armed): the
+    whole mapping stamped and the adapter enabled;
+  * base-only local batches, multi-adapter batches, and stale idle stamps on
+    token-bearing batches: tail stays -1 (adapter-disabled) — foreign tokens are
+    never given a delta this rank cannot attribute.
+
+The backend object is stubbed (only the fields _add_moe_lora_info reads are
+populated) so the tests run hermetically without a server or dist groups; the
+gathered length is forced via forward_batch.global_dp_buffer_len.
+
+Usage:
+    python -m pytest test/registered/unit/lora/test_moe_lora_tail_stamp.py -v
+"""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=9, suite="stage-b-test-1-gpu-small-amd")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+from sglang.srt.lora.utils import LoRABatchInfo
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+GATHERED = 16  # forced gathered length (> any local num_tokens used below)
+# buffer slots: 0 = the None/base uid slot (rank 0), 1/2 = adapters (rank 8), 3 = free
+RANKS = [0, 8, 8, 0]
+
+
+def _forward_batch(num_tokens: int):
+    mode = SimpleNamespace(
+        is_extend=lambda: False,
+        is_idle=lambda: num_tokens == 0,
+        is_cuda_graph=lambda: False,
+    )
+    return SimpleNamespace(
+        forward_mode=mode,
+        batch_size=num_tokens,  # decode: 1 token per seq
+        extend_seq_lens_cpu=None,
+        global_dp_buffer_len=GATHERED,
+        global_num_tokens_cpu=[num_tokens, GATHERED - num_tokens],
+    )
+
+
+def _batch_info(weight_indices, num_tokens):
+    bs = len(weight_indices)
+    return LoRABatchInfo(
+        use_cuda_graph=False,
+        bs=bs,
+        num_segments=bs,
+        seg_indptr=torch.arange(bs + 1, dtype=torch.int32, device=DEVICE),
+        weight_indices=torch.tensor(weight_indices, dtype=torch.int32, device=DEVICE),
+        lora_ranks=torch.tensor(RANKS, dtype=torch.int64, device=DEVICE),
+        scalings=torch.ones(len(RANKS), dtype=torch.float, device=DEVICE),
+        max_len=1,
+        seg_lens=torch.ones(bs, dtype=torch.int32, device=DEVICE),
+        permutation=None,
+        expected_tokens=num_tokens,
+    )
+
+
+def _run(weight_indices, num_tokens, idle_bid=None, single_bid=None):
+    stub = SimpleNamespace(
+        is_moe_lora=True,
+        _idle_rank_active_buffer_id=idle_bid,
+        _single_loaded_buffer_id=single_bid,
+    )
+    out = BaseLoRABackend._add_moe_lora_info(
+        stub, _forward_batch(num_tokens), _batch_info(weight_indices, num_tokens)
+    )
+    info = out.moe_lora_info
+    return info.token_lora_mapping.tolist(), info.adapter_enabled.tolist()
+
+
+class TestMoELoRATailStamp(unittest.TestCase):
+    def test_base_only_local_batch_keeps_disabled_tail(self):
+        # All local tokens on the base (None-uid) slot, nothing armed: the
+        # gathered tail must stay -1 and no adapter may be enabled.
+        mapping, enabled = _run([0, 0, 0, 0], num_tokens=4)
+        self.assertTrue(all(x == -1 for x in mapping[4:]), mapping)
+        self.assertEqual(enabled, [0, 0, 0, 0])
+
+    def test_stale_idle_stamp_ignored_on_token_bearing_batch(self):
+        # Defense in depth: an idle stamp must only be consumed when the rank is
+        # truly idle (num_tokens == 0), never on a batch with local tokens.
+        mapping, enabled = _run([0, 0, 0, 0], num_tokens=4, idle_bid=2)
+        self.assertTrue(all(x == -1 for x in mapping[4:]), mapping)
+        self.assertEqual(enabled[2], 0)
+
+    def test_multi_adapter_batch_keeps_disabled_tail(self):
+        # Two adapters used locally: the foreign tokens' adapter identity is
+        # unknowable host-side, so the tail must stay -1 (no mis-stamping with
+        # whatever the last local token happened to use).
+        mapping, _ = _run([1, 1, 2, 2], num_tokens=4)
+        self.assertTrue(all(x == -1 for x in mapping[4:]), mapping)
+
+    def test_idle_rank_stamps_whole_mapping_and_enables_adapter(self):
+        # True idle rank under Tier-1: the whole gathered mapping is stamped with
+        # the single loaded adapter and the adapter is enabled, so foreign tokens
+        # routed to this rank's experts get the LoRA delta.
+        mapping, enabled = _run([], num_tokens=0, idle_bid=2)
+        self.assertTrue(all(x == 2 for x in mapping), mapping)
+        self.assertEqual(enabled[2], 1)
+
+    def test_active_rank_stamps_tail_with_single_adapter(self):
+        # Local tokens actively use the single loaded adapter: the tail is
+        # stamped with its buffer id (not a copy of an arbitrary local slot).
+        mapping, enabled = _run([2, 2], num_tokens=2, single_bid=2)
+        self.assertTrue(all(x == 2 for x in mapping[2:]), mapping)
+        self.assertEqual(enabled[2], 1)
+
+    def test_single_adapter_loaded_but_local_base_keeps_disabled_tail(self):
+        # An adapter is loaded but this rank's local tokens are all base (the
+        # manager arms no stamp in this case): tail stays -1.
+        mapping, enabled = _run([0, 0], num_tokens=2)
+        self.assertTrue(all(x == -1 for x in mapping[2:]), mapping)
+        self.assertEqual(enabled, [0, 0, 0, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_abort_request_prefix.py
+++ b/test/registered/unit/managers/test_abort_request_prefix.py
@@ -1,0 +1,440 @@
+"""Unit tests for abort-by-rid-prefix.
+
+Tokenizer side: with prefix=True, the rid is treated as a prefix — the
+early-return gate matches any tracked rid starting with it, matching
+tokenizer-held (not yet dispatched) requests are resolved locally, and the
+AbortReq is forwarded with prefix=True.
+
+Scheduler side: matching is prefix-based (``rid.startswith``) regardless of
+the flag, because batch requests derive child rids as ``f"{rid}_{i}"``.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.tokenizer_manager import ReqState, TokenizerManager
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tokenizer_manager(rids=(), tokenizer_worker_num=1) -> TokenizerManager:
+    """Create a TokenizerManager with mocked dependencies, bypassing __init__."""
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.server_args = MagicMock()
+    tm.server_args.tokenizer_worker_num = tokenizer_worker_num
+    tm.enable_metrics = False
+    tm.rid_to_state = {rid: Mock() for rid in rids}
+    tm.send_to_scheduler = MagicMock()
+    tm.tokenizer_ipc_name = None
+    # The IPC boundary: sock_send's wire format varies (pickle/msgpack), so
+    # tests observe dispatched objects here instead of on the zmq socket.
+    tm._dispatch_to_scheduler = MagicMock()
+    return tm
+
+
+def _sent_req(tm) -> AbortReq:
+    tm._dispatch_to_scheduler.assert_called_once()
+    return tm._dispatch_to_scheduler.call_args.args[0]
+
+
+class TestAbortRequestPrefix(CustomTestCase):
+    def test_prefix_match_sends_abort(self):
+        tm = _make_tokenizer_manager(rids=["job-1-seq-0", "job-1-seq-1", "other"])
+        tm.abort_request(rid="job-1", prefix=True)
+
+        req = _sent_req(tm)
+        self.assertEqual(req.rid, "job-1")
+        self.assertTrue(req.prefix)
+        self.assertFalse(req.abort_all)
+
+    def test_prefix_without_match_is_ignored(self):
+        tm = _make_tokenizer_manager(rids=["other-1", "other-2"])
+        tm.abort_request(rid="job-1", prefix=True)
+
+        tm._dispatch_to_scheduler.assert_not_called()
+
+    def test_prefix_requires_full_prefix_not_substring(self):
+        tm = _make_tokenizer_manager(rids=["seq-job-1"])
+        tm.abort_request(rid="job-1", prefix=True)
+
+        tm._dispatch_to_scheduler.assert_not_called()
+
+    def test_exact_match_still_works_without_prefix(self):
+        tm = _make_tokenizer_manager(rids=["job-1"])
+        tm.abort_request(rid="job-1")
+
+        req = _sent_req(tm)
+        self.assertEqual(req.rid, "job-1")
+        self.assertFalse(req.prefix)
+
+    def test_exact_mode_does_not_prefix_match(self):
+        # rid is only a prefix of a tracked request; exact mode must ignore it.
+        tm = _make_tokenizer_manager(rids=["job-1-seq-0"])
+        tm.abort_request(rid="job-1")
+
+        tm._dispatch_to_scheduler.assert_not_called()
+
+    def test_empty_rid_is_ignored(self):
+        # An empty rid would prefix-match every request on the scheduler.
+        tm = _make_tokenizer_manager(rids=["job-1"])
+        tm.abort_request(rid="", prefix=True)
+
+        tm._dispatch_to_scheduler.assert_not_called()
+
+    def test_multi_tokenizer_worker_skips_local_check(self):
+        # With >1 tokenizer workers, rid_to_state is not authoritative; the
+        # abort must be forwarded even if this worker tracks no matching rid.
+        tm = _make_tokenizer_manager(rids=[], tokenizer_worker_num=2)
+        tm.abort_request(rid="job-1", prefix=True)
+
+        req = _sent_req(tm)
+        self.assertEqual(req.rid, "job-1")
+        self.assertTrue(req.prefix)
+
+
+def _make_state(rid: str) -> ReqState:
+    obj = SimpleNamespace(rid=rid, stream=False, return_logprob=False)
+    return ReqState([], False, asyncio.Event(), obj, MagicMock())
+
+
+def _make_tokenizer_manager_with_states(rids) -> TokenizerManager:
+    tm = _make_tokenizer_manager()
+    tm.rid_to_state = {rid: _make_state(rid) for rid in rids}
+    return tm
+
+
+class TestAbortTokenizerHeldRequests(CustomTestCase):
+    """An abort must also cover requests admitted to the tokenizer (rid_to_state
+    populated in _init_req_state) but not yet dispatched to the scheduler —
+    e.g. parked at the pause gate during a weight update. The scheduler cannot
+    match those rids, so abort_request flags them and the dispatch path
+    resolves them as aborted instead of sending them."""
+
+    def test_prefix_abort_flags_matching_states(self):
+        tm = _make_tokenizer_manager_with_states(
+            ["job-1-seq-0", "job-1-seq-1", "other"]
+        )
+        tm.abort_request(rid="job-1", prefix=True)
+
+        self.assertTrue(tm.rid_to_state["job-1-seq-0"].abort_before_dispatch)
+        self.assertTrue(tm.rid_to_state["job-1-seq-1"].abort_before_dispatch)
+        self.assertFalse(tm.rid_to_state["other"].abort_before_dispatch)
+        # The AbortReq is still forwarded for already-dispatched requests.
+        self.assertEqual(_sent_req(tm).rid, "job-1")
+
+    def test_exact_abort_flags_only_exact_state(self):
+        tm = _make_tokenizer_manager_with_states(["job-1", "job-1-seq-0"])
+        tm.abort_request(rid="job-1")
+
+        self.assertTrue(tm.rid_to_state["job-1"].abort_before_dispatch)
+        self.assertFalse(tm.rid_to_state["job-1-seq-0"].abort_before_dispatch)
+
+    def test_abort_all_flags_every_state(self):
+        tm = _make_tokenizer_manager_with_states(["a", "b"])
+        tm.abort_request(abort_all=True)
+
+        self.assertTrue(tm.rid_to_state["a"].abort_before_dispatch)
+        self.assertTrue(tm.rid_to_state["b"].abort_before_dispatch)
+
+    def test_dispatch_resolves_flagged_request_locally(self):
+        tm = _make_tokenizer_manager_with_states(["job-1-seq-0"])
+        tm.server_args.weight_version = "v0"
+        state = tm.rid_to_state["job-1-seq-0"]
+        tm.abort_request(rid="job-1", prefix=True)
+        tm._dispatch_to_scheduler.reset_mock()
+
+        tm._send_one_request(SimpleNamespace(rid="job-1-seq-0"))
+
+        # Never dispatched; resolved as aborted so _wait_one_response returns.
+        tm._dispatch_to_scheduler.assert_not_called()
+        self.assertTrue(state.finished)
+        self.assertTrue(state.event.is_set())
+        self.assertNotIn("job-1-seq-0", tm.rid_to_state)
+        finish_reason = state.out_list[-1]["meta_info"]["finish_reason"]
+        self.assertEqual(finish_reason["type"], "abort")
+
+    def test_dispatch_sends_unflagged_request(self):
+        tm = _make_tokenizer_manager_with_states(["job-1", "other"])
+        tm.abort_request(rid="job-1")
+        tm._dispatch_to_scheduler.reset_mock()
+
+        tokenized_obj = MagicMock()
+        tokenized_obj.rid = "other"
+        with unittest.mock.patch(
+            "sglang.srt.managers.tokenizer_manager.wrap_shm_features",
+            side_effect=lambda obj: obj,
+        ):
+            tm._send_one_request(tokenized_obj)
+
+        tm._dispatch_to_scheduler.assert_called_once_with(tokenized_obj)
+        self.assertIn("other", tm.rid_to_state)
+
+    def test_batch_dispatch_filters_flagged_requests(self):
+        tm = _make_tokenizer_manager_with_states(["job-1-seq-0", "job-1-seq-1"])
+        tm.server_args.weight_version = "v0"
+        tm.abort_request(rid="job-1", prefix=True)
+        tm._dispatch_to_scheduler.reset_mock()
+
+        tm._send_batch_request(
+            [SimpleNamespace(rid="job-1-seq-0"), SimpleNamespace(rid="job-1-seq-1")]
+        )
+
+        tm._dispatch_to_scheduler.assert_not_called()
+        self.assertEqual(tm.rid_to_state, {})
+
+
+class FakeReq:
+    def __init__(self, rid: str):
+        self.rid = rid
+        self.mamba_pool_idx = None
+        self.to_finish = None
+
+    def finished(self) -> bool:
+        return False
+
+
+def _make_scheduler(waiting_rids=(), running_rids=(), chunked_rid=None):
+    sched = SimpleNamespace()
+    sched.chunked_req = FakeReq(chunked_rid) if chunked_rid is not None else None
+    sched.waiting_queue = [FakeReq(rid) for rid in waiting_rids]
+    sched.enable_hicache_storage = False
+    sched.disaggregation_mode = DisaggregationMode.NULL
+    sched.grammar_manager = MagicMock()
+    sched.running_batch = SimpleNamespace(reqs=[FakeReq(rid) for rid in running_rids])
+    sched.cur_batch = None
+    sched.ipc_channels = MagicMock()
+    return sched
+
+
+class TestSchedulerAbortMatching(CustomTestCase):
+    """Scheduler-side matching semantics for AbortReq (see io_struct.AbortReq:
+    always ``rid.startswith``, so batch children ``f"{rid}_{i}"`` are covered)."""
+
+    def test_prefix_abort_isolates_namespaces(self):
+        sched = _make_scheduler(
+            waiting_rids=["A::1", "A::2", "B::1"],
+            running_rids=["A::3", "B::2"],
+        )
+        Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        self.assertEqual([req.rid for req in sched.waiting_queue], ["B::1"])
+        running = {req.rid: req for req in sched.running_batch.reqs}
+        self.assertIsInstance(running["A::3"].to_finish, FINISH_ABORT)
+        self.assertIsNone(running["B::2"].to_finish)
+        # Every waiting-queue abort echoes back to the tokenizer for cleanup.
+        aborted_rids = {
+            call.args[0].rid
+            for call in sched.ipc_channels.send_to_tokenizer.send_output.call_args_list
+        }
+        self.assertEqual(aborted_rids, {"A::1", "A::2"})
+
+    def test_matching_is_prefix_based_even_without_prefix_flag(self):
+        # Pre-existing scheduler semantics: batch requests derive child rids as
+        # f"{rid}_{i}", so an exact-mode abort for the parent must cover them.
+        sched = _make_scheduler(waiting_rids=["job-1_0", "job-1_1", "job-2_0"])
+        Scheduler.abort_request(sched, AbortReq(rid="job-1", prefix=False))
+
+        self.assertEqual([req.rid for req in sched.waiting_queue], ["job-2_0"])
+
+    def test_chunked_request_is_prefix_matched(self):
+        sched = _make_scheduler(chunked_rid="A::9")
+        Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        self.assertIs(sched._pending_chunked_abort_req, sched.chunked_req)
+
+    def test_abort_all_covers_everything(self):
+        sched = _make_scheduler(waiting_rids=["A::1"], running_rids=["B::1"])
+        Scheduler.abort_request(sched, AbortReq(abort_all=True))
+
+        self.assertEqual(sched.waiting_queue, [])
+        self.assertIsInstance(sched.running_batch.reqs[0].to_finish, FINISH_ABORT)
+
+
+def _make_disagg_req(rid: str, pending_bootstrap: bool = False) -> FakeReq:
+    req = FakeReq(rid)
+    req.pending_bootstrap = pending_bootstrap
+    req.disagg_kv_sender = Mock()
+    return req
+
+
+def _make_prefill_scheduler(waiting_rids=(), bootstrap_rids=(), inflight_rids=()):
+    sched = _make_scheduler()
+    sched.disaggregation_mode = DisaggregationMode.PREFILL
+    sched.waiting_queue = [
+        _make_disagg_req(rid, pending_bootstrap=True) for rid in waiting_rids
+    ]
+    sched.req_to_metadata_buffer_idx_allocator = MagicMock()
+    sched.disagg_prefill_bootstrap_queue = SimpleNamespace(
+        queue=[_make_disagg_req(rid) for rid in bootstrap_rids]
+    )
+    sched.disagg_prefill_inflight_queue = [
+        _make_disagg_req(rid) for rid in inflight_rids
+    ]
+    return sched
+
+
+def _make_decode_req(rid: str) -> SimpleNamespace:
+    return SimpleNamespace(req=FakeReq(rid), kv_receiver=Mock())
+
+
+def _make_retracted_req(rid: str) -> SimpleNamespace:
+    return SimpleNamespace(rid=rid, kv_cache_cpu=object())
+
+
+def _make_decode_scheduler(
+    waiting_rids=(), prealloc_rids=(), transfer_rids=(), retracted_rids=()
+):
+    sched = _make_scheduler(waiting_rids=waiting_rids)
+    sched.disaggregation_mode = DisaggregationMode.DECODE
+    sched.tree_cache = MagicMock()
+    sched.disagg_decode_prealloc_queue = SimpleNamespace(
+        queue=[_make_decode_req(rid) for rid in prealloc_rids],
+        retracted_queue=[_make_retracted_req(rid) for rid in retracted_rids],
+    )
+    sched.disagg_decode_transfer_queue = SimpleNamespace(
+        queue=[_make_decode_req(rid) for rid in transfer_rids]
+    )
+    return sched
+
+
+def _echoed_rids(sched) -> set:
+    return {
+        call.args[0].rid
+        for call in sched.ipc_channels.send_to_tokenizer.send_output.call_args_list
+    }
+
+
+class TestSchedulerDisaggPrefillAbort(CustomTestCase):
+    """PREFILL-side disaggregation abort matching: the bootstrap and in-flight
+    queues hold requests the waiting queue no longer tracks, and the waiting
+    queue itself must release the metadata buffer slot and abort a
+    still-bootstrapping KV sender."""
+
+    def test_bootstrap_and_inflight_queues_prefix_matched(self):
+        sched = _make_prefill_scheduler(
+            bootstrap_rids=["A::1", "B::1"], inflight_rids=["A::2", "B::2"]
+        )
+        Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        bootstrap = {r.rid: r for r in sched.disagg_prefill_bootstrap_queue.queue}
+        bootstrap["A::1"].disagg_kv_sender.abort.assert_called_once()
+        bootstrap["B::1"].disagg_kv_sender.abort.assert_not_called()
+        inflight = {r.rid: r for r in sched.disagg_prefill_inflight_queue}
+        inflight["A::2"].disagg_kv_sender.abort.assert_called_once()
+        inflight["B::2"].disagg_kv_sender.abort.assert_not_called()
+
+    def test_waiting_queue_releases_metadata_buffer(self):
+        sched = _make_prefill_scheduler(waiting_rids=["A::1", "B::1"])
+        with patch(
+            "sglang.srt.managers.scheduler.maybe_release_metadata_buffer"
+        ) as release:
+            Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        self.assertEqual([r.rid for r in sched.waiting_queue], ["B::1"])
+        release.assert_called_once()
+        released_req, allocator = release.call_args.args
+        self.assertEqual(released_req.rid, "A::1")
+        self.assertIs(allocator, sched.req_to_metadata_buffer_idx_allocator)
+        self.assertEqual(_echoed_rids(sched), {"A::1"})
+
+    def test_waiting_queue_pending_bootstrap_gates_sender_abort(self):
+        pending = _make_disagg_req("A::1", pending_bootstrap=True)
+        bootstrapped = _make_disagg_req("A::2", pending_bootstrap=False)
+        sched = _make_prefill_scheduler()
+        sched.waiting_queue = [pending, bootstrapped]
+        with patch("sglang.srt.managers.scheduler.maybe_release_metadata_buffer"):
+            Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        pending.disagg_kv_sender.abort.assert_called_once()
+        bootstrapped.disagg_kv_sender.abort.assert_not_called()
+
+    def test_abort_all_covers_prefill_queues(self):
+        sched = _make_prefill_scheduler(bootstrap_rids=["A::1"], inflight_rids=["B::1"])
+        Scheduler.abort_request(sched, AbortReq(abort_all=True))
+
+        sched.disagg_prefill_bootstrap_queue.queue[
+            0
+        ].disagg_kv_sender.abort.assert_called_once()
+        sched.disagg_prefill_inflight_queue[
+            0
+        ].disagg_kv_sender.abort.assert_called_once()
+
+
+class TestSchedulerDisaggDecodeAbort(CustomTestCase):
+    """DECODE-side disaggregation abort matching: prealloc/transfer queues
+    abort their KV receivers, the retracted queue frees CPU KV cache and
+    echoes the abort back to the tokenizer, and waiting-queue requests
+    release their preallocated KV cache."""
+
+    def test_prealloc_and_transfer_queues_prefix_matched(self):
+        sched = _make_decode_scheduler(
+            prealloc_rids=["A::1", "B::1"], transfer_rids=["A::2", "B::2"]
+        )
+        Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        prealloc = {d.req.rid: d for d in sched.disagg_decode_prealloc_queue.queue}
+        prealloc["A::1"].kv_receiver.abort.assert_called_once()
+        prealloc["B::1"].kv_receiver.abort.assert_not_called()
+        transfer = {d.req.rid: d for d in sched.disagg_decode_transfer_queue.queue}
+        transfer["A::2"].kv_receiver.abort.assert_called_once()
+        transfer["B::2"].kv_receiver.abort.assert_not_called()
+
+    def test_retracted_queue_frees_cpu_cache_and_echoes(self):
+        sched = _make_decode_scheduler(retracted_rids=["A::1", "B::1"])
+        aborted = sched.disagg_decode_prealloc_queue.retracted_queue[0]
+        Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        self.assertEqual(
+            [d.rid for d in sched.disagg_decode_prealloc_queue.retracted_queue],
+            ["B::1"],
+        )
+        self.assertFalse(hasattr(aborted, "kv_cache_cpu"))
+        self.assertEqual(_echoed_rids(sched), {"A::1"})
+
+    def test_waiting_queue_releases_kv_cache(self):
+        sched = _make_decode_scheduler(waiting_rids=["A::1", "B::1"])
+        with patch("sglang.srt.managers.scheduler.release_kv_cache") as release:
+            Scheduler.abort_request(sched, AbortReq(rid="A::", prefix=True))
+
+        self.assertEqual([r.rid for r in sched.waiting_queue], ["B::1"])
+        release.assert_called_once()
+        self.assertEqual(release.call_args.args[0].rid, "A::1")
+
+    def test_exact_mode_is_still_prefix_matched_in_disagg_queues(self):
+        # Same load-bearing semantics as the non-disagg queues: batch children
+        # derive rids as f"{rid}_{i}", so exact-mode must cover them here too.
+        sched = _make_decode_scheduler(prealloc_rids=["job-1_0"])
+        Scheduler.abort_request(sched, AbortReq(rid="job-1", prefix=False))
+
+        sched.disagg_decode_prealloc_queue.queue[
+            0
+        ].kv_receiver.abort.assert_called_once()
+
+    def test_abort_all_covers_decode_queues(self):
+        sched = _make_decode_scheduler(
+            prealloc_rids=["A::1"], transfer_rids=["B::1"], retracted_rids=["C::1"]
+        )
+        Scheduler.abort_request(sched, AbortReq(abort_all=True))
+
+        sched.disagg_decode_prealloc_queue.queue[
+            0
+        ].kv_receiver.abort.assert_called_once()
+        sched.disagg_decode_transfer_queue.queue[
+            0
+        ].kv_receiver.abort.assert_called_once()
+        self.assertEqual(sched.disagg_decode_prealloc_queue.retracted_queue, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/managers/test_abort_request_prefix.py
+++ b/test/registered/unit/managers/test_abort_request_prefix.py
@@ -34,6 +34,7 @@ def _make_tokenizer_manager(rids=(), tokenizer_worker_num=1) -> TokenizerManager
     tm.server_args = MagicMock()
     tm.server_args.tokenizer_worker_num = tokenizer_worker_num
     tm.enable_metrics = False
+    tm.enable_lora = False
     tm.rid_to_state = {rid: Mock() for rid in rids}
     tm.send_to_scheduler = MagicMock()
     tm.tokenizer_ipc_name = None
@@ -104,7 +105,11 @@ class TestAbortRequestPrefix(CustomTestCase):
 
 
 def _make_state(rid: str) -> ReqState:
-    obj = SimpleNamespace(rid=rid, stream=False, return_logprob=False)
+    # lora_path / lora_id model the real input-struct contract: always present,
+    # None = base model (the lease finalizer does plain None checks on them).
+    obj = SimpleNamespace(
+        rid=rid, stream=False, return_logprob=False, lora_path=None, lora_id=None
+    )
     return ReqState([], False, asyncio.Event(), obj, MagicMock())
 
 
@@ -209,10 +214,15 @@ def _make_scheduler(waiting_rids=(), running_rids=(), chunked_rid=None):
     sched.chunked_req = FakeReq(chunked_rid) if chunked_rid is not None else None
     sched.waiting_queue = [FakeReq(rid) for rid in waiting_rids]
     sched.enable_hicache_storage = False
+    sched.dllm_config = None  # abort_request reads it since the dLLM rework (#27877)
     sched.disaggregation_mode = DisaggregationMode.NULL
     sched.grammar_manager = MagicMock()
     sched.running_batch = SimpleNamespace(reqs=[FakeReq(rid) for rid in running_rids])
     sched.cur_batch = None
+    # abort_request collects in-flight reqs from (running_batch, last_batch) on
+    # the pp_size == 1 path since the v0.5.16 rebase.
+    sched.ps = SimpleNamespace(pp_size=1)
+    sched.last_batch = None
     sched.ipc_channels = MagicMock()
     return sched
 

--- a/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
+++ b/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
@@ -63,9 +63,17 @@ def _contains_dataclass(obj) -> bool:
     return False
 
 
-def _parallelism_info() -> ParallelismInfo:
+def _parallelism_info(role: str = "target") -> ParallelismInfo:
     return ParallelismInfo(
-        tp_rank=0, tp_size=2, dp_rank=0, dp_size=1, pp_rank=0, pp_size=1, rank=0, size=2
+        role=role,
+        tp_rank=0,
+        tp_size=2,
+        dp_rank=0,
+        dp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        rank=0,
+        size=2,
     )
 
 
@@ -73,7 +81,8 @@ def _checksum_info(tag: str) -> ChecksumInfo:
     return ChecksumInfo(
         checksums={f"model.layers.{tag}": "deadbeef"},
         per_gpu_checksum="cafef00d",
-        parallelism_info=_parallelism_info(),
+        # One entry per role: the target model plus each speculative draft runner.
+        parallelism_info=[_parallelism_info("target"), _parallelism_info("draft")],
     )
 
 
@@ -192,29 +201,46 @@ class TestMsgpackIpcRoundtrip(CustomTestCase):
         self.assertEqual(len(decoded.payload), 2)
         as_dict = msgspec_to_builtins(decoded.payload[0])
         self.assertEqual(as_dict["per_gpu_checksum"], "cafef00d")
-        self.assertIn("tp_rank", as_dict["parallelism_info"])
+        self.assertEqual(
+            [pi["role"] for pi in as_dict["parallelism_info"]], ["target", "draft"]
+        )
+        self.assertIn("tp_rank", as_dict["parallelism_info"][0])
 
     def test_check_weights_producer_conversion(self):
-        # Mirrors weight_updater.check_weights: WeightChecker returns
-        # ChecksumInfo.model_dump() (a dict), converted to the msgspec struct via
-        # msgspec.convert, and the result round-trips as the payload.
-        pydantic_checksum = PydanticChecksumInfo(
-            checksums={"model.layers.0": "deadbeef"},
-            per_gpu_checksum="cafef00d",
-            parallelism_info=PydanticParallelismInfo(
-                tp_rank=0,
-                tp_size=2,
-                dp_rank=0,
-                dp_size=1,
-                pp_rank=0,
-                pp_size=1,
-                rank=0,
-                size=2,
-            ),
+        # Mirrors weight_updater.check_weights end to end: each runner's
+        # WeightChecker returns a single-role ChecksumInfo.model_dump(),
+        # _merge_checksum_payloads folds the roles into one per-role payload, and
+        # that is what msgspec.convert has to accept.
+        from sglang.srt.managers.scheduler_components.weight_updater import (
+            _merge_checksum_payloads,
         )
-        converted = msgspec.convert(pydantic_checksum.model_dump(), ChecksumInfo)
-        self.assertEqual(converted.per_gpu_checksum, "cafef00d")
-        self.assertEqual(converted.parallelism_info.tp_rank, 0)
+
+        def _dump(role_tag):
+            return PydanticChecksumInfo(
+                checksums={f"model.layers.0{role_tag}": "deadbeef"},
+                per_gpu_checksum="cafef00d",
+                parallelism_info=PydanticParallelismInfo(
+                    tp_rank=0,
+                    tp_size=2,
+                    dp_rank=0,
+                    dp_size=1,
+                    pp_rank=0,
+                    pp_size=1,
+                    rank=0,
+                    size=2,
+                ),
+            ).model_dump()
+
+        merged = _merge_checksum_payloads([("", _dump("")), ("draft", _dump(""))])
+        converted = msgspec.convert(merged, ChecksumInfo)
+        # Draft keys are role-prefixed so they never collide with the target's.
+        self.assertEqual(
+            sorted(converted.checksums), ["draft.model.layers.0", "model.layers.0"]
+        )
+        self.assertEqual(
+            [pi.role for pi in converted.parallelism_info], ["target", "draft"]
+        )
+        self.assertEqual(converted.parallelism_info[0].tp_rank, 0)
         output = CheckWeightsReqOutput(success=True, message="ok", payload=[converted])
         self.assertEqual(_round_trip(output), output)
 

--- a/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
+++ b/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
@@ -15,6 +15,7 @@ import msgspec
 
 from sglang.srt.managers import io_struct
 from sglang.srt.managers.io_struct import (
+    AbortReq,
     BackupDramReq,
     ChecksumInfo,
     CheckWeightsReqOutput,
@@ -37,6 +38,7 @@ from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 from sglang.srt.utils.weight_checker import ChecksumInfo as PydanticChecksumInfo
 from sglang.srt.utils.weight_checker import ParallelismInfo as PydanticParallelismInfo
+from sglang.srt.utils.weight_versions import WeightVersionSpan
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -261,6 +263,35 @@ class TestMsgpackIpcRoundtrip(CustomTestCase):
 
         output = GetInternalStateReqOutput(internal_state=sanitized)
         self.assertEqual(_round_trip(output), output)
+
+
+class TestWeightVersionSpansRoundTrip(CustomTestCase):
+    """The per-request weight-version spans ride the same msgpack IPC path."""
+
+    def test_abort_req_carries_spans(self):
+        """A scheduler-side abort keeps its spans across the wire."""
+        obj = AbortReq(
+            rid="r0",
+            weight_versions=[
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+        )
+
+        decoded = _double_hop(obj)
+
+        self.assertEqual(
+            decoded.weight_versions,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+        )
+        self.assertIsInstance(decoded.weight_versions[0], WeightVersionSpan)
+
+    def test_abort_req_defaults_to_no_spans(self):
+        """The field is optional on the wire, so an abort without spans decodes to None."""
+        self.assertIsNone(_round_trip(AbortReq(rid="r0")).weight_versions)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.utils.weight_versions import WeightVersionSpan
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
@@ -76,6 +77,13 @@ def _make_batch_str_output() -> BatchStrOutput:
         placeholder_tokens_idx=[None, None],
         placeholder_tokens_val=[None, None],
         retraction_counts=[0, 0],
+        weight_versions=[
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=5),
+            ],
+            [WeightVersionSpan(version="v2", start=0, end=2)],
+        ],
     )
 
 
@@ -91,6 +99,31 @@ class TestMultiTokenizerMixin(unittest.TestCase):
             single_output.cached_tokens_details,
             [{"device": 1, "host": 3}],
         )
+
+    def test_batch_str_output_keeps_weight_versions_nested_per_request(self):
+        """Per-request segment lists stay one level nested after the split."""
+        output = _make_batch_str_output()
+
+        self.assertEqual(
+            _handle_output_by_index(output, 0).weight_versions,
+            [
+                [
+                    WeightVersionSpan(version="v1", start=0, end=3),
+                    WeightVersionSpan(version="v2", start=3, end=5),
+                ]
+            ],
+        )
+        self.assertEqual(
+            _handle_output_by_index(output, 1).weight_versions,
+            [[WeightVersionSpan(version="v2", start=0, end=2)]],
+        )
+
+    def test_batch_str_output_without_weight_versions_stays_none(self):
+        """An output from an older server without the field splits into None."""
+        output = _make_batch_str_output()
+        output.weight_versions = None
+
+        self.assertIsNone(_handle_output_by_index(output, 0).weight_versions)
 
     def test_get_tokenizer_worker_class_uses_default(self):
         self.assertIs(get_tokenizer_worker_class(DefaultServerArgs()), TokenizerWorker)

--- a/test/registered/unit/managers/test_output_streamer_customized_info.py
+++ b/test/registered/unit/managers/test_output_streamer_customized_info.py
@@ -1,22 +1,38 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import unwrap_from_pickle
 from sglang.srt.managers.scheduler_components.output_streamer import (
+    SchedulerOutputStreamer,
     _GenerationStreamAccumulator,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils.weight_versions import (
+    WeightVersionSpan,
+    record_weight_version_events,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class _FakeReq:
-    def __init__(self, rid, output_ids, customized_info=None):
+    def __init__(
+        self,
+        rid,
+        output_ids,
+        customized_info=None,
+        *,
+        finished=False,
+    ):
         self.rid = rid
         self.http_worker_ipc = None
-        self.finished_reason = None
+        self._finished = finished
+        self.finished_reason = (
+            SimpleNamespace(to_json=lambda: {"type": "stop"}) if finished else None
+        )
         self.finished_output = False
         self.finished_len = None
         self.stream = False
@@ -37,14 +53,19 @@ class _FakeReq:
         self.cached_tokens = 0
         self.retraction_count = 0
         self.time_stats = None
+        self.return_hidden_states = False
+        self.return_routed_experts = False
+        self.return_indexer_topk = False
+        self.return_sampling_mask = False
         self.mm_image_tokens = 0
         self.mm_audio_tokens = 0
         self.mm_video_tokens = 0
         self.multimodal_inputs = None
         self.customized_info = customized_info
+        self.weight_version_events = []
 
     def finished(self):
-        return False
+        return self._finished
 
     def init_incremental_detokenize(self):
         return self.output_ids_through_stop, 0
@@ -53,19 +74,38 @@ class _FakeReq:
         return False
 
 
+def _accumulator(current_weight_version="default"):
+    return _GenerationStreamAccumulator(
+        return_logprob=False,
+        return_hidden_states=False,
+        return_routed_experts=False,
+        return_indexer_topk=False,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+        disaggregation_mode=DisaggregationMode.NULL,
+        default_stream_interval=1,
+        default_force_stream_interval=1,
+        get_cached_tokens_details=lambda req: None,
+        current_weight_version=current_weight_version,
+    )
+
+
 class TestOutputStreamerCustomizedInfo(unittest.TestCase):
-    def test_customized_info_is_padded_for_mixed_batches(self):
-        accumulator = _GenerationStreamAccumulator(
-            return_logprob=False,
-            return_hidden_states=False,
-            return_routed_experts=False,
-            return_indexer_topk=False,
-            spec_algorithm=SpeculativeAlgorithm.NONE,
-            disaggregation_mode=DisaggregationMode.NULL,
-            default_stream_interval=1,
-            default_force_stream_interval=1,
-            get_cached_tokens_details=lambda req: None,
+    def setUp(self):
+        serving_patch = patch(
+            "sglang.srt.managers.scheduler_components.output_streamer.get_serving",
+            return_value=SimpleNamespace(stream_interval=1, weight_version="default"),
         )
+        observability_patch = patch(
+            "sglang.srt.managers.scheduler_components.output_streamer.get_observability",
+            return_value=SimpleNamespace(enable_request_time_stats_logging=False),
+        )
+        serving_patch.start()
+        observability_patch.start()
+        self.addCleanup(serving_patch.stop)
+        self.addCleanup(observability_patch.stop)
+
+    def test_customized_info_is_padded_for_mixed_batches(self):
+        accumulator = _accumulator()
 
         accumulator.accept(req=_FakeReq("r0", [10, 11]))
         accumulator.accept(
@@ -89,6 +129,248 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
             customized_info["other"],
             [[None, None], [None, None, None], [300]],
         )
+
+    def test_additional_customized_info_uses_the_existing_payload(self):
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+            def build_additional_customized_info(self, reqs):
+                return {"request_info": [[req.rid] for req in reqs]}
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(
+                stream_interval=1,
+                enable_request_time_stats_logging=False,
+            ),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+
+        streamer._stream_output_generation([_FakeReq("r0", [], finished=True)], False)
+
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(
+            unwrap_from_pickle(outputs[0].customized_info),
+            {"request_info": [["r0"]]},
+        )
+
+    def test_additional_customized_info_only_indexes_emitted_requests(self):
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+            def build_additional_customized_info(self, reqs):
+                return {"request_info": [[req.rid] for req in reqs]}
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(
+                stream_interval=1,
+                enable_request_time_stats_logging=False,
+            ),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+        quiet = _FakeReq("quiet", [10, 11])
+        quiet.stream = True
+        quiet.sampling_params.stream_interval = 2
+        terminal = _FakeReq("terminal", [20], finished=True)
+
+        streamer._stream_output_generation([quiet, terminal], False)
+
+        self.assertEqual(outputs[0].rids, ["terminal"])
+        self.assertEqual(
+            unwrap_from_pickle(outputs[0].customized_info),
+            {"request_info": [["terminal"]]},
+        )
+
+    def test_additional_customized_info_handles_suppressed_request_last(self):
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+            def build_additional_customized_info(self, reqs):
+                return {"request_info": [[req.rid] for req in reqs]}
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(
+                stream_interval=1,
+                enable_request_time_stats_logging=False,
+            ),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+        terminal = _FakeReq("terminal", [20], finished=True)
+        quiet = _FakeReq("quiet", [10, 11])
+        quiet.stream = True
+        quiet.sampling_params.stream_interval = 2
+
+        streamer._stream_output_generation([terminal, quiet], False)
+
+        self.assertEqual(outputs[0].rids, ["terminal"])
+        self.assertEqual(
+            unwrap_from_pickle(outputs[0].customized_info),
+            {"request_info": [["terminal"]]},
+        )
+
+    def test_additional_customized_info_preserves_duplicate_rid_requests(self):
+        accepted_reqs = []
+
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+            def build_additional_customized_info(self, reqs):
+                accepted_reqs.extend(reqs)
+                return {"request_info": [[req.rid] for req in reqs]}
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(
+                stream_interval=1,
+                enable_request_time_stats_logging=False,
+            ),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+        first = _FakeReq("duplicate", [10], finished=True)
+        second = _FakeReq("duplicate", [20], finished=True)
+
+        streamer._stream_output_generation([first, second], False)
+
+        self.assertEqual(accepted_reqs, [first, second])
+
+    def test_additional_customized_info_hook_is_opt_in(self):
+        class Streamer(SchedulerOutputStreamer):
+            build_additional_customized_info = Mock()
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+
+        streamer._stream_output_generation([_FakeReq("r0", [], finished=True)], False)
+
+        Streamer.build_additional_customized_info.assert_not_called()
+        self.assertIsNone(outputs[0].customized_info)
+
+    def test_additional_customized_info_hook_can_skip_inactive_batches(self):
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+            build_additional_customized_info = Mock()
+            should_build_additional_customized_info = Mock(return_value=False)
+
+            def get_cached_tokens_details(self, req):
+                return None
+
+        outputs = []
+        streamer = Streamer(
+            send_to_detokenizer=SimpleNamespace(send_output=outputs.append),
+            tree_cache=None,
+            ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+            server_args=SimpleNamespace(),
+            is_generation=True,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            disaggregation_mode=DisaggregationMode.NULL,
+            enable_hicache_storage=lambda: False,
+        )
+
+        streamer._stream_output_generation([_FakeReq("r0", [], finished=True)], False)
+
+        Streamer.should_build_additional_customized_info.assert_called_once_with()
+        Streamer.build_additional_customized_info.assert_not_called()
+        self.assertIsNone(outputs[0].customized_info)
+
+    def test_additional_customized_info_rejects_rust_egress(self):
+        class Streamer(SchedulerOutputStreamer):
+            has_additional_customized_info = True
+
+        with self.assertRaisesRegex(ValueError, "Rust egress"):
+            Streamer(
+                send_to_detokenizer=SimpleNamespace(),
+                tree_cache=None,
+                ps=SimpleNamespace(),
+                server_args=SimpleNamespace(),
+                is_generation=True,
+                spec_algorithm=SpeculativeAlgorithm.NONE,
+                disaggregation_mode=DisaggregationMode.NULL,
+                enable_hicache_storage=lambda: False,
+                rust_server=object(),
+            )
+
+
+class TestOutputStreamerWeightVersions(unittest.TestCase):
+    def test_payload_carries_spans_for_finished_requests(self):
+        """Finished requests report their spans; still-generating ones report nothing."""
+        streaming_req = _FakeReq("r0", [10, 11])
+        finished_req = _FakeReq("r1", [20, 21, 22], finished=True)
+        record_weight_version_events([finished_req], old_version="v1")
+        finished_req.output_ids.extend([23, 24])
+
+        accumulator = _accumulator(current_weight_version="v2")
+        accumulator.accept(req=streaming_req)
+        accumulator.accept(req=finished_req)
+        payload = accumulator.to_payload(dp_rank=0, is_idle_batch=False)
+
+        self.assertEqual(
+            payload.weight_versions,
+            [
+                None,
+                [
+                    WeightVersionSpan(version="v1", start=0, end=3),
+                    WeightVersionSpan(version="v2", start=3, end=5),
+                ],
+            ],
+        )
+
+    def test_payload_omits_spans_while_all_requests_stream(self):
+        """A batch of unfinished requests puts nothing on the wire."""
+        accumulator = _accumulator(current_weight_version="v2")
+        accumulator.accept(req=_FakeReq("r0", [10]))
+        payload = accumulator.to_payload(dp_rank=0, is_idle_batch=False)
+
+        self.assertIsNone(payload.weight_versions)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -41,6 +41,8 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
         req = MagicMock()
         req.priority = priority
         req.rid = "req"
+        req.output_ids = []
+        req.weight_version_events = []
         req.time_stats = MagicMock()
         req.time_stats.trace_ctx = MagicMock()
         return req
@@ -73,7 +75,11 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
         scheduler.abort_on_priority_when_disabled = True
         req = self._new_req(priority=10)
 
-        scheduler._add_request_to_queue(req)
+        with patch(
+            "sglang.srt.managers.scheduler.get_serving",
+            return_value=SimpleNamespace(weight_version="v0"),
+        ):
+            scheduler._add_request_to_queue(req)
 
         scheduler.disagg_decode_prealloc_queue.add.assert_not_called()
         scheduler.ipc_channels.send_to_tokenizer.send_output.assert_called_once()

--- a/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
@@ -1,0 +1,109 @@
+import unittest
+from collections import deque
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=6, suite="base-c-test-cpu")
+
+
+def _make_req(is_retracted: bool) -> MagicMock:
+    req = MagicMock()
+    req.is_retracted = is_retracted
+    return req
+
+
+class TestSchedulerFlushCacheAfterRetract(unittest.TestCase):
+    """Regression coverage for flush_cache() no-oping while the engine is paused.
+
+    With generation paused and running_batch drained, nothing in waiting_queue
+    holds KV/pool state: neither requests pause_generation(mode="retract") just
+    moved there, nor requests that were never scheduled at all. The latter are
+    always present under high concurrency (in-flight targets exceed engine
+    parallelism), where gating the flush on them starves weight updates until
+    the caller's retry budget times out (reproduced in RL training at 512
+    in-flight requests). See RETRACT_MODE_FLUSH_CACHE_FIX.md in miles."""
+
+    def _new_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._engine_paused = True
+        scheduler.enable_overlap = False
+        scheduler.last_batch = None
+        scheduler.cur_batch = None
+        scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.running_batch = MagicMock()
+        scheduler.running_batch.is_empty.return_value = True
+        scheduler.result_queue = deque()
+        scheduler.waiting_queue = []
+        scheduler.dllm_manager = MagicMock()
+        scheduler.dllm_manager.any_staging_reqs.return_value = False
+        scheduler._pp_microbatches_drained = MagicMock(return_value=True)
+        scheduler.grammar_manager = MagicMock()
+        scheduler.grammar_manager.grammar_queue = []
+        scheduler.enable_hierarchical_cache = False
+        scheduler.enable_hisparse = False
+        scheduler.tree_cache = MagicMock()
+        scheduler.req_to_token_pool = MagicMock()
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.draft_worker = None
+        scheduler.metrics_reporter = MagicMock()
+        return scheduler
+
+    def test_flush_cache_succeeds_when_only_retracted_reqs_are_waiting(self):
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
+        scheduler.req_to_token_pool.clear.assert_called_once()
+        scheduler.token_to_kv_pool_allocator.clear.assert_called_once()
+
+    def test_flush_cache_succeeds_with_never_scheduled_reqs_while_paused(self):
+        """A request that was queued but never scheduled holds no KV/pool state
+        either; a paused-engine flush must not starve on it."""
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=False)]
+
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
+
+    def test_flush_cache_succeeds_on_mixed_queue_while_paused(self):
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [
+            _make_req(is_retracted=True),
+            _make_req(is_retracted=False),
+        ]
+
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
+
+    def test_is_fully_idle_default_ignores_nothing(self):
+        """Regression guard: every other is_fully_idle() caller passes no args,
+        so a non-empty waiting_queue must still report not-idle by default."""
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertFalse(scheduler.is_fully_idle())
+        self.assertTrue(scheduler.is_fully_idle(ignore_waiting=True))
+
+    def test_flush_cache_does_not_ignore_waiting_reqs_while_unpaused(self):
+        """ignore_waiting is gated on _engine_paused inside flush_cache — a
+        flush issued without pausing first must not be silently permissive."""
+        scheduler = self._new_scheduler()
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertFalse(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_internal_state_env_vars.py
+++ b/test/registered/unit/managers/test_scheduler_internal_state_env_vars.py
@@ -1,0 +1,126 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import GetInternalStateReq
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSchedulerInternalStateEnvVars(unittest.TestCase):
+    def _get_internal_state(self) -> dict:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.metrics_reporter = SimpleNamespace(
+            last_gen_throughput=1.0,
+            spec_total_num_forward_ct=0,
+            spec_total_num_accept_tokens=0,
+            step_time_dict={},
+        )
+        scheduler.tp_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(weight_load_mem_usage=1.0),
+            graph_memory_usage=None,
+        )
+        scheduler.token_to_kv_pool_allocator = SimpleNamespace(
+            get_kvcache=lambda: SimpleNamespace(mem_usage=3.0)
+        )
+        scheduler.startup_available_gpu_memory_gb = 4.0
+        scheduler.startup_time = 1.0
+        scheduler.max_total_num_tokens = 100
+        scheduler.swa_tokens_per_layer = None
+        scheduler.max_running_requests = 8
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: True,
+            is_dspark=lambda: False,
+        )
+        scheduler.draft_worker = None
+
+        with patch(
+            "sglang.srt.managers.scheduler.get_context",
+            return_value=SimpleNamespace(resolved_server_args_dict=dict),
+        ), patch(
+            "sglang.srt.managers.scheduler.get_exec",
+            return_value=SimpleNamespace(moe=SimpleNamespace(elastic_ep_backend=None)),
+        ), patch(
+            "sglang.srt.managers.scheduler.get_server_args", return_value=None
+        ), patch(
+            "sglang.srt.managers.scheduler.compute_world_size", return_value=1
+        ):
+            output = scheduler.get_internal_state(recv_req=GetInternalStateReq())
+
+        return output.internal_state
+
+    def test_the_gate_is_declared_off(self):
+        """Nothing is exposed unless an operator opts in, so the declared default is the safety net."""
+        self.assertIs(envs.SGLANG_EXPOSE_OWN_ENV_VARS.default, False)
+
+    def test_env_vars_absent_when_disabled(self):
+        """The env_vars key must not exist at all when the gate is off."""
+        with envs.SGLANG_EXPOSE_OWN_ENV_VARS.override(False):
+            internal_state = self._get_internal_state()
+
+        self.assertNotIn("env_vars", internal_state)
+
+    def test_declared_env_vars_exposed_when_enabled(self):
+        """Enabling the gate exposes the declared, non secret environment of the scheduler."""
+        with envs.SGLANG_EXPOSE_OWN_ENV_VARS.override(True):
+            with patch.dict(
+                "os.environ",
+                {"SGLANG_LOG_SCHEDULER_STATUS_TARGET": "some-value"},
+            ):
+                internal_state = self._get_internal_state()
+
+        self.assertIn("env_vars", internal_state)
+        self.assertEqual(
+            internal_state["env_vars"]["SGLANG_LOG_SCHEDULER_STATUS_TARGET"],
+            "some-value",
+        )
+
+    def test_undeclared_env_vars_never_exposed(self):
+        """Only what Envs declares is auditable; the SGLANG_ namespace also holds real credentials."""
+        with envs.SGLANG_EXPOSE_OWN_ENV_VARS.override(True):
+            with patch.dict(
+                "os.environ",
+                {
+                    "SGLANG_LOG_SCHEDULER_STATUS_TARGET": "some-value",
+                    "SGLANG_S3_SECRET_ACCESS_KEY": "a-cloud-credential",
+                    "SGLANG_DIFFUSION_SLACK_TOKEN": "a-slack-token",
+                },
+            ):
+                internal_state = self._get_internal_state()
+
+        exported = internal_state["env_vars"]
+        self.assertNotIn("SGLANG_S3_SECRET_ACCESS_KEY", exported)
+        self.assertNotIn("SGLANG_DIFFUSION_SLACK_TOKEN", exported)
+        self.assertNotIn("a-cloud-credential", json.dumps(exported))
+
+    def test_a_field_marked_secret_is_never_exposed(self):
+        """A declared credential is still a credential, so the declaration has to be able to say so."""
+        with envs.SGLANG_EXPOSE_OWN_ENV_VARS.override(True):
+            with patch.dict("os.environ", {"EXA_API_KEY": "a-credential"}):
+                internal_state = self._get_internal_state()
+
+        self.assertNotIn("EXA_API_KEY", internal_state["env_vars"])
+
+    def test_a_non_utf8_value_is_encoded_rather_than_dropped(self):
+        """An undecodable byte in one variable must not cost the whole response its json encoding."""
+        with envs.SGLANG_EXPOSE_OWN_ENV_VARS.override(True):
+            with patch.dict(
+                "os.environ", {"SGLANG_LOG_SCHEDULER_STATUS_TARGET": "bad-\udcff"}
+            ):
+                internal_state = self._get_internal_state()
+
+        exported = internal_state["env_vars"]["SGLANG_LOG_SCHEDULER_STATUS_TARGET"]
+        self.assertTrue(exported.startswith("base64:"))
+        json.dumps(internal_state["env_vars"]).encode()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_internal_state_world_size.py
+++ b/test/registered/unit/managers/test_scheduler_internal_state_world_size.py
@@ -1,0 +1,128 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import GetInternalStateReq
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.server_args import ServerArgs, compute_world_size
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_server_args(
+    *, tp_size: int, pp_size: int, dp_size: int, enable_dp_attention: bool
+) -> ServerArgs:
+    return ServerArgs(
+        model_path="dummy",
+        tp_size=tp_size,
+        pp_size=pp_size,
+        dp_size=dp_size,
+        enable_dp_attention=enable_dp_attention,
+    )
+
+
+class TestComputeWorldSize(unittest.TestCase):
+    def test_a_single_gpu_server_holds_one_gpu(self):
+        """The default shape has to come out as one, or every consumer is off by a factor."""
+        server_args = _make_server_args(
+            tp_size=1, pp_size=1, dp_size=1, enable_dp_attention=False
+        )
+
+        self.assertEqual(compute_world_size(server_args), 1)
+
+    def test_tensor_and_pipeline_stages_multiply(self):
+        """Each (pp_rank, tp_rank) pair is its own scheduler process on its own gpu."""
+        server_args = _make_server_args(
+            tp_size=2, pp_size=3, dp_size=1, enable_dp_attention=False
+        )
+
+        self.assertEqual(compute_world_size(server_args), 6)
+
+    def test_plain_data_parallel_replicas_each_hold_their_own_gpus(self):
+        """Without dp attention every replica launches a full tensor-parallel group of its own."""
+        server_args = _make_server_args(
+            tp_size=2, pp_size=1, dp_size=2, enable_dp_attention=False
+        )
+
+        self.assertEqual(compute_world_size(server_args), 4)
+
+    def test_data_parallel_attention_shares_the_tensor_parallel_gpus(self):
+        """With dp attention the dp ranks live inside the tensor-parallel world, not beside it."""
+        server_args = _make_server_args(
+            tp_size=4, pp_size=1, dp_size=2, enable_dp_attention=True
+        )
+
+        self.assertEqual(compute_world_size(server_args), 4)
+
+
+class TestSchedulerInternalStateWorldSize(unittest.TestCase):
+    def _get_internal_state(self, server_args: ServerArgs) -> dict:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.metrics_reporter = SimpleNamespace(
+            last_gen_throughput=1.0,
+            spec_total_num_forward_ct=0,
+            spec_total_num_accept_tokens=0,
+            step_time_dict={},
+        )
+        scheduler.tp_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(weight_load_mem_usage=1.0),
+            graph_memory_usage=None,
+        )
+        scheduler.token_to_kv_pool_allocator = SimpleNamespace(
+            get_kvcache=lambda: SimpleNamespace(mem_usage=3.0)
+        )
+        scheduler.startup_available_gpu_memory_gb = 4.0
+        scheduler.startup_time = 1.0
+        scheduler.max_total_num_tokens = 100
+        scheduler.swa_tokens_per_layer = None
+        scheduler.max_running_requests = 8
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: True,
+            is_dspark=lambda: False,
+        )
+        scheduler.draft_worker = None
+
+        with patch(
+            "sglang.srt.managers.scheduler.get_context",
+            return_value=SimpleNamespace(resolved_server_args_dict=dict),
+        ), patch(
+            "sglang.srt.managers.scheduler.get_exec",
+            return_value=SimpleNamespace(moe=SimpleNamespace(elastic_ep_backend=None)),
+        ), patch(
+            "sglang.srt.managers.scheduler.get_server_args",
+            return_value=server_args,
+        ):
+            output = scheduler.get_internal_state(recv_req=GetInternalStateReq())
+
+        return output.internal_state
+
+    def test_the_internal_state_reports_the_whole_server(self):
+        """A consumer sizing an external fleet reads the gpus the server occupies, not the declared sizes."""
+        server_args = _make_server_args(
+            tp_size=2, pp_size=1, dp_size=2, enable_dp_attention=False
+        )
+
+        internal_state = self._get_internal_state(server_args)
+
+        self.assertEqual(internal_state["world_size"], 4)
+
+    def test_the_reported_size_is_not_one_replica_of_a_data_parallel_server(self):
+        """Each plain dp replica has its own process group, so no scheduler can report the whole server from it."""
+        server_args = _make_server_args(
+            tp_size=2, pp_size=1, dp_size=2, enable_dp_attention=False
+        )
+
+        internal_state = self._get_internal_state(server_args)
+
+        self.assertNotEqual(
+            internal_state["world_size"], server_args.tp_size * server_args.pp_size
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -34,6 +34,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.last_batch = None
         scheduler.cur_batch_for_debug = None
         scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
         scheduler.running_batch = MagicMock()
         scheduler.running_batch.reqs = []
         scheduler.running_batch.is_empty.return_value = True

--- a/test/registered/unit/managers/test_scheduler_timeouts.py
+++ b/test/registered/unit/managers/test_scheduler_timeouts.py
@@ -9,7 +9,7 @@ scheduler/test_scheduler_control.py.
 import time
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -29,6 +29,8 @@ class _FakeReq:
         self.rid = rid
         self.to_finish = None
         self._finished = is_finished
+        self.output_ids = []
+        self.weight_version_events = []
         self.time_stats = SimpleNamespace(
             wait_queue_entry_time=wait_entry,
             forward_entry_time=forward_entry,
@@ -54,6 +56,14 @@ def _scheduler(waiting_queue):
 
 
 class TestWaitingTimeout(CustomTestCase):
+    def setUp(self):
+        patcher = patch(
+            "sglang.srt.managers.scheduler.get_serving",
+            return_value=SimpleNamespace(weight_version="v0"),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_drops_only_reqs_past_the_deadline(self):
         now = time.perf_counter()
         stale = _req("stale", wait_entry=now - 10)

--- a/test/registered/unit/managers/test_scheduler_weight_version_tracking.py
+++ b/test/registered/unit/managers/test_scheduler_weight_version_tracking.py
@@ -1,0 +1,221 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.weight_updater import (
+    SchedulerWeightUpdaterManager,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _ServingStub:
+    def __init__(self, weight_version: str):
+        self.weight_version = weight_version
+
+
+class _ContextStub:
+    def __init__(self, serving: _ServingStub):
+        self.serving = serving
+
+    def override(self, source, **fields):
+        self.serving.weight_version = fields["weight_version"]
+
+
+class TestSchedulerRecordWeightVersionChange(CustomTestCase):
+    def _serving(self, version: str) -> _ServingStub:
+        serving = _ServingStub(version)
+        for name, value in (
+            ("get_serving", serving),
+            ("get_context", _ContextStub(serving)),
+        ):
+            patcher = patch(f"sglang.srt.managers.scheduler.{name}", return_value=value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        return serving
+
+    def _scheduler(
+        self, *, inflight=(), waiting=(), chunked=None, staging=()
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            collect_inflight_reqs=lambda: set(inflight),
+            waiting_queue=list(waiting),
+            chunked_req=chunked,
+            hisparse_coordinator=(
+                SimpleNamespace(
+                    ack_staging_queue=[SimpleNamespace(req=req) for req in staging]
+                )
+                if staging
+                else None
+            ),
+        )
+
+    def test_a_new_version_is_adopted(self):
+        """The scheduler has to end up on the version it was told about, or nothing downstream can read it."""
+        serving = self._serving("v1")
+
+        Scheduler.record_weight_version_change(self._scheduler(), new_version="v2")
+
+        self.assertEqual(serving.weight_version, "v2")
+
+    def test_same_version_is_a_noop(self):
+        """Re-announcing the current version must not be treated as a change."""
+        serving = self._serving("v1")
+
+        Scheduler.record_weight_version_change(self._scheduler(), new_version="v1")
+
+        self.assertEqual(serving.weight_version, "v1")
+
+    def test_none_version_is_a_noop(self):
+        """An update that carries no version must leave the recorded one alone."""
+        serving = self._serving("v1")
+
+        Scheduler.record_weight_version_change(self._scheduler(), new_version=None)
+
+        self.assertEqual(serving.weight_version, "v1")
+
+    def test_every_source_of_live_requests_is_stamped(self):
+        """A request missed here keeps attributing its next tokens to the superseded version."""
+        self._serving("v1")
+        inflight, queued, chunked, staged = (object() for _ in range(4))
+        scheduler = self._scheduler(
+            inflight=[inflight], waiting=[queued], chunked=chunked, staging=[staged]
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler.record_weight_version_events",
+            return_value=0,
+        ) as recorder:
+            Scheduler.record_weight_version_change(scheduler, new_version="v2")
+
+        self.assertEqual(
+            set(recorder.call_args.args[0]), {inflight, queued, chunked, staged}
+        )
+
+
+class TestRecordWeightVersionAfterUpdate(CustomTestCase):
+    def _updater(
+        self, target_result, draft_result=None, method="update_weights_from_disk"
+    ):
+        self.recorded = []
+        return SchedulerWeightUpdaterManager(
+            tp_worker=SimpleNamespace(**{method: lambda recv_req: target_result}),
+            draft_worker=(
+                None
+                if draft_result is None
+                else SimpleNamespace(**{method: lambda recv_req: draft_result})
+            ),
+            tp_cpu_group=None,
+            memory_saver_adapter=None,
+            flush_cache=lambda **kwargs: True,
+            is_fully_idle=lambda **kwargs: True,
+            scheduler=SimpleNamespace(
+                record_weight_version_change=lambda new_version: self.recorded.append(
+                    new_version
+                )
+            ),
+        )
+
+    def _request(self, **fields):
+        return SimpleNamespace(
+            weight_version="v2",
+            flush_cache=True,
+            torch_empty_cache=False,
+            **fields,
+        )
+
+    def test_successful_update_records_the_version(self):
+        """A refit that reports success advances the scheduler-side version."""
+        updater = self._updater(target_result=(True, "ok"))
+
+        output = updater.update_weights_from_disk(self._request())
+
+        self.assertTrue(output.success)
+        self.assertEqual(self.recorded, ["v2"])
+
+    def test_failed_update_does_not_record_the_version(self):
+        """A refit that fails must leave the version alone, or later tokens are mislabelled."""
+        updater = self._updater(target_result=(False, "boom"))
+
+        output = updater.update_weights_from_disk(self._request())
+
+        self.assertFalse(output.success)
+        self.assertEqual(self.recorded, [])
+
+    def test_draft_failure_does_not_record_the_version(self):
+        """The target succeeding is not enough: a failed draft refit leaves the engine mixed."""
+        updater = self._updater(
+            target_result=(True, "ok"), draft_result=(False, "draft boom")
+        )
+
+        output = updater.update_weights_from_disk(self._request())
+
+        self.assertFalse(output.success)
+        self.assertEqual(self.recorded, [])
+
+    def test_successful_distributed_update_records_the_version(self):
+        """The distributed refit is the path an RL trainer actually drives, so it must record too."""
+        updater = self._updater(
+            target_result=(True, "ok"), method="update_weights_from_distributed"
+        )
+
+        output = updater.update_weights_from_distributed(self._request())
+
+        self.assertTrue(output.success)
+        self.assertEqual(self.recorded, ["v2"])
+
+    def test_failed_distributed_update_does_not_record_the_version(self):
+        """A failed distributed refit leaves the version alone, exactly like the disk path."""
+        updater = self._updater(
+            target_result=(False, "boom"), method="update_weights_from_distributed"
+        )
+
+        output = updater.update_weights_from_distributed(self._request())
+
+        self.assertFalse(output.success)
+        self.assertEqual(self.recorded, [])
+
+    def test_successful_tensor_update_records_the_version(self):
+        """The tensor refit records the version once the load reports success."""
+        updater = self._updater(
+            target_result=(True, "ok"), method="update_weights_from_tensor"
+        )
+
+        with patch("torch.distributed.barrier"):
+            output = updater.update_weights_from_tensor(
+                self._request(disable_draft_model=True)
+            )
+
+        self.assertTrue(output.success)
+        self.assertEqual(self.recorded, ["v2"])
+
+    def test_successful_ipc_update_records_the_version(self):
+        """The checkpoint-engine IPC refit records the version like every other path."""
+        updater = self._updater(
+            target_result=(True, "ok"), method="update_weights_from_ipc"
+        )
+
+        with patch("torch.distributed.barrier"):
+            output = updater.update_weights_from_ipc(self._request())
+
+        self.assertTrue(output.success)
+        self.assertEqual(self.recorded, ["v2"])
+
+    def test_failed_ipc_update_does_not_record_the_version(self):
+        """The IPC path branches on success separately from the cache flush, so failure must record nothing."""
+        updater = self._updater(
+            target_result=(False, "boom"), method="update_weights_from_ipc"
+        )
+
+        with patch("torch.distributed.barrier"):
+            output = updater.update_weights_from_ipc(self._request())
+
+        self.assertFalse(output.success)
+        self.assertEqual(self.recorded, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -2,6 +2,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     _split_hicache_size,
@@ -53,6 +54,39 @@ class TestDraftSidecarPoolDispatch(CustomTestCase):
 
         self.assertEqual(specs, [])
         self.assertEqual(entries, [])
+
+    def test_full_builder_sizes_sidecar_for_anchor_logical_space(self):
+        draft_kv_pool = SimpleNamespace(layer_num=1, size=800)
+        draft_host_pool = SimpleNamespace(layer_num=1)
+        tree_cache = SimpleNamespace(
+            cache_controller=SimpleNamespace(
+                mem_pool_host=SimpleNamespace(size=100, logical_size=800),
+                page_size=512,
+            )
+        )
+        server_args = SimpleNamespace(hicache_mem_layout="page_first")
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+                "_build_mha_mla_host_pool",
+                return_value=draft_host_pool,
+            ) as build_host_pool,
+            patch(
+                "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+                "_get_allocator_type",
+                return_value="default",
+            ),
+        ):
+            specs, entries = build_full_draft_pools(
+                draft_kv_pool=draft_kv_pool,
+                tree_cache=tree_cache,
+                server_args=server_args,
+            )
+
+        self.assertEqual(build_host_pool.call_args.kwargs["host_to_device_ratio"], 1.0)
+        self.assertEqual(len(specs), 1)
+        self.assertIs(entries[0].host_pool, draft_host_pool)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -693,6 +693,28 @@ class TestModelOptFp4LoaderSelection(CustomTestCase):
 
 
 class TestModelOptMixedPrecisionConfig(CustomTestCase):
+    def test_fp8_pb_wo_dispatches_to_native_block_fp8(self):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.layers.0.self_attn.q_proj": {"quant_algo": "FP8_PB_WO"},
+                },
+                "packed_modules_mapping": {},
+            }
+        )
+
+        # Type dispatch only needs a LinearBase instance; skip GPU weight setup.
+        linear = ReplicatedLinear.__new__(ReplicatedLinear)
+        method = quant_config.get_quant_method(
+            linear, "model.layers.0.self_attn.q_proj"
+        )
+
+        self.assertIsInstance(method, Fp8LinearMethod)
+        self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+        self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+        self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+
     def test_minimax_mixed_precision_resolves_runtime_names_and_mxfp8(self):
         quant_config = ModelOptMixedPrecisionConfig.from_config(
             {

--- a/test/registered/unit/models/test_kimi_k3_bfa_overlap.py
+++ b/test/registered/unit/models/test_kimi_k3_bfa_overlap.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.srt.models.kimi_k3 import KimiK3DeltaAttention
+from sglang.srt.models.kimi_k3 import (
+    KimiK3DeltaAttention,
+    _get_k3_dense_weight,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -39,9 +42,9 @@ def _make_owner(with_stream: bool):
     owner = SimpleNamespace(
         use_full_rank_gate=True,
         _bfa_w=_randn(_BFA_W_ROWS, _H).contiguous(),
+        _bfa_f_b_w=_randn(1536, _N_FA).contiguous(),
         _bfa_fa_size=_N_FA,
         _bfa_b_size=_N_B,
-        f_b_proj=SimpleNamespace(weight=_randn(1536, _N_FA).contiguous()),
         fused_qkvg_proj=fused_qkvg_proj,
         split_sizes=[3 * 1536, 1536],
         _bfa_alt_stream=torch.cuda.Stream() if with_stream else None,
@@ -96,6 +99,39 @@ class TestKimiK3BfaOverlap(CustomTestCase):
         overlap = _run(_make_owner(with_stream=True), x)  # capture mode False
         for got, ref in zip(overlap, serial):
             self.assertTrue(torch.equal(got, ref))
+
+    def test_block_fp8_weight_is_dequantized_for_tiny_gemm(self):
+        module = SimpleNamespace(
+            weight=torch.nn.Parameter(
+                torch.ones((130, 129), device="cuda", dtype=torch.float8_e4m3fn),
+                requires_grad=False,
+            ),
+            weight_scale_inv=torch.nn.Parameter(
+                torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda"),
+                requires_grad=False,
+            ),
+            quant_method=SimpleNamespace(weight_block_size=[128, 128]),
+            params_dtype=torch.bfloat16,
+        )
+
+        weight = _get_k3_dense_weight(module)
+
+        self.assertEqual(weight.dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            weight[[0, 0, 128, 128], [0, 128, 0, 128]].float(),
+            torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda"),
+        )
+
+    def test_per_tensor_fp8_weight_is_not_block_dequantized(self):
+        weight = torch.nn.Parameter(
+            torch.ones((2, 2), device="cuda", dtype=torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        module = SimpleNamespace(
+            weight=weight, weight_scale=torch.ones(1, device="cuda")
+        )
+
+        self.assertEqual(_get_k3_dense_weight(module).data_ptr(), weight.data_ptr())
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -154,6 +154,38 @@ def test_streaming_recovers_missing_think_separator() -> None:
     assert content == "reply"
 
 
+_TOOLS_CHANNEL = (
+    f'{TOOLS_OPEN}<|open|>call tool="python" index="1"<|sep|>'
+    "<|close|>call<|sep|>"
+    f"{TOOLS_CLOSE}"
+)
+
+
+def test_non_stream_tools_channel_before_think_close_is_not_reasoning() -> None:
+    """A tools channel emitted inside the think block, with think closing after
+    it, must still reach the tool-call parser.
+
+    The reasoning grammar is deferred until think closes, so nothing stops the
+    model from opening the tools channel first. Splitting on think_end put the
+    whole call in reasoning_text, dropping it with no log line.
+    """
+    detector = KimiK3Detector(force_reasoning=True)
+    result = detector.detect_and_parse(
+        f"thought{_TOOLS_CHANNEL}{THINK_CLOSE}{MESSAGE_CLOSE}"
+    )
+    assert result.reasoning_text == "thought"
+    assert TOOLS_OPEN in result.normal_text
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 1000])
+def test_streaming_tools_channel_before_think_close(chunk_size: int) -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    text = f"thought{_TOOLS_CHANNEL}{THINK_CLOSE}{MESSAGE_CLOSE}"
+    reasoning, content = _stream(detector, _chunks(text, chunk_size))
+    assert reasoning == "thought"
+    assert TOOLS_OPEN in content
+
+
 def test_reasoning_parser_registration() -> None:
     assert isinstance(ReasoningParser("kimi_k3").detector, KimiK3Detector)
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2212,5 +2212,35 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestDcpKvEventContract(CustomTestCase):
+    """DCP widens the radix-tree page to page_size * dcp_size, which the
+    advertised KV-event block size must reflect."""
+
+    KV_EVENTS = '{"publisher":"zmq","topic":"kv","endpoint":"tcp://*:5557"}'
+
+    def test_kv_events_descriptor_reports_logical_block_size(self):
+        """Advertising the physical page_size made every KV-aware router hash
+        prompts at a width no emitted block can match, silently pinning its
+        hit rate to zero while stores kept applying cleanly."""
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=4,
+            dcp_size=4,
+            page_size=64,
+            kv_events_config=self.KV_EVENTS,
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 256)
+        args = ServerArgs(
+            model_path="dummy", page_size=64, kv_events_config=self.KV_EVENTS
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 64)
+
+    def test_kv_event_block_size_widens_a_single_token_page(self):
+        # page_size=1 + DCP is a real deployment shape: the allocator is still
+        # paged, at dcp_size.
+        args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
+        self.assertEqual(args.kv_event_block_size, 8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -267,6 +267,18 @@ class TestPostprocessTensors(CustomTestCase):
             [("weird.cos_sin_cache.foo.bar", False, RawComparable(t))],
         )
 
+    def test_skip_set_marks_quantized_entry_not_compared(self):
+        qweight, sf_fp32, _ = _build_fp8_quant_pair()
+        raw = {"x.weight": qweight, "x.weight_scale_inv": sf_fp32}
+        quantized_set = {
+            "x.weight": QuantizedWeight(Fp8BlockComparable, "x.weight_scale_inv")
+        }
+        ref = Fp8BlockComparable(qweight, sf_fp32)
+        _assert_entries_close(
+            _build_check_entries(raw, {"x.weight"}, quantized_set),
+            [("x.weight", False, ref)],
+        )
+
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
 
     def test_fp8_quant_pair_yields_lazy_pair(self):

--- a/test/registered/unit/utils/test_weight_versions.py
+++ b/test/registered/unit/utils/test_weight_versions.py
@@ -1,0 +1,629 @@
+import random
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.scheduler import Scheduler, _make_abort_req
+from sglang.srt.utils.weight_versions import (
+    WeightVersionEvent,
+    WeightVersionSpan,
+    add_weight_versions_to_meta_info,
+    build_endpoint_weight_version_metadata,
+    compute_weight_version_spans,
+    record_weight_version_events,
+    truncate_weight_version_events,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _ReqStub:
+    def __init__(self, output_len: int):
+        self.output_ids = [0] * output_len
+        self.weight_version_events = []
+
+    def record_weight_version_change(self, old_version):
+        record_weight_version_events([self], old_version=old_version)
+
+    def compute_weight_version_spans(self, current_version, num_output_tokens):
+        return compute_weight_version_spans(
+            self.weight_version_events,
+            current_version=current_version,
+            num_output_tokens=num_output_tokens,
+        )
+
+
+def _expected_spans(events, current_version, num_output_tokens):
+    """Reference model: name the version that sampled each token, then run-length encode."""
+    per_token = []
+    for index in range(num_output_tokens):
+        owner = next(
+            (event.old_version for event in events if event.num_output_tokens > index),
+            current_version,
+        )
+        per_token.append(owner)
+
+    if not per_token:
+        first_event_end_at_zero = next(
+            (event for event in events if event.num_output_tokens >= 0), None
+        )
+        version = (
+            first_event_end_at_zero.old_version
+            if first_event_end_at_zero is not None
+            else current_version
+        )
+        return [WeightVersionSpan(version=version, start=0, end=0)]
+
+    spans = []
+    for index, version in enumerate(per_token):
+        if spans and spans[-1].version == version:
+            spans[-1].end = index + 1
+        else:
+            spans.append(WeightVersionSpan(version=version, start=index, end=index + 1))
+    return spans
+
+
+class TestComputeWeightVersionSpans(CustomTestCase):
+    def test_no_events_returns_single_span(self):
+        """A request untouched by updates gets one span covering all output tokens."""
+        self.assertEqual(
+            _ReqStub(5).compute_weight_version_spans(
+                current_version="v1", num_output_tokens=5
+            ),
+            [WeightVersionSpan(version="v1", start=0, end=5)],
+        )
+
+    def test_zero_output_tokens_returns_empty_span_span(self):
+        """A request finishing with no output still reports the current version."""
+        self.assertEqual(
+            _ReqStub(0).compute_weight_version_spans(
+                current_version="v1", num_output_tokens=0
+            ),
+            [WeightVersionSpan(version="v1", start=0, end=0)],
+        )
+
+    def test_one_update_splits_into_two_spans(self):
+        """An update at 3 output tokens attributes [0,3) to the old version and the rest to the new."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 4)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=7),
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+        )
+
+    def test_two_updates_split_into_three_spans(self):
+        """Each update the request lives through adds one span."""
+        req = _ReqStub(2)
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 3)
+        req.record_weight_version_change(old_version="v2")
+        req.output_ids.extend([0] * 1)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v3", num_output_tokens=6),
+            [
+                WeightVersionSpan(version="v1", start=0, end=2),
+                WeightVersionSpan(version="v2", start=2, end=5),
+                WeightVersionSpan(version="v3", start=5, end=6),
+            ],
+        )
+
+    def test_update_before_first_token_records_no_event(self):
+        """An update while the request has no output leaves the whole output on the new version."""
+        req = _ReqStub(0)
+        req.record_weight_version_change(old_version="v1")
+        self.assertEqual(req.weight_version_events, [])
+        req.output_ids.extend([0] * 4)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=4),
+            [WeightVersionSpan(version="v2", start=0, end=4)],
+        )
+
+    def test_back_to_back_updates_skip_empty_span(self):
+        """Two updates with no tokens in between produce no empty span."""
+        req = _ReqStub(2)
+        req.record_weight_version_change(old_version="v1")
+        req.record_weight_version_change(old_version="v2")
+        req.output_ids.extend([0] * 2)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v3", num_output_tokens=4),
+            [
+                WeightVersionSpan(version="v1", start=0, end=2),
+                WeightVersionSpan(version="v3", start=2, end=4),
+            ],
+        )
+
+    def test_update_at_final_length_yields_no_trailing_span(self):
+        """An event recorded exactly at the final output length adds no empty trailing span."""
+        req = _ReqStub(4)
+        req.record_weight_version_change(old_version="v1")
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=4),
+            [WeightVersionSpan(version="v1", start=0, end=4)],
+        )
+
+    def test_event_beyond_reported_length_is_clamped(self):
+        """A spec-decode overshoot event is clamped to the reported output length."""
+        req = _ReqStub(6)
+        req.record_weight_version_change(old_version="v1")
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=4),
+            [WeightVersionSpan(version="v1", start=0, end=4)],
+        )
+
+    def test_clamp_to_zero_reports_the_pre_update_version(self):
+        """With no visible tokens the single span keeps the version that sampled them."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=0),
+            [WeightVersionSpan(version="v1", start=0, end=0)],
+        )
+
+    def test_clamped_output_can_end_before_the_current_version(self):
+        """When the visible tokens stop early the newest version never appears."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 2)
+        req.record_weight_version_change(old_version="v2")
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v3", num_output_tokens=4),
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=4),
+            ],
+        )
+
+    def test_clamping_collapses_events_and_merges_into_one_span(self):
+        """Events beyond the visible range collapse instead of leaving empty spans."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 2)
+        req.record_weight_version_change(old_version="v2")
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v1", num_output_tokens=2),
+            [WeightVersionSpan(version="v1", start=0, end=2)],
+        )
+
+    def test_duplicate_event_at_the_same_length_is_idempotent(self):
+        """Recording twice at the same token count matches recording once."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 2)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v2", num_output_tokens=5),
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=5),
+            ],
+        )
+
+    def test_version_returning_after_tokens_keeps_separate_spans(self):
+        """A version that comes back after another one sampled tokens gets its own span."""
+        req = _ReqStub(2)
+        req.record_weight_version_change(old_version="v1")
+        req.output_ids.extend([0] * 2)
+        req.record_weight_version_change(old_version="v2")
+        req.output_ids.extend([0] * 2)
+        self.assertEqual(
+            req.compute_weight_version_spans(current_version="v1", num_output_tokens=6),
+            [
+                WeightVersionSpan(version="v1", start=0, end=2),
+                WeightVersionSpan(version="v2", start=2, end=4),
+                WeightVersionSpan(version="v1", start=4, end=6),
+            ],
+        )
+
+    def test_spans_are_never_empty_even_when_everything_is_clamped_away(self):
+        """add_weight_versions_to_meta_info reads the newest span by index, so an empty list would crash it."""
+        req = _ReqStub(3)
+        req.record_weight_version_change(old_version="v1")
+        req.record_weight_version_change(old_version="v2")
+
+        for current_version in ("v1", "v3"):
+            self.assertTrue(
+                req.compute_weight_version_spans(
+                    current_version=current_version, num_output_tokens=0
+                )
+            )
+        self.assertTrue(
+            _ReqStub(0).compute_weight_version_spans(
+                current_version="v1", num_output_tokens=0
+            )
+        )
+
+    def test_spans_satisfy_the_contract_for_random_event_sequences(self):
+        """Randomized event sequences always yield ordered, contiguous, non-duplicated spans."""
+        rng = random.Random(0)
+        versions = ["v0", "v1", "v2"]
+        for _ in range(300):
+            counts = sorted(rng.randint(1, 8) for _ in range(rng.randint(0, 5)))
+            events = [
+                WeightVersionEvent(
+                    old_version=rng.choice(versions), num_output_tokens=count
+                )
+                for count in counts
+            ]
+            current_version = rng.choice(versions)
+            num_output_tokens = rng.randint(0, 10)
+            spans = compute_weight_version_spans(
+                events,
+                current_version=current_version,
+                num_output_tokens=num_output_tokens,
+            )
+
+            self.assertEqual(
+                spans,
+                _expected_spans(events, current_version, num_output_tokens),
+            )
+            self.assertTrue(spans)
+            self.assertEqual(spans[0].start, 0)
+            self.assertEqual(spans[-1].end, num_output_tokens)
+            for previous, current in zip(spans, spans[1:]):
+                self.assertEqual(previous.end, current.start)
+                self.assertNotEqual(previous.version, current.version)
+            if num_output_tokens == 0:
+                self.assertEqual(len(spans), 1)
+                self.assertEqual(spans[0].end, 0)
+            else:
+                for span in spans:
+                    self.assertLess(span.start, span.end)
+
+
+class _ServingStub:
+    def __init__(self, weight_version):
+        self.weight_version = weight_version
+
+
+class _ContextStub:
+    def __init__(self, serving: _ServingStub):
+        self.serving = serving
+
+    def override(self, source, **fields):
+        self.serving.weight_version = fields["weight_version"]
+
+
+class _SchedulerStub:
+    collect_inflight_reqs = Scheduler.collect_inflight_reqs
+
+    def __init__(
+        self,
+        version,
+        running,
+        waiting,
+        chunked=None,
+        last_batch=None,
+        pp_size=1,
+        hisparse=None,
+    ):
+        self.serving = _ServingStub(version)
+        self.ps = SimpleNamespace(pp_size=pp_size)
+        self.running_batch = SimpleNamespace(reqs=running)
+        self.last_batch = last_batch
+        self.waiting_queue = waiting
+        self.chunked_req = chunked
+        self.hisparse_coordinator = hisparse
+
+
+class TestSchedulerRecordWeightVersionChange(CustomTestCase):
+    def _scheduler(self, *args, **kwargs):
+        scheduler = _SchedulerStub(*args, **kwargs)
+        for name, value in (
+            ("get_serving", scheduler.serving),
+            ("get_context", _ContextStub(scheduler.serving)),
+        ):
+            patcher = patch(f"sglang.srt.managers.scheduler.{name}", return_value=value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        return scheduler
+
+    def test_records_on_running_waiting_and_chunked_requests(self):
+        """A version change records an event on every live request holding output tokens."""
+        running_req = _ReqStub(3)
+        waiting_req = _ReqStub(5)
+        chunked_req = _ReqStub(2)
+        scheduler = self._scheduler(
+            "v1", [running_req], [waiting_req], chunked=chunked_req
+        )
+
+        Scheduler.record_weight_version_change(scheduler, new_version="v2")
+
+        self.assertEqual(scheduler.serving.weight_version, "v2")
+        for req, output_len in (
+            (running_req, 3),
+            (waiting_req, 5),
+            (chunked_req, 2),
+        ):
+            self.assertEqual(len(req.weight_version_events), 1)
+            self.assertEqual(req.weight_version_events[0].old_version, "v1")
+            self.assertEqual(req.weight_version_events[0].num_output_tokens, output_len)
+
+    def test_records_on_last_batch_requests_exactly_once(self):
+        """A request in both the running and last batch is recorded once, and last-batch-only requests are recorded too."""
+        shared_req = _ReqStub(3)
+        prefill_req = _ReqStub(1)
+        scheduler = self._scheduler(
+            "v1",
+            [shared_req],
+            [],
+            last_batch=SimpleNamespace(reqs=[shared_req, prefill_req]),
+        )
+
+        Scheduler.record_weight_version_change(scheduler, new_version="v2")
+
+        self.assertEqual(len(shared_req.weight_version_events), 1)
+        self.assertEqual(len(prefill_req.weight_version_events), 1)
+
+    def test_records_on_all_pp_microbatches(self):
+        """With pipeline parallelism every microbatch is visited, not just the selected one."""
+        mb0_req = _ReqStub(2)
+        mb1_req = _ReqStub(4)
+        pending_req = _ReqStub(6)
+        scheduler = self._scheduler("v1", [], [], pp_size=2)
+        scheduler.running_mbs = [
+            SimpleNamespace(reqs=[mb0_req]),
+            SimpleNamespace(reqs=[mb1_req]),
+        ]
+        scheduler.mbs = [None, SimpleNamespace(reqs=[pending_req])]
+
+        Scheduler.record_weight_version_change(scheduler, new_version="v2")
+
+        for req in (mb0_req, mb1_req, pending_req):
+            self.assertEqual(len(req.weight_version_events), 1)
+
+    def test_records_on_hisparse_staging_requests(self):
+        """Requests parked in the HiSparse staging queue are swept like any live request."""
+        staging_req = _ReqStub(2)
+        coordinator = SimpleNamespace(
+            ack_staging_queue=[SimpleNamespace(req=staging_req)]
+        )
+        scheduler = self._scheduler("v1", [], [], hisparse=coordinator)
+
+        Scheduler.record_weight_version_change(scheduler, new_version="v2")
+
+        self.assertEqual(len(staging_req.weight_version_events), 1)
+        self.assertEqual(staging_req.weight_version_events[0].old_version, "v1")
+        self.assertEqual(staging_req.weight_version_events[0].num_output_tokens, 2)
+
+    def test_same_version_is_a_noop(self):
+        """Re-announcing the current version must not record events."""
+        req = _ReqStub(3)
+        scheduler = self._scheduler("v1", [req], [])
+
+        Scheduler.record_weight_version_change(scheduler, new_version="v1")
+
+        self.assertEqual(scheduler.serving.weight_version, "v1")
+        self.assertEqual(req.weight_version_events, [])
+
+    def test_none_version_is_a_noop(self):
+        """An update without a weight version must not disturb attribution."""
+        req = _ReqStub(3)
+        scheduler = self._scheduler("v1", [req], [])
+
+        Scheduler.record_weight_version_change(scheduler, new_version=None)
+
+        self.assertEqual(scheduler.serving.weight_version, "v1")
+        self.assertEqual(req.weight_version_events, [])
+
+
+class TestRecordWeightVersionEvents(CustomTestCase):
+    def test_records_only_for_requests_that_have_output(self):
+        """Requests without output tokens are skipped without stopping the sweep."""
+        empty_req = _ReqStub(0)
+        started_req = _ReqStub(4)
+
+        num_recorded = record_weight_version_events(
+            [empty_req, started_req, _ReqStub(2)], old_version="v1"
+        )
+
+        self.assertEqual(num_recorded, 2)
+        self.assertEqual(empty_req.weight_version_events, [])
+        self.assertEqual(len(started_req.weight_version_events), 1)
+        self.assertEqual(started_req.weight_version_events[0].old_version, "v1")
+        self.assertEqual(started_req.weight_version_events[0].num_output_tokens, 4)
+
+
+class TestTruncateWeightVersionEvents(CustomTestCase):
+    def test_events_within_the_kept_prefix_are_preserved(self):
+        """Events entirely inside the streamed prefix survive a retract untouched."""
+        events = [WeightVersionEvent(old_version="v1", num_output_tokens=3)]
+        self.assertEqual(
+            truncate_weight_version_events(events, num_kept_tokens=5), events
+        )
+
+    def test_events_beyond_the_kept_prefix_are_clamped(self):
+        """An event past the streamed prefix is clamped so re-generated tokens forget it."""
+        events = [
+            WeightVersionEvent(old_version="v1", num_output_tokens=3),
+            WeightVersionEvent(old_version="v2", num_output_tokens=9),
+        ]
+        self.assertEqual(
+            truncate_weight_version_events(events, num_kept_tokens=5),
+            [
+                WeightVersionEvent(old_version="v1", num_output_tokens=3),
+                WeightVersionEvent(old_version="v2", num_output_tokens=5),
+            ],
+        )
+
+    def test_zero_kept_tokens_drops_all_events(self):
+        """With nothing streamed yet the whole history is discarded, as before the fix."""
+        events = [WeightVersionEvent(old_version="v1", num_output_tokens=3)]
+        self.assertEqual(truncate_weight_version_events(events, num_kept_tokens=0), [])
+
+
+class TestSpanlessAbortPaths(CustomTestCase):
+    def test_priority_disabled_rejection_attaches_spans(self):
+        """The pre-scheduler priority rejection reports spans like every other abort."""
+        req = _ReqStub(0)
+        req.rid = "r0"
+        req.priority = 5
+        req.time_stats = SimpleNamespace(
+            trace_ctx=SimpleNamespace(abort=lambda abort_info: None)
+        )
+        sent = []
+        scheduler = SimpleNamespace(
+            enable_priority_scheduling=False,
+            abort_on_priority_when_disabled=True,
+            ipc_channels=SimpleNamespace(
+                send_to_tokenizer=SimpleNamespace(
+                    send_output=lambda obj, req_arg: sent.append(obj)
+                )
+            ),
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler.get_serving",
+            return_value=SimpleNamespace(weight_version="v1"),
+        ):
+            accepted = Scheduler._set_or_validate_priority(scheduler, req)
+
+        self.assertFalse(accepted)
+        self.assertEqual(
+            sent[0].weight_versions, [WeightVersionSpan(version="v1", start=0, end=0)]
+        )
+
+
+class TestMakeAbortReq(CustomTestCase):
+    def test_abort_req_carries_spans_clamped_to_sampled_tokens(self):
+        """An aborted request reports the versions that sampled the tokens it produced."""
+        req = _ReqStub(4)
+        req.rid = "r0"
+        req.weight_version_events.append(
+            WeightVersionEvent(old_version="v1", num_output_tokens=3)
+        )
+        with patch(
+            "sglang.srt.managers.scheduler.get_serving",
+            return_value=SimpleNamespace(weight_version="v2"),
+        ):
+            abort_req = _make_abort_req(req)
+
+        self.assertIsInstance(abort_req, AbortReq)
+        self.assertEqual(abort_req.rid, "r0")
+        self.assertEqual(
+            abort_req.weight_versions,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=4),
+            ],
+        )
+
+
+class TestBuildEndpointWeightVersionMetadata(CustomTestCase):
+    def test_metadata_projects_only_the_weight_fields(self):
+        """Endpoint metadata exposes the version fields and nothing else from meta_info."""
+        spans = [
+            {"version": "v1", "start": 0, "end": 3},
+            {"version": "v2", "start": 3, "end": 7},
+        ]
+        metadata = build_endpoint_weight_version_metadata(
+            {
+                "weight_version": "v2",
+                "weight_versions": spans,
+                "id": "r0",
+                "completion_tokens": 7,
+            }
+        )
+        self.assertEqual(metadata, {"weight_version": "v2", "weight_versions": spans})
+
+    def test_metadata_omits_spans_when_absent(self):
+        """Responses without spans still report the legacy version alone."""
+        metadata = build_endpoint_weight_version_metadata({"weight_version": "v2"})
+        self.assertEqual(metadata, {"weight_version": "v2"})
+
+
+class TestAddWeightVersionsToMetaInfo(CustomTestCase):
+    def test_meta_info_gets_dict_spans_and_legacy_field(self):
+        """Spans become dicts and the legacy weight_version reports the newest span."""
+        meta_info = {"weight_version": "stale"}
+        add_weight_versions_to_meta_info(
+            meta_info,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+            num_output_tokens=7,
+        )
+        self.assertEqual(
+            meta_info["weight_versions"],
+            [
+                {"version": "v1", "start": 0, "end": 3},
+                {"version": "v2", "start": 3, "end": 7},
+            ],
+        )
+        self.assertEqual(meta_info["weight_version"], "v2")
+
+    def test_spans_are_clamped_to_returned_tokens(self):
+        """Aborts returning fewer tokens than sampled clamp spans to the visible range."""
+        meta_info = {}
+        add_weight_versions_to_meta_info(
+            meta_info,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+            num_output_tokens=5,
+        )
+        self.assertEqual(
+            meta_info["weight_versions"],
+            [
+                {"version": "v1", "start": 0, "end": 3},
+                {"version": "v2", "start": 3, "end": 5},
+            ],
+        )
+        self.assertEqual(meta_info["weight_version"], "v2")
+
+    def test_clamp_never_extends_spans(self):
+        """A response longer than the sampled range leaves the spans untouched."""
+        meta_info = {}
+        add_weight_versions_to_meta_info(
+            meta_info,
+            [WeightVersionSpan(version="v1", start=0, end=3)],
+            num_output_tokens=10,
+        )
+        self.assertEqual(
+            meta_info["weight_versions"], [{"version": "v1", "start": 0, "end": 3}]
+        )
+        self.assertEqual(meta_info["weight_version"], "v1")
+
+    def test_clamp_drops_trailing_spans_and_rewrites_the_legacy_field(self):
+        """Dropping invisible spans also moves the legacy version back."""
+        meta_info = {}
+        add_weight_versions_to_meta_info(
+            meta_info,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+            num_output_tokens=3,
+        )
+        self.assertEqual(
+            meta_info["weight_versions"], [{"version": "v1", "start": 0, "end": 3}]
+        )
+        self.assertEqual(meta_info["weight_version"], "v1")
+
+    def test_clamp_to_zero_tokens_keeps_a_degenerate_span(self):
+        """A response with no visible tokens still reports a well-formed empty span."""
+        meta_info = {}
+        add_weight_versions_to_meta_info(
+            meta_info,
+            [
+                WeightVersionSpan(version="v1", start=0, end=3),
+                WeightVersionSpan(version="v2", start=3, end=7),
+            ],
+            num_output_tokens=0,
+        )
+        self.assertEqual(
+            meta_info["weight_versions"], [{"version": "v1", "start": 0, "end": 0}]
+        )
+        self.assertEqual(meta_info["weight_version"], "v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/models/test_params_mapping.py
+++ b/test/srt/models/test_params_mapping.py
@@ -1,0 +1,292 @@
+"""Unit tests for ParameterMapper."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.model_loader.parameter_mapper import ParameterMapper
+
+_DEEPSEEK_N_ROUTED = 4
+_DEEPSEEK_N_LOCAL = _DEEPSEEK_N_ROUTED + 1  # +1 fused shared expert
+_QWEN3MOE_N = 4
+_GLM4LITE_N_ROUTED = 4
+_GLM4LITE_N_LOCAL = _GLM4LITE_N_ROUTED + 1  # +1 fused shared expert
+
+
+def _make_model(**kwargs):
+    """Create a stub model object for ParameterMapper.from_model()."""
+    return SimpleNamespace(**kwargs)
+
+
+def _deepseek_mutate(name):
+    if "mlp.shared_experts" in name:
+        return name.replace("mlp.shared_experts", f"mlp.experts.{_DEEPSEEK_N_ROUTED}")
+    return name
+
+
+def _deepseek_scale_remap(name):
+    for s in ["k_scale", "v_scale"]:
+        if s in name:
+            return name.replace(f"{s[0]}_proj", "attn_mqa")
+    return name
+
+
+def _glm4lite_mutate(name):
+    if "mlp.shared_experts" in name:
+        return name.replace("mlp.shared_experts", f"mlp.experts.{_GLM4LITE_N_ROUTED}")
+    return name
+
+
+_LLAMA_SCALE_PATTERNS = [
+    (".activation_scale", ".activation_scale", ".input_scale"),
+    (".weight_scale_inv", ".weight_scale_inv", ".weight_scale"),
+]
+
+
+def _llama_scale_remap(name):
+    for suffix, pattern, replacement in _LLAMA_SCALE_PATTERNS:
+        if name.endswith(suffix) and pattern in name:
+            return name.replace(pattern, replacement)
+    return name
+
+
+@pytest.fixture
+def qwen_mapper():
+    """Qwen2/Qwen3 (dense): QKV fusion, gate/up fusion, no experts."""
+    return ParameterMapper.from_model(
+        _make_model(
+            stacked_params_mapping=[
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            ],
+        )
+    )
+
+
+@pytest.fixture
+def llama_mapper():
+    """Llama/GLM4 (dense): dot-prefixed stacked params, custom scale remap."""
+    return ParameterMapper.from_model(
+        _make_model(
+            stacked_params_mapping=[
+                (".qkv_proj", ".q_proj", "q"),
+                (".qkv_proj", ".k_proj", "k"),
+                (".qkv_proj", ".v_proj", "v"),
+                (".gate_up_proj", ".gate_proj", 0),
+                (".gate_up_proj", ".up_proj", 1),
+            ],
+            custom_scale_remap=_llama_scale_remap,
+        )
+    )
+
+
+@pytest.fixture
+def qwen3moe_mapper():
+    """Qwen3-MoE: QKV fusion + experts, no shared expert fusion."""
+    return ParameterMapper.from_model(
+        _make_model(
+            stacked_params_mapping=[
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            ],
+            expert_params_mapping=FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                num_experts=_QWEN3MOE_N,
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def deepseek_mapper():
+    """DeepSeek V2/V3: MLA A-proj fusion, shared expert fusion, custom scale remap."""
+    return ParameterMapper.from_model(
+        _make_model(
+            stacked_params_mapping=[
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+                ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
+                ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
+            ],
+            expert_params_mapping=FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                num_experts=_DEEPSEEK_N_LOCAL,
+            ),
+            mutate_weight_preload=_deepseek_mutate,
+            custom_scale_remap=_deepseek_scale_remap,
+        )
+    )
+
+
+@pytest.fixture
+def glm4lite_mapper():
+    """GLM4-MoE-Lite (GLM-4.7): QKV fusion, MLA A-proj fusion, shared expert fusion, custom scale remap."""
+    return ParameterMapper.from_model(
+        _make_model(
+            stacked_params_mapping=[
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+                ("fused_qkv_a_proj_with_mqa", "q_a_proj", 0),
+                ("fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa", 1),
+            ],
+            expert_params_mapping=FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                num_experts=_GLM4LITE_N_LOCAL,
+            ),
+            mutate_weight_preload=_glm4lite_mutate,
+            custom_scale_remap=_deepseek_scale_remap,
+        )
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def to_expect(name, shard=None, n=1, expert=None, n_exp=None):
+    """Shorthand for expected MappingResult fields."""
+    return (name, shard, n, expert, n_exp)
+
+
+def _assert(mapper, ckpt, expected):
+    r = mapper.map(ckpt)
+    name, shard, n, expert, n_exp = expected
+    assert (
+        r.sglang_name,
+        r.shard_id,
+        r.num_shards,
+        r.expert_id,
+        r.num_local_experts,
+    ) == (name, shard, n, expert, n_exp), f"map({ckpt!r}) = {r}"
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+# fmt: off
+_QWEN_CASES = [
+    # QKV fusion (Qwen2, Qwen3, GLM4-MoE)
+    ("layers.0.attn.q_proj.weight",     to_expect("layers.0.attn.qkv_proj.weight", "q", 3)),
+    ("layers.0.attn.k_proj.weight",     to_expect("layers.0.attn.qkv_proj.weight", "k", 3)),
+    ("layers.0.attn.v_proj.weight",     to_expect("layers.0.attn.qkv_proj.weight", "v", 3)),
+    # Gate/Up fusion
+    ("layers.0.mlp.gate_proj.weight",   to_expect("layers.0.mlp.gate_up_proj.weight", 0, 2)),
+    ("layers.0.mlp.up_proj.weight",     to_expect("layers.0.mlp.gate_up_proj.weight", 1, 2)),
+    # Pass-through
+    ("layers.0.mlp.down_proj.weight",   to_expect("layers.0.mlp.down_proj.weight")),
+    ("embed_tokens.weight",             to_expect("embed_tokens.weight")),
+    # Standard scale remap (no custom_scale_remap)
+    ("model.layers.0.self_attn.k_scale", to_expect("model.layers.0.self_attn.attn.k_scale")),
+    ("model.layers.0.self_attn.v_scale", to_expect("model.layers.0.self_attn.attn.v_scale")),
+]
+
+_LLAMA_CASES = [
+    # Dot-prefixed QKV fusion (Llama, GLM4)
+    ("model.layers.0.self_attn.q_proj.weight", to_expect("model.layers.0.self_attn.qkv_proj.weight", "q", 3)),
+    ("model.layers.0.self_attn.k_proj.weight", to_expect("model.layers.0.self_attn.qkv_proj.weight", "k", 3)),
+    # Dot-prefixed gate/up
+    ("model.layers.0.mlp.gate_proj.weight",    to_expect("model.layers.0.mlp.gate_up_proj.weight", 0, 2)),
+    # Llama-specific scale remap + stacked (scales follow their weights)
+    ("model.layers.0.mlp.gate_proj.activation_scale", to_expect("model.layers.0.mlp.gate_up_proj.input_scale", 0, 2)),
+    ("model.layers.0.mlp.gate_proj.weight_scale_inv", to_expect("model.layers.0.mlp.gate_up_proj.weight_scale", 0, 2)),
+    # Pass-through
+    ("model.layers.0.mlp.down_proj.weight",    to_expect("model.layers.0.mlp.down_proj.weight")),
+]
+
+_QWEN3MOE_CASES = [
+    # QKV fusion
+    ("model.layers.0.self_attn.q_proj.weight",          to_expect("model.layers.0.self_attn.qkv_proj.weight", "q", 3)),
+    # Expert mapping (no shared expert fusion)
+    ("model.layers.0.mlp.experts.0.gate_proj.weight",   to_expect("model.layers.0.mlp.experts.w13_weight", "w1", 2, 0, _QWEN3MOE_N)),
+    ("model.layers.0.mlp.experts.3.down_proj.weight",   to_expect("model.layers.0.mlp.experts.w2_weight", "w2", 1, 3, _QWEN3MOE_N)),
+    # shared_experts falls through to stacked mapping (no mutate_weight_preload)
+    ("model.layers.0.mlp.shared_experts.gate_proj.weight", to_expect("model.layers.0.mlp.shared_experts.gate_up_proj.weight", 0, 2)),
+]
+
+_DEEPSEEK_CASES = [
+    # MLA A-proj fusion
+    ("model.layers.0.self_attn.q_a_proj.weight",            to_expect("model.layers.0.self_attn.fused_qkv_a_proj_with_mqa.weight", 0, 2)),
+    ("model.layers.0.self_attn.kv_a_proj_with_mqa.weight",  to_expect("model.layers.0.self_attn.fused_qkv_a_proj_with_mqa.weight", 1, 2)),
+    # Shared expert fusion via mutate_weight_preload
+    ("model.layers.0.mlp.shared_experts.gate_proj.weight",   to_expect("model.layers.0.mlp.experts.w13_weight", "w1", 2, _DEEPSEEK_N_ROUTED, _DEEPSEEK_N_LOCAL)),
+    ("model.layers.0.mlp.shared_experts.down_proj.weight",   to_expect("model.layers.0.mlp.experts.w2_weight", "w2", 1, _DEEPSEEK_N_ROUTED, _DEEPSEEK_N_LOCAL)),
+    # Custom scale remap (k_proj/v_proj -> attn_mqa, NOT double-remapped)
+    ("model.layers.0.self_attn.k_proj.k_scale",             to_expect("model.layers.0.self_attn.attn_mqa.k_scale")),
+    ("model.layers.0.self_attn.v_proj.v_scale",             to_expect("model.layers.0.self_attn.attn_mqa.v_scale")),
+    # kv_b_proj pass-through (decomposed in post_load_weights)
+    ("model.layers.0.self_attn.kv_b_proj.weight",           to_expect("model.layers.0.self_attn.kv_b_proj.weight")),
+]
+
+_GLM4LITE_CASES = [
+    # QKV fusion (GLM-4.7 uses standard QKV unlike DeepSeek which uses MLA-only)
+    ("model.layers.0.self_attn.q_proj.weight",              to_expect("model.layers.0.self_attn.qkv_proj.weight", "q", 3)),
+    ("model.layers.0.self_attn.k_proj.weight",              to_expect("model.layers.0.self_attn.qkv_proj.weight", "k", 3)),
+    ("model.layers.0.self_attn.v_proj.weight",              to_expect("model.layers.0.self_attn.qkv_proj.weight", "v", 3)),
+    # MLA A-proj fusion (GLM-4.7 also uses MLA with q_lora_rank)
+    ("model.layers.0.self_attn.q_a_proj.weight",            to_expect("model.layers.0.self_attn.fused_qkv_a_proj_with_mqa.weight", 0, 2)),
+    ("model.layers.0.self_attn.kv_a_proj_with_mqa.weight",  to_expect("model.layers.0.self_attn.fused_qkv_a_proj_with_mqa.weight", 1, 2)),
+    # Gate/Up fusion (non-expert layers)
+    ("model.layers.0.mlp.gate_proj.weight",                 to_expect("model.layers.0.mlp.gate_up_proj.weight", 0, 2)),
+    ("model.layers.0.mlp.up_proj.weight",                   to_expect("model.layers.0.mlp.gate_up_proj.weight", 1, 2)),
+    # Expert mapping
+    ("model.layers.0.mlp.experts.0.gate_proj.weight",       to_expect("model.layers.0.mlp.experts.w13_weight", "w1", 2, 0, _GLM4LITE_N_LOCAL)),
+    ("model.layers.0.mlp.experts.0.up_proj.weight",         to_expect("model.layers.0.mlp.experts.w13_weight", "w3", 2, 0, _GLM4LITE_N_LOCAL)),
+    ("model.layers.0.mlp.experts.3.down_proj.weight",       to_expect("model.layers.0.mlp.experts.w2_weight", "w2", 1, 3, _GLM4LITE_N_LOCAL)),
+    # Shared expert fusion via mutate_weight_preload
+    ("model.layers.0.mlp.shared_experts.gate_proj.weight",  to_expect("model.layers.0.mlp.experts.w13_weight", "w1", 2, _GLM4LITE_N_ROUTED, _GLM4LITE_N_LOCAL)),
+    ("model.layers.0.mlp.shared_experts.down_proj.weight",  to_expect("model.layers.0.mlp.experts.w2_weight", "w2", 1, _GLM4LITE_N_ROUTED, _GLM4LITE_N_LOCAL)),
+    # Custom scale remap (same as DeepSeek: k_proj/v_proj -> attn_mqa)
+    ("model.layers.0.self_attn.k_proj.k_scale",             to_expect("model.layers.0.self_attn.attn_mqa.k_scale")),
+    ("model.layers.0.self_attn.v_proj.v_scale",             to_expect("model.layers.0.self_attn.attn_mqa.v_scale")),
+    # Pass-through
+    ("model.layers.0.mlp.down_proj.weight",                 to_expect("model.layers.0.mlp.down_proj.weight")),
+    ("model.layers.0.self_attn.kv_b_proj.weight",           to_expect("model.layers.0.self_attn.kv_b_proj.weight")),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize("ckpt,expected", _QWEN_CASES, ids=[c[0] for c in _QWEN_CASES])
+def test_qwen(qwen_mapper, ckpt, expected):
+    _assert(qwen_mapper, ckpt, expected)
+
+
+@pytest.mark.parametrize(
+    "ckpt,expected", _LLAMA_CASES, ids=[c[0] for c in _LLAMA_CASES]
+)
+def test_llama(llama_mapper, ckpt, expected):
+    _assert(llama_mapper, ckpt, expected)
+
+
+@pytest.mark.parametrize(
+    "ckpt,expected", _QWEN3MOE_CASES, ids=[c[0] for c in _QWEN3MOE_CASES]
+)
+def test_qwen3moe(qwen3moe_mapper, ckpt, expected):
+    _assert(qwen3moe_mapper, ckpt, expected)
+
+
+@pytest.mark.parametrize(
+    "ckpt,expected", _DEEPSEEK_CASES, ids=[c[0] for c in _DEEPSEEK_CASES]
+)
+def test_deepseek(deepseek_mapper, ckpt, expected):
+    _assert(deepseek_mapper, ckpt, expected)
+
+
+@pytest.mark.parametrize(
+    "ckpt,expected", _GLM4LITE_CASES, ids=[c[0] for c in _GLM4LITE_CASES]
+)
+def test_glm4lite(glm4lite_mapper, ckpt, expected):
+    _assert(glm4lite_mapper, ckpt, expected)


### PR DESCRIPTION
## Summary

Start Inkling on ROCm without CUTE and initialize pure-SWA KV pools safely.

## Symptom & Reproduction

- **Symptom:** [`stage-c-4-gpu-mi350 (0) / run`](https://github.com/radixark/miles/actions/runs/33259345919/job/99118506030) failed at Miles revision `721c020bc3cde81b07ee6189d2f571f440ff1824`: importing `sglang.srt.models.inkling` reported missing `cutlass`, model resolution fell through to the misleading Transformers/`auto_map` error, and the retry classifier later mislabeled exit code 1 as OOM.
- **Reproduction:** `python3 /__w/miles/miles/tests/e2e/megatron/model_scripts/test_inkling_small_4layer_ci.py` failed before the SGLang engine became healthy.

## Root Cause

1. `inkling_common.attn` imported CUTE helpers during model discovery.
2. `ModelRegistry.register` skipped Inkling when `cutlass` was unavailable.
3. `SWAKVPool.get_v_head_dim` indexed an empty pure-SWA full pool.

## Fix

Keep the CUTE-only batch-invariance helper inside Inkling's existing optional CUTE import boundary, so ROCm Triton startup can register the model without `cutlass` while the CUTE path retains its behavior. Read the value head dimension from `full_kv_pool`'s construction-time metadata instead of indexing a full-attention buffer that does not exist for pure-SWA Inkling.

## Upstream Check

- Current SGLang `main` at `253020450290328e9deb307eece1e402fa17f35e` still imports the CUTE batch-invariance helper unconditionally; no matching open or merged PR was found for the ROCm registration failure.
- #35292 and #35154 add the original `SWAKVPool.get_v_head_dim()` startup fix. `sglang-miles` already carries the same buffer-indexing implementation in `812e2f37733beb59b9439356c79555ad6c1f0faf`; those candidates do not handle a pure-SWA pool with zero full-attention layers, so cherry-picking them would not fix this failure.

## Verification

- [`stage-c-4-gpu-mi350 (0) / run`](https://github.com/radixark/miles/actions/runs/33299539697/job/99224942881): checked out exact SGLang SHA `c38aafe72791704bd60a3517c92a96db75307d48`; `test_inkling_small_4layer_ci.py` passed in 493s and the shard reported `2/2 passed`.
- `python3 -m py_compile python/sglang/srt/models/inkling_common/attn.py python/sglang/srt/mem_cache/swa_memory_pool.py`: passed.
- `git diff --check 2f51d3764b7581b42190d9707b897f7b164ead48...c38aafe72791704bd60a3517c92a96db75307d48`: passed against the current `sglang-miles` base.

## Review Focus

- `inkling_common.attn`: optional CUTE absence must affect only CUTE-specific kernels, not model registration or the ROCm Triton path.
- `SWAKVPool.get_v_head_dim`: zero full-attention layers must use stored pool metadata without changing non-empty pool semantics.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33442835756](https://github.com/sgl-project/sglang/actions/runs/33442835756)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33442835577](https://github.com/sgl-project/sglang/actions/runs/33442835577)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33442835739](https://github.com/sgl-project/sglang/actions/runs/33442835739)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->