### PR TITLE
[CPU][Spec] Prepack the DFlash draft context projection for AMX

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -621,19 +621,16 @@ class DFlashDraftModel(nn.Module):
         num_context_features = len(target_layer_ids)
 
         self.num_context_features = int(num_context_features)
-        if self.is_nemotron_35_draft:
-            fc_prefix = f"{prefix}.fc" if prefix else "fc"
-            self.fc = ReplicatedLinear(
-                self.num_context_features * hidden_size,
-                hidden_size,
-                bias=False,
-                quant_config=quant_config,
-                prefix=fc_prefix,
-            )
-        else:
-            self.fc = nn.Linear(
-                self.num_context_features * hidden_size, hidden_size, bias=False
-            )
+        # ReplicatedLinear rather than nn.Linear: only a layer carrying a
+        # quant_method reaches process_weights_after_loading, which is what
+        # prepacks the weight for the CPU AMX GEMM.
+        self.fc = ReplicatedLinear(
+            self.num_context_features * hidden_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc" if prefix else "fc",
+        )
         self.hidden_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
 
     def set_block_size(self, block_size: int) -> None:
@@ -662,9 +659,7 @@ class DFlashDraftModel(nn.Module):
 
     def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
         """Project concatenated target-layer hidden states into draft hidden_size."""
-        expected = int(
-            self.fc.input_size if self.is_nemotron_35_draft else self.fc.in_features
-        )
+        expected = int(self.fc.input_size)
         if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
             raise ValueError(
                 "DFLASH target_hidden feature dim mismatch. "
@@ -674,9 +669,7 @@ class DFlashDraftModel(nn.Module):
                 "This usually means the target model is capturing a different number of layer features than "
                 "the draft checkpoint/config expects."
             )
-        projected = self.fc(target_hidden)
-        if self.is_nemotron_35_draft:
-            projected = projected[0]
+        projected, _ = self.fc(target_hidden)
         return self.hidden_norm(projected)
 
     @torch.no_grad()
@@ -771,24 +764,19 @@ class DFlashDraftModel(nn.Module):
                     continue
                 param = params_dict[resolved_name]
                 if resolved_name.endswith("fc.weight"):
