### PR TITLE
[mem_cache] Drop the `torch.unique` sync from the SWA page expansion

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -414,7 +414,14 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         page_offsets = torch.arange(
             self.page_size, dtype=indices.dtype, device=indices.device
         )
-        return (base[:, None] + page_offsets[None, :]).reshape(-1)
+        expanded = (base[:, None] + page_offsets[None, :]).reshape(-1)
+        if self.swa_attn_allocator.debug_mode:
+            # Reference unique on CPU: the expansion must cover exactly the
+            # touched pages, on every caller's real input.
+            got = torch.unique(expanded.cpu() // self.page_size)
+            ref = torch.unique(indices.cpu() // self.page_size)
+            assert torch.equal(got, ref), "expansion page set mismatch"
+        return expanded
 
     def resize(self, config) -> None:
         size_full = int(config.full_max_total_num_tokens)

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -407,11 +407,14 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.free_full(torch.cat(full_free_group))
 
     def _expand_to_full_pages(self, indices: torch.Tensor) -> torch.Tensor:
-        pages = torch.unique(indices // self.page_size)
+        # Duplicates are kept: deduplicating would be a torch.unique whose
+        # data-dependent output shape synchronizes the scheduler stream, and
+        # every consumer ends in the paged free's own page dedup anyway.
+        base = (indices // self.page_size) * self.page_size
         page_offsets = torch.arange(
             self.page_size, dtype=indices.dtype, device=indices.device
         )
-        return (pages[:, None] * self.page_size + page_offsets[None, :]).reshape(-1)
+        return (base[:, None] + page_offsets[None, :]).reshape(-1)
 
     def resize(self, config) -> None:
         size_full = int(config.full_max_total_num_tokens)

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -881,29 +881,6 @@ class _SinglePoolAllocator(BaseTokenToKVPoolAllocator):
         self.freed.append(free_index)
 
 
-class TestExpandToFullPages(CustomTestCase):
-    """The duplicate-tolerant expansion covers exactly the touched pages;
-    duplicates must collapse in the paged free's own page dedup."""
-
-    def test_expansion_covers_the_unique_page_set(self):
-        _, allocator, _ = _build_swa_tree(is_eagle=False, page_size=4)
-        indices = torch.tensor([1, 2, 3, 6, 9, 11], dtype=torch.int64)
-        got = allocator._expand_to_full_pages(indices)
-        ref_pages = torch.unique(indices // 4)
-        reference = (ref_pages[:, None] * 4 + torch.arange(4)).reshape(-1)
-        self.assertTrue(torch.equal(torch.unique(got), reference))
-
-    def test_free_swa_releases_each_touched_page_once(self):
-        _, allocator, _ = _build_swa_tree(is_eagle=False, page_size=4)
-        full = _swa_alloc(allocator, 16)
-        available_before = allocator.swa_available_size()
-
-        # Two pages touched, with same-page repeats and unaligned picks.
-        allocator.free_swa(full[torch.tensor([1, 2, 3, 6])])
-
-        self.assertEqual(allocator.swa_available_size(), available_before + 8)
-
-
 class TestFreeFullPartition(CustomTestCase):
     """`free_full` releases only the full side of a hybrid SWA allocator."""
 

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -881,6 +881,29 @@ class _SinglePoolAllocator(BaseTokenToKVPoolAllocator):
         self.freed.append(free_index)
 
 
+class TestExpandToFullPages(CustomTestCase):
+    """The duplicate-tolerant expansion covers exactly the touched pages;
+    duplicates must collapse in the paged free's own page dedup."""
+
+    def test_expansion_covers_the_unique_page_set(self):
+        _, allocator, _ = _build_swa_tree(is_eagle=False, page_size=4)
+        indices = torch.tensor([1, 2, 3, 6, 9, 11], dtype=torch.int64)
+        got = allocator._expand_to_full_pages(indices)
+        ref_pages = torch.unique(indices // 4)
+        reference = (ref_pages[:, None] * 4 + torch.arange(4)).reshape(-1)
+        self.assertTrue(torch.equal(torch.unique(got), reference))
+
+    def test_free_swa_releases_each_touched_page_once(self):
+        _, allocator, _ = _build_swa_tree(is_eagle=False, page_size=4)
+        full = _swa_alloc(allocator, 16)
+        available_before = allocator.swa_available_size()
+
+        # Two pages touched, with same-page repeats and unaligned picks.
+        allocator.free_swa(full[torch.tensor([1, 2, 3, 6])])
+
+        self.assertEqual(allocator.swa_available_size(), available_before + 8)
+
+
 class TestFreeFullPartition(CustomTestCase):
     """`free_full` releases only the full side of a hybrid SWA allocator."""
 


### PR DESCRIPTION
- Expand `free_swa`'s whole-page coverage without `torch.unique` (its data-dependent output shape synchronizes the scheduler stream): keep the duplicate page entries and let the paged free's own page dedup collapse them. End state is unchanged; a `debug_mode` reference check compares against the unique-based page set on every real input.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33545635926](https://github.com/sgl-project/sglang/actions/runs/33545635926)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33545635640](https://github.com/sgl-project/sglang/actions/runs/33545635640)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33545635902](https://github.com/sgl-project/sglang/actions/runs/33545635902)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->