### PR TITLE
[Docs] Fix --log-requests-level flag name in observability

### DIFF
--- a/docs/docs/advanced_features/observability.mdx
+++ b/docs/docs/advanced_features/observability.mdx
@@ -15,7 +15,7 @@ See [Production Metrics](../references/production_metrics) and [Production Reque
 ## Logging
 
 By default, SGLang does not log any request contents. You can log them by using `--log-requests`.
-You can control the verbosity by using `--log-request-level`.
+You can control the verbosity by using `--log-requests-level`.
 See [Logging](./server_arguments#logging) for more details.
 
 You can change verbosity at runtime:


### PR DESCRIPTION
## Summary

Observability docs still document `--log-request-level` (singular *request*), but the server registers `--log-requests-level` (plural *requests*). This PR updates the one drifted mention.

## What drifted

On `main` (`079afaffb19abbe42c09f0ebb8322d6e9f6f2905`):

```18:18:docs/docs/advanced_features/observability.mdx
You can control the verbosity by using `--log-request-level`.
```

That flag is not registered. `ServerArgs.log_requests_level` is auto-converted to a CLI option by `_field_to_cli_name()`:

```1455:1462:python/sglang/srt/server_args.py
    log_requests_level: A[
        int,
        Arg(
            help="0: Log metadata (no sampling parameters). 1: Log metadata and sampling parameters. 2: Log metadata, sampling parameters and partial input/output. 3: Log every input/output.",
            choices=[0, 1, 2, 3],
        ),
        NS("observability"),
    ] = 2
```

```216:218:python/sglang/srt/arg_groups/arg_utils.py
def _field_to_cli_name(name: str) -> str:
    return "--" + name.replace("_", "-")
```

So the registered flag is `--log-requests-level`. The field has no `cli_name` or `aliases` for the singular form. Neighboring docs in `server_arguments.mdx` already use the plural flag; `--log-requests` help text also points at `--log-requests-level`.

## How reproduced

Fetched `docs/docs/advanced_features/observability.mdx` and `python/sglang/srt/server_args.py` from `sgl-project/sglang@main` via the GitHub API (no full clone). A small Python snippet grepped both files:

- docs line 18: `--log-request-level`
- `server_args.py` line 1455: field `log_requests_level` (no `--log-request-level` string)
- `_field_to_cli_name("log_requests_level")` => `--log-requests-level`

## Why the new flag is correct

CLI names are derived from dataclass fields (`log_requests_level` → `--log-requests-level`). Using the singular name would fail argparse as an unrecognized argument.

## Test plan

- [x] Confirmed no other `--log-request-level` hits in-repo code search
- [x] Confirmed `server_arguments.mdx` already documents `--log-requests-level`
- [ ] Docs preview of Observability → Logging section shows the plural flag

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33456659524](https://github.com/sgl-project/sglang/actions/runs/33456659524)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33456659117](https://github.com/sgl-project/sglang/actions/runs/33456659117)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->