### PR TITLE
[unified-memory] PD disaggregation for the tri-pool (full + SWA + state)

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -408,24 +408,12 @@ class KVCacheConfigurator:
         # from one byte buffer, then return. Gated to the target worker
         # (req_to_token_pool is None); supports hybrid Mamba and hybrid SWA (not DSV4).
         if get_memory().enable_unified_memory and req_to_token_pool is None:
-            pd_enabled = get_disagg().disaggregation_mode != "null"
             is_dsv4 = is_deepseek_v4(self.model_config.hf_config)
             # Order matters: an Inkling-class model is BOTH mambaish and
             # hybrid-SWA, and the mamba pair would store every SWA layer's KV at
             # FULL lifetime -- its branch reads the HF config's
             # full_attention_layer_ids, which for Inkling is ALL layers.
             if self.mambaish_config is not None and self.is_hybrid_swa and not is_dsv4:
-                if pd_enabled:
-                    # Same limitation as the 2-pool SWA branch below: the
-                    # tri-pool carries an SWA sub-pool, and there is no
-                    # whole-envelope transfer scheme for it.
-                    raise ValueError(
-                        "--enable-unified-memory with PD disaggregation does "
-                        "not support hybrid-SWA models yet (no whole-envelope "
-                        "transfer scheme for the SWA sub-pool); this model "
-                        "routes to the mamba+SWA tri-pool, which has one. Drop "
-                        "--enable-unified-memory or run without PD."
-                    )
                 bundle = self._init_unified_mamba_swa_pools(
                     max_num_reqs=sizes.max_running_requests,
                     full_max_total_num_tokens=sizes.full_max_total_num_tokens,
@@ -773,6 +761,13 @@ class KVCacheConfigurator:
             unified_total_bytes=(None if self.is_draft_worker else unified_total_bytes),
             # bs=1 feasibility floor input (context len is already passed).
             sliding_window_size=self.model_config.sliding_window_size,
+            # Decode nodes hand out request rows to PREALLOCATED transfers on
+            # top of the running set; the 2-pool mamba factory takes the same.
+            decode_pre_alloc_size=(
+                get_disagg().disaggregation_decode_extra_slots
+                if get_disagg().disaggregation_mode == "decode"
+                else 0
+            ),
         )
 
     def _init_unified_swa_pools(

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -3475,6 +3475,74 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             self.swa_attn_allocator.alloc_with_virtual(new_virtual_pages)
             return out_indices  # virtual TOKEN ids
 
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+    ) -> Optional[torch.Tensor]:
+        """Decode-node prealloc: full KV for the whole sequence, sliding-window
+        KV for the live window tail only.
+
+        The static composite allocates the two sides independently and records
+        a full->swa index mapping. That is not representable here: the two
+        sides SHARE one virtual id space (a virtual page names a full-physical
+        page and, if bound, a swa-physical one), which is why
+        `set_full_to_swa_mapping` is a no-op on this allocator and
+        `translate_loc_from_full_to_swa` derives the swa id from the virtual id
+        instead of a table. Running the static body would call `alloc_extend`
+        on the swa sub-allocator, which asserts it is not the id owner.
+
+        The tail is expressed by binding swa for the TAIL's virtual pages only.
+        A new page left unbound has no swa-physical page, which reads as the
+        sink and is skipped by `free`'s `swa_v2p_page > 0` mask -- exactly the
+        out-of-window state the ratchet produces via `free_swa`.
+
+        Admission is priced at the FULL side's page count, as plain
+        `alloc_extend` is: pessimistic when the tail is short, but it reuses
+        the composite's audited joint capacity path, and the bytes actually
+        held still follow the tail.
+        """
+        assert len(prefix_lens_cpu) == 1
+        assert 0 <= swa_tail_len <= extend_num_tokens
+        with record_function("UnifiedSWAAlloc.alloc_extend_swa_tail"):
+            ps = self.page_size
+            num_new_pages = get_num_new_pages(
+                seq_lens=seq_lens_cpu, page_size=ps, prefix_lens=prefix_lens_cpu
+            )
+            need_tokens = num_new_pages * ps
+            if need_tokens > self.available_size():
+                if not _relieve_for_alloc(self, need_tokens):
+                    return None
+
+            fa = self.full_attn_allocator
+            new_virtual_pages = fa.free_virtual_ids[:num_new_pages].clone()
+            out_indices = fa.alloc_extend(
+                prefix_lens,
+                prefix_lens_cpu,
+                seq_lens,
+                seq_lens_cpu,
+                last_loc,
+                extend_num_tokens,
+                num_new_pages=num_new_pages,
+            )
+            assert out_indices is not None, (
+                "UnifiedSWA.alloc_extend_swa_tail: full.alloc_extend returned "
+                "None after joint pre-check passed — internal-state inconsistency"
+            )
+            if swa_tail_len > 0 and new_virtual_pages.numel() > 0:
+                tail_pages = torch.unique(out_indices[-swa_tail_len:] // ps)
+                # Only NEW pages need binding; a tail page carried in from the
+                # prefix is already bound on the swa side.
+                to_bind = new_virtual_pages[torch.isin(new_virtual_pages, tail_pages)]
+                if to_bind.numel() > 0:
+                    self.swa_attn_allocator.alloc_with_virtual(to_bind)
+            return out_indices  # virtual TOKEN ids
+
     def alloc_decode(
         self,
         seq_lens: torch.Tensor,
@@ -3899,6 +3967,17 @@ class UnifiedMambaSWATokenToKVPoolAllocator(UnifiedSWATokenToKVPoolAllocator):
             else:
                 hi_n = mid - 1
         return lo_n * self.page_size
+
+    def set_disagg_move_gate(self, gate: Callable[[], bool]) -> None:
+        """Install the PD move gate on ALL THREE members.
+
+        The 2-pool override reaches full and swa only; the mamba end compacts
+        independently and its slot envelopes are transferred as
+        `StateType.MAMBA`, so leaving it ungated would let a conv/SSM slot
+        relocate under an in-flight state transfer.
+        """
+        super().set_disagg_move_gate(gate)
+        self.mamba_allocator.disagg_move_gate = gate
 
     def _flush_targets(self):
         """All three members, same reasoning as the 2-pool pair with one

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -1848,6 +1848,7 @@ def init_unified_mamba_swa_pools(
     lazy_compaction: bool = False,
     unified_total_bytes: Optional[int] = None,
     sliding_window_size: Optional[int] = None,
+    decode_pre_alloc_size: int = 0,
 ) -> UnifiedPoolBundle:
     """Build the TRI-pool unified-memory-pool stack for models with full KV +
     SWA KV + mamba/conv state (Inkling-class: `mambaish_config` AND
@@ -1973,6 +1974,7 @@ def init_unified_mamba_swa_pools(
         speculative_num_draft_tokens=speculative_num_draft_tokens,
         enable_overlap_schedule=not disable_overlap_schedule,
         start_layer=start_layer,
+        pre_alloc_size=decode_pre_alloc_size,
     )
     allocator = UnifiedMambaSWATokenToKVPoolAllocator(
         unified_buffer=shared_pool,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -873,8 +873,10 @@ class ServerArgs:
         "Replace the statically-partitioned hybrid-model pools (full-attn KV + "
         "SWA/Mamba state) with one byte buffer split dynamically between "
         "sub-pools. Requires the Triton attention / linear-attn / Mamba "
-        "backends; not yet compatible with PD disaggregation or speculative "
-        "decoding.",
+        "backends. PD disaggregation is supported over mooncake at equal "
+        "attention TP with pp=1; not yet compatible with hierarchical / "
+        "host-tiered KV cache, prefill cuda-graph capture, or speculative "
+        "decoding other than DSPARK.",
         NS("memory"),
     ] = False
     disable_chunked_prefix_cache: A[

--- a/test/registered/disaggregation/test_disaggregation_unified_memory_tri.py
+++ b/test/registered/disaggregation/test_disaggregation_unified_memory_tri.py
@@ -1,0 +1,86 @@
+"""PD disaggregation for a TRI-pool model on the unified memory pool.
+
+Inkling is the only in-tree architecture that is both mambaish and hybrid-SWA,
+so one unified buffer carries three components with three independent
+compactions -- ``[conv state (up END) | swa (FLOAT) | full (down END)]`` -- and
+PD must ship all three per request: full KV on the ``kv_data_ptrs`` channel,
+sliding-window KV as ``StateType.SWA``, ShortConv state as ``StateType.MAMBA``
+(via the ``req_to_token_pool`` fallback, since the KV pool here is a
+``UnifiedSWAKVPool`` rather than a ``HybridLinearKVPool``).
+
+Two failures this pins that the 2-pool cases cannot:
+
+  * the FLOAT sub-pool moves for reasons neither END does, so a move gate that
+    reaches only full and swa still lets a conv slot relocate under an
+    in-flight state transfer;
+  * ``page_size > 1`` turns on the decode node's SWA-tail prealloc, whose
+    static body allocates the swa side independently -- an assertion failure
+    against this composite's single virtual id space, and, once that is
+    handled, the first path that can bind the WRONG swa pages.
+
+Logprob parity against a non-PD unified reference is the check: the tiny
+``test`` revision is undertrained, so answer quality carries no signal, but a
+dropped or misaddressed component moves logprobs immediately.
+"""
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.pd_parity_kit import PDLogprobParityMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+
+register_cuda_ci(est_time=900, stage="extra-b", runner_config="2-gpu-large")
+
+_MODEL_PATH = os.environ.get("INKLING_TEST_MODEL_PATH", "thinkingmachines/Inkling")
+_MODEL_REVISION = os.environ.get("INKLING_TEST_MODEL_REVISION", "test")
+
+# The unified radix tree is what merges the three components into one tree.
+SERVER_ENV = {"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"}
+
+UNIFIED_TRI_ARGS = [
+    "--skip-tokenizer-init",
+    "--random-seed",
+    "1",
+    "--enable-unified-memory",
+    # Unified requires the Triton strided page-major read/write paths.
+    "--attention-backend",
+    "triton",
+    "--page-size",
+    "128",
+    "--mamba-radix-cache-strategy",
+    "extra_buffer",
+    "--swa-full-tokens-ratio",
+    "0.1",
+    "--mamba-full-memory-ratio",
+    "0.1",
+    "--mem-fraction-static",
+    "0.5",
+    # Inkling defaults to a FULL prefill graph, which unified rejects at boot.
+    "--cuda-graph-backend-prefill",
+    "disabled",
+    "--revision",
+    _MODEL_REVISION,
+]
+
+
+class TestUnifiedMemoryDisaggregationTriPool(
+    PDLogprobParityMixin, PDDisaggregationServerBase
+):
+    """1 prefill + 1 decode, both unified, vs a non-PD unified reference."""
+
+    model = _MODEL_PATH
+    extra_prefill_env = SERVER_ENV
+    extra_decode_env = SERVER_ENV
+    prefill_tp_size = 1
+    decode_tp_size = 1
+    decode_base_gpu_id = 1
+    baseline_args = UNIFIED_TRI_ARGS
+    extra_prefill_args = UNIFIED_TRI_ARGS
+    extra_decode_args = UNIFIED_TRI_ARGS
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
+++ b/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
@@ -197,10 +197,16 @@ class TestUnifiedAllocatorsPublishTheTransferContract(CustomTestCase):
     An AST-level check because instantiating these composites needs a GPU.
     """
 
+    # Composites that own the full-side virtual ids and so must define the
+    # transfer translate themselves.
     _COMPOSITES = (
         "UnifiedMambaTokenToKVPoolAllocator",
         "UnifiedSWATokenToKVPoolAllocator",
     )
+    # Every composite must define the gate setter, including the tri-pool,
+    # which inherits the SWA translates (same full side) but has a THIRD
+    # member the 2-pool setter does not reach.
+    _GATE_COMPOSITES = _COMPOSITES + ("UnifiedMambaSWATokenToKVPoolAllocator",)
 
     @staticmethod
     def _own_methods(cls_name: str) -> Set[str]:
@@ -230,7 +236,7 @@ class TestUnifiedAllocatorsPublishTheTransferContract(CustomTestCase):
                 )
 
     def test_move_gate_setter_is_defined(self):
-        for name in self._COMPOSITES:
+        for name in self._GATE_COMPOSITES:
             with self.subTest(composite=name):
                 self.assertIn(
                     "set_disagg_move_gate",


### PR DESCRIPTION
**Stack 3/4** — main ← #37415 ← #37416 ← **cheng/um-pd-tri** ← cheng/um-prefill-cuda-graph
Targets #37416; review that one first.

Inkling is the only in-tree architecture that is both mambaish and hybrid-SWA, so one unified buffer carries three components with three independent compactions — `[conv state (up END) | swa (FLOAT) | full (down END)]` — and PD must ship all three: full KV on the `kv_data_ptrs` channel, sliding-window KV as `StateType.SWA`, ShortConv state as `StateType.MAMBA` (through the `req_to_token_pool` fallback, since the KV pool here is a `UnifiedSWAKVPool` rather than a `HybridLinearKVPool`).

The transfer translates come free from the 2-pool SWA composite — same full side, same swa side. Three things did not:

- **`set_disagg_move_gate` reached only full and swa.** The state end compacts for reasons neither attention band does, so a conv slot could relocate under an in-flight `StateType.MAMBA` transfer.
- **No `pre_alloc_size` on the tri-pool's `UnifiedHybridReqToTokenPool`**, so a decode node had no rows for preallocated transfers.
- **`page_size > 1` turns on the decode node's SWA-tail prealloc**, and the inherited `alloc_extend_swa_tail` allocates the swa side independently: `AssertionError: alloc_extend on a non-id-owner allocator ('swa')`. It cannot simply be ported — the two sides share **one** virtual id space here, which is why `set_full_to_swa_mapping` is a no-op on this allocator and `translate_loc_from_full_to_swa` derives the swa id rather than reading a table.

  The override expresses the tail by binding swa for the tail's virtual pages only. A new page left unbound has no swa-physical page, reads as the sink, and is skipped by `free`'s `swa_v2p_page > 0` mask — the same state the window ratchet reaches via `free_swa`. Admission is priced at the full side's page count, as plain `alloc_extend` is: pessimistic for a short tail, but it reuses the audited joint capacity path and the bytes actually held still follow the tail.

## Validation

Tiny Inkling `test` revision, 1 prefill + 1 decode on H200, mooncake, page-size 128: logprob parity PD-unified vs non-PD-unified passes (new CI test). All 5 unified-PD classes (kimi MLA, kimi chunked, qwen MHA, gpt-oss SWA, inkling tri) pass together.

Also refreshes the `--enable-unified-memory` help text, which still claimed PD disaggregation was unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33504906044](https://github.com/sgl-project/sglang/actions/runs/33504906044)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33504905840](https://github.com/sgl-project/sglang/actions/runs/33504905840)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33504906021](https://github.com/sgl-project/sglang/actions/runs/33504906021)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->