### PR TITLE
[SM120] Pad small-M in_proj_ba GEMMs in Qwen3.5 GDN past a cuBLAS heuristic cliff

### DIFF
--- a/benchmark/kernels/bench_skinny_gemm_pad.py
+++ b/benchmark/kernels/bench_skinny_gemm_pad.py
@@ -1,0 +1,110 @@
+"""Where does cuBLAS fall off the skinny-GEMM cliff, and does row padding fix it?
+
+Times a bf16 ``[M, K] x [K, N]`` GEMM for M = 1..16, plain and padded with
+``sglang.srt.utils.skinny_gemm_pad.skinny_gemm_pad_rows``, over every
+Qwen3.5-family GDN ``in_proj_ba`` shape (N = 2 * num_v_heads / TP, K = hidden).
+Weights rotate through ~160 MB so the timing is HBM-resident, like a decode
+step. A "cliff" row is one where the plain kernel is > 1.5x the padded one.
+
+    python benchmark/kernels/bench_skinny_gemm_pad.py
+    python benchmark/kernels/bench_skinny_gemm_pad.py --shapes 48:5120 96:5120
+"""
+
+import argparse
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.utils.skinny_gemm_pad import skinny_gemm_pad_rows
+
+QWEN3_5_SHAPES = [
+    ("27B tp1", 96, 5120),
+    ("27B tp2", 48, 5120),
+    ("35B-A3B tp1", 64, 2048),
+    ("35B-A3B tp2", 32, 2048),
+    ("122B tp1", 128, 4096),
+    ("122B tp2", 64, 4096),
+    ("122B tp4", 32, 4096),
+    ("397B tp1", 128, 6144),
+    ("397B tp2", 64, 6144),
+    ("397B tp4", 32, 6144),
+]
+
+
+def time_us(fn, iters):
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) * 1e3 / iters
+
+
+def bench_shape(name, n, k, device, max_m):
+    rotation = max(2, (160 << 20) // (n * k * 2))
+    weights = [
+        torch.randn(n, k, dtype=torch.bfloat16, device=device) * 0.02
+        for _ in range(rotation)
+    ]
+    plain_us, padded_us, cliff = [], [], []
+    for m in range(1, max_m + 1):
+        x = torch.randn(m, k, dtype=torch.bfloat16, device=device)
+        pad_to = skinny_gemm_pad_rows(m=m, n=n, k=k)
+        counter = [0]
+
+        def plain():
+            w = weights[counter[0] % rotation]
+            counter[0] += 1
+            return F.linear(x, w)
+
+        def padded():
+            w = weights[counter[0] % rotation]
+            counter[0] += 1
+            if not pad_to:
+                return F.linear(x, w)
+            return F.linear(F.pad(x, (0, 0, 0, pad_to - m)), w)[:m]
+
+        for fn in (plain, padded):
+            for _ in range(rotation):
+                fn()
+        t_plain, t_padded = time_us(plain, 2 * rotation), time_us(padded, 2 * rotation)
+        plain_us.append(t_plain)
+        padded_us.append(t_padded)
+        if t_plain > 1.5 * t_padded:
+            cliff.append(m)
+    pad_to = skinny_gemm_pad_rows(m=2, n=n, k=k)
+    print(f"{name:>12} N={n:<4} K={k:<5} pad_to={pad_to:<3} cliff M={cliff}")
+    print(f"{'':>12}   M     : " + " ".join(f"{m:5d}" for m in range(1, max_m + 1)))
+    print(f"{'':>12}   plain : " + " ".join(f"{t:5.1f}" for t in plain_us))
+    print(f"{'':>12}   padded: " + " ".join(f"{t:5.1f}" for t in padded_us), flush=True)
+    torch.cuda.empty_cache()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--max-m", type=int, default=16)
+    parser.add_argument(
+        "--shapes",
+        nargs="*",
+        help="N:K pairs; default is every Qwen3.5-family in_proj_ba shape",
+    )
+    args = parser.parse_args()
+    torch.manual_seed(0)
+    shapes = QWEN3_5_SHAPES
+    if args.shapes:
+        shapes = [(s, *map(int, s.split(":"))) for s in args.shapes]
+    major, minor = torch.cuda.get_device_capability(args.device)
+    print(
+        f"{torch.cuda.get_device_name(args.device)} sm{major}{minor}"
+        f" torch {torch.__version__} cuda {torch.version.cuda}; times in us"
+    )
+    for name, n, k in shapes:
+        bench_shape(name, n, k, args.device, args.max_m)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -715,6 +715,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>For DeepSeek V4, quantize the SWA FP8 KV cache from BF16-rounded values instead of FP32 registers. This matches trainer-side QAT and the DSA prefill-CP path, at the cost of an extra BF16 KV materialization and separate cache-store kernels.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_ENABLE_GDN_BA_PAD</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>On SM120 (RTX 50 series) GPUs, pad the small-M rows of the unquantized Qwen3.5 GDN <code>in_proj_ba</code> GEMM past a cuBLAS heuristic cliff (speculative verify steps at low batch sizes). Set to <code>false</code> to disable.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1589,6 +1589,8 @@ class Envs:
 
     # Qwen3.5 and GDN
     SGLANG_ENABLE_GDN_DECODE_FUSED_PROJ_CONV = EnvBool(True)
+    # SM120 only: pad small-M in_proj_ba GEMMs past a cuBLAS heuristic cliff.
+    SGLANG_ENABLE_GDN_BA_PAD = EnvBool(True)
     SGLANG_TRACE_QWEN35_FINAL_NORM = EnvBool(False)
     SGLANG_QWEN35_NATIVE_FINAL_NORM = EnvBool(False)
     # One switch enables deferred MoE finalize and AR + residual + RMSNorm.

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -67,6 +67,7 @@ from sglang.srt.layers.parameter import (
     PerTensorScaleParameter,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -100,6 +101,7 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
+    get_platform,
     get_stream,
 )
 
@@ -120,6 +122,10 @@ from sglang.srt.utils import (
     use_intel_amx_backend,
 )
 from sglang.srt.utils.hf_transformers_utils import get_processor, get_rope_config
+from sglang.srt.utils.skinny_gemm_pad import (
+    apply_with_padded_rows,
+    skinny_gemm_pad_rows,
+)
 
 logger = logging.getLogger(__name__)
 _is_cuda = is_cuda()
@@ -380,6 +386,19 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
         )
