### PR TITLE
fix(function_call): don't emit qwen3_coder separator whitespace durin…

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -471,6 +471,20 @@ class Qwen3CoderDetector(BaseFormatDetector):
             self.parsed_pos = 0
 
         normal_text = "".join(normal_text_chunks) if normal_text_chunks else ""
+        # The separator between </tool_call> and the next <tool_call> is returned
+        # in the same StreamingParseResult as the calls, and serving_chat.py emits
+        # normal_text before them. It therefore lands between a tool call's
+        # argument fragments and its closing brace, and any consumer that tracks
+        # content-block type closes the tool_use block mid-arguments. Whitespace-
+        # only text while a tool call is in flight is only ever a separator, so
+        # drop it. See #24293; same approach as #29410 for the DeepSeek V3.2
+        # detector.
+        if (
+            normal_text
+            and not normal_text.strip()
+            and (calls or self.current_tool_id >= 0)
+        ):
+            normal_text = ""
         return StreamingParseResult(calls=calls, normal_text=normal_text)
 
     def supports_structural_tag(self) -> bool:


### PR DESCRIPTION
### Problem

`Qwen3CoderDetector` returns the `\n` separator between `</tool_call>` and the
next `<tool_call>` as `normal_text`. That is correct in isolation, but
`parse_streaming_increment()` accumulates `calls` and `normal_text_chunks` across
loop iterations and returns both in a single `StreamingParseResult`, and
`serving_chat.py` emits `normal_text` **before** the calls (~line 2394).

So the separator is delivered *between a tool call's argument fragments and its
closing brace*:

```
TOOL idx=0 name='Glob' args=''
TOOL idx=0 args='{'
TOOL idx=0 args='"pattern": "*.md"'
CONTENT '\n'          <- separator, emitted out of order
TOOL idx=0 args='}'
```

Calls with no separator inside their argument run are unaffected, which is why
the symptom looks intermittent — it depends on where the model puts its
boundaries.

Any consumer that switches content-block type on a content delta then closes the
`tool_use` block mid-arguments. That is #24293 for SGLang's own `/v1/messages`
adapter, and it also corrupts LiteLLM's Anthropic translation: the trailing `}`
becomes a *new, nameless* `tool_use` block, and Claude Code reports
`No such tool available:` with `__unparsedToolInput {"raw": "}"}`.

The three existing `is_inside_tool_call` guards are all correct — the separator
genuinely is outside the call. Only the emission order places it inside the
argument run.

### Fix

Drop whitespace-only `normal_text` while a tool call is in flight. It is only
ever a separator. Same approach as #29410 for the DeepSeek V3.2 detector.

### Relationship to #24293 / #29410

#24293 reported the symptom against SGLang's own `/v1/messages` adapter, with
`qwen3_coder` as the generator. #29410 applied the "suppress whitespace-only
`normal_text` once a tool call is in flight" approach to the **DeepSeek V3.2**
detector. This applies the same approach to `qwen3_coder`, which still emits the
separator on `main` today.

Fixing it in the detector removes the interleave at source, so **every**
downstream consumer benefits — including OpenAI-dialect proxies SGLang does not
control, where the same stream corrupts parallel tool calls entirely.

### Testing

Running in production on a DGX Spark (GB10) since 2026-09-01 with
`Qwen3.8-27B-NVFP4` + DFlash2 speculative decoding, `--tool-call-parser
qwen3_coder`.

Before — four parallel tool calls through an Anthropic translator:

```
idx 2: name='Glob' args='{"pattern": "*.md"'    MALFORMED
idx 4: name=''     args='}'                     orphaned
idx 5: name='Grep' args='{"pattern": ...'       MALFORMED
idx 7: name=''     args='}'                     orphaned
```

After:

```
idx 2: Glob {"pattern": "*.md"}                            OK
idx 3: Grep {"pattern": "milestone", "path": "/etc"}       OK
idx 4: Read {"file_path": "/etc/hostname"}                 OK
idx 5: Bash {"command": "ls /etc", ...}                    OK
```

Contiguous indices, names present, valid JSON. The leading text before the first
tool call is preserved — `current_tool_id` is still `-1` at that point, so genuine
content is unaffected. Claude Code completes multi-file agentic work against this
engine again.

⚠️ Note the bug only reproduces on a client parsing the SSE stream incrementally;
`curl` and buffered clients reassemble and never see it.

<!-- pr-states:start -->


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Existing coverage: `test_streaming_with_text_and_tool` in
`test/registered/unit/function_call/test_function_call_parser.py` already asserts that
text preceding a tool call survives, which this change preserves — `current_tool_id`
is still `-1` at that point. No existing test asserts the separator is emitted.
Happy to add a dedicated streaming test if reviewers want one.

Accuracy and speed are unaffected: this changes only whether whitespace is emitted as
`normal_text`, never sampling or model output.

### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33500425626](https://github.com/sgl-project/sglang/actions/runs/33500425626)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33500425268](https://github.com/sgl-project/sglang/actions/runs/33500425268)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33500425433](https://github.com/sgl-project/sglang/actions/runs/33500425433)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->