### PR TITLE
[HiCache] Add Mooncake replica placement controls

### DIFF
--- a/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
@@ -299,6 +299,54 @@ You can enable it in any of the three supported configuration methods:
 
 > **Note:** `enable_ssd_offload` requires a Mooncake version that supports the `enable_ssd_offload` parameter in `MooncakeDistributedStore.setup()`. If the installed version does not support it, SGLang will automatically fall back to the old behavior and print a warning.
 
+**Mooncake Replica Placement (`replica_num`, `dfs_replica_num`):**
+
+> **Warning:** Descriptor-based DFS is a work-in-progress feature intended only
+> for development and evaluation. It is not covered by Mooncake's production
+> fault-tolerance, HA, durability, or multi-tenant guarantees. In particular,
+> DFS allocator state is not reconstructed after a master restart or HA
+> failover, and DFS writes currently have no DFS-specific timeout,
+> cancellation, or `fsync` durability guarantee. See the
+> [Mooncake descriptor-based DFS documentation](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/deployment/mooncake-store-deployment-guide.md#descriptor-based-dfs-storage)
+> for the current limitations.
+
+Use `replica_num` and `dfs_replica_num` in
+`--hicache-storage-backend-extra-config` to control the number of memory and
+descriptor-based DFS replicas created for each HiCache object. The defaults are
+`1` and `0`, respectively. Mooncake currently supports at most one DFS replica,
+and a DFS replica must be accompanied by at least one memory replica. The
+following example uses the default embedded Real Client mode:
+
+```bash
+python -m sglang.launch_server \
+    --enable-hierarchical-cache \
+    --hicache-storage-backend mooncake \
+    --model-path [model_path] \
+    --hicache-storage-backend-extra-config \
+    '{"master_server_address":"127.0.0.1:50051","replica_num":1,"dfs_replica_num":1,"enable_ssd_offload":true,"ssd_offload_path":"/tmp/mooncake-file-storage"}'
+```
+
+Descriptor-based DFS currently requires the default Mooncake tenant. Start the
+Mooncake master with `MOONCAKE_ENABLE_DFS=1`, and configure the master and every
+Real Client with the same `MOONCAKE_DFS_*` layout. Although DFS data is written
+under `MOONCAKE_DFS_ROOT_DIR`, each Real Client must also initialize FileStorage
+with the distributed backend and an existing absolute file-storage path.
+
+In the default embedded Real Client mode, the Real Client runs inside SGLang.
+Set `MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=distributed_storage_backend`
+in the SGLang process, and pass `enable_ssd_offload=true` plus an absolute
+`ssd_offload_path` as shown above.
+
+With `standalone_storage=true`, SGLang runs only a Dummy Client. Configure the
+external `mooncake_client` process instead: set the same `MOONCAKE_DFS_*`
+layout,
+`MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=distributed_storage_backend`,
+`MOONCAKE_OFFLOAD_ENABLED=true`, and an absolute
+`MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`. SGLang only needs `replica_num`,
+`dfs_replica_num`, `standalone_storage=true`, and `client_server_address`; the
+Dummy Client forwards the request-level replica configuration to the external
+Real Client.
+
 **Mooncake Group Semantics (`enable_group_semantics`):**
 
 When `enable_group_semantics` is set to `true`, SGLang passes Mooncake `group_ids` for physical objects derived from the same logical HiCache page. This allows Mooncake to apply group-aware metadata routing, lease refresh, and eviction behavior to related KV objects such as MHA K/V pairs, split-head shards, MLA objects, and supported sidecar objects.

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -90,6 +90,12 @@ def _normalize_tenant_id(value) -> str:
     return tenant_id if tenant_id else DEFAULT_TENANT_ID
 
 
+def _parse_replica_count(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Mooncake {name} must be an integer")
+    return value
+
+
 @dataclass
 class MooncakeStoreConfig:
     local_hostname: str
@@ -394,6 +400,75 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 if storage_config
                 else None
             )
+            self.replica_num = _parse_replica_count(
+                "replica_num",
+                extra_config.get("replica_num", 1) if extra_config else 1,
+            )
+            self.dfs_replica_num = _parse_replica_count(
+                "dfs_replica_num",
+                extra_config.get("dfs_replica_num", 0) if extra_config else 0,
+            )
+            if self.replica_num < 1:
+                raise ValueError("Mooncake replica_num must be at least 1")
+            if self.dfs_replica_num not in (0, 1):
+                raise ValueError("Mooncake dfs_replica_num must be 0 or 1")
+            if self.dfs_replica_num > 0 and self.config.tenant_id != DEFAULT_TENANT_ID:
+                raise ValueError(
+                    "Mooncake DFS replicas currently require tenant_id='default'"
+                )
+            if self.dfs_replica_num > 0 and not self.config.standalone_storage:
+                if not self.config.enable_ssd_offload:
+                    raise ValueError(
+                        "Mooncake DFS replicas in embedded mode require "
+                        "enable_ssd_offload=true"
+                    )
+                if os.getenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR") != (
+                    "distributed_storage_backend"
+                ):
+                    raise ValueError(
+                        "Mooncake DFS replicas in embedded mode require "
+                        "MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR="
+                        "distributed_storage_backend"
+                    )
+                if not isinstance(
+                    self.config.ssd_offload_path, str
+                ) or not os.path.isabs(self.config.ssd_offload_path):
+                    raise ValueError(
+                        "Mooncake DFS replicas in embedded mode require an "
+                        "absolute ssd_offload_path"
+                    )
+
+            self._use_custom_replica_config = (
+                self.replica_num != 1 or self.dfs_replica_num != 0
+            )
+            if self._use_custom_replica_config:
+                if self._replicate_config_cls is None:
+                    raise RuntimeError(
+                        "The installed Mooncake package does not expose "
+                        "ReplicateConfig. Please upgrade Mooncake to configure "
+                        "HiCache replicas."
+                    )
+                replicate_config = self._replicate_config_cls()
+                unsupported_fields = [
+                    name
+                    for name, value, default in (
+                        ("replica_num", self.replica_num, 1),
+                        ("dfs_replica_num", self.dfs_replica_num, 0),
+                    )
+                    if value != default and not hasattr(replicate_config, name)
+                ]
+                if unsupported_fields:
+                    raise RuntimeError(
+                        "The installed Mooncake package does not support "
+                        f"ReplicateConfig.{', ReplicateConfig.'.join(unsupported_fields)}. "
+                        "Please upgrade Mooncake to configure HiCache replicas."
+                    )
+                logger.info(
+                    "Using Mooncake replication config: replica_num=%d, "
+                    "dfs_replica_num=%d",
+                    self.replica_num,
+                    self.dfs_replica_num,
+                )
             self.enable_group_semantics = bool(
                 extra_config.get("enable_group_semantics", False)
                 if extra_config
@@ -723,6 +798,17 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
     def _can_use_group_semantics(self) -> bool:
         return self._use_group_semantics
+
+    def _new_replicate_config(self, group_ids: Optional[List[str]] = None):
+        """Build a request-scoped config without mutating ``self.config``."""
+        replicate_config = self._replicate_config_cls()
+        if self.replica_num != 1:
+            replicate_config.replica_num = self.replica_num
+        if self.dfs_replica_num != 0:
+            replicate_config.dfs_replica_num = self.dfs_replica_num
+        if group_ids is not None:
+            replicate_config.group_ids = list(group_ids)
+        return replicate_config
 
     def _make_group_id(self, logical_key: str) -> str:
         return f"sglang-hicache:{logical_key}"
@@ -1317,24 +1403,28 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         buffer_sizes: List[Any],
         group_ids: Optional[List[str]] = None,
     ) -> List[int]:
