### PR TITLE
[mm] Release multimodal features at consumption (opt-in) to bound host memory

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -113,6 +113,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Release image feature tensors once their token spans enter the KV cache (bounds multimodal host memory; requires radix caching and `pp_size==1`)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_ENABLE_TORCH_COMPILE`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable torch.compile</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1239,6 +1239,9 @@ class Envs:
     # For pre-tokenized (list[int]) multimodal prompts,
     # preserve the user's original tokens to avoid retokenization drift.
     SGLANG_MM_AVOID_RETOKENIZE = EnvBool(True)
+    # Opt-in: release image feature tensors once their token spans enter the
+    # KV cache instead of retaining them until request completion.
+    SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION = EnvBool(False)
 
     # ===================================================================
     # Multimodal CUDA IPC transport

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -624,6 +624,46 @@ def _embed_mm_inputs_with_split(
     return input_embeds, other_info
 
 
+def _is_releasable_feature(feature) -> bool:
+    if isinstance(feature, torch.Tensor):
+        return True
+    return (
+        isinstance(feature, (list, tuple))
+        and bool(feature)
+        and all(isinstance(tensor, torch.Tensor) for tensor in feature)
+    )
+
+
+def should_release_mm_features(server_args) -> bool:
+    """Requires radix caching (retract re-prefill reads the retained prompt
+    KV) and pp_size==1 (only the first PP stage releases)."""
+    if not envs.SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION.get():
+        return False
+    if getattr(server_args, "pp_size", 1) != 1:
+        return False
+    return not getattr(server_args, "disable_radix_cache", False)
+
+
+def release_consumed_mm_features(
+    mm_inputs_list: List[MultimodalInputs],
+    extend_prefix_lens: List[int],
+    extend_seq_lens: List[int],
+) -> None:
+    """Release image features fully covered by this extend chunk."""
+    for mm_inputs, prefix_len, seq_len in zip(
+        mm_inputs_list, extend_prefix_lens, extend_seq_lens, strict=True
+    ):
+        chunk_end = prefix_len + seq_len
+        for item in mm_inputs.mm_items:
+            if (
+                item.is_image()
+                and _is_releasable_feature(item.feature)
+                and item.offsets
+                and all(end < chunk_end for _, end in item.offsets)
+            ):
+                item.release_feature(consumed=True)
+
+
 def general_mm_embed_routine(
     input_ids: torch.Tensor,
     forward_batch: ForwardBatch,
@@ -713,6 +753,10 @@ def general_mm_embed_routine(
             # best-effort, offloading to CPU ensures we have a reliable fallback
             # if a cache miss occurs in subsequent chunks, while still freeing up
             # critical GPU memory.
+            if mm_inputs_list and should_release_mm_features(server_args):
+                release_consumed_mm_features(
+                    mm_inputs_list, extend_prefix_lens, extend_seq_lens
+                )
             if mm_inputs_list:
                 for mm_input_obj in mm_inputs_list:
                     if mm_input_obj and hasattr(mm_input_obj, "mm_items"):
@@ -1327,28 +1371,37 @@ class ShmPointerMMData:
         self.dtype = state["dtype"]
         self.precomputed_hash = state.get("precomputed_hash")
         self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
-        # Zero-copy view into shared memory (no clone, no unlink)
         self.tensor = torch.frombuffer(self._shm_handle.buf, dtype=self.dtype).reshape(
             self.shape
         )
+        self.tensor.untyped_storage()._shm_keepalive = self._shm_handle
 
     def materialize(self) -> torch.Tensor:
         """Clone tensor from shm to owned memory, then release shm handle."""
         tensor = self.tensor.clone()
         if self._shm_handle is not None:
-            self._shm_handle.close()
             try:
                 self._shm_handle.unlink()
             except FileNotFoundError:
                 pass  # Another rank already unlinked
             self._shm_handle = None
+        self.tensor = None
         return tensor
 
+    def release(self) -> None:
+        """Unlink the receiver segment without invalidating live tensor views."""
+        handle = getattr(self, "_shm_handle", None)
+        self.tensor = None
+        self._shm_handle = None
+        if handle is None:
+            return
+        try:
+            handle.unlink()
+        except FileNotFoundError:
+            pass  # Another rank already unlinked
+
     def __del__(self):
-        # Only close; never unlink. Unlinking is materialize()'s job.
-        if getattr(self, "_shm_handle", None) is not None:
-            self._shm_handle.close()
-            self._shm_handle = None
+        self.release()
 
 
 def _get_is_default_transport():

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -364,6 +364,8 @@ class MultimodalDataItem(msgspec.Struct, kw_only=True, dict=True, array_like=Tru
         default_factory=dict
     )
 
+    feature_released: bool = False
+
     def __post_init__(self) -> None:
         if self.hash is not None:
             msgspec.Struct.__setattr__(self, "hash", self.hash & _MM_HASH_MASK)
@@ -519,6 +521,11 @@ class MultimodalDataItem(msgspec.Struct, kw_only=True, dict=True, array_like=Tru
         )
         return min(requested_count, proxy_count)
 
+    def release_feature(self, *, consumed: bool = False) -> None:
+        """Drop the raw feature and record whether it was consumed."""
+        self.feature = None
+        self.feature_released = self.feature_released or consumed
+
 
 class MultimodalProcessorOutput(
     msgspec.Struct, kw_only=True, dict=True, array_like=True, weakref=True
@@ -643,7 +650,18 @@ class MultimodalInputs:
     def release_features(self):
         """Release feature tensors to free GPU memory."""
         for item in self.mm_items:
-            item.feature = None
+            item.release_feature()
+
+    def has_released_items_beyond_prefix(self, prefix_len: int) -> bool:
+        """Whether re-prefill needs a feature released after consumption."""
+        for item in self.mm_items:
+            if not getattr(item, "feature_released", False):
+                continue
+            if item.precomputed_embeddings is not None or not item.offsets:
+                continue
+            if any(end >= prefix_len for _, end in item.offsets):
+                return True
+        return False
 
     @staticmethod
     def from_processor_output(obj: MultimodalProcessorOutput):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2989,6 +2989,9 @@ class Scheduler(
             req_to_abort,
         )
         req_to_abort.time_stats.trace_ctx.abort(abort_info={"reason": message})
+        # Session requests share mm_inputs with later turns; never release those.
+        if req_to_abort.multimodal_inputs is not None and not req_to_abort.session:
+            req_to_abort.multimodal_inputs.release_features()
         return req_to_abort.rid == recv_req.rid
 
     def _abort_on_waiting_timeout(self):
@@ -3014,6 +3017,8 @@ class Scheduler(
                     ),
                     req,
                 )
+                if req.multimodal_inputs is not None and not req.session:
+                    req.multimodal_inputs.release_features()
                 deleted_reqs.add(req)
                 self.beam_coordinator.retire_group(req)
 
@@ -3021,6 +3026,40 @@ class Scheduler(
             self.waiting_queue = [
                 req for req in self.waiting_queue if req not in deleted_reqs
             ]
+
+    def _abort_mm_req_with_released_features(self, req: Req) -> None:
+        """Abort a waiting request that can no longer re-encode MM features."""
+        if (
+            req.kv is not None
+            and req.kv.holds_mamba
+            and self.disaggregation_mode != DisaggregationMode.DECODE
+        ):
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+        if self.enable_hicache_storage:
+            self.tree_cache.release_aborted_request(req.rid)
+        elif self.enable_hierarchical_cache:
+            self.tree_cache.terminate_prefetch(req.rid)
+        if req.multimodal_inputs is not None and not req.session:
+            req.multimodal_inputs.release_features()
+        self.beam_coordinator.retire_group(req)
+        message = (
+            "Multimodal features for this request were released after prefill "
+            "and its cached KV prefix was evicted after retraction/preemption, "
+            "so it cannot be re-encoded. Please retry the request."
+        )
+        logger.warning("Aborting request %s: %s", req.rid, message)
+        self.ipc_channels.send_to_tokenizer.send_output(
+            _make_abort_req(
+                req,
+                finished_reason={
+                    "type": "abort",
+                    "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
+                    "message": message,
+                },
+            ),
+            req,
+        )
+        req.time_stats.trace_ctx.abort(abort_info={"reason": message})
 
     def handle_embedding_request(
         self,
@@ -3504,6 +3543,7 @@ class Scheduler(
         if mamba_allocator is not None:
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
         # Get requests from the waiting queue to a new prefill batch
+        mm_released_abort_reqs: List[Req] = []
         for req in self.waiting_queue:
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
@@ -3561,6 +3601,17 @@ class Scheduler(
                 if held_tokens > 0:
                     req.host_hit_length = held_tokens
                     req.swa_host_hit_length = held_swa_tokens
+
+            if (
+                req.multimodal_inputs is not None
+                and req.multimodal_inputs.has_released_items_beyond_prefix(
+                    len(req.prefix_indices) + req.host_hit_length
+                )
+            ):
+                self._abort_mm_req_with_released_features(req)
+                mm_released_abort_reqs.append(req)
+                continue
+
             res = adder.add_one_req(
                 req,
                 has_chunked_req=(self.chunked_req is not None),
@@ -3598,6 +3649,10 @@ class Scheduler(
 
         if mamba_allocator is not None:
             mamba_allocator.alloc_group_end()
+
+        if mm_released_abort_reqs:
+            aborted_set = set(mm_released_abort_reqs)
+            self.waiting_queue = [x for x in self.waiting_queue if x not in aborted_set]
 
         # Update waiting queue
         can_run_list: List[Req] = adder.can_run_list
@@ -4865,6 +4920,8 @@ class Scheduler(
                 and self.disaggregation_mode != DisaggregationMode.DECODE
             ):
                 release_kv_cache(req, self.tree_cache, is_insert=False)
+            if req.multimodal_inputs is not None and not req.session:
+                req.multimodal_inputs.release_features()
             logger.debug(f"Abort queued request. {req.rid=}")
 
         if self.dllm_config is not None:

--- a/test/registered/unit/managers/test_mm_release_at_consumption.py
+++ b/test/registered/unit/managers/test_mm_release_at_consumption.py
@@ -1,0 +1,213 @@
+"""Multimodal release-at-consumption lifecycle (opt-in).
+
+With SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION=1, image features are dropped
+once their token spans are fully inside the KV cache (the radix tree retains
+the prompt KV for retract re-prefill), instead of being retained per TP rank
+until request completion.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import sys
+from array import array
+from http import HTTPStatus
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.io_struct import AbortReq
+    from sglang.srt.managers.schedule_batch import MultimodalDataItem, Req
+
+
+def _types():
+    from sglang.srt.managers.mm_utils import (
+        ShmPointerMMData,
+        release_consumed_mm_features,
+    )
+    from sglang.srt.managers.schedule_batch import (
+        Modality,
+        MultimodalDataItem,
+        MultimodalInputs,
+        Req,
+    )
+
+    return (
+        ShmPointerMMData,
+        release_consumed_mm_features,
+        Modality,
+        MultimodalDataItem,
+        MultimodalInputs,
+        Req,
+    )
+
+
+def _image_item(offsets: list[tuple[int, int]], feature: object) -> MultimodalDataItem:
+    _, _, Modality, MultimodalDataItem, _, _ = _types()
+    return MultimodalDataItem(
+        modality=Modality.IMAGE,
+        offsets=offsets,
+        feature=cast(torch.Tensor, feature),
+        hash=1,
+        pad_value=1,
+    )
+
+
+def _req(rid: str, input_len: int = 3) -> Req:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    return Req(rid, "", array("q", range(input_len)), SamplingParams())
+
+
+def test_release_and_reprefill_boundaries() -> None:
+    _, release, _, _, MultimodalInputs, _ = _types()
+    base = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+    items = [
+        _image_item([(0, 1)], base[0:2]),
+        _image_item([(2, 3)], [base[2:3], base[3:4]]),  # list-backed feature
+        _image_item([(4, 5)], base[4:6]),
+    ]
+    mm_inputs = MultimodalInputs(mm_items=items)
+
+    # Chunk [0, 4): items ending inside are released, the straddler is kept.
+    release([mm_inputs], [0], [4])
+    assert items[0].feature is None and items[0].feature_released
+    assert items[1].feature is None and items[1].feature_released
+    assert isinstance(items[2].feature, torch.Tensor)
+    assert not items[2].feature_released
+
+    # Re-prefill guard: safe while the cached prefix covers released spans.
+    assert not mm_inputs.has_released_items_beyond_prefix(4)
+    assert mm_inputs.has_released_items_beyond_prefix(3)
+
+
+def test_release_policy_requires_opt_in_radix_and_pp1() -> None:
+    from sglang.srt.environ import envs
+    from sglang.srt.managers.mm_utils import should_release_mm_features
+
+    def args(**kw: object) -> SimpleNamespace:
+        return SimpleNamespace(**{"disable_radix_cache": False, "pp_size": 1, **kw})
+
+    assert not should_release_mm_features(args())  # opt-in flag unset
+    with envs.SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION.override(True):
+        assert should_release_mm_features(args())
+        assert not should_release_mm_features(args(disable_radix_cache=True))
+        assert not should_release_mm_features(args(pp_size=2))
+
+
+def test_released_feature_cache_miss_aborts_retryable_503() -> None:
+    from sglang.srt.managers.scheduler import Scheduler
+    from sglang.srt.runtime_context import get_context
+
+    _, _, _, _, MultimodalInputs, _ = _types()
+    override = get_context().override_server_args()
+    override.install()
+    try:
+        scheduler = object.__new__(Scheduler)
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_hierarchical_cache = False
+        scheduler.tree_cache = None
+        retired: list[object] = []
+        scheduler.beam_coordinator = SimpleNamespace(retire_group=retired.append)
+        sent: list[tuple[object, object]] = []
+        object.__setattr__(
+            scheduler,
+            "ipc_channels",
+            SimpleNamespace(
+                send_to_tokenizer=SimpleNamespace(
+                    send_output=lambda out, req=None: sent.append((out, req))
+                )
+            ),
+        )
+
+        req = _req("rid-mm-abort")
+        released = _image_item([(0, 99)], torch.zeros(4, 2))
+        released.release_feature(consumed=True)
+        pending = _image_item([(100, 199)], torch.zeros(4, 2))
+        req.multimodal_inputs = MultimodalInputs(mm_items=[released, pending])
+        req.reset_for_retract()
+
+        scheduler._abort_mm_req_with_released_features(req)
+
+        abort_output, abort_target = sent[0]
+        abort_req = cast("AbortReq", abort_output)
+        assert abort_target is req
+        assert abort_req.finished_reason is not None
+        assert (
+            abort_req.finished_reason["status_code"] == HTTPStatus.SERVICE_UNAVAILABLE
+        )
+        # Terminal cleanup: remaining features dropped, beam group retired.
+        assert pending.feature is None
+        assert retired == [req]
+    finally:
+        override.restore()
+
+
+def test_terminal_release_spares_session_features() -> None:
+    from sglang.srt.managers.scheduler import Scheduler
+    from sglang.srt.runtime_context import get_context
+
+    _, _, _, _, MultimodalInputs, _ = _types()
+    override = get_context().override_server_args()
+    override.install()
+    try:
+        scheduler = object.__new__(Scheduler)
+        scheduler.enable_hicache_storage = False
+        scheduler.enable_priority_scheduling = False
+        scheduler.max_queued_requests = 0
+        scheduler.waiting_queue = []
+        object.__setattr__(
+            scheduler,
+            "ipc_channels",
+            SimpleNamespace(
+                send_to_tokenizer=SimpleNamespace(
+                    send_output=lambda out, req=None: None
+                )
+            ),
+        )
+
+        session_req = _req("rid-session", input_len=1)
+        session_req.session = object()  # later turns share these mm_inputs
+        session_item = _image_item([(0, 0)], torch.zeros(1, 2))
+        session_req.multimodal_inputs = MultimodalInputs(mm_items=[session_item])
+        assert scheduler._abort_on_queued_limit(session_req)
+        assert session_item.feature is not None
+
+        plain_req = _req("rid-plain", input_len=1)
+        plain_item = _image_item([(0, 0)], torch.zeros(1, 2))
+        plain_req.multimodal_inputs = MultimodalInputs(mm_items=[plain_item])
+        assert scheduler._abort_on_queued_limit(plain_req)
+        assert plain_item.feature is None
+    finally:
+        override.restore()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires /dev/shm and /proc")
+def test_shm_release_keeps_views_alive() -> None:
+    ShmPointerMMData, _, _, _, _, _ = _types()
+    src = torch.arange(64, dtype=torch.float32)
+    sender = ShmPointerMMData(src)
+    receiver = ShmPointerMMData.__new__(ShmPointerMMData)
+    receiver.__setstate__(sender.__getstate__())
+    assert receiver.tensor is not None
+    view = receiver.tensor[8:16]
+    name = sender.shm_name
+
+    receiver.release()
+
+    assert not os.path.exists(f"/dev/shm/{name}")
+    # The view must still read the original data (no use-after-unmap).
+    torch.testing.assert_close(view, src[8:16])
+    del view, receiver
+    gc.collect()
+    with open("/proc/self/maps") as maps:
+        assert name not in maps.read()


### PR DESCRIPTION
## Motivation

Multimodal CPU feature tensors are retained until a request fully finishes. Under high-concurrency vision serving with long decodes (and multi-turn clients that resend image history each turn), the retained pool grows with live requests × images and can exhaust host memory on the serving node.

Once an image's features have been consumed into the multimodal embedding for prefill, the CPU-side tensor is no longer needed for that request: with radix caching enabled, a retracted request re-prefills from the retained prompt KV, not from the features. This PR releases each feature at that point instead of at request finish, bounding host memory by in-flight prefill rather than in-flight requests.

## Modifications

- New opt-in flag `SGLANG_ENABLE_MM_RELEASE_AT_CONSUMPTION` (default off; documented in `environment_variables.mdx`). Policy helper `should_release_mm_features` additionally requires radix caching (retract re-prefill reads the retained prompt KV) and `pp_size == 1` (only the first PP stage consumes features).
- `mm_utils.release_consumed_mm_features`: releases each mm item (tensor- or list-backed) once its token span is fully covered by the prefilled/matched prefix, using per-item offsets vs. the chunk end.
- Retraction re-prefills through the radix prefix as usual. If the prefix was evicted after features were released, the request is aborted with a retryable 503 via a new scheduler helper (`_abort_mm_req_with_released_features`) that releases the request's KV, retires its beam group, and releases remaining features, instead of recomputing with missing features.
- Terminal paths that shed a request from the waiting queue without prefilling it release features too, sparing session requests, whose `mm_inputs` are shared across turns.
- SHM-backed feature holders get an explicit `release()` with correct view lifetime (views keep the backing storage alive; `materialize()` no longer closes the mapping). This lifetime fix applies unconditionally, independent of the flag.

With the flag off (default), feature retention behavior is unchanged; the only additions on that path are the policy check and the SHM lifetime fix above.

## Accuracy Tests

`test/registered/unit/managers/test_mm_release_at_consumption.py` (5 CPU tests included in this PR) covers:

- release/re-prefill offset boundaries of `release_consumed_mm_features`,
- the enablement policy truth-table (flag × radix × pp_size),
- the released-feature abort: retryable 503, remaining features released, beam group retired,
- queue-shed releases sparing session requests,
- SHM view lifetime across `release()`.

## Speed Tests and Profiling

Opt-in and off by default. Enabled, the release check is per-chunk bookkeeping over the request's mm items and their offsets on the scheduler CPU path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Opt-in flag, off by default; no model-output change. Correctness covered by the unit tests above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->