### PR TITLE
[Benchmark] Add JSONL dataset support for embeddings

### DIFF
--- a/docs/docs/developer_guide/bench_serving.mdx
+++ b/docs/docs/developer_guide/bench_serving.mdx
@@ -95,6 +95,7 @@ Select with `--dataset-name`:
 - `sharegpt` (default): loads ShareGPT-style pairs; optionally restrict with `--sharegpt-context-len` and override outputs with `--sharegpt-output-len`
 - `random`: random text lengths; sampled from ShareGPT token space
 - `random-ids`: random token ids (can lead to gibberish)
+- `embedding`: reads OpenAI-compatible embedding requests from a JSONL file; each line must contain an `input` string or a non-empty list of strings. Other fields such as `dimensions` and `encoding_format` are passed through to `/v1/embeddings`.
 - `image`: generates images and wraps them in chat messages; supports custom resolutions, multiple formats, and different content types
 - `generated-shared-prefix`: synthetic dataset with shared long system prompts and short questions
 - `mmmu`: samples from MMMU (Math split) and includes images
@@ -109,6 +110,25 @@ Common dataset flags:
 
 - `--apply-chat-template`: apply tokenizer chat template when constructing prompts
 - `--dataset-path PATH`: file path for ShareGPT json; if blank and missing, it will be downloaded and cached
+
+Embedding dataset JSONL example:
+
+```json
+{"input": "Represent this sentence for retrieval", "encoding_format": "float"}
+{"input": ["query text", "document text"], "dimensions": 256}
+```
+
+Run it with an embedding server:
+
+```bash Command
+python3 -m sglang.benchmark.serving \
+  --backend sglang-embedding \
+  --model Qwen/Qwen3-Embedding-0.6B \
+  --dataset-name embedding \
+  --dataset-path ./embedding_requests.jsonl \
+  --num-prompts 1000 \
+  --max-concurrency 64
+```
 
 Generated Shared Prefix flags (for `generated-shared-prefix`):
 
@@ -478,3 +498,4 @@ The `--fake-prefill` flag automatically injects special sentinel values into eac
 
 - The script raises the file descriptor soft limit (`RLIMIT_NOFILE`) to help with many concurrent connections.
 - For sglang, `/server_info` is queried post-run to report speculative decoding accept length when available.
+

--- a/python/sglang/benchmark/datasets/__init__.py
+++ b/python/sglang/benchmark/datasets/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from sglang.benchmark.datasets.agentic_trace import AgenticTraceDataset
 from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
 from sglang.benchmark.datasets.custom import CustomDataset
+from sglang.benchmark.datasets.embedding import EmbeddingDataset
 from sglang.benchmark.datasets.generated_shared_prefix import (
     GeneratedSharedPrefixDataset,
 )