-        config = None
+        request_group_ids = None
         if self._can_use_group_semantics() and group_ids is not None:
             if len(group_ids) != len(key_strs):
                 raise ValueError(
                     "Mooncake group_ids length must match key_strs length: "
                     f"{len(group_ids)} != {len(key_strs)}"
                 )
-            config = self._replicate_config_cls()
-            config.group_ids = group_ids
+            request_group_ids = group_ids
+
+        replicate_config = None
+        if self._use_custom_replica_config or request_group_ids is not None:
+            replicate_config = self._new_replicate_config(request_group_ids)
 
         if self._uses_multi_buffer(buffer_ptrs):
-            config = config or self._replicate_config_cls()
+            if replicate_config is None:
+                replicate_config = self._new_replicate_config()
             return self.store.batch_put_from_multi_buffers(
-                key_strs, buffer_ptrs, buffer_sizes, config
+                key_strs, buffer_ptrs, buffer_sizes, replicate_config
             )
-        elif config is not None:
+        elif replicate_config is not None:
             return self.store.batch_put_from(
-                key_strs, buffer_ptrs, buffer_sizes, config
+                key_strs, buffer_ptrs, buffer_sizes, replicate_config
             )
         else:
             return self.store.batch_put_from(key_strs, buffer_ptrs, buffer_sizes)

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -18,6 +18,8 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 class ReplicateConfigWithGroupIds:
     def __init__(self):
         self.group_ids = None
