### PR TITLE
[Docs] Remove deleted runtime example files from README

### DIFF
--- a/examples/runtime/README.md
+++ b/examples/runtime/README.md
@@ -6,8 +6,6 @@ The below examples will mostly need you to start a server in a separate terminal
 
 * `lora.py`: An example how to use LoRA adapters.
 * `multimodal_embedding.py`: An example how perform [multi modal embedding](https://huggingface.co/Alibaba-NLP/gme-Qwen2-VL-2B-Instruct).
-* `openai_batch_chat.py`: An example how to process batch requests for chat completions.
-* `openai_batch_complete.py`: An example how to process batch requests for text completions.
 * **`openai_chat_with_response_prefill.py`**:
   An example that demonstrates how to [prefill a response](https://eugeneyan.com/writing/prompting/#prefill-claudes-responses) using the OpenAI API by enabling the `continue_final_message` parameter.
   When enabled, the final (partial) assistant message is removed and its content is used as a prefill so that the model continues that message rather  than starting a new turn. See [Anthropic's prefill example](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response#example-structured-data-extraction-with-prefilling) for more context.
@@ -22,7 +20,6 @@ The `engine` folder contains that examples that show how to use [Offline Engine 
 * `embedding.py`: An example how to extract embeddings.
 * `launch_engine.py`: An example how to launch the Engine.
 * `offline_batch_inference_eagle.py`: An example how to perform speculative decoding using [EAGLE](https://docs.sglang.io/advanced_features/speculative_decoding.html).
-* `offline_batch_inference_torchrun.py`: An example how to perform inference using [torchrun](https://pytorch.org/docs/stable/elastic/run.html).
 * `offline_batch_inference_vlm.py`: An example how to use VLMs with the engine.
 * `offline_batch_inference.py`: An example how to use the engine to perform inference on a batch of examples.
 


### PR DESCRIPTION
## Summary

`examples/runtime/README.md` still lists three example scripts that were removed from the tree in #7400 and #7326. This docs-only PR deletes those three ghost rows and keeps every remaining valid example.

Does **not** pile onto open #37313 / #37336 / #37341.

## What drifted

On `main` (`b21000aef1c337945f420dbf32385525bb7d6323`), `examples/runtime/README.md` still says:

```
* `openai_batch_chat.py`: An example how to process batch requests for chat completions.
* `openai_batch_complete.py`: An example how to process batch requests for text completions.
```

```
* `offline_batch_inference_torchrun.py`: An example how to perform inference using [torchrun](https://pytorch.org/docs/stable/elastic/run.html).
```

Those paths 404 on the same SHA:

```
GET /repos/sgl-project/sglang/contents/examples/runtime/openai_batch_chat.py
{"message":"Not Found","status":"404"}

GET /repos/sgl-project/sglang/contents/examples/runtime/openai_batch_complete.py
{"message":"Not Found","status":"404"}

GET /repos/sgl-project/sglang/contents/examples/runtime/engine/offline_batch_inference_torchrun.py
{"message":"Not Found","status":"404"}
```

`examples/runtime` on `main` has `lora.py`, `multimodal_embedding.py`, `openai_chat_with_response_prefill.py`, `reward_model.py`, `vertex_predict.py`, `chain_of_verification.py`, and `README.md` — not the two `openai_batch_*.py` files.

`examples/runtime/engine` on `main` has `offline_batch_inference.py`, `offline_batch_inference_eagle.py`, `offline_batch_inference_vlm.py`, etc. — not `offline_batch_inference_torchrun.py`.

The files were removed in:

- #7400 — "Remove batches api in docs & example"
- #7326 — "Purge VerlEngine"

## How reproduced

Fetched `examples/runtime/README.md` and listed `examples/runtime` plus `examples/runtime/engine` from `sgl-project/sglang@main` via the GitHub API (no full clone). README lines vs contents 404 is the mismatch quoted above.

No open PR already covers these three rows (`openai_batch_chat`, `openai_batch_complete`, `offline_batch_inference_torchrun` search returned none).

## Test plan

- [x] Confirmed the three paths 404 on `main`
- [x] Confirmed remaining README example names still exist under `examples/runtime` / `examples/runtime/engine`
- [x] Diff is three deletions in `examples/runtime/README.md` only
- [ ] README Native API / Engine lists no longer mention the deleted scripts

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33468087829](https://github.com/sgl-project/sglang/actions/runs/33468087829)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33468087739](https://github.com/sgl-project/sglang/actions/runs/33468087739)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->