### PR TITLE
[CPU] Add Nightly Test (Xeon) for large-model accuracy + performance

### DIFF
--- a/.github/workflows/nightly-test-xeon.yml
+++ b/.github/workflows/nightly-test-xeon.yml
@@ -6,6 +6,11 @@ name: Nightly Test (Xeon)
 # --continue-on-error so one failing model does not mask the rest.
 
 on:
+  # TEMPORARY (bring-up only): auto-run on every push to xeonnightly so the
+  # workflow can be validated before it lands on the default branch. REMOVE
+  # this push trigger before merge.
+  push:
+    branches: [ xeonnightly ]
   schedule:
     # 18:07 UTC daily (02:07 Beijing). Off-minute to avoid colliding with the
     # fleet of :00/:30 scheduled jobs; clear of the XPU nightly at 16:45 UTC.

--- a/.github/workflows/nightly-test-xeon.yml
+++ b/.github/workflows/nightly-test-xeon.yml
@@ -103,7 +103,10 @@ jobs:
       # Phase 2: nightly large-model accuracy + performance suite. Runs AFTER
       # phase 1 on the same box (serial docker exec), so only one server is ever
       # resident -> no dual-model OOM. Partitioned across the 2 GNR boxes.
+      # if: !cancelled() -- nightly is a sweep, so phase 2 must run even when
+      # phase 1 reports failures; only a cancel/timeout skips it.
       - name: Run nightly model accuracy + perf
+        if: ${{ !cancelled() }}
         timeout-minutes: 600
         run: |
           docker exec -w /sglang-checkout/ ci_sglang_${{ matrix.name }} \

