### PR TITLE
[GLM-5.3-Flash] Handle optional vision configuration and NextN weight loading

### DIFF
--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -283,7 +283,7 @@ class Glm5NextTextConfig(PretrainedConfig):
 class Glm5NextVisionConfig(GlmOcrVisionConfig):
     def __init__(
         self,
-        swiglu_limit: float,
+        swiglu_limit: Optional[float] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -142,10 +142,11 @@ _GLM_AITER_FUSED_MHC_LOGGED = False
 
 
 @torch.compile
-def swiglu_clamped(y: torch.Tensor, limit: float):
+def swiglu_clamped(y: torch.Tensor, limit: Optional[float] = None):
     gate, up = torch.chunk(y, 2, dim=-1)
-    gate = torch.clamp(gate, max=limit)
-    up = torch.clamp(up, min=-limit, max=limit)
+    if limit is not None:
+        gate = torch.clamp(gate, max=limit)
+        up = torch.clamp(up, min=-limit, max=limit)
     return F.silu(gate) * up
 
 
@@ -154,7 +155,7 @@ class Glm5NextVisionMLP(GlmOcrVisionMLP):
         self,
         in_features: int,
         hidden_features: int,
-        swiglu_limit: float,
+        swiglu_limit: Optional[float] = None,
         bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
@@ -182,7 +183,7 @@ class Glm5NextVisionPatchMerger(GlmOcrVisionPatchMerger):
         self,
         d_model: int,
         context_dim: int,
-        swiglu_limit: float,
+        swiglu_limit: Optional[float] = None,
         quant_config: Optional[QuantizationConfig] = None,
         bias: bool = False,
         prefix: str = "",
@@ -213,7 +214,7 @@ class Glm5NextVisionBlock(GlmOcrVisionBlock):
         dim: int,
         intermediate_dim: int,
         num_heads: int,
-        swiglu_limit: float,
+        swiglu_limit: Optional[float] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         attn_qkv_bias: bool = True,
@@ -282,6 +283,7 @@ class Glm5NextVisionModel(GlmOcrVisionModel):
             is_neox_style=True,
         )
 
