### PR TITLE
[Quant] Preserve ModelOpt FP4 quantization for NextN drafts

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -273,7 +273,7 @@ class ModelOptQuantConfig(QuantizationConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]],
     ):
         super().__init__()
-        self.packed_modules_mapping = packed_modules_mapping
+        self.packed_modules_mapping = packed_modules_mapping or {}
         self.exclude_modules = exclude_modules or []
         self.kv_cache_quant_algo = kv_cache_quant_algo
         self.use_per_token_activation = False

--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -70,8 +70,10 @@ _FALLBACK_FUSED_SHARDS: Mapping[str, List[str]] = {
 def is_layer_skipped(
     prefix: str,
     ignored_layers: List[str],
-    fused_mapping: Mapping[str, List[str]] = MappingProxyType({}),
+    fused_mapping: Optional[Mapping[str, List[str]]] = None,
 ) -> bool:
+    if fused_mapping is None:
+        fused_mapping = MappingProxyType({})
     # prefix: model.layers.0.self_attn.q_proj
     # proj_name: q_proj
     proj_name = prefix.split(".")[-1]

--- a/python/sglang/srt/models/bailing_moe_nextn.py
+++ b/python/sglang/srt/models/bailing_moe_nextn.py
@@ -44,7 +44,9 @@ from sglang.srt.models.bailing_moe_linear import (
 from sglang.srt.models.bailing_moe_v3 import (
     BailingMoELinearDecoderLayer as BailingMoeV3DecoderLayer,
 )
-from sglang.srt.models.bailing_moe_v3 import BailingMoeV3ForCausalLM
+from sglang.srt.models.bailing_moe_v3 import (
+    BailingMoeV3ForCausalLM,
+)
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import BumpAllocator, add_prefix

--- a/python/sglang/srt/models/bailing_moe_nextn.py
+++ b/python/sglang/srt/models/bailing_moe_nextn.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2023 Antgroup and The HuggingFace Inc. team. All rights reserved.
 #
 # This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
@@ -19,8 +18,9 @@
 # limitations under the License.
 """SGLang BailingMoENextN model."""
 
+import copy
 import logging
-from typing import Iterable, Optional, Tuple
+from collections.abc import Iterable
 
 import torch
 from torch import nn
@@ -44,9 +44,7 @@ from sglang.srt.models.bailing_moe_linear import (
 from sglang.srt.models.bailing_moe_v3 import (
     BailingMoELinearDecoderLayer as BailingMoeV3DecoderLayer,
 )
-from sglang.srt.models.bailing_moe_v3 import (
-    BailingMoeV3ForCausalLM,
-)
+from sglang.srt.models.bailing_moe_v3 import BailingMoeV3ForCausalLM
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import BumpAllocator, add_prefix
@@ -67,7 +65,7 @@ class BailingMoEModelNextN(nn.Module):
     def __init__(
         self,
         config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         num_fused_shared_experts: int = 0,
     ) -> None:
@@ -78,12 +76,6 @@ class BailingMoEModelNextN(nn.Module):
         self.total_num_layers = 1
         self.vocab_size = config.vocab_size
         config.for_nextn_model = True
-
-        if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
-            logger.warning(
-                "Overriding DeepseekV3ForCausalLMNextN quant config for modelopt_fp4 Deepseek model."
-            )
-            quant_config = None
 
         self.vocab_size = config.vocab_size
 
@@ -212,10 +204,124 @@ class BailingMoeForCausalLMNextN(nn.Module):
             expected_architecture="BailingMoeForCausalLMNextN",
         )
 
+    _NEXTN_SPEC_WEIGHT_NAMES = ("final_layernorm", "eh_proj", "enorm", "hnorm")
+
+    @classmethod
+    def _is_mtp_module(cls, name: str, layer_prefix: str) -> bool:
+        short_layer_prefix = f"layers.{layer_prefix.split('.')[-1]}"
+        mtp_prefixes = (layer_prefix, short_layer_prefix, "model.decoder", "decoder")
+        for pfx in mtp_prefixes:
+            if (
+                name == pfx
+                or name == f"{pfx}*"
+                or name == f"{pfx}.*"
+                or name.startswith(f"{pfx}.")
+            ):
+                return True
+        for spec in cls._NEXTN_SPEC_WEIGHT_NAMES:
+            if name == f"model.{spec}" or name.startswith(f"model.{spec}."):
+                return True
+        return False
+
+    @classmethod
+    def _map_mtp_ckpt_name(cls, name: str, layer_prefix: str) -> str:
+        is_spec = any(part in name for part in cls._NEXTN_SPEC_WEIGHT_NAMES)
+        target_prefix = "model" if is_spec else "model.decoder"
+        short_layer_prefix = f"layers.{layer_prefix.split('.')[-1]}"
+        prefixes = (layer_prefix, short_layer_prefix, "model.decoder", "decoder")
+
+        for pfx in prefixes:
+            if name.startswith(f"{pfx}."):
+                remainder = name[len(pfx) + 1 :]
+                return f"{target_prefix}.{remainder}"
+            if name in (pfx, f"{pfx}*", f"{pfx}.*"):
+                if is_spec:
+                    return target_prefix
+                return f"{target_prefix}.*" if name.endswith("*") else target_prefix
+
+        return name
+
+    def _resolve_nextn_quant_config(self, config, quant_config):
+        if quant_config is None:
+            return None
+
+        quant_name = (
+            quant_config.get_name() if hasattr(quant_config, "get_name") else None
+        )
+
+        if quant_name == "quark":
+            from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+
+            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+            if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
+                return None
+            return quant_config
+
+        if quant_name == "modelopt_fp4" or (
+            hasattr(quant_config, "exclude_modules")
+            and isinstance(quant_config.exclude_modules, list)
+        ):
+            # Supported Checkpoint Contract:
+            # 1. If an MTP draft layer/module is explicitly listed in `exclude_modules`
+            #    (using checkpoint prefixes like `model.layers.<N>.*`, `layers.<N>.*`,
+            #    or already-remapped runtime names like `model.decoder.*`), the draft
+            #    decoder modules (linear and/or FusedMoE) will be excluded from quantization.
+            # 2. If no MTP layer/module exclusion is present in `exclude_modules`, the MTP
+            #    draft layer is treated as quantized (ModelOpt FP4), retaining `quant_config`
+            #    for models with quantized draft weights (e.g. GLM-5.3-Flash / GLM NextN).
+            layer_prefix = f"model.layers.{config.num_hidden_layers}"
+            short_layer_prefix = f"layers.{config.num_hidden_layers}"
+            whole_layer_prefixes = (
+                layer_prefix,
+                short_layer_prefix,
+                "model.decoder",
+                "decoder",
+            )
+
+            exclude_modules = quant_config.exclude_modules or []
+            mtp_excluded = [
+                name
+                for name in exclude_modules
+                if self._is_mtp_module(name, layer_prefix)
+            ]
+            if not mtp_excluded:
+                return quant_config
+
+            names = set(exclude_modules)
+            has_whole_mtp_excluded = False
+            has_expert_excluded = False
+
+            for name in mtp_excluded:
+                mapped = self._map_mtp_ckpt_name(name, layer_prefix)
+                names.add(mapped)
+
+                for pfx in whole_layer_prefixes:
+                    if name in (pfx, f"{pfx}*", f"{pfx}.*"):
+                        has_whole_mtp_excluded = True
+                        break
+
+                if ".mlp.experts" in name or ".mlp.experts" in mapped:
+                    has_expert_excluded = True
+
+            if has_whole_mtp_excluded:
+                names.add("model.decoder")
+                names.add("model.decoder.*")
+                names.add("model.decoder.mlp.experts")
+                for spec in self._NEXTN_SPEC_WEIGHT_NAMES:
+                    names.add(f"model.{spec}")
+            elif has_expert_excluded:
+                names.add("model.decoder.mlp.experts")
+
+            quant_config = copy.copy(quant_config)
+            quant_config.exclude_modules = list(names)
+            return quant_config
+        return quant_config
+
     def __init__(
         self,
         config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         nn.Module.__init__(self)
@@ -230,9 +336,11 @@ class BailingMoeForCausalLMNextN(nn.Module):
             # Asystem has determine_num_fused_shared_experts but theta does not.
             self.determine_num_fused_shared_experts("BailingMoeForCausalLMNextN")
 
+        nextn_quant_config = self._resolve_nextn_quant_config(config, quant_config)
+
         self.model = BailingMoEModelNextN(
             config,
-            quant_config,
+            nextn_quant_config,
             prefix=add_prefix("model", prefix),
             num_fused_shared_experts=self.num_fused_shared_experts,
         )
@@ -286,7 +394,7 @@ class BailingMoeForCausalLMNextN(nn.Module):
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         self.base_load_weights_func(self, weights, is_nextn=True)
 
     def post_load_weights(self, is_nextn=True, weight_names=None):

--- a/python/sglang/srt/models/bailing_moe_nextn.py
+++ b/python/sglang/srt/models/bailing_moe_nextn.py
@@ -89,12 +89,15 @@ class BailingMoEModelNextN(nn.Module):
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
+        nextn_layer_id = (
+            0 if config.num_hidden_layers == 1 else config.num_hidden_layers
+        )
         self.eh_proj = ReplicatedLinear(
             2 * config.hidden_size,
             config.hidden_size,
             bias=False,
             quant_config=quant_config,
-            prefix=add_prefix(f"layers.{config.num_hidden_layers}.eh_proj", prefix),
+            prefix=add_prefix(f"layers.{nextn_layer_id}.eh_proj", prefix),
         )
 
         self.is_hybrid = (
@@ -107,7 +110,7 @@ class BailingMoEModelNextN(nn.Module):
                 "quant_config": quant_config,
                 "layer_id": 0,
                 "is_nextn": True,
-                "prefix": add_prefix(f"layers.{config.num_hidden_layers}", prefix),
+                "prefix": add_prefix(f"layers.{nextn_layer_id}", prefix),
             }
             if _is_bailing_moe_v3_config(config):
                 decoder_layer_cls = BailingMoeV3DecoderLayer
@@ -219,7 +222,12 @@ class BailingMoeForCausalLMNextN(nn.Module):
             ):
                 return True
         for spec in cls._NEXTN_SPEC_WEIGHT_NAMES:
-            if name == f"model.{spec}" or name.startswith(f"model.{spec}."):
+            if (
+                name == spec
+                or name.startswith(f"{spec}.")
+                or name == f"model.{spec}"
+                or name.startswith(f"model.{spec}.")
+            ):
                 return True
         return False
 
@@ -249,10 +257,14 @@ class BailingMoeForCausalLMNextN(nn.Module):
             quant_config.get_name() if hasattr(quant_config, "get_name") else None
         )
 
+        nextn_layer_id = (
+            0 if config.num_hidden_layers == 1 else config.num_hidden_layers
+        )
+
         if quant_name == "quark":
             from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
 
-            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+            ckpt_prefix = f"model.layers.{nextn_layer_id}"
             mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
             if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
                 return None
@@ -265,13 +277,14 @@ class BailingMoeForCausalLMNextN(nn.Module):
             # Supported Checkpoint Contract:
             # 1. If an MTP draft layer/module is explicitly listed in `exclude_modules`
             #    (using checkpoint prefixes like `model.layers.<N>.*`, `layers.<N>.*`,
-            #    or already-remapped runtime names like `model.decoder.*`), the draft
+            #    `model.layers.<N>*`, or already-remapped runtime names like
+            #    `model.decoder.*`, `model.decoder*`, `model.decoder`), the draft
             #    decoder modules (linear and/or FusedMoE) will be excluded from quantization.
             # 2. If no MTP layer/module exclusion is present in `exclude_modules`, the MTP
             #    draft layer is treated as quantized (ModelOpt FP4), retaining `quant_config`
             #    for models with quantized draft weights (e.g. GLM-5.3-Flash / GLM NextN).
-            layer_prefix = f"model.layers.{config.num_hidden_layers}"
-            short_layer_prefix = f"layers.{config.num_hidden_layers}"
+            layer_prefix = f"model.layers.{nextn_layer_id}"
+            short_layer_prefix = f"layers.{nextn_layer_id}"
             whole_layer_prefixes = (
                 layer_prefix,
                 short_layer_prefix,
@@ -301,17 +314,43 @@ class BailingMoeForCausalLMNextN(nn.Module):
                         has_whole_mtp_excluded = True
                         break
 
-                if ".mlp.experts" in name or ".mlp.experts" in mapped:
+                if (
+                    ".mlp.experts" in name
+                    or ".mlp.experts" in mapped
+                    or ".experts" in name
+                    or ".experts" in mapped
+                ):
                     has_expert_excluded = True
 
             if has_whole_mtp_excluded:
                 names.add("model.decoder")
                 names.add("model.decoder.*")
+                names.add("model.decoder*")
                 names.add("model.decoder.mlp.experts")
+                names.add("decoder")
+                names.add("decoder.*")
+                names.add("decoder*")
+                names.add(layer_prefix)
+                names.add(f"{layer_prefix}.*")
+                names.add(f"{layer_prefix}*")
+                names.add(f"{layer_prefix}.experts")
+                names.add(f"{layer_prefix}.mlp.experts")
+                names.add(short_layer_prefix)
+                names.add(f"{short_layer_prefix}.*")
+                names.add(f"{short_layer_prefix}*")
+                names.add(f"{short_layer_prefix}.experts")
+                names.add(f"{short_layer_prefix}.mlp.experts")
+                names.add(f"{layer_prefix}.eh_proj")
+                names.add(f"{short_layer_prefix}.eh_proj")
                 for spec in self._NEXTN_SPEC_WEIGHT_NAMES:
                     names.add(f"model.{spec}")
+                    names.add(spec)
             elif has_expert_excluded:
                 names.add("model.decoder.mlp.experts")
+                names.add(f"{layer_prefix}.experts")
+                names.add(f"{layer_prefix}.mlp.experts")
+                names.add(f"{short_layer_prefix}.experts")
+                names.add(f"{short_layer_prefix}.mlp.experts")
 
             quant_config = copy.copy(quant_config)
             quant_config.exclude_modules = list(names)

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -14,10 +14,11 @@
 
 """Inference-only DeepSeek NextN Speculative Decoding."""
 
+import copy
 import logging
 import os
+from collections.abc import Iterable
 from contextlib import ExitStack
-from typing import Iterable, Optional, Tuple
 
 import torch
 from safetensors.torch import load_file
@@ -103,7 +104,7 @@ class DeepseekModelNextN(nn.Module):
     def __init__(
         self,
         config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -115,12 +116,6 @@ class DeepseekModelNextN(nn.Module):
             )
         else:
             moe_quant_config_override = None
-
-        if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
-            logger.warning(
-                "Overriding DeepseekV3ForCausalLMNextN quant config for modelopt_fp4 Deepseek model."
-            )
-            quant_config = None
 
         self.vocab_size = config.vocab_size
 
@@ -321,22 +316,124 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         },
     )
 
