### PR TITLE
[unified-memory] PD disaggregation for hybrid-SWA models

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1401,7 +1401,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     decode_req.req.kv.req_pool_idx, window_start:seq_len
                 ]
                 window_kv_indices_swa = (
-                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                    self.token_to_kv_pool_allocator.translate_swa_indices_for_transfer(
                         window_kv_indices_full
                     )
                 )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1458,6 +1458,11 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        # Same reason as in `send_kvcache`: a unified sub-pool
+                        # registers ONE region holding every layer's K and V per
+                        # slot envelope, and the MHA branch would half-split it
+                        # into zero layers and ship nothing.
+                        force_flat=get_memory().enable_unified_memory,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1230,7 +1230,7 @@ class SchedulerDisaggregationPrefillMixin:
                     req.kv.req_pool_idx, window_start:seq_len
                 ]
                 window_kv_indices_swa = (
-                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                    self.token_to_kv_pool_allocator.translate_swa_indices_for_transfer(
                         window_kv_indices_full
                     )
                 )

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -149,6 +149,19 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert self._kvcache.full_to_swa_index_mapping is not None
         return self._kvcache.translate_loc_from_full_to_swa(kv_indices)
 
+    def translate_swa_indices_for_transfer(
+        self, kv_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """Sliding-window token ids as the PD transfer engine addresses them.
+
+        The sibling of `translate_kv_indices_for_transfer` for the SWA state
+        component. On a static pool the sliding-window buffers are indexed by
+        the same ids the kernels use, so the read-path translate IS the answer.
+        A virtual-id pool must override: the transfer addresses raw bytes and
+        needs PHYSICAL ids, not kernel-facing ones.
+        """
+        return self.translate_loc_from_full_to_swa(kv_indices)
+
     def alloc(self, need_size: int):
         assert self.page_size == 1
         if need_size > self.full_attn_allocator.available_size():

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -152,11 +152,21 @@ def resolve_decode_retraction_backup(*, tp_worker: BaseTpWorker) -> str:
         )
         # Host-pool retraction transfers full and sliding-window components
         # only, so a model with recurrent state stays on cpu_tensor.
