### PR TITLE
Support token ids in chat completion streams

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1245,6 +1245,8 @@ class DeltaMessage(BaseModel):
 class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
+    token_ids: Optional[List[int]] = None
+    prompt_token_ids: Optional[List[int]] = None
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[
         Literal[
@@ -1252,6 +1254,15 @@ class ChatCompletionResponseStreamChoice(BaseModel):
         ]
     ] = None
     matched_stop: Union[None, int, str] = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if self.token_ids is None:
+            data.pop("token_ids", None)
+        if self.prompt_token_ids is None:
+            data.pop("prompt_token_ids", None)
+        return data
 
 
 class ChatCompletionStreamResponse(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -723,6 +723,7 @@ class OpenAIServingChat(OpenAIServingBase):
         index: int,
         request: ChatCompletionRequest,
         stream_offsets: Dict[int, int],
+        token_id_offsets: Dict[int, int],
         reasoning_parser_dict: Dict,
         parser_dict: Dict,
         has_tool_calls: Dict[int, bool],
@@ -735,16 +736,28 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> AsyncGenerator[str, None]:
         """Generate SSE chunks for streaming content."""
         offset = stream_offsets.get(index, 0)
+        text = content.get("text") or ""
         if self.tokenizer_manager.server_args.incremental_streaming_output:
-            delta = content["text"]
+            delta = text
         else:
-            delta = content["text"][offset:]
-            stream_offsets[index] = len(content["text"])
+            delta = text[offset:]
+            stream_offsets[index] = len(text)
+
+        chunk_token_ids = None
+        if request.return_token_ids:
+            output_ids = content.get("output_ids") or []
+            if self.tokenizer_manager.server_args.incremental_streaming_output:
+                chunk_token_ids = output_ids
+            else:
+                n_prev_token_id = token_id_offsets.get(index, 0)
+                chunk_token_ids = output_ids[n_prev_token_id:]
+                token_id_offsets[index] = len(output_ids)
 
         # Attach logprobs to the first chunk emitted this step (reasoning,
         # tool-call, or content) so they aren't dropped when a parser is active
         # nor duplicated across chunks; flush any leftover at the end.
         remaining_logprobs = choice_logprobs
+        remaining_token_ids = chunk_token_ids
 
         # Handle reasoning content
         if self.reasoning_parser and request.separate_reasoning:
@@ -772,10 +785,12 @@ class OpenAIServingChat(OpenAIServingBase):
                     model=request.model,
                     index=index,
                     reasoning_content=reasoning_text,
+                    token_ids=remaining_token_ids,
                     logprobs=remaining_logprobs,
                     usage=usage,
                 )
                 remaining_logprobs = None
+                remaining_token_ids = None
 
         # Handle tool calls
         if self._tool_call_parsing_active(request):
@@ -803,7 +818,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
         else:
             # Regular content
-            if delta:
+            if delta or remaining_token_ids:
                 usage = None
                 if continuous_usage_stats:
                     usage = UsageProcessor.calculate_token_usage(
@@ -819,19 +834,24 @@ class OpenAIServingChat(OpenAIServingBase):
                     model=request.model,
                     index=index,
                     content=delta,
+                    token_ids=remaining_token_ids,
                     logprobs=remaining_logprobs,
                     usage=usage,
                 )
                 remaining_logprobs = None
+                remaining_token_ids = None
 
         # Flush logprobs still unattached this step — only when a parser is
-        # active, since _process_tool_call_stream may consume the delta and emit
-        # no content chunk. On the plain path an empty-delta step has no chunk
-        # to attach to either way, and a standalone empty-delta logprobs chunk
-        # is not a shape clients expect.
-        if remaining_logprobs is not None and (
+        # active, since _process_tool_call_stream may consume the delta and
+        # emit no content chunk. Token IDs use the same fallback, preserving
+        # the raw token stream independently from parsed deltas.
+        should_flush_logprobs = remaining_logprobs is not None and (
             self.reasoning_parser or self.tool_call_parser
-        ):
+        )
+        should_flush_token_ids = bool(remaining_token_ids) and (
+            self.reasoning_parser or self._tool_call_parsing_active(request)
+        )
+        if should_flush_logprobs or should_flush_token_ids:
             usage = None
             if continuous_usage_stats:
                 usage = UsageProcessor.calculate_token_usage(
@@ -846,6 +866,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 created=int(time.time()),
                 model=request.model,
                 index=index,
+                token_ids=remaining_token_ids,
                 logprobs=remaining_logprobs,
                 usage=usage,
             )
