### PR TITLE
[Speculative Decoding] Add pluggable acceptance-policy seam for DSpark

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/acceptance_policy.py
+++ b/python/sglang/srt/speculative/dspark_components/acceptance_policy.py
@@ -1,0 +1,82 @@
+"""Pluggable acceptance policy seam for DSpark verification.
+
+A policy lets a custom speculative algorithm replace how verified draft
+tokens are accepted -- e.g. a relaxed or approximate acceptance rule --
+while reusing DSpark's drafting, target verification, KV commit, and
+finalization paths.
+
+The hot interface must return the same ``(correct_len, bonus,
+cap_trim_lens)`` contract as the native greedy verifier, so every
+downstream consumer (finalization, KV commit, request tokens, next draft
+input) stays unchanged and unaware of the policy.
+
+Policies are injected by overriding
+:meth:`DSparkWorkerV2._build_acceptance_policy
+<sglang.srt.speculative.dspark_components.dspark_worker_v2.DSparkWorkerV2._build_acceptance_policy>`;
+the intended pattern is a custom speculative algorithm registered via
+``SpeculativeAlgorithm.register`` whose worker subclasses
+``DSparkWorkerV2``. Returning ``None`` (the default) keeps DSpark's native
+strict greedy verification with zero overhead.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple
+
+import torch
+
+AcceptTuple = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+
+class DSparkAcceptancePolicy:
+    """Base class for substituting DSpark's greedy acceptance rule.
+
+    Subclasses must implement :meth:`accept`. The lifecycle hooks are
+    no-ops by default; override them to keep per-request state (e.g.
+    budgets) bound to request identities across decode steps.
+    """
+
+    def bind_batch(self, batch) -> None:
+        """Called at the prefill lifecycle point, before decode steps.
+
+        Override to bind per-request state to request identities. The
+        batch carries ``reqs`` (with ``rid`` and ``req_pool_idx``) and the
+        request-pool mapping; heavy bookkeeping belongs here rather than
+        on the decode hot path.
+        """
+
+    def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
+        """Called when a request finishes; release its per-request state."""
+
+    def accept(
+        self,
+        *,
+        candidates: torch.Tensor,
+        target_logits: Optional[torch.Tensor],
+        cutoff_verify_lens: Optional[torch.Tensor],
+        req_pool_indices: torch.Tensor,
+        all_greedy: bool,
+        native_accept: Callable[[], AcceptTuple],
+    ) -> AcceptTuple:
+        """Choose the acceptance outcome for one verify batch.
+
+        Args:
+            candidates: ``[bs, verify_num_draft_tokens]`` candidate ids;
+                column 0 is the anchor token, columns ``1..gamma`` the
+                drafts under verification.
+            target_logits: ``[bs * verify_num_draft_tokens, vocab]``
+                next-token logits produced by the target forward, or
+                ``None`` when the backend folds them away.
+            cutoff_verify_lens: per-request verify budget from the ragged
+                planner (``None`` for the static layout).
+            req_pool_indices: request-pool device indices of the batch.
+            all_greedy: whether every request in the batch is greedy.
+            native_accept: callable returning the native strict greedy
+                ``(correct_len, bonus, cap_trim_lens)``; policies may
+                delegate to it (e.g. on a non-greedy batch).
+
+        Returns:
+            ``(correct_len, bonus, cap_trim_lens)`` with the same shapes
+            and semantics as the native greedy verifier.
+        """
+        raise NotImplementedError

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -32,6 +32,9 @@ from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, Forw
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import apply_dflash_verify_logits_adjustments
+from sglang.srt.speculative.dspark_components.acceptance_policy import (
+    DSparkAcceptancePolicy,
+)
 from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockResult
 from sglang.srt.speculative.dspark_components.dspark_kv_inject import (
     TargetHiddenKvInjector,
@@ -90,6 +93,7 @@ class TargetVerifyExecutor:
         tp_sync: SpecTpSync,
         verify_epilogue=None,
         simulate_acc_len: float = 0.0,
+        acceptance_policy: Optional["DSparkAcceptancePolicy"] = None,
     ) -> None:
         self.target_worker = target_worker
         self.gamma = int(gamma)
@@ -98,6 +102,7 @@ class TargetVerifyExecutor:
         self.kv_injector = kv_injector
         self._tp_sync = tp_sync
         self.verify_epilogue = verify_epilogue
+        self._acceptance_policy = acceptance_policy
         self._verify_backend_self_adds_seq_lens_cache: Optional[bool] = None
         self._simulate_acc_len = float(simulate_acc_len)
         self._simulated_correct_drafts_buf: Optional[torch.Tensor] = None
@@ -115,6 +120,7 @@ class TargetVerifyExecutor:
         layout: Optional[RaggedVerifyLayout],
         prefix_lens: torch.Tensor,
         draft_tokens: torch.Tensor,
+        req_pool_indices: Optional[torch.Tensor] = None,
     ) -> AcceptOuts:
         """Produce the per-request accept outcome after target verify.
 
