### PR TITLE
[Docs] Fix --encoder-transfer-backend default and options

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -3103,9 +3103,9 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--encoder-transfer-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The backend for encoder disaggregation transfer. Default is zmq_to_scheduler.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`zmq_to_scheduler`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>zmq_to_scheduler</code>, <code>zmq_to_tokenizer</code>, <code>mooncake</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The backend for encoder disaggregation transfer. Default is <code>auto</code>, which selects a model- and TP-aware backend.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>zmq_to_scheduler</code>, <code>zmq_to_tokenizer</code>, <code>mooncake</code></td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--encoder-urls`</td>


### PR DESCRIPTION
## Motivation

The server arguments table documents `--encoder-transfer-backend` with a default and an option list that contradict `server_args.py` on current `main`. The table gives the default as `zmq_to_scheduler` and lists only `zmq_to_scheduler`, `zmq_to_tokenizer`, `mooncake`:

```python
encoder_transfer_backend: A[
    str,
    Arg(
        help="The backend for encoder disaggregation transfer. Auto selects a model- and TP-aware backend.",
        choices=["auto", "zmq_to_scheduler", "zmq_to_tokenizer", "mooncake"],
    ),
    NS("disagg"),
] = "auto"
```

So `auto` is both the real default and an accepted value, and it is absent from the table. It is not a synonym for `zmq_to_scheduler`: `resolve_encoder_transfer_backend` returns `zmq_to_tokenizer` for `KimiK3ForConditionalGeneration` when `tp_size > 1`.

## Modifications

Three cells in that one row of `docs/docs/advanced_features/server_arguments.mdx`: default becomes `auto`, `auto` is added to the options, and the description takes the `Default is <code>auto</code>, which ...` form already used by `--deepep-mode`.

## Accuracy Tests

N/A. Documentation only.

## Speed Tests and Profiling

N/A. Documentation only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Ran `trailing-whitespace`, `end-of-file-fixer` and `codespell` on the changed file; all passed.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). N/A, no code change.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A, no code change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33513399172](https://github.com/sgl-project/sglang/actions/runs/33513399172)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33513398562](https://github.com/sgl-project/sglang/actions/runs/33513398562)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->