### PR TITLE
[Cookbook] DeepSeek-V4: add DGX Spark (2x GB10) Flash Official FP4 recipe

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -32,7 +32,7 @@ For how to launch the image, see [Install → Method 3: Using Docker](../../../d
 
 **NVIDIA GPUs**
 
-A single image — `lmsysorg/sglang:latest` — covers the **datacenter GPUs** in this cookbook (B200 / B300 / GB200 / GB300 / H100 / H200 / RTX PRO 6000). The one exception is **Flash Vision (Exp)**, whose support has not shipped in a release yet: its cells use the preview image `lmsysorg/sglang:dev-dsv4-flash-vision` (the command panel picks it automatically — see the [Flash Vision notes](#vision-note)).
+A single image — `lmsysorg/sglang:latest` — covers the **datacenter GPUs** in this cookbook (B200 / B300 / GB200 / GB300 / H100 / H200 / RTX PRO 6000). The one exception is **Flash Vision (Exp)**, whose support has not shipped in a release yet: its cells use the preview image `lmsysorg/sglang:dev-dsv4-flash-vision` (the command panel picks it automatically — see the [Flash Vision notes](#vision-note)). **DGX Spark** is the other exception: its single Flash Official FP4 cell uses the DGX Spark–only preview image `lmsysorg/sglang:dev-v4f-2dgx` (the command panel picks it automatically — see the [DGX Spark notes](#spark-note)); do not use that image on any other hardware.
 
 ```bash Command
 docker pull lmsysorg/sglang:latest
@@ -214,6 +214,17 @@ For the original Flash and Pro checkpoints:
 - `balanced`: steps=1, draft-tokens=2 → gentler MTP, reduces throughput hit at higher batch.
 - `high-throughput`: MTP disabled — at saturation the verify step costs more than it saves.
 - MTP runs on the v2 speculative path.
+
+<a id="spark-note" />
+
+**DGX Spark (2x GB10, Flash Official FP4)**
+
+The **DGX Spark** row has a single recipe: **Flash Official (0731) · FP4 · Balanced · Multi-Nodes** — the 284B checkpoint does not fit one 128GB GB10, so it runs TP=2 across two DGX Sparks connected over ConnectX-7 (RoCE). Every other DGX Spark combination is greyed out on purpose.
+
+- **Docker image** — the cell uses `lmsysorg/sglang:dev-v4f-2dgx`, a preview build made **only for DGX Spark**: it bakes in the SM12x `b12x` MoE (W4A8) and compressed-MLA attention kernels ([#34878](https://github.com/sgl-project/sglang/pull/34878), [#35899](https://github.com/sgl-project/sglang/pull/35899), [#34018](https://github.com/sgl-project/sglang/pull/34018)) plus the CuTeDSL and NCCL pins the GB10 pair needs. Do not use it on other hardware, and use the panel's Docker mode — the bare Python command needs the `b12x` kernel package this image ships.
+- **Run the same command on both Sparks** with `--node-rank 0` / `--node-rank 1` and `--dist-init-addr` pointing at node 0 over the ConnectX-7 link. The `docker run` flags the panel emits (`--network host --ulimit memlock=-1:-1 --cap-add IPC_LOCK --device /dev/infiniband`) are what let NCCL use RDMA; without them NCCL silently falls back to TCP and decode slows by roughly 40%.
+- **Env knobs** in the cell are part of the recipe: `SGLANG_SM120_FLASHMLA_BACKEND=b12x` selects the b12x attention path, `SGLANG_B12X_MAX_TOKENS` must equal `--chunked-prefill-size`, and `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` avoids unified-memory fragmentation OOMs on GB10.
+- **Text only** — the image predates Flash Vision support, and the b12x kernels do not yet cover image prefill on SM12x; there is no DGX Spark cell for the Flash Vision variant.
 
 <a id="vision-note" />
 

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -9,6 +9,10 @@ export const config = {
   supportedHardware: [
     "h100", "h200", "b200", "b300", "gb200", "gb300",
     "rtx6000", "rtx5090",
+    // NVIDIA DGX Spark (GB10, SM121) — Flash Official FP4 only, as a 2-node
+    // TP=2 pair over ConnectX-7 RoCE; the shared HARDWARE_CATALOG carries the
+    // entry and its multi-node Docker flags.
+    "dgx-spark",
     // AMD ROCm — MI300X (Flash FP8) + MI355X (Flash/Pro, FP4/FP8).
     "mi300x", "mi355x",
   ],
@@ -192,6 +196,12 @@ sgl-eval run mmmu_pro \\
     // (sgl-project/sglang#37253) — until it does, the variant needs this
     // preview build on every hardware.
     "flash-vision|fp4": "lmsysorg/sglang:dev-dsv4-flash-vision",
+    // DGX Spark ONLY. A dedicated preview build for the 2x GB10 pair: it bakes
+    // in the SM12x b12x MoE/attention kernels (sgl-project/sglang#34878,
+    // #35899, #34018) and CuTeDSL/NCCL pins the GB10 recipe needs, none of
+    // which are in `latest`. It is not built for, and must not be used on, any
+    // other hardware — every other row keeps its own image.
+    "dgx-spark|flash-official|fp4": "lmsysorg/sglang:dev-v4f-2dgx",
     // NVFP4 checkpoints crash at weight load on v0.5.18 (the MXFP4-packed MTP
     // layer's FP8 delegate needs the #36275 guard, merged 2026-08-26) — route
     // every NVFP4 cell to the nightly until a release contains that fix.
@@ -3014,6 +3024,50 @@ sgl-eval run mmmu_pro \\
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",
         "--speculative-num-draft-tokens 4",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+
+    // ====================================================================
+    // DGX Spark (GB10 / SM121) — Flash Official FP4, 2-node TP=2, Balanced
+    // ====================================================================
+    // One cell only: the verified GB10 recipe. It runs the SM12x b12x MoE
+    // (W4A8) + b12x compressed-MLA attention with DSpark, split TP=2 across two
+    // DGX Sparks over ConnectX-7 RoCE. Verified end to end on 2x DGX Spark with
+    // the `lmsysorg/sglang:dev-v4f-2dgx` image (GSM8K 96%, AgentX c1/c2 clean).
+    // Every other DGX Spark combination (other variants / quants / strategies /
+    // single node) is intentionally absent and greys out: a single 128GB GB10
+    // cannot hold the checkpoint, and the b12x kernels are text-only today
+    // (image prefill for Flash Vision is unsupported on SM12x).
+    // Env: b12x attention + FP8 wo_a opt-in + MHC post/pre fusion are the GB10
+    // tuning knobs; SGLANG_B12X_MAX_TOKENS must track --chunked-prefill-size;
+    // expandable_segments avoids unified-memory fragmentation OOMs.
+    {
+      match: { hw: "dgx-spark", variant: "flash-official", quant: "fp4", strategy: "balanced", nodes: "multi-2" },
+      verified: true,
+      warn: "The Docker image lmsysorg/sglang:dev-v4f-2dgx is a DGX Spark-only preview build (2x GB10, TP=2 over ConnectX-7) — do not use it on other hardware. Use Docker mode: the bare Python command needs the b12x kernel package this image ships. See [DGX Spark notes](#spark-note).",
+      env: [
+        "SGLANG_SM120_FLASHMLA_BACKEND=b12x",
+        "B12X_MLA_SM120_DSV4_H16_NATIVE=1",
+        "SGLANG_OPT_FUSE_MHC_POST_PRE=1",
+        "SGLANG_OPT_FP8_WO_A_GEMM=1",
+        "SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1",
+        "SGLANG_B12X_MAX_TOKENS=8192",
+        "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
+      ],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 2",
+        "--moe-runner-backend b12x",
+        "--speculative-algorithm DSPARK",
+        "--chunked-prefill-size 8192",
+        "--context-length 327680",
+        "--mem-fraction-static 0.80",
+        "--swa-full-tokens-ratio 0.2",
+        "--cuda-graph-max-bs-decode 32",
+        "--max-running-requests 32",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],


### PR DESCRIPTION
## Motivation

Add **NVIDIA DGX Spark** as a hardware row on the DeepSeek-V4 cookbook page, with the one recipe that is verified on that platform: **Flash Official (0731) · FP4 · Balanced · Multi-Nodes** — TP=2 across two DGX Sparks (GB10, 128 GB unified memory each) over ConnectX-7 RoCE. Every other DGX Spark combination is intentionally absent, so it greys out in the panel: the 284B checkpoint does not fit a single GB10, and the SM12x `b12x` kernels are text-only today (no Flash Vision cell).

## Modifications

`docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx`
- `supportedHardware`: add `dgx-spark` (already in the shared `HARDWARE_CATALOG` with its multi-node Docker flags — no engine edit).
- `dockerImages`: `dgx-spark|flash-official|fp4` → `lmsysorg/sglang:dev-v4f-2dgx`, a **DGX Spark-only** preview build that bakes in the SM12x b12x MoE (W4A8) + compressed-MLA attention kernels (#34878, #35899, #34018) and the CuTeDSL/NCCL pins the GB10 pair needs. Commented as such; must not be used on other hardware.
- One `verified: true` cell with the GB10 recipe (b12x MoE runner, b12x attention env, DSpark, chunked-prefill 8192, ctx 327680, mem 0.80, 32 slots) and a `warn` banner telling users the image is DGX Spark-only and to use Docker mode.

`docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`
- Install → Docker tab: DGX Spark listed as the second image exception (next to Flash Vision).
- New **DGX Spark notes** section (`#spark-note`) under Configuration Tips: topology, image scope, the RDMA docker flags (and the silent TCP fallback if they are missing), the env knobs, text-only status.

No benchmark card entry for this cell yet (bench_serving numbers to follow in a later PR).

## Verification

Run end to end on 2× DGX Spark (rdxa-int-spark-01/02) with `lmsysorg/sglang:dev-v4f-2dgx` and the **exact `docker run` line the panel emits** for this cell (`--network host --ulimit memlock=-1:-1 --cap-add IPC_LOCK --device /dev/infiniband`, no `--privileged`):
- NCCL transport: `Using network IB`, all channels `via NET/IB` (RoCE), confirmed from `NCCL_DEBUG=INFO`.
- GSM8K (`sglang.test.few_shot_gsm8k`, 200 q): accuracy 0.955–0.975, throughput 210 → 224 → 224 tok/s across 3 consecutive runs (parity with the same image under `--privileged`: 213 → 228)
- Decode microbench and AgentX (Claude Code trace replay) c1/c2 at parity with the qualified stack, 0 failed requests (measured on the same image with `--privileged`; see the report in the internal handoff).

Static checks: `node docs/scripts/check_cookbook_configs.mjs` OK · `mint validate` passed · `mint broken-links` clean.

## Checklist

- [x] Verified cell tested on real hardware
- [x] `check_cookbook_configs.mjs`, `mint validate`, `mint broken-links` pass
- [ ] Benchmark card numbers (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33566610951](https://github.com/sgl-project/sglang/actions/runs/33566610951)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33566610780](https://github.com/sgl-project/sglang/actions/runs/33566610780)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->