### PR TITLE
[AMD] Pick the MoRI dispatch format from the MoE's input contract

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -360,6 +360,7 @@ class AiterDispatchFormat(str, Enum):
     """Activation format AITER's MoE will consume; what a dispatcher should send.
     BF16 doubles as "unknown" -- the receive path always accepts it."""
 
+    FP8 = "fp8"  # fp8 + per-128 fp32 scales (per_1x128)
     MXFP8 = "mxfp8"  # fp8 + group-32 e8m0 scales (a8w4)
     MXFP4 = "mxfp4"  # packed fp4x2 + group-32 e8m0 scales (a4w4)
     BF16 = "bf16"  # unquantized
@@ -377,41 +378,44 @@ class AiterDispatchChoice(NamedTuple):
 def _aiter_dispatch_dtype_api():
     """AITER's `resolve_activation_dtype`, on builds that expose it."""
     try:
-        from aiter import QuantType, dtypes
+        from aiter import dtypes
         from aiter.fused_moe import resolve_activation_dtype
         from aiter.ops.flydsl.moe_common import GateMode
     except ImportError:
         return None
 
-    return (
-        resolve_activation_dtype,
-        QuantType,
-        GateMode,
-        {
-            dtypes.fp8: AiterDispatchFormat.MXFP8,
-            dtypes.fp4x2: AiterDispatchFormat.MXFP4,
-            dtypes.bf16: AiterDispatchFormat.BF16,
-        },
-    )
+    # (quant type, activation dtype AITER resolves to) -> what to put on the
+    # wire. The fp8 rows differ only in scale layout: per_1x128 pairs the fp8
+    # payload with fp32 scales every 128 elements, per_1x32 with e8m0
+    # microscales every 32. Combinations absent here have no MoRI format --
+    # per_Token fp8 above all -- and fall back to bf16.
+    wire_format = {
+        (AiterQuantType.PER_128X128, dtypes.fp8): AiterDispatchFormat.FP8,
+        (AiterQuantType.PER_1X32, dtypes.fp8): AiterDispatchFormat.MXFP8,
+        (AiterQuantType.PER_1X32, dtypes.fp4x2): AiterDispatchFormat.MXFP4,
+    }
+    return resolve_activation_dtype, GateMode, dtypes.bf16, wire_format
 
 
 def resolve_aiter_dispatch_format(
+    quant_type: Optional[AiterQuantType],
     weight_dtype: Optional[torch.dtype],
     activation: str = "silu",
     swiglu_limit: Optional[float] = None,
 ) -> AiterDispatchChoice:
-    """Which activation format AITER's fused_moe wants for MXFP4 expert weights.
+    """Which activation format AITER's fused_moe will consume for this layer.
 
-    Asks AITER, which resolves it from the activation, gate mode, arch and token
-    count M. A dispatch format is fixed when the all-to-all buffers are sized, so
-    M is not passed and AITER answers None wherever it would have been needed.
-    Every branch that is not a committed format answers BF16, which the receive
-    path always accepts, so an unsure answer costs transport bytes and nothing
-    else.
+    Asks AITER, which resolves it from the quant type, weight dtype, activation,
+    gate mode, arch and token count M. A dispatch format is fixed when the
+    all-to-all buffers are sized, so M is not passed and AITER answers None
+    wherever it would have been needed. Every branch that is not a committed
+    format answers BF16, which the receive path always accepts, so an unsure
+    answer costs transport bytes and nothing else.
     """
-    if weight_dtype != torch.float4_e2m1fn_x2:
-        # Only MXFP4 weights are ambiguous; callers settle the rest themselves.
-        return AiterDispatchChoice(AiterDispatchFormat.BF16, "not MXFP4 weights")
+    if quant_type is None or weight_dtype is None:
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16, "quant method did not report the MoE numerics"
+        )
 
     api = _aiter_dispatch_dtype_api()
     if api is None:
@@ -421,16 +425,15 @@ def resolve_aiter_dispatch_format(
             "the dispatch format follow what the MoE consumes",
             actionable=True,
         )
-    resolve_activation_dtype, QuantType, GateMode, formats = api
+    resolve_activation_dtype, GateMode, aiter_bf16, wire_format = api
 
     # Mirrors AiterRunnerCore.run: only a clamped-SwiGLU layer sets gate_mode.
     interleave = bool(swiglu_limit and swiglu_limit > 0) and get_bool_env_var(
         "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
     )
 
-    # MXFP4 expert weights always reach fused_moe as per_1x32.
     q_dtype_a = resolve_activation_dtype(
-        QuantType.per_1x32,
+        _aiter_quant_type(quant_type),
         weight_dtype,
         activation=_aiter_activation(activation),
         gate_mode=GateMode.INTERLEAVE if interleave else GateMode.SEPARATED,
@@ -447,9 +450,16 @@ def resolve_aiter_dispatch_format(
             "and allow mxfp8 dispatch",
             actionable=True,
         )
-    return AiterDispatchChoice(
-        formats.get(q_dtype_a, AiterDispatchFormat.BF16), f"MoE consumes {q_dtype_a}"
-    )
+    if q_dtype_a == aiter_bf16:
+        return AiterDispatchChoice(AiterDispatchFormat.BF16, "MoE consumes bf16")
+
+    fmt = wire_format.get((quant_type, q_dtype_a))
+    if fmt is None:
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16,
+            f"no MoRI wire format carries {q_dtype_a} for {quant_type.value}",
+        )
+    return AiterDispatchChoice(fmt, f"MoE consumes {q_dtype_a} ({quant_type.value})")
 
 
 def _resolve_mori_quant_type(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -378,6 +378,37 @@ class AiterDispatchChoice(NamedTuple):
     actionable: bool = False
 
 
+_MXFP8_BOUND_HINT = (
+    "MoE activation dtype varies with batch size (AITER_BF16_FP8_MOE_BOUND={bound}); "
+    "set it to 0 to pin fp8 and allow mxfp8 dispatch"
+)
+_SEPARATED_SWIGLU_REASON = "SwiGLU on SEPARATED varies with batch size"
+
+
+@functools.cache
+def _aiter_dispatch_dtype_api():
+    """AITER's own activation-dtype resolution, when the wheel exposes it.
+
+    Returns None otherwise, and the caller mirrors the decision instead.
+    """
+    try:
+        from aiter import dtypes
+        from aiter.fused_moe import resolve_activation_dtype
+        from aiter.ops.flydsl.moe_common import GateMode
+    except ImportError:
+        return None
+
+    return (
+        resolve_activation_dtype,
+        GateMode,
+        {
+            dtypes.fp8: AiterDispatchFormat.MXFP8,
+            dtypes.fp4x2: AiterDispatchFormat.MXFP4,
+            dtypes.bf16: AiterDispatchFormat.BF16,
+        },
+    )
+
+
 def resolve_aiter_dispatch_format(
     weight_dtype: Optional[torch.dtype],
     activation: str = "silu",
@@ -388,20 +419,14 @@ def resolve_aiter_dispatch_format(
 ) -> AiterDispatchChoice:
     """Which activation format AITER's fused_moe wants for MXFP4 expert weights.
 
