### PR TITLE
[Fix] Preserve background flag in GenerateReqInput.__getitem__

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -907,6 +907,7 @@ class GenerateReqInput:
             return_flat_raw_top_logprobs_b64=self.return_flat_raw_top_logprobs_b64,
             stream=self.stream,
             log_metrics=self.log_metrics,
+            background=self.background,
             return_hidden_states=(
                 self.return_hidden_states[i]
                 if isinstance(self.return_hidden_states, list)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -712,6 +712,28 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             ["batch_0", "batch_1", "batch_2", "batch_3"],
         )
 
+    def test_parallel_sampling_preserves_background(self):
+        """background=True dropped by __getitem__ causes spurious disconnect
+        aborts in _stream_one_response for Responses API background requests
+        with n>1."""
+        single = GenerateReqInput(
+            text="Hello",
+            rid="bg-single",
+            sampling_params={"n": 3},
+            background=True,
+        )
+        single.normalize_batch_and_arguments()
+        self.assertTrue(all(single[i].background for i in range(3)))
+
+        batch = GenerateReqInput(
+            text=["Hello", "World"],
+            rid="bg-batch",
+            sampling_params={"n": 2},
+            background=True,
+        )
+        batch.normalize_batch_and_arguments()
+        self.assertTrue(all(batch[i].background for i in range(4)))
+
     def test_audio_data_handling(self):
         """Test handling of audio_data."""
         req = copy.deepcopy(self.base_req)


### PR DESCRIPTION
## Motivation

Fixes #27231.

`GenerateReqInput.__getitem__` doesn't propagate `background` to the
sub-objects it constructs. Since `background` defaults to `False`, the
omission fails silently rather than raising.

1. `serving_responses.py` sets `background=True`
2. `sampling_params` with `n > 1` flips `is_single=False` in
   `_handle_parallel_sampling`
3. `_handle_batch_request` calls `obj[i]`
4. sub-objects get `background=False`
5. `_stream_one_response`: `if request is not None and not obj.background and
   await request.is_disconnected(): self.abort_request(obj.rid)`

A background Responses API request with `n > 1` is aborted on client
disconnect — the thing `background` exists to prevent. Single requests without
parallel sampling are unaffected, since `__getitem__` isn't called there.

No existing test caught this: `test_getitem_method` and the other
`__getitem__` tests never set `background`.

Note there are two existing PRs for this issue, #27255 and #27466. This one is
rebased on current main and adds batch-case coverage neither has. Happy to
close in favour of either if a maintainer prefers — flagging so nobody
duplicates review effort.

## Modifications

One line. `background` is a batch-shared scalar, forwarded as-is alongside
`stream` and `log_metrics` immediately above it.

Adds `test_parallel_sampling_preserves_background`, following
`test_parallel_sampling_preserves_reasoning_controls`. Covers single-text with
n=3 and a 2-prompt batch with n=2.

## Accuracy Tests

CPU-only, `base-c-test-cpu`.

With the fix reverted, the test fails at
`assertTrue(all(single[i].background for i in range(3)))` — `False is not
true`. With it, passes. Both runs on current upstream/main.

Full `test_io_struct.py`: 49 passed, 2 skipped (CUDA-gated).
`test_embed_overrides.py`, `test_mm_hashes.py`,
`test_flat_raw_top_logprobs.py`: 77 passed, 2 skipped.
`test_rust_tokenized_generate_schema_stays_in_lockstep` passes — this
propagates an existing field rather than altering the wire schema.

## Speed Tests and Profiling

N/A — correctness fix.

## Note

`__getitem__` is a hand-maintained allowlist, so any field added without
updating it is dropped silently. Auditing the dataclass turned up 11
unforwarded fields. #27217 is an independently-reported instance of the same
failure mode.

Keeping this PR to the one reachable bug. Happy to follow up with the
remaining fields plus a `dataclasses.fields()` guard test that fails CI when a
new field is added without being classified — if that's wanted.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33553352014](https://github.com/sgl-project/sglang/actions/runs/33553352014)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33553351807](https://github.com/sgl-project/sglang/actions/runs/33553351807)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33553352090](https://github.com/sgl-project/sglang/actions/runs/33553352090)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->