### PR TITLE
[NPU] Support GLM-5.2 on Ascend A5 in the DSA path

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -11,6 +11,7 @@ from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
     is_fia_nz,
     is_mla_preprocess_enabled,
 )
+from sglang.srt.hardware_backend.npu.utils import has_batch_matmul_transpose
 from sglang.srt.layers.attention.dsa.dsa_npu_indexer import scattered_to_tp_attn_full
 from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
@@ -523,17 +524,28 @@ def forward_dsa_core_npu(
         and not forward_batch.forward_mode.is_draft_extend_v2()
         and not forward_batch.forward_mode.is_target_verify()
     ):
-        attn_output = attn_output.transpose(0, 1)
-        torch.bmm(
+        attn_bmm_output = torch_npu.npu_transpose_batchmatmul(
             attn_output,
             m.w_vc,
-            out=attn_bmm_output.view(-1, m.num_local_heads, m.v_head_dim).transpose(
-                0, 1
-            ),
+            perm_x1=(1, 0, 2),
+            perm_x2=(0, 1, 2),
+            perm_y=(1, 0, 2),
+            batch_split_factor=1,
         )
     else:
-        attn_output = attn_output.contiguous()
-        torch.ops.npu.batch_matmul_transpose(attn_output, m.w_vc, attn_bmm_output)
+        # batch_matmul_transpose is not supported on A5
+        if not has_batch_matmul_transpose():
+            attn_bmm_output = torch_npu.npu_transpose_batchmatmul(
+                attn_output,
+                m.w_vc,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+        else:
+            attn_output = attn_output.contiguous()
+            torch.ops.npu.batch_matmul_transpose(attn_output, m.w_vc, attn_bmm_output)
 
     attn_bmm_output = attn_bmm_output.reshape(-1, m.num_local_heads * m.v_head_dim)
 

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -30,6 +30,14 @@ class NPUACLFormat(IntEnum):
     ACL_FORMAT_FRACTAL_NZ = 29
 
 
+# Ships in the sgl-kernel-npu; absent on A5
+# Cached because torch does not negatively cache a missing
+# torch.ops lookup. Should be called during forward pass.
+@functools.lru_cache(maxsize=1)
+def has_batch_matmul_transpose() -> bool:
+    return hasattr(torch.ops.npu, "batch_matmul_transpose")
+
+
 def _call_once(fn: Callable):
 
     @functools.wraps(fn)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

GLM-5.2 does not run on Ascend A5.

The NPU DSA attention path (`AttnForwardMethod.DSA_NPU` -> `forward_dsa_core_npu`)
computes the `attn_output @ w_vc` projection with
`torch.ops.npu.batch_matmul_transpose`, a custom op provided by the sgl-kernel-npu, which is not supported on A5.

This PR makes the projection select its kernel from op availability rather than
assuming `batch_matmul_transpose` is always present, and switches the extend
branch to the fused `npu_transpose_batchmatmul` op.

## Modifications

**`python/sglang/srt/hardware_backend/npu/utils.py`**

- Add `has_batch_matmul_transpose()`: an `lru_cache`d probe for
  `torch.ops.npu.batch_matmul_transpose`. Caching is required to not affect decode path.
  It must only be called from a forward path: at import time the first
  lookup would run before the custom-kernel packages are registered by
  `init_npu_backend()` and cache the wrong answer.

**`python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py`**
(`forward_dsa_core_npu`)

- Prefill: replace `torch.bmm` with `torch_npu.npu_transpose_batchmatmul`. **This applies to all NPU
  hardware, not only A5.** (Testing TBD)
- Decode: gate on `has_batch_matmul_transpose()`. Where the op is missing (A5), use `torch_npu.npu_transpose_batchmatmul`; elsewhere keep the existing `torch.ops.npu.batch_matmul_transpose` call unchanged.

Non-NPU backends are untouched.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33510691227](https://github.com/sgl-project/sglang/actions/runs/33510691227)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33510690789](https://github.com/sgl-project/sglang/actions/runs/33510690789)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33510691207](https://github.com/sgl-project/sglang/actions/runs/33510691207)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->