+        # Narrow-N in_proj_ba hits an SM120 cuBLAS cliff at small M (the spec
+        # verify shape); padding rows keeps shapes static, so it is CUDA-graph safe.
+        self._ba_pad_to = 0
+        if (
+            envs.SGLANG_ENABLE_GDN_BA_PAD.get()
+            and get_platform().is_sm120
+            and isinstance(self.in_proj_ba.quant_method, UnquantizedLinearMethod)
+        ):
+            self._ba_pad_to = skinny_gemm_pad_rows(
+                m=2,
+                n=self.in_proj_ba.output_size_per_partition,
+                k=self.in_proj_ba.input_size,
+            )
 
         # Override weight loaders for packed checkpoint format.
         # Important: for FP8, this must cover not only `.weight` but also
@@ -644,6 +663,13 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         return query, key, value, z, b, a
 
+    def _ba_proj(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self._ba_pad_to:
+            return apply_with_padded_rows(
+                lambda x: self.in_proj_ba(x)[0], hidden_states, pad_to=self._ba_pad_to
+            )
+        return self.in_proj_ba(hidden_states)[0]
+
     def _forward_input_proj(self, hidden_states: torch.Tensor):
         # AMD/aiter fused AR+RMSNorm+per-group-quant path ships a
         # ``(bf16, fp8, scale)`` 3-tuple so the FP8 ``in_proj_qkvz`` can
@@ -673,7 +699,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             self.alt_stream.wait_stream(current_stream)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
             with torch.cuda.stream(self.alt_stream):
-                projected_states_ba, _ = self.in_proj_ba(hidden_states)
+                projected_states_ba = self._ba_proj(hidden_states)
             current_stream.wait_stream(self.alt_stream)
         elif self._fused_input_proj_cpu_enabled.value:
             projected_states_qkvz, projected_states_ba = (
@@ -686,7 +712,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             )
         else:
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            projected_states_ba = self._ba_proj(hidden_states)
         return projected_states_qkvz, projected_states_ba
 
     def _forward_input_proj_fused_quant_amd(self, hidden_states):

--- a/python/sglang/srt/utils/skinny_gemm_pad.py
+++ b/python/sglang/srt/utils/skinny_gemm_pad.py
@@ -1,0 +1,40 @@
+"""Row padding for skinny bf16 GEMMs on SM120, where cuBLAS picks a kernel
+4-6x slower than the split-K one below ``M * N * K = 2**21`` elements.
+Thresholds measured on an RTX 5090 (``benchmark/kernels/bench_skinny_gemm_pad.py``).
+"""
+
+from typing import Callable
+
+import torch
+
+# cuBLAS 13.1 switches to a split-K kernel at M * N * K >= 2**21; re-fit when
+# torch's bundled cuBLAS changes.
+SM120_SKINNY_GEMM_MIN_ELEMS = 1 << 21
+# Below this K the slow kernel is already as fast as the alternative.
+SM120_SKINNY_GEMM_MIN_K = 4096
+# M == 1 is a GEMV and does not hit the cliff.
+SM120_SKINNY_GEMM_MIN_M = 2
+
+
+def skinny_gemm_pad_rows(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    min_elems: int = SM120_SKINNY_GEMM_MIN_ELEMS,
+    min_k: int = SM120_SKINNY_GEMM_MIN_K,
+) -> int:
+    """Smallest row count past the cliff for an ``[m, k] x [k, n]`` GEMM, or 0."""
+    if m < SM120_SKINNY_GEMM_MIN_M or k < min_k or m * n * k >= min_elems:
+        return 0
+    return -(-min_elems // (n * k))
+
+
+def apply_with_padded_rows(
+    fn: Callable[[torch.Tensor], torch.Tensor], x: torch.Tensor, *, pad_to: int
+) -> torch.Tensor:
+    m = x.shape[0]
+    if not SM120_SKINNY_GEMM_MIN_M <= m < pad_to:
+        return fn(x)
+    padded = torch.nn.functional.pad(x, (0, 0, 0, pad_to - m))
+    return fn(padded)[:m]

--- a/test/registered/unit/utils/test_skinny_gemm_pad.py
+++ b/test/registered/unit/utils/test_skinny_gemm_pad.py
@@ -1,0 +1,85 @@
+"""Unit tests for srt/utils/skinny_gemm_pad.py -- no server, no model loading."""
+
+import unittest
+
+import torch
+
+from sglang.srt.utils.skinny_gemm_pad import (
+    SM120_SKINNY_GEMM_MIN_ELEMS,
+    SM120_SKINNY_GEMM_MIN_K,
+    apply_with_padded_rows,
+    skinny_gemm_pad_rows,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+# ((m, n, k), pad target) measured on an RTX 5090 for every Qwen3.5-family
+# in_proj_ba shape (N = 2 * num_v_heads / TP, K = hidden_size).
+MEASURED = [
+    # 27B TP=2: cliff at 2 <= M <= 8, gone at M=9.
+    ((8, 48, 5120), 9),
+    ((2, 48, 5120), 9),
+    ((9, 48, 5120), 0),
+    ((1, 48, 5120), 0),
+    # 27B TP=1: cliff only at 2 <= M <= 4; M=8 must stay untouched.
+    ((4, 96, 5120), 5),
+    ((5, 96, 5120), 0),
+    ((8, 96, 5120), 0),
+    # 122B TP=4 (K=4096); 397B TP=2 and TP=4 (K=6144).
+    ((15, 32, 4096), 16),
+    ((16, 32, 4096), 0),
+    ((5, 64, 6144), 6),
+    ((6, 64, 6144), 0),
+    ((10, 32, 6144), 11),
+    ((11, 32, 6144), 0),
+    # 35B-A3B (K=2048): no cliff at any M.
+    ((8, 64, 2048), 0),
+    ((2, 32, 2048), 0),
+]
+
+
+class TestSkinnyGemmPadRows(CustomTestCase):
+    def test_measured_shapes(self):
+        for (m, n, k), want in MEASURED:
+            self.assertEqual(skinny_gemm_pad_rows(m=m, n=n, k=k), want, (m, n, k))
+
+    def test_pad_target_is_the_first_row_past_the_threshold(self):
+        for n, k in [(48, 5120), (96, 5120), (32, 4096), (64, 6144), (32, 6144)]:
+            pad_to = skinny_gemm_pad_rows(m=2, n=n, k=k)
+            self.assertGreaterEqual(pad_to * n * k, SM120_SKINNY_GEMM_MIN_ELEMS)
+            self.assertLess((pad_to - 1) * n * k, SM120_SKINNY_GEMM_MIN_ELEMS)
+            for m in range(2, pad_to):
+                self.assertEqual(skinny_gemm_pad_rows(m=m, n=n, k=k), pad_to)
+            self.assertEqual(skinny_gemm_pad_rows(m=pad_to, n=n, k=k), 0)
+
+    def test_gemv_and_short_k_are_never_padded(self):
+        self.assertEqual(skinny_gemm_pad_rows(m=1, n=48, k=5120), 0)
+        self.assertEqual(
+            skinny_gemm_pad_rows(m=8, n=64, k=SM120_SKINNY_GEMM_MIN_K - 1), 0
+        )
+        self.assertEqual(skinny_gemm_pad_rows(m=8, n=64, k=2048, min_k=2048), 16)
+        self.assertEqual(skinny_gemm_pad_rows(m=8, n=48, k=5120, min_elems=1 << 20), 0)
+
+
+class TestApplyWithPaddedRows(CustomTestCase):
+    def test_padded_rows_are_dropped_and_others_pass_through(self):
+        torch.manual_seed(0)
+        w = torch.randn(48, 64)
+        calls = []
+
+        def linear(x):
+            calls.append(x.shape[0])
+            return x @ w.T
+
+        for m in (1, 2, 8, 9, 16):
+            x = torch.randn(m, 64)
+            out = apply_with_padded_rows(linear, x, pad_to=9)
+            torch.testing.assert_close(out, x @ w.T)
+        # M=1 (GEMV) and M >= pad_to run unpadded; 2 <= M < pad_to run at pad_to.
+        self.assertEqual(calls, [1, 9, 9, 9, 16])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On SM120, cuBLAS picks a no-split-K kernel for bf16 `[M, K] x [K, N]` while `M * N * K < 2**21`. For Qwen3.5 GDN `in_proj_ba` (`N = 2 * num_v_heads / TP`, `K = hidden_size`) that kernel is 4-6x slower than the split-K kernel one row later: 32 us vs 5.5 us at `(M=8, N=48, K=5120)` (27B TP=2). M=8 is every speculative verify step at batch 1. At TP=1 (N=96) the same M=8 is already past the cliff, so the pad target is derived from N,K rather than hardcoded.

Pad M to `ceil(2**21 / (N * K))` (9 for 27B TP=2, 5 for TP=1) and slice. Shapes stay static, so CUDA graphs are unaffected. Gated on `get_platform().is_sm120` and an unquantized `in_proj_ba`; `SGLANG_ENABLE_GDN_BA_PAD` (default on) is the kill switch.

## Modifications

- `python/sglang/srt/utils/skinny_gemm_pad.py`: pad target for a shape (0 = leave alone; skip M=1 and K<4096) and the pad/call/slice helper.
- `python/sglang/srt/models/qwen3_5.py`: compute `_ba_pad_to` once in `__init__` from `in_proj_ba` N/K; both CUDA branches of `_forward_input_proj` go through it. No-op on other arches and on quantized `in_proj_ba`.
- `SGLANG_ENABLE_GDN_BA_PAD` in `environ.py`, documented in the env-var reference.
- CPU unit tests (`test/registered/unit/utils/test_skinny_gemm_pad.py`, `base-a-test-cpu`) and `benchmark/kernels/bench_skinny_gemm_pad.py` (re-fit when bundled cuBLAS changes).

## Accuracy Tests

GSM8K, 300 questions, greedy, conc=6, Qwen3.8-27B NVFP4 + DFlash2, TP=2, 2x RTX 5090: 282/300 pad on vs 280/300 pad off (15 vs 16 truncated at 2048). Padded rows are zeros and sliced off; the only numerical difference is bf16 rounding from the split-K accumulation order.

## Speed Tests and Profiling

Microbenchmark on RTX 5090, us per GEMM, HBM-resident weights. "Cliff" = plain > 1.5x padded, which matches `M * N * K < 2**21`:

| shape | N | K | cliff M | plain on cliff | padded | plain off cliff |
|---|---|---|---|---|---|---|
| 27B TP=1 | 96 | 5120 | 2-4 | 32.3 | 11.7 | 5.5 |
| 27B TP=2 | 48 | 5120 | 2-8 | 32.0 | 11.6 | 5.5 |
| 35B-A3B TP=1/2 | 64/32 | 2048 | none | 13.6 | (not padded) | 12.4 |
| 122B TP=1 | 128 | 4096 | 2-3 | 24.3 | 11.4 | 5.4 |
| 122B TP=2 | 64 | 4096 | 2-7 | 24.1 | 11.3 | 5.4 |
| 122B TP=4 | 32 | 4096 | 2-15 | 25.9 | 11.3 | 5.3 |
| 397B TP=1 | 128 | 6144 | 2 | 39.0 | 11.6 | 5.5 |
| 397B TP=2 | 64 | 6144 | 2-5 | 38.5 | 11.6 | 5.5 |
| 397B TP=4 | 32 | 6144 | 2-10 | 38.0 | 11.6 | 5.5 |

CUDA graph, `(M=8, N=48, K=5120)`: 7.1 us padded vs 31.9 us plain.

E2E, Qwen3.8-27B NVFP4 + DFlash2, 2x RTX 5090, default on vs `SGLANG_ENABLE_GDN_BA_PAD=0` (two runs):

| | pad off | pad on | change |
|---|---|---|---|
| TP=2, 1 stream, ms/verify step | 15.15 / 15.17 | 14.25 / 14.21 | -6.1% |
| TP=2, 1 stream, tok/s | 321.4 / 321.6 | 341.2 / 342.6 | +6.3% |
| TP=2, 6 streams, ms/step/stream | 23.14 | 23.16 | 0 (M=48) |
| TP=1 decode BS=8, ms/step | 17.10 / 17.13 | 17.09 / 17.13 | 0 (M=8 off cliff) |
| TP=1 decode BS=4, ms/step | 16.63 / 16.62 | 15.98 / 16.03 | -3.7% |

A fixed pad-to-16 (first draft) cost +0.5% at TP=1 BS=8, which is why the target is `ceil(2**21 / (N * K))` and not a constant.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33573575516](https://github.com/sgl-project/sglang/actions/runs/33573575516)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33573575595](https://github.com/sgl-project/sglang/actions/runs/33573575595)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33573575987](https://github.com/sgl-project/sglang/actions/runs/33573575987)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->