@@ -982,17 +1003,6 @@ class OpenAIServingChat(OpenAIServingBase):
             request.reasoning_effort = reasoning_effort
 
         if request.stream:
-            if request.return_prompt_token_ids:
-                raise ValueError(
-                    "return_prompt_token_ids is not supported with streaming. "
-                    "Please set stream=false when using return_prompt_token_ids=true."
-                )
-            if request.return_token_ids:
-                raise ValueError(
-                    "return_token_ids is not supported with streaming on "
-                    "/v1/chat/completions. Please set stream=false when using "
-                    "return_token_ids=true."
-                )
             if request.return_meta_info:
                 raise ValueError(
                     "return_meta_info is not supported with streaming. "
@@ -1554,6 +1564,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # State tracking for streaming
         is_firsts = {}
         stream_offsets = {}
+        token_id_offsets = {}
         n_prev_tokens = {}
         has_tool_calls = {}
         finish_reasons = {}
@@ -1653,6 +1664,12 @@ class OpenAIServingChat(OpenAIServingBase):
                         index=index,
                         role="assistant",
                         content="",
+                        prompt_token_ids=(
+                            content.get("prompt_token_ids")
+                            if request.return_prompt_token_ids
+                            or request.return_token_ids
+                            else None
+                        ),
                     )
                     stream_started = True
 
@@ -1662,6 +1679,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     index=index,
                     request=request,
                     stream_offsets=stream_offsets,
+                    token_id_offsets=token_id_offsets,
                     reasoning_parser_dict=reasoning_parser_dict,
                     parser_dict=parser_dict,
                     has_tool_calls=has_tool_calls,

--- a/python/sglang/srt/entrypoints/openai/sse_utils.py
+++ b/python/sglang/srt/entrypoints/openai/sse_utils.py
@@ -49,6 +49,51 @@ class StreamChunk(msgspec.Struct, omit_defaults=True):
 _stream_encoder = msgspec.json.Encoder()
 
 
