### PR TITLE
Prevent HiCache transfer corruption from mismatched DSA cache row sizes

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -59,10 +59,15 @@ class DecodeKVCacheOffloadManager:
         kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
         if not isinstance(kv_cache, (MHATokenToKVPool, MLATokenToKVPool)):
             raise ValueError("Unsupported KV cache type for decode offload")
+        use_mla = isinstance(kv_cache, MLATokenToKVPool)
         self.decode_host_mem_pool = build_kv_host_pool(
             kv_pool=kv_cache,
             page_size=self.page_size,
-            use_mla=isinstance(kv_cache, MLATokenToKVPool),
+            use_mla=use_mla,
+            # Host rows must have the device pool's row geometry; a packed DSA
+            # row is wider than the width the MLA host pool assumes without
+            # the override.
+            override_kv_cache_dim=kv_cache.kv_cache_dim if use_mla else None,
         )
 
         self.tp_group = tp_group

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -803,6 +803,10 @@ def build_hybrid_mamba_stack(
         kv_pool=kv_pool,
         page_size=params.page_size,
         use_mla=use_mla,
+        # Host rows must have the device pool's row geometry. A packed DSA
+        # row is wider than kv_lora_rank + qk_rope_head_dim, the width the
+        # MLA host pool assumes without the override.
+        override_kv_cache_dim=kv_pool.kv_cache_dim if use_mla else None,
         host_size=kv_host_size,
         mtp_draft_device_pools=mtp_draft_device_pools,
     )

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -77,6 +77,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
     ):
         self.override_kv_cache_dim = override_kv_cache_dim
         self.mtp_draft_device_pools = tuple(mtp_draft_device_pools)
+        self._check_host_row_geometry(device_pool, pool_label)
         self._is_dummy = is_dummy
 
         if is_dummy:
@@ -200,6 +201,51 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         self.lock = threading.RLock()
         self.clear()
 
+    def _host_kv_cache_dim(self, device_pool) -> int:
+        """Row width, in store dtype elements, of every host row."""
+        return self.override_kv_cache_dim or (
+            device_pool.kv_lora_rank + device_pool.qk_rope_head_dim
+        )
+
+    def _check_host_row_geometry(self, device_pool, pool_label: str) -> None:
+        """Reject a host row geometry that differs from the device rows.
+
+        The host buffer has a single row width and dtype for every layer, and
+        the transfer paths address the target and packed MTP draft device
+        rows with that same geometry (the kernel paths use the host stride
+        for both sides, the direct path copies row slices). The host row must
+        therefore match the target's row, and every packed draft pool must
+        have the target's row geometry. Runs before any host allocation.
+        """
+        host_dim = self._host_kv_cache_dim(device_pool)
+        target_dtype = device_pool.store_dtype
+        # MLATokenToKVPool and its subclasses always set kv_cache_dim (a packed
+        # DSA row is wider than kv_lora_rank + qk_rope_head_dim). Duck-typed
+        # device pools that do not model row packing, such as lightweight test
+        # doubles, may omit it; only then is the host width taken on trust.
+        target_dim = getattr(device_pool, "kv_cache_dim", host_dim)
+        if host_dim != target_dim:
+            raise ValueError(
+                f"HiCache {pool_label} host pool rows must have the device "
+                f"pool's row geometry, but the host row is kv_cache_dim="
+                f"{host_dim} while the device pool has kv_cache_dim="
+                f"{target_dim}. Construct the host pool with "
+                "override_kv_cache_dim=device_pool.kv_cache_dim."
+            )
+        for draft_id, draft_pool in enumerate(self.mtp_draft_device_pools):
+            draft_dtype = draft_pool.store_dtype
+            draft_dim = draft_pool.kv_cache_dim
+            if draft_dtype != target_dtype or draft_dim != target_dim:
+                raise ValueError(
+                    f"HiCache {pool_label} host pool packs MTP draft KV layers "
+                    "next to the target layers, so every draft pool must have "
+                    f"the target's row geometry; draft pool {draft_id} has "
+                    f"store_dtype={draft_dtype}, kv_cache_dim={draft_dim} but "
+                    f"the target has store_dtype={target_dtype}, "
+                    f"kv_cache_dim={target_dim}. Use the same --kv-cache-dtype "
+                    "and --speculative-draft-kv-cache-dtype."
+                )
+
     def get_contiguous_buf_infos(self):
         """Return (data_ptrs, data_lens, item_lens) in the same format as device pool,
         for registering host memory with the disaggregation transfer engine."""
