### PR TITLE
Expose prefill completion lifecycle events for unary requests

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -429,6 +429,7 @@ class RuntimeHandle:
         result["kv_events"] = describe_kv_events_publisher(
             self.tokenizer_manager.server_args
         )
+        result["request_lifecycle"] = {"prefill_completed": True}
         return json.dumps(msgspec_to_builtins(result), default=str)
 
     def health_check(self) -> bool:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -836,6 +836,7 @@ async def server_info():
             # `None` when publishing is disabled or misconfigured; see
             # `runtime_context.describe_kv_events_publisher` for the contract.
             "kv_events": describe_kv_events_publisher(server_args),
+            "request_lifecycle": {"prefill_completed": True},
         }
     )
 
@@ -951,6 +952,19 @@ async def generate_request(obj: GenerateReqInput, request: Request):
         except ValueError as e:
             logger.error(f"[http_server] Error: {e}")
             return _create_error_response(e)
+
+
+@app.get("/v1/request_lifecycle/{rid}/prefill_completed")
+async def wait_for_prefill_completed(rid: str):
+    """Wait for the engine's first output without consuming its response body."""
+    observed_at = await _global_state.tokenizer_manager.wait_for_prefill_completed(rid)
+    return orjson_response(
+        {
+            "request_id": rid,
+            "event": "prefill_completed",
+            "observed_at": observed_at,
+        }
+    )
 
 
 @app.api_route("/encode", methods=["POST", "PUT"])

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -28,7 +28,7 @@ import sys
 import threading
 import time
 from array import array
-from collections import deque
+from collections import OrderedDict, deque
 from contextlib import nullcontext
 from datetime import datetime
 from enum import Enum
@@ -176,6 +176,7 @@ from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 _REQUEST_STATE_WAIT_TIMEOUT = envs.SGLANG_REQUEST_STATE_WAIT_TIMEOUT.get()
+_MAX_COMPLETED_REQUEST_LIFECYCLE_EVENTS = 8192
 
 logger = logging.getLogger(__name__)
 
@@ -588,6 +589,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.event_loop = None
         self.asyncio_tasks = set()
 
+        # Request lifecycle observers are intentionally independent from response
+        # delivery. A non-streaming caller only receives the terminal response, but
+        # an in-process sidecar can still observe that prefill completed when the
+        # first scheduler output reaches the tokenizer manager.
+        self._prefill_completed: OrderedDict[str, float] = OrderedDict()
+        self._prefill_completion_waiters: Dict[
+            str, set[asyncio.Future[float]]
+        ] = {}
+
         # Health check
         self.server_status = ServerStatus.Starting
         self.gracefully_exit = False
@@ -598,6 +608,38 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Subprocess liveness watchdog — set by Engine or http_server after construction
         self._subprocess_watchdog = None
+
+    def mark_prefill_completed(self, rid: str) -> float:
+        """Publish an idempotent request lifecycle event for ``rid``."""
+        if timestamp := self._prefill_completed.get(rid):
+            return timestamp
+
+        timestamp = real_time()
+        self._prefill_completed[rid] = timestamp
+        while (
+            len(self._prefill_completed) > _MAX_COMPLETED_REQUEST_LIFECYCLE_EVENTS
+        ):
+            self._prefill_completed.popitem(last=False)
+
+        for waiter in self._prefill_completion_waiters.pop(rid, set()):
+            if not waiter.done():
+                waiter.set_result(timestamp)
+        return timestamp
+
+    async def wait_for_prefill_completed(self, rid: str) -> float:
+        """Wait until the first scheduler output proves prefill has completed."""
+        if timestamp := self._prefill_completed.get(rid):
+            return timestamp
+
+        waiter = asyncio.get_running_loop().create_future()
+        waiters = self._prefill_completion_waiters.setdefault(rid, set())
+        waiters.add(waiter)
+        try:
+            return await waiter
+        finally:
+            waiters.discard(waiter)
+            if not waiters:
+                self._prefill_completion_waiters.pop(rid, None)
 
     def init_request_logging_and_dumping(self):
         # TODO: Refactor and organize the log export code.
@@ -2439,6 +2481,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # This is the single write point for first_token_time.
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
+                self.mark_prefill_completed(rid)
 
             if state.finished:
                 if state.time_stats.trace_ctx.tracing_enable:

