### PR TITLE
[ROCm] gpt-oss: slice pre-padded hidden for router/topk in moe_impl

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -351,8 +351,12 @@ class GptOssSparseMoeBlock(nn.Module):
 def moe_impl(layer_id: int, hidden_states: torch.Tensor) -> torch.Tensor:
     forward_context = get_tc_piecewise_forward_context()
     moe_fusion = forward_context.moe_fusions[layer_id]
-    router_logits, _ = moe_fusion.router(hidden_states)
-    topk_output = moe_fusion.topk(hidden_states, router_logits)
+    router_input = hidden_states
+    router_in_dim = moe_fusion.router.weight.shape[-1]
+    if hidden_states.shape[-1] != router_in_dim:
+        router_input = hidden_states[..., :router_in_dim]
+    router_logits, _ = moe_fusion.router(router_input)
+    topk_output = moe_fusion.topk(router_input, router_logits)
     final_hidden_states = moe_fusion.experts(hidden_states, topk_output)
     return final_hidden_states
 


### PR DESCRIPTION
## What

`moe_impl` (the PCG custom op for gpt-oss MoE) feeds `hidden_states` straight into the router GEMM. When the preceding RMSNorm fused the MoE input pad (`SGLANG_AITER_FUSE_RMSNORM_PAD=1`, mxfp4-weighted MoE), that tensor arrives pre-padded to `(M, 3072)` and the `(2880, 128)` router matmul crashes:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (16384x3072 and 2880x128)
```

`forward_normal` already handles this (router/topk on the unpadded slice, experts on the padded view); `moe_impl` postdates that fix and never learned it. Mirror the same slice. No-op when the input arrives unpadded.

## Why it matters on main today

On HIP, `eager_runner.py` enters the PCG context for **any** eager prefill fallback when a prefill-graph runner exists, so `forward_normal` routes through `moe_impl` for every batch above the prefill capture budget — and ROCm's default prefill graph backend is tc_piecewise, which uses `moe_impl` directly. Default ROCm config + a fused-pad-eligible gpt-oss checkpoint + one prefill batch above the capture budget = crash. Reproduced with `amd/gpt-oss-120b-w-mxfp4-a-fp8` (Quark W4A8), TP1, MI350X/MI355X gfx950, 16384-token chunks over a `--cuda-graph-max-bs-prefill 8192` capture list; this one-line-shaped fix unblocks it.

## Validation

- Eager 16k/61k-token prefill chunks complete after the fix (previously crashed at the first over-budget batch).
- gsm8k n=200 on the fixed path: 0.870 / 0.010 invalid.
- The slice is a no-op for unpadded inputs (default path byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33456076665](https://github.com/sgl-project/sglang/actions/runs/33456076665)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33456076262](https://github.com/sgl-project/sglang/actions/runs/33456076262)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33456076476](https://github.com/sgl-project/sglang/actions/runs/33456076476)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->