### PR TITLE
[diffusion] docs: verify the DGX Spark H3 recipe

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1253,6 +1253,15 @@ cards and a Host RAM selector: pick your budget and it emits this command with
 your tier's measured expectations attached as comments. The table below is the
 same data in one view.
 
+**Unified-memory machines are the exception**: on a DGX Spark (GB10, 128 GB
+shared between CPU and GPU) launch with **no flags at all**. The deployment
+still exceeds the pool, automatic offload engages on its own, and its placement
+beat the explicit recipe above by 2.1× on the denoise (12.1 vs 25.8 s/it
+measured on the same box) — the VRAM/host split that justifies every flag in
+this section does not exist there. Expect ~12 min of load, a ~5.5 min text
+encoding stage per request (steady-state compute on this chip, not a stall),
+and ~12 min per warm 480P request.
+
 **Two budgets, and what each one buys**
 
 | | 12 GB VRAM + 32 GB host | host free, VRAM 16 GB |

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -24,10 +24,11 @@ const CONSUMER_24G = ["rtx4090", "rtx3090"];
 // their recipes are derived from the tier logic, not verified runs.
 const WORKSTATION_48G = ["rtx6000ada"];
 const WORKSTATION_96G = ["rtxpro6000"];
-// GB10 unified memory: 128 GB shared between CPU and GPU, so the VRAM/host
-// split that shapes every tier above does not exist. The whole 108 GB
-// deployment fits, and an offloaded component's "copy to device" is an
-// in-memory copy on the coherent bus. No hard-cap anchor was measured.
+// GB10 unified memory: 128 GB shared between CPU and GPU (121.7 GB visible
+// to torch), so the VRAM/host split that shapes every tier above does not
+// exist. The 134 GiB deployment still exceeds the pool, and the loader's
+// automatic placement handles that split better than any explicit flag set:
+// verified on DGX Spark, see unified128Flags().
 const UNIFIED_128G = ["dgx-spark"];
 const CONSUMER_SINGLE = [
   ...CONSUMER_12G,
@@ -73,14 +74,12 @@ function consumerFlags(s) {
 }
 
 function unified128Flags() {
-  // Unified memory holds the whole deployment: the memory manager pins every
-  // component (the budget sees ~128 GB), and streamed copies move at memory
-  // speed on the coherent bus. video_vae=36 still buys the fast decode.
-  return [
-    "--performance-mode memory",
-    "--layerwise-offload-components dit,text_encoder,vae",
-    "--layerwise-resident-layers video_vae=36",
-  ];
+  // No flags: the deployment (134 GiB) exceeds the pool, automatic offload
+  // engages on its own and pins 42 of 50 DiT layers. Measured on DGX Spark,
+  // the explicit discrete-GPU recipe (--performance-mode memory + offload
+  // components + video_vae=36) ran the same denoise 2.1x slower (25.8 vs
+  // 12.1 s/it) -- do not carry discrete-card flags onto unified memory.
+  return [];
 }
 
 function workstation96Flags() {
@@ -117,8 +116,10 @@ function consumerHints(s) {
   }
   if (UNIFIED_128G.includes(s.hw)) {
     return [
-      "derived recipe, not yet verified: the 128 GB unified pool holds the whole 108 GB deployment, so the memory manager pins every component and offload copies run at memory speed on the coherent bus",
-      "expect step times above the discrete-GPU rows: the GB10's ~273 GB/s memory bandwidth is the denoise ceiling, not the placement",
+      "verified on DGX Spark at 480P: ~12.1 s per denoise step steady-state, ~40 s decode, ~12 min per warm request -- with no flags at all; adding the discrete-GPU offload flags measured 2.1x slower on the same box",
+      "the text encoder runs ~5.5 min per request and does not warm up: it is steady-state compute on this chip, not a stall -- budget for it",
+      "expect ~12 min of server load before the first request; the first request itself runs at full speed (no JIT tax was measured)",
+      "step times sit above the discrete-GPU rows because the GB10's ~273 GB/s memory bandwidth is the denoise ceiling, not the placement",
     ];
   }
   if (WORKSTATION_96G.includes(s.hw)) {


### PR DESCRIPTION
## Motivation

The consumer cookbook shipped the `dgx-spark` tier as a derived recipe (#36169): it reused the discrete-GPU flag set on the assumption that unified memory would make offload copies free. A verified A/B on a DGX Spark (GB10, 121.7 GB unified visible to torch) shows the opposite: the derived flags are a 2.1× denoise regression, and the right recipe is **no flags at all**.

## Measurements

MiniMax-H3 fl2va, 480P 16:9 5 s, 19 denoise steps, clean box, cold + warm request per arm:

| Arm | TE | Denoise | Decode | Warm e2e |
|---|---|---|---|---|
| **no flags (auto placement)** | 318–342 s | **310–323 s (12.1 s/it steady)** | 40 s | **~712 s** |
| derived recipe (`--performance-mode memory` + offload components + `video_vae=36`) | 339 s | 431–491 s (25.8 s/it warm) | 37–83 s | ~867 s |

The 134 GiB deployment exceeds the pool either way, so automatic offload engages on its own (DiT pins 42/50). The explicit recipe produces a near-identical layout yet runs the denoise at half speed — the regression follows the `memory` performance mode and the forced VAE residency, not the placement. Thermal throttling was ruled out (slowdown counters flat under load).

Also folded into the tier hints: ~12 min server load, TE is ~5.5 min per request of steady-state compute (it does not warm up — cold and warm requests run at the same speed), and step times sit above discrete-GPU rows because the ~273 GB/s memory bandwidth is the denoise ceiling.

## Modifications

- `unified128Flags()` now returns no flags, with the measured 2.1× comparison in the comment.
- The `dgx-spark` hints move from "derived, not yet verified" to verified numbers with cold-start expectations.
- The Consumer GPU tuning section gets a short unified-memory exception paragraph so readers don't carry discrete-card flags onto these machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33541028227](https://github.com/sgl-project/sglang/actions/runs/33541028227)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33541027991](https://github.com/sgl-project/sglang/actions/runs/33541027991)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->