-    Mirrors the `q_dtype_a` decision in `aiter/fused_moe.py`, which also depends
-    on the activation, gate mode, arch and token count M. A dispatch format is
-    fixed when the all-to-all buffers are sized and cannot follow M, so this only
-    commits to a compressed format when the answer is M-independent; every other
-    branch answers BF16, which the receive path always accepts.
-
-    Mirroring is a stopgap -- better would be for AITER to expose the resolution.
+    A dispatch format is fixed when the all-to-all buffers are sized, while
+    AITER's choice also depends on the token count M, so the format is only
+    committed when the answer is M-independent; every other branch answers BF16,
+    which the receive path always accepts.
     """
     if weight_dtype != torch.float4_e2m1fn_x2:
         # Only MXFP4 weights are ambiguous; callers settle the rest themselves.
         return AiterDispatchChoice(AiterDispatchFormat.BF16, "not MXFP4 weights")
-
-    if is_gfx95 is None:
-        is_gfx95 = is_gfx95_supported()
 
     if is_gfx1250 is None:
         is_gfx1250 = is_gfx1250_supported()
@@ -418,6 +443,42 @@ def resolve_aiter_dispatch_format(
         "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
     )
 
+    api = _aiter_dispatch_dtype_api()
+    if api is not None:
+        resolve_activation_dtype, GateMode, formats = api
+        from aiter import QuantType
+
+        # MXFP4 expert weights always reach fused_moe as per_1x32. M is omitted:
+        # AITER answers None wherever its choice would have needed it.
+        q_dtype_a = resolve_activation_dtype(
+            QuantType.per_1x32,
+            weight_dtype,
+            activation=_aiter_activation(activation),
+            gate_mode=GateMode.INTERLEAVE if interleave else GateMode.SEPARATED,
+        )
+        if q_dtype_a is not None:
+            return AiterDispatchChoice(
+                formats.get(q_dtype_a, AiterDispatchFormat.BF16),
+                f"MoE consumes {q_dtype_a}",
+            )
+        # AITER deferred, so its answer needs M. Only the fp8 bound is worth
+        # pointing at: the SwiGLU/SEPARATED one gates fp4, not mxfp8.
+        if activation == "swiglu" and not interleave:
+            return AiterDispatchChoice(
+                AiterDispatchFormat.BF16, _SEPARATED_SWIGLU_REASON
+            )
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16,
+            _MXFP8_BOUND_HINT.format(
+                bound=get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
+            ),
+            actionable=True,
+        )
+
+    # AITER without the API: mirror the same decision from its inputs.
+    if is_gfx95 is None:
+        is_gfx95 = is_gfx95_supported()
+
     if activation == "situ":
         # AITER resolves this before the INTERLEAVE branch; never M-dependent.
         if get_bool_env_var("AITER_SITUV2_A8W4", "false"):
@@ -428,13 +489,11 @@ def resolve_aiter_dispatch_format(
 
     if activation == "swiglu" and not interleave:
         # `bf16 if M < GPTOSS_SWIGLU_MXFP4_BF16_BOUND else fp4x2` -- M-dependent.
-        return AiterDispatchChoice(
-            AiterDispatchFormat.BF16, "SwiGLU on SEPARATED varies with batch size"
-        )
+        return AiterDispatchChoice(AiterDispatchFormat.BF16, _SEPARATED_SWIGLU_REASON)
 
     if activation == "swiglu" or interleave:
-        # `bf16 if gfx != gfx950 or M < AITER_BF16_FP8_MOE_BOUND else fp8`;
-        # only a bound of 0 or 1 removes the M dependency. AITER matches gfx950
+        # `bf16 if gfx != gfx950 or M < AITER_BF16_FP8_MOE_BOUND else fp8`; since
+        # M >= 0, only a bound of 0 removes the M dependency. AITER matches gfx950
         # exactly while is_gfx95_supported() is a prefix test, so a future gfx95x
         # that AITER has not adopted would be read as capable here.
         bound = get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
@@ -442,12 +501,10 @@ def resolve_aiter_dispatch_format(
             return AiterDispatchChoice(
                 AiterDispatchFormat.BF16, "MoE takes bf16 activations off gfx95"
             )
-        if bound > 1:
+        if bound > 0:
             return AiterDispatchChoice(
                 AiterDispatchFormat.BF16,
-                "MoE activation dtype varies with batch size "
-                f"(AITER_BF16_FP8_MOE_BOUND={bound}); set it to 0 to pin fp8 and "
-                "allow mxfp8 dispatch",
+                _MXFP8_BOUND_HINT.format(bound=bound),
                 actionable=True,
             )
         return AiterDispatchChoice(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -374,6 +374,10 @@ class AiterDispatchChoice(NamedTuple):
     actionable: bool = False
 
 
+# fp8 checkpoints carry either variant and both ride the same wire format.
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+
+
 @functools.cache
 def _aiter_dispatch_dtype_api():
     """AITER's `resolve_activation_dtype`, on builds that expose it."""
@@ -389,12 +393,16 @@ def _aiter_dispatch_dtype_api():
     # payload with fp32 scales every 128 elements, per_1x32 with e8m0
     # microscales every 32. Combinations absent here have no MoRI format --
     # per_Token fp8 above all -- and fall back to bf16.
+    #
+    # Keyed on `dtypes.fp8`, but AITER returns the weight dtype itself for
+    # per_1x128, so an fnuz checkpoint on an fn build answers with the other
+    # variant. Both mean the same wire format, hence _FP8_DTYPES below.
     wire_format = {
         (AiterQuantType.PER_128X128, dtypes.fp8): AiterDispatchFormat.FP8,
         (AiterQuantType.PER_1X32, dtypes.fp8): AiterDispatchFormat.MXFP8,
         (AiterQuantType.PER_1X32, dtypes.fp4x2): AiterDispatchFormat.MXFP4,
     }
