### PR TITLE
[diffusion][cpu] add fused_nplace_qknorm_rope kernel

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/fused_inplace_qknorm_rope_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/fused_inplace_qknorm_rope_cpu.cpp
@@ -1,0 +1,142 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+template <typename scalar_t>
+float rms_rscale(const scalar_t* input, int64_t head_dim, float eps) {
+  float sum = 0.0f;
+  for (int64_t d = 0; d < head_dim; ++d) {
+    const float value = static_cast<float>(input[d]);
+    sum += value * value;
+  }
+  return 1.0f / std::sqrt(sum / static_cast<float>(head_dim) + eps);
+}
+
+template <typename scalar_t>
+void rmsnorm_row(
+    scalar_t* output,
+    const scalar_t* input,
+    const scalar_t* weight,
+    int64_t head_dim,
+    float eps) {
+  const float rscale = rms_rscale(input, head_dim, eps);
+  for (int64_t d = 0; d < head_dim; ++d) {
+    output[d] = static_cast<scalar_t>(
+        static_cast<float>(input[d]) * rscale * static_cast<float>(weight[d]));
+  }
+}
+
+template <typename scalar_t>
+void apply_neox_rope_inplace(
+    scalar_t* output,
+    const scalar_t* normalized,
+    const scalar_t* cache,
+    int64_t head_dim,
+    int64_t rope_dim) {
+  const int64_t half = rope_dim / 2;
+  for (int64_t d = 0; d < half; ++d) {
+    const float x = static_cast<float>(normalized[d]);
+    const float y = static_cast<float>(normalized[half + d]);
+    const float cos = static_cast<float>(cache[d]);
+    const float sin = static_cast<float>(cache[half + d]);
+    output[d] = static_cast<scalar_t>(x * cos - y * sin);
+    output[half + d] = static_cast<scalar_t>(y * cos + x * sin);
+  }
+  for (int64_t d = rope_dim; d < head_dim; ++d) {
+    output[d] = normalized[d];
+  }
+}
+
+template <typename scalar_t>
+void fused_inplace_qknorm_rope_kernel(
+    scalar_t* q,
+    scalar_t* k,
+    const scalar_t* q_weight,
+    const scalar_t* k_weight,
+    const scalar_t* cache,
+    const int64_t* positions,
+    int64_t num_tokens,
+    int64_t num_heads,
+    int64_t head_dim,
+    int64_t rope_dim,
+    int64_t q_stride_token,
+    int64_t q_stride_head,
+    int64_t k_stride_token,
+    int64_t k_stride_head,
+    float eps) {
+  const int64_t rows = num_tokens * num_heads;
+  at::parallel_for(0, rows, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    scalar_t q_tmp[128];
+    scalar_t k_tmp[128];
+    for (int64_t row = begin; row < end; ++row) {
+      const int64_t token = row / num_heads;
+      const int64_t head = row % num_heads;
+      scalar_t* q_row = q + token * q_stride_token + head * q_stride_head;
+      scalar_t* k_row = k + token * k_stride_token + head * k_stride_head;
+      const scalar_t* cache_row = cache + positions[token] * rope_dim;
+      rmsnorm_row(q_tmp, q_row, q_weight, head_dim, eps);
+      rmsnorm_row(k_tmp, k_row, k_weight, head_dim, eps);
+      apply_neox_rope_inplace(q_row, q_tmp, cache_row, head_dim, rope_dim);
+      apply_neox_rope_inplace(k_row, k_tmp, cache_row, head_dim, rope_dim);
+    }
+  });
+}
+
+}  // namespace
+
+void fused_inplace_qknorm_rope_cpu(
+    at::Tensor& q,
+    at::Tensor& k,
+    const at::Tensor& q_weight,
+    const at::Tensor& k_weight,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
+    double eps,
+    int64_t head_dim,
+    int64_t rope_dim,
+    bool is_neox,
+    bool round_norm_before_rope) {
+  CHECK_CPU(q);
+  CHECK_CPU(k);
+  CHECK_CPU(q_weight);
+  CHECK_CPU(k_weight);
+  CHECK_CPU(cos_sin_cache);
+  CHECK_CPU(positions);
+  CHECK_LAST_DIM_CONTIGUOUS(q);
+  CHECK_LAST_DIM_CONTIGUOUS(k);
+  CHECK_EQ(q.scalar_type(), at::kBFloat16);
+  CHECK_EQ(k.scalar_type(), q.scalar_type());
+  CHECK_EQ(q_weight.scalar_type(), q.scalar_type());
+  CHECK_EQ(k_weight.scalar_type(), q.scalar_type());
+  CHECK_EQ(cos_sin_cache.scalar_type(), q.scalar_type());
+  TORCH_CHECK(positions.scalar_type() == at::kLong, "positions must be int64");
+  CHECK_DIM(3, q);
+  CHECK_DIM(3, k);
+  CHECK_DIM(2, cos_sin_cache);
+  CHECK_DIM(1, positions);
+  CHECK_DIM(1, q_weight);
+  CHECK_DIM(1, k_weight);
+  CHECK_EQ(q.size(0), k.size(0));
+  CHECK_EQ(q.size(1), k.size(1));
+  CHECK_EQ(q.size(2), head_dim);
+  CHECK_EQ(k.size(2), head_dim);
+  CHECK_EQ(q_weight.size(0), head_dim);
+  CHECK_EQ(k_weight.size(0), head_dim);
+  CHECK_EQ(positions.numel(), q.size(0));
+  TORCH_CHECK(is_neox, "CPU fused qknorm+rope only supports is_neox=True");
+  TORCH_CHECK(round_norm_before_rope, "CPU fused qknorm+rope requires rounded norm");
+  TORCH_CHECK(head_dim == 128, "CPU fused qknorm+rope only supports head_dim=128");
+  TORCH_CHECK(rope_dim == 96, "CPU fused qknorm+rope only supports rope_dim=96");
+  TORCH_CHECK(cos_sin_cache.size(1) == rope_dim, "cos_sin_cache width must equal rope_dim");
+  TORCH_CHECK(
+      positions.numel() == 0 || positions.max().item<int64_t>() < cos_sin_cache.size(0),
+      "positions exceed cos_sin_cache rows");
+
+  fused_inplace_qknorm_rope_kernel<at::BFloat16>(
+      q.data_ptr<at::BFloat16>(), k.data_ptr<at::BFloat16>(),
+      q_weight.data_ptr<at::BFloat16>(), k_weight.data_ptr<at::BFloat16>(),
+      cos_sin_cache.data_ptr<at::BFloat16>(), positions.data_ptr<int64_t>(),
+      q.size(0), q.size(1), head_dim, rope_dim, q.stride(0), q.stride(1),
+      k.stride(0), k.stride(1), static_cast<float>(eps));
+}

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -30,6 +30,19 @@ at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
 // fused_sigmoid_mul
 void fused_sigmoid_mul_cpu(at::Tensor& input, const at::Tensor& gate);
 
