### PR TITLE
[LoRA] Accumulate torch-native graph expand GEMM into output

### DIFF
--- a/benchmark/kernels/benchmark_graph_lora_direct_accumulation.py
+++ b/benchmark/kernels/benchmark_graph_lora_direct_accumulation.py
@@ -1,0 +1,283 @@
+"""Benchmark direct accumulation for the torch-native graph LoRA-B path.
+
+Examples:
+    python3 benchmark/kernels/benchmark_graph_lora_direct_accumulation.py
+    python3 benchmark/kernels/benchmark_graph_lora_direct_accumulation.py \
+        --repetitions 1000 --output results.csv
+    python3 benchmark/kernels/benchmark_graph_lora_direct_accumulation.py --eager
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import statistics
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+import torch
+
+
+class Case(NamedTuple):
+    name: str
+    tokens: int
+    rank: int
+    width: int
+    adapters: int
+    dtype: torch.dtype
+    packed: bool
+
+
+CASES = (
+    Case("control-1", 1, 8, 4096, 1, torch.float16, False),
+    Case("control-3", 8, 16, 4096, 3, torch.bfloat16, True),
+    Case("decode", 32, 16, 4096, 4, torch.float16, True),
+    Case("batch", 128, 32, 4096, 4, torch.bfloat16, False),
+    Case("qkv", 32, 32, 12288, 4, torch.float16, True),
+    Case("wide", 512, 64, 11008, 8, torch.bfloat16, True),
+)
+
+
+def baseline(
+    output: torch.Tensor,
+    inputs: torch.Tensor,
+    weights: torch.Tensor,
+    weight_indices: torch.Tensor,
+) -> None:
+    for adapter_idx in range(weights.shape[0]):
+        masked = torch.where((weight_indices == adapter_idx).unsqueeze(1), inputs, 0)
+        output.add_(torch.mm(masked, weights[adapter_idx].t()))
+
+
+def candidate(
+    output: torch.Tensor,
+    inputs: torch.Tensor,
+    weights: torch.Tensor,
+    weight_indices: torch.Tensor,
+) -> None:
+    if weights.shape[0] < 4:
+        baseline(output, inputs, weights, weight_indices)
+        return
+    for adapter_idx in range(weights.shape[0]):
+        masked = torch.where((weight_indices == adapter_idx).unsqueeze(1), inputs, 0)
+        output.addmm_(masked, weights[adapter_idx].t())
+
+
+def make_tensors(case: Case):
+    padding = 64 if case.packed else 0
+    generator = torch.Generator(device="cuda").manual_seed(20260901)
+    inputs = torch.randn(
+        case.tokens,
+        case.rank,
+        dtype=case.dtype,
+        device="cuda",
+        generator=generator,
+    )
+    weights = torch.randn(
+        case.adapters,
+        case.width,
+        case.rank,
+        dtype=case.dtype,
+        device="cuda",
+        generator=generator,
+    )
+    weight_indices = torch.arange(
+        case.tokens, dtype=torch.int32, device="cuda"
+    ).remainder(case.adapters + 1)
+    weight_indices[weight_indices == case.adapters] = -1
+    base = torch.randn(
+        case.tokens,
+        case.width + 2 * padding,
+        dtype=case.dtype,
+        device="cuda",
+        generator=generator,
+    )
+    output_slice = slice(padding, padding + case.width)
+    return inputs, weights, weight_indices, base, output_slice
+
+
+def run(
+    operation: Callable,
+    backing: torch.Tensor,
+    inputs: torch.Tensor,
+    weights: torch.Tensor,
+    weight_indices: torch.Tensor,
+    base: torch.Tensor,
+    output_slice: slice,
+) -> None:
+    backing.copy_(base)
+    operation(backing[:, output_slice], inputs, weights, weight_indices)
+
+
+def capture(
+    operation: Callable, backing: torch.Tensor, tensors
+) -> torch.cuda.CUDAGraph:
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        run(operation, backing, *tensors)
+    torch.cuda.current_stream().wait_stream(side_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run(operation, backing, *tensors)
+    return graph
+
+
+def time_operation(
+    operation: Callable,
+    backing: torch.Tensor,
+    tensors,
+    eager: bool,
+    warmups: int,
+    repetitions: int,
+) -> list[float]:
+    if eager:
+        replay = lambda: run(operation, backing, *tensors)
+    else:
+        replay = capture(operation, backing, tensors).replay
+
+    for _ in range(warmups):
+        replay()
+    torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(repetitions):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return samples
+
+
+def percentiles(samples: list[float]) -> tuple[float, float, float]:
+    ordered = sorted(samples)
+    return tuple(
+        ordered[round(percentile * (len(ordered) - 1))]
+        for percentile in (0.10, 0.50, 0.90)
+    )
+
+
+def extra_peak_bytes(operation: Callable, backing: torch.Tensor, tensors) -> int:
+    torch.cuda.synchronize()
+    before = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    run(operation, backing, *tensors)
+    torch.cuda.synchronize()
+    return torch.cuda.max_memory_allocated() - before
+
+
+def benchmark_case(case: Case, args: argparse.Namespace) -> dict:
+    tensors = make_tensors(case)
+    base = tensors[-2]
+    baseline_backing = base.clone()
+    candidate_backing = base.clone()
+    with torch.inference_mode():
+        run(baseline, baseline_backing, *tensors)
+        run(candidate, candidate_backing, *tensors)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            candidate_backing, baseline_backing, rtol=3e-2, atol=3e-2
+        )
+        baseline_times = percentiles(
+            time_operation(
+                baseline,
+                baseline_backing,
+                tensors,
+                args.eager,
+                args.warmups,
+                args.repetitions,
+            )
+        )
+        candidate_times = percentiles(
+            time_operation(
+                candidate,
+                candidate_backing,
+                tensors,
+                args.eager,
+                args.warmups,
+                args.repetitions,
+            )
+        )
+        baseline_peak = extra_peak_bytes(baseline, baseline_backing, tensors)
+        candidate_peak = extra_peak_bytes(candidate, candidate_backing, tensors)
+
+    return {
+        "case": case.name,
+        "tokens": case.tokens,
+        "rank": case.rank,
+        "width": case.width,
+        "adapters": case.adapters,
+        "dtype": str(case.dtype).removeprefix("torch."),
+        "layout": "packed" if case.packed else "whole",
+        "execution": "eager" if args.eager else "cudagraph",
+        "baseline_p10_us": baseline_times[0],
+        "baseline_p50_us": baseline_times[1],
+        "baseline_p90_us": baseline_times[2],
+        "candidate_p10_us": candidate_times[0],
+        "candidate_p50_us": candidate_times[1],
+        "candidate_p90_us": candidate_times[2],
+        "speedup": baseline_times[1] / candidate_times[1],
+        "baseline_extra_peak_bytes": baseline_peak,
+        "candidate_extra_peak_bytes": candidate_peak,
+    }
+
+
+def print_results(results: list[dict], repetitions: int) -> None:
+    capability = torch.cuda.get_device_capability()
+    print(f"GPU: {torch.cuda.get_device_name()} (SM{capability[0]}{capability[1]})")
+    print(f"PyTorch: {torch.__version__}; CUDA: {torch.version.cuda}")
+    print(f"Execution: {results[0]['execution']}; repetitions: {repetitions}\n")
+    print(
+        "| case | dtype | layout | baseline p10/p50/p90 (us) | "
+        "candidate p10/p50/p90 (us) | speedup | extra peak bytes (base -> cand) |"
+    )
+    print("| --- | --- | --- | ---: | ---: | ---: | ---: |")
+    for result in results:
+        print(
+            f"| {result['case']} | {result['dtype']} | {result['layout']} | "
+            f"{result['baseline_p10_us']:.3f}/{result['baseline_p50_us']:.3f}/"
+            f"{result['baseline_p90_us']:.3f} | "
+            f"{result['candidate_p10_us']:.3f}/{result['candidate_p50_us']:.3f}/"
+            f"{result['candidate_p90_us']:.3f} | {result['speedup']:.3f}x | "
+            f"{result['baseline_extra_peak_bytes']} -> "
+            f"{result['candidate_extra_peak_bytes']} |"
+        )
+    speedups = [result["speedup"] for result in results if result["adapters"] >= 4]
+    geomean = math.exp(statistics.fmean(math.log(value) for value in speedups))
+    print(f"\nDirect-path p50 geometric-mean speedup: {geomean:.3f}x")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--eager", action="store_true")
+    parser.add_argument("--warmups", type=int, default=25)
+    parser.add_argument("--repetitions", type=int, default=100)
+    parser.add_argument("--output", type=Path, help="optional CSV output path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if args.warmups < 1 or args.repetitions < 1:
+        raise ValueError("warmups and repetitions must be positive")
+
+    results = [benchmark_case(case, args) for case in CASES]
+    print_results(results, repetitions=args.repetitions)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", newline="") as output_file:
+            writer = csv.DictWriter(output_file, fieldnames=results[0])
+            writer.writeheader()
+            writer.writerows(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/lora/torch_ops/graph_lora_ops.py
+++ b/python/sglang/srt/lora/torch_ops/graph_lora_ops.py
@@ -3,6 +3,8 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 
+_MIN_DIRECT_ACCUMULATION_LORAS = 4
+
 
 def sgemm_lora_a_embedding_graph_fwd(
     inputs: torch.Tensor,
@@ -85,6 +87,12 @@ def sgemm_lora_b_graph_fwd(
             total_seq_len, total_output_dim, dtype=inputs.dtype, device=inputs.device
         )
 
+    # With fewer slots, CUDA Graph replay removes enough launch overhead that
+    # the beta-enabled GEMM can be slower than the existing mm + add sequence.
+    use_direct_accumulation = (
+        num_loras >= _MIN_DIRECT_ACCUMULATION_LORAS and not torch.is_grad_enabled()
+    )
+
     num_slices = len(slice_offsets) - 1
     max_rank = input_dim // num_slices
 
@@ -110,8 +118,14 @@ def sgemm_lora_b_graph_fwd(
             w_slice = weights[
                 lora_idx, slice_start_output:slice_end_output
             ]  # (slice_dim, max_rank)
-            output[..., slice_start_output:slice_end_output].add_(
-                torch.mm(x_slice, w_slice.t())
-            )
+            output_slice = output[..., slice_start_output:slice_end_output]
+            if (
+                use_direct_accumulation
+                and output_slice.dtype == x_slice.dtype
+                and x_slice.dtype == w_slice.dtype
+            ):
+                output_slice.addmm_(x_slice, w_slice.t())
+            else:
+                output_slice.add_(torch.mm(x_slice, w_slice.t()))
 
     return output

--- a/test/registered/unit/lora/test_graph_lora_direct_accumulation.py
+++ b/test/registered/unit/lora/test_graph_lora_direct_accumulation.py
@@ -1,0 +1,258 @@
+"""Regression tests for destination-backed CUDA-graph LoRA-B expansion."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+_SOURCE = (
+    Path(__file__).resolve().parents[4]
+    / "python/sglang/srt/lora/torch_ops/graph_lora_ops.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_graph_lora_ops", _SOURCE)
+assert _SPEC is not None and _SPEC.loader is not None
+_GRAPH_LORA_OPS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_GRAPH_LORA_OPS)
+sgemm_lora_b_graph_fwd = _GRAPH_LORA_OPS.sgemm_lora_b_graph_fwd
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _case(dtype: torch.dtype = torch.float32, num_loras: int = 2):
+    torch.manual_seed(7)
+    num_tokens = 4
+    rank = 2
+    slice_widths = (3, 4)
+    slice_offsets = torch.tensor((0, 3, 7), dtype=torch.int32)
+    inputs = torch.randn(num_tokens, len(slice_widths) * rank, dtype=dtype)
+    weights = torch.randn(num_loras, sum(slice_widths), rank, dtype=dtype)
+    weight_indices = torch.tensor((0, 1, -1, 0), dtype=torch.int32)
+    seg_lens = torch.ones(num_tokens, dtype=torch.int32)
+
+    backing = torch.randn(num_tokens, sum(slice_widths) + 2, dtype=dtype)
+    base_output = backing[:, 1:-1]
+    return (
+        inputs,
+        weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+        backing,
+        base_output,
+    )
+
+
+def _reference(
+    inputs: torch.Tensor,
+    weights: torch.Tensor,
+    weight_indices: torch.Tensor,
+    slice_offsets: torch.Tensor,
+    base_output: torch.Tensor,
+) -> torch.Tensor:
+    expected = base_output.clone()
+    num_slices = len(slice_offsets) - 1
+    rank = inputs.shape[-1] // num_slices
+    for lora_idx in range(weights.shape[0]):
+        rows = (weight_indices == lora_idx).unsqueeze(1)
+        masked_inputs = torch.where(rows, inputs, 0)
+        for slice_idx in range(num_slices):
+            input_start = slice_idx * rank
+            input_end = input_start + rank
+            output_start = int(slice_offsets[slice_idx])
+            output_end = int(slice_offsets[slice_idx + 1])
+            expected[:, output_start:output_end].add_(
+                masked_inputs[:, input_start:input_end]
+                @ weights[lora_idx, output_start:output_end].t()
+            )
+    return expected
+
+
+def test_inference_accumulates_directly_into_packed_output(monkeypatch):
+    (
+        inputs,
+        weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+        backing,
+        base_output,
+    ) = _case(num_loras=4)
+    expected = _reference(inputs, weights, weight_indices, slice_offsets, base_output)
+    padding_before = backing[:, (0, -1)].clone()
+
+    real_addmm_ = torch.Tensor.addmm_
+    calls: list[torch.Tensor] = []
+
+    def recording_addmm_(self, mat1, mat2, *, beta=1, alpha=1):
+        calls.append(self)
+        return real_addmm_(self, mat1, mat2, beta=beta, alpha=alpha)
+
+    monkeypatch.setattr(torch.Tensor, "addmm_", recording_addmm_)
+    with torch.inference_mode():
+        actual = sgemm_lora_b_graph_fwd(
+            inputs,
+            weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            base_output,
+        )
+
+    assert len(calls) == weights.shape[0] * (len(slice_offsets) - 1)
+    assert all(
+        destination.untyped_storage().data_ptr()
+        == base_output.untyped_storage().data_ptr()
+        for destination in calls
+    )
+    assert actual.data_ptr() == base_output.data_ptr()
+    assert not actual.is_contiguous()
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(backing[:, (0, -1)], padding_before)
+
+
+def _forbid_addmm_(*args, **kwargs):
+    raise AssertionError("the direct-accumulation fast path must not run")
+
+
+@pytest.mark.parametrize("num_loras", (1, 2, 3))
+def test_small_lora_pool_uses_existing_fallback(monkeypatch, num_loras):
+    (
+        inputs,
+        weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+        _,
+        base_output,
+    ) = _case(num_loras=num_loras)
+    expected = _reference(inputs, weights, weight_indices, slice_offsets, base_output)
+
+    monkeypatch.setattr(torch.Tensor, "addmm_", _forbid_addmm_)
+    with torch.inference_mode():
+        actual = sgemm_lora_b_graph_fwd(
+            inputs,
+            weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            base_output,
+        )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_autograd_uses_existing_fallback_and_preserves_gradients(monkeypatch):
+    inputs, weights, weight_indices, seg_lens, slice_offsets, _, _ = _case(
+        torch.float64, num_loras=4
+    )
+    actual_inputs = inputs.clone().requires_grad_()
+    actual_weights = weights.clone().requires_grad_()
+    expected_inputs = inputs.clone().requires_grad_()
+    expected_weights = weights.clone().requires_grad_()
+
+    monkeypatch.setattr(torch.Tensor, "addmm_", _forbid_addmm_)
+    actual = sgemm_lora_b_graph_fwd(
+        actual_inputs,
+        actual_weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+    )
+    expected = _reference(
+        expected_inputs,
+        expected_weights,
+        weight_indices,
+        slice_offsets,
+        torch.zeros_like(actual),
+    )
+
+    actual.square().sum().backward()
+    expected.square().sum().backward()
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_inputs.grad, expected_inputs.grad)
+    torch.testing.assert_close(actual_weights.grad, expected_weights.grad)
+
+
+def test_mixed_output_dtype_uses_existing_fallback(monkeypatch):
+    (
+        inputs,
+        weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+        _,
+        low_precision_base,
+    ) = _case(torch.float16, num_loras=4)
+    backing = torch.randn(low_precision_base.shape[0], low_precision_base.shape[1] + 2)
+    base_output = backing[:, 1:-1]
+    expected = _reference(inputs, weights, weight_indices, slice_offsets, base_output)
+
+    monkeypatch.setattr(torch.Tensor, "addmm_", _forbid_addmm_)
+    with torch.inference_mode():
+        actual = sgemm_lora_b_graph_fwd(
+            inputs,
+            weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            base_output,
+        )
+
+    assert actual.dtype == torch.float32
+    assert actual.data_ptr() == base_output.data_ptr()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_torch_compile_fullgraph_uses_direct_accumulation():
+    (
+        inputs,
+        weights,
+        weight_indices,
+        seg_lens,
+        slice_offsets,
+        _,
+        base_output,
+    ) = _case(num_loras=4)
+    expected = _reference(inputs, weights, weight_indices, slice_offsets, base_output)
+
+    def run_compiled(inputs, weights, weight_indices, base_output):
+        return sgemm_lora_b_graph_fwd(
+            inputs,
+            weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            base_output,
+        )
+
+    captured_graphs = []
+
+    def recording_backend(graph_module, _example_inputs):
+        captured_graphs.append(graph_module)
+        return graph_module.forward
+
+    compiled = torch.compile(run_compiled, backend=recording_backend, fullgraph=True)
+    with (
+        patch.dict(sys.modules, {sgemm_lora_b_graph_fwd.__module__: _GRAPH_LORA_OPS}),
+        torch.inference_mode(),
+    ):
+        actual = compiled(inputs, weights, weight_indices, base_output)
+
+    torch.testing.assert_close(actual, expected)
+    assert len(captured_graphs) == 1
+    assert any(
+        node.op == "call_method" and node.target == "addmm_"
+        for node in captured_graphs[0].graph.nodes
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_graph_lora_direct_accumulation_cuda.py
+++ b/test/registered/unit/lora/test_graph_lora_direct_accumulation_cuda.py
@@ -1,0 +1,139 @@
+"""CUDA Graph replay coverage for destination-backed LoRA-B expansion."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+_SOURCE = (
+    Path(__file__).resolve().parents[4]
+    / "python/sglang/srt/lora/torch_ops/graph_lora_ops.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_graph_lora_cuda_ops", _SOURCE)
+assert _SPEC is not None and _SPEC.loader is not None
+_GRAPH_LORA_OPS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_GRAPH_LORA_OPS)
+sgemm_lora_b_graph_fwd = _GRAPH_LORA_OPS.sgemm_lora_b_graph_fwd
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+_CUDA_GRAPH_AVAILABLE = bool(
+    torch.cuda.is_available()
+    and torch.version.hip is None
+    and torch.cuda.get_device_capability()[0] >= 8
+)
+
+
+def _reference(
+    inputs: torch.Tensor,
+    weights: torch.Tensor,
+    weight_indices: torch.Tensor,
+    slice_offsets: torch.Tensor,
+    base_output: torch.Tensor,
+) -> torch.Tensor:
+    expected = base_output.clone()
+    num_slices = len(slice_offsets) - 1
+    rank = inputs.shape[-1] // num_slices
+    for lora_idx in range(weights.shape[0]):
+        masked_inputs = torch.where(
+            (weight_indices == lora_idx).unsqueeze(1), inputs, 0
+        )
+        for slice_idx in range(num_slices):
+            input_start = slice_idx * rank
+            input_end = input_start + rank
+            output_start = int(slice_offsets[slice_idx])
+            output_end = int(slice_offsets[slice_idx + 1])
+            expected[:, output_start:output_end].add_(
+                masked_inputs[:, input_start:input_end]
+                @ weights[lora_idx, output_start:output_end].t()
+            )
+    return expected
+
+
+@pytest.mark.skipif(
+    not _CUDA_GRAPH_AVAILABLE,
+    reason="requires an NVIDIA GPU with BF16 and CUDA Graph support",
+)
+@pytest.mark.parametrize("dtype", (torch.float16, torch.bfloat16))
+def test_changed_inputs_replay_into_packed_output(dtype):
+    device = torch.device("cuda")
+    num_tokens = 8
+    num_loras = 4
+    rank = 4
+    total_output_dim = 12
+    slice_offsets = torch.tensor((0, 5, 12), dtype=torch.int32)
+    seg_lens = torch.ones(num_tokens, dtype=torch.int32, device=device)
+    weight_indices = torch.tensor(
+        (0, 1, 2, 3, -1, 0, 2, 3), dtype=torch.int32, device=device
+    )
+
+    torch.manual_seed(17)
+    static_inputs = torch.randn(num_tokens, 2 * rank, dtype=dtype, device=device)
+    static_weights = torch.randn(
+        num_loras, total_output_dim, rank, dtype=dtype, device=device
+    )
+    base_template = torch.randn(
+        num_tokens, total_output_dim + 2, dtype=dtype, device=device
+    )
+    static_backing = base_template.clone()
+    static_output = static_backing[:, 1:-1]
+
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream), torch.inference_mode():
+        sgemm_lora_b_graph_fwd(
+            static_inputs,
+            static_weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            static_output,
+        )
+    torch.cuda.current_stream().wait_stream(side_stream)
+    static_backing.copy_(base_template)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.inference_mode(), torch.cuda.graph(graph):
+        captured_output = sgemm_lora_b_graph_fwd(
+            static_inputs,
+            static_weights,
+            weight_indices,
+            seg_lens,
+            slice_offsets,
+            static_output,
+        )
+
+    for replay_seed in (23, 29):
+        torch.manual_seed(replay_seed)
+        new_inputs = torch.randn_like(static_inputs)
+        new_weights = torch.randn_like(static_weights)
+        static_inputs.copy_(new_inputs)
+        static_weights.copy_(new_weights)
+        static_backing.copy_(base_template)
+
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected = _reference(
+            new_inputs,
+            new_weights,
+            weight_indices,
+            slice_offsets,
+            base_template[:, 1:-1],
+        )
+        assert captured_output.data_ptr() == static_output.data_ptr()
+        assert not captured_output.is_contiguous()
+        torch.testing.assert_close(captured_output, expected, rtol=3e-2, atol=3e-2)
+        torch.testing.assert_close(
+            static_backing[:, (0, -1)], base_template[:, (0, -1)]
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Purpose

The torch-native CUDA-Graph LoRA-B expand path currently materializes a
full-width `torch.mm` result and launches a separate in-place add for every
adapter and output slice. This adds one full-output temporary and one CUDA
kernel per expand GEMM.

## Changes

For inference with matching input, weight, and output dtypes, accumulate the
expand GEMM directly into the destination view:

```python
output_slice.addmm_(x_slice, w_slice.t())
```

The direct path is enabled for pools with at least four LoRA slots. Measurements
showed that beta-enabled GEMM can lose for one-, two-, and three-slot pools, so
those sizes retain the existing `mm + add_` path. Autograd-enabled calls and
mixed-dtype outputs also retain the existing path.

The threshold is named `_MIN_DIRECT_ACCUMULATION_LORAS`, and tests cover slots
1/2/3 fallback plus the slot-4 boundary. The explicit in-place form remains in
the captured graph under `torch.compile(fullgraph=True)`.

## Test plan

```bash
PYTHONPATH=python python3 -m pytest -q \
  test/registered/unit/lora/test_graph_lora_direct_accumulation.py \
  test/registered/unit/lora/test_graph_lora_direct_accumulation_cuda.py

pre-commit run --files \
  benchmark/kernels/benchmark_graph_lora_direct_accumulation.py \
  python/sglang/srt/lora/torch_ops/graph_lora_ops.py \
  test/registered/unit/lora/test_graph_lora_direct_accumulation.py \
  test/registered/unit/lora/test_graph_lora_direct_accumulation_cuda.py
```

Result on RTX 4090: `9 passed, 1 warning`. Coverage includes destination
aliasing, packed non-contiguous output and padding, slots 1/2/3/4 selection,
autograd and mixed-dtype fallback, FP16/BF16, an FX-node assertion for
`torch.compile(fullgraph=True)`, and two CUDA-Graph replays with changed inputs
and weights. All applicable pre-commit hooks pass.

## Performance

Command:

```bash
PYTHONPATH=python python3 \
  benchmark/kernels/benchmark_graph_lora_direct_accumulation.py \
  --warmups 25 --repetitions 1000 \
  --output graph-lora-direct-accumulation.csv
```

Environment: RTX 4090 (SM89), PyTorch 2.12.1+cu130, CUDA 13.0. Timings are
CUDA-Graph replay percentiles in microseconds; each case checks the full backing
buffer for numerical parity before measurement.

| Case | Dtype | Layout | Baseline p10/p50/p90 | Candidate p10/p50/p90 | Speedup | Extra peak bytes (base -> candidate) |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| control, slots 1 | FP16 | whole | 12.256/12.288/12.288 | 12.192/12.288/12.288 | 1.000x | 8,704 -> 8,704 |
| control, slots 3 | BF16 | packed | 24.512/24.576/25.600 | 23.552/24.576/24.576 | 1.000x | 66,048 -> 66,048 |
| decode, slots 4 | FP16 | packed | 32.768/32.768/33.792 | 25.600/26.560/26.624 | 1.234x | 263,168 -> 3,072 |
| batch, slots 4 | BF16 | whole | 33.792/33.792/35.840 | 26.528/27.648/28.672 | 1.222x | 1,056,768 -> 17,408 |
| QKV, slots 4 | FP16 | packed | 33.792/33.792/34.752 | 25.600/26.528/26.624 | 1.274x | 788,480 -> 5,120 |
| wide, slots 8 | BF16 | packed | 198.656/199.680/201.728 | 129.024/130.048/132.096 | 1.535x | 11,337,728 -> 132,096 |

The four direct-path cases have a **1.310x p50 geometric-mean speedup**. The two
guarded controls are unchanged. Independent target cases previously measured
1.167x-1.626x on H100 (SM90) and 1.142x-1.529x on RTX PRO 4000 Blackwell
(SM120).

## Scope

This is a component-level CUDA-Graph operator optimization. It does not change
LoRA loading, activation, merging, scheduling, model-specific behavior, or the
LoRA-A path, and it does not claim end-to-end server throughput gains. LoRA-A
keeps its existing implementation because its scale is a device tensor and
cannot be passed as `addmm(alpha=...)` without a host read.

## Checklist

- [x] Rebased onto current `main`.
- [x] Added focused CPU, compile, and CUDA-Graph tests.
- [x] Added a reproducible representative benchmark.
- [x] Ran all applicable pre-commit hooks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33833075851](https://github.com/sgl-project/sglang/actions/runs/33833075851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33833075716](https://github.com/sgl-project/sglang/actions/runs/33833075716)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33833075869](https://github.com/sgl-project/sglang/actions/runs/33833075869)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->