### PR TITLE
[diffusion][cpu] add fused indexed-scale-shift-bf16 kernel

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/indexed_modulation.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/indexed_modulation.cpp
@@ -1,0 +1,124 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+template <typename index_t>
+void validate_indices_in_range(
+    const index_t* __restrict__ indices, int64_t rows, int64_t table_rows) {
+  for (int64_t row = 0; row < rows; ++row) {
+    const int64_t idx = static_cast<int64_t>(indices[row]);
+    TORCH_CHECK(
+        idx >= 0 && idx < table_rows,
+        "indexed_scale_shift_bf16_: indices[",
+        row,
+        "] = ",
+        idx,
+        " out of range for table rows ",
+        table_rows);
+  }
+}
+
+template <typename index_t>
+void indexed_scale_shift_bf16_kernel_impl(
+    at::BFloat16* __restrict__ x,
+    const at::BFloat16* __restrict__ shift,
+    const at::BFloat16* __restrict__ scale,
+    const index_t* __restrict__ indices,
+    int64_t rows,
+    int64_t hidden_size,
+    int64_t x_stride_row,
+    int64_t shift_stride_row,
+    int64_t scale_stride_row) {
+  using bVec = at::vec::Vectorized<at::BFloat16>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();
+
+  at::parallel_for(0, rows, 0, [&](int64_t begin, int64_t end) {
+    const fVec one_vec(1.0f);
+    for (int64_t row = begin; row < end; ++row) {
+      const int64_t idx = static_cast<int64_t>(indices[row]);
+      at::BFloat16* x_ptr = x + row * x_stride_row;
+      const at::BFloat16* shift_ptr = shift + idx * shift_stride_row;
+      const at::BFloat16* scale_ptr = scale + idx * scale_stride_row;
+
+      int64_t d = 0;
+#pragma GCC unroll 4
+      for (; d <= hidden_size - kVecSize; d += kVecSize) {
+        auto [x_fvec0, x_fvec1] = load_float_vec2(x_ptr + d);
+        auto [shift_fvec0, shift_fvec1] = load_float_vec2(shift_ptr + d);
+        auto [scale_fvec0, scale_fvec1] = load_float_vec2(scale_ptr + d);
+        auto one_plus_scale_bf16 = convert_from_float_ext<at::BFloat16>(
+            scale_fvec0 + one_vec, scale_fvec1 + one_vec);
+        fVec one_plus_scale_fvec0, one_plus_scale_fvec1;
+        std::tie(one_plus_scale_fvec0, one_plus_scale_fvec1) =
+            at::vec::convert_to_float(one_plus_scale_bf16);
+        auto scaled_bf16 = convert_from_float_ext<at::BFloat16>(
+            x_fvec0 * one_plus_scale_fvec0, x_fvec1 * one_plus_scale_fvec1);
+        fVec scaled_fvec0, scaled_fvec1;
+        std::tie(scaled_fvec0, scaled_fvec1) = at::vec::convert_to_float(scaled_bf16);
+        auto output_bf16 = convert_from_float_ext<at::BFloat16>(
+            scaled_fvec0 + shift_fvec0, scaled_fvec1 + shift_fvec1);
+        output_bf16.store(x_ptr + d);
+      }
+#pragma GCC unroll 4
+      for (; d < hidden_size; ++d) {
+        const float scale_rounded = static_cast<float>(static_cast<at::BFloat16>(
+            1.0f + static_cast<float>(scale_ptr[d])));
+        const float scaled = static_cast<float>(static_cast<at::BFloat16>(
+            static_cast<float>(x_ptr[d]) * scale_rounded));
+        x_ptr[d] = static_cast<at::BFloat16>(scaled + static_cast<float>(shift_ptr[d]));
+      }
+    }
+  });
+}
+
+}  // namespace
+
+at::Tensor indexed_scale_shift_bf16_cpu_impl(
+    at::Tensor& x,
+    const at::Tensor& shift,
+    const at::Tensor& scale,
+    const at::Tensor& indices) {
+  CHECK_INPUT(x);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(shift);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(scale);
+  CHECK_INPUT(indices);
+  CHECK_DIM(2, x);
+  CHECK_DIM(2, shift);
+  CHECK_DIM(2, scale);
+  CHECK_DIM(1, indices);
+  TORCH_CHECK(x.scalar_type() == at::kBFloat16, "x must be bfloat16");
+  TORCH_CHECK(shift.scalar_type() == at::kBFloat16, "shift must be bfloat16");
+  TORCH_CHECK(scale.scalar_type() == at::kBFloat16, "scale must be bfloat16");
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt || indices.scalar_type() == at::kLong,
+      "indices must be int32 or int64");
+  CHECK_EQ(x.size(0), indices.size(0));
+  CHECK_EQ(shift.size(0), scale.size(0));
+  CHECK_EQ(shift.size(1), scale.size(1));
+  CHECK_EQ(x.size(1), shift.size(1));
+
+  const int64_t rows = x.size(0);
+  if (rows == 0) {
+    return x;
+  }
+  const int64_t table_rows = shift.size(0);
+  const int64_t hidden_size = x.size(1);
+  if (indices.scalar_type() == at::kInt) {
+    const auto* indices_ptr = indices.data_ptr<int32_t>();
+    validate_indices_in_range(indices_ptr, rows, table_rows);
+    indexed_scale_shift_bf16_kernel_impl(
+        x.data_ptr<at::BFloat16>(), shift.data_ptr<at::BFloat16>(),
+        scale.data_ptr<at::BFloat16>(), indices_ptr, rows, hidden_size,
+        x.stride(0), shift.stride(0), scale.stride(0));
+  } else {
+    const auto* indices_ptr = indices.data_ptr<int64_t>();
+    validate_indices_in_range(indices_ptr, rows, table_rows);
+    indexed_scale_shift_bf16_kernel_impl(
+        x.data_ptr<at::BFloat16>(), shift.data_ptr<at::BFloat16>(),
+        scale.data_ptr<at::BFloat16>(), indices_ptr, rows, hidden_size,
+        x.stride(0), shift.stride(0), scale.stride(0));
+  }
+  return x;
+}

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -30,6 +30,13 @@ at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
 // fused_sigmoid_mul
 void fused_sigmoid_mul_cpu(at::Tensor& input, const at::Tensor& gate);
 
