### PR TITLE
[Fix][CPU] fix xeon ci failure by test_qwen35_flashinfer_fusion

### DIFF
--- a/test/registered/unit/layers/moe/test_qwen35_flashinfer_fusion.py
+++ b/test/registered/unit/layers/moe/test_qwen35_flashinfer_fusion.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -17,7 +18,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.models.qwen3_5_text import Qwen3_5ForCausalLM
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=20, suite="base-c-test-cpu")
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
 
 
 @dataclass(frozen=True)
@@ -59,15 +60,16 @@ def test_supported_forward_modes(forward_mode, expected):
     assert is_supported_forward_mode(forward_mode) is expected
 
 
-def test_framework_capacity_is_maximum_of_all_sources():
+@patch(
+    "sglang.srt.layers.moe.qwen35_flashinfer_fusion.cutedsl_moe_max_num_tokens",
+    return_value=8192,
+)
+def test_framework_capacity_is_maximum_of_all_sources(_cutedsl_moe_max_num_tokens):
     graph = SimpleNamespace(
         decode=SimpleNamespace(max_bs=512, bs=[1, 64, 256]),
         prefill=SimpleNamespace(max_bs=4096, bs=[1024, 2048, 4096]),
     )
-    server_args = SimpleNamespace(
-        cuda_graph_config=graph,
-        cutedsl_moe_max_num_tokens=lambda: 8192,
-    )
+    server_args = SimpleNamespace(cuda_graph_config=graph)
     runner = SimpleNamespace(server_args=server_args, max_running_requests=2048)
 
     assert resolve_max_m(runner) == 8192


### PR DESCRIPTION
This is a test-fixture regression, not a production-code bug in #32733. The helper already has real `ServerArgs` coverage in `test_server_args.py`.

## Modifications
- Patch `qwen35_flashinfer_fusion.cutedsl_moe_max_num_tokens` at the usage point to return `8192`.
- Drop the obsolete `cutedsl_moe_max_num_tokens=lambda...` attribute on `SimpleNamespace`.
- Move registration from `base-c-test-cpu` to `base-a-test-cpu` (pure logic unit test; no Xeon/AMX).
- No production-code change.

## Accuracy Tests
N/A — test-only.

## Speed Tests and Profiling
N/A — test-only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33464250864](https://github.com/sgl-project/sglang/actions/runs/33464250864)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33464250716](https://github.com/sgl-project/sglang/actions/runs/33464250716)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33464251136](https://github.com/sgl-project/sglang/actions/runs/33464251136)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->