### PR TITLE
[Fix] Cap reasoning_tokens at the emitted length when a speculative run crosses max_new_tokens

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1717,6 +1717,19 @@ class Req(ReqDllmMixin):
         if self.finished_len is not None and self.finished_len > max_new_tokens:
             self.finished_reason = FINISH_LENGTH(length=max_new_tokens)
             self.finished_len = max_new_tokens
+        self._cap_reasoning_tokens_at_finished_len()
+
+    def _cap_reasoning_tokens_at_finished_len(self) -> None:
+        """Bound ``reasoning_tokens`` by the tokens actually emitted.
+
+        ``update_reasoning_tokens`` advances over the whole accepted run, and it
+        runs before the finish state truncates the output at ``finished_len``.
+        A speculative run that crosses the budget therefore leaves the counter
+        above the emitted length. Reasoning tokens are a prefix of the output,
+        so ``finished_len`` is a hard upper bound.
+        """
+        if self.finished_len is not None and self.reasoning_tokens > self.finished_len:
+            self.reasoning_tokens = self.finished_len
 
     def update_finish_state(self, new_accepted_len: int = 1):
         if self.finished():
@@ -1754,6 +1767,7 @@ class Req(ReqDllmMixin):
                 length=self.sampling_params.max_new_tokens
             )
             self.finished_len = self.sampling_params.max_new_tokens
+            self._cap_reasoning_tokens_at_finished_len()
             return
 
         if self.grammar is not None and self.grammar.is_terminated():

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -147,6 +147,43 @@ class TestReasoningTokenAccounting(CustomTestCase):
         self.assertEqual(req.reasoning_tokens, 3)
         self.assertTrue(req._is_reasoning_over)
 