+// indexed modulation
+at::Tensor indexed_scale_shift_bf16_cpu_impl(
+    at::Tensor& x,
+    const at::Tensor& shift,
+    const at::Tensor& scale,
+    const at::Tensor& indices);
+
 // l2norm
 at::Tensor l2norm_cpu(at::Tensor& input, double eps);
 
@@ -582,6 +589,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("gelu_and_mul_cpu", torch::kCPU, &gelu_and_mul_cpu);
   m.def("fused_sigmoid_mul_cpu(Tensor(a!) input, Tensor gate) -> ()");
   m.impl("fused_sigmoid_mul_cpu", torch::kCPU, &fused_sigmoid_mul_cpu);
+
+    m.def(
+            "indexed_scale_shift_bf16_(Tensor(a!) x, Tensor shift, Tensor scale, Tensor indices) -> Tensor(a!)");
+    m.impl("indexed_scale_shift_bf16_", torch::kCPU, &indexed_scale_shift_bf16_cpu_impl);
 
   // norm
   m.def("rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");

--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -464,6 +464,7 @@ _EXPORTS: dict[str, str] = {
     "indexed_gate_bf16": "modulate.indexed_modulation_triton",
     "indexed_gate_bf16_": "modulate.indexed_modulation_triton",
     "indexed_scale_shift_bf16_": "modulate.indexed_modulation_triton",
+    "can_use_indexed_scale_shift_bf16_cpu": "modulate.indexed_modulation_triton",
     "ltx2_ada_values9": "modulate.ltx2_ada_values_triton",
     "can_use_modulate_scale_shift_cuda": "modulate.modulate_scale_shift_jit",
     "modulate_scale_shift": "modulate.modulate_scale_shift_jit",

--- a/python/sglang/kernels/ops/diffusion/modulate/indexed_modulation_triton.py
+++ b/python/sglang/kernels/ops/diffusion/modulate/indexed_modulation_triton.py
@@ -83,6 +83,47 @@ def _indexed_gate_bf16_kernel(
     )
 
 
+def _is_compiling() -> bool:
+    return torch.compiler.is_compiling()
+
+
+def can_use_indexed_scale_shift_bf16_cpu(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> bool:
+    return (
+        not _is_compiling()
+        and x.device.type == shift.device.type == scale.device.type == indices.device.type == "cpu"
+        and x.dtype == shift.dtype == scale.dtype == torch.bfloat16
+        and indices.dtype in (torch.int32, torch.int64)
+        and x.dim() == shift.dim() == scale.dim() == 2
+        and indices.dim() == 1
+        and x.is_contiguous()
+        and indices.is_contiguous()
+        and shift.stride(-1) == 1
+        and scale.stride(-1) == 1
+        and x.shape[0] == indices.shape[0]
+        and shift.shape == scale.shape
+        and x.shape[1] == shift.shape[1]
+    )
+
+
+def _eager_indexed_scale_shift_bf16_(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    x.copy_(
+        (x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)).to(
+            x.dtype
+        )
+    )
+    return x
+
+
 def indexed_scale_shift_bf16_(
     x: torch.Tensor,
     shift: torch.Tensor,
@@ -92,22 +133,22 @@ def indexed_scale_shift_bf16_(
     rows, hidden_size = x.shape
     if rows == 0:
         return x
-    block_n = triton.next_power_of_2(hidden_size)
-    _indexed_scale_shift_bf16_kernel[(rows,)](
-        x,
-        x,
-        shift,
-        scale,
-        indices,
-        hidden_size,
-        x.stride(0),
-        shift.stride(0),
-        scale.stride(0),
-        indices.stride(0),
-        BLOCK_N=block_n,
-        num_warps=8,
-    )
-    return x
+    if _is_compiling():
+        return _eager_indexed_scale_shift_bf16_(x, shift, scale, indices)
+    if x.is_cuda:
+        block_n = triton.next_power_of_2(hidden_size)
+        _indexed_scale_shift_bf16_kernel[(rows,)](
+            x, x, shift, scale, indices, hidden_size, x.stride(0), shift.stride(0),
+            scale.stride(0), indices.stride(0), BLOCK_N=block_n, num_warps=8
+        )
+        return x
+    if can_use_indexed_scale_shift_bf16_cpu(x, shift, scale, indices):
+        import sgl_kernel  # noqa: F401
+
+        return torch.ops.sgl_kernel.indexed_scale_shift_bf16_(
+            x, shift, scale, indices
+        )
+    return _eager_indexed_scale_shift_bf16_(x, shift, scale, indices)
 
 
 def _indexed_gate_bf16(

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -24,6 +24,7 @@ from sglang.kernels.ops.activation.activation import (
     silu_and_mul_with_activation_rounding_,
 )
 from sglang.kernels.ops.diffusion import (
+    can_use_indexed_scale_shift_bf16_cpu,
     can_use_fused_inplace_qknorm_rope,
     fused_inplace_qknorm_rope,
     indexed_gate_bf16,
@@ -349,12 +350,15 @@ def _modulate_scale_shift(
     """Apply indexed affine modulation, reusing disposable CUDA BF16 input."""
     # Apply per-index affine modulation: x * (1 + scale[idx]) + shift[idx].
     if (
-        x.is_cuda
-        and x.dtype == _BF16_DTYPE
+        x.dtype == _BF16_DTYPE
         and dtype == _BF16_DTYPE
         and shift.dtype == _BF16_DTYPE
         and scale.dtype == _BF16_DTYPE
         and x.is_contiguous()
+        and (
+            x.is_cuda
+            or can_use_indexed_scale_shift_bf16_cpu(x, shift, scale, indices)
+        )
     ):
         return indexed_scale_shift_bf16_(x, shift, scale, indices)
     return (

--- a/test/registered/cpu/test_indexed_scale_shift_cpu.py
+++ b/test/registered/cpu/test_indexed_scale_shift_cpu.py
@@ -1,0 +1,73 @@
+import pytest
+import sgl_kernel  # noqa: F401
+import torch
+
+from sglang.kernels.ops.diffusion.modulate.indexed_modulation_triton import (
+    can_use_indexed_scale_shift_bf16_cpu,
+    indexed_scale_shift_bf16_,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-b-test-cpu")
+
+
+def _make_chunk_view(rows: int, hidden: int, chunk_index: int) -> torch.Tensor:
+    storage = torch.randn(rows, hidden * 6, dtype=torch.bfloat16)
+    return storage.chunk(6, dim=-1)[chunk_index]
+
+
+def _reference(x, shift, scale, indices):
+    gathered_scale = scale.index_select(0, indices)
+    gathered_shift = shift.index_select(0, indices)
+    one_plus_scale = (1.0 + gathered_scale.float()).to(torch.bfloat16)
+    scaled = (x.float() * one_plus_scale.float()).to(torch.bfloat16)
+    return (scaled.float() + gathered_shift.float()).to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_indexed_scale_shift_cpu_exact_bf16_parity(index_dtype):
+    rows, hidden, table_rows = 257, 5376, 19
+    x = torch.randn(rows, hidden, dtype=torch.bfloat16)
+    shift = _make_chunk_view(table_rows, hidden, 1)
+    scale = _make_chunk_view(table_rows, hidden, 4)
+    indices = torch.randint(0, table_rows, (rows,), dtype=index_dtype)
+    assert can_use_indexed_scale_shift_bf16_cpu(x, shift, scale, indices)
+
+    out = x.clone()
+    result = indexed_scale_shift_bf16_(out, shift, scale, indices)
+    assert result.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out.view(torch.int16), _reference(x, shift, scale, indices).view(torch.int16))
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_indexed_scale_shift_cpu_zero_rows_noop(index_dtype):
+    hidden = 5376
+    x = torch.empty((0, hidden), dtype=torch.bfloat16)
+    shift = _make_chunk_view(4, hidden, 0)
+    scale = _make_chunk_view(4, hidden, 2)
+    indices = torch.empty((0,), dtype=index_dtype)
+    result = indexed_scale_shift_bf16_(x, shift, scale, indices)
+    assert result.data_ptr() == x.data_ptr()
+    assert result.shape == x.shape
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_indexed_scale_shift_cpu_out_of_range_raises(index_dtype):
+    x = torch.randn(8, 64, dtype=torch.bfloat16)
+    shift = _make_chunk_view(3, 64, 0)
+    scale = _make_chunk_view(3, 64, 1)
+    indices = torch.tensor([0, 1, 2, 0, 1, 2, 3, 0], dtype=index_dtype)
+    with pytest.raises(RuntimeError, match=r"indices\[6\].*out of range"):
+        torch.ops.sgl_kernel.indexed_scale_shift_bf16_(x, shift, scale, indices)
+
+
+def test_indexed_scale_shift_cpu_rejects_strided_table():
+    x = torch.randn(33, 96, dtype=torch.bfloat16)
+    shift = torch.randn(7, 192, dtype=torch.bfloat16)[:, ::2]
+    scale = torch.randn(7, 192, dtype=torch.bfloat16)[:, ::2]
+    indices = torch.randint(0, 7, (33,), dtype=torch.int64)
+    assert not can_use_indexed_scale_shift_bf16_cpu(x, shift, scale, indices)
+    expected = _reference(x, shift, scale, indices)
+    result = indexed_scale_shift_bf16_(x, shift, scale, indices)
+    assert result.data_ptr() == x.data_ptr()
+    torch.testing.assert_close(x, expected, atol=0, rtol=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve CPU inference performance for diffusion model modulation by adding a fused BF16 indexed scale-shift operation. The operation computes `x * (1 + scale[index]) + shift[index]`, avoiding separate indexed gathers and elementwise PyTorch operations.

## Modifications

- Add a fused CPU BF16 indexed scale-shift kernel.
- Perform the operation in place.
- Support both `int32` and `int64` indices.
- Preserve BF16 rounding behavior for scale addition and multiplication.
- Validate indexed rows and report out-of-range indices.
- Support modulation tables whose last dimension is contiguous, including valid strided table views.
- Register the new operator in the CPU AOT kernel extension.
- Add CPU eligibility checks for device, dtype, shape, layout, and index type.
- Route eligible CPU inputs through the fused operator.
- Preserve the existing CUDA path and eager fallback behavior.
- Avoid using the custom operator during Torch compilation.
- Add unit tests for:
  - Exact BF16 parity with the reference implementation.
  - `int32` and `int64` indices.
  - Empty inputs.
  - Out-of-range indices.
  - Unsupported table layouts.
  - In-place output semantics.
  - Torch compile fallback behavior.
 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33529265969](https://github.com/sgl-project/sglang/actions/runs/33529265969)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33529265690](https://github.com/sgl-project/sglang/actions/runs/33529265690)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33529266067](https://github.com/sgl-project/sglang/actions/runs/33529266067)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->