### PR TITLE
perf(grpc): skip unused output detokenization

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -2242,6 +2242,7 @@ class MMReceiverBase(ABC):
             top_logprobs_num=recv_req.top_logprobs_num,
             token_ids_logprob=recv_req.token_ids_logprob,
             stream=recv_req.stream,
+            output_text_required=recv_req.output_text_required,
             lora_id=recv_req.lora_id,
             input_embeds=recv_req.input_embeds,
             custom_logit_processor=recv_req.custom_logit_processor,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -265,12 +265,29 @@ class RuntimeHandle:
         }
         return self._openai_serving_classes
 
+    def _observability_requires_output_text(self, obj) -> bool:
+        """Keep text for enabled internal consumers that can record it."""
+        request_logger = self.tokenizer_manager.request_logger
+        if request_logger.log_requests and request_logger.log_requests_level >= 2:
+            return True
+
+        if obj.log_metrics and (
+            self.tokenizer_manager.dump_requests_folder
+            or self.tokenizer_manager.crash_dump_folder
+        ):
+            return True
+
+        return (
+            self.tokenizer_manager.request_metrics_exporter_manager.exporter_enabled()
+        )
+
     def submit_request(
         self,
         *,
         req_type: str,
         req_dict: dict,
         chunk_callback,
+        output_text_required: bool = True,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         mock_request = (
@@ -282,6 +299,11 @@ class RuntimeHandle:
             from sglang.srt.managers.io_struct import GenerateReqInput
 
             obj = GenerateReqInput(**req_dict)
+            # Private bridge-only state. It is intentionally not part of the
+            # public GenerateReqInput schema.
+            obj._output_text_required = (
+                output_text_required or self._observability_requires_output_text(obj)
+            )
             stream = req_dict.get("stream", False)
             self._submit_on_tm_loop(
                 self._run_generate(obj, chunk_callback, stream, mock_request)

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -298,13 +298,19 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             results[i] = text
         return results
 
-    def _decode_batch_token_id_output(self, recv_obj: BatchTokenIDOutput):
+    def _decode_batch_token_id_output(
+        self,
+        recv_obj: BatchTokenIDOutput,
+        decode_indices: Optional[List[int]] = None,
+    ):
         bs = len(recv_obj.rids)
         vocab_size = self.vocab_size
+        if decode_indices is None:
+            decode_indices = list(range(bs))
 
         # Initialize decode status
         read_ids, surr_ids = [], []
-        for i in range(bs):
+        for i in decode_indices:
             rid = recv_obj.rids[i]
             if rid not in self.decode_status:
                 s = DecodeStatus(
@@ -335,13 +341,13 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         if not self.disable_tokenizer_batch_decode:
             surr_texts = self._grouped_batch_decode(
                 surr_ids,
-                recv_obj.skip_special_tokens,
-                recv_obj.spaces_between_special_tokens,
+                [recv_obj.skip_special_tokens[i] for i in decode_indices],
+                [recv_obj.spaces_between_special_tokens[i] for i in decode_indices],
             )
             read_texts = self._grouped_batch_decode(
                 read_ids,
-                recv_obj.skip_special_tokens,
-                recv_obj.spaces_between_special_tokens,
+                [recv_obj.skip_special_tokens[i] for i in decode_indices],
+                [recv_obj.spaces_between_special_tokens[i] for i in decode_indices],
             )
         else:
             # Do not use batch decode to prevent some detokenization edge cases (e.g., gpt-oss).
@@ -351,8 +357,8 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                 )
                 for surr, skip, space in zip(
                     surr_ids,
-                    recv_obj.skip_special_tokens,
-                    recv_obj.spaces_between_special_tokens,
+                    (recv_obj.skip_special_tokens[i] for i in decode_indices),
+                    (recv_obj.spaces_between_special_tokens[i] for i in decode_indices),
                 )
             ]
             read_texts = [
@@ -361,14 +367,14 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                 )
                 for read, skip, space in zip(
                     read_ids,
-                    recv_obj.skip_special_tokens,
-                    recv_obj.spaces_between_special_tokens,
+                    (recv_obj.skip_special_tokens[i] for i in decode_indices),
+                    (recv_obj.spaces_between_special_tokens[i] for i in decode_indices),
                 )
             ]
 
         # Incremental decoding
-        output_strs = []
-        for i in range(bs):
+        output_strs = [""] * bs
+        for decoded_i, i in enumerate(decode_indices):
             rid = recv_obj.rids[i]
             try:
                 s = self.decode_status[rid]
@@ -381,7 +387,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                     f"The current value is {DETOKENIZER_MAX_STATES}. "
                     "For more details, see: https://github.com/sgl-project/sglang/issues/2812"
                 )
