### PR TITLE
[DSV4] fp8 SoA unified_kv path with aiter decode/prefill kernels

### DIFF
--- a/poc/README.md
+++ b/poc/README.md
@@ -1,0 +1,37 @@
+# Stage-3 PoC — split-source unified_kv decode
+
+Proves the core hard part of the FP8 main-KV plan: a single online-softmax
+decode K-loop that dispatches each slot to one of TWO physical buffers by
+`slot >= swa_pages`, reading BF16 SWA rows or dequantizing packed
+(448 fp8 + 64 bf16 + ue8m0 scale, 584 B) compressed rows in-kernel.
+
+## Files
+- `python/.../unified_kv_kernels/paged_decode_split_src.py`
+  PoC Triton kernel `sparse_attn_v4_paged_decode_split_src`. Byte-identical
+  arithmetic to the existing `_paged_decode_fused_kernel`; only the KV load is
+  replaced with per-slot source dispatch. Fused single-pass path only
+  (split-K is a mechanical copy of the same load block — deferred).
+- `poc/poc_split_src_decode.py`  (needs GPU + torch/triton/aiter)
+  Self-test. Oracle = production `dequantize_k_cache_paged` -> bf16 unified
+  buffer -> existing `sparse_attn_v4_paged_decode`. PoC reads split buffers and
+  must match to fp32-accum tolerance. Covers ratio_comp 0.0/0.5/0.7/1.0,
+  T=1/16/32, H=16/64/128, page_size 1/64/128.
+- `poc/addr_math_check.py`  (runs anywhere, numpy only)
+  Independent numpy port of BOTH the production dequant ref AND the PoC
+  kernel's exact address expressions; asserts they compute identical offsets.
+  STATUS: PASS for page_size 1/64/128 (max_abs_diff 0.0).
+
+## How to run the GPU self-test (on an MI355 node with the sglang runtime)
+    cd unified_kv_fp8/sglang
+    python -m poc.poc_split_src_decode
+Expect: every case `OK`, final `ALL OK`.
+
+## Status
+- addr_math_check.py: PASS locally (no GPU needed).
+- poc_split_src_decode.py: NOT yet run — this box has no torch/triton/aiter and
+  the GPU is low-power; requires dispatch to a GPU runtime.
+
+## CUDAGraph-safety note
+Source dispatch is a runtime `tl.where` over slot VALUES + masked loads; launch
+grid depends only on capture-time (T, H). No host-side control flow, no
+shape-varying allocation. Safe to capture.