+void fused_inplace_qknorm_rope_cpu(
+    at::Tensor& q,
+    at::Tensor& k,
+    const at::Tensor& q_weight,
+    const at::Tensor& k_weight,
+    const at::Tensor& cos_sin_cache,
+    const at::Tensor& positions,
+    double eps,
+    int64_t head_dim,
+    int64_t rope_dim,
+    bool is_neox,
+    bool round_norm_before_rope);
+
 // l2norm
 at::Tensor l2norm_cpu(at::Tensor& input, double eps);
 
@@ -582,6 +595,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("gelu_and_mul_cpu", torch::kCPU, &gelu_and_mul_cpu);
   m.def("fused_sigmoid_mul_cpu(Tensor(a!) input, Tensor gate) -> ()");
   m.impl("fused_sigmoid_mul_cpu", torch::kCPU, &fused_sigmoid_mul_cpu);
+
+    m.def(
+            "fused_inplace_qknorm_rope_cpu(Tensor(a!) q, Tensor(a!) k, Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, Tensor positions, float eps, int head_dim, int rope_dim, bool is_neox, bool round_norm_before_rope) -> ()");
+    m.impl("fused_inplace_qknorm_rope_cpu", torch::kCPU, &fused_inplace_qknorm_rope_cpu);
 
   // norm
   m.def("rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");