+    _NEXTN_SPEC_WEIGHT_NAMES = ("shared_head.norm", "eh_proj", "enorm", "hnorm")
+
+    @classmethod
+    def _is_mtp_module(cls, name: str, layer_prefix: str) -> bool:
+        short_layer_prefix = f"layers.{layer_prefix.split('.')[-1]}"
+        mtp_prefixes = (layer_prefix, short_layer_prefix, "model.decoder", "decoder")
+        for pfx in mtp_prefixes:
+            if (
+                name == pfx
+                or name == f"{pfx}*"
+                or name == f"{pfx}.*"
+                or name.startswith(f"{pfx}.")
+            ):
+                return True
+        for spec in cls._NEXTN_SPEC_WEIGHT_NAMES:
+            if name == f"model.{spec}" or name.startswith(f"model.{spec}."):
+                return True
+        return False
+
+    @classmethod
+    def _map_mtp_ckpt_name(cls, name: str, layer_prefix: str) -> str:
+        is_spec = any(part in name for part in cls._NEXTN_SPEC_WEIGHT_NAMES)
+        target_prefix = "model" if is_spec else "model.decoder"
+        short_layer_prefix = f"layers.{layer_prefix.split('.')[-1]}"
+        prefixes = (layer_prefix, short_layer_prefix, "model.decoder", "decoder")
+
+        for pfx in prefixes:
+            if name.startswith(f"{pfx}."):
+                remainder = name[len(pfx) + 1 :]
+                return f"{target_prefix}.{remainder}"
+            if name in (pfx, f"{pfx}*", f"{pfx}.*"):
+                if is_spec:
+                    return target_prefix
+                return f"{target_prefix}.*" if name.endswith("*") else target_prefix
+
+        return name
+
     def _resolve_nextn_quant_config(self, config, quant_config):
