### PR TITLE
[Fix] Normalize Gemma3n attention output before o_proj

### DIFF
--- a/python/sglang/srt/models/gemma3n_causal.py
+++ b/python/sglang/srt/models/gemma3n_causal.py
@@ -494,6 +494,8 @@ class Gemma3nAttention(nn.Module):
             save_kv_cache=not self.is_kv_shared_layer,
         )
 
+        if attn_output.dim() == 3:
+            attn_output = attn_output.flatten(-2, -1)
         output, _ = self.o_proj(attn_output)
         return output
 

--- a/test/registered/unit/models/test_gemma3n_attention.py
+++ b/test/registered/unit/models/test_gemma3n_attention.py
@@ -1,0 +1,67 @@
+"""Unit tests for Gemma3n attention output normalization."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import torch
+from torch import nn
+
+from sglang.srt.models.gemma3n_causal import Gemma3nAttention
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGemma3nAttention(CustomTestCase):
+    def test_flattens_head_shaped_output_before_o_proj(self):
+        num_tokens = 3
+        num_heads = 2
+        num_kv_heads = 1
+        head_dim = 4
+
+        attention = object.__new__(Gemma3nAttention)
+        nn.Module.__init__(attention)
+        attention.num_heads = num_heads
+        attention.num_kv_heads = num_kv_heads
+        attention.head_dim = head_dim
+        attention.q_size = num_heads * head_dim
+        attention.kv_size = num_kv_heads * head_dim
+        attention.is_kv_shared_layer = False
+        attention.kv_shared_layer_index = None
+        attention.qkv_proj = MagicMock(
+            return_value=(
+                torch.zeros((num_tokens, attention.q_size + 2 * attention.kv_size)),
+                None,
+            )
+        )
+        attention.q_norm = nn.Identity()
+        attention.k_norm = nn.Identity()
+        attention.v_norm = nn.Identity()
+        attention.rotary_emb = MagicMock(side_effect=lambda _, q, k: (q, k))
+        attention.attn = MagicMock(
+            return_value=torch.zeros((num_tokens, num_heads, head_dim))
+        )
+        attention.o_proj = MagicMock(
+            return_value=(torch.zeros((num_tokens, num_heads * head_dim)), None)
+        )
+
+        output = attention(
+            torch.zeros((num_tokens, 1)),
+            torch.arange(num_tokens),
+            object(),
+        )
+
+        self.assertEqual(output.shape, (num_tokens, num_heads * head_dim))
+        self.assertEqual(
+            attention.o_proj.call_args.args[0].shape,
+            (num_tokens, num_heads * head_dim),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Gemma3n reshapes its query to `[num_tokens, num_heads, head_dim]` before calling `RadixAttention`. On the failing Triton extend path, the attention result keeps this 3-D layout and is passed directly to `o_proj`, whose input width is `num_heads * head_dim`. This produces the reported `mat1 and mat2 shapes cannot be multiplied (...x256 and 2048x2048)` error.

Gemma4 already normalizes this backend-dependent output layout before its output projection. Apply the same normalization to Gemma3n.

## Modifications

- Flatten a 3-D Gemma3n attention output over its head and head-dimension axes before `o_proj`.
- Add a CPU unit test with mocked projections/attention to guard the 3-D output contract without loading model weights.

2-D attention outputs are unchanged.

## Accuracy Tests

Reported external NVIDIA H20 validation on base `gemma-3n-E2B` (fork at `dad6fd0f04`):

- Triton: before the change, the first request failed with the 256-to-2048 projection shape error; after the change, warmup completed and text and image requests produced coherent output.
- FA3 and FlashInfer: coherent text and image-related output; results matched Triton for the tested prompts.
- Long prompt (2602 tokens): no crash after the change.

The exact `-it` E2B/E4B variants from the issue and the current upstream revision still need a follow-up NVIDIA run. The reported FA3/FlashInfer historical degeneration is not claimed as part of this change.

## Local Checks

- `python3 -m py_compile python/sglang/srt/models/gemma3n_causal.py test/registered/unit/models/test_gemma3n_attention.py`
- `ruff check --select F401,F821,UP037 ...`
- `black --check ...`
- `python3 scripts/lint/check_registered_tests.py test/registered/unit/models/test_gemma3n_attention.py`

The full unit test could not run in this checkout because PyTorch and Transformers are not installed.

Refs #36690

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33584380261](https://github.com/sgl-project/sglang/actions/runs/33584380261)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33584379785](https://github.com/sgl-project/sglang/actions/runs/33584379785)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33584380289](https://github.com/sgl-project/sglang/actions/runs/33584380289)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->