### PR TITLE
[CI] Add entrypoint to hc_combine test for standalone execution

### DIFF
--- a/test/registered/kernels/ops/layernorm/test_hc_combine.py
+++ b/test/registered/kernels/ops/layernorm/test_hc_combine.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 import torch
 
 from sglang.kernels.ops.layernorm.mhc import hc_combine
@@ -51,3 +52,7 @@ def test_hc_combine_strided_pre():
     ref = _reference(x_flat, pre, hc, torch.bfloat16)
     scale = ref.float().abs().max().clamp(min=1e-6)
     assert (got.float() - ref.float()).abs().max() / scale < 5e-2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/kernels/ops/layernorm/test_hc_combine.py
+++ b/test/registered/kernels/ops/layernorm/test_hc_combine.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 import torch
 
 from sglang.kernels.ops.layernorm.mhc import hc_combine


### PR DESCRIPTION
### Description
Adds the standard `if __name__ == "__main__": sys.exit(pytest.main([__file__]))` block to `test/registered/kernels/ops/layernorm/test_hc_combine.py`, allowing the test to be run directly via `python test_hc_combine.py` (useful for quick manual runs on GPU hosts). This matches the convention already used by 19 sibling kernel tests (e.g. `test_mhc_kernels.py`, `test_fused_op.py`).

fix #35118 breaking test suites

### Changes
- Add `__main__` entrypoint invoking pytest to `test_hc_combine.py`

### Notes
- No logic changes; pure test-runner convenience.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33509256039](https://github.com/sgl-project/sglang/actions/runs/33509256039)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33509255905](https://github.com/sgl-project/sglang/actions/runs/33509255905)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33509256061](https://github.com/sgl-project/sglang/actions/runs/33509256061)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->