### PR TITLE
[CPU] Part 2: Add DeepSeek3.x/GLM5.x support and optimizations on CPU

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/quant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsa/quant_k_cache.py
@@ -7,6 +7,44 @@ def quantize_k_cache(cache_k):
     return _quantize_k_cache_fast_wrapped(cache_k)
 
 
+def _quantize_k_cache_ref_separate(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    group_size: int = 128,
+):
+    """
+    :param k_nope: (num_tokens, dim_nope 512) bfloat16
+    :param k_rope: (num_tokens, dim_rope 64) bfloat16
+    :return: same (nope_part_u8, rope_part_u8) byte layout as
+        ``_quantize_k_cache_fast_separate``.
+    """
+    num_tokens, dim_nope = k_nope.shape
+    _, dim_rope = k_rope.shape
+    assert dim_nope % group_size == 0
+    num_tiles = dim_nope // group_size
+
+    k_nope = k_nope.contiguous()
+    k_rope = k_rope.contiguous()
+
+    nope_part = torch.empty(
+        (num_tokens, dim_nope + num_tiles * 4),
+        dtype=torch.float8_e4m3fn,
+        device=k_nope.device,
+    )
+    nope_q = nope_part[:, :dim_nope]
+    nope_s = nope_part[:, dim_nope:].view(torch.float32)
+
+    k_nope_tiled = k_nope.view(num_tokens, num_tiles, group_size)
+    scale = k_nope_tiled.abs().amax(dim=-1).float() / 448.0
+    nope_s[:] = scale
+    quantized = (k_nope_tiled.float() / scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+    nope_q.view(num_tokens, num_tiles, group_size)[:] = quantized
+
+    rope_part_u8 = k_rope.view(torch.uint8).view(num_tokens, dim_rope * k_rope.element_size())
+
+    return nope_part.view(torch.uint8).unsqueeze(1), rope_part_u8.unsqueeze(1)
+
+
 def quantize_k_cache_separate(
     k_nope: torch.Tensor,
     k_rope: torch.Tensor,
@@ -48,6 +86,11 @@ def quantize_k_cache_separate(
     if k_rope_2d.shape[0] != num_tokens:
         raise ValueError(
             f"k_nope and k_rope must have same num_tokens, got {num_tokens} vs {k_rope_2d.shape[0]}"
+        )
+
+    if k_nope_2d.device.type == "cpu":
+        return _quantize_k_cache_ref_separate(
+            k_nope=k_nope_2d, k_rope=k_rope_2d, group_size=tile_size
         )
 
     return _quantize_k_cache_fast_separate(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -797,10 +797,12 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
 
     if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
         # Set attention backend for DeepSeek
-        if server_args.is_attention_backend_not_set():
+        if server_args.is_attention_backend_not_set() or (
+            server_args.device == "cpu" and server_args.attention_backend == "intel_amx"
+        ):
             overrides["attention_backend"] = "dsa"
             logger.info("Use dsa attention backend for DeepSeek with DSA.")
-        if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
+        if not is_npu() and not is_xpu():  # CUDA or ROCm GPU or CPU
             if cfg.enable_prefill_cp:
                 logger.warning(
                     "Context parallel feature is still under experiment. It has only been verified on Hopper platform."

--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -89,7 +89,50 @@ def adjust_tp_num_heads_if_necessary(model_config, tp_size, is_post_update):
     # is_post_update: whether to update an existing config
     from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
 
-    # Linear attn check logic
+    # GLM/DeepSeekV2 MLA check logic.
+    if all(
+        hasattr(model_config, attr)
+        for attr in ["num_attention_heads", "qk_nope_head_dim", "v_head_dim"]
+    ):
+        import math
+
+        old_num_attention_heads = model_config.num_attention_heads
+        kv_b_head_dim = model_config.qk_nope_head_dim + model_config.v_head_dim
+
+        block_n = None
+        quant_config = getattr(model_config, "quantization_config", None)
+        if isinstance(quant_config, dict):
+            weight_block_size = quant_config.get("weight_block_size")
+            if isinstance(weight_block_size, list) and len(weight_block_size) >= 1:
+                block_n = weight_block_size[0]
+
+        required_multiple = tp_size
+        if block_n is not None:
+            # Ensure (num_heads * kv_b_head_dim / tp_size) aligns to block_n.
+            align_base = tp_size * block_n
+            heads_multiple_for_block = align_base // math.gcd(kv_b_head_dim, align_base)
+            required_multiple = math.lcm(required_multiple, heads_multiple_for_block)
+
+        new_num_attention_heads = pad_vocab_size(
+            old_num_attention_heads, required_multiple
+        )
+        if new_num_attention_heads != old_num_attention_heads:
+            update_config(model_config, "num_attention_heads", new_num_attention_heads)
+
+            # Keep KV-head ratio unchanged when applicable.
+            if hasattr(model_config, "num_key_value_heads"):
+                old_num_kv_heads = model_config.num_key_value_heads
+                if (
+                    isinstance(old_num_kv_heads, int)
+                    and old_num_kv_heads > 0
+                    and old_num_attention_heads % old_num_kv_heads == 0
+                ):
+                    query_heads_per_kv = old_num_attention_heads // old_num_kv_heads
+                    if new_num_attention_heads % query_heads_per_kv == 0:
+                        new_num_kv_heads = new_num_attention_heads // query_heads_per_kv
+                        update_config(model_config, "num_key_value_heads", new_num_kv_heads)
+
+    # Linear attention check logic for mamba/qwen models.
     if hasattr(model_config, "linear_num_key_heads") and hasattr(
         model_config, "linear_num_value_heads"
     ):
@@ -216,6 +259,43 @@ def update_config(model_config, attr_name, new_value):
     setattr(model_config, attr_name, new_value)
 
 
+def _iter_hf_text_like_configs(model_config):
+    """Yield unique HF config objects that may carry text head fields."""
+    seen = set()
+    candidates = [
+        getattr(model_config, "hf_config", None),
+        getattr(model_config, "hf_text_config", None),
+        getattr(getattr(model_config, "hf_config", None), "text_config", None),
+    ]
+    for cfg in candidates:
+        if cfg is None:
+            continue
+        cfg_id = id(cfg)
+        if cfg_id in seen:
+            continue
+        seen.add(cfg_id)
+        yield cfg
+
+
+def _sync_attention_head_fields(model_config):
+    """Keep ModelConfig caches and all text-like HF configs consistent."""
+    source_cfg = getattr(model_config, "hf_text_config", None)
+    if source_cfg is None:
+        source_cfg = getattr(getattr(model_config, "hf_config", None), "text_config", None)
+    if source_cfg is None:
+        source_cfg = getattr(model_config, "hf_config", None)
+    if source_cfg is None:
+        return
+
+    for field in ["num_attention_heads", "num_key_value_heads"]:
+        if not hasattr(source_cfg, field):
+            continue
+        value = getattr(source_cfg, field)
+        update_config(model_config, field, value)
+        for cfg in _iter_hf_text_like_configs(model_config):
+            update_config(cfg, field, value)
+
+
 def adjust_config_with_unaligned_cpu_tp(
     model_config: ModelConfig, load_config: LoadConfig, tp_size: int
 ) -> ModelConfig:
@@ -275,11 +355,10 @@ def adjust_config_with_unaligned_cpu_tp(
             update_config(config, "num_key_value_heads", num_key_value_heads)
             update_config(config, "num_attention_heads", num_attention_heads)
 
-    adjust_tp_num_heads_if_necessary(model_config.hf_config, tp_size, True)
-    if hasattr(model_config.hf_config, "text_config"):
-        adjust_tp_num_heads_if_necessary(
-            model_config.hf_config.text_config, tp_size, True
-        )
+    for config in _iter_hf_text_like_configs(model_config):
+        adjust_tp_num_heads_if_necessary(config, tp_size, True)
+
+    _sync_attention_head_fields(model_config)
 
     intermediate_padding_size = tp_size * get_moe_padding_size(weight_block_size)
     if model_config.quantization == "mxfp4":

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+import psutil
 import torch
 from einops import rearrange
 
@@ -51,7 +52,11 @@ from sglang.srt.state_capturer.indexer_topk import (
 from sglang.srt.utils import (
     add_prefix,
     ceil_align,
+    cpu_has_amx_support,
+    get_available_gpu_memory,
     get_bool_env_var,
+    get_cpu_memory_capacity,
+    is_cpu,
     is_cuda,
     is_gfx95_supported,
     is_hip,
@@ -66,8 +71,9 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
-
-if not _is_npu:
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
+if not (_is_npu or _is_cpu):
     from sglang.kernels.ops.attention.dsa import (
         aiter_paged_mqa_logits,
         cutedsl_paged_mqa_logits,
@@ -88,6 +94,9 @@ else:
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
+
+_CPU_SKIP_INDEXER_HADAMARD = True
+
 # Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
 # KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
 # path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
@@ -121,6 +130,7 @@ from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
+    get_req_to_token_pool,
     get_token_to_kv_pool,
 )
 from sglang.srt.model_executor.runner import get_is_capture_mode
@@ -201,6 +211,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
     _MQA_LOGITS_STATIC_SKIP_ELEMS = 8_000_000
     _MQA_LOGITS_TOTAL_MEM_FRACTION = 0.3
     _mqa_logits_budget_bytes: Dict[int, int] = {}
+    _CPU_MQA_LOGITS_BUDGET_KEY = -1
 
     @staticmethod
     def _mqa_logits_free_mem_fraction() -> float:
@@ -235,7 +246,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         self.q_lora_rank = q_lora_rank
         self.layer_id = layer_id
         self.use_dsa_indexer_fusion = (
-            _is_cuda
+            (_is_cuda or _is_cpu)
             and not envs.SGLANG_DISABLE_DSA_INDEXER_FUSION.get()
             and not is_neox_style
         )
@@ -291,7 +302,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             self.k_norm = RMSNorm(self.head_dim)
         else:
             self.k_norm = LayerNorm(
-                self.head_dim, dtype=torch.bfloat16 if _use_aiter else torch.float32
+                self.head_dim, dtype=torch.bfloat16 if (_use_aiter or (_is_cpu and _cpu_amx)) else torch.float32
             )
         self.rotary_emb = get_rope_wrapper(
             rope_head_dim,
@@ -385,7 +396,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
     def _maybe_rotate(self, x: torch.Tensor) -> torch.Tensor:
         # Fusion drops the (logit-preserving) Hadamard rotation; without it the
         # index-K cache here matches the fused path that decode reads back.
-        return x if self.use_dsa_indexer_fusion else rotate_activation(x)
+        return x if self.use_dsa_indexer_fusion or (_is_cpu and _CPU_SKIP_INDEXER_HADAMARD) else rotate_activation(x)
 
     def _should_skip_logits_computation(self, forward_batch: ForwardBatch) -> bool:
         # When kv_len <= index_topk the top-k selects ALL valid positions, so the
@@ -569,6 +580,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
     ):
         # Non-fusion path only; self.wk does not exist when fusion is on.
         key, _ = self.wk(x)
+        key = key.to(torch.bfloat16)
         key = self.k_norm(key)
         k_rope, _ = torch.split(
             key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
@@ -582,7 +594,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             dummy_q_rope = k_rope
         _, k_rope = self.rotary_emb(positions, dummy_q_rope, k_rope)
         self._update_rope_guarded(key[..., : self.rope_head_dim], k_rope)
-        key = rotate_activation(key)
+        key = self._maybe_rotate(key)
 
         return key
 
@@ -602,6 +614,21 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if hasattr(pool, "invalidate_index_buffer_for_layer"):
             pool.invalidate_index_buffer_for_layer(layer_id)
         if hasattr(pool, "_is_layer_owned") and not pool._is_layer_owned(layer_id):
+            return
+        if _is_cpu:
+            if not out_cache_loc.is_contiguous():
+                out_cache_loc = out_cache_loc.contiguous()
+            torch.ops.sgl_kernel.fused_k_indexer_norm_rope_store_cpu(
+                key_raw,
+                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+                out_cache_loc,
+                self.k_norm.weight,
+                self.k_norm.bias,
+                self.k_norm.variance_epsilon,
+                self._indexer_cos_sin_cache,
+                positions,
+                page_size,
+            )
             return
         if (
             not _is_fp8_fnuz
@@ -636,6 +663,21 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             key=key,
             act_quant=act_quant,
             out_cache_loc=out_cache_loc,
+        )
+
+    def _fused_q_rope_quant(
+        self,
+        q: torch.Tensor,
+        weights_raw: torch.Tensor,
+        q_scale_gate: float,
+        positions: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if _is_cpu:
+            return torch.ops.sgl_kernel.fused_q_indexer_rope_first_quant_cpu(
+                q, weights_raw, q_scale_gate, self._indexer_cos_sin_cache, positions
+            )
+        return fused_q_indexer_rope_first_quant(
+            q, weights_raw, q_scale_gate, self._indexer_cos_sin_cache, positions
         )
 
     def _fused_q_prepare_and_store(
@@ -675,12 +717,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             q = self.wq_b(q_lora)[0].view(-1, self.n_heads, self.head_dim)
             if num_tokens is not None:
                 q = q[:num_tokens]
-            return fused_q_indexer_rope_first_quant(
-                q.contiguous(),
-                weights_raw,
-                q_scale_gate,
-                self._indexer_cos_sin_cache,
-                positions,
+            return self._fused_q_rope_quant(
+                q.contiguous(), weights_raw, q_scale_gate, positions
             )
 
         # Two overlap stages: wq_b GEMM (alt) || wk_weights_proj GEMM (current),
@@ -702,12 +740,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         current_stream.wait_stream(self.alt_stream)
         self.alt_stream.wait_stream(current_stream)
-        q_fp8, weights = fused_q_indexer_rope_first_quant(
-            q.contiguous(),
-            weights_raw,
-            q_scale_gate,
-            self._indexer_cos_sin_cache,
-            positions,
+        q_fp8, weights = self._fused_q_rope_quant(
+            q.contiguous(), weights_raw, q_scale_gate, positions
         )
         with torch.cuda.stream(self.alt_stream):
             self._fused_k_prepare_and_store(
@@ -888,7 +922,17 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
 
-        if self.paged_mqa_logits_backend.is_aiter():
+        if _is_cpu:
+            logits = torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
+                q_fp8.unsqueeze(1),
+                kv_cache_fp8,
+                weights,
+                seqlens_32,
+                block_tables,
+                max_seq_len,
+                False,
+            )
+        elif self.paged_mqa_logits_backend.is_aiter():
             logits = aiter_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -962,11 +1006,21 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     def _get_mqa_logits_budget_bytes(self, device_index: int) -> int:
         free_mem_fraction = self._mqa_logits_free_mem_fraction()
+        if _is_cpu:
+            assert device_index == self._CPU_MQA_LOGITS_BUDGET_KEY
         cached_budget = self._mqa_logits_budget_bytes.get(device_index)
         if cached_budget is not None:
             return cached_budget
 
-        total_mem = torch.cuda.get_device_properties(device_index).total_memory
+        if _is_cpu:
+            cpu_mem_capacity_mb = get_cpu_memory_capacity()
+            total_mem = (
+                int(cpu_mem_capacity_mb * (1 << 20))
+                if cpu_mem_capacity_mb is not None
+                else int(psutil.virtual_memory().total)
+            )
+        else:
+            total_mem = torch.cuda.get_device_properties(device_index).total_memory
 
         total_mem_budget = int(total_mem * self._MQA_LOGITS_TOTAL_MEM_FRACTION)
         mem_fraction_static = get_schedule().mem_fraction_static
@@ -987,9 +1041,12 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             return static_budget
 
         # Match the original free-memory guard: logits_bytes * 2 > free_mem.
-        # torch.cuda.mem_get_info synchronizes the host, so cache the result,
+        # Querying free memory synchronizes/reads the host, so cache the result,
         # capped by the workload-independent serving-memory headroom.
-        free_mem, _ = torch.cuda.mem_get_info(device_index)
+        if _is_cpu:
+            free_mem = int(get_available_gpu_memory("cpu", 0) * (1 << 30))
+        else:
+            free_mem, _ = torch.cuda.mem_get_info(device_index)
         budget_bytes = min(int(free_mem * free_mem_fraction), static_budget)
 
         budget_bytes = max(1, budget_bytes)
@@ -1212,6 +1269,154 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 ke_offset=lengths_chunk,
                 batch_idx_list=batch_idx_chunk,
                 topk_indices_offset_override=topk_offset_chunk,
+            )
+            topk_result[start:end] = raw_topk_chunk
+            start = end
+
+        return topk_result
+
+    def _get_topk_ragged_cpu(
+        self,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        metadata: BaseIndexerMetadata,
+        topk_result: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if TYPE_CHECKING:
+            assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
+
+        assert forward_batch.forward_mode.is_extend_without_speculative()
+
+        page_size = get_token_to_kv_pool().page_size
+        assert page_size == 64, "CPU DSA indexer only supports page size 64"
+
+        assert len(weights.shape) == 3
+        assert (
+            forward_batch.seq_lens_cpu is not None
+            and forward_batch.extend_seq_lens_cpu is not None
+        )
+        weights = weights.squeeze(-1)
+
+        block_tables = metadata.get_page_table_64()
+
+        batch_size = len(block_tables)
+        token_nums, _, _ = q_fp8.shape
+
+        if topk_result is None:
+            topk_result = torch.full(
+                (token_nums, self.index_topk), -1, device="cpu", dtype=torch.int32
+            )
+        if batch_size == 0:
+            return topk_result
+
+        ks, ke = metadata.get_indexer_kvcache_range()
+
+        indexer_seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
+        seq_len_sum = torch.sum(indexer_seq_lens_cpu).item()
+        max_seq_len = torch.max(indexer_seq_lens_cpu).item()
+        k_fp8, k_scale = get_token_to_kv_pool().get_index_k_scale_buffer(
+            layer_id,
+            metadata.get_indexer_seq_len(),
+            block_tables,
+            seq_len_sum,
+            max_seq_len,
+        )
+        k_fp8 = k_fp8.view(torch.float8_e4m3fn)
+        k_scale = k_scale.view(torch.float32).squeeze(-1)
+
+        seq_lens_expanded = metadata.get_seqlens_expanded()
+        q_offset = ks.shape[0]
+        k_offset = k_fp8.shape[0]
+
+        # Per-request row boundaries in the same (expanded) token domain as
+        # ks/ke, so the kernel can align its row-tiles to request boundaries
+        # instead of straddling two requests' disjoint k-ranges.
+        extend_lens_cpu = metadata.get_dsa_extend_len_cpu()
+        assert sum(extend_lens_cpu) == q_offset
+
+        assert q_fp8[:q_offset].shape[0] != 0
+        need_chunk, logits_budget_bytes = self._should_chunk_mqa_logits(
+            q_offset, k_offset, self._CPU_MQA_LOGITS_BUDGET_KEY
+        )
+
+        if not need_chunk:
+            cu_seqlens_q = torch.zeros(len(extend_lens_cpu) + 1, dtype=torch.int32)
+            cu_seqlens_q[1:] = torch.tensor(extend_lens_cpu, dtype=torch.int32).cumsum(
+                0
+            )
+            logits = torch.ops.sgl_kernel.fp8_mqa_logits_cpu(
+                q_fp8[:q_offset],
+                k_fp8,
+                k_scale,
+                weights[:q_offset],
+                ks,
+                ke,
+                cu_seqlens_q,
+                False,
+            )
+            assert logits.shape[0] == len(seq_lens_expanded)
+            assert logits.shape[1] == k_offset
+
+            self._mask_init_and_local_tokens(logits, seq_lens_expanded, ks)
+            raw_topk_result = metadata.topk_transform(logits, self.index_topk, ks=ks)
+            topk_result[:q_offset] = raw_topk_result
+            return topk_result
+
+        # The dense [num_q, k_offset] logits buffer would exceed the per-NUMA-node
+        # memory budget (k_fp8/k_scale stay full-size across chunks - only the
+        # quadratic-in-batch-size row dimension is bounded here). Chunk on
+        # whole-request boundaries (never split one request's rows across chunks)
+        # so each chunk gets its own request-local cu_seqlens_q starting at 0.
+        bytes_per_row = k_offset * self._MQA_LOGITS_BYTES_PER_ELEM
+        max_rows = max(1, int(logits_budget_bytes // max(bytes_per_row, 1)))
+        token_to_batch_idx = metadata.get_token_to_batch_idx()
+
+        start = 0
+        req_idx = 0
+        num_reqs = len(extend_lens_cpu)
+        while start < q_offset:
+            chunk_reqs = []
+            chunk_len = 0
+            while req_idx < num_reqs and (
+                chunk_len == 0 or chunk_len + extend_lens_cpu[req_idx] <= max_rows
+            ):
+                chunk_reqs.append(extend_lens_cpu[req_idx])
+                chunk_len += extend_lens_cpu[req_idx]
+                req_idx += 1
+            end = start + chunk_len
+
+            cu_seqlens_q_chunk = torch.zeros(len(chunk_reqs) + 1, dtype=torch.int32)
+            cu_seqlens_q_chunk[1:] = torch.tensor(
+                chunk_reqs, dtype=torch.int32
+            ).cumsum(0)
+
+            logits_chunk = torch.ops.sgl_kernel.fp8_mqa_logits_cpu(
+                q_fp8[start:end],
+                k_fp8,
+                k_scale,
+                weights[start:end],
+                ks[start:end],
+                ke[start:end],
+                cu_seqlens_q_chunk,
+                False,
+            )
+            assert logits_chunk.shape[1] == k_offset
+
+            lengths_chunk = seq_lens_expanded[start:end]
+            self._mask_init_and_local_tokens(
+                logits_chunk, lengths_chunk, ks[start:end]
+            )
+            # PAGED transform: each row is its own length-1 "sequence".
+            cu_seqlens_q_topk_chunk = torch.ones(end - start, dtype=torch.int32)
+            raw_topk_chunk = metadata.topk_transform(
+                logits_chunk,
+                self.index_topk,
+                ks=ks[start:end],
+                cu_seqlens_q=cu_seqlens_q_topk_chunk,
+                ke_offset=lengths_chunk,
+                batch_idx_list=token_to_batch_idx[start:end],
             )
             topk_result[start:end] = raw_topk_chunk
             start = end
@@ -1897,5 +2102,139 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     )
         else:
             raise NotImplementedError("DSA indexer only supports CUDA, HIP, and NPU")
+        topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
+        return maybe_capture_indexer_topk(layer_id, topk_result)
+
+    def forward_cpu(
+        self,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        return_indices: bool = True,
+    ) -> Optional[torch.Tensor]:
+        def act_quant_cpu(
+            x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
+            return torch.ops.sgl_kernel.act_quant_cpu(x, block_size, scale_fmt)
+        if TYPE_CHECKING:
+            assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
+
+        # When upstream uses fused FP8 RMSNorm+quant, activations may be passed as
+        # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
+        x_meta = x[0] if isinstance(x, tuple) else x
+        metadata = get_attn_backend().get_indexer_metadata(layer_id, forward_batch)
+        if metadata is None:
+            return None
+
+        # Determine if should skip topk based on sequence length
+        skip_logits_computation = False
+        if forward_batch.forward_mode.is_extend_without_speculative():
+            if forward_batch.seq_lens_cpu is not None:
+                max_kv_len = forward_batch.seq_lens_cpu.max().item()
+                skip_logits_computation = max_kv_len <= self.index_topk
+
+        # fast path when skipping topk computation
+        if skip_logits_computation and (not self.dsa_enable_prefill_cp):
+            topk_result = self._forward_cuda_k_only(
+                x,
+                positions,
+                forward_batch,
+                layer_id,
+                act_quant_cpu,
+                metadata,
+                return_indices,
+            )
+            topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
+            return maybe_capture_indexer_topk(layer_id, topk_result)
+
+        weights_proj_lora = not self.use_dsa_indexer_fusion and getattr(
+            self.weights_proj, "set_lora", False
+        )
+        if self.use_dsa_indexer_fusion and forward_batch.attn_cp_metadata is None:
+            q_fp8, weights = self._fused_q_prepare_and_store(
+                x,
+                q_lora,
+                positions,
+                forward_batch,
+                layer_id,
+                act_quant_cpu,
+                enable_dual_stream=False,
+            )
+        elif forward_batch.forward_mode.is_decode_or_idle():
+            weights = self.weights_proj(x)[0].float() * self.n_heads**-0.5
+            query, key, weights_raw = self._get_q_k_bf16(
+                q_lora, x, positions, False, forward_batch=forward_batch
+            )
+            q_fp8, q_scale = act_quant_cpu(query, self.block_size, self.scale_fmt)
+            self._store_index_k_cache(
+                forward_batch=forward_batch,
+                layer_id=layer_id,
+                key=key,
+                act_quant=act_quant_cpu,
+            )
+            weights = weights.unsqueeze(-1) * (q_scale * self.softmax_scale)
+        else:
+            query, key, weights_raw = self._get_q_k_bf16(
+                q_lora, x, positions, False, forward_batch=forward_batch
+            )
+            q_fp8, q_scale = act_quant_cpu(query, self.block_size, self.scale_fmt)
+            self._store_index_k_cache(
+                forward_batch=forward_batch,
+                layer_id=layer_id,
+                key=key,
+                act_quant=act_quant_cpu,
+            )
+            if isinstance(x, tuple):
+                assert len(x) in (
+                    2,
+                    3,
+                ), "For tuple input, only (x, x_s) or (x, x_s, y) formats are accepted"
+                x_q, x_s = x[0], x[1]
+                if (
+                    x_s is not None
+                    and x_q.dim() == 2
+                    and x_s.dim() == 2
+                    and x_q.shape[0] == x_s.shape[0]
+                ):
+                    m, n = x_q.shape
+                    ng = x_s.shape[1]
+                    if ng > 0 and n % ng == 0:
+                        group = n // ng
+                        x_for_gate = (
+                            x_q.to(torch.float32)
+                            .view(m, ng, group)
+                            .mul_(x_s.to(torch.float32).unsqueeze(-1))
+                            .view(m, n)
+                            .to(torch.bfloat16)
+                        )
+                    else:
+                        x_for_gate = x_q.to(torch.bfloat16)
+                else:
+                    x_for_gate = x_q.to(torch.bfloat16)
+            else:
+                x_for_gate = x
+            if weights_proj_lora:
+                weights = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
+                weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
+            else:
+                weights = self._get_logits_head_gate(x_for_gate, q_scale)
+        if (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            topk_result = self._get_topk_paged(
+                forward_batch, layer_id, q_fp8, weights, metadata
+            )
+        else:
+            topk_result = self._get_topk_ragged_cpu(
+                forward_batch,
+                layer_id,
+                q_fp8,
+                weights,
+                metadata,
+            )
         topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
         return maybe_capture_indexer_topk(layer_id, topk_result)

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -118,7 +118,8 @@ class DSATopKBackend(Enum):
         # matches we commit to v2 and never silently fall back to the legacy
         # page_size=1 path from here.
         if (
-            self.should_use_topk_v2()
+            logits.is_cuda  # the v2 kernel is a CUDA JIT kernel; no CPU counterpart exists
+            and self.should_use_topk_v2()
             and topk_transform_method == TopkTransformMethod.PAGED
             and row_starts is None
             and batch_idx_list is None

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -75,7 +75,9 @@ from sglang.srt.layers.utils.cp_utils import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_buffer
 from sglang.srt.utils import (
+    cpu_has_amx_support,
     get_bool_env_var,
+    is_cpu,
     is_cuda,
     is_gfx95_supported,
     is_hip,
@@ -135,6 +137,8 @@ def materialize_full_kv_cp(
 
 
 _is_hip = is_hip()
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 if _is_hip:
     from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
@@ -283,6 +287,7 @@ _DSA_IMPL_T: TypeAlias = Literal[
     "fa3",
     "tilelang",
     "trtllm",
+    "flashmla_cpu",
 ]
 
 
@@ -340,6 +345,9 @@ class DeepseekSparseAttnBackend(
         self.supports_mha_one_shot: bool = True
         self.dsa_prefill_impl: _DSA_IMPL_T = get_exec().kernel.dsa_prefill_backend
         self.dsa_decode_impl: _DSA_IMPL_T = get_exec().kernel.dsa_decode_backend
+        if _is_cpu:
+            self.dsa_prefill_impl = self.dsa_prefill_impl or "flashmla_cpu"
+            self.dsa_decode_impl = self.dsa_decode_impl or "flashmla_cpu"
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
@@ -400,9 +408,27 @@ class DeepseekSparseAttnBackend(
                 "Disabling fused DSA top-k for IndexShare under PD disaggregation."
             )
 
-        self.device_capability = torch.cuda.get_device_capability()
+        self.device_capability = (0, 0) if _is_cpu else torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
         self.kv_cache_dtype = model_runner.kv_cache_dtype
+
+        if _is_cpu:
+            assert (
+                model_runner.server_args.speculative_algorithm is None
+            ), "DSA CPU backend does not support speculative decoding."
+            assert (
+                not is_dsa_enable_prefill_cp()
+            ), "DSA CPU backend does not support context parallel."
+            assert (
+                self.hisparse_coordinator is None
+            ), "DSA CPU backend does not support HiSparse."
+            assert (
+                not model_runner.server_args.enable_two_batch_overlap
+            ), "DSA CPU backend does not support two-batch overlap."
+            assert self.kv_cache_dtype in (
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+            ), "DSA CPU backend only supports a bfloat16 or fp8_e4m3 KV cache."
 
         # `flashmla_sparse_q8` = the native FP8 SM90 sparse-prefill kernel. It always
         # runs FP8 (requires fp8_e4m3 KV) and is SM90-only, so validate both at
@@ -700,7 +726,7 @@ class DeepseekSparseAttnBackend(
         # target-verify / draft-extend, whose expanded row count is exactly what v2
         # sees -- otherwise the helper's plan-present assertion fires. None only
         # when the SGL v2 path is disabled; such metadata is never dispatched to v2.
-        if not self.dsa_topk_backend.should_use_topk_v2():
+        if not is_cuda() or not self.dsa_topk_backend.should_use_topk_v2():
             return None
         from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
 
@@ -1927,12 +1953,18 @@ class DeepseekSparseAttnBackend(
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
-                    layer,
-                    cache_loc,
-                    k,
-                    k_rope,
-                )
+                if k_rope is None:
+                    # CPU fused qkv+rope prepare path (MLA_FUSED_ROPE_CPU): k
+                    # already holds the combined kv_lora_rank+qk_rope_head_dim
+                    # latent.
+                    self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+                else:
+                    self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
 
         # Use MHA kernel if in MHA_ONE_SHOT mode
         if self.use_mha:
@@ -1951,7 +1983,6 @@ class DeepseekSparseAttnBackend(
             )
 
         # Do absorbed multi-latent attention (MLA path)
-        assert q_rope is not None
         kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
 
         if q_rope is not None:
@@ -2176,6 +2207,16 @@ class DeepseekSparseAttnBackend(
                 page_table_1=page_table_1,
                 layer=layer,
             )
+        elif dsa_impl == "flashmla_cpu":
+            return self._forward_flashmla_cpu(
+                q_nope=q_nope,
+                q_rope=q_rope,
+                kv_cache=kv_cache,
+                v_head_dim=layer.v_head_dim,
+                page_table_1=page_table_1,
+                topk_length=metadata.dsa_cache_seqlens_int32,
+                sm_scale=layer.scaling,
+            )
         else:
             raise ValueError(
                 f"Unsupported {dsa_impl = } for forward_extend. Consider using an other attention backend."
@@ -2227,12 +2268,18 @@ class DeepseekSparseAttnBackend(
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
-                    layer,
-                    cache_loc,
-                    k,
-                    k_rope,
-                )
+                if k_rope is None:
+                    # CPU fused qkv+rope prepare path (MLA_FUSED_ROPE_CPU): k
+                    # already holds the combined kv_lora_rank+qk_rope_head_dim
+                    # latent, same convention intel_amx uses.
+                    self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+                else:
+                    self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
 
         # Do absorbed multi-latent attention
         kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
@@ -2347,7 +2394,16 @@ class DeepseekSparseAttnBackend(
                 metadata=metadata,
                 bs=forward_batch.batch_size,
             )
-
+        elif self.dsa_decode_impl == "flashmla_cpu":
+            return self._forward_flashmla_cpu(
+                q_nope=q_nope,
+                q_rope=q_rope,
+                kv_cache=kv_cache,
+                v_head_dim=layer.v_head_dim,
+                page_table_1=page_table_1,
+                topk_length=metadata.dsa_cache_seqlens_int32,
+                sm_scale=layer.scaling,
+            )
         else:
             assert False, f"Unsupported {self.dsa_decode_impl = }"
 
@@ -2451,6 +2507,45 @@ class DeepseekSparseAttnBackend(
             o = o[:, :num_heads, :]
 
         return o
+
+    def _forward_flashmla_cpu(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+        kv_cache: torch.Tensor,
+        v_head_dim: int,
+        page_table_1: torch.Tensor,
+        topk_length: torch.Tensor,
+        sm_scale: float,
+    ) -> torch.Tensor:
+        """CPU sparse-MLA path: same contract as ``_forward_flashmla_sparse``
+        (physical top-k KV-slot indices already resolved by the fused topk
+        transform);
+        q is always cast to bf16, the kernel's only supported query dtype.
+        """
+        from sgl_kernel.flash_mla import flash_mla_with_kvcache_cpu
+
+        num_tokens, num_heads, _ = q_nope.shape
+        q_all = torch.cat([q_nope, q_rope], dim=-1)
+        if q_all.dtype != torch.bfloat16:
+            q_all = q_all.to(torch.bfloat16)
+        q_view = q_all.view(num_tokens, 1, num_heads, q_all.shape[-1])
+
+        k_cache = kv_cache.unsqueeze(0).contiguous()  # [1, capacity, 1, head_dim_qk]
+
+        out, _ = flash_mla_with_kvcache_cpu(
+            q=q_view,
+            k_cache=k_cache,
+            block_table=None,
+            cache_seqlens=None,
+            head_dim_v=v_head_dim,
+            softmax_scale=sm_scale,
+            is_fp8_kvcache=k_cache.dtype == torch.float8_e4m3fn,
+            fp8_layout=1,  # V32FP8Sparse; unused when is_fp8_kvcache=False
+            indices=page_table_1.unsqueeze(1),
+            topk_length=topk_length,
+        )
+        return out.view(num_tokens, num_heads, v_head_dim)
 
     def q8kv8_born_fp8_q_eligible(
         self, forward_batch: ForwardBatch, num_heads: int
@@ -2879,6 +2974,9 @@ class DeepseekSparseAttnBackend(
             f"cu_seqlens_k has {len(cu_seqlens_k)-1} requests"
         )
 
+        if _is_cpu:
+            return self._forward_standard_mha_cpu(q, k, v, layer, forward_batch, metadata)
+
         # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues.
         # gfx950 reports device capability sm_(9,5), so it never enters this SM100+
         # branch and falls through to the aiter flash_attn_varlen_func path below.
@@ -2918,6 +3016,71 @@ class DeepseekSparseAttnBackend(
             max_seqlen_k=max_seqlen_k,
             softmax_scale=layer.scaling,
             causal=causal,
+        )
+
+    def _forward_standard_mha_cpu(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        metadata: DSAMetadata,
+    ) -> torch.Tensor:
+        """CPU MHA_ONE_SHOT dispatch: q/k/v are already the fully materialized
+        (prefix + extend) dense tensors built by forward_mha.py."""
+        assert q.dtype == torch.bfloat16, "CPU MHA_ONE_SHOT only supports bf16"
+        assert not layer.is_cross_attention, "MHA_ONE_SHOT is never cross-attention"
+
+        if sum(forward_batch.extend_prefix_lens_cpu) == 0:
+            """
+            k_buffer/v_buffer come from the MLA latent pool (num_heads_kv=1)
+            """
+            k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+            v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+            assert k_buffer.shape[1] != layer.tp_q_head_num
+
+            req_to_token = self.req_to_token_pool.req_to_token
+            assert forward_batch.extend_seq_lens.dtype == req_to_token.dtype
+            assert forward_batch.extend_start_loc.dtype == req_to_token.dtype
+
+            o = q.new_empty((q.shape[0], layer.tp_q_head_num, layer.v_head_dim))
+            torch.ops.sgl_kernel.extend_attention_cpu(
+                q,
+                k,
+                v,
+                o,
+                k_buffer,
+                v_buffer,
+                req_to_token,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens.to(torch.int64),
+                forward_batch.extend_seq_lens,
+                forward_batch.extend_start_loc,
+                metadata.max_seq_len_q,
+                layer.scaling,
+                layer.logit_cap,
+                layer.is_cross_attention,
+                layer.sliding_window_size + 1,
+                forward_batch.encoder_lens,
+                None,  # sinks
+                None,  # tree_mask
+            )
+            return o
+        # prefix>0 path: q/k/v are already the fully materialized dense
+        # tensors, so this is plain ragged/varlen attention (no KV-cache
+        # indirection); the kernel bottom-right-aligns causal masking when
+        # seqlen_k > seqlen_q.
+        return torch.ops.sgl_kernel.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            metadata.cu_seqlens_q,
+            metadata.cu_seqlens_k,
+            metadata.max_seq_len_q,
+            metadata.max_seq_len_k,
+            True,  # causal
+            layer.scaling,
         )
 
     def _forward_tilelang(
@@ -3324,22 +3487,30 @@ class DeepseekSparseAttnBackend(
             sum_seq_lens = sum(forward_batch.seq_lens_cpu)
             device_sm = get_device_sm()
 
-            # Requirements: H200/B200/MI355X, short sequences, supported dtype, fits in chunk
-            self.use_mha = (
-                self.supports_mha_one_shot
-                and (
-                    device_sm == 90
-                    or (device_sm >= 100 and device_sm < 110)
-                    or _IS_GFX95
-                )  # SM90/SM100 (NVIDIA) or gfx95x (MI355X)
-                and max_kv_len
+            fits_chunk_and_cp = (
+                max_kv_len
                 <= envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()  # Short enough for MHA
-                and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]
                 and sum_seq_lens
                 <= forward_batch.get_max_chunk_capacity()  # Fits in chunk
                 and (not is_dsa_enable_prefill_cp())  # CP not enabled
                 and (self.hisparse_coordinator is None)
             )
+
+            # Requirements: H200/B200/MI355X, short sequences, supported dtype, fits in chunk
+            gpu_eligible = (
+                (
+                    device_sm == 90
+                    or (device_sm >= 100 and device_sm < 110)
+                    or _IS_GFX95
+                )  # SM90/SM100 (NVIDIA) or gfx95x (MI355X)
+                and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]
+            )
+            cpu_eligible = (
+                _is_cpu
+                and _is_cpu_amx_available
+                and self.token_to_kv_pool.dtype in (torch.bfloat16, torch.float8_e4m3fn)
+            )
+            self.use_mha = self.supports_mha_one_shot and fits_chunk_and_cp and (gpu_eligible or cpu_eligible)
         else:
             self.use_mha = False  # Decode/verify always use MLA
 

--- a/python/sglang/srt/layers/rotary_embedding/factory.py
+++ b/python/sglang/srt/layers/rotary_embedding/factory.py
@@ -417,40 +417,44 @@ def get_rope_cpu(
     if cached is not None:
         return cached
 
-    assert rope_scaling is not None
-    scaling_type = rope_scaling["rope_type"]
-    assert (
-        scaling_type == "deepseek_yarn"
-    ), "Only deepseek_yarn is supported for CPU for now"
-
-    scaling_factor = _get_rope_param(rope_scaling, "factor", 1.0, scaling_type)
-    original_max_position = _get_rope_param(
-        rope_scaling, "original_max_position_embeddings", max_position, scaling_type
-    )
-    extra_kwargs = {
-        k: v
-        for k, v in rope_scaling.items()
-        if k
-        in (
-            "extrapolation_factor",
-            "attn_factor",
-            "beta_fast",
-            "beta_slow",
-            "mscale",
-            "mscale_all_dim",
+    if rope_scaling is None:
+        rotary_emb = RotaryEmbedding(
+            head_size, rotary_dim, max_position, base, is_neox_style, dtype
         )
-    }
-    extra_kwargs["device"] = device
-    rotary_emb = DeepseekScalingRotaryEmbedding(
-        head_size,
-        rotary_dim,
-        original_max_position,
-        base,
-        is_neox_style,
-        scaling_factor,
-        dtype,
-        **extra_kwargs,
-    )
+    else:
+        scaling_type = rope_scaling["rope_type"]
+        assert (
+            scaling_type == "deepseek_yarn"
+        ), "Only deepseek_yarn is supported for CPU for now"
+
+        scaling_factor = _get_rope_param(rope_scaling, "factor", 1.0, scaling_type)
+        original_max_position = _get_rope_param(
+            rope_scaling, "original_max_position_embeddings", max_position, scaling_type
+        )
+        extra_kwargs = {
+            k: v
+            for k, v in rope_scaling.items()
+            if k
+            in (
+                "extrapolation_factor",
+                "attn_factor",
+                "beta_fast",
+                "beta_slow",
+                "mscale",
+                "mscale_all_dim",
+            )
+        }
+        extra_kwargs["device"] = device
+        rotary_emb = DeepseekScalingRotaryEmbedding(
+            head_size,
+            rotary_dim,
+            original_max_position,
+            base,
+            is_neox_style,
+            scaling_factor,
+            dtype,
+            **extra_kwargs,
+        )
     _ROPE_DICT[key] = rotary_emb
     return rotary_emb
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4179,13 +4179,26 @@ class MLATokenToKVPool(KVCache):
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id
         )
-        assert not self.dsa_kv_cache_store_fp8
         parallel = get_parallel()
         if parallel.dcp_enabled:
             valid_mask = loc % parallel.attn_dcp_size == parallel.attn_dcp_rank
             if not valid_mask.all():
                 loc = loc[valid_mask]
                 cache_k = cache_k[valid_mask]
+        if self.dsa_kv_cache_store_fp8:
+            # Fused-rope CPU/AMX path (MLA_FUSED_ROPE_CPU): cache_k already
+            # holds the combined kv_lora_rank+qk_rope_head_dim latent; split it
+            # back into nope/rope so the fp8 write path in
+            # `_write_mla_kv_buffer` (nope quantized, rope raw bf16) applies.
+            cache_k_nope = cache_k[..., : self.kv_lora_rank]
+            cache_k_rope = cache_k[..., self.kv_lora_rank :]
+            self._write_mla_kv_buffer(
+                self.kv_buffer[layer_id - self.start_layer],
+                loc,
+                cache_k_nope,
+                cache_k_rope,
+            )
+            return
         if cache_k.dtype != self.dtype:
             cache_k = cache_k.to(self.dtype)
 
@@ -4221,15 +4234,24 @@ class MLATokenToKVPool(KVCache):
                 cache_k_nope, cache_k_rope
             )
 
-            # Reuse existing two-tensor write kernel (works with FP8 byte layout)
             # cache_k_nope_fp8: (num_tokens, 1, 528) uint8 [nope_fp8(512) | scales(16)]
             # cache_k_rope_fp8: (num_tokens, 1, 128) uint8 [rope_bf16_bytes(128)]
-            set_mla_kv_buffer_triton(
-                dst_buffer,
-                loc,
-                cache_k_nope_fp8,
-                cache_k_rope_fp8,
-            )
+            if _is_cpu:
+                nope_bytes = cache_k_nope_fp8.shape[-1]
+                rope_bytes = cache_k_rope_fp8.shape[-1]
+                dst_view = dst_buffer.view(torch.uint8)
+                dst_view[loc, :, :nope_bytes] = cache_k_nope_fp8
+                dst_view[loc, :, nope_bytes : nope_bytes + rope_bytes] = (
+                    cache_k_rope_fp8
+                )
+            else:
+                # Reuse existing two-tensor write kernel (works with FP8 byte layout)
+                set_mla_kv_buffer_triton(
+                    dst_buffer,
+                    loc,
+                    cache_k_nope_fp8,
+                    cache_k_rope_fp8,
+                )
         else:
             if cache_k_nope.dtype != self.dtype:
                 cache_k_nope = cache_k_nope.to(self.dtype)
@@ -4238,12 +4260,17 @@ class MLATokenToKVPool(KVCache):
                 cache_k_nope = cache_k_nope.view(self.store_dtype)
                 cache_k_rope = cache_k_rope.view(self.store_dtype)
 
-            set_mla_kv_buffer_triton(
-                dst_buffer,
-                loc,
-                cache_k_nope,
-                cache_k_rope,
-            )
+            if _is_cpu:
+                nope_dim = cache_k_nope.shape[-1]
+                dst_buffer[loc, :, :nope_dim] = cache_k_nope
+                dst_buffer[loc, :, nope_dim:] = cache_k_rope
+            else:
+                set_mla_kv_buffer_triton(
+                    dst_buffer,
+                    loc,
+                    cache_k_nope,
+                    cache_k_rope,
+                )
 
     def set_mla_kv_buffer(
         self,

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -257,6 +257,7 @@ def register_fake_ops(tp_size: int):
         kv_a_proj_scale,
         is_vnni,
         block_size,
+        need_q_lora,
     ):
         num_seqs = hidden_states.shape[0]
         num_heads = w_kc.shape[0]
@@ -277,7 +278,17 @@ def register_fake_ops(tp_size: int):
             device=hidden_states.device,
         )
         v_input = k_input.narrow(-1, 0, kv_lora_rank)
-        return q_input, k_input, v_input
+        if need_q_lora:
+            q_lora_rank = q_a_proj_weight.shape[0]
+            q_lora = torch.empty(
+                num_seqs,
+                q_lora_rank,
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+        else:
+            q_lora = torch.empty(0, dtype=hidden_states.dtype, device=hidden_states.device)
+        return q_input, k_input, v_input, q_lora
 
     @register_cpu_compile_fake("rotary_embedding_cpu")
     def _(positions, query, key, head_size, cos_sin_cache, is_neox):
@@ -310,6 +321,7 @@ def register_fake_ops(tp_size: int):
         q_lora_rank,
         kv_lora_rank,
         qk_rope_head_dim,
+        need_q_lora,
     ):
         num_seqs = hidden_states.shape[0]
         num_heads = w_kc.shape[0]
@@ -333,7 +345,16 @@ def register_fake_ops(tp_size: int):
             device=hidden_states.device,
         )
         v_input = k_input.narrow(-1, 0, kv_lora_rank)
-        return q_input, k_input, v_input
+        if need_q_lora:
+            q_lora = torch.empty(
+                num_seqs,
+                q_lora_rank,
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+        else:
+            q_lora = torch.empty(0, dtype=hidden_states.dtype, device=hidden_states.device)
+        return q_input, k_input, v_input, q_lora
 
     def get_n_size(mat2, is_vnni):
         tile_n = 16

--- a/python/sglang/srt/model_executor/forward_batch_deepseek_mha_mixin.py
+++ b/python/sglang/srt/model_executor/forward_batch_deepseek_mha_mixin.py
@@ -15,6 +15,7 @@ from sglang.srt.model_executor.forward_context import (
     get_req_to_token_pool,
     get_token_to_kv_pool,
 )
+from sglang.srt.utils import is_cpu
 
 
 class ForwardBatchDeepSeekMHAMixin:
@@ -226,14 +227,23 @@ class ForwardBatchDeepSeekMHAMixin:
         )
         kv_indptr[1:] = torch.cumsum(self.seq_lens, dim=0)
         req_to_token = get_req_to_token_pool().req_to_token
-        create_flashinfer_kv_indices_triton[(self.batch_size,)](
-            req_to_token,
-            self.req_pool_indices,
-            self.seq_lens,
-            kv_indptr,
-            None,
-            kv_indices,
-            req_to_token.shape[1],
-        )
+        if is_cpu():
+            kv_indices = torch.ops.sgl_kernel.create_flashinfer_kv_indices_cpu(
+                req_to_token,
+                self.req_pool_indices,
+                self.seq_lens,
+                kv_indptr,
+                None,
+            )
+        else:
+            create_flashinfer_kv_indices_triton[(self.batch_size,)](
+                req_to_token,
+                self.req_pool_indices,
+                self.seq_lens,
+                kv_indptr,
+                None,
+                kv_indices,
+                req_to_token.shape[1],
+            )
         self.mha_one_shot_kv_indices = kv_indices
         return kv_indices

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -206,7 +206,7 @@ def handle_attention_dsa(attn, forward_batch):
         backend = backend.primary
     if hasattr(backend, "use_mha") and backend.use_mha:
         return AttnForwardMethod.MHA_ONE_SHOT
-    return AttnForwardMethod.MLA
+    return _dispatch_mla_subtype(attn, forward_batch)
 
 
 def handle_attention_triton(attn, forward_batch):

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_cpu.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_cpu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -10,6 +10,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_cpu,
     _is_cpu_amx_available,
 )
+from sglang.srt.state_capturer.indexer_topk import maybe_capture_indexer_topk
 from sglang.srt.utils import BumpAllocator, use_intel_amx_backend
 
 if TYPE_CHECKING:
@@ -71,12 +72,16 @@ class DeepseekMLACpuForwardMixin:
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        prev_topk_indices: Optional[torch.Tensor] = None,
     ):
         assert self.q_lora_rank is not None and use_intel_amx_backend(
             self
         ), "forward_absorb_fused_mla_rope_cpu_prepare requires q_lora_rank is not None and use_intel_amx_backend"
 
-        q_input, k_input, v_input = (
+        # The DSA indexer needs the RMSNorm'd q_a_proj output to compute its top-k scores
+        need_q_lora = getattr(self, "use_dsa", False)
+
+        q_input, k_input, v_input, q_lora = (
             torch.ops.sgl_kernel.qkv_proj_with_rope_fused_weight(
                 hidden_states,
                 self.fused_qkv_a_proj_with_mqa.weight,
@@ -113,15 +118,33 @@ class DeepseekMLACpuForwardMixin:
                 self.q_lora_rank,
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
+                need_q_lora,
             )
         )
-        return (q_input, k_input, v_input, forward_batch, zero_allocator)
+
+        topk_indices = None
+        if need_q_lora:
+            if not self.skip_topk or prev_topk_indices is None:
+                topk_indices = self.indexer(
+                    x=hidden_states,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    layer_id=self.layer_id,
+                )
+            else:
+                topk_indices = maybe_capture_indexer_topk(
+                    self.layer_id, prev_topk_indices
+                )
+
+        return (q_input, k_input, v_input, topk_indices, forward_batch, zero_allocator)
 
     def forward_absorb_fused_mla_rope_cpu_core(
         self: DeepseekV2AttentionMLA,
         q_input,
         k_input,
         v_input,
+        topk_indices,
         forward_batch,
         zero_allocator,
         gate=None,
@@ -130,7 +153,13 @@ class DeepseekMLACpuForwardMixin:
             self
         ), "forward_absorb_fused_mla_rope_cpu_core requires q_lora_rank is not None and use_intel_amx_backend"
 
-        attn_output = self.attn_mqa(q_input, k_input, v_input, forward_batch)
+        attn_output = self.attn_mqa(
+            q_input,
+            k_input,
+            v_input,
+            forward_batch,
+            **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
+        )
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
 
         # [Note] Align shapes of bmm inputs.
@@ -160,4 +189,11 @@ class DeepseekMLACpuForwardMixin:
             attn_output = self._apply_gated(attn_output, gate)
         output, _ = self.o_proj(attn_output)
 
-        return output
+        if self.next_skip_topk is None:
+            return output
+
+        # Return topk_indices for the next layer when enabling index cache
+        if not self.next_skip_topk:
+            return output, None
+        else:
+            return output, topk_indices

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -97,9 +97,10 @@ def _load_fused_indexer_wk(
     param: wk fills the top head_dim rows (dequantized from block-fp8 if needed),
     weights_proj the bottom n_heads rows.
 
-    Returns False when there is no fused param (non-CUDA, or CUDA with
-    SGLANG_DISABLE_DSA_INDEXER_FUSION set, where wk and weights_proj are
-    separate) so the caller falls through to per-tensor loading.
+    Returns False when there is no fused param (fusion disabled, e.g. via
+    SGLANG_DISABLE_DSA_INDEXER_FUSION on CUDA/CPU, or non-neox models on
+    other backends where wk and weights_proj stay separate) so the caller
+    falls through to per-tensor loading.
     """
     fused_name = name.rsplit(".indexer.", 1)[0] + ".indexer.wk_weights_proj.weight"
     fused_param = params_dict.get(fused_name)
@@ -289,7 +290,7 @@ class DeepseekV2WeightLoaderMixin:
                 ):
                     continue
 
-                # CUDA fuses wk + weights_proj into one bf16 wk_weights_proj; the
+                # CUDA/CPU fuses wk + weights_proj into one bf16 wk_weights_proj; the
                 # helper returns True once it has consumed the shard.
                 if (
                     ".indexer.wk." in name or ".indexer.weights_proj." in name

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2164,7 +2164,11 @@ class DeepseekV2AttentionMLA(
             )
         elif attn_forward_method == AttnForwardMethod.MLA_FUSED_ROPE_CPU:
             inner_state = self.forward_absorb_fused_mla_rope_cpu_prepare(
-                positions, hidden_states, forward_batch, zero_allocator
+                positions,
+                hidden_states,
+                forward_batch,
+                zero_allocator,
+                prev_topk_indices,
             )
         elif attn_forward_method == AttnForwardMethod.MHA_NPU:
             inner_state = forward_mha_prepare_npu(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5884,7 +5884,7 @@ class ServerArgs:
                         "shared layers would run sparse attention without indices."
                     )
 
-                if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
+                if not is_npu() and not is_xpu() and not is_cpu():  # CUDA or ROCm GPU
                     if cfg.enable_prefill_cp:
                         # The DSA CP field declarations moved to the override
                         # registry (arg_groups/overrides.py:

--- a/test/registered/cpu/test_dsa_backend_flashmla_cpu.py
+++ b/test/registered/cpu/test_dsa_backend_flashmla_cpu.py
@@ -1,0 +1,239 @@
+"""Unit tests for DeepseekSparseAttnBackend's CPU ``flashmla_cpu`` path.
+
+Exercises the backend construction + KV-cache write path + ``_forward_flashmla_cpu``
+dispatch end-to-end for both bf16 and fp8_e4m3 KV caches, comparing against a
+pure-PyTorch dense-attention reference computed from the original (unquantized)
+K. This covers the CPU fp8 KV-cache quantization write path added in
+``memory_pool.py`` / ``quant_k_cache.py`` (Triton kernels are GPU-only, so the
+CPU backend routes through a pure-PyTorch quantizer with the same formula).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.utils import is_cpu
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-b-test-cpu")
+
+try:
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache_cpu  # noqa: F401
+
+    _IMPORT_ERROR = None
+except Exception as _e:  # pragma: no cover - exercised only when kernel missing
+    _IMPORT_ERROR = _e
+
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+_KV_LORA_RANK = 512
+_QK_ROPE_HEAD_DIM = 64
+_QUANT_BLOCK_SIZE = 128  # matches DSATokenToKVPool.quant_block_size (V32FP8Sparse)
+_NUM_HEADS = 4
+
+
+class _FakeLayer:
+    layer_id = 0
+
+
+def _fp8_override_kv_cache_dim() -> int:
+    # nope + per-tile fp32 scales + rope stored in bf16 (see calculate_mla_kv_cache_dim).
+    num_tiles = _KV_LORA_RANK // _QUANT_BLOCK_SIZE
+    return _KV_LORA_RANK + num_tiles * 4 + _QK_ROPE_HEAD_DIM * 2
+
+
+def _build_backend(kv_cache_dtype: torch.dtype):
+    override_dim = (
+        _fp8_override_kv_cache_dim() if kv_cache_dtype == torch.float8_e4m3fn else None
+    )
+    pool = MLATokenToKVPool(
+        size=64,
+        page_size=1,
+        dtype=kv_cache_dtype,
+        kv_lora_rank=_KV_LORA_RANK,
+        qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
+        use_dsa=True,
+        override_kv_cache_dim=override_dim,
+    )
+
+    hf_config = type(
+        "HfConfig",
+        (),
+        {"architectures": ["DeepseekV3ForCausalLM"], "index_topk": 64},
+    )()
+    model_config = type(
+        "ModelConfig",
+        (),
+        {
+            "context_len": 256,
+            "num_attention_heads": _NUM_HEADS,
+            "kv_lora_rank": _KV_LORA_RANK,
+            "qk_rope_head_dim": _QK_ROPE_HEAD_DIM,
+            "qk_nope_head_dim": _KV_LORA_RANK,
+            "hf_config": hf_config,
+        },
+    )()
+    req_to_token_pool = type(
+        "ReqPool",
+        (),
+        {"size": 8, "req_to_token": torch.zeros(8, 256, dtype=torch.int32)},
+    )()
+    server_args = type(
+        "MockServerArgs",
+        (),
+        {
+            "enable_deterministic_inference": False,
+            "dsa_prefill_backend": "flashmla_cpu",
+            "dsa_decode_backend": "flashmla_cpu",
+            "dsa_topk_backend": "sgl-kernel",
+            "speculative_eagle_topk": None,
+            "speculative_algorithm": None,
+            "enable_two_batch_overlap": False,
+        },
+    )()
+    runner = type(
+        "MockModelRunner",
+        (),
+        {
+            "device": "cpu",
+            "page_size": 1,
+            "server_args": server_args,
+            "model_config": model_config,
+            "token_to_kv_pool": pool,
+            "req_to_token_pool": req_to_token_pool,
+            "hisparse_coordinator": None,
+            "max_running_requests": 8,
+            "kv_cache_dtype": kv_cache_dtype,
+        },
+    )()
+    return DeepseekSparseAttnBackend(runner), pool
+
+
+@unittest.skipUnless(
+    is_cpu(), "requires SGLANG_USE_CPU_ENGINE=1 on a CPU-engine-supported host"
+)
+@unittest.skipIf(
+    _IMPORT_ERROR is not None,
+    f"flash_mla_with_kvcache_cpu unavailable: {_IMPORT_ERROR}",
+)
+class TestDSABackendFlashMLACPU(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._parallel_override = get_parallel().override(attn_tp_size=1)
+        cls._parallel_override.__enter__()
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._parallel_override.__exit__(None, None, None)
+
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def _run_decode_case(self, kv_cache_dtype: torch.dtype, atol: float, rtol: float):
+        backend, pool = self._build_backend_cached(kv_cache_dtype)
+        bs, seq_len, topk = 2, 8, 16
+        total_tokens = bs * seq_len
+
+        k_nope = torch.randn(total_tokens, 1, _KV_LORA_RANK, dtype=torch.bfloat16) * 0.3
+        k_rope = (
+            torch.randn(total_tokens, 1, _QK_ROPE_HEAD_DIM, dtype=torch.bfloat16) * 0.3
+        )
+        loc = torch.arange(total_tokens, dtype=torch.int64)
+        pool.set_mla_kv_buffer(_FakeLayer(), loc, k_nope, k_rope)
+
+        q_nope = torch.randn(bs, _NUM_HEADS, _KV_LORA_RANK, dtype=torch.bfloat16) * 0.3
+        q_rope = (
+            torch.randn(bs, _NUM_HEADS, _QK_ROPE_HEAD_DIM, dtype=torch.bfloat16) * 0.3
+        )
+
+        page_table_1 = torch.full((bs, topk), -1, dtype=torch.int32)
+        for b in range(bs):
+            page_table_1[b, :seq_len] = torch.arange(
+                b * seq_len, (b + 1) * seq_len, dtype=torch.int32
+            )
+        topk_length = torch.full((bs,), seq_len, dtype=torch.int32)
+
+        kv_cache = pool.get_key_buffer(0)
+        sm_scale = 1.0 / (_KV_LORA_RANK + _QK_ROPE_HEAD_DIM) ** 0.5
+
+        out = backend._forward_flashmla_cpu(
+            q_nope=q_nope,
+            q_rope=q_rope,
+            kv_cache=kv_cache,
+            v_head_dim=_KV_LORA_RANK,
+            page_table_1=page_table_1,
+            topk_length=topk_length,
+            sm_scale=sm_scale,
+        )
+        self.assertEqual(out.shape, (bs, _NUM_HEADS, _KV_LORA_RANK))
+
+        # Dense-attention reference against the ORIGINAL (unquantized) K, since
+        # every position is within topk_length (no masking) for this case.
+        q_all = torch.cat([q_nope, q_rope], dim=-1).float()
+        k_all = torch.cat([k_nope, k_rope], dim=-1).float().squeeze(1)
+        ref_out = torch.empty(bs, _NUM_HEADS, _KV_LORA_RANK)
+        for b in range(bs):
+            k_b = k_all[b * seq_len : (b + 1) * seq_len]
+            logits = torch.einsum("hd,sd->hs", q_all[b], k_b) * sm_scale
+            probs = torch.softmax(logits, dim=-1)
+            ref_out[b] = probs @ k_b[:, :_KV_LORA_RANK]
+
+        torch.testing.assert_close(out.float(), ref_out, atol=atol, rtol=rtol)
+
+    def _build_backend_cached(self, kv_cache_dtype: torch.dtype):
+        # Fresh pool/backend per case: KV writes must not leak across dtypes.
+        return _build_backend(kv_cache_dtype)
+
+    def test_decode_bf16_kv_cache(self):
+        self._run_decode_case(torch.bfloat16, atol=0.02, rtol=0.02)
+
+    def test_decode_fp8_kv_cache(self):
+        # Looser tolerance: fp8_e4m3 per-128-tile quantization of K introduces
+        # attention-output error on top of the bf16 baseline.
+        self._run_decode_case(torch.float8_e4m3fn, atol=0.05, rtol=0.05)
+
+    def test_fp8_write_path_roundtrip(self):
+        """Directly validates the CPU fp8 KV-cache quantization write path
+        (memory_pool.py's dsa_kv_cache_store_fp8 branch + quant_k_cache.py's
+        pure-PyTorch quantizer) by dequantizing the written bytes and
+        comparing against the original bf16 K.
+        """
+        _backend, pool = _build_backend(torch.float8_e4m3fn)
+        total_tokens = 8
+        k_nope = torch.randn(total_tokens, 1, _KV_LORA_RANK, dtype=torch.bfloat16) * 0.3
+        k_rope = (
+            torch.randn(total_tokens, 1, _QK_ROPE_HEAD_DIM, dtype=torch.bfloat16) * 0.3
+        )
+        loc = torch.arange(total_tokens, dtype=torch.int64)
+        pool.set_mla_kv_buffer(_FakeLayer(), loc, k_nope, k_rope)
+
+        kv_cache = pool.get_key_buffer(0)[:total_tokens].squeeze(1)  # fp8, (T, 656)
+        num_tiles = _KV_LORA_RANK // _QUANT_BLOCK_SIZE
+        nope_fp8 = kv_cache[:, :_KV_LORA_RANK].float()
+        scales = kv_cache[:, _KV_LORA_RANK : _KV_LORA_RANK + num_tiles * 4].view(
+            torch.float32
+        )
+        rope_bytes = kv_cache[:, _KV_LORA_RANK + num_tiles * 4 :].view(torch.bfloat16)
+
+        dequant_nope = torch.empty(total_tokens, _KV_LORA_RANK)
+        for t in range(num_tiles):
+            sl = slice(t * _QUANT_BLOCK_SIZE, (t + 1) * _QUANT_BLOCK_SIZE)
+            dequant_nope[:, sl] = nope_fp8[:, sl] * scales[:, t : t + 1]
+
+        # Rope is stored losslessly (raw bf16 bytes, no quantization).
+        torch.testing.assert_close(rope_bytes, k_rope.squeeze(1))
+        torch.testing.assert_close(
+            dequant_nope, k_nope.squeeze(1).float(), atol=0.05, rtol=0.05
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds frontend integration support and optimization for DeepSeek3.x/GLM5.x model on CPU, mainly including below changes:

- The frontend integration of the key optimized kernels based on #32222 and #37361 
- Add the flashmla_cpu prefill and decode backend.
- Wire CPU DSA into model forward, CPU graph, configuration, and rotary embedding paths.
- Support BF16 and FP8 DSA KV caches, including CPU quantization and cache writes.
- Add end-to-end CPU backend and KV-cache tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->