### PR TITLE
[XPU][CI] Move XPU tests to nightly and add per-subclass server launch timeout

### DIFF
--- a/python/sglang/test/server_fixtures/spec_eagle_fixture.py
+++ b/python/sglang/test/server_fixtures/spec_eagle_fixture.py
@@ -70,6 +70,10 @@ class SpecEagleServerBase(CustomTestCase):
     dtype = "bfloat16"
     cuda_graph_max_bs_decode = None
     trust_remote_code = True
+    # Seconds to wait for the spec server to report healthy. Overridable per
+    # subclass: EAGLE3 + full CUDA-graph decode capture on XPU can exceed the
+    # 600s default, so the XPU parity test bumps this.
+    server_launch_timeout = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
     # Launch with --enable-return-hidden-states so SpecHiddenStatesKit can probe
     # per-request hidden states; per-request gated, so other requests don't pay.
     enable_return_hidden_states = False
@@ -144,7 +148,7 @@ class SpecEagleServerBase(CustomTestCase):
             cls.process = popen_launch_server(
                 cls.model,
                 cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                timeout=cls.server_launch_timeout,
                 other_args=cls._launch_args(),
             )
 

--- a/test/registered/spec/eagle/test_spec_eagle_parity.py
+++ b/test/registered/spec/eagle/test_spec_eagle_parity.py
@@ -47,6 +47,9 @@ class TestEagle3ParityXPU(SpecParityKit, _Eagle3ParityBase):
     # (via XPUCudaGraphBackend). Opt in explicitly now that it is disabled
     # by default so the coverage is preserved.
     extra_args = ("--cuda-graph-config", '{"decode":{"backend":"full"}}')
+    # EAGLE3 + full CUDA-graph decode capture on XPU takes >600s from cold on
+    # Arc-class GPUs; the 600s default trips a spurious launch timeout here.
+    server_launch_timeout = 1800
 
 
 if __name__ == "__main__":

--- a/test/registered/xpu/test_deepseek_ocr_triton.py
+++ b/test/registered/xpu/test_deepseek_ocr_triton.py
@@ -18,13 +18,11 @@ from sglang.test.test_utils import (
 
 register_xpu_ci(
     est_time=360,
-    suite="stage-b-test-1-gpu-xpu",
-    disabled="Temporarily disabled until Triton-XPU upgrade",
+    suite="nightly-xpu-1-gpu",
+    nightly=True,
 )
 
 
-# TODO: Temporarily disable this test and re-enable it after Triton-XPU is upgraded.
-@unittest.skip("Temporarily disabled until Triton-XPU upgrade")
 class TestDeepSeekOCRTriton(TestDeepSeekOCR):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/xpu/test_gemma_4_e2b.py
+++ b/test/registered/xpu/test_gemma_4_e2b.py
@@ -130,8 +130,8 @@ from sglang.test.ci.ci_register import register_xpu_ci
 # Single e2e test: boot + a short Q&A.
 register_xpu_ci(
     est_time=240,
-    suite="stage-b-test-1-gpu-xpu",
-    disabled="OOM on stage-b XPU runner (server launch fails with --mem-fraction-static)",
+    suite="nightly-xpu-1-gpu",
+    nightly=True,
 )
 
 if __name__ == "__main__":

--- a/test/registered/xpu/test_triton_attention_backend.py
+++ b/test/registered/xpu/test_triton_attention_backend.py
@@ -13,7 +13,17 @@ from sglang.test.test_utils import (
     run_bench_serving,
 )
 
-register_xpu_ci(est_time=600, suite="nightly-xpu-1-gpu", nightly=True)
+register_xpu_ci(
+    est_time=600,
+    suite="nightly-xpu-1-gpu",
+    nightly=True,
+    disabled=(
+        "XPU fused MoE has no fp8-w8a8 kernel: sgl_kernel/moe.py:505 asserts "
+        "use_fp8_w8a8 is False, so the fp8-MoE model "
+        "(DEFAULT_MODEL_NAME_FOR_TEST_FP8_WITH_MOE = gaunernst/DeepSeek-V2-Lite-Chat-FP8) "
+        "crashes the server. Re-enable once an XPU fp8-w8a8 MoE kernel lands."
+    ),
+)
 
 
 def triton_attention_benchmark(extra_args=None, mem_fraction_static="0.84"):


### PR DESCRIPTION
## Summary

- Move `test_deepseek_ocr_triton` and `test_gemma_4_e2b` from disabled stage-b to `nightly-xpu-1-gpu` — the Triton-XPU / stage-b OOM blockers that motivated the skips no longer apply.
- Disable `test_triton_attention_backend` with an anchored reason: XPU fused MoE has no fp8-w8a8 kernel (`sgl_kernel/moe.py:505` asserts `use_fp8_w8a8 is False`), so the fp8-MoE default model (`gaunernst/DeepSeek-V2-Lite-Chat-FP8`) crashes the server. Re-enable once an XPU fp8-w8a8 MoE kernel lands.
- Add `SpecEagleServerBase.server_launch_timeout` so subclasses can override the launch health-check window. Bump it to 1800s in `TestEagle3ParityXPU` where EAGLE3 + full CUDA-graph decode capture on Arc-class GPUs exceeds the 600s default.

## Test plan

- [ ] Nightly XPU 1-GPU suite picks up the two newly-enabled tests and they pass.
- [ ] `test_triton_attention_backend` shows as disabled with the fp8-MoE reason surfaced.
- [ ] `TestEagle3ParityXPU` no longer trips the launch timeout on a cold-cache XPU run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33607958477](https://github.com/sgl-project/sglang/actions/runs/33607958477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33832555687](https://github.com/sgl-project/sglang/actions/runs/33832555687)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33607958414](https://github.com/sgl-project/sglang/actions/runs/33607958414)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->