### PR TITLE
[diffusion][cpu] add indexed-gate-bf16 kernel

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/indexed_modulation.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/indexed_modulation.cpp
@@ -1,0 +1,107 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+template <typename index_t>
+void indexed_gate_bf16_kernel_impl(
+    at::BFloat16* __restrict__ x,
+    const at::BFloat16* __restrict__ gate,
+    const at::BFloat16* __restrict__ other,
+    const index_t* __restrict__ indices,
+    int64_t rows,
+    int64_t hidden,
+    int64_t gate_rows) {
+  using bVec = at::vec::Vectorized<at::BFloat16>;
+  constexpr int64_t kVecSize = bVec::size();
+
+  const auto loop = [&](int64_t begin, int64_t end) {
+    for (int64_t row = begin; row < end; ++row) {
+      const int64_t index = static_cast<int64_t>(indices[row]);
+      TORCH_CHECK(
+          index >= 0 && index < gate_rows,
+          "indices[",
+          row,
+          "] out of range: ",
+          index,
+          " vs rows=",
+          gate_rows);
+
+      at::BFloat16* __restrict__ x_ptr = x + row * hidden;
+      const at::BFloat16* __restrict__ gate_ptr = gate + index * hidden;
+      const at::BFloat16* __restrict__ other_ptr = other + row * hidden;
+
+      int64_t d = 0;
+#pragma GCC unroll 4
+      for (; d <= hidden - kVecSize; d += kVecSize) {
+        auto [x0, x1] = load_float_vec2(x_ptr + d);
+        auto [gate0, gate1] = load_float_vec2(gate_ptr + d);
+        auto [other0, other1] = load_float_vec2(other_ptr + d);
+        x0 = x0 + gate0 * other0;
+        x1 = x1 + gate1 * other1;
+        convert_from_float_ext<at::BFloat16>(x0, x1).store(x_ptr + d);
+      }
+#pragma GCC unroll 4
+      for (; d < hidden; ++d) {
+        const float x_val = static_cast<float>(x_ptr[d]);
+        const float gate_val = static_cast<float>(gate_ptr[d]);
+        const float other_val = static_cast<float>(other_ptr[d]);
+        x_ptr[d] = static_cast<at::BFloat16>(x_val + gate_val * other_val);
+      }
+    }
+  };
+
+  if (at::get_num_threads() == 1 || rows < GRAIN_SIZE) {
+    loop(0, rows);
+    return;
+  }
+
+  at::parallel_for(0, rows, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    loop(begin, end);
+  });
+}
+
+}  // namespace
+
+at::Tensor indexed_gate_bf16_(
+    at::Tensor& x,
+    const at::Tensor& gate,
+    const at::Tensor& other,
+    const at::Tensor& indices) {
+  CHECK_INPUT(x);
+  CHECK_INPUT(gate);
+  CHECK_INPUT(other);
+  CHECK_INPUT(indices);
+  CHECK_DIM(2, x);
+  CHECK_DIM(2, gate);
+  CHECK_DIM(2, other);
+  CHECK_DIM(1, indices);
+  TORCH_CHECK(x.scalar_type() == at::kBFloat16, "x must be bfloat16");
+  TORCH_CHECK(gate.scalar_type() == at::kBFloat16, "gate must be bfloat16");
+  TORCH_CHECK(other.scalar_type() == at::kBFloat16, "other must be bfloat16");
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
+      "indices must be int32 or int64");
+  CHECK_EQ(x.sizes(), other.sizes());
+  CHECK_EQ(indices.size(0), x.size(0));
+  CHECK_EQ(x.size(1), gate.size(1));
+
+  const int64_t rows = x.size(0);
+  if (rows == 0) {
+    return x;
+  }
+  const int64_t hidden = x.size(1);
+  const int64_t gate_rows = gate.size(0);
+
+  AT_DISPATCH_INTEGRAL_TYPES(indices.scalar_type(), "indexed_gate_bf16_", [&] {
+    indexed_gate_bf16_kernel_impl(
+        x.data_ptr<at::BFloat16>(),
+        gate.data_ptr<at::BFloat16>(),
+        other.data_ptr<at::BFloat16>(),
+        indices.data_ptr<scalar_t>(),
+        rows,
+        hidden,
+        gate_rows);
+  });
+  return x;
+}

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -30,6 +30,13 @@ at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
 // fused_sigmoid_mul
 void fused_sigmoid_mul_cpu(at::Tensor& input, const at::Tensor& gate);
 
+// indexed_gate_bf16_
+at::Tensor indexed_gate_bf16_(
+    at::Tensor& x,
+    const at::Tensor& gate,
+    const at::Tensor& other,
+    const at::Tensor& indices);
+
 // l2norm
 at::Tensor l2norm_cpu(at::Tensor& input, double eps);
 
@@ -582,6 +589,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("gelu_and_mul_cpu", torch::kCPU, &gelu_and_mul_cpu);
   m.def("fused_sigmoid_mul_cpu(Tensor(a!) input, Tensor gate) -> ()");
   m.impl("fused_sigmoid_mul_cpu", torch::kCPU, &fused_sigmoid_mul_cpu);
+    m.def("indexed_gate_bf16_(Tensor(a!) x, Tensor gate, Tensor other, Tensor indices) -> Tensor(a!)");
+    m.impl("indexed_gate_bf16_", torch::kCPU, &indexed_gate_bf16_);
 
   // norm
   m.def("rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");

