### PR TITLE
test: update hybrid attention runner fixtures

### DIFF
--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -162,6 +162,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
                 kv_cache_dtype=torch.bfloat16,
                 token_to_kv_pool=None,
                 req_to_token_pool=None,
+                kv_index_translator=None,
                 server_args=SimpleNamespace(speculative_attention_mode="decode"),
                 model_config=SimpleNamespace(context_len=2048),
             ),

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -148,6 +148,7 @@ def _make_hybrid_backend(speculative_attention_mode, prefill_mask, decode_mask):
         kv_cache_dtype=None,
         token_to_kv_pool=object(),
         req_to_token_pool=object(),
+        kv_index_translator=None,
         server_args=SimpleNamespace(
             speculative_attention_mode=speculative_attention_mode
         ),

--- a/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
@@ -37,6 +37,7 @@ def test_split_full_attention_applies_model_wrapper_once():
             kv_cache_dtype=None,
             token_to_kv_pool=object(),
             req_to_token_pool=object(),
+            kv_index_translator=None,
             init_new_workspace=None,
         )
         wrapper_inputs = []

--- a/test/registered/unit/spec/test_dflash_overlap_hostsync.py
+++ b/test/registered/unit/spec/test_dflash_overlap_hostsync.py
@@ -235,6 +235,7 @@ class TestHybridNeedsCpuSeqLens(CustomTestCase):
             kv_cache_dtype=torch.bfloat16,
             token_to_kv_pool=None,
             req_to_token_pool=None,
+            kv_index_translator=None,
             model_config=SimpleNamespace(context_len=2048),
         )
         # The backend takes the mode from the published configuration, not from


### PR DESCRIPTION
## Summary

- add kv_index_translator to mocked model runners that construct HybridAttnBackend
- cover CPU and GPU unit-test fixtures without changing production behavior

## Testing

- python3.11 -m py_compile on the four changed files
- git diff --check
- targeted pytest did not complete locally because platform imports stalled during collection on macOS; registered CI tests provide the full validation

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33468418075](https://github.com/sgl-project/sglang/actions/runs/33468418075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33468417971](https://github.com/sgl-project/sglang/actions/runs/33468417971)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33468418080](https://github.com/sgl-project/sglang/actions/runs/33468418080)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->