### PR TITLE
[gRPC] Expose native pause status

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -11,7 +11,7 @@ service SglangService {
   rpc Tokenize(TokenizeRequest) returns (TokenizeResponse);
   rpc Detokenize(DetokenizeRequest) returns (DetokenizeResponse);
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
-  rpc GetPauseStatus(GetPauseStatusRequest) returns (GetPauseStatusResponse);
+  rpc GetIsReady(GetIsReadyRequest) returns (GetIsReadyResponse);
   rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
@@ -175,13 +175,13 @@ message HealthCheckResponse {
   bool healthy = 1;
 }
 
-// ---- Pause status ----
+// ---- Readiness ----
 
-message GetPauseStatusRequest {}
+message GetIsReadyRequest {}
 
-message GetPauseStatusResponse {
-  // True while new requests are blocked before engine dispatch.
-  bool is_pause = 1;
+message GetIsReadyResponse {
+  // True when the server is ready to receive new requests.
+  bool is_ready = 1;
   // Values are JSON-encoded, matching the existing meta_info convention.
   map<string, string> metadata = 2;
 }

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -11,6 +11,7 @@ service SglangService {
   rpc Tokenize(TokenizeRequest) returns (TokenizeResponse);
   rpc Detokenize(DetokenizeRequest) returns (DetokenizeResponse);
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc GetPauseStatus(GetPauseStatusRequest) returns (GetPauseStatusResponse);
   rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
@@ -172,6 +173,17 @@ message HealthCheckRequest {}
 
 message HealthCheckResponse {
   bool healthy = 1;
+}
+
+// ---- Pause status ----
+
+message GetPauseStatusRequest {}
+
+message GetPauseStatusResponse {
+  // True while new requests are blocked before engine dispatch.
+  bool is_pause = 1;
+  // Values are JSON-encoded, matching the existing meta_info convention.
+  map<string, string> metadata = 2;
 }
 
 // ---- Model info ----

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -441,6 +441,9 @@ class RuntimeHandle:
             ServerStatus.UnHealthy,
         )
 
+    def get_pause_status(self) -> bool:
+        return self.tokenizer_manager.is_pause
+
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         tokenizer = self.tokenizer_manager.tokenizer
         tokens = tokenizer.encode(text, add_special_tokens=add_special_tokens)

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -441,8 +441,8 @@ class RuntimeHandle:
             ServerStatus.UnHealthy,
         )
 
-    def get_pause_status(self) -> bool:
-        return self.tokenizer_manager.is_pause
+    def get_is_ready(self) -> bool:
+        return not self.tokenizer_manager.is_pause
 
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         tokenizer = self.tokenizer_manager.tokenizer

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -442,7 +442,7 @@ class RuntimeHandle:
         )
 
     def get_is_ready(self) -> bool:
-        return not self.tokenizer_manager.is_pause
+        return self.tokenizer_manager.is_ready()
 
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         tokenizer = self.tokenizer_manager.tokenizer

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -659,6 +659,13 @@ async def validate_json_request(raw_request: Request):
 ##### Native API endpoints #####
 
 
+@app.get("/ready")
+async def ready() -> Response:
+    """Report whether the server is ready to receive new requests."""
+    status_code = 503 if _global_state.tokenizer_manager.is_pause else 200
+    return Response(status_code=status_code)
+
+
 @app.get("/health")
 @app.get("/health_generate")
 async def health_generate(request: Request) -> Response:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -662,7 +662,7 @@ async def validate_json_request(raw_request: Request):
 @app.get("/ready")
 async def ready() -> Response:
     """Report whether the server is ready to receive new requests."""
-    status_code = 503 if _global_state.tokenizer_manager.is_pause else 200
+    status_code = 200 if _global_state.tokenizer_manager.is_ready() else 503
     return Response(status_code=status_code)
 
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1997,8 +1997,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     async def continue_generation(self, obj: ContinueGenerationReqInput):
         async with self.is_pause_cond:
-            await self._async_dispatch_to_scheduler(obj)
             self.is_pause = False