-            new_text = read_texts[i][len(surr_texts[i]) :]
+            new_text = read_texts[decoded_i][len(surr_texts[decoded_i]) :]
             if recv_obj.finished_reasons[i] is None:
                 # Streaming. Invariant: sent_offset >= decoded_text_len. The
                 # gap (`pending`) is "printable but uncommitted" text emitted
@@ -394,14 +400,14 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                     s.surr_offset = s.read_offset
                     s.read_offset = len(s.decode_ids)
                     s.sent_offset = s.decoded_text_len
-                    output_strs.append(new_text[pending:] if pending else new_text)
+                    output_strs[i] = new_text[pending:] if pending else new_text
                 else:
                     # Incomplete UTF-8: emit the printable prefix only; do not
                     # commit (token offsets stay so the next iteration retries
                     # with more tokens).
                     printable = find_printable_text(new_text)
                     s.sent_offset = s.decoded_text_len + len(printable)
-                    output_strs.append(printable[pending:] if pending else printable)
+                    output_strs[i] = printable[pending:] if pending else printable
                 continue
 
             if rid in self.decode_status:
@@ -415,9 +421,32 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             )
             incremental_output = output_str[s.sent_offset :]
             s.sent_offset = len(output_str)
-            output_strs.append(incremental_output)
+            output_strs[i] = incremental_output
 
         return output_strs
+
+    @staticmethod
+    def _get_output_text_required(
+        recv_obj: BatchTokenIDOutput,
+    ) -> Optional[List[bool]]:
+        """Return a valid aligned mask, or None for the safe decode fallback."""
+        mask = recv_obj.output_text_required
+        if (
+            not isinstance(mask, list)
+            or len(mask) != len(recv_obj.rids)
+            or any(type(value) is not bool for value in mask)
+        ):
+            return None
+        return mask
+
+    def _cleanup_token_only_decode_status(
+        self, recv_obj: BatchTokenIDOutput, mask: List[bool]
+    ) -> None:
+        # Normally token-only rows never have DecodeStatus. Cleanup also makes
+        # recovery safe if an earlier malformed mask used the decode fallback.
+        for i, output_text_required in enumerate(mask):
+            if not output_text_required and recv_obj.finished_reasons[i] is not None:
+                self.decode_status.pop(recv_obj.rids[i], None)
 
     @staticmethod
     def _b64_encode_per_request(
@@ -441,19 +470,45 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
     def handle_batch_token_id_out(self, recv_obj: BatchTokenIDOutput):
         # Beam decoding is additive: a batch may mix beam leaders with normal
         # requests, so every item still goes through the standard decode.
-        if is_beam_search_batch(recv_obj):
+        is_beam_batch = is_beam_search_batch(recv_obj)
+        if is_beam_batch:
             decode_beam_search_output(
                 recv_obj,
                 tokenizer=self.tokenizer,
                 disable_batch_decode=self.disable_tokenizer_batch_decode,
                 trim_matched_stop=self.trim_matched_stop,
             )
+
+        output_text_required = self._get_output_text_required(recv_obj)
+        if is_beam_batch:
+            # Keep the established beam decode path until token-only beam
+            # output has its own explicit response contract.
+            output_text_required = None
+        elif (
+            len(recv_obj.rids) > 0
+            and output_text_required is not None
+            and not any(output_text_required)
+        ):
+            self._cleanup_token_only_decode_status(recv_obj, output_text_required)
+            return recv_obj
+
         # If handling idle batch, set output_strs to [].
         output_strs = (
-            self._decode_batch_token_id_output(recv_obj)
+            self._decode_batch_token_id_output(
+                recv_obj,
+                (
+                    None
+                    if output_text_required is None or all(output_text_required)
+                    else [
+                        i for i, required in enumerate(output_text_required) if required
+                    ]
+                ),
+            )
             if len(recv_obj.rids) > 0
             else []
         )
+        if output_text_required is not None:
+            self._cleanup_token_only_decode_status(recv_obj, output_text_required)
         routed_experts = self._b64_encode_per_request(recv_obj.routed_experts)
         indexer_topk = self._b64_encode_per_request(recv_obj.indexer_topk)
         return BatchStrOutput(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -965,6 +965,9 @@ class GenerateReqInput:
                 else None
             ),
         )