-    return resolve_activation_dtype, GateMode, dtypes.bf16, wire_format
+    return resolve_activation_dtype, GateMode, dtypes.bf16, dtypes.fp8, wire_format
 
 
 def resolve_aiter_dispatch_format(
@@ -425,7 +433,7 @@ def resolve_aiter_dispatch_format(
             "the dispatch format follow what the MoE consumes",
             actionable=True,
         )
-    resolve_activation_dtype, GateMode, aiter_bf16, wire_format = api
+    resolve_activation_dtype, GateMode, aiter_bf16, aiter_fp8, wire_format = api
 
     # Mirrors AiterRunnerCore.run: only a clamped-SwiGLU layer sets gate_mode.
     interleave = bool(swiglu_limit and swiglu_limit > 0) and get_bool_env_var(
@@ -452,6 +460,8 @@ def resolve_aiter_dispatch_format(
         )
     if q_dtype_a == aiter_bf16:
         return AiterDispatchChoice(AiterDispatchFormat.BF16, "MoE consumes bf16")
+    if q_dtype_a in _FP8_DTYPES:
+        q_dtype_a = aiter_fp8
 
     fmt = wire_format.get((quant_type, q_dtype_a))
     if fmt is None:

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -23,7 +23,6 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
     get_bool_env_var,
     get_int_env_var,
-    is_gfx95_supported,
     is_gfx1250_supported,
 )
 
@@ -378,21 +377,11 @@ class AiterDispatchChoice(NamedTuple):
     actionable: bool = False
 
 
-_MXFP8_BOUND_HINT = (
-    "MoE activation dtype varies with batch size (AITER_BF16_FP8_MOE_BOUND={bound}); "
-    "set it to 0 to pin fp8 and allow mxfp8 dispatch"
-)
-_SEPARATED_SWIGLU_REASON = "SwiGLU on SEPARATED varies with batch size"
-
-
 @functools.cache
 def _aiter_dispatch_dtype_api():
-    """AITER's own activation-dtype resolution, when the wheel exposes it.
-
-    Returns None otherwise, and the caller mirrors the decision instead.
-    """
+    """AITER's `resolve_activation_dtype`, on builds that expose it."""
     try:
-        from aiter import dtypes
+        from aiter import QuantType, dtypes
         from aiter.fused_moe import resolve_activation_dtype
         from aiter.ops.flydsl.moe_common import GateMode
     except ImportError:
@@ -400,6 +389,7 @@ def _aiter_dispatch_dtype_api():
 
     return (
         resolve_activation_dtype,
+        QuantType,
         GateMode,
         {
             dtypes.fp8: AiterDispatchFormat.MXFP8,
@@ -414,15 +404,16 @@ def resolve_aiter_dispatch_format(
     activation: str = "silu",
     swiglu_limit: Optional[float] = None,
     *,
-    is_gfx95: Optional[bool] = None,
     is_gfx1250: Optional[bool] = None,
 ) -> AiterDispatchChoice:
     """Which activation format AITER's fused_moe wants for MXFP4 expert weights.
 
-    A dispatch format is fixed when the all-to-all buffers are sized, while
-    AITER's choice also depends on the token count M, so the format is only
-    committed when the answer is M-independent; every other branch answers BF16,
-    which the receive path always accepts.
+    Asks AITER, which resolves it from the activation, gate mode, arch and token
+    count M. A dispatch format is fixed when the all-to-all buffers are sized, so
+    M is not passed and AITER answers None wherever it would have been needed.
+    Every branch that is not a committed format answers BF16, which the receive
+    path always accepts, so an unsure answer costs transport bytes and nothing
+    else.
     """
     if weight_dtype != torch.float4_e2m1fn_x2:
         # Only MXFP4 weights are ambiguous; callers settle the rest themselves.
@@ -432,87 +423,48 @@ def resolve_aiter_dispatch_format(
         is_gfx1250 = is_gfx1250_supported()
 
     if is_gfx1250:
-        # AITER overrides q_dtype_a after the per_1x32 chain, for every quant
-        # type. fp4 would match, but MoRI EP is unverified on this arch.
+        # AITER wants fp4 here, but MoRI EP is unverified on this arch.
         return AiterDispatchChoice(
-            AiterDispatchFormat.BF16, "gfx1250 overrides the activation dtype"
+            AiterDispatchFormat.BF16, "MoRI EP unverified on gfx1250"
         )
+
+    api = _aiter_dispatch_dtype_api()
+    if api is None:
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16,
+            "AITER does not expose resolve_activation_dtype; upgrade it to let "
+            "the dispatch format follow what the MoE consumes",
+            actionable=True,
+        )
+    resolve_activation_dtype, QuantType, GateMode, formats = api
 
     # Mirrors AiterRunnerCore.run: only a clamped-SwiGLU layer sets gate_mode.
     interleave = bool(swiglu_limit and swiglu_limit > 0) and get_bool_env_var(
         "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
     )
 
-    api = _aiter_dispatch_dtype_api()
-    if api is not None:
-        resolve_activation_dtype, GateMode, formats = api
-        from aiter import QuantType
-
-        # MXFP4 expert weights always reach fused_moe as per_1x32. M is omitted:
-        # AITER answers None wherever its choice would have needed it.
-        q_dtype_a = resolve_activation_dtype(
-            QuantType.per_1x32,
-            weight_dtype,
-            activation=_aiter_activation(activation),
-            gate_mode=GateMode.INTERLEAVE if interleave else GateMode.SEPARATED,
-        )
-        if q_dtype_a is not None:
-            return AiterDispatchChoice(
-                formats.get(q_dtype_a, AiterDispatchFormat.BF16),
-                f"MoE consumes {q_dtype_a}",
-            )
-        # AITER deferred, so its answer needs M. Only the fp8 bound is worth
-        # pointing at: the SwiGLU/SEPARATED one gates fp4, not mxfp8.
-        if activation == "swiglu" and not interleave:
-            return AiterDispatchChoice(
-                AiterDispatchFormat.BF16, _SEPARATED_SWIGLU_REASON
-            )
+    # MXFP4 expert weights always reach fused_moe as per_1x32.
+    q_dtype_a = resolve_activation_dtype(
+        QuantType.per_1x32,
+        weight_dtype,
+        activation=_aiter_activation(activation),
+        gate_mode=GateMode.INTERLEAVE if interleave else GateMode.SEPARATED,
+    )
+    if q_dtype_a is None:
+        # Sending bf16 when AITER wanted fp8 costs a quantize on the receive
+        # side; sending fp8 when it wanted bf16 raises, or at small M returns
+        # garbage. So an M-dependent answer leaves bf16 as the only safe format.
+        bound = get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
         return AiterDispatchChoice(
             AiterDispatchFormat.BF16,
-            _MXFP8_BOUND_HINT.format(
-                bound=get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
-            ),
+            "MoE activation dtype varies with batch size and a dispatch format "
+            f"cannot (AITER_BF16_FP8_MOE_BOUND={bound}); set it to 0 to pin fp8 "
+            "and allow mxfp8 dispatch",
             actionable=True,
         )
-
-    # AITER without the API: mirror the same decision from its inputs.
-    if is_gfx95 is None:
-        is_gfx95 = is_gfx95_supported()
-
-    if activation == "situ":
-        # AITER resolves this before the INTERLEAVE branch; never M-dependent.
-        if get_bool_env_var("AITER_SITUV2_A8W4", "false"):
-            return AiterDispatchChoice(AiterDispatchFormat.MXFP8, "SiTUv2 a8w4")
-        if get_bool_env_var("AITER_SITUV2_A4W4", "false"):
-            return AiterDispatchChoice(AiterDispatchFormat.MXFP4, "SiTUv2 a4w4")
-        return AiterDispatchChoice(AiterDispatchFormat.BF16, "SiTUv2 a16w4")
-
-    if activation == "swiglu" and not interleave:
-        # `bf16 if M < GPTOSS_SWIGLU_MXFP4_BF16_BOUND else fp4x2` -- M-dependent.
-        return AiterDispatchChoice(AiterDispatchFormat.BF16, _SEPARATED_SWIGLU_REASON)
-
-    if activation == "swiglu" or interleave:
-        # `bf16 if gfx != gfx950 or M < AITER_BF16_FP8_MOE_BOUND else fp8`; since
-        # M >= 0, only a bound of 0 removes the M dependency. AITER matches gfx950
-        # exactly while is_gfx95_supported() is a prefix test, so a future gfx95x
-        # that AITER has not adopted would be read as capable here.
-        bound = get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
-        if not is_gfx95:
-            return AiterDispatchChoice(
-                AiterDispatchFormat.BF16, "MoE takes bf16 activations off gfx95"
-            )
-        if bound > 0:
-            return AiterDispatchChoice(
-                AiterDispatchFormat.BF16,
-                _MXFP8_BOUND_HINT.format(bound=bound),
-                actionable=True,
-            )
-        return AiterDispatchChoice(
-            AiterDispatchFormat.MXFP8, "MoE consumes mxfp8 (a8w4)"
-        )
-
-    # Plain activation + SEPARATED: AITER falls through to fp4x2 for any M.
-    return AiterDispatchChoice(AiterDispatchFormat.MXFP4, "MoE consumes fp4x2 (a4w4)")
+    return AiterDispatchChoice(
+        formats.get(q_dtype_a, AiterDispatchFormat.BF16), f"MoE consumes {q_dtype_a}"
+    )
 
 
 def _resolve_mori_quant_type(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import torch
 
@@ -20,7 +20,12 @@ from sglang.srt.layers.moe.moe_runner.base import (
 )
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import get_bool_env_var, get_int_env_var
+from sglang.srt.utils import (
+    get_bool_env_var,
+    get_int_env_var,
+    is_gfx95_supported,
+    is_gfx1250_supported,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
@@ -354,6 +359,103 @@ def _is_mori_dispatch_output(dispatch_output: Any) -> bool:
     # MoriEP{Normal,LL}DispatchOutput carry the post-mori-permute origin_topk_*
     # tensors that the standard DeepEP outputs lack.
     return hasattr(dispatch_output, "origin_topk_ids")
+
+
+class AiterDispatchFormat(str, Enum):
+    """Activation format AITER's MoE will consume; what a dispatcher should send.
+    BF16 doubles as "unknown" -- the receive path always accepts it."""
+
+    MXFP8 = "mxfp8"  # fp8 + group-32 e8m0 scales (a8w4)
+    MXFP4 = "mxfp4"  # packed fp4x2 + group-32 e8m0 scales (a4w4)
+    BF16 = "bf16"  # unquantized
+
+
+class AiterDispatchChoice(NamedTuple):
+    format: AiterDispatchFormat
+    reason: str
+    # A fallback the caller can lift by changing config, and so worth a warning;
+    # the others follow from the hardware or model and would only be noise.
+    actionable: bool = False
+
+
+def resolve_aiter_dispatch_format(
+    weight_dtype: Optional[torch.dtype],
+    activation: str = "silu",
+    swiglu_limit: Optional[float] = None,
+    *,
+    is_gfx95: Optional[bool] = None,
+    is_gfx1250: Optional[bool] = None,
+) -> AiterDispatchChoice:
+    """Which activation format AITER's fused_moe wants for MXFP4 expert weights.
+
+    Mirrors the `q_dtype_a` decision in `aiter/fused_moe.py`, which also depends
+    on the activation, gate mode, arch and token count M. A dispatch format is
+    fixed when the all-to-all buffers are sized and cannot follow M, so this only
+    commits to a compressed format when the answer is M-independent; every other
+    branch answers BF16, which the receive path always accepts.
+
+    Mirroring is a stopgap -- better would be for AITER to expose the resolution.
+    """
+    if weight_dtype != torch.float4_e2m1fn_x2:
+        # Only MXFP4 weights are ambiguous; callers settle the rest themselves.
+        return AiterDispatchChoice(AiterDispatchFormat.BF16, "not MXFP4 weights")
+
+    if is_gfx95 is None:
+        is_gfx95 = is_gfx95_supported()
+
+    if is_gfx1250 is None:
+        is_gfx1250 = is_gfx1250_supported()
+
+    if is_gfx1250:
+        # AITER overrides q_dtype_a after the per_1x32 chain, for every quant
+        # type. fp4 would match, but MoRI EP is unverified on this arch.
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16, "gfx1250 overrides the activation dtype"
+        )
+
+    # Mirrors AiterRunnerCore.run: only a clamped-SwiGLU layer sets gate_mode.
+    interleave = bool(swiglu_limit and swiglu_limit > 0) and get_bool_env_var(
+        "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
+    )
+
+    if activation == "situ":
+        # AITER resolves this before the INTERLEAVE branch; never M-dependent.
+        if get_bool_env_var("AITER_SITUV2_A8W4", "false"):
+            return AiterDispatchChoice(AiterDispatchFormat.MXFP8, "SiTUv2 a8w4")
+        if get_bool_env_var("AITER_SITUV2_A4W4", "false"):
+            return AiterDispatchChoice(AiterDispatchFormat.MXFP4, "SiTUv2 a4w4")
+        return AiterDispatchChoice(AiterDispatchFormat.BF16, "SiTUv2 a16w4")
+
+    if activation == "swiglu" and not interleave:
+        # `bf16 if M < GPTOSS_SWIGLU_MXFP4_BF16_BOUND else fp4x2` -- M-dependent.
+        return AiterDispatchChoice(
+            AiterDispatchFormat.BF16, "SwiGLU on SEPARATED varies with batch size"
+        )
+
+    if activation == "swiglu" or interleave:
+        # `bf16 if gfx != gfx950 or M < AITER_BF16_FP8_MOE_BOUND else fp8`;
+        # only a bound of 0 or 1 removes the M dependency. AITER matches gfx950
+        # exactly while is_gfx95_supported() is a prefix test, so a future gfx95x
+        # that AITER has not adopted would be read as capable here.
+        bound = get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
+        if not is_gfx95:
+            return AiterDispatchChoice(
+                AiterDispatchFormat.BF16, "MoE takes bf16 activations off gfx95"
+            )
+        if bound > 1:
+            return AiterDispatchChoice(
+                AiterDispatchFormat.BF16,
+                "MoE activation dtype varies with batch size "
+                f"(AITER_BF16_FP8_MOE_BOUND={bound}); set it to 0 to pin fp8 and "
+                "allow mxfp8 dispatch",
+                actionable=True,
+            )
+        return AiterDispatchChoice(
+            AiterDispatchFormat.MXFP8, "MoE consumes mxfp8 (a8w4)"
+        )
+
+    # Plain activation + SEPARATED: AITER falls through to fp4x2 for any M.
+    return AiterDispatchChoice(AiterDispatchFormat.MXFP4, "MoE consumes fp4x2 (a4w4)")
 
 
 def _resolve_mori_quant_type(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -20,11 +20,7 @@ from sglang.srt.layers.moe.moe_runner.base import (
 )
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import (
-    get_bool_env_var,
-    get_int_env_var,
-    is_gfx1250_supported,
-)
+from sglang.srt.utils import get_bool_env_var, get_int_env_var
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher.base import CombineInput
@@ -403,8 +399,6 @@ def resolve_aiter_dispatch_format(
     weight_dtype: Optional[torch.dtype],
     activation: str = "silu",
     swiglu_limit: Optional[float] = None,
-    *,
-    is_gfx1250: Optional[bool] = None,
 ) -> AiterDispatchChoice:
     """Which activation format AITER's fused_moe wants for MXFP4 expert weights.
 
@@ -418,15 +412,6 @@ def resolve_aiter_dispatch_format(
     if weight_dtype != torch.float4_e2m1fn_x2:
         # Only MXFP4 weights are ambiguous; callers settle the rest themselves.
         return AiterDispatchChoice(AiterDispatchFormat.BF16, "not MXFP4 weights")
-
-    if is_gfx1250 is None:
-        is_gfx1250 = is_gfx1250_supported()
-
-    if is_gfx1250:
-        # AITER wants fp4 here, but MoRI EP is unverified on this arch.
-        return AiterDispatchChoice(
-            AiterDispatchFormat.BF16, "MoRI EP unverified on gfx1250"
-        )
 
     api = _aiter_dispatch_dtype_api()
     if api is None:

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -357,25 +357,20 @@ def _is_mori_dispatch_output(dispatch_output: Any) -> bool:
 
 
 class AiterDispatchFormat(str, Enum):
-    """Activation format AITER's MoE will consume; what a dispatcher should send.
-    BF16 doubles as "unknown" -- the receive path always accepts it."""
+    """What the dispatcher should send, i.e. what AITER's MoE will consume.
+    BF16 doubles as "unknown": the receive path always accepts it."""
 
-    FP8 = "fp8"  # fp8 + per-128 fp32 scales (per_1x128)
-    MXFP8 = "mxfp8"  # fp8 + group-32 e8m0 scales (a8w4)
-    MXFP4 = "mxfp4"  # packed fp4x2 + group-32 e8m0 scales (a4w4)
-    BF16 = "bf16"  # unquantized
+    FP8 = "fp8"  # fp8 + fp32 scale per 128
+    MXFP8 = "mxfp8"  # fp8 + e8m0 scale per 32
+    MXFP4 = "mxfp4"  # fp4x2 + e8m0 scale per 32
+    BF16 = "bf16"
 
 
 class AiterDispatchChoice(NamedTuple):
     format: AiterDispatchFormat
     reason: str
-    # A fallback the caller can lift by changing config, and so worth a warning;
-    # the others follow from the hardware or model and would only be noise.
+    # Worth a warning: config can lift it. The rest follow from hardware or model.
     actionable: bool = False
-
-
-# fp8 checkpoints carry either variant and both ride the same wire format.
-_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
 
 
 @functools.cache
@@ -388,21 +383,18 @@ def _aiter_dispatch_dtype_api():
     except ImportError:
         return None
 
-    # (quant type, activation dtype AITER resolves to) -> what to put on the
-    # wire. The fp8 rows differ only in scale layout: per_1x128 pairs the fp8
-    # payload with fp32 scales every 128 elements, per_1x32 with e8m0
-    # microscales every 32. Combinations absent here have no MoRI format --
-    # per_Token fp8 above all -- and fall back to bf16.
-    #
-    # Keyed on `dtypes.fp8`, but AITER returns the weight dtype itself for
-    # per_1x128, so an fnuz checkpoint on an fn build answers with the other
-    # variant. Both mean the same wire format, hence _FP8_DTYPES below.
+    # (quant type, dtype AITER resolves to) -> wire format. Both fp8 rows carry
+    # the same payload and differ only in scale layout, which is why the quant
+    # type has to be part of the key. Both fp8 variants appear because AITER
+    # returns the weight dtype itself for per_1x128. Anything absent -- per_Token
+    # fp8 above all -- has no MoRI format.
+    fp8 = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
     wire_format = {
-        (AiterQuantType.PER_128X128, dtypes.fp8): AiterDispatchFormat.FP8,
-        (AiterQuantType.PER_1X32, dtypes.fp8): AiterDispatchFormat.MXFP8,
+        **{(AiterQuantType.PER_128X128, d): AiterDispatchFormat.FP8 for d in fp8},
+        **{(AiterQuantType.PER_1X32, d): AiterDispatchFormat.MXFP8 for d in fp8},
         (AiterQuantType.PER_1X32, dtypes.fp4x2): AiterDispatchFormat.MXFP4,
     }
-    return resolve_activation_dtype, GateMode, dtypes.bf16, dtypes.fp8, wire_format
+    return resolve_activation_dtype, GateMode, dtypes.bf16, wire_format
 
 
 def resolve_aiter_dispatch_format(
@@ -413,12 +405,10 @@ def resolve_aiter_dispatch_format(
 ) -> AiterDispatchChoice:
     """Which activation format AITER's fused_moe will consume for this layer.
 
-    Asks AITER, which resolves it from the quant type, weight dtype, activation,
-    gate mode, arch and token count M. A dispatch format is fixed when the
-    all-to-all buffers are sized, so M is not passed and AITER answers None
-    wherever it would have been needed. Every branch that is not a committed
-    format answers BF16, which the receive path always accepts, so an unsure
-    answer costs transport bytes and nothing else.
+    AITER's answer can depend on the token count M, but a dispatch format is
+    fixed when the all-to-all buffers are sized, so M is not passed and AITER
+    returns None wherever it would have mattered. Anything not committed to a
+    format answers BF16, which the receive path always accepts.
     """
     if quant_type is None or weight_dtype is None:
         return AiterDispatchChoice(
@@ -433,7 +423,7 @@ def resolve_aiter_dispatch_format(
             "the dispatch format follow what the MoE consumes",
             actionable=True,
         )
-    resolve_activation_dtype, GateMode, aiter_bf16, aiter_fp8, wire_format = api
+    resolve_activation_dtype, GateMode, aiter_bf16, wire_format = api
 
     # Mirrors AiterRunnerCore.run: only a clamped-SwiGLU layer sets gate_mode.
     interleave = bool(swiglu_limit and swiglu_limit > 0) and get_bool_env_var(
@@ -447,9 +437,8 @@ def resolve_aiter_dispatch_format(
         gate_mode=GateMode.INTERLEAVE if interleave else GateMode.SEPARATED,
     )
     if q_dtype_a is None:
-        # Sending bf16 when AITER wanted fp8 costs a quantize on the receive
-        # side; sending fp8 when it wanted bf16 raises, or at small M returns
-        # garbage. So an M-dependent answer leaves bf16 as the only safe format.
+        # bf16 where fp8 was wanted costs a quantize on the receive side; fp8
+        # where bf16 was wanted raises, or returns garbage at small M.
         bound = get_int_env_var("AITER_BF16_FP8_MOE_BOUND", 256)
         return AiterDispatchChoice(
             AiterDispatchFormat.BF16,
@@ -460,8 +449,6 @@ def resolve_aiter_dispatch_format(
         )
     if q_dtype_a == aiter_bf16:
         return AiterDispatchChoice(AiterDispatchFormat.BF16, "MoE consumes bf16")
-    if q_dtype_a in _FP8_DTYPES:
-        q_dtype_a = aiter_fp8
 
     fmt = wire_format.get((quant_type, q_dtype_a))
     if fmt is None:

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -411,18 +411,23 @@ class BaseDispatcher(ABC):
 
 
 def build_dispatcher_quant_config(
-    layer: torch.nn.Module, weight_dtype: Optional[torch.dtype]
+    layer: torch.nn.Module,
+    weight_dtype: Optional[torch.dtype],
+    quant_type: Optional[Any] = None,
 ) -> dict:
     """Describe a MoE layer's numerics to its dispatcher.
 
-    For MXFP4 weights the wire format also depends on the activation and gate
-    mode, so ``weight_dtype`` alone is not enough. ``weight_dtype`` is semantic,
-    not storage: MXFP4 is stored as uint8 but reported as float4_e2m1fn_x2.
-    Consumers must tolerate the other two keys being absent.
+    The wire format follows the activation dtype the MoE kernel consumes, which
+    depends on all four of these. ``quant_type`` is the ``AiterQuantType`` the
+    layer will hand AITER; it is what separates the two fp8 activation formats,
+    whose scale layouts differ. ``weight_dtype`` is semantic, not storage: MXFP4
+    is stored as uint8 but reported as float4_e2m1fn_x2. Consumers must tolerate
+    every key but ``weight_dtype`` being absent.
     """
     runner_config = getattr(layer, "moe_runner_config", None)
     return {
         "weight_dtype": weight_dtype,
+        "quant_type": quant_type,
         "activation": getattr(runner_config, "activation", "silu"),
         "swiglu_limit": getattr(runner_config, "swiglu_limit", None),
     }

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -408,3 +408,21 @@ class BaseDispatcher(ABC):
     def clear_overlap_args(self) -> None:
         self.overlap_args = None
         self.meta_overlap_args = None
+
+
+def build_dispatcher_quant_config(
+    layer: torch.nn.Module, weight_dtype: Optional[torch.dtype]
+) -> dict:
+    """Describe a MoE layer's numerics to its dispatcher.
+
+    For MXFP4 weights the wire format also depends on the activation and gate
+    mode, so ``weight_dtype`` alone is not enough. ``weight_dtype`` is semantic,
+    not storage: MXFP4 is stored as uint8 but reported as float4_e2m1fn_x2.
+    Consumers must tolerate the other two keys being absent.
+    """
+    runner_config = getattr(layer, "moe_runner_config", None)
+    return {
+        "weight_dtype": weight_dtype,
+        "activation": getattr(runner_config, "activation", "silu"),
+        "swiglu_limit": getattr(runner_config, "swiglu_limit", None),
+    }

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -417,12 +417,10 @@ def build_dispatcher_quant_config(
 ) -> dict:
     """Describe a MoE layer's numerics to its dispatcher.
 
-    The wire format follows the activation dtype the MoE kernel consumes, which
-    depends on all four of these. ``quant_type`` is the ``AiterQuantType`` the
-    layer will hand AITER; it is what separates the two fp8 activation formats,
-    whose scale layouts differ. ``weight_dtype`` is semantic, not storage: MXFP4
-    is stored as uint8 but reported as float4_e2m1fn_x2. Consumers must tolerate
-    every key but ``weight_dtype`` being absent.
+    ``quant_type`` is the ``AiterQuantType`` the layer will hand AITER; it is
+    what separates the two fp8 activation formats. ``weight_dtype`` is semantic,
+    not storage: MXFP4 is stored as uint8 but reported as float4_e2m1fn_x2.
+    Consumers must tolerate every key but ``weight_dtype`` being absent.
     """
     runner_config = getattr(layer, "moe_runner_config", None)
     return {

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -492,6 +492,7 @@ class _MoriEPDispatcherImplBase:
 
         return (
             resolve_aiter_dispatch_format(
+                self.quant_config.get("quant_type"),
                 self.quant_config.get("weight_dtype"),
                 activation=self.quant_config.get("activation", "silu"),
                 swiglu_limit=self.quant_config.get("swiglu_limit"),
@@ -593,14 +594,7 @@ class _MoriEPDispatcherImplBase:
         self.quant_config = quant_config
         weight_dtype = quant_config.get("weight_dtype", None)
 
-        if weight_dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
-            # per_1x128 takes fp8 activations directly, so the weight dtype
-            # does settle it here.
-            self.dispatch_dtype = DispatchDtype.fp8
-        elif weight_dtype == torch.float4_e2m1fn_x2:
-            self.dispatch_dtype = self._resolve_mxfp4_dispatch_dtype(quant_config)
-        else:
-            self.dispatch_dtype = DispatchDtype.bf16
+        self.dispatch_dtype = self._resolve_dispatch_dtype(quant_config)
 
         # Combine has no receiver format to match (bf16 in, bf16 out), so it is
         # keyed off the weight dtype rather than the dispatch format: an MXFP4
@@ -614,29 +608,17 @@ class _MoriEPDispatcherImplBase:
         # Apply env var override immediately so dispatch_a sees correct flags
         self._apply_dispatch_dtype_override()
 
-    def _resolve_mxfp4_dispatch_dtype(self, quant_config: dict) -> DispatchDtype:
-        """Pick the wire format for MXFP4 expert weights.
-
-        MXFP4 weights run on a16w4 / a8w4 / a4w4 and the weight dtype does not
-        say which, so this defers to the AITER runner.
-        """
+    def _resolve_dispatch_dtype(self, quant_config: dict) -> DispatchDtype:
+        """Pick the wire format from the activation dtype the MoE consumes."""
         from sglang.srt.layers.moe.moe_runner.aiter import (
             AiterDispatchFormat,
             resolve_aiter_dispatch_format,
         )
 
-        if "activation" not in quant_config:
-            # Older quant methods send a bare weight_dtype; defaulting the
-            # missing keys would read as SEPARATED and pick fp4, which is a guess.
-            logger.info_once(
-                "[MORI] auto dispatch_dtype=bf16: quant method did not report the "
-                "MoE activation, so the receiving kernel is unknown"
-            )
-            return DispatchDtype.bf16
-
         choice = resolve_aiter_dispatch_format(
+            quant_config.get("quant_type"),
             quant_config.get("weight_dtype"),
-            activation=quant_config["activation"],
+            activation=quant_config.get("activation", "silu"),
             swiglu_limit=quant_config.get("swiglu_limit"),
         )
         actionable = choice.actionable
@@ -653,6 +635,8 @@ class _MoriEPDispatcherImplBase:
                 )
         elif choice.format == AiterDispatchFormat.MXFP4:
             chosen, why = DispatchDtype.fp4, choice.reason
+        elif choice.format == AiterDispatchFormat.FP8:
+            chosen, why = DispatchDtype.fp8, choice.reason
         else:
             chosen, why = DispatchDtype.bf16, choice.reason
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -70,23 +70,28 @@ def _should_record_expert_distribution() -> bool:
 
 @functools.lru_cache(maxsize=1)
 def _aiter_supports_mxfp8_dispatch() -> bool:
-    """Whether this aiter can consume fp8 activations with group-32 e8m0 scales.
+    """Can this aiter both emit and consume mxfp8 activations?
 
-    Probed rather than assumed, because the failure is silent in the worst way:
-    an older per_1x32 quant still returns fp8, but with continuous fp32 scales,
-    which the MoE then reads as e8m0 bytes and produces garbage rather than an
-    exception. Checking the signature keeps this a startup-time fallback instead
-    of a runtime corruption.
+    The two halves ship in different aiter commits (ROCm/aiter#4954 is the
+    receive side) and builds with only the first exist, where the fp8
+    activations reach a bf16-only quantizer and abort. aiter exposes no
+    capability flag, hence the probes.
     """
     try:
         import inspect
 
+        import aiter.fused_moe as aiter_fused_moe
         from aiter import get_hip_quant
 
-        return "scale_type" in inspect.signature(get_hip_quant).parameters or any(
+        can_emit = "scale_type" in inspect.signature(get_hip_quant).parameters or any(
             "scale_type" in inspect.signature(f).parameters
             for f in (get_hip_quant(QuantType.per_1x32),)
         )
+        can_consume = (
+            "hidden_states.dtype == dtypes.fp8 and a1_scale is not None"
+            in inspect.getsource(aiter_fused_moe)
+        )
+        return can_emit and can_consume
     except Exception:
         return False
 
@@ -470,6 +475,30 @@ class _MoriEPDispatcherImplBase:
             )
         return self._mori_op
 
+    def _moe_will_consume_mxfp8(self) -> bool:
+        """Would AITER take mxfp8 activations for this layer?
+
+        Only the mxfp8 override needs this: bf16 and fp4 land somewhere whatever
+        the MoE decides, mxfp8 only has the `q_dtype_a == fp8` branch. True when
+        the quant config is unset, since this also runs before weights load.
+        """
+        if not self.quant_config:
+            return True
+
+        from sglang.srt.layers.moe.moe_runner.aiter import (
+            AiterDispatchFormat,
+            resolve_aiter_dispatch_format,
+        )
+
+        return (
+            resolve_aiter_dispatch_format(
+                self.quant_config.get("weight_dtype"),
+                activation=self.quant_config.get("activation", "silu"),
+                swiglu_limit=self.quant_config.get("swiglu_limit"),
+            ).format
+            == AiterDispatchFormat.MXFP8
+        )
+
     def _apply_dispatch_dtype_override(self):
         """Apply env var override to fp8_dispatch/fp4_dispatch/fp8_combine flags."""
         if "SGLANG_MORI_DISPATCH_DTYPE" in os.environ:
@@ -482,17 +511,27 @@ class _MoriEPDispatcherImplBase:
                 elif dispatch_dtype == "fp4":
                     self.dispatch_dtype = DispatchDtype.fp4
                 elif dispatch_dtype == "mxfp8":
-                    if _aiter_supports_mxfp8_dispatch():
+                    if not self._moe_will_consume_mxfp8():
+                        # Refused rather than warned about: a mismatch aborts
+                        # at large M but silently returns garbage at decode
+                        # batch sizes.
+                        logger.warning_once(
+                            "SGLANG_MORI_DISPATCH_DTYPE=mxfp8 ignored: this "
+                            "layer's MoE does not resolve to fp8 activations "
+                            "(a8w4), so mxfp8 on the wire has no receiver. "
+                            "Needs gfx950 + AITER_BF16_FP8_MOE_BOUND<=1 + a "
+                            "clamped-SwiGLU layer on gate_mode=INTERLEAVE "
+                            "(SGLANG_USE_AITER_MOE_GU_ITLV=1). Falling back to "
+                            "bf16 dispatch."
+                        )
+                    elif _aiter_supports_mxfp8_dispatch():
                         self.dispatch_dtype = DispatchDtype.mxfp8
                     else:
                         logger.warning_once(
-                            "SGLANG_MORI_DISPATCH_DTYPE=mxfp8 requires an aiter "
-                            "build whose per_1x32 quant accepts scale_type "
-                            "(for the group-32 e8m0 byte layout the MoE kernels "
-                            "consume). This aiter does not, so the send-side "
-                            "quant would emit continuous fp32 scales and the "
-                            "MoE would read them as e8m0 bytes. Falling back to "
-                            "bf16 dispatch."
+                            "SGLANG_MORI_DISPATCH_DTYPE=mxfp8 needs an aiter that "
+                            "can emit group-32 e8m0 scales and consume them without "
+                            "re-deriving (ROCm/aiter#4954); this build cannot. "
+                            "Falling back to bf16 dispatch."
                         )
         elif (
             "SGLANG_MORI_FP8_DISP" in os.environ or "SGLANG_MORI_FP4_DISP" in os.environ
@@ -552,19 +591,74 @@ class _MoriEPDispatcherImplBase:
 
     def set_quant_config(self, quant_config: dict) -> None:
         self.quant_config = quant_config
-        # Auto-detect dispatch quantization from weight dtype
         weight_dtype = quant_config.get("weight_dtype", None)
+
         if weight_dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+            # per_1x128 takes fp8 activations directly, so the weight dtype
+            # does settle it here.
             self.dispatch_dtype = DispatchDtype.fp8
-            self.combine_dtype = CombineDtype.bf16
         elif weight_dtype == torch.float4_e2m1fn_x2:
-            self.dispatch_dtype = DispatchDtype.fp4
-            self.combine_dtype = CombineDtype.fp8
+            self.dispatch_dtype = self._resolve_mxfp4_dispatch_dtype(quant_config)
         else:
             self.dispatch_dtype = DispatchDtype.bf16
+
+        # Combine has no receiver format to match (bf16 in, bf16 out), so it is
+        # keyed off the weight dtype rather than the dispatch format: an MXFP4
+        # layer that fell back to bf16 dispatch still wants the cheaper combine.
+        # Values unchanged.
+        if weight_dtype == torch.float4_e2m1fn_x2:
+            self.combine_dtype = CombineDtype.fp8
+        else:
             self.combine_dtype = CombineDtype.bf16
+
         # Apply env var override immediately so dispatch_a sees correct flags
         self._apply_dispatch_dtype_override()
+
+    def _resolve_mxfp4_dispatch_dtype(self, quant_config: dict) -> DispatchDtype:
+        """Pick the wire format for MXFP4 expert weights.
+
+        MXFP4 weights run on a16w4 / a8w4 / a4w4 and the weight dtype does not
+        say which, so this defers to the AITER runner.
+        """
+        from sglang.srt.layers.moe.moe_runner.aiter import (
+            AiterDispatchFormat,
+            resolve_aiter_dispatch_format,
+        )
+
+        if "activation" not in quant_config:
+            # Older quant methods send a bare weight_dtype; defaulting the
+            # missing keys would read as SEPARATED and pick fp4, which is a guess.
+            logger.info_once(
+                "[MORI] auto dispatch_dtype=bf16: quant method did not report the "
+                "MoE activation, so the receiving kernel is unknown"
+            )
+            return DispatchDtype.bf16
+
+        choice = resolve_aiter_dispatch_format(
+            quant_config.get("weight_dtype"),
+            activation=quant_config["activation"],
+            swiglu_limit=quant_config.get("swiglu_limit"),
+        )
+        actionable = choice.actionable
+
+        if choice.format == AiterDispatchFormat.MXFP8:
+            if _aiter_supports_mxfp8_dispatch():
+                chosen, why = DispatchDtype.mxfp8, choice.reason
+            else:
+                chosen, why, actionable = (
+                    DispatchDtype.bf16,
+                    "MoE consumes mxfp8 (a8w4) but this aiter cannot emit or "
+                    "consume it (needs ROCm/aiter#4954)",
+                    True,
+                )
+        elif choice.format == AiterDispatchFormat.MXFP4:
+            chosen, why = DispatchDtype.fp4, choice.reason
+        else:
+            chosen, why = DispatchDtype.bf16, choice.reason
+
+        log = logger.warning_once if actionable else logger.info_once
+        log(f"[MORI] auto dispatch_dtype={chosen.name}: {why}")
+        return chosen
 
     def set_overlap_args(
         self, combine_overlap_args: CombineOverlapArgs, meta_overlap_args: dict

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -475,31 +475,6 @@ class _MoriEPDispatcherImplBase:
             )
         return self._mori_op
 
-    def _moe_will_consume_mxfp8(self) -> bool:
-        """Would AITER take mxfp8 activations for this layer?
-
-        Only the mxfp8 override needs this: bf16 and fp4 land somewhere whatever
-        the MoE decides, mxfp8 only has the `q_dtype_a == fp8` branch. True when
-        the quant config is unset, since this also runs before weights load.
-        """
-        if not self.quant_config:
-            return True
-
-        from sglang.srt.layers.moe.moe_runner.aiter import (
-            AiterDispatchFormat,
-            resolve_aiter_dispatch_format,
-        )
-
-        return (
-            resolve_aiter_dispatch_format(
-                self.quant_config.get("quant_type"),
-                self.quant_config.get("weight_dtype"),
-                activation=self.quant_config.get("activation", "silu"),
-                swiglu_limit=self.quant_config.get("swiglu_limit"),
-            ).format
-            == AiterDispatchFormat.MXFP8
-        )
-
     def _apply_dispatch_dtype_override(self):
         """Apply env var override to fp8_dispatch/fp4_dispatch/fp8_combine flags."""
         if "SGLANG_MORI_DISPATCH_DTYPE" in os.environ:
@@ -512,20 +487,7 @@ class _MoriEPDispatcherImplBase:
                 elif dispatch_dtype == "fp4":
                     self.dispatch_dtype = DispatchDtype.fp4
                 elif dispatch_dtype == "mxfp8":
-                    if not self._moe_will_consume_mxfp8():
-                        # Refused rather than warned about: a mismatch aborts
-                        # at large M but silently returns garbage at decode
-                        # batch sizes.
-                        logger.warning_once(
-                            "SGLANG_MORI_DISPATCH_DTYPE=mxfp8 ignored: this "
-                            "layer's MoE does not resolve to fp8 activations "
-                            "(a8w4), so mxfp8 on the wire has no receiver. "
-                            "Needs gfx950 + AITER_BF16_FP8_MOE_BOUND<=1 + a "
-                            "clamped-SwiGLU layer on gate_mode=INTERLEAVE "
-                            "(SGLANG_USE_AITER_MOE_GU_ITLV=1). Falling back to "
-                            "bf16 dispatch."
-                        )
-                    elif _aiter_supports_mxfp8_dispatch():
+                    if _aiter_supports_mxfp8_dispatch():
                         self.dispatch_dtype = DispatchDtype.mxfp8
                     else:
                         logger.warning_once(

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -72,10 +72,9 @@ def _should_record_expert_distribution() -> bool:
 def _aiter_supports_mxfp8_dispatch() -> bool:
     """Can this aiter both emit and consume mxfp8 activations?
 
-    The two halves ship in different aiter commits (ROCm/aiter#4954 is the
-    receive side) and builds with only the first exist, where the fp8
-    activations reach a bf16-only quantizer and abort. aiter exposes no
-    capability flag, hence the probes.
+    The halves ship in different commits (ROCm/aiter#4954 is the receive side),
+    and on a build with only the first the activations reach a bf16-only
+    quantizer and abort. No capability flag exists, hence the probes.
     """
     try:
         import inspect
@@ -558,10 +557,8 @@ class _MoriEPDispatcherImplBase:
 
         self.dispatch_dtype = self._resolve_dispatch_dtype(quant_config)
 
-        # Combine has no receiver format to match (bf16 in, bf16 out), so it is
-        # keyed off the weight dtype rather than the dispatch format: an MXFP4
-        # layer that fell back to bf16 dispatch still wants the cheaper combine.
-        # Values unchanged.
+        # Combine has no receiver format to match (bf16 in, bf16 out), so it
+        # stays keyed off the weight dtype. Values unchanged.
         if weight_dtype == torch.float4_e2m1fn_x2:
             self.combine_dtype = CombineDtype.fp8
         else:
@@ -583,24 +580,21 @@ class _MoriEPDispatcherImplBase:
             activation=quant_config.get("activation", "silu"),
             swiglu_limit=quant_config.get("swiglu_limit"),
         )
-        actionable = choice.actionable
+        chosen = {
+            AiterDispatchFormat.FP8: DispatchDtype.fp8,
+            AiterDispatchFormat.MXFP8: DispatchDtype.mxfp8,
+            AiterDispatchFormat.MXFP4: DispatchDtype.fp4,
+            AiterDispatchFormat.BF16: DispatchDtype.bf16,
+        }[choice.format]
+        why, actionable = choice.reason, choice.actionable
 
-        if choice.format == AiterDispatchFormat.MXFP8:
-            if _aiter_supports_mxfp8_dispatch():
-                chosen, why = DispatchDtype.mxfp8, choice.reason
-            else:
-                chosen, why, actionable = (
-                    DispatchDtype.bf16,
-                    "MoE consumes mxfp8 (a8w4) but this aiter cannot emit or "
-                    "consume it (needs ROCm/aiter#4954)",
-                    True,
-                )
-        elif choice.format == AiterDispatchFormat.MXFP4:
-            chosen, why = DispatchDtype.fp4, choice.reason
-        elif choice.format == AiterDispatchFormat.FP8:
-            chosen, why = DispatchDtype.fp8, choice.reason
-        else:
-            chosen, why = DispatchDtype.bf16, choice.reason
+        if chosen is DispatchDtype.mxfp8 and not _aiter_supports_mxfp8_dispatch():
+            chosen, why, actionable = (
+                DispatchDtype.bf16,
+                "MoE consumes mxfp8 (a8w4) but this aiter cannot emit or consume "
+                "it (needs ROCm/aiter#4954)",
+                True,
+            )
 
         log = logger.warning_once if actionable else logger.info_once
         log(f"[MORI] auto dispatch_dtype={chosen.name}: {why}")

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2194,7 +2194,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             self._prepare_hpc_ops_weights(layer)
 
         if hasattr(layer, "dispatcher"):
-            layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
+            from sglang.srt.layers.moe.token_dispatcher.base import (
+                build_dispatcher_quant_config,
+            )
+
+            layer.dispatcher.set_quant_config(
+                build_dispatcher_quant_config(layer, layer.w13_weight.dtype)
+            )
 
     def _prepare_flashinfer_trtllm_activation_params(self, layer: Module) -> None:
         """Materialize optional TRT-LLM SwiGLU parameters once per expert."""

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2199,7 +2199,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
 
             layer.dispatcher.set_quant_config(
-                build_dispatcher_quant_config(layer, layer.w13_weight.dtype)
+                build_dispatcher_quant_config(
+                    layer, layer.w13_weight.dtype, self._aiter_moe_quant_type()
+                )
             )
 
     def _prepare_flashinfer_trtllm_activation_params(self, layer: Module) -> None:
@@ -2713,6 +2715,22 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         self._cutlass_buffers_ready = True
 
+    def _aiter_moe_quant_type(self):
+        """The quant_type this method hands AITER.
+
+        Also what the dispatcher needs: it separates the two fp8 activation
+        formats, which share a payload but not a scale layout.
+        """
+        from sglang.srt.layers.moe.moe_runner.aiter import AiterQuantType
+
+        if not self.block_quant:
+            return AiterQuantType.PER_TOKEN
+        return (
+            AiterQuantType.PER_1X32
+            if self.is_fp4_expert
+            else AiterQuantType.PER_128X128
+        )
+
     def maybe_get_hip_aiter_quant_info(
         self,
         layer: torch.nn.Module,
@@ -2722,21 +2740,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             return None
         assert not no_combine, f"{no_combine=} is not supported."
 
-        from sglang.srt.layers.moe.moe_runner.aiter import (
-            AiterMoeQuantInfo,
-            AiterQuantType,
-        )
+        from sglang.srt.layers.moe.moe_runner.aiter import AiterMoeQuantInfo
 
         w13_weight = layer.w13_weight
         w2_weight = layer.w2_weight
 
+        quant_type = self._aiter_moe_quant_type()
         if self.block_quant:
-            quant_type = (
-                AiterQuantType.PER_1X32
-                if self.is_fp4_expert
-                else AiterQuantType.PER_128X128
-            )
-
             if self.is_fp4_expert:
                 fp4_weight_dtype = _require_fp4_dtype()
                 w13_weight = w13_weight.view(fp4_weight_dtype)
@@ -2747,7 +2757,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_scale = layer.w13_weight_scale_inv
             w2_scale = layer.w2_weight_scale_inv
         else:
-            quant_type = AiterQuantType.PER_TOKEN
             w13_scale = layer.w13_weight_scale1
             w2_scale = layer.w2_weight_scale1
         return AiterMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2716,11 +2716,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self._cutlass_buffers_ready = True
 
     def _aiter_moe_quant_type(self):
-        """The quant_type this method hands AITER.
-
-        Also what the dispatcher needs: it separates the two fp8 activation
-        formats, which share a payload but not a scale layout.
-        """
+        """The quant_type this method hands AITER, which the dispatcher also
+        needs: it separates the two fp8 activation formats."""
         from sglang.srt.layers.moe.moe_runner.aiter import AiterQuantType
 
         if not self.block_quant:

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -879,8 +879,14 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             layer.w2_weight.is_shuffled = True
 
         if hasattr(layer, "dispatcher"):
+            from sglang.srt.layers.moe.token_dispatcher.base import (
+                build_dispatcher_quant_config,
+            )
+
             # Weights are stored as torch.uint8 but semantically MXFP4
-            layer.dispatcher.set_quant_config({"weight_dtype": torch.float4_e2m1fn_x2})
+            layer.dispatcher.set_quant_config(
+                build_dispatcher_quant_config(layer, torch.float4_e2m1fn_x2)
+            )
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -879,13 +879,16 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             layer.w2_weight.is_shuffled = True
 
         if hasattr(layer, "dispatcher"):
+            from sglang.srt.layers.moe.moe_runner.aiter import AiterQuantType
             from sglang.srt.layers.moe.token_dispatcher.base import (
                 build_dispatcher_quant_config,
             )
 
             # Weights are stored as torch.uint8 but semantically MXFP4
             layer.dispatcher.set_quant_config(
-                build_dispatcher_quant_config(layer, torch.float4_e2m1fn_x2)
+                build_dispatcher_quant_config(
+                    layer, torch.float4_e2m1fn_x2, AiterQuantType.PER_1X32
+                )
             )
 
     def create_moe_runner(

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a8_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a8_mxfp4_moe.py
@@ -392,13 +392,16 @@ class QuarkW4A8MXFp4MoE(QuarkMoEScheme):
         )
 
         if hasattr(layer, "dispatcher"):
+            from sglang.srt.layers.moe.moe_runner.aiter import AiterQuantType
             from sglang.srt.layers.moe.token_dispatcher.base import (
                 build_dispatcher_quant_config,
             )
 
             # Weights are stored as torch.uint8 but semantically MXFP4
             layer.dispatcher.set_quant_config(
-                build_dispatcher_quant_config(layer, torch.float4_e2m1fn_x2)
+                build_dispatcher_quant_config(
+                    layer, torch.float4_e2m1fn_x2, AiterQuantType.PER_1X32
+                )
             )
 
     def create_moe_runner(

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a8_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a8_mxfp4_moe.py
@@ -392,8 +392,14 @@ class QuarkW4A8MXFp4MoE(QuarkMoEScheme):
         )
 
         if hasattr(layer, "dispatcher"):
+            from sglang.srt.layers.moe.token_dispatcher.base import (
+                build_dispatcher_quant_config,
+            )
+
             # Weights are stored as torch.uint8 but semantically MXFP4
-            layer.dispatcher.set_quant_config({"weight_dtype": torch.float4_e2m1fn_x2})
+            layer.dispatcher.set_quant_config(
+                build_dispatcher_quant_config(layer, torch.float4_e2m1fn_x2)
+            )
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig


### PR DESCRIPTION
MoRI's auto dispatch picks the wire format from the expert weight dtype alone,
which does not say what the receiving kernel consumes. MXFP4 weights run a16w4,
a8w4 or a4w4 depending on the activation, gate mode, arch and token count; and
fp8 activations have two formats that share a payload but not a scale layout.

Ask AITER instead, through `resolve_activation_dtype()` (ROCm/aiter#5221), and
pass the quant type alongside the weight dtype so those two stay apart. No rule
is duplicated on this side; an AITER without that API dispatches bf16 and warns.

| quant type | AITER consumes | dispatch | scales |
| --- | --- | --- | --- |
| per_1x128 | fp8 | fp8 | fp32 per 128 |
| per_1x32 | fp8 | **mxfp8** | e8m0 per 32 |
| per_1x32 | fp4x2 | fp4 | e8m0 per 32 |
| anything else, or an answer that depends on M | — | bf16 | — |

`per_Token` lands in the last row on purpose: MoRI has no per-token fp8 format.
It reached bf16 before too, but through an `else` branch, where a deliberate
answer and an unhandled case looked the same.

On DeepSeek-V4-Pro the MoE is a8w4, so the old fp4 guess cost an `upscale_mxfp4`
plus a re-quantize on every layer, in both prefill and decode, with nothing in
the log to say so. gsm8k 200 questions on MI355X / TP8 + DP8 attention + EP8
MoRI: **100.0 s -> 62-67 s**, accuracy unchanged (0.955-0.980 vs 0.965-0.975
bf16; the ranges overlap). DeepSeek-R1 is unaffected: R1-0528-MXFP4 still
dispatches fp4, R1-0528 still dispatches fp8 with a bf16 combine.

## Why the answer is so often bf16

A dispatch format is fixed when the all-to-all buffers are sized -- before any
token exists -- while AITER's answer may depend on M. So M is not passed, and
AITER returns None wherever it would have been needed.

Falling back rather than guessing is not caution for its own sake; the two
directions are not symmetric. Sending bf16 when AITER wanted fp8 costs a
quantize on the receive side. Sending fp8 when it wanted bf16 raises
`Unsupported kernel config for moe heuristic dispatch` at M=64, and at M=2
returns garbage without raising (max|delta| 2.3e6 against a reference whose own
max is 0.88).

`AITER_BF16_FP8_MOE_BOUND` is the usual reason M matters. At its default of 256
every decode batch is under the bound, AITER takes bf16 activations, and auto
must send bf16 -- 74 s instead of 62 s, with nothing to explain it. Setting it
to 0 pins fp8 for every M. That fallback warns and names the variable; fallbacks
that follow from the hardware stay at info.

## Related

- #36119 added `DispatchDtype.mxfp8` and the receive-side handling but left auto
  on the weight-dtype rule. Its capability probe also covered only the send
  side; builds that emit e8m0 scales but lack the passthrough exist, and there
  it returned True while the receiver still did the round trip.
- ROCm/aiter#4954 is the receive-side passthrough this depends on. Without it
  the probe declines and falls back to bf16, so older aiter builds are safe.
- ROCm/aiter#5221 exposes the resolution this PR calls.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33742736028](https://github.com/sgl-project/sglang/actions/runs/33742736028)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33742735405](https://github.com/sgl-project/sglang/actions/runs/33742735405)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33742735617](https://github.com/sgl-project/sglang/actions/runs/33742735617)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->