### PR TITLE
[Spec][Fix] Fall back to eager DFlash sampler above graph batch limit

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -120,7 +120,8 @@ class _DflashDraftSampler:
         self.org_vocab_start = int(org_vocab_start)
         self.tp_group = tp_group
         self.tp_size = int(tp_group.world_size) if tp_group is not None else 1
-        max_tokens = int(max_bs) * (self.block_size - 1)
+        self.max_bs = int(max_bs)
+        max_tokens = self.max_bs * (self.block_size - 1)
         device = weight.device
         self.out = torch.empty((max_tokens,), dtype=torch.int64, device=device)
         if self.tp_size > 1:
@@ -228,6 +229,7 @@ class _SelectorDraftSampler:
         self.selector = draft_model.candidate_selector
         self.block_size = int(block_size)
         max_bs, gamma, top_k = int(max_bs), self.block_size - 1, self.selector.top_k
+        self.max_bs = max_bs
         self.out = torch.empty((max_bs * gamma,), dtype=torch.int64, device=device)
         # Written by the host before replay, or read after it; the addresses are
         # baked into the captured graph.
@@ -679,6 +681,20 @@ class DFlashWorkerV2(BaseSpecWorker):
             max_bs=max(get_exec().graph.cuda_graph_config.decode.bs),
             tp_group=tp_group if tp_group.world_size > 1 else None,
         )
+
+    def _prepare_draft_sampler(self, *, batch, bs: int) -> bool:
+        """Stage graph-folded sampling only for captured batch sizes.
+
+        Batches larger than the largest captured CUDA graph run eagerly.  The
+        folded sampler's static buffers are sized to that graph limit, so they
+        must not be staged for an eager fallback batch.
+        """
+        sampler = self._draft_sampler
+        if sampler is None or bs > sampler.max_bs:
+            return False
+        if self.selector is not None:
+            sampler.stage_sampling_params(bs=bs, sampling_info=batch.sampling_info)
+        return True
 
     def _init_fused_kv_helper(self) -> None:
         """Initialize the fused KV materialization helper with pre-stacked weights."""
@@ -2125,17 +2141,14 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if self.selector is not None:
             self._selector_sample = None
-            if self._draft_sampler is not None:
-                # Consumed by the in-graph sample; must be staged before the replay.
-                self._draft_sampler.stage_sampling_params(
-                    bs=bs, sampling_info=batch.sampling_info
-                )
+        # Consumed by the in-graph sample; must be staged before the replay.
+        draft_sampler_ready = self._prepare_draft_sampler(batch=batch, bs=bs)
 
         with torch.inference_mode():
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        folded = self._draft_sampler is not None and draft_out.can_run_graph
+        folded = draft_sampler_ready and draft_out.can_run_graph
         if folded:
             draft_next = self._draft_sampler.out[
                 : bs * (int(self.block_size) - 1)

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -263,6 +263,32 @@ def test_worker_folds_a_gate_admitted_quantized_selector_head(monkeypatch):
     assert worker.draft_model.lm_head is None
 
 
+def test_worker_skips_graph_folded_sampler_above_capture_limit():
+    """A batch above the captured graph limit must use the eager sampler.
+
+    max-running-requests can exceed cuda-graph-max-bs-decode.  Such a batch is
+    valid, but staging it into graph-sized static buffers would overflow them
+    before the model runner gets a chance to fall back to eager execution.
+    """
+    from sglang.srt.speculative import dflash_worker_v2 as worker_mod
+
+    staged = []
+    sampler = SimpleNamespace(
+        max_bs=8,
+        stage_sampling_params=lambda **kwargs: staged.append(kwargs),
+    )
+    worker = SimpleNamespace(_draft_sampler=sampler, selector=object())
+    batch = SimpleNamespace(sampling_info=object())
+
+    assert worker_mod.DFlashWorkerV2._prepare_draft_sampler(worker, batch=batch, bs=8)
+    assert staged == [{"bs": 8, "sampling_info": batch.sampling_info}]
+
+    assert not worker_mod.DFlashWorkerV2._prepare_draft_sampler(
+        worker, batch=batch, bs=9
+    )
+    assert len(staged) == 1
+
+
 def test_grouped_conv_supports_runtime_block_sizes():
     """The conv indexes a position inside the block, so it must follow whatever
     block size the worker resolved -- including one that is not a power of two."""


### PR DESCRIPTION
## Motivation

`--max-running-requests` may be larger than `--cuda-graph-max-bs-decode`; batches above the largest captured batch size are expected to fall back to eager execution. DFlash's graph-folded selector sampler currently stages sampling parameters before the model runner decides whether it can replay a CUDA graph. Its static buffers are sized only to the largest captured graph batch, so a larger eager batch overflows those buffers and terminates both TP scheduler processes.

For example, with DFlash draft size 8, `--max-running-requests 9`, and `--cuda-graph-max-bs-decode 8`, a batch of 9 fails with:

```text
UserWarning: An output ... had shape [8], which does not match the required output shape [9]
RuntimeError: The size of tensor a (8) must match the size of tensor b (9)
  at dflash_worker_v2.py, in stage_sampling_params
  self.greedy_mask[:bs].copy_(...)
```

## Changes

- Record the captured batch capacity on both graph-folded DFlash samplers.
- Stage the selector's static sampling parameters only when the current batch fits that capacity.
- Reuse the same capacity check when deciding whether to consume graph-folded sampler output; larger batches use the existing eager selector path.
- Add a CPU unit regression test for the `max graph batch = 8`, runtime batch `= 9` case.

This does not enlarge graph buffers or restrict `max-running-requests` to the graph capture limit.

## Validation

Tested on two GPUs with SGLang nightly commit `783af667fb`, TP=2, DFlash block/draft size 8, `--max-running-requests 9`, and `--cuda-graph-max-bs-decode 8`.

To deterministically admit batch 9 in the integration test, `--min-free-slots-delay 0` was used with 64 text requests and 16 clients:

- Before: 25/64 completed, then both TP schedulers exited with the 8-vs-9 error above.
- After: 64/64 completed; logs repeatedly reported `Decode batch, #running-req: 9, cuda graph: False`; the health endpoint remained responsive.

The original multimodal workload (64 requests, five 1024x1024 images each, 16 clients) also completed 64/64 after the fix.

For captured batch size 8, two steady-state throughput runs were 582.22/587.43 output tok/s before and 596.14/606.68 output tok/s after; no regression was observed.

```text
pytest -q test/registered/unit/spec/test_dflash_logits.py
8 passed

ruff check --select=F401,F821,UP037 \
  python/sglang/srt/speculative/dflash_worker_v2.py \
  test/registered/unit/spec/test_dflash_logits.py
All checks passed!

black --check \
  python/sglang/srt/speculative/dflash_worker_v2.py \
  test/registered/unit/spec/test_dflash_logits.py
2 files would be left unchanged.
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35676958165](https://github.com/sgl-project/sglang/actions/runs/35676958165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35676957979](https://github.com/sgl-project/sglang/actions/runs/35676957979)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35676958101](https://github.com/sgl-project/sglang/actions/runs/35676958101)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->