+def _build_token_id_sse_payload(
+    chunk_id: str,
+    created: int,
+    model: str,
+    index: int,
+    role: Optional[str],
+    content: Optional[str],
+    reasoning_content: Optional[str],
+    finish_reason: Optional[str],
+    logprobs: Optional[dict],
+    matched_stop: Union[None, int, str],
+    usage: Optional[dict],
+    token_ids: Optional[List[int]],
+    prompt_token_ids: Optional[List[int]],
+) -> dict:
+    delta = {"reasoning_content": reasoning_content}
+    if role is not None:
+        delta["role"] = role
+    if content is not None:
+        delta["content"] = content
+
+    choice = {
+        "index": index,
+        "delta": delta,
+        "logprobs": logprobs,
+        "finish_reason": finish_reason,
+        "matched_stop": matched_stop,
+    }
+    if token_ids is not None:
+        choice["token_ids"] = token_ids
+    if prompt_token_ids is not None:
+        choice["prompt_token_ids"] = prompt_token_ids
+
+    payload = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [choice],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
 def build_sse_content(
     chunk_id: str,
     created: int,
@@ -61,6 +106,8 @@ def build_sse_content(
     logprobs: Optional[dict] = None,
     matched_stop: Union[None, int, str] = None,
     usage: Optional[dict] = None,
+    token_ids: Optional[List[int]] = None,
+    prompt_token_ids: Optional[List[int]] = None,
 ) -> str:
     """Build an SSE chunk string for content/reasoning updates.
 
@@ -76,10 +123,30 @@ def build_sse_content(
         logprobs: Log probabilities if requested
         matched_stop: Stop token/string that was matched
         usage: Token usage statistics
+        token_ids: Output token ID delta for this choice
+        prompt_token_ids: Prompt token IDs, usually only on the first chunk
 
     Returns:
         SSE-formatted string "data: {...}\\n\\n"
     """
+    if token_ids is not None or prompt_token_ids is not None:
+        payload = _build_token_id_sse_payload(
+            chunk_id=chunk_id,
+            created=created,
+            model=model,
+            index=index,
+            role=role,
+            content=content,
+            reasoning_content=reasoning_content,
+            finish_reason=finish_reason,
+            logprobs=logprobs,
+            matched_stop=matched_stop,
+            usage=usage,
+            token_ids=token_ids,
+            prompt_token_ids=prompt_token_ids,
+        )
+        return (_SSE_DATA_B + _stream_encoder.encode(payload) + _SSE_NL_B).decode()
+
     delta = StreamDelta(role=role, content=content, reasoning_content=reasoning_content)
     choice = StreamChoice(
         index=index,

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -25,8 +25,10 @@ from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
+    ChatCompletionResponseStreamChoice,
     ChatMessage,
     CompletionRequest,
+    DeltaMessage,
     Function,
     ModelCard,
     ModelList,
@@ -690,6 +692,28 @@ class TestModelSerialization(unittest.TestCase):
         self.assertNotIn("token_ids", data)
         self.assertEqual(data["response_token_ids"], [4, 5])
         self.assertEqual(data["meta_info"], {"prompt_tokens": 3})
+
+    def test_stream_choice_token_ids_serialization(self):
+        """Test that stream token ID fields serialize only when set."""
+        default_choice = ChatCompletionResponseStreamChoice(
+            index=0,
+            delta=DeltaMessage(role="assistant", content="Hello"),
+            finish_reason=None,
+        )
+        default_data = default_choice.model_dump()
+        self.assertNotIn("token_ids", default_data)
+        self.assertNotIn("prompt_token_ids", default_data)
+
+        choice = ChatCompletionResponseStreamChoice(
+            index=0,
+            delta=DeltaMessage(role="assistant", content="Hello"),
+            finish_reason=None,
+            token_ids=[4, 5],
+            prompt_token_ids=[1, 2, 3],
+        )
+        data = choice.model_dump()
+        self.assertEqual(data["token_ids"], [4, 5])
+        self.assertEqual(data["prompt_token_ids"], [1, 2, 3])
 
 
 class TestFunctionDeferLoading(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -103,6 +103,7 @@ class _MockTokenizerManager:
             reasoning_parser=None,
             stream_response_default_include_usage=False,
             default_chat_template_kwargs=None,
+            incremental_streaming_output=False,
         )
         self.model_path = self.server_args.model_path
         # The manager tracks the served name itself; a weight update rewrites it.
@@ -365,16 +366,172 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(request.model_dump(), body)
         self.assertFalse(hasattr(request, "conversation_id"))
 
-    def test_convert_to_internal_request_rejects_stream_token_ids(self):
-        for field in ("return_prompt_token_ids", "return_token_ids"):
-            req = ChatCompletionRequest(
-                model="x",
-                messages=[{"role": "user", "content": "Hi?"}],
-                stream=True,
-                **{field: True},
+    def test_convert_to_internal_request_allows_stream_token_ids(self):
+        processed_messages = MessageProcessingResult(
+            "Test prompt", [1, 2, 3], None, None, [], [], None
+        )
+
+        with patch.object(
+            self.chat, "_process_messages", return_value=processed_messages
+        ):
+            for field in ("return_prompt_token_ids", "return_token_ids"):
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "user", "content": "Hi?"}],
+                    stream=True,
+                    **{field: True},
+                )
+                with self.subTest(field=field):
+                    adapted, processed = self.chat._convert_to_internal_request(
+                        req, self.fastapi_request
+                    )
+                    self.assertTrue(adapted.stream)
+                    self.assertEqual(getattr(processed, field), True)
+                    self.assertTrue(adapted.return_prompt_token_ids)
+                    self.assertEqual(processed, req)
+
+    def test_convert_to_internal_request_allows_stream_token_ids_with_tools(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            stream=True,
+            return_token_ids=True,
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        )
+        processed_messages = MessageProcessingResult(
+            "Test prompt", [1, 2, 3], None, None, [], [], None
+        )
+
+        with patch.object(
+            self.chat, "_process_messages", return_value=processed_messages
+        ):
+            adapted, processed = self.chat._convert_to_internal_request(
+                req, self.fastapi_request
             )
