### PR TITLE
Fix GLM5 RunAI streamer fused MLA weight ownership

### DIFF
--- a/python/sglang/srt/model_loader/runai_utils.py
+++ b/python/sglang/srt/model_loader/runai_utils.py
@@ -1,0 +1,23 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+RUNAI_STREAMER_TENSOR_ATTR = "_sglang_runai_streamer_tensor"
+
+
+def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Own tensors retained beyond the current RunAI streamer iteration."""
+    if getattr(tensor, RUNAI_STREAMER_TENSOR_ATTR, False):
+        return tensor.clone().detach()
+    return tensor

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -16,6 +16,7 @@ from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
 from sglang.srt.configs.model_config import ModelConfig, ModelImpl
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +297,7 @@ def should_async_load(weight: torch.Tensor) -> bool:
     RunAI-streamed tensors are zero-copy views into a reused CPU buffer. They
     must be consumed synchronously before the streamer fills its next batch.
     """
-    if getattr(weight, "_sglang_runai_streamer_tensor", False):
+    if getattr(weight, RUNAI_STREAMER_TENSOR_ATTR, False):
         return False
 
     device = getattr(weight, "device", None)

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -56,6 +56,7 @@ from sglang.srt.model_loader.ci_weight_validation import (
     ci_download_with_validation_and_retry,
     ci_validate_and_cleanup_local_snapshot,
 )
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
     BAR_FORMAT,
@@ -73,9 +74,6 @@ except ImportError:
     SafeTensorsFileLoader = SingleGroup = None
 
 logger = logging.getLogger(__name__)
-
-RUNAI_STREAMER_TENSOR_ATTR = "_sglang_runai_streamer_tensor"
-
 
 # Matches routed-expert weight keys in both HF-style layouts
 # (``...mlp.experts.<N>.{gate,up,down}_proj.weight``) and DeepSeek V4

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -40,13 +40,13 @@ from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,
 )
 from sglang.srt.layers.utils import get_layer_id