+        # Preserve private response-shaping state when batch normalization or
+        # parallel sampling materializes an individual request.
+        sub._output_text_required = getattr(self, "_output_text_required", True)
         cache[i] = sub
         return sub
 
@@ -1067,6 +1070,10 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
+
+    # Internal response shaping. Appended for array-like IPC compatibility.
+    # False means the downstream caller consumes token IDs without output text.
+    output_text_required: bool = True
 
     def wrap_pickle_fields(self):
         self.time_stats = wrap_as_pickle(self.time_stats)
@@ -1429,7 +1436,7 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     decoded_texts: List[str]
     decode_ids: List[array]  # List[array[int]]
     read_offsets: List[int]
-    # Only used when `--skip-tokenizer-init` is on
+    # Used by skip-tokenizer-init and internal token-only response paths.
     output_ids: Optional[List[array]]  # Optional[List[array[int]]]
     # Detokenization configs
     skip_special_tokens: List[bool]
@@ -1526,6 +1533,10 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     input_top_logprobs_val_flat: Optional[List[Optional[np.ndarray]]] = None
     input_top_logprobs_idx_flat: Optional[List[Optional[np.ndarray]]] = None
     input_top_logprobs_flat_null_prefix: Optional[List[Optional[int]]] = None
+
+    # Per-request response shaping. Appended for array-like IPC compatibility.
+    # None is the safe fallback and means every row must be detokenized.
+    output_text_required: Optional[List[bool]] = None
 
 
 class BatchStrOutput(BaseBatchReq, kw_only=True):

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -179,6 +179,9 @@ def _handle_output_by_index(output, i):
             decode_ids=_extract_field_by_index(output, "decode_ids", i),
             read_offsets=_extract_field_by_index(output, "read_offsets", i),
             output_ids=_extract_field_by_index(output, "output_ids", i),
+            output_text_required=_extract_field_by_index(
+                output, "output_text_required", i
+            ),
             skip_special_tokens=_extract_field_by_index(
                 output, "skip_special_tokens", i
             ),

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -950,6 +950,7 @@ class Req(ReqDllmMixin):
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
         cache_salt: Optional[str] = None,
+        output_text_required: bool = True,
     ):
         # Input and output info
         self.rid = rid
@@ -1041,6 +1042,7 @@ class Req(ReqDllmMixin):
         # Note: We should never set finished_reason in the middle, the req will get filtered and never respond
         self.to_finish: Optional[BaseFinishReason] = None
         self.stream = stream
