### PR TITLE
[Cookbook] Add NVFP4 options for DeepSeek-V4 Flash Official (0731) and Pro Official (0813)

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -311,7 +311,10 @@ sglang serve \
 The [`nvidia/DeepSeek-V4-Pro-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4) and
 [`nvidia/DeepSeek-V4-Flash-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Flash-NVFP4) checkpoints
 quantize MoE experts to **NVFP4** while keeping attention and dense layers in
-**FP8**. It requires `--moe-runner-backend flashinfer_trtllm_routed` which will be automatically selected if not provided.
+**FP8**. The official releases have matching NVFP4 checkpoints at
+[`nvidia/DeepSeek-V4-Flash-0731-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Flash-0731-NVFP4) and
+[`nvidia/DeepSeek-V4-Pro-0813-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Pro-0813-NVFP4).
+All of them require `--moe-runner-backend flashinfer_trtllm_routed` which will be automatically selected if not provided.
 
 ```bash Command
 sglang serve \
@@ -330,6 +333,11 @@ sglang serve \
 Requires Blackwell (SM100+). The MTP layer in this checkpoint stays
 MXFP4-packed and is routed through the `Mxfp4FlashinferTrtllmMoEMethod` path
 automatically.
+
+The official (0731 / 0813) NVFP4 checkpoints preserve the bundled DSpark draft
+head, so their low-latency recipes use `--speculative-algorithm DSPARK` instead
+of the EAGLE/MTP shape flags — same as the corresponding original-precision
+official checkpoints.
 
 <a id="hopper-note" />
 

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
@@ -119,6 +119,16 @@ export const benchmarks = [
         ttft_ms: 509, tpot_ms: 11.13, tokens_per_sec_per_gpu: 1210 },
     ],
   },
+  {
+    match: { hw: "b200", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "dev@07c8f7294",
+    accuracy: { gsm8k_pct: 96.82, aime25_pct: 98.96 },
+  },
+  {
+    match: { hw: "b200", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "dev@07c8f7294",
+    accuracy: { gsm8k_pct: 96.44, aime25_pct: 98.33 },
+  },
   // ====================================================================
   // B300 + FP4
   // ====================================================================

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -192,6 +192,13 @@ sgl-eval run mmmu_pro \\
     // (sgl-project/sglang#37253) — until it does, the variant needs this
     // preview build on every hardware.
     "flash-vision|fp4": "lmsysorg/sglang:dev-dsv4-flash-vision",
+    // NVFP4 checkpoints crash at weight load on v0.5.18 (the MXFP4-packed MTP
+    // layer's FP8 delegate needs the #36275 guard, merged 2026-08-26) — route
+    // every NVFP4 cell to the nightly until a release contains that fix.
+    "b200|nvfp4":  "lmsysorg/sglang:dev",
+    "b300|nvfp4":  "lmsysorg/sglang:dev",
+    "gb200|nvfp4": "lmsysorg/sglang:dev",
+    "gb300|nvfp4": "lmsysorg/sglang:dev",
     h100:  "lmsysorg/sglang:latest",
     h200:  "lmsysorg/sglang:latest",
     b200:  "lmsysorg/sglang:latest",
@@ -855,11 +862,12 @@ sgl-eval run mmmu_pro \\
     // B200 + NVFP4 — Official (0731 / 0813)
     // Mirrors the Flash/Pro NVFP4 cells; the official checkpoints bundle a
     // DSpark draft head, so low-latency uses `--speculative-algorithm DSPARK`
-    // instead of the EAGLE shape flags. NOT yet run end-to-end on this hardware.
+    // instead of the EAGLE shape flags. Verified on 8xB200 (GSM8K + AIME25,
+    // sgl-eval; see the benchmarks entries).
     // ====================================================================
     {
       match: { hw: "b200", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -875,7 +883,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "b200", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -941,7 +949,7 @@ sgl-eval run mmmu_pro \\
     // ====================================================================
     {
       match: { hw: "b300", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -957,7 +965,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "b300", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1207,7 +1215,7 @@ sgl-eval run mmmu_pro \\
     // ====================================================================
     {
       match: { hw: "gb200", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1223,7 +1231,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "gb200", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "multi-2" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1893,7 +1901,7 @@ sgl-eval run mmmu_pro \\
     // ====================================================================
     {
       match: { hw: "gb300", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1909,7 +1917,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "gb300", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -50,11 +50,13 @@ export const config = {
     "flash|fp8": "deepseek-ai/DeepSeek-V4-Flash",
     "flash|nvfp4": "nvidia/DeepSeek-V4-Flash-NVFP4",
     "flash-official|fp4": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "flash-official|nvfp4": "nvidia/DeepSeek-V4-Flash-0731-NVFP4",
     "flash-vision|fp4": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
     "pro|fp4":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|fp8":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|nvfp4": "nvidia/DeepSeek-V4-Pro-NVFP4",
     "pro-official|fp4": "deepseek-ai/DeepSeek-V4-Pro-0813",
+    "pro-official|nvfp4": "nvidia/DeepSeek-V4-Pro-0813-NVFP4",
     // H200 FP8 needs the sgl-project repackaging (Hopper can't run FP4-mixed Instruct).
     "h200|flash|fp8": "sgl-project/DeepSeek-V4-Flash-FP8",
     "h200|pro|fp8":   "sgl-project/DeepSeek-V4-Pro-FP8",
@@ -850,6 +852,45 @@ sgl-eval run mmmu_pro \\
       ],
     },
     // ====================================================================
+    // B200 + NVFP4 — Official (0731 / 0813)
+    // Mirrors the Flash/Pro NVFP4 cells; the official checkpoints bundle a
+    // DSpark draft head, so low-latency uses `--speculative-algorithm DSPARK`
+    // instead of the EAGLE shape flags. NOT yet run end-to-end on this hardware.
+    // ====================================================================
+    {
+      match: { hw: "b200", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b200", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
+        "--chunked-prefill-size 8192",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // ====================================================================
     // B300 + NVFP4
     // ====================================================================
     {
@@ -884,6 +925,46 @@ sgl-eval run mmmu_pro \\
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 4",
+        "--chunked-prefill-size 8192",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--mem-fraction-static 0.90",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // ====================================================================
+    // B300 + NVFP4 — Official (0731 / 0813)
+    // Mirrors the Flash/Pro NVFP4 cells; the official checkpoints bundle a
+    // DSpark draft head, so low-latency uses `--speculative-algorithm DSPARK`
+    // instead of the EAGLE shape flags. NOT yet run end-to-end on this hardware.
+    // ====================================================================
+    {
+      match: { hw: "b300", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
         "--chunked-prefill-size 8192",
         "--disable-flashinfer-autotune",
         "--swa-full-tokens-ratio 0.1",
@@ -1110,6 +1191,46 @@ sgl-eval run mmmu_pro \\
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 4",
+        "--chunked-prefill-size 8192",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--mem-fraction-static 0.90",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // ====================================================================
+    // GB200 + NVFP4 — Official (0731 / 0813)
+    // Mirrors the Flash/Pro NVFP4 cells; the official checkpoints bundle a
+    // DSpark draft head, so low-latency uses `--speculative-algorithm DSPARK`
+    // instead of the EAGLE shape flags. NOT yet run end-to-end on this hardware.
+    // ====================================================================
+    {
+      match: { hw: "gb200", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb200", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "multi-2" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
         "--chunked-prefill-size 8192",
         "--disable-flashinfer-autotune",
         "--swa-full-tokens-ratio 0.1",
@@ -1722,7 +1843,7 @@ sgl-eval run mmmu_pro \\
     },
 
     // ====================================================================
-    // GB200 + NVFP4
+    // GB300 + NVFP4
     // ====================================================================
     {
       match: { hw: "gb300", variant: "flash", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
@@ -1756,6 +1877,46 @@ sgl-eval run mmmu_pro \\
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 4",
+        "--chunked-prefill-size 8192",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--mem-fraction-static 0.90",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // ====================================================================
+    // GB300 + NVFP4 — Official (0731 / 0813)
+    // Mirrors the Flash/Pro NVFP4 cells; the official checkpoints bundle a
+    // DSpark draft head, so low-latency uses `--speculative-algorithm DSPARK`
+    // instead of the EAGLE shape flags. NOT yet run end-to-end on this hardware.
+    // ====================================================================
+    {
+      match: { hw: "gb300", variant: "flash-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
+        "--disable-flashinfer-autotune",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "pro-official", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_trtllm_routed",
+        "--speculative-algorithm DSPARK",
         "--chunked-prefill-size 8192",
         "--disable-flashinfer-autotune",
         "--swa-full-tokens-ratio 0.1",


### PR DESCRIPTION
## Motivation

NVIDIA published NVFP4 quantizations of the official DeepSeek-V4 checkpoints — [`nvidia/DeepSeek-V4-Flash-0731-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Flash-0731-NVFP4) and [`nvidia/DeepSeek-V4-Pro-0813-NVFP4`](https://huggingface.co/nvidia/DeepSeek-V4-Pro-0813-NVFP4) — but the cookbook only offers NVFP4 on the original Flash/Pro variants. This PR makes NVFP4 selectable for the Flash Official (0731) and Pro Official (0813) variants.

## Modifications

**`docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx`**
- `modelNames`: map `flash-official|nvfp4` / `pro-official|nvfp4` to the two NVIDIA repos.
- Add 8 low-latency cells (B200 / B300 / GB200 / GB300 × Flash Official / Pro Official), mirroring the existing Flash/Pro NVFP4 cells (`--moe-runner-backend flashinfer_trtllm_routed`), with one difference: the official checkpoints bundle a DSpark draft head, so the EAGLE/MTP shape flags are replaced by `--speculative-algorithm DSPARK` — same as the FP4 official cells. Both NVFP4 repos were checked to preserve the `mtp.*` draft-head tensors.
- NVFP4 stays Blackwell-only (no Hopper/AMD cells), matching the existing Flash/Pro NVFP4 coverage; on other hardware the quant chip greys out.
- Fix a section-header typo (`GB200 + NVFP4` → `GB300 + NVFP4`).

All new cells are marked `verified: false` (not yet run end-to-end); no benchmark entries are added.

**`docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`**
- Extend the *NVFP4 Hybrid Checkpoints* note with the two official repos and the DSpark-instead-of-EAGLE guidance.

## Checklist

- [x] `mint validate` and `mint broken-links` pass.
- [x] `mint dev` spot-check: commands render with the right model paths and DSPARK, multi-node GB200 cell injects `--nnodes 2` + fabric hints, "Not Verified" badge shows, NVFP4 greys out on non-Blackwell hardware, Playground DSpark draft-token slider appears for the official variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33484568608](https://github.com/sgl-project/sglang/actions/runs/33484568608)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33485220228](https://github.com/sgl-project/sglang/actions/runs/33485220228)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->