### PR TITLE
[VLM] Redact multimodal inputs from load errors

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -17,6 +17,7 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib.parse import urlsplit
 
 import numpy as np
 import torch
@@ -48,6 +49,8 @@ from sglang.srt.runtime_context import (
 )
 from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,
+    ImageData,
+    VideoData,
     configure_media_url_security,
     envs,
     is_cpu,
@@ -62,6 +65,59 @@ from sglang.srt.utils import (
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+
+_DATA_URI_PATTERN = re.compile(r"data:[^,\s]*,[^\s'\"<>]+", re.IGNORECASE)
+_MEDIA_URL_PATTERN = re.compile(r"(?:https?|file)://[^\s'\"<>]+", re.IGNORECASE)
+_MIME_TYPE_PATTERN = re.compile(r"[a-z0-9][a-z0-9.+-]*/[a-z0-9][a-z0-9.+-]*")
+
+
+def _describe_media_input(data) -> str:
+    if isinstance(data, (ImageData, VideoData)):
+        data = data.url
+    if isinstance(data, str):
+        if data.startswith("data:"):
+            metadata, separator, payload = data.partition(",")
+            mime_type = metadata[5:].split(";", 1)[0].lower()
+            if not _MIME_TYPE_PATTERN.fullmatch(mime_type):
+                mime_type = "unknown"
+            encoded_length = len(payload) if separator else 0
+            return f"<data-uri mime={mime_type} encoded_length={encoded_length}>"
+        if data.startswith(("http://", "https://")):
+            return f"<url scheme={urlsplit(data).scheme.lower()}>"
+        if data.startswith("file://"):
+            return "<file-uri>"
+        return f"<string length={len(data)}>"
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return f"<bytes length={len(data)}>"
+    if isinstance(data, Image.Image):
+        return f"<image mode={data.mode} size={data.width}x{data.height}>"
+    return f"<{type(data).__name__}>"
+
+
+def _redact_media_text(text: str, data) -> str:
+    descriptor = _describe_media_input(data)
+    raw_values = {str(data), repr(data)}
+    if isinstance(data, (ImageData, VideoData)):
+        raw_values.update((data.url, repr(data.url)))
+    for raw_value in sorted(raw_values, key=len, reverse=True):
+        if raw_value:
+            text = text.replace(raw_value, descriptor)
+    text = _DATA_URI_PATTERN.sub("<data-uri>", text)
+    return _MEDIA_URL_PATTERN.sub("<url>", text)
+
+
+def _sanitize_media_exception(error: Exception, data) -> Exception:
+    message = _redact_media_text(str(error), data)
+    try:
+        sanitized = type(error)(message)
+    except Exception:
+        sanitized = RuntimeError(f"{type(error).__name__}: {message}")
+    if error.__cause__ is not None:
+        sanitized.__cause__ = _sanitize_media_exception(error.__cause__, data)
+    elif error.__context__ is not None:
+        sanitized.__context__ = _sanitize_media_exception(error.__context__, data)
+    sanitized.__suppress_context__ = error.__suppress_context__
+    return sanitized
 
 
 @dataclasses.dataclass
@@ -890,6 +946,8 @@ class BaseMultimodalProcessor(ABC):
         """
         if cls._is_preprocessed_input(data):
             return data
+        load_error = None
+        is_client_error = False
         try:
             if modality == Modality.IMAGE:
                 img, _ = load_image(data, cls.gpu_image_decode)
@@ -904,15 +962,20 @@ class BaseMultimodalProcessor(ABC):
                 return load_audio(data, audio_sample_rate)
 
         except CLIENT_MEDIA_EXCEPTIONS as e:
-            data_str = str(data)
-            if len(data_str) > 100:
-                data_str = data_str[:100] + "..."
-            raise ValueError(f"Error while loading data {data_str}: {e}") from e
+            load_error = e
+            is_client_error = True
         except Exception as e:
-            data_str = str(data)
-            if len(data_str) > 100:
-                data_str = data_str[:100] + "..."
-            raise RuntimeError(f"Error while loading data {data_str}: {e}") from e
+            load_error = e
+
+        if load_error is not None:
+            sanitized_cause = _sanitize_media_exception(load_error, data)
+            message = (
+                f"Error while loading {modality.name.lower()} data "
+                f"{_describe_media_input(data)}: "
+                f"{type(load_error).__name__}: {sanitized_cause}"
+            )
+            exception_type = ValueError if is_client_error else RuntimeError
+            raise exception_type(message) from sanitized_cause
 
     @staticmethod
     def _get_preprocessed_input_format(data):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -17,7 +17,6 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.parse import urlsplit
 
 import numpy as np
 import torch
@@ -83,7 +82,8 @@ def _describe_media_input(data) -> str:
             encoded_length = len(payload) if separator else 0
             return f"<data-uri mime={mime_type} encoded_length={encoded_length}>"
         if data.startswith(("http://", "https://")):
-            return f"<url scheme={urlsplit(data).scheme.lower()}>"
+            scheme = data.partition(":")[0].lower()
+            return f"<url scheme={scheme}>"
         if data.startswith("file://"):
             return "<file-uri>"
         return f"<string length={len(data)}>"

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -119,6 +119,19 @@ class TestServerFaultStaysServerError(CustomTestCase):
 class TestBadInputDoesNotLeakMedia(CustomTestCase):
     """Loader failures must not expose request media in formatted exceptions."""
 
+    def test_malformed_url_preserves_sanitized_client_error(self):
+        url = "https://[invalid"
+
+        with self.assertRaises(ValueError) as ctx:
+            _StubProcessor._load_single_item(url, Modality.IMAGE)
+
+        formatted = "".join(traceback.format_exception(ctx.exception))
+        self.assertNotIn(url, formatted)
+        self.assertIn("Error while loading image data <url scheme=https>", formatted)
+        self.assertIsInstance(ctx.exception.__cause__, ValueError)
+        self.assertIn("<url scheme=https>", str(ctx.exception.__cause__))
+        self.assertIsNone(ctx.exception.__context__)
+
     def test_authenticated_url_is_redacted_from_client_error(self):
         url = (
             "https://media-user:media-password@example.com/private.jpg"

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -11,6 +11,7 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 import base64
 import binascii
 import io
+import traceback
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -19,7 +20,7 @@ from PIL import Image
 
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
-from sglang.srt.utils.common import CLIENT_MEDIA_EXCEPTIONS
+from sglang.srt.utils.common import CLIENT_MEDIA_EXCEPTIONS, ImageData
 from sglang.test.test_utils import CustomTestCase
 
 MODALITIES = (Modality.IMAGE, Modality.AUDIO, Modality.VIDEO)
@@ -113,6 +114,56 @@ class TestServerFaultStaysServerError(CustomTestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "too many open files"):
                 _StubProcessor._load_single_item("file:///image.png", Modality.IMAGE)
+
+
+class TestBadInputDoesNotLeakMedia(CustomTestCase):
+    """Loader failures must not expose request media in formatted exceptions."""
+
+    def test_authenticated_url_is_redacted_from_client_error(self):
+        url = (
+            "https://media-user:media-password@example.com/private.jpg"
+            "?token=MOCK_PRIVATE_TOKEN"
+        )
+        loader_error = requests.HTTPError(f"404 Client Error for url: {url}")
+
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            side_effect=loader_error,
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                _StubProcessor._load_single_item(ImageData(url=url), Modality.IMAGE)
+
+        formatted = "".join(traceback.format_exception(ctx.exception))
+        self.assertNotIn(url, formatted)
+        self.assertNotIn("media-password", formatted)
+        self.assertNotIn("MOCK_PRIVATE_TOKEN", formatted)
+        self.assertIn("<url scheme=https>", formatted)
+        self.assertIn("404 Client Error", formatted)
+        self.assertIsInstance(ctx.exception.__cause__, requests.HTTPError)
+        self.assertIsNone(ctx.exception.__context__)
+
+    def test_data_uri_is_redacted_from_client_error(self):
+        encoded = base64.b64encode(b"MOCK_PRIVATE_MEDIA").decode()
+        data_uri = f"data:image/jpeg;base64,{encoded}"
+        loader_error = binascii.Error(f"Non-base64 digit found in {data_uri}")
+
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            side_effect=loader_error,
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                _StubProcessor._load_single_item(data_uri, Modality.IMAGE)
+
+        formatted = "".join(traceback.format_exception(ctx.exception))
+        self.assertNotIn(data_uri, formatted)
+        self.assertNotIn(encoded, formatted)
+        self.assertNotIn("data:image/jpeg;base64", formatted)
+        self.assertIn(
+            f"<data-uri mime=image/jpeg encoded_length={len(encoded)}>", formatted
+        )
+        self.assertIn("Non-base64 digit found", formatted)
+        self.assertIsInstance(ctx.exception.__cause__, binascii.Error)
+        self.assertIsNone(ctx.exception.__context__)
 
 
 class TestClientMediaExceptions(CustomTestCase):


### PR DESCRIPTION
## Motivation

Multimodal loader failures currently include the first 100 characters of client-supplied media and chain the original loader exception. Authenticated URLs and data URIs can therefore expose credentials or media content in the API error and formatted traceback.

Fixes #37419.

## Modifications

- Replace raw media input text with safe descriptors that retain modality, input kind, MIME type, and encoded length where applicable.
- Redact the exact request value plus remaining URL/data-URI text from loader error messages.
- Rebuild a sanitized same-type cause chain outside the active exception handler, preserving useful decoder/fetch context without retaining the raw exception as `__context__`.
- Preserve `ValueError` for client media failures and `RuntimeError` for unexpected server faults.
- Add CPU regressions covering an authenticated `ImageData` URL and a data URI across the full formatted traceback.

## Accuracy Tests

Not applicable; this changes error reporting only.

## Speed Tests and Profiling

Not applicable; the new formatting runs only after a media load failure.

## Validation

- `test_base_processor_bad_input.py`: 12 tests passed, 15 subtests passed. The local Apple Silicon run used lightweight stubs for unrelated import-only manager/cache/transport/runtime-context modules; the changed module, real loaders, exception types, and all test bodies executed.
- Black 26.1.0, isort 7.0.0, Ruff 0.15.1 (`F401,F821,UP037`), codespell 2.4.1, and `compileall` passed for both changed files.
- `check_no_bare_pytest_main.py`, `check_no_registered_tests_in_package.py`, and `git diff --check` passed.

## Checklist

- [x] Format the changed code according to the repository pre-commit configuration.
- [x] Add focused CPU unit tests.
- [x] Documentation is not needed because public behavior is unchanged apart from redacting error details.
- [x] Accuracy and speed benchmarks are not applicable to the error-only path.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33551231784](https://github.com/sgl-project/sglang/actions/runs/33551231784)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33551231560](https://github.com/sgl-project/sglang/actions/runs/33551231560)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33551231824](https://github.com/sgl-project/sglang/actions/runs/33551231824)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->