### PR TITLE
[mem_cache] Split duplicate insert frees at the SWA eviction floor

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1071,9 +1071,17 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
             dup_start = max(0, state.params.prev_prefix_len - state.total_prefix_length)
             if dup_start < consumed_from:
-                step_actions.append(
-                    FreeDeviceKV([value_slice[dup_start:consumed_from]])
+                # The duplicate slice may straddle this request's own eviction
+                # floor; below it only the full side is still ours to release.
+                dup = value_slice[dup_start:consumed_from]
+                abs_start = state.total_prefix_length + dup_start
+                swa_already_freed = min(
+                    max(state.params.swa_evicted_seqlen - abs_start, 0), dup.numel()
                 )
+                if swa_already_freed > 0:
+                    step_actions.append(FreeDeviceKVFullOnly([dup[:swa_already_freed]]))
+                if swa_already_freed < dup.numel():
+                    step_actions.append(FreeDeviceKV([dup[swa_already_freed:]]))
 
         if self._inc_hit_count_and_check(node, state.params.chunked):
             step_actions.append(self._build_backup_kv_action(node))

--- a/rust/sglang-radix-tree/src/tests/components/swa.rs
+++ b/rust/sglang-radix-tree/src/tests/components/swa.rs
@@ -851,11 +851,11 @@ fn insert_overlap_straddling_the_boundary_splits_and_recovers_the_tail() {
             node_id,
             source_value,
         },
-        CacheAction::FreeDeviceKV(duplicates),
+        CacheAction::FreeDeviceKVFullOnly(duplicates),
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKV, got {:?}",
+            "expected FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKVFullOnly, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };
@@ -898,10 +898,10 @@ fn insert_overlap_straddling_with_a_locked_full_defers_the_tail() {
             kept_full,
             incoming_full,
         },
-        CacheAction::FreeDeviceKV(duplicates),
+        CacheAction::FreeDeviceKVFullOnly(duplicates),
     ] = result.cache_actions.as_slice()
     else {
-        panic!("expected RecoverSwaWithLockedFull then FreeDeviceKV");
+        panic!("expected RecoverSwaWithLockedFull then FreeDeviceKVFullOnly");
     };
     assert_eq!(*node_id, tc.arena.node(node).id);
     assert!(kept_full.equal(&Tensor::from_slice(&[12i64, 13])));
@@ -920,8 +920,8 @@ fn insert_overlap_entirely_outside_the_window_is_all_duplicate() {
         /* prev_prefix_len = */ 0,
         /* swa_evicted_seqlen = */ 3,
     ));
-    let [CacheAction::FreeDeviceKV(freed)] = result.cache_actions.as_slice() else {
-        panic!("expected one FreeDeviceKV action");
+    let [CacheAction::FreeDeviceKVFullOnly(freed)] = result.cache_actions.as_slice() else {
+        panic!("expected one FreeDeviceKVFullOnly action");
     };
     assert!(freed[0].equal(&Tensor::from_slice(&[20i64, 21, 22])));
 }
