### PR TITLE
[CI] Remove duplicate MUSA CI registration entries

### DIFF
--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -15,7 +15,6 @@ __all__ = [
     "register_musa_ci",
     "register_npu_ci",
     "register_xpu_ci",
-    "register_musa_ci",
     "register_mlx_ci",
     "ut_parse_one_file",
 ]
@@ -137,19 +136,6 @@ def register_xpu_ci(
     return None
 
 
-def register_musa_ci(
-    est_time: float,
-    suite: Optional[str] = None,
-    nightly: bool = False,
-    disabled: Optional[str] = None,
-    *,
-    stage: Optional[str] = None,
-    runner_config: Optional[str] = None,
-):
-    """Marker for MUSA CI registration (parsed via AST; runtime no-op)."""
-    return None
-
-
 def register_mlx_ci(
     est_time: float,
     suite: Optional[str] = None,
@@ -170,7 +156,6 @@ REGISTER_MAPPING = {
     "register_musa_ci": HWBackend.MUSA,
     "register_npu_ci": HWBackend.NPU,
     "register_xpu_ci": HWBackend.XPU,
-    "register_musa_ci": HWBackend.MUSA,
     "register_mlx_ci": HWBackend.MLX,
 }
 


### PR DESCRIPTION
## Motivation

The MUSA CI marker is registered twice in python/sglang/test/ci/ci_register.py: in the public export list, as a complete function definition, and in REGISTER_MAPPING. The duplicate entries are currently identical, but keeping two copies adds ambiguity and allows them to drift independently.

## Modifications

- Remove the duplicate register_musa_ci export.
- Remove the duplicate register_musa_ci function definition.
- Remove the duplicate REGISTER_MAPPING entry.

The remaining MUSA marker and backend mapping are unchanged.

## Accuracy Tests

Not applicable. This cleanup does not affect model outputs.

Validation performed:

- Python syntax compilation passed.
- Ruff passed.
- Black check passed.
- AST invariant check confirmed exactly one MUSA definition, export, and mapping.
- Direct module import and MUSA mapping smoke test passed.

## Speed Tests and Profiling

Not applicable. This cleanup does not affect runtime inference paths.

## Checklist

- [x] Format the modified file.
- [x] Verify the CI registry module and MUSA mapping.
- [x] No documentation update is required.
- [x] No accuracy or performance benchmark is required.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33525997271](https://github.com/sgl-project/sglang/actions/runs/33525997271)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33525997004](https://github.com/sgl-project/sglang/actions/runs/33525997004)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33525997269](https://github.com/sgl-project/sglang/actions/runs/33525997269)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->