### PR TITLE
spec: require dflash_config.target_layer_ids instead of guessing tap layers

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -172,7 +172,6 @@ def _resolve_dflash_aux_hidden_state(
 
         target_layer_ids = dflash_draft_config.resolve_target_layer_ids(
             target_num_layers=int(target_num_layers),
-            draft_num_layers=int(draft_num_layers),
         )
 
         # These Muse drafts use HF layer-output ids, while the Muse target captures

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -616,7 +616,7 @@ class DFlashDraftModel(nn.Module):
         else:
             target_num_layers = num_layers
         target_layer_ids = draft_config.resolve_target_layer_ids(
-            target_num_layers=target_num_layers, draft_num_layers=num_layers
+            target_num_layers=target_num_layers
         )
         num_context_features = len(target_layer_ids)
 

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -354,46 +354,6 @@ def _get_or_create_chain_verify_buffers(
     )
 
 
-def build_target_layer_ids(num_target_layers: int, num_draft_layers: int) -> List[int]:
-    """Select target layer indices used to build DFlash context features.
-
-    Args:
-        num_target_layers: Number of transformer layers in the runtime target model.
-        num_draft_layers: Number of layers in the DFlash draft model.
-
-    Returns:
-        A list of 0-based target layer indices of length `num_draft_layers`.
-
-    Notes:
-        - DFlash uses hidden states after each selected target layer (HF-style).
-        - SGLang captures "before layer i", so the model hook will typically add +1
-          when mapping to capture points.
-    """
-    if num_target_layers <= 0:
-        raise ValueError(
-            f"num_target_layers must be positive, got {num_target_layers}."
-        )
-    if num_draft_layers <= 0:
-        raise ValueError(f"num_draft_layers must be positive, got {num_draft_layers}.")
-
-    if num_draft_layers == 1:
-        return [num_target_layers // 2]
-
-    start = 1
-    end = num_target_layers - 3
-    if end < start:
-        raise ValueError(
-            "DFlash layer selection requires num_target_layers >= 4. "
-            f"Got num_target_layers={num_target_layers}."
-        )
-
-    span = end - start
-    return [
-        int(round(start + (i * span) / (num_draft_layers - 1)))
-        for i in range(num_draft_layers)
-    ]
-
-
 def get_dflash_layer_types(config: Any) -> Optional[Sequence[str]]:
     text_config = _get_text_config(config)
     layer_types = _cfg_get(text_config, "layer_types", _cfg_get(config, "layer_types"))
@@ -555,7 +515,6 @@ class DFlashDraftConfig:
         self,
         *,
         target_num_layers: int,
-        draft_num_layers: Optional[int] = None,
     ) -> List[int]:
         target_num_layers = int(target_num_layers)
         if target_num_layers <= 0:
@@ -564,9 +523,14 @@ class DFlashDraftConfig:
             )
 
         if self.target_layer_ids is None:
-            if draft_num_layers is None:
-                draft_num_layers = self.require_num_layers()
-            return build_target_layer_ids(target_num_layers, int(draft_num_layers))
+            # The tap layers are a training-time choice baked into the
+            # checkpoint (fc input width and which layers were trained on),
+            # so no load-time guess can be correct; see z-lab/dflash#156.
+            raise ValueError(
+                "DFLASH requires dflash_config.target_layer_ids in the draft "
+                "config. Every published DFlash checkpoint sets this key; a "
+                "guessed layer list can silently read the wrong target layers."
+            )
 
         resolved = list(self.target_layer_ids)
         if len(resolved) <= 0:

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -294,5 +294,38 @@ def test_grouped_conv_supports_runtime_block_sizes():
         torch.testing.assert_close(actual, expected)
 
 
+def test_dflash_missing_target_layer_ids_raises():
+    """A draft config without dflash_config.target_layer_ids must fail loudly:
+    the tap list is baked into the trained weights and cannot be guessed."""
+    config = parse_dflash_draft_config(
+        draft_hf_config={
+            "num_hidden_layers": 5,
+            "dflash_config": {"selector_rank": 256, "selector_top_k": 16},
+        }
+    )
+    with pytest.raises(ValueError, match="target_layer_ids"):
+        config.resolve_target_layer_ids(target_num_layers=36)
+
+
+def test_dflash_target_layer_ids_resolved_verbatim():
+    config = parse_dflash_draft_config(
+        draft_hf_config={
+            "num_hidden_layers": 5,
+            "dflash_config": {
+                "selector_rank": 256,
+                "selector_top_k": 16,
+                "target_layer_ids": [1, 9, 17, 25, 33],
+            },
+        }
+    )
+    assert config.resolve_target_layer_ids(target_num_layers=36) == [
+        1,
+        9,
+        17,
+        25,
+        33,
+    ]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

Fixes #37475.

`resolve_target_layer_ids` fell back to `build_target_layer_ids` when the draft config omits `dflash_config.target_layer_ids`. The tap list is a training-time choice baked into the checkpoint (it sets `fc`'s input width and which target layers the drafter was trained on), so no load-time formula can recover it. Per the reference-repo survey in z-lab/dflash#156: every published DFlash/DFlash2 checkpoint sets the key (the fallback is dead code today), the guess would be wrong for 14 of 20 checkpoints if it ever ran, and in the count-collision case (right tap count, wrong layers, e.g. `Qwen3.8-27B-DFlash2`) weights load cleanly and the draft silently reads the wrong target layers, collapsing acceptance with no diagnostic. The reference implementation is removing the helper the same way (z-lab/dflash#157).

## Modifications

- `resolve_target_layer_ids` raises a `ValueError` naming the missing key instead of guessing; the now-unused `draft_num_layers` parameter is dropped from it and from both call sites.
- `build_target_layer_ids` is deleted (its only caller was the fallback).
- Existing validation for explicit ids (non-empty, in range) is unchanged.

Net -4 lines outside tests.

## Test

Added two CPU cases to `test/registered/unit/spec/test_dflash_logits.py` (registered `base-a-test-cpu` suite): a config without `target_layer_ids` raises a `ValueError` naming the key, and explicit ids resolve verbatim with range validation intact. Verified locally by loading `dflash_utils.py` standalone and exercising both paths plus the out-of-range check.

## Checklist

- [x] Format your code with pre-commit formatters (black, isort applied to touched files)
- [x] Add unit tests
- [x] Update documentation as needed (none applicable)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33559432726](https://github.com/sgl-project/sglang/actions/runs/33559432726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33559431373](https://github.com/sgl-project/sglang/actions/runs/33559431373)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33559431486](https://github.com/sgl-project/sglang/actions/runs/33559431486)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->