### PR TITLE
docs: note flashinfer-cubin upgrade path for pip users

### DIFF
--- a/docs/docs/get-started/install.mdx
+++ b/docs/docs/get-started/install.mdx
@@ -243,3 +243,13 @@ echo "Build and push completed successfully!"
 
 - [FlashInfer](https://github.com/flashinfer-ai/flashinfer) is the default attention kernel backend. It only supports sm75 and above. If you encounter any FlashInfer-related issues on sm75+ devices (e.g., T4, A10, A100, L4, L40S, H100), please switch to other kernels by adding `--attention-backend triton --sampling-backend pytorch` and open an issue on GitHub.
 - To reinstall flashinfer locally, use the following command: `pip3 install --upgrade flashinfer-python --force-reinstall --no-deps` and then delete the cache with `rm -rf ~/.cache/flashinfer`.
+
+<Note>
+**Upgrading FlashInfer optional packages**
+
+SGLang installs `flashinfer-python` from PyPI. The optional `flashinfer-cubin` and `flashinfer-jit-cache` packages are hosted on [flashinfer.ai/whl](https://flashinfer.ai/whl), not current PyPI.
+
+If you upgrade SGLang while older optional packages remain installed, `import flashinfer` can fail with a version mismatch. Either upgrade them (`flashinfer install-cubin-wheel` and `flashinfer install-jit-cache-wheel`; see [FlashInfer artifact management](https://docs.flashinfer.ai/cli.html#artifact-management)), or uninstall both to use runtime JIT.
+
+On DGX Spark / GB10 (SM121), `flashinfer-cubin` is optional.
+</Note>


### PR DESCRIPTION
## Summary
- Document that `flashinfer-cubin` and `flashinfer-jit-cache` are on [flashinfer.ai/whl](https://flashinfer.ai/whl), not current PyPI.
- Add upgrade troubleshooting when `import flashinfer` fails after `pip install -U sglang`.
- Note DGX Spark / GB10 (SM121) does not require `flashinfer-cubin`.

## Related
Related to [flashinfer-ai/flashinfer#4781](https://github.com/flashinfer-ai/flashinfer/issues/4781).

## Test plan
- [x] Docs-only change; no runtime tests required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33483348378](https://github.com/sgl-project/sglang/actions/runs/33483348378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33483348263](https://github.com/sgl-project/sglang/actions/runs/33483348263)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->