### PR TITLE
docs(cookbook): enable FlashInfer GDN for Qwen3.5 B200

### DIFF
--- a/docs/src/snippets/autoregressive/qwen35-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen35-deployment.jsx
@@ -438,6 +438,15 @@ export const Qwen35Deployment = () => {
       }
     }
 
+    // B200 NVFP4 with MTP runs TP2/EP2 (set above). Keep Triton as the base
+    // linear-attention backend while routing GDN decode and prefill through
+    // FlashInfer.
+    if (model === '397b' && hardware === 'b200' && quantization === 'fp4' && speculative === 'enabled') {
+      cmd += ` \\\n  --linear-attn-backend triton`;
+      cmd += ` \\\n  --linear-attn-decode-backend flashinfer`;
+      cmd += ` \\\n  --linear-attn-prefill-backend flashinfer`;
+    }
+
     // Append backend configurations
     if (hardware === 'b200' || (hardware === 'b300' && quantization === 'fp4')) {
       cmd += ` \\\n  --attention-backend trtllm_mha`;


### PR DESCRIPTION
## Motivation

The Qwen3.5-397B NVFP4 B200 MTP recipe runs with TP2/EP2. The exact configuration was validated by [SemiAnalysisAI/InferenceX#2790](https://github.com/SemiAnalysisAI/InferenceX/pull/2790) in [Run Sweep 33451222974, attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974) on head `0c32f3c2ba871287587bb1baf0d21cee65c44bd4`.

This change carries the validated Gated Delta Network backend routing into the generated cookbook command.

## Modifications

- Keep Triton as the base linear-attention backend for Qwen3.5-397B NVFP4 on B200 with MTP.
- Route both GDN decode and prefill through FlashInfer.
- Scope the flags to the B200 + FP4 + MTP selection; MTP-off, B300, and FP8 commands are unchanged.

## Accuracy Tests

The exact InferenceX head passed the TP2/EP2 evaluation jobs in Run Sweep 33451222974, attempt 2:

- [TP2/EP2 MTP, concurrency 32](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974/job/99726193813)
- [TP2/EP2 MTP, concurrency 64](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974/job/99726194824)

## Speed Tests and Profiling

The same run passed the 8K input / 1K output TP2/EP2 MTP jobs at:

- [Concurrency 16](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974/job/99726193821)
- [Concurrency 32](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974/job/99726193755)
- [Concurrency 64](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33451222974/job/99726193820)

## Validation

- Generated-command probe: target command contains TP2/EP2 and all three linear-attention flags.
- Negative probes: the flags are absent for MTP-off, B300, and FP8 selections.
- `node docs/scripts/check_cookbook_configs.mjs`
- `mint validate` with Mint 4.2.559 on Node 20
- `mint broken-links --check-anchors --check-redirects` with Mint 4.2.559 on Node 20
- `git diff --check`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Documentation-only generator change; covered by generated-command target and negative probes.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33477375407](https://github.com/sgl-project/sglang/actions/runs/33477375407)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33477375183](https://github.com/sgl-project/sglang/actions/runs/33477375183)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->