### PR TITLE
deepep_v2: accept the situ activation in the DeepGEMM pre-permute

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -1592,7 +1592,7 @@ def pre_permute_deepep_v2_to_deep_gemm(
             "DeepEP v2 -> DeepGEMM requires FP8 dispatch output with activation "
             "scales, but the dispatch output carried none."
         )
-    assert runner_config.activation == "silu"
+    assert runner_config.activation in ("silu", "situ")
 
     if is_expanded:
         if psum_num_recv_tokens_per_expert is None:


### PR DESCRIPTION
## Motivation

`pre_permute_deepep_v2_to_deep_gemm` asserts `activation == "silu"`, which is stricter than every other site on the path it feeds. Kimi-K3's `hidden_act` is `situ`, so `--moe-a2a-backend deepep_v2 --moe-runner-backend deep_gemm` dies on the first forward pass:

```
sglang/srt/layers/moe/moe_runner/deep_gemm.py:1595 in pre_permute_deepep_v2_to_deep_gemm
AssertionError
```

Everything else on that path already handles `situ`, in the same file:

| line | site | situ support |
|---|---|---|
| `:272` | `DeepGemmMoeRunner.__init__` | `assert activation in ("silu", "situ")` |
| `:378` | `_run_contiguous_gemm` | situ branch → `_situ_mul_quant_contig_kernel` |
| `:702` | `_run_masked_gemm` | situ branch → `_varlen_deep_gemm_situ_mul_quant` → `kernels.ops.kimi_k3.situ_and_mul_masked_post_quant` |
| `:1244` | `pre_permute_deepep_normal_to_deep_gemm` (v1) | `assert activation in ("silu", "situ")` |
| **`:1595`** | **`pre_permute_deepep_v2_to_deep_gemm` (v2)** | **`== "silu"` — the only holdout** |

The runner constructor accepts situ, both GEMM paths branch on it — the masked one into a K3-specific CUDA kernel — and the v1 pre-permute one screen up accepts it. Only the v2 pre-permute was not widened when situ landed. A pre-permute cannot be stricter than the GEMM whose input it prepares, so this looks like an oversight rather than a real constraint.

## Modifications

One line: `assert runner_config.activation == "silu"` → `assert runner_config.activation in ("silu", "situ")`, matching `:272`, `:1244`, and the two GEMM paths.

No comment added — the rationale is cross-file and belongs here rather than in a one-liner next to the assert.

## Accuracy Tests

Run on 8 × B300 (sm_103), Kimi-K3, `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729`.

Reference arm `--moe-a2a-backend deepep --deepep-mode auto --moe-runner-backend deep_gemm`, test arm the same with `deepep_v2`. **First-token top-5 logprobs are byte-identical: 15/15 tokens and 15/15 logprob values across three fixed prompts.**

```
The capital of France is   ' Paris' -0.295707  ' Berlin' -3.983207  ' {' -3.983207 ...
2 + 2 =                    ' '      -0.149297  ' -'      -4.211796  ' \\' -4.961796 ...
def fibonacci(n):          ' \n'    -1.517094  ' #'      -2.267094  ' '   -2.392094 ...
```

Scope of that evidence, stated plainly:

- Reaching a running v2 server on K3 also needs `validate_deepep_v2_model_architecture` and `_validate_deepep_v2_quant_method` relaxed (K3 is not whitelisted, and it is MXFP4). **Those are separate questions and deliberately not in this PR** — this change is model-agnostic and stands on the four in-file precedents above.
- First-token logprobs exercise the prefill/contiguous path. On the masked/decode path I only have weaker evidence: median TPOT 42.05 ms (v2) vs 41.56 ms (v1), and long greedy completions agreeing exactly on 2 of 4 prompts (divergence after ~60 tokens is expected from reduction order once sampling amplifies a tie).
- Single node only. Not validated cross-node.
- No standard accuracy benchmark (GSM8K/MMLU) was run.

For a silu model this change is a no-op: `in ("silu", "situ")` accepts everything `== "silu"` accepted.

## Speed Tests and Profiling

No performance impact — the change is to an assertion, not to any kernel or launch path. (For context, not as a claim about this PR: at matched chunk 2048, v2 prefill ISL=8K was 5903.74 vs v1 5540.26 tok/s.)

## Checklist

- [x] Format your code according to Format code with pre-commit
- [ ] Add unit tests — see note below
- [ ] Update documentation — n/a
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style guidance

On unit tests: per `.claude/rules/unit-test-admission.md`, a test here would need to construct a `MoeRunnerConfig` plus a DeepEP v2 dispatch output and assert that no `AssertionError` is raised. Happy to add one if a reviewer wants it, but it reads close to a mirror test of the assert, and the failure mode it would guard is already pinned by the four in-file precedents. Guidance welcome.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33584361052](https://github.com/sgl-project/sglang/actions/runs/33584361052)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33584360903](https://github.com/sgl-project/sglang/actions/runs/33584360903)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33584361316](https://github.com/sgl-project/sglang/actions/runs/33584361316)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->