### PR TITLE
[Diffusion][Perf] Consume packed Ulysses QKV without copies

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -47,6 +47,7 @@ from sglang.multimodal_gen.runtime.layers.attention.turbo_layer import (
     async_a2a_communicate,
 )
 from sglang.multimodal_gen.runtime.layers.usp import (
+    _can_use_zero_copy_qkv_a2a_4d,
     _ipc_input_a2a_qkv,
     _merge_attention_partials,
     _ring_attention_varlen,
@@ -78,6 +79,14 @@ _PYTORCH_DEFAULT_CUDA_SDP_BACKENDS = [
 # Set ``SGLANG_VARLEN_FA=0`` to disable the varlen FA fast path in
 # USPAttention masked branch and fall back to SDPA.
 _VARLEN_FA_ENABLED = os.environ.get("SGLANG_VARLEN_FA", "1") != "0"
+
+# FA3/FA4 accept arbitrary Q/K/V strides as long as head_size is contiguous.
+# For batch-one dense Ulysses attention, consume the packed receive buffer
+# directly and remove three full-tensor unpack copies.  Set to zero for A/B or
+# rollback.
+_USP_ZERO_COPY_PACKED_QKV = (
+    os.environ.get("SGLANG_DIFFUSION_USP_ZERO_COPY_QKV", "1") != "0"
+)
 
 
 def _resolve_sp_attention_mode(
@@ -1345,6 +1354,15 @@ class USPAttention(nn.Module):
                 q = q.contiguous()
                 k = k.contiguous()
                 v = v.contiguous()
+            elif (
+                _USP_ZERO_COPY_PACKED_QKV
+                and self.backend == AttentionBackendEnum.FA
+                and _fa_backend.fa_ver in (3, 4)
+                and self.head_size != 256
+                and get_ring_parallel_world_size() == 1
+                and _can_use_zero_copy_qkv_a2a_4d(q, k, v, sp_size)
+            ):
+                q, k, v = _usp_input_all_to_all_qkv(q, k, v, materialize=False)
             else:
                 q, k, v = _usp_input_all_to_all_qkv(q, k, v)
 

--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -402,10 +402,24 @@ def _can_use_packed_qkv_a2a_4d(
     )
 
 
+def _can_use_zero_copy_qkv_a2a_4d(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, world_size: int
+) -> bool:
+    """Whether packed receive storage can be consumed directly by attention."""
+    return (
+        _can_use_packed_qkv_a2a_4d(q, k, v, world_size)
+        and q.shape[0] == 1
+        and not torch.is_grad_enabled()
+        and not torch.cuda.is_current_stream_capturing()
+    )
+
+
 def _usp_input_all_to_all_qkv(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    *,
+    materialize: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Ulysses input exchange for Q/K/V with heads at dim=2.
 
@@ -427,6 +441,8 @@ def _usp_input_all_to_all_qkv(
         )
 
     b, s_local, h_global, d = q.shape
+    if not materialize and b != 1:
+        raise ValueError("zero-copy packed QKV receive requires batch size one")
     h_local = h_global // world_size
     rows = b * s_local
     packed = pack_qkv_destination_major(
@@ -438,7 +454,13 @@ def _usp_input_all_to_all_qkv(
             "usp_packed_qkv_src", (world_size, rows, h_local, 3 * d), q.dtype, q.device
         ),
     )
-    packed = _usp_all_to_all_single(packed, role="usp_packed_qkv_recv")
+    # The materialized path copies Q/K/V out and can safely recycle one global
+    # receive staging buffer.  The zero-copy path instead allocates one packed
+    # receive tensor: its three views retain the storage until attention has
+    # consumed them, and PyTorch's stream-aware allocator then recycles it.
+    packed = _usp_all_to_all_single(
+        packed, role="usp_packed_qkv_recv" if materialize else None
+    )
     if b == 1:
         # Received chunks are already sequence-major: rank j's rows arrive at
         # offset j * s_local, so flattening the leading dims is a free view.
@@ -451,6 +473,8 @@ def _usp_input_all_to_all_qkv(
             .view(b, world_size * s_local, h_local, 3 * d)
         )
     q, k, v = packed.split(d, dim=-1)
+    if not materialize:
+        return q, k, v
     # Copy out before the staging buffer is recycled by the next collective.
     return q.contiguous(), k.contiguous(), v.contiguous()
 

--- a/python/sglang/multimodal_gen/test/unit/test_usp_packed_qkv_a2a.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_packed_qkv_a2a.py
@@ -173,7 +173,7 @@ class TestPackedQKVInputA2A(CustomTestCase):
                     )
                     self.assertTrue(packed[r][i].is_contiguous())
 
-    def test_batch_one_zero_copy_views_match_materialized_exchange(self):
+    def test_batch_one_zero_copy_views_match_reference(self):
         world, b, s_global, h_global, d = 4, 1, 128, 24, 64
         torch.manual_seed(9876)
         s_local, h_local = s_global // world, h_global // world
@@ -199,20 +199,6 @@ class TestPackedQKVInputA2A(CustomTestCase):
                 expected = full[index][:, :, rank * h_local : (rank + 1) * h_local]
                 self.assertTrue(torch.equal(views[rank][index], expected))
                 self.assertEqual(views[rank][index].stride(-1), 1)
-                self.assertFalse(views[rank][index].is_contiguous())
-
-    def test_zero_copy_rejects_batch_greater_than_one(self):
-        world, b, s_global, h_global, d = 2, 2, 16, 4, 8
-        s_local = s_global // world
-        shards = [
-            torch.randn(b, s_local, h_global, d, dtype=torch.bfloat16, device="cuda")
-            for _ in range(3)
-        ]
-        with (
-            patch(f"{_USP}.get_ulysses_parallel_world_size", return_value=world),
-            self.assertRaisesRegex(ValueError, "batch size one"),
-        ):
-            usp_mod._usp_input_all_to_all_qkv(*shards, materialize=False)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_usp_packed_qkv_a2a.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_packed_qkv_a2a.py
@@ -173,6 +173,47 @@ class TestPackedQKVInputA2A(CustomTestCase):
                     )
                     self.assertTrue(packed[r][i].is_contiguous())
 
+    def test_batch_one_zero_copy_views_match_materialized_exchange(self):
+        world, b, s_global, h_global, d = 4, 1, 128, 24, 64
+        torch.manual_seed(9876)
+        s_local, h_local = s_global // world, h_global // world
+        full = [
+            torch.randn(b, s_global, h_global, d, dtype=torch.bfloat16, device="cuda")
+            for _ in range(3)
+        ]
+        shards = [
+            tuple(t[:, r * s_local : (r + 1) * s_local].contiguous() for t in full)
+            for r in range(world)
+        ]
+
+        views = self._run_all_ranks(
+            lambda rank: usp_mod._usp_input_all_to_all_qkv(
+                *shards[rank], materialize=False
+            ),
+            world,
+        )
+        for rank in range(world):
+            storages = {tensor.untyped_storage().data_ptr() for tensor in views[rank]}
+            self.assertEqual(len(storages), 1)
+            for index in range(3):
+                expected = full[index][:, :, rank * h_local : (rank + 1) * h_local]
+                self.assertTrue(torch.equal(views[rank][index], expected))
+                self.assertEqual(views[rank][index].stride(-1), 1)
+                self.assertFalse(views[rank][index].is_contiguous())
+
+    def test_zero_copy_rejects_batch_greater_than_one(self):
+        world, b, s_global, h_global, d = 2, 2, 16, 4, 8
+        s_local = s_global // world
+        shards = [
+            torch.randn(b, s_local, h_global, d, dtype=torch.bfloat16, device="cuda")
+            for _ in range(3)
+        ]
+        with (
+            patch(f"{_USP}.get_ulysses_parallel_world_size", return_value=world),
+            self.assertRaisesRegex(ValueError, "batch size one"),
+        ):
+            usp_mod._usp_input_all_to_all_qkv(*shards, materialize=False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

This is a low-risk first increment toward #33708. It does not claim to complete
the issue's compute/communication-overlap target.

The packed Ulysses input path relayouts Q/K/V destination-major, exchanges them
with one `all_to_all_single`, and then splits the packed receive tensor back into
Q/K/V. The current path materializes all three split tensors with
`q.contiguous()`, `k.contiguous()`, and `v.contiguous()` before FlashAttention.
For long video sequences, those are three repeated full-tensor device copies in
every attention block and denoising step.

FA3 and FA4 accept arbitrary Q/K/V strides when the head dimension is
contiguous, so batch-one dense attention can consume the split views directly.

## Roadmap alignment

This increment directly maps to the current SGLang-Diffusion roadmap (#23035):

- **graph-level optimization**: propagate the destination-major packed layout
  across the input A2A -> FlashAttention boundary instead of materializing three
  intermediate tensors;
- **kernel-first optimization**: build on the hand-written Ulysses relayout
  kernels from #33667 and validate the change at whole-block, denoising-stage,
  and request level rather than reporting only a kernel microbenchmark;
- **hybrid parallelism within pipeline stages**: reduce exposed data movement in
  the generic Ulysses sequence-parallel attention path without changing its
  collective count, communication volume, or numerical semantics.

It is also a measured, low-risk implementation increment for #33708. It does
not claim true compute/communication overlap or the full planning target.

## Changes

- Add an opt-in-at-the-helper-level `materialize=False` mode to the packed QKV
  input exchange.
- Allocate a fresh packed receive tensor for that mode and return three split
  views that retain its storage until attention finishes consuming them. This
  avoids lifetime hazards from the reusable global receive staging buffer.
- Automatically use the zero-copy path only for eligible batch-one dense FA3/FA4
  CUDA attention without ring parallelism, autograd, or CUDA graph capture.
- Keep the existing materialized behavior as the default for other callers and
  all unsupported shapes/backends.
- Add `SGLANG_DIFFUSION_USP_ZERO_COPY_QKV=0` as a runtime rollback/A-B switch.
- Add focused CUDA unit coverage for batch-one reference parity and shared
  backing storage.

No collective type, collective count, communication volume, or numerical
operation changes in this PR.

## Deliberately excluded follow-up fusions

This PR intentionally does not combine either of these broader boundary
changes:

1. fusing Q/K normalization and RoPE into destination-major QKV A2A packing;
2. fusing output A2A with `to_out` through partial projection/reduce-scatter.

Both cross numerical-operation or collective-reduction boundaries. Fusing
normalization/RoPE with packing can change BF16 materialization and rounding
behavior, while partial projection plus reduce-scatter changes floating-point
accumulation order. They therefore cannot currently satisfy this PR's bit-exact
bar and may introduce numerical drift or output-quality risk. They need separate
accuracy/quality evaluation and are deliberately out of scope here.

The submitted path is restricted to removing pure copies after input A2A; it
preserves the existing math and collective semantics and is bit exact in the
reported tests.

## Benchmark

Hardware and model:

- 1 node, NVIDIA H200, BF16, FlashAttention 3
- `Wan2.2-TI2V-5B-Diffusers`, Ulysses degree 4
- batch 1, 121 frames, 5 denoising steps, guidance 5.0, seed 42
- real padded global sequence lengths: 12,092 and 27,280

Method:

- fresh-process `A1 baseline -> B1 candidate -> B2 candidate -> A2 baseline`
- one warmup and two measured requests per phase
- synchronized stage timing
- speedup is `baseline / candidate - 1`

| Resolution | Metric | Baseline | Candidate | Speedup |
|---|---|---:|---:|---:|
| 480x832 | input A2A -> FA -> output A2A block | 1.169968 ms | 1.091216 ms | **7.22%** |
| 480x832 | median denoising step | 157.374176 ms | 154.615636 ms | **1.78%** |
| 480x832 | five-step denoising stage | 787.963561 ms | 772.386888 ms | **2.02%** |
| 480x832 | request wall time | 5681.393861 ms | 5672.192124 ms | **0.16%** |
| 704x1280 | input A2A -> FA -> output A2A block | 3.859056 ms | 3.710768 ms | **4.00%** |
| 704x1280 | median denoising step | 453.182999 ms | 440.829106 ms | **2.80%** |
| 704x1280 | five-step denoising stage | 2257.104864 ms | 2216.476377 ms | **1.83%** |
| 704x1280 | request wall time | 12388.106015 ms | 12107.094581 ms | **2.32%** |

The microbenchmark direct comparison and eight unsynchronized allocator-reuse
iterations were bit exact (`max_abs_diff=0`). All fixed-seed E2E phases produced
the same output hash within each resolution.

The benchmark was collected at base `4c2c169e6` and candidate `584888218`; this
branch has since been rebased onto current `main`. The subsequent upstream change
in `layer.py` is confined to attention-backend capability plumbing outside the
benchmarked Ulysses forward path; the `usp.py` hot path is unchanged.

## Rejected overlap prototype

I also evaluated the issue's head-tiled A2A/attention overlap direction. At
Ulysses-4, Wan2.2-TI2V-5B has only six local heads per rank, and the additional
collectives plus smaller FA launches cost more than the hidden communication:

| Resolution | Baseline | Head-tiled overlap | Change |
|---|---:|---:|---:|
| 480x832 | 1.160464 ms | 1.302352 ms | **-10.90%** |
| 704x1280 | 3.853968 ms | 3.931360 ms | **-1.97%** |

That prototype is not included in this PR.

## Test plan

- [x] `pre-commit run --files` on all three changed files
- [x] Python bytecode compilation for all three changed files
- [x] CUDA unit tests added for the packed-view invariants
- [x] Four-GPU H200 microbenchmark with direct and no-sync reuse parity checks
- [x] Four-phase H200 E2E benchmark at both required resolutions

## Scope

Related to #33708. This PR deliberately does not close it: the measured denoising
improvement is positive at both resolutions, but remains below the issue's full
planning targets for communication overlap.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33612244805](https://github.com/sgl-project/sglang/actions/runs/33612244805)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33612244536](https://github.com/sgl-project/sglang/actions/runs/33612244536)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33612244487](https://github.com/sgl-project/sglang/actions/runs/33612244487)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

