### PR TITLE
DeepSeek-V4 decode context parallelism on AMD HIP (unified_kv)

### DIFF
--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -496,6 +496,8 @@ def _dcp_lse_combine_kernel(
     out_stride_B,
     out_stride_H,
     out_stride_D,
+    out_lse_stride_B,
+    out_lse_stride_H,
     N: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     IS_BASE_E: tl.constexpr,
@@ -567,7 +569,11 @@ def _dcp_lse_combine_kernel(
             global_lse = tl.log(weight_sum) + lse_max
         else:
             global_lse = tl.log2(weight_sum) + lse_max
-        out_lse_offset = batch_idx * recv_lse_stride_B + head_idx * recv_lse_stride_H
+        # NOTE: out_lse is a distinct (contiguous) buffer, NOT a strided view
+        # into the recv transport, so it needs its OWN strides here. Reusing
+        # recv_lse_stride_{B,H} silently corrupts / overruns out_lse whenever
+        # the a2a caller hands in a strided recv_lse (last-dim stride == D+lpd).
+        out_lse_offset = batch_idx * out_lse_stride_B + head_idx * out_lse_stride_H
         tl.store(out_lse_ptr + out_lse_offset, global_lse)
 
 
@@ -599,6 +605,12 @@ def dcp_lse_combine_triton(
         else recv_lse.new_empty(0)
     )
 
+    # out_lse is a 0-sized placeholder when return_lse is False; its strides are
+    # never read by the kernel then, so pass harmless zeros.
+    out_lse_stride_B, out_lse_stride_H = (
+        (out_lse.stride(0), out_lse.stride(1)) if return_lse else (0, 0)
+    )
+
     grid = (B, H_local)
     _dcp_lse_combine_kernel[grid](
         recv_output,
@@ -615,6 +627,8 @@ def dcp_lse_combine_triton(
         out.stride(0),
         out.stride(1),
         out.stride(2),
+        out_lse_stride_B,
+        out_lse_stride_H,
         N=N,
         HEAD_DIM=D,
         IS_BASE_E=is_lse_base_on_e,

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/dcp_compact.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/dcp_compact.py
@@ -1,0 +1,197 @@
+"""Host-side owner filtering + compaction of DCP decode streams.
+
+PR #29185 masks non-owned entries *inside* the decode kernel
+(``_dcp_row_owner``): the K loop still walks every entry of every row and only
+the loads are predicated off. That cuts HBM traffic to 1/dcp but leaves the
+kernel's iteration count -- and therefore its MFMA work and its runtime --
+unchanged.
+
+Compacting on the metadata side instead makes each row physically 1/dcp long,
+so the decode kernel's work drops too. As a bonus the compaction also applies
+the PHYSICAL row remap (``SWA_PAGES + (slot-SWA_PAGES)//dcp``), which means the
+decode kernel can then run with ``DCP_SIZE=1, PHYSICAL=False``: after this pass
+the stream is a plain local stream and the kernel needs no DCP awareness at all.
+
+Ownership rules mirror ``_dcp_row_owner`` exactly:
+  * read-only DCP  : owner = (position within the row) % dcp   -- stride-1
+  * PHYSICAL       : SWA slot      -> owner = slot % dcp,  row = slot
+                     compressed    -> owner = (slot-SWA)%dcp,
+                                      row = SWA + (slot-SWA)//dcp
+
+Empty local rows are legal and are handled by the decode kernel (it emits
+out=0 / lse=-inf, which contributes nothing to the cross-rank merge).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+_buf_cache: Dict[tuple, torch.Tensor] = {}
+
+
+def _cached(key: tuple, factory):
+    t = _buf_cache.get(key)
+    if t is None:
+        t = factory()
+        _buf_cache[key] = t
+    return t
+
+
+@triton.jit
+def _owner_of(
+    slot,
+    pos,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    PHYSICAL: tl.constexpr,
+    SWA_PAGES: tl.constexpr,
+):
+    """(is_owned, local_row) for one entry -- mirrors _dcp_row_owner."""
+    if PHYSICAL:
+        is_swa = slot < SWA_PAGES
+        page = slot - SWA_PAGES
+        owner = tl.where(is_swa, slot % DCP_SIZE, page % DCP_SIZE)
+        row = tl.where(is_swa, slot, SWA_PAGES + page // DCP_SIZE)
+    else:
+        owner = pos % DCP_SIZE
+        row = slot
+    return owner == DCP_RANK, row
+
+
+@triton.jit
+def _count_kernel(
+    indices_ptr,
+    indptr_ptr,
+    out_len_ptr,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    PHYSICAL: tl.constexpr,
+    SWA_PAGES: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    t = tl.program_id(0)
+    start = tl.load(indptr_ptr + t)
+    end = tl.load(indptr_ptr + t + 1)
+    n = end - start
+
+    if PHYSICAL:
+        # Data-dependent: ownership depends on the slot value.
+        total = 0
+        for k in range(0, tl.cdiv(n, BLOCK)):
+            pos = k * BLOCK + tl.arange(0, BLOCK)
+            m = pos < n
+            slot = tl.load(indices_ptr + start + pos, mask=m, other=0)
+            keep, _ = _owner_of(slot, pos, DCP_SIZE, DCP_RANK, PHYSICAL, SWA_PAGES)
+            total += tl.sum((keep & m).to(tl.int32), axis=0)
+        tl.store(out_len_ptr + t, total)
+    else:
+        # Analytic: owner is the position modulo dcp, so the count is exact
+        # without touching the data -- ceil((n - rank) / dcp), clamped at 0.
+        c = (n - DCP_RANK + DCP_SIZE - 1) // DCP_SIZE
+        tl.store(out_len_ptr + t, tl.maximum(c, 0))
+
+
+@triton.jit
+def _compact_kernel(
+    indices_ptr,
+    indptr_ptr,
+    out_indices_ptr,
+    out_indptr_ptr,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    PHYSICAL: tl.constexpr,
+    SWA_PAGES: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    t = tl.program_id(0)
+    start = tl.load(indptr_ptr + t)
+    end = tl.load(indptr_ptr + t + 1)
+    n = end - start
+    out_start = tl.load(out_indptr_ptr + t)
+
+    acc = 0
+    for k in range(0, tl.cdiv(n, BLOCK)):
+        pos = k * BLOCK + tl.arange(0, BLOCK)
+        m = pos < n
+        slot = tl.load(indices_ptr + start + pos, mask=m, other=0)
+        keep, row = _owner_of(slot, pos, DCP_SIZE, DCP_RANK, PHYSICAL, SWA_PAGES)
+        keep = keep & m
+        # exclusive scan within the tile, offset by what earlier tiles wrote
+        rank_in_tile = tl.cumsum(keep.to(tl.int32), axis=0) - 1
+        tl.store(out_indices_ptr + out_start + acc + rank_in_tile, row, mask=keep)
+        acc += tl.sum(keep.to(tl.int32), axis=0)
+
+
+def compact_dcp_streams(
+    indices: torch.Tensor,  # [total] int32, flat concatenated rows
+    indptr: torch.Tensor,  # [T+1] int32
+    *,
+    dcp_size: int,
+    dcp_rank: int,
+    physical: bool = False,
+    swa_pages: int = 0,
+    block: int = 1024,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Filter each row down to this rank's entries and compact them.
+
+    Returns ``(local_indices, local_indptr)`` where the indices are already
+    remapped to local rows, so the caller runs the decode kernel with
+    ``dcp_size=1`` (no in-kernel owner masking).
+
+    Buffers are cached per (shape, device) and reused in place, keeping the pass
+    CUDA-graph capturable. The output index buffer is sized like the input,
+    which is always a safe upper bound.
+    """
+    T = indptr.numel() - 1
+    if T <= 0:
+        return indices, indptr
+    device = indices.device
+
+    out_len = _cached(
+        ("len", device, T, indptr.dtype),
+        lambda: torch.empty((T,), dtype=indptr.dtype, device=device),
+    )
+    out_indptr = _cached(
+        ("indptr", device, T + 1, indptr.dtype),
+        lambda: torch.empty((T + 1,), dtype=indptr.dtype, device=device),
+    )
+    out_indices = _cached(
+        ("idx", device, indices.numel(), indices.dtype),
+        lambda: torch.empty_like(indices),
+    )
+
+    grid = (T,)
+    _count_kernel[grid](
+        indices,
+        indptr,
+        out_len,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
+        PHYSICAL=physical,
+        SWA_PAGES=swa_pages,
+        BLOCK=block,
+        num_warps=4,
+    )
+    # Same idiom as runtime._lengths_to_indptr, but written into a persistent
+    # buffer instead of allocating (F.pad would allocate on every step).
+    out_indptr[0] = 0
+    # NB: do not pass dtype= together with out= -- some torch builds reject the
+    # combination. out_len and out_indptr already share indptr's dtype.
+    torch.cumsum(out_len, dim=0, out=out_indptr[1:])
+    _compact_kernel[grid](
+        indices,
+        indptr,
+        out_indices,
+        out_indptr,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
+        PHYSICAL=physical,
+        SWA_PAGES=swa_pages,
+        BLOCK=block,
+        num_warps=4,
+    )
+    return out_indices, out_indptr

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/dcp_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/dcp_indexer.py
@@ -1,0 +1,223 @@
+"""Torch-only helpers for DCP sharding of the DeepSeek-V4 C4 indexer.
+
+Split out of srt/layers/attention/dsv4/indexer.py so the pure-tensor logic can
+be imported (and GPU-tested) without pulling in the full sglang attention stack
+-- the dsv4 kernels package __init__ imports compiled extensions.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+_local_arange_cache: Dict[str, torch.Tensor] = {}
+
+# ---------------------------------------------------------------------------
+# DCP: shard the indexer CANDIDATE axis (scoring), not just the selection.
+#
+# #29185 shards only the top-k *selection*: every rank still scores the whole
+# context, so the O(c4_len) HBM traffic of the indexer scan (the single largest
+# read term in a DSV4 decode step) is still paid dcp_size times over.
+#
+# Scoring is driven entirely by (page_table, seq_lens) -- see
+# _aiter_fp8_paged_mqa_logits -- so sharding the candidate axis is a pure
+# metadata operation: hand each rank a page-strided slice of the page table.
+# Page granularity is c4_page_size (= page_size//4 = 64 c4 rows = 256 raw
+# tokens), i.e. the slice lands on COMPRESSED rows and cannot break the c4
+# recurrence.
+#
+# Because topk_transform resolves a candidate to its physical page by indexing
+# through the page table, mapping local -> global coordinates is free: we do the
+# indirection with the LOCAL page table BEFORE the all-gather, so what goes on
+# the wire is already global physical page indices.
+# ---------------------------------------------------------------------------
+
+
+# Persistent buffers: the sharded path must be CUDA-graph capturable, so the
+# local page table and local sequence lengths live in preallocated tensors that
+# are filled in place (never reallocated) once a shape has been seen.
+_dcp_shard_cache: Dict[tuple, torch.Tensor] = {}
+
+
+def _dcp_cached(key: tuple, factory) -> torch.Tensor:
+    t = _dcp_shard_cache.get(key)
+    if t is None:
+        t = factory()
+        _dcp_shard_cache[key] = t
+    return t
+
+
+def dcp_candidate_shard(
+    page_table: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    c4_page_size: int,
+    dcp_size: int,
+    dcp_rank: int,
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
+    """Page-strided slice of the indexer candidate axis for this DCP rank.
+
+    Rank ``r`` owns global c4 pages ``{r, r+N, r+2N, ...}``. Returns
+    ``(local_page_table, local_c4_seq_lens, local_max_c4_len)``.
+
+    Validity stays a prefix in local coordinates: the global sequence is a
+    prefix, and pages are handed out in increasing order, so a rank's local
+    pages are "all full, plus at most one partial tail" -- exactly the shape the
+    ``positions < seq_lens`` masks in the scorer and in topk_transform assume.
+
+        P        = ceil(S / c4_page_size)                     # global pages
+        n_local  = ceil((P - r) / N)                          # clamped at 0
+        owns_last= ((P - 1) % N == r) and P > 0
+        local_S  = n_local*page - (page - tail) if owns_last else n_local*page
+
+    NOTE: ``page_table`` is shared with the main attention metadata
+    (``indexer_metadata.page_table is core_metadata.page_table``), so it must
+    never be sliced in place -- we materialise into our own buffer.
+    """
+    B, p_max = page_table.shape
+    device = page_table.device
+    n_local = max((p_max - dcp_rank + dcp_size - 1) // dcp_size, 1)
+
+    # Built as arange(n_local)*N + r then clamped, NOT as
+    # arange(r, p_max, N): when p_max <= r (a batch whose whole context fits in
+    # fewer pages than there are ranks) the latter is EMPTY while n_local is
+    # floored at 1, and index_select would raise on the shape mismatch. The
+    # clamped form always yields exactly n_local valid indices; the rows those
+    # ranks read are then masked off by local_seq_len == 0.
+    idx = _dcp_cached(
+        ("pages", device, p_max, dcp_size, dcp_rank, n_local),
+        lambda: torch.clamp(
+            torch.arange(n_local, device=device) * dcp_size + dcp_rank,
+            max=max(p_max - 1, 0),
+        ),
+    )
+    local_pt = _dcp_cached(
+        ("pt", device, B, n_local, page_table.dtype),
+        lambda: torch.empty((B, n_local), dtype=page_table.dtype, device=device),
+    )
+    torch.index_select(page_table, 1, idx, out=local_pt)
+
+    sl = c4_seq_lens.view(B, -1)[:, 0] if c4_seq_lens.dim() > 1 else c4_seq_lens.view(B)
+    S = sl.to(torch.int64)
+    P = (S + c4_page_size - 1) // c4_page_size
+    nl = torch.clamp((P - dcp_rank + dcp_size - 1) // dcp_size, min=0)
+    tail = S - (P - 1) * c4_page_size  # only meaningful where P > 0
+    owns_last = ((P - 1) % dcp_size == dcp_rank) & (P > 0)
+    local_S = nl * c4_page_size - torch.where(
+        owns_last, c4_page_size - tail, torch.zeros_like(tail)
+    )
+    local_S = torch.clamp(local_S, min=0)
+
+    local_sl = _dcp_cached(
+        ("sl", device, B, c4_seq_lens.dtype),
+        lambda: torch.empty((B,), dtype=c4_seq_lens.dtype, device=device),
+    )
+    local_sl.copy_(local_S.to(c4_seq_lens.dtype))
+    return local_pt, local_sl, n_local * c4_page_size
+
+
+def topk_transform_512_dcp_sharded(
+    scores: torch.Tensor,
+    local_seq_lens: torch.Tensor,
+    local_page_table: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    dcp_group,
+    dcp_size: int,
+    dcp_rank: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    """Merge top-k when ``scores`` are already this rank's candidate shard.
+
+    Unlike ``topk_transform_512_dcp`` (which slices a full score row), here the
+    scores only cover the rank's own pages, so there is no local->global index
+    arithmetic on the score axis. Instead we resolve each local candidate to its
+    physical page through ``local_page_table`` *before* the all-gather, so the
+    gathered payload is already in global coordinates and no rank ever has to
+    interpret another rank's local indices.
+
+    Equivalence: a globally top-k candidate is necessarily top-k within its own
+    shard, so the union of per-shard top-k always contains the exact global
+    top-k. Output page order may differ from the single-rank kernel; the
+    downstream sparse attention is order-invariant.
+    """
+    TOPK = out_page_indices.shape[1]
+    B, N = scores.shape
+    device = scores.device
+    neg_inf = float("-inf")
+
+    page_bits = (page_size - 1).bit_length() if page_size > 1 else 0
+    page_mask = page_size - 1
+
+    cache = _local_arange_cache
+    key_seq = f"arange_{N}_{device}"
+    if key_seq not in cache:
+        cache[key_seq] = torch.arange(N, device=device)
+    positions = cache[key_seq].unsqueeze(0)
+    valid = positions < local_seq_lens.view(B, 1)
+    masked = torch.where(valid, scores, torch.full_like(scores, neg_inf))
+
+    k = min(TOPK, N)
+    local_scores, local_idx = torch.topk(masked, k, dim=1, largest=True, sorted=False)
+
+    # Local candidate -> global physical page index, using the LOCAL page table.
+    lidx = local_idx.to(torch.int64)
+    page_idx = lidx >> page_bits
+    offset = lidx & page_mask
+    physical = torch.gather(local_page_table.to(torch.int64), 1, page_idx)
+    local_pages = ((physical << page_bits) | offset).to(torch.int32)
+    live = local_scores != neg_inf
+    local_pages = torch.where(live, local_pages, torch.full_like(local_pages, -1))
+
+    gather_raw = out_raw_indices is not None
+    if gather_raw:
+        # Global raw c4 token index of a local candidate:
+        #   (dcp_rank + local_page*dcp_size) * page_size + offset
+        g_page = dcp_rank + page_idx * dcp_size
+        local_raw = ((g_page << page_bits) | offset).to(torch.int32)
+        local_raw = torch.where(live, local_raw, torch.full_like(local_raw, -1))
+
+    if k < TOPK:
+        pad = TOPK - k
+        local_scores = F.pad(local_scores, (0, pad), value=neg_inf)
+        local_pages = F.pad(local_pages, (0, pad), value=-1)
+        if gather_raw:
+            local_raw = F.pad(local_raw, (0, pad), value=-1)
+
+    # Ship every channel in ONE all-gather. These payloads are a few KB, and at
+    # that size a collective costs the same whether it carries 4 B or 12 KB
+    # (measured: 28.3 us vs 31.7 us on 8x MI355X), so the cost is per call, not
+    # per byte. Channel-major [C, B, TOPK] gathered on the last dim keeps every
+    # channel contiguous afterwards, so no repacking is needed on the way out.
+    channels = 3 if gather_raw else 2
+    pack_key = f"pack_{channels}_{B}_{TOPK}_{device}"
+    if pack_key not in cache:
+        cache[pack_key] = torch.empty(
+            (channels, B, TOPK), dtype=torch.float32, device=device
+        )
+    packed = cache[pack_key]
+    # int32 payloads ride along bit-for-bit; all-gather only copies bytes.
+    packed[0] = local_scores
+    packed[1] = local_pages.view(torch.float32)
+    if gather_raw:
+        packed[2] = local_raw.view(torch.float32)
+
+    gathered = dcp_group.all_gather(packed, dim=2)
+    g_scores = gathered[0]
+    g_pages = gathered[1].view(torch.int32)
+
+    m_scores, m_pos = torch.topk(g_scores, TOPK, dim=1, largest=True, sorted=False)
+    final_valid = m_scores != neg_inf
+
+    final_pages = torch.gather(g_pages, 1, m_pos)
+    final_pages = torch.where(
+        final_valid, final_pages, torch.full_like(final_pages, -1)
+    )
+    out_page_indices.copy_(final_pages)
+
+    if gather_raw:
+        g_raw = gathered[2].view(torch.int32)
+        final_raw = torch.gather(g_raw, 1, m_pos)
+        final_raw = torch.where(final_valid, final_raw, torch.full_like(final_raw, -1))
+        out_raw_indices.copy_(final_raw.to(out_raw_indices.dtype))

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/env_gate.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/env_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import os
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_hip
@@ -10,3 +11,19 @@ from sglang.srt.utils import is_hip
 def is_unified_kv_triton() -> bool:
     # unified_kv_triton is only implemented on HIP (ROCm)
     return is_hip() and envs.SGLANG_HACK_FLASHMLA_BACKEND.get() == "unified_kv_triton"
+
+
+@functools.lru_cache(maxsize=1)
+def is_dcp_physical() -> bool:
+    """Opt-in physical DCP sharding of the unified_kv pool.
+
+    When enabled (and dcp_size>1), each DCP rank physically stores only its
+    1/dcp shard of the unified_kv rows (owner = unified_slot % dcp_size, local
+    row = unified_slot // dcp_size); the SWA/compressed WRITE locations are
+    remapped to the local shard and decode reads only owned rows then merges via
+    cp_lse_ag_out_rs. Default off -> read-only DCP / baseline byte-for-byte
+    unchanged. HIP + unified_kv only.
+    """
+    return is_unified_kv_triton() and os.environ.get(
+        "SGLANG_DSV4_DCP_PHYSICAL", "0"
+    ) not in ("0", "", "false", "False")

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode.py
@@ -214,6 +214,39 @@ def _kv_splits_heuristic(
 
 
 @triton.jit
+def _dcp_row_owner(
+    slot,
+    k_pos,
+    valid,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    PHYSICAL: tl.constexpr,
+    SWA_PAGES: tl.constexpr,
+):
+    """Map a global unified slot to (physical row, owner-masked valid).
+
+    - PHYSICAL: SWA region [0,SWA_PAGES) is replicated -> row=slot, owner=slot%dcp;
+      compressed region is sharded -> row=SWA_PAGES + (slot-SWA_PAGES)//dcp,
+      owner=(slot-SWA_PAGES)%dcp. Each rank reads only owned rows.
+    - read-only DCP (DCP_SIZE>1, not PHYSICAL): mask by stream position k_pos%dcp,
+      row=slot (full replicated pool).
+    - else: row=slot.
+    """
+    if PHYSICAL:
+        is_swa = slot < SWA_PAGES
+        page = slot - SWA_PAGES
+        owner = tl.where(is_swa, slot % DCP_SIZE, page % DCP_SIZE)
+        row = tl.where(is_swa, slot, SWA_PAGES + page // DCP_SIZE)
+        valid = valid & (owner == DCP_RANK)
+    elif DCP_SIZE > 1:
+        valid = valid & ((k_pos % DCP_SIZE) == DCP_RANK)
+        row = slot
+    else:
+        row = slot
+    return row, valid
+
+
+@triton.jit
 def _paged_decode_fused_kernel(
     q_ptr,  # [N, H, D]
     unified_kv_ptr,  # [total_pages, D] bf16/fp16, or fp8 when QUANT_KV
@@ -222,6 +255,7 @@ def _paged_decode_fused_kernel(
     kv_indptr_ptr,  # [N+1] int32
     attn_sink_ptr,  # [H]
     out_ptr,  # [N, H, D]
+    lse_ptr,  # [N, H] fp32 (natural-log LSE), written only when RETURN_LSE
     q_stride_t,
     q_stride_h,
     q_stride_d,
@@ -231,6 +265,8 @@ def _paged_decode_fused_kernel(
     out_stride_t,
     out_stride_h,
     out_stride_d,
+    lse_stride_t,
+    lse_stride_h,
     qk_scale,  # = softmax_scale * LOG2E
     log2e,  # = LOG2E, to lift natural-log sink into log2 domain
     H: tl.constexpr,
@@ -241,6 +277,12 @@ def _paged_decode_fused_kernel(
     QUANT_KV: tl.constexpr,  # True → dequant fp8 KV via kv_scales
     GROUP_SIZE: tl.constexpr,  # scale block width along D (e.g. 64)
     NUM_GROUPS: tl.constexpr,  # D // GROUP_SIZE (constexpr; D % GROUP_SIZE == 0)
+    APPLY_SINK: tl.constexpr,  # fold attn_sink into the denom (False under DCP)
+    RETURN_LSE: tl.constexpr,  # write per-(token,head) natural-log LSE
+    DCP_SIZE: tl.constexpr,  # decode-context-parallel group size (1 = no DCP)
+    DCP_RANK: tl.constexpr,  # this rank within the DCP group
+    PHYSICAL: tl.constexpr,  # physical-DCP: rows physically sharded (slot//dcp)
+    SWA_PAGES: tl.constexpr,  # boundary between replicated SWA and sharded compress
 ):
     """Single-pass online-softmax with sink folded inline — fast path for
     cases where ``kv_splits = 1`` (base grid already saturates the GPU). Skips
@@ -296,11 +338,12 @@ def _paged_decode_fused_kernel(
             mask=valid,
             other=0,  # any in-bounds slot; the read is masked out below
         )
+        row, valid = _dcp_row_owner(
+            slot, k_pos, valid, DCP_SIZE, DCP_RANK, PHYSICAL, SWA_PAGES
+        )
 
         kv_raw = tl.load(
-            unified_kv_ptr
-            + slot[:, None] * kv_stride_n
-            + d_offs[None, :] * kv_stride_d,
+            unified_kv_ptr + row[:, None] * kv_stride_n + d_offs[None, :] * kv_stride_d,
             mask=valid[:, None] & d_mask[None, :],
             other=0.0,
         )
@@ -312,7 +355,7 @@ def _paged_decode_fused_kernel(
             # [BLOCK_K, BLOCK_D] scales tile but in IR is a coalesced
             # NUM_GROUPS-wide load per row.
             scales_full = tl.load(
-                kv_scales_ptr + slot[:, None] * ks_stride_n + g_idx_per_d[None, :],
+                kv_scales_ptr + row[:, None] * ks_stride_n + g_idx_per_d[None, :],
                 mask=valid[:, None] & d_mask[None, :],
                 other=0.0,
             ).to(q.dtype)
@@ -342,14 +385,20 @@ def _paged_decode_fused_kernel(
 
     # Fold attn_sink as a virtual K of weight 1. sink is a natural-log bias;
     # multiply by log2e so it lives in the same log2 domain as our online m_i.
-    sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
-        tl.float32
-    )
-    sink = sink_raw * log2e
-    m_final = tl.maximum(m_i, sink)
-    alpha_kv = tl.exp2(m_i - m_final)
-    alpha_sink = tl.exp2(sink - m_final)
-    l_final = l_i * alpha_kv + alpha_sink
+    # Under DCP, the sink is applied once after the cross-rank merge, so each
+    # shard runs sink-less here (APPLY_SINK=False) and emits pre-sink LSE.
+    if APPLY_SINK:
+        sink_raw = tl.load(attn_sink_ptr + h_offs, mask=h_mask, other=neg_large).to(
+            tl.float32
+        )
+        sink = sink_raw * log2e
+        m_final = tl.maximum(m_i, sink)
+        alpha_kv = tl.exp2(m_i - m_final)
+        alpha_sink = tl.exp2(sink - m_final)
+        l_final = l_i * alpha_kv + alpha_sink
+    else:
+        alpha_kv = tl.full((BLOCK_H,), 1.0, dtype=tl.float32)
+        l_final = l_i
 
     denom = tl.maximum(l_final, 1.0e-30)
     out = tl.where(
@@ -363,6 +412,17 @@ def _paged_decode_fused_kernel(
         out.to(out_ptr.dtype.element_ty),
         mask=h_mask[:, None] & d_mask[None, :],
     )
+    if RETURN_LSE:
+        # Natural-log LSE of this shard's softmax denom (pre-sink):
+        #   lse = ln(Σ exp(qk)) = (m_i + log2(l_i)) / log2e.
+        # Empty shard (l_i == 0, e.g. DCP rank owns no entries) → -inf, which
+        # contributes 0 to the cross-rank logsumexp merge.
+        lse_val = tl.where(l_i > 0.0, (m_i + tl.log2(l_i)) / log2e, neg_large)
+        tl.store(
+            lse_ptr + t * lse_stride_t + h_offs * lse_stride_h,
+            lse_val,
+            mask=h_mask,
+        )
 
 
 @triton.jit
@@ -401,6 +461,10 @@ def _paged_decode_split_kernel(
     QUANT_KV: tl.constexpr,  # True → dequant fp8 KV via kv_scales
     GROUP_SIZE: tl.constexpr,  # scale block width along D (e.g. 64)
     NUM_GROUPS: tl.constexpr,  # D // GROUP_SIZE
+    DCP_SIZE: tl.constexpr,  # decode-context-parallel group size (1 = no DCP)
+    DCP_RANK: tl.constexpr,  # this rank within the DCP group
+    PHYSICAL: tl.constexpr,  # physical-DCP: rows physically sharded (slot//dcp)
+    SWA_PAGES: tl.constexpr,  # boundary between replicated SWA and sharded compress
 ):
     """3D split-K + exp2-softmax sparse paged-decode. Grid: (N, ceil(H/BLOCK_H), KV_SPLITS).
 
@@ -462,17 +526,18 @@ def _paged_decode_split_kernel(
             mask=valid,
             other=0,  # any in-bounds slot; masked out below
         )
+        row, valid = _dcp_row_owner(
+            slot, k_pos, valid, DCP_SIZE, DCP_RANK, PHYSICAL, SWA_PAGES
+        )
 
         kv_raw = tl.load(
-            unified_kv_ptr
-            + slot[:, None] * kv_stride_n
-            + d_offs[None, :] * kv_stride_d,
+            unified_kv_ptr + row[:, None] * kv_stride_n + d_offs[None, :] * kv_stride_d,
             mask=valid[:, None] & d_mask[None, :],
             other=0.0,
         )
         if QUANT_KV:
             scales_full = tl.load(
-                kv_scales_ptr + slot[:, None] * ks_stride_n + g_idx_per_d[None, :],
+                kv_scales_ptr + row[:, None] * ks_stride_n + g_idx_per_d[None, :],
                 mask=valid[:, None] & d_mask[None, :],
                 other=0.0,
             ).to(q.dtype)
@@ -517,6 +582,7 @@ def _paged_decode_reduce_kernel(
     attn_sink_ptr,  # [H]
     kv_indptr_ptr,  # [N+1] int32
     out_ptr,  # [N, H, D]
+    lse_ptr,  # [N, H] fp32 (natural-log LSE), written only when RETURN_LSE
     mp_stride_t,
     mp_stride_k,
     mp_stride_h,
@@ -530,6 +596,8 @@ def _paged_decode_reduce_kernel(
     out_stride_t,
     out_stride_h,
     out_stride_d,
+    lse_stride_t,
+    lse_stride_h,
     log2e,  # = LOG2E, used to convert natural-log sink → log2 domain
     H: tl.constexpr,
     D: tl.constexpr,
@@ -537,6 +605,8 @@ def _paged_decode_reduce_kernel(
     BLOCK_D: tl.constexpr,
     D_CHUNK: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    APPLY_SINK: tl.constexpr,  # fold attn_sink (False under DCP)
+    RETURN_LSE: tl.constexpr,  # write per-(token,head) natural-log LSE
 ):
     """2D-tile reduce: combine KV_SPLITS partials, fold attn_sink, write
     final output. Grid: ``(T, H, ceil(D / D_CHUNK))`` — one CTA owns one
@@ -591,6 +661,8 @@ def _paged_decode_reduce_kernel(
             tl.zeros([D_CHUNK], dtype=out_ptr.dtype.element_ty),
             mask=d_mask,
         )
+        if RETURN_LSE and dc == 0:
+            tl.store(lse_ptr + t * lse_stride_t + h * lse_stride_h, neg_large)
         return
     tiles_per_segment = tl.cdiv(kv_len, KV_SPLITS * BLOCK_K)
     act_num_segments = tl.cdiv(kv_len, tl.maximum(tiles_per_segment, 1) * BLOCK_K)
@@ -625,13 +697,25 @@ def _paged_decode_reduce_kernel(
     l_combined = tl.sum(l_p * alpha_split, axis=0)  # scalar
     acc_combined = tl.sum(a_p * alpha_split[:, None], axis=0)  # [D_CHUNK]
 
-    # Fold attn_sink (recomputed across dc — scalar work, negligible).
-    sink_raw = tl.load(attn_sink_ptr + h).to(tl.float32)
-    sink = sink_raw * log2e
-    m_final = tl.maximum(m_max, sink)
-    alpha_kv = tl.exp2(m_max - m_final)
-    alpha_sink = tl.exp2(sink - m_final)
-    l_final = l_combined * alpha_kv + alpha_sink
+    # Fold attn_sink (recomputed across dc — scalar work, negligible). Under
+    # DCP the sink is applied once after the cross-rank merge, so skip it here
+    # and emit the pre-sink LSE for the merge.
+    if APPLY_SINK:
+        sink_raw = tl.load(attn_sink_ptr + h).to(tl.float32)
+        sink = sink_raw * log2e
+        m_final = tl.maximum(m_max, sink)
+        alpha_kv = tl.exp2(m_max - m_final)
+        alpha_sink = tl.exp2(sink - m_final)
+        l_final = l_combined * alpha_kv + alpha_sink
+    else:
+        alpha_kv = 1.0
+        l_final = l_combined
+
+    if RETURN_LSE and dc == 0:
+        lse_val = tl.where(
+            l_combined > 0.0, (m_max + tl.log2(l_combined)) / log2e, neg_large
+        )
+        tl.store(lse_ptr + t * lse_stride_t + h * lse_stride_h, lse_val)
 
     denom = tl.maximum(l_final, 1.0e-30)
     # Direct divide (acc*alpha_kv)/denom, matching the single-CTA reference.
@@ -666,7 +750,13 @@ def _sparse_attn_v4_paged_decode_triton(
     block_h: int | None = None,
     kv_splits: int | None = None,
     block_k: int | None = None,
-) -> torch.Tensor:
+    apply_sink: bool = True,
+    return_lse: bool = False,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
+    physical: bool = False,
+    swa_pages: int = 0,
+):
     """V4 sparse decode Triton implementation: split-K with FUSED fast path,
     exp2 softmax, CG-safe heuristic. ``block_h`` and ``kv_splits`` are
     escape hatches for benchmarks; production callers pass neither.
@@ -715,6 +805,17 @@ def _sparse_attn_v4_paged_decode_triton(
 
     T, H, D = q.shape
     out = torch.empty_like(q)
+    # LSE buffer (natural-log) for cross-rank DCP merge. Always shape [T, H] so
+    # cuda-graph capture/replay sees a static allocation; the bf16 path passes a
+    # 1-elem dummy to keep one launch signature.
+    if return_lse:
+        lse = torch.empty((T, H), dtype=torch.float32, device=q.device)
+        lse_stride_t = lse.stride(0)
+        lse_stride_h = lse.stride(1)
+    else:
+        lse = q.new_empty(1, dtype=torch.float32)
+        lse_stride_t = 0
+        lse_stride_h = 0
 
     if block_h is None:
         block_h = triton.next_power_of_2(min(H, 64))
@@ -765,6 +866,7 @@ def _sparse_attn_v4_paged_decode_triton(
             kv_indptr,
             attn_sink,
             out,
+            lse,
             q.stride(0),
             q.stride(1),
             q.stride(2),
@@ -774,6 +876,8 @@ def _sparse_attn_v4_paged_decode_triton(
             out.stride(0),
             out.stride(1),
             out.stride(2),
+            lse_stride_t,
+            lse_stride_h,
             qk_scale,
             LOG2E,
             H,
@@ -784,10 +888,16 @@ def _sparse_attn_v4_paged_decode_triton(
             QUANT_KV=quant_kv,
             GROUP_SIZE=_FP8_GROUP_SIZE,
             NUM_GROUPS=num_groups_arg,
+            APPLY_SINK=apply_sink,
+            RETURN_LSE=return_lse,
+            DCP_SIZE=dcp_size,
+            DCP_RANK=dcp_rank,
+            PHYSICAL=physical,
+            SWA_PAGES=swa_pages,
             num_warps=num_warps,
             num_stages=num_stages,
         )
-        return out
+        return (out, lse) if return_lse else out
 
     # Split-K path: split kernel writes (m, l, acc) partials in log2 domain;
     # reduce kernel combines them, folds attn_sink, writes final output.
@@ -837,6 +947,10 @@ def _sparse_attn_v4_paged_decode_triton(
         QUANT_KV=quant_kv,
         GROUP_SIZE=_FP8_GROUP_SIZE,
         NUM_GROUPS=num_groups_arg,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
+        PHYSICAL=physical,
+        SWA_PAGES=swa_pages,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -867,6 +981,7 @@ def _sparse_attn_v4_paged_decode_triton(
         attn_sink,
         kv_indptr,
         out,
+        lse,
         m_partial.stride(0),
         m_partial.stride(1),
         m_partial.stride(2),
@@ -880,6 +995,8 @@ def _sparse_attn_v4_paged_decode_triton(
         out.stride(0),
         out.stride(1),
         out.stride(2),
+        lse_stride_t,
+        lse_stride_h,
         LOG2E,
         H,
         D,
@@ -887,9 +1004,11 @@ def _sparse_attn_v4_paged_decode_triton(
         BLOCK_D=block_d,
         D_CHUNK=d_chunk,
         BLOCK_K=block_k,
+        APPLY_SINK=apply_sink,
+        RETURN_LSE=return_lse,
         num_warps=4,
     )
-    return out
+    return (out, lse) if return_lse else out
 
 
 def sparse_attn_v4_paged_decode(
@@ -900,13 +1019,37 @@ def sparse_attn_v4_paged_decode(
     attn_sink: torch.Tensor,
     softmax_scale: float,
     kv_scales: torch.Tensor | None = None,
-) -> torch.Tensor:
+    apply_sink: bool = True,
+    return_lse: bool = False,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
+    physical: bool = False,
+    swa_pages: int = 0,
+):
     """V4 decode sparse attention over a unified KV pool with paged indices.
 
     When ``kv_scales`` is provided, ``unified_kv`` must be fp8 (e4m3fnuz) and
     will be dequantized in-kernel using 1xGROUP_SIZE (default 64) block scales.
+
+    Decode context parallel (DCP): pass ``dcp_size>1`` so each rank attends only
+    its round-robin shard of every token's KV stream, ``apply_sink=False`` to
+    defer the attn_sink fold to the cross-rank merge, and ``return_lse=True`` to
+    also return the per-(token,head) natural-log LSE used by that merge. Returns
+    ``out`` (or ``(out, lse)`` when ``return_lse``).
     """
-    if _is_gfx1250_supported:
+    # The aiter gfx1250 fast path does not implement decode context parallelism
+    # (no per-rank shard, LSE return, sink deferral, physical relayout or SWA),
+    # so it can only serve the plain single-rank default configuration. Any DCP
+    # or non-default request falls back to the Triton kernel below.
+    use_aiter_fast_path = (
+        _is_gfx1250_supported
+        and dcp_size == 1
+        and not return_lse
+        and apply_sink
+        and not physical
+        and swa_pages == 0
+    )
+    if use_aiter_fast_path:
         # aiter ships only on ROCm, and this module is imported by a CPU-registered
         # test, so the import has to sit behind the same gate as the call.
         from aiter.ops.triton.attention.pa_decode_sparse import pa_decode_sparse
@@ -921,13 +1064,18 @@ def sparse_attn_v4_paged_decode(
             has_invalid=False,
             kv_scales=kv_scales,
         )
-    else:
-        return _sparse_attn_v4_paged_decode_triton(
-            q,
-            unified_kv,
-            kv_indices,
-            kv_indptr,
-            attn_sink,
-            softmax_scale,
-            kv_scales=kv_scales,
-        )
+    return _sparse_attn_v4_paged_decode_triton(
+        q,
+        unified_kv,
+        kv_indices,
+        kv_indptr,
+        attn_sink,
+        softmax_scale,
+        kv_scales=kv_scales,
+        apply_sink=apply_sink,
+        return_lse=return_lse,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+        physical=physical,
+        swa_pages=swa_pages,
+    )

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
@@ -171,15 +171,37 @@ def _lengths_to_indptr(lengths: torch.Tensor) -> torch.Tensor:
 
 def decode(
     *,
-    q: torch.Tensor,  # [T, H, D] (local heads)
+    q: torch.Tensor,  # [T, H, D] (local heads, or all-gathered DCP-group heads)
     unified_kv: torch.Tensor,  # [pages, D] bf16
     kv_indices: torch.Tensor,
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,  # [H] fp32
     softmax_scale: float,
-) -> torch.Tensor:
+    apply_sink: bool = True,
+    return_lse: bool = False,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
+    physical: bool = False,
+    swa_pages: int = 0,
+):
+    """Decode attention. With ``dcp_size>1`` each rank attends its round-robin
+    KV shard and (with ``return_lse=True``, ``apply_sink=False``) returns the
+    sink-less ``(out, lse)`` partials for the cross-rank merge. ``physical=True``
+    switches the per-rank shard from stream-position round-robin to physical
+    unified-slot ownership (``swa_pages`` marks the replicated-SWA boundary)."""
     return sparse_attn_v4_paged_decode(
-        q, unified_kv, kv_indices, kv_indptr, attn_sink, softmax_scale
+        q,
+        unified_kv,
+        kv_indices,
+        kv_indptr,
+        attn_sink,
+        softmax_scale,
+        apply_sink=apply_sink,
+        return_lse=return_lse,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+        physical=physical,
+        swa_pages=swa_pages,
     )
 
 

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -151,12 +151,69 @@ def handle_dcp_validation(server_args: Any):
     if cfg.dcp_replicate_q_proj:
         if cfg.dcp_size <= 1:
             raise ValueError("--dcp-replicate-q-proj requires --dcp-size > 1.")
-        if cfg.dcp_comm_backend not in ("a2a", "fi_a2a"):
+        if cfg.dcp_comm_backend not in ("a2a", "fi_a2a") and not get_platform().is_hip:
             raise ValueError(
                 "--dcp-replicate-q-proj only applies to the a2a/fi_a2a DCP "
                 "communication backend (it removes the head-dim Q all-gather); "
-                f"got --dcp-comm-backend={cfg.dcp_comm_backend}."
+                f"got --dcp-comm-backend={cfg.dcp_comm_backend}. On AMD HIP the "
+                "DeepSeek-V4 DCP decode path merges through its own _decode_dcp "
+                "helper, so any dcp_comm_backend is accepted."
             )
+
+    if cfg.dcp_size > 1:
+        if cfg.tp_size % cfg.dcp_size != 0:
+            raise ValueError(
+                "Decode context parallel requires --dcp-size to divide "
+                f"--tp-size, but got dcp_size={cfg.dcp_size}, "
+                f"tp_size={cfg.tp_size}."
+            )
+        if get_platform().is_hip:
+            _handle_dsv4_dcp_validation(cfg)
+
+
+def _handle_dsv4_dcp_validation(cfg: Any) -> None:
+    """Fail fast on DeepSeek-V4 DCP configurations that would silently misbehave.
+
+    The V4 decode-CP path is implemented entirely on the HIP unified_kv backend
+    (deepseek_v4_backend_hip_radix._decode_dcp) and is driven by environment
+    variables rather than server args, so a typo or a missing companion flag
+    otherwise degrades into wrong numbers instead of an error.
+    """
+
+    def _on(name: str, default: str = "0") -> bool:
+        return os.environ.get(name, default) not in ("0", "", "false", "False")
+
+    if cfg.attention_backend != "dsv4":
+        return
+
+    if os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND") != "unified_kv_triton":
+        raise ValueError(
+            "DeepSeek-V4 decode context parallel (--dcp-size > 1 with "
+            "--attention-backend dsv4) is only implemented on the unified_kv "
+            "path; set SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton. Got "
+            f"{os.environ.get('SGLANG_HACK_FLASHMLA_BACKEND')!r}."
+        )
+
+    physical = _on("SGLANG_DSV4_DCP_PHYSICAL")
+    if physical and cfg.disaggregation_mode != "null":
+        # Only the mori backend implements the compressed-row transfer plan that
+        # a sharded decode pool needs. Any other transfer backend would write
+        # full-layout rows into a 1/dcp buffer.
+        if cfg.disaggregation_transfer_backend != "mori":
+            raise ValueError(
+                "SGLANG_DSV4_DCP_PHYSICAL=1 shards the decode KV pool, so the "
+                "PD transfer layer must scatter rows to their owning decode "
+                "rank. Only --disaggregation-transfer-backend mori implements "
+                f"this; got {cfg.disaggregation_transfer_backend!r}."
+            )
+
+    if _on("SGLANG_DSV4_DCP_INDEXER_SCORING") and _on("SGLANG_DSV4_DCP_INDEXER_TOPK"):
+        raise ValueError(
+            "SGLANG_DSV4_DCP_INDEXER_SCORING already shards the top-k selection "
+            "(it selects over this rank's candidate shard), so "
+            "SGLANG_DSV4_DCP_INDEXER_TOPK must not also be set -- the two would "
+            "shard the candidate axis twice."
+        )
 
 
 def handle_data_parallelism(server_args: Any):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import functools
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -76,6 +77,38 @@ def _create_flashmla_metadata():
     import sgl_kernel.flash_mla as flash_mla
 
     return flash_mla.get_mla_metadata()[0]
+
+
+# Below this many total stream entries, compaction costs more than it saves.
+# Measured on MI355X (dcp/evidence/02-gpu-validation-report.md, P1 vs P2): the
+# compaction pass is a flat ~45-56 us regardless of size, while the kernel time
+# it removes scales with the stream. Net effect vs total entries (T x row_len):
+#     16384 -> -0.043 ms    65536 -> -0.003 ms
+#    131072 -> +0.045 ms   262144 -> +0.111 ms   2097152 -> +1.228 ms
+# Break-even sits at ~65536, so gate one doubling above it.
+_DCP_COMPACT_MIN_ENTRIES = int(os.environ.get("SGLANG_DSV4_DCP_COMPACT_MIN", "131072"))
+
+
+def _dcp_compact_streams_enabled(kv_indices: torch.Tensor) -> bool:
+    """Whether to owner-filter + compact this decode stream on the host side.
+
+    Compaction is a strict accuracy no-op (verified: it agrees with the
+    in-kernel mask path to the last bit) and a large win on long streams --
+    in-kernel masking only predicates the loads off, so the K loop still runs
+    and it buys ~4%, while compaction cuts the iteration count and measures
+    5-6x. But it is a fixed ~50 us, so on short streams it is a pure loss.
+
+    The gate reads ``kv_indices.numel()``, i.e. the ALLOCATED buffer size
+    (N * (win + csa_width)), which is a host-side static shape -- not a
+    data-dependent quantity. That keeps the branch identical between HIP-graph
+    capture and replay; gating on the true per-step length would not.
+    """
+    v = os.environ.get("SGLANG_DSV4_DCP_COMPACT", "auto")
+    if v in ("0", "", "false", "False"):
+        return False
+    if v == "auto":
+        return kv_indices.numel() >= _DCP_COMPACT_MIN_ENTRIES
+    return True
 
 
 def _create_dummy_paged_compress_data(compress_ratio: int):
@@ -232,7 +265,30 @@ class DSV4AttnMetadata:
             ],
         )
 
-    def init_compression_metadata(self, unified_swa_pages: int = 0):
+    @staticmethod
+    def _physical_compress_loc(
+        page: torch.Tensor,
+        swa_pages: int,
+        dcp_size: int,
+        dcp_rank: int,
+        dead_row: int,
+    ) -> torch.Tensor:
+        """Map raw compress page id -> physical write row under physical DCP:
+        owner = page % dcp_size, local row = swa_pages + page // dcp_size;
+        non-owned (and any negative sentinel) pages go to the DEAD row."""
+        owned = ((page % dcp_size) == dcp_rank) & (page >= 0)
+        local = swa_pages + page // dcp_size
+        return torch.where(owned, local, torch.full_like(page, dead_row))
+
+    def init_compression_metadata(
+        self,
+        unified_swa_pages: int = 0,
+        dcp_size: int = 1,
+        dcp_rank: int = 0,
+        physical: bool = False,
+        dead_c4: int = 0,
+        dead_c128: int = 0,
+    ):
         assert self.page_table.dim() == 2
         assert (
             self.raw_out_loc.shape == self.seq_lens_casual.shape
@@ -263,8 +319,19 @@ class DSV4AttnMetadata:
         if unified_swa_pages:
             if self.unified is None:
                 self.unified = UnifiedKvMetadata()
-            self.unified.c4_out_loc = self.c4_out_loc + unified_swa_pages
-            self.unified.c128_out_loc = self.c128_out_loc + unified_swa_pages
+            if physical and dcp_size > 1:
+                # Physical DCP: compressed pages are sharded across the group;
+                # each rank writes only its owned pages to its local row, others
+                # to the per-ratio DEAD row (overwritten, never read).
+                self.unified.c4_out_loc = self._physical_compress_loc(
+                    self.c4_out_loc, unified_swa_pages, dcp_size, dcp_rank, dead_c4
+                )
+                self.unified.c128_out_loc = self._physical_compress_loc(
+                    self.c128_out_loc, unified_swa_pages, dcp_size, dcp_rank, dead_c128
+                )
+            else:
+                self.unified.c4_out_loc = self.c4_out_loc + unified_swa_pages
+                self.unified.c128_out_loc = self.c128_out_loc + unified_swa_pages
 
     _CP_REINDEX_FIELDS = [
         "seq_lens_casual",
@@ -482,6 +549,33 @@ class DeepseekV4HipRadixBackend(
             DSV4RawVerifyMetadata,
             DSV4RawDecodeMetadata,
         ] = None
+
+        # Decode context parallel (DCP). For DSV4's MLA unified_kv the KV latent
+        # is replicated across every TP rank (num_key_value_heads=1), so DCP does
+        # not physically reshard KV; instead each rank attends only its
+        # round-robin shard of every token's KV stream and the partial softmax
+        # outputs are merged via an LSE all-gather + output all-reduce inside the
+        # DCP group (a sub-group of TP). This halves the per-rank KV read
+        # bandwidth of decode without changing the KV pool / allocator. HIP-only:
+        # this backend is selected only on ROCm.
+        self.dcp_size = getattr(model_runner, "dcp_size", 1) or 1
+        self.dcp_rank = getattr(model_runner, "dcp_rank", 0) or 0
+        self._dcp_group = None
+        # --dcp-replicate-q-proj: when the model projects the whole DCP-group
+        # head range locally, the decode Q already carries all
+        # ``n_local_heads * dcp_size`` heads, so _decode_dcp skips its Q
+        # all-gather. Detected purely by head count against this precomputed
+        # value; None (unknown) keeps the always-gather behaviour.
+        self._dcp_group_q_heads = None
+        if self.dcp_size > 1:
+            try:
+                from sglang.srt.runtime_context import get_parallel
+
+                n_heads = model_runner.model_config.num_attention_heads
+                attn_tp = get_parallel().attn_tp_size
+                self._dcp_group_q_heads = (n_heads // attn_tp) * self.dcp_size
+            except Exception:
+                self._dcp_group_q_heads = None
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
@@ -1213,6 +1307,139 @@ class DeepseekV4HipRadixBackend(
         core.unified.pf_cu_q = cu_q_per_req[bid]
         core.unified.pf_final_pos = (seq_lens - 1)[bid]
 
+    def _get_dcp_group(self):
+        if self._dcp_group is None:
+            from sglang.srt.distributed.parallel_state import get_dcp_group
+
+            self._dcp_group = get_dcp_group()
+        return self._dcp_group
+
+    def _decode_dcp(
+        self,
+        *,
+        q: torch.Tensor,  # [T, H_local, D]
+        unified: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        attn_sink: torch.Tensor,  # [H_local]
+    ) -> torch.Tensor:
+        """DCP decode merge.
+
+        The DCP group is a sub-group of TP; the KV latent is replicated on every
+        rank. Steps:
+          1. All-gather Q heads across the group so every rank holds all
+             ``H_local * dcp_size`` group heads.
+          2. Each rank runs the sink-less decode over only its round-robin KV
+             shard (``DCP_RANK::DCP_SIZE`` stream entries), returning the partial
+             softmax output and its natural-log LSE.
+          3. ``cp_lse_ag_out_rs`` all-gathers the LSEs, recomputes the global
+             softmax denom, rescales + all-reduces the outputs, and slices this
+             rank's head block back out — yielding the sink-less full-KV result.
+          4. Fold attn_sink once over the merged denom:
+             ``O = O_nosink * sigmoid(global_lse - attn_sink)`` (equivalent to
+             dividing by ``Σexp + exp(sink)`` instead of ``Σexp``).
+        """
+        # NOTE(rebase of #29185): (1) the unified_kv kernels moved from
+        # srt/layers/attention/dsv4/unified_kv_kernels/ to
+        # kernels/ops/attention/dsv4/unified_kv_kernels/; (2) upstream #29365
+        # moved the DCP merge helpers out of layers/attention/utils.py into
+        # layers/dcp/comm.py and split them into _mha / _mla variants. We gather Q
+        # along the HEAD dim, so the merge that slices this rank's head block back
+        # out is the *_mha variant (the _mla one reduce-scatters along tokens and
+        # returns no LSE).
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels import runtime
+        from sglang.srt.layers.dcp.comm import (
+            cp_lse_ag_out_rs_mha as cp_lse_ag_out_rs,
+        )
+        from sglang.srt.layers.dcp.comm import dcp_a2a_lse_reduce
+
+        dcp_group = self._get_dcp_group()
+        # [T, H_local, D] -> [T, H_local * dcp_size, D]; rank r's heads land at
+        # [r * H_local : (r+1) * H_local], matching cp_lse_ag_out_rs's slice.
+        # With --dcp-replicate-q-proj the model already projects all group heads
+        # locally (q arrives with H_local * dcp_size heads), so the all-gather is
+        # skipped; head count is the discriminator (a sharded q always has fewer
+        # heads than the full group). Shapes are static under CUDA-graph capture.
+        if (
+            self._dcp_group_q_heads is not None
+            and q.shape[1] == self._dcp_group_q_heads
+        ):
+            q_full = q.contiguous()
+        else:
+            q_full = dcp_group.all_gather(q.contiguous(), dim=1)
+        pool = self.token_to_kv_pool
+        physical = getattr(pool, "unified_physical_dcp", False)
+        swa_pages = getattr(pool, "unified_swa_pages", 0) if physical else 0
+
+        if _dcp_compact_streams_enabled(kv_indices):
+            # Filter + compact on the metadata side so each row is physically
+            # 1/dcp long: this cuts the decode kernel's ITERATION count, not just
+            # its loads (the in-kernel _dcp_row_owner mask only predicates the
+            # loads off, so the K loop still walks every entry). The compaction
+            # also applies the PHYSICAL row remap, so the kernel below runs
+            # DCP-unaware (dcp_size=1) over a plain local stream.
+            from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.dcp_compact import (
+                compact_dcp_streams,
+            )
+
+            kv_indices, kv_indptr = compact_dcp_streams(
+                kv_indices,
+                kv_indptr,
+                dcp_size=self.dcp_size,
+                dcp_rank=self.dcp_rank,
+                physical=physical,
+                swa_pages=swa_pages,
+            )
+            k_dcp_size, k_dcp_rank, k_physical, k_swa_pages = 1, 0, False, 0
+        else:
+            k_dcp_size, k_dcp_rank = self.dcp_size, self.dcp_rank
+            k_physical, k_swa_pages = physical, swa_pages
+
+        out_shard, lse_shard = runtime.decode(
+            q=q_full,
+            unified_kv=unified,
+            kv_indices=kv_indices,
+            kv_indptr=kv_indptr,
+            attn_sink=attn_sink,
+            softmax_scale=self.softmax_scale,
+            apply_sink=False,
+            return_lse=True,
+            dcp_size=k_dcp_size,
+            dcp_rank=k_dcp_rank,
+            physical=k_physical,
+            swa_pages=k_swa_pages,
+        )
+        # DCP reduction backend. Default "ag_rs" = all_gather(LSE) +
+        # all_reduce(out): 2 collectives/layer. "a2a" packs this rank's per-head
+        # (out, LSE) partials into ONE all_to_all (the fp32 LSE rides as
+        # output-dtype columns appended to D), then combines locally: 1
+        # collective/layer, dtype-agnostic, no GEMM blow-up. Both return this
+        # rank's head block [r*H_local:(r+1)*H_local] and its merged global LSE,
+        # so the sink fold below is identical. runtime.decode emits natural-log
+        # LSE, so is_lse_base_on_e=True. fi_a2a needs MNNVL (not on HIP), so it
+        # falls through to ag_rs here.
+        if get_parallel().dcp_comm_backend == "a2a":
+            o_nosink, global_lse = dcp_a2a_lse_reduce(
+                out_shard.contiguous(),
+                lse_shard.to(torch.float32).contiguous(),
+                dcp_group,
+                is_lse_base_on_e=True,
+                comm_backend="a2a",
+                return_lse=True,
+            )
+        else:
+            o_nosink, global_lse = cp_lse_ag_out_rs(
+                out_shard, lse_shard, dcp_group, return_lse=True
+            )
+        # o_nosink: [T, H_local, D] fp32; global_lse: [T, H_local] fp32.
+        # attn_sink is the full [n_heads] param; the non-DCP unified_kv kernel
+        # folds attn_sink[0:H_local] (h_offs in [0, H_local)) for every rank, so
+        # mirror that here: fold the first H_local sinks over the merged denom.
+        h_local = global_lse.shape[1]
+        sink = attn_sink.to(torch.float32)[:h_local].view(1, h_local)
+        scale = torch.sigmoid(global_lse - sink).unsqueeze(-1)  # [T, H_local, 1]
+        return (o_nosink.to(torch.float32) * scale).to(q.dtype)
+
     def _forward_unified_kv(
         self,
         *,
@@ -1288,6 +1515,14 @@ class DeepseekV4HipRadixBackend(
                 )
             else:
                 raise ValueError(f"bad compress_ratio {compress_ratio}")
+            if self.dcp_size > 1:
+                return self._decode_dcp(
+                    q=q,
+                    unified=unified,
+                    kv_indices=kv_indices,
+                    kv_indptr=kv_indptr,
+                    attn_sink=attn_sink,
+                )
             return runtime.decode(
                 q=q,
                 unified_kv=unified,
@@ -1704,8 +1939,16 @@ class DeepseekV4HipRadixBackend(
         )
 
         if need_compress:
+            pool = self.token_to_kv_pool
+            _physical = getattr(pool, "unified_physical_dcp", False)
+            _dead = getattr(pool, "unified_compress_dead_row", {}) or {}
             core_attn_metadata.init_compression_metadata(
-                unified_swa_pages=getattr(self.token_to_kv_pool, "unified_swa_pages", 0)
+                unified_swa_pages=getattr(pool, "unified_swa_pages", 0),
+                dcp_size=self.dcp_size,
+                dcp_rank=self.dcp_rank,
+                physical=_physical,
+                dead_c4=int(_dead.get(4, 0)),
+                dead_c128=int(_dead.get(128, 0)),
             )
             core_attn_metadata.init_flashmla_related()
         else:

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -369,6 +370,137 @@ def topk_transform_512_pytorch_vectorized(
         out_raw_indices,
         topk_op=torch.topk,
         topk_op_kwargs={"dim": 1, "largest": True, "sorted": False},
+    )
+
+
+def _dcp_indexer_topk_enabled() -> bool:
+    """Opt-in distributed (DCP) sharding of the C4 indexer top-k selection.
+
+    The HIP ``deepseek_v4_topk_transform_kernel`` launches a single block per
+    batch row, so at small decode batch the O(c4_seq_len) radix-select runs on a
+    single CU and dominates context-length scaling (profiled: ~7.7ms/step of the
+    +8ms/step at 1M). When enabled (and dcp_size>1, decode, long context), the
+    candidate axis is sharded across the DCP group and merged, giving ~dcp-fold
+    parallelism. Default off -> baseline byte-for-byte unchanged."""
+    return os.environ.get("SGLANG_DSV4_DCP_INDEXER_TOPK", "0") not in (
+        "0",
+        "",
+        "false",
+        "False",
+    )
+
+
+# Minimum indexer (c4) sequence length before the distributed top-k path is
+# worth the per-layer all-gather latency; below this we keep the local kernel.
+_DCP_TOPK_MIN_C4_LEN = int(os.environ.get("SGLANG_DSV4_DCP_INDEXER_TOPK_MIN", "16384"))
+
+
+def topk_transform_512_dcp(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    dcp_group,
+    dcp_size: int,
+    dcp_rank: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    """Distributed (DCP) equivalent of ``topk_transform_512``.
+
+    Shards the candidate (score) axis across the DCP group: rank ``r`` selects
+    the local top-k over its contiguous ``1/dcp`` slice of each score row, the
+    group all-gathers ``(score, global_token_index)`` pairs, and every rank
+    re-selects the global top-k from the ``dcp*k`` union. Each globally-top-k
+    token is also top-k within its own slice, so the union always contains the
+    exact global top-k -> the selected page set is identical to the non-sharded
+    kernel (output order may differ; downstream sparse attention is invariant to
+    page order). All shapes are static and helper tensors cached, so the path is
+    CUDA-graph capturable (mirrors the existing DCP attention all-gather)."""
+
+    TOPK = out_page_indices.shape[1]
+    B = scores.shape[0]
+    N = scores.shape[1]
+    device = scores.device
+    neg_inf = float("-inf")
+
+    page_bits = (page_size - 1).bit_length() if page_size > 1 else 0
+    page_mask = page_size - 1
+
+    chunk = (N + dcp_size - 1) // dcp_size
+    padded = chunk * dcp_size
+    base = dcp_rank * chunk
+
+    cache = _arange_cache
+    key_chunk = f"arange_{chunk}_{device}"
+    if key_chunk not in cache:
+        cache[key_chunk] = torch.arange(chunk, device=device)
+    # Global token index of each position in this rank's slice: [1, chunk].
+    local_pos = (cache[key_chunk] + base).unsqueeze(0)
+
+    if padded != N:
+        scores_p = F.pad(scores, (0, padded - N), value=neg_inf)
+    else:
+        scores_p = scores.contiguous()
+    local = scores_p.view(B, dcp_size, chunk)[:, dcp_rank, :]  # [B, chunk]
+
+    if seq_lens.dim() > 1:
+        _sl = seq_lens.view(B, -1)[:, 0:1]
+    else:
+        _sl = seq_lens.view(B, 1)
+    valid = local_pos < _sl  # [B, chunk]
+    local = torch.where(valid, local, torch.full_like(local, neg_inf))
+
+    k = min(TOPK, chunk)
+    local_scores, local_idx = torch.topk(local, k, dim=1, largest=True, sorted=False)
+    global_raw = local_idx.to(torch.int32) + base  # [B, k] global token idx
+    if k < TOPK:
+        pad = TOPK - k
+        local_scores = F.pad(local_scores, (0, pad), value=neg_inf)
+        global_raw = F.pad(global_raw, (0, pad), value=0)
+
+    # Gather every rank's local top-k -> [B, dcp*TOPK], rank-ordered.
+    g_scores = dcp_group.all_gather(local_scores.contiguous(), dim=1)
+    g_raw = dcp_group.all_gather(global_raw.contiguous(), dim=1)
+
+    m_scores, m_pos = torch.topk(g_scores, TOPK, dim=1, largest=True, sorted=False)
+    final_raw = torch.gather(g_raw, 1, m_pos)  # [B, TOPK] global token idx (int32)
+    final_valid = m_scores != neg_inf
+
+    raw_i = final_raw.clamp(min=0)
+    page_idx = raw_i >> page_bits
+    offset = raw_i & page_mask
+    physical = torch.gather(page_tables, 1, page_idx.to(torch.int64))
+    page_indices = ((physical << page_bits) | offset).to(torch.int32)
+    page_indices = torch.where(
+        final_valid, page_indices, torch.full_like(page_indices, -1)
+    )
+    out_page_indices.copy_(page_indices)
+
+    if out_raw_indices is not None:
+        rr = torch.where(final_valid, final_raw, torch.full_like(final_raw, -1))
+        out_raw_indices.copy_(rr.to(out_raw_indices.dtype))
+
+
+# DCP candidate-axis sharding lives in a torch-only module so it can be loaded
+# and tested without pulling in the full sglang attention stack (the dsv4
+# kernels package __init__ imports compiled extensions).
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.dcp_indexer import (  # noqa: E402
+    dcp_candidate_shard,
+    topk_transform_512_dcp_sharded,
+)
+
+
+def _dcp_indexer_scoring_enabled() -> bool:
+    """Opt-in DCP sharding of the C4 indexer SCORING (candidate axis).
+
+    Implies the sharded selection (the local top-k is computed over the local
+    scores). Default off -> baseline byte-for-byte unchanged."""
+    return os.environ.get("SGLANG_DSV4_DCP_INDEXER_SCORING", "0") not in (
+        "0",
+        "",
+        "false",
+        "False",
     )
 
 
@@ -801,6 +933,25 @@ class C4IndexerBackendMixin:
             c4_seq_lens=c4_seq_lens,
             query_rows=query_rows,
         )
+        # DCP: shard the candidate axis (scoring) across the group. Only on the
+        # paged decode path -- the nonpaged plan has its own gathered layout, and
+        # prefill still scores the full context (it also consumes raw indices).
+        dcp_shard = None
+        if (
+            nonpaged_plan is None
+            and _dcp_indexer_scoring_enabled()
+            and getattr(self, "dcp_size", 1) > 1
+            and forward_batch.forward_mode.is_decode()
+            and indexer_metadata.max_c4_seq_len > _DCP_TOPK_MIN_C4_LEN
+        ):
+            dcp_shard = dcp_candidate_shard(
+                page_table,
+                _c4sl,
+                indexer_metadata.c4_page_size,
+                int(self.dcp_size),
+                int(self.dcp_rank),
+            )
+
         if nonpaged_plan is not None:
             assert isinstance(q_indexer, torch.Tensor)
             logits = self._forward_nonpaged_indexer(
@@ -819,16 +970,29 @@ class C4IndexerBackendMixin:
             c4_indexer_kv_cache = c4_indexer_kv_cache.view(
                 c4_indexer_kv_cache.shape[0], 64, 1, head_dim_with_sf
             )
-            logits = fn(
-                q,
-                c4_indexer_kv_cache,
-                weights,
-                _c4sl,
-                page_table,
-                indexer_metadata.deep_gemm_metadata,
-                indexer_metadata.max_c4_seq_len,
-                False,
-            )
+            if dcp_shard is not None:
+                _local_pt, _local_sl, _local_max = dcp_shard
+                logits = fn(
+                    q,
+                    c4_indexer_kv_cache,
+                    weights,
+                    _local_sl,
+                    _local_pt,
+                    indexer_metadata.deep_gemm_metadata,
+                    _local_max,
+                    False,
+                )
+            else:
+                logits = fn(
+                    q,
+                    c4_indexer_kv_cache,
+                    weights,
+                    _c4sl,
+                    page_table,
+                    indexer_metadata.deep_gemm_metadata,
+                    indexer_metadata.max_c4_seq_len,
+                    False,
+                )
 
         assert indexer_metadata.page_table is core_metadata.page_table
         if self.debug_use_external_c4_sparse_indices:
@@ -852,7 +1016,41 @@ class C4IndexerBackendMixin:
         elif core_metadata.c4_sparse_raw_indices is not None:
             raw_indices = core_metadata.c4_sparse_raw_indices
 
-        if self.dsa_topk_backend.is_torch():
+        if dcp_shard is not None:
+            _local_pt, _local_sl, _ = dcp_shard
+            topk_transform_512_dcp_sharded(
+                logits,
+                _local_sl,
+                _local_pt,
+                c4_sparse_page_indices,
+                indexer_metadata.c4_page_size,
+                self._get_dcp_group(),
+                int(self.dcp_size),
+                int(self.dcp_rank),
+                raw_indices,
+            )
+
+        use_dcp_topk = dcp_shard is None and (
+            _dcp_indexer_topk_enabled()
+            and getattr(self, "dcp_size", 1) > 1
+            and forward_batch.forward_mode.is_decode()
+            and indexer_metadata.max_c4_seq_len > _DCP_TOPK_MIN_C4_LEN
+        )
+        if dcp_shard is not None:
+            pass  # already merged above
+        elif use_dcp_topk:
+            topk_transform_512_dcp(
+                logits,
+                c4_seq_lens,
+                page_table,
+                c4_sparse_page_indices,
+                indexer_metadata.c4_page_size,
+                self._get_dcp_group(),
+                int(self.dcp_size),
+                int(self.dcp_rank),
+                raw_indices,
+            )
+        elif self.dsa_topk_backend.is_torch():
             topk_transform_512_pytorch_vectorized(
                 logits,
                 c4_seq_lens,

--- a/python/sglang/srt/layers/dcp/capacity.py
+++ b/python/sglang/srt/layers/dcp/capacity.py
@@ -1,0 +1,54 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Logical KV-capacity semantics for decode context parallelism.
+
+Most DCP backends use the virtual paged allocator: every rank stores one
+physical shard while the allocator exposes ``dcp_size`` times as many logical
+token slots.  DeepSeek-V4 is currently different.  Its read-only mode keeps the
+whole pool replicated, and its experimental physical mode shards unified-KV
+rows without widening the SWA allocator or the DSV4 pool configurator.  Both
+DSV4 modes therefore expose only the profiled logical capacity, not
+``dcp_size`` times that capacity.
+
+Keep this distinction centralized.  Communication parallelism and logical KV
+capacity are separate properties and must not both be inferred from
+``dcp_size``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def dcp_kv_capacity_multiplier(
+    *, dcp_size: int, attention_backend: Optional[str]
+) -> int:
+    """Return the logical-capacity multiplier exposed by the allocator."""
+    if dcp_size <= 1 or attention_backend == "dsv4":
+        return 1
+    return dcp_size
+
+
+def aggregate_dcp_kv_capacity(
+    per_rank_capacity: int,
+    *,
+    dcp_size: int,
+    attention_backend: Optional[str],
+) -> int:
+    """Convert a profiled per-rank capacity to the allocator-visible total."""
+    return per_rank_capacity * dcp_kv_capacity_multiplier(
+        dcp_size=dcp_size,
+        attention_backend=attention_backend,
+    )

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -456,18 +456,22 @@ def dcp_a2a_lse_reduce(
     is_lse_base_on_e: bool = True,
     cuda_graph_buffers: Optional[dict] = None,
     comm_backend: str = "a2a",
-) -> torch.Tensor:
+    return_lse: bool = False,
+):
     """A2A DCP reduce: all-to-all exchange of head partials, then local Triton
     combine. Output + fp32 LSE are packed into ONE all_to_all (LSE reinterpreted
     as output-dtype columns along D) -> 1 NCCL call/layer instead of 2.
     is_lse_base_on_e: True=base-e (FlashAttention), False=base-2 (FlashInfer-MLA).
+    return_lse: also return the merged global LSE (needed by callers that fold an
+    attention sink over the cross-rank denom, e.g. DeepSeek-V4). The returned LSE
+    is in the same log base as the inputs (``is_lse_base_on_e``).
     """
     if cp_group.world_size == 1:
-        return cp_attn_out
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
 
     if comm_backend == "fi_a2a":
         return _dcp_fi_a2a_lse_reduce(
-            cp_attn_out, cp_attn_lse, cp_group, is_lse_base_on_e
+            cp_attn_out, cp_attn_lse, cp_group, is_lse_base_on_e, return_lse=return_lse
         )
 
     N = cp_group.world_size
@@ -509,10 +513,10 @@ def dcp_a2a_lse_reduce(
     recv_output = recv_combined[:, :B, :, :D]
     recv_lse = recv_combined.view(torch.float32)[:, :B, :, D // lpd]
 
-    combined, _ = dcp_lse_combine_triton(
-        recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e
+    combined, global_lse = dcp_lse_combine_triton(
+        recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e, return_lse=return_lse
     )
-    return combined
+    return (combined, global_lse) if return_lse else combined
 
 
 def _dcp_fi_a2a_lse_reduce(
@@ -520,7 +524,8 @@ def _dcp_fi_a2a_lse_reduce(
     cp_attn_lse: torch.Tensor,
     cp_group: "GroupCoordinator",
     is_lse_base_on_e: bool = True,
-) -> torch.Tensor:
+    return_lse: bool = False,
+):
     """fi_a2a: delegate only the cross-rank exchange to FlashInfer's MNNVL kernel,
     then reuse the local Triton LSE combine. FlashInfer takes output + LSE as
     separate tensors: partial_o [B, H_per_rank, cp_size, D] (peer axis 2nd-to-last),
@@ -566,7 +571,7 @@ def _dcp_fi_a2a_lse_reduce(
     recv_output = o_out.permute(2, 0, 1, 3)
     recv_lse = stats_out[..., 0].permute(2, 0, 1)
 
-    combined, _ = dcp_lse_combine_triton(
-        recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e
+    combined, global_lse = dcp_lse_combine_triton(
+        recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e, return_lse=return_lse
     )
-    return combined
+    return (combined, global_lse) if return_lse else combined

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -103,6 +103,7 @@ from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
 from sglang.srt.environ import envs, exportable_env_vars
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+from sglang.srt.layers.dcp.capacity import aggregate_dcp_kv_capacity
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
@@ -2221,10 +2222,18 @@ class Scheduler(
             enable_hisparse=self.enable_hisparse,
             full_tokens_per_layer=self.full_tokens_per_layer,
             swa_tokens_per_layer=self.swa_tokens_per_layer,
-            max_total_num_tokens=self.max_total_num_tokens
-            * get_parallel().attn_dcp_size,
+            max_total_num_tokens=self._reported_max_total_num_tokens(),
             get_last_batch=lambda: self.last_batch,
             get_running_batch=lambda: self.running_batch,
+        )
+
+    def _reported_max_total_num_tokens(self) -> int:
+        """Allocator-visible KV capacity, including virtual DCP expansion."""
+        server_args = getattr(self, "server_args", None)
+        return aggregate_dcp_kv_capacity(
+            self.max_total_num_tokens,
+            dcp_size=getattr(server_args, "dcp_size", 1),
+            attention_backend=getattr(server_args, "attention_backend", None),
         )
 
     def init_invariant_checker(self) -> None:
@@ -2396,7 +2405,7 @@ class Scheduler(
             min(
                 max_new_tokens,
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens * get_parallel().attn_dcp_size
+                self._reported_max_total_num_tokens()
                 - paged_input_len
                 - self.page_size
                 - 1,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -25,6 +25,7 @@ from sglang.srt.beam_search.logits_capture import capture_pre_sample_logits
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.dcp.capacity import aggregate_dcp_kv_capacity
 from sglang.srt.managers.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
     GetWeightsByNameReqInput,
@@ -57,6 +58,7 @@ from sglang.srt.runtime_context import (
     get_device,
     get_exec,
     get_model,
+    get_parallel,
     get_schedule,
     get_serving,
     get_spec,
@@ -427,7 +429,11 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            aggregate_dcp_kv_capacity(
+                self.model_runner.effective_max_total_num_tokens,
+                dcp_size=get_parallel().attn_dcp_size,
+                attention_backend=self.server_args.attention_backend,
+            )
             - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
@@ -542,7 +548,11 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            aggregate_dcp_kv_capacity(
+                self.model_runner.effective_max_total_num_tokens,
+                dcp_size=get_parallel().attn_dcp_size,
+                attention_backend=self.server_args.attention_backend,
+            )
             - 1,
         )
         return (

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -418,6 +418,8 @@ class DeepSeekV4UnifiedKVPool:
         memory_saver_adapter,
         custom_mem_pool,
         swa_ring_size: int,
+        dcp_size: int = 1,
+        dcp_rank: int = 0,
     ):
         self.swa_ring_size = swa_ring_size
         self.head_dim = qk_nope_head_dim + qk_rope_head_dim
@@ -426,6 +428,24 @@ class DeepSeekV4UnifiedKVPool:
         self.num_blocks = num_blocks
         self.page_size = page_size
         self.k_per_block = dict(self.K_PER_BLOCK)
+
+        # Physical DCP: shard only the COMPRESSED region (the big, context-scaled
+        # part) across the DCP group; keep the SWA ring REPLICATED (small).
+        # Layout per layer: [ swa_pages (replicated) | compress_local (1/dcp) | DEAD(1) ].
+        #   compress row p (0-based within compress region) -> owner p % dcp,
+        #   local row swa_pages + p // dcp; non-owned writes go to the DEAD row.
+        # Read masks owner per slot; SWA slot s owner = s % dcp (read from the
+        # full replicated ring). Gated by SGLANG_DSV4_DCP_PHYSICAL.
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_dcp_physical,
+        )
+
+        self.dcp_size = dcp_size if (dcp_size and dcp_size > 1) else 1
+        self.dcp_rank = dcp_rank if self.dcp_size > 1 else 0
+        self.physical_dcp = self.dcp_size > 1 and is_dcp_physical()
+        # ratio -> DEAD row index (only for physical_dcp; same across layers of
+        # a ratio since compress rows depend only on num_blocks/k_per_block).
+        self.compress_dead_row: dict = {}
 
         bufs = []
         with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
@@ -440,9 +460,20 @@ class DeepSeekV4UnifiedKVPool:
                     compress_rows = self.num_blocks * self.k_per_block[ratio]
                     rows_per_page = self.page_size // ratio if ratio else 0
                     padded_compress_rows = compress_rows + rows_per_page
+                    if self.physical_dcp and padded_compress_rows > 0:
+                        # NOTE(rebase): shard the PADDED row count, so the null-slot
+                        # padding page keeps its owner arithmetic identical to the
+                        # unsharded layout (raw row -> owner = row % dcp).
+                        local_compress = (
+                            padded_compress_rows + self.dcp_size - 1
+                        ) // self.dcp_size
+                        rows = self.swa_pages + local_compress + 1  # +1 DEAD row
+                        self.compress_dead_row[ratio] = self.swa_pages + local_compress
+                    else:
+                        rows = self.swa_pages + padded_compress_rows
                     bufs.append(
                         torch.zeros(
-                            self.swa_pages + padded_compress_rows,
+                            rows,
                             self.head_dim,
                             dtype=torch.bfloat16,
                             device=device,
@@ -488,7 +519,11 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
         num_req_slots: Optional[int] = None,
+        dcp_size: int = 1,
+        dcp_rank: int = 0,
     ):
+        self.dcp_size = dcp_size if (dcp_size and dcp_size > 1) else 1
+        self.dcp_rank = dcp_rank if self.dcp_size > 1 else 0
         super().__init__(
             swa_size,
             page_size,
@@ -599,11 +634,20 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 memory_saver_adapter=self.memory_saver_adapter,
                 custom_mem_pool=self.custom_mem_pool,
                 swa_ring_size=self.sliding_window + spec_extra,
+                dcp_size=self.dcp_size,
+                dcp_rank=self.dcp_rank,
             )
 
             self.unified_swa_window = self.sliding_window
             self.unified_swa_ring_size = self.sliding_window + spec_extra
             self.unified_swa_pages = self.unified_kv_pool.swa_pages
+            # Physical-DCP knobs surfaced for the attention backend and for the
+            # PD transfer layer (which must scatter compressed rows to the
+            # owning decode rank; see mori/conn.py::send_kvcache_dsv4_physical).
+            self.unified_physical_dcp = self.unified_kv_pool.physical_dcp
+            self.unified_dcp_size = self.unified_kv_pool.dcp_size
+            self.unified_dcp_rank = self.unified_kv_pool.dcp_rank
+            self.unified_compress_dead_row = self.unified_kv_pool.compress_dead_row
         else:
             self.unified_kv_pool = None
             self.swa_kv_pool = self._make_kv_pool(

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1311,6 +1311,12 @@ class KVCacheConfigurator:
             end_layer=self.layer_info.end_layer,
             enable_hisparse=get_memory().enable_hisparse,
             online_mtp_max_draft_tokens=(max_speculative_num_draft_tokens() or 0),
+            # NOTE(rebase of #29185): the original call site passed
+            # ModelRunner.dcp_size/dcp_rank, which are valid for both DCP=1 and
+            # DCP>1. The attention accessors preserve that contract when the
+            # DCP group is intentionally absent at world size one.
+            dcp_size=get_parallel().attn_dcp_size,
+            dcp_rank=get_parallel().attn_dcp_rank,
         )
         return token_to_kv_pool
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1017,6 +1017,7 @@ class ModelRunner:
 
         if get_parallel().dcp_enabled and get_parallel().dcp_replicate_q_proj:
             self._prepare_replicated_q_proj()
+            self._prepare_replicated_q_proj_dsv4()
 
     def _prepare_replicated_q_proj(self) -> None:
         # --dcp-replicate-q-proj: gather each rank's attn_tp head-shard of
@@ -1055,6 +1056,32 @@ class ModelRunner:
             n_prepared += 1
         logger.info(
             "dcp_replicate_q_proj: prepared full-head Q weights for %d MLA layers",
+            n_prepared,
+        )
+
+    def _prepare_replicated_q_proj_dsv4(self) -> None:
+        # --dcp-replicate-q-proj for DeepSeek-V4 (MqaAttentionBase). V4 uses a
+        # fused wq_b (q_lora_rank -> n_heads*head_dim, ColumnParallel-sharded on
+        # attn_tp) rather than DeepseekV2AttentionMLA's q_b_proj/w_kc absorb, and
+        # the V4-Pro checkpoint is fp8 block-quantized, so the bf16-only path in
+        # _prepare_replicated_q_proj skips it. Here we all-gather each rank's
+        # wq_b weight (and its block scale) along the output/head dim across the
+        # DCP group, so a rank can project the full DCP-group head range locally
+        # and the decode path can skip the per-layer Q all-gather.
+        from sglang.srt.models.deepseek_v4 import MqaAttentionBase
+
+        dcp_group = get_parallel().dcp_group
+        if dcp_group.world_size <= 1:
+            return
+        n_prepared = 0
+        for m in self.model.modules():
+            if not isinstance(m, MqaAttentionBase):
+                continue
+            if m.maybe_prepare_dcp_replicated_q_proj(dcp_group):
+                n_prepared += 1
+        logger.info(
+            "dcp_replicate_q_proj (DSV4): prepared full-head Q weights for "
+            "%d MQA layers",
             n_prepared,
         )
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -955,6 +955,81 @@ class MQALayer(MqaAttentionBase):
         fused_q_norm_rope(q, q_out, self.eps, self.freqs_cis, positions)
         return q_out
 
+    # ------------------------------------------------------------------
+    # DCP: --dcp-replicate-q-proj (see model_runner._prepare_replicated_q_proj_dsv4)
+    #
+    # When active, each DCP rank holds the wq_b weight (and block scale) of the
+    # WHOLE DCP-group head range, all-gathered once at load time along the output
+    # dim. The decode path then projects all ``n_local_heads * dcp_size`` group
+    # heads locally and the backend skips the per-layer Q all-gather -- trading a
+    # latency-bound collective (~30us/layer) for a dcp_size-larger local GEMM.
+    # No-op unless the flag is on AND the fp8 gather succeeded at load time.
+    # ------------------------------------------------------------------
+    def maybe_prepare_dcp_replicated_q_proj(self, dcp_group) -> bool:
+        """Gather this rank's wq_b weight/scale across the DCP group (dim=0).
+
+        Returns True when the replicated weights were prepared. Only the fp8
+        block-quantized wq_b (the V4-Pro checkpoint) is supported; other quant
+        schemes keep the per-layer Q all-gather (returns False).
+        """
+        import types
+
+        self.wq_b_qrep_weight = None
+        self.wq_b_qrep_weight_scale_inv = None
+        self._wq_b_qrep_shim = None
+        self.dcp_qrep_group_heads = None
+        self._dcp_qrep_world = int(dcp_group.world_size)
+
+        qb = self.wq_b
+        qm = getattr(qb, "quant_method", None)
+        scale = getattr(qb, "weight_scale_inv", None)
+        # fp8 block-quant only: apply() reads exactly layer.weight and
+        # layer.weight_scale_inv on this path, so a tiny shim is enough.
+        if qm is None or not getattr(qm, "block_quant", False) or scale is None:
+            return False
+
+        # Output/head dim is the leading dim of both weight and block scale, and
+        # each rank's shard is 128-block aligned (n_local_heads*head_dim), so a
+        # plain dim=0 all-gather + concat reconstructs the group-head weight even
+        # when the checkpoint was bpreshuffle'd (tiles never cross the boundary).
+        w = dcp_group.all_gather(qb.weight.data.contiguous(), dim=0)
+        s = dcp_group.all_gather(scale.data.contiguous(), dim=0)
+        if getattr(scale, "format_ue8m0", False):
+            s.format_ue8m0 = True
+
+        self.wq_b_qrep_weight = w
+        self.wq_b_qrep_weight_scale_inv = s
+        self._wq_b_qrep_shim = types.SimpleNamespace(
+            weight=w, weight_scale_inv=s
+        )
+        self.dcp_qrep_group_heads = self.n_local_heads * self._dcp_qrep_world
+        return True
+
+    def _dcp_q_replicate_active(self, forward_batch) -> bool:
+        """True when this decode step should project the full DCP-group heads."""
+        if getattr(self, "wq_b_qrep_weight", None) is None:
+            return False
+        if not get_parallel().dcp_replicate_q_proj:
+            return False
+        if not forward_batch.forward_mode.is_decode_or_idle():
+            return False
+        # maybe_use_decode_attn_tp can resize n_local_heads at decode; the
+        # gathered weight assumes the capture-time shard, so fall back to the
+        # all-gather path if the head count no longer matches.
+        if self.n_local_heads * self._dcp_qrep_world != self.dcp_qrep_group_heads:
+            return False
+        return True
+
+    def _project_wq_b(self, x, replicate_active: bool) -> torch.Tensor:
+        """wq_b projection, full DCP-group heads when replicate is active."""
+        if replicate_active:
+            # Same fp8 block-GEMM apply() the real wq_b uses (handles both the
+            # plain and pre-quantized (fp8, scale) tuple input), but over the
+            # gathered group-head weight.
+            return self.wq_b.quant_method.apply(self._wq_b_qrep_shim, x, bias=None)
+        q, _ = self.wq_b(x)
+        return q
+
     def _compute_kv_to_cache(
         self,
         x: torch.Tensor,
@@ -1225,16 +1300,17 @@ class MQALayer(MqaAttentionBase):
             qkv_a = None
 
         if self.use_fused_qk_norm_rope:
+            q_replicate = self._dcp_q_replicate_active(forward_batch)
             if _is_gfx95_supported or _is_gfx1250_supported:
                 q_for_wqb, q_lora = _fused_rmsnorm_fp8_quant(
                     q_lora,
                     self.q_norm.weight,
                     self.q_norm.variance_epsilon,
                 )
-                q, _ = self.wq_b(q_for_wqb)
+                q = self._project_wq_b(q_for_wqb, q_replicate)
             else:
                 q_lora = self.q_norm(q_lora)
-                q, _ = self.wq_b(q_lora)
+                q = self._project_wq_b(q_lora, q_replicate)
 
             kv = (
                 qkv_a[..., self.q_lora_rank :]
@@ -1342,16 +1418,17 @@ class MQALayer(MqaAttentionBase):
         )
 
         if do_fused_qk_norm_rope:
+            q_replicate = self._dcp_q_replicate_active(forward_batch)
             if _is_gfx95_supported or _is_gfx1250_supported:
                 q_for_wqb, q_lora = _fused_rmsnorm_fp8_quant(
                     q_lora,
                     self.q_norm.weight,
                     self.q_norm.variance_epsilon,
                 )
-                q, _ = self.wq_b(q_for_wqb)
+                q = self._project_wq_b(q_for_wqb, q_replicate)
             else:
                 q_lora = self.q_norm(q_lora)
-                q, _ = self.wq_b(q_lora)
+                q = self._project_wq_b(q_lora, q_replicate)
 
             kv = (
                 qkv_a[..., self.q_lora_rank :]
@@ -1572,7 +1649,17 @@ class MQALayer(MqaAttentionBase):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        if self.attn_tp_size > 1:
+        if self._dcp_q_replicate_active(forward_batch):
+            # --dcp-replicate-q-proj: project the whole DCP-group head range
+            # locally (n_local_heads * dcp_size heads) so the backend can skip
+            # the per-layer Q all-gather. Every head is written by the GEMM, so
+            # no TP padding/slicing is needed; the DCP decode merge slices this
+            # rank's head block back out of the group-head output.
+            q_padded = x.new_empty(
+                x.shape[0], self.dcp_qrep_group_heads, self.head_dim
+            )
+            q_out = q_padded
+        elif self.attn_tp_size > 1:
             # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
             # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
             # dispatch the cheaper decode::head64 variant; attn_sink is sliced to

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -435,6 +435,91 @@ class TestGetDcpLens(CustomTestCase):
         self.assertEqual(dcp4_allocator.page_size, 256)
         self.assertEqual(dcp4_allocator.num_pages, 16)
 
+    def test_dsv4_pool_builder_uses_safe_attention_dcp_values(self):
+        class StrictParallel:
+            def __init__(self, size: int, rank: int):
+                self.attn_dcp_size = size
+                self.attn_dcp_rank = rank
+
+            @property
+            def dcp_size(self):
+                raise AssertionError("raw DCP size requires an initialized group")
+
+            @property
+            def dcp_rank(self):
+                raise AssertionError("raw DCP rank requires an initialized group")
+
+        configurator = SimpleNamespace(
+            is_draft_worker=False,
+            layer_info=SimpleNamespace(
+                num_effective_layers=2,
+                start_layer=0,
+                end_layer=2,
+            ),
+            model_config=SimpleNamespace(
+                compress_ratios=[0, 128],
+                window_size=128,
+                qk_nope_head_dim=128,
+                qk_rope_head_dim=64,
+                index_head_dim=128,
+            ),
+            kv_cache_dtype=torch.bfloat16,
+            device="cpu",
+            server_args=SimpleNamespace(max_speculative_num_draft_tokens=None),
+        )
+        req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.empty((7, 16), dtype=torch.int64)
+        )
+
+        captured = {}
+
+        def fake_pool(**kwargs):
+            captured.update(kwargs)
+            return captured
+
+        module = "sglang.srt.mem_cache.kv_cache_configurator"
+        with (
+            patch(f"{module}._is_npu", False),
+            patch(f"{module}.DeepSeekV4TokenToKVPool", new=fake_pool),
+            patch(
+                f"{module}.get_schedule",
+                return_value=SimpleNamespace(page_size=256),
+            ),
+            patch(
+                f"{module}.get_exec",
+                return_value=SimpleNamespace(
+                    features=SimpleNamespace(enable_memory_saver=False)
+                ),
+            ),
+            patch(
+                f"{module}.get_memory",
+                return_value=SimpleNamespace(enable_hisparse=False),
+            ),
+        ):
+            for size, rank in ((1, 0), (8, 3)):
+                captured.clear()
+                with patch(
+                    f"{module}.get_parallel",
+                    return_value=StrictParallel(size, rank),
+                ):
+                    result = KVCacheConfigurator._build_dsv4_kv_pool(
+                        configurator,
+                        max_running_requests=4,
+                        swa_max_total_num_tokens=1024,
+                        c4_max_total_num_tokens=256,
+                        c128_max_total_num_tokens=256,
+                        c4_state_pool_size=16,
+                        c128_state_pool_size=16,
+                        c4_state_dtype=torch.float32,
+                        c128_state_dtype=torch.float32,
+                        req_to_token_pool=req_to_token_pool,
+                    )
+
+                self.assertIs(result, captured)
+                self.assertEqual(captured["dcp_size"], size)
+                self.assertEqual(captured["dcp_rank"], rank)
+                self.assertEqual(captured["num_req_slots"], 7)
+
     def test_live_cell_and_page_ownership_formulas(self):
         dcp_size = 4
         physical_page_size = 64


### PR DESCRIPTION
## Goal

Add decode context parallelism (DCP) for **DeepSeek-V4** on the AMD HIP
`unified_kv` attention path. DCP round-robin-shards each token's KV
stream across a TP sub-group (owner rule `pos % dcp_size == rank ->
pos // dcp_size`): every rank attends only its shard and returns a
partial `(out, LSE)`, and a cross-rank merge reconstructs the full-KV
softmax. The aim is to cut per-rank decode KV residency and bandwidth at
long context while keeping the TP GEMM layout unchanged.

## What this PR contains

- **unified_kv decode kernels** – per-rank shard walk with an in-kernel
  owner mask (logical) or a compacted `1/dcp` stream (physical), sink
  deferral and natural-log LSE return for the merge. The aiter gfx1250
  fast path is preserved for the plain single-rank default and bypassed
  for any DCP / non-default request.
- **merge backends** – `ag_rs` (all_gather LSE + all_reduce out) and a
  packed `a2a` (one all_to_all of out + fp32 LSE, local Triton combine).
- **`--dcp-replicate-q-proj`** – project the full DCP-group Q heads
  locally to remove the per-layer head-dim Q all-gather, trading it for a
  redundant Q-projection GEMM. On HIP the V4 decode path merges through
  its own helper, so it is accepted with any `dcp_comm_backend`.
- **indexer sharding** – score the sparse-indexer candidate axis on the
  local shard and pack the per-rank top-k all-gathers into one
  collective (the scoring and top-k env knobs are mutually exclusive).
- **capacity + validation** – a single source of truth for how DCP
  affects KV capacity (logical DCP keeps the fully replicated pool;
  physical DCP compacts to `1/dcp`), a fix for the scheduler
  over-reporting `max_total_num_tokens` by `dcp_size` under logical DCP,
  and fail-fast validation of the V4 DCP configuration.
- **unit tests** for the ownership formulas and the pool builder.

## Current state

- Draft. The path is exercised on MI355X with `tp=dcp=8` on
  DeepSeek-V4-Pro (single node, non-PD) at 128k context; logical DCP
  (`SGLANG_DSV4_DCP_PHYSICAL=0`) is stable, and the `ag_rs`/`a2a` merges
  and `--dcp-replicate-q-proj` are functional.
- The physical-DCP prefill relayout still has a known fault at high
  concurrency that is being tracked separately; logical DCP is the
  recommended default until it lands.
- Feedback on the merge-backend selection and the env-var vs server-arg
  surface for the V4 DCP knobs is welcome.

## Not in this PR (follow-up)

The PD / mori physical-DCP KV transfer path (row-scatter to the owning
decode rank, plus its checksum diagnosis) is deferred to a separate PR:
it overlaps heavily with the recent `mori/conn.py` rework and warrants
its own review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33500126792](https://github.com/sgl-project/sglang/actions/runs/33500126792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33500126609](https://github.com/sgl-project/sglang/actions/runs/33500126609)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33500126775](https://github.com/sgl-project/sglang/actions/runs/33500126775)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->