### PR TITLE
[Cookbook] Verify DeepSeek-V4 Flash Vision balanced and high-throughput on B200

### DIFF
--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
@@ -653,8 +653,18 @@ export const benchmarks = [
     accuracy: { mmmu_pro_pct: 75.14 },
     notes: "MMMU-Pro (standard, 10-option) measured with sgl-eval on 4×B200 (TP=4) at temperature 1.0, top-p 0.95, --reasoning-effort max, with the bundled DSpark head enabled (--speculative-algorithm DSPARK).",
   },
-  { match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "balanced", nodes: "single" } },
-  { match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "high-throughput", nodes: "single" } },
+  {
+    match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "balanced", nodes: "single" },
+    sglang_version: "PR #37253 @ 31854c3",
+    accuracy: { mmmu_pro_pct: 74.10 },
+    notes: "MMMU-Pro (standard, 10-option) measured with sgl-eval on 4×B200 (TP=4, DP=4, DeepEP) at temperature 1.0, top-p 0.95, --reasoning-effort max; target-only (DP Attention is incompatible with DSpark).",
+  },
+  {
+    match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "PR #37253 @ 31854c3",
+    accuracy: { mmmu_pro_pct: 73.76 },
+    notes: "MMMU-Pro (standard, 10-option) measured with sgl-eval on 4×B200 (TP=4, DP=4, MegaMoE) at temperature 1.0, top-p 0.95, --reasoning-effort max; target-only (DP Attention is incompatible with DSpark).",
+  },
   // B300 / GB200 / GB300 / H200 / H100 — Flash Vision (Exp), all pending
   { match: { hw: "b300", variant: "flash-vision", quant: "fp4", strategy: "low-latency", nodes: "single" } },
   { match: { hw: "b300", variant: "flash-vision", quant: "fp4", strategy: "balanced", nodes: "single" } },

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -3047,8 +3047,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "balanced", nodes: "single" },
-      verified: false,
-      verificationStatus: "in-progress",
+      verified: true,
       warn: "DeepSeek-V4-Flash-Vision-Exp support has not shipped in an SGLang release yet (sglang PR 37253): Docker mode already points at the preview image; for Python mode install SGLang from that PR. See [Flash Vision notes](#vision-note).",
       env: ["SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=1024"],
       flags: [
@@ -3065,8 +3064,7 @@ sgl-eval run mmmu_pro \\
     },
     {
       match: { hw: "b200", variant: "flash-vision", quant: "fp4", strategy: "high-throughput", nodes: "single" },
-      verified: false,
-      verificationStatus: "in-progress",
+      verified: true,
       warn: "DeepSeek-V4-Flash-Vision-Exp support has not shipped in an SGLang release yet (sglang PR 37253): Docker mode already points at the preview image; for Python mode install SGLang from that PR. See [Flash Vision notes](#vision-note).",
       env: [
         "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320",


### PR DESCRIPTION
## Motivation

Follow-up to #37293 / #37301: the B200 Flash Vision **balanced** (DeepEP) and **high-throughput** (MegaMoE) cells shipped as `verificationStatus: "in-progress"` with bare benchmark stubs. This PR lands their verification round.

## Verification

Both cells were run **verbatim** on 4(×2)×B200 (TP=4, DP=4) with the cookbook MMMU-Pro command (`sgl-eval run mmmu_pro --reasoning-effort max --temperature 1.0 --top-p 0.95`), on `lmsysorg/sglang:dev` (`07c8f7294`) + a checkout of the #37253 model-support head (`31854c3156`):

| Strategy | MoE path | MMMU-Pro (standard, 10-option) | truncated / error |
|---|---|---|---|
| balanced | DeepEP | **74.10** | 0.06% / 0% |
| high-throughput | MegaMoE | **73.76** | 0.06% / 0% |

Reference: the verified low-latency cell (with the bundled DSpark head) measures 75.14 — the balanced/HT numbers sit inside the temperature-1.0 noise band of the target-only runs (74.96 was the earlier target-only low-latency figure). Both strategies stay target-only because DP Attention is incompatible with DSpark.

## Modifications

- `deepseek-v4.jsx`: flip the two B200 Flash Vision cells to `verified: true` (the preview-image `warn` stays — #37253 has not shipped in a release).
- `deepseek-v4-benchmarks.jsx`: fill the two bare stubs with the measured MMMU-Pro accuracy, `sglang_version: "PR #37253 @ 31854c3"`, and run-shape notes.

Other hardware rows keep their pending stubs.

## Checklist

- [x] `mint validate` passes.
- [x] Config parsed programmatically: B200 flash-vision low-latency/balanced/high-throughput all render VERIFIED; benchmark entries resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33552173286](https://github.com/sgl-project/sglang/actions/runs/33552173286)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33552174355](https://github.com/sgl-project/sglang/actions/runs/33552174355)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->