-        if quant_config is None or quant_config.get_name() != "quark":
+        if quant_config is None:
+            return None
+
+        quant_name = (
+            quant_config.get_name() if hasattr(quant_config, "get_name") else None
+        )
+
+        if quant_name == "quark":
+            from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+
+            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+            if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
+                return None
             return quant_config
 
-        from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+        if quant_name == "modelopt_fp4" or (
+            hasattr(quant_config, "exclude_modules")
+            and isinstance(quant_config.exclude_modules, list)
+        ):
+            # Supported Checkpoint Contract:
+            # 1. If an MTP draft layer/module is explicitly listed in `exclude_modules`
+            #    (using checkpoint prefixes like `model.layers.<N>.*`, `layers.<N>.*`,
+            #    or already-remapped runtime names like `model.decoder.*`), the draft
+            #    decoder modules (linear and/or FusedMoE) will be excluded from quantization.
+            # 2. If no MTP layer/module exclusion is present in `exclude_modules`, the MTP
+            #    draft layer is treated as quantized (ModelOpt FP4), retaining `quant_config`
+            #    for models with quantized draft weights (e.g. GLM-5.3-Flash / GLM NextN).
+            layer_prefix = f"model.layers.{config.num_hidden_layers}"
+            short_layer_prefix = f"layers.{config.num_hidden_layers}"
+            whole_layer_prefixes = (
+                layer_prefix,
+                short_layer_prefix,
+                "model.decoder",
+                "decoder",
+            )
 
-        ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
-        mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
-        if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
-            return None
+            exclude_modules = quant_config.exclude_modules or []
+            mtp_excluded = [
+                name
+                for name in exclude_modules
+                if self._is_mtp_module(name, layer_prefix)
+            ]
+            if not mtp_excluded:
+                return quant_config
+
+            names = set(exclude_modules)
+            has_whole_mtp_excluded = False
+            has_expert_excluded = False
+
+            for name in mtp_excluded:
+                mapped = self._map_mtp_ckpt_name(name, layer_prefix)
+                names.add(mapped)
+
+                for pfx in whole_layer_prefixes:
+                    if name in (pfx, f"{pfx}*", f"{pfx}.*"):
+                        has_whole_mtp_excluded = True
+                        break
+
+                if ".mlp.experts" in name or ".mlp.experts" in mapped:
+                    has_expert_excluded = True
+
+            if has_whole_mtp_excluded:
+                names.add("model.decoder")
+                names.add("model.decoder.*")
+                names.add("model.decoder.mlp.experts")
+                for spec in self._NEXTN_SPEC_WEIGHT_NAMES:
+                    names.add(f"model.{spec}")
+            elif has_expert_excluded:
+                names.add("model.decoder.mlp.experts")
+
+            quant_config = copy.copy(quant_config)
+            quant_config.exclude_modules = list(names)
+            return quant_config
         return quant_config
 
     def __init__(
         self,
         config: PretrainedConfig,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         nn.Module.__init__(self)
@@ -404,7 +501,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             input_ids, hidden_states, self.lm_head, forward_batch
         )
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         super().load_weights(weights, is_nextn=True)
 
     def post_load_weights(self, is_nextn=True, weight_names=None):

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -159,8 +159,10 @@ class DeepseekModelNextN(nn.Module):
         if _is_npu and (
             get_spec().speculative_draft_model_path == get_model().model_path
         ):
-            layer_name = "layers." + str(config.num_hidden_layers)
-
+            nextn_layer_id = (
+                0 if config.num_hidden_layers == 1 else config.num_hidden_layers
+            )
+            layer_name = f"layers.{nextn_layer_id}"
         self.quant_config = quant_config
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
@@ -331,7 +333,12 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             ):
                 return True
         for spec in cls._NEXTN_SPEC_WEIGHT_NAMES:
-            if name == f"model.{spec}" or name.startswith(f"model.{spec}."):
+            if (
+                name == spec
+                or name.startswith(f"{spec}.")
+                or name == f"model.{spec}"
+                or name.startswith(f"model.{spec}.")
+            ):
                 return True
         return False
 
@@ -361,10 +368,14 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             quant_config.get_name() if hasattr(quant_config, "get_name") else None
         )
 
+        nextn_layer_id = (
+            0 if config.num_hidden_layers == 1 else config.num_hidden_layers
+        )
+
         if quant_name == "quark":
             from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
 
-            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+            ckpt_prefix = f"model.layers.{nextn_layer_id}"
             mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
             if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
                 return None
@@ -377,13 +388,14 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             # Supported Checkpoint Contract:
             # 1. If an MTP draft layer/module is explicitly listed in `exclude_modules`
             #    (using checkpoint prefixes like `model.layers.<N>.*`, `layers.<N>.*`,
-            #    or already-remapped runtime names like `model.decoder.*`), the draft
+            #    `model.layers.<N>*`, or already-remapped runtime names like
+            #    `model.decoder.*`, `model.decoder*`, `model.decoder`), the draft
             #    decoder modules (linear and/or FusedMoE) will be excluded from quantization.
             # 2. If no MTP layer/module exclusion is present in `exclude_modules`, the MTP
             #    draft layer is treated as quantized (ModelOpt FP4), retaining `quant_config`
             #    for models with quantized draft weights (e.g. GLM-5.3-Flash / GLM NextN).