@@ -20,6 +21,7 @@ DATASET_MAPPING: Dict[str, Type[BaseDataset]] = {
     "sharegpt": ShareGPTDataset,
     "custom": CustomDataset,
     "openai": OpenAIDataset,
+    "embedding": EmbeddingDataset,
     # TODO: "random" vs "random-ids" should be a flag (e.g. --random-source=sharegpt|integers),
     # not two separate dataset names sharing the same class.
     "random": RandomDataset,
@@ -51,3 +53,4 @@ __all__ = [
     "DatasetRow",
     "get_dataset",
 ]
+

--- a/python/sglang/benchmark/datasets/embedding.py
+++ b/python/sglang/benchmark/datasets/embedding.py
@@ -1,0 +1,94 @@
+import json
+from argparse import Namespace
+from dataclasses import dataclass
+from typing import Any, List, Union
+
+import numpy as np
+from transformers import PreTrainedTokenizerBase
+
+from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
+
+
+EmbeddingInput = Union[str, List[str]]
+
+
+@dataclass
+class EmbeddingDataset(BaseDataset):
+    """Load OpenAI-compatible embedding requests from a JSONL file."""
+
+    dataset_path: str
+    num_requests: int
+
+    @classmethod
+    def from_args(cls, args: Namespace) -> "EmbeddingDataset":
+        return cls(
+            dataset_path=args.dataset_path,
+            num_requests=args.num_prompts,
+        )
+
+    def load(
+        self, tokenizer: PreTrainedTokenizerBase, model_id=None
+    ) -> List[DatasetRow]:
+        return sample_embedding_requests(
+            dataset_path=self.dataset_path,
+            num_requests=self.num_requests,
+            tokenizer=tokenizer,
+        )
+
+
+def _get_embedding_input(value: Any) -> EmbeddingInput | None:
+    if isinstance(value, str):
+        return value if value.strip() else None
+    if isinstance(value, list) and value and all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        return value
+    return None
+
+
+def sample_embedding_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[DatasetRow]:
+    """Load embedding requests from JSONL without requiring model inference.
+
+    Each line must contain an ``input`` string or non-empty list of strings.
+    Other fields are passed through to the OpenAI-compatible embeddings API.
+    """
+    requests: List[DatasetRow] = []
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if num_requests > 0 and len(requests) >= num_requests:
+                break
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+
+            input_value = _get_embedding_input(data.get("input"))
+            if input_value is None:
+                continue
+
+            inputs = [input_value] if isinstance(input_value, str) else input_value
+            prompt_len = sum(len(tokenizer.encode(text)) for text in inputs)
+            extra_body = {
+                key: value for key, value in data.items() if key != "input"
+            }
+            requests.append(
+                DatasetRow(
+                    prompt=input_value,
+                    prompt_len=prompt_len,
+                    output_len=0,
+                    extra_request_body=extra_body,
+                )
+            )
+
+    print(f"Loaded {len(requests)} embedding requests")
+    print(f"#Input tokens: {np.sum([x.prompt_len for x in requests])}")
+    return requests
+

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -2242,6 +2242,7 @@ def cli_main():
             "sharegpt",
             "custom",
             "openai",
+            "embedding",
             "random",
             "random-ids",
             "generated-shared-prefix",
@@ -2758,3 +2759,4 @@ def cli_main():
 
 if __name__ == "__main__":
     cli_main()
+

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -33,6 +33,7 @@ from sglang.benchmark.datasets.agentic_trace import (
 )
 from sglang.benchmark.datasets.common import DatasetRow, gen_mm_prompt
 from sglang.benchmark.datasets.custom import sample_custom_requests
+from sglang.benchmark.datasets.embedding import sample_embedding_requests
 from sglang.benchmark.datasets.generated_shared_prefix import (
     GeneratedSharedPrefixDataset,
     _zipf_group_probs,
@@ -158,7 +159,6 @@ class TestEmbeddingBenchmarkBackends(CustomTestCase):
             ASYNC_REQUEST_FUNCS["vllm-embedding"], async_request_openai_embeddings
         )
         self.assertEqual(_BACKEND_API_PATHS["vllm-embedding"], "/v1/embeddings")
-
 
 class TestBenchmarkCacheFlush(CustomTestCase):
     def test_cache_flush_uses_the_backend_specific_request(self):
@@ -941,6 +941,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
             "sharegpt",
             "custom",
             "openai",
+            "embedding",
             "random",
             "random-ids",
             "generated-shared-prefix",
@@ -1030,6 +1031,39 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         agentic_rows = get_dataset(agentic_args, self.tokenizer, model_id="dummy-model")
         self.assertEqual(len(agentic_rows), 2)
         self.assertTrue(all(isinstance(row, DatasetRow) for row in agentic_rows))
+
+    def test_embedding_dataset_supports_single_and_batch_inputs(self):
+        dataset_path = self.tmpdir_path / "embeddings.jsonl"
+        rows = [
+            {"input": "single input", "encoding_format": "float"},
+            {
+                "input": ["batch input one", "batch input two"],
+                "dimensions": 128,
+            },
+            {"input": ""},
+            {"input": ["valid input", 123]},
+        ]
+        with dataset_path.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+        requests = sample_embedding_requests(
+            dataset_path=str(dataset_path),
+            num_requests=10,
+            tokenizer=self.tokenizer,
+        )
+
+        self.assertEqual(len(requests), 2)
+        self.assertEqual(requests[0].prompt, "single input")
+        self.assertEqual(requests[0].output_len, 0)
+        self.assertEqual(requests[0].extra_request_body, {"encoding_format": "float"})
+        self.assertEqual(requests[1].prompt, ["batch input one", "batch input two"])
+        self.assertEqual(requests[1].extra_request_body, {"dimensions": 128})
+        self.assertEqual(
+            requests[1].prompt_len,
+            len(self.tokenizer.encode("batch input one"))
+            + len(self.tokenizer.encode("batch input two")),
+        )
 
     def test_get_dataset_unknown_dataset(self):
         args = make_args(dataset_name="not-a-dataset")
@@ -1480,3 +1514,4 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary

Related to #9674.

This PR adds the remaining dataset-usage piece for the embedding benchmark flow:

- add an `embedding` dataset to `sglang.benchmark.serving`
- accept OpenAI-compatible JSONL records with a string or list-of-strings `input`
- pass through per-request fields such as `dimensions` and `encoding_format`
- count input tokens and keep embedding requests free of generation-token metrics
- add CPU-test coverage and documentation

Example:

```json
{"input": "Represent this sentence for retrieval", "encoding_format": "float"}
{"input": ["query text", "document text"], "dimensions": 256}
```

## Validation

- `py_compile` passed for changed Python files
- standalone embedding dataset smoke test passed
- full pytest collection is blocked in the current Windows environment because the repository runtime requires Linux `resource` and Triton dependencies

The online serving backend and offline benchmark metrics already exist on current `main`; this change makes real JSONL embedding workloads directly usable with that flow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33577911123](https://github.com/sgl-project/sglang/actions/runs/33577911123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33577910922](https://github.com/sgl-project/sglang/actions/runs/33577910922)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33577911101](https://github.com/sgl-project/sglang/actions/runs/33577911101)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->