### PR TITLE
[Metrics] Export scheduler stage wall time

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -95,6 +95,11 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_GET_NEXT_BATCH,
+    SCHEDULER_STAGE_PROCESS_QUEUE,
+    scheduler_stage_method,
+)
 from sglang.srt.runtime_context import (
     get_disagg,
     get_memory,
@@ -102,7 +107,6 @@ from sglang.srt.runtime_context import (
 )
 from sglang.srt.utils import ceil_align, get_num_new_pages, is_npu
 from sglang.srt.utils.network import NetworkAddress
-from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
@@ -2459,6 +2463,7 @@ class SchedulerDisaggregationDecodeMixin:
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
             self.process_decode_queue()
 
@@ -2502,6 +2507,7 @@ class SchedulerDisaggregationDecodeMixin:
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
             self.process_decode_queue()
 
@@ -2556,7 +2562,7 @@ class SchedulerDisaggregationDecodeMixin:
 
         return GenerationBatchResult()
 
-    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
+    @scheduler_stage_method(SCHEDULER_STAGE_GET_NEXT_BATCH)
     def get_next_disagg_decode_batch_to_run(
         self: Scheduler, running_batch: ScheduleBatch
     ) -> NextBatchPlan:
@@ -2664,6 +2670,7 @@ class SchedulerDisaggregationDecodeMixin:
 
         return new_batch
 
+    @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_QUEUE)
     def process_decode_queue(self: Scheduler):
         if self.enable_decode_hicache:
             self.tree_cache.check_hicache_events()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -72,13 +72,17 @@ from sglang.srt.mem_cache.common import (
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_GET_NEXT_BATCH,
+    SCHEDULER_STAGE_PROCESS_QUEUE,
+    scheduler_stage_method,
+)
 from sglang.srt.runtime_context import (
     get_disagg,
     get_parallel,
     get_schedule,
 )
 from sglang.srt.utils import is_npu
