### PR TITLE
[CI] Clean up HiCache file-backend pages after tests

### DIFF
--- a/python/sglang/test/ci/ci_utils.py
+++ b/python/sglang/test/ci/ci_utils.py
@@ -1,14 +1,18 @@
+import glob
 import json
 import logging
 import os
 import re
+import shutil
 import subprocess
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Union
 
 from sglang.srt.debug_utils import cuda_coredump
+from sglang.srt.environ import envs
 from sglang.srt.utils.common import kill_process_tree
 from sglang.test.ci.ci_register import CIRegistry
 
@@ -209,6 +213,52 @@ DERIVED_TIMEOUT_FACTOR = 1.5
 def derive_timeout_per_file(est_time: float) -> float:
     est = float(est_time)
     return max(est * DERIVED_TIMEOUT_FACTOR, est + DERIVED_TIMEOUT_SLACK)
+
+
+HICACHE_SCRATCH_PREFIX = "sglang_ci_hicache_"
+# A run killed by a job timeout or a cancelled workflow never reaches the
+# cleanup, so its scratch dir is orphaned. Nothing this old can belong to a live
+# job (CI caps a suite far below it), which keeps the sweep safe on a runner
+# hosting several agents at once.
+HICACHE_SCRATCH_STALE_SECONDS = 6 * 3600
+
+
+def _sweep_stale_hicache_scratch_dirs() -> None:
+    cutoff = time.time() - HICACHE_SCRATCH_STALE_SECONDS
+    pattern = os.path.join(tempfile.gettempdir(), f"{HICACHE_SCRATCH_PREFIX}*")
+    for path in glob.glob(pattern):
+        try:
+            stale = os.path.getmtime(path) < cutoff
+        except OSError:
+            continue
+        if stale:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def setup_hicache_scratch_dir() -> Optional[str]:
+    """Redirect the HiCache file backend to a per-run scratch dir.
+
+    The backend defaults to a persistent /tmp/hicache and only evicts once a cap
+    is configured, so a test that leaves the default on strands its 8 MiB pages
+    on the runner. Returns the dir to hand to cleanup_hicache_scratch_dir, or
+    None when the caller already pinned one. A test keeps its own dir either by
+    passing env= to popen_launch_server, which layers over os.environ, or by
+    overriding the var in-process.
+    """
+    _sweep_stale_hicache_scratch_dirs()
+    if envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.is_set():
+        return None
+    scratch_dir = tempfile.mkdtemp(prefix=HICACHE_SCRATCH_PREFIX)
+    envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.set(scratch_dir)
+    return scratch_dir
+
+
+def cleanup_hicache_scratch_dir(scratch_dir: Optional[str]) -> None:
+    """Remove a scratch dir returned by setup_hicache_scratch_dir."""
+    if scratch_dir is None:
+        return
+    envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.clear()
+    shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
 def run_unittest_files(

--- a/test/registered/hicache/test_hicache_storage.py
+++ b/test/registered/hicache/test_hicache_storage.py
@@ -3,6 +3,8 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 register_cuda_ci(est_time=99, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=300, suite="stage-b-test-1-gpu-small-amd")
 
+import shutil
+import tempfile
 import time
 import unittest
 
@@ -25,10 +27,19 @@ class TestHiCache(CustomTestCase, MMLUMixin):
     mmlu_num_examples = 256
     mmlu_num_threads = 32
 
+    # Set before the server launch so tearDownClass can clean up after a
+    # setUpClass that raised part-way (CustomTestCase runs it either way).
+    process = None
+    storage_dir = None
+
     @classmethod
     def setUpClass(cls):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
+        # The file backend defaults to a persistent /tmp/hicache and only evicts
+        # when a cap is configured, so an un-redirected run leaks its 8 MiB
+        # pages onto the runner for good.
+        cls.storage_dir = tempfile.mkdtemp(prefix="hicache_storage_")
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -44,12 +55,16 @@ class TestHiCache(CustomTestCase, MMLUMixin):
                 "--hicache-storage-backend",
                 "file",
             ],
+            env={"SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.storage_dir},
         )
 
     @classmethod
     def tearDownClass(cls):
-        terminate_and_kill_process_tree(cls.process)
+        if cls.process is not None:
+            terminate_and_kill_process_tree(cls.process)
         time.sleep(5)
