### PR TITLE
[PD] Gate deferred decode KV release on backend capability

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -101,6 +101,8 @@ class KVPoll:
 class BaseKVManager(ABC):
     """Base class for managing transfer states"""
 
+    enable_deferred_decode_kv_release: bool = False
+
     @abstractmethod
     def __init__(
         self,

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2304,6 +2304,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
                 if (
                     self.enable_deferred_kv_release
+                    and decode_req.kv_receiver.kv_mgr.enable_deferred_decode_kv_release
                     and decode_req.kv_receiver.abort_notified
                 ):
                     # Decode-initiated abort: a prefill write may still target

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -99,6 +99,8 @@ class FakeKVReceiver(BaseKVReceiver):
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
     ):
+        self.kv_mgr = mgr
+        self.abort_notified: bool = False
         self.bootstrap_done = False
         self.has_sent_metadata = False
         self.require_staging: bool = False

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -9,6 +9,7 @@ from sglang.srt.disaggregation.decode import (
     DecodeTransferQueue,
     HiCacheRestoreResult,
 )
+from sglang.srt.disaggregation.fake.conn import FakeKVManager, FakeKVReceiver
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
@@ -307,7 +308,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
     @patch("sglang.srt.disaggregation.decode.release_kv_cache")
     @patch("sglang.srt.disaggregation.decode.prepare_abort")
     @patch("sglang.srt.disaggregation.decode.poll_and_all_reduce")
-    def test_transfer_failure_clears_receiver_before_removing_request(
+    def test_transfer_failure_cleanup_respects_deferred_release_gates(
         self, mock_poll, mock_prepare_abort, mock_release_kv_cache
     ):
         receiver = FakeReceiver()
@@ -359,6 +360,32 @@ class TestDecodeQueueCleanup(CustomTestCase):
         mock_release_kv_cache.assert_called_once_with(
             req, queue.tree_cache, is_insert=False
         )
+
+        receiver = FakeReceiver()
+        receiver.kv_mgr = FakeKVManager.__new__(FakeKVManager)
+        decode_req.kv_receiver = receiver
+        queue.queue = [decode_req]
+        queue.enable_deferred_kv_release = True
+        queue.req_to_metadata_buffer_idx_allocator.reset_mock()
+        mock_release_kv_cache.reset_mock()
+
+        transferred = queue.pop_transferred()
+
+        self.assertEqual(transferred, [])
+        self.assertEqual(queue.queue, [])
+        self.assertTrue(receiver.clear_called)
+        self.assertIsNone(decode_req.kv_receiver)
+        queue.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(3)
+        mock_release_kv_cache.assert_called_once_with(
+            req, queue.tree_cache, is_insert=False
+        )
+
+    def test_fake_receiver_initializes_deferred_release_state(self):
+        manager = MagicMock()
+        receiver = FakeKVReceiver(manager, "")
+
+        self.assertIs(receiver.kv_mgr, manager)
+        self.assertFalse(receiver.abort_notified)
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)


### PR DESCRIPTION
## Motivation

Deferred decode-side KV release relies on backend-specific abort tracking. When the global feature flag is enabled, the transfer-failure path currently assumes every KV manager supports that protocol. Managers that only implement the base interface should instead use immediate cleanup.

## Modifications

- Add a default-disabled deferred-release capability to `BaseKVManager`.
- Enter deferred cleanup only when both the global feature and the backend capability are enabled.
- Initialize the fake receiver state required by the shared failure paths.
- Extend CPU regression coverage for global disablement, backend opt-out, and fake receiver initialization.

## Test Plan

- Passed: `uv run --no-cache --no-project --with pre-commit pre-commit run --files python/sglang/srt/disaggregation/base/conn.py python/sglang/srt/disaggregation/decode.py python/sglang/srt/disaggregation/fake/conn.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py`
- Passed: `python3 -m py_compile python/sglang/srt/disaggregation/base/conn.py python/sglang/srt/disaggregation/decode.py python/sglang/srt/disaggregation/fake/conn.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py`
- Blocked locally during collection: `pytest -q test/registered/unit/disaggregation/test_deferred_decode_kv_release.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py`; the available environment has older dependency APIs than current `main`, so no test assertions ran. CI is requested below.

## Accuracy Tests

Not applicable; this changes failure-path resource cleanup only.

## Speed Tests and Profiling

Not applicable; this adds one boolean check on the transfer-failure path.

## Original commits

- `729abe9e8`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33539063997](https://github.com/sgl-project/sglang/actions/runs/33539063997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33539063596](https://github.com/sgl-project/sglang/actions/runs/33539063596)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33539063969](https://github.com/sgl-project/sglang/actions/runs/33539063969)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->