### PR TITLE
fix(disagg): poll receivers during decode preallocation

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -868,17 +868,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if not self.queue:
             return
 
-        # Still poll if any receiver was aborted, otherwise it stays stuck.
-        if (
-            self.pp_size <= 1
-            and all(decode_req.waiting_for_input for decode_req in self.queue)
-            and not any(
-                decode_req.kv_receiver.conclude_state == KVPoll.Failed
-                for decode_req in self.queue
-            )
-        ):
-            return
-
+        # Receiver polling observes asynchronous failures while KV allocation
+        # is blocked.
         if self.pp_size > 1:
             polls = poll_and_all_reduce_pp(
                 (decode_req.req.rid for decode_req in self.queue),

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -23,6 +23,7 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 class FakeReceiver:
     def __init__(self):
         self.clear_called = False
+        self.conclude_state = None
 
     def clear(self):
         self.clear_called = True
@@ -94,18 +95,22 @@ class TestDecodeQueueCleanup(CustomTestCase):
         receiver = FakeReceiver()
         req = SimpleNamespace(
             rid="abort-prealloc",
-            finished_reason=FINISH_ABORT("aborted"),
+            bootstrap_room=42,
+            finished_reason=None,
             return_logprob=False,
         )
-        decode_req = SimpleNamespace(req=req, kv_receiver=receiver)
+        decode_req = SimpleNamespace(
+            req=req, kv_receiver=receiver, waiting_for_input=True
+        )
 
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
         queue.pp_size = 1
+        queue.tp_rank = 0
+        queue.gloo_group = object()
         queue.queue = [decode_req]
         queue.pending_reqs = []
         queue.retracted_queue = []
         queue._resolve_pending_reqs = MagicMock()
-        queue._update_handshake_waiters = MagicMock()
         queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
         queue._allocatable_token_budgets = MagicMock(return_value=0)
         queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
@@ -114,16 +119,23 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.running_batch.reqs = []
         scheduler.enable_priority_scheduling = False
         scheduler.enable_hisparse = False
+        scheduler.metrics_reporter.enable_metrics = False
         scheduler.output_streamer = MagicMock()
         queue.scheduler = scheduler
 
-        preallocated, failed = queue.pop_preallocated()
+        with patch(
+            "sglang.srt.disaggregation.decode.poll_and_all_reduce",
+            return_value=[KVPoll.Failed],
+        ) as poll:
+            preallocated, failed = queue.pop_preallocated()
 
+        poll.assert_called_once_with([receiver], queue.gloo_group)
         self.assertEqual(preallocated, [])
         self.assertEqual(failed, [decode_req])
         self.assertEqual(queue.queue, [])
         self.assertTrue(receiver.clear_called)
         self.assertIsNone(decode_req.kv_receiver)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
         scheduler.output_streamer.stream_output.assert_called_once_with(
             [req], req.return_logprob
         )


### PR DESCRIPTION
## Motivation

`DecodePreallocQueue` stops polling after every queued receiver reaches `WaitingForInput`. This optimization dates to the original PD state machine, where `WaitingForInput` was stable until the scheduler allocated destination KV and published its metadata. Skipping subsequent polls avoided repeating the receiver scan and status all-reduce while allocation was blocked.

Receiver state can now change asynchronously while a request remains in the preallocation queue, for example after a peer failure or remote abort. The scheduler learns about those transitions through `poll()`, then reduces the status across ranks. If polling is skipped, a failed request can remain eligible for KV allocation and metadata publication before it is eventually rejected in the transfer phase.

The original cached-state assumption therefore no longer holds. Decode needs to continue polling receivers until each request either fails or leaves the preallocation queue.

## Modifications

- Remove the non-PP early return that skips receiver polling when every request has reached `WaitingForInput`.
- Continue using the existing status all-reduce so every rank observes a failure before `_pre_alloc` or `send_metadata`.
- Extend the preallocation cleanup test to start from `WaitingForInput`, return `KVPoll.Failed` from polling under zero KV capacity, and verify that the request is aborted, streamed, cleared, and removed.

The successful protocol remains unchanged:

`Allocate KV -> publish destination metadata -> transfer KV`

No handshake, wire protocol, or version changes are introduced.

## Accuracy Tests

Not applicable. This changes failure handling before KV transfer and does not change model execution or outputs.

## Speed Tests and Profiling

No benchmark was run. The tradeoff is one existing CPU status all-reduce per configured decode polling interval while requests are blocked on KV allocation. `--disaggregation-decode-polling-interval` remains available to tune the polling frequency.

## Testing

- `pre-commit run --files python/sglang/srt/disaggregation/decode.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py` — passed.
- `python3 -m py_compile python/sglang/srt/disaggregation/decode.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py` — passed.
- `uv run pytest -q test/registered/unit/disaggregation/test_decode_queue_cleanup.py` — not run locally because the macOS ARM host is incompatible with the Linux-only locked `sgl-deep-ep` wheel; the focused regression test is included for CI.

## Original commits

- `21a2922eaafded17a130d47ccd9f84c87f1ef866`
- `ef3d18ca03ada965ba1dd8efc999adfc5dcf27e1`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed for this internal scheduler correction.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). The sections above explain why accuracy testing is not applicable and disclose the unbenchmarked polling tradeoff.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33568239768](https://github.com/sgl-project/sglang/actions/runs/33568239768)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33568239642](https://github.com/sgl-project/sglang/actions/runs/33568239642)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33568239753](https://github.com/sgl-project/sglang/actions/runs/33568239753)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->