--- a/poc/addr_math_check.py
+++ b/poc/addr_math_check.py
@@ -1,0 +1,135 @@
+"""Validate the PoC kernel's packed byte-addressing + ue8m0 dequant math
+against the production dequant_k_cache_paged_ref formula, using numpy only
+(no torch/triton). This isolates the highest-risk part of the Stage-3 kernel:
+the compressed-slot address arithmetic.
+"""
+import numpy as np
+
+DIM_NOPE = 448
+DIM_ROPE = 64
+TILE_SIZE = 64
+NUM_SCALE_TILES = DIM_NOPE // TILE_SIZE      # 7
+NOPE_ROPE_BYTES = DIM_NOPE + DIM_ROPE * 2    # 576
+PADDED_SCALE_PER_TOKEN = NUM_SCALE_TILES + 1 # 8
+D = DIM_NOPE + DIM_ROPE                       # 512
+
+
+def e4m3fnuz_decode(byte):
+    """Decode a uint8 as OCP fp8 e4m3fnuz -> float (enough for parity test).
+    fnuz: 1-4-3, bias 8, no inf, sign+all-exp+all-mant==0x80 is NaN."""
+    b = int(byte)
+    s = (b >> 7) & 1
+    e = (b >> 3) & 0xF
+    m = b & 0x7
+    if b == 0x80:
+        return np.nan
+    if e == 0:
+        val = (m / 8.0) * 2.0 ** (1 - 8)      # subnormal, bias 8
+    else:
+        val = (1.0 + m / 8.0) * 2.0 ** (e - 8)
+    return -val if s else val
+
+
+def build_random_packed(C, page_size, rng):
+    raw = page_size * (NOPE_ROPE_BYTES + PADDED_SCALE_PER_TOKEN)
+    bytes_per_page = ((raw + NOPE_ROPE_BYTES - 1) // NOPE_ROPE_BYTES) * NOPE_ROPE_BYTES
+    num_pages = (C + page_size - 1) // page_size + 1
+    # random bytes; keep scale exponents in a sane range so dequant is finite
+    buf = rng.integers(0, 256, size=(num_pages, bytes_per_page), dtype=np.uint8)
+    return buf, bytes_per_page
+
+
+def prod_ref(buf, locs, page_size, bytes_per_page):
+    """Vectorized numpy port of dequantize_k_cache_paged_ref."""
+    flat_u8 = buf.reshape(-1)
+    flat_bf16_view_ok = True  # we emulate bf16 via uint16 pairs below
+    s_offset_bytes = page_size * NOPE_ROPE_BYTES
+    out = np.zeros((len(locs), D), dtype=np.float32)
+    for i, loc in enumerate(locs):
+        page_idx = loc // page_size
+        in_page = loc % page_size
+        page_byte_base = page_idx * bytes_per_page
+        tdb = page_byte_base + in_page * NOPE_ROPE_BYTES
+        tsb = page_byte_base + s_offset_bytes + in_page * PADDED_SCALE_PER_TOKEN
+        # nope
+        for t in range(NUM_SCALE_TILES):
+            su8 = int(flat_u8[tsb + t])
+            scale = 2.0 ** (su8 - 127)
+            if scale < 2.0 ** -126:
+                scale = 0.0
+            for k in range(TILE_SIZE):
+                d = t * TILE_SIZE + k
+                out[i, d] = e4m3fnuz_decode(flat_u8[tdb + d]) * scale
+        # rope: bf16 at byte (tdb+448)+2*(d-448)
+        for r in range(DIM_ROPE):
+            byte = tdb + DIM_NOPE + 2 * r
+            lo = int(flat_u8[byte]); hi = int(flat_u8[byte + 1])
+            u16 = (hi << 8) | lo
+            out[i, DIM_NOPE + r] = bf16_to_f32(u16)
+    return out
+
+
+def kernel_addr(buf, locs, page_size, bytes_per_page):
+    """Reproduce EXACTLY the address expressions in
+    paged_decode_split_src._paged_decode_fused_split_src_kernel for the
+    compressed branch, then decode bytes the same way, to prove the kernel's
+    offsets equal the production reference's offsets."""
+    flat_u8 = buf.reshape(-1)
+    S_OFFSET_BYTES = page_size * NOPE_ROPE_BYTES
+    out = np.zeros((len(locs), D), dtype=np.float32)
+    d_offs = np.arange(D)
+    nope_mask = d_offs < DIM_NOPE
+    rope_mask = (d_offs >= DIM_NOPE) & (d_offs < DIM_NOPE + DIM_ROPE)
+    g_idx_per_d = d_offs // TILE_SIZE
+    for i, loc in enumerate(locs):
+        page_idx = loc // page_size
+        in_page = loc % page_size
+        page_byte_base = page_idx * bytes_per_page
+        token_data_base = page_byte_base + in_page * NOPE_ROPE_BYTES
+        token_scale_base = page_byte_base + S_OFFSET_BYTES + in_page * PADDED_SCALE_PER_TOKEN
+        # nope: fp8_off = token_data_base + d ; scale_off = token_scale_base + d//64
+        fp8_off = token_data_base + d_offs
+        scale_off = token_scale_base + g_idx_per_d
+        for d in range(D):
+            if nope_mask[d]:
+                su8 = int(flat_u8[scale_off[d]])
+                scale = 2.0 ** (su8 - 127)
+                if scale < 2.0 ** -126:
+                    scale = 0.0
+                out[i, d] = e4m3fnuz_decode(flat_u8[fp8_off[d]]) * scale
+        # rope: bf16 elem off = (token_data_base + DIM_NOPE)//2 + (d-DIM_NOPE)
+        rope_base = (token_data_base + DIM_NOPE) // 2
+        for d in range(D):
+            if rope_mask[d]:
+                elem = rope_base + (d - DIM_NOPE)
+                byte = elem * 2
+                lo = int(flat_u8[byte]); hi = int(flat_u8[byte + 1])
+                u16 = (hi << 8) | lo
+                out[i, d] = bf16_to_f32(u16)
+    return out
+
+
+def bf16_to_f32(u16):
+    return np.frombuffer(np.uint32(u16 << 16).tobytes(), dtype=np.float32)[0]
+
+
+def main():
+    rng = np.random.default_rng(0)
+    all_ok = True
+    for page_size in (1, 64, 128):
+        C = 300
+        buf, bpp = build_random_packed(C, page_size, rng)
+        locs = rng.integers(0, C, size=37).tolist()
+        ref = prod_ref(buf, locs, page_size, bpp)
+        ker = kernel_addr(buf, locs, page_size, bpp)
+        # compare, treating NaN==NaN
+        eq = np.array_equal(np.nan_to_num(ref, nan=1e30), np.nan_to_num(ker, nan=1e30))
+        print(f"page_size={page_size:3d} bpp={bpp:5d} C={C} -> "
+              f"{'OK' if eq else 'FAIL'} (max_abs_diff="
+              f"{np.nanmax(np.abs(ref-ker)):.3e})")
+        all_ok &= eq
+    print("ADDRESS MATH:", "ALL OK" if all_ok else "SOME FAILED")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_quant_ref.py
+++ b/poc/bench_quant_ref.py
@@ -1,0 +1,113 @@
+"""Diagnostic: isolate whether the slowdown is the PACKED AoS FORMAT+exp2 or the
+decode kernel itself. Benchmark three decoders on identical shapes:
+
+  (A) bf16 baseline           : sparse_attn_v4_paged_decode (unified bf16)
+  (B) QUANT_KV clean SoA fp8  : sparse_attn_v4_paged_decode(kv_scales=...)
+                                unified_kv fp8[pages,512] + fp32 scale[pages,8]
+                                (the existing TUNED fp8 path; 1x64 block-scale)
+  (C) v2 packed AoS           : sparse_attn_v4_paged_decode_split_src_v2
+
+If (B) ~ 1.2-1.5x (A) but (C) >> (A), the mixed-packed AoS byte layout + ue8m0
+exp2 is the culprit, and the production path should use a clean SoA fp8 layout
+(nope fp8 contiguous + rope bf16 contiguous + scale contiguous).
+"""
+import time
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+    _FP8_DTYPE,
+    _FP8_GROUP_SIZE,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_split_src_v2 import (
+    sparse_attn_v4_paged_decode_split_src_v2,
+)
+from poc_split_src_decode import _build_packed_buffer
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _quantize_soa(kv_bf16):
+    """Clean 1x64 block-scale fp8 quant: returns (fp8[N,512], scale[N,8] fp32)."""
+    N, D = kv_bf16.shape
+    G = _FP8_GROUP_SIZE
+    x = kv_bf16.float().view(N, D // G, G)
+    amax = x.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+    fmax = torch.finfo(_FP8_DTYPE).max
+    scale = amax / fmax
+    q = (x / scale).clamp(-fmax, fmax).to(_FP8_DTYPE).view(N, D)
+    return q.contiguous(), scale.squeeze(-1).contiguous().float()
+
+
+def _case(*, T, H, D, swa_pages, C, page_size, kv_len, ratio_comp, seed=0):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+    q = torch.randn(T, H, D, device=device, dtype=dtype) * 0.5
+    swa_kv = torch.randn(swa_pages, D, device=device, dtype=dtype) * 0.5
+    compressed_bf16 = torch.randn(C, D, device=device, dtype=dtype) * 0.5
+    attn_sink = torch.randn(H, device=device, dtype=torch.float32)
+    scale = 1.0 / (D**0.5)
+
+    # (A) bf16 unified
+    packed, _ = _build_packed_buffer(compressed_bf16, page_size)
+    loc = torch.arange(C, dtype=torch.int32, device=device)
+    comp_dq = dequantize_k_cache_paged(packed, loc, page_size).view(C, D)
+    unified_bf16 = torch.cat([swa_kv, comp_dq], 0).contiguous()
+
+    # (B) QUANT_KV clean SoA fp8 for the WHOLE unified buffer
+    fp8_kv, kv_scales = _quantize_soa(unified_bf16)
+
+    # monotone [swa|comp] indices
+    torch.manual_seed(seed + 7)
+    comp_len = int(round(kv_len * ratio_comp)); swa_l = kv_len - comp_len
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=device)
+    parts = []
+    for _t in range(T):
+        s = torch.randint(0, swa_pages, (swa_l,), device=device, dtype=torch.int32)
+        c = swa_pages + torch.randint(0, C, (comp_len,), device=device, dtype=torch.int32)
+        parts.append(torch.cat([s, c]))
+    indices = torch.cat(parts).to(torch.int32)
+    swa_len = torch.full((T,), swa_l, dtype=torch.int32, device=device)
+
+    A = lambda: sparse_attn_v4_paged_decode(q, unified_bf16, indices, indptr, attn_sink, scale)  # noqa
+    B = lambda: sparse_attn_v4_paged_decode(q, fp8_kv, indices, indptr, attn_sink, scale, kv_scales=kv_scales)  # noqa
+    Cc = lambda: sparse_attn_v4_paged_decode_split_src_v2(q, swa_kv, packed, indices, indptr, swa_len, attn_sink, scale, swa_pages=swa_pages, packed_page_size=page_size)  # noqa
+
+    ta, tb, tc = _bench(A), _bench(B), _bench(Cc)
+    print(
+        f"T={T:>3} H={H:>3} kv_len={kv_len:>5} rc={ratio_comp:.1f} | "
+        f"(A)bf16={ta:7.1f}  (B)fp8-SoA={tb:7.1f} [{tb/ta:4.2f}x]  "
+        f"(C)packed-AoS-v2={tc:8.1f} [{tc/ta:5.2f}x]"
+    )
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}")
+    cases = [
+        dict(T=1, H=128, kv_len=2048, ratio_comp=1.0),
+        dict(T=1, H=128, kv_len=8192, ratio_comp=1.0),
+        dict(T=16, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=16384, ratio_comp=1.0),
+        dict(T=128, H=128, kv_len=8192, ratio_comp=0.9),
+    ]
+    for i, c in enumerate(cases):
+        _case(D=512, swa_pages=2048, C=32768, page_size=64, seed=i, **c)
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_split_src_decode.py
+++ b/poc/bench_split_src_decode.py
@@ -1,0 +1,93 @@
+"""Stage-3 PoC performance test: split-source unified_kv decode vs the existing
+all-bf16 unified decode. Also reports the per-row byte saving that motivates the
+change (bf16 1024 B/row -> packed 584 B/row for compressed).
+
+Runs on one GPU inside the sglang-rocm container.
+"""
+import time
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_split_src import (
+    sparse_attn_v4_paged_decode_split_src,
+)
+from poc_split_src_decode import _build_packed_buffer  # noqa: E402  (same dir)
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6  # us/iter
+
+
+def _case(*, T, H, D, swa_pages, C, page_size, kv_len, ratio_comp, seed=0):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+    q = torch.randn(T, H, D, device=device, dtype=dtype) * 0.5
+    swa_kv = torch.randn(swa_pages, D, device=device, dtype=dtype) * 0.5
+    compressed_bf16 = torch.randn(C, D, device=device, dtype=dtype) * 0.5
+    attn_sink = torch.randn(H, device=device, dtype=torch.float32)
+    scale = 1.0 / (D**0.5)
+
+    packed, _ = _build_packed_buffer(compressed_bf16, page_size)
+    loc = torch.arange(C, dtype=torch.int32, device=device)
+    comp_dq = dequantize_k_cache_paged(packed, loc, page_size).view(C, D)
+    unified_bf16 = torch.cat([swa_kv, comp_dq], 0).contiguous()
+
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=device)
+    total = T * kv_len
+    r = torch.rand(total, device=device)
+    swa_slots = torch.randint(0, swa_pages, (total,), device=device, dtype=torch.int32)
+    comp_slots = swa_pages + torch.randint(0, C, (total,), device=device, dtype=torch.int32)
+    indices = torch.where(r < ratio_comp, comp_slots, swa_slots).to(torch.int32)
+
+    ref = lambda: sparse_attn_v4_paged_decode(  # noqa: E731
+        q, unified_bf16, indices, indptr, attn_sink, scale
+    )
+    poc = lambda: sparse_attn_v4_paged_decode_split_src(  # noqa: E731
+        q, swa_kv, packed, indices, indptr, attn_sink, scale,
+        swa_pages=swa_pages, packed_page_size=page_size,
+    )
+    t_ref = _bench(ref)
+    t_poc = _bench(poc)
+    print(
+        f"T={T:>3} H={H:>3} kv_len={kv_len:>5} ratio_comp={ratio_comp:.1f} | "
+        f"bf16-oracle={t_ref:8.1f}us  split-src={t_poc:8.1f}us  "
+        f"ratio={t_poc / t_ref:5.2f}x"
+    )
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}")
+    # per-row byte accounting (the point of the change)
+    bf16_row = 512 * 2
+    packed_row = 448 + 64 * 2 + 8
+    print(
+        f"compressed row bytes: bf16={bf16_row}  packed={packed_row}  "
+        f"saving={100 * (1 - packed_row / bf16_row):.1f}%"
+    )
+    cases = [
+        dict(T=1, H=128, kv_len=2048, ratio_comp=1.0),
+        dict(T=1, H=128, kv_len=8192, ratio_comp=1.0),
+        dict(T=16, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=16384, ratio_comp=1.0),
+    ]
+    for i, c in enumerate(cases):
+        _case(D=512, swa_pages=2048, C=32768, page_size=64, seed=i, **c)
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_v2_decode.py
+++ b/poc/bench_v2_decode.py
@@ -1,0 +1,104 @@
+"""Stage-3 PoC v2 performance test: two-segment single-source unified_kv decode
+vs the all-bf16 baseline (existing sparse_attn_v4_paged_decode, the Triton HIP
+kernel that is the current unmodified unified_kv decode path).
+
+Indices are built in the REAL runtime layout: per request [ SWA | compressed ]
+contiguous, so each BLOCK_K tile is single-source. Reports v2/baseline ratio and
+the resident-byte saving (bf16 1024 B/row -> packed 584 B/row).
+"""
+import time
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_split_src_v2 import (
+    sparse_attn_v4_paged_decode_split_src_v2,
+)
+from poc_split_src_decode import _build_packed_buffer  # noqa: E402
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _monotone(T, kv_len, swa_pages, C, ratio_comp, device, seed):
+    torch.manual_seed(seed + 7)
+    comp_len = int(round(kv_len * ratio_comp))
+    swa_l = kv_len - comp_len
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=device)
+    parts = []
+    for _t in range(T):
+        s = torch.randint(0, swa_pages, (swa_l,), device=device, dtype=torch.int32)
+        c = swa_pages + torch.randint(0, C, (comp_len,), device=device, dtype=torch.int32)
+        parts.append(torch.cat([s, c]))
+    indices = torch.cat(parts).to(torch.int32)
+    swa_len = torch.full((T,), swa_l, dtype=torch.int32, device=device)
+    return indices, indptr, swa_len
+
+
+def _case(*, T, H, D, swa_pages, C, page_size, kv_len, ratio_comp, seed=0):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+    q = torch.randn(T, H, D, device=device, dtype=dtype) * 0.5
+    swa_kv = torch.randn(swa_pages, D, device=device, dtype=dtype) * 0.5
+    compressed_bf16 = torch.randn(C, D, device=device, dtype=dtype) * 0.5
+    attn_sink = torch.randn(H, device=device, dtype=torch.float32)
+    scale = 1.0 / (D**0.5)
+
+    packed, _ = _build_packed_buffer(compressed_bf16, page_size)
+    loc = torch.arange(C, dtype=torch.int32, device=device)
+    comp_dq = dequantize_k_cache_paged(packed, loc, page_size).view(C, D)
+    unified_bf16 = torch.cat([swa_kv, comp_dq], 0).contiguous()
+
+    indices, indptr, swa_len = _monotone(T, kv_len, swa_pages, C, ratio_comp, device, seed)
+
+    ref = lambda: sparse_attn_v4_paged_decode(  # noqa: E731
+        q, unified_bf16, indices, indptr, attn_sink, scale
+    )
+    v2 = lambda: sparse_attn_v4_paged_decode_split_src_v2(  # noqa: E731
+        q, swa_kv, packed, indices, indptr, swa_len, attn_sink, scale,
+        swa_pages=swa_pages, packed_page_size=page_size,
+    )
+    t_ref = _bench(ref)
+    t_v2 = _bench(v2)
+    print(
+        f"T={T:>3} H={H:>3} kv_len={kv_len:>5} ratio_comp={ratio_comp:.1f} | "
+        f"bf16-baseline={t_ref:8.1f}us  v2={t_v2:8.1f}us  ratio={t_v2 / t_ref:5.2f}x"
+    )
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}")
+    bf16_row = 512 * 2
+    packed_row = 448 + 64 * 2 + 8
+    print(
+        f"compressed row bytes: bf16={bf16_row}  packed={packed_row}  "
+        f"saving={100 * (1 - packed_row / bf16_row):.1f}%"
+    )
+    cases = [
+        dict(T=1, H=128, kv_len=2048, ratio_comp=1.0),
+        dict(T=1, H=128, kv_len=8192, ratio_comp=1.0),
+        dict(T=16, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=4096, ratio_comp=0.5),
+        dict(T=32, H=128, kv_len=16384, ratio_comp=1.0),
+        dict(T=128, H=128, kv_len=8192, ratio_comp=0.9),
+    ]
+    for i, c in enumerate(cases):
+        _case(D=512, swa_pages=2048, C=32768, page_size=64, seed=i, **c)
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_v3_decode.py
+++ b/poc/bench_v3_decode.py
@@ -1,0 +1,75 @@
+"""v3 SoA fp8 decode perf vs bf16 baseline AND the existing clean-SoA QUANT_KV."""
+import time
+import torch
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode, _FP8_DTYPE, _FP8_GROUP_SIZE,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_soa_v3 import (
+    sparse_attn_v4_paged_decode_soa_v3,
+)
+from poc_v3_common import quant_soa
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup): fn()
+    torch.cuda.synchronize(); t0 = time.perf_counter()
+    for _ in range(iters): fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _quant512(kv):
+    N, D = kv.shape; G = _FP8_GROUP_SIZE
+    x = kv.float().view(N, D // G, G)
+    fmax = torch.finfo(_FP8_DTYPE).max
+    s = x.abs().amax(-1, keepdim=True).clamp(min=1e-6) / fmax
+    q = (x / s).clamp(-fmax, fmax).to(_FP8_DTYPE).view(N, D)
+    return q.contiguous(), s.squeeze(-1).contiguous().float()
+
+
+def _mono(T, kv_len, swa_pages, C, rc, dev, seed):
+    torch.manual_seed(seed + 7)
+    cl = int(round(kv_len * rc)); sl = kv_len - cl
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=dev)
+    parts = []
+    for _t in range(T):
+        s = torch.randint(0, swa_pages, (sl,), device=dev, dtype=torch.int32)
+        c = swa_pages + torch.randint(0, C, (cl,), device=dev, dtype=torch.int32)
+        parts.append(torch.cat([s, c]))
+    return torch.cat(parts).to(torch.int32), indptr, torch.full((T,), sl, dtype=torch.int32, device=dev)
+
+
+def _case(*, T, H, D, swa_pages, C, kv_len, rc, seed=0):
+    torch.manual_seed(seed); dev = "cuda"; dt = torch.bfloat16
+    q = torch.randn(T, H, D, device=dev, dtype=dt) * 0.5
+    swa = torch.randn(swa_pages, D, device=dev, dtype=dt) * 0.5
+    comp = torch.randn(C, D, device=dev, dtype=dt) * 0.5
+    sink = torch.randn(H, device=dev, dtype=torch.float32); sc = 1.0 / (D ** 0.5)
+    nope_fp8, rope_bf16, scale_f32, comp_dq = quant_soa(comp)
+    unified = torch.cat([swa, comp_dq], 0).contiguous()
+    fp8_kv, kv_scales = _quant512(unified)
+    idx, indptr, swa_len = _mono(T, kv_len, swa_pages, C, rc, dev, seed)
+    A = lambda: sparse_attn_v4_paged_decode(q, unified, idx, indptr, sink, sc)
+    B = lambda: sparse_attn_v4_paged_decode(q, fp8_kv, idx, indptr, sink, sc, kv_scales=kv_scales)
+    Cc = lambda: sparse_attn_v4_paged_decode_soa_v3(q, swa, nope_fp8, rope_bf16, scale_f32, idx, indptr, swa_len, sink, sc, swa_pages=swa_pages)
+    ta, tb, tc = _bench(A), _bench(B), _bench(Cc)
+    print(f"T={T:>3} H={H:>3} kv_len={kv_len:>5} rc={rc:.1f} | (A)bf16={ta:7.1f}  (B)fp8-512-SoA={tb:8.1f}[{tb/ta:5.2f}x]  (C)v3-nopeFp8={tc:7.1f}[{tc/ta:5.2f}x]")
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}")
+    for i, c in enumerate([
+        dict(T=1, H=128, kv_len=2048, rc=1.0),
+        dict(T=1, H=128, kv_len=8192, rc=1.0),
+        dict(T=16, H=128, kv_len=4096, rc=0.5),
+        dict(T=32, H=128, kv_len=4096, rc=0.5),
+        dict(T=32, H=128, kv_len=16384, rc=1.0),
+        dict(T=128, H=128, kv_len=8192, rc=0.9),
+    ]):
+        _case(D=512, swa_pages=2048, C=32768, seed=i, **c)
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_v3_tune.py
+++ b/poc/bench_v3_tune.py
@@ -1,0 +1,92 @@
+"""v3 tuning bench: sweep compressed-loop num_stages (NS_C) and BLOCK_KC to
+measure how much of the fp8 dequant we can hide behind MFMA via deeper software
+pipelining + the bf16-direct dequant (no f32 intermediate).
+
+Reports us/iter vs the bf16 oracle. Also reports the split-K auto path.
+"""
+import time
+import torch
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_soa_v3 import (
+    sparse_attn_v4_paged_decode_soa_v3,
+)
+from poc_v3_common import quant_soa
+
+
+def _bench(fn, iters=50, warmup=10):
+    for _ in range(warmup): fn()
+    torch.cuda.synchronize(); t0 = time.perf_counter()
+    for _ in range(iters): fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _mono(T, kv_len, swa_pages, C, rc, dev, seed):
+    torch.manual_seed(seed + 7)
+    cl = int(round(kv_len * rc)); sl = kv_len - cl
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=dev)
+    parts = []
+    for _t in range(T):
+        s = torch.randint(0, swa_pages, (sl,), device=dev, dtype=torch.int32)
+        c = swa_pages + torch.randint(0, C, (cl,), device=dev, dtype=torch.int32)
+        parts.append(torch.cat([s, c]))
+    return torch.cat(parts).to(torch.int32), indptr, torch.full((T,), sl, dtype=torch.int32, device=dev)
+
+
+def _refmax(a, b):
+    return (a.float() - b.float()).abs().max().item()
+
+
+def _case(*, T, H, D, swa_pages, C, kv_len, rc, seed=0):
+    torch.manual_seed(seed); dev = "cuda"; dt = torch.bfloat16
+    q = torch.randn(T, H, D, device=dev, dtype=dt) * 0.5
+    swa = torch.randn(swa_pages, D, device=dev, dtype=dt) * 0.5
+    comp = torch.randn(C, D, device=dev, dtype=dt) * 0.5
+    sink = torch.randn(H, device=dev, dtype=torch.float32); sc = 1.0 / (D ** 0.5)
+    nope_fp8, rope_bf16, scale_f32, comp_dq = quant_soa(comp)
+    unified = torch.cat([swa, comp_dq], 0).contiguous()
+    idx, indptr, swa_len = _mono(T, kv_len, swa_pages, C, rc, dev, seed)
+
+    oracle = sparse_attn_v4_paged_decode(q, unified, idx, indptr, sink, sc)
+    ta = _bench(lambda: sparse_attn_v4_paged_decode(q, unified, idx, indptr, sink, sc))
+
+    def v3(ns_c, bk, ks, ns_a=3):
+        return sparse_attn_v4_paged_decode_soa_v3(
+            q, swa, nope_fp8, rope_bf16, scale_f32, idx, indptr, swa_len, sink, sc,
+            swa_pages=swa_pages, block_k=bk, ns_a=ns_a, ns_c=ns_c, kv_splits=ks)
+
+    print(f"--- T={T} H={H} kv_len={kv_len} rc={rc} | bf16 oracle={ta:7.1f}us")
+    err = _refmax(oracle, v3(4, 32, None))
+    print(f"    max|v3-oracle|={err:.4f}  (tol 2e-2)")
+    # PRODUCTION PATH: split-K auto, now with pipelined tl.range loops.
+    # Sweep compressed-loop pipelining depth NS_C x tile width BLOCK_K.
+    best = None
+    for ns_c in (1, 2, 3, 4):
+        for bk in (16, 32):
+            t = _bench(lambda: v3(ns_c, bk, None))
+            tag = f"split-K ns_c={ns_c} bk={bk:>2}"
+            print(f"    {tag} : {t:7.1f}us  [{t/ta:5.2f}x]")
+            if best is None or t < best[0]:
+                best = (t, tag)
+    print(f"    >>> BEST: {best[1]}  {best[0]:.1f}us  [{best[0]/ta:.2f}x]")
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}")
+    for i, c in enumerate([
+        dict(T=1, H=128, kv_len=2048, rc=1.0),
+        dict(T=1, H=128, kv_len=8192, rc=1.0),
+        dict(T=16, H=128, kv_len=4096, rc=0.5),
+        dict(T=32, H=128, kv_len=4096, rc=0.5),
+        dict(T=32, H=128, kv_len=16384, rc=1.0),
+        dict(T=128, H=128, kv_len=8192, rc=0.9),
+    ]):
+        _case(D=512, swa_pages=2048, C=32768, seed=i, **c)
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/bench_v4_ctx.py
+++ b/poc/bench_v4_ctx.py
@@ -1,0 +1,108 @@
+"""DSV4 real-shape long-context decode bench.
+Shapes: D=512 (448 nope-fp8 + 64 rope-bf16), H=128 heads.
+kv_len in {128K, 256K}; bs in {1,16,32,64,128}; rc=0.9 (~swa_full_tokens_ratio 0.075).
+Step 1: PRECISION (v3 vs bf16 oracle over identical dequant KV). Step 2: PERF table.
+"""
+import time, torch
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_soa_v3 import (
+    sparse_attn_v4_paged_decode_soa_v3,
+)
+from poc_v3_common import quant_soa
+
+D, H = 512, 128
+KVS = {"128K": 131072, "256K": 262144}
+BS = [1, 16, 32, 64, 128]
+RC = 0.9
+
+
+def _bench(fn, iters, warmup):
+    for _ in range(warmup): fn()
+    torch.cuda.synchronize(); t0 = time.perf_counter()
+    for _ in range(iters): fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _build(T, kv_len, seed):
+    dev = "cuda"; dt = torch.bfloat16
+    torch.manual_seed(seed)
+    cl = int(round(kv_len * RC)); sl = kv_len - cl
+    swa_pages = max(sl + 1024, kv_len // 8)
+    C = cl + 1024
+    q = torch.randn(T, H, D, device=dev, dtype=dt) * 0.5
+    swa = torch.randn(swa_pages, D, device=dev, dtype=dt) * 0.5
+    comp = torch.randn(C, D, device=dev, dtype=dt) * 0.5
+    sink = torch.randn(H, device=dev, dtype=torch.float32); sc = 1.0 / (D ** 0.5)
+    nope_fp8, rope_bf16, scale_f32, comp_dq = quant_soa(comp)
+    unified = torch.cat([swa, comp_dq], 0).contiguous()
+    indptr = torch.arange(0, (T + 1) * kv_len, kv_len, dtype=torch.int32, device=dev)
+    parts = []
+    for _t in range(T):
+        s = torch.randint(0, swa_pages, (sl,), device=dev, dtype=torch.int32)
+        c = swa_pages + torch.randint(0, C, (cl,), device=dev, dtype=torch.int32)
+        parts.append(torch.cat([s, c]))
+    idx = torch.cat(parts).to(torch.int32)
+    swa_len = torch.full((T,), sl, dtype=torch.int32, device=dev)
+    return dict(q=q, swa=swa, unified=unified, nope_fp8=nope_fp8, rope_bf16=rope_bf16,
+                scale_f32=scale_f32, sink=sink, sc=sc, idx=idx, indptr=indptr,
+                swa_len=swa_len, swa_pages=swa_pages)
+
+
+def _oracle(d):
+    return sparse_attn_v4_paged_decode(d["q"], d["unified"], d["idx"], d["indptr"], d["sink"], d["sc"])
+
+def _v3(d):
+    return sparse_attn_v4_paged_decode_soa_v3(
+        d["q"], d["swa"], d["nope_fp8"], d["rope_bf16"], d["scale_f32"],
+        d["idx"], d["indptr"], d["swa_len"], d["sink"], d["sc"], swa_pages=d["swa_pages"])
+
+
+def main():
+    assert torch.cuda.is_available()
+    print(f"device={torch.cuda.get_device_name(0)}  D={D} H={H} rc={RC}")
+
+    print("\n########## STEP 1: PRECISION (v3 vs bf16 oracle) ##########")
+    ok = True
+    for name, L in KVS.items():
+        for T in (1, 32, 128):
+            d = _build(T, L, seed=hash((name, T)) & 0xffff)
+            a = _oracle(d).float(); b = _v3(d).float()
+            mabs = (a - b).abs().max().item()
+            rel = ((a - b).abs().max() / a.abs().max().clamp(min=1e-6)).item()
+            flag = "OK" if mabs < 2e-2 else "FAIL"
+            if mabs >= 2e-2: ok = False
+            print(f"  kv={name} bs={T:>3}: max_abs={mabs:.3e} rel={rel:.3e} -> {flag}")
+            del d, a, b; torch.cuda.empty_cache()
+    print("PRECISION", "ALL OK" if ok else "FAILED")
+
+    print("\n########## STEP 2: PERFORMANCE (us/iter, ratio vs bf16) ##########")
+    print(f"{'kv_len':>7} {'bs':>4} | {'bf16(us)':>10} {'v3-fp8(us)':>11} {'ratio':>7}")
+    rows = {}
+    for name, L in KVS.items():
+        for T in BS:
+            d = _build(T, L, seed=hash((name, T, 'p')) & 0xffff)
+            # heavier cases -> fewer iters
+            big = (L * T)
+            iters = 30 if big <= 4_000_000 else (15 if big <= 16_000_000 else 8)
+            warm = max(3, iters // 4)
+            ta = _bench(lambda: _oracle(d), iters, warm)
+            tb = _bench(lambda: _v3(d), iters, warm)
+            rows[(name, T)] = (ta, tb)
+            print(f"{name:>7} {T:>4} | {ta:10.1f} {tb:11.1f} {tb/ta:6.2f}x")
+            del d; torch.cuda.empty_cache()
+    print("\n########## SUMMARY TABLE ##########")
+    print(f"{'bs':>4} | " + " | ".join(f"{n:>16}" for n in KVS))
+    for T in BS:
+        cells = []
+        for n in KVS:
+            ta, tb = rows[(n, T)]
+            cells.append(f"{tb/ta:5.2f}x ({tb:6.0f}/{ta:6.0f})")
+        print(f"{T:>4} | " + " | ".join(f"{c:>16}" for c in cells))
+    print("BENCH DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/poc_split_src_decode.py
+++ b/poc/poc_split_src_decode.py
@@ -1,0 +1,139 @@
+"""Stage-3 PoC self-test: split-source unified_kv decode.
+
+Oracle: dequantize the packed compressed buffer to bf16 with the PRODUCTION
+dequant (dsv4.dequant_k_cache), splice it into a fully-bf16 unified buffer, and
+run the EXISTING unified decode kernel (sparse_attn_v4_paged_decode). The PoC
+kernel reads swa(bf16) + packed(uint8) directly and must reproduce that output.
+
+Since the oracle's compressed rows == dequant(packed) and the PoC dequants the
+same bytes with the same addressing, the two KV tiles fed to the dot are
+bit-identical, so outputs must match to fp32-accumulation tolerance.
+"""
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.dequant_k_cache import (
+    NOPE_ROPE_BYTES,
+    PADDED_SCALE_PER_TOKEN,
+    dequantize_k_cache_paged,
+)
+from sglang.kernels.ops.attention.dsv4.index_buf_accessor import SetKAndS
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+    quant_to_nope_fp8_rope_bf16_pack_triton,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_split_src import (
+    sparse_attn_v4_paged_decode_split_src,
+)
+
+
+class _FakePool:
+    """Minimal pool shim for SetKAndS (needs .page_size)."""
+
+    def __init__(self, page_size):
+        self.page_size = page_size
+
+
+def _build_packed_buffer(compressed_bf16, page_size):
+    """Quantize [C, 512] bf16 -> production packed [num_pages, bpp] uint8.
+    Returns (packed_uint8, bytes_per_page). Row i stored at loc=i."""
+    C = compressed_bf16.shape[0]
+    device = compressed_bf16.device
+    raw_bytes_per_page = page_size * (NOPE_ROPE_BYTES + PADDED_SCALE_PER_TOKEN)
+    bytes_per_page = (
+        (raw_bytes_per_page + NOPE_ROPE_BYTES - 1) // NOPE_ROPE_BYTES
+    ) * NOPE_ROPE_BYTES
+    num_pages = (C + page_size - 1) // page_size + 1  # +1 pad page (null slot)
+    packed = torch.zeros((num_pages, bytes_per_page), dtype=torch.uint8, device=device)
+
+    pack = quant_to_nope_fp8_rope_bf16_pack_triton(compressed_bf16.contiguous())
+    loc = torch.arange(C, dtype=torch.int64, device=device)
+    SetKAndS.execute(_FakePool(page_size), packed, loc, pack)
+    return packed, bytes_per_page
+
+
+def _run_case(*, T, H, D, swa_pages, C, page_size, seed=0, ratio_comp=0.5):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    q = torch.randn(T, H, D, device=device, dtype=dtype) * 0.5
+    swa_kv = torch.randn(swa_pages, D, device=device, dtype=dtype) * 0.5
+    compressed_bf16 = torch.randn(C, D, device=device, dtype=dtype) * 0.5
+    attn_sink = torch.randn(H, device=device, dtype=torch.float32)
+    softmax_scale = 1.0 / (D**0.5)
+
+    packed, _bpp = _build_packed_buffer(compressed_bf16, page_size)
+
+    # Production dequant of the packed rows -> bf16 ground-truth compressed KV.
+    loc = torch.arange(C, dtype=torch.int32, device=device)
+    comp_dq = dequantize_k_cache_paged(packed, loc, page_size).view(C, D)
+
+    # Build a fully-bf16 unified buffer: [0, swa_pages) SWA ++ [swa_pages, ...) comp.
+    unified_bf16 = torch.cat([swa_kv, comp_dq], dim=0).contiguous()
+
+    # Random ragged indices mixing SWA slots and compressed slots.
+    torch.manual_seed(seed + 1)
+    lens = torch.randint(1, 40, (T,), device=device, dtype=torch.int32)
+    indptr = torch.zeros(T + 1, dtype=torch.int32, device=device)
+    indptr[1:] = torch.cumsum(lens, 0)
+    total = int(indptr[-1].item())
+    r = torch.rand(total, device=device)
+    swa_slots = torch.randint(0, swa_pages, (total,), device=device, dtype=torch.int32)
+    comp_slots = (
+        swa_pages
+        + torch.randint(0, C, (total,), device=device, dtype=torch.int32)
+    )
+    indices = torch.where(r < ratio_comp, comp_slots, swa_slots).to(torch.int32)
+
+    # Oracle: existing kernel over the fully-bf16 unified buffer.
+    out_ref = sparse_attn_v4_paged_decode(
+        q, unified_bf16, indices, indptr, attn_sink, softmax_scale
+    )
+    # PoC: split-source kernel over swa(bf16) + packed(uint8).
+    out_poc = sparse_attn_v4_paged_decode_split_src(
+        q,
+        swa_kv,
+        packed,
+        indices,
+        indptr,
+        attn_sink,
+        softmax_scale,
+        swa_pages=swa_pages,
+        packed_page_size=page_size,
+    )
+
+    diff = (out_poc.float() - out_ref.float()).abs()
+    max_abs = diff.max().item()
+    denom = out_ref.float().abs().max().item() + 1e-6
+    rel = max_abs / denom
+    ok = torch.allclose(out_poc, out_ref, atol=2e-2, rtol=2e-2)
+    print(
+        f"[T={T} H={H} D={D} swa_pages={swa_pages} C={C} ps={page_size} "
+        f"ratio_comp={ratio_comp}] max_abs={max_abs:.3e} rel={rel:.3e} "
+        f"-> {'OK' if ok else 'FAIL'}"
+    )
+    return ok
+
+
+def main():
+    assert torch.cuda.is_available(), "PoC needs a CUDA/HIP device"
+    cases = [
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, page_size=64, ratio_comp=1.0),
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, page_size=64, ratio_comp=0.0),
+        dict(T=1, H=128, D=512, swa_pages=512, C=4096, page_size=64, ratio_comp=0.5),
+        dict(T=16, H=128, D=512, swa_pages=512, C=4096, page_size=64, ratio_comp=0.5),
+        dict(T=32, H=16, D=512, swa_pages=1024, C=8192, page_size=128, ratio_comp=0.5),
+        dict(T=32, H=64, D=512, swa_pages=1024, C=8192, page_size=1, ratio_comp=0.7),
+    ]
+    all_ok = True
+    for i, c in enumerate(cases):
+        all_ok &= _run_case(seed=i, **c)
+    print("ALL OK" if all_ok else "SOME FAILED")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/poc_v2_decode.py
+++ b/poc/poc_v2_decode.py
@@ -1,0 +1,119 @@
+"""Stage-3 PoC v2 self-test: two-segment single-source unified_kv decode.
+
+Same oracle as v1 (production dequant -> bf16 unified -> existing decode kernel),
+but the index stream is built in the REAL runtime layout: per request the slots
+are CONTIGUOUS and MONOTONE  [ SWA prefix (swa_len[t]) | compressed tail ].
+We pass swa_len[t] to the v2 kernel as the crossover point.
+"""
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_split_src_v2 import (
+    sparse_attn_v4_paged_decode_split_src_v2,
+)
+
+# reuse the validated packed-buffer builder from v1 poc
+from poc_split_src_decode import _build_packed_buffer
+
+
+def _build_monotone_indices(T, swa_pages, C, ratio_comp, device, seed):
+    """Per request: [swa_len swa slots][comp_len compressed slots], concatenated."""
+    torch.manual_seed(seed + 1)
+    total_lens = torch.randint(4, 48, (T,), device=device)
+    comp_lens = (total_lens.float() * ratio_comp).round().to(torch.int64)
+    comp_lens = torch.minimum(comp_lens, total_lens)
+    swa_lens = total_lens - comp_lens
+
+    indptr = torch.zeros(T + 1, dtype=torch.int32, device=device)
+    indptr[1:] = torch.cumsum(total_lens, 0)
+    total = int(indptr[-1].item())
+    indices = torch.empty(total, dtype=torch.int32, device=device)
+
+    off = 0
+    for t in range(T):
+        sl = int(swa_lens[t].item())
+        cl = int(comp_lens[t].item())
+        if sl > 0:
+            indices[off : off + sl] = torch.randint(
+                0, swa_pages, (sl,), device=device, dtype=torch.int32
+            )
+        if cl > 0:
+            indices[off + sl : off + sl + cl] = swa_pages + torch.randint(
+                0, C, (cl,), device=device, dtype=torch.int32
+            )
+        off += sl + cl
+    return indices, indptr, swa_lens.to(torch.int32)
+
+
+def _run_case(*, T, H, D, swa_pages, C, page_size, seed=0, ratio_comp=0.5):
+    torch.manual_seed(seed)
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    q = torch.randn(T, H, D, device=device, dtype=dtype) * 0.5
+    swa_kv = torch.randn(swa_pages, D, device=device, dtype=dtype) * 0.5
+    compressed_bf16 = torch.randn(C, D, device=device, dtype=dtype) * 0.5
+    attn_sink = torch.randn(H, device=device, dtype=torch.float32)
+    softmax_scale = 1.0 / (D**0.5)
+
+    packed, _bpp = _build_packed_buffer(compressed_bf16, page_size)
+    loc = torch.arange(C, dtype=torch.int32, device=device)
+    comp_dq = dequantize_k_cache_paged(packed, loc, page_size).view(C, D)
+    unified_bf16 = torch.cat([swa_kv, comp_dq], dim=0).contiguous()
+
+    indices, indptr, swa_len = _build_monotone_indices(
+        T, swa_pages, C, ratio_comp, device, seed
+    )
+
+    out_ref = sparse_attn_v4_paged_decode(
+        q, unified_bf16, indices, indptr, attn_sink, softmax_scale
+    )
+    out_poc = sparse_attn_v4_paged_decode_split_src_v2(
+        q,
+        swa_kv,
+        packed,
+        indices,
+        indptr,
+        swa_len,
+        attn_sink,
+        softmax_scale,
+        swa_pages=swa_pages,
+        packed_page_size=page_size,
+    )
+
+    diff = (out_poc.float() - out_ref.float()).abs()
+    max_abs = diff.max().item()
+    denom = out_ref.float().abs().max().item() + 1e-6
+    rel = max_abs / denom
+    ok = torch.allclose(out_poc, out_ref, atol=2e-2, rtol=2e-2)
+    print(
+        f"[T={T} H={H} D={D} swa_pages={swa_pages} C={C} ps={page_size} "
+        f"ratio_comp={ratio_comp}] max_abs={max_abs:.3e} rel={rel:.3e} "
+        f"-> {'OK' if ok else 'FAIL'}"
+    )
+    return ok
+
+
+def main():
+    assert torch.cuda.is_available(), "PoC needs a CUDA/HIP device"
+    cases = [
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, page_size=64, ratio_comp=1.0),
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, page_size=64, ratio_comp=0.0),
+        dict(T=1, H=128, D=512, swa_pages=512, C=4096, page_size=64, ratio_comp=0.5),
+        dict(T=16, H=128, D=512, swa_pages=512, C=4096, page_size=64, ratio_comp=0.5),
+        dict(T=32, H=16, D=512, swa_pages=1024, C=8192, page_size=128, ratio_comp=0.5),
+        dict(T=32, H=64, D=512, swa_pages=1024, C=8192, page_size=1, ratio_comp=0.7),
+    ]
+    all_ok = True
+    for i, c in enumerate(cases):
+        all_ok &= _run_case(seed=i, **c)
+    print("ALL OK" if all_ok else "SOME FAILED")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/poc_v3_common.py
+++ b/poc/poc_v3_common.py
@@ -1,0 +1,30 @@
+"""Shared helpers for v3 SoA fp8 unified_kv decode PoC."""
+import torch
+
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_soa_v3 import (
+    _FP8_DTYPE, _DIM_NOPE, _DIM_ROPE, _GROUP, _NUM_G, _NUM_G_PAD,
+)
+
+
+def quant_soa(kv_bf16):
+    """[C,512] bf16 -> (nope_fp8[C,448], rope_bf16[C,64], scale_f32[C,8]).
+    RoPE kept exactly bf16; nope 1x64 block-scale fp8. Returns also the
+    bf16 ground-truth dequant for oracle."""
+    C, D = kv_bf16.shape
+    assert D == _DIM_NOPE + _DIM_ROPE
+    dev = kv_bf16.device
+    nope = kv_bf16[:, :_DIM_NOPE].float().view(C, _NUM_G, _GROUP)
+    fmax = torch.finfo(_FP8_DTYPE).max
+    amax = nope.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+    scale = (amax / fmax)  # [C,7,1]
+    q = (nope / scale).clamp(-fmax, fmax).to(_FP8_DTYPE)  # [C,7,64]
+    nope_fp8 = q.reshape(C, _DIM_NOPE).contiguous()
+    rope_bf16 = kv_bf16[:, _DIM_NOPE:].contiguous()
+    scale_f32 = torch.ones((C, _NUM_G_PAD), dtype=torch.float32, device=dev)
+    scale_f32[:, :_NUM_G] = scale.squeeze(-1)
+    scale_f32 = scale_f32.contiguous()
+
+    # ground-truth dequant -> bf16
+    nope_dq = (q.float() * scale).reshape(C, _DIM_NOPE)
+    unified_dq = torch.cat([nope_dq.to(torch.bfloat16), rope_bf16], dim=1).contiguous()
+    return nope_fp8, rope_bf16, scale_f32, unified_dq

