### PR TITLE
Decouple ragged CUDA graph request and token capacities

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -338,6 +338,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
             model_runner, self.captured_req_width
         )
+        self.max_bs = max(self.capture_bs)
         if KTRANSFORMERS_AVAILABLE:
             KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
 
@@ -368,8 +369,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
 
         # Attention backend
-        self.max_bs = max(self.capture_bs)
-        self.max_num_token = self.max_bs * self.captured_req_width
+        self.max_num_token = (
+            max(self.capture_num_tokens)
+            if self.capture_num_tokens is not None
+            else self.max_bs * self.captured_req_width
+        )
         self.attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
 
         # Init PDMux if needed


### PR DESCRIPTION
## Summary

- Preserve the original request-slot capacity before building customizable ragged verification token buckets.
- Size attention CUDA graph token buffers from the token buckets that are actually captured.
- Keep existing non-ragged and default ragged behavior unchanged.

## Motivation

Ragged target verification has two independent capacities: the maximum number of request slots accepted by a graph and the maximum number of packed token rows represented by captured graph keys. Custom runners may prune the packed-token bucket grid while retaining the full request capacity. Coupling both capacities through `max_bs * captured_req_width` overallocates token-row buffers, while deriving `max_bs` after bucket customization can incorrectly reduce request admission capacity.

The default ragged bucket builder still produces `bs * captured_req_width` for every capture batch size, so this change is behavior-preserving for existing runners. Non-ragged decode continues to use the original expression.

## Tests

```text
python3 -m pytest -q test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
12 passed
```

Pre-commit hooks passed for the changed file.

## Original commits

- `d9458d5a247d3198fe13503ad252477d4d0ea6ee`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33449458322](https://github.com/sgl-project/sglang/actions/runs/33449458322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33486688547](https://github.com/sgl-project/sglang/actions/runs/33486688547)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33449458202](https://github.com/sgl-project/sglang/actions/runs/33449458202)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->