### PR TITLE
[spec] Keep DSPARK draft tokens within the target vocabulary

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -819,7 +819,8 @@ def cap_correct_len(
     verify_lens: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     ell_r = (verify_lens.to(device=correct_len.device) - 1).to(correct_len.dtype)
-    capped = torch.minimum(correct_len, ell_r)
+    # verify_lens==0 (padded) rows would yield -1, an out-of-bounds index downstream.
+    capped = torch.clamp(torch.minimum(correct_len, ell_r), min=0)
     cap_trim_lens = correct_len - capped
     return capped, cap_trim_lens
 
@@ -839,7 +840,8 @@ def _cap_correct_len_kernel(
     cl = tl.load(correct_len_ptr + offs, mask=mask, other=0).to(tl.int64)
     vl = tl.load(verify_lens_ptr + offs, mask=mask, other=0).to(tl.int64)
     ell = vl - 1
-    capped = tl.minimum(cl, ell)
+    # verify_lens==0 (padded) rows would yield -1, an out-of-bounds index downstream.
+    capped = tl.maximum(tl.minimum(cl, ell), 0)
     trim = cl - capped
     tl.store(capped_ptr + offs, capped, mask=mask)
     tl.store(trim_ptr + offs, trim, mask=mask)

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -851,15 +851,19 @@ def build_out_tokens(
     verify_num_draft_tokens: int,
     gamma: int,
 ) -> torch.Tensor:
+    """Return accepted drafts, the bonus token, and zero-filled tail slots."""
     bs = draft_tokens.shape[0]
-    out_tokens = torch.empty(
+    out_tokens = torch.zeros(
         (bs, verify_num_draft_tokens),
         dtype=torch.int64,
         device=draft_tokens.device,
     )
-    out_tokens[:, :gamma].copy_(draft_tokens)
-    out_tokens[:, gamma].fill_(0)
-    out_tokens.scatter_(1, correct_len.to(torch.int64)[:, None], bonus[:, None])
+    correct_len = correct_len.to(torch.int64)
+    keep = (
+        torch.arange(gamma, device=draft_tokens.device)[None, :] < correct_len[:, None]
+    )
+    out_tokens[:, :gamma] = torch.where(keep, draft_tokens.to(torch.int64), 0)
+    out_tokens.scatter_(1, correct_len[:, None], bonus[:, None])
     return out_tokens
 
 
@@ -883,7 +887,8 @@ def _build_out_tokens_kernel(
     bonus = tl.load(bonus_ptr + b, mask=mask, other=0)
     draft_mask = mask & (k < gamma)
     draft = tl.load(draft_tokens_ptr + b * gamma + k, mask=draft_mask, other=0)
-    val = tl.where(k == cl, bonus, tl.where(k < gamma, draft, 0))
+    # Rejected drafts must not reach downstream token gathers.
+    val = tl.where(k == cl, bonus, tl.where(k < cl, draft, 0))
     tl.store(out_ptr + offs, val.to(tl.int64), mask=mask)
 
 

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -155,6 +155,7 @@ class VanillaMarkov(nn.Module):
         base_logits: torch.Tensor,
         *,
         first_prev_tokens: torch.Tensor,
+        vocab_limit: Optional[int] = None,
     ) -> Optional[torch.Tensor]:
         """Greedy-only draft-block sampling via the fused per-step
         [bias-dot + add + argmax] kernel (see MarkovGreedyStep) — one pass over
@@ -172,6 +173,12 @@ class VanillaMarkov(nn.Module):
             return torch.empty(
                 batch_size, 0, dtype=torch.long, device=base_logits.device
             )
+        # Slice base logits and the step-bias rows together so the Torch and
+        # Triton implementations argmax over the same capped vocabulary.
+        w2_weight = self.markov_w2.weight
+        if vocab_limit is not None and base_logits.shape[-1] > vocab_limit:
+            base_logits = base_logits[..., :vocab_limit]
+            w2_weight = w2_weight[:vocab_limit]
         sampled_tokens = []
         prev_tokens = first_prev_tokens.long()
         for step_idx in range(proposal_len):
@@ -179,7 +186,7 @@ class VanillaMarkov(nn.Module):
             prev_tokens = MarkovGreedyStep.execute(
                 base_logits=base_logits[:, step_idx, :],
                 prev_embeds=prev_embeds,
-                w2_weight=self.markov_w2.weight,
+                w2_weight=w2_weight,
             )
             sampled_tokens.append(prev_tokens)
         return torch.stack(sampled_tokens, dim=1)
@@ -253,6 +260,7 @@ class GatedMarkovHead(VanillaMarkov):
         base_logits: torch.Tensor,
         *,
         first_prev_tokens: torch.Tensor,
+        vocab_limit: Optional[int] = None,
     ) -> Optional[torch.Tensor]:
         # The gated step bias depends on hidden state; the fused vanilla
         # kernel does not apply.
@@ -367,6 +375,7 @@ class RNNHead(VanillaMarkov):
         base_logits: torch.Tensor,
         *,
         first_prev_tokens: torch.Tensor,
+        vocab_limit: Optional[int] = None,
     ) -> Optional[torch.Tensor]:
         # The recurrent step bias depends on hidden state; the fused vanilla
         # kernel does not apply.

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -318,13 +318,15 @@ def _get_or_create_chain_verify_buffers(
         retrieve_next_sibling = torch.full(
             (new_cap, draft_token_num), -1, dtype=torch.int64, device=device
         )
-        predicts = torch.empty(
+        # The accept kernel skips rows with no verify candidates (padded graph
+        # rows); zeros keep their first-use slots in range for the bonus gather.
+        predicts = torch.zeros(
             (new_cap * draft_token_num,), dtype=torch.int32, device=device
         )
-        accept_index = torch.empty(
+        accept_index = torch.zeros(
             (new_cap, draft_token_num), dtype=torch.int32, device=device
         )
-        accept_token_num = torch.empty((new_cap,), dtype=torch.int32, device=device)
+        accept_token_num = torch.zeros((new_cap,), dtype=torch.int32, device=device)
         cached = {
             "cap_bs": int(new_cap),
             "retrieve_index": retrieve_index,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -127,6 +127,15 @@ def resolve_greedy_mask(
     return (sampling_info.top_ks <= 1).view(-1)
 
 
+def cap_step_logits(
+    step_logits: torch.Tensor, sample_vocab_size: Optional[int]
+) -> torch.Tensor:
+    """Restrict draft sampling to IDs the target can score."""
+    if sample_vocab_size is not None and step_logits.shape[-1] > sample_vocab_size:
+        return step_logits[..., :sample_vocab_size]
+    return step_logits
+
+
 def sample_draft_block(
     *,
     base_logits: torch.Tensor,
@@ -136,6 +145,7 @@ def sample_draft_block(
     markov_head,
     device: torch.device,
     tp_sync: SpecTpSync,
+    sample_vocab_size: Optional[int] = None,
 ) -> DraftBlockResult:
     bs = base_logits.shape[0]
     greedy_mask = resolve_greedy_mask(bs=bs, sampling_info=sampling_info, device=device)
@@ -153,6 +163,7 @@ def sample_draft_block(
 
         def sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
             expect(_DRAFT_STEP_LOGITS, step_logits, msg=f"step {step_idx}")
+            step_logits = cap_step_logits(step_logits, sample_vocab_size)
             return tp_sync.sync(
                 SpecTpSyncSite.DSPARK_DRAFT_GREEDY, torch.argmax(step_logits, dim=-1)
             )
@@ -161,6 +172,7 @@ def sample_draft_block(
 
         def sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
             expect(_DRAFT_STEP_LOGITS, step_logits, msg=f"step {step_idx}")
+            step_logits = cap_step_logits(step_logits, sample_vocab_size)
             if fast_sampling:
                 exp_noise = torch.empty(
                     step_logits.shape, dtype=torch.float32, device=step_logits.device
@@ -192,6 +204,8 @@ def sample_draft_block(
         hidden_states=draft_hidden,
         sampler=sampler,
     )
+    # Verify softmaxes these as the proposal q; crop to the sampled vocabulary.
+    corrected_logits = cap_step_logits(corrected_logits, sample_vocab_size)
     return DraftBlockResult(
         draft_tokens=draft_tokens,
         corrected_logits=corrected_logits,
@@ -211,10 +225,12 @@ class DraftBlockProposer:
         draft_block_spec_info,
         tp_sync: SpecTpSync,
         dp_moe_sync: bool = False,
+        sample_vocab_size: Optional[int] = None,
     ) -> None:
         self.draft_model = draft_model
         self.draft_model_runner = draft_model_runner
         self.gamma = gamma
+        self.sample_vocab_size = sample_vocab_size
         self.sample_from_anchor = bool(draft_model.sample_from_anchor)
         self.query_token_num = self.gamma if self.sample_from_anchor else self.gamma + 1
         self._mask_token_id = mask_token_id
@@ -323,6 +339,7 @@ class DraftBlockProposer:
                 markov_head=self.draft_model.markov_head,
                 device=device,
                 tp_sync=self._tp_sync,
+                sample_vocab_size=self.sample_vocab_size,
             )
         proposal_block_ids = (
             draft_block_ids

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
 from sglang.srt.environ import DsparkFoldedSampling, envs
 from sglang.srt.models.dspark import VanillaMarkov
 from sglang.srt.speculative.dspark_components.dspark_draft import (
+    cap_step_logits,
     select_draft_hidden_without_anchor,
 )
 from sglang.srt.speculative.spec_tp_sync import SpecTpSync, SpecTpSyncSite
@@ -50,10 +51,14 @@ class DsparkDraftSampler:
         confidence_fn=None,
         out=None,
         folded_sampling: bool = True,
+        sample_vocab_size: Optional[int] = None,
     ):
         self.model = model
         self.markov_head = model.markov_head
         self.gamma = int(gamma)
+        self.sample_vocab_size = (
+            int(sample_vocab_size) if sample_vocab_size is not None else None
+        )
         self.sample_from_anchor = bool(model.sample_from_anchor)
         self.query_token_num = self.gamma if self.sample_from_anchor else self.gamma + 1
         max_bs = int(max_bs)
@@ -81,15 +86,16 @@ class DsparkDraftSampler:
         self.corrected_out = None
         if folded_sampling:
             vocab = int(model.lm_head.org_vocab_size)
+            capped_vocab = min(vocab, self.sample_vocab_size or vocab)
             self.temperatures = torch.ones(
                 (max_bs,), dtype=torch.float32, device=device
             )
             self.greedy_mask = torch.ones((max_bs,), dtype=torch.bool, device=device)
             self.exp_noise = torch.empty(
-                (max_bs, vocab), dtype=torch.float32, device=device
+                (max_bs, capped_vocab), dtype=torch.float32, device=device
             )
             self.corrected_out = torch.empty(
-                (max_bs * self.gamma, vocab),
+                (max_bs * self.gamma, capped_vocab),
                 dtype=_base_logits_dtype(model),
                 device=device,
             )
@@ -135,7 +141,9 @@ class DsparkDraftSampler:
             and isinstance(self.markov_head, VanillaMarkov)
         ):
             draft_tokens = self.markov_head.sample_block_greedy_fused(
-                base_logits, first_prev_tokens=anchor
+                base_logits,
+                first_prev_tokens=anchor,
+                vocab_limit=self.sample_vocab_size,
             )
 
         if draft_tokens is None:
@@ -143,6 +151,7 @@ class DsparkDraftSampler:
 
                 def sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
                     del step_idx
+                    step_logits = cap_step_logits(step_logits, self.sample_vocab_size)
                     # In-graph philox noise: each replay advances the generator
                     # and redraws.
                     noise = self.exp_noise[:bs].exponential_()
@@ -161,7 +170,10 @@ class DsparkDraftSampler:
                 def sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
                     return self._tp_sync.sync(
                         SpecTpSyncSite.DSPARK_GRAPH_GREEDY,
-                        greedy_step_sampler(step_logits, step_idx),
+                        greedy_step_sampler(
+                            cap_step_logits(step_logits, self.sample_vocab_size),
+                            step_idx,
+                        ),
                     )
 
             draft_tokens, corrected_logits = self.markov_head.sample_block(
@@ -172,8 +184,12 @@ class DsparkDraftSampler:
                 collect_corrected=self.folded_sampling,
             )
             if self.folded_sampling:
+                # Verify softmaxes these as the proposal q; crop to the sampled vocabulary.
                 self.corrected_out[: bs * self.gamma].copy_(
-                    corrected_logits.reshape(bs * self.gamma, -1)
+                    cap_step_logits(
+                        corrected_logits.reshape(bs * self.gamma, -1),
+                        self.sample_vocab_size,
+                    )
                 )
 
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
@@ -188,7 +204,14 @@ class DsparkDraftSampler:
 
 
 def _resolve_folded_sampling(
-    *, model, gamma, max_bs, device, tp_rank, available_memory_gb: float
+    *,
+    model,
+    gamma,
+    max_bs,
+    device,
+    tp_rank,
+    available_memory_gb: float,
+    sample_vocab_size: Optional[int] = None,
 ) -> bool:
     """The sampling buffers are baked into the captured draft graph, so AUTO
     must decide before capture from a free-memory probe. ``available_memory_gb``
@@ -199,7 +222,8 @@ def _resolve_folded_sampling(
     if mode == DsparkFoldedSampling.FORCE:
         return True
     vocab = int(model.lm_head.org_vocab_size)
-    noise_bytes = max_bs * vocab * 4
+    capped_vocab = min(vocab, sample_vocab_size or vocab)
+    noise_bytes = max_bs * capped_vocab * 4
     logits_bytes = max_bs * gamma * vocab * _base_logits_dtype(model).itemsize
     need_gb = (noise_bytes + logits_bytes) / (1 << 30)
     if available_memory_gb - need_gb >= _CAPTURE_HEADROOM_GB:
@@ -228,6 +252,7 @@ def maybe_build_draft_sampler(
     available_memory_gb: float,
     confidence_fn=None,
     out=None,
+    sample_vocab_size: Optional[int] = None,
 ) -> Optional[DsparkDraftSampler]:
     """Build the graph-folded draft sampler, or None (reason logged) when the
     proposal must stay eager."""
@@ -250,6 +275,7 @@ def maybe_build_draft_sampler(
         device=device,
         tp_rank=tp_rank,
         available_memory_gb=available_memory_gb,
+        sample_vocab_size=sample_vocab_size,
     )
     if tp_rank == 0:
         logger.info(
@@ -265,4 +291,5 @@ def maybe_build_draft_sampler(
         confidence_fn=confidence_fn,
         out=out,
         folded_sampling=folded_sampling,
+        sample_vocab_size=sample_vocab_size,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -163,6 +163,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             target_model_config.hf_text_config, "logits_mup_width_multiplier", None
         )
         self._target_is_mambaish = mambaish_config(target_model_config) is not None
+        # Padded head rows are input-only and must never be sampled.
+        self._sample_vocab_size = int(target_model_config.vocab_size)
         runtime_config = resolve_runtime_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config,
             speculative_num_draft_tokens=get_spec().speculative_num_draft_tokens,
@@ -266,6 +268,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             draft_block_spec_info=self._draft_block_spec_info,
             tp_sync=self._tp_sync,
             dp_moe_sync=self._draft_is_moe and get_parallel().enable_dp_attention,
+            sample_vocab_size=self._sample_vocab_size,
         )
         self._verify_epilogue = None
         if (
@@ -424,6 +427,7 @@ class DSparkWorkerV2(BaseSpecWorker):
     def _maybe_build_draft_sampler(self, *, available_memory_gb: float):
         return maybe_build_draft_sampler(
             draft_model=self.draft_model,
+            sample_vocab_size=self._sample_vocab_size,
             gamma=self.gamma,
             max_bs=max(get_exec().graph.cuda_graph_config.decode.bs),
             device=self.device,

--- a/test/registered/spec/dspark/test_dspark_kernel_parity.py
+++ b/test/registered/spec/dspark/test_dspark_kernel_parity.py
@@ -108,14 +108,21 @@ def _case_build_out_tokens(tc):
     for cl_dtype in (torch.int32, torch.int64):
         # Bonus insertion swept through every position 0..gamma.
         cl = (torch.arange(bs, device=DEVICE) % (gamma + 1)).to(cl_dtype)
-        tc._parity(
+        # Rejected drafts (id beyond the target vocab) must not reach out_tokens.
+        draft_tokens = _ri(0, VOCAB, (bs, gamma))
+        draft_tokens[:, -1] = VOCAB + 10_000
+        got, _ = tc._parity(
             dspark_verify_window.BuildOutTokens,
-            draft_tokens=_ri(0, VOCAB, (bs, gamma)),
+            draft_tokens=draft_tokens,
             correct_len=cl,
             bonus=_ri(0, VOCAB, (bs,)),
             verify_num_draft_tokens=gamma + 1,
             gamma=gamma,
         )
+        # Slots past the bonus position (rejected drafts / tail) must be 0.
+        pos = torch.arange(gamma + 1, device=DEVICE)[None, :]
+        rejected = pos > cl.to(torch.int64)[:, None]
+        tc.assertTrue((got[rejected] == 0).all().item())
 
 
 def _case_build_ragged_verify_window(tc):
@@ -163,10 +170,14 @@ def _case_build_step_local(tc):
 def _case_cap_correct_len(tc):
     torch.manual_seed(6)
     bs, nd = 64, 6
-    verify_lens = _ri(1, nd + 1, (bs,), torch.int32)
+    # verify_lens == 0 (padded graph rows) must clamp to 0, never -1.
+    verify_lens = _ri(0, nd + 1, (bs,), torch.int32)
     for cl_dtype in (torch.int32, torch.int64):
         cl = (torch.arange(bs, device=DEVICE) % (nd + 1)).to(cl_dtype)
-        tc._parity(dspark_accept.CapCorrectLen, correct_len=cl, verify_lens=verify_lens)
+        (capped, _trim), _ = tc._parity(
+            dspark_accept.CapCorrectLen, correct_len=cl, verify_lens=verify_lens
+        )
+        tc.assertGreaterEqual(int(capped.min().item()), 0)
 
 
 def _case_causal_swa_page_indices(tc):

--- a/test/registered/unit/spec/test_dspark_vocab_bounds.py
+++ b/test/registered/unit/spec/test_dspark_vocab_bounds.py
@@ -1,0 +1,88 @@
+"""DSPARK draft tokens must stay within the target's true vocabulary.
+
+The draft head may be padded wider than the target's true vocab; padded rows
+are input-only and must never be sampled. A sampled pad-range id propagates
+through verify into token gathers and kills the engine with device-side
+scatter/gather asserts. Verification must also normalize the proposal
+distribution q over the same capped vocabulary that was sampled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.speculative.dspark_components.dspark_draft import (
+    sample_draft_block,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_TP_SYNC = SimpleNamespace(sync=lambda _site, value: value)
+# Padded draft head: 5 rows, true target vocab 3. The pad rows carry the
+# largest logits, so an uncapped path deterministically samples them.
+_PADDED_LOGITS = torch.tensor([[1.0, 2.0, 3.0, 100.0, 200.0]])
+_TARGET_VOCAB = 3
+
+
+def _sample_block(
+    _base_logits: torch.Tensor,
+    *,
+    sampler: Callable[[torch.Tensor, int], torch.Tensor],
+    **_kwargs: object,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    tokens = sampler(_PADDED_LOGITS, 0)
+    return tokens.reshape(1, 1), _PADDED_LOGITS[:, None, :]
+
+
+@pytest.mark.parametrize("greedy", [True, False], ids=["greedy", "sampled"])
+def test_eager_draft_block_caps_proposals_and_q(greedy: bool) -> None:
+    sampling_info = (
+        None
+        if greedy
+        else SimpleNamespace(
+            is_all_greedy=False,
+            top_ks=torch.tensor([2]),
+            temperatures=torch.tensor([[1.0]]),
+        )
+    )
+    with envs.SGLANG_DSPARK_FAST_SAMPLING.override(False):
+        result = sample_draft_block(
+            base_logits=torch.zeros(1, 5),
+            anchor_tokens=torch.zeros(1, dtype=torch.int64),
+            draft_hidden=torch.zeros(1, 1),
+            sampling_info=sampling_info,
+            markov_head=SimpleNamespace(sample_block=_sample_block),
+            device=torch.device("cpu"),
+            tp_sync=_TP_SYNC,
+            sample_vocab_size=_TARGET_VOCAB,
+        )
+
+    assert int(result.draft_tokens.max().item()) < _TARGET_VOCAB
+    # q (corrected_logits) must be cropped to the same capped vocabulary.
+    assert result.corrected_logits.shape[-1] == _TARGET_VOCAB
+
+
+def test_chain_verify_buffers_start_zeroed() -> None:
+    from sglang.srt.speculative.dflash_utils import (
+        _DFLASH_CHAIN_VERIFY_BUFFERS,
+        _get_or_create_chain_verify_buffers,
+    )
+
+    _DFLASH_CHAIN_VERIFY_BUFFERS.clear()
+    try:
+        _ri, _rnt, _rns, predicts, accept_index, accept_token_num = (
+            _get_or_create_chain_verify_buffers(
+                bs=2, draft_token_num=4, device=torch.device("cpu")
+            )
+        )
+        assert torch.count_nonzero(predicts).item() == 0
+        assert torch.count_nonzero(accept_index).item() == 0
+        assert torch.count_nonzero(accept_token_num).item() == 0
+    finally:
+        _DFLASH_CHAIN_VERIFY_BUFFERS.clear()


### PR DESCRIPTION
## Motivation

DSPARK speculative decoding can emit and consume out-of-range token ids, which surface as runtime errors or device-side asserts (`probability tensor contains either inf, nan or element < 0`, scatter/gather index asserts) that bring down the whole engine — the failing rank's CUDA context dies and peer TP ranks abort their communicators. Two variants of the same class:

1. **Padded draft heads**: when the draft head is padded wider than the target's true vocabulary, draft sampling can propose pad-range ids, which then flow through verify into token gathers.
2. **Padding-independent verify bookkeeping**: chain-verify buffers are allocated with `torch.empty` and rows with no verify candidates (padded CUDA-graph rows, `verify_lens == 0`) are never written by the accept kernel — their uninitialized slots still feed the bonus-token gather; `correct_len` can go to `-1` unclamped; and rejected drafts are propagated into `out_tokens`. This variant fires even with an unpadded draft head and is load-dependent, since the buffers grow (fresh uninitialized memory) when the batch reaches a new size tier.

Both variants are covered by tests included in this PR (see Accuracy Tests).

## Modifications

- Cap draft sampling to the target's true vocabulary at all three entry points (eager block sampling, folded sampler, fused-greedy path — the last via a `vocab_limit` that slices base logits and the step-bias rows together).
- Crop the verify-side proposal distribution `q` (`corrected_logits`) to the same capped vocabulary that was sampled. With a padded head this corrects q's normalization (the softmax previously included pad rows that were never sampleable); with an unpadded head both the cap and the crop are no-op widths.
- Clamp `correct_len >= 0` for `verify_lens == 0` rows.
- Zero-initialize the chain-verify buffers (`predicts`, `accept_index`, `accept_token_num`) so first-use padded rows read a benign index instead of uninitialized memory.
- Zero-fill rejected and tail slots in `out_tokens` instead of propagating rejected drafts.

## Accuracy Tests

- GPU kernel parity suite extended (`test/registered/spec/dspark/test_dspark_kernel_parity.py`): two new subtests fail on the base commit on real behavior — `verify_lens == 0` yields `correct_len == -1` unclamped, and rejected/tail slots stay populated in `out_tokens` — and pass with this PR. The existing 20 parity subtests verify the accept path is unchanged for valid rows.
- CPU unit tests (`test/registered/unit/spec/test_dspark_vocab_bounds.py`): `test_chain_verify_buffers_start_zeroed` asserts the buffers start zeroed (fails on the base commit's `torch.empty` allocation in practice; `torch.empty` contents are unspecified, so that red is not guaranteed). `test_eager_draft_block_caps_proposals_and_q` shows a padded head whose pad rows carry the largest logits cannot be sampled past the true vocabulary, and that q is cropped to the same width (the capping parameter is new in this PR, so this test exercises the new path rather than reproducing the old failure).

## Speed Tests and Profiling

The cap is a logits slice (no-op width when the head is unpadded); buffer zero-init happens only on (re)allocation; the clamp and zero-fills are elementwise ops on tensors the verify path already touches.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing surface changed.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Bounds/initialization guards; correctness covered by the kernel parity suite and unit tests above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35659364476](https://github.com/sgl-project/sglang/actions/runs/35659364476)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35659364340](https://github.com/sgl-project/sglang/actions/runs/35659364340)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35659364517](https://github.com/sgl-project/sglang/actions/runs/35659364517)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->