### PR TITLE
fix(humming): support CP decode attention TP for GLM W4AFP8

### DIFF
--- a/python/sglang/srt/layers/quantization/humming.py
+++ b/python/sglang/srt/layers/quantization/humming.py
@@ -675,6 +675,19 @@ class HummingConfig(QuantizationConfig):
             fp8_config.is_fp4_experts = True
             return fp8_config.get_quant_method(layer, prefix)
 
+        # CP decode slices these projections along logical dimensions. Humming's
+        # packed-K layout is not sliceable, so keep their standard FP8 layout.
+        if (
+            isinstance(layer, LinearBase)
+            and self._w4afp8_config is not None
+            and prefix.endswith((".self_attn.q_b_proj", ".self_attn.o_proj"))
+        ):
+            from sglang.srt.runtime_context import get_parallel
+
+            parallel = get_parallel()
+            if parallel.enable_cp_decode_attn_tp and parallel.attn_cp_size > 1:
+                return self._w4afp8_config.get_quant_method(layer, prefix)
+
         quant_config = self.get_quant_config_for_layer(prefix, layer_type)
         if quant_config is None:
             if isinstance(layer, FusedMoE):

--- a/test/registered/unit/layers/quantization/test_humming_w4afp8_schemas.py
+++ b/test/registered/unit/layers/quantization/test_humming_w4afp8_schemas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
@@ -13,13 +14,84 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
+from sglang.srt.layers.linear import LinearBase  # noqa: E402
 from sglang.srt.layers.quantization.humming import (  # noqa: E402
     HummingConfig,
     _StackedBlockFp8CheckpointWeightSchema,
     _W4AFp8CheckpointWeightSchema,
 )
+from sglang.srt.runtime_context import get_context  # noqa: E402
 
 register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _TestLinear(LinearBase):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+
+
+class TestHummingCpDecodeRouting(CustomTestCase):
+    def test_cp_decode_uses_w4afp8_only_for_sharded_attention_projections(self):
+        config = HummingConfig(
+            {
+                "quant_method": "w4afp8",
+                "group_size": 128,
+                "weight_block_size": [128, 128],
+            }
+        )
+        layer = _TestLinear()
+        w4afp8_method = object()
+        humming_method = object()
+
+        with (
+            patch.object(
+                config._w4afp8_config,
+                "get_quant_method",
+                return_value=w4afp8_method,
+            ) as get_w4afp8_method,
+            patch.object(config, "get_quant_config_for_layer", return_value=object()),
+            patch(
+                "sglang.srt.layers.quantization.humming.HummingLinearMethod",
+                return_value=humming_method,
+            ),
+        ):
+            with get_context().override_server_args(
+                tp_size=8,
+                attn_cp_size=8,
+                enable_cp_decode_attn_tp=True,
+            ):
+                for suffix in ("q_b_proj", "o_proj"):
+                    prefix = f"model.layers.0.self_attn.{suffix}"
+                    self.assertIs(config.get_quant_method(layer, prefix), w4afp8_method)
+
+                self.assertIs(
+                    config.get_quant_method(
+                        layer, "model.layers.0.self_attn.kv_b_proj"
+                    ),
+                    humming_method,
+                )
+
+            with get_context().override_server_args(
+                tp_size=8,
+                attn_cp_size=8,
+                enable_cp_decode_attn_tp=False,
+            ):
+                self.assertIs(
+                    config.get_quant_method(layer, "model.layers.0.self_attn.q_b_proj"),
+                    humming_method,
+                )
+
+            with get_context().override_server_args(
+                tp_size=8,
+                attn_cp_size=1,
+                enable_cp_decode_attn_tp=True,
+            ):
+                self.assertIs(
+                    config.get_quant_method(layer, "model.layers.0.self_attn.q_b_proj"),
+                    humming_method,
+                )
+
+        self.assertEqual(get_w4afp8_method.call_count, 2)
 
 
 class TestW4AFp8CheckpointSchema(CustomTestCase):


