### PR TITLE
[AMD][CI] Exclude unavailable MI355X nodes and skip 4N nightly

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -131,6 +131,7 @@ jobs:
       CONFIG_FILE: ${{ matrix.config.config_file }}
       RESULT_FILENAME: mi355x-${{ matrix.config.name }}
       MATRIX_CONFIG_NAME: ${{ matrix.config.name }}
+      SLURM_EXCLUDE: mia1-p01-g20,mia1-p01-g09
       # NOTE: RUNNER_NAME is a built-in default env var on every runner, so the
       # launch + cleanup steps read it directly. Do NOT set it here from
       # ${{ runner.name }} -- the `runner` context is not available in job-level
@@ -255,7 +256,8 @@ jobs:
       - setup
       - nightly-mi355x-2n
     if: |
-      !cancelled() && github.repository == 'sgl-project/sglang'
+      false
+      && !cancelled() && github.repository == 'sgl-project/sglang'
       && needs.setup.result == 'success'
       && needs.setup.outputs.matrix-4n != '{"include":[]}'
     runs-on: linux-sglang-mi35x-di


### PR DESCRIPTION
## Summary

- exclude mia1-p01-g20 and mia1-p01-g09 from MI355X nightly Slurm allocations
- temporarily skip the 4-node nightly job while those nodes are unavailable

## Validation

- git diff --check

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33576692928](https://github.com/sgl-project/sglang/actions/runs/33576692928)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33576692677](https://github.com/sgl-project/sglang/actions/runs/33576692677)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->