### PR TITLE
test: add GLM-5.3 Flash DFlash2 B200 coverage

### DIFF
--- a/test/registered/models_e2e/test_glm53_flash_b200.py
+++ b/test/registered/models_e2e/test_glm53_flash_b200.py
@@ -1,8 +1,8 @@
 """B200 per-commit coverage for the GLM-5.3-Flash serving recipes.
 
-Runs the Low Latency and High Throughput TP4/EP4 recipes on four B200 GPUs.
-Both recipes must retain GSM8K accuracy; the Low Latency recipe also checks
-EAGLE speculative acceptance and single-request decode performance.
+Runs the Low Latency, DFlash2, and High Throughput TP4/EP4 recipes on four
+B200 GPUs. All recipes must retain GSM8K accuracy; the Low Latency recipe also
+checks EAGLE speculative acceptance and single-request decode performance.
 """
 
 import unittest
@@ -19,9 +19,10 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=1800, stage="base-c", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=2400, stage="base-c", runner_config="4-gpu-b200")
 
 MODEL_PATH = "zai-org/GLM-5.3-Flash"
+DFLASH2_DRAFT_MODEL_PATH = "incoai/GLM-5.3-Flash-DFlash2"
 SERVER_LAUNCH_TIMEOUT = 3600
 GPU_IDLE_TIMEOUT = 120
 
@@ -112,6 +113,24 @@ class TestGLM53FlashB200HighThroughput(
         "4",
         "--moe-a2a-backend",
         "deepep",
+    ]
+
+
+class TestGLM53FlashB200DFlash2(
+    GSM8KMixin,
+    _GLM53FlashB200Base,
+):
+    gsm8k_score_threshold = 0.93
+    gsm8k_num_examples = 500
+    gsm8k_num_shots = 20
+    server_args = [
+        *COMMON_SERVER_ARGS,
+        "--speculative-algorithm",
+        "DFLASH",
+        "--speculative-draft-model-path",
+        DFLASH2_DRAFT_MODEL_PATH,
+        "--speculative-draft-attention-backend",
+        "fa4",
     ]
 
 


### PR DESCRIPTION
Follow-up to #36507.

## Summary
- add a third GLM-5.3 Flash B200 E2E configuration for DFlash2
- launch `zai-org/GLM-5.3-Flash` with TP4/EP4, TensorRT-LLM DSA backends, FP8 KV cache, DeepGEMM MoE, and the `incoai/GLM-5.3-Flash-DFlash2` draft using FA4
- reuse the existing GSM8K quality gate: score >= 0.93 over 500 examples with 20 shots
- increase the file runtime estimate from 1800s to 2400s for the additional server lifecycle and evaluation

## Validation
- configuration contract check verifies the complete DFlash2 server argument list and GSM8K settings
- Python compile, pre-commit formatting/lint, registered-test CI validation, and `git diff --check`
- targeted 4-GPU B200 rerun-test passed: [run 33571486309](https://github.com/sgl-project/sglang/actions/runs/33571486309)
  - `TestGLM53FlashB200DFlash2`: 1/1 passed in 438s
  - GSM8K score: 0.940 (threshold: 0.93; 500 examples, 20 shots)
  - output throughput: 336.483 token/s

No `run-ci` label or full-CI request was added; GPU validation used only the targeted rerun-test above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33571432618](https://github.com/sgl-project/sglang/actions/runs/33571432618)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33571431866](https://github.com/sgl-project/sglang/actions/runs/33571431866)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33571432543](https://github.com/sgl-project/sglang/actions/runs/33571432543)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->