--- a/test/registered/unit/managers/test_request_lifecycle.py
+++ b/test/registered/unit/managers/test_request_lifecycle.py
@@ -1,0 +1,53 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+
+
+def lifecycle_manager() -> TokenizerManager:
+    manager = TokenizerManager.__new__(TokenizerManager)
+    manager.init_running_status()
+    return manager
+
+
+def test_prefill_completion_wakes_waiter_and_is_idempotent():
+    async def run():
+        manager = lifecycle_manager()
+        waiter = asyncio.create_task(manager.wait_for_prefill_completed("request-1"))
+        await asyncio.sleep(0)
+
+        first = manager.mark_prefill_completed("request-1")
+        assert await waiter == first
+        assert manager.mark_prefill_completed("request-1") == first
+        assert await manager.wait_for_prefill_completed("request-1") == first
+
+    asyncio.run(run())
+
+
+def test_cancelled_waiter_is_removed():
+    async def run():
+        manager = lifecycle_manager()
+        waiter = asyncio.create_task(manager.wait_for_prefill_completed("request-2"))
+        await asyncio.sleep(0)
+        waiter.cancel()
+
+        try:
+            await waiter
+        except asyncio.CancelledError:
+            pass
+
+        assert "request-2" not in manager._prefill_completion_waiters
+
+    asyncio.run(run())


### PR DESCRIPTION
Expose an out-of-band prefill-completed lifecycle event from the tokenizer manager and advertise it through HTTP and native gRPC server discovery. This lets unary `/generate` consumers release prefill bookkeeping before the final response without forcing SGLang or an external proxy to stream or reinterpret engine-owned response metadata.

### How This Was Implemented
- Mark prefill completion at the existing single write point for `first_token_time`, when the first scheduler output reaches the tokenizer manager.
- Retain the most recent 8,192 completion timestamps and wake all registered waiters idempotently, including observers that arrive after the event.
- Add `GET /v1/request_lifecycle/{rid}/prefill_completed` as an independent long-poll endpoint.
- Advertise `request_lifecycle.prefill_completed=true` from both HTTP `/server_info` and native gRPC `GetServerInfo`.

<details>
<summary>Walkthrough</summary>

#### Mental model

Unary generation already consumes scheduler outputs internally; it only withholds them from the HTTP caller until the request finishes. This change observes that existing internal first-output transition and exposes it independently from response delivery.

```mermaid
sequenceDiagram
    participant P as External proxy
    participant H as SGLang HTTP server
    participant T as TokenizerManager
    participant S as Scheduler
    par Unary response
        P->>H: POST /generate stream=false
        H->>T: Start generation
    and Lifecycle observation
        P->>H: GET /request_lifecycle/{rid}/prefill_completed
        H->>T: Register waiter
    end
    S-->>T: First scheduler output
    T-->>H: Complete lifecycle waiter
    H-->>P: prefill_completed event
    S-->>T: Remaining outputs and terminal result
    T-->>H: Final assembled response
    H-->>P: One unary JSON response
```

#### State and ordering

`mark_prefill_completed` records one timestamp per request ID and resolves every current waiter. A bounded ordered map also handles the inverse race: if the first scheduler output arrives before the lifecycle GET is registered, the observer receives the retained timestamp immediately.

The event is emitted at the same transition that initializes `first_token_time`. It therefore means the first scheduler output has proved prefill completion; it is not a separate low-level CUDA-kernel event.

#### Request lifecycle

The lifecycle GET and unary POST are independent requests. Cancelling a waiter removes its future without affecting generation, while successful generation continues assembling the existing terminal response normally.

Streaming and unary response formatting are unchanged. The new endpoint carries only request identity, event name, and observation timestamp; it never consumes or reconstructs response fields.

#### Boundaries and limitations

This initial API expects request IDs to be unique while retained; reusing an ID can observe its earlier completion timestamp. Requests aborted before their first scheduler output do not emit this event, so observers must cancel their wait when the generation request terminates.

The completion cache is process-local and bounded rather than durable. This PR does not define retry-attempt identity or a general request-event protocol.

</details>

### Validation
- `python -m pytest test/registered/unit/managers/test_request_lifecycle.py -q` — 2 passed.
- `python -m py_compile python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/entrypoints/http_server.py python/sglang/srt/entrypoints/grpc_bridge.py` — passed.
- Targeted Ruff checks for the new test and changed code — passed; unrelated pre-existing diagnostics in the large entrypoint modules were excluded.
- Manual end-to-end validation: an external sidecar received the lifecycle event before unary `/generate` completed, and the existing streaming path remained successful.
