### PR TITLE
[MLX] Fall back to no_buffer mamba radix cache on Apple Silicon

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -69,6 +69,7 @@ from sglang.srt.arg_groups.model_override_base import (  # noqa: F401
 
 logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.runtime_context import (
     get_context,
@@ -546,7 +547,8 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
 def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
     """Whether ``model_arch`` supports the extra_buffer strategy on the
     configured linear-attention backend (pure read)."""
-    if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS:
+    # MLX only implements the no_buffer mamba radix-cache strategy.
+    if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS and not use_mlx():
         return view.linear_attn_backend == "triton"
     return False
 

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2330,6 +2330,41 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )
         )
 
+    def test_mlx_never_uses_mamba_extra_buffer(self):
+        # Regression: on the MLX backend (Apple Silicon, SGLANG_USE_MLX=1) the
+        # extra_buffer Mamba radix-cache strategy is unimplemented, so the
+        # auto-resolution must fall back to no_buffer instead of picking
+        # extra_buffer and crashing in validate_mamba_extra_buffer with
+        # "extra_buffer needs CUDA/MUSA/NPU/ROCm/XPU (FLA)".
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _mamba_radix_cache_resolution,
+        )
+
+        view = ResolvedView(
+            SimpleNamespace(
+                _model_config=SimpleNamespace(
+                    hf_config=SimpleNamespace(architectures=["Qwen3NextForCausalLM"])
+                ),
+                disable_radix_cache=False,
+                mamba_radix_cache_strategy="auto",
+                disable_overlap_schedule=False,
+                page_size=None,
+                linear_attn_backend="triton",
+                linear_attn_prefill_backend=None,
+            )
+        )
+        target = "sglang.srt.arg_groups.overrides"
+        with patch(target + ".use_mlx", return_value=True):
+            self.assertEqual(
+                _mamba_radix_cache_resolution(view),
+                {
+                    "uses_mamba_radix_cache": True,
+                    "mamba_radix_cache_strategy": "no_buffer",
+                    "disable_overlap_schedule": True,
+                },
+            )
+
     def test_qwen3_5_hybrid_coupled_declaration(self):
         from sglang.srt.arg_groups.model_overrides.qwen3_5 import (
             _qwen3_5_hybrid_overrides,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Running a hybrid Mamba/linear-attention model on the MLX backend (Apple Silicon, `SGLANG_USE_MLX=1`) fails during server-argument resolution:

```yaml
AssertionError: extra_buffer needs CUDA/MUSA/NPU/ROCm/XPU (FLA).
```

With `--mamba-radix-cache-strategy auto` (the default), hybrid architectures that support the `extra_buffer` strategy (e.g. `FalconH1ForCausalLM`, `Qwen3NextForCausalLM`, `NemotronHForCausalLM`) resolve to `extra_buffer` whenever overlap scheduling or paging is desired. But MLX never implements `extra_buffer` — it has no overlap scheduler or paged extra buffer — so `validate_mamba_extra_buffer` trips the platform assertion before any model loads. The MLX backend should therefore always fall back to the `no_buffer` strategy.

## Modifications

In `python/sglang/srt/arg_groups/overrides.py`, `supports_mamba_cache_extra_buffer` now returns `False` on the MLX backend (`use_mlx()`, which is only true when `SGLANG_USE_MLX=1` and the MLX runtime validates). The gate is folded into the existing architecture check, so the function body changes by one line only:

```python
# MLX only implements the no_buffer mamba radix-cache strategy.
if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS and not use_mlx():
    return view.linear_attn_backend == "triton"
return False
```

Because the `auto` resolution in `_mamba_radix_cache_resolution` gates on this predicate, MLX automatically selects `no_buffer` and disables overlap scheduling — the only Mamba radix-cache strategy the MLX backend implements — while CUDA/MUSA/NPU/ROCm/XPU remain unaffected. `use_mlx()` is lazy, so non-MLX platforms take the exact same path as before.

Added a unit regression test `test_mlx_never_uses_mamba_extra_buffer` in `test/registered/unit/test_model_overrides.py` that mocks the MLX backend and asserts `_mamba_radix_cache_resolution` resolves `auto` to `no_buffer` on `Qwen3NextForCausalLM`.

## Accuracy Tests

This change only alters which Mamba radix-cache strategy is selected during argument resolution on the MLX backend; it does not touch any model forward or kernel code, so model outputs are unchanged. Verified locally on Apple Silicon with `mlx-community/Falcon-H1-0.5B-Instruct-4bit` (`SGLANG_USE_MLX=1`): the server now gets past resolution (`mamba_radix_cache_strategy: no_buffer`, `disable_overlap_schedule: True`) and proceeds to MLX model loading instead of aborting on the `extra_buffer` assertion.

## Speed Tests and Profiling

No speed impact. Previously the server never got past startup argument resolution on MLX for these hybrid models; with the fix it starts and reaches the MLX model runner, where performance is governed by the existing MLX runtime.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33722291655](https://github.com/sgl-project/sglang/actions/runs/33722291655)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33722291513](https://github.com/sgl-project/sglang/actions/runs/33722291513)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33722291630](https://github.com/sgl-project/sglang/actions/runs/33722291630)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
