### PR TITLE
[CI] Double the base-b-test-1-gpu-large timeout

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -333,7 +333,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      run_timeout_minutes: '30'
+      run_timeout_minutes: '60'
       timeout_per_file: '1800'
       rust_ext_artifact: ${{ needs.rust-ext-build.outputs.artifact_name }}
     secrets: inherit


### PR DESCRIPTION
> Generated by Claude.

`jit-kernel-unit-test` had its step timeout doubled in #37435 for a cold-JIT-compile overrun. `base-b-test-1-gpu-large` hits the same wall and is still on 30 minutes.

Any PR touching a shared header under `python/sglang/kernels/jit/include/` invalidates the JIT cache on every runner, so each shard pays a full cold `nvcc` pass on top of its own tests. Nothing sets `SGLANG_JIT_CACHE_DIR` to a shared mount in CI, so the cache never carries across jobs and every runner is cold.

Measured on four shards of a single run. **None of them had a failing test** — `passed:false` was 0 everywhere; they were all killed by the clock:

| shard | files done | test time | budget | note |
|---|---|---|---|---|
| (1) | 16 / 16 | 1798s (30.0m) | 1800s | ran everything green, still killed at 30m07s |
| (7) | 9 / 16 | 1799s (30.0m) | 1800s | |
| (5) | 10 / 14 | 1770s (29.5m) | 1800s | |
| (4) | 9 / 14 | 1291s (21.5m) | 1800s | ~8.5m of the wall clock is outside the tests |

Shard (1) is the clearest case: it finished every file, and the tests alone consumed 1798 of the 1800 seconds, so any compile time on top could only push it over.

`timeout_per_file` is left at 1800s, so a single hung test still fails fast — this only lifts the ceiling on the shard as a whole.

Two follow-ups worth doing separately, both of which would let this be lowered again:
- Point `SGLANG_JIT_CACHE_DIR` at a shared persistent mount in CI, which removes the cold-compile cost entirely (the variable's own comment already describes this use).
- `test/registered/kernels/ops/moe/test_moe_wna16_marlin.py` declares `est_time=10` but measures 536s, a 53x underestimate that skews `--auto-partition` packing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33538470559](https://github.com/sgl-project/sglang/actions/runs/33538470559)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33538470131](https://github.com/sgl-project/sglang/actions/runs/33538470131)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->