-            with self.subTest(field=field), self.assertRaisesRegex(ValueError, field):
-                self.chat._convert_to_internal_request(req, self.fastapi_request)
+
+        self.assertTrue(adapted.stream)
+        self.assertTrue(processed.return_token_ids)
+        self.assertTrue(adapted.return_prompt_token_ids)
+
+    def test_streaming_token_ids_deltas_cover_output_exactly(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            max_tokens=10,
+            stream=True,
+            return_token_ids=True,
+        )
+        processed_messages = MessageProcessingResult(
+            "Test prompt", [1, 2, 3], None, None, [], [], None
+        )
+        with patch.object(
+            self.chat, "_process_messages", return_value=processed_messages
+        ):
+            adapted_request, _ = self.chat._convert_to_internal_request(
+                req, self.fastapi_request
+            )
+        self.chat.tokenizer_manager.server_args.stream_response_default_include_usage = (
+            False
+        )
+
+        for incremental in (False, True):
+            with self.subTest(incremental_streaming_output=incremental):
+                self.chat.tokenizer_manager.server_args.incremental_streaming_output = (
+                    incremental
+                )
+                texts = ("a", "b", "c") if incremental else ("a", "ab", "abc")
+                output_ids = (
+                    ([5], [6], [7]) if incremental else ([5], [5, 6], [5, 6, 7])
+                )
+                chunks = [
+                    {
+                        "text": text,
+                        "output_ids": ids,
+                        "prompt_token_ids": [1, 2],
+                        "meta_info": {
+                            "id": "chatcmpl-test",
+                            "prompt_tokens": 2,
+                            "completion_tokens": i + 1,
+                            "finish_reason": {"type": "stop"} if i == 2 else None,
+                            "weight_version": "default",
+                        },
+                        "index": 0,
+                    }
+                    for i, (text, ids) in enumerate(zip(texts, output_ids))
+                ]
+
+                async def _mock_generate(*args, _chunks=chunks, **kwargs):
+                    for chunk in _chunks:
+                        yield chunk
+
+                self.chat.tokenizer_manager.generate_request = _mock_generate
+
+                async def run_stream():
+                    return [
+                        chunk
+                        async for chunk in self.chat._generate_chat_stream(
+                            adapted_request, req, self.fastapi_request
+                        )
+                    ]
+
+                raw_chunks = get_or_create_event_loop().run_until_complete(run_stream())
+
+                choices = []
+                for raw in raw_chunks:
+                    if not raw.startswith("data: ") or raw.strip() == "data: [DONE]":
+                        continue
+                    data = json.loads(raw[len("data: ") :])
+                    choices.extend(data.get("choices", []))
+
+                token_ids = [tid for c in choices for tid in c.get("token_ids", [])]
+                text = "".join(
+                    c["delta"].get("content", "") or ""
+                    for c in choices
+                    if "delta" in c
+                )
+                self.assertEqual(text, "abc")
+                self.assertEqual(token_ids, [5, 6, 7])
+                self.assertEqual(choices[0]["prompt_token_ids"], [1, 2])
+                for choice in choices[1:]:
+                    self.assertNotIn("prompt_token_ids", choice)
+
+    def test_streaming_token_ids_emit_when_text_is_deferred(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            return_token_ids=True,
+        )
+
+        async def collect():
+            return [
+                chunk
+                async for chunk in self.chat._generate_stream_content(
+                    content={
+                        "text": None,
+                        "output_ids": [11],
+                        "meta_info": {"id": "chatcmpl-test"},
+                    },
+                    index=0,
+                    request=req,
+                    stream_offsets={},
+                    token_id_offsets={},
+                    reasoning_parser_dict={},
+                    parser_dict={},
+                    has_tool_calls={},
+                    choice_logprobs=None,
+                    finish_reason_type=None,
+                    continuous_usage_stats=False,
+                    prompt_tokens={},
+                    reasoning_tokens={},
+                    completion_tokens={},
+                )
+            ]
+
+        chunks = get_or_create_event_loop().run_until_complete(collect())
+        payload = json.loads(chunks[0].removeprefix("data: ").strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "")
+        self.assertEqual(payload["choices"][0]["token_ids"], [11])
 
     def test_validate_request_rejects_sampling_mask_without_meta_info(self):
         req = ChatCompletionRequest(
@@ -2338,6 +2495,7 @@ class ServingChatTestCase(unittest.TestCase):
             index=0,
             request=req,
             stream_offsets={},
+            token_id_offsets={},
             reasoning_parser_dict={},
             parser_dict={},
             has_tool_calls={},
@@ -2451,6 +2609,51 @@ class ServingChatTestCase(unittest.TestCase):
             logprob_chunks,
             "logprobs dropped: no flush chunk carried logprobs when tool parser buffered the delta",
         )