+        self.replica_num = 1
+        self.dfs_replica_num = 0
 
 
 class ReplicateConfigWithoutGroupIds:
@@ -29,6 +31,12 @@ class ReplicateConfigWithClassGroupIdsAndRequiredInit:
 
     def __init__(self, required):
         self.group_ids = required
+
+
+class ReplicateConfigWithoutDfsReplica:
+    def __init__(self):
+        self.group_ids = None
+        self.replica_num = 1
 
 
 def _fake_mooncake_modules(fake_store_cls, replicate_config_cls):
@@ -199,6 +207,11 @@ class FakeMultiBufferPool:
 def _make_config(
     *,
     enable_group_semantics=True,
+    replica_num=1,
+    dfs_replica_num=0,
+    tenant_id="default",
+    enable_ssd_offload=None,
+    ssd_offload_path=None,
     extra_backend_tag=None,
     model_name=None,
     is_mla_model=False,
@@ -207,11 +220,21 @@ def _make_config(
     tp_size=1,
     tp_lcm_size=None,
 ):
+    if enable_ssd_offload is None:
+        enable_ssd_offload = dfs_replica_num > 0
+    if ssd_offload_path is None and dfs_replica_num > 0:
+        ssd_offload_path = "/tmp"
+
     extra_config = {
         "master_server_address": "127.0.0.1:50051",
         "check_server": False,
         "global_segment_size": 1024 * 1024,
         "enable_group_semantics": enable_group_semantics,
+        "replica_num": replica_num,
+        "dfs_replica_num": dfs_replica_num,
+        "tenant_id": tenant_id,
+        "enable_ssd_offload": enable_ssd_offload,
+        "ssd_offload_path": ssd_offload_path,
     }
     if extra_backend_tag is not None:
         extra_config["extra_backend_tag"] = extra_backend_tag
@@ -237,6 +260,12 @@ def _make_store(
     *,
     enable_group_semantics=True,
     replicate_config_cls=ReplicateConfigWithGroupIds,
+    replica_num=1,
+    dfs_replica_num=0,
+    tenant_id="default",
+    enable_ssd_offload=None,
+    ssd_offload_path=None,
+    storage_backend_descriptor="distributed_storage_backend",
     extra_backend_tag=None,
     model_name=None,
     is_mla_model=False,
@@ -248,6 +277,11 @@ def _make_store(
     fake_store_cls = _fake_store_class()
     cfg = _make_config(
         enable_group_semantics=enable_group_semantics,
+        replica_num=replica_num,
+        dfs_replica_num=dfs_replica_num,
+        tenant_id=tenant_id,
+        enable_ssd_offload=enable_ssd_offload,
+        ssd_offload_path=ssd_offload_path,
         extra_backend_tag=extra_backend_tag,
         model_name=model_name,
         is_mla_model=is_mla_model,
@@ -258,17 +292,21 @@ def _make_store(
     )
 
     with patch.dict(
-        "sys.modules",
-        {
-            **_fake_mooncake_modules(fake_store_cls, replicate_config_cls),
-            **_fake_host_pool_modules(),
-        },
+        "os.environ",
+        {"MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR": storage_backend_descriptor},
     ):
-        from sglang.srt.mem_cache.storage.mooncake_store.mooncake_store import (
-            MooncakeStore,
-        )
+        with patch.dict(
+            "sys.modules",
+            {
+                **_fake_mooncake_modules(fake_store_cls, replicate_config_cls),
+                **_fake_host_pool_modules(),
+            },
+        ):
+            from sglang.srt.mem_cache.storage.mooncake_store.mooncake_store import (
+                MooncakeStore,
+            )
 
-        store = MooncakeStore(cfg)
+            store = MooncakeStore(cfg)
 
     return store, fake_store_cls.instances[-1]
 
@@ -311,6 +349,128 @@ class TestMooncakeGroupSemantics(CustomTestCase):
             fake_store.batch_put_calls[0]["keys"], ["page0_0_k", "page0_0_v"]
         )
         self.assertEqual(fake_store.batch_put_calls[0]["args"], ())
+
+    def test_dfs_replica_config_is_forwarded(self):
+        store, fake_store = _make_store(
+            enable_group_semantics=False,
+            replica_num=1,
+            dfs_replica_num=1,
+        )
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+
+        result = store.batch_set_v1(["page0"], torch.tensor([0]))
+
+        self.assertEqual(result, [True])
+        call = fake_store.batch_put_calls[0]
+        self.assertEqual(len(call["args"]), 1)
+        self.assertEqual(call["args"][0].replica_num, 1)
+        self.assertEqual(call["args"][0].dfs_replica_num, 1)
+
+    def test_replica_config_composes_with_group_semantics(self):
+        store, fake_store = _make_store(replica_num=2, dfs_replica_num=1)
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+
+        result = store.batch_set_v1(["page0"], torch.tensor([0]))
+
+        self.assertEqual(result, [True])
+        config = fake_store.batch_put_calls[0]["args"][0]
+        self.assertEqual(config.replica_num, 2)
+        self.assertEqual(config.dfs_replica_num, 1)
+        self.assertEqual(
+            config.group_ids,
+            ["sglang-hicache:page0", "sglang-hicache:page0"],
+        )
+
+    def test_replica_config_is_request_scoped(self):
+        store, fake_store = _make_store(dfs_replica_num=1)
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+
+        store.batch_set_v1(["page0"], torch.tensor([0]))
+        store.batch_set_v1(["page1"], torch.tensor([1]))
+
+        first_config = fake_store.batch_put_calls[0]["args"][0]
+        second_config = fake_store.batch_put_calls[1]["args"][0]
+        self.assertIsNot(first_config, second_config)
+        self.assertEqual(
+            first_config.group_ids,
+            ["sglang-hicache:page0", "sglang-hicache:page0"],
+        )
+        self.assertEqual(
+            second_config.group_ids,
+            ["sglang-hicache:page1", "sglang-hicache:page1"],
+        )
+
+    def test_dfs_replica_config_is_forwarded_to_multi_buffer_put(self):
+        store, fake_store = _make_store(
+            enable_group_semantics=False,
+            dfs_replica_num=1,
+            is_mla_model=True,
+        )
+        store.register_mem_host_pool_v2(FakeMultiBufferPool(), PoolName.DEEPSEEK_V4_C4)
+
+        result = store.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DEEPSEEK_V4_C4,
+                    keys=["page0"],
+                    host_indices=torch.tensor([0]),
+                )
+            ]
+        )
+
+        self.assertEqual(result[PoolName.DEEPSEEK_V4_C4], [True])
+        call = fake_store.batch_put_calls[0]
+        self.assertEqual(call["method"], "batch_put_from_multi_buffers")
+        self.assertEqual(call["args"][0].dfs_replica_num, 1)
+
+    def test_invalid_replica_counts_fail_during_initialization(self):
+        with self.assertRaisesRegex(ValueError, "replica_num must be at least 1"):
+            _make_store(replica_num=0)
+
+        with self.assertRaisesRegex(ValueError, "dfs_replica_num must be 0 or 1"):
+            _make_store(dfs_replica_num=2)
+
+    def test_non_integer_replica_counts_fail_during_initialization(self):
+        for field, value in (
+            ("replica_num", 1.5),
+            ("dfs_replica_num", 0.5),
+            ("replica_num", True),
+        ):
+            with self.subTest(field=field, value=value):
+                with self.assertRaisesRegex(ValueError, f"{field} must be an integer"):
+                    _make_store(**{field: value})
+
+    def test_dfs_replica_rejects_non_default_tenant(self):
+        with self.assertRaisesRegex(
+            ValueError, "DFS replicas currently require tenant_id='default'"
+        ):
+            _make_store(dfs_replica_num=1, tenant_id="tenant-a")
+
+    def test_embedded_dfs_replica_requires_ssd_offload(self):
+        with self.assertRaisesRegex(ValueError, "enable_ssd_offload=true"):
+            _make_store(dfs_replica_num=1, enable_ssd_offload=False)
+
+    def test_embedded_dfs_replica_requires_distributed_backend(self):
+        with self.assertRaisesRegex(
+            ValueError, "MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR"
+        ):
+            _make_store(
+                dfs_replica_num=1,
+                storage_backend_descriptor="bucket_storage_backend",
+            )
+
+    def test_embedded_dfs_replica_requires_absolute_storage_path(self):
+        for path in ("", "relative/path", 123):
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(ValueError, "absolute ssd_offload_path"):
+                    _make_store(dfs_replica_num=1, ssd_offload_path=path)
+
+    def test_dfs_replica_requires_new_mooncake(self):
+        with self.assertRaisesRegex(RuntimeError, "dfs_replica_num"):
+            _make_store(
+                replicate_config_cls=ReplicateConfigWithoutDfsReplica,
+                dfs_replica_num=1,
+            )
 
     def test_mha_group_ids_use_tagged_logical_page_key(self):
         store, fake_store = _make_store(extra_backend_tag="tag")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