+        swiglu_limit = getattr(vision_config, "swiglu_limit", None)
         self.blocks = nn.ModuleList(
             [
                 Glm5NextVisionBlock(
@@ -293,7 +295,7 @@ class Glm5NextVisionModel(GlmOcrVisionModel):
                     rms_norm_eps=vision_config.rms_norm_eps,
                     attn_qkv_bias=vision_config.attention_bias,
                     use_data_parallel=use_data_parallel,
-                    swiglu_limit=vision_config.swiglu_limit,
+                    swiglu_limit=swiglu_limit,
                 )
                 for layer_idx in range(vision_config.depth)
             ]
@@ -312,7 +314,7 @@ class Glm5NextVisionModel(GlmOcrVisionModel):
             bias=False,
             prefix=add_prefix("merger", prefix),
             use_data_parallel=use_data_parallel,
-            swiglu_limit=vision_config.swiglu_limit,
+            swiglu_limit=swiglu_limit,
         )
 
         self.downsample = nn.Conv2d(
@@ -1290,7 +1292,8 @@ class Glm5NextForConditionalGeneration(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        vision_utils.update_vit_attn_dummy_heads_config(config)
+        if getattr(config, "vision_config", None) is not None:
+            vision_utils.update_vit_attn_dummy_heads_config(config)
         self.mm_config = config
         text_config = config.text_config
         self.encoder_only = bool(getattr(config, "encoder_only", False))
@@ -1366,7 +1369,10 @@ class Glm5NextForConditionalGeneration(nn.Module):
 
         self.use_data_parallel = get_mm().mm_enable_dp_encoder
         self.visual = None
-        if not self.language_only:
+        if (
+            not self.language_only
+            and getattr(config, "vision_config", None) is not None
+        ):
             self.visual = Glm5NextVisionModel(
                 config.vision_config,
                 quant_config=quant_config,
@@ -1687,7 +1693,9 @@ class Glm5NextForConditionalGeneration(nn.Module):
             is_visual_weight = "visual" in name
             if getattr(self, "encoder_only", False) and not is_visual_weight:
                 continue
-            if getattr(self, "language_only", False) and is_visual_weight:
+            if (
+                getattr(self, "language_only", False) or self.visual is None
+            ) and is_visual_weight:
                 continue
 
             if "language_model." in name:
@@ -1695,7 +1703,10 @@ class Glm5NextForConditionalGeneration(nn.Module):
             if "model.visual." in name:
                 name = name.replace("model.visual.", "visual.")
 
-            if "visual" in name:
+            if (
+                "visual" in name
+                and getattr(self.mm_config, "vision_config", None) is not None
+            ):
                 name = name.replace("attn.qkv.", "attn.qkv_proj.")
                 loaded_weight = vision_utils.pad_vit_attn_dummy_heads(
                     self.mm_config, name, loaded_weight

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1694,7 +1694,8 @@ class Glm5NextForConditionalGeneration(nn.Module):
             if getattr(self, "encoder_only", False) and not is_visual_weight:
                 continue
             if (
-                getattr(self, "language_only", False) or self.visual is None
+                getattr(self, "language_only", False)
+                or getattr(self, "visual", None) is None
             ) and is_visual_weight:
                 continue
 
@@ -1705,7 +1706,8 @@ class Glm5NextForConditionalGeneration(nn.Module):
 
             if (
                 "visual" in name
-                and getattr(self.mm_config, "vision_config", None) is not None
+                and getattr(getattr(self, "mm_config", None), "vision_config", None)
+                is not None
             ):
                 name = name.replace("attn.qkv.", "attn.qkv_proj.")
                 loaded_weight = vision_utils.pad_vit_attn_dummy_heads(

--- a/test/registered/unit/configs/test_glm5_next_config.py
+++ b/test/registered/unit/configs/test_glm5_next_config.py
@@ -193,6 +193,9 @@ class TestGlm5NextVisionConfig(CustomTestCase):
             ),
             get_parallel().override(tp_size=1, attn_tp_size=1),
             get_context().override_server_args(mm_enable_dp_encoder=False),
+            patch(
+                "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads"
+            ) as mock_pad,
         ):
             model = Glm5NextForConditionalGeneration(config)
             visual_weight = torch.randn(4, 4)
@@ -200,6 +203,29 @@ class TestGlm5NextVisionConfig(CustomTestCase):
             # Should execute cleanly without dereferencing missing vision_config
             model.load_weights(weights)
             self.assertIsNone(model.visual)
+            mock_pad.assert_not_called()
+
+    def test_glm5_next_for_conditional_generation_load_weights_with_language_only(
+        self,
+    ):
+        config = Glm5NextConfig(vision_config={}, language_only=True, encoder_only=True)
+        with (
+            patch(
+                "sglang.srt.models.glm5_next.get_pp_group",
+                return_value=SimpleNamespace(is_last_rank=True, world_size=1),
+            ),
+            get_parallel().override(tp_size=1, attn_tp_size=1),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+            patch(
+                "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads"
+            ) as mock_pad,
+        ):
+            model = Glm5NextForConditionalGeneration(config)
+            visual_weight = torch.randn(4, 4)
+            weights = [("visual.attn.qkv.weight", visual_weight)]
+            model.load_weights(weights)
+            self.assertIsNone(model.visual)
+            mock_pad.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/configs/test_glm5_next_config.py
+++ b/test/registered/unit/configs/test_glm5_next_config.py
@@ -1,9 +1,23 @@
 """Unit tests for GLM-5 Next configuration compatibility."""
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.srt.configs.glm5_next import Glm5NextTextConfig
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.configs.glm5_next import (
+    Glm5NextConfig,
+    Glm5NextTextConfig,
+    Glm5NextVisionConfig,
+)
 from sglang.srt.configs.mamba_utils import KimiLinearStateShape
+from sglang.srt.models.glm5_next import (
+    Glm5NextForConditionalGeneration,
+    swiglu_clamped,
+)
+from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -101,6 +115,91 @@ class TestGlm5NextTextConfig(CustomTestCase):
         )
 
         self.assertIs(config.linear_attn_config, linear_attn_config)
+
+
+class TestGlm5NextVisionConfig(CustomTestCase):
+    def test_vision_config_defaults_swiglu_limit_to_none(self):
+        config = Glm5NextVisionConfig()
+        self.assertIsNone(config.swiglu_limit)
+
+    def test_vision_config_preserves_explicit_swiglu_limit(self):
+        config = Glm5NextVisionConfig(swiglu_limit=10.0)
+        self.assertEqual(config.swiglu_limit, 10.0)
+
+    def test_glm5_next_config_instantiates_vision_config_without_swiglu_limit(self):
+        config = Glm5NextConfig(vision_config={})
+        self.assertIsNotNone(config.vision_config)
+        self.assertIsNone(config.vision_config.swiglu_limit)
+
+    def test_glm5_next_config_preserves_vision_swiglu_limit(self):
+        config = Glm5NextConfig(vision_config={"swiglu_limit": 10.0})
+        self.assertIsNotNone(config.vision_config)
+        self.assertEqual(config.vision_config.swiglu_limit, 10.0)
+
+    def test_swiglu_clamped_with_none_matches_unclamped_swiglu(self):
+        x = torch.randn(2, 8, dtype=torch.float32)
+        out_none = swiglu_clamped(x, None)
+        gate, up = torch.chunk(x, 2, dim=-1)
+        expected = F.silu(gate) * up
+        torch.testing.assert_close(out_none, expected)
+
+    def test_swiglu_clamped_with_limit_clamps_activations(self):
+        x = torch.tensor([[100.0, -100.0]], dtype=torch.float32)
+        out_clamped = swiglu_clamped(x, 5.0)
+        gate, up = torch.chunk(x, 2, dim=-1)
+        gate = torch.clamp(gate, max=5.0)
+        up = torch.clamp(up, min=-5.0, max=5.0)
+        expected = F.silu(gate) * up
+        torch.testing.assert_close(out_clamped, expected)
+
+    def test_glm5_next_config_with_none_vision_config(self):
+        config = Glm5NextConfig(vision_config=None)
+        self.assertIsNone(config.vision_config)
+
+    def test_glm5_next_for_conditional_generation_init_with_none_vision_config(self):
+        config = Glm5NextConfig(vision_config=None, encoder_only=True)
+        with (
+            patch(
+                "sglang.srt.models.glm5_next.get_pp_group",
+                return_value=SimpleNamespace(is_last_rank=True, world_size=1),
+            ),
+            get_parallel().override(tp_size=1, attn_tp_size=1),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+        ):
+            model = Glm5NextForConditionalGeneration(config)
+            self.assertIsNone(model.visual)
+
+    def test_glm5_next_for_conditional_generation_init_with_language_only(self):
+        config = Glm5NextConfig(vision_config={}, language_only=True, encoder_only=True)
+        with (
+            patch(
+                "sglang.srt.models.glm5_next.get_pp_group",
+                return_value=SimpleNamespace(is_last_rank=True, world_size=1),
+            ),
+            get_parallel().override(tp_size=1, attn_tp_size=1),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+        ):
+            model = Glm5NextForConditionalGeneration(config)
+            self.assertIsNone(model.visual)
+
+    def test_glm5_next_for_conditional_generation_load_weights_with_none_vision_config(
+        self,
+    ):
+        config = Glm5NextConfig(vision_config=None, encoder_only=True)
+        with (
+            patch(
+                "sglang.srt.models.glm5_next.get_pp_group",
+                return_value=SimpleNamespace(is_last_rank=True, world_size=1),
+            ),
+            get_parallel().override(tp_size=1, attn_tp_size=1),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+        ):
+            model = Glm5NextForConditionalGeneration(config)
+            visual_weight = torch.randn(4, 4)
+            weights = [("visual.attn.qkv.weight", visual_weight)]
+            # Should execute cleanly without dereferencing missing vision_config
+            model.load_weights(weights)
+            self.assertIsNone(model.visual)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/configs/test_glm5_next_config.py
+++ b/test/registered/unit/configs/test_glm5_next_config.py
@@ -15,6 +15,7 @@ from sglang.srt.configs.glm5_next import (
 from sglang.srt.configs.mamba_utils import KimiLinearStateShape
 from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
+    Glm5NextVisionModel,
     swiglu_clamped,
 )
 from sglang.srt.runtime_context import get_context, get_parallel
@@ -226,6 +227,102 @@ class TestGlm5NextVisionConfig(CustomTestCase):
             model.load_weights(weights)
             self.assertIsNone(model.visual)
             mock_pad.assert_not_called()
+
+    def test_glm5_next_for_conditional_generation_load_weights_with_vision_present(
+        self,
+    ):
+        class _FakeParam:
+            def __init__(self):
+                self.loaded = None
+
+            def weight_loader(self, param, loaded_weight, *args, **kwargs):
+                self.loaded = (param, loaded_weight, args, kwargs)
+
+        param = _FakeParam()
+        params = {"visual.blocks.0.attn.qkv_proj.weight": param}
+        fake_self = SimpleNamespace(
+            config=SimpleNamespace(
+                num_hidden_layers=32,
+                num_nextn_predict_layers=0,
+                n_routed_experts=0,
+                q_lora_rank=None,
+            ),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            encoder_only=True,
+            language_only=False,
+            visual=object(),
+            mm_config=SimpleNamespace(
+                vision_config=SimpleNamespace(num_dummy_heads=2, head_dim=64)
+            ),
+            named_parameters=lambda: list(params.items()),
+        )
+
+        raw_weight = torch.randn(6, 64)
+        padded_weight = torch.randn(8, 64)
+
+        with patch(
+            "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads",
+            return_value=padded_weight,
+        ) as mock_pad:
+            weights = [("visual.blocks.0.attn.qkv.weight", raw_weight)]
+            Glm5NextForConditionalGeneration.load_weights(fake_self, weights)
+
+            mock_pad.assert_called_once_with(
+                fake_self.mm_config,
+                "visual.blocks.0.attn.qkv_proj.weight",
+                raw_weight,
+            )
+            self.assertIsNotNone(param.loaded)
+            self.assertIs(param.loaded[1], padded_weight)
+
+    def test_glm5_next_vision_model_swiglu_limit_propagation(self):
+        config_with_limit = Glm5NextVisionConfig(
+            depth=2,
+            hidden_size=64,
+            num_heads=4,
+            intermediate_size=128,
+            out_hidden_size=64,
+            patch_size=14,
+            spatial_merge_size=2,
+            temporal_patch_size=1,
+            in_channels=3,
+            swiglu_limit=5.0,
+        )
+        self.assertEqual(config_with_limit.swiglu_limit, 5.0)
+
+        with (
+            get_parallel().override(
+                tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
+            ),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+        ):
+            model = Glm5NextVisionModel(config_with_limit)
+            self.assertEqual(model.blocks[0].mlp.swiglu_limit, 5.0)
+            self.assertEqual(model.merger.swiglu_limit, 5.0)
+
+        config_omitted = Glm5NextVisionConfig(
+            depth=2,
+            hidden_size=64,
+            num_heads=4,
+            intermediate_size=128,
+            out_hidden_size=64,
+            patch_size=14,
+            spatial_merge_size=2,
+            temporal_patch_size=1,
+            in_channels=3,
+        )
+        self.assertIsNone(config_omitted.swiglu_limit)
+
+        with (
+            get_parallel().override(
+                tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
+            ),
+            get_context().override_server_args(mm_enable_dp_encoder=False),
+        ):
+            model_omitted = Glm5NextVisionModel(config_omitted)
+            self.assertIsNone(model_omitted.blocks[0].mlp.swiglu_limit)
+            self.assertIsNone(model_omitted.merger.swiglu_limit)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
@@ -231,6 +231,51 @@ class TestGlm5NextNextNWeightLoading(unittest.TestCase):
         )
         mock_pad_helper.assert_not_called()
 
+    def test_delegated_load_weights_direct_call_vision_present(self):
+        head_param = _FakeParam()
+        visual_param = _FakeParam()
+        params = {
+            "model.shared_head.norm.weight": head_param,
+            "visual.blocks.0.attn.qkv_proj.weight": visual_param,
+        }
+        vision_present_self = SimpleNamespace(
+            config=SimpleNamespace(
+                num_hidden_layers=1,
+                num_nextn_predict_layers=0,
+                n_routed_experts=0,
+                q_lora_rank=None,
+            ),
+            encoder_only=True,
+            language_only=False,
+            visual=object(),
+            mm_config=SimpleNamespace(
+                vision_config=SimpleNamespace(num_dummy_heads=2, head_dim=64)
+            ),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            named_parameters=lambda: list(params.items()),
+        )
+
+        raw_weight = torch.randn(6, 64)
+        padded_weight = torch.randn(8, 64)
+        weights = [("visual.blocks.0.attn.qkv.weight", raw_weight)]
+
+        with patch(
+            "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads",
+            return_value=padded_weight,
+        ) as mock_pad_helper:
+            Glm5NextForConditionalGeneration.load_weights(
+                vision_present_self, weights, is_nextn=False
+            )
+
+        mock_pad_helper.assert_called_once_with(
+            vision_present_self.mm_config,
+            "visual.blocks.0.attn.qkv_proj.weight",
+            raw_weight,
+        )
+        self.assertIsNotNone(visual_param.loaded)
+        self.assertIs(visual_param.loaded[1], padded_weight)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_nextn_weight_loading.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for Glm5NextForConditionalGenerationNextN.load_weights.
+
+Regression tests ensuring NextN draft model weight loading delegates cleanly to
+Glm5NextForConditionalGeneration.load_weights without raising AttributeError on
+instances that lack visual attributes or multimodal configurations.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+from sglang.srt.models.glm5_next_nextn import Glm5NextForConditionalGenerationNextN
+
+
+class _FakeParam:
+    def __init__(self):
+        self.loaded = None
+
+    def weight_loader(self, param, loaded_weight, *args, **kwargs):
+        self.loaded = (param, loaded_weight, args, kwargs)
+
+
+class TestGlm5NextNextNWeightLoading(unittest.TestCase):
+    def _make_minimal_model(self, named_parameters=(), mm_config=None):
+        model = object.__new__(Glm5NextForConditionalGenerationNextN)
+        model.config = SimpleNamespace(
+            num_hidden_layers=80,
+            num_nextn_predict_layers=1,
+            n_routed_experts=0,
+            q_lora_rank=None,
+        )
+        model.num_fused_shared_experts = 0
+        model.quant_config = None
+        model.model = SimpleNamespace(decoder=SimpleNamespace(self_attn=None))
+        if mm_config is not None:
+            model.mm_config = mm_config
+        model.named_parameters = lambda: iter(named_parameters)
+        return model
+
+    def test_nextn_loads_weights_without_visual_attribute(self):
+        param = _FakeParam()
+        model = self._make_minimal_model([("model.shared_head.norm.weight", param)])
+        self.assertFalse(hasattr(model, "visual"))
+
+        loaded_weight = torch.ones(1)
+        model.load_weights([("model.layers.80.shared_head.norm.weight", loaded_weight)])
+
+        self.assertEqual(param.loaded, (param, loaded_weight, (), {}))
+
+    def test_nextn_spec_weights_map_to_model_prefix(self):
+        params = {
+            "model.enorm.weight": _FakeParam(),
+            "model.hnorm.weight": _FakeParam(),
+            "model.eh_proj.weight": _FakeParam(),
+            "model.shared_head.norm.weight": _FakeParam(),
+        }
+        model = self._make_minimal_model(list(params.items()))
+        weights = [
+            ("model.layers.80.enorm.weight", torch.ones(1)),
+            ("model.layers.80.hnorm.weight", torch.ones(1)),
+            ("model.layers.80.eh_proj.weight", torch.ones(1)),
+            ("model.layers.80.shared_head.norm.weight", torch.ones(1)),
+        ]
+
+        model.load_weights(weights)
+
+        for name, param in params.items():
+            self.assertIsNotNone(param.loaded, f"{name} was not loaded")
+
+    def test_nextn_decoder_layer_weights_map_to_decoder_prefix(self):
+        param = _FakeParam()
+        model = self._make_minimal_model(
+            [("model.decoder.input_layernorm.weight", param)]
+        )
+        loaded_weight = torch.ones(1)
+
+        model.load_weights([("model.layers.80.input_layernorm.weight", loaded_weight)])
+
+        self.assertEqual(param.loaded, (param, loaded_weight, (), {}))
+
+    def test_nextn_skips_visual_weights(self):
+        head_param = _FakeParam()
+        visual_decoder_param = _FakeParam()
+        visual_qkv_param = _FakeParam()
+        params = {
+            "model.shared_head.norm.weight": head_param,
+            "model.decoder.visual.weight": visual_decoder_param,
+            "model.decoder.visual.attn.qkv_proj.weight": visual_qkv_param,
+        }
+        mm_config = SimpleNamespace(
+            vision_config=SimpleNamespace(num_dummy_heads=0, head_dim=64)
+        )
+        model = self._make_minimal_model(list(params.items()), mm_config=mm_config)
+        weights = [
+            ("visual.attn.qkv.weight", torch.ones(4, 4)),
+            ("model.visual.patch_embed.proj.weight", torch.ones(4, 4)),
+            ("model.layers.80.visual.weight", torch.ones(4, 4)),
+            (
+                "model.language_model.layers.80.visual.attn.qkv.weight",
+                torch.ones(4, 4),
+            ),
+            ("model.layers.80.shared_head.norm.weight", torch.ones(1)),
+        ]
+
+        with patch(
+            "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads"
+        ) as mock_pad_helper:
+            model.load_weights(weights)
+
+        self.assertIsNotNone(head_param.loaded)
+        self.assertIsNone(
+            visual_decoder_param.loaded,
+            "model.layers.80.visual.weight should have been skipped",
+        )
+        self.assertIsNone(
+            visual_qkv_param.loaded,
+            "model.language_model.layers.80.visual.attn.qkv.weight should have been skipped",
+        )
+        mock_pad_helper.assert_not_called()
+
+    def test_nextn_embed_tokens_and_shared_head_head_skipped(self):
+        params = {
+            "model.embed_tokens.weight": _FakeParam(),
+            "model.shared_head.head.weight": _FakeParam(),
+        }
+        model = self._make_minimal_model(list(params.items()))
+        weights = [
+            ("model.layers.80.embed_tokens.weight", torch.ones(1)),
+            ("model.layers.80.shared_head.head.weight", torch.ones(1)),
+        ]
+
+        model.load_weights(weights)
+
+        for name, param in params.items():
+            self.assertIsNone(param.loaded, f"{name} should have been skipped")
+
+    def test_delegated_load_weights_direct_call_on_no_visual_self(self):
+        head_param = _FakeParam()
+        visual_param_1 = _FakeParam()
+        visual_param_2 = _FakeParam()
+        params = {
+            "model.shared_head.norm.weight": head_param,
+            "visual.blocks.0.weight": visual_param_1,
+            "model.decoder.visual.weight": visual_param_2,
+        }
+        # Bare object without visual or mm_config
+        no_visual_self = SimpleNamespace(
+            config=SimpleNamespace(
+                num_hidden_layers=1,
+                num_nextn_predict_layers=1,
+                n_routed_experts=0,
+            ),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            model=SimpleNamespace(decoder=SimpleNamespace(self_attn=None)),
+            named_parameters=lambda: list(params.items()),
+        )
+
+        weights = [
+            ("model.layers.0.shared_head.norm.weight", torch.ones(1)),
+            ("model.visual.blocks.0.weight", torch.ones(1)),
+            ("model.layers.0.visual.weight", torch.ones(1)),
+        ]
+
+        with patch(
+            "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads"
+        ) as mock_pad_helper:
+            Glm5NextForConditionalGeneration.load_weights(
+                no_visual_self, weights, is_nextn=True
+            )
+
+        self.assertIsNotNone(head_param.loaded)
+        self.assertIsNone(
+            visual_param_1.loaded,
+            "visual.blocks.0.weight should have been skipped on no-visual model",
+        )
+        self.assertIsNone(
+            visual_param_2.loaded,
+            "model.layers.0.visual.weight should have been skipped on no-visual model",
+        )
+        mock_pad_helper.assert_not_called()
+
+    def test_delegated_load_weights_direct_call_language_only(self):
+        head_param = _FakeParam()
+        visual_param = _FakeParam()
+        params = {
+            "model.shared_head.norm.weight": head_param,
+            "visual.attn.qkv_proj.weight": visual_param,
+        }
+        language_only_self = SimpleNamespace(
+            config=SimpleNamespace(
+                num_hidden_layers=1,
+                num_nextn_predict_layers=1,
+                n_routed_experts=0,
+            ),
+            language_only=True,
+            visual=None,
+            mm_config=SimpleNamespace(
+                vision_config=SimpleNamespace(num_dummy_heads=2, head_dim=64)
+            ),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            model=SimpleNamespace(decoder=SimpleNamespace(self_attn=None)),
+            named_parameters=lambda: list(params.items()),
+        )
+
+        weights = [
+            ("model.layers.0.shared_head.norm.weight", torch.ones(1)),
+            ("visual.attn.qkv.weight", torch.ones(4, 4)),
+        ]
+
+        with patch(
+            "sglang.srt.models.glm5_next.vision_utils.pad_vit_attn_dummy_heads"
+        ) as mock_pad_helper:
+            Glm5NextForConditionalGeneration.load_weights(
+                language_only_self, weights, is_nextn=True
+            )
+
+        self.assertIsNotNone(head_param.loaded)
+        self.assertIsNone(
+            visual_param.loaded,
+            "visual.attn.qkv.weight should have been skipped on language-only model",
+        )
+        mock_pad_helper.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fix the text-only/language-only GLM-5.3-Flash configuration failure on the GLM-5.3 support branch. Checkpoints that omit `vision_config` and/or `swiglu_limit` currently fail during config/model initialization, and NextN weight loading can dereference `self.visual` on the delegated draft object.

## Modifications

- Make `Glm5NextVisionConfig.swiglu_limit` optional and preserve the existing clamped path when it is provided.
- Skip the clamp when the limit is absent, preserving the ordinary SwiGLU computation.
- Guard vision dummy-head setup, visual-model construction, and visual weight handling when `vision_config`/`visual` is absent.
- Make delegated NextN `load_weights` visual access None-safe.
- Add config, model-construction, and positive/negative weight-loading regression tests.

This is stacked on #36507. The base branch is `xinyuan/glm-5.3-flash-support`; these GLM-5.3 files are not on `main`. The branch is based on feature-branch commit `4464e0f540408855e55c1f51fabf4338049f9104` and has no file overlap with the currently open stacked PRs #37298, #37131, #36989, #36904, #36903, and #36745.

## Accuracy Tests

```text
CUDA_HOME=/usr PYTHONPATH=python:. uv run --with-editable ./python/ --with pytest pytest test/registered/unit/models/test_glm5_next_nextn_weight_loading.py test/registered/unit/configs/test_glm5_next_config.py -v
```

Result: `27 passed, 16 warnings in 20.52s`.

The suite covers omitted and explicit `swiglu_limit`, `vision_config=None`, language-only/no-vision initialization, delegated NextN loading, and vision-present QKV rename/padding. A full GLM-5.3-Flash checkpoint load/generation run was not performed locally.

## Speed Tests and Profiling

No kernel or model-forward algorithm change. The `@torch.compile` SwiGLU function now has an optional-limit branch; no speed benchmark or profiler run was performed.

## Checklist

- [x] Format code according to the pre-commit format guidance.
- [x] Add unit tests according to the unit-test guidance.
- [ ] Update documentation according to the documentation guidance; no user-facing documentation change is needed for this compatibility fix.
- [ ] Provide full checkpoint accuracy and speed benchmark results; no full checkpoint or benchmark run was performed locally.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33458462422](https://github.com/sgl-project/sglang/actions/runs/33458462422)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33458462204](https://github.com/sgl-project/sglang/actions/runs/33458462204)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33458462368](https://github.com/sgl-project/sglang/actions/runs/33458462368)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->