### PR TITLE
[CI][MLX] Restore the mamba_branching_seqlen attribute the MLX runner reads off a request

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -1520,6 +1520,7 @@ if _HAS_MLX:
     class FakeRequest:
         def __init__(self):
             self.kv = ReqKvInfo()
+            self.mamba_branching_seqlen = None
             self.inflight_middle_chunks = 0
 
     class FakeTpWorker:


### PR DESCRIPTION
## Motivation

`pr-test-mlx.yml` `stage-a-unit-test-mlx` fails on essentially every open PR:

```
ERROR: test_auxiliary_state_prefill_advances_tracked_boundary_after_cached_prefix
  File "python/sglang/srt/hardware_backend/mlx/model_runner.py", line 382, in _select_auxiliary_state_track_len
    branching_len = req.mamba_branching_seqlen
AttributeError: 'FakeRequest' object has no attribute 'mamba_branching_seqlen'
```

#37164 tightened the read in `MlxModelRunner._select_auxiliary_state_track_len` from
`getattr(req, "mamba_branching_seqlen", None)` to a direct `req.mamba_branching_seqlen`.
That is correct against a real `Req` — `schedule_batch.Req.__init__` always defines the
attribute — but the MLX unit test's `FakeRequest` stub never carried it, so every test
that drives `prefill_start` through the auxiliary-state path now errors.

The suite runs failfast, so this one error also hides
`test_auxiliary_state_prefill_restores_prefix_state` and
`test_auxiliary_state_prefill_tracks_chunk_aligned_auxiliary_state`, which take the same path.

## Modifications

Give `FakeRequest` the `mamba_branching_seqlen = None` default a real `Req` has. The
production read stays strict.

## Accuracy Test

N/A — unit-test stub only.

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-files).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33539026598](https://github.com/sgl-project/sglang/actions/runs/33539026598)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33539036520](https://github.com/sgl-project/sglang/actions/runs/33539036520)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33539026568](https://github.com/sgl-project/sglang/actions/runs/33539026568)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->