### PR TITLE
[CI] Re-enable GB300 jobs

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -100,14 +100,12 @@ jobs:
   run:
     name: ${{ inputs.self_name }} (${{ matrix.partition }})
     # Runs on schedule / parallel-dispatch / non-failed PR with main_package or sgl_kernel changes.
-    # Temporarily skip the broken GB300 runner before GitHub tries to allocate it.
     # `runner_filter` is matched here rather than in each caller's job `if`: a
     # caller that declares its runners as a matrix cannot, since job-level `if`
     # sees github/needs/vars/inputs but not `matrix`. Callers that never declare
     # the input read back null and match every runner_config.
     if: |
       always() &&
-      inputs.runner_config != '4-gpu-gb300' &&
       (fromJson(inputs.caller_inputs).runner_filter == null ||
        fromJson(inputs.caller_inputs).runner_filter == '' ||
        fromJson(inputs.caller_inputs).runner_filter == 'all' ||

--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -194,10 +194,9 @@ jobs:
           # - arch_label: sm120
           #   runner: 1-gpu-5090
           #   wheel_arch: x86_64
-          # Temporarily disabled while the GB300 runner is unavailable.
-          # - arch_label: sm100-aarch64
-          #   runner: 4-gpu-gb300
-          #   wheel_arch: aarch64
+          - arch_label: sm100-aarch64
+            runner: 4-gpu-gb300
+            wheel_arch: aarch64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -87,8 +87,7 @@ permissions:
 
 jobs:
   rerun-test-cuda:
-    # Temporarily reject reruns targeting the broken GB300 runner.
-    if: inputs.mode == 'cuda' && inputs.runs_on != '4-gpu-gb300'
+    if: inputs.mode == 'cuda'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 120
     permissions:
@@ -200,8 +199,7 @@ jobs:
         if: failure()
 
   rerun-test-multimodal-gen:
-    # Temporarily reject reruns targeting the broken GB300 runner.
-    if: inputs.mode == 'multimodal_gen' && inputs.runs_on != '4-gpu-gb300'
+    if: inputs.mode == 'multimodal_gen'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 120
     permissions:


### PR DESCRIPTION
## Motivation

The 4-gpu-gb300 runner is back, so this reverts #36981, which disabled GB300 jobs while the machine was unavailable.

The cluster was drained and reprovisioned, which deleted the runner pod along with its namespace. The replacement pod runs with `restartPolicy: Always` and a priority class a devbox can't preempt, so a node replacement no longer takes the runner out permanently.

## Modifications

Revert of #36981, keeping the `runner_filter` logic that landed in `_pr-test-stage.yml` afterwards:
- Drop the `runner_config != '4-gpu-gb300'` guard from the shared CUDA stage.
- Allow CUDA and multimodal reruns to target 4-gpu-gb300 again.
- Restore the GB300 aarch64 entry in the DeepGEMM CUDA 13 test matrix.

## Verification

Runner is online with the `4-gpu-gb300` label. All four GPUs exercised in-pod before opening this: 64M-element axpy per device with exact results, and peer-to-peer copies across all 12 ordered pairs at 753-759 GB/s. No uncorrected ECC, no pending row remaps.

## Checklist

- [x] Format the code with pre-commit.
- [x] Workflow files validated (YAML parse + pre-commit workflow checks).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33586611727](https://github.com/sgl-project/sglang/actions/runs/33586611727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33586611627](https://github.com/sgl-project/sglang/actions/runs/33586611627)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->