-            layer_prefix = f"model.layers.{config.num_hidden_layers}"
-            short_layer_prefix = f"layers.{config.num_hidden_layers}"
+            layer_prefix = f"model.layers.{nextn_layer_id}"
+            short_layer_prefix = f"layers.{nextn_layer_id}"
             whole_layer_prefixes = (
                 layer_prefix,
                 short_layer_prefix,
@@ -413,12 +425,18 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
                         has_whole_mtp_excluded = True
                         break
 
-                if ".mlp.experts" in name or ".mlp.experts" in mapped:
+                if (
+                    ".mlp.experts" in name
+                    or ".mlp.experts" in mapped
+                    or ".experts" in name
+                    or ".experts" in mapped
+                ):
                     has_expert_excluded = True
 
             if has_whole_mtp_excluded:
                 names.add("model.decoder")
                 names.add("model.decoder.*")
+                names.add("model.decoder*")
                 names.add("model.decoder.mlp.experts")
                 for spec in self._NEXTN_SPEC_WEIGHT_NAMES:
                     names.add(f"model.{spec}")

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -1452,20 +1452,14 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
     # _resolve_nextn_quant_config below instead.
     hf_to_sglang_mapper = WeightsMapper()
 
-    _NEXTN_SPEC_WEIGHT_NAMES = ("shared_head.norm", "eh_proj", "enorm", "hnorm")
-
-    @classmethod
-    def _map_mtp_ckpt_name(cls, name: str, layer_prefix: str) -> str:
-        # Keep this mapping in sync with DeepseekV2WeightLoaderMixin's
-        # NextN rule: MTP-specific weights live under model.*, while the
-        # decoder block weights live under model.decoder.*.
-        if any(part in name for part in cls._NEXTN_SPEC_WEIGHT_NAMES):
-            return name.replace(layer_prefix, "model", 1)
-        return name.replace(layer_prefix, "model.decoder", 1)
-
     def _resolve_nextn_quant_config(self, config, quant_config):
-        if quant_config is None or quant_config.get_name() != "quark":
-            return quant_config
+        if quant_config is None:
+            return None
+        quant_name = (
+            quant_config.get_name() if hasattr(quant_config, "get_name") else None
+        )
+        if quant_name != "quark":
+            return super()._resolve_nextn_quant_config(config, quant_config)
 
         layer_prefix = f"model.layers.{config.num_hidden_layers}"
 
@@ -1476,7 +1470,19 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
         # keys need the same remap as exclude_layers below, or they silently
         # fall back to the wrong (layer-type/global) scheme.
         layer_quant_config = quant_config.quant_config.get("layer_quant_config")
+        mtp_excluded = [
+            name
+            for name in quant_config.exclude_layers
+            if name.startswith(layer_prefix + ".")
+        ]
+        if not layer_quant_config and not mtp_excluded:
+            return quant_config
+
+        import copy
+
+        quant_config = copy.copy(quant_config)
         if layer_quant_config:
+            quant_config.quant_config = copy.copy(quant_config.quant_config)
             quant_config.quant_config["layer_quant_config"] = {
                 (
                     self._map_mtp_ckpt_name(pattern, layer_prefix)
@@ -1486,30 +1492,21 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
                 for pattern, pattern_config in layer_quant_config.items()
             }
 
-        mtp_excluded = [
-            name
-            for name in quant_config.exclude_layers
-            if name.startswith(layer_prefix + ".")
-        ]
-        if not mtp_excluded:
-            return quant_config
+        if mtp_excluded:
+            names = set(quant_config.exclude_layers)
+            for name in mtp_excluded:
+                names.add(self._map_mtp_ckpt_name(name, layer_prefix))
 
-        names = set(quant_config.exclude_layers)
-        for name in mtp_excluded:
-            names.add(self._map_mtp_ckpt_name(name, layer_prefix))
+            # Fused routed experts are queried by the coarse module prefix
+            # "model.decoder.mlp.experts". Expanded per-expert leaf excludes do not
+            # match that prefix, so add the coarse prefix when any routed expert in
+            # the MTP layer is excluded. This keeps only that fused MoE module bf16
+            # while allowing the remaining draft modules to use their quant config.
+            if any(".mlp.experts." in name for name in mtp_excluded):
+                names.add("model.decoder.mlp.experts")
 
-        # Fused routed experts are queried by the coarse module prefix
-        # "model.decoder.mlp.experts". Expanded per-expert leaf excludes do not
-        # match that prefix, so add the coarse prefix when any routed expert in
-        # the MTP layer is excluded. This keeps only that fused MoE module bf16
-        # while allowing the remaining draft modules to use their quant config.
-        if any(".mlp.experts." in name for name in mtp_excluded):
-            names.add("model.decoder.mlp.experts")
+            quant_config.exclude_layers = list(names)
 
-        import copy
-
-        quant_config = copy.copy(quant_config)
-        quant_config.exclude_layers = list(names)
         return quant_config
 
 

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -1461,7 +1461,10 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
         if quant_name != "quark":
             return super()._resolve_nextn_quant_config(config, quant_config)
 
-        layer_prefix = f"model.layers.{config.num_hidden_layers}"
+        nextn_layer_id = (
+            0 if config.num_hidden_layers == 1 else config.num_hidden_layers
+        )
+        layer_prefix = f"model.layers.{nextn_layer_id}"
 
         # Quark's per-module scheme selection (e.g. MTP self_attn in PTPC-FP8
         # while MTP MoE is MXFP4) is keyed by "layer_quant_config" patterns

--- a/test/registered/unit/models/test_nextn_modelopt_quant.py
+++ b/test/registered/unit/models/test_nextn_modelopt_quant.py
@@ -57,8 +57,15 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4Config,
+    ModelOptFp4LinearMethod,
+    ModelOptNvFp4FusedMoEMethod,
+)
+from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.models.bailing_moe_nextn import (
     BailingMoeForCausalLMNextN,
     BailingMoEModelNextN,
@@ -76,6 +83,14 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _mock_linear():
+    return object.__new__(ReplicatedLinear)
+
+
+def _mock_fused_moe():
+    return object.__new__(FusedMoE)
 
 
 class _FakeQuarkConfig(QuantizationConfig):
@@ -362,7 +377,8 @@ class TestDeepseekNextNModelOptQuantResolution(CustomTestCase):
 
     def test_loader_mapper_before_resolver_single_expert_excluded(self):
         """When exclude_modules=["model.layers.61.mlp.experts.0"], mapper turns it into
-        "model.decoder.mlp.experts.0". Resolver must add coarse "model.decoder.mlp.experts"."""
+        "model.decoder.mlp.experts.0". Resolver must add coarse "model.decoder.mlp.experts".
+        """
         model = self._make_model()
         config = SimpleNamespace(num_hidden_layers=61)
         quant_cfg = ModelOptFp4Config(
@@ -455,6 +471,110 @@ class TestDeepseekNextNModelOptQuantResolution(CustomTestCase):
         self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
         self.assertFalse(res.is_layer_excluded("model.eh_proj"))
         self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_modelopt_fp4_wildcard_no_dot_before_mapper(self):
+        """Production wildcard spelling 'model.layers.61*' before mapper."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
+
+    def test_modelopt_fp4_wildcard_no_dot_after_mapper(self):
+        """Production wildcard spelling 'model.layers.61*' after mapper transforms it into 'model.decoder*'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61*", "lm_head"],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder*", quant_cfg.exclude_modules)
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
+
+    def test_modelopt_fp4_legacy_layer0_num_hidden_layers_1(self):
+        """Legacy checkpoint with num_hidden_layers == 1 uses canonical NextN layer index 0."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.0.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+
+    def test_quark_legacy_layer0_num_hidden_layers_1(self):
+        """Quark exclusion with num_hidden_layers == 1 correctly targets layer 0."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quark_cfg = _FakeQuarkConfig(exclude_layers=["model.layers.0"])
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+        self.assertIsNone(res)
+
+    def test_modelopt_fp4_consumer_get_quant_method_semantics(self):
+        """Verify get_quant_method consumer semantics directly on Linear and FusedMoE."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
 
     def test_quark_quant_config_excluded_returns_none(self):
         model = self._make_model()
@@ -687,6 +807,170 @@ class TestBailingMoeNextNModelOptQuantResolution(CustomTestCase):
         self.assertFalse(res.is_layer_excluded("model.final_layernorm"))
         self.assertTrue(res.is_layer_excluded("lm_head"))
 
+    def test_bailing_wildcard_no_dot(self):
+        """Production wildcard spelling 'model.layers.30*' and 'layers.30*'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.experts")
+        )
+
+    def test_bailing_legacy_layer0_num_hidden_layers_1(self):
+        """Legacy Bailing config with num_hidden_layers == 1 uses canonical NextN layer index 0."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.0.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.final_layernorm"))
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.0.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.0.experts")
+        )
+
+    def test_bailing_quark_legacy_layer0_num_hidden_layers_1(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quark_cfg = _FakeQuarkConfig(exclude_layers=["model.layers.0"])
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+        self.assertIsNone(res)
+
+    def test_bailing_hybrid_runtime_prefixes_consumer_get_quant_method(self):
+        """Bailing hybrid/V3 layout uses model.layers.<N> for decoder/FusedMoE and layers.<N> for eh_proj.
+        Verify with ModelOptFp4Config get_quant_method consumers that all runtime forms are unquantized.
+        """
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        # Bailing hybrid runtime linear layers (eh_proj, attention projections):
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "layers.30.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.attention.q_b_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "layers.30.attention.q_b_proj"),
+            UnquantizedLinearMethod,
+        )
+        # Bailing hybrid runtime FusedMoE layers (both model.layers.<N>.experts and model.layers.<N>.mlp.experts):
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.experts")
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.mlp.experts")
+        )
+        self.assertIsNone(res.get_quant_method(_mock_fused_moe(), "layers.30.experts"))
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "layers.30.mlp.experts")
+        )
+        # Standard decoder layout forms also retained:
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+
+    def test_bailing_hybrid_quantized_mtp_consumer_get_quant_method(self):
+        """When MTP is not excluded, Bailing hybrid runtime layers retain ModelOpt FP4 methods."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.eh_proj"),
+            ModelOptFp4LinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.attention.q_b_proj"),
+            ModelOptFp4LinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.experts"),
+            ModelOptNvFp4FusedMoEMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts"),
+            ModelOptNvFp4FusedMoEMethod,
+        )
+
+    def test_bailing_hybrid_moe_only_excluded_consumer_get_quant_method(self):
+        """When only MTP MoE is excluded, FusedMoE is unquantized while attention remains quantized."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.mlp.experts.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.layers.30.attention.q_b_proj"),
+            ModelOptFp4LinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.experts")
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.layers.30.mlp.experts")
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
+
 
 class TestGlmMoeDsaNextNModelOptQuantResolution(CustomTestCase):
     def _make_model(self):
