### PR TITLE
[CI] Double JIT kernel unit test timeout

### DIFF
--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -86,7 +86,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd test/
           python3 run_suite.py --hw cuda \


### PR DESCRIPTION
## Motivation

JIT kernel refactors can invalidate compiled artifacts and force broad recompilation during the unit-test lane. In that case, the current 30-minute step timeout can terminate an otherwise progressing run, as seen in #36176.

Increasing the timeout threshold does not increase normal CI runtime; it only gives full-rebuild runs more headroom.

## Changes

- Increase the H100 JIT kernel unit-test `Run test` timeout from 30 to 60 minutes.
- Keep the dependency-install timeout and 240-minute job-level timeout unchanged.

## Validation

- `git diff --check`
- Parsed `.github/workflows/pr-test-jit-kernel.yml` with Ruby YAML parser

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33518947774](https://github.com/sgl-project/sglang/actions/runs/33518947774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33518947563](https://github.com/sgl-project/sglang/actions/runs/33518947563)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->