### PR TITLE
[CI] Fix hybrid wrapper test fake missing kv_index_translator

### DIFF
--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -151,6 +151,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
                 token_to_kv_pool=None,
                 req_to_token_pool=None,
                 needs_cpu_seq_lens=False,
+                kv_index_translator=None,
                 init_forward_metadata_in_graph=lambda fb: calls.append(name),
             )
 


### PR DESCRIPTION


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33482825678](https://github.com/sgl-project/sglang/actions/runs/33482825678)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33482825480](https://github.com/sgl-project/sglang/actions/runs/33482825480)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33482825724](https://github.com/sgl-project/sglang/actions/runs/33482825724)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->