### PR TITLE
[Diffusion][RL] Reuse disk LoRA mapping and FFN swap on H3 IPC updates

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -39,12 +39,10 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = init_logger(__name__)
 
 
-def _swap_peft_swiglu_fc1_lora_b(
+def swap_peft_swiglu_fc1_lora_b(
     source_name: str, target_name: str, weight: torch.Tensor
 ) -> torch.Tensor:
-    # Only the PEFT -> native H3 FFN rewrite: ff.net.0.proj [value; gate]
-    # onto mlp.fc1 [gate; value]. Native fused mlp.fc1 and other models'
-    # ff.net.0.proj (e.g. Flux) must not match.
+    """Rewrite PEFT H3 FFN lora_B from [value; gate] to native [gate; value]."""
     if (
         weight.dim() != 2
         or ".ff.net.0.proj.lora_B" not in source_name
@@ -848,7 +846,7 @@ class LoRAPipeline(ComposedPipelineBase):
                 else:
                     continue
 
-            weight = _swap_peft_swiglu_fc1_lora_b(name, target_name, weight)
+            weight = swap_peft_swiglu_fc1_lora_b(name, target_name, weight)
             if target_name in self.lora_adapters[lora_nickname]:
                 raise ValueError(
                     f"Dit target weight name {target_name} already exists in lora_adapters[{lora_nickname}]"

--- a/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
@@ -61,6 +61,7 @@ from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import Diffusers
 from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import (
     LoRAPipeline,
     stack_or_compose_fused_lora,
+    swap_peft_swiglu_fc1_lora_b,
 )
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -258,12 +259,18 @@ def _resolve_lora_ipc_layer_dict_key(
     if map_name is None:
         return None, layer_prefix, None
 
-    mapped_name, merge_index = map_name(f"{layer_prefix}.weight")
-    mapped = _strip_param_weight_suffix(mapped_name)
-    if mapped != layer_prefix:
-        layer = layer_dict.get(mapped)
-        if layer is not None:
-            return layer, mapped, merge_index
+    # miles-h3 disk mapping is LoRA-suffix-only; main also maps ".weight".
+    for suffix in (".weight", ".lora_A"):
+        mapped_name, merge_index = map_name(f"{layer_prefix}{suffix}")
+        mapped = (
+            mapped_name[: -len(suffix)]
+            if mapped_name.endswith(suffix)
+            else _strip_param_weight_suffix(mapped_name)
+        )
+        if mapped != layer_prefix:
+            layer = layer_dict.get(mapped)
+            if layer is not None:
+                return layer, mapped, merge_index
 
     return None, layer_prefix, None
 
@@ -660,7 +667,7 @@ class WeightsUpdater:
         plain_pairs: list[tuple[torch.Tensor, torch.Tensor, Any]] = []
         fused_sections: dict[Any, dict[int, tuple[torch.Tensor, torch.Tensor]]] = {}
         for layer_name, (lora_a, lora_b) in pairs.items():
-            layer, _resolved_key, merge_index = _resolve_lora_ipc_layer_dict_key(
+            layer, resolved_key, merge_index = _resolve_lora_ipc_layer_dict_key(
                 layer_name, layer_dict, dit_module
             )
             if layer is None:
@@ -672,6 +679,15 @@ class WeightsUpdater:
                 unknown_layers.append(layer_name)
                 skipped += 1
                 continue
+            # Same PEFT → native rewrite as disk load_lora_adapter: fused QKV
+            # uses merge_index; H3 gated FFN swaps [up, gate] → [gate, up].
+            # Native names already in lora_layers skip both transforms.
+            lora_a = swap_peft_swiglu_fc1_lora_b(
+                f"{layer_name}.lora_A", f"{resolved_key}.lora_A", lora_a
+            )
+            lora_b = swap_peft_swiglu_fc1_lora_b(
+                f"{layer_name}.lora_B", f"{resolved_key}.lora_B", lora_b
+            )
             inferred_rank = int(lora_a.shape[-2])
             if lora_rank is not None and lora_rank != inferred_rank:
                 logger.warning(

--- a/python/sglang/multimodal_gen/test/unit/test_fused_lora_compose.py
+++ b/python/sglang/multimodal_gen/test/unit/test_fused_lora_compose.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 import torch
 import torch.nn.functional as F
 
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import MiniMaxH3DiTArchConfig
 from sglang.multimodal_gen.runtime.layers.lora.linear import (
     MergedColumnParallelLinearWithLoRA,
 )
-from sglang.multimodal_gen.configs.models.dits.minimax_h3 import MiniMaxH3DiTArchConfig
 from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import (
     LoRAPipeline,
     stack_or_compose_fused_lora,

--- a/python/sglang/multimodal_gen/test/unit/test_fused_lora_compose.py
+++ b/python/sglang/multimodal_gen/test/unit/test_fused_lora_compose.py
@@ -11,9 +11,11 @@ import torch.nn.functional as F
 from sglang.multimodal_gen.runtime.layers.lora.linear import (
     MergedColumnParallelLinearWithLoRA,
 )
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import MiniMaxH3DiTArchConfig
 from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import (
     LoRAPipeline,
     stack_or_compose_fused_lora,
+    swap_peft_swiglu_fc1_lora_b,
 )
 from sglang.multimodal_gen.runtime.post_training.weights_updater import (
     _resolve_lora_ipc_layer_dict_key,
@@ -371,3 +373,44 @@ def test_apply_composed_adapter_end_to_end():
         + _reference_delta(x, a_list, b_list, adapter_alpha) * strength
     )
     torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_h3_ipc_reuses_disk_mapping_and_ffn_swap():
+    module = torch.nn.Module()
+    module.param_names_mapping = MiniMaxH3DiTArchConfig().param_names_mapping
+    qkv, fc1 = object(), object()
+    layer_dict = {
+        "blocks.0.attn.qkv_proj": qkv,
+        "blocks.0.mlp.fc1": fc1,
+        "token_refiner.blocks.1.attn.qkv_proj": qkv,
+    }
+    cases = [
+        ("transformer_blocks.0.attn.to_k", qkv, "blocks.0.attn.qkv_proj", 1),
+        ("transformer_blocks.0.ff.net.0.proj", fc1, "blocks.0.mlp.fc1", None),
+        (
+            "token_refiner.refiner_blocks.1.attn.to_q",
+            qkv,
+            "token_refiner.blocks.1.attn.qkv_proj",
+            0,
+        ),
+    ]
+    for src, layer, key, merge_index in cases:
+        assert _resolve_lora_ipc_layer_dict_key(src, layer_dict, module) == (
+            layer,
+            key,
+            merge_index,
+        )
+
+    peft_b = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    swapped = swap_peft_swiglu_fc1_lora_b(
+        "transformer_blocks.0.ff.net.0.proj.lora_B",
+        "blocks.0.mlp.fc1.lora_B",
+        peft_b,
+    )
+    torch.testing.assert_close(swapped, torch.cat([peft_b[2:], peft_b[:2]]))
+    assert (
+        swap_peft_swiglu_fc1_lora_b(
+            "blocks.0.mlp.fc1.lora_B", "blocks.0.mlp.fc1.lora_B", swapped
+        )
+        is swapped
+    )


### PR DESCRIPTION
## Summary
- LoRA IPC now reuses the same PEFT → native name mapping as disk `--lora-path`.
- Apply the same H3 FFN `lora_B` swap (`[value; gate]` → `[gate; value]`) on IPC writes.
- On miles-h3, resolve also probes the `*.lora_A` suffix the disk mapping already understands.
- Other models are unchanged: the swap only matches PEFT `ff.net.0.proj` → native `mlp.fc1`.

## Test plan
- [ ] `pytest python/sglang/multimodal_gen/test/unit/test_fused_lora_compose.py::test_h3_ipc_reuses_disk_mapping_and_ffn_swap`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33472749295](https://github.com/sgl-project/sglang/actions/runs/33472749295)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33472749167](https://github.com/sgl-project/sglang/actions/runs/33472749167)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33472749258](https://github.com/sgl-project/sglang/actions/runs/33472749258)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->