--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -463,6 +463,8 @@ _EXPORTS: dict[str, str] = {
     # adaLN modulation, gating and timestep conditioning
     "indexed_gate_bf16": "modulate.indexed_modulation_triton",
     "indexed_gate_bf16_": "modulate.indexed_modulation_triton",
+    "can_use_indexed_gate_bf16_cpu": "modulate.indexed_modulation_triton",
+    "indexed_gate_bf16_cpu_": "modulate.indexed_modulation_triton",
     "indexed_scale_shift_bf16_": "modulate.indexed_modulation_triton",
     "ltx2_ada_values9": "modulate.ltx2_ada_values_triton",
     "can_use_modulate_scale_shift_cuda": "modulate.modulate_scale_shift_jit",

--- a/python/sglang/kernels/ops/diffusion/modulate/indexed_modulation_triton.py
+++ b/python/sglang/kernels/ops/diffusion/modulate/indexed_modulation_triton.py
@@ -148,6 +148,44 @@ def indexed_gate_bf16_(
     return _indexed_gate_bf16(x, x, gate, other, indices)
 
 
+def can_use_indexed_gate_bf16_cpu(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> bool:
+    return (
+        x.device.type == "cpu"
+        and gate.device.type == "cpu"
+        and other.device.type == "cpu"
+        and indices.device.type == "cpu"
+        and x.dtype == torch.bfloat16
+        and gate.dtype == torch.bfloat16
+        and other.dtype == torch.bfloat16
+        and indices.dtype in (torch.int32, torch.int64)
+        and x.dim() == gate.dim() == other.dim() == 2
+        and indices.dim() == 1
+        and x.is_contiguous()
+        and gate.is_contiguous()
+        and other.is_contiguous()
+        and indices.is_contiguous()
+        and x.shape == other.shape
+        and x.shape[0] == indices.numel()
+        and x.shape[1] == gate.shape[1]
+    )
+
+
+def indexed_gate_bf16_cpu_(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    import sgl_kernel  # noqa: F401
+
+    return torch.ops.sgl_kernel.indexed_gate_bf16_(x, gate, other, indices)
+
+
 def indexed_gate_bf16(
     x: torch.Tensor,
     gate: torch.Tensor,

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -24,10 +24,12 @@ from sglang.kernels.ops.activation.activation import (
     silu_and_mul_with_activation_rounding_,
 )
 from sglang.kernels.ops.diffusion import (
+    can_use_indexed_gate_bf16_cpu,
     can_use_fused_inplace_qknorm_rope,
     fused_inplace_qknorm_rope,
     indexed_gate_bf16,
     indexed_gate_bf16_,
+    indexed_gate_bf16_cpu_,
     indexed_scale_shift_bf16_,
 )
 from sglang.kernels.ops.layernorm.norm import fused_inplace_qknorm
@@ -128,6 +130,7 @@ def _diffusers_h3_checkpoint(
 
 _BF16_DTYPE = torch.bfloat16
 _FP32_DTYPE = torch.float32
+_FORCE_CPU_INDEXED_GATE_FALLBACK_ENV = "SGLANG_MINIMAX_H3_INDEXED_GATE_FORCE_FALLBACK"
 _MPS_MLP_TOKEN_CHUNK_SIZE = 128
 # keep MPS activation chunks below the allocator high-watermark; CUDA keeps
 # its fused full-sequence projection
@@ -385,6 +388,14 @@ def _modulate_gate(
         if allow_inplace:
             return indexed_gate_bf16_(x, gate, other, indices)
         return indexed_gate_bf16(x, gate, other, indices)
+    if (
+        allow_inplace
+        and not envs.SGLANG_MINIMAX_H3_INDEXED_GATE_FORCE_FALLBACK
+        and not torch.compiler.is_compiling()
+        and dtype == _BF16_DTYPE
+        and can_use_indexed_gate_bf16_cpu(x, gate, other, indices)
+    ):
+        return indexed_gate_bf16_cpu_(x, gate, other, indices)
     return (x + gate.index_select(0, indices) * other).to(dtype)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve CPU inference performance for diffusion models by adding a fused BF16 indexed gate operation. The operation computes `x + gate[index] * other` and is used in MiniMax H3 modulation workloads, where the current implementation requires an indexed gather followed by elementwise operations.

## Modifications

- Add a fused CPU BF16 indexed gate kernel.
- Perform the gated residual computation in place.
- Support both `int32` and `int64` indices.
- Validate indexed rows and report out-of-range indices.
- Register the new operator in the CPU AOT kernel extension.
- Add CPU input eligibility checks for device, dtype, shape, layout, and index type.
- Route eligible CPU inputs through the fused operator.
- Preserve the existing CUDA path and eager fallback behavior.
- Avoid using the custom operator during Torch compilation.
- Add unit tests for:
  - Numerical parity with the PyTorch fallback.
  - `int32` and `int64` indices.
  - Repeated and non-monotonic indices.
  - Empty inputs.
  - Out-of-range indices.
  - Forced fallback behavior.
  - Unsupported tensor layouts.
  - Torch compile compatibility.
  - In-place output semantics.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33529203064](https://github.com/sgl-project/sglang/actions/runs/33529203064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33529203038](https://github.com/sgl-project/sglang/actions/runs/33529203038)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33529202974](https://github.com/sgl-project/sglang/actions/runs/33529202974)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->