### PR TITLE
[kernel] Add tuned fused_moe config for NVIDIA RTX PRO 5000 Blackwell (SM120), E=288/N=256 (corrected key)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=256,device_name=NVIDIA_RTX_PRO_5000_72GB_Blackwell,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=256,device_name=NVIDIA_RTX_PRO_5000_72GB_Blackwell,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,50 @@
+{
+  "8": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "24": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 4
+  },
+  "64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 8,
+    "num_stages": 3
+  },
+  "8192": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 8,
+    "num_stages": 3
+  }
+}


### PR DESCRIPTION
## Description

Adds a tuned fused_moe Triton config for NVIDIA RTX PRO 5000 72GB Blackwell (SM120, cc 12.0), currently absent from the configs tree (the kernel falls back to the default config on this device).

- Shape: E=36, N=256, dtype=fp8_w8a8, block_shape=[128,128] — GLM-5.3-Flash serving shape (288 routed experts / TP8, moe_intermediate 2048 / TP8, top_k=8)
- Triton: 3.7.1

## Tuning methodology

Per benchmark/kernels/fused_moe_triton: CUDA-graph replay (10 invocations/graph) with L2 cache flush between iterations and per-iteration routing refresh; pruned search grid (348 configs) over BLOCK_M/N/K, GROUP_SIZE_M, num_warps, num_stages; M in {8, 24, 64, 512, 2048, 8192}.

## Measured effect (serving level)

8x RTX PRO 5000 TP8, agent workload, 24 concurrent requests, 3x240s median:
- Total TPM: +9.5% vs fallback default config
- TTFT p95: 1938ms -> 1673ms

## Notes for reviewers

- Config format follows the existing naming convention (E=,N=,device_name=,dtype=,block_shape=.json under configs/triton_3_7_1/)
- Winners per M: M=8: 32x64x128/w4s3g1 | M=24: 16x64x128/w4s4g32 | M=64: 32x64x128/w4s3g32 | M=512: 64x64x128/w4s2g1 | M=2048/8192: 64x128x64/w8s3g16

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34831902731](https://github.com/sgl-project/sglang/actions/runs/34831902731)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34831902444](https://github.com/sgl-project/sglang/actions/runs/34831902444)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34831902943](https://github.com/sgl-project/sglang/actions/runs/34831902943)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->