### PR TITLE
[ROCm] aiter backend: CK varlen route for long full-attention sinks extends (−15…−16% TTFT at 64k uncached)

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -144,6 +144,7 @@ class ForwardMetadata:
     swa_page_table: Optional[torch.Tensor] = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: Optional[torch.Tensor] = None
+    unified_page_table: Optional[torch.Tensor] = None
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
@@ -1529,6 +1530,25 @@ class AiterAttnBackend(AttentionBackend):
                         ).to(torch.int32)
                     )
 
+                unified_page_table = None
+                if self.use_triton_unified_attention:
+                    kv_indices_2d = torch.zeros(
+                        bs, max_kv_len, dtype=torch.int32, device=self.device
+                    )
+                    create_flashmla_kv_indices_triton[
+                        (bs, get_num_kv_index_blocks_flashmla(max_kv_len, 1))
+                    ](
+                        self.req_to_token,
+                        forward_batch.req_pool_indices,
+                        forward_batch.seq_lens,
+                        None,
+                        kv_indices_2d,
+                        self.req_to_token.stride(0),
+                        max_kv_len,
+                        1,
+                    )
+                    unified_page_table = self._transform_table_1_to_real(kv_indices_2d)
+
                 self.forward_metadata = ForwardMetadata(
                     self.indices_updater_prefill.kv_indptr,
                     self.indices_updater_prefill.kv_indices,
@@ -1538,6 +1558,7 @@ class AiterAttnBackend(AttentionBackend):
                     forward_batch.seq_lens_cpu.max().item(),
                     swa_page_table=swa_page_table,
                     swa_out_cache_loc=swa_out_cache_loc,
+                    unified_page_table=unified_page_table,
                 )
 
     def init_cuda_graph_state(
@@ -2719,6 +2740,52 @@ class AiterAttnBackend(AttentionBackend):
                 if o.dtype != self.input_dtype:
                     o = o.to(self.input_dtype)
                 return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+            if (
+                self.use_triton_unified_attention
+                and sinks is not None
+                and self.forward_metadata.unified_page_table is not None
+                and self.kv_cache_dtype != fp8_dtype
+            ):
+                k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+                if layer.qk_head_dim != layer.v_head_dim:
+                    o = q.new_empty(
+                        (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+                    )
+                else:
+                    o = torch.empty_like(q)
+                unified_window = (-1, -1)
+                if (
+                    layer.sliding_window_size is not None
+                    and layer.sliding_window_size > -1
+                ):
+                    unified_window = (layer.sliding_window_size - 1, 0)
+                unified_attention(
+                    q=q.contiguous().view(
+                        -1, layer.tp_q_head_num, layer.qk_head_dim
+                    ),
+                    k=k_cache.view(
+                        -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
+                    ),
+                    v=v_cache.view(
+                        -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                    ),
+                    out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                    cu_seqlens_q=self.qo_indptr[:bs0],
+                    seqused_k=forward_batch.seq_lens,
+                    max_seqlen_q=self.forward_metadata.max_q_len,
+                    max_seqlen_k=self.forward_metadata.max_kv_len,
+                    softmax_scale=layer.scaling,
+                    causal=True,
+                    window_size=unified_window,
+                    block_table=self.forward_metadata.unified_page_table,
+                    softcap=layer.logit_cap,
+                    q_descale=None,
+                    k_descale=k_descale,
+                    v_descale=v_descale,
+                    sinks=sinks,
+                )
+                return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
             if self.kv_cache_is_vectorized_5d:
                 return forward_extend_vectorized_5d(

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -89,6 +89,7 @@ from sglang.srt.utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
+
 # Use aiter mla persist design for fp8-kv cache
 _use_mla_ps_kernel = get_bool_env_var("SGLANG_AITER_MLA_PERSIST", "True")
 
@@ -2746,6 +2747,72 @@ class AiterAttnBackend(AttentionBackend):
                 and sinks is not None
                 and self.forward_metadata.unified_page_table is not None
                 and self.kv_cache_dtype != fp8_dtype
+                and (
+                    layer.sliding_window_size is None or layer.sliding_window_size <= -1
+                )
+                and self.forward_metadata.max_q_len is not None
+                and self.forward_metadata.max_q_len >= 8192
+                and not torch.cuda.is_current_stream_capturing()
+            ):
+                k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+                k_flat = k_cache.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                v_flat = v_cache.view(-1, layer.tp_v_head_num, layer.v_head_dim)
+                num_seqs = bs0 - 1
+                kv_indptr_t = self.forward_metadata.kv_indptr
+                kv_indices_t = self.forward_metadata.kv_indices
+                cache_loc = forward_batch.out_cache_loc
+                prefix_lens = forward_batch.extend_prefix_lens_cpu
+                extend_lens = forward_batch.extend_seq_lens_cpu
+                tok_chunks = []
+                cu_k_list = [0]
+                p0 = 0
+                e0 = 0
+                max_kv_i = 0
+                for i in range(num_seqs):
+                    p_len = int(prefix_lens[i])
+                    e_len = int(extend_lens[i])
+                    ext = cache_loc[e0 : e0 + e_len].to(torch.int64)
+                    if p_len:
+                        pfx = kv_indices_t[p0 : p0 + p_len].to(torch.int64)
+                        tok_chunks.append(torch.cat((pfx, ext)))
+                    else:
+                        tok_chunks.append(ext)
+                    cu_k_list.append(cu_k_list[-1] + p_len + e_len)
+                    max_kv_i = max(max_kv_i, p_len + e_len)
+                    p0 += p_len
+                    e0 += e_len
+                gather_idx = tok_chunks[0] if num_seqs == 1 else torch.cat(tok_chunks)
+                k_full = k_flat.index_select(0, gather_idx)
+                v_full = v_flat.index_select(0, gather_idx)
+                cu_q = self.qo_indptr[:bs0].to(torch.int32)
+                cu_k = torch.tensor(cu_k_list, device=q.device, dtype=torch.int32)
+                if layer.qk_head_dim != layer.v_head_dim:
+                    o = q.new_empty(
+                        (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+                    )
+                else:
+                    o = torch.empty_like(q)
+                flash_attn_varlen_func(
+                    q.contiguous().view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                    k_full,
+                    v_full,
+                    cu_q,
+                    cu_k,
+                    self.forward_metadata.max_q_len,
+                    max_kv_i,
+                    softmax_scale=layer.scaling,
+                    causal=True,
+                    window_size=(-1, 0, 0),
+                    sink_ptr=sinks,
+                    out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                )
+                return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+            if (
+                self.use_triton_unified_attention
+                and sinks is not None
+                and self.forward_metadata.unified_page_table is not None
+                and self.kv_cache_dtype != fp8_dtype
             ):
                 k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
                 if layer.qk_head_dim != layer.v_head_dim:
@@ -2761,9 +2828,7 @@ class AiterAttnBackend(AttentionBackend):
                 ):
                     unified_window = (layer.sliding_window_size - 1, 0)
                 unified_attention(
-                    q=q.contiguous().view(
-                        -1, layer.tp_q_head_num, layer.qk_head_dim
-                    ),
+                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                     k=k_cache.view(
                         -1, self.page_size, layer.tp_k_head_num, layer.qk_head_dim
                     ),


### PR DESCRIPTION
## What

Stacked on #37310. CK `flash_attn_varlen_func` carries native runtime sinks (`sink_ptr`) and sliding windows, and at a 61k-token self-causal extend it beats the triton `unified_attention` kernel 49.6 vs 54.2 ms/layer on gfx950. This routes window-inactive sinks extends with `max_q_len >= 8192` through it: full-sequence KV gathered to contiguous varlen buffers from `kv_indices` + `out_cache_loc` (proven bitwise-identical to the page-table decode on 342/342 real forwards, including churned radix tables and a 47k-token cached request), SWA layers and short extends stay on `unified_attention` where it wins, and the branch never fires under stream capture (captured buckets keep the graph-safe unified path).

## Measured (MI355X gfx950 TP1, gpt-oss-120b Quark W4A8, 64k ISL / 4k cached, OSL 1, NP 96)

| cc | before (p50) | after (p50) | Δ |
|---|---|---|---|
| 1 | 1,643.5 ms | 1,394.7 ms | **−15.1%** |
| 8 | 12,454.7 ms | 10,435.2 ms | **−16.2%** |

The 60k-cached shape is unaffected (extends ~4k, below the gate; measured unchanged at cc1–8).

## Gates

- Planted-fact long-context retrieval: 8/8 pass-pattern concordance with the triton reference (greedy agreement on random text is tie-sensitive between correct kernels and was deliberately not used).
- Paired back-to-back gsm8k n=200: delta +0.025 in this route's favor (0.860 vs 0.835).
- Gather comparator (temporary, removed): bitwise 0-mismatch across single-request churned prefills and concurrent multi-request batches.

Review note: only reviewable after #37310 (first commit is shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33456345222](https://github.com/sgl-project/sglang/actions/runs/33456345222)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33456345033](https://github.com/sgl-project/sglang/actions/runs/33456345033)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33456345272](https://github.com/sgl-project/sglang/actions/runs/33456345272)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->