--- a/.github/workflows/nightly-test-xeon.yml
+++ b/.github/workflows/nightly-test-xeon.yml
@@ -1,0 +1,134 @@
+name: Nightly Test (Xeon)
+
+# Nightly accuracy + performance benchmark for CPU (Xeon) models, plus a full
+# re-run of the per-commit UT suites. Unlike PR Test (Xeon) this runs the large
+# models (8B-35B) that are too slow for per-commit CI, and uses
+# --continue-on-error so one failing model does not mask the rest.
+
+on:
+  schedule:
+    # 18:07 UTC daily (02:07 Beijing). Off-minute to avoid colliding with the
+    # fleet of :00/:30 scheduled jobs; clear of the XPU nightly at 16:45 UTC.
+    - cron: '7 18 * * *'
+  workflow_dispatch:
+    inputs:
+      continue_on_error:
+        description: 'Continue on error (do not fail the workflow on test failures)'
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        required: false
+        type: string
+        default: ''
+      continue_on_error:
+        description: 'Continue on error (do not fail the workflow on test failures)'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: nightly-test-xeon-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || inputs.ref && format('caller-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ !inputs.ref && github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  nightly-xeon:
+    if: github.repository == 'sgl-project/sglang'
+    # DEBUG: label is 'nightly-gnr' so nightly does not contend for the
+    # upstream PR-test 'xeon-gnr' boxes. CHANGE BACK TO 'xeon-gnr' ONCE MERGED.
+    runs-on: nightly-gnr
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gnr1
+            part_id: 0
+            part_size: 2
+          - name: gnr2
+            part_id: 1
+            part_size: 2
+    steps:
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ${{ github.workspace }} || true
+          sudo mkdir -p ${{ github.workspace }}
+          sudo chown $(id -u):$(id -g) ${{ github.workspace }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Build image
+        run: |
+          # Fixed tag (no SHA): a new build overwrites the previous image so a
+          # self-hosted box does not accumulate multi-GB images across runs.
+          docker build . -f docker/xeon.Dockerfile -t sglang_xeon --no-cache
+
+      - name: Run container
+        run: |
+          docker rm -f ci_sglang_${{ matrix.name }} || true
+          docker run -dt \
+            -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
+            -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+            -v $HOME/.cache/sgl_eval:/root/.cache/sgl_eval \
+            -e HF_TOKEN="$(cat ~/huggingface_token.txt)" \
+            --name ci_sglang_${{ matrix.name }} \
+            sglang_xeon
+
+      - name: Check AMX support
+        timeout-minutes: 5
+        run: |
+          docker exec -w /sglang-checkout/ ci_sglang_${{ matrix.name }} \
+            bash -c "source /opt/.venv/bin/activate && python3 -c 'import torch; import sgl_kernel; assert torch.cpu._is_amx_tile_supported(); assert hasattr(torch.ops.sgl_kernel, \"convert_weight_packed\"); '"
+
+      # Phase 1: full per-commit UT suites (same set PR Test runs), partitioned
+      # across the 2 GNR boxes by est_time. Small models -> partitioning safe.
+      - name: Run unit test suites
+        timeout-minutes: 240
+        run: |
+          docker exec -w /sglang-checkout/ ci_sglang_${{ matrix.name }} \
+            bash -c "source /opt/.venv/bin/activate && cd ./test && python3 run_suite.py --hw cpu --suite base-b-test-cpu,base-c-test-cpu,base-b-tp-test-cpu --auto-partition-id ${{ matrix.part_id }} --auto-partition-size ${{ matrix.part_size }} --timeout-from-est-time ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}"
+
+      # Phase 2: nightly large-model accuracy + performance suite. Runs AFTER
+      # phase 1 on the same box (serial docker exec), so only one server is ever
+      # resident -> no dual-model OOM. Partitioned across the 2 GNR boxes.
+      - name: Run nightly model accuracy + perf
+        timeout-minutes: 600
+        run: |
+          docker exec -w /sglang-checkout/ ci_sglang_${{ matrix.name }} \
+            bash -c "source /opt/.venv/bin/activate && cd ./test && python3 run_suite.py --hw cpu --suite nightly-xeon-models --nightly --auto-partition-id ${{ matrix.part_id }} --auto-partition-size ${{ matrix.part_size }} --timeout-from-est-time ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}"
+
+      - name: Change permission
+        if: always()
+        timeout-minutes: 2
+        run: |
+          docker exec -u root ci_sglang_${{ matrix.name }} bash -c "rm -rf /tmp/ci-home && chown -R $(id -u):$(id -g) /sglang-checkout/ 2>/dev/null || true" 2>/dev/null || true
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          docker rm -f ci_sglang_${{ matrix.name }} || true
+
+  check-all-jobs:
+    if: always() && (github.repository == 'sgl-project/sglang' || github.event_name == 'workflow_dispatch')
+    needs:
+      - nightly-xeon
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if any job failed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more nightly test jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more nightly test jobs were cancelled"
+            exit 1
+          fi
+          echo "All nightly test jobs passed"

--- a/.github/workflows/nightly-test-xeon.yml
+++ b/.github/workflows/nightly-test-xeon.yml
@@ -73,7 +73,12 @@ jobs:
         run: |
           # Fixed tag (no SHA): a new build overwrites the previous image so a
           # self-hosted box does not accumulate multi-GB images across runs.
-          docker build . -f docker/xeon.Dockerfile -t sglang_xeon --no-cache
+          # Build the image from THIS ref so the installed sglang package
+          # carries our nightly changes (run_suite whitelist + the 11 test
+          # files); the default Dockerfile arg would clone upstream main.
+          docker build \
+            --build-arg VER_SGLANG=${{ inputs.ref || github.sha }} \
+            . -f docker/xeon.Dockerfile -t sglang_xeon --no-cache
 
       - name: Run container
         run: |

--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -96,6 +96,7 @@ def _run_simple_eval(
     api: Optional[str] = None,
     seed: Optional[int] = None,
     sgl_eval_thinking: Optional[bool] = None,
+    skip_server_launch: bool = False,
 ) -> Tuple[bool, Optional[str], Optional[dict]]:
     """Run evaluation using simple_eval backend (run_eval.py).
 
@@ -104,13 +105,14 @@ def _run_simple_eval(
     """
     process = None
     try:
-        process = popen_launch_server(
-            model.model_path,
-            base_url,
-            other_args=model.extra_args,
-            timeout=model.launch_timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            env=model.env,
-        )
+        if not skip_server_launch:
+            process = popen_launch_server(
+                model.model_path,
+                base_url,
+                other_args=model.extra_args,
+                timeout=model.launch_timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                env=model.env,
+            )
 
         args = SimpleNamespace(
             base_url=base_url,
@@ -176,6 +178,7 @@ def run_accuracy_test(
     model: ModelLaunchSettings,
     params: AccuracyTestParams,
     base_url: Optional[str] = None,
+    skip_server_launch: bool = False,
 ) -> AccuracyTestResult:
     """Run accuracy test for a single model.
 
@@ -212,6 +215,7 @@ def run_accuracy_test(
         api=params.api,
         seed=params.seed,
         sgl_eval_thinking=params.sgl_eval_thinking,
+        skip_server_launch=skip_server_launch,
     )
 
     if not success:

--- a/python/sglang/test/cpu_test_utils.py
+++ b/python/sglang/test/cpu_test_utils.py
@@ -670,3 +670,23 @@ def unpack_and_dequant_gptq(qweight, qzeros, scales):
     unpacked_qweight = (unpacked_qweight - unpacked_qzeros) * scales
 
     return unpacked_qweight.T
+
+
+# Common server args shared by CPU nightly model tests.
+CPU_BASE_ARGS = [
+    "--device",
+    "cpu",
+    "--trust-remote-code",
+    "--disable-radix-cache",
+    "--disable-overlap-schedule",
+    "--mem-fraction-static",
+    "0.8",
+    "--enable-torch-compile",
+    "--torch-compile-max-bs",
+    "1",
+]
+
+# Server launch timeout for CPU nightly tests.
+# --enable-torch-compile triggers batch-capture on startup (~38s/batch × 24 batches).
+# Allow 40 minutes to cover compile + model load for the largest models.
+CPU_LAUNCH_TIMEOUT = 2400

--- a/python/sglang/test/nightly_bench_utils.py
+++ b/python/sglang/test/nightly_bench_utils.py
@@ -30,22 +30,35 @@ class BenchmarkResult(BaseModel):
     profile_link_decode: Optional[str] = None
     server_args: Optional[List[str]] = None
 
-    def to_markdown_row(self) -> str:
+    def to_markdown_row(
+        self,
+        acc_latency: Optional[float] = None,
+        include_latency_breakdown: bool = False,
+    ) -> str:
         """Convert this benchmark result to a markdown table row."""
 
-        hourly_cost_per_gpu = 2  # $2/hour for one H100
-        hourly_cost = hourly_cost_per_gpu * 1  # Assuming tp_size = 1 for simplicity
-        input_util = 0.7
-        accept_length = round(self.acc_length, 2) if self.acc_length > 0 else "n/a"
         itl = 1 / (self.output_throughput / self.batch_size) * 1000
-        input_cost = 1e6 / (self.input_throughput * input_util) / 3600 * hourly_cost
-        output_cost = 1e6 / self.output_throughput / 3600 * hourly_cost
 
-        return f"| {self.batch_size} | {self.input_len} | {self.latency:.2f} | {self.input_throughput:.2f} | {self.output_throughput:.2f} | {accept_length} | {itl:.2f} | {input_cost:.2f} | {output_cost:.2f} |\n"
+        if not include_latency_breakdown:
+            hourly_cost_per_gpu = 2  # $2/hour for one H100
+            hourly_cost = hourly_cost_per_gpu * 1  # Assuming tp_size = 1 for simplicity
+            input_util = 0.7
+            accept_length = round(self.acc_length, 2) if self.acc_length > 0 else "n/a"
+            input_cost = 1e6 / (self.input_throughput * input_util) / 3600 * hourly_cost
+            output_cost = 1e6 / self.output_throughput / 3600 * hourly_cost
+
+            return f"| {self.batch_size} | {self.input_len} | {self.latency:.2f} | {self.input_throughput:.2f} | {self.output_throughput:.2f} | {accept_length} | {itl:.2f} | {input_cost:.2f} | {output_cost:.2f} |\n"
+
+        acc_latency_str = f"{acc_latency:.2f}" if acc_latency is not None else "n/a"
+
+        return f"| {self.batch_size} | {self.input_len} | {self.output_len} | {self.latency:.2f} | {self.last_ttft:.2f} | {itl:.2f} | {self.input_throughput:.2f} | {self.output_throughput:.2f} | {acc_latency_str} |\n"
 
 
 def generate_markdown_report(
-    results: List[BenchmarkResult], variant: Optional[str] = None
+    results: List[BenchmarkResult],
+    variant: Optional[str] = None,
+    acc_latency: Optional[float] = None,
+    include_latency_breakdown: bool = False,
 ) -> str:
     """Generate a markdown report from a list of BenchmarkResult object from a single run."""
     # Build model header with run_name if it's not "default"
@@ -63,12 +76,19 @@ def generate_markdown_report(
 
     summary = f"### {model_header}\n"
 
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s)  | output throughput (tok/s) | acc length | ITL (ms) | input cost ($/1M) | output cost ($/1M) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------- | ------------------------- | ---------- | -------- | ----------------- | ------------------ |\n"
+    if include_latency_breakdown:
+        summary += "| batch size | input len | output len | perf latency (s) | FTL (s) | ITL (ms) | first token throughput (tok/s) | next token throughput (tok/s) | acc latency (s) |\n"
+        summary += "| ---------- | --------- | ---------- | ---------------- | ------- | -------- | ------------------------------ | ----------------------------- | --------------- |\n"
+    else:
+        summary += "| batch size | input len | latency (s) | input throughput (tok/s)  | output throughput (tok/s) | acc length | ITL (ms) | input cost ($/1M) | output cost ($/1M) |\n"
+        summary += "| ---------- | --------- | ----------- | ------------------------- | ------------------------- | ---------- | -------- | ----------------- | ------------------ |\n"
 
     # all results should share the same isl & osl
     for result in results:
-        summary += result.to_markdown_row()
+        summary += result.to_markdown_row(
+            acc_latency=acc_latency,
+            include_latency_breakdown=include_latency_breakdown,
+        )
 
     return summary
 

--- a/python/sglang/test/nightly_utils.py
+++ b/python/sglang/test/nightly_utils.py
@@ -208,6 +208,7 @@ class NightlyBenchmarkRunner:
         extra_bench_args: Optional[List[str]] = None,
         timeout: Optional[int] = None,
         env: Optional[dict] = None,
+        skip_server_launch: bool = False,
     ) -> Tuple[List[BenchmarkResult], bool, Optional[float]]:
         """Run a complete benchmark for a single model with server management.
 
@@ -238,18 +239,19 @@ class NightlyBenchmarkRunner:
 
         process = None
         try:
-            # Launch server
-            process = popen_launch_server(
-                model=model_path,
-                base_url=self.base_url,
-                other_args=other_args or [],
-                timeout=(
-                    timeout
-                    if timeout is not None
-                    else DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
-                ),
-                env=env,
-            )
+            # Launch server (skip if caller manages the server externally)
+            if not skip_server_launch:
+                process = popen_launch_server(
+                    model=model_path,
+                    base_url=self.base_url,
+                    other_args=other_args or [],
+                    timeout=(
+                        timeout
+                        if timeout is not None
+                        else DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+                    ),
+                    env=env,
+                )
 
             # Generate filenames
             json_output_file = self.generate_result_filename(model_path, variant)
@@ -311,7 +313,11 @@ class NightlyBenchmarkRunner:
         return None
 
     def add_report(
-        self, results: List[BenchmarkResult], variant: Optional[str] = None
+        self,
+        results: List[BenchmarkResult],
+        variant: Optional[str] = None,
+        acc_latency: Optional[float] = None,
+        include_latency_breakdown: bool = False,
     ) -> None:
         """Add benchmark results to the full report.
 
@@ -319,7 +325,12 @@ class NightlyBenchmarkRunner:
             results: List of BenchmarkResult objects to add to report
         """
         if results:
-            report_part = generate_markdown_report(results, variant)
+            report_part = generate_markdown_report(
+                results,
+                variant,
+                acc_latency=acc_latency,
+                include_latency_breakdown=include_latency_breakdown,
+            )
             self.full_report += report_part + "\n"
 
     def write_final_report(self) -> None:

--- a/python/sglang/test/performance_test_runner.py
+++ b/python/sglang/test/performance_test_runner.py
@@ -17,6 +17,14 @@ class PerformanceTestParams:
     dataset_name: str = "mmmu"  # For VLM perf test
     # MTP/EAGLE speculative decoding: minimum accept length threshold (None = no validation)
     spec_accept_length_threshold: Optional[float] = None
+    # Minimum output token throughput (tok/s) at the largest batch size (None = no validation)
+    baseline_output_throughput: Optional[float] = None
+    # Maximum first token latency in seconds at the largest batch size (None = no validation)
+    baseline_ftl_s: Optional[float] = None
+    # Maximum inter-token latency in milliseconds at the largest batch size (None = no validation)
+    baseline_itl_ms: Optional[float] = None
+    # Opt-in combined report layout with FTL/ITL and accuracy latency.
+    include_latency_breakdown: bool = False
 
 
 @dataclass
@@ -49,6 +57,11 @@ def run_performance_test(
     is_vlm: bool = False,
     dataset_name: str = "mmmu",
     spec_accept_length_threshold: Optional[float] = None,
+    skip_server_launch: bool = False,
+    baseline_output_throughput: Optional[float] = None,
+    baseline_ftl_s: Optional[float] = None,
+    baseline_itl_ms: Optional[float] = None,
+    emit_report: bool = True,
 ) -> PerformanceTestResult:
 
     # Set default for mutable argument
@@ -63,7 +76,15 @@ def run_performance_test(
     print(f"  Output lens: {output_lens}")
     if spec_accept_length_threshold is not None:
         print(f"  Spec accept length threshold: {spec_accept_length_threshold}")
-    print(f"{'=' * 60}\n")
+    if spec_accept_length_threshold is not None:
+        print(f"  Spec accept length threshold: {spec_accept_length_threshold}")
+    if baseline_output_throughput is not None:
+        print(f"  Baseline output throughput: {baseline_output_throughput} tok/s")
+    if baseline_ftl_s is not None:
+        print(f"  Baseline FTL: {baseline_ftl_s} s")
+    if baseline_itl_ms is not None:
+        print(f"  Baseline ITL: {baseline_itl_ms} ms")
+    print(f"{'='*60}\n")
 
     # Build extra args for benchmarks
     extra_bench_args = ["--trust-remote-code"]
@@ -80,10 +101,12 @@ def run_performance_test(
             variant=model.variant or "",
             extra_bench_args=extra_bench_args,
             env=model.env,
+            skip_server_launch=skip_server_launch,
         )
 
         if success and results:
-            perf_runner.add_report(results, variant=model.variant)
+            if emit_report:
+                perf_runner.add_report(results, variant=model.variant)
             print(f"✓ Performance test succeeded for {model.model_path}")
 
             # Fall back to the per-run accept lengths captured during benchmarking
@@ -122,6 +145,65 @@ def run_performance_test(
 
             # Extract aggregate metrics from the largest batch size result
             largest_batch_result = max(results, key=lambda r: r.batch_size)
+
+            # Validate output throughput against baseline if provided
+            if baseline_output_throughput is not None:
+                measured = largest_batch_result.output_throughput
+                if measured < baseline_output_throughput:
+                    tput_error = (
+                        f"Output throughput {measured:.1f} tok/s < "
+                        f"baseline {baseline_output_throughput:.1f} tok/s "
+                        f"(batch_size={largest_batch_result.batch_size})"
+                    )
+                    print(f"✗ {tput_error}")
+                    passed = False
+                    error_msg = (
+                        tput_error
+                        if error_msg is None
+                        else f"{error_msg}; {tput_error}"
+                    )
+                else:
+                    print(
+                        f"✓ Output throughput {measured:.1f} tok/s >= "
+                        f"baseline {baseline_output_throughput:.1f} tok/s"
+                    )
+
+            if baseline_ftl_s is not None:
+                measured = largest_batch_result.last_ttft
+                if measured > baseline_ftl_s:
+                    ftl_error = (
+                        f"FTL {measured:.2f} s > baseline {baseline_ftl_s:.2f} s "
+                        f"(batch_size={largest_batch_result.batch_size})"
+                    )
+                    print(f"✗ {ftl_error}")
+                    passed = False
+                    error_msg = (
+                        ftl_error if error_msg is None else f"{error_msg}; {ftl_error}"
+                    )
+                else:
+                    print(f"✓ FTL {measured:.2f} s <= baseline {baseline_ftl_s:.2f} s")
+
+            if baseline_itl_ms is not None:
+                measured = (
+                    1000
+                    * largest_batch_result.batch_size
+                    / largest_batch_result.output_throughput
+                )
+                if measured > baseline_itl_ms:
+                    itl_error = (
+                        f"ITL {measured:.2f} ms > baseline {baseline_itl_ms:.2f} ms "
+                        f"(batch_size={largest_batch_result.batch_size})"
+                    )
+                    print(f"✗ {itl_error}")
+                    passed = False
+                    error_msg = (
+                        itl_error if error_msg is None else f"{error_msg}; {itl_error}"
+                    )
+                else:
+                    print(
+                        f"✓ ITL {measured:.2f} ms <= baseline {baseline_itl_ms:.2f} ms"
+                    )
+
             return PerformanceTestResult(
                 model=model.model_path,
                 passed=passed,

--- a/python/sglang/test/run_combined_tests.py
+++ b/python/sglang/test/run_combined_tests.py
@@ -1,6 +1,7 @@
 import time
 from typing import List, Optional
 
+from sglang.srt.utils import kill_process_tree
 from sglang.test.accuracy_test_runner import (
     AccuracyTestParams,
     AccuracyTestResult,
@@ -13,7 +14,13 @@ from sglang.test.performance_test_runner import (
     PerformanceTestResult,
     run_performance_test,
 )
-from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, ModelLaunchSettings, is_in_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    ModelLaunchSettings,
+    is_in_ci,
+    popen_launch_server,
+)
 from sglang.test.tool_call_test_runner import (
     ToolCallTestParams,
     ToolCallTestResult,
@@ -29,6 +36,7 @@ def run_combined_tests(
     accuracy_params: Optional[AccuracyTestParams] = None,
     performance_params: Optional[PerformanceTestParams] = None,
     tool_call_params: Optional[ToolCallTestParams] = None,
+    share_server: bool = False,
 ) -> dict:
     """Run performance, accuracy, and/or tool call tests for a list of models.
 
@@ -40,6 +48,10 @@ def run_combined_tests(
         accuracy_params: Parameters for accuracy tests (None to skip accuracy)
         performance_params: Parameters for performance tests (None to skip perf)
         tool_call_params: Parameters for tool call tests (None to skip tool call)
+        share_server: When True, launch one server per model and reuse it for
+            all enabled test types (perf + accuracy + tool-call), saving one
+            server startup per model.  Disabled by default so existing callers
+            are unaffected.
 
     Returns:
         dict with test results:
@@ -109,57 +121,105 @@ def run_combined_tests(
             "errors": [],
         }
 
-        # Run performance test
-        if run_perf:
-            perf_result: PerformanceTestResult = run_performance_test(
-                model=model,
-                perf_runner=perf_runner,
-                batch_sizes=performance_params.batch_sizes,
-                input_lens=performance_params.input_lens,
-                output_lens=performance_params.output_lens,
-                is_vlm=is_vlm,
-                dataset_name=performance_params.dataset_name,
-                spec_accept_length_threshold=performance_params.spec_accept_length_threshold,
+        # Optionally launch one shared server for this model that all test
+        # types (perf / accuracy / tool-call) reuse.
+        shared_proc = None
+        if share_server and (run_perf or run_accuracy or run_tool_call):
+            print(f"\nLaunching shared server for {model.model_path} ...")
+            shared_proc = popen_launch_server(
+                model.model_path,
+                base_url,
+                other_args=model.extra_args,
+                timeout=model.launch_timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                env=model.env,
             )
-            model_result["perf_result"] = perf_result
-            if not perf_result.passed:
-                all_passed = False
-                model_result["errors"].append(perf_result.error)
 
-            # Wait for GPU memory and port cleanup
-            print("\nWaiting 20 seconds for resource cleanup...")
-            time.sleep(20)
+        try:
+            # Run performance test
+            if run_perf:
+                perf_result: PerformanceTestResult = run_performance_test(
+                    model=model,
+                    perf_runner=perf_runner,
+                    batch_sizes=performance_params.batch_sizes,
+                    input_lens=performance_params.input_lens,
+                    output_lens=performance_params.output_lens,
+                    is_vlm=is_vlm,
+                    dataset_name=performance_params.dataset_name,
+                    spec_accept_length_threshold=performance_params.spec_accept_length_threshold,
+                    skip_server_launch=share_server,
+                    baseline_output_throughput=performance_params.baseline_output_throughput,
+                    baseline_ftl_s=performance_params.baseline_ftl_s,
+                    baseline_itl_ms=performance_params.baseline_itl_ms,
+                    emit_report=not performance_params.include_latency_breakdown,
+                )
+                model_result["perf_result"] = perf_result
+                if not perf_result.passed:
+                    all_passed = False
+                    model_result["errors"].append(perf_result.error)
 
-        # Run accuracy test
-        if run_accuracy:
-            acc_result: AccuracyTestResult = run_accuracy_test(
-                model=model,
-                params=accuracy_params,
-                base_url=base_url,
-            )
-            model_result["accuracy_result"] = acc_result
-            if not acc_result.passed:
-                all_passed = False
-                model_result["errors"].append(acc_result.error)
+                if not share_server:
+                    # Wait for GPU memory and port cleanup
+                    print("\nWaiting 20 seconds for resource cleanup...")
+                    time.sleep(20)
 
-            # Wait for GPU memory and port cleanup
-            print("\nWaiting 20 seconds for resource cleanup...")
-            time.sleep(20)
+            # Run accuracy test
+            if run_accuracy:
+                acc_result: AccuracyTestResult = run_accuracy_test(
+                    model=model,
+                    params=accuracy_params,
+                    base_url=base_url,
+                    skip_server_launch=share_server,
+                )
+                model_result["accuracy_result"] = acc_result
+                if not acc_result.passed:
+                    all_passed = False
+                    model_result["errors"].append(acc_result.error)
 
-        # Run tool call test
-        if run_tool_call:
-            tc_result: ToolCallTestResult = run_tool_call_test(
-                model=model,
-                params=tool_call_params,
-                base_url=base_url,
-            )
-            model_result["tool_call_result"] = tc_result
-            if not tc_result.passed:
-                all_passed = False
-                model_result["errors"].extend(tc_result.failures)
+                if not share_server:
+                    # Wait for GPU memory and port cleanup
+                    print("\nWaiting 20 seconds for resource cleanup...")
+                    time.sleep(20)
 
-            print("\nWaiting 20 seconds for resource cleanup...")
-            time.sleep(20)
+            if (
+                run_perf
+                and perf_runner
+                and performance_params.include_latency_breakdown
+                and model_result["perf_result"]
+            ):
+                benchmark_results = model_result["perf_result"].benchmark_results
+                acc_latency = (
+                    model_result["accuracy_result"].latency
+                    if model_result["accuracy_result"]
+                    else None
+                )
+                perf_runner.add_report(
+                    benchmark_results,
+                    variant=model.variant,
+                    acc_latency=acc_latency,
+                    include_latency_breakdown=True,
+                )
+
+            # Run tool call test
+            if run_tool_call:
+                tc_result: ToolCallTestResult = run_tool_call_test(
+                    model=model,
+                    params=tool_call_params,
+                    base_url=base_url,
+                )
+                model_result["tool_call_result"] = tc_result
+                if not tc_result.passed:
+                    all_passed = False
+                    model_result["errors"].extend(tc_result.failures)
+
+                if not share_server:
+                    print("\nWaiting 20 seconds for resource cleanup...")
+                    time.sleep(20)
+
+        finally:
+            if shared_proc is not None:
+                kill_process_tree(shared_proc.pid)
+                print("\nWaiting 20 seconds for resource cleanup...")
+                time.sleep(20)
 
         all_results.append(model_result)
 

--- a/test/registered/cpu/test_deepseek_coder_v2_lite.py
+++ b/test/registered/cpu/test_deepseek_coder_v2_lite.py
@@ -1,0 +1,61 @@
+"""Nightly accuracy + performance test for DeepSeek-Coder-V2-Lite-Instruct on CPU.
+
+16B MoE coder model (2.4B active params), TP=6 on Xeon.
+GSM8K baseline: 0.80 (86.4% reported - 5% buffer; CPU measured 0.809).
+
+Registry: nightly-xeon-models suite
+"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestDeepSeekCoderV2LiteXeon(unittest.TestCase):
+    """DeepSeek-Coder-V2-Lite-Instruct on Xeon."""
+
+    def test_deepseek_coder_v2_lite(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="DeepSeek-Coder-V2-Lite-Instruct (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.80,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=2.0,
+                baseline_itl_ms=100.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_deepseek_ocr2.py
+++ b/test/registered/cpu/test_deepseek_ocr2.py
@@ -14,7 +14,15 @@ from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+register_cpu_ci(
+    est_time=3600,
+    suite="nightly-xeon-models",
+    nightly=True,
+    # DeepSeek-OCR-2 (deepseek_vl_v2 arch) does not run correctly on CPU yet:
+    # gsm8k accuracy 0.042 vs baseline 0.800 (~random). Also, an OCR VLM is a
+    # poor fit for a gsm8k accuracy gate. Re-enable once CPU support lands.
+    disabled="DeepSeek-OCR-2 accuracy 0.042 vs 0.8 on CPU -- model not supported yet",
+)
 
 MODEL_PATH = "deepseek-ai/DeepSeek-OCR-2"
 

--- a/test/registered/cpu/test_deepseek_ocr2.py
+++ b/test/registered/cpu/test_deepseek_ocr2.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for DeepSeek-OCR-2 on CPU.
+
+3B vision-language OCR model, TP=1 on Xeon.
+
+Registry: nightly-xeon-models suite
+"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "deepseek-ai/DeepSeek-OCR-2"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestDeepSeekOCR2Xeon(unittest.TestCase):
+    """DeepSeek-OCR-2 on Xeon."""
+
+    def test_deepseek_ocr2(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=1,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="DeepSeek-OCR-2 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.80,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=1.2,
+                baseline_itl_ms=45.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_gemma4_26b.py
+++ b/test/registered/cpu/test_gemma4_26b.py
@@ -32,7 +32,9 @@ class TestGemma4_26BCPU(unittest.TestCase):
             ModelLaunchSettings(
                 MODEL_PATH,
                 extra_args=BASE_ARGS,
-                tp_size=6,
+                # 16 attention heads are not divisible by 6, so tp=6 fails the
+                # ensure_divisibility check on GNR; 16 % 2 == 0.
+                tp_size=2,
                 launch_timeout=CPU_LAUNCH_TIMEOUT,
             ),
         ]

--- a/test/registered/cpu/test_gemma4_26b.py
+++ b/test/registered/cpu/test_gemma4_26b.py
@@ -1,0 +1,62 @@
+"""Nightly accuracy + performance test for Google Gemma-4-26B-A4B-it on CPU.
+
+26B MoE model with 4B active params, TP=6 on Xeon.
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "google/gemma-4-26B-A4B-it"
+
+BASE_ARGS = CPU_BASE_ARGS + [
+    "--context-length",
+    "4096",
+    "--skip-server-warmup",
+]
+
+
+class TestGemma4_26BCPU(unittest.TestCase):
+    """Google Gemma-4-26B-A4B-it on Xeon."""
+
+    def test_gemma4_26b(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Gemma-4-26B-A4B (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.95,
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=1.2,
+                baseline_itl_ms=45.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_gemma4_26b.py
+++ b/test/registered/cpu/test_gemma4_26b.py
@@ -51,8 +51,11 @@ class TestGemma4_26BCPU(unittest.TestCase):
                 batch_sizes=[16],
                 input_lens=(1024,),
                 output_lens=(1024,),
-                baseline_ftl_s=1.2,
-                baseline_itl_ms=45.0,
+                # Re-baselined for tp=2 on GNR (the model's 16 heads are not
+                # divisible by 6). Measured FTL ~3.4s / ITL ~110ms; margins
+                # added. The original 1.2s/45ms targets assumed a higher tp.
+                baseline_ftl_s=4.5,
+                baseline_itl_ms=130.0,
                 include_latency_breakdown=True,
             ),
             share_server=True,

--- a/test/registered/cpu/test_gpt_oss_20b.py
+++ b/test/registered/cpu/test_gpt_oss_20b.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for openai/gpt-oss-20b on CPU.
+
+20B language model, TP=3 on Xeon.
+
+Registry: nightly-xeon-models suite
+"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "openai/gpt-oss-20b"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestGPTOSS20BXeon(unittest.TestCase):
+    """GPT-OSS-20B on Xeon."""
+
+    def test_gpt_oss_20b(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=3,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="GPT-OSS-20B (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.80,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=3.5,
+                baseline_itl_ms=45.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_llama31_8b.py
+++ b/test/registered/cpu/test_llama31_8b.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for Llama-3.1-8B-Instruct on CPU.
+
+Dense 8B instruction model, TP=6 on Xeon.
+GSM8K baseline: 0.80 (84.5% reported - 5% buffer).
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "meta-llama/Llama-3.1-8B-Instruct"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestLlama31_8BXeon(unittest.TestCase):
+    """Meta Llama-3.1-8B-Instruct on Xeon."""
+
+    def test_llama31_8b(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Llama-3.1-8B-Instruct (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.74,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=3.0,
+                baseline_itl_ms=65.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_llama31_8b_w8a8.py
+++ b/test/registered/cpu/test_llama31_8b_w8a8.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for RedHatAI Llama-3.1-8B-Instruct w8a8 on CPU.
+
+8B dense model with int8 weight+activation quantization (llmcompressor), TP=6 on Xeon.
+Quantization config is embedded in the HF repo; SGLang auto-detects it.
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+
+BASE_ARGS = CPU_BASE_ARGS + ["--quantization", "w8a8_int8"]
+
+
+class TestLlama31_8BW8A8Xeon(unittest.TestCase):
+    """RedHatAI Llama-3.1-8B-Instruct-quantized.w8a8 on Xeon."""
+
+    def test_llama31_8b_w8a8(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Llama-3.1-8B-Instruct-quantized.w8a8 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.75,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=2.2,
+                baseline_itl_ms=50.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_phi4_reasoning.py
+++ b/test/registered/cpu/test_phi4_reasoning.py
@@ -1,0 +1,61 @@
+"""Nightly accuracy + performance test for Microsoft Phi-4-reasoning on CPU.
+
+Dense 14B reasoning model with <think> chain-of-thought, TP=1 on Xeon.
+GSM8K baseline: 0.90 (~94% reported - 5% buffer).
+Uses deepseek-r1 reasoning parser (compatible <think>/</think> format).
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "microsoft/Phi-4-reasoning"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestPhi4ReasoningCPU(unittest.TestCase):
+    """Microsoft Phi-4-reasoning on Xeon."""
+
+    def test_phi4_reasoning(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=2,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Phi-4-reasoning (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.90,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=23.0,
+                baseline_itl_ms=310.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_qwen35_35b_a3b_gptq_int4.py
+++ b/test/registered/cpu/test_qwen35_35b_a3b_gptq_int4.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 on CPU.
+
+35B language model, TP=1 on Xeon.
+
+Registry: nightly-xeon-models suite
+"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestQwen35_35BXeon(unittest.TestCase):
+    """Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 on Xeon."""
+
+    def test_qwen_35_35b_a3b_gptq_int4(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=1,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.80,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=4.5,
+                baseline_itl_ms=45.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_qwen35_35b_fp8.py
+++ b/test/registered/cpu/test_qwen35_35b_fp8.py
@@ -1,0 +1,62 @@
+"""Nightly accuracy + performance test for Qwen3.5-35B-A3B-FP8 on CPU.
+
+35B MoE with 3B active params, FP8 weight quantization, TP=6 on Xeon.
+GSM8K baseline: 0.83.
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+# export SGLANG_DEEPSEEK_FP8A8=1
+# build sgl-kernel using SGLANG_CPU_FP8_BRGEMM=1 on DMR
+MODEL_PATH = "Qwen/Qwen3.5-35B-A3B-FP8"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestQwen35_35BFPS8Xeon(unittest.TestCase):
+    """Qwen3.5-35B-A3B-FP8 on Xeon."""
+
+    def test_qwen35_35b_fp8(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Qwen3.5-35B-A3B-FP8 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.83,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=3.2,
+                baseline_itl_ms=155.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_qwen35_4b_w8a8.py
+++ b/test/registered/cpu/test_qwen35_4b_w8a8.py
@@ -1,0 +1,60 @@
+"""Nightly accuracy + performance test for RedHatAI Qwen3.5-4B w8a8 on CPU.
+
+4B dense model with int8 weight+activation quantization (llmcompressor), TP=6 on Xeon.
+Quantization config is embedded in the HF repo; SGLang auto-detects it.
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "RedHatAI/Qwen3.5-4B-quantized.w8a8"
+
+BASE_ARGS = CPU_BASE_ARGS + ["--quantization", "w8a8_int8"]
+
+
+class TestQwen35_4BW8A8Xeon(unittest.TestCase):
+    """RedHatAI Qwen3.5-4B-quantized.w8a8 on Xeon."""
+
+    def test_qwen35_4b_w8a8(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Qwen3.5-4B-quantized.w8a8 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.52,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=2.0,
+                baseline_itl_ms=40.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cpu/test_qwen3_1b7_fp8.py
+++ b/test/registered/cpu/test_qwen3_1b7_fp8.py
@@ -1,0 +1,59 @@
+"""Nightly accuracy + performance test for Qwen3-1.7B-FP8 on CPU.
+
+1.7B dense model with FP8 weight quantization, TP=6 on Xeon.
+
+Registry: nightly-xeon-models suite"""
+
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.cpu_test_utils import CPU_BASE_ARGS, CPU_LAUNCH_TIMEOUT
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cpu_ci(est_time=3600, suite="nightly-xeon-models", nightly=True)
+
+MODEL_PATH = "Qwen/Qwen3-1.7B-FP8"
+
+BASE_ARGS = CPU_BASE_ARGS
+
+
+class TestQwen3_1B7FP8Xeon(unittest.TestCase):
+    """Qwen3-1.7B-FP8 on Xeon."""
+
+    def test_qwen3_1b7_fp8(self):
+        models = [
+            ModelLaunchSettings(
+                MODEL_PATH,
+                extra_args=BASE_ARGS,
+                tp_size=6,
+                launch_timeout=CPU_LAUNCH_TIMEOUT,
+            ),
+        ]
+        result = run_combined_tests(
+            models=models,
+            test_name="Qwen3-1.7B-FP8 (Xeon)",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=0.67,
+                api="completion",
+                num_threads=64,
+                return_latency=True,
+            ),
+            performance_params=PerformanceTestParams(
+                batch_sizes=[16],
+                input_lens=(1024,),
+                output_lens=(1024,),
+                baseline_ftl_s=1.2,
+                baseline_itl_ms=35.0,
+                include_latency_breakdown=True,
+            ),
+            share_server=True,
+        )
+        self.assertTrue(result["all_passed"], f"Test failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -155,7 +155,9 @@ NIGHTLY_SUITES = {
     HWBackend.MUSA: [
         "nightly-musa-1-gpu",
     ],
-    HWBackend.CPU: [],
+    HWBackend.CPU: [
+        "nightly-xeon-models",
+    ],
     HWBackend.NPU: [
         "nightly-1-npu-a2",
         "nightly-1-npu-a3",


### PR DESCRIPTION
Motivation

  PR Test (Xeon) only covers small-model unit tests on every commit. Large CPU models (8B–35B) are too slow for per-commit CI but still need accuracy + performance regression coverage. This adds a nightly workflow that runs
  those large models plus a full re-run of the per-commit UT suites.

  Modifications

  - New workflow nightly-test-xeon.yml: runs on 2 GNR boxes, each taking one --auto-partition half.
    - Phase 1 — full per-commit UT suites (base-b-test-cpu, base-c-test-cpu, base-b-tp-test-cpu).
    - Phase 2 — nightly-xeon-models large-model accuracy (GSM8K) + performance (FTL/ITL) suite.
    - Phases run serially on the same box so only one server is resident at a time — avoids dual-model host-RAM OOM (sglang auto-computes mem_fraction_static from host memory and ignores cgroup limits).
    - Uses --continue-on-error so one failing model does not mask the rest.
    - Triggers: schedule (daily), workflow_dispatch, workflow_call.
  - Cherry-pick the nightly-xeon-models suite from #34708: 11 CPU model tests + shared run_combined_tests / CPU_BASE_ARGS infra.
  - Register nightly-xeon-models in run_suite.py NIGHTLY_SUITES[CPU] (was empty), otherwise validate_all_suites() fails fast on the newly registered nightly tests.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829380175](https://github.com/sgl-project/sglang/actions/runs/34829380175)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829379978](https://github.com/sgl-project/sglang/actions/runs/34829379978)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829380126](https://github.com/sgl-project/sglang/actions/runs/34829380126)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->