### PR TITLE
[Docs] Align server_arguments.mdx with current CLI flags

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -2989,12 +2989,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
     </tr>
-        <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--debug-tensor-dump-inject`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Inject the outputs from jax as the input of every layer.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
   </tbody>
 </table>
 
@@ -3064,8 +3058,8 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-retries`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill retries that will skip the bootstrap wait.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-attempts`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill forward passes that skip the bootstrap wait.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>
@@ -3466,16 +3460,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Note: Note: --prefill-round-robin-balance is deprecated now.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>N/A</td>
-    </tr>
-
-
-
-
-        <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--hybrid-kvcache-ratio`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Mix ratio in [0,1] between uniform and hybrid kv buffers (0.0 = pure uniform: swa_size / full_size = 1)(1.0 = pure hybrid: swa_size / full_size = local_attention_size / context_length)</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Optional[float]</td>
     </tr>
 
 


### PR DESCRIPTION
## Summary

`docs/docs/advanced_features/server_arguments.mdx` still documents three CLI names that do not match `python/sglang/srt/server_args.py` on `main`. This docs-only PR:

1. Renames `--optimistic-prefill-retries` to `--optimistic-prefill-attempts` (and updates the help text to the current field help).
2. Removes `--debug-tensor-dump-inject` (deleted from CLI).
3. Removes `--hybrid-kvcache-ratio` from the Deprecated table (removed from CLI, including deprecated registration).

Same file, one PR. Does **not** pile onto open #37313 / #37336, and does not touch SWA env vars (#35285).

## What drifted

On `main` (`60f881b40c4138f2f4859d02cb3b4e7c0ee166f4`):

Docs (`docs/docs/advanced_features/server_arguments.mdx`):

```
`--optimistic-prefill-retries`
Number of optimistic prefill retries that will skip the bootstrap wait.
Default: `0`
```

```
`--debug-tensor-dump-inject`
Inject the outputs from jax as the input of every layer.
Default: `False`
```

```
`--hybrid-kvcache-ratio`   (Deprecated arguments)
Mix ratio in [0,1] between uniform and hybrid kv buffers ...
Default: `None`
```

Code (`python/sglang/srt/server_args.py`):

```3239:3243:python/sglang/srt/server_args.py
    optimistic_prefill_attempts: A[
        int,
        "Number of optimistic prefill forward passes that skip the bootstrap wait.",
        NS("disagg"),
    ] = 0
```

```3536:3550:python/sglang/srt/server_args.py
    debug_tensor_dump_output_folder: A[
        Optional[str],
        "The output folder for dumping tensors. In Eagle mode, tensor outputs from draft and target models are stored in separate subdirectories ('draft' and 'target').",
        NS("observability"),
    ] = None
    # None means dump all layers.
    debug_tensor_dump_layers: A[
        Optional[List[int]],
        "The layer ids to dump. Dump all layers if not specified.",
        NS("observability"),
    ] = None
    # TODO(guoyuhong): clean the old dumper code.
    debug_tensor_dump_input_file: A[
        Optional[str], "The input filename for dumping tensors", NS("observability")
    ] = None
```

No `debug_tensor_dump_inject` field remains. Deprecated CLI registration still has `--prefill-round-robin-balance`, not `--hybrid-kvcache-ratio`:

```3861:3865:python/sglang/srt/server_args.py
        parser.add_argument(
            "--prefill-round-robin-balance",
            action=DeprecatedAction,
            help="Note: --prefill-round-robin-balance is deprecated now.",
        )
```

CLI names are derived from dataclass fields by `_field_to_cli_name()`:

```216:218:python/sglang/srt/arg_groups/arg_utils.py
def _field_to_cli_name(name: str) -> str:
    return "--" + name.replace("_", "-")
```

So `optimistic_prefill_attempts` registers `--optimistic-prefill-attempts`. A grep of `server_args.py` finds no `optimistic_prefill_retries`, `debug_tensor_dump_inject`, or `hybrid_kvcache_ratio`.

## How reproduced

Fetched `docs/docs/advanced_features/server_arguments.mdx` and `python/sglang/srt/server_args.py` from `sgl-project/sglang@main` (`60f881b40c4138f2f4859d02cb3b4e7c0ee166f4`) via the GitHub API (no full clone). Grep of the two files is the mismatch quoted above.

## Test plan

- [x] Confirmed `optimistic_prefill_attempts` is the live field (default `0`); no retries alias
- [x] Confirmed debug-tensor-dump CLI is only `output-folder` / `layers` / `input-file`
- [x] Confirmed `--hybrid-kvcache-ratio` is not registered, including deprecated `parser.add_argument` entries
- [x] Confirmed no open PR already covering these three docs rows (skipped #37313 / #37336)
- [ ] Docs preview of Server Arguments shows `--optimistic-prefill-attempts` and no longer lists the two deleted flags

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33466062337](https://github.com/sgl-project/sglang/actions/runs/33466062337)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33466062254](https://github.com/sgl-project/sglang/actions/runs/33466062254)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->