@@ -972,7 +972,7 @@ fn insert_overlap_boundary_at_the_node_start_recovers_the_whole_node() {
             .equal(&Tensor::from_slice(&[23i64, 24]))
     );
     let [
-        CacheAction::FreeDeviceKV(duplicates),
+        CacheAction::FreeDeviceKVFullOnly(duplicates),
         CacheAction::FreeDeviceKVFullOnly(old_full),
         CacheAction::SwaRebuild {
             node_id,
@@ -981,7 +981,7 @@ fn insert_overlap_boundary_at_the_node_start_recovers_the_whole_node() {
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKV, FreeDeviceKVFullOnly, SwaRebuild, got {:?}",
+            "expected FreeDeviceKVFullOnly, FreeDeviceKVFullOnly, SwaRebuild, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };
@@ -1027,17 +1027,17 @@ fn insert_overlap_straddling_a_second_level_node_recovers_the_tail() {
             .equal(&Tensor::from_slice(&[24i64]))
     );
     let [
-        CacheAction::FreeDeviceKV(duplicates_head),
+        CacheAction::FreeDeviceKVFullOnly(duplicates_head),
         CacheAction::FreeDeviceKVFullOnly(old_tail),
         CacheAction::SwaRebuild {
             node_id,
             source_value,
         },
-        CacheAction::FreeDeviceKV(duplicates_tail),
+        CacheAction::FreeDeviceKVFullOnly(duplicates_tail),
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKV, FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKV, got {:?}",
+            "expected FreeDeviceKVFullOnly, FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKVFullOnly, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };
@@ -1080,17 +1080,17 @@ fn insert_overlap_straddling_a_second_level_locked_node_defers_the_tail() {
             .equal(&Tensor::from_slice(&[14i64]))
     );
     let [
-        CacheAction::FreeDeviceKV(duplicates_head),
+        CacheAction::FreeDeviceKVFullOnly(duplicates_head),
         CacheAction::RecoverSwaWithLockedFull {
             node_id,
             kept_full,
             incoming_full,
         },
-        CacheAction::FreeDeviceKV(duplicates_tail),
+        CacheAction::FreeDeviceKVFullOnly(duplicates_tail),
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKV, RecoverSwaWithLockedFull, FreeDeviceKV, got {:?}",
+            "expected FreeDeviceKVFullOnly, RecoverSwaWithLockedFull, FreeDeviceKVFullOnly, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };
@@ -1321,7 +1321,7 @@ fn reinsert_boundary_at_the_node_start_rebuilds_the_whole_node() {
     ));
     assert_eq!(tc.arena.node(b).key, vec![4, 5]);
     let [
-        CacheAction::FreeDeviceKV(duplicates),
+        CacheAction::FreeDeviceKVFullOnly(duplicates),
         CacheAction::SwaRebuild {
             node_id,
             source_value,
@@ -1329,7 +1329,7 @@ fn reinsert_boundary_at_the_node_start_rebuilds_the_whole_node() {
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKV then SwaRebuild, got {:?}",
+            "expected FreeDeviceKVFullOnly then SwaRebuild, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };
@@ -3137,11 +3137,11 @@ fn insert_overlap_straddling_with_a_partial_prev_prefix_recovers_the_tail() {
             node_id,
             source_value,
         },
-        CacheAction::FreeDeviceKV(duplicates),
+        CacheAction::FreeDeviceKVFullOnly(duplicates),
     ] = result.cache_actions.as_slice()
     else {
         panic!(
-            "expected FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKV, got {:?}",
+            "expected FreeDeviceKVFullOnly, SwaRebuild, FreeDeviceKVFullOnly, got {:?}",
             action_kinds(&result.cache_actions)
         );
     };

--- a/rust/sglang-radix-tree/src/tests/unified_tree_core.rs
+++ b/rust/sglang-radix-tree/src/tests/unified_tree_core.rs
@@ -1939,30 +1939,6 @@ fn insert_prev_prefix_len_narrows_the_dup_window() {
 }
 
 #[test]
-fn insert_dup_below_swa_floor_frees_full_only() {
-    let mut tc = core();
-    tc.insert(&insert_params(&vec![1, 2, 3, 4], &[10, 11, 12, 13]));
-    // Below the request's eviction floor the SWA peers are already gone, so
-    // only the full side of the duplicate slice is still ours to release.
-    let result = tc.insert(&InsertParams {
-        swa_evicted_seqlen: 2,
-        ..insert_params(&vec![1, 2, 3, 4], &[20, 21, 22, 23])
-    });
-    let [
-        CacheAction::FreeDeviceKVFullOnly(full_only),
-        CacheAction::FreeDeviceKV(freed),
-    ] = result.cache_actions.as_slice()
-    else {
-        panic!(
-            "expected FreeDeviceKVFullOnly then FreeDeviceKV, got {:?}",
-            action_kinds(&result.cache_actions)
-        );
-    };
-    assert!(full_only[0].equal(&Tensor::from_slice(&[20i64, 21])));
-    assert!(freed[0].equal(&Tensor::from_slice(&[22i64, 23])));
-}
-
-#[test]
 fn insert_extends_an_existing_prefix() {
     let mut tc = core();
     tc.insert(&insert_params(&vec![1, 2, 3], &[10, 11, 12]));

--- a/rust/sglang-radix-tree/src/tests/unified_tree_core.rs
+++ b/rust/sglang-radix-tree/src/tests/unified_tree_core.rs
@@ -1939,6 +1939,30 @@ fn insert_prev_prefix_len_narrows_the_dup_window() {
 }
 
 #[test]
+fn insert_dup_below_swa_floor_frees_full_only() {
+    let mut tc = core();
+    tc.insert(&insert_params(&vec![1, 2, 3, 4], &[10, 11, 12, 13]));
+    // Below the request's eviction floor the SWA peers are already gone, so
+    // only the full side of the duplicate slice is still ours to release.
+    let result = tc.insert(&InsertParams {
+        swa_evicted_seqlen: 2,
+        ..insert_params(&vec![1, 2, 3, 4], &[20, 21, 22, 23])
+    });
+    let [
+        CacheAction::FreeDeviceKVFullOnly(full_only),
+        CacheAction::FreeDeviceKV(freed),
+    ] = result.cache_actions.as_slice()
+    else {
+        panic!(
+            "expected FreeDeviceKVFullOnly then FreeDeviceKV, got {:?}",
+            action_kinds(&result.cache_actions)
+        );
+    };
+    assert!(full_only[0].equal(&Tensor::from_slice(&[20i64, 21])));
+    assert!(freed[0].equal(&Tensor::from_slice(&[22i64, 23])));
+}
+
+#[test]
 fn insert_extends_an_existing_prefix() {
     let mut tc = core();
     tc.insert(&insert_params(&vec![1, 2, 3], &[10, 11, 12]));

--- a/rust/sglang-radix-tree/src/unified_tree_core.rs
+++ b/rust/sglang-radix-tree/src/unified_tree_core.rs
@@ -1539,13 +1539,31 @@ impl<K: ChildKeyType> UnifiedTreeCore<K> {
 
             let dup_start = state.prev_prefix_len.saturating_sub(cursor);
             if dup_start < consumed_from {
-                state
-                    .pending_actions
-                    .push(CacheAction::FreeDeviceKV(vec![value_slice.narrow(
-                        0,
-                        dup_start as i64,
-                        (consumed_from - dup_start) as i64,
-                    )]));
+                // The duplicate slice may straddle this request's own eviction
+                // floor; below it only the full side is still ours to release.
+                let dup_len = consumed_from - dup_start;
+                let swa_already_freed = state
+                    .swa_evicted_seqlen
+                    .saturating_sub(cursor + dup_start)
+                    .min(dup_len);
+                if swa_already_freed > 0 {
+                    state
+                        .pending_actions
+                        .push(CacheAction::FreeDeviceKVFullOnly(vec![value_slice.narrow(
+                            0,
+                            dup_start as i64,
+                            swa_already_freed as i64,
+                        )]));
+                }
+                if swa_already_freed < dup_len {
+                    state.pending_actions.push(CacheAction::FreeDeviceKV(vec![
+                        value_slice.narrow(
+                            0,
+                            (dup_start + swa_already_freed) as i64,
+                            (dup_len - swa_already_freed) as i64,
+                        ),
+                    ]));
+                }
             }
         }
 

--- a/test/registered/unit/mem_cache/test_rust_tree_core_integration.py
+++ b/test/registered/unit/mem_cache/test_rust_tree_core_integration.py
@@ -1292,7 +1292,9 @@ def test_swa_straddling_insert_crosses_the_boundary_actions():
     assert free_tail.indices[0].tolist() == [12, 13]
     assert isinstance(rebuild, SWARebuild)
     assert rebuild.source_value.tolist() == [22, 23]
-    assert isinstance(free_duplicates, FreeDeviceKV)
+    # Below the floor the duplicate's SWA peers are gone: full side only.
+    assert isinstance(free_duplicates, FreeDeviceKVFullOnly)
+    assert free_duplicates.indices[0].tolist() == [20, 21]
 
 
 def test_every_pool_name_crosses_the_prefetch_commit_boundary():

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -58,6 +58,7 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     FreeComponentDeviceSlot,
     FreeComponentHostSlot,
     FreeDeviceKV,
+    FreeDeviceKVFullOnly,
     RebuildFullToSWAMapping,
     RecoverSWAWithLockedFull,
     ReplaceWriteThroughOnNodeSplit,
@@ -8094,6 +8095,39 @@ class TestResumableInsertWalkSWA(_InsertWalkSuite):
         self.assertIsNone(_device_value(cache, prefix_node, ComponentType.SWA))
         self.assertIsNotNone(_device_value(cache, window_node, ComponentType.SWA))
         self.assertIsNotNone(_device_value(cache, window_node, ComponentType.FULL))
+        cache.sanity_check()
+
+    def test_dup_slice_below_eviction_floor_frees_full_only(self):
+        """A re-insert whose duplicate slice starts below the request's eviction
+        floor gives back only the full side there: window eviction already
+        released those SWA peers, so freeing both sides would double-free."""
+        sw = self.cfg.sliding_window_size
+        cache, allocator, _ = build_fixture(self.cfg)
+        seq = list(range(1, 2 * sw + 1))
+        key = RadixKey(array("q", seq))
+        cache.insert(InsertParams(key=key, value=self._alloc(allocator, len(seq))))
+
+        value = self._alloc(allocator, len(seq))
+        actions = []
+        step = cache.tree_core.begin_insert(
+            InsertParams(key=key, value=value, swa_evicted_seqlen=sw)
+        )
+        while True:
+            actions.extend(step.actions)
+            cache._apply_cache_actions(step.actions)
+            if step.result is not None:
+                break
+            step = cache.tree_core.resume_insert()
+        tail = cache.tree_core.end_insert()
+        actions.extend(tail)
+        cache._apply_cache_actions(tail)
+
+        full_only = [
+            i for a in actions if isinstance(a, FreeDeviceKVFullOnly) for i in a.indices
+        ]
+        both = [i for a in actions if isinstance(a, FreeDeviceKV) for i in a.indices]
+        torch.testing.assert_close(torch.cat(full_only), value[:sw])
+        torch.testing.assert_close(torch.cat(both), value[sw:])
         cache.sanity_check()
 
     def test_dec_swa_lock_only_early_release_keeps_full_lock(self):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -8099,8 +8099,7 @@ class TestResumableInsertWalkSWA(_InsertWalkSuite):
 
     def test_dup_slice_below_eviction_floor_frees_full_only(self):
         """A re-insert whose duplicate slice starts below the request's eviction
-        floor gives back only the full side there: window eviction already
-        released those SWA peers, so freeing both sides would double-free."""
+        floor gives back only the full side there: those SWA peers are gone."""
         sw = self.cfg.sliding_window_size
         cache, allocator, _ = build_fixture(self.cfg)
         seq = list(range(1, 2 * sw + 1))
@@ -8108,19 +8107,11 @@ class TestResumableInsertWalkSWA(_InsertWalkSuite):
         cache.insert(InsertParams(key=key, value=self._alloc(allocator, len(seq))))
 
         value = self._alloc(allocator, len(seq))
-        actions = []
-        step = cache.tree_core.begin_insert(
-            InsertParams(key=key, value=value, swa_evicted_seqlen=sw)
-        )
-        while True:
-            actions.extend(step.actions)
-            cache._apply_cache_actions(step.actions)
-            if step.result is not None:
-                break
-            step = cache.tree_core.resume_insert()
-        tail = cache.tree_core.end_insert()
-        actions.extend(tail)
-        cache._apply_cache_actions(tail)
+        with mock.patch.object(
+            cache, "_apply_cache_action", wraps=cache._apply_cache_action
+        ) as spy:
+            cache.insert(InsertParams(key=key, value=value, swa_evicted_seqlen=sw))
+        actions = [c.args[0] for c in spy.call_args_list]
 
         full_only = [
             i for a in actions if isinstance(a, FreeDeviceKVFullOnly) for i in a.indices


### PR DESCRIPTION
## Summary
- `_insert_walk_step` splits the duplicate slice of an insert at the request's `swa_evicted_seqlen`: `FreeDeviceKVFullOnly` below it, `FreeDeviceKV` above it, in both the Python and the Rust tree core
- Matches what `SWARadixCache._insert_helper` already does through `free_kv_row_segments`

## Why
- Below the floor the slice's SWA peers were already released by window eviction, so a both-side free there releases them a second time
- Today `free_swa` reads `mapping = 0` for those slots and the `swa_indices > 0` filter drops them, at the cost of one host sync per release; once that filter becomes a contract (#36723) the same free trips `swa.peer_mapped`
- Both insert producers reach this one emission site: the regular `cache_unfinished_req` insert and the HiCache load-back insert (`floor = span_end - len(swa_dev)`)

<img width="1920" height="760" alt="dup-free-floor-split" src="https://github.com/user-attachments/assets/1f3a3590-da5e-4837-b9d0-ab372db1fee2" />

## Tests
- `test_dup_slice_below_eviction_floor_frees_full_only` asserts the emitted actions in the shared unified suite, so it runs under both tree-core backends; fails on the current code with no `FreeDeviceKVFullOnly` emitted
- The eight `components/swa.rs` overlap tests whose duplicate slice lies entirely below the floor now expect `FreeDeviceKVFullOnly`
- Full `test_unified_radix_cache_unittest.py` and `cargo test --locked` pass

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33573510228](https://github.com/sgl-project/sglang/actions/runs/33573510228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33573509920](https://github.com/sgl-project/sglang/actions/runs/33573509920)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33573510276](https://github.com/sgl-project/sglang/actions/runs/33573510276)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