-                    if self.is_nemotron_35_draft:
-                        expected_shape = (
-                            int(self.config.hidden_size),
-                            int(self.num_context_features * self.config.hidden_size),
-                        )
-                        loaded_shape = _logical_linear_weight_shape(
-                            param,
-                            loaded_weight,
-                            output_features=expected_shape[0],
-                        )
-                        shape_matches = loaded_shape == expected_shape or (
-                            getattr(param, "pack_factor", None) is None
-                            and tuple(loaded_weight.shape) == tuple(param.shape)
-                        )
-                    else:
-                        expected_shape = tuple(param.shape)
-                        loaded_shape = tuple(loaded_weight.shape)
-                        shape_matches = loaded_shape == expected_shape
+                    expected_shape = (
+                        int(self.config.hidden_size),
+                        int(self.num_context_features * self.config.hidden_size),
+                    )
+                    loaded_shape = _logical_linear_weight_shape(
+                        param,
+                        loaded_weight,
+                        output_features=expected_shape[0],
+                    )
+                    shape_matches = loaded_shape == expected_shape or (
+                        getattr(param, "pack_factor", None) is None
+                        and tuple(loaded_weight.shape) == tuple(param.shape)
+                    )
                     if not shape_matches:
                         raise ValueError(
                             "DFLASH fc.weight shape mismatch. This usually means the draft checkpoint's "
@@ -879,9 +867,7 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
         return layer.input_layernorm(ctx_hidden)
 
     def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
-        expected = int(
-            self.fc.input_size if self.is_nemotron_35_draft else self.fc.in_features
-        )
+        expected = int(self.fc.input_size)
         if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
             raise ValueError(
                 "Laguna DFLASH target_hidden feature dim mismatch. "
@@ -900,9 +886,7 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
         for i, norm in enumerate(self.aux_hidden_norms):
             normed[:, i, :] = norm(slices[:, i, :])
         fused = normed.reshape(target_hidden.shape[0], -1)
-        projected = self.fc(fused)
-        if self.is_nemotron_35_draft:
-            projected = projected[0]
+        projected, _ = self.fc(fused)
         return self.hidden_norm(projected)
 
 


### PR DESCRIPTION
## Motivation

`DFlashDraftModel` projects the concatenated target-layer hidden states down to the
draft hidden size through `self.fc`, once per verify step. For the Nemotron-3.5
draft this is a `ReplicatedLinear`; for every other DFlash draft it was a raw
`nn.Linear`.

A raw `nn.Linear` has no `quant_method`, so the model loader never calls
`process_weights_after_loading` on it, so `_amx_process_weight_after_loading`
never runs and the layer never gets the AMX-prepacked weight layout. It stays an
unpacked `F.linear`.

In a CPU profile of Llama-3.1-8B-Instruct + `z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat`
(`tp=4`, `intel_amx`, block size 9) it shows up as a single `aten::mm` costing
**1.55 ms of a 42.3 ms verify step** — the largest remaining unpacked GEMM in the
DFlash path. The draft LM head and the draft decoder layers are already packed;
this one layer was the outlier.

A standalone microbenchmark of the same GEMM shape on the same machine
(32 threads, one NUMA node) measures the packed kernel at **1.6–2.1x** the
throughput of `F.linear` for `K=3`/`K=4`:

| K | in_features | weight MB | M | `F.linear` | `weight_packed_linear` | speedup |
|---|---|---|---|---|---|---|
| 3 | 12288 | 96 | 1 | 0.390 ms | 0.200 ms | 1.95x |
| 3 | 12288 | 96 | 9 | 0.377 ms | 0.215 ms | 1.76x |
| 4 | 16384 | 128 | 1 | 0.682 ms | 0.316 ms | 2.16x |
| 4 | 16384 | 128 | 9 | 0.690 ms | 0.323 ms | 2.14x |

## Modifications

`python/sglang/srt/models/dflash.py`:

| | Before | After |
|---|---|---|
| `DFlashDraftModel.__init__` | `ReplicatedLinear` if Nemotron-3.5, else `nn.Linear` | always `ReplicatedLinear` |
| `DFlashDraftModel.project_target_hidden` | `self.fc.input_size` / `self.fc.in_features` branch; unwrap `projected[0]` only for Nemotron | `self.fc.input_size`; `projected, _ = self.fc(...)` |
| `DFlashLagunaForCausalLM.project_target_hidden` | same branch | same simplification |
| `load_weights` `fc.weight` shape check | packed-aware check for Nemotron, plain-shape check otherwise | the packed-aware check for both |

The parameter keeps the same name (`fc.weight`) and the same shape
(`[hidden_size, K * hidden_size]`), and `ReplicatedLinear.weight_loader` is a
plain `copy_` with a size assert, so checkpoint loading is unchanged. The
`load_weights` shape check is unified onto the branch that already handles
packed params, which is a no-op for unquantized weights
(`_logical_linear_weight_shape` returns the loaded shape when `pack_factor is
None`).

On CUDA, `UnquantizedLinearMethod.apply` is `F.linear`, so this is neutral there.

This removes three `is_nemotron_35_draft` special cases; net −16 lines.

*Note:* `ReplicatedLinear` here is deliberate but not obviously optimal; it is what the Nemotron-3.5 branch
already used, so unifying onto it removes branches instead of introducing a new
pattern, and it preserves the existing weight-loading contract exactly.
## Accuracy Test

Covered by the existing DFlash end-to-end tests, which all exercise
`project_target_hidden` against real checkpoints and would catch either the
tuple unwrap or a `load_weights` break:

- `test/registered/spec/dflash/test_dflash.py`
- `test/registered/spec/dflash/test_muse_glimmer_dflash_assistant_gsm8k.py`
- `test/registered/core/test_basic_sanity_dflash.py`
- `test/registered/models_e2e/test_nvidia_nemotron_3_nano.py` (the Nemotron-3.5
  branch, which is the one that already used `ReplicatedLinear`)

No new unit test: an `isinstance(model.fc, ReplicatedLinear)` assertion would be
a mirror of the implementation line, and the behavioral surface is already
covered above.

On the CPU AMX path this is not bit-exact with the previous `F.linear`: the
prepacked kernel uses a different reduction order (a standalone comparison of
the two kernels on this shape shows `max_err` up to 5e-4 in bf16). `fc` lives
only in the draft — at `temperature 0` DFlash accepts a draft token exactly when it
equals the target's argmax, so the emitted text stays target-determined and only
the acceptance rate can move. It moved up, from 3.75 to 3.77, deterministically
across runs; total generated tokens are identical.

## Benchmarking and Profiling

Xeon 6 (128 physical cores, 4 NUMA nodes), `SGLANG_USE_CPU_ENGINE=1`,
`--tp 4 --attention-backend intel_amx`, `meta-llama/Llama-3.1-8B-Instruct` +
`z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat`, `--speculative-dflash-block-size 9`,
20 HumanEval prompts, `--max-concurrency 1 --temperature 0 --seed 42`.

| | before | after |
|---|---|---|
| Benchmark duration (s) | 30.69 | **29.86** |
| Output token throughput (tok/s) | 83.40 | **85.72** | 
| Mean TPOT (ms) | 11.28 | **11.01** | 
| Median ITL (ms) | 6.97 | 6.81 | 
| Accept length | 3.75 | 3.77 | 
| Non-spec baseline TPOT (ms) | 28.53 | 28.41 | 

"after" is the mean of two runs (85.52 / 85.92 tok/s), both reporting accept
length 3.77. SGLang reports mean ITL per token, so the verify-step cost is
derived as `TPOT x accept_length`: **42.30 ms -> 41.51 ms, i.e. 0.79 ms/step**.

A CPU profile of the same run confirms the mechanism independently. Previously
the interval after each target forward contained `aten::mm 1.55ms x1` (the
unpacked `fc`) plus `weight_packed_linear ~0.37ms x5` (the draft layers' KV
projections). It now contains `weight_packed_linear 1.06-1.19ms x6` and no
`aten::mm` at all — **0.82 ms/step**, matching the end-to-end delta.

## Checklist

- [x] Format the code with `pre-commit run --all-files`
- [x] Add / update documentation where relevant — n/a
- [ ] Add unit tests — deliberately none; see Accuracy Test above
- [x] Update benchmarks / profiling numbers — see above


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33573534287](https://github.com/sgl-project/sglang/actions/runs/33573534287)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33573534146](https://github.com/sgl-project/sglang/actions/runs/33573534146)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33573534266](https://github.com/sgl-project/sglang/actions/runs/33573534266)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->