+
+    def test_streaming_token_ids_flushed_when_tool_parser_buffers_delta(self):
+        """Raw token ids must keep streaming even when the tool parser buffers text."""
+        self.chat.tool_call_parser = "hermes"
+
+        content = {
+            "text": "(<",
+            "output_ids": [42],
+            "meta_info": {
+                "id": "chatcmpl-tool",
+                "prompt_tokens": 5,
+                "completion_tokens": 1,
+                "cached_tokens": 0,
+                "finish_reason": {"type": "stop", "matched": None},
+            },
+            "index": 0,
+        }
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            stream=True,
+            return_token_ids=True,
+        )
+
+        async def _empty_tool_stream(*args, **kwargs):
+            return
+            yield  # make it an async generator
+
+        with patch.object(self.chat, "_process_tool_call_stream", _empty_tool_stream):
+            chunks = get_or_create_event_loop().run_until_complete(
+                self._collect_stream_content(content, None, req)
+            )
+
+        parsed = self._parse_chunks(chunks)
+        token_id_chunks = [
+            c for c in parsed if c["choices"][0].get("token_ids") is not None
+        ]
+        self.assertEqual(
+            [c["choices"][0]["token_ids"] for c in token_id_chunks],
+            [[42]],
+        )
+        self.assertNotIn("content", token_id_chunks[0]["choices"][0]["delta"])
+        self.assertNotIn("tool_calls", token_id_chunks[0]["choices"][0]["delta"])
 
     def test_streaming_logprobs_not_flushed_on_empty_delta_step_without_parser(self):
         """With no parser active, an empty-delta step must not emit a standalone
@@ -2848,6 +3051,7 @@ class ServingChatTestCase(unittest.TestCase):
                 index=0,
                 request=req,
                 stream_offsets={},
+                token_id_offsets={},
                 reasoning_parser_dict={},
                 parser_dict={},
                 has_tool_calls={},


### PR DESCRIPTION
## Motivation

This PR enables `return_token_ids` for streamed `/v1/chat/completions` responses.

The related discussion in #36431 asks for raw generated token IDs in chat streaming so clients can support resumable generation without re-tokenizing streamed text. This extends the token-id support added in #30917 to the chat streaming path.

## Modifications

- Allow `return_token_ids` and `return_prompt_token_ids` with streamed `/v1/chat/completions` requests.
- Emit output token deltas as `choices[*].token_ids` in streamed chat chunks.
- Emit prompt token IDs on the first streamed choice chunk as `choices[*].prompt_token_ids`.
- Treat token IDs as a raw side channel, independent of parsed `content`, `reasoning_content`, and `tool_calls` deltas.
- Preserve raw generated token IDs for tool-call streaming. This PR does not attempt to reconstruct a partially parsed `tool_calls` state after interruption; if the tool-call parser buffers or consumes text, it emits a token-only chunk so token IDs are not dropped.
- Add focused unit coverage for serialization, request conversion, streaming token-id deltas, deferred text, and tool-parser buffering.

Fixes #36431.

## Accuracy Tests

N/A. This PR only changes OpenAI-compatible response metadata and does not change model outputs.

## Speed Tests and Profiling

N/A. This PR only adds optional metadata serialization when token IDs are requested.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not updated; this PR follows the existing `return_token_ids` API shape.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A as noted above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## Tests

`python3.12 -m compileall -q` on the modified OpenAI entrypoint and unit test files.

`git diff --check HEAD~1..HEAD`

Focused unit tests:

`PYTHONPATH=python python3 -m pytest test/registered/unit/entrypoints/openai/test_protocol.py::TestModelSerialization::test_stream_choice_token_ids_serialization test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_convert_to_internal_request_allows_stream_token_ids test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_convert_to_internal_request_allows_stream_token_ids_with_tools test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_token_ids_deltas_cover_output_exactly test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_token_ids_emit_when_text_is_deferred test/registered/unit/entrypoints/openai/test_serving_chat.py::ServingChatTestCase::test_streaming_token_ids_flushed_when_tool_parser_buffers_delta`

Result: `6 passed, 26 warnings`.

Related streaming test subset:

`PYTHONPATH=python python3 -m pytest test/registered/unit/entrypoints/openai/test_serving_chat.py -k "streaming_token_ids or streaming_logprobs or continuous_usage"`

Result: `8 passed, 110 deselected, 24 warnings`.
