### PR TITLE
[Fix ] Fix Spark2.5 hybrid SWA config

### DIFF
--- a/python/sglang/srt/configs/spark2_5.py
+++ b/python/sglang/srt/configs/spark2_5.py
@@ -59,5 +59,9 @@ class Spark2_5Config(PretrainedConfig):
                     "partial_rotary_factor": 1.0,
                 },
             }
-
+        self.hybrid_layer_pattern = [
+            1 if layer_type == "sliding_attention" else 0
+            for layer_type in self.layer_types
+        ]
+        self.is_hybrid_swa = any(self.hybrid_layer_pattern)
         super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)


### PR DESCRIPTION
• ## Summary

  Fix Spark2.5 config by adding hybrid SWA metadata derived from `layer_types`.

  ## Changes

  - Add `hybrid_layer_pattern` to mark sliding attention layers.
  - Add `is_hybrid_swa` to indicate whether the model uses hybrid sliding-window
  attention.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33463759454](https://github.com/sgl-project/sglang/actions/runs/33463759454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33463759196](https://github.com/sgl-project/sglang/actions/runs/33463759196)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33463759449](https://github.com/sgl-project/sglang/actions/runs/33463759449)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->