--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -487,6 +487,7 @@ _EXPORTS: dict[str, str] = {
     "can_use_ltx25_decoder_rope": "rope.ltx25_decoder_rope_jit",
     "fused_ltx25_decoder_rope": "rope.ltx25_decoder_rope_jit",
     "can_use_fused_inplace_qknorm_rope": "rope.qknorm_rope_jit",
+    "can_use_fused_inplace_qknorm_rope_cpu": "rope.qknorm_rope_jit",
     "fused_inplace_qknorm_rope": "rope.qknorm_rope_jit",
     "fused_qknorm_rope_pack_kv": "rope.qknorm_rope_jit",
     "try_fused_qwen_qkv_epilogue": "rope.qwen_qkv_epilogue_jit",

--- a/python/sglang/kernels/ops/diffusion/rope/qknorm_rope_jit.py
+++ b/python/sglang/kernels/ops/diffusion/rope/qknorm_rope_jit.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 
 _SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 _SUPPORTED_CACHE_DTYPES = (*_SUPPORTED_DTYPES, torch.float32)
+_CPU_RELEASE_HEAD_DIM = 128
+_CPU_RELEASE_ROPE_DIM = 96
 
 
 @cache_once
@@ -127,6 +129,31 @@ def _can_use_fused_qknorm_rope(
 
 @torch.compiler.assume_constant_result
 @cache_once
+def can_use_fused_inplace_qknorm_rope_cpu(
+    head_dim: int,
+    rope_dim: int,
+    is_neox: bool,
+    dtype: torch.dtype,
+    cache_dtype: torch.dtype = torch.float32,
+    round_norm_before_rope: bool = False,
+) -> bool:
+    if dtype != torch.bfloat16 or cache_dtype != torch.bfloat16:
+        return False
+    if head_dim != _CPU_RELEASE_HEAD_DIM or rope_dim != _CPU_RELEASE_ROPE_DIM:
+        return False
+    if not is_neox or not round_norm_before_rope:
+        return False
+    try:
+        import sgl_kernel  # noqa: F401
+
+        return hasattr(torch.ops.sgl_kernel, "fused_inplace_qknorm_rope_cpu")
+    except Exception as exc:
+        logger.warning("Failed to load CPU fused QK norm + RoPE kernel: %s", exc)
+        return False
+
+
+@torch.compiler.assume_constant_result
+@cache_once
 def can_use_fused_inplace_qknorm_rope(
     head_dim: int,
     rope_dim: int,
@@ -149,8 +176,8 @@ def can_use_fused_inplace_qknorm_rope(
     )
 
 
-@register_custom_op(mutates_args=["q", "k"])
-def fused_inplace_qknorm_rope(
+@register_custom_op(op_name="fused_inplace_qknorm_rope", mutates_args=["q", "k"])
+def _fused_inplace_qknorm_rope_cuda(
     q: torch.Tensor,
     k: torch.Tensor,
     q_weight: torch.Tensor,
@@ -180,6 +207,41 @@ def fused_inplace_qknorm_rope(
         cache_has_full_width,
     )
     module.qknorm_rope(q, k, q_weight, k_weight, cos_sin_cache, positions, eps)
+
+
+def fused_inplace_qknorm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    is_neox: bool,
+    eps: float = 1e-6,
+    head_dim: int = 0,
+    rope_dim: int = 0,
+    round_norm_before_rope: bool = False,
+    cache_has_full_width: bool = False,
+) -> None:
+    head_dim = head_dim or q.size(-1)
+    if not rope_dim:
+        cache_width = cos_sin_cache.size(-1)
+        rope_dim = cache_width // 2 if cache_has_full_width else cache_width
+    if q.device.type == "cpu":
+        import sgl_kernel  # noqa: F401
+
+        torch.ops.sgl_kernel.fused_inplace_qknorm_rope_cpu(
+            q, k, q_weight, k_weight, cos_sin_cache, positions, eps,
+            head_dim, rope_dim, is_neox, round_norm_before_rope
+        )
+        return
+    _fused_inplace_qknorm_rope_cuda(
+        q, k, q_weight, k_weight, cos_sin_cache, positions,
+        is_neox=is_neox, eps=eps, head_dim=head_dim, rope_dim=rope_dim,
+        round_norm_before_rope=round_norm_before_rope,
+        cache_has_full_width=cache_has_full_width,
+    )
 
 
 @register_custom_op(mutates_args=["q", "packed_kv"])

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -24,6 +24,7 @@ from sglang.kernels.ops.activation.activation import (
     silu_and_mul_with_activation_rounding_,
 )
 from sglang.kernels.ops.diffusion import (
+    can_use_fused_inplace_qknorm_rope_cpu,
     can_use_fused_inplace_qknorm_rope,
     fused_inplace_qknorm_rope,
     indexed_gate_bf16,
@@ -738,14 +739,27 @@ class MiniMaxH3Attention(nn.Module):
         # cache width covers cos/sin for temporal, height, and width frequencies
         rope_dim = 6 * arch.rope_inv_freq_len
         self._use_fused_qknorm_rope = (
-            current_platform.is_cuda()
-            and can_use_fused_inplace_qknorm_rope(
-                arch.attention_head_dim,
-                rope_dim,
-                True,
-                _BF16_DTYPE,
-                cache_dtype=_BF16_DTYPE,
-                round_norm_before_rope=True,
+            (
+                current_platform.is_cuda()
+                and can_use_fused_inplace_qknorm_rope(
+                    arch.attention_head_dim,
+                    rope_dim,
+                    True,
+                    _BF16_DTYPE,
+                    cache_dtype=_BF16_DTYPE,
+                    round_norm_before_rope=True,
+                )
+            )
+            or (
+                current_platform.is_cpu()
+                and can_use_fused_inplace_qknorm_rope_cpu(
+                    arch.attention_head_dim,
+                    rope_dim,
+                    True,
+                    _BF16_DTYPE,
+                    cache_dtype=_BF16_DTYPE,
+                    round_norm_before_rope=True,
+                )
             )
         )
         self.out_proj = RowParallelLinear(

--- a/test/registered/cpu/benchmark/bench_qknorm_rope_cpu.py
+++ b/test/registered/cpu/benchmark/bench_qknorm_rope_cpu.py
@@ -1,0 +1,295 @@
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+import sgl_kernel  # noqa: F401
+from sglang.kernels.ops.diffusion.rope.qknorm_rope_jit import fused_inplace_qknorm_rope
+
+DTYPE = torch.bfloat16
+NUM_HEADS = 56
+HEAD_DIM = 128
+ROPE_DIM = 96
+EPS = 1e-6
+DEFAULT_CASES = [256, 1024, 4096]
+
+
+def create_cos_sin_cache(rotary_dim: int, max_position: int) -> torch.Tensor:
+    inv_freq = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(DTYPE)
+
+
+def make_case(num_tokens: int) -> dict[str, torch.Tensor]:
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(10_000 + num_tokens)
+    return {
+        "q": torch.randn(num_tokens, NUM_HEADS, HEAD_DIM, dtype=DTYPE, generator=gen),
+        "k": torch.randn(num_tokens, NUM_HEADS, HEAD_DIM, dtype=DTYPE, generator=gen),
+        "q_weight": torch.randn(HEAD_DIM, dtype=DTYPE, generator=gen),
+        "k_weight": torch.randn(HEAD_DIM, dtype=DTYPE, generator=gen),
+        "positions": torch.arange(num_tokens, dtype=torch.int64),
+        "cos_sin_cache": create_cos_sin_cache(ROPE_DIM, max_position=num_tokens),
+    }
+
+
+def rmsnorm_baseline(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    norm = nn.RMSNorm(x.shape[-1], eps=eps, dtype=x.dtype)
+    with torch.no_grad():
+        norm.weight.copy_(weight)
+    return norm(x)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rope_baseline(x: torch.Tensor, cos_sin_cache: torch.Tensor) -> torch.Tensor:
+    half = cos_sin_cache.shape[-1] // 2
+    cos_half, sin_half = cos_sin_cache.split(half, dim=-1)
+    cos = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)
+    sin = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+    x_rot, x_pass = x[..., : cos.shape[-1]], x[..., cos.shape[-1] :]
+    x_rot = (x_rot * cos) + (rotate_half(x_rot) * sin)
+    return torch.cat((x_rot, x_pass), dim=-1)
+
+
+def baseline_fn(q: torch.Tensor, k: torch.Tensor, case: dict[str, torch.Tensor]) -> None:
+    q_norm = rmsnorm_baseline(q, case["q_weight"], EPS)
+    k_norm = rmsnorm_baseline(k, case["k_weight"], EPS)
+    cache = case["cos_sin_cache"].index_select(0, case["positions"])
+    apply_rope_baseline(q_norm, cache)
+    apply_rope_baseline(k_norm, cache)
+
+
+def fused_fn(q: torch.Tensor, k: torch.Tensor, case: dict[str, torch.Tensor]) -> None:
+    fused_inplace_qknorm_rope(
+        q,
+        k,
+        case["q_weight"],
+        case["k_weight"],
+        case["cos_sin_cache"],
+        case["positions"],
+        is_neox=True,
+        eps=EPS,
+        head_dim=HEAD_DIM,
+        rope_dim=ROPE_DIM,
+        round_norm_before_rope=True,
+    )
+
+
+def time_case(case: dict[str, torch.Tensor], warmup: int, iters: int) -> dict:
+    q_work = torch.empty_like(case["q"])
+    k_work = torch.empty_like(case["k"])
+
+    def bench(label: str, fn):
+        for _ in range(warmup):
+            q_work.copy_(case["q"])
+            k_work.copy_(case["k"])
+            fn(q_work, k_work)
+        times = []
+        for _ in range(iters):
+            q_work.copy_(case["q"])
+            k_work.copy_(case["k"])
+            start = time.perf_counter()
+            fn(q_work, k_work)
+            end = time.perf_counter()
+            times.append(end - start)
+        return {
+            "provider": label,
+            "latency_median_ms": statistics.median(times) * 1000.0,
+            "latency_min_ms": min(times) * 1000.0,
+            "latency_max_ms": max(times) * 1000.0,
+            "latency_p95_ms": statistics.quantiles(times, n=20)[-1] * 1000.0
+            if len(times) >= 20
+            else max(times) * 1000.0,
+            "samples_ms": [round(t * 1000.0, 6) for t in times],
+        }
+
+    baseline = bench(
+        "baseline_minimax_cpu",
+        lambda q, k: baseline_fn(q, k, case),
+    )
+    fused = bench("fused_cpu", lambda q, k: fused_fn(q, k, case))
+    speedup = baseline["latency_median_ms"] / fused["latency_median_ms"]
+    return {
+        "num_tokens": case["q"].shape[0],
+        "num_heads": NUM_HEADS,
+        "head_dim": HEAD_DIM,
+        "rope_dim": ROPE_DIM,
+        "dtype": str(DTYPE),
+        "baseline": baseline,
+        "fused": fused,
+        "speedup": speedup,
+    }
+
+
+def shell_output(command: list[str]) -> str:
+    try:
+        return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
+    except Exception as exc:
+        return f"unavailable: {exc}"
+
+
+def format_cpu_ranges(cpus: list[int]) -> str:
+    if not cpus:
+        return ""
+    ranges = []
+    start = prev = cpus[0]
+    for cpu in cpus[1:]:
+        if cpu == prev + 1:
+            prev = cpu
+            continue
+        ranges.append(f"{start}-{prev}" if start != prev else str(start))
+        start = prev = cpu
+    ranges.append(f"{start}-{prev}" if start != prev else str(start))
+    return ",".join(ranges)
+
+
+def read_thread_affinity_map() -> dict[int, str]:
+    affinity_map: dict[int, str] = {}
+    for task_dir in Path("/proc/self/task").iterdir():
+        status_path = task_dir / "status"
+        try:
+            for line in status_path.read_text().splitlines():
+                if line.startswith("Cpus_allowed_list"):
+                    affinity_map[int(task_dir.name)] = line.split(":", 1)[1].strip()
+                    break
+        except OSError:
+            continue
+    return affinity_map
+
+
+def summarize_thread_affinity(affinity_map: dict[int, str]) -> dict:
+    counts = Counter(affinity_map.values())
+    singleton_cpus = sorted(
+        int(mask) for mask in counts if mask.isdigit()
+    )
+    return {
+        "thread_count": len(affinity_map),
+        "unique_masks": len(counts),
+        "single_cpu_thread_count": sum(counts[mask] for mask in counts if mask.isdigit()),
+        "single_cpu_binding_head": singleton_cpus[:16],
+        "single_cpu_binding_range": format_cpu_ranges(singleton_cpus),
+        "top_masks": [
+            {"mask": mask, "threads": count}
+            for mask, count in counts.most_common(16)
+        ],
+    }
+
+
+def current_thread_affinity_snapshot() -> dict:
+    cpus = sorted(os.sched_getaffinity(0))
+    return {
+        "count": len(cpus),
+        "head": cpus[:16],
+        "range": format_cpu_ranges(cpus),
+    }
+
+
+def read_cpuset_effective() -> str | None:
+    for candidate in [
+        Path("/sys/fs/cgroup/cpuset.cpus.effective"),
+        Path("/sys/fs/cgroup/cpuset.cpus"),
+    ]:
+        try:
+            value = candidate.read_text().strip()
+        except OSError:
+            continue
+        if value:
+            return value
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, nargs="*", default=DEFAULT_CASES)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--result-file", type=Path, default=None)
+    parser.add_argument("--require-min-speedup", type=float, default=None)
+    args = parser.parse_args()
+
+    omp_threads = os.environ.get("OMP_NUM_THREADS")
+    if omp_threads:
+        torch.set_num_threads(int(omp_threads))
+
+    pre_parallel_affinity = current_thread_affinity_snapshot()
+    pre_parallel_taskset = shell_output(["bash", "-lc", "taskset -pc $$"])
+    pre_parallel_thread_affinity = summarize_thread_affinity(read_thread_affinity_map())
+
+    results = [time_case(make_case(tokens), args.warmup, args.iters) for tokens in args.tokens]
+    min_speedup = min(item["speedup"] for item in results)
+
+    post_parallel_affinity = current_thread_affinity_snapshot()
+    post_parallel_taskset = shell_output(["bash", "-lc", "taskset -pc $$"])
+    post_parallel_thread_affinity = summarize_thread_affinity(read_thread_affinity_map())
+
+    payload = {
+        "command": sys.argv,
+        "cwd": os.getcwd(),
+        "python": sys.version,
+        "torch_version": torch.__version__,
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "torch_num_threads": torch.get_num_threads(),
+        "cpuset_cgroup_effective": read_cpuset_effective(),
+        "pre_parallel_main_thread_affinity": pre_parallel_affinity,
+        "pre_parallel_taskset": pre_parallel_taskset,
+        "pre_parallel_thread_affinity": pre_parallel_thread_affinity,
+        "post_parallel_main_thread_affinity": post_parallel_affinity,
+        "post_parallel_taskset": post_parallel_taskset,
+        "post_parallel_thread_affinity": post_parallel_thread_affinity,
+        "affinity_note": (
+            "post_parallel_main_thread_affinity reports the calling thread after the first OpenMP/oneDNN parallel region; "
+            "inspect post_parallel_thread_affinity for worker placement across the launch cpuset"
+        ),
+        "env": {
+            key: os.environ.get(key)
+            for key in [
+                "OMP_NUM_THREADS",
+                "MKL_NUM_THREADS",
+                "KMP_AFFINITY",
+                "OMP_PROC_BIND",
+                "OMP_PLACES",
+                "SGLANG_CPU_OMP_THREADS_BIND",
+            ]
+        },
+        "lscpu": shell_output(["lscpu"]),
+        "numactl_h": shell_output(["numactl", "-H"]),
+        "parallel_info": torch.__config__.parallel_info(),
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "results": results,
+        "min_speedup": min_speedup,
+    }
+
+    if args.result_file is not None:
+        args.result_file.parent.mkdir(parents=True, exist_ok=True)
+        args.result_file.write_text(json.dumps(payload, indent=2) + "\n")
+
+    print(json.dumps(payload, indent=2))
+
+    if args.require_min_speedup is not None and min_speedup < args.require_min_speedup:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/registered/cpu/test_qknorm_rope_cpu.py
+++ b/test/registered/cpu/test_qknorm_rope_cpu.py
@@ -1,0 +1,249 @@
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+import sgl_kernel  # noqa: F401
+from sglang.kernels.ops.diffusion.rope.qknorm_rope_jit import (
+    can_use_fused_inplace_qknorm_rope_cpu,
+    fused_inplace_qknorm_rope,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=12, suite="base-b-test-cpu")
+
+torch.manual_seed(1234)
+
+DTYPE = torch.bfloat16
+NUM_HEADS = 56
+HEAD_DIM = 128
+ROPE_DIM = 96
+EPS = 1e-6
+MINIMAX_SOURCE = Path(__file__).parents[3] / "python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py"
+
+
+def create_cos_sin_cache(rotary_dim: int, max_position: int) -> torch.Tensor:
+    inv_freq = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim
+        )
+    )
+    t = torch.arange(max_position, dtype=torch.float32)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(DTYPE)
+
+
+def rmsnorm_baseline(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    norm = nn.RMSNorm(x.shape[-1], eps=eps, dtype=x.dtype)
+    with torch.no_grad():
+        norm.weight.copy_(weight)
+    return norm(x)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rope_baseline(x: torch.Tensor, cos_sin_cache: torch.Tensor) -> torch.Tensor:
+    half = cos_sin_cache.shape[-1] // 2
+    cos_half, sin_half = cos_sin_cache.split(half, dim=-1)
+    cos = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)
+    sin = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+    x_rot, x_pass = x[..., : cos.shape[-1]], x[..., cos.shape[-1] :]
+    x_rot = (x_rot * cos) + (rotate_half(x_rot) * sin)
+    return torch.cat((x_rot, x_pass), dim=-1)
+
+
+def baseline_qknorm_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_norm = rmsnorm_baseline(q, q_weight, EPS)
+    k_norm = rmsnorm_baseline(k, k_weight, EPS)
+    cache = cos_sin_cache.index_select(0, positions)
+    return apply_rope_baseline(q_norm, cache), apply_rope_baseline(k_norm, cache)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 17, 257])
+def test_fused_qknorm_rope_cpu_matches_baseline(num_tokens: int) -> None:
+    q = torch.randn(num_tokens, NUM_HEADS, HEAD_DIM, dtype=DTYPE)
+    k = torch.randn_like(q)
+    q_weight = torch.randn(HEAD_DIM, dtype=DTYPE)
+    k_weight = torch.randn(HEAD_DIM, dtype=DTYPE)
+    positions = torch.arange(num_tokens, dtype=torch.int64)
+    cos_sin_cache = create_cos_sin_cache(ROPE_DIM, max_position=num_tokens)
+
+    q_ref, k_ref = baseline_qknorm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+    )
+    q_fused, k_fused = q.clone(), k.clone()
+    fused_inplace_qknorm_rope(
+        q_fused,
+        k_fused,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        is_neox=True,
+        eps=EPS,
+        head_dim=HEAD_DIM,
+        rope_dim=ROPE_DIM,
+        round_norm_before_rope=True,
+    )
+
+    torch.testing.assert_close(q_ref, q_fused, atol=6.25e-2, rtol=5e-2)
+    torch.testing.assert_close(k_ref, k_fused, atol=6.25e-2, rtol=5e-2)
+
+
+def test_fused_qknorm_rope_cpu_mutates_inputs_in_place() -> None:
+    q = torch.randn(8, NUM_HEADS, HEAD_DIM, dtype=DTYPE)
+    k = torch.randn_like(q)
+    q_weight = torch.randn(HEAD_DIM, dtype=DTYPE)
+    k_weight = torch.randn(HEAD_DIM, dtype=DTYPE)
+    positions = torch.arange(8, dtype=torch.int64)
+    cos_sin_cache = create_cos_sin_cache(ROPE_DIM, max_position=8)
+    q_ptr = q.data_ptr()
+    k_ptr = k.data_ptr()
+
+    fused_inplace_qknorm_rope(
+        q,
+        k,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        is_neox=True,
+        eps=EPS,
+        head_dim=HEAD_DIM,
+        rope_dim=ROPE_DIM,
+        round_norm_before_rope=True,
+    )
+
+    assert q.data_ptr() == q_ptr
+    assert k.data_ptr() == k_ptr
+
+
+def test_can_use_fused_qknorm_rope_cpu_release_slice() -> None:
+    assert can_use_fused_inplace_qknorm_rope_cpu(
+        HEAD_DIM,
+        ROPE_DIM,
+        True,
+        DTYPE,
+        cache_dtype=DTYPE,
+        round_norm_before_rope=True,
+    )
+    assert not can_use_fused_inplace_qknorm_rope_cpu(
+        HEAD_DIM,
+        ROPE_DIM,
+        False,
+        DTYPE,
+        cache_dtype=DTYPE,
+        round_norm_before_rope=True,
+    )
+    assert not can_use_fused_inplace_qknorm_rope_cpu(
+        HEAD_DIM,
+        ROPE_DIM,
+        True,
+        torch.float16,
+        cache_dtype=torch.float16,
+        round_norm_before_rope=True,
+    )
+    assert not can_use_fused_inplace_qknorm_rope_cpu(
+        64,
+        ROPE_DIM,
+        True,
+        DTYPE,
+        cache_dtype=DTYPE,
+        round_norm_before_rope=True,
+    )
+    assert not can_use_fused_inplace_qknorm_rope_cpu(
+        HEAD_DIM,
+        ROPE_DIM,
+        True,
+        DTYPE,
+        cache_dtype=DTYPE,
+        round_norm_before_rope=False,
+    )
+
+
+def test_minimax_attention_runtime_uses_fused_cpu_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sglang.multimodal_gen.runtime.models.dits import minimax_h3 as minimax_h3_mod
+
+    attn = object.__new__(minimax_h3_mod.MiniMaxH3Attention)
+    nn.Module.__init__(attn)
+    attn.local_inner_dim = NUM_HEADS * HEAD_DIM
+    attn.num_heads = NUM_HEADS
+    attn.head_dim = HEAD_DIM
+    attn._use_fused_qknorm_rope = True
+    attn.q_norm = nn.RMSNorm(HEAD_DIM, eps=EPS, dtype=DTYPE)
+    attn.k_norm = nn.RMSNorm(HEAD_DIM, eps=EPS, dtype=DTYPE)
+    attn.bcg_breakpoint = False
+
+    num_tokens = 4
+    q = torch.randn(num_tokens, NUM_HEADS, HEAD_DIM, dtype=DTYPE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    qkv = torch.cat([q.reshape(num_tokens, -1), k.reshape(num_tokens, -1), v.reshape(num_tokens, -1)], dim=-1)
+
+    class QKVProj:
+        def __call__(self, x):
+            return qkv.clone(), None
+
+    class OutProj:
+        def __call__(self, x):
+            return x, None
+
+    attn.qkv_proj = QKVProj()
+    attn.out_proj = OutProj()
+
+    calls = {"fused": 0}
+    real_fused = minimax_h3_mod.fused_inplace_qknorm_rope
+
+    def fused_spy(*args, **kwargs):
+        calls["fused"] += 1
+        return real_fused(*args, **kwargs)
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("fallback path should not run")
+
+    monkeypatch.setattr(minimax_h3_mod, "fused_inplace_qknorm_rope", fused_spy)
+    monkeypatch.setattr(minimax_h3_mod, "_apply_qk_norm", should_not_run)
+    monkeypatch.setattr(minimax_h3_mod, "_apply_rope_qk", should_not_run)
+    monkeypatch.setattr(minimax_h3_mod, "_minimax_h3_attention_core_impl", lambda self, q, k, v, **kwargs: q)
+    monkeypatch.setattr(minimax_h3_mod, "_minimax_h3_attention_core_bcg", lambda self, q, k, v, **kwargs: q)
+
+    out = minimax_h3_mod.MiniMaxH3Attention.forward(
+        attn,
+        torch.empty(num_tokens, 1, dtype=DTYPE),
+        rope_cache=(create_cos_sin_cache(ROPE_DIM, num_tokens), torch.arange(num_tokens, dtype=torch.int64)),
+        cu_seqlens=torch.tensor([0, num_tokens], dtype=torch.int32),
+        cu_seqlens_host=None,
+        max_seqlen=num_tokens,
+    )
+
+    assert out.shape == (num_tokens, NUM_HEADS * HEAD_DIM)
+    assert calls["fused"] == 1
+
+
+def test_minimax_cpu_dispatch_gate_present_in_source() -> None:
+    text = MINIMAX_SOURCE.read_text()
+    assert "can_use_fused_inplace_qknorm_rope_cpu" in text
+    assert "current_platform.is_cpu()" in text
+    assert "fused_inplace_qknorm_rope(" in text
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation

Improve CPU inference performance for diffusion workloads by adding a fused BF16 QK normalization and NeoX RoPE kernel. MiniMax H3 repeatedly performs these operations together, so fusing them reduces intermediate tensors, memory traffic, and PyTorch operator overhead.

## Modifications

- Add a fused CPU BF16 QK normalization + NeoX RoPE kernel.
- Perform RMS normalization and RoPE transformation in place.
- Support the MiniMax H3 CPU release configuration:
  - `head_dim=128`
  - `rope_dim=96`
  - BF16 input and cache
  - NeoX RoPE
  - Rounded normalization before RoPE
- Register the new operator in the CPU AOT kernel extension.
- Add CPU capability detection and dispatch in the qknorm + RoPE wrapper.
- Enable the fused CPU path for MiniMax H3 attention.
- Preserve the existing JIT CUDA path.
- Add unit tests for:
  - Numerical accuracy against the PyTorch baseline.
  - In-place mutation behavior.
  - Supported and unsupported configurations.
  - MiniMax H3 CPU dispatch.
- Add a CPU benchmark covering latency, speedup, thread affinity, and NUMA information.
- Include benchmark results showing more than 3x speedup over the baseline implementation.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33529145984](https://github.com/sgl-project/sglang/actions/runs/33529145984)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33529145220](https://github.com/sgl-project/sglang/actions/runs/33529145220)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33529146004](https://github.com/sgl-project/sglang/actions/runs/33529146004)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->