@@ -791,6 +1075,91 @@ class TestGlmMoeDsaNextNModelOptQuantResolution(CustomTestCase):
 
         self.assertIsNot(res, quant_cfg)
         self.assertEqual(quant_cfg.exclude_modules, orig_exclude)
+
+    def test_glm_moe_dsa_wildcard_no_dot(self):
+        """Production wildcard spelling 'model.layers.46*'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
+
+    def test_glm_moe_dsa_legacy_layer0_num_hidden_layers_1(self):
+        """Legacy GLM config with num_hidden_layers == 1 uses canonical NextN layer index 0."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.0.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+
+    def test_glm_moe_dsa_quark_legacy_layer0_num_hidden_layers_1(self):
+        """Quark resolution with num_hidden_layers == 1 correctly targets layer 0."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=1)
+        quark_cfg = _FakeQuarkConfig(
+            exclude_layers=["model.layers.0.mlp.experts.0"],
+            layer_quant_config={"model.layers.0.self_attn.q_a_proj": {"scheme": "fp8"}},
+        )
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+
+        self.assertIsNot(res, quark_cfg)
+        self.assertIn("model.decoder.mlp.experts.0", res.exclude_layers)
+        self.assertIn("model.decoder.mlp.experts", res.exclude_layers)
+        self.assertIn(
+            "model.decoder.self_attn.q_a_proj",
+            res.quant_config["layer_quant_config"],
+        )
+
+    def test_glm_moe_dsa_consumer_get_quant_method_semantics(self):
+        """Verify get_quant_method consumer semantics directly on Linear and FusedMoE."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.decoder.self_attn.q_a_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsInstance(
+            res.get_quant_method(_mock_linear(), "model.eh_proj"),
+            UnquantizedLinearMethod,
+        )
+        self.assertIsNone(
+            res.get_quant_method(_mock_fused_moe(), "model.decoder.mlp.experts")
+        )
 
 
 class TestNextNModelQuantConfigRetention(CustomTestCase):

