### PR TITLE
feat(moe): add opt-in NCCL dispatcher with local route metadata

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -40,6 +40,7 @@ from sglang.srt.layers.moe.token_dispatcher.ascend_tp import (
 from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
 from sglang.srt.layers.moe.token_dispatcher.deepep_v2 import DeepEPv2Dispatcher
 from sglang.srt.layers.moe.token_dispatcher.flashinfer import FlashinferDispatcher
+from sglang.srt.layers.moe.token_dispatcher.nccl import NcclDispatcher
 from sglang.srt.layers.moe.token_dispatcher.standard import (
     StandardDispatcher,
 )
@@ -206,6 +207,11 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             num_experts=moe_runner_config.num_experts,
             num_local_experts=moe_runner_config.num_local_experts,
             hidden_size=moe_runner_config.hidden_size,
+            moe_runner_config=moe_runner_config,
+        )
+    elif a2a_backend.is_nccl():
+        return NcclDispatcher(
+            group=get_moe_ep_group().device_group,
             moe_runner_config=moe_runner_config,
         )
     else:

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -19,6 +19,10 @@ from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import is_cuda, is_gfx95_supported, is_hip
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.nccl import (
+        NcclCombineInput,
+        NcclDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -332,4 +336,39 @@ def post_permute_triton_to_standard(
 
     return StandardCombineInput(
         hidden_states=runner_output.hidden_states,
+    )
+
+
+@register_pre_permute("nccl", "triton")
+def pre_permute_nccl_to_triton(
+    dispatch_output: NcclDispatchOutput,
+    quant_info: TritonMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> TritonRunnerInput:
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+
+    running_state["nccl_route_handle"] = dispatch_output.route_handle
+    standard_output = StandardDispatchOutput(
+        hidden_states=dispatch_output.hidden_states,
+        hidden_states_scale=None,
+        topk_output=dispatch_output.topk_output,
+    )
+    return pre_permute_standard_to_triton(
+        standard_output, quant_info, runner_config, running_state
+    )
+
+
+@register_post_permute("triton", "nccl")
+def post_permute_triton_to_nccl(
+    runner_output: TritonRunnerOutput,
+    quant_info: TritonMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> NcclCombineInput:
+    from sglang.srt.layers.moe.token_dispatcher.nccl import NcclCombineInput
+
+    return NcclCombineInput(
+        hidden_states=runner_output.hidden_states,
+        route_handle=running_state["nccl_route_handle"],
     )

--- a/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
@@ -42,6 +42,12 @@ from sglang.srt.layers.moe.token_dispatcher.moriep import (
     MoriEPNormalCombineInput,
     MoriEPNormalDispatchOutput,
 )
+from sglang.srt.layers.moe.token_dispatcher.nccl import (
+    NcclCombineInput,
+    NcclDispatcher,
+    NcclDispatchOutput,
+    NcclRouteHandle,
+)
 from sglang.srt.layers.moe.token_dispatcher.nixl import (
     NixlEPCombineInput,
     NixlEPDispatcher,
@@ -83,6 +89,10 @@ __all__ = [
     "NixlEPCombineInput",
     "NixlEPDispatchOutput",
     "NixlEPDispatcher",
+    "NcclCombineInput",
+    "NcclDispatcher",
+    "NcclDispatchOutput",
+    "NcclRouteHandle",
     "PplxCombineInput",
     "PplxDispatchOutput",
     "PplxDispatcher",

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
         DeepEPv2DispatchOutput,
         FlashinferCombineInput,
         FlashinferDispatchOutput,
+        NcclCombineInput,
+        NcclDispatchOutput,
         StandardCombineInput,
         StandardDispatchOutput,
     )
@@ -173,6 +175,12 @@ class DispatchOutputChecker:
     ) -> TypeGuard[DeepEPv2DispatchOutput]:
         return dispatch_output.format.is_deepep_v2()
 
+    @staticmethod
+    def format_is_nccl(
+        dispatch_output: DispatchOutput,
+    ) -> TypeGuard[NcclDispatchOutput]:
+        return dispatch_output.format.is_nccl()
+
 
 class DispatchOutputFormat(Enum):
 
@@ -182,6 +190,7 @@ class DispatchOutputFormat(Enum):
     FLASHINFER = "flashinfer"
     DEEPEP_V2 = "deepep_v2"
     ASCEND_TP = "ascend_tp"
+    NCCL = "nccl"
 
     def is_standard(self) -> bool:
         return self == DispatchOutputFormat.STANDARD
@@ -206,6 +215,9 @@ class DispatchOutputFormat(Enum):
 
     def is_deepep_v2(self) -> bool:
         return self == DispatchOutputFormat.DEEPEP_V2
+
+    def is_nccl(self) -> bool:
+        return self == DispatchOutputFormat.NCCL
 
 
 @runtime_checkable
@@ -267,6 +279,12 @@ class CombineInputChecker:
     ) -> TypeGuard[DeepEPv2CombineInput]:
         return combine_input.format == CombineInputFormat.DEEPEP_V2
 
+    @staticmethod
+    def format_is_nccl(
+        combine_input: CombineInput,
+    ) -> TypeGuard[NcclCombineInput]:
+        return combine_input.format == CombineInputFormat.NCCL
+
 
 class CombineInputFormat(Enum):
     STANDARD = "standard"
@@ -275,6 +293,7 @@ class CombineInputFormat(Enum):
     FLASHINFER = "flashinfer"
     DEEPEP_V2 = "deepep_v2"
     ASCEND_TP = "ascend_tp"
+    NCCL = "nccl"
 
 
 @runtime_checkable

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple, Optional
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.base import (
+    BaseDispatcher,
+    CombineInputFormat,
+    DispatchOutputFormat,
+)
+from sglang.srt.layers.moe.topk import (
+    StandardTopKOutput,
+    TopKOutput,
+    TopKOutputChecker,
+)
+
+
+@dataclass
+class NcclRouteHandle:
+    """State required to reverse one variable-split dispatch."""
+
+    send_counts: torch.Tensor
+    recv_counts: torch.Tensor
+    send_token_idx: torch.Tensor
+    send_route_idx: torch.Tensor
+    num_input_tokens: int
+
+    @property
+    def send_splits(self) -> list[int]:
+        return self.send_counts.cpu().tolist()
+
+    @property
+    def recv_splits(self) -> list[int]:
+        return self.recv_counts.cpu().tolist()
+
+
+class NcclDispatchOutput(NamedTuple):
+    hidden_states: torch.Tensor
+    topk_output: StandardTopKOutput
+    route_handle: NcclRouteHandle
+
+    @property
+    def format(self) -> DispatchOutputFormat:
+        return DispatchOutputFormat.NCCL
+
+
+class NcclCombineInput(NamedTuple):
+    hidden_states: torch.Tensor
+    route_handle: NcclRouteHandle
+
+    @property
+    def format(self) -> CombineInputFormat:
+        return CombineInputFormat.NCCL
+
+
+class NcclDispatcher(BaseDispatcher):
+    """Correctness-first NCCL dispatcher for CUDA architectures such as SM80.
+
+    The eager implementation emits one record per token/expert pair. It uses
+    PyTorch's variable-split ``all_to_all_single`` and intentionally does not
+    claim CUDA-graph support or a fused metadata transport yet.
+    """
+
+    def __init__(self, group: dist.ProcessGroup, moe_runner_config: MoeRunnerConfig):
+        super().__init__()
+        self.group = group
+        self.world_size = dist.get_world_size(group)
+        self.num_experts = moe_runner_config.num_experts
+        self.num_local_experts = moe_runner_config.num_local_experts
+        self.num_fused_shared_experts = moe_runner_config.num_fused_shared_experts or 0
+
+        if self.num_experts is None or self.num_local_experts is None:
+            raise ValueError("NCCL dispatcher requires global and local expert counts")
+        if self.num_fused_shared_experts:
+            raise NotImplementedError(
+                "NCCL dispatcher does not yet support fused shared experts"
+            )
+        if self.num_local_experts * self.world_size != self.num_experts:
+            raise ValueError(
+                "NCCL dispatcher currently requires an equal contiguous expert "
+                "partition: num_local_experts * world_size == num_experts"
+            )
+
+    def _exchange_counts(self, send_counts: torch.Tensor) -> torch.Tensor:
+        recv_counts = torch.empty_like(send_counts)
+        dist.all_to_all_single(recv_counts, send_counts, group=self.group)
+        return recv_counts
+
+    def _exchange(
+        self,
+        tensor: torch.Tensor,
+        send_splits: list[int],
+        recv_splits: list[int],
+    ) -> torch.Tensor:
+        output = torch.empty(
+            (sum(recv_splits), *tensor.shape[1:]),
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        dist.all_to_all_single(
+            output,
+            tensor,
+            output_split_sizes=recv_splits,
+            input_split_sizes=send_splits,
+            group=self.group,
+        )
+        return output
+
+    def dispatch(
+        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+    ) -> NcclDispatchOutput:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "NCCL MoE dispatcher is correctness-first and eager-only; "
+                "launch with --disable-cuda-graph"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise NotImplementedError(
+                "NCCL MoE dispatcher currently supports BF16 activations only"
+            )
+        if not TopKOutputChecker.format_is_standard(topk_output):
+            raise TypeError("NCCL MoE dispatcher requires standard top-k output")
+
+        topk_ids = topk_output.topk_ids.to(torch.int64)
+        topk_weights = topk_output.topk_weights.to(torch.float32)
+        num_tokens, top_k = topk_ids.shape
+        token_idx = torch.arange(
+            num_tokens, dtype=torch.int64, device=hidden_states.device
+        ).repeat_interleave(top_k)
+        # Retain the original flattened (token, top-k slot) row identity. The
+        # reverse all-to-all returns rows in destination-chunk order, which
+        # differs across physical expert maps; combine uses this key to restore
+        # the model's canonical top-k accumulation order.
+        route_idx = torch.arange(
+            num_tokens * top_k, dtype=torch.int64, device=hidden_states.device
+        )
+        expert_idx = topk_ids.reshape(-1)
+        router_weight = topk_weights.reshape(-1)
+
+        valid = (expert_idx >= 0) & (expert_idx < self.num_experts)
+        token_idx = token_idx[valid]
+        route_idx = route_idx[valid]
+        expert_idx = expert_idx[valid]
+        router_weight = router_weight[valid]
+        destination = torch.div(
+            expert_idx, self.num_local_experts, rounding_mode="floor"
+        )
+
+        order = torch.argsort(destination, stable=True)
+        destination = destination[order]
+        send_counts = torch.bincount(
+            destination, minlength=self.world_size
+        ).to(torch.int64)
+        recv_counts = self._exchange_counts(send_counts)
+        send_splits = send_counts.cpu().tolist()
+        recv_splits = recv_counts.cpu().tolist()
+
+        send_token_idx = token_idx[order].contiguous()
+        send_route_idx = route_idx[order].contiguous()
+        send_expert_idx = expert_idx[order].contiguous()
+        send_weight = router_weight[order].contiguous()
+        send_hidden_states = hidden_states[send_token_idx].contiguous()
+
+        recv_hidden_states = self._exchange(
+            send_hidden_states, send_splits, recv_splits
+        )
+        recv_expert_idx = self._exchange(send_expert_idx, send_splits, recv_splits)
+        recv_weight = self._exchange(send_weight, send_splits, recv_splits)
+
+        local_expert_idx = torch.remainder(
+            recv_expert_idx, self.num_local_experts
+        ).to(torch.int32).unsqueeze(1)
+        local_weight = recv_weight.unsqueeze(1)
+        local_topk_output = StandardTopKOutput(
+            topk_weights=local_weight,
+            topk_ids=local_expert_idx,
+            router_logits=torch.empty(
+                (recv_hidden_states.shape[0], 0),
+                dtype=torch.float32,
+                device=hidden_states.device,
+            ),
+        )
+        handle = NcclRouteHandle(
+            send_counts=send_counts,
+            recv_counts=recv_counts,
+            send_token_idx=send_token_idx,
+            send_route_idx=send_route_idx,
+            num_input_tokens=num_tokens,
+        )
+        return NcclDispatchOutput(
+            hidden_states=recv_hidden_states,
+            topk_output=local_topk_output,
+            route_handle=handle,
+        )
+
+    def combine(self, combine_input: NcclCombineInput) -> torch.Tensor:
+        hidden_states, handle = combine_input
+        recv_splits = handle.recv_splits
+        send_splits = handle.send_splits
+        expected_records = sum(recv_splits)
+        if hidden_states.shape[0] != expected_records:
+            raise RuntimeError(
+                "NCCL MoE runner changed the dispatched record count: "
+                f"output={hidden_states.shape[0]}, "
+                f"expected={expected_records}"
+            )
+
+        returned_hidden_states = self._exchange(
+            hidden_states,
+            recv_splits,
+            send_splits,
+        )
+        # Reverse all-to-all preserves row order inside every peer chunk. The
+        # returned rows therefore line up with the source-side send order, so
+        # token indices never need to cross the network in either direction.
+        #
+        # Do not use CUDA scatter_add_ here: every token has up to top-k rows,
+        # so duplicate indices would be accumulated by unordered atomics. That
+        # made greedy generations placement-dependent and non-reproducible.
+        # Sorting once and adding one unique token row at a time keeps the
+        # accumulation order fixed while preserving the BF16/FP32 dtype. The
+        # route key restores the original flattened top-k slot order, so the
+        # result is independent of which physical map determined chunk order.
+        return self._deterministic_combine(
+            returned_hidden_states,
+            handle.send_token_idx,
+            handle.num_input_tokens,
+            handle.send_route_idx,
+        )
+
+    @staticmethod
+    def _deterministic_combine(
+        hidden_states: torch.Tensor,
+        token_indices: torch.Tensor,
+        num_input_tokens: int,
+        route_order: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Sum dispatched rows per token without duplicate-index atomics."""
+        if hidden_states.shape[0] != token_indices.numel():
+            raise RuntimeError(
+                "NCCL combine token-index count does not match returned rows: "
+                f"rows={hidden_states.shape[0]}, indices={token_indices.numel()}"
+            )
+        if route_order is None:
+            route_order = torch.arange(
+                hidden_states.shape[0], dtype=torch.int64, device=hidden_states.device
+            )
+        if route_order.numel() != token_indices.numel():
+            raise RuntimeError(
+                "NCCL combine route-order count does not match returned rows: "
+                f"rows={hidden_states.shape[0]}, route_order={route_order.numel()}"
+            )
+
+        combined = torch.zeros(
+            (num_input_tokens, hidden_states.shape[1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        if hidden_states.shape[0] == 0:
+            return combined
+
+        # First restore the original flattened top-k order, then stably group
+        # by token. Stable sorting on the second key preserves slot order within
+        # each token regardless of destination/expert chunk order.
+        route_order_idx = torch.argsort(route_order, stable=True)
+        route_ordered_tokens = token_indices.index_select(0, route_order_idx)
+        token_order = torch.argsort(route_ordered_tokens, stable=True)
+        order = route_order_idx.index_select(0, token_order)
+        sorted_token_indices = token_indices.index_select(0, order)
+        sorted_hidden_states = hidden_states.index_select(0, order)
+        counts = torch.bincount(
+            sorted_token_indices,
+            minlength=num_input_tokens,
+        )
+        starts = torch.cumsum(counts, dim=0) - counts
+
+        # The maximum count is top-k for valid rows (and less for padded rows),
+        # so this loop is bounded by the model's small routing fan-out.
+        for slot in range(int(counts.max().item())):
+            active_tokens = torch.nonzero(counts > slot, as_tuple=False).flatten()
+            sorted_rows = starts[active_tokens] + slot
+            updates = combined.index_select(0, active_tokens) + sorted_hidden_states.index_select(
+                0, sorted_rows
+            )
+            combined.index_copy_(0, active_tokens, updates)
+        return combined

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl.py
@@ -152,9 +152,9 @@ class NcclDispatcher(BaseDispatcher):
 
         order = torch.argsort(destination, stable=True)
         destination = destination[order]
-        send_counts = torch.bincount(
-            destination, minlength=self.world_size
-        ).to(torch.int64)
+        send_counts = torch.bincount(destination, minlength=self.world_size).to(
+            torch.int64
+        )
         recv_counts = self._exchange_counts(send_counts)
         send_splits = send_counts.cpu().tolist()
         recv_splits = recv_counts.cpu().tolist()
@@ -171,9 +171,11 @@ class NcclDispatcher(BaseDispatcher):
         recv_expert_idx = self._exchange(send_expert_idx, send_splits, recv_splits)
         recv_weight = self._exchange(send_weight, send_splits, recv_splits)
 
-        local_expert_idx = torch.remainder(
-            recv_expert_idx, self.num_local_experts
-        ).to(torch.int32).unsqueeze(1)
+        local_expert_idx = (
+            torch.remainder(recv_expert_idx, self.num_local_experts)
+            .to(torch.int32)
+            .unsqueeze(1)
+        )
         local_weight = recv_weight.unsqueeze(1)
         local_topk_output = StandardTopKOutput(
             topk_weights=local_weight,
@@ -283,8 +285,8 @@ class NcclDispatcher(BaseDispatcher):
         for slot in range(int(counts.max().item())):
             active_tokens = torch.nonzero(counts > slot, as_tuple=False).flatten()
             sorted_rows = starts[active_tokens] + slot
-            updates = combined.index_select(0, active_tokens) + sorted_hidden_states.index_select(
-                0, sorted_rows
-            )
+            updates = combined.index_select(
+                0, active_tokens
+            ) + sorted_hidden_states.index_select(0, sorted_rows)
             combined.index_copy_(0, active_tokens, updates)
         return combined

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -44,6 +44,7 @@ class MoeA2ABackend(Enum):
     MEGAMOE = "megamoe"
     DEEPEP_V2 = "deepep_v2"
     PPLX = "pplx"
+    NCCL = "nccl"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -87,6 +88,9 @@ class MoeA2ABackend(Enum):
 
     def is_pplx(self):
         return self == MoeA2ABackend.PPLX
+
+    def is_nccl(self):
+        return self == MoeA2ABackend.NCCL
 
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
@@ -719,6 +723,10 @@ def should_skip_post_experts_all_reduce(*, is_tp_path: bool) -> bool:
     if get_moe_a2a_backend().is_pplx():
         # pplx's AllToAll.combine already sums each token's expert outputs back
         # to the source rank
+        return True
+    if get_moe_a2a_backend().is_nccl():
+        # The NCCL dispatcher's reverse all-to-all and scatter-add already
+        # restore the complete routed-expert sum on each source rank.
         return True
     return False
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2234,6 +2234,7 @@ class ServerArgs:
                 "megamoe",
                 "deepep_v2",
                 "pplx",
+                "nccl",
                 "ascend_tp",
             ],
             resolvable=True,
@@ -2376,6 +2377,7 @@ class ServerArgs:
             "deepep_v2",
             "ascend_tp",
             "pplx",
+            "nccl",
         ],
         Arg(
             help="Choose the backend for MoE A2A.",
@@ -2390,6 +2392,7 @@ class ServerArgs:
                 "megamoe",
                 "deepep_v2",
                 "pplx",
+                "nccl",
                 "ascend_tp",
             ],
             resolvable=True,

--- a/test/manual/ep/test_nccl_dispatcher.py
+++ b/test/manual/ep/test_nccl_dispatcher.py
@@ -1,0 +1,204 @@
+import unittest
+
+import torch
+
+from sglang.srt.distributed import init_distributed_environment
+from sglang.srt.distributed.parallel_state import (
+    get_moe_ep_group,
+    initialize_model_parallel,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.nccl import (
+    NcclCombineInput,
+    NcclDispatcher,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+
+class TestNcclDispatcher(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        init_distributed_environment(
+            world_size=-1,
+            rank=-1,
+            local_rank=-1,
+            backend="nccl",
+        )
+        world_size = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+        torch.cuda.set_device(rank % torch.cuda.device_count())
+        initialize_model_parallel(
+            tensor_model_parallel_size=world_size,
+            expert_model_parallel_size=world_size,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+    def _create_dispatcher(self, hidden_size: int) -> NcclDispatcher:
+        world_size = torch.distributed.get_world_size()
+        return NcclDispatcher(
+            group=get_moe_ep_group().device_group,
+            moe_runner_config=MoeRunnerConfig(
+                num_experts=world_size * 4,
+                num_local_experts=4,
+                num_fused_shared_experts=0,
+                hidden_size=hidden_size,
+                top_k=2,
+                params_dtype=torch.bfloat16,
+            ),
+        )
+
+    def test_uneven_dispatch_combine(self):
+        world_size = torch.distributed.get_world_size()
+        if world_size < 2:
+            self.skipTest("requires at least two ranks")
+
+        rank = torch.distributed.get_rank()
+        num_tokens, hidden_size, top_k = 257, 128, 2
+        token = torch.arange(num_tokens, device="cuda")
+        feature = torch.arange(hidden_size, device="cuda")
+        hidden_states = (
+            rank + token[:, None] / 512.0 + feature[None, :] / 4096.0
+        ).to(torch.bfloat16)
+
+        destinations = torch.stack(
+            [
+                torch.where(
+                    token % 10 < 7,
+                    torch.zeros_like(token),
+                    (rank + token) % world_size,
+                ),
+                (rank + token + 1) % world_size,
+            ],
+            dim=1,
+        )
+        local_experts = torch.stack(
+            [(token + rank + slot) % 4 for slot in range(top_k)], dim=1
+        )
+        topk_ids = (destinations * 4 + local_experts).to(torch.int32)
+        topk_weights = torch.tensor(
+            [2.0 / 3.0, 1.0 / 3.0], dtype=torch.float32, device="cuda"
+        ).expand(num_tokens, -1)
+        topk_output = StandardTopKOutput(topk_weights, topk_ids, None)
+
+        dispatcher = self._create_dispatcher(hidden_size)
+        dispatch_output = dispatcher.dispatch(hidden_states, topk_output)
+        local_ids = dispatch_output.topk_output.topk_ids
+        self.assertEqual(local_ids.dtype, torch.int32)
+        self.assertTrue(torch.all((local_ids >= 0) & (local_ids < 4)).item())
+
+        scales = 1.0 + local_ids[:, 0].float() / 8.0
+        local_output = (
+            dispatch_output.hidden_states.float()
+            * dispatch_output.topk_output.topk_weights[:, 0, None]
+            * scales[:, None]
+        )
+        combined = dispatcher.combine(
+            NcclCombineInput(local_output, dispatch_output.route_handle)
+        )
+
+        reference = torch.zeros_like(combined)
+        for slot in range(top_k):
+            scale = 1.0 + local_experts[:, slot].float() / 8.0
+            reference += (
+                hidden_states.float()
+                * topk_weights[:, slot, None]
+                * scale[:, None]
+            )
+        torch.testing.assert_close(combined, reference, rtol=1e-5, atol=1e-5)
+
+    def test_empty_source_rank(self):
+        world_size = torch.distributed.get_world_size()
+        if world_size < 2:
+            self.skipTest("requires at least two ranks")
+
+        rank = torch.distributed.get_rank()
+        hidden_size = 16
+        num_tokens = 0 if rank == 1 else 8
+        hidden_states = torch.full(
+            (num_tokens, hidden_size),
+            rank + 1.0,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        target = (rank + 1) % world_size
+        topk_ids = torch.full(
+            (num_tokens, 1), target * 4, dtype=torch.int32, device="cuda"
+        )
+        topk_weights = torch.ones(
+            (num_tokens, 1), dtype=torch.float32, device="cuda"
+        )
+        dispatcher = self._create_dispatcher(hidden_size)
+        dispatch_output = dispatcher.dispatch(
+            hidden_states, StandardTopKOutput(topk_weights, topk_ids, None)
+        )
+        combined = dispatcher.combine(
+            NcclCombineInput(
+                dispatch_output.hidden_states.float(), dispatch_output.route_handle
+            )
+        )
+        self.assertEqual(combined.shape, (num_tokens, hidden_size))
+        if num_tokens:
+            torch.testing.assert_close(
+                combined,
+                hidden_states.float(),
+                rtol=0,
+                atol=0,
+            )
+
+    def test_all_ranks_empty(self):
+        world_size = torch.distributed.get_world_size()
+        if world_size < 2:
+            self.skipTest("requires at least two ranks")
+
+        hidden_states = torch.empty(
+            (0, 16), dtype=torch.bfloat16, device="cuda"
+        )
+        topk_ids = torch.empty((0, 1), dtype=torch.int32, device="cuda")
+        topk_weights = torch.empty((0, 1), dtype=torch.float32, device="cuda")
+        dispatcher = self._create_dispatcher(hidden_size=16)
+        dispatched = dispatcher.dispatch(
+            hidden_states, StandardTopKOutput(topk_weights, topk_ids, None)
+        )
+        combined = dispatcher.combine(
+            NcclCombineInput(dispatched.hidden_states, dispatched.route_handle)
+        )
+        self.assertEqual(combined.shape, (0, 16))
+
+    def test_deterministic_combine_repeatability(self):
+        """Duplicate top-k rows must combine bitwise-identically on CUDA."""
+        hidden_size, num_input_tokens = 32, 257
+        num_records = num_input_tokens * 8
+        hidden_states = torch.randn(
+            (num_records, hidden_size), dtype=torch.bfloat16, device="cuda"
+        )
+        token_indices = torch.arange(
+            num_records, dtype=torch.int64, device="cuda"
+        ) % num_input_tokens
+        route_order = torch.arange(num_records, dtype=torch.int64, device="cuda")
+
+        first = NcclDispatcher._deterministic_combine(
+            hidden_states, token_indices, num_input_tokens, route_order
+        )
+        second = NcclDispatcher._deterministic_combine(
+            hidden_states, token_indices, num_input_tokens, route_order
+        )
+        torch.testing.assert_close(first, second, rtol=0, atol=0)
+
+        # A different physical expert map changes returned chunk order. The
+        # canonical route key must nevertheless reproduce the same sum.
+        permutation = torch.randperm(num_records, device="cuda")
+        remapped = NcclDispatcher._deterministic_combine(
+            hidden_states.index_select(0, permutation),
+            token_indices.index_select(0, permutation),
+            num_input_tokens,
+            route_order.index_select(0, permutation),
+        )
+        torch.testing.assert_close(first, remapped, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/manual/ep/test_nccl_dispatcher.py
+++ b/test/manual/ep/test_nccl_dispatcher.py
@@ -60,9 +60,9 @@ class TestNcclDispatcher(unittest.TestCase):
         num_tokens, hidden_size, top_k = 257, 128, 2
         token = torch.arange(num_tokens, device="cuda")
         feature = torch.arange(hidden_size, device="cuda")
-        hidden_states = (
-            rank + token[:, None] / 512.0 + feature[None, :] / 4096.0
-        ).to(torch.bfloat16)
+        hidden_states = (rank + token[:, None] / 512.0 + feature[None, :] / 4096.0).to(
+            torch.bfloat16
+        )
 
         destinations = torch.stack(
             [
@@ -104,9 +104,7 @@ class TestNcclDispatcher(unittest.TestCase):
         for slot in range(top_k):
             scale = 1.0 + local_experts[:, slot].float() / 8.0
             reference += (
-                hidden_states.float()
-                * topk_weights[:, slot, None]
-                * scale[:, None]
+                hidden_states.float() * topk_weights[:, slot, None] * scale[:, None]
             )
         torch.testing.assert_close(combined, reference, rtol=1e-5, atol=1e-5)
 
@@ -128,9 +126,7 @@ class TestNcclDispatcher(unittest.TestCase):
         topk_ids = torch.full(
             (num_tokens, 1), target * 4, dtype=torch.int32, device="cuda"
         )
-        topk_weights = torch.ones(
-            (num_tokens, 1), dtype=torch.float32, device="cuda"
-        )
+        topk_weights = torch.ones((num_tokens, 1), dtype=torch.float32, device="cuda")
         dispatcher = self._create_dispatcher(hidden_size)
         dispatch_output = dispatcher.dispatch(
             hidden_states, StandardTopKOutput(topk_weights, topk_ids, None)
@@ -154,9 +150,7 @@ class TestNcclDispatcher(unittest.TestCase):
         if world_size < 2:
             self.skipTest("requires at least two ranks")
 
-        hidden_states = torch.empty(
-            (0, 16), dtype=torch.bfloat16, device="cuda"
-        )
+        hidden_states = torch.empty((0, 16), dtype=torch.bfloat16, device="cuda")
         topk_ids = torch.empty((0, 1), dtype=torch.int32, device="cuda")
         topk_weights = torch.empty((0, 1), dtype=torch.float32, device="cuda")
         dispatcher = self._create_dispatcher(hidden_size=16)
@@ -175,9 +169,10 @@ class TestNcclDispatcher(unittest.TestCase):
         hidden_states = torch.randn(
             (num_records, hidden_size), dtype=torch.bfloat16, device="cuda"
         )
-        token_indices = torch.arange(
-            num_records, dtype=torch.int64, device="cuda"
-        ) % num_input_tokens
+        token_indices = (
+            torch.arange(num_records, dtype=torch.int64, device="cuda")
+            % num_input_tokens
+        )
         route_order = torch.arange(num_records, dtype=torch.int64, device="cuda")
 
         first = NcclDispatcher._deterministic_combine(


### PR DESCRIPTION
## Summary

- Add an opt-in NCCL expert-parallel all-to-all dispatcher for Triton MoE execution.
- Keep token indices and route order as source-local metadata, so combine reconstructs source positions without a separate token-index exchange.
- Preserve the route handle through the Triton permutation adapter and use a deterministic BF16 combine order for duplicate routes.

## Changes by area

- **Dispatcher:** pack variable-size routes by EP destination rank, exchange hidden states/expert IDs/router weights with torch.distributed.all_to_all_single, and reverse the exchange during combine.
- **Local metadata:** retain source token indices and canonical route order in NcclRouteHandle; the reverse exchange uses returned row order to restore source tokens.
- **Triton integration:** register NCCL pre/post permutation adapters, preserve the route handle across the runner boundary, and avoid an extra EP all-reduce after combine.
- **Validation:** add manual 2/8-rank tests covering uneven routes, empty sources, and deterministic repeated combine results.
- **Scope:** the backend is opt-in and currently requires BF16 activations, standard top-k routing, equal contiguous expert partitions, eager execution, and no fused shared experts.

## Test plan

- git diff --check
- Python compile checks for all changed modules.
- Recorded 2-rank and 8-rank NCCL dispatcher checks: uneven and empty-route cases have maximum absolute error 0.
- Recorded Triton runner adapter check: pre/post adapters register and preserve route-handle identity.
- Recorded 2-rank and 8-rank Triton-kernel gates: maximum absolute error 0.
- Qwen3 teacher-forced integration check: 96 continuation positions have identical log-probabilities and top-5 lists between baseline and candidate.
- Fixed-token prefill overhead gate: service e2e median 0.23995 s (baseline) vs 0.24004 s (candidate, +0.04%); no throughput improvement is claimed.
- The full SGLang CI matrix has not been run locally; please rely on repository CI for the broader matrix.

## Compatibility

The existing MoE backends remain unchanged. The new path is selected explicitly with --moe-a2a-backend nccl; unsupported model/layout combinations fail with an explicit validation error.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33587157228](https://github.com/sgl-project/sglang/actions/runs/33587157228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33587157118](https://github.com/sgl-project/sglang/actions/runs/33587157118)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33587157226](https://github.com/sgl-project/sglang/actions/runs/33587157226)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->