### PR TITLE
[LoRA] Restore GDN in_proj target-module choices lost in the rebase

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -4347,6 +4347,9 @@ SUPPORTED_LORA_TARGET_MODULES = [
     # Inkling attention projections (merged q/k/v/r and its row-parallel output).
     "qkvr",
     "wo_ud",
+    # GDN (GatedDeltaNet) projections
+    "in_proj_qkvz",
+    "in_proj_ba",
 ]
 
 LORA_TARGET_ALL_MODULES = "all"


### PR DESCRIPTION
The v0.5.19 rebase of sglang-miles dropped `in_proj_qkvz` / `in_proj_ba` from `SUPPORTED_LORA_TARGET_MODULES` (the Inkling entries `qkvr`/`wo_ud` were carried over, the GDN ones were not). The runtime support is intact — `lora.py` still ships `_normalize_in_proj_qkvz` / `_normalize_in_proj_ba` — only the argparse choices went missing, so any `--lora-target-modules in_proj_qkvz` launch dies at ServerArgs parsing.

miles' GDN LoRA converter emits exactly these names (`in_proj -> [in_proj_qkvz, in_proj_ba]`, used by the Qwen3.5-35B-A3B LoRA recipe on miles main), and miles CPU CI installs this branch's tip, so every miles PR currently fails `TestLoraTargetModules::test_gdn_attention_targets_are_named_one_by_one`.

Verified: with the two entries restored, that miles test class passes 5/5 (fails 1/5 without).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33551572792](https://github.com/sgl-project/sglang/actions/runs/33551572792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33551572623](https://github.com/sgl-project/sglang/actions/runs/33551572623)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33551572745](https://github.com/sgl-project/sglang/actions/runs/33551572745)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->