### PR TITLE
[Fix] Use a valid --quantization value in save_sharded_state example

### DIFF
--- a/examples/runtime/engine/save_sharded_state.py
+++ b/examples/runtime/engine/save_sharded_state.py
@@ -8,7 +8,7 @@ Example usage:
 
 python save_sharded_state.py \
     --model-path /path/to/load \
-    --quantization deepspeedfp \
+    --quantization fp8 \
     --tensor-parallel-size 8 \
     --output /path/to/save
 
@@ -17,7 +17,7 @@ Then, the model can be loaded with
 llm = Engine(
     model_path="/path/to/save",
     load_format="sharded_state",
-    quantization="deepspeedfp",
+    quantization="fp8",
     tensor_parallel_size=8,
 )
 """


### PR DESCRIPTION
## Summary

`examples/runtime/engine/save_sharded_state.py` documents `--quantization deepspeedfp`, but that string is not in `QUANTIZATION_CHOICES` on current `main`. `ServerArgs.add_cli_args` exposes `--quantization` with `choices=QUANTIZATION_CHOICES`, so the documented command would fail argparse validation.

This updates the example to `fp8`, which is present in `QUANTIZATION_CHOICES`. `--tensor-parallel-size` / `tensor_parallel_size` is left unchanged; it is a valid alias for `tp_size`.

## QUANTIZATION_CHOICES evidence

Verified on `sgl-project/sglang` `main` at `5e791101225ffef29e6a6897471eba281eafc801`.

In `python/sglang/srt/server_args.py`:

```python
QUANTIZATION_CHOICES = [
    "awq",
    "fp8",  # MOE + linear online quantization.
    "mxfp8",  # MOE + linear online quantization.
    "gptq",
    "marlin",
    "gptq_marlin",
    "awq_marlin",
    "bitsandbytes",
    "gguf",
    "modelopt",
    "modelopt_fp8",
    "modelopt_fp4",
    "nvfp4_online",
    "modelopt_mixed",
    "petit_nvfp4",
    "w8a8_int8",
    "w8a8_fp8",
    "moe_wna16",
    "w4afp8",
    "mxfp4",
    "auto-round",
    "auto-round-int8",
    "compressed-tensors",
    "modelslim",
    "mxfp_w4a8",
    "quark",
    "quark_int4fp8_moe",
    "quark_mxfp4",
    "mlx_q4",
    "mlx_q8",
    "unquant",
    "humming",
]
```

`deepspeedfp` is not in this list. `fp8` is. The `--quantization` argument uses `choices=QUANTIZATION_CHOICES`.

## How verified

- Fetched `examples/runtime/engine/save_sharded_state.py` from `main` HEAD; both the CLI snippet and the `Engine(...)` snippet used `deepspeedfp`.
- Fetched `python/sglang/srt/server_args.py` from the same SHA and extracted `QUANTIZATION_CHOICES` (32 values); `deepspeedfp` is absent, `fp8` is present.
- Confirmed `--quantization` is declared with `choices=QUANTIZATION_CHOICES`.
- Code search for `deepspeedfp` on HEAD only hits this example file.
- No other files changed. `--tensor-parallel-size` / `tensor_parallel_size` kept as-is.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33477999646](https://github.com/sgl-project/sglang/actions/runs/33477999646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33477999375](https://github.com/sgl-project/sglang/actions/runs/33477999375)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->