+    def test_reasoning_tokens_capped_when_accepted_run_crosses_budget(self):
+        """A spec run that crosses max_new_tokens must not inflate the counter.
+
+        ``_maybe_update_reasoning_tokens`` advances over the whole accepted run
+        and runs before ``update_finish_state`` truncates the output, so the
+        counter can end up above the number of tokens actually emitted.
+        """
+        req = _make_req(terminate_after=99)
+        req.require_reasoning = True
+        req.sampling_params.max_new_tokens = 4
+        processor = _make_processor()
+        processor.model_config.think_end_ids = [7, 8]
+
+        # One verified run of 6 tokens crosses the 4-token budget.
+        run = [10, 11, 12, 13, 14, 15]
+        req.output_ids.extend(run)
+        processor._maybe_update_reasoning_tokens(req, run)
+        req.update_finish_state(len(run))
+
+        self.assertEqual(len(req.output_ids_through_stop), 4)
+        self.assertEqual(req.reasoning_tokens, 4)
+
+    def test_reasoning_tokens_kept_when_accepted_run_fits_budget(self):
+        req = _make_req(terminate_after=99)
+        req.require_reasoning = True
+        req.sampling_params.max_new_tokens = 16
+        processor = _make_processor()
+        processor.model_config.think_end_ids = [7, 8]
+
+        run = [10, 11, 12, 13, 14, 15]
+        req.output_ids.extend(run)
+        processor._maybe_update_reasoning_tokens(req, run)
+        req.update_finish_state(len(run))
+
+        self.assertIsNone(req.finished_len)
+        self.assertEqual(req.reasoning_tokens, 6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`usage.reasoning_tokens` can come back **larger than `usage.completion_tokens`** when speculative decoding is enabled and the request stops on the length budget.

Observed serving GLM-5.3 on 8xB300:

```
python3 -m sglang.launch_server --model-path GLM-5.3 --tp-size 8 \
  --speculative-algorithm DFLASH --speculative-draft-model-path GLM-5.3-DFlash2 \
  --reasoning-parser glm45 ...
```

12 identical requests with `max_tokens=64`, and the returned text re-tokenized with the model's own tokenizer:

| completion_tokens | reasoning_tokens | tokenizer count of the returned text |
|---|---|---|
| 64 | **67** | 64 |
| 64 | 64 | 64 |
| 64 | **68** | 64 |
| 64 | **69** | 64 |
| 64 | 64 | 64 |
| 64 | **66** | 64 |
| 64 | 64 | 64 |
| 64 | **71** | 64 |
| 64 | **67** | 64 |
| 64 | 64 | 64 |
| 64 | **65** | 64 |
| 64 | **67** | 64 |

`reasoning_tokens - completion_tokens` distribution: `max_tokens=64` → `{0: 4, 1: 1, 2: 1, 3: 3, 4: 1, 5: 1, 7: 1}`, `max_tokens=128` → `{0: 6, 1: 2, 2: 2, 3: 1, 5: 1}`.

The tokenizer count matches `completion_tokens` in every trial, so `completion_tokens` is correct and `reasoning_tokens` is the number that overshoots. The overshoot is bounded by the draft length and does not scale with `max_tokens`, and it never appears when the request ends on a stop/EOS inside the budget (there `reasoning_tokens < completion_tokens`, as expected).

Downstream this surfaces as a thinking-token count that exceeds the output-token count, which billing and usage reporting have to clamp by hand.

## Root cause

In `SchedulerBatchResultProcessor._process_batch_result_decode`, the reasoning counter is advanced **before** the finish state truncates the output:

```python
# next_token_id is a per-req list: 1 token for non-spec, the verified
# run for spec (already grammar-truncated in _resolve_spec_v2_tokens).
next_token_id = next_token_ids[i]
req.output_ids.extend(next_token_id)
new_accept_len = len(next_token_id)

self._maybe_update_reasoning_tokens(req, next_token_id)   # counts the whole run
req.update_finish_state(new_accept_len)                   # only here is the run capped
```

`Req.update_reasoning_tokens` adds the whole accepted run (`self.reasoning_tokens += len(token_id)`), while `update_finish_state` afterwards sets `finished_len = max_new_tokens`. The emitted output is `output_ids_through_stop == output_ids[:finished_len]`, so a speculative run that crosses the budget in its final step leaves `reasoning_tokens` above the number of tokens actually emitted. With non-speculative decoding the run is one token, so the overshoot is structurally impossible — which is why this only shows up under speculative decoding.

`finished_len` itself already handles exactly this hazard for stop strings and EOS, via `_cap_finished_len_at_max_new_tokens`:

> Speculative decoding can accept a run that both crosses `max_new_tokens` and contains a stop; a stop located past the cap must not extend the emitted output beyond the cap.

`reasoning_tokens` is simply missing from that capping.

## Modifications

Reasoning tokens are a prefix of the output, so the emitted length is a hard upper bound. `_cap_reasoning_tokens_at_finished_len()` enforces that whenever a finish sets `finished_len`:

- called from `_cap_finished_len_at_max_new_tokens()`, which already funnels the vocab-boundary, stop-string and stop-token/EOS paths;
- called from the plain length branch of `update_finish_state`.

It is O(1) and runs only on the finishing step, so the decode loop is untouched. `update_reasoning_tokens` itself is left alone, so this does not conflict with #34634, which reworks how that counter is advanced.

## Accuracy Test

Not applicable — usage accounting only, generated tokens are unchanged.

## Benchmark and Profiling Results

Not applicable — the added work is one integer comparison per finished request.

## Checklist

- [x] Unit tests added to `test/registered/unit/managers/test_batch_result_processor_spec_grammar.py` (CPU CI suite `base-a-test-cpu`, no GPU required):
  - `test_reasoning_tokens_capped_when_accepted_run_crosses_budget` — a 6-token accepted run against `max_new_tokens=4` emits 4 tokens; fails on `main` with `AssertionError: 6 != 4`, passes with this change.
  - `test_reasoning_tokens_kept_when_accepted_run_fits_budget` — a run inside the budget is left untouched, guarding against over-clamping.
- [x] `pytest test/registered/unit/managers/` → 573 passed, 15 skipped, 610 subtests passed. The 3 errors in `test_customized_info_streaming.py` reproduce identically on an unmodified tree and are unrelated.

Verified by the unit tests above and by the production measurements that motivated the report. I have not yet re-run the 8xB300 server on a patched build, so the "after" numbers on real hardware are not included here; happy to add them.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33537376307](https://github.com/sgl-project/sglang/actions/runs/33537376307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33537375964](https://github.com/sgl-project/sglang/actions/runs/33537375964)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33537376201](https://github.com/sgl-project/sglang/actions/runs/33537376201)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->