### PR TITLE
[Fix] Derive a safe simulated acceptance token

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -669,6 +669,7 @@ def eagle_sample(
     batch: ScheduleBatch,
     logits_output: LogitsProcessorOutput,
     grammar_mask: Optional[GrammarMask] = None,
+    simulate_acc_token_id: Optional[int] = None,
 ):
     """
     Verify and find accepted tokens based on logits output and batch
@@ -915,6 +916,7 @@ def eagle_sample(
             target_predict=target_predict,
             simulate_acc_len=SIMULATE_ACC_LEN,
             simulate_acc_token_mode=SIMULATE_ACC_TOKEN_MODE,
+            simulate_acc_token_id=simulate_acc_token_id,
             bs=bs,
             spec_steps=verify_input.max_tree_depth - 1,
         )

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -26,6 +26,7 @@ from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
+    get_simulated_accept_token_id,
     move_accept_tokens_to_target_kvcache,
     record_stream_each,
     record_stream_for_v2_verify,
@@ -584,7 +585,13 @@ def run_eagle_verify(
         predict,
         accept_lens,
         accept_index,
-    ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
+    ) = eagle_sample(
+        verify_input,
+        batch,
+        logits_output,
+        grammar_mask,
+        simulate_acc_token_id=get_simulated_accept_token_id(target_worker),
+    )
     new_seq_lens = batch.seq_lens + accept_lens
     clear_unaccepted_c128 = getattr(
         token_to_kv_pool_allocator.get_kvcache(),

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -29,6 +29,7 @@ from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
+    get_simulated_accept_token_id,
     move_accept_tokens_to_target_kvcache,
     prepare_mamba_track_for_verify,
     record_stream_for_v2_verify,
@@ -483,7 +484,13 @@ class NGRAMWorker(BaseSpecWorker):
                 predict,
                 accept_lens,
                 accept_index,
-            ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
+            ) = eagle_sample(
+                verify_input,
+                batch,
+                logits_output,
+                grammar_mask,
+                simulate_acc_token_id=get_simulated_accept_token_id(self.target_worker),
+            )
             new_seq_lens = batch.seq_lens + accept_lens
             commit_mamba_states_after_verify(
                 self.target_worker,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -66,6 +66,7 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.async_probe import maybe_detect_oob
 from sglang.srt.utils.nvtx_utils import profile_range
+from sglang.srt.utils.patch_tokenizer import decode_without_hf_kwargs
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
@@ -182,6 +183,9 @@ def sample_draft_proposal(next_token_logits: torch.Tensor, temperatures: torch.T
 SIMULATE_ACC_LEN = envs.SGLANG_SIMULATE_ACC_LEN.get()  # turn off if < 0
 SIMULATE_ACC_METHOD = envs.SGLANG_SIMULATE_ACC_METHOD.get()
 SIMULATE_ACC_TOKEN_MODE = envs.SGLANG_SIMULATE_ACC_TOKEN_MODE.get()
+
+_SIMULATED_ACCEPT_TOKEN_ID_ATTR = "_sglang_simulated_accept_token_id"
+_SIMULATED_ACCEPT_TOKEN_PROBES = ("a", "A", "0", ".")
 
 TREE_TRAVERSE_TIME_THRESHOLD = 1  # TODO: set this properly
 TREE_SPEC_KERNEL_AVAILABLE = (
@@ -395,6 +399,88 @@ def sample_simulated_acc_len(
     return int(simulate_acc_len)
 
 
+def _decode_complete_token(tokenizer, token_id: int) -> Optional[str]:
+    try:
+        text = decode_without_hf_kwargs(
+            tokenizer, [int(token_id)], skip_special_tokens=True
+        )
+    except Exception:
+        return None
+    return text if text and "\ufffd" not in text else None
+
+
+def resolve_simulated_accept_token_id(
+    tokenizer,
+    *,
+    vocab_size: Optional[int] = None,
+) -> int:
+    """Resolve a fixed benchmark token that decodes to complete text."""
+    if tokenizer is None:
+        raise ValueError(
+            "Fixed simulated acceptance needs a tokenizer to derive a safe token. "
+            "Use SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token when "
+            "--skip-tokenizer-init is enabled."
+        )
+
+    candidates = []
+    for probe in _SIMULATED_ACCEPT_TOKEN_PROBES:
+        candidates.extend(tokenizer.encode(probe, add_special_tokens=False))
+
+    seen = set()
+    for token_id in candidates:
+        token_id = int(token_id)
+        if token_id in seen:
+            continue
+        seen.add(token_id)
+        if token_id < 0 or (vocab_size is not None and token_id >= vocab_size):
+            continue
+        if _decode_complete_token(tokenizer, token_id) is not None:
+            return token_id
+
+    try:
+        tokenizer_size = len(tokenizer)
+    except TypeError:
+        tokenizer_size = getattr(tokenizer, "vocab_size", None)
+    if tokenizer_size is None:
+        tokenizer_size = vocab_size
+    if tokenizer_size is None:
+        raise ValueError(
+            "The tokenizer does not expose a vocabulary size, so a complete "
+            "simulated-acceptance token could not be derived."
+        )
+    scan_size = (
+        tokenizer_size if vocab_size is None else min(tokenizer_size, vocab_size)
+    )
+    for token_id in range(scan_size):
+        if token_id not in seen and _decode_complete_token(tokenizer, token_id):
+            return token_id
+
+    raise ValueError(
+        "Could not derive a token that decodes to complete text for fixed "
+        "simulated acceptance. Use "
+        "SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token instead."
+    )
+
+
+def get_simulated_accept_token_id(target_worker) -> Optional[int]:
+    """Resolve and cache the fixed benchmark token once per target worker."""
+    if SIMULATE_ACC_LEN <= 0 or SIMULATE_ACC_TOKEN_MODE != "fixed":
+        return None
+
+    cached = getattr(target_worker, _SIMULATED_ACCEPT_TOKEN_ID_ATTR, None)
+    if cached is not None:
+        return cached
+
+    model_config = getattr(target_worker, "model_config", None)
+    token_id = resolve_simulated_accept_token_id(
+        getattr(target_worker, "tokenizer", None),
+        vocab_size=getattr(model_config, "vocab_size", None),
+    )
+    setattr(target_worker, _SIMULATED_ACCEPT_TOKEN_ID_ATTR, token_id)
+    logger.info("Using token id %d for fixed simulated acceptance.", token_id)
+    return token_id
+
+
 def generate_simulated_accept_index(
     accept_index,
     predict,
@@ -406,6 +492,7 @@ def generate_simulated_accept_index(
     simulate_acc_len: float = SIMULATE_ACC_LEN,
     simulate_acc_method: str = SIMULATE_ACC_METHOD,
     simulate_acc_token_mode: str = SIMULATE_ACC_TOKEN_MODE,
+    simulate_acc_token_id: Optional[int] = None,
 ):
     use_real_draft_tokens = simulate_acc_token_mode == "real-draft-token"
 
@@ -424,7 +511,11 @@ def generate_simulated_accept_index(
     num_correct_drafts.fill_(simulate_acc_len - 1)
 
     if not use_real_draft_tokens:
-        predict.fill_(100)  # some legit token id
+        if simulate_acc_token_id is None:
+            raise ValueError(
+                "simulate_acc_token_id is required for fixed simulated acceptance."
+            )
+        predict.fill_(simulate_acc_token_id)
         return sim_accept_index
 
     # Use the topk=1 draft chain for forced acceptance, then a target-derived bonus.

--- a/test/registered/unit/spec/test_simulated_acceptance_token.py
+++ b/test/registered/unit/spec/test_simulated_acceptance_token.py
@@ -1,0 +1,98 @@
+import unittest
+
+import torch
+
+from sglang.srt.speculative.spec_utils import (
+    generate_simulated_accept_index,
+    resolve_simulated_accept_token_id,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _ByteFallbackTokenizer:
+    all_special_ids = []
+
+    def __len__(self):
+        return 128
+
+    def encode(self, text, add_special_tokens=False):
+        assert not add_special_tokens
+        return {"a": [100], "A": [64], "0": [15], ".": [13]}[text]
+
+    def decode(self, token_ids):
+        pieces = {
+            13: ".",
+            15: "0",
+            32: "A",
+            64: "a",
+            100: "\ufffd",
+        }
+        return "".join(pieces.get(token_id, "") for token_id in token_ids)
+
+
+class TestSimulatedAcceptanceToken(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = _ByteFallbackTokenizer()
+
+    def test_resolves_token_that_decodes_to_complete_text(self):
+        token_id = resolve_simulated_accept_token_id(
+            self.tokenizer,
+            vocab_size=len(self.tokenizer),
+        )
+
+        self.assertEqual(token_id, 64)
+        self.assertEqual(self.tokenizer.decode([token_id]), "a")
+        self.assertEqual(self.tokenizer.decode([100]), "\ufffd")
+
+    def test_requires_tokenizer_in_fixed_mode(self):
+        with self.assertRaisesRegex(ValueError, "needs a tokenizer"):
+            resolve_simulated_accept_token_id(None, vocab_size=128)
+
+    def test_fixed_mode_fills_predict_with_resolved_token(self):
+        token_id = resolve_simulated_accept_token_id(
+            self.tokenizer,
+            vocab_size=len(self.tokenizer),
+        )
+        accept_index = torch.tensor([[0, -1, -1, -1]], dtype=torch.int32)
+        predict = torch.full((4,), 100, dtype=torch.int32)
+        num_correct_drafts = torch.empty((1,), dtype=torch.int32)
+
+        simulated_accept_index = generate_simulated_accept_index(
+            accept_index=accept_index,
+            predict=predict,
+            num_correct_drafts=num_correct_drafts,
+            candidates=torch.zeros((1, 4), dtype=torch.int64),
+            target_predict=torch.zeros((1, 4), dtype=torch.int64),
+            bs=1,
+            spec_steps=3,
+            simulate_acc_len=3,
+            simulate_acc_method="match-expected",
+            simulate_acc_token_mode="fixed",
+            simulate_acc_token_id=token_id,
+        )
+
+        self.assertEqual(simulated_accept_index.tolist(), [[0, 1, 2, -1]])
+        self.assertEqual(num_correct_drafts.tolist(), [2])
+        self.assertEqual(predict.tolist(), [64, 64, 64, 64])
+
+    def test_fixed_mode_requires_token_id(self):
+        with self.assertRaisesRegex(ValueError, "simulate_acc_token_id is required"):
+            generate_simulated_accept_index(
+                accept_index=torch.tensor([[0, -1]], dtype=torch.int32),
+                predict=torch.zeros((2,), dtype=torch.int32),
+                num_correct_drafts=torch.empty((1,), dtype=torch.int32),
+                candidates=torch.zeros((1, 2), dtype=torch.int64),
+                target_predict=torch.zeros((1, 2), dtype=torch.int64),
+                bs=1,
+                spec_steps=1,
+                simulate_acc_len=1,
+                simulate_acc_method="match-expected",
+                simulate_acc_token_mode="fixed",
+                simulate_acc_token_id=None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- fixes Defect A of #34740 without overlapping with #34852
- derives the fixed simulated-acceptance token from the active tokenizer instead of hardcoding token id `100`
- rejects empty or U+FFFD-decoding tokens and caches the resolved id per target worker
- adds a CPU regression test for byte-fallback vocabularies

## Validation

- `21 passed`: simulated-acceptance, `spec_utils`, and NGRAM unit tests
- all pre-commit hooks passed for changed files
- GPT-2 reproduction on macOS: id `100` decodes to `�`; the resolver selects id `64`, which decodes to `a`

## Platform

Tested on Apple Silicon macOS, CPU only. CUDA end-to-end validation was not available locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33452808467](https://github.com/sgl-project/sglang/actions/runs/33452808467)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33452808356](https://github.com/sgl-project/sglang/actions/runs/33452808356)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33452808778](https://github.com/sgl-project/sglang/actions/runs/33452808778)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->