+            await self._async_dispatch_to_scheduler(obj)
             self.is_pause_cond.notify_all()
 
     async def update_weights_from_disk(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -599,6 +599,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Subprocess liveness watchdog — set by Engine or http_server after construction
         self._subprocess_watchdog = None
 
+    def is_ready(self) -> bool:
+        """Return whether this server should receive new requests."""
+        return (
+            not self.is_pause
+            and not self.gracefully_exit
+            and self.server_status == ServerStatus.Up
+        )
+
     def init_request_logging_and_dumping(self):
         # TODO: Refactor and organize the log export code.
         # Request logging

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1997,8 +1997,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     async def continue_generation(self, obj: ContinueGenerationReqInput):
         async with self.is_pause_cond:
-            self.is_pause = False
             await self._async_dispatch_to_scheduler(obj)
+            self.is_pause = False
             self.is_pause_cond.notify_all()
 
     async def update_weights_from_disk(

--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -90,14 +90,19 @@ def decide_request_auth(
       it must be rejected (403) even if api_key is provided.
 
     NOTE :
-    - Health/metrics endpoints are always allowed (even when api_key/admin_api_key is set),
-      to support k8s/liveness/readiness and Prometheus scraping without embedding secrets.
+    - Health/readiness/metrics endpoints are always allowed (even when
+      api_key/admin_api_key is set), to support k8s probes and Prometheus
+      scraping without embedding secrets.
     - We match them by prefix to cover common variants like /health_generate.
     """
     if method == "OPTIONS":
         return AuthDecision(allowed=True)
 
-    if path.startswith("/health") or path.startswith("/metrics"):
+    if (
+        path.startswith("/health")
+        or path.startswith("/ready")
+        or path.startswith("/metrics")
+    ):
         return AuthDecision(allowed=True)
 
     def _check_bearer_token(

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -288,6 +288,13 @@ impl PyBridge {
         })
     }
 
+    pub fn get_pause_status(&self) -> PyResult<bool> {
+        Python::attach(|py| {
+            let result = self.runtime_handle.call_method0(py, "get_pause_status")?;
+            result.extract::<bool>(py)
+        })
+    }
+
     /// Tokenize via Python (fallback when Rust tokenizer unavailable).
     pub fn tokenize_py(&self, text: &str, add_special_tokens: bool) -> PyResult<String> {
         Python::attach(|py| {

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -288,9 +288,9 @@ impl PyBridge {
         })
     }
 
-    pub fn get_pause_status(&self) -> PyResult<bool> {
+    pub fn get_is_ready(&self) -> PyResult<bool> {
         Python::attach(|py| {
-            let result = self.runtime_handle.call_method0(py, "get_pause_status")?;
+            let result = self.runtime_handle.call_method0(py, "get_is_ready")?;
             result.extract::<bool>(py)
         })
     }

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -563,16 +563,16 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         Ok(Response::new(proto::HealthCheckResponse { healthy }))
     }
 
-    async fn get_pause_status(
+    async fn get_is_ready(
         &self,
-        _request: Request<proto::GetPauseStatusRequest>,
-    ) -> Result<Response<proto::GetPauseStatusResponse>, Status> {
-        let is_pause = self
-            .blocking_bridge_call("Failed to get pause status", PyBridge::get_pause_status)
+        _request: Request<proto::GetIsReadyRequest>,
+    ) -> Result<Response<proto::GetIsReadyResponse>, Status> {
+        let is_ready = self
+            .blocking_bridge_call("Failed to get readiness", PyBridge::get_is_ready)
             .await?;
 
-        Ok(Response::new(proto::GetPauseStatusResponse {
-            is_pause,
+        Ok(Response::new(proto::GetIsReadyResponse {
+            is_ready,
             metadata: HashMap::new(),
         }))
     }

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -494,14 +494,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            let text = req.text.clone();
-            move || bridge.tokenize_py(&text, add_special)
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Tokenize failed"))?;
+        let text = req.text.clone();
+        let json_str = self
+            .blocking_bridge_call("Tokenize failed", move |bridge| {
+                bridge.tokenize_py(&text, add_special)
+            })
+            .await?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -539,14 +537,11 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            let tokens = req.tokens;
-            move || bridge.detokenize_py(tokens)
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Detokenize failed"))?;
+        let json_str = self
+            .blocking_bridge_call("Detokenize failed", move |bridge| {
+                bridge.detokenize_py(req.tokens)
+            })
+            .await?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -561,13 +556,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::HealthCheckRequest>,
     ) -> Result<Response<proto::HealthCheckResponse>, Status> {
-        let healthy = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.health_check()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Health check failed"))?;
+        let healthy = self
+            .blocking_bridge_call("Health check failed", PyBridge::health_check)
+            .await?;
 
         Ok(Response::new(proto::HealthCheckResponse { healthy }))
     }
@@ -576,13 +567,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetIsReadyRequest>,
     ) -> Result<Response<proto::GetIsReadyResponse>, Status> {
-        let is_ready = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.get_is_ready()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to get readiness"))?;
+        let is_ready = self
+            .blocking_bridge_call("Failed to get readiness", PyBridge::get_is_ready)
+            .await?;
 
         Ok(Response::new(proto::GetIsReadyResponse {
             is_ready,
@@ -594,13 +581,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetModelInfoRequest>,
     ) -> Result<Response<proto::GetModelInfoResponse>, Status> {
-        let json_info = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.get_model_info()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to get model info"))?;
+        let json_info = self
+            .blocking_bridge_call("Failed to get model info", PyBridge::get_model_info)
+            .await?;
 
         Ok(Response::new(proto::GetModelInfoResponse {
             model_path: extract_model_path(&json_info),
@@ -612,13 +595,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetServerInfoRequest>,
     ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
-        let json_info = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.get_server_info()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to get server info"))?;
+        let json_info = self
+            .blocking_bridge_call("Failed to get server info", PyBridge::get_server_info)
+            .await?;
 
         Ok(Response::new(proto::GetServerInfoResponse { json_info }))
     }
@@ -627,13 +606,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::ListModelsRequest>,
     ) -> Result<Response<proto::ListModelsResponse>, Status> {
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.list_models()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to list models"))?;
+        let json_str = self
+            .blocking_bridge_call("Failed to list models", PyBridge::list_models)
+            .await?;
 
         let models_arr: Vec<serde_json::Value> = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse models JSON: {}", e)))?;
@@ -865,8 +840,20 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     }
 }
 
-// Helper methods for OpenAI pass-through RPCs.
+// Shared RPC helpers.
 impl SglangServiceImpl {
+    async fn blocking_bridge_call<T, F>(&self, context: &str, call: F) -> Result<T, Status>
+    where
+        T: Send + 'static,
+        F: FnOnce(&PyBridge) -> Result<T, PyErr> + Send + 'static,
+    {
+        let bridge = self.bridge.clone();
+        tokio::task::spawn_blocking(move || call(&bridge))
+            .await
+            .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+            .map_err(|e| pyerr_to_status(e, context))
+    }
+
     async fn openai_streaming_rpc(
         &self,
         request: Request<proto::OpenAiRequest>,

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -494,14 +494,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            let text = req.text.clone();
-            move || bridge.tokenize_py(&text, add_special)
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Tokenize failed"))?;
+        let text = req.text.clone();
+        let json_str = self
+            .blocking_bridge_call("Tokenize failed", move |bridge| {
+                bridge.tokenize_py(&text, add_special)
+            })
+            .await?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -539,14 +537,11 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            let tokens = req.tokens;
-            move || bridge.detokenize_py(tokens)
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Detokenize failed"))?;
+        let json_str = self
+            .blocking_bridge_call("Detokenize failed", move |bridge| {
+                bridge.detokenize_py(req.tokens)
+            })
+            .await?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -561,28 +556,34 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::HealthCheckRequest>,
     ) -> Result<Response<proto::HealthCheckResponse>, Status> {
-        let healthy = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.health_check()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Health check failed"))?;
+        let healthy = self
+            .blocking_bridge_call("Health check failed", PyBridge::health_check)
+            .await?;
 
         Ok(Response::new(proto::HealthCheckResponse { healthy }))
+    }
+
+    async fn get_pause_status(
+        &self,
+        _request: Request<proto::GetPauseStatusRequest>,
+    ) -> Result<Response<proto::GetPauseStatusResponse>, Status> {
+        let is_pause = self
+            .blocking_bridge_call("Failed to get pause status", PyBridge::get_pause_status)
+            .await?;
+
+        Ok(Response::new(proto::GetPauseStatusResponse {
+            is_pause,
+            metadata: HashMap::new(),
+        }))
     }
 
     async fn get_model_info(
         &self,
         _request: Request<proto::GetModelInfoRequest>,
     ) -> Result<Response<proto::GetModelInfoResponse>, Status> {
-        let json_info = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.get_model_info()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to get model info"))?;
+        let json_info = self
+            .blocking_bridge_call("Failed to get model info", PyBridge::get_model_info)
+            .await?;
 
         Ok(Response::new(proto::GetModelInfoResponse {
             model_path: extract_model_path(&json_info),
@@ -594,13 +595,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetServerInfoRequest>,
     ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
-        let json_info = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.get_server_info()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to get server info"))?;
+        let json_info = self
+            .blocking_bridge_call("Failed to get server info", PyBridge::get_server_info)
+            .await?;
 
         Ok(Response::new(proto::GetServerInfoResponse { json_info }))
     }
@@ -609,13 +606,9 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::ListModelsRequest>,
     ) -> Result<Response<proto::ListModelsResponse>, Status> {
-        let json_str = tokio::task::spawn_blocking({
-            let bridge = self.bridge.clone();
-            move || bridge.list_models()
-        })
-        .await
-        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-        .map_err(|e| pyerr_to_status(e, "Failed to list models"))?;
+        let json_str = self
+            .blocking_bridge_call("Failed to list models", PyBridge::list_models)
+            .await?;
 
         let models_arr: Vec<serde_json::Value> = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse models JSON: {}", e)))?;
@@ -847,8 +840,20 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     }
 }
 
-// Helper methods for OpenAI pass-through RPCs.
+// Shared RPC helpers.
 impl SglangServiceImpl {
+    async fn blocking_bridge_call<T, F>(&self, context: &str, call: F) -> Result<T, Status>
+    where
+        T: Send + 'static,
+        F: FnOnce(&PyBridge) -> Result<T, PyErr> + Send + 'static,
+    {
+        let bridge = self.bridge.clone();
+        tokio::task::spawn_blocking(move || call(&bridge))
+            .await
+            .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+            .map_err(|e| pyerr_to_status(e, context))
+    }
+
     async fn openai_streaming_rpc(
         &self,
         request: Request<proto::OpenAiRequest>,

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -494,12 +494,14 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let text = req.text.clone();
-        let json_str = self
-            .blocking_bridge_call("Tokenize failed", move |bridge| {
-                bridge.tokenize_py(&text, add_special)
-            })
-            .await?;
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            let text = req.text.clone();
+            move || bridge.tokenize_py(&text, add_special)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Tokenize failed"))?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -537,11 +539,14 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         }
 
         // Fallback to Python
-        let json_str = self
-            .blocking_bridge_call("Detokenize failed", move |bridge| {
-                bridge.detokenize_py(req.tokens)
-            })
-            .await?;
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            let tokens = req.tokens;
+            move || bridge.detokenize_py(tokens)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Detokenize failed"))?;
 
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
@@ -556,9 +561,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::HealthCheckRequest>,
     ) -> Result<Response<proto::HealthCheckResponse>, Status> {
-        let healthy = self
-            .blocking_bridge_call("Health check failed", PyBridge::health_check)
-            .await?;
+        let healthy = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.health_check()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Health check failed"))?;
 
         Ok(Response::new(proto::HealthCheckResponse { healthy }))
     }
@@ -567,9 +576,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetIsReadyRequest>,
     ) -> Result<Response<proto::GetIsReadyResponse>, Status> {
-        let is_ready = self
-            .blocking_bridge_call("Failed to get readiness", PyBridge::get_is_ready)
-            .await?;
+        let is_ready = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.get_is_ready()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Failed to get readiness"))?;
 
         Ok(Response::new(proto::GetIsReadyResponse {
             is_ready,
@@ -581,9 +594,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetModelInfoRequest>,
     ) -> Result<Response<proto::GetModelInfoResponse>, Status> {
-        let json_info = self
-            .blocking_bridge_call("Failed to get model info", PyBridge::get_model_info)
-            .await?;
+        let json_info = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.get_model_info()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Failed to get model info"))?;
 
         Ok(Response::new(proto::GetModelInfoResponse {
             model_path: extract_model_path(&json_info),
@@ -595,9 +612,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetServerInfoRequest>,
     ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
-        let json_info = self
-            .blocking_bridge_call("Failed to get server info", PyBridge::get_server_info)
-            .await?;
+        let json_info = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.get_server_info()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Failed to get server info"))?;
 
         Ok(Response::new(proto::GetServerInfoResponse { json_info }))
     }
@@ -606,9 +627,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::ListModelsRequest>,
     ) -> Result<Response<proto::ListModelsResponse>, Status> {
-        let json_str = self
-            .blocking_bridge_call("Failed to list models", PyBridge::list_models)
-            .await?;
+        let json_str = tokio::task::spawn_blocking({
+            let bridge = self.bridge.clone();
+            move || bridge.list_models()
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
+        .map_err(|e| pyerr_to_status(e, "Failed to list models"))?;
 
         let models_arr: Vec<serde_json::Value> = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse models JSON: {}", e)))?;
@@ -840,20 +865,8 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     }
 }
 
-// Shared RPC helpers.
+// Helper methods for OpenAI pass-through RPCs.
 impl SglangServiceImpl {
-    async fn blocking_bridge_call<T, F>(&self, context: &str, call: F) -> Result<T, Status>
-    where
-        T: Send + 'static,
-        F: FnOnce(&PyBridge) -> Result<T, PyErr> + Send + 'static,
-    {
-        let bridge = self.bridge.clone();
-        tokio::task::spawn_blocking(move || call(&bridge))
-            .await
-            .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
-            .map_err(|e| pyerr_to_status(e, context))
-    }
-
     async fn openai_streaming_rpc(
         &self,
         request: Request<proto::OpenAiRequest>,

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -44,14 +44,14 @@ def _make_runtime_handle(responses):
 
 
 class TestNativeGrpcReadiness(CustomTestCase):
-    def test_readiness_is_inverse_of_pause_state(self):
-        tokenizer_manager = SimpleNamespace(is_pause=False)
+    def test_readiness_comes_from_tokenizer_manager(self):
+        tokenizer_manager = SimpleNamespace(is_ready=lambda: True)
         handle = RuntimeHandle.__new__(RuntimeHandle)
         handle.tokenizer_manager = tokenizer_manager
 
         self.assertTrue(handle.get_is_ready())
 
-        tokenizer_manager.is_pause = True
+        tokenizer_manager.is_ready = lambda: False
         self.assertFalse(handle.get_is_ready())
 
 

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -4,7 +4,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
-from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -44,50 +43,16 @@ def _make_runtime_handle(responses):
     return handle
 
 
-class TestNativeGrpcPauseStatus(CustomTestCase):
-    def test_status_tracks_pause_and_continue(self):
-        async def run_test():
-            tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
-            tokenizer_manager.is_pause = False
-            tokenizer_manager.is_pause_cond = asyncio.Condition()
-            dispatch_started = asyncio.Event()
-            finish_dispatch = asyncio.Event()
+class TestNativeGrpcReadiness(CustomTestCase):
+    def test_readiness_is_inverse_of_pause_state(self):
+        tokenizer_manager = SimpleNamespace(is_pause=False)
+        handle = RuntimeHandle.__new__(RuntimeHandle)
+        handle.tokenizer_manager = tokenizer_manager
 
-            async def dispatch_to_scheduler(_obj):
-                dispatch_started.set()
-                await finish_dispatch.wait()
+        self.assertTrue(handle.get_is_ready())
 
-            tokenizer_manager._async_dispatch_to_scheduler = dispatch_to_scheduler
-            handle = RuntimeHandle.__new__(RuntimeHandle)
-            handle.tokenizer_manager = tokenizer_manager
-
-            self.assertFalse(handle.get_pause_status())
-
-            pause_task = asyncio.create_task(
-                tokenizer_manager.pause_generation(SimpleNamespace(mode="in_place"))
-            )
-            await dispatch_started.wait()
-
-            self.assertTrue(handle.get_pause_status())
-
-            finish_dispatch.set()
-            await pause_task
-
-            dispatch_started.clear()
-            finish_dispatch.clear()
-            continue_task = asyncio.create_task(
-                tokenizer_manager.continue_generation(SimpleNamespace())
-            )
-            await dispatch_started.wait()
-
-            self.assertTrue(handle.get_pause_status())
-
-            finish_dispatch.set()
-            await continue_task
-
-            self.assertFalse(handle.get_pause_status())
-
-        asyncio.run(run_test())
+        tokenizer_manager.is_pause = True
+        self.assertFalse(handle.get_is_ready())
 
 
 class TestNativeGrpcParallelResponses(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -4,6 +4,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -41,6 +42,52 @@ def _make_runtime_handle(responses):
     handle = RuntimeHandle.__new__(RuntimeHandle)
     handle.tokenizer_manager = _FakeTokenizerManager(responses)
     return handle
+
+
+class TestNativeGrpcPauseStatus(CustomTestCase):
+    def test_status_tracks_pause_and_continue(self):
+        async def run_test():
+            tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
+            tokenizer_manager.is_pause = False
+            tokenizer_manager.is_pause_cond = asyncio.Condition()
+            dispatch_started = asyncio.Event()
+            finish_dispatch = asyncio.Event()
+
+            async def dispatch_to_scheduler(_obj):
+                dispatch_started.set()
+                await finish_dispatch.wait()
+
+            tokenizer_manager._async_dispatch_to_scheduler = dispatch_to_scheduler
+            handle = RuntimeHandle.__new__(RuntimeHandle)
+            handle.tokenizer_manager = tokenizer_manager
+
+            self.assertFalse(handle.get_pause_status())
+
+            pause_task = asyncio.create_task(
+                tokenizer_manager.pause_generation(SimpleNamespace(mode="in_place"))
+            )
+            await dispatch_started.wait()
+
+            self.assertTrue(handle.get_pause_status())
+
+            finish_dispatch.set()
+            await pause_task
+
+            dispatch_started.clear()
+            finish_dispatch.clear()
+            continue_task = asyncio.create_task(
+                tokenizer_manager.continue_generation(SimpleNamespace())
+            )
+            await dispatch_started.wait()
+
+            self.assertTrue(handle.get_pause_status())
+
+            finish_dispatch.set()
+            await continue_task
+
+            self.assertFalse(handle.get_pause_status())
+
+        asyncio.run(run_test())
 
 
 class TestNativeGrpcParallelResponses(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_ready.py
+++ b/test/registered/unit/entrypoints/test_ready.py
@@ -1,0 +1,31 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints import http_server
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestReadyEndpoint(CustomTestCase):
+    def call_ready(self, *, is_pause: bool):
+        prior_state = http_server.get_global_state()
+        http_server.set_global_state(
+            SimpleNamespace(tokenizer_manager=SimpleNamespace(is_pause=is_pause))
+        )
+        try:
+            return asyncio.run(http_server.ready())
+        finally:
+            http_server._global_state = prior_state
+
+    def test_ready_while_accepting_requests(self):
+        self.assertEqual(self.call_ready(is_pause=False).status_code, 200)
+
+    def test_not_ready_while_paused(self):
+        self.assertEqual(self.call_ready(is_pause=True).status_code, 503)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/test_ready.py
+++ b/test/registered/unit/entrypoints/test_ready.py
@@ -3,6 +3,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints import http_server
+from sglang.srt.managers.tokenizer_manager import ServerStatus, TokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -10,10 +11,21 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestReadyEndpoint(CustomTestCase):
-    def call_ready(self, *, is_pause: bool):
+    def call_ready(
+        self,
+        *,
+        is_pause: bool = False,
+        gracefully_exit: bool = False,
+        server_status: ServerStatus = ServerStatus.Up,
+    ):
+        tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
+        tokenizer_manager.is_pause = is_pause
+        tokenizer_manager.gracefully_exit = gracefully_exit
+        tokenizer_manager.server_status = server_status
+
         prior_state = http_server.get_global_state()
         http_server.set_global_state(
-            SimpleNamespace(tokenizer_manager=SimpleNamespace(is_pause=is_pause))
+            SimpleNamespace(tokenizer_manager=tokenizer_manager)
         )
         try:
             return asyncio.run(http_server.ready())
@@ -21,10 +33,23 @@ class TestReadyEndpoint(CustomTestCase):
             http_server._global_state = prior_state
 
     def test_ready_while_accepting_requests(self):
-        self.assertEqual(self.call_ready(is_pause=False).status_code, 200)
+        self.assertEqual(self.call_ready().status_code, 200)
 
     def test_not_ready_while_paused(self):
         self.assertEqual(self.call_ready(is_pause=True).status_code, 503)
+
+    def test_not_ready_while_starting(self):
+        self.assertEqual(
+            self.call_ready(server_status=ServerStatus.Starting).status_code, 503
+        )
+
+    def test_not_ready_while_unhealthy(self):
+        self.assertEqual(
+            self.call_ready(server_status=ServerStatus.UnHealthy).status_code, 503
+        )
+
+    def test_not_ready_while_gracefully_exiting(self):
+        self.assertEqual(self.call_ready(gracefully_exit=True).status_code, 503)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -80,6 +80,17 @@ class TestDecideRequestAuth(CustomTestCase):
         )
         self.assertTrue(decision.allowed)
 
+    def test_ready_path_always_allowed(self):
+        decision = decide_request_auth(
+            method="GET",
+            path="/ready",
+            authorization_header=None,
+            api_key="secret",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertTrue(decision.allowed)
+
     def test_metrics_path_always_allowed(self):
         decision = decide_request_auth(
             method="GET",

--- a/test/registered/unit/utils/test_http_server_auth.py
+++ b/test/registered/unit/utils/test_http_server_auth.py
@@ -274,6 +274,7 @@ class TestHttpServerAdminAuth(unittest.TestCase):
         paths_allowed = [
             "/health",
             "/health_generate",
+            "/ready",
             "/metrics",
             "/metrics/",
             "/metrics/prometheus",


### PR DESCRIPTION
## Summary

- add a lightweight GetPauseStatus RPC returning the existing TokenizerManager is_pause flag
- keep metadata as an empty extensible map using the existing JSON-encoded string convention
- keep is_pause set until continue_generation finishes reopening engine admission
- consolidate repeated blocking Python bridge calls without touching the generation hot path

## Validation

- cargo +1.96.1 test -p sglang-grpc
- cargo +1.96.1 clippy -p sglang-grpc --all-targets -- -D warnings
- pause/continue lifecycle smoke test against the exact source methods
- Python syntax compilation and git diff checks

Full Python pytest execution was not available in this environment because its Python dependencies are not installed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35024790068](https://github.com/sgl-project/sglang/actions/runs/35024790068)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35024790274](https://github.com/sgl-project/sglang/actions/runs/35024790274)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35024789759](https://github.com/sgl-project/sglang/actions/runs/35024789759)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->