+from sglang.srt.model_loader.runai_utils import _clone_if_runai_streamed_tensor
 from sglang.srt.model_loader.utils import (
     maybe_executor_submit,
     should_async_load,
     should_deepgemm_weight_requant_ue8m0,
 )
 from sglang.srt.model_loader.weight_utils import (
-    RUNAI_STREAMER_TENSOR_ATTR,
     default_weight_loader,
 )
 from sglang.srt.models.deepseek_common.utils import (
@@ -70,12 +70,6 @@ logger = logging.getLogger(__name__)
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
-
-
-def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
-    if getattr(tensor, RUNAI_STREAMER_TENSOR_ATTR, False):
-        return tensor.clone().detach()
-    return tensor
 
 
 def _get_indexer_weight_block_size(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -99,6 +99,7 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
     DeepseekV2WeightLoaderMixin,
+    _clone_if_runai_streamed_tensor,
 )
 from sglang.srt.models.deepseek_common.utils import (
     _device_sm,
@@ -1796,7 +1797,9 @@ class Glm5NextForConditionalGeneration(nn.Module):
                     if fuse_qkv_a_proj and (
                         "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                     ):
-                        cached_a_proj[name] = loaded_weight
+                        cached_a_proj[name] = _clone_if_runai_streamed_tensor(
+                            loaded_weight
+                        )
                         q_a_proj_name = (
                             name
                             if "q_a_proj" in name

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -93,13 +93,13 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     PPProxyTensors,
 )
+from sglang.srt.model_loader.runai_utils import _clone_if_runai_streamed_tensor
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
 )
 from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
     DeepseekV2WeightLoaderMixin,
-    _clone_if_runai_streamed_tensor,
 )
 from sglang.srt.models.deepseek_common.utils import (
     _device_sm,

--- a/test/registered/unit/models/test_glm5_next_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_weight_loading.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.srt.model_loader.weight_utils import RUNAI_STREAMER_TENSOR_ATTR
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
 from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/models/test_glm5_next_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_weight_loading.py
@@ -1,0 +1,60 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_loader.weight_utils import RUNAI_STREAMER_TENSOR_ATTR
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _FakeParam:
+    def __init__(self):
+        self.loaded = None
+
+    def weight_loader(self, _param, loaded_weight):
+        self.loaded = loaded_weight
+
+
+class TestGlm5NextWeightLoading(unittest.TestCase):
+    @patch("sglang.srt.models.glm5_next.DeepseekV2WeightLoaderMixin.post_load_weights")
+    def test_runai_streamed_fused_qkv_a_proj_owns_buffer(self, post_load):
+        fused_param = _FakeParam()
+        model = SimpleNamespace(
+            config=SimpleNamespace(n_routed_experts=0, num_hidden_layers=1),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            fuse_qkv_a_proj=True,
+            named_parameters=lambda: iter(
+                [
+                    (
+                        "model.layers.0.self_attn.fused_qkv_a_proj_with_mqa.weight",
+                        fused_param,
+                    )
+                ]
+            ),
+        )
+
+        staging_buffer = torch.tensor([1, 2], dtype=torch.float32)
+
+        def streamed_weights():
+            q_view = staging_buffer[:]
+            setattr(q_view, RUNAI_STREAMER_TENSOR_ATTR, True)
+            yield "model.layers.0.self_attn.q_a_proj.weight", q_view
+
+            staging_buffer.copy_(torch.tensor([3, 4], dtype=torch.float32))
+            kv_view = staging_buffer[:]
+            setattr(kv_view, RUNAI_STREAMER_TENSOR_ATTR, True)
+            yield "model.layers.0.self_attn.kv_a_proj_with_mqa.weight", kv_view
+
+        Glm5NextForConditionalGeneration.load_weights(model, streamed_weights())
+
+        self.assertEqual(fused_param.loaded.tolist(), [1, 2, 3, 4])
+        post_load.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37369.

GLM-5.3-Flash caches `q_a_proj` and `kv_a_proj_with_mqa` RunAI streamer views before concatenating them into `fused_qkv_a_proj_with_mqa`. Distributed streaming can reuse the staging buffer between these yields, overwriting the cached q shard and causing intermittent corrupted fused MLA weights and malformed output. DFLASH draft-model loading uses the same `Glm5NextForConditionalGeneration.load_weights` path and is covered by the same ownership requirement.

## Modifications

- Added the standalone `sglang.srt.model_loader.runai_utils` module for the RunAI marker and ownership clone helper.
- Clone RunAI-marked q/kv-a projection tensors before storing them in the GLM5 fused-MLA cache.
- Centralized the marker in the loader utilities and retained compatibility for DeepSeek loader callers.
- Added a deterministic reusable-buffer regression test that verifies the fused tensor preserves both q and kv values.

## Accuracy Tests

- Synthetic regression test reproduces staging-buffer reuse and verifies the fused q/kv tensor contents.
- Full GLM-5.3-Flash FP8 and DFLASH GPU/Kubernetes accuracy testing was not available locally because runtime dependencies and a cluster deployment were unavailable; CI/deployment validation is required.

## Speed Tests and Profiling

The clone is limited to RunAI-marked tensors held across streamer iterations. No measurable impact is expected for ordinary local or non-streamed loading. No benchmark environment was available locally.

## Checklist

- [x] Format checks passed through the repository pre-commit hooks during commit.
- [x] Added a focused unit regression test.
- [ ] Updated documentation (not applicable; behavior is internal).
- [ ] Provided full accuracy and speed benchmarks (requires GPU/Kubernetes environment).
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33480708833](https://github.com/sgl-project/sglang/actions/runs/33480708833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33480708282](https://github.com/sgl-project/sglang/actions/runs/33480708282)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33480708899](https://github.com/sgl-project/sglang/actions/runs/33480708899)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->