### PR TITLE
feat(dp): DP waiting-queue load balancing with PD-prefill migration (mori)

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -297,6 +297,12 @@ class DecodeRequest:
     metadata_buffer_index: int = -1
     is_rebootstrap: bool = False
 
+    # queue_lb (PD prefill migration): the exact args last passed to
+    # ``kv_receiver.send_metadata`` so we can replay them verbatim to a new
+    # prefill dp_rank if the source prefill migrates this queued request. None
+    # until the request has published its destination to a prefill peer.
+    last_sent_metadata: Optional[dict] = None
+
     # HiCache Status
     prefix_match: Optional[DecodePrefixMatch] = None
     hicache_restored_kv_indices: Optional[torch.Tensor] = None
@@ -1515,6 +1521,14 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 self.transfer_queue.staging_handler.register_decode_req(
                     decode_req.req.bootstrap_room, decode_req
                 )
+            # queue_lb: remember exactly what we published so a PD prefill
+            # migration can replay it verbatim to the destination dp_rank.
+            decode_req.last_sent_metadata = {
+                "page_indices": page_indices,
+                "aux_index": decode_req.metadata_buffer_index,
+                "state_indices": state_indices,
+                "metadata_kwargs": metadata_kwargs,
+            }
             decode_req.kv_receiver.send_metadata(
                 page_indices,
                 decode_req.metadata_buffer_index,
@@ -2446,6 +2460,68 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
 
 class SchedulerDisaggregationDecodeMixin:
+    def process_prefill_migration_rebootstrap(self: Scheduler) -> None:
+        """queue_lb (PD prefill migration): re-point queued requests whose prefill
+        peer moved to another dp_rank.
+
+        The source prefill notifies us over the KV control channel (mori
+        REBOOTSTRAP); the manager buffers ``room -> new_dp_rank`` and we drain it
+        here. For each still-in-flight request we invalidate the cached prefill
+        bootstrap info, re-init the receiver against the new dp_rank, and replay
+        the exact ``send_metadata`` we already published so the destination
+        prefill can pick the handshake up under the same bootstrap_room.
+        """
+        prealloc_queue = self.disagg_decode_prealloc_queue
+        if prealloc_queue is None:
+            return
+        kv_manager = prealloc_queue.kv_manager
+        drain = getattr(kv_manager, "drain_rebootstrap_requests", None)
+        if drain is None:
+            return
+        pending = drain()
+        if not pending:
+            return
+
+        # A request awaiting KV lives in the transfer queue (metadata already
+        # sent); one still resolving/preallocating lives in the prealloc queue.
+        by_room: Dict[int, DecodeRequest] = {}
+        for dr in self.disagg_decode_transfer_queue.queue:
+            by_room[dr.req.bootstrap_room] = dr
+        for dr in prealloc_queue.queue:
+            by_room.setdefault(dr.req.bootstrap_room, dr)
+
+        for room, new_dp_rank in pending.items():
+            decode_req = by_room.get(room)
+            if decode_req is None or decode_req.kv_receiver is None:
+                logger.debug(
+                    "REBOOTSTRAP for unknown/concluded room %s (dp_rank %s); skip",
+                    room,
+                    new_dp_rank,
+                )
+                continue
+            try:
+                decode_req.req.disagg_prefill_dp_rank = new_dp_rank
+                decode_req.kv_receiver.invalidate_cached_bootstrap_infos()
+                decode_req.kv_receiver.init(new_dp_rank)
+                sent = decode_req.last_sent_metadata
+                if sent is not None:
+                    decode_req.kv_receiver.send_metadata(
+                        sent["page_indices"],
+                        sent["aux_index"],
+                        sent["state_indices"],
+                        **sent["metadata_kwargs"],
+                    )
+                logger.info(
+                    "queue_lb: re-pointed room %s to prefill dp_rank %s", room, new_dp_rank
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to re-point room %s to dp_rank %s: %s",
+                    room,
+                    new_dp_rank,
+                    e,
+                )
+
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
@@ -2460,6 +2536,8 @@ class SchedulerDisaggregationDecodeMixin:
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
+            # queue_lb: re-point requests whose prefill peer migrated dp_rank.
+            self.process_prefill_migration_rebootstrap()
             self.process_decode_queue()
 
             # Get the next batch to run
@@ -2503,6 +2581,8 @@ class SchedulerDisaggregationDecodeMixin:
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
                 continue
+            # queue_lb: re-point requests whose prefill peer migrated dp_rank.
+            self.process_prefill_migration_rebootstrap()
             self.process_decode_queue()
 
             # Get the next batch to run

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -51,6 +51,13 @@ logger = logging.getLogger(__name__)
 MORI_GUARD = b"MoriMsgGuard"
 _TAG_ABORT = b"ABORT"
 
+# queue_lb (PD prefill migration): a prefill->decode control status that is
+# distinct from any real KVPoll value (KVPoll spans 0..4). When the decode
+# status worker sees this code it does NOT fail/complete the room; instead it
+# records "re-handshake this room against a new prefill dp_rank" so the decode
+# scheduler can re-point the request. The new dp_rank rides in the reason slot.
+MORI_STATUS_REBOOTSTRAP = -1
+
 
 def _normalize_state_indices_per_component(
     state_indices: Optional[List],
@@ -333,8 +340,29 @@ class MoriKVManager(CommonKVManager):
             self._start_bootstrap_thread()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.room_to_bootstrap_addr: Dict[int, str] = {}
+            # queue_lb: rooms the source prefill asked us to re-handshake against
+            # a new prefill dp_rank (room -> new_dp_rank). Filled by the decode
+            # status worker thread, drained by the decode scheduler loop.
+            self._rebootstrap_lock = threading.Lock()
+            self._rooms_to_rebootstrap: Dict[int, int] = {}
             self._start_decode_thread()
             self._start_heartbeat_checker_thread()
+
+    def note_rebootstrap_request(self, bootstrap_room: int, new_dp_rank: int) -> None:
+        """Thread-safe: record a queue_lb re-handshake request from a source
+        prefill rank. Latest write wins (a room can only be migrating to one
+        destination at a time)."""
+        with self._rebootstrap_lock:
+            self._rooms_to_rebootstrap[bootstrap_room] = new_dp_rank
+
+    def drain_rebootstrap_requests(self) -> Dict[int, int]:
+        """Return and clear all pending queue_lb re-handshake requests."""
+        with self._rebootstrap_lock:
+            if not self._rooms_to_rebootstrap:
+                return {}
+            drained = self._rooms_to_rebootstrap
+            self._rooms_to_rebootstrap = {}
+            return drained
 
     def _init_engine(self) -> IOEngine:
         if self.kv_args.ib_device:
@@ -809,7 +837,28 @@ class MoriKVManager(CommonKVManager):
                         else None
                     )
 
-                    if status_code == KVPoll.Success:
+                    if status_code == MORI_STATUS_REBOOTSTRAP:
+                        # queue_lb: the source prefill migrated this queued req
+                        # to a new dp_rank. The new rank rides in the reason
+                        # slot (payload[3]). Hand it to the decode scheduler to
+                        # re-point the receiver; do NOT touch request_status here
+                        # (the room stays WaitingForInput while we re-handshake).
+                        try:
+                            new_dp_rank = int(failure_reason)
+                        except (TypeError, ValueError):
+                            logger.warning(
+                                "Malformed REBOOTSTRAP dp_rank %r for room %s",
+                                failure_reason,
+                                bootstrap_room,
+                            )
+                            continue
+                        self.note_rebootstrap_request(bootstrap_room, new_dp_rank)
+                        logger.debug(
+                            "Room %s asked to rebootstrap onto prefill dp_rank %s",
+                            bootstrap_room,
+                            new_dp_rank,
+                        )
+                    elif status_code == KVPoll.Success:
                         tracker = self.prefill_response_tracker[bootstrap_room]
                         tracker.add(prefill_rank)
                         expected = self.required_prefill_response_num_table.get(
@@ -875,6 +924,30 @@ class MoriKVManager(CommonKVManager):
                     info.dst_port,
                     bootstrap_room,
                 )
+
+    def notify_decode_rebootstrap(
+        self,
+        infos: List[TransferInfo],
+        bootstrap_room: int,
+        new_dp_rank: int,
+    ) -> None:
+        """queue_lb: tell the decode peer(s) of ``bootstrap_room`` to re-handshake
+        against ``new_dp_rank``. Reuses the notify_decode_status frame shape with
+        the REBOOTSTRAP status sentinel; the new dp_rank rides in the reason slot
+        so the decode status worker can parse it without a new message type."""
+        self.notify_decode_status(
+            infos,
+            bootstrap_room,
+            MORI_STATUS_REBOOTSTRAP,
+            failure_reason=str(int(new_dp_rank)),
+        )
+
+    def get_transfer_infos(self, bootstrap_room: int) -> List[TransferInfo]:
+        """queue_lb: snapshot the decode-side TransferInfo(s) for a room (used to
+        address the rebootstrap notification before we tear the room down)."""
+        with self.transfer_lock:
+            infos = self.transfer_infos.get(bootstrap_room)
+            return list(infos.values()) if infos else []
 
     def _add_remote_peer(self, register_info: KVArgsRegisterInfo) -> None:
         engine_key = register_info.engine_key

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -598,6 +598,9 @@ class SchedulerDisaggregationPrefillMixin:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            # queue_lb: drain peer-migrated requests (they re-enter via the
+            # normal request path -> disagg_prefill_bootstrap_queue).
+            self.poll_migration_inbox()
             if self._engine_paused:
                 continue
             self.waiting_queue.extend(
@@ -637,6 +640,9 @@ class SchedulerDisaggregationPrefillMixin:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            # queue_lb: drain peer-migrated requests (they re-enter via the
+            # normal request path -> disagg_prefill_bootstrap_queue).
+            self.poll_migration_inbox()
             if self._engine_paused:
                 continue
             self.waiting_queue.extend(

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -34,6 +34,7 @@ from sglang.srt.managers.io_struct import (
     BatchTokenizedGenerateReqInput,
     BlockReqInput,
     ElasticScaleUpdateReq,
+    MigrateOutReq,
     ProfileReq,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
@@ -42,6 +43,7 @@ from sglang.srt.managers.io_struct import (
     unwrap_from_pickle,
     wrap_as_pickle,
 )
+from sglang.srt.managers.dp_queue_lb import DPQueueBalancer
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import run_scheduler_process
@@ -190,6 +192,24 @@ class DataParallelController:
             caller="DataParallelController",
         )
         self._last_refresh_time = 0.0
+
+        # DP waiting-queue load balancing (queue_lb feature, Phase 1).
+        self.queue_balancer: Optional[DPQueueBalancer] = None
+        if (
+            server_args.enable_dp_queue_balance
+            and get_parallel().config.enable_dp_attention
+        ):
+            self.queue_balancer = DPQueueBalancer(
+                server_args, get_parallel().config.dp_size
+            )
+            logger.info(
+                "DP waiting-queue load balancing enabled (interval=%sms, "
+                "threshold=%s, min_abs=%s, cap=%s).",
+                server_args.dp_queue_balance_interval_ms,
+                server_args.dp_queue_balance_threshold,
+                server_args.dp_queue_balance_min_abs,
+                server_args.dp_queue_balance_cap_per_round,
+            )
 
         # To protect changing env vars to set CUDA_VISIBLE_DEVICES.
         self.env_lock = threading.Lock()
@@ -803,8 +823,37 @@ class DataParallelController:
         )
         sock_send(self.workers[target_worker], req)
 
+    def maybe_run_queue_balance(self):
+        """Periodically rebalance per-rank waiting queues (queue_lb feature).
+
+        Reads the per-rank ``LoadSnapshot`` already collected for dispatch and,
+        when a rank is overloaded, sends a ``MigrateOutReq`` trigger to the donor
+        scheduler, which then ships requests peer-to-peer to the recipient.
+        """
+        if self.queue_balancer is None:
+            return
+        orders = self.queue_balancer.maybe_plan(self.load_snapshot_reader.read_all())
+        for order in orders:
+            src = order.src_dp_rank
+            if (
+                src >= len(self.workers)
+                or self.workers[src] is None
+                or not self.status[src]
+                or not self.status[order.dst_dp_rank]
+            ):
+                continue
+            sock_send(
+                self.workers[src],
+                MigrateOutReq(
+                    src_dp_rank=src,
+                    dst_dp_rank=order.dst_dp_rank,
+                    count=order.count,
+                ),
+            )
+
     def event_loop(self):
         while True:
+            self.maybe_run_queue_balance()
             while True:
                 self.soft_watchdog.feed()
                 try:

--- a/python/sglang/srt/managers/dp_queue_lb.py
+++ b/python/sglang/srt/managers/dp_queue_lb.py
@@ -1,0 +1,238 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+"""DP waiting-queue load balancing (queue_lb feature).
+
+Under DP attention with a consistent-hashing / dp-aware router, requests are
+routed to DP ranks by prefix key. This gives good prefix-cache locality but
+tends to make the per-rank waiting queues badly imbalanced (e.g. dp0 has 100
+queued reqs while dp6 has 3). Because DP attention is hard lock-step (the EP
+all-to-all synchronizes every rank each step), the most-loaded rank dictates the
+step time, so instantaneous queue imbalance directly creates bubbles.
+
+This module implements the runtime rebalancer:
+
+* ``DPQueueBalancer`` (runs inside the DataParallelController): reads the per-rank
+  ``LoadSnapshot`` it already collects and, with a naive threshold policy,
+  decides how many requests to move and where (``MigrationOrder``).
+* ``SchedulerMigrationAgent`` (runs inside each Scheduler): owns the peer-to-peer
+  ZMQ mesh used to actually ship migrated requests between DP ranks.
+
+Phase 1 (this skeleton): only requests that are still purely queued (not yet
+prefilled, no KV allocated) are migrated, so no KV cache has to travel with the
+request. Phase 2 will add KV migration through the shared UMBP DRAM pool.
+
+See queue_lb/PLAN.md for the full design.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import zmq
+
+from sglang.srt.managers.io_struct import MigrateBatchReq, sock_recv, sock_send
+from sglang.srt.utils.network import get_zmq_socket
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.load_snapshot import LoadSnapshot
+    from sglang.srt.server_args import PortArgs, ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def migration_endpoint(port_args: "PortArgs", dp_rank: int) -> str:
+    """Deterministic ipc:// endpoint for a DP rank's migration PULL socket.
+
+    Every DP-rank scheduler must derive the SAME endpoint for a given peer, so
+    the seed has to be a PortArgs field that is identical across all ranks.
+
+    ``scheduler_input_ipc_name`` and ``nccl_port`` are per-rank unique (each
+    scheduler gets its own via ``PortArgs.init_new``), so seeding on them makes
+    every rank bind/connect a different path and migrated requests are silently
+    dropped. Only ``tokenizer_ipc_name`` / ``detokenizer_ipc_name`` /
+    ``instance_id`` are explicitly kept shared across ranks
+    (see DataParallelController.launch_dp_schedulers), so seed on those.
+    """
+    seed = (
+        getattr(port_args, "tokenizer_ipc_name", None)
+        or getattr(port_args, "instance_id", None)
+        or "sglang"
+    )
+    digest = hashlib.sha1(str(seed).encode("utf-8")).hexdigest()[:12]
+    return f"ipc:///tmp/sglang_dp_migrate_{digest}_{dp_rank}.sock"
+
+
+@dataclass
+class MigrationOrder:
+    src_dp_rank: int
+    dst_dp_rank: int
+    count: int
+
+
+class DPQueueBalancer:
+    """Controller-side decision engine (naive threshold policy)."""
+
+    def __init__(self, server_args: "ServerArgs", dp_size: int):
+        self.dp_size = dp_size
+        self.threshold = server_args.dp_queue_balance_threshold
+        self.min_abs = server_args.dp_queue_balance_min_abs
+        self.cap_per_round = server_args.dp_queue_balance_cap_per_round
+        self.interval_s = server_args.dp_queue_balance_interval_ms / 1000.0
+        self._last_time = 0.0
+
+    def maybe_plan(
+        self, loads: List["LoadSnapshot"], now: Optional[float] = None
+    ) -> List[MigrationOrder]:
+        """Throttled entry point: returns [] until ``interval_ms`` has elapsed."""
+        now = now if now is not None else time.perf_counter()
+        if now - self._last_time < self.interval_s:
+            return []
+        self._last_time = now
+        return self.plan(loads)
+
+    def plan(self, loads: List["LoadSnapshot"]) -> List[MigrationOrder]:
+        """Compute migration orders from the current per-rank load snapshots.
+
+        Threshold policy:
+          * mean = average waiting-queue length over active ranks
+          * donor:     waiting > mean*(1+thr) and waiting >= min_abs
+          * recipient: waiting < mean*(1-thr)
+          * per donor budget = min(donor_excess, cap_per_round)
+          * per pair move = min(remaining_budget, recipient_deficit)
+        Greedy match: largest donors -> smallest recipients.
+        """
+        # waiting[rank] = queue length; None => no fresh snapshot for that rank.
+        waiting: Dict[int, int] = {}
+        for s in loads:
+            if 0 <= s.dp_rank < self.dp_size:
+                waiting[s.dp_rank] = int(s.num_waiting_reqs)
+        if len(waiting) < 2:
+            return []
+
+        values = list(waiting.values())
+        mean = sum(values) / len(values)
+        if mean <= 0:
+            return []
+
+        hi = mean * (1.0 + self.threshold)
+        lo = mean * (1.0 - self.threshold)
+
+        donors = sorted(
+            (
+                (rank, q)
+                for rank, q in waiting.items()
+                if q > hi and q >= self.min_abs
+            ),
+            key=lambda kv: kv[1],
+            reverse=True,
+        )
+        recipients = sorted(
+            ((rank, q) for rank, q in waiting.items() if q < lo),
+            key=lambda kv: kv[1],
+        )
+        if not donors or not recipients:
+            return []
+
+        # Mutable deficits/excess so a single round is internally consistent.
+        excess = {rank: int(q - mean) for rank, q in donors}
+        deficit = {rank: int(mean - q) for rank, q in recipients}
+
+        orders: List[MigrationOrder] = []
+        r_idx = 0
+        recipient_ranks = [rank for rank, _ in recipients]
+        for src, _ in donors:
+            src_budget = min(excess[src], self.cap_per_round)
+            while src_budget > 0 and r_idx < len(recipient_ranks):
+                dst = recipient_ranks[r_idx]
+                if deficit[dst] <= 0:
+                    r_idx += 1
+                    continue
+                move = min(src_budget, deficit[dst])
+                if move <= 0:
+                    break
+                orders.append(MigrationOrder(src, dst, move))
+                src_budget -= move
+                excess[src] -= move
+                deficit[dst] -= move
+            if r_idx >= len(recipient_ranks):
+                break
+
+        if orders:
+            logger.info("DPQueueBalancer plan (waiting=%s): %s", waiting, orders)
+        return orders
+
+
+class SchedulerMigrationAgent:
+    """Scheduler-side owner of the peer-to-peer migration ZMQ mesh.
+
+    Each DP-rank leader binds one PULL socket at ``migration_endpoint(rank)`` and
+    lazily opens PUSH sockets to peers when it needs to ship requests.
+    """
+
+    def __init__(
+        self,
+        context: zmq.Context,
+        port_args: "PortArgs",
+        dp_rank: int,
+        dp_size: int,
+        enabled: bool,
+    ):
+        self.enabled = enabled
+        self.dp_rank = dp_rank
+        self.dp_size = dp_size
+        self.port_args = port_args
+        self.context = context
+        self.recv_socket: Optional[zmq.Socket] = None
+        self._send_sockets: Dict[int, zmq.Socket] = {}
+
+        if not self.enabled:
+            return
+        endpoint = migration_endpoint(port_args, dp_rank)
+        # bind=True: this rank owns (creates) its own inbound endpoint.
+        self.recv_socket = get_zmq_socket(context, zmq.PULL, endpoint, True)
+        logger.info("SchedulerMigrationAgent dp_rank=%s listening on %s", dp_rank, endpoint)
+
+    def _get_send_socket(self, dst_rank: int) -> zmq.Socket:
+        sock = self._send_sockets.get(dst_rank)
+        if sock is None:
+            endpoint = migration_endpoint(self.port_args, dst_rank)
+            sock = get_zmq_socket(self.context, zmq.PUSH, endpoint, False)
+            self._send_sockets[dst_rank] = sock
+        return sock
+
+    def send_batch(self, msg: MigrateBatchReq) -> None:
+        if not self.enabled:
+            return
+        sock_send(self._get_send_socket(msg.dst_dp_rank), msg)
+
+    def poll(self) -> List[MigrateBatchReq]:
+        """Drain all pending migrated batches addressed to this rank."""
+        if not self.enabled or self.recv_socket is None:
+            return []
+        out: List[MigrateBatchReq] = []
+        while True:
+            try:
+                msg = sock_recv(self.recv_socket, flags=zmq.NOBLOCK)
+            except zmq.ZMQError:
+                break
+            if isinstance(msg, MigrateBatchReq):
+                out.append(msg)
+            else:
+                logger.warning("Migration mesh got unexpected message: %r", type(msg))
+        return out
+
+    def close(self) -> None:
+        for sock in self._send_sockets.values():
+            try:
+                sock.close(0)
+            except Exception:
+                pass
+        if self.recv_socket is not None:
+            try:
+                self.recv_socket.close(0)
+            except Exception:
+                pass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2053,6 +2053,40 @@ class AbortReq(BaseReq, kw_only=True):
             self.rid = ""
 
 
+class MigrateOutReq(BaseReq, kw_only=True):
+    """DP controller -> source scheduler.
+
+    Instructs the source DP rank to migrate up to ``count`` queued (un-prefilled)
+    requests to ``dst_dp_rank``. Part of the queue_lb DP waiting-queue load
+    balancing feature (Phase 1). See queue_lb/PLAN.md.
+    """
+
+    src_dp_rank: int = 0
+    dst_dp_rank: int = 0
+    count: int = 0
+
+
+class MigrateBatchReq(BaseReq, kw_only=True):
+    """Source scheduler -> destination scheduler (peer-to-peer mesh).
+
+    Carries the migrated requests as their original tokenized inputs so the
+    destination can re-enqueue them via the normal request path.
+
+    Phase 1: only un-prefilled requests migrate, so no KV cache travels with the
+    message. Phase 2 (``migrate_kv=True``): requests that already matched a
+    prefix KV may also migrate; the matched prefix is bridged through the shared
+    UMBP storage backend (content-addressed, dp-rank-independent for MLA), so the
+    KV bytes still do not travel on this socket — the destination re-fetches them
+    from storage via its normal prefetch path. ``migrate_kv`` is carried for
+    observability/logging; the destination path is identical either way.
+    """
+
+    src_dp_rank: int = 0
+    dst_dp_rank: int = 0
+    reqs: List[TokenizedGenerateReqInput] = msgspec.field(default_factory=list)
+    migrate_kv: bool = False
+
+
 class ActiveRanksOutput(BaseReq, kw_only=True):
     status: List[bool]
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -112,6 +112,9 @@ from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
 from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+import zmq
+
+from sglang.srt.managers.dp_queue_lb import SchedulerMigrationAgent
 from sglang.srt.managers.io_struct import (
     AbortReq,
     ActiveRanksOutput,
@@ -152,6 +155,8 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     LoadLoRAAdapterReqOutput,
     MMInputsProcessError,
+    MigrateBatchReq,
+    MigrateOutReq,
     OpenSessionReqInput,
     PauseGenerationReqInput,
     ProfileReq,
@@ -802,6 +807,10 @@ class Scheduler(
 
         self.load_snapshot_writer = None
         self.recv_from_tokenizer = None
+        # Defined on every rank so non-leader ranks (attn_tp_rank != 0), which
+        # still run handle_generate_request via broadcast, don't AttributeError.
+        self.migration_agent = None
+        self._migration_context = None
 
         if not is_rank_zero:
             return
@@ -817,6 +826,84 @@ class Scheduler(
             )
         except Exception as e:
             logger.warning("load snapshot writer init failed: %s", e)
+
+        self.init_migration_agent(port_args, dp_rank)
+
+    def init_migration_agent(self, port_args: PortArgs, dp_rank: int):
+        """Init the DP waiting-queue migration mesh (queue_lb feature, Phase 1)."""
+        self.migration_agent = None
+        enabled = bool(
+            getattr(self.server_args, "enable_dp_queue_balance", False)
+            and get_parallel().config.enable_dp_attention
+        )
+        if enabled and self.ps.attn_tp_size != 1:
+            # Phase 1 does not broadcast migrated reqs inside an attn_tp group,
+            # so it only supports attn_tp_size == 1 (e.g. dp8/tp8/ep8).
+            logger.warning(
+                "enable_dp_queue_balance requires attn_tp_size == 1 "
+                "(got %s); disabling DP queue balancing on this scheduler.",
+                self.ps.attn_tp_size,
+            )
+            enabled = False
+        self._migration_context = zmq.Context(2) if enabled else None
+        self.migration_agent = SchedulerMigrationAgent(
+            context=self._migration_context,
+            port_args=port_args,
+            dp_rank=dp_rank,
+            dp_size=self.ps.dp_size,
+            enabled=enabled,
+        )
+
+        # queue_lb Phase 2: also migrate queued reqs that already matched a
+        # prefix KV, bridging the prefix through the shared UMBP storage backend.
+        # Requires hicache storage (the shared L3 that both ranks read/write) and
+        # a RANK-REPLICATED KV cache so the storage key is dp/tp-rank independent
+        # (the same content hash resolves on the destination). That is exactly the
+        # condition hicache itself uses for a rank-independent key
+        # (cache_controller: is_rank_replicated = is_mla_model or
+        # is_compressed_mla_model): true MLA models AND DeepSeek-V4, whose
+        # DeepSeekV4TokenToKVPool is compressed-MLA rank-replicated even though its
+        # attention_arch is reported as MHA. Otherwise degrade to Phase 1.
+        self.migrate_kv_enabled = False
+        # rids of reqs that arrived via a Phase 2 (migrate_kv) batch on THIS rank,
+        # so we can prove the storage-bridge fired (destination storage_hit>0)
+        # rather than a plain recompute. Consumed once at schedule time.
+        self._migrate_kv_in_rids = set()
+        if enabled and getattr(
+            self.server_args, "dp_queue_balance_migrate_kv", False
+        ):
+            arch = getattr(self.model_config, "attention_arch", None)
+            is_mla = arch is not None and getattr(arch, "name", str(arch)) == "MLA"
+            # DeepSeek-V4's KV pool is compressed-MLA rank-replicated (shared,
+            # rank-independent storage key) even though attention_arch==MHA.
+            # NOTE: init_migration_agent runs before self.tp_worker is built, so
+            # read the already-initialized self.model_config (set above) rather
+            # than the worker's model_runner (which does not exist yet).
+            try:
+                hf_cfg = self.model_config.hf_config
+                is_compressed_mla = is_deepseek_v4(hf_cfg)
+            except Exception:
+                is_compressed_mla = False
+            is_rank_replicated = is_mla or is_compressed_mla
+            if self.enable_hicache_storage and is_rank_replicated:
+                self.migrate_kv_enabled = True
+                logger.info(
+                    "queue_lb Phase 2 KV migration enabled (hicache storage + "
+                    "rank-replicated KV: is_mla=%s is_compressed_mla=%s); "
+                    "matched-prefix queued reqs bridge through shared storage.",
+                    is_mla,
+                    is_compressed_mla,
+                )
+            else:
+                logger.warning(
+                    "dp_queue_balance_migrate_kv set but requires hicache storage "
+                    "(got enable_hicache_storage=%s) and a rank-replicated KV cache "
+                    "(got is_mla=%s is_compressed_mla=%s); degrading to Phase 1 "
+                    "(un-prefilled reqs only).",
+                    self.enable_hicache_storage,
+                    is_mla,
+                    is_compressed_mla,
+                )
 
     def init_idle_sleeper(self) -> None:
         if (
@@ -1624,6 +1711,8 @@ class Scheduler(
                 (AttachHiCacheStorageReqInput, self.attach_hicache_storage_wrapped),
                 (DetachHiCacheStorageReqInput, self.detach_hicache_storage_wrapped),
                 (AbortReq, self.abort_request),
+                (MigrateOutReq, self.handle_migrate_out),
+                (MigrateBatchReq, self.handle_migrate_in),
                 (OpenSessionReqInput, self.open_session),
                 (CloseSessionReqInput, self.close_session),
                 (
@@ -1814,6 +1903,7 @@ class Scheduler(
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            self.poll_migration_inbox()
             if self._engine_paused:
                 continue
 
@@ -1858,6 +1948,7 @@ class Scheduler(
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            self.poll_migration_inbox()
             if self._engine_paused:
                 continue
 
@@ -2656,6 +2747,11 @@ class Scheduler(
             )
             req.tokenizer = self.tokenizer
 
+            # queue_lb (Phase 1): keep the original tokenized input so a queued,
+            # un-prefilled request can be shipped verbatim to another DP rank.
+            if self.migration_agent is not None and self.migration_agent.enabled:
+                req.migration_src_recv_req = recv_req
+
             if radix_native_session:
                 req.session_generation = self.tree_cache.ensure_session_generation(
                     recv_req.session_id
@@ -3014,6 +3110,315 @@ class Scheduler(
                 req.storage_prefetch_retry_attempts,
             )
             self._prefetch_kvcache(req)
+
+    def poll_migration_inbox(self):
+        """Drain peer-migrated request batches and re-enqueue them.
+
+        Called once per scheduler loop. Migrated requests arrive as their
+        original ``TokenizedGenerateReqInput`` and are re-injected through the
+        normal request path, so they behave exactly like freshly dispatched
+        requests on this DP rank (queue_lb feature, Phase 1).
+        """
+        if self.migration_agent is None or not self.migration_agent.enabled:
+            return
+        for batch in self.migration_agent.poll():
+            # Undo the pickle-field wrapping applied before the peer socket hop
+            # (mirrors SchedulerRequestReceiver.unwrap_pickle_wrapper).
+            for sub_req in batch.reqs:
+                sub_req.unwrap_pickle_fields()
+            # Phase 2: remember which arrivals came through the KV-bridge path so
+            # we can later confirm the destination served their prefix from shared
+            # storage (storage_hit>0) instead of recomputing it.
+            if getattr(batch, "migrate_kv", False):
+                for sub_req in batch.reqs:
+                    rid = getattr(sub_req, "rid", None)
+                    if rid is not None:
+                        self._migrate_kv_in_rids.add(rid)
+            self.process_input_requests(batch.reqs)
+
+    def _is_migratable_waiting_req(self, req: Req) -> bool:
+        """Phase 1: only migrate requests that have not started prefill.
+
+        Such a request owns no KV cache and no radix-tree prefix lock, so it can
+        be re-run verbatim on the destination rank without any state transfer.
+        """
+        return (
+            getattr(req, "migration_src_recv_req", None) is not None
+            and len(req.output_ids) == 0
+            and req.req_pool_idx is None
+            and req.kv is None
+            and (req.prefix_indices is None or len(req.prefix_indices) == 0)
+            and not req.is_retracted
+            and req.finished_reason is None
+            # Phase 1: skip multimodal / embedding requests (their side inputs
+            # are not carried over the migration mesh yet).
+            and getattr(req, "multimodal_inputs", None) is None
+            and req.input_embeds is None
+        )
+
+    def _is_kv_migratable_req(self, req: Req) -> bool:
+        """Phase 2: migrate a queued req that already matched a prefix KV.
+
+        The matched prefix lives in shared radix nodes (not owned by this req);
+        we bridge it through the shared UMBP storage backend so the destination
+        re-fetches it by content hash instead of recomputing. Superset of the
+        Phase 1 predicate: drops the "no matched prefix" restriction but still
+        requires a request that has not started decode and holds no own KV pool
+        slot (i.e. still purely queued, not mid-prefill).
+        """
+        return (
+            getattr(req, "migration_src_recv_req", None) is not None
+            and len(req.output_ids) == 0
+            and req.req_pool_idx is None
+            and req.kv is None
+            and not req.is_retracted
+            and req.finished_reason is None
+            and getattr(req, "multimodal_inputs", None) is None
+            and req.input_embeds is None
+        )
+
+    def _is_pd_prefill_migratable_req(self, req: Req) -> bool:
+        """queue_lb (PD prefill): migrate a fully-bootstrapped, un-prefilled req.
+
+        Superset of the Phase 1 gate plus ``not pending_bootstrap``: the request
+        must sit in ``waiting_queue`` with its KV sender finalized
+        (``sender.init()`` done ⟺ room reached ``WaitingForInput`` ⟺ the decode
+        peer already published its transfer info), so we know the decode endpoint
+        to send the REBOOTSTRAP notification to and the handshake state is clean.
+
+        This deliberately excludes:
+          * requests mid-chunk (`self.chunked_req`, not in `waiting_queue`);
+          * requests that started prefill (`req_pool_idx`/`kv` set);
+          * optimistic re-queues (`is_retracted` after `reset_for_retract`);
+          * optimistic pre-handshake admissions (`pending_bootstrap`).
+        """
+        return (
+            getattr(req, "migration_src_recv_req", None) is not None
+            and len(req.output_ids) == 0
+            and req.req_pool_idx is None
+            and req.kv is None
+            and (req.prefix_indices is None or len(req.prefix_indices) == 0)
+            and not req.is_retracted
+            and req.finished_reason is None
+            and not getattr(req, "pending_bootstrap", False)
+            and getattr(req, "disagg_kv_sender", None) is not None
+            and getattr(req, "multimodal_inputs", None) is None
+            and req.input_embeds is None
+        )
+
+    def _backup_prefix_for_migration(self, req: Req) -> None:
+        """Ensure a migrating req's matched prefix is in shared storage (UMBP).
+
+        Idempotent: skips root / already-backed-up nodes. On any failure the
+        migration still proceeds — the destination just gets a storage miss and
+        recomputes the prefix, so correctness is preserved (only locality lost).
+        """
+        node = getattr(req, "last_host_node", None) or getattr(req, "last_node", None)
+        if node is None:
+            return
+        try:
+            if self.tree_cache.is_root(node) or self.tree_cache.is_backuped(node):
+                return
+            self.tree_cache.write_backup_storage(node)
+        except Exception as e:
+            logger.warning("migrate-kv prefix backup failed for %s: %s", req.rid, e)
+
+    def handle_migrate_out(self, recv_req: MigrateOutReq):
+        """Ship up to ``count`` queued requests to ``dst_dp_rank`` (queue_lb)."""
+        if self.migration_agent is None or not self.migration_agent.enabled:
+            return
+        if recv_req.dst_dp_rank == self.ps.dp_rank or recv_req.count <= 0:
+            return
+
+        # PD prefill uses a dedicated path: migrated reqs already hold a live KV
+        # sender + decode handshake, so we must tear that down and re-point the
+        # decode peer rather than just re-run them verbatim.
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            return self._handle_migrate_out_pd_prefill(recv_req)
+
+        # Phase 2: when KV migration is enabled we also move queued reqs that
+        # already matched a prefix KV (bridged via shared storage); otherwise
+        # only un-prefilled reqs move (Phase 1).
+        migratable = (
+            self._is_kv_migratable_req
+            if self.migrate_kv_enabled
+            else self._is_migratable_waiting_req
+        )
+
+        # Pick from the tail: these are the requests scheduled last, so moving
+        # them perturbs prefix-cache locality the least.
+        picked: List[Req] = []
+        keep: List[Req] = []
+        for req in reversed(self.waiting_queue):
+            if len(picked) < recv_req.count and migratable(req):
+                picked.append(req)
+            else:
+                keep.append(req)
+        if not picked:
+            return
+        # `keep` was built from a reversed walk; restore original order.
+        self.waiting_queue = list(reversed(keep))
+
+        migrated_inputs = []
+        for req in picked:
+            # Phase 2: flush this req's matched prefix to shared storage before it
+            # leaves, so the destination can re-fetch it by content hash.
+            if self.migrate_kv_enabled and self.enable_hicache_storage:
+                self._backup_prefix_for_migration(req)
+            src_input = req.migration_src_recv_req
+            # Re-target routing metadata so the destination (and any downstream
+            # bookkeeping) sees the request as belonging to the new DP rank.
+            src_input.routed_dp_rank = recv_req.dst_dp_rank
+            # Re-wrap pickle-only fields (e.g. time_stats) for the socket hop;
+            # the destination unwraps them in poll_migration_inbox().
+            src_input.wrap_pickle_fields()
+            migrated_inputs.append(src_input)
+            self._cleanup_migrated_out_req(req)
+
+        self.migration_agent.send_batch(
+            MigrateBatchReq(
+                src_dp_rank=self.ps.dp_rank,
+                dst_dp_rank=recv_req.dst_dp_rank,
+                reqs=migrated_inputs,
+                migrate_kv=self.migrate_kv_enabled,
+            )
+        )
+        logger.info(
+            "Migrated %s queued reqs dp%s -> dp%s (queue=%s, migrate_kv=%s).",
+            len(migrated_inputs),
+            self.ps.dp_rank,
+            recv_req.dst_dp_rank,
+            len(self.waiting_queue),
+            self.migrate_kv_enabled,
+        )
+
+    def _handle_migrate_out_pd_prefill(self, recv_req: MigrateOutReq):
+        """queue_lb PD prefill: migrate fully-bootstrapped, un-prefilled reqs.
+
+        For each picked request we (1) notify its decode peer to re-handshake
+        against ``dst_dp_rank`` over the KV control channel, (2) tear down the
+        local KV sender and free its metadata buffer / room state, then (3) ship
+        the original tokenized input over the migration mesh. The destination
+        re-enters it through the normal bootstrap queue and picks the handshake
+        back up under the same bootstrap_room.
+        """
+        from sglang.srt.disaggregation.base.conn import KVPoll
+        from sglang.srt.disaggregation.prefill import maybe_release_metadata_buffer
+
+        bootstrap_queue = self.disagg_prefill_bootstrap_queue
+        kv_manager = bootstrap_queue.kv_manager
+        notify = getattr(kv_manager, "notify_decode_rebootstrap", None)
+        get_infos = getattr(kv_manager, "get_transfer_infos", None)
+        if notify is None or get_infos is None:
+            logger.warning(
+                "queue_lb: KV backend %s lacks rebootstrap support; "
+                "PD prefill migration disabled.",
+                type(kv_manager).__name__,
+            )
+            return
+
+        picked: List[Req] = []
+        keep: List[Req] = []
+        for req in reversed(self.waiting_queue):
+            if (
+                len(picked) < recv_req.count
+                and self._is_pd_prefill_migratable_req(req)
+                # Defensive: the room must actually be WaitingForInput so its
+                # decode transfer info exists to address the notification.
+                and kv_manager.request_status.get(req.bootstrap_room)
+                == KVPoll.WaitingForInput
+            ):
+                picked.append(req)
+            else:
+                keep.append(req)
+        if not picked:
+            return
+        # `keep` was built from a reversed walk; restore original order.
+        self.waiting_queue = list(reversed(keep))
+
+        migrated_inputs = []
+        for req in picked:
+            room = req.bootstrap_room
+            # 1) Address + notify the decode peer(s) BEFORE tearing the room down
+            #    (teardown clears transfer_infos, losing the decode endpoint).
+            infos = get_infos(room)
+            if not infos:
+                # No decode endpoint recorded — cannot re-point safely; keep it.
+                self.waiting_queue.append(req)
+                continue
+            notify(infos, room, recv_req.dst_dp_rank)
+
+            # 2) Tear down the local sender + room state and free the metadata
+            #    buffer. We must NOT call sender.abort(): for mori that routes
+            #    through _finalize_failure() and pushes KVPoll.Failed to the very
+            #    decode peer we just told to re-handshake, racing it into a hard
+            #    failure. Instead clear the room's local bookkeeping silently:
+            #    clear() drops request_status/transfer_infos/req_to_decode_prefix
+            #    and _cleanup_room_tracking() detaches it from the sender-side
+            #    decode-liveness tracker so no stray failure is ever emitted.
+            try:
+                req.disagg_kv_sender.clear()
+                cleanup = getattr(kv_manager, "_cleanup_room_tracking", None)
+                if cleanup is not None:
+                    cleanup(room)
+            except Exception as e:
+                logger.warning("migrate-out sender teardown failed: %s", e)
+            maybe_release_metadata_buffer(
+                req, bootstrap_queue.req_to_metadata_buffer_idx_allocator
+            )
+            req.disagg_kv_sender = None
+            req.pending_bootstrap = True
+            req.metadata_buffer_index = -1
+
+            # 3) Re-target routing metadata and ship the original tokenized input.
+            src_input = req.migration_src_recv_req
+            src_input.routed_dp_rank = recv_req.dst_dp_rank
+            src_input.wrap_pickle_fields()
+            migrated_inputs.append(src_input)
+            self._cleanup_migrated_out_req(req)
+
+        if not migrated_inputs:
+            return
+
+        self.migration_agent.send_batch(
+            MigrateBatchReq(
+                src_dp_rank=self.ps.dp_rank,
+                dst_dp_rank=recv_req.dst_dp_rank,
+                reqs=migrated_inputs,
+                migrate_kv=False,
+            )
+        )
+        logger.info(
+            "Migrated %s PD-prefill reqs dp%s -> dp%s (queue=%s).",
+            len(migrated_inputs),
+            self.ps.dp_rank,
+            recv_req.dst_dp_rank,
+            len(self.waiting_queue),
+        )
+
+    def _cleanup_migrated_out_req(self, req: Req):
+        """Release local bookkeeping for a request leaving this rank.
+
+        The request keeps living on the destination rank under the same rid, so
+        (unlike abort) we must NOT notify the tokenizer here.
+        """
+        if self.enable_hicache_storage:
+            # Cancel any prefetch started by _prefetch_kvcache().
+            try:
+                self.tree_cache.release_aborted_request(req.rid)
+            except Exception as e:
+                logger.warning("migrate-out prefetch release failed: %s", e)
+
+    def handle_migrate_in(self, recv_req: MigrateBatchReq):
+        """Receive peer-migrated requests (queue_lb). See poll_migration_inbox.
+
+        Normally migrated batches arrive on the peer mesh and are handled by
+        poll_migration_inbox(); this dispatcher entry is a safety net for the
+        (unused) control-channel path.
+        """
+        for sub_req in recv_req.reqs:
+            sub_req.unwrap_pickle_fields()
+        self.process_input_requests(recv_req.reqs)
 
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
         if not self._set_or_validate_priority(req):
@@ -3681,6 +4086,20 @@ class Scheduler(
                 loaded_tokens = self.tree_cache.pop_prefetch_loaded_tokens(req.rid)
                 if loaded_tokens > 0:
                     req.storage_hit_length = loaded_tokens
+                # Phase 2 proof: a req that migrated in via the KV-bridge and now
+                # loaded its prefix from shared storage confirms the bridge worked
+                # (destination reused the cached prefix instead of recomputing).
+                if self._migrate_kv_in_rids:
+                    if req.rid in self._migrate_kv_in_rids:
+                        self._migrate_kv_in_rids.discard(req.rid)
+                        if loaded_tokens > 0:
+                            logger.info(
+                                "queue_lb Phase 2 storage-bridge hit: migrated req "
+                                "%s loaded %d prefix tokens from shared storage on "
+                                "this rank.",
+                                req.rid,
+                                loaded_tokens,
+                            )
 
             req.init_next_round_input(self.tree_cache)
             if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1093,6 +1093,53 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = False
+    # ---- DP waiting-queue load balancing (queue_lb feature) ----
+    # Periodically migrate queued requests from overloaded DP ranks to
+    # underloaded ones so that dp-attention lock-step bubbles shrink. See
+    # queue_lb/PLAN.md. Phase 1 only migrates un-prefilled waiting requests
+    # (no KV transfer yet); requires attn_tp_size == 1 (e.g. dp8/tp8/ep8).
+    enable_dp_queue_balance: A[
+        bool,
+        "Enable active load balancing of scheduler waiting queues across DP "
+        "ranks under DP attention (queue_lb feature, Phase 1).",
+        NS("parallel"),
+    ] = False
+    dp_queue_balance_interval_ms: A[
+        int,
+        "Minimum interval (ms) between two DP waiting-queue rebalance rounds.",
+        NS("parallel"),
+    ] = 200
+    dp_queue_balance_threshold: A[
+        float,
+        "Relative threshold over the mean queue length used to classify a DP "
+        "rank as a donor/recipient. A rank with queue length > mean*(1+thr) is "
+        "a donor; < mean*(1-thr) is a recipient.",
+        NS("parallel"),
+    ] = 0.5
+    dp_queue_balance_min_abs: A[
+        int,
+        "Minimum absolute waiting-queue length for a DP rank to be eligible as "
+        "a migration donor.",
+        NS("parallel"),
+    ] = 8
+    dp_queue_balance_cap_per_round: A[
+        int,
+        "Maximum number of requests migrated out of a single donor rank per "
+        "rebalance round.",
+        NS("parallel"),
+    ] = 32
+    dp_queue_balance_migrate_kv: A[
+        bool,
+        "queue_lb Phase 2: also migrate queued requests that already matched a "
+        "prefix KV, bridging that prefix through the shared hicache storage "
+        "backend instead of losing cache locality. Requires "
+        "--enable-hierarchical-cache with a shared --hicache-storage-backend "
+        "(e.g. file or umbp) and a rank-replicated KV cache so the storage key is "
+        "dp/tp-rank independent -- true MLA models or DeepSeek-V4 (compressed-MLA "
+        "rank-replicated pool); otherwise it degrades to Phase 1 (un-prefilled "
+        "reqs only) with a warning.",
+        NS("parallel"),
+    ] = False
     enable_tp_lm_head_all_to_all: A[
         Optional[bool],
         Arg(


### PR DESCRIPTION
## Goal
In data-parallel attention mode the per-DP-rank waiting queues can drift badly
out of balance (a shared long prefix or a skewed router pins bursts onto one
rank while its peers idle), which inflates prefill TTFT and wastes the other
ranks. This PR adds an opt-in balancer that migrates **queued, not-yet-prefilled**
requests from an overloaded DP rank to an idle one.

For PD-disaggregated prefill (mori KV backend) the migration also re-points the
decode side to the destination prefill rank via a mori REBOOTSTRAP sentinel, so
the KV is pulled from where it is actually computed and end-to-end correctness
is preserved.

## Design
- A per-scheduler balancer detects waiting-queue skew across DP ranks and plans
  `MigrationOrder(src, dst, count)` under configurable thresholds.
- Only fully-bootstrapped, un-prefilled requests are eligible: they sit in
  `waiting_queue` with the KV sender finalized (room at `WaitingForInput`) and
  hold no KV-pool slot or radix prefix lock, so they can be re-homed with no
  in-flight state transfer. Mid-chunk / retracted / pre-handshake requests are
  excluded.
- Migrate-out on the source is a silent teardown of the stale KV sender; the
  decode peer re-initializes its receiver against the new prefill rank.

## Server args (all default off — no behavior change when unset)
```
--enable-dp-queue-balance
--dp-queue-balance-interval-ms
--dp-queue-balance-threshold
--dp-queue-balance-min-abs
--dp-queue-balance-cap-per-round
```

## Status
- **Draft / RFC.** Rebased onto current `main`; the 8 touched files compile.
- Functional A/B on a single-node 1P1D DeepSeek-V4 setup (mori KV, skewed load
  pinned to one prefill DP rank) showed the migration path working end-to-end:
  requests were re-homed, the decode side re-pointed to the new prefill rank,
  and all requests completed, with a clear makespan / prefill-throughput
  improvement over the unbalanced baseline.
- **Multi-node full-window A/B — done (with a caveat, read carefully).**
  DeepSeek-V4 fp4, PD-disaggregated 1P1D (prefill TP8/EP8/dp-attn + decode
  TP8/EP8/dp-attn, 16 GPUs), mori KV + HiCache-DRAM, MTP-3, concurrency 192,
  agentic multi-turn trace replay, 3600 s measured window. Same recipe both arms;
  ON adds `--enable-dp-queue-balance` (interval 150 ms / threshold 0.4 /
  min-abs 4 / cap-per-round 32). **Single run per arm.**

  Important confound: the two arms did *not* land on the same realized
  prefix-cache hit ratio, so any token-throughput number that counts cached input
  tokens is not a clean queue_lb signal. The trace's *theoretical* cache-hit
  ceiling was the same (OFF 95.3% vs ON 95.5%), but the *realized* share of prompt
  tokens served from cache differed by ~8 pp (OFF 57.3% vs ON 65.1%). So the raw
  aiperf input-token throughput (OFF 43.4k → ON 53.4k tok/s, +23%) is inflated by
  ON simply hitting cache more this run.

  | metric | OFF | ON (queue_lb) | Δ | clean? |
  |---|--:|--:|--:|:--|
  | realized prefix-cache hit (of prompt tok) | 57.3% | 65.1% | +7.8 pp | — (confound) |
  | raw input throughput (tok/s, counts cache hits) | 43,835 | 53,959 | +23.1% | no (cache-inflated) |
  | **computed-prefill throughput (cache-miss tok/s)** | **34,871** | **37,557** | **+7.7%** | cache-independent |
  | requests completed | 1530 | 1618 | +5.8% | partly cache-confounded |
  | TTFT mean | 434.6 s | 358.0 s | −17.6% | partly cache-confounded |
  | TTFT p50 | 203.7 s | 167.2 s | −17.9% | partly cache-confounded |
  | TTFT p95 | 1211 s | 1313 s | +8.4% | — |
  | decode ITL / tpot mean | 12.25 ms | 12.29 ms | ~flat | yes |

  Honest reading: removing the cache-accounting inflation, the compute-normalized
  prefill throughput gain is **~+7.7%**, not +23%, and with a single run per arm
  and an unmatched 8 pp cache-hit gap that estimate is not yet separable from
  run-to-run variance. What *is* solidly established here is correctness/robustness,
  not a precise speedup: the balancer stayed active across the full window (tens of
  thousands of `MigrationOrder`s) with no correctness fallout — no stray KV
  failures, no cascading decode aborts, every migrated room re-homed and completed,
  window not truncated. A clean throughput number needs cache-hit-matched repeats
  (fixed router seed / warm-cache pinning, N≥3 per arm); that is the next step.

## Notes / open questions for reviewers
- Currently wired for the mori transfer backend; other PD backends would need
  an equivalent re-point hook.
- Threshold defaults are conservative; feedback welcome on the balancing policy
  (interval / abs / relative-threshold / per-round cap) and on the migratable
  predicate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33494727003](https://github.com/sgl-project/sglang/actions/runs/33494727003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33494726726](https://github.com/sgl-project/sglang/actions/runs/33494726726)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33494726761](https://github.com/sgl-project/sglang/actions/runs/33494726761)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

