### PR TITLE
[CI] Validate registered test __main__ before /rerun-test dispatch

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1,4 +1,5 @@
 import glob
+import importlib.util
 import json
 import os
 import re
@@ -32,6 +33,59 @@ PRECISION_BASELINE_REFRESH_FLAG = "--refresh-precision-baseline"
 
 
 MAINTENANCE_ISSUE_NUMBER = 21065
+_CI_REGISTER_MODULE = None
+
+
+def _load_ci_register_module():
+    global _CI_REGISTER_MODULE
+    if _CI_REGISTER_MODULE is None:
+        module_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "..",
+            "..",
+            "python",
+            "sglang",
+            "test",
+            "ci",
+            "ci_register.py",
+        )
+        spec = importlib.util.spec_from_file_location("ci_register", module_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load ci_register from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _CI_REGISTER_MODULE = module
+    return _CI_REGISTER_MODULE
+
+
+def _validate_registered_test_main_entries(resolved_specs):
+    """
+    Mirror run_suite.py's collect_tests(..., sanity_check=True) gate for
+    /rerun-test before any workflow dispatch.
+
+    Returns a list of {"spec", "error"} dicts.
+    """
+    ci_register = _load_ci_register_module()
+    failures = []
+    checked_files = set()
+
+    for spec in resolved_specs:
+        if spec["mode"] == "multimodal_gen":
+            continue
+
+        test_file = spec["test_command"].split(" ", 1)[0].split("::", 1)[0]
+        repo_path = os.path.join("test", test_file)
+        if repo_path in checked_files:
+            continue
+        checked_files.add(repo_path)
+
+        try:
+            ci_register.collect_tests([repo_path], sanity_check=True)
+        except ValueError as exc:
+            failures.append({"spec": spec["spec"], "error": str(exc)})
+
+    return failures
 
 
 def _check_rebase_gate(gh_repo, pr, token):
@@ -1266,6 +1320,9 @@ def handle_rerun_test(
                 continue
             seen_commands.add(key)
             resolved.append(r)
+
+    for failure in _validate_registered_test_main_entries(resolved):
+        _record_failure(failure["spec"], failure["error"])
 
     if refresh_precision_baseline:
         is_exact_precision_test = (

--- a/scripts/ci/utils/test_slash_command_handler.py
+++ b/scripts/ci/utils/test_slash_command_handler.py
@@ -1,0 +1,115 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_module():
+    module_name = "slash_command_handler_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    requests_stub = types.ModuleType("requests")
+    sys.modules.setdefault("requests", requests_stub)
+
+    github_stub = types.ModuleType("github")
+    github_stub.Auth = object
+    github_stub.Github = object
+    sys.modules.setdefault("github", github_stub)
+
+    runner_configs_stub = types.ModuleType("runner_configs")
+    runner_configs_stub.load = lambda: {}
+    sys.modules.setdefault("runner_configs", runner_configs_stub)
+
+    module_path = pathlib.Path(__file__).with_name("slash_command_handler.py")
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+    return module
+
+
+slash_command_handler = _load_module()
+
+
+class ValidateRegisteredTestMainEntriesTest(unittest.TestCase):
+    def test_reports_missing_main_once_per_registered_file(self):
+        fake_ci_register = mock.Mock()
+        fake_ci_register.collect_tests.side_effect = ValueError(
+            'test/registered/foo/test_missing_main.py: missing `if __name__ == "__main__":` entry.'
+        )
+        resolved_specs = [
+            {
+                "spec": "registered/foo/test_missing_main.py",
+                "test_command": "registered/foo/test_missing_main.py TestCase.test_one",
+                "mode": "cuda",
+            },
+            {
+                "spec": "registered/foo/test_missing_main.py::TestCase.test_two",
+                "test_command": "registered/foo/test_missing_main.py TestCase.test_two",
+                "mode": "cuda",
+            },
+            {
+                "spec": "python/sglang/multimodal_gen/test/unit/test_mm.py",
+                "test_command": "python/sglang/multimodal_gen/test/unit/test_mm.py::test_mm",
+                "mode": "multimodal_gen",
+            },
+        ]
+
+        with mock.patch.object(
+            slash_command_handler,
+            "_load_ci_register_module",
+            return_value=fake_ci_register,
+        ):
+            failures = slash_command_handler._validate_registered_test_main_entries(
+                resolved_specs
+            )
+
+        self.assertEqual(
+            failures,
+            [
+                {
+                    "spec": "registered/foo/test_missing_main.py",
+                    "error": 'test/registered/foo/test_missing_main.py: missing `if __name__ == "__main__":` entry.',
+                }
+            ],
+        )
+        fake_ci_register.collect_tests.assert_called_once_with(
+            ["test/registered/foo/test_missing_main.py"], sanity_check=True
+        )
+
+    def test_allows_valid_registered_and_multimodal_specs(self):
+        fake_ci_register = mock.Mock()
+        resolved_specs = [
+            {
+                "spec": "registered/foo/test_ok.py",
+                "test_command": "registered/foo/test_ok.py",
+                "mode": "cpu",
+            },
+            {
+                "spec": "python/sglang/multimodal_gen/test/unit/test_mm.py",
+                "test_command": "python/sglang/multimodal_gen/test/unit/test_mm.py::test_mm",
+                "mode": "multimodal_gen",
+            },
+        ]
+
+        with mock.patch.object(
+            slash_command_handler,
+            "_load_ci_register_module",
+            return_value=fake_ci_register,
+        ):
+            failures = slash_command_handler._validate_registered_test_main_entries(
+                resolved_specs
+            )
+
+        self.assertEqual(failures, [])
+        fake_ci_register.collect_tests.assert_called_once_with(
+            ["test/registered/foo/test_ok.py"], sanity_check=True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[by Codex]

## Summary

This makes `/rerun-test` apply the same registered-test `__main__` sanity check that the normal suite path already uses.

## Changes

- load `python/sglang/test/ci/ci_register.py` from the slash-command handler
- validate resolved registered test files with `collect_tests(..., sanity_check=True)` before dispatch
- add a regression test covering the missing-`__main__` rejection path

## Validation

- `python3 -m unittest scripts/ci/utils/test_slash_command_handler.py`
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch /home/pohanh/.local/bin/pre-commit run --all-files --show-diff-on-failure`

## Related

- follow-up to PR #37406
- addresses TER issue #37526

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33587614149](https://github.com/sgl-project/sglang/actions/runs/33587614149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33587613978](https://github.com/sgl-project/sglang/actions/runs/33587613978)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33587614079](https://github.com/sgl-project/sglang/actions/runs/33587614079)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->