+        self.output_text_required = output_text_required
         self.eos_token_ids = eos_token_ids
         self.vocab_size = vocab_size
         self.priority = priority

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2621,6 +2621,7 @@ class Scheduler(
                 return_sampling_mask=recv_req.return_sampling_mask,
                 return_flat_raw_top_logprobs=recv_req.return_flat_raw_top_logprobs,
                 stream=recv_req.stream,
+                output_text_required=recv_req.output_text_required,
                 lora_id=recv_req.lora_id,
                 session_id=recv_req.session_id,
                 input_embeds=recv_req.input_embeds,
@@ -2727,6 +2728,7 @@ class Scheduler(
                 recv_req.sampling_params,
                 vocab_size=self.model_config.vocab_size,
                 http_worker_ipc=recv_req.http_worker_ipc,
+                output_text_required=recv_req.output_text_required,
             )
             req.tokenizer = self.tokenizer
             req.set_finish_with_abort(error_msg)

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -331,6 +331,7 @@ class _GenerationStreamAccumulator:
     decode_ids_list: list = field(default_factory=list)
     read_offsets: list = field(default_factory=list)
     output_ids: list = field(default_factory=list)
+    output_text_required: list = field(default_factory=list)
     skip_special_tokens: list = field(default_factory=list)
     spaces_between_special_tokens: list = field(default_factory=list)
     no_stop_trim: list = field(default_factory=list)
@@ -458,6 +459,7 @@ class _GenerationStreamAccumulator:
         # Exclude the tokens after stop condition
         output_ids_ = req.output_ids_through_stop
         self.output_ids.append(output_ids_[send_token_offset:])
+        self.output_text_required.append(req.output_text_required)
         req.send_token_offset = len(output_ids_)
         self.prompt_tokens.append(len(req.origin_input_ids))
         # Index-aligned with the batch items so mixed batches resolve per-item
@@ -476,11 +478,18 @@ class _GenerationStreamAccumulator:
             # block. The parallel lists stay empty; the payload goes straight to
             # `push_generation`, which only indexes the fields appended above.
             self.http_worker_ipcs.append(req.http_worker_ipc)
-            self.decoded_texts.append(req.decoded_text)
-            decode_ids, read_offset = req.init_incremental_detokenize()
-            self.decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
-            req.send_decode_id_offset = len(decode_ids)
-            self.read_offsets.append(read_offset)
+            if req.output_text_required:
+                self.decoded_texts.append(req.decoded_text)
+                decode_ids, read_offset = req.init_incremental_detokenize()
+                self.decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
+                req.send_decode_id_offset = len(decode_ids)
+                self.read_offsets.append(read_offset)
+            else:
+                # Keep the payload arrays aligned without creating scheduler
+                # or detokenizer incremental-decode state.
+                self.decoded_texts.append("")
+                self.decode_ids_list.append(req.output_ids[:0])
+                self.read_offsets.append(0)
             self.skip_special_tokens.append(req.sampling_params.skip_special_tokens)
             self.spaces_between_special_tokens.append(
                 req.sampling_params.spaces_between_special_tokens
@@ -708,6 +717,7 @@ class _GenerationStreamAccumulator:
             decode_ids=self.decode_ids_list,
             read_offsets=self.read_offsets,
             output_ids=self.output_ids,
+            output_text_required=self.output_text_required,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
             no_stop_trim=self.no_stop_trim,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1388,6 +1388,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 return_sampling_mask=obj.return_sampling_mask,
                 return_flat_raw_top_logprobs=obj.return_flat_raw_top_logprobs,
                 stream=obj.stream,
+                output_text_required=getattr(obj, "_output_text_required", True),
                 rid=obj.rid,
                 http_worker_ipc=obj.http_worker_ipc,
                 bootstrap_host=obj.bootstrap_host,
@@ -2330,7 +2331,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             if beam_out_dict is not None:
                 out_dict = beam_out_dict
-            elif isinstance(recv_obj, BatchStrOutput):
+            elif isinstance(recv_obj, BatchStrOutput) and getattr(
+                state.obj, "_output_text_required", True
+            ):
                 # Not all request types have `stream` (e.g., EmbeddingReqInput). Default to non-streaming.
                 is_stream = getattr(state.obj, "stream", False)
                 incremental = is_stream and self.incremental_streaming_output
@@ -2379,7 +2382,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     out_dict = None
                 if out_dict is not None and state.prompt_token_ids is not None:
                     out_dict["prompt_token_ids"] = state.prompt_token_ids
-            elif isinstance(recv_obj, BatchTokenIDOutput):
+            elif isinstance(recv_obj, (BatchStrOutput, BatchTokenIDOutput)):
                 is_stream = getattr(state.obj, "stream", False)
                 incremental = is_stream and self.incremental_streaming_output
                 delta_output_ids = list(recv_obj.output_ids[i])

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -299,6 +299,7 @@ class Session:
             session=self,
             custom_logit_processor=req.custom_logit_processor,
             stream=req.stream,
+            output_text_required=req.output_text_required,
             return_logprob=req.return_logprob,
             top_logprobs_num=req.top_logprobs_num,
             token_ids_logprob=req.token_ids_logprob,

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -183,6 +183,16 @@ impl PyBridge {
         req_type: &str,
         req_dict: HashMap<String, serde_json::Value>,
     ) -> PyResult<Receiver<ResponseChunk>> {
+        self.submit_request_with_output_mode(rid, req_type, req_dict, true)
+    }
+
+    pub(crate) fn submit_request_with_output_mode(
+        &self,
+        rid: &str,
+        req_type: &str,
+        req_dict: HashMap<String, serde_json::Value>,
+        output_text_required: bool,
+    ) -> PyResult<Receiver<ResponseChunk>> {
         let receiver = self.create_channel(rid)?;
         let rid_owned = rid.to_string();
 
@@ -194,6 +204,7 @@ impl PyBridge {
             kwargs.set_item("req_type", req_type)?;
             kwargs.set_item("req_dict", py_req_dict)?;
             kwargs.set_item("chunk_callback", callback)?;
+            kwargs.set_item("output_text_required", output_text_required)?;
 
             self.runtime_handle
                 .call_method(py, "submit_request", (), Some(&kwargs))?;

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -302,7 +302,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let mut receiver = self
             .bridge
-            .submit_request(&rid, "generate", req_dict)
+            .submit_request_with_output_mode(&rid, "generate", req_dict, false)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -111,5 +111,78 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
 
 
+class TestNativeGrpcOutputShape(CustomTestCase):
+    @staticmethod
+    def _submit_generate(*, tokenizer_manager=None, **kwargs):
+        handle = RuntimeHandle.__new__(RuntimeHandle)
+        handle.tokenizer_manager = tokenizer_manager or SimpleNamespace(
+            request_logger=SimpleNamespace(log_requests=False, log_requests_level=0),
+            dump_requests_folder="",
+            crash_dump_folder="",
+            request_metrics_exporter_manager=SimpleNamespace(
+                exporter_enabled=lambda: False
+            ),
+        )
+        captured = []
+
+        async def capture(obj, chunk_callback, stream, request):
+            captured.append(obj)
+
+        handle._run_generate = capture
+        handle._submit_on_tm_loop = asyncio.run
+        handle.submit_request(
+            req_type="generate",
+            req_dict={"input_ids": [1], "sampling_params": {}, "stream": True},
+            chunk_callback=_RecordingCallback(),
+            **kwargs,
+        )
+        return captured[0]
+
+    def test_submit_request_marks_token_id_generate_no_text(self):
+        obj = self._submit_generate(output_text_required=False)
+
+        self.assertFalse(obj._output_text_required)
+
+    def test_submit_request_defaults_to_text_required(self):
+        obj = self._submit_generate()
+
+        self.assertTrue(obj._output_text_required)
+
+    def test_internal_output_consumers_keep_text(self):
+        cases = {
+            "request logging": {
+                "request_logger": SimpleNamespace(
+                    log_requests=True, log_requests_level=2
+                )
+            },
+            "request dump": {"dump_requests_folder": "/dump"},
+            "crash dump": {"crash_dump_folder": "/crash"},
+            "metrics exporter": {
+                "request_metrics_exporter_manager": SimpleNamespace(
+                    exporter_enabled=lambda: True
+                )
+            },
+        }
+        for name, overrides in cases.items():
+            with self.subTest(name=name):
+                manager_config = {
+                    "request_logger": SimpleNamespace(
+                        log_requests=False, log_requests_level=0
+                    ),
+                    "dump_requests_folder": "",
+                    "crash_dump_folder": "",
+                    "request_metrics_exporter_manager": SimpleNamespace(
+                        exporter_enabled=lambda: False
+                    ),
+                }
+                manager_config.update(overrides)
+                manager = SimpleNamespace(**manager_config)
+                obj = self._submit_generate(
+                    tokenizer_manager=manager, output_text_required=False
+                )
+
+                self.assertTrue(obj._output_text_required)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -123,6 +123,26 @@ class TestTokenizedReqInputMsgpack(unittest.TestCase):
         )
         return decoded.mm_inputs
 
+    def test_output_text_required_round_trip(self):
+        decoded = self._round_trip(
+            TokenizedGenerateReqInput(
+                input_text="",
+                input_ids=array("q", [1]),
+                input_embeds=None,
+                mm_inputs=None,
+                token_type_ids=None,
+                sampling_params=SamplingParams(),
+                return_logprob=False,
+                logprob_start_len=0,
+                top_logprobs_num=0,
+                token_ids_logprob=None,
+                stream=True,
+                output_text_required=False,
+            )
+        )
+
+        self.assertFalse(decoded.output_text_required)
+
     def test_generate_mm_inputs_round_trip_without_pickle_wrapper(self):
         decoded = self._round_trip(
             TokenizedGenerateReqInput(
@@ -392,7 +412,20 @@ class TestTokenizedReqInputMsgpack(unittest.TestCase):
 
 
 class TestGenerateReqInputNormalization(CustomTestCase):
-    """Test the normalization of GenerateReqInput for batch processing and different input formats."""
+    """Test GenerateReqInput normalization for batches and input formats."""
+
+    def test_parallel_sampling_preserves_output_text_required(self):
+        req = GenerateReqInput(
+            text="Hello",
+            rid="token-only",
+            sampling_params={"n": 2},
+        )
+        req._output_text_required = False
+
+        req.normalize_batch_and_arguments()
+
+        self.assertFalse(req[0]._output_text_required)
+        self.assertFalse(req[1]._output_text_required)
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/unit/managers/test_output_streamer_customized_info.py
+++ b/test/registered/unit/managers/test_output_streamer_customized_info.py
@@ -26,6 +26,7 @@ class _FakeReq:
         customized_info=None,
         *,
         finished=False,
+        output_text_required=True,
     ):
         self.rid = rid
         self.http_worker_ipc = None
@@ -45,6 +46,7 @@ class _FakeReq:
         )
         self.output_ids = output_ids
         self.output_ids_through_stop = output_ids
+        self.output_text_required = output_text_required
         self.send_token_offset = 0
         self.send_output_token_logprobs_offset = 0
         self.send_decode_id_offset = 0
@@ -130,6 +132,21 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
             customized_info["other"],
             [[None, None], [None, None, None], [300]],
         )
+
+    def test_token_only_output_skips_incremental_decode_setup(self):
+        accumulator = _accumulator()
+        req = _FakeReq("r0", [10], output_text_required=False)
+        req.init_incremental_detokenize = Mock(
+            side_effect=AssertionError("token-only output must not initialize decode")
+        )
+
+        accumulator.accept(req=req)
+        payload = accumulator.to_payload(dp_rank=0, is_idle_batch=False)
+
+        self.assertEqual(payload.output_text_required, [False])
+        self.assertEqual(payload.decoded_texts, [""])
+        self.assertEqual(payload.decode_ids, [[]])
+        self.assertEqual(payload.read_offsets, [0])
 
     def test_additional_customized_info_uses_the_existing_payload(self):
         class Streamer(SchedulerOutputStreamer):

--- a/test/registered/unit/managers/test_output_streamer_logprobs.py
+++ b/test/registered/unit/managers/test_output_streamer_logprobs.py
@@ -28,6 +28,7 @@ class _FakeReq:
         )
         self.output_ids = []
         self.output_ids_through_stop = []
+        self.output_text_required = True
         self.send_token_offset = 0
         self.send_output_token_logprobs_offset = 0
         self.send_decode_id_offset = 0

--- a/test/registered/unit/managers/test_token_only_detokenization.py
+++ b/test/registered/unit/managers/test_token_only_detokenization.py
@@ -1,0 +1,118 @@
+import unittest
+from array import array
+
+from sglang.srt.managers.detokenizer_manager import DetokenizerManager
+from sglang.srt.managers.io_struct import BatchStrOutput, BatchTokenIDOutput
+from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeTokenizer:
+    is_fast = True
+
+    def __init__(self):
+        self.calls = []
+
+    def batch_decode(self, ids_list, **kwargs):
+        rows = [list(ids) for ids in ids_list]
+        self.calls.append(rows)
+        return [",".join(str(token_id) for token_id in row) for row in rows]
+
+
+def _make_manager():
+    manager = object.__new__(DetokenizerManager)
+    manager.tokenizer = _FakeTokenizer()
+    manager.vocab_size = 1024
+    manager.decode_status = {}
+    manager.disable_tokenizer_batch_decode = False
+    manager.is_tool_call_parser_gpt_oss = False
+    return manager
+
+
+def _make_output(mask):
+    n = 2
+    return BatchTokenIDOutput(
+        rids=["text", "tokens"],
+        http_worker_ipcs=["worker", "worker"],
+        finished_reasons=[None] * n,
+        decoded_texts=[""] * n,
+        decode_ids=[array("q", [65]), array("q", [66])],
+        read_offsets=[0] * n,
+        output_ids=[array("q", [65]), array("q", [66])],
+        output_text_required=mask,
+        skip_special_tokens=[True] * n,
+        spaces_between_special_tokens=[True] * n,
+        no_stop_trim=[False] * n,
+        prompt_tokens=[1] * n,
+        reasoning_tokens=[0] * n,
+        completion_tokens=[1] * n,
+        cached_tokens=[0] * n,
+        input_token_logprobs_val=[[], []],
+        input_token_logprobs_idx=[[], []],
+        output_token_logprobs_val=[[], []],
+        output_token_logprobs_idx=[[], []],
+        input_top_logprobs_val=[[], []],
+        input_top_logprobs_idx=[[], []],
+        output_top_logprobs_val=[[], []],
+        output_top_logprobs_idx=[[], []],
+        input_token_ids_logprobs_val=[[], []],
+        input_token_ids_logprobs_idx=[[], []],
+        output_token_ids_logprobs_val=[[], []],
+        output_token_ids_logprobs_idx=[[], []],
+        output_token_entropy_val=None,
+        output_token_sampling_mask=None,
+        output_token_sampling_logprobs=None,
+        output_hidden_states=None,
+        routed_experts=None,
+        indexer_topk=None,
+        placeholder_tokens_idx=None,
+        placeholder_tokens_val=None,
+    )
+
+
+class TestTokenOnlyDetokenization(unittest.TestCase):
+    def test_all_token_rows_bypass_detokenizer(self):
+        manager = _make_manager()
+        recv_obj = _make_output([False, False])
+
+        output = manager.handle_batch_token_id_out(recv_obj)
+
+        self.assertIs(output, recv_obj)
+        self.assertEqual(manager.tokenizer.calls, [])
+        self.assertEqual(manager.decode_status, {})
+
+    def test_mixed_batch_decodes_only_text_rows(self):
+        manager = _make_manager()
+
+        output = manager.handle_batch_token_id_out(_make_output([True, False]))
+
+        self.assertIsInstance(output, BatchStrOutput)
+        self.assertEqual(output.rids, ["text", "tokens"])
+        self.assertEqual([list(ids) for ids in output.output_ids], [[65], [66]])
+        self.assertEqual(output.prompt_tokens, [1, 1])
+        self.assertEqual(output.output_strs, ["65", ""])
+        self.assertEqual(manager.tokenizer.calls, [[[65]]])
+        self.assertEqual(set(manager.decode_status), {"text"})
+
+    def test_invalid_mask_falls_back_to_full_decode(self):
+        for mask in (None, [False], [True, 0]):
+            with self.subTest(mask=mask):
+                manager = _make_manager()
+
+                output = manager.handle_batch_token_id_out(_make_output(mask))
+
+                self.assertEqual(output.output_strs, ["65", "66"])
+                self.assertEqual(manager.tokenizer.calls, [[[65], [66]]])
+                self.assertEqual(set(manager.decode_status), {"text", "tokens"})
+
+    def test_multi_detokenizer_split_preserves_mask(self):
+        output = _handle_output_by_index(_make_output([True, False]), 1)
+
+        self.assertEqual(output.rids, ["tokens"])
+        self.assertEqual(output.output_text_required, [False])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -318,6 +318,21 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
 
         self.assertIn(rid, tm.rid_to_state)
 
+    def test_token_only_row_ignores_text_from_mixed_batch(self):
+        tm = _make_tokenizer_manager(self)
+        rid = "token_only_mixed_batch"
+        state = _make_req_state(rid)
+        state.obj._output_text_required = False
+        tm.rid_to_state[rid] = state
+        batch_output = _make_batch_str_output(rid)
+        batch_output.output_strs = ["must not be returned"]
+        batch_output.output_ids = [[7]]
+
+        asyncio.run(tm._handle_batch_output(batch_output))
+
+        self.assertEqual(state.out_list[0]["output_ids"], [7])
+        self.assertNotIn("text", state.out_list[0])
+
 
 class TestInitReqStateDuplicateDetection(CustomTestCase):
     """Test that _init_req_state raises ValueError for duplicate rids."""


### PR DESCRIPTION
## Motivation

Native gRPC `Generate` accepts token IDs and returns token IDs, but SGLang still detokenizes every streamed scheduler output. The native bridge then discards that text. With `--stream-interval 1`, this adds detokenizer CPU and GIL work for every output token used by Dynamo.

## Modifications

- Add a private output-text marker with a safe default of `true`.
- Select token-only output for native token-ID `Generate` requests when no enabled internal logger, dump hook, or metrics exporter needs output text.
- Carry an aligned text-required mask through scheduler output and multi-detokenizer splitting.
- Skip incremental decode-state creation for token-only requests.
- Pass all-token batches through the detokenizer without tokenizer decode. For mixed batches, decode only text rows and keep row order.
- Build native gRPC responses from output IDs while preserving metadata, logprobs, finish handling, and request cleanup.
- Use the existing full-detokenization path if the marker is missing, invalid, or misaligned.

This change does not modify protobufs, public request models, defaults, response cadence, or the tokenizer requirement. `TextGenerate`, HTTP, OpenAI, Engine, embedding, and classification paths keep their existing output form. The tokenizer stays initialized, so string stops and other request-side tokenizer features still work.

## Accuracy Tests

A matched direct native gRPC check compared current upstream main (`bb3e3cbceb`) with this PR. It used Qwen3-0.6B revision `c1899de289a04d12100db370d81485cdf75e47ca`, two concurrent streams, one shared 129-token prompt, 1,024 output tokens, radix caching, and eight Tonic connections.

- Both runs were valid and had zero errors.
- Both runs produced 2,048 total output tokens and reported 128 cached prompt tokens for every request.
- The captured request had 1,024 messages and identical ordered token IDs.
- Stable response data matched exactly, including finish state, token counts, cache details, request ID, DP rank, and weight-version data. Only runtime timestamps and latency values were excluded from value comparison.

Focused tests cover native versus text output selection, the internal-consumer compatibility gate, safe fallback behavior, all-token and mixed detokenizer batches, split-batch marker propagation, parallel `n=2` request expansion, decode-state creation, metadata, and request cleanup. Existing output-streamer logprob tests also pass with the new payload field.

- Python: 103 passed, with 29 passed subtests.
- Rust `sglang-grpc`: 13 passed.
- Full changed-file pre-commit suite: passed, including Rust clippy and rustfmt.

## Speed Tests and Profiling

The performance profile used baseline `579270d459` and the measured token-only commit `fd8a0268ba`. The current PR rebases the same fast path onto upstream main and adds only the compatibility gate for enabled internal text consumers. Those consumers were disabled in the benchmark, so the measured fast path is unchanged.

Setup: Qwen3-0.6B revision `c1899de289a04d12100db370d81485cdf75e47ca`, one shared 129-token prompt, 1,024 output tokens, `temperature=0`, `ignore_eos=true`, native streaming token-ID `Generate`, eight Tonic connections, radix cache enabled, `--incremental-streaming-output`, and `--stream-interval 1`. Results are the mean of three c256 runs after a 30-second warm-up and a 60-second measurement.

| Metric | Baseline | Token-only | Change |
|---|---:|---:|---:|
| Detokenizer CPU | 5.663 CPU-s/M messages | 2.805 | **-50.47%** |
| Detokenizer GIL hold + wait | 5.428 us/message | 2.562 | **-52.80%** |
| Frontend + detokenizer CPU | 32.320 CPU-s/M messages | 29.275 | **-9.42%** |
| Messages/s | 21,297.650 | 21,313.389 | +0.074% |
| Protobuf bytes/message | 267.2147 | 267.2311 | +0.006% |
| TTFT p99 | 79.402 ms | 72.511 ms | -8.68% |
| Inter-token p99 | 38.772 ms | 38.804 ms | +0.08% |

Each state processed exactly 3,932,160 output tokens from 3,840 completed requests, with zero errors and 128 cached prompt tokens for every request. Native `perf` also measured a 53.8% detokenizer CPU reduction, and tokenizer-extension samples fell from 60 to zero. Scheduler CPU stayed flat.

Throughput was flat in this GPU-busy workload. This result shows lower host CPU and GIL cost for equal work; it does not establish a model roofline.

## Checklist

- [x] Format the code with pre-commit.
- [x] Add focused unit tests.
- [x] Documentation is not needed because this changes no public API, option, or behavior.
- [x] Provide direct output-parity and matched profile results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

This is a draft. CI and maintainer review are still pending.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33530030343](https://github.com/sgl-project/sglang/actions/runs/33530030343)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33530029757](https://github.com/sgl-project/sglang/actions/runs/33530029757)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33530030458](https://github.com/sgl-project/sglang/actions/runs/33530030458)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->