### PR TITLE
fix(unified-memory): forward the KV-index translator through every wrapper backend

### DIFF
--- a/python/sglang/srt/layers/attention/dots_hybrid_backend.py
+++ b/python/sglang/srt/layers/attention/dots_hybrid_backend.py
@@ -140,6 +140,7 @@ class DotsSWAMLAAttnBackend(AttentionBackend):
         self._active_backend = backend
         self.token_to_kv_pool = backend.token_to_kv_pool
         self.req_to_token_pool = backend.req_to_token_pool
+        self.kv_index_translator = backend.kv_index_translator
         self.needs_cpu_seq_lens = True
         self._prefill_metadata: DotsSWAMLAPrefillMetadata | None = None
         self._dp_rebuilt_batch_id: int | None = None
@@ -404,6 +405,7 @@ class DotsHybridAttnBackend(AttentionBackend):
         self.swa_backend = swa_backend
         self.token_to_kv_pool = swa_backend.token_to_kv_pool
         self.req_to_token_pool = swa_backend.req_to_token_pool
+        self.kv_index_translator = swa_backend.kv_index_translator
         # SWA latent expansion uses host sequence-length mirrors.
         self.needs_cpu_seq_lens = True
         self._dp_rebuilt_batch_id: int | None = None

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -36,6 +36,7 @@ class HybridAttnBackend(AttentionBackend):
         self.data_type = model_runner.kv_cache_dtype
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token_pool = model_runner.req_to_token_pool
+        self.kv_index_translator = model_runner.kv_index_translator
         self.spec_attn_is_decode = get_spec().speculative_attention_mode == "decode"
         self.spec_attn_is_prefill = get_spec().speculative_attention_mode == "prefill"
         # Gates the FutureMap's per-step seq_lens D2H (decide_needs_cpu_seq_lens

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -997,6 +997,7 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.attn_backend_list = [full_attn_backend, linear_attn_backend]
         self.token_to_kv_pool = full_attn_backend.token_to_kv_pool
         self.req_to_token_pool = full_attn_backend.req_to_token_pool
+        self.kv_index_translator = full_attn_backend.kv_index_translator
         self.max_context_len = getattr(full_attn_backend, "max_context_len", None)
         self.needs_cpu_seq_lens = (
             full_attn_backend.needs_cpu_seq_lens

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -1617,6 +1617,7 @@ class MiniMaxHybridAttnBackend(AttentionBackend):
     ):
         self.dense = dense_backend
         self.sparse = sparse_backend
+        self.kv_index_translator = dense_backend.kv_index_translator
         self.sparse_layer_ids = sparse_layer_ids
         # Let the sparse decode reuse the dense paged backend (page table + workspace).
         self.sparse.dense_backend = dense_backend

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -308,6 +308,22 @@ class KVIndexTranslator:
         self._index_table_memo = (weakref.ref(forward_batch), view)
         return view
 
+    def assert_backends_carry_translator(self, backends) -> None:
+        """Boot guard: under the unified pool every backend a forward can reach
+        must carry THIS translator."""
+        if not self.is_translating:
+            return
+        for backend in backends:
+            if backend is None:
+                continue
+            assert backend.kv_index_translator is self, (
+                f"{type(backend).__name__} does not carry the runner's "
+                "KVIndexTranslator. A backend (or wrapper) reachable under "
+                "--enable-unified-memory must forward `kv_index_translator`, or "
+                "read-index producers silently skip the virtual->kernel-facing "
+                "translation."
+            )
+
     # -- write loc (phase 1; phase 2 lives in build_index_table) ----------------
 
     def rebind_write_loc(self, forward_batch) -> None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1011,6 +1011,9 @@ class ModelRunner:
         self.attn_backend = backends.attn_backend
         self.decode_attn_backend = backends.decode_attn_backend
         self.decode_attn_backend_group = backends.decode_attn_backend_group
