### PR TITLE
[Intel][XPU] Device-generic device timer; scripted chunked-prefill fixes

### DIFF
--- a/python/sglang/srt/utils/device_timer.py
+++ b/python/sglang/srt/utils/device_timer.py
@@ -5,6 +5,8 @@ from typing import Callable, Deque, Dict, List, Optional
 
 import torch
 
+from sglang.srt.utils.common import get_device_module
+
 
 def device_timer_ctx(timer: Optional["DeviceTimer"], category: str):
     """Timing context for one forward segment; no-op when the timer is absent.
@@ -84,18 +86,18 @@ class GapTimer(DeviceTimer):
 
 @dataclass
 class _TimingInterval:
-    start_event: torch.cuda.Event
-    end_event: Optional[torch.cuda.Event] = None
+    start_event: torch.Event
+    end_event: Optional[torch.Event] = None
     metadata: Optional[Dict] = None
 
     @staticmethod
     def create():
-        start_event = torch.cuda.Event(enable_timing=True)
+        start_event = get_device_module().Event(enable_timing=True)
         start_event.record()
         return _TimingInterval(start_event=start_event)
 
     def end(self, metadata: Dict):
-        end_event = torch.cuda.Event(enable_timing=True)
+        end_event = get_device_module().Event(enable_timing=True)
         end_event.record()
 
         assert self.end_event is None

--- a/python/sglang/test/scripted_runtime/req_handle.py
+++ b/python/sglang/test/scripted_runtime/req_handle.py
@@ -52,7 +52,11 @@ class ScriptedReqHandle:
         req = self.req
         if req is None:
             return 0
-        node = resolve_node(self.context.scheduler.tree_cache, req.last_node)
+        tree_cache = self.context.scheduler.tree_cache
+        if tree_cache.is_root(req.last_node):
+            # The root's lock_ref is a permanent sentinel, never a req's lock.
+            return 0
+        node = resolve_node(tree_cache, req.last_node)
         if node is None:
             return 0
         return _node_lock_ref(node)

--- a/test/manual/chunked_prefill/test_scripted_invariants.py
+++ b/test/manual/chunked_prefill/test_scripted_invariants.py
@@ -2,7 +2,6 @@ import unittest
 
 from sglang.srt.utils import is_xpu
 from sglang.test.scripted_runtime.context import ScriptedContext
-from sglang.test.scripted_runtime.http_server import DEFAULT_RUN_TIMEOUT_S
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
     DEFAULT_CHUNK_SIZE,
@@ -13,6 +12,11 @@ from sglang.test.scripted_runtime_chunked_helpers import (
     run_until_all_finished,
     run_until_finished,
 )
+
+_is_xpu = is_xpu()
+
+# Measured on the XPU canary runner; DEFAULT_RUN_TIMEOUT_S is not enough there.
+XPU_RUN_TIMEOUT_S: float = 360.0
 
 
 class TestInvariantsBasic(ScriptedTestCase):
@@ -187,10 +191,14 @@ class TestInvariantsBasic(ScriptedTestCase):
         final = t.engine_stats()
         assert final["kv_pool_free"] >= baseline["kv_pool_free"]
 
+    @unittest.skipIf(_is_xpu, "Non-XPU runners only")
     def test_sustained_long_chunked_load(self):
-        timeout_s = 360.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(self._script_sustained_long_chunked_load)
+
+    @unittest.skipUnless(_is_xpu, "XPU runner only")
+    def test_sustained_long_chunked_load_xpu(self):
         self.server.execute_script(
-            self._script_sustained_long_chunked_load, timeout_s=timeout_s
+            self._script_sustained_long_chunked_load, timeout_s=XPU_RUN_TIMEOUT_S
         )
 
     @staticmethod
@@ -245,10 +253,14 @@ class TestInvariantsBasic(ScriptedTestCase):
         final = t.engine_stats()
         assert final["kv_pool_free"] >= baseline["kv_pool_free"]
 
+    @unittest.skipIf(_is_xpu, "Non-XPU runners only")
     def test_long_decode_then_many_short(self):
-        timeout_s = 360.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(self._script_long_decode_then_many_short)
+
+    @unittest.skipUnless(_is_xpu, "XPU runner only")
+    def test_long_decode_then_many_short_xpu(self):
         self.server.execute_script(
-            self._script_long_decode_then_many_short, timeout_s=timeout_s
+            self._script_long_decode_then_many_short, timeout_s=XPU_RUN_TIMEOUT_S
         )
 
     @staticmethod

--- a/test/manual/chunked_prefill/test_scripted_invariants.py
+++ b/test/manual/chunked_prefill/test_scripted_invariants.py
@@ -1,6 +1,8 @@
 import unittest
 
+from sglang.srt.utils import is_xpu
 from sglang.test.scripted_runtime.context import ScriptedContext
+from sglang.test.scripted_runtime.http_server import DEFAULT_RUN_TIMEOUT_S
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
     DEFAULT_CHUNK_SIZE,
@@ -186,7 +188,10 @@ class TestInvariantsBasic(ScriptedTestCase):
         assert final["kv_pool_free"] >= baseline["kv_pool_free"]
 
     def test_sustained_long_chunked_load(self):
-        self.server.execute_script(self._script_sustained_long_chunked_load)
+        timeout_s = 360.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(
+            self._script_sustained_long_chunked_load, timeout_s=timeout_s
+        )
 
     @staticmethod
     def _script_sustained_long_chunked_load(t: ScriptedContext):
@@ -241,7 +246,10 @@ class TestInvariantsBasic(ScriptedTestCase):
         assert final["kv_pool_free"] >= baseline["kv_pool_free"]
 
     def test_long_decode_then_many_short(self):
-        self.server.execute_script(self._script_long_decode_then_many_short)
+        timeout_s = 360.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(
+            self._script_long_decode_then_many_short, timeout_s=timeout_s
+        )
 
     @staticmethod
     def _script_long_decode_then_many_short(t: ScriptedContext):

--- a/test/manual/chunked_prefill/test_scripted_pp.py
+++ b/test/manual/chunked_prefill/test_scripted_pp.py
@@ -31,7 +31,9 @@ def _expected_chunks(prompt_len: int, chunk_size: int) -> int:
 def _drain_until_released(t, *handles):
     for _ in range(16):
         if all(
-            h.kv_pages == 0 and (h.req is None or h.req.kv.req_pool_idx is None)
+            h.kv_pages == 0
+            and h.lock_refs == 0
+            and (h.req is None or h.req.kv.req_pool_idx is None)
             for h in handles
         ):
             return

--- a/test/manual/chunked_prefill/test_scripted_regression.py
+++ b/test/manual/chunked_prefill/test_scripted_regression.py
@@ -14,16 +14,21 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 )
 
 
-def _drain_until_released(t, *handles):
+def _drain_until_released(*reqs):
     for _ in range(12):
-        if all(
-            h.kv_pages == 0
-            and h.lock_refs == 0
-            and (h.req is None or h.req.kv.req_pool_idx is None)
-            for h in handles
-        ):
+        if all(r.kv.req_pool_idx is None and r.kv.is_kv_released for r in reqs):
             return
         yield
+
+
+def _run_until_prefix_locked(r):
+    # A chunk is inserted into the radix tree on the step after its forward,
+    # so last_node is still the root -- unlocked -- right after chunks_done ticks.
+    for _ in range(8):
+        if r.lock_refs >= 1:
+            return
+        yield
+    raise AssertionError(f"radix lock_ref must be held mid-chunk; got {r.lock_refs}")
 
 
 class TestRegressionBasic(ScriptedTestCase):
@@ -34,17 +39,21 @@ class TestRegressionBasic(ScriptedTestCase):
 
     @staticmethod
     def _script_abort_waiting_releases_all(t: ScriptedContext):
+        baseline_refs = sum(t.get_all_node_lock_refs().values())
         r = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         yield from run_until(r, lambda h: h.is_chunking)
 
-        t.abort(r)
-        yield from _drain_until_released(t, r)
+        req = r.req
+        assert req is not None
 
-        assert r.kv_pages == 0
-        assert r.req.kv.req_pool_idx is None
-        assert r.lock_refs == 0
+        t.abort(r)
+        yield from _drain_until_released(req)
+
+        assert req.kv.is_kv_released, f"kv_allocated_len={req.kv.kv_allocated_len}"
+        assert req.kv.req_pool_idx is None
+        assert sum(t.get_all_node_lock_refs().values()) == baseline_refs
         assert not r.is_chunking
-        assert r.req.inflight_middle_chunks == 0
+        assert req.inflight_middle_chunks == 0
 
     def test_pause_covers_waiting_chunked(self):
         self.server.execute_script(self._script_pause_covers_waiting_chunked)
@@ -239,26 +248,28 @@ class TestRegressionBasic(ScriptedTestCase):
         baseline_refs = sum(t.get_all_node_lock_refs().values())
         r = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         yield from run_until(r, lambda h: h.is_chunking and h.chunks_done >= 1)
+        yield from _run_until_prefix_locked(r)
 
-        assert r.req.kv.req_pool_idx is not None, "row must be held mid-chunk"
+        req = r.req
+        assert req is not None
+        assert req.kv.req_pool_idx is not None, "row must be held mid-chunk"
         assert r.kv_pages > 0, "committed KV must be held mid-chunk"
-        assert r.lock_refs >= 1, "radix lock_ref must be held mid-chunk"
 
         t.abort(r)
-        yield from _drain_until_released(t, r)
+        yield from _drain_until_released(req)
 
         assert (
-            r.req.kv.req_pool_idx is None
-        ), f"96d4749094: abort must release row; got row_idx={r.req.kv.req_pool_idx!r}"
+            req.kv.req_pool_idx is None
+        ), f"96d4749094: abort must release row; got row_idx={req.kv.req_pool_idx!r}"
         assert (
-            r.kv_pages == 0
-        ), f"96d4749094: abort must release KV; got kv_pages={r.kv_pages}"
-        assert (
-            r.lock_refs == 0
-        ), f"96d4749094: abort must release lock_ref; got lock_refs={r.lock_refs}"
+            req.kv.is_kv_released
+        ), f"96d4749094: abort must release KV; got kv_allocated_len={req.kv.kv_allocated_len}"
+        assert sum(t.get_all_node_lock_refs().values()) == baseline_refs, (
+            f"96d4749094: abort must release lock_ref; tree lock_refs drifted "
+            f"from {baseline_refs} to {sum(t.get_all_node_lock_refs().values())}"
+        )
         assert not r.is_chunking
-        assert r.req.inflight_middle_chunks == 0
-        assert sum(t.get_all_node_lock_refs().values()) == baseline_refs
+        assert req.inflight_middle_chunks == 0
 
     def test_pause_retract_releases_waiting_chunked_resume(self):
         self.server.execute_script(
@@ -269,6 +280,7 @@ class TestRegressionBasic(ScriptedTestCase):
     def _script_pause_retract_releases_waiting_chunked_resume(t: ScriptedContext):
         r = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         yield from run_until(r, lambda h: h.is_chunking and h.chunks_done >= 1)
+        yield from _run_until_prefix_locked(r)
         assert r.req.kv.req_pool_idx is not None and r.kv_pages > 0 and r.lock_refs >= 1
 
         t.pause_generation(mode="retract")
@@ -338,6 +350,9 @@ class TestRegressionPp(ScriptedTestCase):
 
         yield from run_until(r, lambda h: h.chunks_done >= 1 and h.is_chunking)
 
+        req = r.req
+        assert req is not None
+
         t.abort(r)
         yield
 
@@ -348,7 +363,7 @@ class TestRegressionPp(ScriptedTestCase):
             f"waiting_queue; got {occurrences} occurrences of rid="
             f"{r.rid} (pre-fix bug would yield 3)"
         )
-        yield from _drain_until_released(t, r)
+        yield from _drain_until_released(req)
         assert r.finished
 
 

--- a/test/manual/chunked_prefill/test_scripted_sampling.py
+++ b/test/manual/chunked_prefill/test_scripted_sampling.py
@@ -1,7 +1,9 @@
 import unittest
 
 from sglang.srt.managers.schedule_batch import FINISH_LENGTH, FINISH_MATCHED_TOKEN
+from sglang.srt.utils import is_xpu
 from sglang.test.scripted_runtime.context import ScriptedContext
+from sglang.test.scripted_runtime.http_server import DEFAULT_RUN_TIMEOUT_S
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
     DEFAULT_CHUNK_SIZE,
@@ -53,7 +55,10 @@ class TestSamplingBasic(ScriptedTestCase):
         )
 
     def test_max_new_tokens_1000_long_chunked(self):
-        self.server.execute_script(self._script_max_new_tokens_1000_long_chunked)
+        timeout_s = 1400.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(
+            self._script_max_new_tokens_1000_long_chunked, timeout_s=timeout_s
+        )
 
     @staticmethod
     def _script_max_new_tokens_1000_long_chunked(t: ScriptedContext):

--- a/test/manual/chunked_prefill/test_scripted_sampling.py
+++ b/test/manual/chunked_prefill/test_scripted_sampling.py
@@ -3,7 +3,6 @@ import unittest
 from sglang.srt.managers.schedule_batch import FINISH_LENGTH, FINISH_MATCHED_TOKEN
 from sglang.srt.utils import is_xpu
 from sglang.test.scripted_runtime.context import ScriptedContext
-from sglang.test.scripted_runtime.http_server import DEFAULT_RUN_TIMEOUT_S
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
     DEFAULT_CHUNK_SIZE,
@@ -12,6 +11,11 @@ from sglang.test.scripted_runtime_chunked_helpers import (
     run_until,
     run_until_finished,
 )
+
+_is_xpu = is_xpu()
+
+# Measured on the XPU canary runner; DEFAULT_RUN_TIMEOUT_S is not enough there.
+XPU_RUN_TIMEOUT_S: float = 1400.0
 
 
 class TestSamplingBasic(ScriptedTestCase):
@@ -54,10 +58,14 @@ class TestSamplingBasic(ScriptedTestCase):
             f"{len(r.req.output_ids)}"
         )
 
+    @unittest.skipIf(_is_xpu, "Non-XPU runners only")
     def test_max_new_tokens_1000_long_chunked(self):
-        timeout_s = 1400.0 if is_xpu() else DEFAULT_RUN_TIMEOUT_S
+        self.server.execute_script(self._script_max_new_tokens_1000_long_chunked)
+
+    @unittest.skipUnless(_is_xpu, "XPU runner only")
+    def test_max_new_tokens_1000_long_chunked_xpu(self):
         self.server.execute_script(
-            self._script_max_new_tokens_1000_long_chunked, timeout_s=timeout_s
+            self._script_max_new_tokens_1000_long_chunked, timeout_s=XPU_RUN_TIMEOUT_S
         )
 
     @staticmethod


### PR DESCRIPTION
Follow-up to #33520 (KV Canary on Intel XPU). Independent of that branch -- no file overlap -- so it can land on its own.

## Motivation

Two blockers surfaced while running the XPU canary and the scripted chunked-prefill suite:

- `DeviceTimer` builds `torch.cuda.Event` directly, so the forward-pass timing metric (`metrics_reporter.py`, `model_runner.py`) raises on `--device xpu`.
- `ScriptedReqHandle.lock_refs` reported the radix root's permanent `lock_ref` sentinel as if it were the request's own lock. Every cache seeds the root with a lock that request locking never inc/decs, so a mid-chunk request whose `last_node` is still the root looked locked, and abort/release assertions read a value no request owned.

## Modifications

- `srt/utils/device_timer.py`: `torch.cuda.Event` -> `get_device_module().Event`; hints relaxed to `torch.Event`. No CUDA behavior change -- `get_device_module()` returns `torch.cuda` there.
- `test/scripted_runtime/req_handle.py`: `lock_refs` returns 0 when `last_node` is the root, checked before resolving the node.
- `test/manual/chunked_prefill/`:
  - `test_scripted_regression.py`: `_drain_until_released` takes the `Req` captured before abort instead of the handle. Once the request leaves the scheduler `h.req` is `None`, which made `h.kv_pages == 0` / `h.lock_refs == 0` vacuously true -- the release assertions could pass without anything being released. Release is now asserted via `req.kv.is_kv_released` and a whole-tree `lock_ref` baseline. Added `_run_until_prefix_locked`: a chunk is inserted into the radix tree on the step *after* its forward, so `last_node` is still the root right after `chunks_done` ticks.
  - `test_scripted_pp.py`: drain also waits for `lock_refs == 0`, matching the abort suite.
  - `test_scripted_invariants.py`, `test_scripted_sampling.py`: longer `execute_script` timeouts on XPU only (`is_xpu()`); CUDA keeps `DEFAULT_RUN_TIMEOUT_S`.

## Accuracy Tests

No model-output path touched -- device timing metrics and test-harness probes only.

## Speed Tests and Profiling

No inference-path change. The XPU-only timeout bumps reflect the slower XPU forward; CUDA timeouts are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Note for reviewers: the `lock_refs` fix changes what that probe reports for any request sitting at the root, so it touches the chunked-prefill scripted suite broadly (88 usages across 14 files) even though only two of those files change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33646553830](https://github.com/sgl-project/sglang/actions/runs/33646553830)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33646553583](https://github.com/sgl-project/sglang/actions/runs/33646553583)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33646553633](https://github.com/sgl-project/sglang/actions/runs/33646553633)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->