### PR TITLE
[Docs] Use --speculative-draft-window-size in speculative decoding

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -32,7 +32,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
 - **Model is MTP-enabled**: Use **MTP via speculative decoding** (often with small `speculative_num_steps/topk/num_draft_tokens`, see the example section).
 - **You have a DFlash draft checkpoint**: Use **DFLASH** with `--speculative-algorithm DFLASH` and `--speculative-draft-model-path ...`.
 - **You have a smaller draft LLM**: Use **STANDALONE** (`--speculative-algorithm STANDALONE`).
-- **No extra model available**: Use **NGRAM** (`--speculative-algorithm NGRAM`, CUDA-only).
+- **No extra model available**: Use **NGRAM** (`--speculative-algorithm NGRAM`, CUDA or CPU).
 
 ### Method comparison (mini table)
 
@@ -94,6 +94,13 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No <code>--enable-dp-attention</code>; <code>pp_size == 1</code>; disables overlap scheduler &amp; mixed chunked prefill</td>
     </tr>
 <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>DSPARK</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSpark draft model (block / gamma verification)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Usually; some target checkpoints bundle it</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm DSPARK</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>CUDA/NPU; <code>pp_size == 1</code>; <code>--speculative-num-steps</code> and <code>--speculative-eagle-topk</code> forced to 1</td>
+    </tr>
+<tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>STANDALONE</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Smaller draft LLM (token-level)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Yes</td>
@@ -105,7 +112,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Ngram cache from previous tokens</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm NGRAM</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>CUDA-only; no <code>--enable-dp-attention</code>; disables overlap scheduler &amp; mixed chunked prefill</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>CUDA or CPU; no <code>--enable-dp-attention</code>; disables overlap scheduler &amp; mixed chunked prefill</td>
     </tr>
 </tbody>
 </table>
@@ -470,7 +477,7 @@ Relevant parameters:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-draft-window-size</code></td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-window-size</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Draft KV sliding-window size. Must be <code>&gt;= speculative-num-draft-tokens</code> when set.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
     </tr>
@@ -689,7 +696,7 @@ Enable it with:
 </table>
 
 Notes:
-- Ngram speculative decoding **only supports CUDA**.
+- Ngram speculative decoding **supports CUDA and CPU**.
 - It currently **does not support** `--enable-dp-attention`.
 - It disables the overlap scheduler and mixed chunked prefill.
 - If `--speculative-ngram-max-bfs-breadth > 1` (thus `speculative_eagle_topk > 1`) and `page_size > 1`, use `--attention-backend flashinfer`; otherwise the server will error.
@@ -753,7 +760,7 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-algorithm</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Algorithm to use: <code>DFLASH</code>, <code>EAGLE</code>, <code>EAGLE3</code>, <code>STANDALONE</code>, <code>NGRAM</code>, <code>NEXTN</code> (alias of <code>EAGLE</code>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Algorithm to use: <code>DFLASH</code>, <code>DSPARK</code>, <code>EAGLE</code>, <code>EAGLE3</code>, <code>STANDALONE</code>, <code>NGRAM</code>, <code>NEXTN</code> (alias of <code>EAGLE</code>)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-model-path</code></td>
@@ -798,10 +805,10 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DFlash-only alias of <code>--speculative-num-draft-tokens</code></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-draft-window-size</code></td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-window-size</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DFlash-only draft KV sliding-window size</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Sliding window size for the draft model. Honored by Llama EAGLE-3 and DFLASH; default is full attention/context</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-accept-threshold-single</code></td>


### PR DESCRIPTION
## Summary

`docs/docs/advanced_features/speculative_decoding.mdx` still documents `--speculative-dflash-draft-window-size` as the real flag. On `main` that name is only a hidden deprecated alias; the live CLI is `--speculative-draft-window-size`.

Same file leftovers that are still true:

- Method comparison table listed DFLASH but not DSPARK.
- NGRAM was described as CUDA-only; `_handle_ngram` allows CUDA or CPU.

Docs-only. Does **not** pile onto open #37313 / #37336 / #37341 / #37344 (those touch other files). Left `server_arguments.mdx` alone even though it still lists the hidden alias, because that file is already in #37341.

## What drifted

On `main` (`b21000aef1c337945f420dbf32385525bb7d6323`), docs say:

```473:473:docs/docs/advanced_features/speculative_decoding.mdx
<code>--speculative-dflash-draft-window-size</code>
```

```801:804:docs/docs/advanced_features/speculative_decoding.mdx
<code>--speculative-dflash-draft-window-size</code>
...
DFlash-only draft KV sliding-window size
```

`python/sglang/srt/server_args.py` on the same SHA:

```2208:2212:python/sglang/srt/server_args.py
    speculative_draft_window_size: A[
        Optional[int],
        "Sliding window size for the draft model. Honored by Llama EAGLE-3 (`LlamaForCausalLMEagle3`) and DFLASH only; ... Default is full attention/context.",
        NS("spec"),
    ] = None
```

No `cli_name=` override. `add_cli_args_from_dataclass` uses `_field_to_cli_name`:

```216:218:python/sglang/srt/arg_groups/arg_utils.py
def _field_to_cli_name(name: str) -> str:
    """Convert a field name like ``model_path`` to ``--model-path``."""
    return "--" + name.replace("_", "-")
```

So **field** `speculative_draft_window_size` → **cli_name** `--speculative-draft-window-size`.

The old name is a hidden deprecated alias (`help=argparse.SUPPRESS`):

```3911:3917:python/sglang/srt/server_args.py
        parser.add_argument(
            "--speculative-dflash-draft-window-size",
            type=int,
            dest="speculative_draft_window_size",
            action=DeprecatedAliasStoreAction,
            new_flag="--speculative-draft-window-size",
            help=argparse.SUPPRESS,
        )
```

NGRAM (same file): docs say `CUDA-only` / `only supports CUDA`. `_handle_ngram` raises unless `cfg.device in ("cuda", "cpu")`.

DSPARK (same file): `speculative_algorithm` help lists `EAGLE, EAGLE3, NEXTN, STANDALONE, NGRAM, DFLASH, DSPARK`. The method table had DFLASH but not DSPARK.

## How reproduced

Fetched `docs/docs/advanced_features/speculative_decoding.mdx` and `python/sglang/srt/server_args.py` from `sgl-project/sglang@main` via the GitHub API (no full clone). Quoted docs vs field / `_field_to_cli_name` / hidden `DeprecatedAliasStoreAction` as above.

No open PR already retargets `--speculative-dflash-draft-window-size` in this file.

## Test plan

- [x] Confirmed field `speculative_draft_window_size` has no custom `cli_name` (auto `--speculative-draft-window-size`)
- [x] Confirmed `--speculative-dflash-draft-window-size` is `DeprecatedAliasStoreAction` + `help=argparse.SUPPRESS`
- [x] Confirmed NGRAM allows `cuda` and `cpu`; DSPARK is a builtin algorithm
- [x] Diff is `docs/docs/advanced_features/speculative_decoding.mdx` only
- [ ] Speculative decoding docs show `--speculative-draft-window-size`, DSPARK in the method table, and NGRAM as CUDA or CPU

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33469390572](https://github.com/sgl-project/sglang/actions/runs/33469390572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33469390464](https://github.com/sgl-project/sglang/actions/runs/33469390464)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->