--- a/poc/poc_v3_decode.py
+++ b/poc/poc_v3_decode.py
@@ -1,0 +1,69 @@
+"""v3 SoA fp8 decode correctness vs bf16 oracle (monotone [swa|comp] indices)."""
+import torch
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    sparse_attn_v4_paged_decode,
+)
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_soa_v3 import (
+    sparse_attn_v4_paged_decode_soa_v3,
+)
+from poc_v3_common import quant_soa
+
+
+def _mono(T, swa_pages, C, rc, dev, seed):
+    torch.manual_seed(seed + 1)
+    tot = torch.randint(4, 48, (T,), device=dev)
+    cl = (tot.float() * rc).round().to(torch.int64).clamp(max=tot)
+    sl = tot - cl
+    indptr = torch.zeros(T + 1, dtype=torch.int32, device=dev)
+    indptr[1:] = torch.cumsum(tot, 0)
+    idx = torch.empty(int(indptr[-1]), dtype=torch.int32, device=dev)
+    off = 0
+    for t in range(T):
+        s, c = int(sl[t]), int(cl[t])
+        if s: idx[off:off+s] = torch.randint(0, swa_pages, (s,), device=dev, dtype=torch.int32)
+        if c: idx[off+s:off+s+c] = swa_pages + torch.randint(0, C, (c,), device=dev, dtype=torch.int32)
+        off += s + c
+    return idx, indptr, sl.to(torch.int32)
+
+
+def _run(*, T, H, D, swa_pages, C, seed=0, rc=0.5):
+    torch.manual_seed(seed)
+    dev = "cuda"; dt = torch.bfloat16
+    q = torch.randn(T, H, D, device=dev, dtype=dt) * 0.5
+    swa = torch.randn(swa_pages, D, device=dev, dtype=dt) * 0.5
+    comp = torch.randn(C, D, device=dev, dtype=dt) * 0.5
+    sink = torch.randn(H, device=dev, dtype=torch.float32)
+    sc = 1.0 / (D ** 0.5)
+    nope_fp8, rope_bf16, scale_f32, comp_dq = quant_soa(comp)
+    unified = torch.cat([swa, comp_dq], 0).contiguous()
+    idx, indptr, swa_len = _mono(T, swa_pages, C, rc, dev, seed)
+    ref = sparse_attn_v4_paged_decode(q, unified, idx, indptr, sink, sc)
+    got = sparse_attn_v4_paged_decode_soa_v3(
+        q, swa, nope_fp8, rope_bf16, scale_f32, idx, indptr, swa_len, sink, sc,
+        swa_pages=swa_pages,
+    )
+    d = (got.float() - ref.float()).abs()
+    ma = d.max().item(); rel = ma / (ref.float().abs().max().item() + 1e-6)
+    ok = torch.allclose(got, ref, atol=2e-2, rtol=2e-2)
+    print(f"[T={T} H={H} swa={swa_pages} C={C} rc={rc}] max_abs={ma:.3e} rel={rel:.3e} -> {'OK' if ok else 'FAIL'}")
+    return ok
+
+
+def main():
+    assert torch.cuda.is_available()
+    cases = [
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, rc=1.0),
+        dict(T=1, H=16, D=512, swa_pages=256, C=1024, rc=0.0),
+        dict(T=1, H=128, D=512, swa_pages=512, C=4096, rc=0.5),
+        dict(T=16, H=128, D=512, swa_pages=512, C=4096, rc=0.5),
+        dict(T=32, H=64, D=512, swa_pages=1024, C=8192, rc=0.7),
+    ]
+    ok = True
+    for i, c in enumerate(cases):
+        ok &= _run(seed=i, **c)
+    print("ALL OK" if ok else "SOME FAILED")
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/poc/test_atom_soa_layout.py
+++ b/poc/test_atom_soa_layout.py
@@ -1,0 +1,112 @@
+"""Prove sglang's ATOM SoA packing == aiter's expected byte layout.
+
+Pipeline:
+  bf16 [R,512] --sglang quantizer--> NopeFp8RopeBf16Pack --pack_to_atom_soa-->
+      (nope_scale[R,512]u8, rope[R,64]bf16)
+Compared against aiter's reference _native_to_2buff_for_asm(bf16) and read back
+with aiter's _quant_2buff_to_native. Runs on MI355X (gfx950, fp8_e4m3fn).
+"""
+import sys, torch
+
+torch.manual_seed(0)
+dev = "cuda"
+
+# --- sglang side ---
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+    quant_to_nope_fp8_rope_bf16_pack_triton,
+)
+from sglang.kernels.ops.attention.dsv4.atom_soa_pack import (
+    pack_to_atom_soa, atom_soa_to_bf16, store_atom_soa,
+)
+
+# --- aiter reference helpers (verbatim from op_tests/test_mla_v4_kargpreld.py) ---
+from aiter import dtypes
+_FP8_MAX = torch.finfo(dtypes.fp8).max
+_QD, _QDN, _QDR, _TILE = 512, 448, 64, 64
+
+def _cast_scale_inv_to_ue8m0(t):
+    return torch.exp2(torch.ceil(torch.log2(t)))
+
+def _native_to_2buff_for_asm(x):
+    nope = x[..., :_QDN]; rope = x[..., _QDN:].contiguous()
+    buf = torch.zeros(x.shape[:-1] + (_QD,), dtype=dtypes.fp8, device=x.device)
+    npart = buf[..., :_QDN]
+    spart = buf[..., _QDN:_QDN + 14].view(dtypes.fp8_e8m0)
+    for t in range(_QDN // _TILE):
+        s, e = t * _TILE, (t + 1) * _TILE
+        tile = nope[..., s:e]
+        sc = torch.abs(tile).max(dim=-1).values.float() / _FP8_MAX
+        sc = _cast_scale_inv_to_ue8m0(sc)
+        spart[..., 2 * t] = sc.to(dtypes.fp8_e8m0)
+        spart[..., 2 * t + 1] = sc.to(dtypes.fp8_e8m0)
+        npart[..., s:e] = (tile.float() / sc.unsqueeze(-1)).to(dtypes.fp8)
+    return buf, rope
+
+def _quant_2buff_to_native(buf, rope):
+    npart = buf[..., :_QDN]
+    spart = buf[..., _QDN:_QDN + 14].view(dtypes.fp8_e8m0)
+    out = torch.empty(buf.shape[:-1] + (_QD,), dtype=dtypes.bf16, device=buf.device)
+    for t in range(_QDN // _TILE):
+        s, e = t * _TILE, (t + 1) * _TILE
+        out[..., s:e] = npart[..., s:e].to(dtypes.bf16) * spart[..., 2 * t : 2 * t + 1].to(dtypes.bf16)
+    out[..., _QDN:] = rope
+    return out
+
+# ---------------------------------------------------------------------------
+R = 4096
+x = (torch.randn(R, 512, device=dev) * 3.0).to(torch.bfloat16)
+
+pack = quant_to_nope_fp8_rope_bf16_pack_triton(x)
+mine_ns, mine_rope = pack_to_atom_soa(pack)               # [R,512]u8, [R,64]bf16
+aiter_ns, aiter_rope = _native_to_2buff_for_asm(x)        # [R,512]fp8, [R,64]bf16
+aiter_ns_u8 = aiter_ns.view(torch.uint8)
+
+print(f"shapes: mine_ns={tuple(mine_ns.shape)}{mine_ns.dtype} "
+      f"aiter_ns={tuple(aiter_ns.shape)}{aiter_ns.dtype}")
+
+# 1) byte-exact NOPE region [0:448]
+nope_eq = (mine_ns[:, :448] == aiter_ns_u8[:, :448]).float().mean().item()
+# 2) byte-exact SCALE region [448:462] (dup)
+sc_eq = (mine_ns[:, 448:462] == aiter_ns_u8[:, 448:462]).float().mean().item()
+# 3) scale duplication correctness (even==odd)
+dup_ok = (mine_ns[:, 448:462:2] == mine_ns[:, 449:462:2]).all().item()
+# 4) pad zero
+pad_ok = (mine_ns[:, 462:512] == 0).all().item()
+# 5) rope byte-exact
+rope_eq = (mine_rope.view(torch.uint8) == aiter_rope.view(torch.uint8)).float().mean().item()
+
+print(f"[byte] nope_match={nope_eq*100:.4f}%  scale_match={sc_eq*100:.4f}%  "
+      f"rope_match={rope_eq*100:.4f}%  dup_ok={dup_ok}  pad_zero={pad_ok}")
+
+# 6) feed MY buffers into AITER's reader -> reconstruct, compare vs original
+recon_by_aiter = _quant_2buff_to_native(mine_ns.view(dtypes.fp8), mine_rope)
+recon_by_mine = atom_soa_to_bf16(mine_ns, mine_rope)
+aiter_full = _quant_2buff_to_native(aiter_ns, aiter_rope)
+
+def stats(a, b, name):
+    a = a.float(); b = b.float()
+    err = (a - b)
+    rel = err.norm() / (b.norm() + 1e-9)
+    cos = torch.nn.functional.cosine_similarity(a.flatten(), b.flatten(), dim=0)
+    print(f"[num] {name:32s} rel_l2={rel.item():.3e}  cos={cos.item():.7f}  "
+          f"max_abs={err.abs().max().item():.3e}")
+
+stats(recon_by_aiter, aiter_full, "aiter-reads-MINE vs aiter-full")   # ~0 if bytes match
+stats(recon_by_mine, aiter_full, "MINE-dequant vs aiter-full")
+stats(recon_by_aiter, x, "aiter-reads-MINE vs original(bf16)")        # fp8 quant err
+
+# 7) paged store round-trip
+page_size = 8
+num_pages = (R + page_size - 1) // page_size + 1
+ns_buf = torch.zeros(num_pages, page_size * 512, dtype=torch.uint8, device=dev)
+rp_buf = torch.zeros(num_pages, page_size * 64, dtype=torch.bfloat16, device=dev)
+loc = torch.arange(R, device=dev, dtype=torch.int64)
+store_atom_soa(ns_buf, rp_buf, loc, pack, page_size)
+ns_flat = ns_buf.view(num_pages, page_size, 512)[loc // page_size, loc % page_size]
+rp_flat = rp_buf.view(num_pages, page_size, 64)[loc // page_size, loc % page_size]
+paged_ok = (ns_flat == mine_ns).all().item() and (rp_flat.view(torch.uint8) == mine_rope.view(torch.uint8)).all().item()
+print(f"[paged] store/gather round-trip exact = {paged_ok}")
+
+ok = (nope_eq > 0.999 and sc_eq > 0.999 and rope_eq > 0.999 and dup_ok and pad_ok and paged_ok)
+print("RESULT:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)

--- a/poc/test_unified_kv_fp8_dispatch.py
+++ b/poc/test_unified_kv_fp8_dispatch.py
@@ -1,0 +1,113 @@
+"""Integration test: runtime_fp8 (aiter fp8 kernels) vs runtime (bf16 Triton/OPUS)
+golden, driven through the SAME unified_kv ragged index streams.
+
+Proves the two aiter kernels run correctly end-to-end through sglang's SoA store +
+dispatch code: decode -> mla_decode_fwd_v4_nm (#3112), prefill ->
+pa_sparse_prefill_fp8_opus (#3751). Difference vs the bf16 golden = fp8 quant noise
+only (both q and kv are fp8 in the aiter path, matching deployment).
+
+MI355X (gfx950). head_dim = 448 nope + 64 rope = 512; v_head_dim = 512.
+"""
+import sys, torch, torch.nn.functional as F
+
+torch.manual_seed(0)
+dev = "cuda"
+H, D, VD = 16, 512, 512
+
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import runtime, runtime_fp8
+
+
+def build_pool_from_bf16(src_kv):
+    """src_kv [rows,512] bf16 -> (nope_buf[rows,512]u8, rope_buf[rows,64]bf16)."""
+    ns, rp = runtime_fp8.quant_to_soa(src_kv)
+    return ns.contiguous(), rp.contiguous()
+
+
+def ragged(lengths):
+    return F.pad(torch.cumsum(lengths, 0, dtype=torch.int32), (1, 0))
+
+
+def stats(name, a, b):
+    a = a.float(); b = b.float()
+    rel = (a - b).norm() / (b.norm() + 1e-9)
+    cos = F.cosine_similarity(a.flatten(), b.flatten(), dim=0).item()
+    snr = 20 * torch.log10(b.norm() / ((a - b).norm() + 1e-9)).item()
+    print(f"[{name}] rel_l2={rel.item():.4e} cos={cos:.6f} SNR={snr:5.1f}dB "
+          f"max_abs={(a-b).abs().max().item():.3e}")
+    return cos, rel.item()
+
+
+ok = True
+
+# =========================== DECODE ===========================
+print("########## DECODE: mla_decode_fwd_v4_nm vs bf16 golden ##########")
+T = 4
+rows = 4096
+src_kv = (torch.randn(rows, D, device=dev) * 2.0).to(torch.bfloat16)
+nope_buf, rope_buf = build_pool_from_bf16(src_kv)
+
+q = (torch.randn(T, H, D, device=dev) * 1.5).to(torch.bfloat16)
+sink = (torch.randn(H, device=dev) * 0.1).to(torch.float32)
+scale = D ** -0.5
+
+# each token attends to a distinct ragged set of unified rows
+lens = torch.tensor([128, 256, 192, 64], device=dev, dtype=torch.int32)[:T]
+kv_indptr = ragged(lens)
+kv_indices = torch.cat([
+    torch.randint(0, rows, (int(l),), device=dev, dtype=torch.int32) for l in lens
+])
+
+out_fp8 = runtime_fp8.decode(
+    q=q, nope_buf=nope_buf, rope_buf=rope_buf,
+    kv_indices=kv_indices, kv_indptr=kv_indptr,
+    attn_sink=sink, softmax_scale=scale,
+)
+out_bf16 = runtime.decode(
+    q=q, unified_kv=src_kv,
+    kv_indices=kv_indices, kv_indptr=kv_indptr,
+    attn_sink=sink, softmax_scale=scale,
+)
+print(f"shapes: fp8={tuple(out_fp8.shape)} bf16={tuple(out_bf16.shape)}")
+c, r = stats("decode", out_fp8, out_bf16)
+ok = ok and (c > 0.99 and r < 0.08)
+
+# =========================== PREFILL ===========================
+print("########## PREFILL: pa_sparse_prefill_fp8_opus vs bf16 golden ##########")
+Tp = 4
+src_pref = (torch.randn(rows, D, device=dev) * 2.0).to(torch.bfloat16)
+nope_p, rope_p = build_pool_from_bf16(src_pref)
+qp = (torch.randn(Tp, H, D, device=dev) * 1.5).to(torch.bfloat16)
+
+# prefix (paged) region
+plen = torch.tensor([128, 64, 192, 128], device=dev, dtype=torch.int32)[:Tp]
+pidptr = ragged(plen)
+pidx = torch.cat([
+    torch.randint(0, rows, (int(l),), device=dev, dtype=torch.int32) for l in plen
+])
+# extend region (this fwd's fresh K)
+ext_tokens = 64
+kv_ext = (torch.randn(ext_tokens, D, device=dev) * 2.0).to(torch.bfloat16)
+elen = torch.tensor([16, 16, 16, 16], device=dev, dtype=torch.int32)[:Tp]
+eidptr = ragged(elen)
+eidx = torch.cat([
+    torch.randint(0, ext_tokens, (int(l),), device=dev, dtype=torch.int32) for l in elen
+])
+
+out_pf8 = runtime_fp8.prefill(
+    q=qp, nope_buf=nope_p, rope_buf=rope_p,
+    kv_indices_prefix=pidx, kv_indptr_prefix=pidptr,
+    kv_extend=kv_ext, kv_indices_extend=eidx, kv_indptr_extend=eidptr,
+    attn_sink=sink, softmax_scale=scale,
+)
+out_pbf = runtime.prefill(
+    q=qp, unified_kv=src_pref,
+    kv_indices_prefix=pidx, kv_indptr_prefix=pidptr,
+    kv_extend=kv_ext, kv_indices_extend=eidx, kv_indptr_extend=eidptr,
+    attn_sink=sink, softmax_scale=scale,
+)
+print(f"shapes: fp8={tuple(out_pf8.shape)} bf16={tuple(out_pbf.shape)}")
+c2, r2 = stats("prefill", out_pf8, out_pbf)
+ok = ok and (c2 > 0.99 and r2 < 0.08)
+
+print("RESULT:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)

--- a/poc/test_unified_kv_fp8_pool.py
+++ b/poc/test_unified_kv_fp8_pool.py
@@ -1,0 +1,111 @@
+"""Assembled-path smoke test: construct DeepSeekV4UnifiedKVPoolFp8 through the real
+sglang package, drive SWA + compressed stores into its two fp8 buffers, then run
+the aiter decode/prefill dispatch reading straight from the pool buffers.
+
+Validates: env gate (unified_kv_aiter), fp8 pool class + accessors, runtime_fp8
+store scatter into pool buffers, and both aiter kernels consuming them. Requires
+gfx950 + aiter. Import-checks the backend/compressor modules too.
+"""
+import os, sys, torch, torch.nn.functional as F
+
+os.environ["SGLANG_HACK_FLASHMLA_BACKEND"] = "unified_kv_aiter"
+torch.manual_seed(0)
+dev = "cuda"
+
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+    is_unified_kv_aiter, is_unified_kv_triton,
+)
+assert is_unified_kv_aiter() and is_unified_kv_triton(), "gate mismatch"
+print("gate: unified_kv_aiter=True unified_kv_triton=True  OK")
+
+# import-check the wired backend + compressor modules (catches syntax/name errors)
+import importlib
+importlib.import_module("sglang.srt.layers.attention.dsv4.compressor_v2")
+print("compressor_v2 import OK")
+
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4UnifiedKVPoolFp8
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import runtime_fp8
+
+
+class _NullSaver:
+    from contextlib import contextmanager
+    @contextmanager
+    def region(self, *a, **k):
+        yield
+
+
+# small pool: c128 ratio, 2 layers
+num_slots, swa_ring = 8, 128
+pool = DeepSeekV4UnifiedKVPoolFp8(
+    stage_ratios=[128, 128],
+    num_slots=num_slots,
+    num_blocks=64,
+    page_size=128,
+    qk_nope_head_dim=448,
+    qk_rope_head_dim=64,
+    device=dev,
+    memory_saver_adapter=_NullSaver(),
+    custom_mem_pool=None,
+    swa_ring_size=swa_ring,
+)
+nope = pool.get_unified_kv_nope(0)
+rope = pool.get_unified_kv_rope(0)
+print(f"pool nope={tuple(nope.shape)}{nope.dtype} rope={tuple(rope.shape)}{rope.dtype} "
+      f"swa_pages={pool.swa_pages}")
+assert nope.dtype == torch.float8_e4m3fn and rope.dtype == torch.bfloat16
+assert nope.shape[1] == 512 and rope.shape[1] == 64
+
+nope_u8 = pool.nope_scale_buffer[0]
+rope_b = pool.rope_buffer[0]
+
+# ---- SWA store into ring rows ----
+T = 4
+kv = (torch.randn(T, 512, device=dev) * 2).to(torch.bfloat16)
+state_slot = torch.arange(T, device=dev, dtype=torch.int32)
+positions = torch.tensor([10, 20, 30, 40], device=dev, dtype=torch.int32)
+runtime_fp8.store_swa_into_unified_fp8(
+    kv=kv, state_slot=state_slot, positions=positions,
+    nope_buf=nope_u8, rope_buf=rope_b, win=swa_ring, ring_stride=swa_ring,
+    final_pos=positions,
+)
+# verify round-trip of a stored row
+from sglang.kernels.ops.attention.dsv4.atom_soa_pack import atom_soa_to_bf16
+loc0 = int(state_slot[0]) * swa_ring + int(positions[0]) % swa_ring
+deq = atom_soa_to_bf16(nope_u8[loc0:loc0+1], rope_b[loc0:loc0+1])[0]
+cos_swa = F.cosine_similarity(deq.float(), kv[0].float(), dim=0).item()
+print(f"SWA store round-trip cos={cos_swa:.5f}")
+assert cos_swa > 0.99
+
+# ---- compressed store into compressed rows ----
+M = 6
+kvc = (torch.randn(M, 512, device=dev) * 2).to(torch.bfloat16)
+out_loc = (pool.swa_pages + torch.arange(M, device=dev, dtype=torch.int32))
+runtime_fp8.store_compress_into_unified_fp8(
+    kv_compressed=kvc, out_loc=out_loc, nope_buf=nope_u8, rope_buf=rope_b,
+)
+deqc = atom_soa_to_bf16(nope_u8[int(out_loc[1]):int(out_loc[1])+1],
+                        rope_b[int(out_loc[1]):int(out_loc[1])+1])[0]
+cos_c = F.cosine_similarity(deqc.float(), kvc[1].float(), dim=0).item()
+print(f"compress store round-trip cos={cos_c:.5f}")
+assert cos_c > 0.99
+
+# ---- decode reading straight from pool buffers ----
+H = 16
+q = (torch.randn(T, H, 512, device=dev) * 1.5).to(torch.bfloat16)
+sink = (torch.randn(H, device=dev) * 0.1).to(torch.float32)
+lens = torch.tensor([2, 3, 1, 2], device=dev, dtype=torch.int32)
+kv_indptr = F.pad(torch.cumsum(lens, 0, dtype=torch.int32), (1, 0))
+# indices reference the rows we actually wrote (swa ring slot0 + compressed rows)
+wrote = torch.cat([torch.tensor([loc0], device=dev),
+                   out_loc.to(torch.int64)]).to(torch.int32)
+kv_indices = wrote[torch.randint(0, wrote.numel(), (int(lens.sum()),), device=dev)]
+out = runtime_fp8.decode(
+    q=q, nope_buf=nope, rope_buf=rope,
+    kv_indices=kv_indices, kv_indptr=kv_indptr,
+    attn_sink=sink, softmax_scale=512 ** -0.5,
+)
+print(f"decode out={tuple(out.shape)}{out.dtype} finite={torch.isfinite(out).all().item()}")
+assert out.shape == (T, H, 512) and torch.isfinite(out).all()
+
+print("RESULT: PASS")
+sys.exit(0)

--- a/python/sglang/kernels/ops/attention/dsv4/atom_soa_pack.py
+++ b/python/sglang/kernels/ops/attention/dsv4/atom_soa_pack.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+# ATOM-compatible SoA packing for DeepSeek-V4 fp8 unified/compressed KV.
+#
+# aiter's fp8 decode (mla_decode_fwd_v4_nm, #3112) and fp8 prefill
+# (pa_sparse_prefill_fp8_opus, #3751) read a two-buffer SoA layout:
+#
+#   nope_scale_buf : per (token) 512 bytes fp8 =
+#                      [ nope 448 fp8 | e8m0 scale 14 (each of 7 tile-scales x2)
+#                        | pad 50 ]
+#   rope_buf       : per (token) 64  bf16 (separate tensor, NOT quantized)
+#
+# sglang already produces `NopeFp8RopeBf16Pack` (k_nope_fp8[.,448] fp8,
+# k_rope_bf16[.,64] bf16, scale_k_nope_ue8m0[.,7] uint8 e8m0=exp+127) with the
+# identical fp8 numerics (FP8_MAX=448, 1x64 block, pow2 e8m0). The ONLY delta to
+# feed aiter is the byte LAYOUT: duplicate each of the 7 scales into 14 inline
+# bytes at [448:462] of a 512-wide nope block, and keep rope as its own tensor.
+#
+# The scale duplication is mandatory: the v4 nm asm shader reads each 64-tile
+# scale TWICE consecutively (s0,s0,s1,s1,...,s6,s6); a 32-block prefill reader
+# sees consistent pairs -> the SAME single cache feeds BOTH kernels (no double
+# storage). This module is layout-only; it performs NO re-quantization.
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.index_buf_accessor import (
+    NopeFp8RopeBf16Pack,
+    fp8_dtype,
+)
+
+DIM_NOPE = 448
+DIM_ROPE = 64
+N_TILE = 7          # 448 / 64
+N_SCALE_DUP = 14    # 2 * N_TILE
+NOPE_BLOCK = 512    # 448 nope + 14 scale + 50 pad
+
+
+def _validate(pack: NopeFp8RopeBf16Pack) -> None:
+    assert pack.k_nope_fp8.shape[-1] == DIM_NOPE
+    assert pack.k_rope_bf16.shape[-1] == DIM_ROPE
+    assert pack.scale_k_nope_ue8m0.shape[-1] == N_TILE
+    assert pack.k_nope_fp8.dtype == fp8_dtype
+    assert pack.k_rope_bf16.dtype == torch.bfloat16
+    assert pack.scale_k_nope_ue8m0.dtype == torch.uint8
+
+
+def pack_to_atom_soa(pack: NopeFp8RopeBf16Pack):
+    """Dense layout transform: NopeFp8RopeBf16Pack -> aiter two-buffer SoA.
+
+    Returns
+        nope_scale_buf : [R, 512] uint8  (view as fp8_e4m3 for the kernel)
+        rope_buf       : [R, 64]  bf16   (separate tensor)
+    No re-quantization; only re-arranges the bytes aiter's readers expect.
+    """
+    _validate(pack)
+    nope = pack.k_nope_fp8
+    rope = pack.k_rope_bf16
+    scale = pack.scale_k_nope_ue8m0  # [R, 7] uint8
+    R = nope.shape[0]
+    dev = nope.device
+
+    nope_scale_buf = torch.zeros(R, NOPE_BLOCK, dtype=torch.uint8, device=dev)
+    # [0:448) nope fp8 bytes
+    nope_scale_buf[:, :DIM_NOPE] = nope.view(torch.uint8)
+    # [448:462) 14 scale bytes = each tile-scale duplicated (s0,s0,...,s6,s6)
+    nope_scale_buf[:, DIM_NOPE : DIM_NOPE + N_SCALE_DUP : 2] = scale
+    nope_scale_buf[:, DIM_NOPE + 1 : DIM_NOPE + N_SCALE_DUP : 2] = scale
+    # [462:512) pad stays zero (asm reader never reads it)
+    rope_buf = rope.contiguous()
+    return nope_scale_buf, rope_buf
+
+
+def atom_soa_to_bf16(nope_scale_buf: torch.Tensor, rope_buf: torch.Tensor):
+    """Inverse (reference dequant): read the aiter SoA back to bf16 [R, 512].
+    Reads only the first byte of each duplicated scale pair. Mirrors aiter's
+    _quant_2buff_to_native."""
+    R = nope_scale_buf.shape[0]
+    dev = nope_scale_buf.device
+    nope_fp8 = nope_scale_buf[:, :DIM_NOPE].view(fp8_dtype)
+    scale_e8m0 = nope_scale_buf[:, DIM_NOPE : DIM_NOPE + N_SCALE_DUP : 2].to(torch.int32)
+    # e8m0 byte b -> 2^(b-127)
+    scale_f32 = torch.exp2((scale_e8m0 - 127).float())  # [R, 7]
+    out = torch.empty(R, DIM_NOPE + DIM_ROPE, dtype=torch.bfloat16, device=dev)
+    nope_f = nope_fp8.to(torch.float32).view(R, N_TILE, 64)
+    deq = (nope_f * scale_f32.unsqueeze(-1)).view(R, DIM_NOPE)
+    out[:, :DIM_NOPE] = deq.to(torch.bfloat16)
+    out[:, DIM_NOPE:] = rope_buf
+    return out
+
+
+def store_atom_soa(
+    nope_scale_buf: torch.Tensor,  # [num_pages, page_size * 512] uint8
+    rope_buf: torch.Tensor,        # [num_pages, page_size * 64]  bf16
+    loc: torch.Tensor,             # [num_tokens] int
+    pack: NopeFp8RopeBf16Pack,
+    page_size: int,
+) -> None:
+    """Paged scatter of a token pack into the aiter SoA buffers (torch ref).
+    Slot ``loc`` -> page ``loc // page_size``, offset ``loc % page_size``.
+    A Triton port can replace this for production throughput."""
+    _validate(pack)
+    dense_nope_scale, dense_rope = pack_to_atom_soa(pack)  # [T,512]u8, [T,64]bf16
+    page = (loc // page_size).long()
+    off = (loc % page_size).long()
+    ns_view = nope_scale_buf.view(nope_scale_buf.shape[0], page_size, NOPE_BLOCK)
+    rp_view = rope_buf.view(rope_buf.shape[0], page_size, DIM_ROPE)
+    ns_view[page, off] = dense_nope_scale
+    rp_view[page, off] = dense_rope

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/env_gate.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/env_gate.py
@@ -7,6 +7,23 @@ from sglang.srt.utils import is_hip
 
 
 @functools.lru_cache(maxsize=1)
+def is_unified_kv_aiter() -> bool:
+    """FP8 SoA unified_kv path driving aiter's mla_decode_fwd_v4_nm (#3112) and
+    pa_sparse_prefill_fp8_opus (#3751). Shares ALL of the unified_kv metadata /
+    radix plumbing (so ``is_unified_kv_triton`` also returns True), but swaps the
+    single bf16 unified buffer for a two-buffer fp8-nope + bf16-rope SoA store and
+    dispatches the aiter fp8 kernels instead of the vendored Triton ones."""
+    return (
+        is_hip() and envs.SGLANG_HACK_FLASHMLA_BACKEND.get() == "unified_kv_aiter"
+    )
+
+
+@functools.lru_cache(maxsize=1)
 def is_unified_kv_triton() -> bool:
-    # unified_kv_triton is only implemented on HIP (ROCm)
-    return is_hip() and envs.SGLANG_HACK_FLASHMLA_BACKEND.get() == "unified_kv_triton"
+    # unified_kv is only implemented on HIP (ROCm). Both the Triton (bf16) and the
+    # aiter (fp8 SoA) variants use the same unified_kv metadata/radix plumbing, so
+    # this gate is True for either; is_unified_kv_aiter() selects the fp8 kernels.
+    return is_hip() and envs.SGLANG_HACK_FLASHMLA_BACKEND.get() in (
+        "unified_kv_triton",
+        "unified_kv_aiter",
+    )

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_soa_v3.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_soa_v3.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: MIT
+# Stage-3 PoC v3: SoA fp8 unified_kv decode with COMPACT scale load.
+#
+# Diagnostic finding (MI355X, jobs 27646/27653): both the packed-AoS dequant AND
+# the existing "tuned" clean-SoA QUANT_KV path are 1.3-13x SLOWER than the bf16
+# baseline at large batch/context, despite reading fewer bytes. Root cause: the
+# fp8 decode is COMPUTE/ISSUE bound, dominated by the per-tile 512-wide scale
+# BROADCAST load (only D/GROUP=8 distinct scales per token, read 512-wide -> 64x
+# over-read) plus fp8->f32 casts.
+#
+# v3 fixes the scale traffic: scales are loaded COMPACT as [BLOCK_K, 8] (fp32,
+# pre-exponentiated at store so no in-kernel exp2) and broadcast to [BLOCK_K,512]
+# IN REGISTERS. RoPE stays bf16 (phase-1 requirement) in its own contiguous
+# buffer. Layout (Structure-of-Arrays, all coalesced):
+#     nope_fp8  : [C, 448]  fp8    (7 groups x 64, 1x64 block scale)
+#     rope_bf16 : [C,  64]  bf16   (kept exactly bf16)
+#     scale_f32 : [C,   8]  fp32   (7 real group scales + 1 pad=1.0)
+#
+# Two-segment single-source (SWA bf16 | compressed SoA-fp8), one online-softmax
+# accumulator; each tile issues exactly one source's loads.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode import (
+    _paged_decode_reduce_kernel,
+    _kv_splits_heuristic,
+    _cu_count,
+)
+
+LOG2E = 1.4426950408889634
+_FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+_DIM_NOPE = 448
+_DIM_ROPE = 64
+_GROUP = 64
+_NUM_G = _DIM_NOPE // _GROUP  # 7
+_NUM_G_PAD = 8
+
+
+@triton.jit
+def _decode_soa_v3_kernel(
+    q_ptr,  # [N,H,D]
+    swa_ptr,  # [swa_pages, D] bf16
+    nope_ptr,  # [C, 448] fp8
+    rope_ptr,  # [C, 64] bf16
+    scale_ptr,  # [C, 8] fp32
+    kv_indices_ptr,  # [tot] int32
+    kv_indptr_ptr,  # [N+1] int32
+    swa_len_ptr,  # [N] int32
+    attn_sink_ptr,  # [H] fp32
+    out_ptr,  # [N,H,D]
+    q_st, q_sh, q_sd,
+    swa_sn, swa_sd,
+    nope_sn, rope_sn, scale_sn,
+    o_st, o_sh, o_sd,
+    qk_scale, log2e, swa_pages,
+    H: tl.constexpr, D: tl.constexpr,
+    BLOCK_H: tl.constexpr, BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr, BLOCK_KC: tl.constexpr,
+    DIM_NOPE: tl.constexpr, DIM_ROPE: tl.constexpr,
+    GROUP: tl.constexpr, NUM_G_PAD: tl.constexpr,
+    NS_A: tl.constexpr, NS_C: tl.constexpr,
+):
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+
+    q = tl.load(
+        q_ptr + t * q_st + h_offs[:, None] * q_sh + d_offs[None, :] * q_sd,
+        mask=h_mask[:, None] & d_mask[None, :], other=0.0,
+    )
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+    swa_len = tl.load(swa_len_ptr + t)
+    swa_len = tl.minimum(tl.maximum(swa_len, 0), kv_len)
+
+    neg = -3.4028234663852886e38
+    m_i = tl.full((BLOCK_H,), neg, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+
+    # ---- LOOP A: SWA bf16 ----
+    k_offs = tl.arange(0, BLOCK_K)
+    na = tl.cdiv(swa_len, BLOCK_K)
+    for j in tl.range(0, na, num_stages=NS_A):
+        k_pos = j * BLOCK_K + k_offs
+        valid = k_pos < swa_len
+        slot = tl.load(kv_indices_ptr + kv_start + k_pos, mask=valid, other=0)
+        kv = tl.load(
+            swa_ptr + slot[:, None] * swa_sn + d_offs[None, :] * swa_sd,
+            mask=valid[:, None] & d_mask[None, :], other=0.0,
+        )
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg)
+        m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    # ---- LOOP B: compressed SoA fp8 ----
+    kc_offs = tl.arange(0, BLOCK_KC)
+    g_of_d = d_offs // GROUP  # [BLOCK_D] group index per column (0..7)
+    nope_mask = d_offs < DIM_NOPE
+    rope_mask = (d_offs >= DIM_NOPE) & (d_offs < DIM_NOPE + DIM_ROPE)
+    g_cols = tl.arange(0, NUM_G_PAD)  # 0..7
+    comp_len = kv_len - swa_len
+    nb = tl.cdiv(comp_len, BLOCK_KC)
+    for j in tl.range(0, nb, num_stages=NS_C):
+        k_pos = j * BLOCK_KC + kc_offs
+        valid = k_pos < comp_len
+        slot = tl.load(
+            kv_indices_ptr + kv_start + swa_len + k_pos, mask=valid, other=swa_pages
+        )
+        loc = slot - swa_pages  # compressed row id
+
+        # --- dequant DIRECT to q.dtype (bf16); no f32 intermediate ---
+        # fp8_e4m3 -> bf16 is exact (3 mantissa bits fit in bf16's 7). scale is a
+        # pure power-of-two (ue8m0, pre-exponentiated), exactly representable in
+        # bf16, so bf16*bf16 here is a lossless exponent shift == f32-then-round.
+        # Materializing bf16 (not f32) halves VGPR pressure -> higher occupancy
+        # -> better latency hiding for the fp8 loads.
+        nope_q = tl.load(
+            nope_ptr + loc[:, None] * nope_sn + d_offs[None, :],
+            mask=valid[:, None] & nope_mask[None, :], other=0.0,
+        ).to(q.dtype)
+        # COMPACT scale load [BLOCK_KC, 8], broadcast in REGISTERS.
+        scale8 = tl.load(
+            scale_ptr + loc[:, None] * scale_sn + g_cols[None, :],
+            mask=valid[:, None], other=1.0,
+        ).to(q.dtype)  # [BLOCK_KC, 8], pow2 -> exact in bf16
+        nope3 = tl.reshape(nope_q, (BLOCK_KC, NUM_G_PAD, GROUP))
+        nope3 = nope3 * scale8[:, :, None]
+        nope_deq = tl.reshape(nope3, (BLOCK_KC, BLOCK_D))
+        # rope bf16 [BLOCK_KC, 64] placed at d in [DIM_NOPE, DIM_NOPE+DIM_ROPE)
+        rope_val = tl.load(
+            rope_ptr + loc[:, None] * rope_sn + (d_offs[None, :] - DIM_NOPE),
+            mask=valid[:, None] & rope_mask[None, :], other=0.0,
+        ).to(q.dtype)
+        kv = tl.where(nope_mask[None, :], nope_deq, rope_val)
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg)
+        m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg).to(tl.float32)
+    sink = sink_raw * log2e
+    m_final = tl.maximum(m_i, sink)
+    alpha_kv = tl.exp2(m_i - m_final)
+    alpha_sink = tl.exp2(sink - m_final)
+    l_final = l_i * alpha_kv + alpha_sink
+    denom = tl.maximum(l_final, 1.0e-30)
+    out = tl.where(l_final[:, None] > 0.0, (acc * alpha_kv[:, None]) / denom[:, None], 0.0)
+    tl.store(
+        out_ptr + t * o_st + h_offs[:, None] * o_sh + d_offs[None, :] * o_sd,
+        out.to(out_ptr.dtype.element_ty),
+        mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+@triton.jit
+def _decode_soa_v3_split_kernel(
+    q_ptr, swa_ptr, nope_ptr, rope_ptr, scale_ptr,
+    kv_indices_ptr, kv_indptr_ptr, swa_len_ptr,
+    m_partial_ptr, l_partial_ptr, acc_partial_ptr,
+    q_st, q_sh, q_sd,
+    swa_sn, swa_sd,
+    nope_sn, rope_sn, scale_sn,
+    mp_st, mp_sk, mp_sh,
+    lp_st, lp_sk, lp_sh,
+    ap_st, ap_sk, ap_sh, ap_sd,
+    qk_scale, swa_pages,
+    H: tl.constexpr, D: tl.constexpr, KV_SPLITS: tl.constexpr,
+    BLOCK_H: tl.constexpr, BLOCK_D: tl.constexpr, BLOCK_K: tl.constexpr,
+    DIM_NOPE: tl.constexpr, DIM_ROPE: tl.constexpr,
+    GROUP: tl.constexpr, NUM_G_PAD: tl.constexpr,
+    NS_A: tl.constexpr, NS_C: tl.constexpr,
+):
+    """Split-K variant. Partitions the WHOLE [0,kv_len) stream identically to
+    the baseline _paged_decode_split_kernel so the shared reduce kernel's
+    tiles_per_segment / act_num_segments masking stays consistent. Within a
+    segment, the swa (bf16) and compressed (SoA fp8) portions are processed in
+    two single-source sub-loops sharing one online-softmax state, emitting
+    pre-sink (m,l,acc) partials."""
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_k = tl.program_id(2)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+    q = tl.load(
+        q_ptr + t * q_st + h_offs[:, None] * q_sh + d_offs[None, :] * q_sd,
+        mask=h_mask[:, None] & d_mask[None, :], other=0.0,
+    )
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+    swa_len = tl.load(swa_len_ptr + t)
+    swa_len = tl.minimum(tl.maximum(swa_len, 0), kv_len)
+
+    tiles_per_segment = tl.cdiv(kv_len, KV_SPLITS * BLOCK_K)
+    seg_lo = pid_k * tiles_per_segment * BLOCK_K
+    if seg_lo >= kv_len:
+        return
+    seg_hi = tl.minimum((pid_k + 1) * tiles_per_segment * BLOCK_K, kv_len)
+
+    neg = -3.4028234663852886e38
+    m_i = tl.full((BLOCK_H,), neg, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+    k_offs = tl.arange(0, BLOCK_K)
+
+    # ---- SWA sub-range within this segment (tl.range -> software-pipelined) ----
+    swa_lo = seg_lo
+    swa_hi = tl.minimum(seg_hi, swa_len)
+    na = tl.cdiv(swa_hi - swa_lo, BLOCK_K)  # 0 when this segment has no swa
+    for jj in tl.range(0, na, num_stages=NS_A):
+        k_pos = swa_lo + jj * BLOCK_K + k_offs
+        valid = k_pos < swa_hi
+        slot = tl.load(kv_indices_ptr + kv_start + k_pos, mask=valid, other=0)
+        kv = tl.load(
+            swa_ptr + slot[:, None] * swa_sn + d_offs[None, :] * swa_sd,
+            mask=valid[:, None] & d_mask[None, :], other=0.0,
+        )
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg)
+        m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    # ---- compressed sub-range within this segment (tl.range -> pipelined) ----
+    comp_lo = tl.maximum(seg_lo, swa_len)
+    comp_hi = seg_hi
+    g_cols = tl.arange(0, NUM_G_PAD)
+    nope_mask = d_offs < DIM_NOPE
+    rope_mask = (d_offs >= DIM_NOPE) & (d_offs < DIM_NOPE + DIM_ROPE)
+    nb = tl.cdiv(comp_hi - comp_lo, BLOCK_K)  # 0 when this segment has no compressed
+    for jj in tl.range(0, nb, num_stages=NS_C):
+        k_pos = comp_lo + jj * BLOCK_K + k_offs
+        valid = k_pos < comp_hi
+        slot = tl.load(
+            kv_indices_ptr + kv_start + k_pos, mask=valid, other=swa_pages
+        )
+        loc = slot - swa_pages
+        # dequant DIRECT to q.dtype (bf16); no f32 intermediate (see fused kernel).
+        nope_q = tl.load(
+            nope_ptr + loc[:, None] * nope_sn + d_offs[None, :],
+            mask=valid[:, None] & nope_mask[None, :], other=0.0,
+        ).to(q.dtype)
+        scale8 = tl.load(
+            scale_ptr + loc[:, None] * scale_sn + g_cols[None, :],
+            mask=valid[:, None], other=1.0,
+        ).to(q.dtype)
+        nope3 = tl.reshape(nope_q, (BLOCK_K, NUM_G_PAD, GROUP))
+        nope3 = nope3 * scale8[:, :, None]
+        nope_deq = tl.reshape(nope3, (BLOCK_K, BLOCK_D))
+        rope_val = tl.load(
+            rope_ptr + loc[:, None] * rope_sn + (d_offs[None, :] - DIM_NOPE),
+            mask=valid[:, None] & rope_mask[None, :], other=0.0,
+        ).to(q.dtype)
+        kv = tl.where(nope_mask[None, :], nope_deq, rope_val)
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg)
+        m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    m_base = t * mp_st + pid_k * mp_sk
+    tl.store(m_partial_ptr + m_base + h_offs * mp_sh, m_i, mask=h_mask)
+    l_base = t * lp_st + pid_k * lp_sk
+    tl.store(l_partial_ptr + l_base + h_offs * lp_sh, l_i, mask=h_mask)
+    a_base = t * ap_st + pid_k * ap_sk
+    tl.store(
+        acc_partial_ptr + a_base + h_offs[:, None] * ap_sh + d_offs[None, :] * ap_sd,
+        acc, mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+def sparse_attn_v4_paged_decode_soa_v3(
+    q, swa_kv, nope_fp8, rope_bf16, scale_f32,
+    kv_indices, kv_indptr, swa_len, attn_sink, softmax_scale,
+    swa_pages, block_h=None, block_k=None, block_kc=None, kv_splits=None,
+    ns_a=3, ns_c=3,
+):
+    assert q.is_cuda and q.dtype in (torch.bfloat16, torch.float16)
+    assert swa_kv.dtype == q.dtype
+    assert nope_fp8.dtype == _FP8_DTYPE and nope_fp8.is_contiguous()
+    assert rope_bf16.dtype == torch.bfloat16 and rope_bf16.is_contiguous()
+    assert scale_f32.dtype == torch.float32 and scale_f32.is_contiguous()
+    T, H, D = q.shape
+    swa_len = swa_len.to(torch.int32)
+    out = torch.empty_like(q)
+    if block_h is None:
+        block_h = triton.next_power_of_2(min(H, 64))
+    block_h = max(triton.next_power_of_2(block_h), 16)
+    block_d = triton.next_power_of_2(D)
+    if block_k is None:
+        block_k = 16  # measured optimum (job 27984): narrow tile keeps VGPR low
+    if block_kc is None:
+        block_kc = 16
+    n_hb = (H + block_h - 1) // block_h
+    h_padded = n_hb * block_h
+    qk_scale = float(softmax_scale) * LOG2E
+    nw = 4 if block_h <= 32 else 8
+
+    if kv_splits is None:
+        kv_splits = _kv_splits_heuristic(T, H, block_h)
+
+    # -------- fused single-pass (grid already saturates GPU) --------
+    if kv_splits == 1:
+        grid = (T, n_hb)
+        _decode_soa_v3_kernel[grid](
+            q, swa_kv, nope_fp8, rope_bf16, scale_f32,
+            kv_indices, kv_indptr, swa_len, attn_sink, out,
+            q.stride(0), q.stride(1), q.stride(2),
+            swa_kv.stride(0), swa_kv.stride(1),
+            nope_fp8.stride(0), rope_bf16.stride(0), scale_f32.stride(0),
+            out.stride(0), out.stride(1), out.stride(2),
+            qk_scale, LOG2E, swa_pages,
+            H=H, D=D, BLOCK_H=block_h, BLOCK_D=block_d,
+            BLOCK_K=block_k, BLOCK_KC=block_kc,
+            DIM_NOPE=_DIM_NOPE, DIM_ROPE=_DIM_ROPE,
+            GROUP=_GROUP, NUM_G_PAD=_NUM_G_PAD,
+            NS_A=ns_a, NS_C=ns_c,
+            num_warps=nw, num_stages=1,
+        )
+        return out
+
+    # -------- split-K: v3 split kernel writes partials, reuse baseline reduce --------
+    # split path uses a single BLOCK_K for the whole stream partitioning so the
+    # reduce's tiles_per_segment / act_num_segments math stays consistent.
+    bk = block_k
+    m_partial = torch.empty((T, kv_splits, h_padded), dtype=torch.float32, device=q.device)
+    l_partial = torch.empty_like(m_partial)
+    acc_partial = torch.empty((T, kv_splits, h_padded, D), dtype=torch.float32, device=q.device)
+    grid_split = (T, n_hb, kv_splits)
+    _decode_soa_v3_split_kernel[grid_split](
+        q, swa_kv, nope_fp8, rope_bf16, scale_f32,
+        kv_indices, kv_indptr, swa_len,
+        m_partial, l_partial, acc_partial,
+        q.stride(0), q.stride(1), q.stride(2),
+        swa_kv.stride(0), swa_kv.stride(1),
+        nope_fp8.stride(0), rope_bf16.stride(0), scale_f32.stride(0),
+        m_partial.stride(0), m_partial.stride(1), m_partial.stride(2),
+        l_partial.stride(0), l_partial.stride(1), l_partial.stride(2),
+        acc_partial.stride(0), acc_partial.stride(1), acc_partial.stride(2), acc_partial.stride(3),
+        qk_scale, swa_pages,
+        H=H, D=D, KV_SPLITS=kv_splits,
+        BLOCK_H=block_h, BLOCK_D=block_d, BLOCK_K=bk,
+        DIM_NOPE=_DIM_NOPE, DIM_ROPE=_DIM_ROPE,
+        GROUP=_GROUP, NUM_G_PAD=_NUM_G_PAD,
+        NS_A=ns_a, NS_C=ns_c,
+        num_warps=nw, num_stages=1,
+    )
+
+    base_grid_t_h = T * H
+    target_reduce_wg = 2 * _cu_count()
+    if base_grid_t_h >= target_reduce_wg:
+        d_chunk = block_d
+    else:
+        d_chunks_needed = max(1, target_reduce_wg // base_grid_t_h)
+        d_chunks_needed = min(d_chunks_needed, block_d // 32)
+        d_chunk = max(32, triton.next_power_of_2(block_d // d_chunks_needed))
+    grid_reduce = (T, H, (D + d_chunk - 1) // d_chunk)
+    _paged_decode_reduce_kernel[grid_reduce](
+        m_partial, l_partial, acc_partial, attn_sink, kv_indptr, out,
+        m_partial.stride(0), m_partial.stride(1), m_partial.stride(2),
+        l_partial.stride(0), l_partial.stride(1), l_partial.stride(2),
+        acc_partial.stride(0), acc_partial.stride(1), acc_partial.stride(2), acc_partial.stride(3),
+        out.stride(0), out.stride(1), out.stride(2),
+        LOG2E, H, D, kv_splits,
+        BLOCK_D=block_d, D_CHUNK=d_chunk, BLOCK_K=bk, num_warps=4,
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_split_src.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_split_src.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: MIT
+# Stage-3 PoC: split-source unified_kv decode.
+#
+# "Logical unified, physical split": one logical unified_kv slot space, backed by
+# TWO physical buffers of different dtype/layout:
+#
+#   swa_kv     : [swa_pages, D]                    bf16   (1024 B/row for D=512)
+#   packed_kv  : [num_pages, bytes_per_page]       uint8  (mixed packed, 584 B/row)
+#                per-token: 448 fp8 nope + 64 bf16 rope (=576 B) + 7 ue8m0 scale (+1 pad)
+#                per-page : [P tokens nope+rope (P*576)] [P tokens scale (P*8)] padded
+#
+# Slot dispatch (matches runtime.py index contract):
+#   slot <  swa_pages  -> SWA ring entry   -> read swa_kv[slot]        (bf16)
+#   slot >= swa_pages  -> compressed entry -> read packed_kv[slot-swa_pages]
+#                                             (fp8 nope * exp2(scale-127) ++ bf16 rope)
+#
+# The dequant addressing is copied verbatim from dsv4.dequant_k_cache so the
+# in-kernel dequant is bit-identical to the production non-unified reader.
+#
+# This PoC implements ONLY the single-pass fused path (kv_splits == 1). The
+# split-K path is a mechanical copy of the same KV-load block into
+# paged_decode._paged_decode_split_kernel; deferred to the production patch.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+
+LOG2E = 1.4426950408889634
+_FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+# Packed layout constants (must match dsv4.dequant_k_cache).
+_DIM_NOPE = 448
+_DIM_ROPE = 64
+_TILE_SIZE = 64
+_NUM_SCALE_TILES = _DIM_NOPE // _TILE_SIZE  # 7
+_NOPE_ROPE_BYTES = _DIM_NOPE + _DIM_ROPE * 2  # 576
+_PADDED_SCALE_PER_TOKEN = _NUM_SCALE_TILES + 1  # 8
+
+
+@triton.jit
+def _paged_decode_fused_split_src_kernel(
+    q_ptr,  # [N, H, D] bf16/fp16
+    swa_ptr,  # [swa_pages, D] bf16  (same dtype as q)
+    pk_fp8_ptr,  # packed buffer viewed as fp8   (flat)
+    pk_bf16_ptr,  # packed buffer viewed as bf16  (flat)
+    pk_u8_ptr,  # packed buffer viewed as uint8 (flat)
+    kv_indices_ptr,  # [total_indices] int32   (logical slots)
+    kv_indptr_ptr,  # [N+1] int32
+    attn_sink_ptr,  # [H] fp32
+    out_ptr,  # [N, H, D]
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    swa_stride_n,
+    swa_stride_d,
+    out_stride_t,
+    out_stride_h,
+    out_stride_d,
+    qk_scale,
+    log2e,
+    swa_pages,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    # packed-layout constexprs
+    BYTES_PER_PAGE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    DIM_NOPE: tl.constexpr,
+    DIM_ROPE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    NOPE_ROPE_BYTES: tl.constexpr,
+    PADDED_SCALE_PER_TOKEN: tl.constexpr,
+    S_OFFSET_BYTES: tl.constexpr,
+):
+    """Single-pass online-softmax decode with per-slot source dispatch.
+
+    Identical arithmetic to paged_decode._paged_decode_fused_kernel; the only
+    change is the KV tile is assembled from two physical buffers based on
+    ``slot >= swa_pages``. CUDAGraph-safe: dispatch is a runtime tl.where over
+    slot VALUES, launch shape depends only on capture-time (T, H).
+    """
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+
+    q = tl.load(
+        q_ptr
+        + t * q_stride_t
+        + h_offs[:, None] * q_stride_h
+        + d_offs[None, :] * q_stride_d,
+        mask=h_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+    num_tiles = tl.cdiv(kv_len, BLOCK_K)
+
+    neg_large = -3.4028234663852886e38
+    m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+
+    k_offs = tl.arange(0, BLOCK_K)
+
+    # Per-D compile-time masks for the packed split (nope vs rope tail).
+    nope_mask = d_offs < DIM_NOPE
+    rope_mask = (d_offs >= DIM_NOPE) & (d_offs < DIM_NOPE + DIM_ROPE)
+    g_idx_per_d = d_offs // TILE_SIZE  # nope scale-tile index per column
+
+    for j in tl.range(0, num_tiles, num_stages=3):
+        k_start = j * BLOCK_K
+        k_pos = k_start + k_offs
+        valid = k_pos < kv_len
+        slot = tl.load(kv_indices_ptr + kv_start + k_pos, mask=valid, other=0)
+
+        is_comp = slot >= swa_pages  # [BLOCK_K]
+
+        # ---- SWA branch (bf16, full D) ----
+        swa_v = tl.load(
+            swa_ptr
+            + slot[:, None] * swa_stride_n
+            + d_offs[None, :] * swa_stride_d,
+            mask=valid[:, None] & (~is_comp)[:, None] & d_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        # ---- compressed branch (packed: fp8 nope * ue8m0 scale ++ bf16 rope) ----
+        loc = slot - swa_pages  # compressed token id
+        page_idx = loc // PAGE_SIZE
+        in_page = loc % PAGE_SIZE
+        page_byte_base = page_idx * BYTES_PER_PAGE
+        token_data_base = page_byte_base + in_page * NOPE_ROPE_BYTES  # [BLOCK_K]
+        token_scale_base = (
+            page_byte_base + S_OFFSET_BYTES + in_page * PADDED_SCALE_PER_TOKEN
+        )
+
+        cmask = valid[:, None] & is_comp[:, None] & d_mask[None, :]
+
+        # nope: fp8 byte offset = token_data_base + d  (d < DIM_NOPE)
+        fp8_off = token_data_base[:, None] + d_offs[None, :]
+        fp8_vals = tl.load(
+            pk_fp8_ptr + fp8_off, mask=cmask & nope_mask[None, :], other=0.0
+        ).to(tl.float32)
+        scale_off = token_scale_base[:, None] + g_idx_per_d[None, :]
+        scale_u8 = tl.load(
+            pk_u8_ptr + scale_off, mask=cmask & nope_mask[None, :], other=127
+        ).to(tl.int32)
+        scale_pow2 = tl.exp2((scale_u8 - 127).to(tl.float32))
+        nope_val = fp8_vals * scale_pow2
+
+        # rope: bf16 elem offset = (token_data_base + DIM_NOPE)//2 + (d - DIM_NOPE)
+        rope_base = (token_data_base + DIM_NOPE) // 2
+        bf16_off = rope_base[:, None] + (d_offs[None, :] - DIM_NOPE)
+        rope_val = tl.load(
+            pk_bf16_ptr + bf16_off, mask=cmask & rope_mask[None, :], other=0.0
+        ).to(tl.float32)
+
+        comp_v = tl.where(nope_mask[None, :], nope_val, rope_val)
+
+        # ---- merge sources ----
+        kv = tl.where(is_comp[:, None], comp_v, swa_v).to(q.dtype)
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg_large)
+
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_new = l_i * alpha + tl.sum(p, axis=1)
+
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+        l_i = l_new
+
+    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
+        tl.float32
+    )
+    sink = sink_raw * log2e
+    m_final = tl.maximum(m_i, sink)
+    alpha_kv = tl.exp2(m_i - m_final)
+    alpha_sink = tl.exp2(sink - m_final)
+    l_final = l_i * alpha_kv + alpha_sink
+
+    denom = tl.maximum(l_final, 1.0e-30)
+    out = tl.where(
+        l_final[:, None] > 0.0, (acc * alpha_kv[:, None]) / denom[:, None], 0.0
+    )
+    tl.store(
+        out_ptr
+        + t * out_stride_t
+        + h_offs[:, None] * out_stride_h
+        + d_offs[None, :] * out_stride_d,
+        out.to(out_ptr.dtype.element_ty),
+        mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+def sparse_attn_v4_paged_decode_split_src(
+    q: torch.Tensor,  # [N, H, D]
+    swa_kv: torch.Tensor,  # [swa_pages, D] bf16
+    packed_kv: torch.Tensor,  # [num_pages, bytes_per_page] uint8
+    kv_indices: torch.Tensor,  # [total_indices] int32 (logical slots)
+    kv_indptr: torch.Tensor,  # [N+1] int32
+    attn_sink: torch.Tensor,  # [H] fp32
+    softmax_scale: float,
+    swa_pages: int,
+    packed_page_size: int,
+    block_h: int | None = None,
+    block_k: int = 16,
+) -> torch.Tensor:
+    """PoC split-source unified_kv decode (fused single-pass only)."""
+    assert q.is_cuda and q.dtype in (torch.bfloat16, torch.float16)
+    assert swa_kv.dtype == q.dtype
+    assert packed_kv.dtype == torch.uint8 and packed_kv.is_contiguous()
+    T, H, D = q.shape
+    assert swa_kv.shape[1] == D
+
+    u8 = packed_kv.view(torch.uint8)
+    bytes_per_page = u8.shape[-1]
+    pk_fp8 = u8.view(_FP8_DTYPE).reshape(-1)
+    pk_bf16 = u8.view(torch.bfloat16).reshape(-1)
+    pk_u8 = u8.reshape(-1)
+
+    out = torch.empty_like(q)
+    if block_h is None:
+        block_h = triton.next_power_of_2(min(H, 64))
+    block_h = max(triton.next_power_of_2(block_h), 16)
+    block_d = triton.next_power_of_2(D)
+    n_head_blocks = (H + block_h - 1) // block_h
+    qk_scale = float(softmax_scale) * LOG2E
+
+    grid = (T, n_head_blocks)
+    _paged_decode_fused_split_src_kernel[grid](
+        q,
+        swa_kv,
+        pk_fp8,
+        pk_bf16,
+        pk_u8,
+        kv_indices,
+        kv_indptr,
+        attn_sink,
+        out,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        swa_kv.stride(0),
+        swa_kv.stride(1),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        qk_scale,
+        LOG2E,
+        swa_pages,
+        H=H,
+        D=D,
+        BLOCK_H=block_h,
+        BLOCK_D=block_d,
+        BLOCK_K=block_k,
+        BYTES_PER_PAGE=bytes_per_page,
+        PAGE_SIZE=packed_page_size,
+        DIM_NOPE=_DIM_NOPE,
+        DIM_ROPE=_DIM_ROPE,
+        TILE_SIZE=_TILE_SIZE,
+        NOPE_ROPE_BYTES=_NOPE_ROPE_BYTES,
+        PADDED_SCALE_PER_TOKEN=_PADDED_SCALE_PER_TOKEN,
+        S_OFFSET_BYTES=packed_page_size * _NOPE_ROPE_BYTES,
+        num_warps=4 if block_h <= 32 else 8,
+        num_stages=2,
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_split_src_v2.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode_split_src_v2.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: MIT
+# Stage-3 PoC v2: TWO-SEGMENT single-source unified_kv decode.
+#
+# Motivation (from PoC v1 measurement on MI355X, job 27639):
+#   v1 loaded BOTH the bf16 SWA tile and the packed compressed tile for EVERY
+#   BLOCK_K tile and merged with tl.where. That triples/quadruples KV memory
+#   traffic vs the bf16 baseline (1 coalesced load/tile) and adds dequant ALU,
+#   giving a 3.9x-22.9x slowdown despite the 43% resident-byte saving.
+#
+# Key layout fact (verified in runtime.build_decode_streams / fill_compress_tail):
+#   per request the index stream is CONTIGUOUS and MONOTONE:
+#       [  SWA slots  (swa_len[t] of them)  |  compressed slots (tail)  ]
+#   so a request has exactly ONE crossover point at swa_len[t]. Therefore a
+#   BLOCK_K tile is (almost) always single-source; the only mixed tile is the
+#   single boundary tile, and we avoid even that by iterating the two segments
+#   in SEPARATE K-loops that share one online-softmax accumulator.
+#
+#   loop A: k in [0, swa_len)      -> load ONLY bf16 swa_kv         (baseline-fast)
+#   loop B: k in [swa_len, kv_len) -> load ONLY packed compressed    (dequant)
+#
+# Each tile issues exactly one KV load of its own source. No tl.where merge, no
+# double traffic. Online softmax is associative so processing the two segments
+# sequentially in one (m_i, l_i, acc) state is exact.
+#
+# The packed dequant addressing is byte-identical to dsv4.dequant_k_cache and to
+# PoC v1 (already validated bitwise on MI355X).
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+
+LOG2E = 1.4426950408889634
+_FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+# Packed layout constants (must match dsv4.dequant_k_cache).
+_DIM_NOPE = 448
+_DIM_ROPE = 64
+_TILE_SIZE = 64
+_NUM_SCALE_TILES = _DIM_NOPE // _TILE_SIZE  # 7
+_NOPE_ROPE_BYTES = _DIM_NOPE + _DIM_ROPE * 2  # 576
+_PADDED_SCALE_PER_TOKEN = _NUM_SCALE_TILES + 1  # 8
+
+_NEG = -3.4028234663852886e38
+
+
+@triton.jit
+def _paged_decode_v2_kernel(
+    q_ptr,  # [N, H, D] bf16/fp16
+    swa_ptr,  # [swa_pages, D] bf16
+    pk_fp8_ptr,  # packed buffer, fp8 view (flat)
+    pk_bf16_ptr,  # packed buffer, bf16 view (flat)
+    pk_u8_ptr,  # packed buffer, uint8 view (flat)
+    kv_indices_ptr,  # [total_indices] int32 (logical slots, [swa|comp] per req)
+    kv_indptr_ptr,  # [N+1] int32
+    swa_len_ptr,  # [N] int32  per-request SWA prefix length (crossover point)
+    attn_sink_ptr,  # [H] fp32
+    out_ptr,  # [N, H, D]
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    swa_stride_n,
+    swa_stride_d,
+    out_stride_t,
+    out_stride_h,
+    out_stride_d,
+    qk_scale,
+    log2e,
+    swa_pages,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_KC: tl.constexpr,  # separate K tile for the (heavier) compressed loop
+    # packed-layout constexprs
+    BYTES_PER_PAGE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    DIM_NOPE: tl.constexpr,
+    DIM_ROPE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    NOPE_ROPE_BYTES: tl.constexpr,
+    PADDED_SCALE_PER_TOKEN: tl.constexpr,
+    S_OFFSET_BYTES: tl.constexpr,
+):
+    t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    h_offs = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    d_offs = tl.arange(0, BLOCK_D)
+    h_mask = h_offs < H
+    d_mask = d_offs < D
+
+    q = tl.load(
+        q_ptr + t * q_stride_t + h_offs[:, None] * q_stride_h + d_offs[None, :] * q_stride_d,
+        mask=h_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+
+    kv_start = tl.load(kv_indptr_ptr + t)
+    kv_end = tl.load(kv_indptr_ptr + t + 1)
+    kv_len = kv_end - kv_start
+    swa_len = tl.load(swa_len_ptr + t)
+    # clamp defensively
+    swa_len = tl.minimum(tl.maximum(swa_len, 0), kv_len)
+
+    neg_large = -3.4028234663852886e38
+    m_i = tl.full((BLOCK_H,), neg_large, dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_D), dtype=tl.float32)
+
+    # =============================== LOOP A: SWA (bf16) ===============================
+    k_offs = tl.arange(0, BLOCK_K)
+    num_tiles_a = tl.cdiv(swa_len, BLOCK_K)
+    for j in tl.range(0, num_tiles_a, num_stages=3):
+        k_pos = j * BLOCK_K + k_offs
+        valid = k_pos < swa_len
+        slot = tl.load(kv_indices_ptr + kv_start + k_pos, mask=valid, other=0)
+        kv = tl.load(
+            swa_ptr + slot[:, None] * swa_stride_n + d_offs[None, :] * swa_stride_d,
+            mask=valid[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg_large)
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    # =========================== LOOP B: compressed (packed) ===========================
+    kc_offs = tl.arange(0, BLOCK_KC)
+    nope_mask = d_offs < DIM_NOPE
+    rope_mask = (d_offs >= DIM_NOPE) & (d_offs < DIM_NOPE + DIM_ROPE)
+    g_idx_per_d = d_offs // TILE_SIZE
+    comp_len = kv_len - swa_len
+    num_tiles_b = tl.cdiv(comp_len, BLOCK_KC)
+    for j in tl.range(0, num_tiles_b, num_stages=3):
+        k_pos = j * BLOCK_KC + kc_offs  # offset WITHIN the compressed segment
+        valid = k_pos < comp_len
+        slot = tl.load(
+            kv_indices_ptr + kv_start + swa_len + k_pos, mask=valid, other=swa_pages
+        )
+        loc = slot - swa_pages  # compressed token id
+        page_idx = loc // PAGE_SIZE
+        in_page = loc % PAGE_SIZE
+        page_byte_base = page_idx * BYTES_PER_PAGE
+        token_data_base = page_byte_base + in_page * NOPE_ROPE_BYTES
+        token_scale_base = page_byte_base + S_OFFSET_BYTES + in_page * PADDED_SCALE_PER_TOKEN
+
+        cmask = valid[:, None] & d_mask[None, :]
+        # nope fp8
+        fp8_off = token_data_base[:, None] + d_offs[None, :]
+        fp8_vals = tl.load(
+            pk_fp8_ptr + fp8_off, mask=cmask & nope_mask[None, :], other=0.0
+        ).to(tl.float32)
+        scale_off = token_scale_base[:, None] + g_idx_per_d[None, :]
+        scale_u8 = tl.load(
+            pk_u8_ptr + scale_off, mask=cmask & nope_mask[None, :], other=127
+        ).to(tl.int32)
+        scale_pow2 = tl.exp2((scale_u8 - 127).to(tl.float32))
+        nope_val = fp8_vals * scale_pow2
+        # rope bf16
+        rope_base = (token_data_base + DIM_NOPE) // 2
+        bf16_off = rope_base[:, None] + (d_offs[None, :] - DIM_NOPE)
+        rope_val = tl.load(
+            pk_bf16_ptr + bf16_off, mask=cmask & rope_mask[None, :], other=0.0
+        ).to(tl.float32)
+        kv = tl.where(nope_mask[None, :], nope_val, rope_val).to(q.dtype)
+
+        scores = tl.dot(q, tl.trans(kv)) * qk_scale
+        scores = tl.where(valid[None, :], scores, neg_large)
+        m_block = tl.max(scores, axis=1)
+        m_new = tl.maximum(m_i, m_block)
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(kv.dtype), kv)
+        m_i = m_new
+
+    # ===================================== EPILOGUE =====================================
+    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(tl.float32)
+    sink = sink_raw * log2e
+    m_final = tl.maximum(m_i, sink)
+    alpha_kv = tl.exp2(m_i - m_final)
+    alpha_sink = tl.exp2(sink - m_final)
+    l_final = l_i * alpha_kv + alpha_sink
+    denom = tl.maximum(l_final, 1.0e-30)
+    out = tl.where(l_final[:, None] > 0.0, (acc * alpha_kv[:, None]) / denom[:, None], 0.0)
+    tl.store(
+        out_ptr + t * out_stride_t + h_offs[:, None] * out_stride_h + d_offs[None, :] * out_stride_d,
+        out.to(out_ptr.dtype.element_ty),
+        mask=h_mask[:, None] & d_mask[None, :],
+    )
+
+
+def sparse_attn_v4_paged_decode_split_src_v2(
+    q: torch.Tensor,
+    swa_kv: torch.Tensor,
+    packed_kv: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    swa_len: torch.Tensor,  # [N] int32 per-request SWA prefix length
+    attn_sink: torch.Tensor,
+    softmax_scale: float,
+    swa_pages: int,
+    packed_page_size: int,
+    block_h: int | None = None,
+    block_k: int | None = None,
+    block_kc: int | None = None,
+) -> torch.Tensor:
+    """v2 two-segment single-source unified_kv decode (fused single-pass)."""
+    assert q.is_cuda and q.dtype in (torch.bfloat16, torch.float16)
+    assert swa_kv.dtype == q.dtype
+    assert packed_kv.dtype == torch.uint8 and packed_kv.is_contiguous()
+    T, H, D = q.shape
+    assert swa_kv.shape[1] == D
+    swa_len = swa_len.to(torch.int32)
+
+    u8 = packed_kv.view(torch.uint8)
+    bytes_per_page = u8.shape[-1]
+    pk_fp8 = u8.view(_FP8_DTYPE).reshape(-1)
+    pk_bf16 = u8.view(torch.bfloat16).reshape(-1)
+    pk_u8 = u8.reshape(-1)
+
+    out = torch.empty_like(q)
+    if block_h is None:
+        block_h = triton.next_power_of_2(min(H, 64))
+    block_h = max(triton.next_power_of_2(block_h), 16)
+    block_d = triton.next_power_of_2(D)
+    if block_k is None:
+        block_k = 32  # bf16 SWA loop; wide tile amortizes MFMA setup
+    if block_kc is None:
+        block_kc = 32  # compressed loop: wider tile amortizes dequant ALU
+    n_head_blocks = (H + block_h - 1) // block_h
+    qk_scale = float(softmax_scale) * LOG2E
+
+    grid = (T, n_head_blocks)
+    _paged_decode_v2_kernel[grid](
+        q,
+        swa_kv,
+        pk_fp8,
+        pk_bf16,
+        pk_u8,
+        kv_indices,
+        kv_indptr,
+        swa_len,
+        attn_sink,
+        out,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        swa_kv.stride(0),
+        swa_kv.stride(1),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        qk_scale,
+        LOG2E,
+        swa_pages,
+        H=H,
+        D=D,
+        BLOCK_H=block_h,
+        BLOCK_D=block_d,
+        BLOCK_K=block_k,
+        BLOCK_KC=block_kc,
+        BYTES_PER_PAGE=bytes_per_page,
+        PAGE_SIZE=packed_page_size,
+        DIM_NOPE=_DIM_NOPE,
+        DIM_ROPE=_DIM_ROPE,
+        TILE_SIZE=_TILE_SIZE,
+        NOPE_ROPE_BYTES=_NOPE_ROPE_BYTES,
+        PADDED_SCALE_PER_TOKEN=_PADDED_SCALE_PER_TOKEN,
+        S_OFFSET_BYTES=packed_page_size * _NOPE_ROPE_BYTES,
+        num_warps=4 if block_h <= 32 else 8,
+        num_stages=2,
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime_fp8.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime_fp8.py
@@ -1,0 +1,201 @@
+"""FP8 SoA dispatch for the unified_kv path (aiter kernels).
+
+Twin of :mod:`runtime` (the bf16 Triton path). Same unified_kv row addressing
+and the same ragged ``kv_indices``/``kv_indptr`` streams built by
+``build_decode_streams`` / ``build_prefill_indices``; the only differences:
+
+  * the unified store is a two-buffer SoA (fp8 nope_scale [rows,512] +
+    bf16 rope [rows,64]) instead of one bf16 [rows,512] buffer;
+  * decode dispatches aiter ``mla_decode_fwd_v4_nm`` (#3112) and prefill
+    dispatches aiter ``pa_sparse_prefill_fp8_opus`` (#3751), both of which read
+    the SoA buffers directly with NO in-kernel dequant.
+
+DSV4 MQA head_dim = 448 nope + 64 rope = 512; v_head_dim = 512. aiter's fixed
+"V4-Pro" nope_scale block is 512 B = [448 fp8 | 14 e8m0 (dup) | 50 pad].
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.ops.attention.dsv4.atom_soa_pack import pack_to_atom_soa
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+    quant_to_nope_fp8_rope_bf16_pack_triton,
+)
+
+HEAD_DIM = 512      # 448 nope + 64 rope
+NOPE_BLOCK = 512    # packed: 448 fp8 + 14 e8m0 + 50 pad
+ROPE_DIM = 64
+V_HEAD_DIM = 512
+
+
+# ---------------------------------------------------------------------------
+# Quantization helpers (bf16 [.,512] -> SoA fp8 nope_scale [.,512] + rope [.,64])
+# ---------------------------------------------------------------------------
+def quant_to_soa(k_bf16: torch.Tensor):
+    """[N, 512] bf16 -> (nope_scale [N,512] uint8, rope [N,64] bf16)."""
+    assert k_bf16.shape[-1] == HEAD_DIM
+    pack = quant_to_nope_fp8_rope_bf16_pack_triton(k_bf16.contiguous())
+    return pack_to_atom_soa(pack)  # ([N,512]u8, [N,64]bf16)
+
+
+def quant_q_to_soa(q: torch.Tensor):
+    """[T, H, 512] bf16 query -> (q_nope [T,H,512] fp8, q_rope [T,H,64] bf16)."""
+    t, h, d = q.shape
+    assert d == HEAD_DIM
+    ns, rp = quant_to_soa(q.reshape(t * h, d))
+    q_nope = ns.view(torch.float8_e4m3fn).view(t, h, NOPE_BLOCK)
+    q_rope = rp.view(t, h, ROPE_DIM)
+    return q_nope, q_rope
+
+
+# ---------------------------------------------------------------------------
+# Unified store (flat row scatter; unified rows are page_size-1 addressed)
+# ---------------------------------------------------------------------------
+def _scatter_soa(nope_buf, rope_buf, loc, ns_dense, rp_dense):
+    loc = loc.long()
+    nope_buf.view(torch.uint8)[loc] = ns_dense
+    rope_buf[loc] = rp_dense
+
+
+def store_swa_into_unified_fp8(
+    *,
+    kv: torch.Tensor,             # [T, 512] bf16
+    state_slot: torch.Tensor,     # [T] int
+    positions: torch.Tensor,      # [T] int
+    nope_buf: torch.Tensor,       # [rows, 512] fp8/uint8
+    rope_buf: torch.Tensor,       # [rows, 64]  bf16
+    win: int,
+    ring_stride: int,
+    final_pos: Optional[torch.Tensor] = None,
+) -> None:
+    """Quantize this fwd's SWA K to SoA fp8 and scatter into the ring rows."""
+    n_rows = kv.shape[0]
+    if n_rows == 0:
+        return
+    pos = positions.to(torch.int64)
+    keep = slice(None)
+    if final_pos is not None:
+        fp = final_pos.to(torch.int64)
+        mask = pos > (fp - win)
+        if not bool(mask.all()):
+            keep = mask
+            kv = kv[keep]
+            pos = pos[keep]
+            state_slot = state_slot[keep]
+    loc = state_slot.to(torch.int64) * ring_stride + (pos % ring_stride)
+    ns_dense, rp_dense = quant_to_soa(kv)
+    _scatter_soa(nope_buf, rope_buf, loc, ns_dense, rp_dense)
+
+
+def store_compress_into_unified_fp8(
+    *,
+    kv_compressed: torch.Tensor,  # [M, 512] bf16 (post norm+rope)
+    out_loc: torch.Tensor,        # [M] int -- absolute unified row ids
+    nope_buf: torch.Tensor,
+    rope_buf: torch.Tensor,
+) -> None:
+    """Quantize compressed K rows to SoA fp8 and scatter into compressed rows."""
+    if kv_compressed.shape[0] == 0:
+        return
+    ns_dense, rp_dense = quant_to_soa(kv_compressed.bfloat16())
+    _scatter_soa(nope_buf, rope_buf, out_loc, ns_dense, rp_dense)
+
+
+# ---------------------------------------------------------------------------
+# Decode dispatch: mla_decode_fwd_v4_nm
+# ---------------------------------------------------------------------------
+def decode(
+    *,
+    q: torch.Tensor,              # [T, H, 512] bf16 query (448 nope + 64 rope)
+    nope_buf: torch.Tensor,       # [rows, 512] fp8 unified nope_scale
+    rope_buf: torch.Tensor,       # [rows, 64]  bf16 unified rope
+    kv_indices: torch.Tensor,     # [total_kv] int32 -- ragged unified row ids
+    kv_indptr: torch.Tensor,      # [T+1] int32
+    attn_sink: torch.Tensor,      # [H] fp32
+    softmax_scale: float,
+) -> torch.Tensor:
+    from aiter.mla import mla_decode_fwd_v4_nm
+
+    t, h, _ = q.shape
+    q_nope, q_rope = quant_q_to_soa(q)                       # [T,H,512]fp8, [T,H,64]bf16
+    rows = nope_buf.shape[0]
+    kv_buffer = nope_buf.view(torch.float8_e4m3fn).view(rows, 1, 1, NOPE_BLOCK)
+    kvrope = rope_buf.view(rows, 1, 1, ROPE_DIM)
+
+    qo_indptr = torch.arange(t + 1, device=q.device, dtype=torch.int32)  # 1 query/seq
+    kv_page_indices = kv_indices.to(torch.int32)
+    kv_indptr = kv_indptr.to(torch.int32)
+
+    output = torch.empty((t, h, V_HEAD_DIM), dtype=torch.bfloat16, device=q.device)
+    sink = attn_sink
+    if sink.shape[0] != h:
+        sink = sink[:h]
+    sink = sink.to(torch.float32).contiguous()
+
+    mla_decode_fwd_v4_nm(
+        q_nope,
+        q_rope,
+        kv_buffer,
+        kvrope,
+        output,
+        qo_indptr,
+        kv_indptr,
+        kv_page_indices,
+        1,  # max_seqlen_q (decode: 1 query per seq)
+        sink=sink,
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Prefill dispatch: pa_sparse_prefill_fp8_opus
+# ---------------------------------------------------------------------------
+def prefill(
+    *,
+    q: torch.Tensor,                  # [T, H, 512] bf16
+    nope_buf: torch.Tensor,           # [rows, 512] fp8 unified nope_scale (prefix)
+    rope_buf: torch.Tensor,           # [rows, 64]  bf16 unified rope (prefix)
+    kv_indices_prefix: torch.Tensor,  # [total_prefix] int32
+    kv_indptr_prefix: torch.Tensor,   # [T+1] int32
+    kv_extend: torch.Tensor,          # [total_tokens, 512] bf16 (this fwd's K)
+    kv_indices_extend: torch.Tensor,  # [total_extend] int32
+    kv_indptr_extend: torch.Tensor,   # [T+1] int32
+    attn_sink: torch.Tensor,          # [H] fp32
+    softmax_scale: float,
+) -> torch.Tensor:
+    from aiter.ops.pa_sparse_prefill_opus import pa_sparse_prefill_fp8_opus
+
+    t, h, _ = q.shape
+    q_nope, q_rope = quant_q_to_soa(q.contiguous())
+
+    rows = nope_buf.shape[0]
+    uk_nope = nope_buf.view(torch.float8_e4m3fn).view(rows, NOPE_BLOCK)
+    uk_rope = rope_buf.view(rows, ROPE_DIM)
+
+    # Extend K (this fwd's fresh K) quantized to the same SoA layout.
+    ext_ns, ext_rp = quant_to_soa(kv_extend.contiguous())
+    ext_nope = ext_ns.view(torch.float8_e4m3fn).view(-1, NOPE_BLOCK)
+    ext_rope = ext_rp.view(-1, ROPE_DIM)
+
+    sink = attn_sink
+    if sink.shape[0] != h:
+        sink = sink[:h]
+    sink = sink.to(torch.float32).contiguous()
+
+    return pa_sparse_prefill_fp8_opus(
+        q_nope,
+        q_rope,
+        uk_nope,
+        uk_rope,
+        kv_indices_prefix.to(torch.int32),
+        kv_indptr_prefix.to(torch.int32),
+        ext_nope,
+        ext_rope,
+        kv_indices_extend.to(torch.int32),
+        kv_indptr_extend.to(torch.int32),
+        sink,
+        float(softmax_scale),
+    )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1225,12 +1225,34 @@ class DeepseekV4HipRadixBackend(
         core_attn_metadata: DSV4AttnMetadata,
         save_kv_cache: bool = True,
     ) -> torch.Tensor:
-        """unified_kv paged-attention path over the bf16 unified_kv"""
+        """unified_kv paged-attention path.
+
+        Two variants share this method (identical index-stream plumbing):
+          * bf16 Triton (``unified_kv_triton``): one bf16 [rows,512] buffer,
+            vendored Triton decode/prefill.
+          * fp8 SoA (``unified_kv_aiter``): two buffers (fp8 nope_scale [rows,512]
+            + bf16 rope [rows,64]), aiter ``mla_decode_fwd_v4_nm`` /
+            ``pa_sparse_prefill_fp8_opus``.
+        """
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import runtime
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_aiter,
+        )
+
+        aiter_fp8 = is_unified_kv_aiter()
+        if aiter_fp8:
+            from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import (
+                runtime_fp8,
+            )
 
         pool = self.token_to_kv_pool
         layer_id = layer.layer_id
-        unified = pool.get_unified_kv(layer_id)
+        if aiter_fp8:
+            unified = None
+            nope_buf = pool.get_unified_kv_nope(layer_id)
+            rope_buf = pool.get_unified_kv_rope(layer_id)
+        else:
+            unified = pool.get_unified_kv(layer_id)
         win = pool.unified_swa_window
         ring_stride = pool.unified_swa_ring_size
         swa_pages = pool.unified_swa_pages
@@ -1259,15 +1281,27 @@ class DeepseekV4HipRadixBackend(
             else:
                 state_slot = forward_batch.req_pool_indices[:T]
             if save_kv_cache:
-                runtime.store_swa_into_unified(
-                    kv=kv,
-                    state_slot=state_slot,
-                    positions=positions,
-                    unified_kv=unified,
-                    win=win,
-                    ring_stride=ring_stride,
-                    final_pos=positions,
-                )
+                if aiter_fp8:
+                    runtime_fp8.store_swa_into_unified_fp8(
+                        kv=kv,
+                        state_slot=state_slot,
+                        positions=positions,
+                        nope_buf=nope_buf,
+                        rope_buf=rope_buf,
+                        win=win,
+                        ring_stride=ring_stride,
+                        final_pos=positions,
+                    )
+                else:
+                    runtime.store_swa_into_unified(
+                        kv=kv,
+                        state_slot=state_slot,
+                        positions=positions,
+                        unified_kv=unified,
+                        win=win,
+                        ring_stride=ring_stride,
+                        final_pos=positions,
+                    )
             unified_metadata = core_attn_metadata.unified
             if compress_ratio == 0:
                 kv_indices = unified_metadata.swa_indices
@@ -1288,6 +1322,16 @@ class DeepseekV4HipRadixBackend(
                 )
             else:
                 raise ValueError(f"bad compress_ratio {compress_ratio}")
+            if aiter_fp8:
+                return runtime_fp8.decode(
+                    q=q,
+                    nope_buf=nope_buf,
+                    rope_buf=rope_buf,
+                    kv_indices=kv_indices,
+                    kv_indptr=kv_indptr,
+                    attn_sink=attn_sink,
+                    softmax_scale=self.softmax_scale,
+                )
             return runtime.decode(
                 q=q,
                 unified_kv=unified,
@@ -1363,17 +1407,31 @@ class DeepseekV4HipRadixBackend(
             pad = T + 1 - kpre_p.shape[0]
             kpre_p = torch.cat([kpre_p, kpre_p[-1:].expand(pad)])
             kext_p = torch.cat([kext_p, kext_p[-1:].expand(pad)])
-        o = runtime.prefill(
-            q=q,
-            unified_kv=unified,
-            kv_indices_prefix=kpre_i,
-            kv_indptr_prefix=kpre_p,
-            kv_extend=kv,
-            kv_indices_extend=kext_i,
-            kv_indptr_extend=kext_p,
-            attn_sink=attn_sink,
-            softmax_scale=self.softmax_scale,
-        )
+        if aiter_fp8:
+            o = runtime_fp8.prefill(
+                q=q,
+                nope_buf=nope_buf,
+                rope_buf=rope_buf,
+                kv_indices_prefix=kpre_i,
+                kv_indptr_prefix=kpre_p,
+                kv_extend=kv,
+                kv_indices_extend=kext_i,
+                kv_indptr_extend=kext_p,
+                attn_sink=attn_sink,
+                softmax_scale=self.softmax_scale,
+            )
+        else:
+            o = runtime.prefill(
+                q=q,
+                unified_kv=unified,
+                kv_indices_prefix=kpre_i,
+                kv_indptr_prefix=kpre_p,
+                kv_extend=kv,
+                kv_indices_extend=kext_i,
+                kv_indptr_extend=kext_p,
+                attn_sink=attn_sink,
+                softmax_scale=self.softmax_scale,
+            )
 
         # write this chunk's SWA K into the ring for future chunks / decode
         # only the final-window tokens per request
@@ -1385,15 +1443,27 @@ class DeepseekV4HipRadixBackend(
             _ring_final_pos = final_pos_full if _cp_active else final_pos
             _ring_positions = positions_full if _cp_active else positions
             n_real = _ring_state_slot.shape[0]
-            runtime.store_swa_into_unified(
-                kv=kv[:n_real],
-                state_slot=_ring_state_slot,
-                positions=_ring_positions[:n_real],
-                unified_kv=unified,
-                win=win,
-                ring_stride=ring_stride,
-                final_pos=_ring_final_pos,
-            )
+            if aiter_fp8:
+                runtime_fp8.store_swa_into_unified_fp8(
+                    kv=kv[:n_real],
+                    state_slot=_ring_state_slot,
+                    positions=_ring_positions[:n_real],
+                    nope_buf=nope_buf,
+                    rope_buf=rope_buf,
+                    win=win,
+                    ring_stride=ring_stride,
+                    final_pos=_ring_final_pos,
+                )
+            else:
+                runtime.store_swa_into_unified(
+                    kv=kv[:n_real],
+                    state_slot=_ring_state_slot,
+                    positions=_ring_positions[:n_real],
+                    unified_kv=unified,
+                    win=win,
+                    ring_stride=ring_stride,
+                    final_pos=_ring_final_pos,
+                )
         return o
 
     def get_swa_out_cache_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -215,8 +215,33 @@ class CompressorBackendMixin:
 
         state_pool = compressor.get_state_pool(self)
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_aiter,
             is_unified_kv_triton,
         )
+
+        # fp8 SoA unified: the compressed (non-indexer) KV must land in the two
+        # fp8 buffers aiter reads. The indexer store is a separate pool and is
+        # left on its existing all-in-one path below.
+        if is_unified_kv_aiter() and not compressor.is_in_indexer:
+            self._forward_unified_compress_fp8(
+                token_to_kv_pool=token_to_kv_pool,
+                kv_score_input=kv_score_input,
+                state_pool=state_pool,
+                compressor=compressor,
+                layer_id=layer_id,
+            )
+            online_c128_mtp = getattr(self, "online_c128_mtp", None)
+            if online_c128_mtp is not None:
+                online_c128_mtp.write_prefix_states(
+                    layer_id=layer_id,
+                    compressor=compressor,
+                    kv_score_input=kv_score_input,
+                    logical_forward_mode=getattr(
+                        forward_batch, "_original_forward_mode", None
+                    )
+                    or forward_batch.forward_mode,
+                )
+            return
 
         out_loc = self._get_out_loc(compressor.ratio)
         use_fp4_indexer = (
@@ -268,6 +293,98 @@ class CompressorBackendMixin:
                 )
                 or forward_batch.forward_mode,
             )
+
+    def _forward_unified_compress_fp8(
+        self,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        kv_score_input: torch.Tensor,
+        state_pool,
+        compressor: Compressor,
+        layer_id: int,
+    ) -> None:
+        """Compressed-KV store for the fp8 SoA unified path (aiter kernels).
+
+        Reuses the exact bf16 compressed-K production of ``_forward_unified_hip``
+        (compress_forward -> fused norm+rope -> decode boundary zeroing), but the
+        write target is the UNIFIED compressed rows (``c{ratio}_out_loc``) and the
+        store quantizes to the two fp8 SoA buffers instead of the packed AoS
+        extra-key pool. Only this step's compressed tokens are materialized in
+        bf16 (small), so the persistent unified store stays fp8.
+        """
+        from sglang.kernels.ops.attention.deepseek_v4_rope import (
+            fused_norm_rope_inplace_triton,
+        )
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import runtime_fp8
+
+        compress_ratio = compressor.ratio
+        head_dim = compressor.head_dim
+        assert not compressor.is_in_indexer
+        assert head_dim == runtime_fp8.HEAD_DIM, (
+            f"fp8 unified compress expects head_dim={runtime_fp8.HEAD_DIM}, "
+            f"got {head_dim}"
+        )
+
+        plan = self._get_paged_compress_metadata(compress_ratio)
+
+        coff = 2 if is_overlap_compress(compress_ratio) else 1
+        last_dim = 2 * head_dim * coff
+        kv_score_buffer = state_pool.kv_score_buffer.kv_score
+        kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
+
+        kv_compressed = compress_forward(
+            kv_score_buffer=kv_score_buffer,
+            kv_score_input=kv_score_input,
+            ape=compressor.ape.view(-1, head_dim),
+            plan=plan,
+            compress_ratio=compress_ratio,
+            head_dim=head_dim,
+            is_online=False,
+        )
+        if kv_compressed.shape[0] == 0:
+            return
+
+        # Decode: zero non-boundary tokens (their out_loc == 0 null slot).
+        if plan.is_decode:
+            plan_raw = plan[1].view(torch.int32)
+            seq_lens_plan = plan_raw[:, 0].to(torch.int32)
+            is_boundary = (seq_lens_plan % compress_ratio == 0).unsqueeze(-1)
+            kv_compressed = torch.where(
+                is_boundary, kv_compressed, torch.zeros_like(kv_compressed)
+            )
+
+        positions = _extract_positions_from_plan(plan, compress_ratio)
+        positions_safe = positions.clamp(min=0)
+        fused_norm_rope_inplace_triton(
+            kv_compressed,
+            compressor.norm.weight,
+            compressor.norm.variance_epsilon,
+            compressor.freqs_cis,
+            positions=positions_safe,
+        )
+
+        # Unified compressed row targets (absolute rows into the unified store).
+        out_loc = getattr(
+            self.forward_metadata.core_metadata.unified,
+            f"c{compress_ratio}_out_loc",
+        )
+        if plan.is_decode:
+            kv_to_store = kv_compressed
+            out_loc_to_store = out_loc
+        else:
+            kv_to_store = kv_compressed
+            plan_raw = plan[1].view(torch.int32)
+            ragged_ids = plan_raw[:, 1].to(torch.int32) & 0xFFFF
+            out_loc_to_store = out_loc[ragged_ids.long()]
+
+        if kv_to_store.shape[0] == 0:
+            return
+
+        runtime_fp8.store_compress_into_unified_fp8(
+            kv_compressed=kv_to_store,
+            out_loc=out_loc_to_store,
+            nope_buf=token_to_kv_pool.get_unified_kv_nope(layer_id),
+            rope_buf=token_to_kv_pool.get_unified_kv_rope(layer_id),
+        )
 
     def _forward_unified_hip(
         self,

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -15,7 +15,10 @@ from sglang.kernels.ops.attention.dsv4 import (
 from sglang.kernels.ops.attention.dsv4 import (
     index_buf_accessor as dsv4_index_buf_accessor,
 )
-from sglang.kernels.ops.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
+from sglang.kernels.ops.attention.dsv4.index_buf_accessor import (
+    NopeFp8RopeBf16Pack,
+    fp8_dtype,
+)
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
@@ -257,6 +260,82 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         raise NotImplementedError("HiSparseC4DevicePool does not support load_cpu_copy")
 
 
+class AtomSoaKVPool(DeepSeekV4SingleKVPool):
+    """Two-buffer SoA storage that aiter's fp8 kernels (mla_decode_fwd_v4_nm #3112,
+    pa_sparse_prefill_fp8_opus #3751) read directly, with NO in-kernel dequant.
+
+    Per (page, slot):
+        nope_scale_buffer : 512 bytes uint8 = [ nope 448 fp8 | e8m0 14 (dup) | pad 50 ]
+        rope_buffer       : 64 bf16 (separate tensor, not quantized)
+
+    Numerics are identical to the base 584B packed pool (same fp8_e4m3fn, 1x64
+    e8m0); only the byte layout differs. Additive drop-in: the base class and its
+    FlashMLA consumers are untouched.
+    """
+
+    NOPE_BLOCK = 512  # 448 nope + 14 e8m0 (dup) + 50 pad
+    ROPE_DIM = 64
+
+    def _create_buffers(self):
+        from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+
+        num_pages = (self.size + self.page_size + 1) // self.page_size
+        self._num_pages = num_pages
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            with (
+                torch.cuda.use_mem_pool(self.custom_mem_pool)
+                if self.custom_mem_pool
+                else nullcontext()
+            ):
+                self.nope_scale_buffer = [
+                    torch.zeros(
+                        num_pages,
+                        self.page_size * self.NOPE_BLOCK,
+                        dtype=torch.uint8,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+                self.rope_buffer = [
+                    torch.zeros(
+                        num_pages,
+                        self.page_size * self.ROPE_DIM,
+                        dtype=torch.bfloat16,
+                        device=self.device,
+                    )
+                    for _ in range(self.layer_num)
+                ]
+        # Compatibility: some call sites probe .kv_buffer; expose the nope block.
+        self.kv_buffer = self.nope_scale_buffer
+
+    def set_key_buffer(self, layer_id, loc, cache_nope_fp8_rope_bf16_pack):
+        from sglang.kernels.ops.attention.dsv4.atom_soa_pack import store_atom_soa
+
+        store_atom_soa(
+            self.nope_scale_buffer[layer_id],
+            self.rope_buffer[layer_id],
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            self.page_size,
+        )
+
+    def set_key_buffer_fused(self, layer_id, loc, cache_k):
+        raise NotImplementedError("AtomSoaKVPool has no fused store yet.")
+
+    def get_nope_scale_buffer(self, layer_id: int) -> torch.Tensor:
+        """[num_pages, page_size, 512] viewed as fp8 for the aiter kernel."""
+        buf = self.nope_scale_buffer[layer_id - self.start_layer]
+        return buf.view(fp8_dtype).view(self._num_pages, self.page_size, self.NOPE_BLOCK)
+
+    def get_rope_buffer(self, layer_id: int) -> torch.Tensor:
+        """[num_pages, page_size, 64] bf16 rope, separate tensor."""
+        buf = self.rope_buffer[layer_id - self.start_layer]
+        return buf.view(self._num_pages, self.page_size, self.ROPE_DIM)
+
+    def get_key_buffer(self, layer_id: int):
+        return self.get_nope_scale_buffer(layer_id)
+
+
 class DeepSeekV4IndexerPool(KVCache):
     quant_block_size = 128
     index_k_with_scale_buffer_dtype = torch.uint8
@@ -460,6 +539,91 @@ class DeepSeekV4UnifiedKVPool:
         return data_ptrs, data_lens, item_lens
 
 
+class DeepSeekV4UnifiedKVPoolFp8:
+    """FP8 SoA twin of :class:`DeepSeekV4UnifiedKVPool` for aiter's fp8 kernels.
+
+    Same row addressing as the bf16 unified pool (rows ``[0, swa_pages)`` = SWA
+    ring, rows ``[swa_pages, ...)`` = compressed), but each ratio is backed by
+    TWO buffers instead of one bf16 ``[rows, head_dim]``:
+
+        nope_scale[L] : ``[rows, 512]`` uint8  = [ 448 fp8 nope | 14 e8m0 (dup) | 50 pad ]
+        rope[L]       : ``[rows, 64]``  bf16    (RoPE kept in bf16, separate tensor)
+
+    aiter ``mla_decode_fwd_v4_nm`` / ``pa_sparse_prefill_fp8_opus`` read these two
+    buffers directly with no in-kernel dequant.
+    """
+
+    K_PER_BLOCK = {0: 0, 4: 32, 128: 1}
+
+    NOPE_BLOCK = 512
+    ROPE_DIM = 64
+
+    def __init__(
+        self,
+        *,
+        stage_ratios: List[int],
+        num_slots: int,
+        num_blocks: int,
+        page_size: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        device: str,
+        memory_saver_adapter,
+        custom_mem_pool,
+        swa_ring_size: int,
+    ):
+        self.swa_ring_size = swa_ring_size
+        self.head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.num_slots = num_slots
+        self.swa_pages = num_slots * self.swa_ring_size
+        self.num_blocks = num_blocks
+        self.page_size = page_size
+        self.k_per_block = dict(self.K_PER_BLOCK)
+
+        nope_bufs: List[torch.Tensor] = []
+        rope_bufs: List[torch.Tensor] = []
+        with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            with (
+                torch.cuda.use_mem_pool(custom_mem_pool)
+                if custom_mem_pool
+                else nullcontext()
+            ):
+                for ratio in stage_ratios:
+                    compress_rows = self.num_blocks * self.k_per_block[ratio]
+                    rows_per_page = self.page_size // ratio if ratio else 0
+                    rows = self.swa_pages + compress_rows + rows_per_page
+                    nope_bufs.append(
+                        torch.zeros(
+                            rows, self.NOPE_BLOCK, dtype=torch.uint8, device=device
+                        )
+                    )
+                    rope_bufs.append(
+                        torch.zeros(
+                            rows, self.ROPE_DIM, dtype=torch.bfloat16, device=device
+                        )
+                    )
+        self.nope_scale_buffer = nope_bufs
+        self.rope_buffer = rope_bufs
+        # Compatibility shim: call sites that only probe ``.kv_buffer`` (buf_infos,
+        # capture-safe checks) see the nope buffers.
+        self.kv_buffer = nope_bufs
+
+    def get_unified_kv_nope(self, local_layer_id: int) -> torch.Tensor:
+        """``[rows, 512]`` viewed as fp8 for the aiter kernel."""
+        return self.nope_scale_buffer[local_layer_id].view(fp8_dtype)
+
+    def get_unified_kv_rope(self, local_layer_id: int) -> torch.Tensor:
+        """``[rows, 64]`` bf16 RoPE."""
+        return self.rope_buffer[local_layer_id]
+
+    def get_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        bufs = self.nope_scale_buffer + self.rope_buffer
+        data_ptrs = [b.data_ptr() for b in bufs]
+        data_lens = [b.nbytes for b in bufs]
+        item_lens = [b[0].nbytes for b in bufs]
+        return data_ptrs, data_lens, item_lens
+
+
 class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def __init__(
@@ -574,10 +738,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         c128_page_size = page_size // 128
 
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_aiter,
             is_unified_kv_triton,
         )
 
         self._unified_kv = is_unified_kv_triton()
+        self._unified_kv_fp8 = is_unified_kv_aiter()
 
         if self._unified_kv:
             self.swa_kv_pool = None
@@ -588,7 +754,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 if get_spec().speculative_algorithm is not None
                 else 0
             )
-            self.unified_kv_pool = DeepSeekV4UnifiedKVPool(
+            unified_pool_cls = (
+                DeepSeekV4UnifiedKVPoolFp8
+                if self._unified_kv_fp8
+                else DeepSeekV4UnifiedKVPool
+            )
+            self.unified_kv_pool = unified_pool_cls(
                 stage_ratios=stage_ratios,
                 num_slots=self.num_req_slots,
                 num_blocks=self.c128_size,
@@ -660,6 +831,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         # layer's transfer before attention reads it. No-op when HiCache is off.
         self.wait_layer_transfer(layer_id)
         return self.unified_kv_pool.get_unified_kv(layer_id - self._stage_start)
+
+    def get_unified_kv_nope(self, layer_id: int) -> torch.Tensor:
+        """FP8 SoA unified nope_scale buffer ``[rows, 512]`` (aiter path only)."""
+        self.wait_layer_transfer(layer_id)
+        return self.unified_kv_pool.get_unified_kv_nope(layer_id - self._stage_start)
+
+    def get_unified_kv_rope(self, layer_id: int) -> torch.Tensor:
+        """FP8 SoA unified rope buffer ``[rows, 64]`` bf16 (aiter path only)."""
+        self.wait_layer_transfer(layer_id)
+        return self.unified_kv_pool.get_unified_kv_rope(layer_id - self._stage_start)
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1324,10 +1324,16 @@ class MQALayer(MqaAttentionBase):
         kv_handle = None
 
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_aiter,
             is_unified_kv_triton,
         )
 
         unified = is_unified_kv_triton()
+        # The fp8 SoA unified path has no single bf16 unified buffer and no
+        # bf16 fused SWA-store kernel; route it through the non-fused branch so
+        # the backend does the SoA store (before attention) + aiter dispatch,
+        # quantizing q internally. Only the bf16 Triton unified path fuses.
+        unified_fp8 = is_unified_kv_aiter()
         is_decode = forward_batch.forward_mode.is_decode_or_idle()
         # The kernel is token-indexed (q, kv and positions are all length M), so
         # a verify batch carrying several draft tokens per request is a shape it
@@ -1337,9 +1343,9 @@ class MQALayer(MqaAttentionBase):
             envs.SGLANG_OPT_FUSED_QK_NORM_ROPE_VERIFY.get()
             and forward_batch.forward_mode.is_target_verify()
         )
-        do_fused_qk_norm_rope = (unified and (is_decode or fuse_verify)) or (
-            not unified and self.use_fused_qk_norm_rope
-        )
+        do_fused_qk_norm_rope = (
+            unified and not unified_fp8 and (is_decode or fuse_verify)
+        ) or (not unified and self.use_fused_qk_norm_rope)
 
         if do_fused_qk_norm_rope:
             if _is_gfx95_supported or _is_gfx1250_supported:


### PR DESCRIPTION
## Goal

Add an fp8 variant of the DSV4 MLA `unified_kv` path on ROCm (gfx950 / MI355X)
so the persistent main KV is stored in fp8 instead of bf16, while keeping RoPE
in bf16. Gated by `SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_aiter`; the existing
bf16 `unified_kv_triton` path is untouched and remains the default.

The design is *logically unified, physically split, perceived by the kernel*:
row addressing is identical to the bf16 unified pool (SWA ring rows + compressed
rows), but each ratio is backed by two buffers instead of one:

- `nope_scale[L]` : `[rows, 512]` uint8 = `[448 fp8 nope | 14 e8m0 scale | 50 pad]`
- `rope[L]` : `[rows, 64]` bf16 (RoPE kept bf16, separate tensor)

aiter `mla_decode_fwd_v4_nm` (decode) and `pa_sparse_prefill_fp8_opus` (prefill)
read the two buffers directly with no in-kernel dequant.

## Changes

- `env_gate`: `is_unified_kv_aiter()`; `is_unified_kv_triton()` true for both variants.
- `deepseek_v4_memory_pool`: `DeepSeekV4UnifiedKVPoolFp8` twin pool + nope/rope
  accessors; `AtomSoaKVPool` SoA single-pool; `DeepSeekV4TokenToKVPool` selects
  the fp8 pool under the gate.
- `compressor_v2`: fp8 compressed-KV store into the unified rows.
- `deepseek_v4_backend_hip_radix`: SoA SWA store + aiter decode/prefill dispatch.
- `deepseek_v4`: route the fp8 path through the non-fused q-norm/rope branch
  (no bf16 fused SWA-store kernel exists for the SoA layout).
- `runtime_fp8` + SoA pack/quant helpers; POC benches/tests under `poc/`.

## Status (draft)

- Works without HiCache.
- Component-level validation on real gfx950 passed on the previous base:
  SoA byte layout byte-exact; decode/prefill dispatch cosine ~0.998; assembled
  fp8-pool smoke test PASS (SWA store cos 0.99965, compress store cos 0.99968,
  decode output finite).
- This branch re-ports those changes onto the latest upstream `main` (which
  refactored `forward_unified` / the HIP backend / the model). End-to-end
  re-validation on gfx950 against the refactored code is still pending.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33492731979](https://github.com/sgl-project/sglang/actions/runs/33492731979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33492731673](https://github.com/sgl-project/sglang/actions/runs/33492731673)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33492732001](https://github.com/sgl-project/sglang/actions/runs/33492732001)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->