@@ -215,9 +261,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         self.qk_rope_head_dim = self.device_pool.qk_rope_head_dim
         self.target_layer_num = self._effective_host_layer_num()
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
-        self.kv_cache_dim = self.override_kv_cache_dim or (
-            self.kv_lora_rank + self.qk_rope_head_dim
-        )
+        self.kv_cache_dim = self._host_kv_cache_dim(self.device_pool)
         return self.kv_cache_dim * self.dtype.itemsize * self.layer_num
 
     def get_ksize_per_token(self):

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -203,9 +203,12 @@ class TestHybridMambaStackHostRowWidth(_PackedRowGeometryFixtures, CustomTestCas
         """
         params = MagicMock()
         params.page_size = self.PAGE_SIZE
-        params.mtp_draft_device_pools = tuple(
-            SimpleNamespace(full_kv_pool=pool) for pool in draft_pools
-        )
+        wrapped_draft_pools = []
+        for pool in draft_pools:
+            wrapper = object.__new__(HybridLinearKVPool)
+            wrapper.full_kv_pool = pool
+            wrapped_draft_pools.append(wrapper)
+        params.mtp_draft_device_pools = tuple(wrapped_draft_pools)
         memory = SimpleNamespace(
             hicache_size=0,
             hicache_ratio=2.0,

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -1,8 +1,11 @@
 """Unit tests for hybrid HiCache pool assembly."""
 
 import unittest
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import torch
 
 from sglang.srt.mem_cache.base_prefix_cache import EvictParams
 from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
@@ -10,8 +13,11 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     _evict_swa_for_device_alloc,
     _split_hicache_size,
     build_full_draft_pools,
+    build_hybrid_mamba_stack,
 )
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.srt.mem_cache.pool_host.common import alloc_with_host_register
+from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -126,6 +132,266 @@ class TestDraftSidecarPoolDispatch(CustomTestCase):
         self.assertEqual(build_host_pool.call_args.kwargs["host_to_device_ratio"], 1.0)
         self.assertEqual(len(specs), 1)
         self.assertIs(entries[0].host_pool, draft_host_pool)
+
+
+class _PackedRowGeometryFixtures:
+    """Fake MLA device pools with nominal-width and packed (wider) rows.
+
+    DSA device pools store packed rows wider than kv_lora_rank +
+    qk_rope_head_dim, the width the MLA host pool assumes without an
+    override.
+    """
+
+    KV_LORA_RANK = 8
+    QK_ROPE_HEAD_DIM = 4
+    NOMINAL_KV_CACHE_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM
+    PACKED_KV_CACHE_DIM = 16  # > NOMINAL_KV_CACHE_DIM
+    PAGE_SIZE = 4
+    LAYER_NUM = 2
+
+    def _fake_device_pool(self, *, store_dtype, kv_cache_dim, layer_num=LAYER_NUM):
+        return SimpleNamespace(
+            size=64,
+            store_dtype=store_dtype,
+            kv_lora_rank=self.KV_LORA_RANK,
+            qk_rope_head_dim=self.QK_ROPE_HEAD_DIM,
+            kv_cache_dim=kv_cache_dim,
+            layer_num=layer_num,
+            start_layer=0,
+            end_layer=layer_num,
+            device="cpu",
+            layers_to_capture=None,
+            layer_shard_enabled=False,
+            data_ptrs=torch.zeros(layer_num, dtype=torch.uint64),
+            kv_buffer=[torch.empty(0, dtype=store_dtype) for _ in range(layer_num)],
+        )
+
+    def _fake_packed_device_pool(self, layer_num=LAYER_NUM):
+        return self._fake_device_pool(
+            store_dtype=torch.uint8,
+            kv_cache_dim=self.PACKED_KV_CACHE_DIM,
+            layer_num=layer_num,
+        )
+
+    def _fake_nominal_device_pool(self, layer_num=LAYER_NUM):
+        return self._fake_device_pool(
+            store_dtype=torch.bfloat16,
+            kv_cache_dim=self.NOMINAL_KV_CACHE_DIM,
+            layer_num=layer_num,
+        )
+
+    @staticmethod
+    def _alloc_unpinned(dims, dtype, device, pin_memory, allocator, **kwargs):
+        # Host rows are allocated without pinning so no CUDA context is needed.
+        return alloc_with_host_register(dims, dtype, device, False, allocator, **kwargs)
+
+
+class TestHybridMambaStackHostRowWidth(_PackedRowGeometryFixtures, CustomTestCase):
+    """The hybrid Mamba stack's MLA host pool must mirror the device rows.
+
+    Packed MTP draft layers share the target's host rows, so a draft pool
+    with a different row geometry must be rejected.
+    """
+
+    def _build_stack(self, kv_pool, *, use_mla, draft_pools=(), extra_patches=()):
+        """Build the hybrid Mamba stack with the real KV host pool class.
+
+        Patched: the published memory/parallel config and allocator lookup,
+        the MLA host pool's allocator (unpinned), plus the Mamba host pool,
+        host pool group, and cache controller, which are not under test.
+        Returns the HostPoolGroup constructor mock.
+        """
+        params = MagicMock()
+        params.page_size = self.PAGE_SIZE
+        params.mtp_draft_device_pools = tuple(
+            SimpleNamespace(full_kv_pool=pool) for pool in draft_pools
+        )
+        memory = SimpleNamespace(
+            hicache_size=0,
+            hicache_ratio=2.0,
+            hicache_mem_layout="layer_first",
+            hicache_write_policy="write_through",
+            hicache_io_backend="direct",
+            hicache_host_memory_mode=None,
+        )
+        parallel = SimpleNamespace(dcp_enabled=False)
+        prefix = "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+
+        with ExitStack() as stack:
+            stack.enter_context(patch(prefix + "get_memory", return_value=memory))
+            stack.enter_context(patch(prefix + "get_parallel", return_value=parallel))
+            stack.enter_context(
+                patch(prefix + "_get_allocator_type", return_value="default")
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.mem_cache.pool_host.mla.ALLOC_MEMORY_FUNCS",
+                    {"cpu": self._alloc_unpinned},
+                )
+            )
+            stack.enter_context(patch(prefix + "MambaPoolHost"))
+            host_pool_group = stack.enter_context(patch(prefix + "HostPoolGroup"))
+            stack.enter_context(patch(prefix + "HybridCacheController"))
+            for extra_patch in extra_patches:
+                stack.enter_context(extra_patch)
+            build_hybrid_mamba_stack(
+                params=params,
+                kv_pool=kv_pool,
+                mamba_pool=MagicMock(),
+                full_layer_mapping={i: i for i in range(kv_pool.layer_num)},
+                mamba_layer_mapping={kv_pool.layer_num: kv_pool.layer_num},
+                load_cache_event=None,
+                storage_backend=None,
+                use_mla=use_mla,
+            )
+        return host_pool_group
+
+    def _kv_host_pool(self, host_pool_group):
+        entries = host_pool_group.call_args.args[0]
+        return entries[0].host_pool
+
+    def test_mla_host_pool_row_width_matches_packed_device_rows(self):
+        kv_pool = self._fake_packed_device_pool()
+        self.assertGreater(kv_pool.kv_cache_dim, self.NOMINAL_KV_CACHE_DIM)
+
+        kv_host_pool = self._kv_host_pool(self._build_stack(kv_pool, use_mla=True))
+
+        self.assertIsInstance(kv_host_pool, MLATokenToKVPoolHost)
+        self.assertEqual(kv_host_pool.kv_cache_dim, kv_pool.kv_cache_dim)
+        self.assertEqual(
+            kv_host_pool.token_stride_size,
+            kv_pool.kv_cache_dim * kv_pool.store_dtype.itemsize,
+        )
+        self.assertEqual(kv_host_pool.kv_buffer.shape[-1], kv_pool.kv_cache_dim)
+
+    def test_non_mla_pool_exposing_kv_cache_dim_gets_no_override(self):
+        # MHA host pool constructors take no override_kv_cache_dim; a non-MLA
+        # pool that happens to expose kv_cache_dim must not trigger one.
+        kv_pool = self._fake_packed_device_pool()
+        mha_host_cls = MagicMock(name="MHAHostPool")
+        prefix = "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+
+        self._build_stack(
+            kv_pool,
+            use_mla=False,
+            extra_patches=(
+                patch(prefix + "get_mha_host_pool_cls", return_value=mha_host_cls),
+            ),
+        )
+
+        mha_host_cls.assert_called_once()
+        self.assertNotIn("override_kv_cache_dim", mha_host_cls.call_args.kwargs)
+
+    def test_packed_draft_pool_with_target_geometry_is_accepted(self):
+        kv_pool = self._fake_packed_device_pool()
+        draft_pool = self._fake_packed_device_pool(layer_num=1)
+
+        kv_host_pool = self._kv_host_pool(
+            self._build_stack(kv_pool, use_mla=True, draft_pools=(draft_pool,))
+        )
+
+        self.assertEqual(kv_host_pool.layer_num, kv_pool.layer_num + 1)
+        self.assertEqual(kv_host_pool.kv_cache_dim, kv_pool.kv_cache_dim)
+        self.assertEqual(kv_host_pool.kv_buffer.shape[0], kv_pool.layer_num + 1)
+
+    def test_packed_draft_pool_with_narrower_rows_is_rejected(self):
+        # fp8 packed target, bf16 nominal-width draft.
+        kv_pool = self._fake_packed_device_pool()
+        draft_pool = self._fake_nominal_device_pool(layer_num=1)
+
+        with self.assertRaisesRegex(ValueError, "draft pool 0"):
+            self._build_stack(kv_pool, use_mla=True, draft_pools=(draft_pool,))
+
+    def test_packed_draft_pool_with_wider_rows_is_rejected(self):
+        # bf16 nominal-width target, fp8 packed draft.
+        kv_pool = self._fake_nominal_device_pool()
+        draft_pool = self._fake_packed_device_pool(layer_num=1)
+
+        with self.assertRaisesRegex(ValueError, "draft pool 0"):
+            self._build_stack(kv_pool, use_mla=True, draft_pools=(draft_pool,))
+
+    def test_same_dtype_draft_pool_with_different_width_is_rejected(self):
+        # Same store dtype, so only the row width differs: fp8 packed target,
+        # fp8 nominal-width draft.
+        kv_pool = self._fake_packed_device_pool()
+        draft_pool = self._fake_device_pool(
+            store_dtype=torch.uint8,
+            kv_cache_dim=self.NOMINAL_KV_CACHE_DIM,
+            layer_num=1,
+        )
+        self.assertEqual(draft_pool.store_dtype, kv_pool.store_dtype)
+
+        with self.assertRaisesRegex(ValueError, "draft pool 0"):
+            self._build_stack(kv_pool, use_mla=True, draft_pools=(draft_pool,))
+
+
+class TestMLAHostPoolRowGeometry(_PackedRowGeometryFixtures, CustomTestCase):
+    """MLATokenToKVPoolHost itself must refuse rows narrower than the device's.
+
+    Exercises the constructor directly so the check does not depend on a
+    builder passing the override.
+    """
+
+    def _host_pool(self, kv_pool, **kwargs):
+        with patch(
+            "sglang.srt.mem_cache.pool_host.mla.ALLOC_MEMORY_FUNCS",
+            {"cpu": self._alloc_unpinned},
+        ):
+            return MLATokenToKVPoolHost(
+                kv_pool,
+                host_to_device_ratio=2.0,
+                host_size=0,
+                page_size=self.PAGE_SIZE,
+                layout="layer_first",
+                pin_memory=False,
+                device="cpu",
+                **kwargs,
+            )
+
+    def test_packed_device_pool_without_override_is_rejected(self):
+        kv_pool = self._fake_packed_device_pool()
+
+        with self.assertRaisesRegex(ValueError, "override_kv_cache_dim"):
+            self._host_pool(kv_pool)
+
+    def test_packed_device_pool_without_override_and_nominal_draft_is_rejected(self):
+        # Without the override the assumed host width equals the nominal
+        # width, so a same-dtype nominal-width draft matches the assumed
+        # width while both differ from the packed device rows. The draft
+        # must be compared against the device pool's kv_cache_dim, not the
+        # assumed width.
+        kv_pool = self._fake_packed_device_pool()
+        draft_pool = self._fake_device_pool(
+            store_dtype=kv_pool.store_dtype,
+            kv_cache_dim=self.NOMINAL_KV_CACHE_DIM,
+            layer_num=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "row geometry"):
+            self._host_pool(kv_pool, mtp_draft_device_pools=(draft_pool,))
+
+    def test_packed_device_pool_with_override_and_matching_draft(self):
+        kv_pool = self._fake_packed_device_pool()
+        draft_pool = self._fake_packed_device_pool(layer_num=1)
+
+        host_pool = self._host_pool(
+            kv_pool,
+            override_kv_cache_dim=kv_pool.kv_cache_dim,
+            mtp_draft_device_pools=(draft_pool,),
+        )
+
+        self.assertEqual(host_pool.kv_cache_dim, kv_pool.kv_cache_dim)
+        self.assertEqual(host_pool.layer_num, kv_pool.layer_num + 1)
+        self.assertEqual(host_pool.kv_buffer.shape[-1], kv_pool.kv_cache_dim)
+
+    def test_nominal_device_pool_needs_no_override(self):
+        # Flat MLA callers pass no override; a nominal-width pool must still
+        # construct because its kv_cache_dim equals the assumed width.
+        kv_pool = self._fake_nominal_device_pool()
+
+        host_pool = self._host_pool(kv_pool)
+
+        self.assertEqual(host_pool.kv_cache_dim, self.NOMINAL_KV_CACHE_DIM)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

HiCache can copy packed DSA cache rows using the wrong byte stride when the hybrid Mamba host pool is narrower than its device pool. Backup or restore then addresses different bytes on the two sides, risking incorrect cache contents or a GPU memory fault. A nominal 576-byte row does not hold the packed 656-byte DSA row, which also contains dequantization scales.

This PR makes the affected host-pool constructors use the device's actual packed width and reject incompatible target/draft geometry before allocation. The hybrid packed-DSA path is introduced by #36507; it was not reachable at this PR's original main base. The decode-offload constructor is corrected too.

This is separate from missing index-buffer transfers: #38212 (the main-based successor to #38161) includes an adapted version of this row-width fix and additionally restores the DSA indexes needed by hybrid HiCache loadback.

## Modifications

- Pass the device row width when constructing MLA host pools in the hybrid Mamba assembler and decode offload manager. Do not pass the MLA-only override to MHA pools.
- Validate row width and packed target/draft storage dtype before allocating host memory.
- Preserve nominal-width pools. At fixed host-memory size, correctly accounting for packed rows reduces the number of host tokens that fit.

## Accuracy Tests

Author CPU validation at `dcb154c1f5`: 36 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `a24b8c4a74` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

The CPU reproducer builds a small packed device-pool fixture and checks that the host buffer width and transfer stride match it. Unpatched main produces `12 != 16`. Additional cases require incompatible target/draft widths or dtypes to fail before allocation and check unchanged nominal/MHA behavior.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/mem_cache/test_hybrid_pool_assembler.py test/registered/unit/mem_cache/test_hicache_dcp_host_pool.py
```

Author-reported results: 17 assembler/geometry tests and 10 DCP host-pool tests passed. These tests construct pools; they do not execute GPU transfers. An author-observed downstream GLM-5.3-Flash TP2 setup stopped crashing under concurrent streams and forced restores after its width correction, but those logs are not attached to this PR.

## Speed Tests and Profiling

No speed benchmark. For 576-byte nominal versus 656-byte packed rows, fixed-token transfers and host storage require about 13.9% more bytes; a fixed-size host pool holds about 12.2% fewer tokens.

## Checklist

- [x] Format changed code and add CPU regression coverage.
- [x] Distinguish pool-geometry tests from transfer validation.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282197312](https://github.com/sgl-project/sglang/actions/runs/34282197312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282197060](https://github.com/sgl-project/sglang/actions/runs/34282197060)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282197226](https://github.com/sgl-project/sglang/actions/runs/34282197226)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