--- a/test/registered/unit/models/test_nextn_modelopt_quant.py
+++ b/test/registered/unit/models/test_nextn_modelopt_quant.py
@@ -1,0 +1,989 @@
+"""
+Unit tests for NextN ModelOpt FP4 quantization resolution and per-layer exclusions.
+
+Tests cover:
+  1. DeepseekV3ForCausalLMNextN._resolve_nextn_quant_config properly resolves
+     ModelOpt FP4 configs, remapping checkpoint MTP layer prefixes (e.g. model.layers.61
+     or dynamic model.layers.<num_hidden_layers>) to runtime decoder prefixes without junk mappings.
+  2. Unquantized/excluded MTP behavior is preserved when exclude_modules targets MTP,
+     while quantized MTP is preserved when not excluded.
+  3. Shared quant configs are not mutated unexpectedly.
+  4. BailingMoeForCausalLMNextN resolves ModelOpt FP4 quant configs and handles MTP exclusions.
+  5. DeepseekModelNextN and BailingMoEModelNextN retain ModelOpt FP4 quant_config
+     without blanket overriding to None.
+  6. Glm4MoeModelNextN, Glm4MoeLiteModelNextN, and GlmOcrModelNextN preserve legacy BF16-MTP
+     by overriding modelopt_fp4 to None.
+"""
+
+import importlib.abc
+import importlib.machinery
+import sys
+from unittest.mock import MagicMock
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+for _pkg in ("deep_ep", "deep_gemm"):
+    try:
+        __import__(_pkg)
+    except (ImportError, OSError, AssertionError):
+        sys.modules.pop(_pkg, None)
+
+        class _GpuPkgLoader(importlib.abc.Loader):
+            def create_module(self, spec):
+                return None
+
+            def exec_module(self, module):
+                module.__getattr__ = lambda name: MagicMock()
+
+        class _GpuPkgFinder(importlib.abc.MetaPathFinder):
+            def __init__(self, pkg_name):
+                self.pkg_name = pkg_name
+
+            def find_spec(self, fullname, path, target=None):
+                if fullname == self.pkg_name or fullname.startswith(
+                    f"{self.pkg_name}."
+                ):
+                    return importlib.machinery.ModuleSpec(
+                        fullname,
+                        _GpuPkgLoader(),
+                        is_package=True,
+                    )
+                return None
+
+        sys.meta_path.insert(0, _GpuPkgFinder(_pkg))
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+from sglang.srt.models.bailing_moe_nextn import (
+    BailingMoeForCausalLMNextN,
+    BailingMoEModelNextN,
+)
+from sglang.srt.models.deepseek_nextn import (
+    DeepseekModelNextN,
+    DeepseekV3ForCausalLMNextN,
+)
+from sglang.srt.models.glm4_moe import GlmMoeDsaForCausalLMNextN
+from sglang.srt.models.glm4_moe_lite_nextn import Glm4MoeLiteModelNextN
+from sglang.srt.models.glm4_moe_nextn import Glm4MoeModelNextN
+from sglang.srt.models.glm_ocr_nextn import GlmOcrModelNextN
+from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeQuarkConfig(QuantizationConfig):
+    def __init__(self, exclude_layers=None, layer_quant_config=None):
+        super().__init__()
+        self.exclude_layers = exclude_layers or []
+        self.quant_config = {}
+        if layer_quant_config:
+            self.quant_config["layer_quant_config"] = layer_quant_config
+
+    def get_name(self) -> str:
+        return "quark"
+
+    def get_quant_method(self, layer, prefix=""):
+        return None
+
+    def get_min_capability(self) -> int:
+        return 0
+
+    @classmethod
+    def get_config_filenames(cls):
+        return []
+
+    @classmethod
+    def from_config(cls, config):
+        return cls()
+
+    def get_scaled_act_names(self):
+        return []
+
+    def get_supported_act_dtypes(self):
+        return []
+
+
+class TestDeepseekNextNModelOptQuantResolution(CustomTestCase):
+    def _make_model(self):
+        return object.__new__(DeepseekV3ForCausalLMNextN)
+
+    def test_none_quant_config_returns_none(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        res = model._resolve_nextn_quant_config(config, None)
+        self.assertIsNone(res)
+
+    def test_modelopt_fp4_not_excluded_returns_config(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertEqual(res.get_name(), "modelopt_fp4")
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_modelopt_fp4_layer61_excluded_remaps_to_decoder(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.kv_b_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_modelopt_fp4_mtp_moe_only_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.mlp.experts.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_modelopt_fp4_dynamic_layer_count_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=28)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.28.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_modelopt_fp4_no_broad_prefix_matching(self):
+        model = self._make_model()
+        # Model has 6 hidden layers (MTP layer 6). Exclude module is for layer 60.
+        config = SimpleNamespace(num_hidden_layers=6)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.60.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        # Layer 6 MTP should not be excluded by layer 60 exclude rule.
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_modelopt_fp4_nextn_specific_weights_mapping(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=[
+                "model.layers.61.eh_proj",
+                "model.layers.61.enorm",
+                "model.layers.61.hnorm",
+                "model.layers.61.shared_head.norm",
+            ],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIn("model.eh_proj", res.exclude_modules)
+        self.assertIn("model.enorm", res.exclude_modules)
+        self.assertIn("model.hnorm", res.exclude_modules)
+        self.assertIn("model.shared_head.norm", res.exclude_modules)
+        self.assertNotIn("model.decoder.eh_proj", res.exclude_modules)
+
+    def test_modelopt_fp4_short_prefix_mapping(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["layers.61.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_modelopt_fp4_no_junk_prefix_mapping(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.self_attn.q_a_proj"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIn("model.decoder.self_attn.q_a_proj", res.exclude_modules)
+        for name in res.exclude_modules:
+            self.assertFalse(
+                name.startswith("model.model."),
+                f"Found junk prefix mapping: {name}",
+            )
+
+    def test_shared_quant_config_not_mutated(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        orig_exclude = ["model.layers.61.self_attn.q_a_proj"]
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=list(orig_exclude),
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNot(res, quant_cfg)
+        self.assertEqual(quant_cfg.exclude_modules, orig_exclude)
+
+    def test_loader_mapper_before_resolver_whole_layer_excluded(self):
+        """Simulate model_loader/loader.py applying hf_to_sglang_mapper before model init.
+
+        When exclude_modules=["model.layers.61.*", "lm_head"], the loader's
+        apply_weight_name_mapper transforms "model.layers.61.*" to "model.decoder.*".
+        The resolver must recognize "model.decoder.*", add coarse FusedMoE prefix
+        "model.decoder.mlp.experts" and NextN spec weights, and exclude all draft layers.
+        """
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.*", "lm_head"],
+        )
+
+        # Step 1: loader applies hf_to_sglang_mapper
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder.*", quant_cfg.exclude_modules)
+
+        # Step 2: model __init__ calls _resolve_nextn_quant_config
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        # Linear attention excluded
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.kv_b_proj"))
+        # FusedMoE coarse prefix excluded
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        # NextN spec weights excluded
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("model.enorm"))
+        self.assertTrue(res.is_layer_excluded("model.hnorm"))
+        self.assertTrue(res.is_layer_excluded("model.shared_head.norm"))
+        # Base model excludes preserved
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_loader_mapper_before_resolver_exact_layer_excluded(self):
+        """When exclude_modules has exact 'model.layers.61', mapper turns it into 'model.decoder'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61", "lm_head"],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder", quant_cfg.exclude_modules)
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+
+    def test_loader_mapper_before_resolver_moe_only_excluded(self):
+        """When exclude_modules=["model.layers.61.mlp.experts.*"], mapper turns it into
+        "model.decoder.mlp.experts.*". Resolver must add coarse "model.decoder.mlp.experts"
+        so FusedMoE is unquantized while attention linear layers remain quantized.
+        """
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.mlp.experts.*"],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder.mlp.experts.*", quant_cfg.exclude_modules)
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.kv_b_proj"))
+        self.assertFalse(res.is_layer_excluded("model.eh_proj"))
+
+    def test_loader_mapper_before_resolver_single_expert_excluded(self):
+        """When exclude_modules=["model.layers.61.mlp.experts.0"], mapper turns it into
+        "model.decoder.mlp.experts.0". Resolver must add coarse "model.decoder.mlp.experts"."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.61.mlp.experts.0"],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder.mlp.experts.0", quant_cfg.exclude_modules)
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_loader_mapper_before_resolver_spec_weights_remapped(self):
+        """When exclude_modules has NextN spec weights, mapper replaces 'model.layers.61' with 'model.decoder'.
+        The resolver must remap 'model.decoder.eh_proj' -> 'model.eh_proj'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=[
+                "model.layers.61.eh_proj",
+                "model.layers.61.enorm",
+                "model.layers.61.hnorm",
+                "model.layers.61.shared_head.norm",
+            ],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        self.assertIn("model.decoder.eh_proj", quant_cfg.exclude_modules)
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("model.enorm"))
+        self.assertTrue(res.is_layer_excluded("model.hnorm"))
+        self.assertTrue(res.is_layer_excluded("model.shared_head.norm"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_loader_mapper_before_resolver_already_mapped_runtime_names(self):
+        """Direct runtime names like 'model.decoder.*' and 'model.decoder.mlp.experts.*'."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.decoder.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_loader_mapper_before_resolver_no_mtp_exclusion_contract(self):
+        """Checkpoint contract for the ambiguous case where no MTP exclusion is present:
+        MTP draft weights are treated as quantized (retaining ModelOpt FP4).
+        Checkpoints with unquantized MTP layers must explicitly declare MTP exclusions.
+        """
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        quant_cfg.apply_weight_name_mapper(
+            DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertEqual(res.get_name(), "modelopt_fp4")
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_quark_quant_config_excluded_returns_none(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quark_cfg = _FakeQuarkConfig(exclude_layers=["model.decoder"])
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+        self.assertIsNone(res)
+
+    def test_quark_quant_config_not_excluded_returns_config(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        quark_cfg = _FakeQuarkConfig(exclude_layers=["model.layers.0"])
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+        self.assertIs(res, quark_cfg)
+
+    def test_unrelated_quant_config_passed_through(self):
+        class _DummyQuantConfig(QuantizationConfig):
+            def get_name(self):
+                return "dummy"
+
+            def get_quant_method(self, layer, prefix=""):
+                return None
+
+            def get_min_capability(self):
+                return 0
+
+            @classmethod
+            def get_config_filenames(cls):
+                return []
+
+            @classmethod
+            def from_config(cls, config):
+                return cls()
+
+            def get_scaled_act_names(self):
+                return []
+
+            def get_supported_act_dtypes(self):
+                return []
+
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=61)
+        dummy_cfg = _DummyQuantConfig()
+
+        res = model._resolve_nextn_quant_config(config, dummy_cfg)
+        self.assertIs(res, dummy_cfg)
+
+    def test_glm_moe_dsa_quark_shared_config_not_mutated(self):
+        model = object.__new__(GlmMoeDsaForCausalLMNextN)
+        config = SimpleNamespace(num_hidden_layers=46)
+        quark_cfg = _FakeQuarkConfig(
+            exclude_layers=["model.layers.46.mlp.experts.0"],
+            layer_quant_config={
+                "model.layers.46.self_attn.q_a_proj": {"scheme": "fp8"}
+            },
+        )
+
+        res = model._resolve_nextn_quant_config(config, quark_cfg)
+
+        self.assertIsNot(res, quark_cfg)
+        self.assertIn("model.decoder.mlp.experts.0", res.exclude_layers)
+        self.assertIn("model.decoder.mlp.experts", res.exclude_layers)
+        self.assertEqual(
+            quark_cfg.exclude_layers,
+            ["model.layers.46.mlp.experts.0"],
+        )
+        self.assertEqual(
+            list(quark_cfg.quant_config["layer_quant_config"].keys()),
+            ["model.layers.46.self_attn.q_a_proj"],
+        )
+        self.assertIn(
+            "model.decoder.self_attn.q_a_proj",
+            res.quant_config["layer_quant_config"],
+        )
+
+
+class TestBailingMoeNextNModelOptQuantResolution(CustomTestCase):
+    def _make_model(self):
+        return object.__new__(BailingMoeForCausalLMNextN)
+
+    def test_modelopt_fp4_not_excluded_returns_config(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertEqual(res.get_name(), "modelopt_fp4")
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_modelopt_fp4_mtp_layer_excluded_remaps(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_modelopt_fp4_mtp_moe_only_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.mlp.experts.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_bailing_single_expert_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.mlp.experts.0"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_bailing_exact_layer_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.final_layernorm"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+
+    def test_bailing_no_broad_prefix_matching(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=3)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.30.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+
+    def test_bailing_nextn_specific_weights_mapping(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=[
+                "model.layers.30.final_layernorm",
+                "model.layers.30.eh_proj",
+                "model.layers.30.enorm",
+                "model.layers.30.hnorm",
+            ],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertIn("model.final_layernorm", res.exclude_modules)
+        self.assertIn("model.eh_proj", res.exclude_modules)
+        self.assertIn("model.enorm", res.exclude_modules)
+        self.assertIn("model.hnorm", res.exclude_modules)
+        self.assertNotIn("model.decoder.final_layernorm", res.exclude_modules)
+
+    def test_bailing_shared_quant_config_not_mutated(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        orig_exclude = ["model.layers.30.self_attn.q_a_proj"]
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=list(orig_exclude),
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNot(res, quant_cfg)
+        self.assertEqual(quant_cfg.exclude_modules, orig_exclude)
+
+    def test_bailing_no_mtp_exclusion_contract(self):
+        """Bailing retains ModelOpt FP4 quant config when no MTP exclusion is present."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=30)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertEqual(res.get_name(), "modelopt_fp4")
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.final_layernorm"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+
+class TestGlmMoeDsaNextNModelOptQuantResolution(CustomTestCase):
+    def _make_model(self):
+        return object.__new__(GlmMoeDsaForCausalLMNextN)
+
+    def test_glm_moe_dsa_modelopt_fp4_not_excluded_retains_quant_config(self):
+        """GLM-5.3-Flash contract: quantized GLM NextN MTP weights retain ModelOpt FP4."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertEqual(res.get_name(), "modelopt_fp4")
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_glm_moe_dsa_modelopt_fp4_mtp_layer_excluded_remaps(self):
+        """When GLM MTP layer 46 is excluded, all draft decoder modules are unquantized."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46.*", "lm_head"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+        self.assertTrue(res.is_layer_excluded("lm_head"))
+
+    def test_glm_moe_dsa_modelopt_fp4_mtp_moe_only_excluded(self):
+        """When only MTP MoE is excluded, FusedMoE is unquantized while attention remains quantized."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46.mlp.experts.*"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_glm_moe_dsa_modelopt_fp4_single_expert_excluded(self):
+        """When single expert is excluded, FusedMoE coarse prefix is added."""
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46.mlp.experts.0"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertFalse(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+
+    def test_glm_moe_dsa_modelopt_fp4_exact_layer_excluded(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.46"],
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.is_layer_excluded("model.decoder.self_attn.q_a_proj"))
+        self.assertTrue(res.is_layer_excluded("model.decoder.mlp.experts"))
+        self.assertTrue(res.is_layer_excluded("model.eh_proj"))
+
+    def test_glm_moe_dsa_modelopt_fp4_shared_quant_config_not_mutated(self):
+        model = self._make_model()
+        config = SimpleNamespace(num_hidden_layers=46)
+        orig_exclude = ["model.layers.46.mlp.experts.0"]
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=list(orig_exclude),
+        )
+
+        res = model._resolve_nextn_quant_config(config, quant_cfg)
+
+        self.assertIsNot(res, quant_cfg)
+        self.assertEqual(quant_cfg.exclude_modules, orig_exclude)
+
+
+class TestNextNModelQuantConfigRetention(CustomTestCase):
+    @patch(
+        "sglang.srt.models.deepseek_nextn.is_mla_prefill_cp_enabled", return_value=False
+    )
+    @patch(
+        "sglang.srt.models.deepseek_nextn.is_dsa_enable_prefill_cp", return_value=False
+    )
+    @patch("sglang.srt.models.deepseek_nextn.VocabParallelEmbedding")
+    @patch("sglang.srt.models.deepseek_nextn.DeepseekV2DecoderLayer")
+    @patch("sglang.srt.models.deepseek_nextn.RMSNorm")
+    @patch("sglang.srt.models.deepseek_nextn.nn.Linear")
+    def test_deepseek_model_nextn_retains_modelopt_fp4_config(
+        self, mock_linear, mock_norm, mock_decoder, mock_embed, mock_dsa_cp, mock_mla_cp
+    ):
+        config = SimpleNamespace(
+            vocab_size=1000,
+            hidden_size=64,
+            rms_norm_eps=1e-6,
+            num_hidden_layers=61,
+        )
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+        )
+
+        with (
+            get_context().override_server_args(
+                enable_dp_attention=False,
+            ),
+            get_parallel().override(
+                tp_size=1,
+                tp_rank=0,
+                attn_tp_size=1,
+                attn_tp_rank=0,
+            ),
+            patch(
+                "sglang.srt.models.deepseek_nextn.enable_nextn_moe_bf16_cast_to_fp8",
+                return_value=False,
+            ),
+        ):
+            model = DeepseekModelNextN(config, quant_config=quant_cfg)
+
+        self.assertIsNotNone(
+            model.quant_config, "DeepseekModelNextN should retain quant_config"
+        )
+        self.assertEqual(model.quant_config.get_name(), "modelopt_fp4")
+        mock_decoder.assert_called_once()
+        _, kwargs = mock_decoder.call_args
+        self.assertEqual(kwargs.get("quant_config"), quant_cfg)
+
+    @patch("sglang.srt.models.bailing_moe_nextn.VocabParallelEmbedding")
+    @patch("sglang.srt.models.bailing_moe_nextn.BailingMoEBlock")
+    @patch("sglang.srt.models.bailing_moe_nextn.RMSNorm")
+    @patch("sglang.srt.models.bailing_moe_nextn.ReplicatedLinear")
+    def test_bailing_moe_model_nextn_retains_modelopt_fp4_config(
+        self, mock_linear, mock_norm, mock_block, mock_embed
+    ):
+        config = SimpleNamespace(
+            vocab_size=1000,
+            hidden_size=64,
+            rms_norm_eps=1e-6,
+            num_hidden_layers=30,
+            model_type="bailing_moe",
+            use_kda=False,
+        )
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+        )
+
+        with (
+            get_context().override_server_args(
+                enable_dp_attention=False,
+            ),
+            get_parallel().override(
+                tp_size=1,
+                tp_rank=0,
+                attn_tp_size=1,
+                attn_tp_rank=0,
+            ),
+        ):
+            _ = BailingMoEModelNextN(config, quant_config=quant_cfg)
+
+        mock_block.assert_called_once()
+        _, kwargs = mock_block.call_args
+        self.assertEqual(kwargs.get("quant_config"), quant_cfg)
+
+
+class TestLegacyGlm4NextNQuantRetention(CustomTestCase):
+    @patch("sglang.srt.models.glm4_moe_nextn.VocabParallelEmbedding")
+    @patch("sglang.srt.models.glm4_moe_nextn.Glm4MoeDecoderLayer")
+    @patch("sglang.srt.models.glm4_moe_nextn.RMSNorm")
+    @patch("sglang.srt.models.glm4_moe_nextn.nn.Linear")
+    def test_glm4_moe_nextn_overrides_modelopt_fp4_to_none(
+        self, mock_linear, mock_norm, mock_decoder, mock_embed
+    ):
+        config = SimpleNamespace(
+            vocab_size=1000,
+            hidden_size=64,
+            rms_norm_eps=1e-6,
+            num_hidden_layers=46,
+        )
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+        )
+        with (
+            get_context().override_server_args(
+                enable_dp_attention=False,
+            ),
+            get_parallel().override(
+                tp_size=1,
+                tp_rank=0,
+                attn_tp_size=1,
+                attn_tp_rank=0,
+            ),
+        ):
+            _ = Glm4MoeModelNextN(config, quant_config=quant_cfg)
+
+        mock_decoder.assert_called_once()
+        _, kwargs = mock_decoder.call_args
+        self.assertIsNone(kwargs.get("quant_config"))
+
+    @patch("sglang.srt.models.glm4_moe_lite_nextn.VocabParallelEmbedding")
+    @patch("sglang.srt.models.glm4_moe_lite_nextn.Glm4MoeLiteDecoderLayer")
+    @patch("sglang.srt.models.glm4_moe_lite_nextn.RMSNorm")
+    @patch("sglang.srt.models.glm4_moe_lite_nextn.nn.Linear")
+    def test_glm4_moe_lite_nextn_overrides_modelopt_fp4_to_none(
+        self, mock_linear, mock_norm, mock_decoder, mock_embed
+    ):
+        config = SimpleNamespace(
+            vocab_size=1000,
+            hidden_size=64,
+            rms_norm_eps=1e-6,
+            num_hidden_layers=46,
+        )
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+        )
+        with (
+            get_context().override_server_args(
+                enable_dp_attention=False,
+            ),
+            get_parallel().override(
+                tp_size=1,
+                tp_rank=0,
+                attn_tp_size=1,
+                attn_tp_rank=0,
+            ),
+        ):
+            _ = Glm4MoeLiteModelNextN(config, quant_config=quant_cfg)
+
+        mock_decoder.assert_called_once()
+        _, kwargs = mock_decoder.call_args
+        self.assertIsNone(kwargs.get("quant_config"))
+
+    @patch("sglang.srt.models.glm_ocr_nextn.VocabParallelEmbedding")
+    @patch("sglang.srt.models.glm_ocr_nextn.Glm4DecoderLayer")
+    @patch("sglang.srt.models.glm_ocr_nextn.RMSNorm")
+    @patch("sglang.srt.models.glm_ocr_nextn.nn.Linear")
+    def test_glm_ocr_nextn_overrides_modelopt_fp4_to_none(
+        self, mock_linear, mock_norm, mock_decoder, mock_embed
+    ):
+        config = SimpleNamespace(
+            vocab_size=1000,
+            hidden_size=64,
+            rms_norm_eps=1e-6,
+            num_hidden_layers=46,
+        )
+        quant_cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+        )
+        with (
+            get_context().override_server_args(
+                enable_dp_attention=False,
+            ),
+            get_parallel().override(
+                tp_size=1,
+                tp_rank=0,
+                attn_tp_size=1,
+                attn_tp_rank=0,
+            ),
+        ):
+            _ = GlmOcrModelNextN(config, quant_config=quant_cfg)
+
+        mock_decoder.assert_called_once()
+        _, kwargs = mock_decoder.call_args
+        self.assertIsNone(kwargs.get("quant_config"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #36599 and addresses the draft-load failure described in #36653. `DeepseekModelNextN` and `BailingMoEModelNextN` currently force `modelopt_fp4` quantization to `None`. That makes quantized GLM-5.3-Flash NextN/MTP weights load into BF16 modules and fail with a packed-versus-unpacked shape mismatch.

## Modifications

- Remove the blanket `modelopt_fp4` to `None` override from the DeepSeek and Bailing NextN paths while preserving the legacy GLM-4.x and GLM-OCR overrides.
- Resolve ModelOpt FP4 MTP exclusions after loader name mapping, including raw and already-remapped wildcard/exact forms, the canonical legacy layer-0 layout, coarse FusedMoE prefixes, and Bailing hybrid runtime prefixes.
- Retain ModelOpt FP4 for checkpoints with quantized MTP weights and exclude only explicitly unquantized MTP modules. This is the supported checkpoint contract.
- Copy quantization configs before changing per-layer exclusions and normalize optional packed-module mappings.
- Add coverage for mapper-before-resolver ordering, production wildcard spelling, exact parent-module matching, ModelOpt consumer behavior, Bailing hybrid prefixes, legacy layer-0 layouts, and configuration immutability.

## Accuracy Tests

```text
CUDA_HOME=/usr PYTHONPATH=python:. uv run --with-editable ./python/ --with pytest pytest test/registered/unit/models/test_nextn_modelopt_quant.py test/registered/unit/layers/quantization/test_modelopt_nvfp4.py test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py -v
```

Result: `75 passed, 15 warnings, 30 subtests passed in 13.77s`.

The unit coverage exercises loader mapper ordering and the downstream ModelOpt `get_quant_method` decisions. No full ModelOpt FP4 checkpoint load, speculative-decoding run, or model-output accuracy run was performed locally.

## Speed Tests and Profiling

This changes NextN module construction and checkpoint weight-loading precision selection; it does not add a kernel benchmark. No throughput benchmark or profiler run was performed.

## Relationship to Other Work

- #34906 derives the NextN rename mapper from checkpoint metadata and removes the static mapper used by this branch. If #34906 lands first, rebase and switch the Quark path to its mapper API.
- #30565 changes the same NextN resolver regions and overlaps on copy-before-mutate behavior. Rebase and resolve the overlap after either change lands.
- #36761 changes ModelOpt exclusion matching in the quantization layer. Coordinate its matcher semantics with this model-level mapping.
- #36596, #36597, and #36598 are related GLM-5.3 bring-up issues but are not implemented by this PR.
- Full GLM-5.3-Flash NVFP4 NextN validation also depends on the vision/model support in #36507.

The branch starts from an older `main` ancestor (`88cf5c9541`); the intervening upstream commits do not touch this PR's changed paths. The branch should be rebased after the overlapping PRs above land.

## Checklist

- [x] Format code according to the pre-commit format guidance.
- [x] Add unit tests according to the unit-test guidance.
- [ ] Update documentation according to the documentation guidance; no user-facing documentation change is needed for this internal loader behavior.
- [ ] Provide full checkpoint accuracy and speed benchmark results; no full checkpoint or benchmark run was performed locally.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33458470679](https://github.com/sgl-project/sglang/actions/runs/33458470679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33458470537](https://github.com/sgl-project/sglang/actions/runs/33458470537)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33458470657](https://github.com/sgl-project/sglang/actions/runs/33458470657)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->