+        if cls.storage_dir is not None:
+            shutil.rmtree(cls.storage_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -138,9 +138,12 @@ class HiCacheFileLRUTestBase(CustomTestCase):
         self.tmpdir = tempfile.mkdtemp(prefix="hicache_lru_unit_")
         self.make_backend = _BackendBuilder(self.tmpdir)
         # Neutralise env vars so user shell can't leak settings into tests.
+        # The storage dir takes precedence over HiCacheFile's file_path arg, so
+        # leaving it set would point every backend below at one shared dir.
         self._env_overrides = [
             envs.SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE.override("0"),
             envs.SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE.override("0"),
+            envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.override(None),
         ]
         for cm in self._env_overrides:
             cm.__enter__()

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -13,7 +13,11 @@ from sglang.test.ci.ci_register import (
     auto_partition,
     collect_tests,
 )
-from sglang.test.ci.ci_utils import run_unittest_files
+from sglang.test.ci.ci_utils import (
+    cleanup_hicache_scratch_dir,
+    run_unittest_files,
+    setup_hicache_scratch_dir,
+)
 
 HW_MAPPING = {
     "cpu": HWBackend.CPU,
@@ -524,7 +528,11 @@ def main():
                 f"but got {args.auto_partition_id}"
             )
 
-    exit_code = run_a_suite(args)
+    hicache_scratch_dir = setup_hicache_scratch_dir()
+    try:
+        exit_code = run_a_suite(args)
+    finally:
+        cleanup_hicache_scratch_dir(hicache_scratch_dir)
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
## Motivation

`test/registered/hicache/test_hicache_storage.py` launches with
`--hicache-storage-backend file` and no storage-dir override, so its KV pages
land in the backend's default `/tmp/hicache`. That path is persistent and the
LRU evictor is inert until a cap is configured, and the test is registered on
both CUDA `base-b` (`1-gpu-small`) and AMD — so every PR run leaves more pages
behind on the runner.

One runner in our fleet had accumulated **44,978 files, ~351 GiB**. Every file
matched this test exactly: suffix `_meta-llama-Llama-3.1-8B-Instruct_0_1`
(tp_rank 0, tp_size 1, non-MLA) and a uniform 8,388,608 B page, which is
`--page-size 64` x 32 layers x 8 KV heads x 128 head_dim x (K+V) x 2 B for
Llama-3.1-8B.

I swept every test touching the file backend; this was the only one leaking.
The other file-backend tests already use a temp dir plus `rmtree`.

## Modifications

**`test/registered/hicache/test_hicache_storage.py`** — give the test its own
`mkdtemp`, pass it through `env=`, and `rmtree` it in `tearDownClass`, matching
the pattern the sibling tests use. `process` / `storage_dir` become class
attributes so teardown is safe when `setUpClass` raises part-way, which
`CustomTestCase` already accounts for by running `tearDownClass` either way.

**`test/run_suite.py` + `python/sglang/test/ci/ci_utils.py`** — a run-level net
for whatever forgets next: point the backend at a per-run scratch dir and remove
it in a `finally`, next to the existing `cuda_coredump.cleanup_dump_dir()`
precedent. A run killed before that `finally` (job timeout, cancelled workflow)
orphans its dir, so stale ones are swept on the next run — age-bounded, so a
concurrent job's dir on a shared runner is left alone.

**`test/registered/unit/mem_cache/test_hicache_file_lru_unit.py`** — the scratch
dir is exported process-wide, and `SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR`
takes precedence over `HiCacheFile`'s `file_path` argument
(`hicache_storage.py`: `envs...get() or file_path`). Without this, every backend
that test builds with `file_path=` would collapse into the one shared dir and
`base-a-test-cpu` would go red. It already neutralises the two eviction vars for
exactly this reason; the storage dir was missing from that list, so the hole
predates this change — an exported storage dir in a developer's shell breaks
those tests today.

## Accuracy Test

No model-facing behavior changes; this is test/CI-infrastructure only. The
serving path is untouched.

## Benchmarking and Profiling

N/A.

## Checklist

- [x] Format with `pre-commit run --all-files` (clean, including the registered
      test-registry validators)
- [x] Verified the `override(None)` -> `file_path` precedence handoff, the
      scratch-dir lifecycle on the `envs` API, and the age-bounded sweep
      (sweeps a stale orphan, spares a live dir and unrelated temp dirs)
- [ ] The GPU tests themselves were not run locally — this machine has no GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VFp2TU331J9wr9gsapKbc

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33445173384](https://github.com/sgl-project/sglang/actions/runs/33445173384)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33445172049](https://github.com/sgl-project/sglang/actions/runs/33445172049)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33445173540](https://github.com/sgl-project/sglang/actions/runs/33445173540)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->