### PR DESCRIPTION
## Motivation

Humming currently cannot be used with CP-decode attention TP for GLM W4AFP8.

When CP-decode attention TP is enabled, `q_b_proj` and `o_proj` need to be sharded along their logical dimensions. However, Humming stores dense FP8 weights in a kernel-specific packed-K layout, which cannot be safely sliced by the generic CP-decode sharding path.

As a result, GLM W4AFP8 deployments have to disable CP-decode attention TP when using Humming.

## Modifications

This PR routes q_b_proj and o_proj through the existing standard FP8 linear method when CP-decode attention TP actually performs sharding:
- enable_cp_decode_attn_tp=True
- attn_cp_size > 1
- the layer is q_b_proj or o_proj
All other linear layers and MoE layers continue to use Humming.

The attn_cp_size > 1 guard avoids disabling Humming when the CP-decode flag is enabled but no actual CP sharding takes place.

## Accuracy Tests

GSM8K was evaluated with max_tokens=4096:

| Configuration | Correct / Total | Accuracy |
| --- | ---: | ---: |
| Humming, CP-decode disabled | 1259 / 1311 | 96.03% |
| Humming, CP-decode enabled | 1264 / 1311 | 96.42% |

## Speed Tests and Profiling

### Test setup

- Model: GLM-5.2-W4AFP8
- Hardware: 8 × NVIDIA H20
- Tensor parallel size: 8
- Attention CP size: 8
- Speculative decoding: EAGLE MTP314
  - speculative steps: 3
  - top-k: 1
  - draft tokens: 4
- Workload: fixed ShareGPT prompts
- Output length: 1,024 tokens per request
- Baseline: Humming without `--enable-cp-decode-attn-tp`
- Candidate: the same configuration with `--enable-cp-decode-attn-tp` and this fix

### Full performance

| Input | Concurrency | Baseline TPOT (ms) | CP-decode TPOT (ms) | TPOT reduction | Baseline output TPS | CP-decode output TPS | TPS improvement |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8K | 1 | 6.307 | 5.765 | 8.6% | 138.56 | 144.44 | 4.2% |
| 8K | 4 | 9.852 | 8.336 | 15.4% | 309.18 | 349.15 | 12.9% |
| 8K | 8 | 14.120 | 12.383 | 12.3% | 415.12 | 459.34 | 10.7% |
| 8K | 12 | 18.450 | 16.393 | 11.2% | 480.27 | 521.96 | 8.7% |
| 8K | 16 | 22.674 | 19.832 | 12.5% | 519.03 | 581.12 | 12.0% |
| 32K | 1 | 8.062 | 7.187 | 10.9% | 91.49 | 98.80 | 8.0% |
| 32K | 4 | 14.417 | 12.582 | 12.7% | 175.05 | 196.14 | 12.0% |
| 32K | 8 | 22.621 | 21.283 | 5.9% | 216.71 | 220.81 | 1.9% |
| 32K | 12 | 28.623 | 27.282 | 4.7% | 213.63 | 218.44 | 2.3% |
| 32K | 16 | 31.019 | 29.298 | 5.5% | 222.31 | 227.11 | 2.2% |
| 64K | 1 | 7.392 | 6.187 | 16.3% | 76.46 | 82.41 | 7.8% |
| 64K | 4 | 17.551 | 16.492 | 6.0% | 120.88 | 125.44 | 3.8% |
| 64K | 8 | 26.492 | 25.555 | 3.5% | 118.98 | 122.13 | 2.6% |

CP-decode reduces TPOT in all 13 tested configurations. The reduction ranges from 3.5% to 16.3%, with an unweighted average of approximately 9.7%.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33588883722](https://github.com/sgl-project/sglang/actions/runs/33588883722)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33588883423](https://github.com/sgl-project/sglang/actions/runs/33588883423)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33588883730](https://github.com/sgl-project/sglang/actions/runs/33588883730)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->