SGLang's Mooncake HiCache backend currently relies on Mooncake's default
replica placement. It does not expose request-level controls for memory or
descriptor-based DFS replicas, so deployments cannot request additional memory
replicas or evaluate Mooncake's DFS replica path through the standard HiCache
configuration.

This PR exposes Mooncake replica placement through the HiCache backend while
preserving the existing default behavior.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Add `replica_num` and `dfs_replica_num` to
  `--hicache-storage-backend-extra-config`, with defaults of `1` and `0`.
- Create a request-scoped `ReplicateConfig` for standard and multi-buffer
  writes, and compose it with the existing `group_ids` setting.
- Validate replica counts and reject Mooncake versions that do not expose the
  requested configuration fields.
- Fail fast when embedded DFS mode is missing SSD offload, the distributed
  storage backend descriptor, or an absolute storage path.
- Keep standalone Dummy Client mode compatible with replica configuration
  owned by the external Real Client.
- Document embedded and standalone DFS setup and the current experimental
  limitations.
- Add unit coverage for validation, compatibility, request isolation, group
  semantics, and multi-buffer writes.

The default configuration continues to use the existing three-argument
`batch_put_from` path.

### Functional Tests

The focused unit tests passed:

```bash
pytest -q \
  test/registered/unit/mem_cache/test_mooncake_group_semantics.py \
  test/registered/unit/mem_cache/test_mooncake_standalone_dummy_mamba.py
```

```text
22 passed, 6 subtests passed
```

A local end-to-end test also passed on an NVIDIA A100 with
`Qwen/Qwen2.5-0.5B-Instruct`, using Mooncake's POSIX DFS adapter and
`replica_num=1, dfs_replica_num=1`:

- The initial 768-token request reported `cached_tokens=0`.
- After the write, the four sparse DFS shards grew from 0 to 9,445,376 bytes
  of allocated storage.
- After flushing SGLang's device cache, replaying the same request reported
  `cached_tokens=704` (11 pages with `page_size=64`).
- Mooncake master logs reported `Replica #2: dfs_file=...`, confirming that
  the second replica was placed in POSIX DFS rather than only in memory.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33489528190](https://github.com/sgl-project/sglang/actions/runs/33489528190)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33489527990](https://github.com/sgl-project/sglang/actions/runs/33489527990)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33489528064](https://github.com/sgl-project/sglang/actions/runs/33489528064)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->