### PR TITLE
fix(model): align GLM5 mHC pipeline proxy contract

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1147,7 +1147,7 @@ class Glm5NextModel(nn.Module):
         else:
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
-            residual = pp_proxy_tensors["residual"]
+            residual = None if self.config.mhc else pp_proxy_tensors["residual"]
         device = hidden_states.device
         zero_allocator = BumpAllocator(
             buffer_size=total_num_layers * 2 * (2 if forward_batch.can_run_tbo else 1),
@@ -1235,12 +1235,10 @@ class Glm5NextModel(nn.Module):
             )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy_tensors = {"hidden_states": hidden_states}
+            if not self.config.mhc:
+                proxy_tensors["residual"] = residual
+            return PPProxyTensors(proxy_tensors)
         else:
             if not forward_batch.forward_mode.is_idle():
                 if residual is None:

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from torch import nn
 
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
@@ -72,6 +73,39 @@ def test_glm5_next_eagle_capture_without_residual():
     actual = model._prepare_aux_hidden_state(hidden_states, None)
 
     torch.testing.assert_close(actual, hidden_states)
+
+
+@pytest.mark.parametrize("mhc", [True, False])
+def test_glm5_next_pp_proxy_matches_mhc_residual_contract(mhc):
+    model = Glm5NextModel.__new__(Glm5NextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(mhc=mhc)
+    model.pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+    model.start_layer = model.end_layer = 0
+    model.first_k_dense_replace = 0
+    model.dflash_capture = False
+    model.dsa_enable_prefill_cp = False
+    model.mla_enable_prefill_cp = False
+    model.layers_to_capture = []
+    model.enable_a2a_moe = False
+
+    hidden_states = torch.arange(24, dtype=torch.float32).reshape(2, 12)
+    proxy_tensors = {"hidden_states": hidden_states}
+    if not mhc:
+        proxy_tensors["residual"] = torch.full_like(hidden_states, 2)
+
+    output = model.forward(
+        input_ids=torch.empty(0, dtype=torch.long),
+        positions=torch.empty(0, dtype=torch.long),
+        forward_batch=SimpleNamespace(can_run_tbo=False, attn_cp_metadata=None),
+        pp_proxy_tensors=PPProxyTensors(proxy_tensors),
+    )
+
+    expected_keys = {"hidden_states"} if mhc else {"hidden_states", "residual"}
+    assert set(output.tensors) == expected_keys
+    torch.testing.assert_close(output["hidden_states"], hidden_states)
+    if not mhc:
+        torch.testing.assert_close(output["residual"], proxy_tensors["residual"])
 
 
 def test_glm5_next_dflash_maps_target_layers_to_capture_points():


### PR DESCRIPTION
## Summary

- Fix the GLM-5.3-Flash mHC pipeline-parallel proxy contract so the mHC path forwards only `hidden_states`.
- Preserve the existing `residual` forwarding behavior for the non-mHC path.
- Add regression coverage for both mHC and non-mHC pipeline-parallel proxy paths.

Fixes #36906

## Relationship to existing work

- The issue discussion and open-PR search found no independent open PR for #36906.
- This is a focused stacked follow-up to #36507, based on `xinyuan/glm-5.3-flash-support`; it addresses the model-side proxy contract without changing the engine.

## Testing

- Focused GLM-5 regression tests: 7 passed.
- `pre-commit`: passed.
- `compileall`: passed.
- `git diff --check`: passed.
- No GPU end-to-end or model evaluation was run in this environment.

## AI assistance

AI assistance was used during implementation and validation. The human submitter should review every changed line and verify the behavior before merging.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33482846710](https://github.com/sgl-project/sglang/actions/runs/33482846710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33482846546](https://github.com/sgl-project/sglang/actions/runs/33482846546)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33482846626](https://github.com/sgl-project/sglang/actions/runs/33482846626)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->