+        self.kv_index_translator.assert_backends_carry_translator(
+            [self.attn_backend, self.decode_attn_backend]
+        )
 
         if get_parallel().dcp_enabled and get_parallel().dcp_replicate_q_proj:
             self._prepare_replicated_q_proj()

--- a/test/registered/models_e2e/test_kimi_linear_models.py
+++ b/test/registered/models_e2e/test_kimi_linear_models.py
@@ -81,26 +81,14 @@ class TestKimiLinearExtraBuffer(
 class TestKimiLinearUnifiedMemory(
     GSM8KMixin, PrefixCacheBranchingMixin, DefaultServerBase
 ):
-    """BUG REGRESSION. The only per-PR cell that pairs the unified pool with an
-    MLA model, so it is the only one that reaches the MLA chunked-prefix /
-    MHA-one-shot path -- the producer that fetches its translator off
-    `get_attn_backend()` and skips translation when a wrapper backend drops it
-    (gsm8k 0.365 vs 0.895 measured on Kimi-Linear, flashinfer, TP2).
-
-    No `--attention-backend` is pinned on purpose: both defects found in review
-    on #32972 were reachable only under a resolved default, which a pinned test
-    hides by construction. CUDA graphs stay on -- graph-off did not reproduce.
-
-    `test_kimi_linear_unified_memory.py` runs this same configuration nightly.
-    The duplication is deliberate: that suite resolves a different default on
-    its H100 runner, and this one has to gate every PR.
-    """
+    """BUG REGRESSION. The unified pool must keep GSM8K at the static-pool bar;
+    a wrapper backend that drops `kv_index_translator` silently skips the MLA
+    prefix translation and the model reads the wrong KV."""
 
     model = KIMI_LINEAR_MODEL
     cache_chunk_size = 64
-    # Same bar as the static-pool cell above: unified memory must not cost
-    # accuracy (measured 0.917 unified vs 0.915 static, 1 sigma ~= 0.015).
     gsm8k_score_threshold = 0.88
+    # No --attention-backend: the resolved default is the coverage.
     other_args = [
         "--trust-remote-code",
         "--tp-size",

--- a/test/registered/models_e2e/test_kimi_linear_models.py
+++ b/test/registered/models_e2e/test_kimi_linear_models.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=600, stage="base-b", runner_config="2-gpu-large")
+register_cuda_ci(est_time=900, stage="base-b", runner_config="2-gpu-large")
 
 KIMI_LINEAR_MODEL = "moonshotai/Kimi-Linear-48B-A3B-Instruct"
 
@@ -75,6 +75,39 @@ class TestKimiLinearExtraBuffer(
         "extra_buffer",
         "--mamba-track-interval",
         "2",
+    ]
+
+
+class TestKimiLinearUnifiedMemory(
+    GSM8KMixin, PrefixCacheBranchingMixin, DefaultServerBase
+):
+    """BUG REGRESSION. The only per-PR cell that pairs the unified pool with an
+    MLA model, so it is the only one that reaches the MLA chunked-prefix /
+    MHA-one-shot path -- the producer that fetches its translator off
+    `get_attn_backend()` and skips translation when a wrapper backend drops it
+    (gsm8k 0.365 vs 0.895 measured on Kimi-Linear, flashinfer, TP2).
+
+    No `--attention-backend` is pinned on purpose: both defects found in review
+    on #32972 were reachable only under a resolved default, which a pinned test
+    hides by construction. CUDA graphs stay on -- graph-off did not reproduce.
+
+    `test_kimi_linear_unified_memory.py` runs this same configuration nightly.
+    The duplication is deliberate: that suite resolves a different default on
+    its H100 runner, and this one has to gate every PR.
+    """
+
+    model = KIMI_LINEAR_MODEL
+    cache_chunk_size = 64
+    # Same bar as the static-pool cell above: unified memory must not cost
+    # accuracy (measured 0.917 unified vs 0.915 static, 1 sigma ~= 0.015).
+    gsm8k_score_threshold = 0.88
+    other_args = [
+        "--trust-remote-code",
+        "--tp-size",
+        "2",
+        "--chunked-prefill-size",
+        "2048",
+        "--enable-unified-memory",
     ]
 
 

--- a/test/registered/unit/layers/attention/test_kv_translate_ownership.py
+++ b/test/registered/unit/layers/attention/test_kv_translate_ownership.py
@@ -17,11 +17,27 @@ consciously.
     python3 -m pytest test/registered/unit/layers/attention/test_kv_translate_ownership.py -v
 """
 
+import ast
 import os
 import re
 import unittest
 
 from sglang.srt.layers.attention import triton_backend as _anchor_module
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dots_hybrid_backend import (
+    DotsHybridAttnBackend,
+    DotsSWAMLAAttnBackend,
+)
+from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    HybridLinearAttnBackend,
+    ShortConvHybridAttnBackend,
+)
+from sglang.srt.layers.attention.minimax_sparse_backend import (
+    MiniMaxHybridAttnBackend,
+)
+from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -77,6 +93,107 @@ class TestUnifiedTranslateBanned(CustomTestCase):
             if "unified_mem_hooks" in src or "unified_mla_hooks" in src
         ]
         self.assertEqual(hits, [])
+
+
+def _derive_wrapper_names():
+    """Wrapper classes, read off the source so a NEW one shows up the day it is
+    written: an AttentionBackend subclass whose own __init__ takes another
+    backend. Per class, not per file -- a file-wide scan passes as soon as any
+    one class in it forwards."""
+    backend = re.compile(r"Att(?:ention|n)Backend")
+    names = set()
+    for _rel, src in _iter_sources():
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if not any(backend.search(ast.unparse(b)) for b in node.bases):
+                continue
+            init = next(
+                (
+                    b
+                    for b in node.body
+                    if isinstance(b, ast.FunctionDef) and b.name == "__init__"
+                ),
+                None,
+            )
+            if init is None:
+                continue
+            if any(
+                a.annotation is not None and backend.search(ast.unparse(a.annotation))
+                for a in init.args.args[1:]
+            ):
+                names.add(node.name)
+    return names
+
+
+class _Inner(AttentionBackend):
+    """Stand-in for a wrapped backend, carrying only what the wrappers' __init__
+    bodies read off their inners."""
+
+    def __init__(self, translator=None):
+        self.kv_index_translator = translator
+        self.token_to_kv_pool = None
+        self.req_to_token_pool = None
+        self.needs_cpu_seq_lens = False
+        self.max_context_len = 8
+
+
+class _InnerModelConfig:
+    context_len = 8
+
+
+class _Runner:
+    """HybridAttnBackend takes its translator from the runner, not an inner."""
+
+    def __init__(self, translator):
+        self.kv_index_translator = translator
+        self.kv_cache_dtype = None
+        self.token_to_kv_pool = None
+        self.req_to_token_pool = None
+        self.model_config = _InnerModelConfig()
+
+
+def _build_wrappers(translator):
+    """One live instance per wrapper. Only the inner that MUST supply the
+    translator carries it; every other inner carries None, so a wrapper that
+    copies from the linear / sparse / DSA side ends up with None and fails."""
+    carrier = _Inner(translator)
+    # HybridAttnBackend reads the spec bag in __init__; the bag is unpublished
+    # outside a launched server.
+    with get_context().override_server_args(speculative_attention_mode="decode"):
+        hybrid = HybridAttnBackend(_Runner(translator), _Inner(), _Inner())
+    return {
+        "DotsSWAMLAAttnBackend": DotsSWAMLAAttnBackend(carrier),
+        "DotsHybridAttnBackend": DotsHybridAttnBackend(_Inner(), carrier),
+        "HybridAttnBackend": hybrid,
+        "HybridLinearAttnBackend": HybridLinearAttnBackend(carrier, _Inner(), [0]),
+        "ShortConvHybridAttnBackend": ShortConvHybridAttnBackend(
+            carrier, _Inner(), [0]
+        ),
+        "MiniMaxHybridAttnBackend": MiniMaxHybridAttnBackend(carrier, _Inner(), [0]),
+        "TboAttnBackend": TboAttnBackend(carrier, [_Inner()]),
+    }
+
+
+class TestWrapperBackendsForwardTranslator(CustomTestCase):
+    """BUG REGRESSION. `AttentionBackend.kv_index_translator` defaults to None,
+    so a wrapper that does not re-expose its inner's copy reads as "needs no
+    translation" and producers that fetch it off `get_attn_backend()` skip the
+    virtual->kernel-facing translation instead of failing."""
+
+    def test_every_wrapper_is_constructed_here(self):
+        self.assertEqual(
+            _derive_wrapper_names(),
+            set(_build_wrappers(object())),
+            "a wrapper backend has no instance in _build_wrappers; add one so "
+            "its translator forwarding is checked",
+        )
+
+    def test_wrappers_forward_the_translator(self):
+        translator = object()
+        for name, wrapper in _build_wrappers(translator).items():
+            with self.subTest(wrapper=name):
+                self.assertIs(wrapper.kv_index_translator, translator)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_kv_translate_ownership.py
+++ b/test/registered/unit/layers/attention/test_kv_translate_ownership.py
@@ -78,45 +78,6 @@ class TestUnifiedTranslateBanned(CustomTestCase):
         ]
         self.assertEqual(hits, [])
 
-    def test_wrapper_backends_forward_the_translator(self):
-        """BUG REGRESSION. A backend that WRAPS another must re-expose the
-        inner backend's `kv_index_translator`.
-
-        `AttentionBackend.kv_index_translator` defaults to None, so a wrapper
-        that omits it reads as "needs no translation" rather than failing.
-        Producers that fetch the translator off `get_attn_backend()` -- the MLA
-        chunked-prefix-cache path does exactly this, under
-        `if src is not None` -- then skip translation and hand a kernel raw
-        VIRTUAL ids. Nothing raises. On a hybrid MLA model with the unified pool
-        and a radix cache (so a shared prefix actually exists to read),
-        gsm8k fell from ~0.91 to 0.05-0.31 while the same config on a backend
-        that does not take that path stayed correct.
-
-        Derived from the source, not a hand-kept list: a wrapper is any
-        AttentionBackend subclass that TAKES another AttentionBackend as a
-        constructor parameter, so a NEW wrapper is covered the day it is
-        written. Keying on the parameter type rather than the attribute name
-        matters -- the wrappers spell their fields `prefill_backend`,
-        `decode_backend`, `backend`, `swa_backend` and `dense`, so any
-        name-based pattern misses most of them. Plain adapters that do not
-        subclass AttentionBackend are out of scope: they never reach
-        `get_attn_backend()`, so no producer reads a translator off them."""
-        is_backend = re.compile(r"^class \w+\([^)]*Att(?:ention|n)Backend[^)]*\):", re.M)
-        wraps = re.compile(r"^\s*\w+\s*:\s*[\"']?\w*Att(?:ention|n)Backend", re.M)
-        forwards = re.compile(r"^\s*self\.kv_index_translator\s*=", re.M)
-        offenders = [
-            rel
-            for rel, src in _iter_sources()
-            if is_backend.search(src) and wraps.search(src) and not forwards.search(src)
-        ]
-        self.assertEqual(
-            offenders,
-            [],
-            "wrapper backend does not forward kv_index_translator, so producers "
-            "reading it off get_attn_backend() silently skip translation: "
-            + ", ".join(offenders),
-        )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/layers/attention/test_kv_translate_ownership.py
+++ b/test/registered/unit/layers/attention/test_kv_translate_ownership.py
@@ -78,6 +78,45 @@ class TestUnifiedTranslateBanned(CustomTestCase):
         ]
         self.assertEqual(hits, [])
 
+    def test_wrapper_backends_forward_the_translator(self):
+        """BUG REGRESSION. A backend that WRAPS another must re-expose the
+        inner backend's `kv_index_translator`.
+
+        `AttentionBackend.kv_index_translator` defaults to None, so a wrapper
+        that omits it reads as "needs no translation" rather than failing.
+        Producers that fetch the translator off `get_attn_backend()` -- the MLA
+        chunked-prefix-cache path does exactly this, under
+        `if src is not None` -- then skip translation and hand a kernel raw
+        VIRTUAL ids. Nothing raises. On a hybrid MLA model with the unified pool
+        and a radix cache (so a shared prefix actually exists to read),
+        gsm8k fell from ~0.91 to 0.05-0.31 while the same config on a backend
+        that does not take that path stayed correct.
+
+        Derived from the source, not a hand-kept list: a wrapper is any
+        AttentionBackend subclass that TAKES another AttentionBackend as a
+        constructor parameter, so a NEW wrapper is covered the day it is
+        written. Keying on the parameter type rather than the attribute name
+        matters -- the wrappers spell their fields `prefill_backend`,
+        `decode_backend`, `backend`, `swa_backend` and `dense`, so any
+        name-based pattern misses most of them. Plain adapters that do not
+        subclass AttentionBackend are out of scope: they never reach
+        `get_attn_backend()`, so no producer reads a translator off them."""
+        is_backend = re.compile(r"^class \w+\([^)]*Att(?:ention|n)Backend[^)]*\):", re.M)
+        wraps = re.compile(r"^\s*\w+\s*:\s*[\"']?\w*Att(?:ention|n)Backend", re.M)
+        forwards = re.compile(r"^\s*self\.kv_index_translator\s*=", re.M)
+        offenders = [
+            rel
+            for rel, src in _iter_sources()
+            if is_backend.search(src) and wraps.search(src) and not forwards.search(src)
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "wrapper backend does not forward kv_index_translator, so producers "
+            "reading it off get_attn_backend() silently skip translation: "
+            + ", ".join(offenders),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`AttentionBackend.kv_index_translator` is a class attribute that defaults to
`None`. A backend that **wraps** another and does not re-expose the inner
backend's copy therefore answers "this backend needs no translation".

Every producer that reaches the translator through the *live backend* rather
than through a runner then skips translation silently. The MLA
chunked-prefix-cache path is one:
`ForwardBatchDeepseekMHAMixin.prepare_chunked_kv_indices` reads
`get_attn_backend().kv_index_translator` and translates only
`if src is not None`, so it hands the kernel raw **virtual** ids for the shared prefix.
Nothing raises — virtual and physical ids share a value range, so the gather
simply reads the wrong rows.

Hybrid models (mamba/GDN + full attention) serve every forward through
`HybridLinearAttnBackend`, which forwards the pool and `req_to_token` but not
the translator. Three other wrappers have the same omission.

The damage needs all three of: `--enable-unified-memory` (translation actually
required), an MLA backend (only fa3 / flashinfer / flashmla take the
chunked-prefix path; Triton does not), and a radix cache (only then is there a
shared prefix to read back). On Kimi-Linear-48B that is **gsm8k 0.89–0.92 →
0.05–0.31 on six of six such cells**, while the same configuration on Triton,
and every chunked-prefill cell, stays correct.

## Modifications

**Four wrappers need the forward, not one.** They spell the wrapped field
`full_attn_backend`, `prefill_backend`/`decode_backend`, `backend`/`swa_backend`
and `dense`, so nothing keyed on the attribute name finds them all:

* `layers/attention/hybrid_linear_attn_backend.py` — from the full-attention
  backend, beside the pool and `req_to_token` it already forwards.
* `layers/attention/hybrid_attn_backend.py` — from the model runner, which is
  where it already takes the pool.
* `layers/attention/dots_hybrid_backend.py` — twice: the DSA wrapper from its
  inner backend, the SWA/MLA wrapper from its swa backend.
* `layers/attention/minimax_sparse_backend.py` — the hybrid wrapper, from its
  dense backend.

`mem_cache/kv_index_translator.py` — `assert_backends_carry_translator`, which
refuses at boot when a reachable backend carries someone else's translator or
none at all, and is inert on a pool that needs no translation.

`model_executor/model_runner.py` — run that guard over the built backends, right
after they are constructed. Adding a forward is easy to forget in a *new*
wrapper and the failure is silent by construction, so the runtime check is what
makes it loud.

`test/registered/unit/layers/attention/test_kv_translate_ownership.py` — an
**object-graph** test in the file that already owns translator ownership. It
builds a live instance of every wrapper and gives only the inner that must
supply the translator a copy; every other inner carries `None`. A wrapper that
copies from the linear / sparse / DSA side ends up with `None` and fails — a
source scan cannot see that.

Derived, not enumerated: a wrapper is any `AttentionBackend` subclass **taking
another `AttentionBackend` as a constructor parameter**, so a new one is covered
the day it is written, and a completeness test asserts the derived set equals
the set with instances. The derivation is per **class**, not per file: an
earlier revision of this PR scanned whole files, which passes as soon as any one
class in a file forwards — and `hybrid_linear_attn_backend.py` holds four
`AttentionBackend` subclasses and one forward, so it covered the very file the
bug lived in. Seven wrappers come out, including `ShortConvHybridAttnBackend`
and `TboAttnBackend`.

Verified by injection, each red on the new test and green on the old scan: drop
the HybridLinear forward while leaving an unrelated
`self.kv_index_translator = None` in that file; point MiniMax at
`sparse_backend`; add a wrapper with no instance.

`test/registered/models_e2e/test_kimi_linear_models.py` — the damage guard.
`assert_backends_carry_translator` only fires when a wrapper is actually built,
and no per-PR job pairs the unified pool with an MLA model, so nothing reached
the chunked-prefix / MHA-one-shot producer. This file is already `base-b` on
`2-gpu-large` and already launches Kimi-Linear twice, so the cost is one more
server start in an allocated job rather than a new 4-GPU job. `est_time`
600 → 900. The nightly `test_kimi_linear_unified_memory.py` keeps its copy: it
resolves a different default backend on its H100 runner.

Red-then-green on that cell: `0.37 not >= 0.88` on main without the fix,
passing on this head.

## Accuracy Tests

Kimi-Linear-48B-A3B-Instruct, tp2, `--enable-unified-memory`, radix cache,
gsm8k (n=200 per cell), unified vs baseline:

| cell | before | after |
|---|---|---|
| radix cg_off fa3 | 0.925 → **0.120** | 0.910 → 0.895 |
| radix cg_off flashinfer | 0.905 → **0.110** | 0.905 → 0.900 |
| radix cg_off flashmla | 0.905 → **0.270** | 0.900 → 0.895 |
| radix cg_on fa3 | 0.900 → **0.200** | 0.905 → 0.900 |
| radix cg_on flashinfer | 0.900 → **0.105** | 0.900 → 0.910 |
| radix cg_on flashmla | 0.895 → **0.050** | 0.900 → 0.885 |

All six back within ±0.015 of baseline. The always-correct cells (chunked
prefill, Triton) are unchanged.

Whole matrix, 68 cells / 240 gsm8k runs across Kimi, Qwen3.5-9B, gpt-oss-20b,
Falcon-H1-7B and Llama-3.1-8B on triton / fa3 / flashinfer / flashmla:
**112 baseline-vs-unified pairs, median +0.005, zero Kimi outliers**, 240 ok /
0 crashed. The residual outliers are all gpt-oss, whose scores sit near 0.5
where the binomial sigma at n=200 is ~0.05.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33463751335](https://github.com/sgl-project/sglang/actions/runs/33463751335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33463751148](https://github.com/sgl-project/sglang/actions/runs/33463751148)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33463751216](https://github.com/sgl-project/sglang/actions/runs/33463751216)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
