### PR TITLE
[Docs] Rename logprob-chunk env vars in environment_variables.mdx

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -367,13 +367,13 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Process logits in chunks to reduce peak memory.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_ENABLE_LOGPROB_CHUNK</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Process input logprobs in chunks to cap peak memory. <code>SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK</code> is a deprecated alias.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_LOGITS_PROCESSER_CHUNK_SIZE</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Chunk size (in tokens) used when logits-processor chunking is enabled.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_LOGPROB_CHUNK_SIZE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Chunk size (in tokens) used when logprob chunking is enabled. <code>SGLANG_LOGITS_PROCESSER_CHUNK_SIZE</code> is a deprecated alias.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>2048</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary

`docs/docs/references/environment_variables.mdx` still documents the pre-#31733 names `SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK` (default `false`) and `SGLANG_LOGITS_PROCESSER_CHUNK_SIZE`. The live registry in `python/sglang/srt/environ.py` exposes `SGLANG_ENABLE_LOGPROB_CHUNK` (default `True`) and `SGLANG_LOGPROB_CHUNK_SIZE` (`2048`), keeping the old names only as `deprecated_name` aliases.

This docs-only PR updates those two table rows to the current names/defaults and notes the aliases. It does **not** change `SGLANG_SWA_EVICTION_INTERVAL_MULTIPLIER`; that rename is already covered by open #35285.

## What drifted

On `main` (`e6f21cdadc91192c54ddeda8e1faa8a5aceb01d3`):

Docs (`docs/docs/references/environment_variables.mdx`):

```
SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK
  Process logits in chunks to reduce peak memory.
  default: false

SGLANG_LOGITS_PROCESSER_CHUNK_SIZE
  Chunk size (in tokens) used when logits-processor chunking is enabled.
  default: 2048
```

Code (`python/sglang/srt/environ.py`):

```1160:1164:python/sglang/srt/environ.py
    SGLANG_ENABLE_LOGPROB_CHUNK = EnvBoolWithAlias(
        True, deprecated_name="SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK"
    )
    SGLANG_LOGPROB_CHUNK_SIZE = EnvIntWithAlias(
        2048, deprecated_name="SGLANG_LOGITS_PROCESSER_CHUNK_SIZE"
    )
```

`LogprobProcessor` reads the new names:

```447:449:python/sglang/srt/layers/logprob_processor.py
        self.enable_logprobs_chunk = envs.SGLANG_ENABLE_LOGPROB_CHUNK.get()
        # chunk size for logprobs processing
        self.logprobs_chunk_size = envs.SGLANG_LOGPROB_CHUNK_SIZE.get()
```

## How reproduced

Fetched `docs/docs/references/environment_variables.mdx` and `python/sglang/srt/environ.py` from `sgl-project/sglang@main` via the GitHub API (no full clone). Grep of the two files is the mismatch quoted above.

## Why skip SWA here

Docs still list ghost `SGLANG_SWA_EVICTION_INTERVAL_MULTIPLIER` (default `1.0`); code is `SGLANG_SWA_EVICTION_INTERVAL = EnvInt(128)`. Open #35285 already renames that row, so this PR leaves it alone.

## Test plan

- [x] Confirmed no other `SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK` / `SGLANG_LOGITS_PROCESSER_CHUNK_SIZE` table-name hits in the docs file
- [x] Confirmed `environ.py` defaults: enable `True`, size `2048`
- [ ] Docs preview of Environment Variables shows `SGLANG_ENABLE_LOGPROB_CHUNK` default `true`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33464018934](https://github.com/sgl-project/sglang/actions/runs/33464018934)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33464018826](https://github.com/sgl-project/sglang/actions/runs/33464018826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->