-from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -524,6 +528,7 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
+    @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_QUEUE)
     def resolve_waiting_queue_bootstrap(self: Scheduler) -> None:
         """Resolve bootstrap status for waiting prefill requests before admission.
 
@@ -565,7 +570,7 @@ class SchedulerDisaggregationPrefillMixin:
             for req in self.waiting_queue
         )
 
-    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
+    @scheduler_stage_method(SCHEDULER_STAGE_GET_NEXT_BATCH)
     def get_next_disagg_prefill_batch_to_run(
         self: Scheduler,
         running_batch: ScheduleBatch,
@@ -599,10 +604,12 @@ class SchedulerDisaggregationPrefillMixin:
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
-            self.waiting_queue.extend(
-                self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
-            )
+            with self.scheduler_stage_metrics.record(SCHEDULER_STAGE_PROCESS_QUEUE):
+                self.waiting_queue.extend(
+                    self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
+                )
 
             # Get the next batch to run
             plan = self.get_next_disagg_prefill_batch_to_run(
@@ -638,10 +645,12 @@ class SchedulerDisaggregationPrefillMixin:
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
-            self.waiting_queue.extend(
-                self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
-            )
+            with self.scheduler_stage_metrics.record(SCHEDULER_STAGE_PROCESS_QUEUE):
+                self.waiting_queue.extend(
+                    self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
+                )
 
             # Get the next batch to run
             plan = self.get_next_disagg_prefill_batch_to_run(
@@ -873,6 +882,7 @@ class SchedulerDisaggregationPrefillMixin:
             dp_cooperation_info=batch.dp_cooperation_info,
         )
 
+    @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_QUEUE)
     def process_disagg_prefill_inflight_queue(
         self: Scheduler, rids_to_check: Optional[List[str]] = None
     ) -> List[Req]:

--- a/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
+++ b/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
@@ -213,6 +213,7 @@ class SchedulerMlxOverlapMixin:
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
 
             # 1. If pending_curr is a pure decode AND no new prefill is waiting,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -289,6 +289,16 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_GET_NEXT_BATCH,
+    SCHEDULER_STAGE_IDLE,
+    SCHEDULER_STAGE_PROCESS_BATCH_RESULT,
+    SCHEDULER_STAGE_PROCESS_REQUESTS,
+    SCHEDULER_STAGE_RUN_BATCH,
+    SCHEDULER_STAGE_SANITY_CHECK_CACHE,
+    SchedulerStageMetricsRecorder,
+    scheduler_stage_method,
+)
 from sglang.srt.observability.startup_time import build_scheduler_startup_time
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.parser.reasoning_parser import ReasoningParser
@@ -333,7 +343,6 @@ from sglang.srt.utils.hf_transformers_utils import (
 )
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
-from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.weight_versions import (
     compute_weight_version_spans,
@@ -416,6 +425,9 @@ class Scheduler(
     SchedulerMlxOverlapMixin,
 ):
     """A scheduler that manages a tensor parallel GPU worker."""
+
+    # Set during normal initialization; pre-initialization calls are uninstrumented.
+    scheduler_stage_metrics: Optional[SchedulerStageMetricsRecorder] = None
 
     # Class-level default so on_idle's stall gate works even if a fork
     # overrides init_load_publisher (which would otherwise not set it).
@@ -632,6 +644,7 @@ class Scheduler(
         self.init_diffusion_llm()
 
         self.init_metrics_reporter(tp_rank, pp_rank, dp_rank)
+        self.scheduler_stage_metrics = self.metrics_reporter.scheduler_stage_metrics
 
         # Init schedule policy and new token estimation
         self.init_schedule_policy()
@@ -1774,6 +1787,7 @@ class Scheduler(
         if use_mlx():
             # MLX overlap uses mx.async_eval for CPU/GPU overlap,
             # not PyTorch MPS streams.
+            self.metrics_reporter.start_scheduler_time_accounting()
             dispatch_event_loop(self)
             return
 
@@ -1796,6 +1810,7 @@ class Scheduler(
         # on the previous forward's read of the unified memory pool.
         self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
         with self.device_module.StreamContext(self.schedule_stream):
+            self.metrics_reporter.start_scheduler_time_accounting()
             dispatch_event_loop(self)
 
     def _apply_war_barrier(self):
@@ -1820,8 +1835,11 @@ class Scheduler(
 
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
+            if recv_reqs:
+                self.metrics_reporter.record_scheduler_active()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
 
             # Get the next batch to run
@@ -1844,7 +1862,10 @@ class Scheduler(
             # Update last_batch
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
-                self.invariant_checker.self_check_during_busy()
+                with self.scheduler_stage_metrics.record(
+                    SCHEDULER_STAGE_SANITY_CHECK_CACHE
+                ):
+                    self.invariant_checker.self_check_during_busy()
 
     @DynamicGradMode()
     def event_loop_overlap(self):
@@ -1864,8 +1885,11 @@ class Scheduler(
 
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
+            if recv_reqs:
+                self.metrics_reporter.record_scheduler_active()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                self._record_scheduler_state_for_paused_engine()
                 continue
 
             # Get the next batch to run
@@ -1919,7 +1943,10 @@ class Scheduler(
             self.last_batch = batch
 
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
-                self.invariant_checker.self_check_during_busy()
+                with self.scheduler_stage_metrics.record(
+                    SCHEDULER_STAGE_SANITY_CHECK_CACHE
+                ):
+                    self.invariant_checker.self_check_during_busy()
 
     def is_disable_overlap_for_batch(
         self, batch: ScheduleBatch, last_batch: Optional[ScheduleBatch]
@@ -1969,7 +1996,7 @@ class Scheduler(
         for prev_batch, prev_result in self.result_queue:
             self.batch_result_processor.advance_grammar_fsm(prev_result, prev_batch)
 
-    @scheduler_nvtx_method("scheduler.process_input_requests")
+    @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_REQUESTS)
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
@@ -2192,6 +2219,7 @@ class Scheduler(
             stream_output=lambda *a, **kw: self.output_streamer.stream_output(*a, **kw),
             get_last_batch=lambda: self.last_batch,
             scripted_scheduler_hook=self.scripted_scheduler_hook,
+            scheduler_stage_metrics=self.scheduler_stage_metrics,
         )
 
     def init_dp_attn_adapter(self) -> None:
@@ -3338,7 +3366,7 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
-    @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
+    @scheduler_stage_method(SCHEDULER_STAGE_GET_NEXT_BATCH)
     def get_next_batch_to_run(
         self, running_batch: ScheduleBatch, last_batch: Optional[ScheduleBatch]
     ) -> NextBatchPlan:
@@ -4016,13 +4044,14 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
-    @scheduler_nvtx_method("scheduler.run_batch")
+    @scheduler_stage_method(SCHEDULER_STAGE_RUN_BATCH)
     def run_batch(
         self,
         batch: ScheduleBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[GenerationBatchResult, EmbeddingBatchResult]:
         """Run a batch."""
+        self.metrics_reporter.record_scheduler_active()
         self.forward_ct += 1
         batch.forward_iter = self.forward_ct
         batch.launch_ts = time.monotonic()
@@ -4360,7 +4389,7 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
-    @scheduler_nvtx_method("scheduler.process_batch_result")
+    @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_BATCH_RESULT)
     def process_batch_result(
         self,
         batch: ScheduleBatch,
@@ -4487,6 +4516,7 @@ class Scheduler(
             if_success = False
         return ClearHiCacheReqOutput(success=if_success)
 
+    @scheduler_stage_method(SCHEDULER_STAGE_IDLE)
     def on_idle(self):
         """Idle housekeeping: guard, check, metrics, reset, sleep."""
         # Flush any health-check signal deferred while the engine was busy.
@@ -4499,7 +4529,9 @@ class Scheduler(
         # path spins without sleeping, so a wall-clock floor bounds the
         # O(queue) get_loads for both sinks; the fully-idle publish runs
         # post-flush below.
-        if not self.is_fully_idle():
+        fully_idle = self.is_fully_idle()
+        if not fully_idle:
+            self.metrics_reporter.record_scheduler_active()
             now = time.monotonic()
             if now - self._last_stall_publish_ts >= LOAD_STALL_REFRESH_S:
                 self._last_stall_publish_ts = now
@@ -4508,6 +4540,7 @@ class Scheduler(
                     self.load_inquirer.get_loads, force=True, snapshot=snapshot
                 )
             return
+        self.metrics_reporter.record_scheduler_idle()
 
         if self.enable_unified_memory:
             try:
@@ -4524,23 +4557,26 @@ class Scheduler(
             self.disaggregation_mode == DisaggregationMode.DECODE
             and self.disagg_decode_transfer_queue.has_pending_deferred_releases()
         )
-        if not self.enable_hisparse and not deferred_pending:
-            has_leak, messages = self.invariant_checker._check_all_pools(
-                self.pool_stats_observer.get_pool_stats(),
-            )
-            if has_leak:
-                self.invariant_checker._report_leak("pool", "\n".join(messages))
-            self.invariant_checker._check_req_pool()
-            # Byte-conservation diagnostic (allocator-owned; static pools
-            # return [] — the token identity above can't see byte leaks).
-            byte_violations = self.token_to_kv_pool_allocator.verify_byte_accounting()
-            if byte_violations:
-                self.invariant_checker._report_leak(
-                    "pool-bytes", "\n".join(byte_violations)
+        with self.scheduler_stage_metrics.record(SCHEDULER_STAGE_SANITY_CHECK_CACHE):
+            if not self.enable_hisparse and not deferred_pending:
+                has_leak, messages = self.invariant_checker._check_all_pools(
+                    self.pool_stats_observer.get_pool_stats(),
                 )
+                if has_leak:
+                    self.invariant_checker._report_leak("pool", "\n".join(messages))
+                self.invariant_checker._check_req_pool()
+                # Byte-conservation diagnostic (allocator-owned; static pools
+                # return [] — the token identity above can't see byte leaks).
+                byte_violations = (
+                    self.token_to_kv_pool_allocator.verify_byte_accounting()
+                )
+                if byte_violations:
+                    self.invariant_checker._report_leak(
+                        "pool-bytes", "\n".join(byte_violations)
+                    )
 
-        # tree cache sanity check
-        self.invariant_checker._check_tree_cache()
+            # tree cache sanity check
+            self.invariant_checker._check_tree_cache()
 
         # metrics every 30s
         self.metrics_reporter._maybe_log_idle_metrics()
@@ -4560,6 +4596,13 @@ class Scheduler(
 
         # sleep until next event
         self.maybe_sleep_on_idle()
+        self.metrics_reporter.record_scheduler_idle()
+
+    def _record_scheduler_state_for_paused_engine(self) -> None:
+        if self.is_fully_idle():
+            self.metrics_reporter.record_scheduler_idle()
+        else:
+            self.metrics_reporter.record_scheduler_active()
 
     def is_fully_idle(self, for_health_check=False) -> bool:
         # Health check piggybacks on running requests in process_output.

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -22,6 +22,9 @@ from sglang.srt.observability.metrics_collector import (
     SchedulerStats,
     compute_routing_key_stats,
 )
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SchedulerStageMetricsRecorder,
+)
 from sglang.srt.runtime_context import (
     exports_expert_balancedness_to_prometheus,
     get_context,
@@ -48,6 +51,8 @@ RECORD_STEP_TIME = envs.SGLANG_RECORD_STEP_TIME.get()
 LOG_FORWARD_ITERS = envs.SGLANG_LOG_FORWARD_ITERS.get()
 ENABLE_METRICS_DEVICE_TIMER = envs.SGLANG_ENABLE_METRICS_DEVICE_TIMER.get()
 CACHE_HIT_RATE_WINDOW_SECONDS = envs.SGLANG_CACHE_HIT_RATE_WINDOW_SECONDS.get()
+# Update scheduler time counters every 1 second.
+_SCHEDULER_TIME_ACCOUNTING_INTERVAL_NS = 1_000_000_000
 
 
 class _CacheHitRateWindow:
@@ -117,6 +122,44 @@ class PrefillStats:
             num_new_seqs=len(adder.can_run_list),
             num_pending_tokens=num_pending_tokens,
         )
+
+
+@dataclass(slots=True)
+class _SchedulerTimeAccountingSnapshot:
+    start_ns: int
+    last_sample_ns: int
+    start_process_cpu_ns: int
+    accumulate_idle_ns: int
+    # Whether the last sample was idle (for example, no work on the engine).
+    is_idle: bool
+
+    @classmethod
+    def init(
+        cls, now_ns: int, now_process_cpu_ns: int, is_idle: bool
+    ) -> _SchedulerTimeAccountingSnapshot:
+        return cls(
+            start_ns=now_ns,
+            last_sample_ns=now_ns,
+            start_process_cpu_ns=now_process_cpu_ns,
+            accumulate_idle_ns=0,
+            is_idle=is_idle,
+        )
+
+    def sample(self, now_ns: int, is_idle: bool) -> None:
+        if self.is_idle:
+            self.accumulate_idle_ns += now_ns - self.last_sample_ns
+        self.last_sample_ns = now_ns
+        self.is_idle = is_idle
+
+    def should_record(self, now_ns: int) -> bool:
+        return now_ns - self.start_ns >= _SCHEDULER_TIME_ACCOUNTING_INTERVAL_NS
+
+    def reset(self, now_ns: int, now_process_cpu_ns: int, is_idle: bool) -> None:
+        self.start_ns = now_ns
+        self.last_sample_ns = now_ns
+        self.start_process_cpu_ns = now_process_cpu_ns
+        self.accumulate_idle_ns = 0
+        self.is_idle = is_idle
 
 
 @dataclass(kw_only=True)
@@ -200,6 +243,12 @@ class SchedulerMetricsReporter:
                 self._mfu_log_write_bytes = 0.0
 
         self.fwd_occupancy = float("nan")
+        self._scheduler_time_accounting: Optional[_SchedulerTimeAccountingSnapshot] = (
+            None
+        )
+        self.scheduler_stage_metrics = SchedulerStageMetricsRecorder(
+            enabled=self.enable_metrics
+        )
 
         self.forward_pass_device_timer: Optional[DeviceTimer] = None
 
@@ -1175,6 +1224,55 @@ class SchedulerMetricsReporter:
         self._device_timer_window_batch_count += 1
         if self._device_timer_window_batch_count >= self.decode_log_interval:
             self._device_timer_window_batch_count = 0
+
+    def start_scheduler_time_accounting(self) -> None:
+        if not self.enable_metrics:
+            return
+        now_wall_ns = time.monotonic_ns()
+        self._scheduler_time_accounting = _SchedulerTimeAccountingSnapshot.init(
+            now_wall_ns, time.process_time_ns(), True
+        )
+        self.scheduler_stage_metrics.start(now_wall_ns)
+
+    def record_scheduler_active(self) -> None:
+        self._record_scheduler_time(is_idle=False)
+
+    def record_scheduler_idle(self) -> None:
+        self._record_scheduler_time(is_idle=True)
+
+    def _record_scheduler_time(self, is_idle: bool) -> None:
+        if not self.enable_metrics:
+            return
+
+        now_wall_ns = time.monotonic_ns()
+        accounting = self._scheduler_time_accounting
+        if accounting is None:
+            self._scheduler_time_accounting = _SchedulerTimeAccountingSnapshot.init(
+                now_wall_ns, time.process_time_ns(), is_idle
+            )
+            self.scheduler_stage_metrics.start(now_wall_ns)
+            return
+
+        accounting.sample(now_wall_ns, is_idle)
+        if not accounting.should_record(now_wall_ns):
+            return
+
+        now_process_cpu_ns = time.process_time_ns()
+        elapsed_process_cpu_ns = now_process_cpu_ns - accounting.start_process_cpu_ns
+        if accounting.accumulate_idle_ns > 0:
+            self.metrics_collector.increment_scheduler_idle_seconds(
+                accounting.accumulate_idle_ns / 1e9
+            )
+        self.metrics_collector.increment_scheduler_process_cpu_seconds(
+            elapsed_process_cpu_ns / 1e9
+        )
+        for stage, elapsed_wall_ns in self.scheduler_stage_metrics.drain(
+            now_wall_ns
+        ).items():
+            self.metrics_collector.increment_scheduler_stage_seconds(
+                stage=stage, seconds=elapsed_wall_ns / 1e9
+            )
+        accounting.reset(now_wall_ns, now_process_cpu_ns, is_idle)
 
     def _reset_device_timer_window(self):
         """Exclude idle time and invalidate the last forward-occupancy sample."""

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -31,12 +31,16 @@ from sglang.srt.managers.mm_utils import (
     has_shm_features,
     unwrap_shm_features,
 )
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_RECV_REQUESTS,
+    SchedulerStageMetricsRecorder,
+    scheduler_stage_method,
+)
 from sglang.srt.runtime_context import get_disagg, get_parallel, is_ep_scale_joiner
 from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
 )
-from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -72,13 +76,14 @@ class SchedulerRequestReceiver:
     stream_output: Callable[..., None]
     get_last_batch: Callable[[], Any]
     scripted_scheduler_hook: Optional[ScriptedSchedulerHook] = None
+    scheduler_stage_metrics: Optional[SchedulerStageMetricsRecorder] = None
 
     def recv_limit_reached(self, num_recv_reqs: int) -> bool:
         if self.max_recv_per_poll < 0:
             return False
         return num_recv_reqs >= self.max_recv_per_poll
 
-    @scheduler_nvtx_method("scheduler.recv_requests")
+    @scheduler_stage_method(SCHEDULER_STAGE_RECV_REQUESTS)
     def recv_requests(
         self,
     ) -> List[Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput, Any]]:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -25,6 +25,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set, Union
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_CATEGORIES,
+)
 from sglang.srt.observability.utils import exponential_buckets, generate_buckets
 from sglang.srt.runtime_context import (
     exports_expert_balancedness_to_prometheus,
@@ -917,6 +920,31 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             ),
             labelnames=list(labels.keys()) + ["category"],
         )
+        self.scheduler_idle_seconds_total = Counter(
+            name="sglang:scheduler_idle_seconds_total",
+            documentation=(
+                "Total wall time while the scheduler has no runnable or queued work."
+            ),
+            labelnames=labels.keys(),
+        )
+        self.scheduler_process_cpu_seconds_total = Counter(
+            name="sglang:scheduler_process_cpu_seconds_total",
+            documentation=(
+                "Total CPU time consumed by the scheduler process across all threads."
+            ),
+            labelnames=labels.keys(),
+        )
+        self.scheduler_stage_seconds_total = Counter(
+            name="sglang:scheduler_stage_seconds_total",
+            documentation=(
+                "Total scheduler-loop wall time exclusively attributed to each stage."
+            ),
+            labelnames=list(labels.keys()) + ["category"],
+        )
+        self.scheduler_idle_seconds_total.labels(**labels)
+        self.scheduler_process_cpu_seconds_total.labels(**labels)
+        for category in SCHEDULER_STAGE_CATEGORIES:
+            self.scheduler_stage_seconds_total.labels(**labels, category=category)
         self.estimated_flops_per_gpu_total = Counter(
             name="sglang:estimated_flops_per_gpu_total",
             documentation=(
@@ -1302,6 +1330,17 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
                 category=category,
                 **dp_cooperation_info.to_labels(),
             ).inc(t)
+
+    def increment_scheduler_idle_seconds(self, t: float) -> None:
+        self.scheduler_idle_seconds_total.labels(**self.labels).inc(t)
+
+    def increment_scheduler_process_cpu_seconds(self, t: float) -> None:
+        self.scheduler_process_cpu_seconds_total.labels(**self.labels).inc(t)
+
+    def increment_scheduler_stage_seconds(self, stage: str, seconds: float) -> None:
+        self.scheduler_stage_seconds_total.labels(**self.labels, category=stage).inc(
+            seconds
+        )
 
     def increment_estimated_perf(
         self,

--- a/python/sglang/srt/observability/scheduler_stage_metrics.py
+++ b/python/sglang/srt/observability/scheduler_stage_metrics.py
@@ -1,0 +1,172 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import TypeVar, cast
+
+from sglang.srt.utils.nvtx_utils import (
+    NVTX_SCHEDULER_ENABLED,
+    profile_range,
+    scheduler_nvtx_method,
+)
+
+SCHEDULER_STAGE_OTHER = "other"
+SCHEDULER_STAGE_RECV_REQUESTS = "recv_requests"
+SCHEDULER_STAGE_PROCESS_REQUESTS = "process_requests"
+SCHEDULER_STAGE_GET_NEXT_BATCH = "get_next_batch"
+SCHEDULER_STAGE_PROCESS_QUEUE = "process_queue"
+SCHEDULER_STAGE_RUN_BATCH = "run_batch"
+SCHEDULER_STAGE_PROCESS_BATCH_RESULT = "process_batch_result"
+SCHEDULER_STAGE_SANITY_CHECK_CACHE = "sanity_check_cache"
+SCHEDULER_STAGE_IDLE = "idle"
+
+SCHEDULER_STAGE_CATEGORIES = (
+    SCHEDULER_STAGE_OTHER,
+    SCHEDULER_STAGE_RECV_REQUESTS,
+    SCHEDULER_STAGE_PROCESS_REQUESTS,
+    SCHEDULER_STAGE_GET_NEXT_BATCH,
+    SCHEDULER_STAGE_PROCESS_QUEUE,
+    SCHEDULER_STAGE_RUN_BATCH,
+    SCHEDULER_STAGE_PROCESS_BATCH_RESULT,
+    SCHEDULER_STAGE_SANITY_CHECK_CACHE,
+    SCHEDULER_STAGE_IDLE,
+)
+_SCHEDULER_STAGE_CATEGORY_SET = frozenset(SCHEDULER_STAGE_CATEGORIES)
+_SCHEDULER_STAGE_TRACE_NAMES = {
+    SCHEDULER_STAGE_PROCESS_REQUESTS: "scheduler.process_input_requests",
+    SCHEDULER_STAGE_GET_NEXT_BATCH: "scheduler.get_next_batch_to_run",
+}
+
+
+def _scheduler_stage_trace_name(stage: str) -> str:
+    return _SCHEDULER_STAGE_TRACE_NAMES.get(stage, f"scheduler.{stage}")
+
+
+@dataclass(slots=True)
+class SchedulerStageMetricsRecorder:
+    """Accumulate mutually exclusive scheduler wall time by stage.
+
+    Nested stages temporarily replace their parent, and uncategorized time is
+    assigned to ``other``. Summing all categories therefore recovers elapsed
+    scheduler-loop wall time. Active torch profilers receive matching
+    ``scheduler.<stage>`` ranges without requiring Python stacks.
+    """
+
+    enabled: bool
+    _current_stage: str = SCHEDULER_STAGE_OTHER
+    _trace_stage: str | None = None
+    _last_wall_ns: int | None = None
+    _wall_ns: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def start(self, wall_ns: int) -> None:
+        if not self.enabled:
+            return
+        self._current_stage = SCHEDULER_STAGE_OTHER
+        self._last_wall_ns = wall_ns
+        self._wall_ns.clear()
+
+    def enter(self, stage: str) -> str | None:
+        if (
+            not self.enabled
+            or self._last_wall_ns is None
+            or self._current_stage == stage
+        ):
+            return None
+        self._sample(time.monotonic_ns())
+        previous_stage = self._current_stage
+        self._current_stage = stage
+        return previous_stage
+
+    def exit(self, previous_stage: str | None) -> None:
+        if previous_stage is None:
+            return
+        self._sample(time.monotonic_ns())
+        self._current_stage = previous_stage
+
+    @contextmanager
+    def record(self, stage: str) -> Iterator[None]:
+        if stage not in _SCHEDULER_STAGE_CATEGORY_SET:
+            raise ValueError(f"Unknown scheduler stage: {stage}")
+        previous_stage = self.enter(stage)
+        previous_trace_stage = self._trace_stage
+        trace_stage_changed = previous_trace_stage != stage
+        if trace_stage_changed:
+            self._trace_stage = stage
+        try:
+            if trace_stage_changed:
+                with profile_range(
+                    _scheduler_stage_trace_name(stage),
+                    nvtx_enabled=NVTX_SCHEDULER_ENABLED,
+                ):
+                    yield
+            else:
+                yield
+        finally:
+            if trace_stage_changed:
+                self._trace_stage = previous_trace_stage
+            self.exit(previous_stage)
+
+    def drain(self, wall_ns: int) -> dict[str, int]:
+        if not self.enabled or self._last_wall_ns is None:
+            return {}
+        self._sample(wall_ns)
+        wall_ns_by_stage = dict(self._wall_ns)
+        self._wall_ns.clear()
+        return wall_ns_by_stage
+
+    def _sample(self, wall_ns: int) -> None:
+        assert self._last_wall_ns is not None
+        self._wall_ns[self._current_stage] += wall_ns - self._last_wall_ns
+        self._last_wall_ns = wall_ns
+
+
+_F = TypeVar("_F", bound=Callable)
+
+
+def scheduler_stage_method(stage: str) -> Callable[[_F], _F]:
+    if stage not in _SCHEDULER_STAGE_CATEGORY_SET:
+        raise ValueError(f"Unknown scheduler stage: {stage}")
+    trace_name = _scheduler_stage_trace_name(stage)
+
+    def decorator(func: _F) -> _F:
+        profiled_func = scheduler_nvtx_method(trace_name)(func)
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            recorder = self.scheduler_stage_metrics
+            if recorder is None:
+                return profiled_func(self, *args, **kwargs)
+
+            previous_stage = recorder.enter(stage)
+            previous_trace_stage = recorder._trace_stage
+            trace_stage_changed = previous_trace_stage != stage
+            if trace_stage_changed:
+                recorder._trace_stage = stage
+            try:
+                return profiled_func(self, *args, **kwargs)
+            finally:
+                if trace_stage_changed:
+                    recorder._trace_stage = previous_trace_stage
+                recorder.exit(previous_stage)
+
+        return cast(_F, wrapper)
+
+    return decorator

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -193,6 +193,9 @@ class TestEnableMetrics(CustomTestCase):
             "sglang:startup_available_gpu_memory_gb",
             "sglang:startup_time_seconds",
             "sglang:startup_cuda_graph_time_seconds",
+            "sglang:scheduler_idle_seconds_total",
+            "sglang:scheduler_process_cpu_seconds_total",
+            "sglang:scheduler_stage_seconds_total",
         ]
         mfu_metrics = [
             "sglang:estimated_flops_per_gpu_total",
@@ -229,6 +232,8 @@ class TestEnableMetrics(CustomTestCase):
             ("sglang:realtime_tokens_total", {"mode": "decode"}),
             ("sglang:forward_execution_seconds_total", {"category": "extend"}),
             ("sglang:forward_execution_seconds_total", {"category": "decode"}),
+            ("sglang:scheduler_process_cpu_seconds_total", {}),
+            ("sglang:scheduler_stage_seconds_total", {"category": "other"}),
             ("sglang:process_cpu_seconds_total", {"component": "tokenizer"}),
             ("sglang:weight_memory_usage_gb", {"model_name": _MODEL_NAME}),
             ("sglang:kv_cache_memory_usage_gb", {"model_name": _MODEL_NAME}),

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import maybe_stub_sgl_kernel
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
@@ -27,7 +27,7 @@ register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="base-c-test-cpu")
 
 
-class TestSchedulerPauseGeneration(unittest.TestCase):
+class TestSchedulerPauseGeneration(CustomTestCase):
     def setUp(self):
         # The scheduler runs after its process publishes; retraction reads the
         # disaggregation and schedule bags rather than the record it is handed.
@@ -142,6 +142,24 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         self.assertIs(scheduler.last_batch, original_last_batch)
         self.assertIs(scheduler.cur_batch_for_debug, original_cur_batch)
         self.assertIs(scheduler.chunked_req, original_chunked_req)
+
+    def test_paused_engine_accounting_uses_current_scheduler_state(self):
+        scheduler = self._new_scheduler()
+        scheduler.is_fully_idle = MagicMock()
+
+        for is_idle in (True, False):
+            with self.subTest(is_idle=is_idle):
+                scheduler.is_fully_idle.return_value = is_idle
+                scheduler.metrics_reporter.reset_mock()
+
+                scheduler._record_scheduler_state_for_paused_engine()
+
+                if is_idle:
+                    scheduler.metrics_reporter.record_scheduler_idle.assert_called_once_with()
+                    scheduler.metrics_reporter.record_scheduler_active.assert_not_called()
+                else:
+                    scheduler.metrics_reporter.record_scheduler_active.assert_called_once_with()
+                    scheduler.metrics_reporter.record_scheduler_idle.assert_not_called()
 
     def test_inplace_does_not_drain_overlap_queue(self):
         """in_place should not process the overlap result_queue."""

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -407,6 +407,109 @@ class TestIdleMetrics(unittest.TestCase):
         self.assertEqual(self.published_occupancies, [])
 
 
+class TestSchedulerTimeAccounting(CustomTestCase):
+    def setUp(self):
+        self.reporter = _make_reporter(self, types.SimpleNamespace())
+        self.idle_seconds = []
+        self.process_cpu_seconds = []
+        self.stage_seconds = []
+        self.reporter.enable_metrics = True
+        self.reporter.scheduler_stage_metrics.enabled = True
+        self.reporter.metrics_collector = types.SimpleNamespace(
+            increment_scheduler_idle_seconds=self.idle_seconds.append,
+            increment_scheduler_process_cpu_seconds=self.process_cpu_seconds.append,
+            increment_scheduler_stage_seconds=lambda **kwargs: self.stage_seconds.append(
+                kwargs
+            ),
+        )
+
+    def test_counts_idle_wall_time_and_process_cpu_time(self):
+        wall_timestamps = [
+            0,
+            1_200_000_000,
+            1_500_000_000,
+            2_700_000_000,
+            3_000_000_000,
+            4_100_000_000,
+        ]
+        process_cpu_timestamps = [
+            0,
+            400_000_000,
+            1_200_000_000,
+            1_900_000_000,
+        ]
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic_ns",
+                side_effect=wall_timestamps,
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.process_time_ns",
+                side_effect=process_cpu_timestamps,
+            ),
+        ):
+            self.reporter.start_scheduler_time_accounting()
+            self.reporter.record_scheduler_idle()
+            self.reporter.record_scheduler_active()
+            self.reporter.record_scheduler_active()
+            self.reporter.record_scheduler_idle()
+            self.reporter.record_scheduler_idle()
+
+        self.assertAlmostEqual(sum(self.idle_seconds), 2.6)
+        self.assertAlmostEqual(sum(self.process_cpu_seconds), 1.9)
+        self.assertAlmostEqual(
+            sum(sample["seconds"] for sample in self.stage_seconds), 4.1
+        )
+        self.assertEqual({sample["stage"] for sample in self.stage_seconds}, {"other"})
+
+    def test_state_transitions_accumulate_until_periodic_update(self):
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic_ns",
+                side_effect=[0, 200_000_000, 400_000_000, 700_000_000, 1_100_000_000],
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.process_time_ns",
+                side_effect=[0, 300_000_000],
+            ) as process_time,
+        ):
+            self.reporter.start_scheduler_time_accounting()
+            accounting = self.reporter._scheduler_time_accounting
+            self.reporter.record_scheduler_active()
+            self.reporter.record_scheduler_idle()
+            self.reporter.record_scheduler_active()
+            self.assertEqual(self.idle_seconds, [])
+            self.assertEqual(self.process_cpu_seconds, [])
+            self.assertEqual(
+                self.reporter._scheduler_time_accounting.accumulate_idle_ns,
+                500_000_000,
+            )
+            self.reporter.record_scheduler_active()
+
+        self.assertIs(self.reporter._scheduler_time_accounting, accounting)
+        self.assertEqual(process_time.call_count, 2)
+        self.assertEqual(self.idle_seconds, [0.5])
+        self.assertAlmostEqual(self.process_cpu_seconds[0], 0.3)
+
+    def test_periodic_update_skips_zero_idle_but_records_cpu_sample(self):
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic_ns",
+                side_effect=[0, 0, 1_000_000_000],
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components.metrics_reporter.time.process_time_ns",
+                side_effect=[0, 0],
+            ),
+        ):
+            self.reporter.start_scheduler_time_accounting()
+            self.reporter.record_scheduler_active()
+            self.reporter.record_scheduler_active()
+
+        self.assertEqual(self.idle_seconds, [])
+        self.assertEqual(self.process_cpu_seconds, [0.0])
+
+
 class TestEstimatedPrefillPerf(CustomTestCase):
     """Causal pair count behind ``est. prefill TFLOPS/s`` and ``estimated_flops``."""
 

--- a/test/registered/unit/observability/test_scheduler_stage_metrics.py
+++ b/test/registered/unit/observability/test_scheduler_stage_metrics.py
@@ -1,0 +1,164 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.observability.scheduler_stage_metrics import (
+    SCHEDULER_STAGE_CATEGORIES,
+    SCHEDULER_STAGE_GET_NEXT_BATCH,
+    SCHEDULER_STAGE_PROCESS_QUEUE,
+    SCHEDULER_STAGE_PROCESS_REQUESTS,
+    SCHEDULER_STAGE_RUN_BATCH,
+    SchedulerStageMetricsRecorder,
+    scheduler_stage_method,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSchedulerStageMetricsRecorder(CustomTestCase):
+    def test_category_names(self):
+        self.assertEqual(
+            set(SCHEDULER_STAGE_CATEGORIES),
+            {
+                "other",
+                "recv_requests",
+                "process_requests",
+                "process_batch_result",
+                "process_queue",
+                "get_next_batch",
+                "run_batch",
+                "sanity_check_cache",
+                "idle",
+            },
+        )
+
+    def test_nested_stages_are_exclusive(self):
+        recorder = SchedulerStageMetricsRecorder(enabled=True)
+        recorder.start(wall_ns=0)
+
+        with patch(
+            "sglang.srt.observability.scheduler_stage_metrics.time.monotonic_ns",
+            side_effect=[10, 30, 50, 80],
+        ):
+            outer = recorder.enter(SCHEDULER_STAGE_GET_NEXT_BATCH)
+            inner = recorder.enter(SCHEDULER_STAGE_PROCESS_QUEUE)
+            recorder.exit(inner)
+            recorder.exit(outer)
+
+        wall_ns = recorder.drain(wall_ns=100)
+
+        self.assertEqual(
+            wall_ns,
+            {
+                "other": 30,
+                "get_next_batch": 50,
+                "process_queue": 20,
+            },
+        )
+        self.assertEqual(sum(wall_ns.values()), 100)
+
+    def test_decorator_restores_stage_after_exception(self):
+        recorder = SchedulerStageMetricsRecorder(enabled=True)
+        recorder.start(wall_ns=0)
+
+        class SchedulerLike:
+            scheduler_stage_metrics = recorder
+
+            @scheduler_stage_method(SCHEDULER_STAGE_RUN_BATCH)
+            def fail(self):
+                raise RuntimeError("boom")
+
+        with (
+            patch(
+                "sglang.srt.observability.scheduler_stage_metrics.time.monotonic_ns",
+                side_effect=[10, 40],
+            ),
+            self.assertRaisesRegex(RuntimeError, "boom"),
+        ):
+            SchedulerLike().fail()
+
+        wall_ns = recorder.drain(wall_ns=50)
+        self.assertEqual(wall_ns, {"other": 20, "run_batch": 30})
+
+    def test_nested_same_stage_does_not_double_count(self):
+        recorder = SchedulerStageMetricsRecorder(enabled=True)
+        recorder.start(wall_ns=0)
+
+        with patch(
+            "sglang.srt.observability.scheduler_stage_metrics.time.monotonic_ns",
+            side_effect=[10, 40],
+        ):
+            with recorder.record(SCHEDULER_STAGE_RUN_BATCH):
+                with recorder.record(SCHEDULER_STAGE_RUN_BATCH):
+                    pass
+
+        wall_ns = recorder.drain(wall_ns=50)
+        self.assertEqual(wall_ns, {"other": 20, "run_batch": 30})
+
+    def test_trace_spans_do_not_require_python_stacks(self):
+        recorder = SchedulerStageMetricsRecorder(enabled=False)
+
+        class SchedulerLike:
+            scheduler_stage_metrics = recorder
+
+            @scheduler_stage_method(SCHEDULER_STAGE_RUN_BATCH)
+            def run(self):
+                with self.scheduler_stage_metrics.record(SCHEDULER_STAGE_PROCESS_QUEUE):
+                    pass
+
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU],
+            with_stack=False,
+            acc_events=True,
+        ) as profiler:
+            SchedulerLike().run()
+
+        stage_events = [
+            event for event in profiler.events() if event.key.startswith("scheduler.")
+        ]
+        self.assertEqual(
+            [event.key for event in stage_events],
+            ["scheduler.run_batch", "scheduler.process_queue"],
+        )
+        self.assertTrue(all(not event.stack for event in stage_events))
+
+    def test_decorator_preserves_existing_trace_names(self):
+        recorder = SchedulerStageMetricsRecorder(enabled=False)
+
+        class SchedulerLike:
+            scheduler_stage_metrics = recorder
+
+            @scheduler_stage_method(SCHEDULER_STAGE_PROCESS_REQUESTS)
+            def process_requests(self):
+                pass
+
+            @scheduler_stage_method(SCHEDULER_STAGE_GET_NEXT_BATCH)
+            def get_next_batch(self):
+                pass
+
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU],
+            with_stack=False,
+            acc_events=True,
+        ) as profiler:
+            scheduler = SchedulerLike()
+            scheduler.process_requests()
+            scheduler.get_next_batch()
+
+        stage_events = [
+            event for event in profiler.events() if event.key.startswith("scheduler.")
+        ]
+        self.assertEqual(
+            [event.key for event in stage_events],
+            [
+                "scheduler.process_input_requests",
+                "scheduler.get_next_batch_to_run",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Scheduler process CPU time and GPU forward occupancy show whether an engine is busy, but not which scheduler phase owns gaps between forwards. This change exports a mutually exclusive scheduler-stage wall-time breakdown while preserving the existing profiler and NVTX spans.

This PR is stacked on #37461 and will remain closed until that prerequisite lands.

## Modifications

- Add `sglang:scheduler_stage_seconds_total{category=...}` for request intake, batch selection, queue processing, execution, result processing, cache checks, idle work, and residual work.
- Layer stage accounting onto `scheduler_nvtx_method` so existing profiler and NVTX instrumentation remains intact.
- Put prefill-bootstrap polling and busy cache checks on the shared component methods, covering normal, pipeline-parallel, and MLX call paths without call-site-specific scopes.
- Wire the recorder explicitly through scheduler components and cover the accounting and partial-scheduler fixtures with unit tests.

## Accuracy Tests

Not applicable. This change does not alter model computation or outputs.

## Speed Tests and Profiling

No end-to-end speed benchmark was run. Stage accounting is enabled only with metrics collection; unit coverage verifies stackless profiler spans and mutually exclusive wall-time accounting.

## Tests

- Focused scheduler metrics, component, disaggregation, multimodal, and fixture tests: 137 passed, 38 skipped, and 4 subtests passed.
- All configured pre-commit hooks passed on the 17 changed files.
- `git diff --check` passed.

## Original commits

- `d47075b40d`
- `f1fe67a450`
- `c109c5b9f8`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
