### PR TITLE
fix: drop in-flight abort token from visible output in chunked prefill (#34112)

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -264,6 +264,10 @@ class SchedulerBatchResultProcessor:
                 if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
 
+                    # The abort may have arrived while this final prefill chunk
+                    # was in flight (abort_request could only set to_finish).
+                    abort_pending = req.to_finish is not None
+
                     # req output_ids are set here
                     req.output_ids.append(next_token_id)
 
@@ -275,6 +279,14 @@ class SchedulerBatchResultProcessor:
                         self._maybe_collect_indexer_topk(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
+                        if abort_pending:
+                            # Drop the token from the visible output so it never
+                            # streams ahead of the abort finish. This must happen
+                            # only after release_kv_cache: under overlap the next
+                            # decode step may already have committed a KV slot for
+                            # this token, and the release accounting derives the
+                            # handled length from len(output_ids).
+                            req.output_ids.pop()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:

--- a/test/manual/chunked_prefill/test_scripted_abort.py
+++ b/test/manual/chunked_prefill/test_scripted_abort.py
@@ -11,6 +11,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
     SMALL_KV_POOL_BALLAST_PROMPT_LEN,
     SMALL_KV_POOL_MAX_TOTAL_TOKENS,
     VERY_LONG_PROMPT_LEN,
+    advance_to_nth_chunk,
     base_engine_kwargs,
     run_until,
     run_until_all_finished,
@@ -251,6 +252,31 @@ class TestAbortBasic(ScriptedTestCase):
         yield from _drain_until_released(t, r)
         assert r.kv_pages == 0
         assert r.req is None or r.req.inflight_middle_chunks == 0
+
+    def test_abort_last_chunk_in_flight_drops_token(self):
+        self.server.execute_script(self._script_abort_last_chunk_in_flight_drops_token)
+
+    @staticmethod
+    def _script_abort_last_chunk_in_flight_drops_token(t: ScriptedContext):
+        # Overlap-only window: the final chunk has been launched (the request
+        # already left the chunked slot) but its result is still in flight, so
+        # the abort can only mark to_finish. The token computed by that chunk
+        # must be dropped, not appended and streamed ahead of the abort.
+        r = t.start_req(
+            prompt_len=2 * DEFAULT_CHUNK_SIZE, max_new_tokens=4, prompt_token=310
+        )
+        yield from advance_to_nth_chunk(r, 2)
+        assert not r.is_chunking, "final chunk scheduled; req left the chunked slot"
+
+        t.abort(r)
+        yield from _drain_until_released(t, r)
+
+        assert r.kv_pages == 0
+        req = r.req
+        assert req is None or len(req.output_ids) == 0, (
+            f"abort with final chunk in flight must drop the computed token; "
+            f"output_ids={list(req.output_ids) if req is not None else None}"
+        )
 
     def test_abort_penultimate_chunk(self):
         self.server.execute_script(self._script_abort_penultimate_chunk)


### PR DESCRIPTION
## Summary

- When an abort arrives while the final prefill chunk is in flight (the overlap window where `abort_request` can only set `req.to_finish`), the chunk's sampled token was appended to `req.output_ids` and streamed before the abort finish. It is now dropped from the visible output once the request finishes.
- The drop happens only after `release_kv_cache`: overlap may already have committed a KV slot for the token, and release accounting derives the handled length from `len(output_ids)` — dropping it earlier leaks one KV pool token.
- Adds a scripted regression test aborting in the final-chunk-in-flight window, asserting zero visible tokens and full KV release.

Fixes #34112

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->