### PR TITLE
[CPU] Fix topk sigmoid for small expert counts

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/topk.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/topk.cpp
@@ -159,16 +159,25 @@ inline void sigmoid(float* __restrict__ out, const scalar_t* __restrict__ input)
   const fVec one = fVec(1.f);
 
   constexpr int kVecSize = bVec::size();
-  for (int d = 0; d < SIZE; d += kVecSize) {
-    bVec x_bvec = bVec::loadu(input + d);
+  if constexpr (SIZE < kVecSize) {
+    bVec x_bvec = bVec::loadu(input, SIZE);
     fVec x_fvec0, x_fvec1;
     std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
     x_fvec0 = one / (one + x_fvec0.neg().exp_u20());
-    x_fvec1 = one / (one + x_fvec1.neg().exp_u20());
+    x_fvec0.store(out, SIZE);
+  } else {
+    for (int d = 0; d < SIZE; d += kVecSize) {
+      bVec x_bvec = bVec::loadu(input + d);
+      fVec x_fvec0, x_fvec1;
+      std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-    x_fvec0.store(out + d);
-    x_fvec1.store(out + d + fVec::size());
+      x_fvec0 = one / (one + x_fvec0.neg().exp_u20());
+      x_fvec1 = one / (one + x_fvec1.neg().exp_u20());
+
+      x_fvec0.store(out + d);
+      x_fvec1.store(out + d + fVec::size());
+    }
   }
 }
 
@@ -177,10 +186,16 @@ inline void sigmoid(float* __restrict__ out, const float* __restrict__ input) {
   using fVec = at::vec::Vectorized<float>;
   const fVec one = fVec(1.f);
   constexpr int kVecSize = fVec::size();
-  for (int d = 0; d < SIZE; d += kVecSize) {
-    fVec in_fvec = fVec::loadu(input + d);
+  if constexpr (SIZE < kVecSize) {
+    fVec in_fvec = fVec::loadu(input, SIZE);
     in_fvec = one / (one + in_fvec.neg().exp_u20());
-    in_fvec.store(out + d);
+    in_fvec.store(out, SIZE);
+  } else {
+    for (int d = 0; d < SIZE; d += kVecSize) {
+      fVec in_fvec = fVec::loadu(input + d);
+      in_fvec = one / (one + in_fvec.neg().exp_u20());
+      in_fvec.store(out + d);
+    }
   }
 }
 

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -383,6 +383,35 @@ class TestCustomTopK(CustomTestCase):
                 topk_weights, expected_weights, atol=1e-4, rtol=1e-4
             )
 
+    def test_topk_sigmoid_with_correction_bias_small_expert_counts(self):
+        """Small expert buffers must not be accessed beyond their logical size."""
+        for dtype, num_experts in itertools.product(
+            [torch.float32, torch.bfloat16], [1, 2, 4, 8]
+        ):
+            hidden_states = torch.zeros((1, 1), dtype=dtype)
+            gating_output = torch.zeros((1, num_experts), dtype=dtype)
+            correction_bias = torch.linspace(-0.5, 0.5, num_experts)
+            topk = min(2, num_experts)
+
+            topk_weights, topk_ids = torch.ops.sgl_kernel.topk_sigmoid_cpu(
+                hidden_states=hidden_states,
+                gating_output=gating_output,
+                topk=topk,
+                renormalize=False,
+                correction_bias=correction_bias,
+            )
+
+            scores = torch.sigmoid(gating_output.float())
+            expected_ids = torch.topk(
+                scores + correction_bias.unsqueeze(0), k=topk, dim=-1
+            ).indices
+            expected_weights = scores.gather(1, expected_ids)
+
+            torch.testing.assert_close(topk_ids.to(torch.int64), expected_ids)
+            torch.testing.assert_close(
+                topk_weights, expected_weights, atol=1e-4, rtol=1e-4
+            )
+
     def test_topk_sigmoid_mixed_input_dtypes(self):
         torch.manual_seed(0)
         hidden_states = torch.randn((17, 16), dtype=torch.bfloat16)


### PR DESCRIPTION
## Motivation

Fixes #36600.

On x86 CPU builds, the correction-bias path of `topk_sigmoid_cpu` performs full-width SIMD loads and stores when the expert count is smaller than one vector. This accesses memory beyond the logical input and score buffers.

## Modifications

- Use count-aware vector loads and stores for partial FP32 and reduced-floating-point vectors.
- Preserve the existing full-vector path for larger expert counts.
- Add regression coverage for 1, 2, 4, and 8 experts with FP32 and BF16 inputs.

## Accuracy Tests

- Before the fix, AddressSanitizer reports a heap-buffer-overflow for one FP32 expert:
  - 64-byte SIMD read immediately after a 4-byte tensor allocation.
- After the fix, AddressSanitizer passes all combinations of:
  - dtypes: FP32, BF16
  - expert counts: 1, 2, 4, 8
- `clang-format --dry-run --Werror` passed.
- `black --check` passed.
- Python syntax compilation passed.

## Speed Tests and Profiling

Not applicable. The existing full-vector path is unchanged; only partial-vector tails use bounded loads and stores.

## Checklist

- [x] Format the modified code.
- [x] Add a bug regression test.
- [x] Follow the SGLang code style guidance.
- [x] No documentation update is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33522479256](https://github.com/sgl-project/sglang/actions/runs/33522479256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33522478846](https://github.com/sgl-project/sglang/actions/runs/33522478846)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33522479251](https://github.com/sgl-project/sglang/actions/runs/33522479251)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->