### PR TITLE
fix(modelopt_fp4): skip NVFP4 swiglu-fusion interleave for shared experts with swiglu_limit

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -779,6 +779,7 @@ class DeepseekV2MoE(nn.Module):
                     ModelOptFp4LinearMethod,
                 )
                 and fc1_n % 128 == 0
+                and self.shared_experts.swiglu_limit is None
                 and not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
             ):
                 self.shared_experts.gate_up_proj._interleave_for_swiglu_fusion = True


### PR DESCRIPTION
## Symptom

Serving an NVFP4 (`modelopt_fp4`) checkpoint of a clamped-swiglu MoE model (GLM-5 family, `swiglu_limit=10.0`) with expert parallelism (`--ep-size 4`) crashes on the first real forward pass, on every rank:

```
deepseek_v2.py _forward_shared_experts → DeepseekV2MLP.forward
  gate_up, _ = self.gate_up_proj(x)
→ linear.py quant_method.apply
→ modelopt_quant.py ModelOptFp4LinearMethod.apply
    w_n, _ = layer.weight.shape
ValueError: not enough values to unpack (expected 2, got 1)
```

TP-only (same flags minus `--ep-size`) is unaffected.

## Root cause

`DeepseekV2MoE.__init__` gates the shared-expert NVFP4 swiglu-fusion weight interleave on SM100 + `fc1_n % 128 == 0` (`python/sglang/srt/models/deepseek_v2.py`, the `_interleave_for_swiglu_fusion` block), but `DeepseekV2MLP.forward` only takes the fused path when `self.swiglu_limit is None`:

```python
if (
    getattr(self, "_enable_nvfp4_gemm_swiglu_fusion", False)
    and self.swiglu_limit is None
    and not isinstance(x, tuple)
):
```

For a clamped-swiglu model (`swiglu_limit=10.0`) with a *separate* shared-experts MLP, the two gates disagree: `ModelOptFp4LinearMethod.process_weights_after_loading` sees `_interleave_for_swiglu_fusion`, builds the interleaved weight, and frees `layer.weight` (`torch.empty(0)` — 1-D), while forward falls back to the unfused `apply`, which unpacks the now-1-D `layer.weight.shape` and crashes.

Under TP-only this path is never exercised because shared-experts fusion folds the shared expert into the FusedMoE (`num_fused_shared_experts=1`, no separate `shared_experts` module). With `moe_ep_size > 1`, `shared_experts_fusion_disable_reason` disables that fusion ("Shared experts fusion is not supported together with expert parallelism yet."), the separate shared-experts MLP is built, and the mismatched gate fires.

Note on serve logs with NEXTN enabled: you will see *both* "Shared experts fusion optimization enabled." and "Config does not support fused shared expert(s). ... disabled." in the same TP-only log. These come from two different model builds with two different gates:

- The **target** model gate (`Glm5NextForConditionalGeneration.shared_experts_fusion_disable_reason`) has no `n_routed_experts` allowlist: TP-only -> fusion enabled (first message, no separate MLP is ever constructed; the spec-off TP-only log shows *only* this message), EP -> vetoed by `moe_ep_size > 1` (separate MLP built -> this bug).
- The **NextN draft** model (`Glm5NextForConditionalGenerationNextN` -> `DeepseekV3ForCausalLMNextN`) uses the `DeepseekV2` gate, whose allowlist (`n_routed_experts in (256, 384)`) rejects 288-expert configs (second message). The draft does build a separate shared-experts MLP, but `deepseek_nextn.py` forces `quant_config=None` for `modelopt_fp4` drafts, so that MLP is unquantized BF16 (`UnquantizedLinearMethod`) and the NVFP4 interleave machinery is never involved. Verified with an init-time probe on the TP-only NEXTN serve: the only separate shared-experts instance is the draft's, with `qm=UnquantizedLinearMethod`, `interleave=False`.

So on a stock TP-only serve of this checkpoint there is no NVFP4 shared-experts MLP instance at all; the bug is specific to the EP target-model path.

## Fix

Add the missing `swiglu_limit is None` condition to the init-time interleave gate so it exactly matches the forward-time condition: no interleave → weight stays 2-D → unfused apply works (with the swiglu clamp applied in `DeepseekV2MLP.forward` as before).

## Verification

Hardware: 4x NVIDIA B300 (SM103), checkpoint GLM-5.3-Flash class NVFP4 (`modelopt_fp4`, `moe_intermediate_size=2048`, `n_shared_experts=1`, `swiglu_limit=10.0`), flags: `--quantization modelopt_fp4 --dsa-prefill-backend trtllm --dsa-decode-backend trtllm --kv-cache-dtype fp8_e4m3 --moe-runner-backend flashinfer_cutlass --tp-size 4`.

| Config | Before | After |
|---|---|---|
| EP (`--ep-size 4`), spec off | crash on first chat (all schedulers die) | healthy; smoke chat `content='42'`, `finish_reason=stop`; bench isl1024/osl256 c16 n80: **787.13 tok/s**, 80/80 ok |
| EP + NEXTN 5/1/6 spec | crash during server-init forward | healthy; bench c16 n80: **1053.91 tok/s**, 80/80 ok |
| TP-only, spec off (regression) | works | still works: healthy, smoke `'42'` / `stop` (unchanged code path — shared experts fused into MoE) |

TP-only reference numbers from the same box/ckpt (pre-fix): spec-off c16 n80 = 863.82 tok/s; NEXTN c16 n80 = 1139.83 tok/s.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33485443192](https://github.com/sgl-project/sglang/actions/runs/33485443192)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33485442643](https://github.com/sgl-project/sglang/actions/runs/33485442643)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33485442785](https://github.com/sgl-project/sglang/actions/runs/33485442785)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
