### PR TITLE
Fix NVFP4 RunAI streamer pending weight ownership

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -70,6 +70,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.model_loader.runai_utils import _clone_if_runai_streamed_tensor
 from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.runtime_context import (
     get_exec,
@@ -896,13 +897,17 @@ class FusedMoE(torch.nn.Module):
             fp8_weight = loaded_weight
             fp8_scale = self._pending_fp8_shared_scales.pop(key, None)
             if fp8_scale is None:
-                self._pending_fp8_shared_weights[key] = loaded_weight
+                self._pending_fp8_shared_weights[key] = _clone_if_runai_streamed_tensor(
+                    loaded_weight
+                )
                 return True
         else:
             fp8_weight = self._pending_fp8_shared_weights.pop(key, None)
             fp8_scale = loaded_weight
             if fp8_weight is None:
-                self._pending_fp8_shared_scales[key] = loaded_weight
+                self._pending_fp8_shared_scales[key] = _clone_if_runai_streamed_tensor(
+                    loaded_weight
+                )
                 return True
 
         logging.getLogger(__name__).warning_once(

--- a/python/sglang/srt/layers/quantization/nvfp4_online.py
+++ b/python/sglang/srt/layers/quantization/nvfp4_online.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.quantization.utils import (
     is_layer_skipped,
     per_tensor_dequantize,
 )
+from sglang.srt.model_loader.runai_utils import _clone_if_runai_streamed_tensor
 
 logger = logging.getLogger(__name__)
 
@@ -492,7 +493,7 @@ class ModelOptNvFp4OnlineFusedMoEMethod(ModelOptNvFp4FusedMoEMethod):
             pending_key = expert_id
             current = (
                 param,
-                loaded_weight,
+                _clone_if_runai_streamed_tensor(loaded_weight),
                 weight_name,
                 shard_id,
                 expert_id,
@@ -574,7 +575,7 @@ class ModelOptNvFp4OnlineFusedMoEMethod(ModelOptNvFp4FusedMoEMethod):
                 if weight_scale is None:
                     pending_fp8_weights[key] = (
                         param,
-                        loaded_weight,
+                        _clone_if_runai_streamed_tensor(loaded_weight),
                         weight_name,
                         shard_id,
                         expert_id,
@@ -596,7 +597,9 @@ class ModelOptNvFp4OnlineFusedMoEMethod(ModelOptNvFp4FusedMoEMethod):
             with pending_fp8_lock:
                 pending = pending_fp8_weights.pop(key, None)
                 if pending is None:
-                    pending_fp8_weight_scales[key] = loaded_weight
+                    pending_fp8_weight_scales[key] = _clone_if_runai_streamed_tensor(
+                        loaded_weight
+                    )
                     return
 
             log_quantization_start()

--- a/python/sglang/srt/model_loader/runai_utils.py
+++ b/python/sglang/srt/model_loader/runai_utils.py
@@ -1,0 +1,23 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+RUNAI_STREAMER_TENSOR_ATTR = "_sglang_runai_streamer_tensor"
+
+
+def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Own tensors retained beyond the current RunAI streamer iteration."""
+    if getattr(tensor, RUNAI_STREAMER_TENSOR_ATTR, False):
+        return tensor.clone().detach()
+    return tensor

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -16,6 +16,7 @@ from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
 from sglang.srt.configs.model_config import ModelConfig, ModelImpl
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +297,7 @@ def should_async_load(weight: torch.Tensor) -> bool:
     RunAI-streamed tensors are zero-copy views into a reused CPU buffer. They
     must be consumed synchronously before the streamer fills its next batch.
     """
-    if getattr(weight, "_sglang_runai_streamer_tensor", False):
+    if getattr(weight, RUNAI_STREAMER_TENSOR_ATTR, False):
         return False
 
     device = getattr(weight, "device", None)

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -56,6 +56,7 @@ from sglang.srt.model_loader.ci_weight_validation import (
     ci_download_with_validation_and_retry,
     ci_validate_and_cleanup_local_snapshot,
 )
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
     BAR_FORMAT,
@@ -73,9 +74,6 @@ except ImportError:
     SafeTensorsFileLoader = SingleGroup = None
 
 logger = logging.getLogger(__name__)
-
-RUNAI_STREAMER_TENSOR_ATTR = "_sglang_runai_streamer_tensor"
-
 
 # Matches routed-expert weight keys in both HF-style layouts
 # (``...mlp.experts.<N>.{gate,up,down}_proj.weight``) and DeepSeek V4

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -40,13 +40,15 @@ from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,
 )
 from sglang.srt.layers.utils import get_layer_id
+from sglang.srt.model_loader.runai_utils import (
+    _clone_if_runai_streamed_tensor,
+)
 from sglang.srt.model_loader.utils import (
     maybe_executor_submit,
     should_async_load,
     should_deepgemm_weight_requant_ue8m0,
 )
 from sglang.srt.model_loader.weight_utils import (
-    RUNAI_STREAMER_TENSOR_ATTR,
     default_weight_loader,
 )
 from sglang.srt.models.deepseek_common.utils import (
@@ -70,12 +72,6 @@ logger = logging.getLogger(__name__)
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
-
-
-def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
-    if getattr(tensor, RUNAI_STREAMER_TENSOR_ATTR, False):
-        return tensor.clone().detach()
-    return tensor
 
 
 def _get_indexer_weight_block_size(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -134,11 +134,9 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     get_tc_piecewise_forward_context,
 )
+from sglang.srt.model_loader.runai_utils import _clone_if_runai_streamed_tensor
 from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_load
-from sglang.srt.model_loader.weight_utils import (
-    RUNAI_STREAMER_TENSOR_ATTR,
-    default_weight_loader,
-)
+from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dbrx import ReplicatedLinear
 from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
     apply_mhc_post_pre_boundary,
@@ -3951,12 +3949,6 @@ def _dequant_fp8(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     )
 
     return result.to(torch.bfloat16)
-
-
-def _clone_if_runai_streamed_tensor(tensor: torch.Tensor) -> torch.Tensor:
-    if getattr(tensor, RUNAI_STREAMER_TENSOR_ATTR, False):
-        return tensor.clone().detach()
-    return tensor
 
 
 def _dequant_fp8_wo_a_streaming(

--- a/test/registered/unit/layers/quantization/test_nvfp4_online_runai_streamer.py
+++ b/test/registered/unit/layers/quantization/test_nvfp4_online_runai_streamer.py
@@ -1,0 +1,79 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.nvfp4_online import (
+    ModelOptNvFp4OnlineFusedMoEMethod,
+)
+from sglang.srt.model_loader.runai_utils import RUNAI_STREAMER_TENSOR_ATTR
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestNvFp4OnlineRunaiStreamer(unittest.TestCase):
+    def test_pending_fp8_weight_owns_streamed_buffer(self):
+        layer = SimpleNamespace(
+            w2_weight_scale=object(),
+            w2_weight_scale_2=object(),
+        )
+        param = torch.nn.Parameter(torch.empty(1))
+        loaded_calls = []
+        dequantized_weights = []
+
+        def original_weight_loader(*args, **kwargs):
+            loaded_calls.append((args, kwargs))
+
+        def fake_dequantizer(weight, _scale, _device):
+            dequantized_weights.append(weight.clone())
+            return torch.zeros((2, 16), dtype=torch.bfloat16)
+
+        def fake_quantize(weight):
+            return (
+                torch.zeros_like(weight, dtype=torch.uint8),
+                torch.zeros_like(weight, dtype=torch.float8_e4m3fn),
+                torch.tensor(1.0),
+            )
+
+        with patch.object(
+            ModelOptNvFp4OnlineFusedMoEMethod,
+            "_quantize_weight_nvfp4",
+            side_effect=fake_quantize,
+        ):
+            loader = ModelOptNvFp4OnlineFusedMoEMethod.get_online_weight_loader(
+                layer,
+                original_weight_loader,
+                layer_log_name="test",
+                fp8_dequantizer=fake_dequantizer,
+            )
+
+            staging_buffer = torch.tensor([1.0, 2.0], dtype=torch.float8_e4m3fn)
+            streamed_weight = staging_buffer[:]
+            setattr(streamed_weight, RUNAI_STREAMER_TENSOR_ATTR, True)
+            loader(
+                param,
+                streamed_weight,
+                "experts.0.w2.weight",
+                shard_id="w2",
+                expert_id=None,
+            )
+
+            staging_buffer.copy_(torch.tensor([9.0, 9.0], dtype=torch.float8_e4m3fn))
+            streamed_scale = staging_buffer[:]
+            setattr(streamed_scale, RUNAI_STREAMER_TENSOR_ATTR, True)
+            loader(
+                param,
+                streamed_scale,
+                "experts.0.w2.weight_scale",
+                shard_id="w2",
+                expert_id=None,
+            )
+
+        self.assertEqual(dequantized_weights[0].to(torch.float32).tolist(), [1.0, 2.0])
+        self.assertEqual(len(loaded_calls), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37368.

With `--load-format runai_streamer`, distributed RunAI Model Streamer may reuse an internal staging buffer between streamed tensors. NVFP4 online MoE loading retains unmatched weights and scales while waiting for their pair, so a retained view can be overwritten and produce intermittent corrupted expert weights and malformed output.

@noa-neria suggested `stream_files(..., owned=True)` as the long-term API. However, it has not yet been supported.

## Modifications

- Added `sglang.srt.model_loader.runai_utils` as the single source of the RunAI tensor marker and ownership clone helper.
- Clone RunAI-marked tensors retained in NVFP4 online pending maps for gated w1/w3 weights, FP8 expert weights, and FP8 weight scales.
- Clone pending shared-expert FP8 weights and scales in the fused MoE path.
- Reuse the helper for DeepSeek V4 delayed streaming and the synchronous-loading decision, while preserving the existing deepseek loader import compatibility.
- Added a deterministic reusable-buffer regression test covering an FP8 weight followed by its scale.

## Accuracy Tests

- Deterministic synthetic regression test verifies that the original pending FP8 values survive staging-buffer reuse before dequantization.
- Full GPU/Kubernetes model accuracy testing was not available in this local environment (`torch`/runtime dependencies are not installed); CI or a RunAI deployment should validate end-to-end output.

## Speed Tests and Profiling

No speed impact is expected for normal tensors. Only RunAI-marked tensors that must remain pending are cloned. No benchmark environment was available locally.

## Checklist

- [x] Format checks passed through the repository pre-commit hooks during commit.
- [x] Added a focused unit regression test.
- [ ] Updated documentation (not applicable; behavior is internal).
- [ ] Provided full accuracy and speed benchmarks (requires GPU/Kubernetes environment).
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33480709110](https://github.com/sgl-project/sglang/actions/runs/33480709110)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33480708977](https://github.com/sgl-project/sglang/actions/runs/33480708977)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33480709071](https://github.com/sgl-project/sglang/actions/runs/33480709071)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->