### PR TITLE
[Docs] Replace removed --enable-piecewise-cuda-graph in multimodal CUDA graph docs

### DIFF
--- a/docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx
+++ b/docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx
@@ -61,14 +61,14 @@ SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
 python3 -m sglang.launch_server \
   --model Qwen/Qwen3-VL-8B-Instruct
 ```
-Or you can run CUDA Graph for ViT together with Piecewise CUDA Graph feature by both setting env variable `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` and setting `--enable-piecewise-cuda-graph`, for example:
+Or you can run CUDA Graph for ViT together with Piecewise CUDA Graph by setting env variable `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` and `--cuda-graph-backend-prefill=tc_piecewise` (needed because multimodal/VLM auto-disables PCG), for example:
 ```shell Command
 SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
 python3 -m sglang.launch_server \
   --model Qwen/Qwen3-VL-8B-Instruct \
-  --piecewise-cuda-graph-max-tokens 4096 \
-  --enable-piecewise-cuda-graph \
-  --piecewise-cuda-graph-compiler eager
+  --cuda-graph-max-bs-prefill 4096 \
+  --cuda-graph-backend-prefill=tc_piecewise \
+  --cuda-graph-tc-compiler eager
 ```
 
 ## Known supported models


### PR DESCRIPTION
## What drifted

`docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx` still documents the removed CLI flag `--enable-piecewise-cuda-graph` and the old companion flags `--piecewise-cuda-graph-max-tokens` / `--piecewise-cuda-graph-compiler`.

## Current flags (upstream HEAD `e874ae64`)

- `--cuda-graph-backend-prefill=tc_piecewise` (replaces `--enable-piecewise-cuda-graph`)
- `--cuda-graph-max-bs-prefill` (replaces `--piecewise-cuda-graph-max-tokens`)
- `--cuda-graph-tc-compiler` (replaces `--piecewise-cuda-graph-compiler`)

## Repro

1. On upstream `main`, search `python/sglang/srt/server_args.py` for `enable-piecewise-cuda-graph` → count = 0 (flag removed).
2. Compare with `docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx`, which still shows the old flag names in examples.
3. Confirm the current piecewise prefill knobs are the `--cuda-graph-*-prefill` / `--cuda-graph-tc-compiler` flags above.

## Change

Update the multimodal CUDA graph docs to use the current flag names so copy-paste examples work on current `main`.

Signed-off-by already on the commit.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33584540836](https://github.com/sgl-project/sglang/actions/runs/33584540836)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33584540707](https://github.com/sgl-project/sglang/actions/runs/33584540707)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->