### PR TITLE
[Apple Silicon] Add an architecture-independent ATen-to-MLX lowering layer

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
+++ b/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
@@ -1,0 +1,745 @@
+"""Architecture-independent FX planning for whole-forward MLX execution.
+
+Torch Dynamo already turns an SGLang model forward into an FX graph. This
+module classifies that graph by operation rather than model architecture. It
+is intentionally a validation backend for now: a production executor can be
+provided once every admitted operation has an MLX lowering and serving-state
+contract.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import operator
+from collections.abc import Sequence
+from dataclasses import dataclass
+from math import sqrt
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import torch
+import torch.fx
+import torch.nn.functional as F
+
+
+class UnsupportedMlxFxGraphError(RuntimeError):
+    """Raised when one FX graph cannot be lowered as a single MLX region."""
+
+
+@dataclass(frozen=True)
+class MlxFxNodePlan:
+    node_name: str
+    node_op: str
+    target: Any
+    lowering: Optional[str]
+
+    @property
+    def supported(self) -> bool:
+        return self.lowering is not None
+
+
+@dataclass(frozen=True)
+class MlxFxGraphPlan:
+    """One captured forward and its operation-level MLX coverage."""
+
+    graph_module: torch.fx.GraphModule
+    nodes: tuple[MlxFxNodePlan, ...]
+
+    @property
+    def unsupported(self) -> tuple[MlxFxNodePlan, ...]:
+        return tuple(node for node in self.nodes if not node.supported)
+
+    @property
+    def fully_supported(self) -> bool:
+        return not self.unsupported
+
+    def require_fully_supported(self) -> None:
+        unsupported = self.unsupported
+        if not unsupported:
+            return
+        details = ", ".join(f"{node.node_op}:{node.target}" for node in unsupported)
+        raise UnsupportedMlxFxGraphError(
+            "FX forward cannot run as one MLX region; unsupported nodes: " + details
+        )
+
+
+class MlxFxLoweringRegistry:
+    """Maps FX operations to reusable MLX lowering names.
+
+    The standard tables are derived from the ``@_lowering`` registrations
+    below: each lowering function declares the ATen overloads, Torch
+    functions, and tensor methods it implements, so adding an op is one
+    self-contained function and never a second table edit.
+    """
+
+    def __init__(self) -> None:
+        self._functions: dict[Any, str] = {}
+        self._methods: dict[str, str] = {}
+
+    def register_function(self, target: Any, lowering: str) -> None:
+        self._functions[target] = lowering
+
+    def register_method(self, target: str, lowering: str) -> None:
+        self._methods[target] = lowering
+
+    def resolve(self, node: torch.fx.Node) -> Optional[str]:
+        if node.op in {"placeholder", "get_attr", "output"}:
+            return node.op
+        if node.op == "call_function":
+            if node.target is torch.ops.higher_order.auto_functionalized_v2:
+                custom_target = node.args[0]
+                lowering = self._functions.get(custom_target)
+                return None if lowering is None else f"functionalized_{lowering}"
+            return self._functions.get(node.target)
+        if node.op == "call_method":
+            return self._methods.get(str(node.target))
+        return None
+
+    @classmethod
+    def standard_decoder(cls) -> MlxFxLoweringRegistry:
+        """Return lowerings used by ordinary dense decoder graphs."""
+        registry = cls()
+        for name, spec in _LOWERINGS.items():
+            for target in spec.functions:
+                registry.register_function(target, name)
+            for target in spec.methods:
+                registry.register_method(target, name)
+        return registry
+
+    @classmethod
+    def standard_export_decoder(cls) -> MlxFxLoweringRegistry:
+        """Return canonical ATen lowerings produced by ``torch.export``."""
+        registry = cls()
+        for name, spec in _LOWERINGS.items():
+            for target in spec.aten:
+                registry.register_function(target, name)
+        return registry
+
+
+def build_mlx_fx_plan(
+    graph_module: torch.fx.GraphModule,
+    registry: MlxFxLoweringRegistry,
+) -> MlxFxGraphPlan:
+    """Classify a captured forward without inspecting its model architecture."""
+    return MlxFxGraphPlan(
+        graph_module=graph_module,
+        nodes=tuple(
+            MlxFxNodePlan(
+                node_name=node.name,
+                node_op=node.op,
+                target=node.target,
+                lowering=registry.resolve(node),
+            )
+            for node in graph_module.graph.nodes
+        ),
+    )
+
+
+def _resolve_fx_value(value: Any, values: dict[torch.fx.Node, Any]) -> Any:
+    if isinstance(value, torch.fx.Node):
+        return values[value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_fx_value(item, values) for item in value)
+    if isinstance(value, list):
+        return [_resolve_fx_value(item, values) for item in value]
+    if isinstance(value, dict):
+        return {key: _resolve_fx_value(item, values) for key, item in value.items()}
+    return value
+
+
+@dataclass(frozen=True)
+class _LoweringSpec:
+    """One MLX lowering and the FX targets that select it."""
+
+    fn: Callable[..., Any]
+    aten: tuple[Any, ...]
+    functions: tuple[Any, ...]
+    methods: tuple[str, ...]
+
+
+_LOWERINGS: dict[str, _LoweringSpec] = {}
+
+
+def _lowering(
+    name: str,
+    *,
+    aten: Sequence[Any] = (),
+    functions: Sequence[Any] = (),
+    methods: Sequence[str] = (),
+    aliases: Sequence[str] = (),
+):
+    """Register ``fn`` as MLX lowering ``name`` for the given FX targets.
+
+    ``aten`` are the canonical overloads ``torch.export`` emits, ``functions``
+    and ``methods`` the eager-FX spellings; ``aliases`` register the same
+    function under additional lowering names (``reshape``/``view``).
+    """
+
+    def register(fn: Callable[..., Any]) -> Callable[..., Any]:
+        spec = _LoweringSpec(fn, tuple(aten), tuple(functions), tuple(methods))
+        for key in (name, *aliases):
+            if key in _LOWERINGS:
+                raise ValueError(f"duplicate MLX lowering: {key}")
+            _LOWERINGS[key] = spec
+        return fn
+
+    return register
+
+
+def _lower_mlx_node(
+    lowering: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    import mlx.core as mx
+
+    spec = _LOWERINGS.get(lowering)
+    if spec is None:
+        raise UnsupportedMlxFxGraphError(f"missing MLX lowering: {lowering}")
+    return spec.fn(mx, args, kwargs)
+
+
+def _arg(args, kwargs, index, name, default=None):
+    return args[index] if len(args) > index else kwargs.get(name, default)
+
+
+@_lowering("assert_metadata", aten=(torch.ops.aten._assert_tensor_metadata.default,))
+def _lower_assert_metadata(mx, args, kwargs):
+    return None
+
+
+@_lowering("alias", aten=(torch.ops.aten.alias.default,))
+def _lower_alias(mx, args, kwargs):
+    return args[0]
+
+
+@_lowering("concatenate", aten=(torch.ops.aten.cat.default,))
+def _lower_concatenate(mx, args, kwargs):
+    return mx.concatenate(tuple(args[0]), axis=_arg(args, kwargs, 1, "dim", 0))
+
+
+@_lowering(
+    "embedding", aten=(torch.ops.aten.embedding.default,), functions=(F.embedding,)
+)
+def _lower_embedding(mx, args, kwargs):
+    if isinstance(args[0], mx.array) and args[0].ndim >= 2:
+        weight, input_ids = args[:2]
+    else:
+        input_ids, weight = args[:2]
+    if len(args) > 3 and args[3] is not None:
+        raise UnsupportedMlxFxGraphError("embedding max_norm is unsupported")
+    return mx.take(weight, input_ids, axis=0)
+
+
+@_lowering(
+    "rms_norm", aten=(torch.ops.aten.rms_norm.default,), functions=(torch.rms_norm,)
+)
+def _lower_rms_norm(mx, args, kwargs):
+    value = args[0]
+    weight = _arg(args, kwargs, 2, "weight")
+    epsilon = _arg(args, kwargs, 3, "eps")
+    if weight is None:
+        raise UnsupportedMlxFxGraphError("MLX RMSNorm requires an explicit weight")
+    if epsilon is None:
+        epsilon = mx.finfo(value.dtype).eps
+    return mx.fast.rms_norm(value, weight, float(epsilon))
+
+
+@_lowering("layer_norm", aten=(torch.ops.aten.layer_norm.default,))
+def _lower_layer_norm(mx, args, kwargs):
+    value, normalized_shape = args[:2]
+    weight = _arg(args, kwargs, 2, "weight")
+    bias = _arg(args, kwargs, 3, "bias")
+    epsilon = _arg(args, kwargs, 4, "eps", 1e-5)
+    if len(normalized_shape) != 1 or normalized_shape[0] != value.shape[-1]:
+        raise UnsupportedMlxFxGraphError(
+            "MLX layer_norm only normalizes the last axis, found "
+            f"normalized_shape={tuple(normalized_shape)}"
+        )
+    return mx.fast.layer_norm(value, weight, bias, float(epsilon))
+
+
+@_lowering(
+    "linear",
+    aten=(torch.ops.aten.linear.default, torch.ops.aten.mm.default),
+    functions=(torch._C._nn.linear,),
+)
+def _lower_linear(mx, args, kwargs):
+    value, weight = args[:2]
+    bias = _arg(args, kwargs, 2, "bias")
+    output = value @ mx.swapaxes(weight, -1, -2)
+    return output if bias is None else output + bias
+
+
+@_lowering("matmul", aten=(torch.ops.aten.matmul.default,))
+def _lower_matmul(mx, args, kwargs):
+    return args[0] @ args[1]
+
+
+@_lowering("mean", aten=(torch.ops.aten.mean.dim,))
+def _lower_mean(mx, args, kwargs):
+    axis = _arg(args, kwargs, 1, "dim")
+    keepdims = _arg(args, kwargs, 2, "keepdim", False)
+    dtype = kwargs.get("dtype")
+    value = args[0] if dtype is None else args[0].astype(_mlx_dtype(dtype, mx))
+    return mx.mean(value, axis=axis, keepdims=keepdims)
+
+
+@_lowering(
+    "sdpa",
+    aten=(torch.ops.aten.scaled_dot_product_attention.default,),
+    functions=(torch._C._nn.scaled_dot_product_attention,),
+)
+def _lower_sdpa(mx, args, kwargs):
+    query, key, value = args[:3]
+    attention_mask = _arg(args, kwargs, 3, "attn_mask")
+    dropout = _arg(args, kwargs, 4, "dropout_p", 0.0)
+    causal = _arg(args, kwargs, 5, "is_causal", False)
+    scale = _arg(args, kwargs, 6, "scale")
+    enable_gqa = _arg(args, kwargs, 7, "enable_gqa", False)
+    if dropout not in (None, 0, 0.0):
+        raise UnsupportedMlxFxGraphError("SDPA dropout is unsupported")
+    if enable_gqa and query.shape[-3] != key.shape[-3]:
+        repeats = query.shape[-3] // key.shape[-3]
+        key = mx.repeat(key, repeats, axis=-3)
+        value = mx.repeat(value, repeats, axis=-3)
+    scale = float(scale) if scale is not None else 1.0 / sqrt(query.shape[-1])
+    scores = (query @ mx.swapaxes(key, -1, -2)) * scale
+    if causal:
+        rows, columns = scores.shape[-2:]
+        offset = columns - rows
+        causal_mask = mx.triu(
+            mx.full((rows, columns), -float("inf"), dtype=scores.dtype),
+            k=1 + offset,
+        )
+        scores = scores + causal_mask
+    if attention_mask is not None:
+        scores = scores + attention_mask
+    return mx.softmax(scores, axis=-1) @ value
+
+
+@_lowering("silu", aten=(torch.ops.aten.silu.default,), functions=(F.silu,))
+def _lower_silu(mx, args, kwargs):
+    return mx.sigmoid(args[0]) * args[0]
+
+
+@_lowering("sigmoid", aten=(torch.ops.aten.sigmoid.default,))
+def _lower_sigmoid(mx, args, kwargs):
+    return mx.sigmoid(args[0])
+
+
+@_lowering("relu", aten=(torch.ops.aten.relu.default,))
+def _lower_relu(mx, args, kwargs):
+    return mx.maximum(args[0], 0)
+
+
+@_lowering("gelu", aten=(torch.ops.aten.gelu.default,))
+def _lower_gelu(mx, args, kwargs):
+    value = args[0]
+    approximate = kwargs.get("approximate", "none")
+    if approximate == "tanh":
+        return (
+            0.5
+            * value
+            * (1 + mx.tanh(sqrt(2 / math.pi) * (value + 0.044715 * value**3)))
+        )
+    if approximate != "none":
+        raise UnsupportedMlxFxGraphError(
+            f"unsupported GELU approximation: {approximate}"
+        )
+    return value * 0.5 * (1 + mx.erf(value / sqrt(2)))
+
+
+@_lowering("tanh", aten=(torch.ops.aten.tanh.default,))
+def _lower_tanh(mx, args, kwargs):
+    return mx.tanh(args[0])
+
+
+@_lowering("stack", aten=(torch.ops.aten.stack.default,))
+def _lower_stack(mx, args, kwargs):
+    return mx.stack(tuple(args[0]), axis=_arg(args, kwargs, 1, "dim", 0))
+
+
+@_lowering("getitem", aten=(operator.getitem,), functions=(operator.getitem,))
+def _lower_getitem(mx, args, kwargs):
+    return args[0][args[1]]
+
+
+@_lowering("add", aten=(torch.ops.aten.add.Tensor,), functions=(operator.add,))
+def _lower_add(mx, args, kwargs):
+    return args[0] + args[1]
+
+
+@_lowering("multiply", aten=(torch.ops.aten.mul.Tensor,), functions=(operator.mul,))
+def _lower_multiply(mx, args, kwargs):
+    return args[0] * args[1]
+
+
+@_lowering("subtract", aten=(torch.ops.aten.sub.Tensor,))
+def _lower_subtract(mx, args, kwargs):
+    return args[0] - args[1] * kwargs.get("alpha", 1)
+
+
+@_lowering("chunk", aten=(torch.ops.aten.chunk.default,), methods=("chunk",))
+def _lower_chunk(mx, args, kwargs):
+    value, chunks = args[:2]
+    axis = _arg(args, kwargs, 2, "dim", 0)
+    width = value.shape[axis]
+    chunk_size = (width + chunks - 1) // chunks
+    indices = tuple(range(chunk_size, width, chunk_size))
+    return tuple(mx.split(value, indices, axis=axis))
+
+
+@_lowering("split", aten=(torch.ops.aten.split.Tensor,))
+def _lower_split(mx, args, kwargs):
+    value, split_size = args[:2]
+    axis = _arg(args, kwargs, 2, "dim", 0)
+    width = value.shape[axis]
+    indices = tuple(range(split_size, width, split_size))
+    return tuple(mx.split(value, indices, axis=axis))
+
+
+@_lowering("split_with_sizes", aten=(torch.ops.aten.split_with_sizes.default,))
+def _lower_split_with_sizes(mx, args, kwargs):
+    value, sizes = args[:2]
+    axis = _arg(args, kwargs, 2, "dim", 0)
+    indices = []
+    offset = 0
+    for size in sizes[:-1]:
+        offset += size
+        indices.append(offset)
+    return tuple(mx.split(value, tuple(indices), axis=axis))
+
+
+@_lowering(
+    "reshape",
+    aten=(torch.ops.aten.reshape.default, torch.ops.aten.view.default),
+    methods=("reshape",),
+    aliases=("view",),
+)
+def _lower_reshape(mx, args, kwargs):
+    shape = args[1] if len(args) == 2 and isinstance(args[1], Sequence) else args[1:]
+    return mx.reshape(args[0], tuple(shape))
+
+
+@_lowering("flatten", aten=(torch.ops.aten.flatten.using_ints,))
+def _lower_flatten(mx, args, kwargs):
+    value = args[0]
+    start = args[1] if len(args) > 1 else 0
+    end = args[2] if len(args) > 2 else -1
+    if end < 0:
+        end += value.ndim
+    flattened = 1
+    for width in value.shape[start : end + 1]:
+        flattened *= width
+    shape = (*value.shape[:start], flattened, *value.shape[end + 1 :])
+    return mx.reshape(value, shape)
+
+
+@_lowering("index_select", aten=(torch.ops.aten.index_select.default,))
+def _lower_index_select(mx, args, kwargs):
+    return mx.take(args[0], args[2], axis=args[1])
+
+
+@_lowering("numpy_transpose", aten=(torch.ops.aten.numpy_T.default,))
+def _lower_numpy_transpose(mx, args, kwargs):
+    return mx.transpose(args[0], axes=tuple(reversed(range(args[0].ndim))))
+
+
+@_lowering("power", aten=(torch.ops.aten.pow.Tensor_Scalar,))
+def _lower_power(mx, args, kwargs):
+    return mx.power(args[0], args[1])
+
+
+@_lowering("rsqrt", aten=(torch.ops.aten.rsqrt.default,))
+def _lower_rsqrt(mx, args, kwargs):
+    return mx.rsqrt(args[0])
+
+
+@_lowering("to_dtype", aten=(torch.ops.aten.to.dtype,))
+def _lower_to_dtype(mx, args, kwargs):
+    return args[0].astype(_mlx_dtype(args[1], mx))
+
+
+@_lowering("unsqueeze", aten=(torch.ops.aten.unsqueeze.default,))
+def _lower_unsqueeze(mx, args, kwargs):
+    return mx.expand_dims(args[0], axis=args[1])
+
+
+@_lowering("empty_like", aten=(torch.ops.aten.empty_like.default,))
+def _lower_empty_like(mx, args, kwargs):
+    dtype = kwargs.get("dtype")
+    if dtype is None:
+        return mx.empty_like(args[0])
+    return mx.empty(args[0].shape, dtype=_mlx_dtype(dtype, mx))
+
+
+@_lowering("slice", aten=(torch.ops.aten.slice.Tensor,))
+def _lower_slice(mx, args, kwargs):
+    value = args[0]
+    axis = args[1] if len(args) > 1 else 0
+    start = args[2] if len(args) > 2 else 0
+    stop = args[3] if len(args) > 3 else value.shape[axis]
+    step = args[4] if len(args) > 4 else 1
+    width = value.shape[axis]
+    if start >= 0:
+        start = min(start, width)
+    if stop >= 0:
+        stop = min(stop, width)
+    slices = [slice(None)] * value.ndim
+    slices[axis] = slice(start, stop, step)
+    return value[tuple(slices)]
+
+
+@_lowering("transpose", methods=("transpose",))
+def _lower_transpose(mx, args, kwargs):
+    return mx.swapaxes(args[0], args[1], args[2])
+
+
+@_lowering("contiguous", methods=("contiguous",))
+def _lower_contiguous(mx, args, kwargs):
+    return mx.contiguous(args[0])
+
+
+def _mlx_dtype(dtype: torch.dtype, mx: Any) -> Any:
+    mapping = {
+        torch.bool: mx.bool_,
+        torch.int8: mx.int8,
+        torch.int16: mx.int16,
+        torch.int32: mx.int32,
+        torch.int64: mx.int64,
+        torch.float16: mx.float16,
+        torch.bfloat16: mx.bfloat16,
+        torch.float32: mx.float32,
+    }
+    try:
+        return mapping[dtype]
+    except KeyError as exc:
+        raise UnsupportedMlxFxGraphError(
+            f"Torch dtype has no MLX Metal lowering: {dtype}"
+        ) from exc
+
+
+def make_mlx_fx_executor(
+    plan: MlxFxGraphPlan,
+    example_inputs: list[Any],
+    *,
+    shapeless: bool = False,
+) -> Callable[..., Any]:
+    """Build one compiled MLX callable for a fully admitted FX graph."""
+    import mlx.core as mx
+
+    from sglang.srt.utils.tensor_bridge import MlxTensorView, mlx_call_multi
+
+    plan.require_fully_supported()
+    attr_nodes = tuple(
+        node for node in plan.graph_module.graph.nodes if node.op == "get_attr"
+    )
+    attr_views = tuple(
+        (
+            MlxTensorView(plan.graph_module.get_parameter(str(node.target)))
+            if str(node.target) in dict(plan.graph_module.named_parameters())
+            else MlxTensorView(plan.graph_module.get_buffer(str(node.target)))
+        )
+        for node in attr_nodes
+    )
+    placeholder_nodes = tuple(
+        node for node in plan.graph_module.graph.nodes if node.op == "placeholder"
+    )
+    if len(placeholder_nodes) != len(example_inputs):
+        raise UnsupportedMlxFxGraphError(
+            "FX placeholder and example-input counts do not match"
+        )
+    tensor_positions = tuple(
+        index
+        for index, value in enumerate(example_inputs)
+        if isinstance(value, torch.Tensor)
+    )
+    scalar_positions = tuple(
+        index for index in range(len(example_inputs)) if index not in tensor_positions
+    )
+    used_scalars = tuple(
+        placeholder_nodes[index]
+        for index in scalar_positions
+        if placeholder_nodes[index].users
+    )
+    if used_scalars:
+        names = ", ".join(node.name for node in used_scalars)
+        raise UnsupportedMlxFxGraphError(
+            "whole-graph MLX lowering requires normalization of used symbolic "
+            f"scalar inputs: {names}"
+        )
+    tensor_placeholder_nodes = tuple(
+        placeholder_nodes[index] for index in tensor_positions
+    )
+
+    def mlx_graph(*arrays):
+        runtime_arrays = arrays[: len(tensor_placeholder_nodes)]
+        captured_arrays = arrays[len(tensor_placeholder_nodes) :]
+        values: dict[torch.fx.Node, Any] = dict(
+            zip(tensor_placeholder_nodes, runtime_arrays)
+        )
+        values.update(zip(attr_nodes, captured_arrays))
+        for node, node_plan in zip(plan.graph_module.graph.nodes, plan.nodes):
+            if node.op in {"placeholder", "get_attr"}:
+                continue
+            args = _resolve_fx_value(node.args, values)
+            kwargs = _resolve_fx_value(node.kwargs, values)
+            if node.op == "output":
+                result = args[0]
+                return tuple(result) if isinstance(result, (tuple, list)) else (result,)
+            if node_plan.lowering is None:
+                raise UnsupportedMlxFxGraphError(
+                    f"missing lowering for admitted node {node.target}"
+                )
+            values[node] = _lower_mlx_node(node_plan.lowering, args, kwargs)
+        raise UnsupportedMlxFxGraphError("FX graph has no output node")
+
+    compiled_graph = mx.compile(mlx_graph, shapeless=shapeless)
+
+    def execute(*torch_inputs):
+        if len(torch_inputs) != len(placeholder_nodes):
+            raise RuntimeError(
+                "compiled MLX graph input count changed: "
+                f"expected {len(placeholder_nodes)}, found {len(torch_inputs)}"
+            )
+        if any(
+            not isinstance(torch_inputs[index], torch.Tensor)
+            or torch_inputs[index].device.type != "mps"
+            for index in tensor_positions
+        ):
+            raise RuntimeError("compiled MLX graph requires Torch MPS tensors")
+        for node, view in zip(attr_nodes, attr_views):
+            target = str(node.target)
+            try:
+                tensor = plan.graph_module.get_parameter(target)
+            except AttributeError:
+                tensor = plan.graph_module.get_buffer(target)
+            if not view.matches(tensor):
+                view.refresh(tensor)
+        return mlx_call_multi(
+            compiled_graph,
+            *(torch_inputs[index] for index in tensor_positions),
+            *attr_views,
+            device="mps",
+        )
+
+    return execute
+
+
+@dataclass(frozen=True)
+class MlxExportPlan:
+    """Functional Export IR plus explicit serving-state mutations."""
+
+    exported_program: Any
+    functional_program: Any
+    graph_plan: MlxFxGraphPlan
+    mutated_user_inputs: tuple[str, ...]
+
+
+def export_mlx_plan(
+    module: torch.nn.Module,
+    args: tuple[Any, ...],
+    registry: MlxFxLoweringRegistry,
+    *,
+    kwargs: Optional[dict[str, Any]] = None,
+    dynamic_shapes: Any = None,
+) -> MlxExportPlan:
+    """Capture and functionalize a model forward before MLX lowering."""
+    exported = torch.export.export(
+        module,
+        args,
+        kwargs=kwargs,
+        dynamic_shapes=dynamic_shapes,
+        strict=True,
+    )
+    functional = exported.run_decompositions()
+    graph_plan = build_mlx_fx_plan(functional.graph_module, registry)
+    mutations = tuple(
+        str(spec.target)
+        for spec in functional.graph_signature.output_specs
+        if str(spec.kind).endswith("USER_INPUT_MUTATION")
+    )
+    return MlxExportPlan(
+        exported_program=exported,
+        functional_program=functional,
+        graph_plan=graph_plan,
+        mutated_user_inputs=mutations,
+    )
+
+
+class MlxFxCaptureBackend:
+    """Dynamo backend that validates whole-graph MLX lowering coverage.
+
+    The default executor returns the captured Torch graph so the capture path
+    can be tested without pretending that MLX execution is implemented. A
+    production ``executor_factory`` receives the complete admitted graph once
+    and must return one callable containing the Torch/MLX bridge boundary.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[MlxFxLoweringRegistry] = None,
+        *,
+        executor_factory: Optional[
+            Callable[[MlxFxGraphPlan, list[Any]], Callable[..., Any]]
+        ] = None,
+        fallback_to_torch: bool = False,
+        report_path: Optional[str] = None,
+    ) -> None:
+        self.registry = registry or MlxFxLoweringRegistry.standard_decoder()
+        self.executor_factory = executor_factory
+        self.fallback_to_torch = fallback_to_torch
+        self.report_path = report_path
+        self.plans: list[MlxFxGraphPlan] = []
+
+    def __call__(
+        self, graph_module: torch.fx.GraphModule, example_inputs: list[Any]
+    ) -> Callable[..., Any]:
+        plan = build_mlx_fx_plan(graph_module, self.registry)
+        self.plans.append(plan)
+        if self.report_path is not None:
+            Path(self.report_path).write_text(
+                json.dumps(
+                    {
+                        "fully_supported": plan.fully_supported,
+                        "nodes": [
+                            {
+                                "name": node.node_name,
+                                "op": node.node_op,
+                                "target": str(node.target),
+                                "lowering": node.lowering,
+                            }
+                            for node in plan.nodes
+                        ],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        if not plan.fully_supported:
+            if self.fallback_to_torch:
+                return graph_module.forward
+            plan.require_fully_supported()
+        if self.executor_factory is None:
+            return graph_module.forward
+        return self.executor_factory(plan, example_inputs)
+
+
+__all__ = [
+    "MlxFxCaptureBackend",
+    "MlxFxGraphPlan",
+    "MlxFxLoweringRegistry",
+    "MlxFxNodePlan",
+    "MlxExportPlan",
+    "UnsupportedMlxFxGraphError",
+    "build_mlx_fx_plan",
+    "export_mlx_plan",
+    "make_mlx_decode_export_executor",
+    "make_mlx_fx_executor",
+    "make_mlx_prefill_export_executor",
+    "run_torch_decode_export_reference",
+    "run_torch_prefill_export_reference",
+]

--- a/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
+++ b/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
@@ -262,7 +262,7 @@ def _lower_layer_norm(mx, args, kwargs):
 
 @_lowering(
     "linear",
-    aten=(torch.ops.aten.linear.default, torch.ops.aten.mm.default),
+    aten=(torch.ops.aten.linear.default,),
     functions=(torch._C._nn.linear,),
 )
 def _lower_linear(mx, args, kwargs):
@@ -272,7 +272,7 @@ def _lower_linear(mx, args, kwargs):
     return output if bias is None else output + bias
 
 
-@_lowering("matmul", aten=(torch.ops.aten.matmul.default,))
+@_lowering("matmul", aten=(torch.ops.aten.matmul.default, torch.ops.aten.mm.default))
 def _lower_matmul(mx, args, kwargs):
     return args[0] @ args[1]
 
@@ -368,7 +368,10 @@ def _lower_getitem(mx, args, kwargs):
 
 @_lowering("add", aten=(torch.ops.aten.add.Tensor,), functions=(operator.add,))
 def _lower_add(mx, args, kwargs):
-    return args[0] + args[1]
+    alpha = _arg(args, kwargs, 2, "alpha", 1)
+    if alpha == 1:
+        return args[0] + args[1]
+    return args[0] + args[1] * alpha
 
 
 @_lowering("multiply", aten=(torch.ops.aten.mul.Tensor,), functions=(operator.mul,))
@@ -378,7 +381,10 @@ def _lower_multiply(mx, args, kwargs):
 
 @_lowering("subtract", aten=(torch.ops.aten.sub.Tensor,))
 def _lower_subtract(mx, args, kwargs):
-    return args[0] - args[1] * kwargs.get("alpha", 1)
+    alpha = _arg(args, kwargs, 2, "alpha", 1)
+    if alpha == 1:
+        return args[0] - args[1]
+    return args[0] - args[1] * alpha
 
 
 @_lowering("chunk", aten=(torch.ops.aten.chunk.default,), methods=("chunk",))
@@ -521,6 +527,23 @@ def _mlx_dtype(dtype: torch.dtype, mx: Any) -> Any:
         ) from exc
 
 
+def _resolve_graph_attr(graph_module: torch.fx.GraphModule, target: str) -> Any:
+    """Resolve a ``get_attr`` target: parameter, buffer, or plain attribute.
+
+    FX ``get_attr`` nodes are not limited to parameters and registered
+    buffers: a module may hang constant tensors or scalars directly on
+    itself, and ``torch.export``'s ``module()`` re-registers lifted tensor
+    constants the same way.
+    """
+    if target in dict(graph_module.named_parameters()):
+        return graph_module.get_parameter(target)
+    if target in dict(graph_module.named_buffers()):
+        return graph_module.get_buffer(target)
+    module_path, _, attr_name = target.rpartition(".")
+    owner = graph_module.get_submodule(module_path) if module_path else graph_module
+    return getattr(owner, attr_name)
+
+
 def make_mlx_fx_executor(
     plan: MlxFxGraphPlan,
     example_inputs: list[Any],
@@ -536,13 +559,23 @@ def make_mlx_fx_executor(
     attr_nodes = tuple(
         node for node in plan.graph_module.graph.nodes if node.op == "get_attr"
     )
+    attr_values = tuple(
+        _resolve_graph_attr(plan.graph_module, str(node.target)) for node in attr_nodes
+    )
+    # Parameters, buffers, and constant-tensor attributes ride as borrowed
+    # views; non-tensor attributes (scalars, shapes) are captured by value.
+    tensor_attr_nodes = tuple(
+        node
+        for node, value in zip(attr_nodes, attr_values)
+        if isinstance(value, torch.Tensor)
+    )
+    constant_attr_values = {
+        node: value
+        for node, value in zip(attr_nodes, attr_values)
+        if not isinstance(value, torch.Tensor)
+    }
     attr_views = tuple(
-        (
-            MlxTensorView(plan.graph_module.get_parameter(str(node.target)))
-            if str(node.target) in dict(plan.graph_module.named_parameters())
-            else MlxTensorView(plan.graph_module.get_buffer(str(node.target)))
-        )
-        for node in attr_nodes
+        MlxTensorView(value) for value in attr_values if isinstance(value, torch.Tensor)
     )
     placeholder_nodes = tuple(
         node for node in plan.graph_module.graph.nodes if node.op == "placeholder"
@@ -580,7 +613,8 @@ def make_mlx_fx_executor(
         values: dict[torch.fx.Node, Any] = dict(
             zip(tensor_placeholder_nodes, runtime_arrays)
         )
-        values.update(zip(attr_nodes, captured_arrays))
+        values.update(zip(tensor_attr_nodes, captured_arrays))
+        values.update(constant_attr_values)
         for node, node_plan in zip(plan.graph_module.graph.nodes, plan.nodes):
             if node.op in {"placeholder", "get_attr"}:
                 continue
@@ -610,12 +644,8 @@ def make_mlx_fx_executor(
             for index in tensor_positions
         ):
             raise RuntimeError("compiled MLX graph requires Torch MPS tensors")
-        for node, view in zip(attr_nodes, attr_views):
-            target = str(node.target)
-            try:
-                tensor = plan.graph_module.get_parameter(target)
-            except AttributeError:
-                tensor = plan.graph_module.get_buffer(target)
+        for node, view in zip(tensor_attr_nodes, attr_views):
+            tensor = _resolve_graph_attr(plan.graph_module, str(node.target))
             if not view.matches(tensor):
                 view.refresh(tensor)
         return mlx_call_multi(

--- a/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
+++ b/python/sglang/srt/hardware_backend/mlx/fx_lowering.py
@@ -432,8 +432,8 @@ def _lower_reshape(mx, args, kwargs):
 @_lowering("flatten", aten=(torch.ops.aten.flatten.using_ints,))
 def _lower_flatten(mx, args, kwargs):
     value = args[0]
-    start = args[1] if len(args) > 1 else 0
-    end = args[2] if len(args) > 2 else -1
+    start = _arg(args, kwargs, 1, "start_dim", 0)
+    end = _arg(args, kwargs, 2, "end_dim", -1)
     if end < 0:
         end += value.ndim
     flattened = 1
@@ -484,10 +484,14 @@ def _lower_empty_like(mx, args, kwargs):
 @_lowering("slice", aten=(torch.ops.aten.slice.Tensor,))
 def _lower_slice(mx, args, kwargs):
     value = args[0]
-    axis = args[1] if len(args) > 1 else 0
-    start = args[2] if len(args) > 2 else 0
-    stop = args[3] if len(args) > 3 else value.shape[axis]
-    step = args[4] if len(args) > 4 else 1
+    axis = _arg(args, kwargs, 1, "dim", 0)
+    start = _arg(args, kwargs, 2, "start", 0)
+    stop = _arg(args, kwargs, 3, "end")
+    step = _arg(args, kwargs, 4, "step", 1)
+    if start is None:
+        start = 0
+    if stop is None:
+        stop = value.shape[axis]
     width = value.shape[axis]
     if start >= 0:
         start = min(start, width)

--- a/test/registered/unit/hardware_backend/mlx/test_fx_lowering.py
+++ b/test/registered/unit/hardware_backend/mlx/test_fx_lowering.py
@@ -433,3 +433,57 @@ def test_unsupported_compiled_graph_falls_back_as_one_torch_region():
     torch.testing.assert_close(actual, model(value))
     assert len(backend.plans) == 1
     assert not backend.plans[0].fully_supported
+
+
+@pytest.mark.skipif(
+    not _HAS_WHOLE_GRAPH_MLX_RUNTIME,
+    reason="requires Torch 2.13 and MLX on MPS",
+)
+def test_review_flagged_ops_match_eager_through_the_export_path():
+    """mm routing, add/sub alpha, slice bounds, and plain-attribute get_attr.
+
+    Each construct was flagged in review: a bare ``mm`` must compute
+    ``a @ b`` rather than ride the transposing linear lowering; ``add`` and
+    ``sub`` must honour ``alpha``; negative and sentinel slice bounds must
+    match Torch's normalization; and a constant tensor hung directly on the
+    module (neither parameter nor registered buffer) must resolve as a
+    ``get_attr``.
+    """
+
+    class ReviewOps(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.shift = torch.full((4, 4), 0.25, device="mps", dtype=torch.bfloat16)
+
+        def forward(self, x, w):
+            product = torch.mm(x, w)
+            subbed = torch.sub(product, self.shift, alpha=2.0)
+            added = torch.add(product, self.shift, alpha=0.5)
+            return added, subbed, x[:, :-1], x[:, 1:], x[:, -3:]
+
+    model = ReviewOps().eval()
+    x = torch.randn(4, 8, device="mps", dtype=torch.bfloat16)
+    w = torch.randn(8, 4, device="mps", dtype=torch.bfloat16)
+    expected = model(x, w)
+
+    graph_module = torch.export.export(model, (x, w), strict=False).module()
+    # The export guard submodule is dead weight the consumer erases before
+    # planning; do the same here.
+    for node in tuple(graph_module.graph.nodes):
+        if node.op == "call_module" and str(node.target) == "_guards_fn":
+            assert not node.users
+            graph_module.graph.erase_node(node)
+    graph_module.recompile()
+    plan = build_mlx_fx_plan(
+        graph_module, MlxFxLoweringRegistry.standard_export_decoder()
+    )
+    plan.require_fully_supported()
+    executor = make_mlx_fx_executor(plan, [x, w])
+    actual = executor(x, w)
+
+    torch.mps.synchronize()
+    assert len(actual) == len(expected)
+    for actual_item, expected_item in zip(actual, expected):
+        torch.testing.assert_close(
+            actual_item.cpu(), expected_item.cpu(), atol=0.008, rtol=0.03
+        )

--- a/test/registered/unit/hardware_backend/mlx/test_fx_lowering.py
+++ b/test/registered/unit/hardware_backend/mlx/test_fx_lowering.py
@@ -1,0 +1,435 @@
+"""CPU tests for architecture-independent whole-forward FX planning."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+from packaging.version import Version
+
+from sglang.srt.hardware_backend.mlx.fx_lowering import (
+    MlxFxCaptureBackend,
+    MlxFxLoweringRegistry,
+    UnsupportedMlxFxGraphError,
+    build_mlx_fx_plan,
+    export_mlx_plan,
+    make_mlx_fx_executor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+_HAS_WHOLE_GRAPH_MLX_RUNTIME = torch.backends.mps.is_available() and Version(
+    torch.__version__
+) >= Version("2.13")
+
+
+@torch.library.custom_op("sglang_mlx_fx_test::kv_commit", mutates_args={"cache"})
+def _kv_commit(cache: torch.Tensor, value: torch.Tensor) -> None:
+    cache.copy_(value)
+
+
+@_kv_commit.register_fake
+def _kv_commit_fake(cache: torch.Tensor, value: torch.Tensor) -> None:
+    return None
+
+
+class _TinyDecoder(torch.nn.Module):
+    """Qwen/Llama-shaped graph without an architecture-specific contract."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedding = torch.nn.Embedding(32, 8)
+        self.norm = torch.nn.RMSNorm(8)
+        self.qkv = torch.nn.Linear(8, 24, bias=False)
+        self.out = torch.nn.Linear(8, 8, bias=False)
+        self.gate_up = torch.nn.Linear(8, 16, bias=False)
+        self.down = torch.nn.Linear(8, 8, bias=False)
+
+    def forward(self, input_ids: torch.Tensor, cache: torch.Tensor):
+        hidden = self.norm(self.embedding(input_ids))
+        q, k, v = self.qkv(hidden).chunk(3, dim=-1)
+        attention = torch.nn.functional.scaled_dot_product_attention(
+            q[None, None], k[None, None], v[None, None]
+        )[0, 0]
+        hidden = self.out(attention)
+        gate, up = self.gate_up(hidden).chunk(2, dim=-1)
+        hidden = self.down(torch.nn.functional.silu(gate) * up)
+        _kv_commit(cache, hidden)
+        return hidden
+
+
+class _TinyMlp(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.norm = torch.nn.RMSNorm(8)
+        self.gate_up = torch.nn.Linear(8, 16, bias=False)
+        self.down = torch.nn.Linear(8, 8, bias=False)
+
+    def forward(self, value):
+        gate, up = self.gate_up(self.norm(value)).chunk(2, dim=-1)
+        return self.down(torch.nn.functional.silu(gate) * up)
+
+
+def _decoder_registry() -> MlxFxLoweringRegistry:
+    registry = MlxFxLoweringRegistry.standard_decoder()
+    registry.register_function(
+        torch.ops.sglang_mlx_fx_test.kv_commit.default, "kv_commit"
+    )
+    return registry
+
+
+def test_dynamo_captures_dense_decoder_and_kv_commit_as_one_supported_graph():
+    torch._dynamo.reset()
+    model = _TinyDecoder().eval()
+    backend = MlxFxCaptureBackend(_decoder_registry())
+    compiled = torch.compile(model, backend=backend, fullgraph=True)
+    input_ids = torch.tensor([1, 2])
+    expected_cache = torch.zeros(2, 8)
+    actual_cache = torch.zeros(2, 8)
+
+    expected = model(input_ids, expected_cache)
+    actual = compiled(input_ids, actual_cache)
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_cache, expected_cache)
+    assert len(backend.plans) == 1
+    assert backend.plans[0].fully_supported
+    lowerings = {node.lowering for node in backend.plans[0].nodes}
+    assert {
+        "embedding",
+        "rms_norm",
+        "linear",
+        "sdpa",
+        "silu",
+        "multiply",
+        "kv_commit",
+    } <= lowerings
+
+
+def test_executor_factory_receives_the_complete_graph_once():
+    torch._dynamo.reset()
+    executor_plans = []
+
+    def executor_factory(plan, _example_inputs):
+        executor_plans.append(plan)
+        return plan.graph_module.forward
+
+    backend = MlxFxCaptureBackend(
+        _decoder_registry(), executor_factory=executor_factory
+    )
+    compiled = torch.compile(_TinyDecoder().eval(), backend=backend, fullgraph=True)
+    compiled(torch.tensor([1, 2]), torch.zeros(2, 8))
+
+    assert executor_plans == backend.plans
+    assert len(executor_plans) == 1
+
+
+@pytest.mark.skipif(
+    not _HAS_WHOLE_GRAPH_MLX_RUNTIME,
+    reason="requires Torch 2.13 and MLX on MPS",
+)
+def test_generic_mlx_executor_matches_torch_in_one_region():
+    torch._dynamo.reset()
+    model = _TinyMlp().to(device="mps", dtype=torch.bfloat16).eval()
+    backend = MlxFxCaptureBackend(
+        executor_factory=make_mlx_fx_executor,
+    )
+    value = torch.randn(4, 8, device="mps", dtype=torch.bfloat16)
+    expected = model(value)
+    actual = torch.compile(model, backend=backend, fullgraph=True)(value)
+
+    torch.mps.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=0.008, rtol=0.03)
+    assert len(backend.plans) == 1
+    assert backend.plans[0].fully_supported
+
+
+@pytest.mark.skipif(
+    not _HAS_WHOLE_GRAPH_MLX_RUNTIME,
+    reason="requires Torch 2.13 and MLX on MPS",
+)
+def test_generic_mlx_executor_reuses_one_torch_graph_across_token_counts():
+    torch._dynamo.reset()
+    model = _TinyMlp().to(device="mps", dtype=torch.bfloat16).eval()
+    backend = MlxFxCaptureBackend(
+        executor_factory=make_mlx_fx_executor,
+    )
+    first = torch.randn(4, 8, device="mps", dtype=torch.bfloat16)
+    torch._dynamo.mark_dynamic(first, 0, min=2, max=16)
+    compiled = torch.compile(model, backend=backend, fullgraph=True, dynamic=True)
+
+    for value in (
+        first,
+        torch.randn(7, 8, device="mps", dtype=torch.bfloat16),
+        torch.randn(12, 8, device="mps", dtype=torch.bfloat16),
+    ):
+        expected = model(value)
+        actual = compiled(value)
+        torch.mps.synchronize()
+        torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=0.008, rtol=0.03)
+
+    assert len(backend.plans) == 1
+
+
+@pytest.mark.skipif(
+    not _HAS_WHOLE_GRAPH_MLX_RUNTIME,
+    reason="requires Torch 2.13 and MLX on MPS",
+)
+def test_generic_mlx_executor_observes_weight_mutation_and_replacement():
+    torch._dynamo.reset()
+    model = _TinyMlp().to(device="mps", dtype=torch.bfloat16).eval()
+    backend = MlxFxCaptureBackend(executor_factory=make_mlx_fx_executor)
+    compiled = torch.compile(model, backend=backend, fullgraph=True)
+    value = torch.randn(4, 8, device="mps", dtype=torch.bfloat16)
+
+    first = compiled(value)
+    with torch.no_grad():
+        model.gate_up.weight.add_(0.25)
+    mutated_expected = model(value)
+    mutated_actual = compiled(value)
+
+    replacement = torch.nn.Parameter(
+        torch.randn_like(model.gate_up.weight) * 0.05,
+        requires_grad=False,
+    )
+    model.gate_up.weight = replacement
+    replaced_expected = model(value)
+    replaced_actual = compiled(value)
+
+    torch.mps.synchronize()
+    assert not torch.allclose(first.cpu(), mutated_actual.cpu())
+    torch.testing.assert_close(
+        mutated_actual.cpu(), mutated_expected.cpu(), atol=0.008, rtol=0.03
+    )
+    torch.testing.assert_close(
+        replaced_actual.cpu(), replaced_expected.cpu(), atol=0.008, rtol=0.03
+    )
+
+
+@pytest.mark.skipif(
+    not _HAS_WHOLE_GRAPH_MLX_RUNTIME,
+    reason="requires Torch 2.13 and MLX on MPS",
+)
+@pytest.mark.parametrize("architecture", ["qwen3", "llama"])
+def test_same_mlx_executor_runs_real_sglang_mlp_architectures(architecture):
+    from sglang.srt.models.llama import LlamaMLP
+    from sglang.srt.models.qwen3 import Qwen3MLP
+    from sglang.srt.runtime_context import _CONTEXT, get_parallel
+
+    old_server_args = _CONTEXT._server_args
+    old_config_bags = _CONTEXT._config_bags
+    old_parallel_config = get_parallel()._config
+    _CONTEXT.set_server_args(
+        SimpleNamespace(rl_on_policy_target=None, enable_torch_compile=False)
+    )
+    deterministic_exec = SimpleNamespace(
+        deterministic=SimpleNamespace(rl_on_policy_target=None)
+    )
+
+    def get_deterministic_exec():
+        return deterministic_exec
+
+    try:
+        with (
+            get_parallel().override(tp_size=1, tp_rank=0),
+            mock.patch(
+                "sglang.srt.layers.activation.get_exec",
+                new=get_deterministic_exec,
+            ),
+            mock.patch(
+                "sglang.srt.models.qwen2.get_exec",
+                new=get_deterministic_exec,
+            ),
+        ):
+            if architecture == "qwen3":
+                model = Qwen3MLP(8, 16, "silu")
+            else:
+                model = LlamaMLP(8, 16, "silu", tp_rank=0, tp_size=1)
+            model = model.to(device="mps", dtype=torch.bfloat16).eval()
+            with torch.no_grad():
+                for parameter in model.parameters():
+                    parameter.normal_(mean=0.0, std=0.02)
+            gate_up_projection = model.gate_up_proj
+            down_projection = model.down_proj
+
+            def single_rank_gate_up_projection(input_):
+                return (
+                    torch.nn.functional.linear(
+                        input_, gate_up_projection.weight, gate_up_projection.bias
+                    ),
+                    None,
+                )
+
+            def single_rank_down_projection(
+                input_, skip_all_reduce=False, forward_batch=None
+            ):
+                return (
+                    torch.nn.functional.linear(
+                        input_, down_projection.weight, down_projection.bias
+                    ),
+                    None,
+                )
+
+            gate_up_projection.forward = single_rank_gate_up_projection
+            down_projection.forward = single_rank_down_projection
+            model.act_fn.enter_torch_compile(num_tokens=4)
+
+            torch._dynamo.reset()
+            backend = MlxFxCaptureBackend(
+                executor_factory=make_mlx_fx_executor,
+            )
+            value = torch.randn(4, 8, device="mps", dtype=torch.bfloat16)
+            expected = model(value)
+            actual = torch.compile(model, backend=backend, fullgraph=True)(value)
+    finally:
+        _CONTEXT._server_args = old_server_args
+        _CONTEXT._config_bags = old_config_bags
+        get_parallel()._config = old_parallel_config
+
+    torch.mps.synchronize()
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=0.008, rtol=0.03)
+    assert len(backend.plans) == 1
+    assert backend.plans[0].fully_supported
+    assert {"linear", "silu", "multiply"} <= {
+        node.lowering for node in backend.plans[0].nodes
+    }
+
+
+def test_export_functionalizes_kv_mutation_into_explicit_graph_output():
+    registry = MlxFxLoweringRegistry.standard_export_decoder()
+    registry.register_function(
+        torch.ops.sglang_mlx_fx_test.kv_commit.default, "kv_commit"
+    )
+    model = _TinyDecoder().eval()
+    plan = export_mlx_plan(
+        model,
+        (torch.tensor([1, 2]), torch.zeros(2, 8)),
+        registry,
+    )
+
+    assert plan.mutated_user_inputs == ("cache",)
+    lowerings = {node.lowering for node in plan.graph_plan.nodes}
+    assert "functionalized_kv_commit" in lowerings
+    # Core ATen decomposition is intentionally not fully registered yet. This
+    # test proves mutation/state representation, not MLX operation coverage.
+    assert not plan.graph_plan.fully_supported
+    output_kinds = {
+        str(spec.kind).rsplit(".", 1)[-1]
+        for spec in plan.functional_program.graph_signature.output_specs
+    }
+    assert output_kinds == {"USER_INPUT_MUTATION", "USER_OUTPUT"}
+
+
+def test_real_qwen3_mlp_exports_without_an_architecture_registry():
+    from sglang.srt.models.qwen3 import Qwen3MLP
+    from sglang.srt.runtime_context import _CONTEXT, get_parallel
+
+    old_server_args = _CONTEXT._server_args
+    old_config_bags = _CONTEXT._config_bags
+    old_parallel_config = get_parallel()._config
+    _CONTEXT.set_server_args(
+        SimpleNamespace(rl_on_policy_target=None, enable_torch_compile=False)
+    )
+    deterministic_exec = SimpleNamespace(
+        deterministic=SimpleNamespace(rl_on_policy_target=None)
+    )
+
+    def get_deterministic_exec():
+        return deterministic_exec
+
+    try:
+        with (
+            get_parallel().override(tp_size=1, tp_rank=0),
+            mock.patch(
+                "sglang.srt.layers.activation.get_exec",
+                new=get_deterministic_exec,
+            ),
+            mock.patch(
+                "sglang.srt.models.qwen2.get_exec",
+                new=get_deterministic_exec,
+            ),
+        ):
+            model = Qwen3MLP(8, 16, "silu").eval()
+            gate_up_projection = model.gate_up_proj
+            down_projection = model.down_proj
+
+            # Export TP=1 compute without initializing process groups or selecting
+            # hardware-specific GEMM wrappers. Those are separate lowerings.
+            def single_rank_gate_up_projection(input_):
+                return (
+                    torch.nn.functional.linear(
+                        input_, gate_up_projection.weight, gate_up_projection.bias
+                    ),
+                    None,
+                )
+
+            def single_rank_down_projection(
+                input_, skip_all_reduce=False, forward_batch=None
+            ):
+                return (
+                    torch.nn.functional.linear(
+                        input_, down_projection.weight, down_projection.bias
+                    ),
+                    None,
+                )
+
+            gate_up_projection.forward = single_rank_gate_up_projection
+            down_projection.forward = single_rank_down_projection
+            model.act_fn.enter_torch_compile(num_tokens=2)
+            exported = torch.export.export(
+                model,
+                (torch.randn(2, 8),),
+                strict=True,
+            )
+    finally:
+        _CONTEXT._server_args = old_server_args
+        _CONTEXT._config_bags = old_config_bags
+        get_parallel()._config = old_parallel_config
+
+    plan = build_mlx_fx_plan(
+        exported.graph_module,
+        MlxFxLoweringRegistry.standard_export_decoder(),
+    )
+
+    assert plan.fully_supported
+    lowerings = [node.lowering for node in plan.nodes]
+    assert lowerings.count("linear") == 2
+    assert {"silu", "slice", "multiply"} <= set(lowerings)
+
+
+def test_unsupported_operation_rejects_the_complete_region():
+    class UnsupportedModel(torch.nn.Module):
+        def forward(self, value):
+            return torch.sin(value)
+
+    graph = torch.fx.symbolic_trace(UnsupportedModel())
+    plan = build_mlx_fx_plan(graph, MlxFxLoweringRegistry.standard_decoder())
+
+    assert not plan.fully_supported
+    assert len(plan.unsupported) == 1
+    try:
+        plan.require_fully_supported()
+    except UnsupportedMlxFxGraphError as exc:
+        assert "sin" in str(exc)
+    else:
+        raise AssertionError("unsupported FX graph was accepted")
+
+
+def test_unsupported_compiled_graph_falls_back_as_one_torch_region():
+    class UnsupportedModel(torch.nn.Module):
+        def forward(self, value):
+            return torch.sin(value) + 1
+
+    torch._dynamo.reset()
+    backend = MlxFxCaptureBackend(fallback_to_torch=True)
+    model = UnsupportedModel()
+    value = torch.randn(4)
+    actual = torch.compile(model, backend=backend, fullgraph=True)(value)
+
+    torch.testing.assert_close(actual, model(value))
+    assert len(backend.plans) == 1
+    assert not backend.plans[0].fully_supported

--- a/test/registered/unit/hardware_backend/mlx/test_fx_lowering_schema_parity.py
+++ b/test/registered/unit/hardware_backend/mlx/test_fx_lowering_schema_parity.py
@@ -1,0 +1,283 @@
+"""Schema-driven parity tests for every registered ATen-to-MLX lowering.
+
+For each ``@_lowering`` registration, read the live ATen ``_schema`` of its
+targets and enumerate argument variants mechanically: the base case, plus one
+case per defaulted argument with the default overridden. Each case runs the
+real op eagerly on CPU torch (the oracle) and the registered lowering on MLX,
+and the two must agree.
+
+The acceptance rule per case is *match or raise*: a lowering may reject a
+case with ``UnsupportedMlxFxGraphError`` (serving falls back to eager), but
+silent numeric disagreement fails. The base case must match, never raise, so
+an op cannot pass by rejecting everything.
+
+Because the schemas are read from the installed torch at collection time, a
+version bump that adds or changes an argument on any op we lower shows up
+here as new generated cases, without anyone editing this file. A new
+``@_lowering`` registration without a recipe below fails the coverage test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+import torch
+
+from sglang.srt.hardware_backend.mlx.fx_lowering import (
+    _LOWERINGS,
+    UnsupportedMlxFxGraphError,
+    _lower_mlx_node,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=2, suite="stage-a-unit-test-mlx")
+
+_HAS_MLX_RUNTIME = (
+    importlib.util.find_spec("mlx") is not None and torch.backends.mps.is_available()
+)
+
+# Lowerings with no comparable eager output: assert_metadata returns None,
+# getitem's only target carries no ATen schema.
+_EXEMPT = {"assert_metadata", "getitem"}
+
+
+def _t(*shape: int) -> torch.Tensor:
+    return torch.randn(*shape, dtype=torch.float32)
+
+
+def _positive(*shape: int) -> torch.Tensor:
+    return torch.rand(*shape, dtype=torch.float32) + 0.5
+
+
+def _indices(count: int, high: int) -> torch.Tensor:
+    return torch.randint(0, high, (count,))
+
+
+# One recipe per lowering: the base arguments (schema order, tensors plus
+# required scalars), optional value pools for defaulted arguments the generic
+# type pools cannot guess, arguments excluded from overriding (e.g. ones that
+# make eager nondeterministic), and extra hand-picked cases. ``compare`` may
+# be "values" (default) or "shape" for ops with unspecified contents.
+_RECIPES: dict[str, dict] = {
+    "alias": dict(args=lambda: (_t(4, 6),)),
+    "add": dict(
+        args=lambda: (_t(4, 4), _t(4, 4)),
+        pools={"alpha": [2, 0.5]},
+        extra=[lambda: ((_t(4, 4), _t(1, 4)), {})],  # broadcasting
+    ),
+    "subtract": dict(
+        args=lambda: (_t(4, 4), _t(4, 4)),
+        pools={"alpha": [2, 0.5]},
+    ),
+    "multiply": dict(
+        args=lambda: (_t(4, 4), _t(4, 4)),
+        extra=[lambda: ((_t(4, 4), _t(1, 4)), {})],
+    ),
+    "concatenate": dict(args=lambda: ([_t(3, 4), _t(3, 4)],), pools={"dim": [1]}),
+    "stack": dict(args=lambda: ([_t(3, 4), _t(3, 4)],), pools={"dim": [1]}),
+    "chunk": dict(args=lambda: (_t(5, 6), 3), pools={"dim": [1]}),
+    "split": dict(args=lambda: (_t(6, 4), 2), pools={"dim": [1]}),
+    "split_with_sizes": dict(args=lambda: (_t(6, 4), [2, 4])),
+    "embedding": dict(args=lambda: (_t(10, 4), _indices(6, 10))),
+    "empty_like": dict(args=lambda: (_t(4, 6),), compare="shape"),
+    "flatten": dict(
+        args=lambda: (_t(2, 3, 4),), pools={"start_dim": [1], "end_dim": [1]}
+    ),
+    "gelu": dict(args=lambda: (_t(4, 4),), pools={"approximate": ["tanh"]}),
+    "relu": dict(args=lambda: (_t(4, 4),)),
+    "silu": dict(args=lambda: (_t(4, 4),)),
+    "sigmoid": dict(args=lambda: (_t(4, 4),)),
+    "tanh": dict(args=lambda: (_t(4, 4),)),
+    "rsqrt": dict(args=lambda: (_positive(4, 4),)),
+    "index_select": dict(args=lambda: (_t(5, 6), 1, _indices(3, 6))),
+    "layer_norm": dict(
+        args=lambda: (_t(4, 8), [8]),
+        pools={"weight": [_t(8)], "bias": [_t(8)], "eps": [1e-3]},
+        rejects=[lambda: ((_t(4, 8), [4, 8]), {})],  # not last-axis only
+    ),
+    "rms_norm": dict(
+        args=lambda: (_t(4, 8), [8], _t(8)),
+        pools={"eps": [1e-3]},
+    ),
+    "linear": dict(args=lambda: (_t(3, 8), _t(5, 8)), pools={"bias": [_t(5)]}),
+    "matmul": dict(args=lambda: (_t(3, 4), _t(4, 5))),
+    "mean": dict(args=lambda: (_t(3, 4, 5), [1]), exclude={"dtype"}),
+    "numpy_transpose": dict(args=lambda: (_t(3, 4),)),
+    "power": dict(
+        args=lambda: (_positive(4, 4), 2.0),
+        extra=[lambda: ((_positive(4, 4), 0.5), {})],
+    ),
+    "reshape": dict(args=lambda: (_t(4, 6), [6, 4])),
+    "sdpa": dict(
+        args=lambda: (_t(2, 3, 5, 4), _t(2, 3, 5, 4), _t(2, 3, 5, 4)),
+        pools={"is_causal": [True], "scale": [0.5]},
+        exclude={"dropout_p", "attn_mask", "enable_gqa"},
+    ),
+    "slice": dict(args=lambda: (_t(4, 8), 1, 1, -1), pools={"step": [2]}),
+    "to_dtype": dict(args=lambda: (_t(4, 4), torch.float16), exclude={"non_blocking"}),
+    "unsqueeze": dict(args=lambda: (_t(3, 4), 1)),
+}
+
+_TYPE_POOLS = {
+    "bool": lambda default: [not default],
+    "float": lambda default: [(default or 0.0) + 0.5],
+    "int": lambda default: [(default or 0) + 1],
+}
+
+
+def _schema_targets(spec):
+    return [t for t in spec.aten if getattr(t, "_schema", None) is not None]
+
+
+def _override_pool(recipe: dict, argument) -> list:
+    pools = recipe.get("pools", {})
+    if argument.name in pools:
+        return pools[argument.name]
+    type_pool = _TYPE_POOLS.get(str(argument.type))
+    if type_pool is None:
+        return []
+    default = argument.default_value if argument.has_default_value() else None
+    return type_pool(default)
+
+
+def _generate_cases():
+    """(case_id, lowering_name, target, args_factory, kwargs, expect_raise)."""
+    cases = []
+    seen_specs = set()
+    for name, spec in _LOWERINGS.items():
+        if name in _EXEMPT or id(spec) in seen_specs:
+            continue
+        seen_specs.add(id(spec))
+        recipe = _RECIPES.get(name)
+        if recipe is None:
+            continue  # the coverage test reports it
+        for target in _schema_targets(spec):
+            op = str(target).replace("aten.", "")
+            cases.append((f"{op}-base", name, target, recipe["args"], {}, False))
+            for argument in target._schema.arguments:
+                if not argument.has_default_value():
+                    continue
+                if argument.name in recipe.get("exclude", ()):
+                    continue
+                for value in _override_pool(recipe, argument):
+                    label = value if not isinstance(value, torch.Tensor) else "tensor"
+                    cases.append(
+                        (
+                            f"{op}-{argument.name}={label}",
+                            name,
+                            target,
+                            recipe["args"],
+                            {argument.name: value},
+                            False,
+                        )
+                    )
+            for index, extra in enumerate(recipe.get("extra", ())):
+                cases.append(
+                    (f"{op}-extra{index}", name, target, *_split(extra), False)
+                )
+            for index, reject in enumerate(recipe.get("rejects", ())):
+                cases.append(
+                    (f"{op}-reject{index}", name, target, *_split(reject), True)
+                )
+    return cases
+
+
+def _split(case_factory):
+    def args_factory():
+        return case_factory()[0]
+
+    kwargs = case_factory()[1]
+    return args_factory, kwargs
+
+
+def _to_mlx(value):
+    import mlx.core as mx
+
+    if isinstance(value, torch.Tensor):
+        return mx.array(value.numpy())
+    if isinstance(value, (list, tuple)) and any(
+        isinstance(item, torch.Tensor) for item in value
+    ):
+        return [_to_mlx(item) for item in value]
+    return value
+
+
+def _to_torch_outputs(value):
+    import numpy as np
+
+    if isinstance(value, (list, tuple)):
+        return [_to_torch_outputs(item) for item in value]
+    return torch.from_numpy(np.array(value)).to(torch.float32)
+
+
+_CASES = _generate_cases()
+
+
+def test_every_schema_bearing_lowering_has_a_recipe():
+    # Aliases ("view" -> the reshape spec) are covered through the spec they
+    # share, so coverage is judged per spec object, not per name.
+    covered_specs = {
+        id(spec) for name, spec in _LOWERINGS.items() if name in set(_RECIPES) | _EXEMPT
+    }
+    missing = sorted(
+        name
+        for name, spec in _LOWERINGS.items()
+        if id(spec) not in covered_specs and _schema_targets(spec)
+    )
+    assert not missing, (
+        "new lowerings need a parity recipe so their schema variants are "
+        f"exercised: {missing}"
+    )
+
+
+@pytest.mark.skipif(not _HAS_MLX_RUNTIME, reason="requires MLX on Apple Silicon")
+@pytest.mark.parametrize(
+    "name,target,args_factory,kwargs,expect_raise",
+    [case[1:] for case in _CASES],
+    ids=[case[0] for case in _CASES],
+)
+def test_lowering_matches_eager_for_schema_variants(
+    name, target, args_factory, kwargs, expect_raise
+):
+    import mlx.core as mx
+
+    torch.manual_seed(0)
+    args = args_factory()
+    try:
+        expected = target(*args, **kwargs)
+    except Exception as error:  # eager itself rejects this combination
+        pytest.skip(f"eager rejects the case: {error}")
+
+    mlx_args = tuple(_to_mlx(value) for value in args)
+    mlx_kwargs = {key: _to_mlx(value) for key, value in kwargs.items()}
+    try:
+        actual = _lower_mlx_node(name, mlx_args, mlx_kwargs)
+    except UnsupportedMlxFxGraphError:
+        if expect_raise or kwargs:
+            return  # declared rejection, or a variant the lowering declines
+        raise AssertionError(
+            f"lowering {name!r} rejected its base case; the plain-arguments "
+            "form must be supported"
+        )
+    assert not expect_raise, f"lowering {name!r} accepted a case it must reject"
+
+    mx.eval(actual) if not isinstance(actual, (list, tuple)) else mx.eval(*actual)
+    actual = _to_torch_outputs(actual)
+    expected_items = (
+        list(expected) if isinstance(expected, (list, tuple)) else [expected]
+    )
+    actual_items = actual if isinstance(actual, list) else [actual]
+    assert len(actual_items) == len(expected_items)
+    for actual_item, expected_item in zip(actual_items, expected_items):
+        if _RECIPES[name].get("compare") == "shape":
+            assert tuple(actual_item.shape) == tuple(expected_item.shape)
+            continue
+        torch.testing.assert_close(
+            actual_item,
+            expected_item.to(torch.float32),
+            atol=5e-3,
+            rtol=5e-3,
+            msg=lambda default, name=name: f"lowering {name!r} diverged: {default}",
+        )


### PR DESCRIPTION
## Motivation

Split out of #36164 (the MLX whole-region serving PR) so that PR stays reviewable and this layer can be reviewed on its own. Review there flagged the ATen-to-MLX mapping as hard-coded in two places (a mapping table plus a 34-branch dispatch chain) and suggested a config file; this PR lands the layer in its final shape instead.

This module is self-contained: it classifies an exported/compiled FX graph by operation rather than model architecture and lowers admitted ATen ops to MLX. No serving state — no KV pools, no attention contract, no runners. #36164 rebases onto it and keeps only the serving executor.

## Modifications

- `hardware_backend/mlx/fx_lowering.py`:
  - Each lowering is one function registered with `@_lowering(name, aten=..., functions=..., methods=...)`; both standard registries are derived from those registrations. Adding an op is a single self-contained function — no table edit, no new branch, and no stringly-typed config entry that can typo silently.
  - 35 op lowerings, FX graph planning (`build_mlx_fx_plan`), a generic single-region MLX executor over borrowed Torch tensors, export planning (`export_mlx_plan`, functionalized with explicit user-input mutations), and the Dynamo validation backend (`MlxFxCaptureBackend`) reporting whole-graph lowering coverage.

## Accuracy Tests

`test_fx_lowering.py` (11 tests; planning on CPU, execution on Metal): whole-graph capture of a dense decoder with a KV-commit custom op; executor parity against eager Torch in one region; one Torch graph reused across token counts; weight mutation/replacement observed through borrowed views; real SGLang MLP architectures (incl. Qwen3) with no per-architecture registry; functionalized KV mutation surfaced as an explicit graph output; whole-region rejection with eager Torch fallback for unsupported ops.

## How torch/MLX version bumps are re-verified

The schema parity suite (`test_fx_lowering_schema_parity.py`) reads both libraries live on every run, nothing is snapshotted. The core check: for every op we lower, the test runs the op twice with identical inputs, once in plain torch and once through the MLX lowering, and the two results must agree.

**Torch bump**
- Test cases are generated from each op's `_schema` read from the installed torch at collection (base case plus one case per defaulted argument with the default overridden).
- A default changed: plain torch now computes with the new default. If our lowering assumed the old one, the results disagree and the test fails.
- A new argument with a default appeared: the suite reads it from the signature and tests it automatically.
- An op we lower was removed or renamed: our registration can't find it and the module fails to import.
- torch.export starts putting a new op into real model graphs: the end-to-end tests (a real Qwen3 MLP exported and executed) reject the graph and say which op has no lowering.

**MLX bump**
- Every test calls the installed MLX functions for real (`mx.fast.rms_norm`, `mx.fast.scaled_dot_product_attention`, and so on). If MLX changed a function's signature, the call throws and the test fails. If MLX changed the numbers it produces, they no longer match torch and the test fails.

This suite caught two keyword-blind lowerings on its first run (flatten and slice dropping keyword arguments, the same class as the alpha bug from review), fixed in 6b1672a and 3cc5e59.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35200822679](https://github.com/sgl-project/sglang/actions/runs/35200822679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35200822402](https://github.com/sgl-project/sglang/actions/runs/35200822402)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35200822575](https://github.com/sgl-project/sglang/actions/runs/35200822575)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
