### PR TITLE
[Bugfix] Preserve parent swa_uuid when compacting SWA radix chain

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -1018,9 +1018,8 @@ class SWARadixCache(BasePrefixCache):
         )
 
     def _compact_single_child_chain(self, node: TreeNode) -> None:
-        # FIXME(ispobock): drifts retract pool accounting (commit 6348cb506);
-        # also overwrites active swa_uuid when window > page_size. Off by
-        # default via SGLANG_OPT_SWA_RADIX_CACHE_COMPACT.
+        # FIXME(ispobock): drifts retract pool accounting (commit 6348cb506).
+        # Off by default via SGLANG_OPT_SWA_RADIX_CACHE_COMPACT.
         while len(node.children) == 1:
             child = next(iter(node.children.values()))
             if len(child.children) == 0:
@@ -1052,7 +1051,8 @@ class SWARadixCache(BasePrefixCache):
             for grandchild in node.children.values():
                 grandchild.parent = node
 
-            if child.swa_uuid is not None:
+            # Keep an existing parent uuid (may be the active lock boundary).
+            if node.swa_uuid is None and child.swa_uuid is not None:
                 node.swa_uuid = child.swa_uuid
 
             if node.hash_value is not None and child.hash_value is not None:

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -949,7 +949,6 @@ class TestCacheUnfinishedReqEvictedPrefix(CustomTestCase):
         tree.sanity_check()
 
 
-
 class TestSWARadixCacheCompact(CustomTestCase):
     def _build_chain(self, n_tokens: int, window: int = 4):
         tree, allocator, _ = _build_swa_tree(

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -949,5 +949,64 @@ class TestCacheUnfinishedReqEvictedPrefix(CustomTestCase):
         tree.sanity_check()
 
 
+
+class TestSWARadixCacheCompact(CustomTestCase):
+    def _build_chain(self, n_tokens: int, window: int = 4):
+        tree, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            kv_size=64,
+            kv_size_swa=64,
+            sliding_window_size=window,
+            page_size=1,
+        )
+        for i in range(1, n_tokens + 1):
+            _insert(tree, allocator, list(range(i)))
+        leaf = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", list(range(n_tokens)))))
+        ).last_device_node
+        return tree, leaf
+
+    def test_compact_preserves_active_swa_uuid(self):
+        window = 4
+        n_tokens = 6
+        tree, leaf = self._build_chain(n_tokens, window=window)
+
+        lock1 = tree.inc_lock_ref(leaf)
+        uuid1 = lock1.swa_uuid_for_lock
+        self.assertIsNotNone(uuid1)
+        tree.dec_lock_ref(leaf, DecLockRefParams(swa_uuid_for_lock=uuid1))
+
+        boundary = leaf
+        while boundary is not tree.root_node and boundary.swa_uuid != uuid1:
+            boundary = boundary.parent
+        self.assertEqual(boundary.swa_uuid, uuid1)
+
+        lock2 = tree.inc_lock_ref(leaf)
+        uuid2 = lock2.swa_uuid_for_lock
+        self.assertEqual(uuid2, uuid1)
+
+        child = next(iter(boundary.children.values()))
+        child.swa_uuid = uuid1 + 99991
+
+        with envs.SGLANG_OPT_SWA_RADIX_CACHE_COMPACT.override(True):
+            leaf2 = tree.match_prefix(
+                MatchPrefixParams(key=RadixKey(array("q", list(range(n_tokens)))))
+            ).last_device_node
+
+        n = leaf2
+        found = False
+        while n is not tree.root_node:
+            if n.swa_uuid == uuid2:
+                found = True
+                break
+            n = n.parent
+        self.assertTrue(found, f"active swa_uuid {uuid2} missing after compact")
+
+        tree.dec_lock_ref(leaf2, DecLockRefParams(swa_uuid_for_lock=uuid2))
+        self.assertEqual(tree.swa_protected_size_, 0)
+        self.assertEqual(tree.full_protected_size_, 0)
+        tree.sanity_check()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `SGLANG_OPT_SWA_RADIX_CACHE_COMPACT` merged single-child internals with `node.swa_uuid = child.swa_uuid` whenever the child had a uuid.
- Unlock never clears `swa_uuid`, so a stale child uuid could overwrite the **active** lock-boundary uuid returned by `inc_lock_ref`.
- `dec_lock_ref` then fails to stop and asserts `swa_lock_ref=0`.
- Fix: only promote `child.swa_uuid` when `node.swa_uuid is None`. Flag stays default-off; retract-pool FIXME remains.

## Test plan
- [x] Unit: `TestSWARadixCacheCompact.test_compact_preserves_active_swa_uuid` (plant stale child uuid → COMPACT match → unlock clears protected)
- [x] CPU falsify against patched module → 3 passed (was 1 FAIL on clobber path)
- [ ] CI: `pytest test/registered/unit/mem_cache/test_swa_unittest.py::TestSWARadixCacheCompact -v`

### Repro (pre-fix)
Expected: unlock assert / missing active uuid after compact with planted stale child uuid.
Actual (post-fix): active uuid preserved; `swa_protected_size_ == 0` after unlock.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33466585417](https://github.com/sgl-project/sglang/actions/runs/33466585417)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33466585242](https://github.com/sgl-project/sglang/actions/runs/33466585242)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33466585429](https://github.com/sgl-project/sglang/actions/runs/33466585429)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->