@@ -124,18 +130,41 @@ class TargetVerifyExecutor:
         override.
         """
         if folded_accept:
+            if self._acceptance_policy is not None:
+                raise RuntimeError(
+                    "a DSpark acceptance policy cannot use folded native "
+                    "acceptance; disable the folded-accept path when a "
+                    "policy is active"
+                )
             return self.verify_epilogue.read_accept(bs)
 
-        correct_len, bonus, cap_trim_lens = accept_draft_tokens(
-            candidates=verify_ids_2d,
-            target_logits=target_logits,
-            draft_block=draft_block,
-            sampling_info=sampling_info,
-            draft_input=draft_input,
-            gamma=self.gamma,
-            verify_num_draft_tokens=self.verify_num_draft_tokens,
-            cutoff_layout=layout,
-        )
+        def native_accept():
+            return accept_draft_tokens(
+                candidates=verify_ids_2d,
+                target_logits=target_logits,
+                draft_block=draft_block,
+                sampling_info=sampling_info,
+                draft_input=draft_input,
+                gamma=self.gamma,
+                verify_num_draft_tokens=self.verify_num_draft_tokens,
+                cutoff_layout=layout,
+            )
+
+        if self._acceptance_policy is None:
+            correct_len, bonus, cap_trim_lens = native_accept()
+        else:
+            if req_pool_indices is None:
+                raise RuntimeError(
+                    "DSpark acceptance policy requires request-pool indices"
+                )
+            correct_len, bonus, cap_trim_lens = self._acceptance_policy.accept(
+                candidates=verify_ids_2d,
+                target_logits=target_logits,
+                cutoff_verify_lens=(None if layout is None else layout.verify_lens),
+                req_pool_indices=req_pool_indices,
+                all_greedy=(sampling_info is None or sampling_info.is_all_greedy),
+                native_accept=native_accept,
+            )
         if self._simulate_acc_len > 0:
             correct_len = self._simulated_correct_len(
                 bs=bs, dtype=correct_len.dtype, device=correct_len.device

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -39,6 +39,9 @@ from sglang.srt.speculative.draft_worker_common import (
     make_draft_block_spec_info,
     make_draft_sampler_capture_hook,
 )
+from sglang.srt.speculative.dspark_components.acceptance_policy import (
+    DSparkAcceptancePolicy,
+)
 from sglang.srt.speculative.dspark_components.dspark_config import (
     DSV4_DRAFT_ATTENTION_BACKEND,
     draft_is_deepseek_v4,
@@ -346,6 +349,8 @@ class DSparkWorkerV2(BaseSpecWorker):
                 f"{self._simulate_acc_len}."
             )
 
+        self._acceptance_policy = self._build_acceptance_policy()
+
         self._verify_executor = TargetVerifyExecutor(
             target_worker=self.target_worker,
             gamma=self.gamma,
@@ -355,6 +360,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             tp_sync=self._tp_sync,
             verify_epilogue=self._verify_epilogue,
             simulate_acc_len=self._simulate_acc_len,
+            acceptance_policy=self._acceptance_policy,
         )
 
         self._forced_budget_frac: Optional[float] = None
@@ -506,6 +512,23 @@ class DSparkWorkerV2(BaseSpecWorker):
 
     def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
         self._observers.note_request_finished(rid=rid, natural_stop=natural_stop)
+        if self._acceptance_policy is not None:
+            self._acceptance_policy.note_request_finished(
+                rid=rid, natural_stop=natural_stop
+            )
+
+    def _build_acceptance_policy(self) -> Optional[DSparkAcceptancePolicy]:
+        """Hook: override to substitute DSpark's greedy acceptance rule.
+
+        Returning ``None`` (the default) keeps DSpark's native strict greedy
+        verification with zero overhead. The intended pattern is a custom
+        speculative algorithm registered via ``SpeculativeAlgorithm.register``
+        whose worker subclasses ``DSparkWorkerV2`` and returns a
+        ``DSparkAcceptancePolicy`` here to replace acceptance (e.g. with a
+        relaxed or approximate rule). The policy's outputs must keep the
+        native ``(correct_len, bonus, cap_trim_lens)`` contract.
+        """
+        return None
 
     def forward_batch_generation(
         self,
@@ -516,6 +539,8 @@ class DSparkWorkerV2(BaseSpecWorker):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
+            if self._acceptance_policy is not None:
+                self._acceptance_policy.bind_batch(batch)
             return self._forward_prefill(batch, on_publish)
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
@@ -816,6 +841,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             layout=layout,
             prefix_lens=prefix_lens,
             draft_tokens=draft_tokens,
+            req_pool_indices=batch.req_pool_indices,
         )
         if batch.return_logprob:
             compute_spec_logprobs(

--- a/test/registered/unit/spec/test_dspark_acceptance_policy.py
+++ b/test/registered/unit/spec/test_dspark_acceptance_policy.py
@@ -1,0 +1,223 @@
+"""Unit tests for the DSpark pluggable acceptance-policy seam.
+
+Covers the DSparkAcceptancePolicy base-class contract, the worker hook
+defaults and lifecycle forwarding, and TargetVerifyExecutor's policy
+routing (native fallback, folded-accept rejection, argument plumbing, and
+the (correct_len, bonus, cap_trim_lens) contract passthrough).
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.speculative.dspark_components.acceptance_policy import (
+    DSparkAcceptancePolicy,
+)
+from sglang.srt.speculative.dspark_components.dspark_verify import (
+    TargetVerifyExecutor,
+)
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import DSparkWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SpyPolicy(DSparkAcceptancePolicy):
+    """Records lifecycle calls; returns a fixed or native-delegated result."""
+
+    def __init__(self, result=None, delegate_native=False):
+        self.accept_calls = []
+        self.bound_batches = []
+        self.finished = []
+        self._result = result
+        self._delegate_native = delegate_native
+
+    def bind_batch(self, batch):
+        self.bound_batches.append(batch)
+
+    def note_request_finished(self, *, rid, natural_stop):
+        self.finished.append((rid, natural_stop))
+
+    def accept(self, **kwargs):
+        self.accept_calls.append(kwargs)
+        if self._delegate_native:
+            return kwargs["native_accept"]()
+        return self._result
+
+
+class _NoopTpSync:
+    def sync(self, site, tensor):
+        pass
+
+
+class TestPolicyBaseClass(CustomTestCase):
+    def test_lifecycle_hooks_are_default_noops(self):
+        policy = DSparkAcceptancePolicy()
+        policy.bind_batch(object())
+        policy.note_request_finished(rid="r0", natural_stop=True)
+
+    def test_accept_is_abstract(self):
+        policy = DSparkAcceptancePolicy()
+        with self.assertRaises(NotImplementedError):
+            policy.accept(
+                candidates=torch.zeros(1, 2, dtype=torch.int64),
+                target_logits=None,
+                cutoff_verify_lens=None,
+                req_pool_indices=torch.zeros(1, dtype=torch.int64),
+                all_greedy=True,
+                native_accept=lambda: None,
+            )
+
+
+class TestWorkerHook(CustomTestCase):
+    def test_default_hook_returns_none(self):
+        # Unbound call: the default hook must not touch worker state, so a
+        # bare sentinel works as `self` without constructing the worker.
+        self.assertIsNone(DSparkWorkerV2._build_acceptance_policy(object()))
+
+    def test_note_request_finished_forwards_to_policy(self):
+        # __new__ skips the heavy __init__; the method only needs the two
+        # attributes it touches.
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        policy = _SpyPolicy()
+
+        class _Observers:
+            def note_request_finished(self, *, rid, natural_stop):
+                pass
+
+        worker._observers = _Observers()
+        worker._acceptance_policy = policy
+        worker.note_request_finished(rid="r1", natural_stop=False)
+        self.assertEqual(policy.finished, [("r1", False)])
+
+
+class TestExecutorSeam(CustomTestCase):
+    """TargetVerifyExecutor routes acceptance through the policy or native."""
+
+    def _executor(self, policy):
+        return TargetVerifyExecutor(
+            target_worker=None,
+            gamma=2,
+            verify_num_draft_tokens=3,
+            model_runner=None,
+            kv_injector=None,
+            tp_sync=_NoopTpSync(),
+            verify_epilogue=None,
+            simulate_acc_len=0.0,
+            acceptance_policy=policy,
+        )
+
+    def _kwargs(self, **overrides):
+        kwargs = dict(
+            folded_accept=False,
+            bs=2,
+            verify_ids_2d=torch.tensor([[7, 8, 9], [10, 11, 12]], dtype=torch.int64),
+            target_logits=torch.randn(6, 8),
+            draft_block=None,
+            sampling_info=None,
+            draft_input=None,
+            layout=None,
+            prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+            draft_tokens=torch.tensor([[1, 2], [3, 4]], dtype=torch.int64),
+            req_pool_indices=torch.tensor([5, 6], dtype=torch.int64),
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_folded_accept_rejects_policy(self):
+        executor = self._executor(_SpyPolicy())
+        with self.assertRaisesRegex(RuntimeError, "folded"):
+            executor.accept_and_finalize(**self._kwargs(folded_accept=True))
+
+    def test_folded_accept_without_policy_reads_epilogue(self):
+        class _Epilogue:
+            def read_accept(self, bs):
+                return ("accept", bs)
+
+        executor = self._executor(None)
+        executor.verify_epilogue = _Epilogue()
+        out = executor.accept_and_finalize(**self._kwargs(folded_accept=True))
+        self.assertEqual(out, ("accept", 2))
+
+    def test_policy_receives_native_contract_arguments(self):
+        policy = _SpyPolicy(
+            result=(
+                torch.tensor([1, 2], dtype=torch.int32),
+                torch.tensor([100, 200], dtype=torch.int64),
+                torch.tensor([0, 1], dtype=torch.int32),
+            )
+        )
+        kwargs = self._kwargs()
+        executor = self._executor(policy)
+        out = executor.accept_and_finalize(**kwargs)
+
+        self.assertEqual(len(policy.accept_calls), 1)
+        call = policy.accept_calls[0]
+        self.assertIs(call["candidates"], kwargs["verify_ids_2d"])
+        self.assertIs(call["target_logits"], kwargs["target_logits"])
+        self.assertIsNone(call["cutoff_verify_lens"])  # layout is None
+        self.assertIs(call["req_pool_indices"], kwargs["req_pool_indices"])
+        self.assertTrue(call["all_greedy"])  # sampling_info is None
+
+        # Passthrough: the policy's tuple is authoritative downstream.
+        self.assertTrue(torch.equal(out.correct_len, torch.tensor([1, 2])))
+        self.assertTrue(torch.equal(out.bonus, torch.tensor([100, 200])))
+        # FinalizeAcceptLens: commit = correct_len + 1; new = prefix + commit.
+        self.assertTrue(torch.equal(out.commit_lens, torch.tensor([2, 3])))
+        self.assertTrue(torch.equal(out.new_seq_lens, torch.tensor([12, 23])))
+        self.assertTrue(torch.equal(out.cap_trim_lens, torch.tensor([0, 1])))
+        # BuildOutTokens: draft prefix kept, bonus scattered at correct_len.
+        self.assertTrue(
+            torch.equal(
+                out.out_tokens,
+                torch.tensor([[1, 100, 0], [3, 4, 200]], dtype=torch.int64),
+            )
+        )
+
+    def test_policy_without_req_pool_indices_raises(self):
+        policy = _SpyPolicy(
+            result=(
+                torch.tensor([1], dtype=torch.int32),
+                torch.tensor([1], dtype=torch.int64),
+                torch.tensor([0], dtype=torch.int32),
+            )
+        )
+        executor = self._executor(policy)
+        with self.assertRaisesRegex(RuntimeError, "request-pool indices"):
+            executor.accept_and_finalize(**self._kwargs(req_pool_indices=None))
+
+    def test_no_policy_calls_native_accept(self):
+        executor = self._executor(None)
+        sentinel = (
+            torch.tensor([1, 2], dtype=torch.int32),
+            torch.tensor([100, 200], dtype=torch.int64),
+            torch.tensor([0, 1], dtype=torch.int32),
+        )
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_verify.accept_draft_tokens",
+            return_value=sentinel,
+        ) as native:
+            out = executor.accept_and_finalize(**self._kwargs())
+        native.assert_called_once()
+        self.assertTrue(torch.equal(out.correct_len, sentinel[0]))
+
+    def test_policy_can_delegate_to_native(self):
+        executor = self._executor(_SpyPolicy(delegate_native=True))
+        sentinel = (
+            torch.tensor([1, 2], dtype=torch.int32),
+            torch.tensor([100, 200], dtype=torch.int64),
+            torch.tensor([0, 1], dtype=torch.int32),
+        )
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_verify.accept_draft_tokens",
+            return_value=sentinel,
+        ):
+            out = executor.accept_and_finalize(**self._kwargs())
+        self.assertTrue(torch.equal(out.correct_len, sentinel[0]))
+        self.assertTrue(torch.equal(out.bonus, sentinel[1]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

DSpark hardcodes strict greedy verification inside `TargetVerifyExecutor`: the first mismatched draft token discards the whole draft suffix. Research algorithms that only relax this acceptance step -- bounded-regret / approximate speculative decoding, budgeted verification, calibrated relaxation -- currently cannot reuse DSpark's drafting, target verification, KV commit, and finalization paths without forking them, because the acceptance decision is not substitutable.

We propose a minimal, algorithm-neutral seam: a `DSparkAcceptancePolicy` that receives the verify-batch tensors and returns the native `(correct_len, bonus, cap_trim_lens)` contract. Policy implementations live out of tree (registered speculative algorithms whose worker subclasses `DSparkWorkerV2`); SGLang carries no algorithm code, no new server args, and no new dependencies. Returning `None` from the worker hook (the default) keeps native strict greedy verification with zero overhead.

Motivating out-of-tree use case (measured with a research evaluator, Qwen3-14B + DSpark block7 draft, 8xL20, greedy): a bounded-regret acceptance policy with a calibrated per-request budget achieves **+13.34% TPS at -0.227 pp GSM8K accuracy** vs strict, and its B=0 setting is token-identical to strict on all 1319 GSM8K requests. That policy now runs entirely as a plugin against this seam (ASD repository, `integrations/sglang-dspark/plugin`), demonstrating the interface is sufficient for a real acceptance-relaxation algorithm.

## Modifications

- `python/sglang/srt/speculative/dspark_components/acceptance_policy.py` (new, 82 lines): `DSparkAcceptancePolicy` base class. `accept()` receives `candidates`, `target_logits`, per-request `cutoff_verify_lens`, `req_pool_indices`, an `all_greedy` flag, and a `native_accept` callable (policies may delegate, e.g. on non-greedy batches). It must return the native `(correct_len, bonus, cap_trim_lens)` tuple, so every downstream consumer -- `FinalizeAcceptLens`, `BuildOutTokens`, KV commit, request tokens, next draft input, metrics -- stays unchanged and unaware of the policy. `bind_batch` / `note_request_finished` lifecycle hooks let stateful policies bind per-request state at prefill and release it at request finish, off the decode hot path (the request-finished call site already exists in `batch_result_processor.py` on main).
- `dspark_verify.py`: `TargetVerifyExecutor` gains an optional `acceptance_policy`. When one is active, acceptance routes through `policy.accept(...)`; the folded-accept (in-graph) path fails loudly instead of silently bypassing the policy, and `req_pool_indices` is plumbed through and required. Without a policy the code path is byte-for-byte the native one (the native call is wrapped in a closure only).
- `dspark_worker_v2.py`: `_build_acceptance_policy` hook (default `None`), lifecycle forwarding (`bind_batch` at prefill, `note_request_finished`), and `req_pool_indices` forwarding to `accept_and_finalize`.
- No server args, no public API changes, no new dependencies, no behavior change when unused.

## Accuracy Tests

`test/registered/unit/spec/test_dspark_acceptance_policy.py` -- 10 registered CPU unit tests (suite `base-a-test-cpu`), covering:

- the base-class contract (lifecycle hooks are no-ops; `accept` is abstract);
- the worker hook (default returns `None`; `note_request_finished` forwards to the policy);
- executor routing: no-policy calls the native verifier; folded-accept rejects a policy; a policy without `req_pool_indices` fails loudly; a policy receives the documented tensor arguments; a policy may delegate to `native_accept`;
- the contract passthrough: a policy-returned `(correct_len, bonus, cap_trim_lens)` flows through the real `FinalizeAcceptLens` / `BuildOutTokens` kernels (CPU torch paths) and produces the exact expected `commit_lens` / `new_seq_lens` / `out_tokens`.

All 10 pass locally against the real kernel implementations (the sglang package cannot be imported on this Windows host, so they were run by loading the real modules with stubbed engine-internal imports; CI will run them natively). `black` / `isort` / `py_compile` pass locally.

Default-path equivalence: with no policy installed, `accept_and_finalize` executes the same native `accept_draft_tokens` call on the same arguments -- the diff wraps it in a closure and adds one `is None` branch, so existing DSpark behavior (and all existing DSpark tests/benchmarks) is unchanged.

Algorithm-level accuracy for the motivating policy (out-of-tree, research evaluator; Qwen3-14B + `deepseek-ai/dspark_qwen3_14b_block7`, 8xL20, greedy, `num_speculative_tokens=7`, `max_new_tokens=256`, fixed seed):

| Arm | GSM8K (1319) | Output vs strict |
|-----|--------------|------------------|
| strict (no policy) | 79.682% (1051/1319) | - |
| policy B=0 (sanity) | 79.682% (1051/1319) | token-identical on all 1319 requests |
| policy B=2.0625 (calibrated q25) | 79.454% (1048/1319) | bounded-regret deviation; -0.227 pp |

The B=0 arm is the correctness gate for any policy built on this seam: a zero budget must reproduce strict greedy exactly, and it does, token for token. Server-level validation of the plugin is pending CUDA 13-capable hardware.

## Speed Tests and Profiling

The seam is designed to add zero cost to the default path: the hook returns `None` before the verify executor is built, and the executor then takes the unchanged native branch (one attribute check). The policy path itself adds one Python call per verify batch; policies are expected to keep the hot path device-side (the reference plugin never synchronizes on decode).

Reference-plugin measurements (research evaluator, same setup as above):

| Arm | TPS (tok/s) | Accept rate | Mean accept length |
|-----|------------:|------------:|-------------------:|
| strict | 66.21 | 48.49% | 3.395 |
| policy B=2.0625 (q25) | 75.04 (+13.34%) | 51.08% | 3.576 |

Server-level TTFT/ITL percentiles (`sglang.bench_serving`) with the plugin are pending the same CUDA 13 hardware; the seam's default-path overhead will be profiled there as well (expected: none, as the native branch is unchanged).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). - docstrings on the interface; happy to add a `docs/` section on pluggable acceptance policies if maintainers want one.
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). - seam unit tests attached; research-evaluator evidence for the motivating policy; server-level numbers pending CUDA 13 hardware.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34320345516](https://github.com/sgl-project/sglang/actions/runs/34320345516)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34320345028](https://github.com/sgl-project/sglang/actions/runs/34320345028)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34320345409](https://github.com/sgl-project/sglang/actions/runs/34320345409)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->