-        supports_host_pool = not uses_ssm_state(
-            tp_worker.model_runner.model_config
-        ) and (
-            isinstance(kv_cache, MHATokenToKVPool)
-            or (isinstance(kv_cache, SWAKVPool) and full_tokens_per_layer > 0)
+        #
+        # The unified pool is excluded for the same reason hierarchical cache is
+        # (see `handle_unified_memory_pool`): the host-transfer path indexes the
+        # device buffers with the ids it is handed, and under the unified pool
+        # those are VIRTUAL. It also cannot be sized from `kv_cache.size`, which
+        # is a KERNEL-FACING row count (`num_pages * 2 * layer_num * page_size`)
+        # rather than a token capacity -- gpt-oss-20b reports 85M "tokens" and
+        # asks for 418 GB of host memory per component.
+        supports_host_pool = (
+            not uses_ssm_state(tp_worker.model_runner.model_config)
+            and not memory.enable_unified_memory
+            and (
+                isinstance(kv_cache, MHATokenToKVPool)
+                or (isinstance(kv_cache, SWAKVPool) and full_tokens_per_layer > 0)
+            )
         )
         schedule = get_schedule()
         priority_preemption = (

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -439,13 +439,6 @@ class KVCacheConfigurator:
                     unified_total_bytes=sizes.unified_total_bytes,
                 )
             elif self.is_hybrid_swa and not is_dsv4:
-                if pd_enabled:
-                    raise ValueError(
-                        "--enable-unified-memory with PD disaggregation does "
-                        "not support hybrid-SWA models yet (no whole-envelope "
-                        "transfer scheme for the SWA sub-pool). Drop "
-                        "--enable-unified-memory or run without PD."
-                    )
                 bundle = self._init_unified_swa_pools(
                     max_num_reqs=sizes.max_running_requests,
                     full_max_total_num_tokens=sizes.full_max_total_num_tokens,
@@ -808,12 +801,28 @@ class KVCacheConfigurator:
         extra_max_context_len = 4
         if get_spec().speculative_num_draft_tokens is not None:
             extra_max_context_len += get_spec().speculative_num_draft_tokens
-        req_to_token_pool = ReqToTokenPool(
-            size=max_num_reqs,
-            max_context_len=self.model_config.context_len + extra_max_context_len,
-            device=self.device,
-            enable_memory_saver=get_exec().features.enable_memory_saver,
-        )
+        if get_disagg().disaggregation_mode == "decode":
+            # A decode node hands out request rows to PREALLOCATED transfers on
+            # top of its running set, so it needs the extra-slot pool (and the
+            # `pre_alloc_size` the scheduler's invariant checker reads). Mirrors
+            # `_build_req_to_token_pool`'s decode branch; the mamba composite
+            # already takes `decode_pre_alloc_size` the same way.
+            from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+
+            req_to_token_pool = DecodeReqToTokenPool(
+                size=max_num_reqs,
+                max_context_len=self.model_config.context_len + extra_max_context_len,
+                device=self.device,
+                enable_memory_saver=get_exec().features.enable_memory_saver,
+                pre_alloc_size=get_disagg().disaggregation_decode_extra_slots,
+            )
+        else:
+            req_to_token_pool = ReqToTokenPool(
+                size=max_num_reqs,
+                max_context_len=self.model_config.context_len + extra_max_context_len,
+                device=self.device,
+                enable_memory_saver=get_exec().features.enable_memory_saver,
+            )
 
         head_num = self.model_config.get_num_kv_heads(
             get_parallel().attn_tp_size, get_parallel().attn_dcp_size

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -3338,6 +3338,42 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         """SWA-layer read path: virtual TOKEN ids -> swa kernel-facing ids."""
         return self.swa_attn_allocator.translate_kv_loc_for_kernel(kv_indices, out=out)
 
+    def translate_kv_indices_for_transfer(
+        self, kv_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """Virtual TOKEN ids -> full-sub-pool PHYSICAL token ids for the PD
+        transfer engine.
+
+        PHYSICAL, not kernel-facing: the transfer registers page ENVELOPES (see
+        `UnifiedMHATokenToKVPool.get_contiguous_buf_infos`). Without this
+        override the base identity would put VIRTUAL ids on the wire, which
+        address real bytes and so corrupt silently rather than fail.
+        """
+        return self.full_attn_allocator.translate_kv_loc(kv_indices.to(torch.int64))
+
+    def translate_swa_indices_for_transfer(
+        self, kv_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """Virtual TOKEN ids -> swa-sub-pool PHYSICAL token ids.
+
+        The SWA counterpart of the above. `translate_loc_from_full_to_swa`
+        cannot serve here: it returns KERNEL-FACING ids (the physical page
+        scaled by the sub-pool's per-page block count), which index the
+        per-layer views, whereas the SWA state component is registered as whole
+        page envelopes and addressed by physical page.
+        """
+        return self.swa_attn_allocator.translate_kv_loc(kv_indices.to(torch.int64))
+
+    def set_disagg_move_gate(self, gate: Callable[[], bool]) -> None:
+        """Install the PD-disaggregation move gate on both sub-allocators."""
+        assert self.lazy_compaction, (
+            "PD disaggregation with the unified memory pool requires lazy "
+            "compaction (eager free-path compaction moves pages under "
+            "in-flight transfers)."
+        )
+        self.full_attn_allocator.disagg_move_gate = gate
+        self.swa_attn_allocator.disagg_move_gate = gate
+
     @property
     def kernel_page_multiplier(self) -> int:
         return self.full_attn_allocator.kernel_page_multiplier

--- a/test/registered/disaggregation/test_disaggregation_unified_memory_swa.py
+++ b/test/registered/disaggregation/test_disaggregation_unified_memory_swa.py
@@ -1,0 +1,67 @@
+"""PD disaggregation for a hybrid-SWA model on the unified memory pool.
+
+A hybrid-SWA model ships TWO attention components: the full-attention KV on the
+ordinary `kv_data_ptrs` channel and the sliding-window KV as `StateType.SWA`.
+Under `--enable-unified-memory` both are whole page envelopes into the SAME raw
+buffer, distinguished only by their per-page stride, and each is addressed by
+its OWN sub-pool's physical page id -- the full and SWA sides run independent
+compactions, so one virtual token names two unrelated physical pages.
+
+That makes three ways to be silently wrong rather than loud:
+  * shipping virtual ids (the base `translate_kv_indices_for_transfer` is the
+    identity, and virtual ids address real bytes);
+  * shipping the SWA side's KERNEL-FACING ids, which the read path uses, in
+    place of its physical ones;
+  * letting compaction relocate a page mid-transfer, which the SWA allocator
+    had no `set_disagg_move_gate` to prevent.
+
+Logprob parity against a non-PD unified reference catches all three; GSM8K on
+gpt-oss is too noisy to (single-server unified and static both score 0.570 at
+200 questions, and PD runs of each span 0.540-0.610).
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.pd_parity_kit import PDLogprobParityMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST_MXFP4_WITH_MOE
+
+register_cuda_ci(est_time=1200, stage="extra-b", runner_config="2-gpu-large")
+
+UNIFIED_SWA_ARGS = [
+    "--skip-tokenizer-init",
+    "--random-seed",
+    "1",
+    "--enable-unified-memory",
+    # gpt-oss uses attention sinks, which flashinfer does not support; triton
+    # reads both sub-pools' per-layer views.
+    "--attention-backend",
+    "triton",
+    "--mem-fraction-static",
+    "0.7",
+    "--cuda-graph-backend-decode",
+    "disabled",
+    "--cuda-graph-backend-prefill",
+    "disabled",
+]
+
+
+class TestUnifiedMemoryDisaggregationSWA(
+    PDLogprobParityMixin, PDDisaggregationServerBase
+):
+    """1 prefill + 1 decode, both unified, vs a non-PD unified reference."""
+
+    model = DEFAULT_MODEL_NAME_FOR_TEST_MXFP4_WITH_MOE
+    prefill_tp_size = 1
+    decode_tp_size = 1
+    decode_base_gpu_id = 1
+    baseline_args = UNIFIED_SWA_ARGS
+    extra_prefill_args = UNIFIED_SWA_ARGS
+    extra_decode_args = UNIFIED_SWA_ARGS
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
+++ b/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
@@ -186,5 +186,70 @@ class TestMoveGateRejectsNonPdNode(CustomTestCase):
             unified_memory_disagg_move_gate(scheduler)
 
 
+class TestUnifiedAllocatorsPublishTheTransferContract(CustomTestCase):
+    """Every unified composite allocator must OVERRIDE the two PD hooks.
+
+    `BaseTokenToKVPoolAllocator.translate_kv_indices_for_transfer` is the
+    IDENTITY, and `set_disagg_move_gate` exists only where a composite defines
+    it. Inheriting either is silent, not loud: identity puts VIRTUAL ids on the
+    wire (they address real bytes, so the peer gets plausible garbage), and a
+    missing gate lets lazy compaction relocate pages under in-flight RDMA.
+    An AST-level check because instantiating these composites needs a GPU.
+    """
+
+    _COMPOSITES = (
+        "UnifiedMambaTokenToKVPoolAllocator",
+        "UnifiedSWATokenToKVPoolAllocator",
+    )
+
+    @staticmethod
+    def _own_methods(cls_name: str) -> Set[str]:
+        import ast
+        import inspect
+
+        import sglang.srt.mem_cache.multi_ended_allocator as mod
+
+        tree = ast.parse(inspect.getsource(mod))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == cls_name:
+                return {
+                    child.name
+                    for child in node.body
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                }
+        raise AssertionError(f"class {cls_name} not found in multi_ended_allocator")
+
+    def test_transfer_translate_is_not_inherited_identity(self):
+        for name in self._COMPOSITES:
+            with self.subTest(composite=name):
+                self.assertIn(
+                    "translate_kv_indices_for_transfer",
+                    self._own_methods(name),
+                    f"{name} inherits the identity transfer translate; PD would "
+                    "ship VIRTUAL ids and corrupt KV without any error",
+                )
+
+    def test_move_gate_setter_is_defined(self):
+        for name in self._COMPOSITES:
+            with self.subTest(composite=name):
+                self.assertIn(
+                    "set_disagg_move_gate",
+                    self._own_methods(name),
+                    f"{name} has no set_disagg_move_gate; Scheduler."
+                    "init_disaggregation would AttributeError, or -- worse, if "
+                    "the call were guarded -- compaction would run unguarded",
+                )
+
+    def test_swa_composite_translates_the_swa_side_separately(self):
+        """The SWA sub-pool runs its OWN compaction, so a full-side physical id
+        does not name the SWA page holding the same virtual token. The read-path
+        `translate_loc_from_full_to_swa` cannot stand in either: it returns
+        kernel-facing ids, and the transfer addresses raw page envelopes."""
+        self.assertIn(
+            "translate_swa_indices_for_transfer",
+            self._own_methods("UnifiedSWATokenToKVPoolAllocator"),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Stack 2/4** — main ← #37415 ← **cheng/um-pd-swa** ← cheng/um-pd-tri ← cheng/um-prefill-cuda-graph
Targets #37415; review that one first.

A hybrid-SWA model ships two attention components — full-attention KV on the `kv_data_ptrs` channel, sliding-window KV as `StateType.SWA`. The configurator refused the pairing outright: *"no whole-envelope transfer scheme for the SWA sub-pool"*.

There is one, and it is the scheme the other sub-pools already use: every unified sub-pool is anchored at byte 0 of the same raw buffer and addressed by its own per-page stride, so full and SWA each register that buffer with their own `item_len` and index it with their own physical page id. What was actually missing sat on the allocator and the wire:

- `UnifiedSWATokenToKVPoolAllocator` inherited the **identity** `translate_kv_indices_for_transfer`, which would put VIRTUAL ids on the wire. Virtual ids address real bytes, so the peer receives plausible garbage rather than an error.
- The SWA side needs its own translate. `translate_loc_from_full_to_swa` cannot serve: it returns KERNEL-FACING ids for the read path, while the transfer addresses raw page envelopes. Hence `translate_swa_indices_for_transfer`, base-defaulted to the read-path translate (an identity change for static pools).
- The composite had no `set_disagg_move_gate`, so the full and SWA allocators — which compact independently — could relocate a page under in-flight RDMA.
- `maybe_send_extra`'s generic-state branch needed the same `force_flat` as `send_kvcache`.

## Latent decode-node bug fixed along the way

`resolve_decode_retraction_backup` defaults to `host_pool` for any `SWAKVPool` without recurrent state, and sizes the host pool from `kv_cache.size` — which for a unified pool is a kernel-facing **row** count, not a token capacity. gpt-oss-20b reported 85M "tokens" and tried to allocate **418 GB of host memory per component**. The unified pool is now excluded for the same reason hierarchical cache is. The unified-SWA decode node also needed a `DecodeReqToTokenPool` for its preallocated-transfer rows.

## Validation

gpt-oss-20b, 1 prefill + 1 decode on H200, mooncake. Logprob parity PD-unified vs non-PD-unified passes (new CI test).

GSM8K(200, 5-shot) single-server: unified **0.570**, static **0.570** — identical. PD runs of both span 0.540–0.610, which is why parity rather than GSM8K is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33504881582](https://github.com/sgl-project/sglang/actions/runs/33504881582)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33504881373](https://github.com/sgl-project/sglang/actions/runs/33504881373)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33504881763](https://github.com/sgl-project/sglang/actions/runs/33504881763)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->