### PR TITLE
[unified-memory] PD disaggregation for MHA full-attention hybrids

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -896,6 +896,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             prefill_data_indices=prefill_kv_indices,
             dst_data_indices=dst_kv_indices,
             executor=executor,
+            # The unified pool registers ONE region holding every layer's K and
+            # V inside each page envelope. The MHA branch would half-split that
+            # single region into K and V halves and compute num_kv_layers = 0,
+            # transferring nothing at all; the flat branch addresses the region
+            # as-is. MLA-unified already reaches the flat branch via
+            # is_mla_backend, so this only adds the MHA-unified peer.
+            force_flat=get_memory().enable_unified_memory,
             src_layer_ids=self.kv_args.kv_layer_ids,
             dst_layer_ids=dst_layer_ids,
             dst_device_data_indices=dst_device_kv_indices,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -433,14 +433,6 @@ class KVCacheConfigurator:
                     unified_total_bytes=sizes.unified_total_bytes,
                 )
             elif self.mambaish_config is not None:
-                if pd_enabled and not self.use_mla_backend:
-                    raise ValueError(
-                        "--enable-unified-memory with PD disaggregation "
-                        "currently supports only MLA hybrid-Mamba models "
-                        "(e.g. kimi-linear); this model uses the MHA full-"
-                        "attention pool. Drop --enable-unified-memory or run "
-                        "without PD disaggregation."
-                    )
                 bundle = self._init_unified_mamba_pools(
                     max_num_reqs=sizes.max_running_requests,
                     max_total_num_tokens=sizes.max_total_num_tokens,

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -624,10 +624,19 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
             env[tgt_pages] = env[src_pages]
 
     def get_contiguous_buf_infos(self):
-        raise NotImplementedError(
-            "unified layout has no per-layer contiguous regions; "
-            "KV transfer / disaggregation is unsupported."
-        )
+        """PD-transfer registration: ONE entry, the raw buffer, addressed as
+        ``raw_ptr + physical_page_id * page_envelope_bytes``.
+
+        Same whole-envelope contract as `UnifiedMLATokenToKVPool`: the transfer
+        item is one page across ALL layers and both K and V, because the
+        per-layer views overlap inside the envelope and index in kernel-facing
+        ids. A peer must therefore build an identical spec -- enforced on the
+        wire by `_validate_envelope_kv_layout`.
+        """
+        # The address formula omits the anchor; a nonzero one would mis-address.
+        assert self._unified_buffer.anchor_bytes(self._sub_pool_name) == 0
+        raw = self._unified_buffer._raw
+        return [raw.data_ptr()], [raw.numel()], [self._page_bytes]
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError(

--- a/test/registered/disaggregation/test_disaggregation_unified_memory.py
+++ b/test/registered/disaggregation/test_disaggregation_unified_memory.py
@@ -9,6 +9,9 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 register_cuda_ci(est_time=900, stage="base-b", runner_config="2-gpu-large")
 
 KIMI_LINEAR_MODEL = "yujiepan/kimi-linear-tiny-random"
+# Smallest in-tree GDN hybrid: MHA full attention + gated-delta-net linear
+# layers, i.e. the unified pool's MHA sub-pool rather than the MLA one.
+QWEN_GDN_MODEL = "Qwen/Qwen3.5-0.8B"
 SERVER_ENV = {"SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM": "0"}
 
 # --attention-backend and --enable-deterministic-inference are deliberately
@@ -61,6 +64,22 @@ class TestUnifiedMemoryDisaggregationChunkedPrefill(TestUnifiedMemoryDisaggregat
     baseline_args = _chunked_args
     extra_prefill_args = _chunked_args
     extra_decode_args = _chunked_args
+
+
+class TestUnifiedMemoryDisaggregationMHA(TestUnifiedMemoryDisaggregation):
+    """The MHA full-attention sub-pool over the wire.
+
+    Kimi-Linear above exercises the MLA sub-pool, whose whole-envelope
+    registration has always been the one PD supports. An MHA envelope is a
+    different shape -- `2 * layer_num` row-blocks per page instead of
+    `layer_num` -- and it reaches a different branch of
+    `_send_kvcache_generic`: without `force_flat` the MHA branch halves the
+    single registered region into K and V, computes `num_kv_layers = 0` and
+    transfers NOTHING, which shows up as garbage decode rather than an error.
+    Logprob parity against a non-PD unified reference is what catches that.
+    """
+
+    model = QWEN_GDN_MODEL
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
+++ b/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
@@ -18,9 +18,11 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.layout.page_major import (
+    build_mha_views,
     build_mla_views,
     build_page_major_mamba_views,
     mamba_entry_bytes,
+    mha_entry_bytes,
     mla_entry_bytes,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -72,6 +74,118 @@ class TestMLAEnvelopeTransferAddressing(CustomTestCase):
                     )
                     got = raw[start : start + row_bytes].view(store_dtype)
                     self.assertTrue(torch.equal(got, val), (page, layer, off))
+
+
+class TestMHAEnvelopeTransferAddressing(CustomTestCase):
+    """The MHA counterpart of the MLA case above.
+
+    An MHA page envelope holds ``2 * layer_num`` row-blocks (layer l's K at
+    block 2l, its V at 2l+1). PD ships that whole envelope as one item, so a
+    row written through ANY per-layer view must land inside its own page's
+    ``page_envelope_bytes`` block -- otherwise the transfer would carry a
+    page's K but another page's V and every kernel would still read fine
+    locally.
+    """
+
+    def test_page_envelope_matches_per_layer_views(self):
+        layer_num, page_size, head_num, head_dim, num_pages = 3, 4, 2, 8, 6
+        store_dtype = torch.bfloat16
+        entry_bytes = mha_entry_bytes(
+            layer_num=layer_num,
+            head_num=head_num,
+            head_dim=head_dim,
+            v_head_dim=head_dim,
+            itemsize=store_dtype.itemsize,
+        )
+        page_bytes = page_size * entry_bytes
+        row_bytes = head_num * head_dim * store_dtype.itemsize
+        self.assertEqual(page_bytes, page_size * 2 * layer_num * row_bytes)
+
+        # One page envelope of tail pad, as UnifiedKVPool allocates for MHA.
+        raw = torch.zeros((num_pages + 1) * page_bytes, dtype=torch.uint8)
+        k_views, v_views = build_mha_views(
+            raw,
+            layer_num=layer_num,
+            head_num=head_num,
+            head_dim=head_dim,
+            v_head_dim=head_dim,
+            store_dtype=store_dtype,
+            page_size=page_size,
+            num_pages=num_pages,
+            anchor_bytes=0,
+        )
+
+        blocks = 2 * layer_num
+        for page in range(num_pages):
+            for layer in range(layer_num):
+                for is_v, views in ((0, k_views), (1, v_views)):
+                    for pos in range(page_size):
+                        row = page * blocks * page_size + pos
+                        views[layer][row].fill_(1)
+                        (nz,) = torch.nonzero(raw, as_tuple=True)
+                        lo, hi = int(nz.min()), int(nz.max())
+                        self.assertGreaterEqual(
+                            lo,
+                            page * page_bytes,
+                            f"page={page} layer={layer} v={is_v} pos={pos} "
+                            "wrote below its page envelope",
+                        )
+                        self.assertLess(
+                            hi,
+                            (page + 1) * page_bytes,
+                            f"page={page} layer={layer} v={is_v} pos={pos} "
+                            "wrote past its page envelope",
+                        )
+                        views[layer][row].zero_()
+
+    def test_envelope_move_is_a_whole_page_copy(self):
+        """Relocating a page envelope must move every layer's K and V with it;
+        this is what `UnifiedMHATokenToKVPool.move_kv_cache` relies on and what
+        makes a physical page id a valid PD transfer index after compaction."""
+        layer_num, page_size, head_num, head_dim, num_pages = 2, 2, 1, 4, 4
+        store_dtype = torch.bfloat16
+        entry_bytes = mha_entry_bytes(
+            layer_num=layer_num,
+            head_num=head_num,
+            head_dim=head_dim,
+            v_head_dim=head_dim,
+            itemsize=store_dtype.itemsize,
+        )
+        page_bytes = page_size * entry_bytes
+        raw = torch.zeros((num_pages + 1) * page_bytes, dtype=torch.uint8)
+        k_views, v_views = build_mha_views(
+            raw,
+            layer_num=layer_num,
+            head_num=head_num,
+            head_dim=head_dim,
+            v_head_dim=head_dim,
+            store_dtype=store_dtype,
+            page_size=page_size,
+            num_pages=num_pages,
+            anchor_bytes=0,
+        )
+        blocks = 2 * layer_num
+        # Distinct content in source page 1, every layer, K and V.
+        for layer in range(layer_num):
+            for pos in range(page_size):
+                row = 1 * blocks * page_size + pos
+                k_views[layer][row].fill_(layer + 1)
+                v_views[layer][row].fill_(-(layer + 1))
+
+        env = raw[: num_pages * page_bytes].view(num_pages, page_bytes)
+        env[3] = env[1]
+
+        for layer in range(layer_num):
+            for pos in range(page_size):
+                row = 3 * blocks * page_size + pos
+                self.assertTrue(
+                    torch.all(k_views[layer][row] == layer + 1),
+                    f"K layer {layer} did not ride the envelope move",
+                )
+                self.assertTrue(
+                    torch.all(v_views[layer][row] == -(layer + 1)),
+                    f"V layer {layer} did not ride the envelope move",
+                )
 
 
 class TestMambaEnvelopeTransferAddressing(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_unified_mha_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mha_views.py
@@ -458,18 +458,36 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
         )
 
     def test_transfer_entry_points_fail_loud(self):
-        """PD / CPU-copy entry points assume per-layer buffers indexed by TOKEN
-        id; against the row space they would silently mis-index (or hit a
-        missing-attr AttributeError). Every one of them must raise."""
+        """The entry points that assume per-layer buffers indexed by TOKEN id
+        would silently mis-index against the row space (or hit a missing-attr
+        AttributeError), so each must raise. `get_contiguous_buf_infos` is NOT
+        among them: PD addresses this pool as whole page envelopes, pinned by
+        `test_pd_registration_is_one_whole_envelope` below."""
         _, pool = _make_pool_and_kv(1)
-        with self.assertRaises(NotImplementedError):
-            pool.get_contiguous_buf_infos()
         with self.assertRaises(NotImplementedError):
             pool.get_cpu_copy(torch.tensor([1]))
         with self.assertRaises(NotImplementedError):
             pool.load_cpu_copy(None, torch.tensor([1]))
         with self.assertRaises(NotImplementedError):
             pool.set_kv_buffer_prefix_valid()
+
+    def test_pd_registration_is_one_whole_envelope(self):
+        """PD registers ONE region -- the whole raw buffer -- with the page
+        envelope as the item, so the transfer engine addresses it as
+        `raw_ptr + physical_page * page_envelope_bytes`. Per-layer regions
+        would be wrong here: the per-layer views overlap inside the envelope
+        and index in kernel-facing ids, not token ids."""
+        kv, pool = _make_pool_and_kv(1)
+        ptrs, lens, item_lens = pool.get_contiguous_buf_infos()
+        self.assertEqual(len(ptrs), 1)
+        self.assertEqual(len(lens), 1)
+        self.assertEqual(len(item_lens), 1)
+        self.assertEqual(ptrs[0], kv._raw.data_ptr())
+        self.assertEqual(lens[0], kv._raw.numel())
+        self.assertEqual(item_lens[0], pool._page_bytes)
+        # The whole addressable page range must fit the registered region, or
+        # the last page's write would run off the end of the RDMA mapping.
+        self.assertLessEqual(pool._num_pages * item_lens[0], lens[0])
 
     def test_hnd_env_cannot_hijack_layout(self):
         """SGLANG_USE_HND_KVCACHE=1 used to flip the inherited env-driven


### PR DESCRIPTION
**Stack 1/4** — `main` ← **cheng/um-pd-mha** ← cheng/um-pd-swa ← cheng/um-pd-tri ← cheng/um-prefill-cuda-graph

`--enable-unified-memory` + PD disaggregation only supported MLA hybrid-Mamba models (kimi-linear). A GDN hybrid such as Qwen3.5 routes its full-attention side to `UnifiedMHATokenToKVPool`, whose `get_contiguous_buf_infos` raised, so the configurator refused the pairing at boot.

The MHA sub-pool needs no new transfer scheme. Every unified sub-pool is anchored at byte 0 of the same raw buffer and addressed by its own stride, so the whole-page-envelope contract MLA already uses generalises verbatim: one registered region, `raw_ptr + physical_page * page_envelope_bytes`. The MHA envelope simply holds `2 * layer_num` row-blocks (layer *l*'s K at block 2*l*, its V at 2*l*+1) instead of `layer_num`.

The one wire-path change is `force_flat`. Without it `_send_kvcache_generic` takes the MHA branch, halves the single registered region into K and V, computes `num_kv_layers = len(src_data_ptrs) // 2 == 0` and **transfers nothing at all** — garbage decode rather than an error. MLA-unified already reached the flat branch through `is_mla_backend`; this adds the MHA-unified peer.

## Validation

Qwen3.5-4B, 1 prefill + 1 decode on H200, mooncake:

| config | GSM8K (200, 5-shot) | invalid |
|---|---|---|
| PD + unified memory | **0.870** | 0.000 |
| PD + static pools | 0.875 | 0.000 |

Parity within noise. `test_disaggregation_unified_memory.py` passes (all 3 classes).

## Tests

- `test_pd_envelope_transfer_layout.py`: MHA page-envelope addressing + envelope-move coverage.
- `test_unified_mha_views.py`: the registration is one whole envelope (replaces the pin on the old raise).
- `test_disaggregation_unified_memory.py::TestUnifiedMemoryDisaggregationMHA`: logprob parity vs a non-PD unified reference on Qwen3.5-0.8B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33504858730](https://github.com/sgl-project/sglang/actions/runs/33504858730)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33552015960](https://github.com/sgl-project/sglang/actions/runs/33552015960)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33504858435](https://github.com/sgl-project/sglang/actions/runs/33504858435)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->