### PR TITLE
Allow CPU image preprocessing to preserve serving GPU memory

### DIFF
--- a/python/sglang/srt/arg_groups/field_order.py
+++ b/python/sglang/srt/arg_groups/field_order.py
@@ -387,6 +387,7 @@ POSITIONAL_FIELD_ORDER = (
     "limit_mm_data_per_request",
     "enable_mm_global_cache",
     "image_processor_backend",
+    "mm_preprocessing_device",
     "mm_global_cache_backend",
     "disable_fast_image_processor",
     "mm_feature_transport",

--- a/python/sglang/srt/arg_groups/fields/mm.py
+++ b/python/sglang/srt/arg_groups/fields/mm.py
@@ -126,6 +126,14 @@ class Mm:
         "Image processor backend. 'auto' lets Transformers select the best "
         "available backend.",
     ] = "auto"
+    mm_preprocessing_device: A[
+        Literal["auto", "cpu", "cuda"],
+        "Device for fast visual (image and video) preprocessing, which runs in "
+        "the tokenizer process. 'auto' takes the model processor's default, "
+        "otherwise the platform's choice (the serving GPU on CUDA). 'cpu' keeps "
+        "preprocessing and JPEG decode off the GPU so the tokenizer process "
+        "creates no CUDA context. 'cuda' forces the serving GPU.",
+    ] = "auto"
     mm_global_cache_backend: A[
         str,
         Arg(

--- a/python/sglang/srt/arg_groups/fields/mm.py
+++ b/python/sglang/srt/arg_groups/fields/mm.py
@@ -131,8 +131,8 @@ class Mm:
         "Device for fast visual (image and video) preprocessing, which runs in "
         "the tokenizer process. 'auto' takes the model processor's default, "
         "otherwise the platform's choice (the serving GPU on CUDA). 'cpu' keeps "
-        "preprocessing and JPEG decode off the GPU so the tokenizer process "
-        "creates no CUDA context. 'cuda' forces the serving GPU.",
+        "base preprocessing and JPEG decode off the GPU. Custom processors "
+        "and feature transports may still use CUDA. 'cuda' forces the serving GPU.",
     ] = "auto"
     mm_global_cache_backend: A[
         str,

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -154,6 +154,7 @@ def check_server_args(server_args: Any):
     assert cfg.detokenizer_worker_num > 0, "Detokenizer worker num must >= 1"
     assert cfg.mm_processor_worker_num >= 0, "Multimodal processor worker num must >= 0"
     assert cfg.mm_io_worker_num >= 0, "Multimodal I/O worker num must >= 0"
+    validate_mm_preprocessing_device(cfg)
     validate_buckets_rule("--prompt-tokens-buckets", cfg.prompt_tokens_buckets)
     validate_buckets_rule("--generation-tokens-buckets", cfg.generation_tokens_buckets)
 
@@ -248,6 +249,21 @@ def check_server_args(server_args: Any):
         )
 
     check_load_publish_args(server_args)
+
+
+def validate_mm_preprocessing_device(cfg: Any) -> None:
+    """The CLI restricts the value through its choices; programmatic
+    construction reaches this check directly."""
+    if cfg.mm_preprocessing_device not in ("auto", "cpu", "cuda"):
+        raise ValueError(
+            "--mm-preprocessing-device must be one of auto, cpu, cuda; got "
+            f"{cfg.mm_preprocessing_device!r}."
+        )
+    if cfg.mm_preprocessing_device == "cuda" and cfg.device != "cuda":
+        raise ValueError(
+            "--mm-preprocessing-device=cuda requires --device=cuda; "
+            f"the server device is {cfg.device!r}."
+        )
 
 
 def validate_buckets_rule(arg_name: str, buckets_rule: List[str]):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -60,6 +60,7 @@ from sglang.srt.utils import (
     logger,
     smart_to_rgb,
 )
+from sglang.srt.utils.common import GPUImageDecodeMode
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
@@ -224,6 +225,11 @@ class BaseMultimodalProcessor(ABC):
     # `_resolve_auto_mm_processor_worker_num`.
     auto_mm_processor_worker_num = None
     auto_mm_io_worker_num = 4
+    # The model's default device for fast visual (image and video)
+    # preprocessing: a device string, or None for the platform's choice. See
+    # `_resolve_mm_preprocessing_device` for how it ranks against the server
+    # setting; the device is handed to the HF processor call as a whole.
+    mm_preprocessing_device: Optional[str] = None
     # Models opt in by assigning a non-zero default. A user-provided server
     # argument overrides this value; zero disables storage and cache-key work.
     auto_mm_preprocess_cache_size_mb = 0
@@ -259,6 +265,18 @@ class BaseMultimodalProcessor(ABC):
         if get_mm().disable_fast_image_processor:
             self.image_processor_backend = "pil"
         self.disable_fast_image_processor = self.image_processor_backend == "pil"
+        self.gpu_image_decode = self._resolve_gpu_image_decode()
+        if (
+            server_args.mm_preprocessing_device != "auto"
+            and self._places_preprocessing_itself()
+        ):
+            logger.warning(
+                "--mm-preprocessing-device=%s is not applied to the fast "
+                "processor call of %s, which places its own preprocessing; "
+                "only JPEG decode follows the setting.",
+                server_args.mm_preprocessing_device,
+                type(self).__name__,
+            )
         self.skip_tokenizer_init = get_serving().skip_tokenizer_init
 
         mm_process_config = get_mm().mm_process_config
@@ -716,20 +734,54 @@ class BaseMultimodalProcessor(ABC):
             return self._processor, self._tokenizer
         return processor, _tokenizer_of(processor)
 
-    def _preprocessing_competes_with_the_scheduler(self) -> bool:
-        """Whether image preprocessing submits its work to the serving GPU.
+    def _resolve_gpu_image_decode(self) -> GPUImageDecodeMode:
+        """The JPEG decode mode: the class default unless preprocessing is on CPU.
 
-        The fast image processor runs inside the tokenizer process but on
-        ``cuda:{base_gpu_id}`` -- the device the scheduler serves from. A second
-        preprocessing worker there is one more competitor for that device rather
-        than added parallelism.
+        nvJPEG decode would create a CUDA context on the current device just
+        as the fast processor would, so a CPU placement (from the server
+        setting or the class default) turns it off as well.
         """
-        if _is_cpu or get_exec().deterministic.rl_on_policy_target is not None:
+        if self._mm_preprocessing_device_choice() == "cpu":
             return False
+        return type(self).gpu_image_decode
+
+    def _uses_fast_image_processor(self, processor) -> bool:
+        """Whether ``processor`` takes the fast path that accepts a device."""
         if self.disable_fast_image_processor:
             return False
-        image_processor = getattr(self._processor, "image_processor", None)
+        image_processor = getattr(processor, "image_processor", None)
         return isinstance(image_processor, BaseImageProcessor)
+
+    def _places_preprocessing_itself(self) -> bool:
+        """Whether this class overrides ``process_mm_data`` without overriding
+        the placement decision, so the base resolver never sees its call."""
+        cls = type(self)
+        return (
+            cls.process_mm_data is not BaseMultimodalProcessor.process_mm_data
+            and cls._mm_preprocessing_device_choice
+            is BaseMultimodalProcessor._mm_preprocessing_device_choice
+        )
+
+    def _preprocessing_competes_with_the_scheduler(self) -> bool:
+        """Whether visual preprocessing submits its work to the serving GPU.
+
+        The fast image processor runs inside the tokenizer process but, by
+        default, on ``cuda:{base_gpu_id}`` -- the device the scheduler serves
+        from. A second preprocessing worker there is one more competitor for
+        that device rather than added parallelism. The answer follows the same
+        placement decision that ``process_mm_data`` uses. A class that places
+        the fast processor call itself (its own ``process_mm_data``, no
+        ``_mm_preprocessing_device_choice`` override) is sized for the
+        platform's device, since neither the server setting nor a class
+        default reaches its call.
+        """
+        if not self._uses_fast_image_processor(self._processor):
+            return False
+        if self._places_preprocessing_itself():
+            device = self._platform_mm_preprocessing_device()
+        else:
+            device = self._mm_preprocessing_device_choice()
+        return device is None or torch.device(device).type != "cpu"
 
     def _resolve_auto_mm_processor_worker_num(self) -> int:
         """The worker count to use when the user did not ask for one.
@@ -753,21 +805,60 @@ class BaseMultimodalProcessor(ABC):
         declared = self.auto_mm_processor_worker_num
         return 2 if declared is None else declared
 
-    def _fast_image_processor_device(self, processor) -> Optional[str]:
-        """The device for the fast image processor, or None to leave it unset.
+    def _platform_mm_preprocessing_device(self) -> str:
+        """The platform's device for fast visual preprocessing.
 
-        Resolved from this processor's own ``server_args``: engines sharing a
-        tokenizer process each carry their own ``base_gpu_id``.
+        The answer comes from this processor's own ``server_args``: engines
+        sharing a tokenizer process each carry their own ``base_gpu_id``.
         """
         server_args = self.server_args
         if _is_cpu or get_exec().deterministic.rl_on_policy_target is not None:
             return "cpu"
         if _is_xpu:
             return "xpu"
-        if not _is_npu:
-            # Per-worker placement travels as a constructor argument, and
-            # this record is that argument.
+        if _is_npu:
+            return "npu"
+        # Per-worker placement travels as a constructor argument, and this
+        # record is that argument.
+        return f"cuda:{server_args.base_gpu_id}"
+
+    def _mm_preprocessing_device_choice(self) -> str:
+        """Where fast visual preprocessing runs; pure and safe to call from
+        ``__init__`` (reads only ``server_args``, class attributes and the
+        platform flags, never ``self._processor``).
+
+        Precedence: ``--mm-preprocessing-device`` when it is not ``auto``;
+        otherwise the platform, except that on a CUDA platform the class's
+        ``mm_preprocessing_device`` replaces ``cuda:{base_gpu_id}`` when set.
+        A class default therefore cannot move XPU or NPU preprocessing onto a
+        CUDA device.
+
+        This is the override point for a subclass whose ``process_mm_data``
+        places the work itself: report that placement here so the worker
+        count and the JPEG decode mode follow it. The override must be
+        init-safe under the same rule.
+        """
+        server_args = self.server_args
+        configured = server_args.mm_preprocessing_device
+        if configured == "cpu":
+            return "cpu"
+        if configured == "cuda":
             return f"cuda:{server_args.base_gpu_id}"
+        platform = self._platform_mm_preprocessing_device()
+        if platform.startswith("cuda") and self.mm_preprocessing_device is not None:
+            return self.mm_preprocessing_device
+        return platform
+
+    def _resolve_mm_preprocessing_device(self, processor) -> Optional[str]:
+        """The device to hand to this fast processor call, or None to leave
+        it unset: the placement choice, plus the NPU processor patches that
+        the NPU path applies on first use."""
+        device = self._mm_preprocessing_device_choice()
+        if device == "npu":
+            return self._apply_npu_processor_patches(processor)
+        return device
+
+    def _apply_npu_processor_patches(self, processor) -> Optional[str]:
         if processor.__class__.__name__ == "MiniMaxVLProcessor":
             # MiniMax's image/video processors create 10-dim tensors during
             # patch extraction, exceeding the Ascend 8-dim limit; patch them
@@ -869,12 +960,8 @@ class BaseMultimodalProcessor(ABC):
                 kwargs.setdefault("audio_kwargs", {}).update(self.audio_config)
 
         processor_device = None
-        if (
-            hasattr(processor, "image_processor")
-            and isinstance(processor.image_processor, BaseImageProcessor)
-            and not self.disable_fast_image_processor
-        ):
-            processor_device = self._fast_image_processor_device(processor)
+        if self._uses_fast_image_processor(processor):
+            processor_device = self._resolve_mm_preprocessing_device(processor)
             if processor_device is not None:
                 kwargs["device"] = processor_device
 
@@ -951,19 +1038,23 @@ class BaseMultimodalProcessor(ABC):
         frame_count_limit=None,
         audio_sample_rate: Optional[int] = None,
         discard_alpha_channel=True,
+        gpu_image_decode: Optional[GPUImageDecodeMode] = None,
     ):
         """
         Load a single multimodal data.
 
         If data is processor_output or precomputed embedding, return directly.
 
-        Class method that can be pickled for multiprocessing
+        Class method that can be pickled for multiprocessing. ``gpu_image_decode``
+        is the instance's resolved mode; None falls back to the class default.
         """
         if cls._is_preprocessed_input(data):
             return data
+        if gpu_image_decode is None:
+            gpu_image_decode = cls.gpu_image_decode
         try:
             if modality == Modality.IMAGE:
-                img, _ = load_image(data, cls.gpu_image_decode)
+                img, _ = load_image(data, gpu_image_decode)
                 if isinstance(img, torch.Tensor):
                     return img  # JPEG already decoded on GPU by nvJPEG
                 # PIL decodes lazily; do it here in the io worker so the decode
@@ -1070,6 +1161,7 @@ class BaseMultimodalProcessor(ABC):
                 None,  # frame_count_limit: no consider for fast path
                 audio_sample_rate,
                 discard_alpha_channel,
+                self.gpu_image_decode,
             )
             futures.append((modality, idx, future))
 
@@ -1130,6 +1222,7 @@ class BaseMultimodalProcessor(ABC):
                         frame_count_limit,
                         audio_sample_rate,
                         discard_alpha_channel,
+                        self.gpu_image_decode,
                     )
                 )
                 task_info.append((modality, data, frame_count_limit))

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -967,7 +967,8 @@ class BaseMultimodalProcessor(ABC):
 
         # Long-video preprocessing stays on CPU to avoid competing with scheduler GPU pools.
         if videos and self.video_preprocessing_device is not None:
-            kwargs["device"] = self.video_preprocessing_device
+            processor_device = self.video_preprocessing_device
+            kwargs["device"] = processor_device
 
         # Avoid double BOS when the chat template already wrote one.
         if self._tokenizer_auto_adds_specials and isinstance(input_text, str):

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -299,6 +299,7 @@ class TestMultimodalFeatureTransportRuntime(CustomTestCase):
             base_gpu_id=2,
             tp_size=8,
             rl_on_policy_target=None,
+            mm_preprocessing_device="auto",
             allowed_media_domains=[],
             media_url_max_file_size_mb=64,
         )

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -649,6 +649,7 @@ def test_kimi_processor_workers_clone_the_gpu_wrapper(processor_cls, wrapper_cls
     server_args = SimpleNamespace(
         base_gpu_id=0,
         rl_on_policy_target=None,
+        mm_preprocessing_device="auto",
         tp_size=1,
     )
     with get_context().override_server_args(

--- a/test/registered/unit/multimodal/rust/qwen/_fixtures.py
+++ b/test/registered/unit/multimodal/rust/qwen/_fixtures.py
@@ -86,6 +86,7 @@ def make_processor(case, config, image_processor_cls=None):
         tokenizer_worker_num=1,
         base_gpu_id=0,
         rl_on_policy_target=None,
+        mm_preprocessing_device="auto",
         allowed_media_domains=[],
         media_url_max_file_size_mb=64,
     )

--- a/test/registered/unit/multimodal/test_processor_device_selection.py
+++ b/test/registered/unit/multimodal/test_processor_device_selection.py
@@ -11,7 +11,7 @@ to the HF processor call and the worker-count decision reads the same answer.
 import unittest
 from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
@@ -40,6 +40,10 @@ class _CpuDefaultProcessor(_StubProcessor):
 
 class _Cuda1DefaultProcessor(_StubProcessor):
     mm_preprocessing_device = "cuda:1"
+
+
+class _CpuVideoProcessor(_StubProcessor):
+    video_preprocessing_device = "cpu"
 
 
 def _make(cls=_StubProcessor, **fields):
@@ -346,6 +350,14 @@ class TestProcessMmDataDevice(CustomTestCase):
         self.assertNotIn("images", kwargs)
         self.assertFalse(mem_pool.called)
 
+    def test_cpu_video_override_does_not_enter_a_cuda_pool(self):
+        """The active call device, not the earlier image default, owns the pool."""
+        processor, events = self._harness(_CpuVideoProcessor)
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", videos=["video"])
+        self.assertEqual(self._call_device(events)[0], "cpu")
+        self.assertFalse(mem_pool.called)
+
     def test_pil_backend_passes_no_device(self):
         processor, events = self._harness(mm_preprocessing_device="cpu")
         processor.disable_fast_image_processor = True
@@ -384,8 +396,8 @@ class TestGpuImageDecodeFollowsThePlacement(CustomTestCase):
                     self._decode(_make(NoGpuDecode, mm_preprocessing_device=setting))
                 )
 
-    def test_load_single_item_uses_the_instance_mode(self):
-        image = SimpleNamespace(mode="RGB")
+    def test_load_single_item_uses_decode_mode_and_forces_pil_decode(self):
+        image = SimpleNamespace(mode="RGB", load=Mock())
         with patch(f"{BASE}.load_image", return_value=(image, None)) as load_image:
             _StubProcessor._load_single_item(
                 "data", Modality.IMAGE, gpu_image_decode=False
@@ -394,6 +406,7 @@ class TestGpuImageDecodeFollowsThePlacement(CustomTestCase):
         self.assertEqual(
             [call.args[1] for call in load_image.call_args_list], [False, True]
         )
+        self.assertEqual(image.load.call_count, 2)
 
 
 class TestFastImageProcessorMemoryPool(CustomTestCase):

--- a/test/registered/unit/multimodal/test_processor_device_selection.py
+++ b/test/registered/unit/multimodal/test_processor_device_selection.py
@@ -1,16 +1,19 @@
-"""The fast-image-processor device comes from the processor's own ServerArgs.
+"""Where fast visual preprocessing runs, and who gets to decide.
 
-Regression: the device decision read the published global ServerArgs, so every
-processor answered with one process-wide device. The encode-server DP workers
-each drive their own GPU, which no process-global value can express — the
-device has to come from what the worker was handed.
+The device comes from the processor's own ServerArgs (regression: it once read
+the published global ServerArgs, so every processor answered with one
+process-wide device, which the encode-server DP workers cannot express). One
+resolver, `_resolve_mm_preprocessing_device`, ranks `--mm-preprocessing-device`
+over the class default over the platform; `process_mm_data` hands its answer
+to the HF processor call and the worker-count decision reads the same answer.
 """
 
 import unittest
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
 from sglang.srt.runtime_context import publish, reset_context
 from sglang.srt.server_args import ServerArgs
@@ -31,7 +34,15 @@ class _StubProcessor(BaseMultimodalProcessor):
         raise NotImplementedError
 
 
-def _make(**fields):
+class _CpuDefaultProcessor(_StubProcessor):
+    mm_preprocessing_device = "cpu"
+
+
+class _Cuda1DefaultProcessor(_StubProcessor):
+    mm_preprocessing_device = "cuda:1"
+
+
+def _make(cls=_StubProcessor, **fields):
     """Both surfaces, because the device decision reads both.
 
     `base_gpu_id` is the instance's own -- two engines in one process keep
@@ -41,12 +52,12 @@ def _make(**fields):
     """
     server_args = ServerArgs(model_path="dummy", **fields)
     publish(server_args, role="tokenizer")
-    processor = _StubProcessor.__new__(_StubProcessor)
+    processor = cls.__new__(cls)
     processor.server_args = server_args
     return processor
 
 
-class TestFastImageProcessorDevice(CustomTestCase):
+class TestResolveMmPreprocessingDevice(CustomTestCase):
     def setUp(self):
         reset_context()
         self.addCleanup(reset_context)
@@ -55,7 +66,7 @@ class TestFastImageProcessorDevice(CustomTestCase):
         flags = {"_is_cpu": False, "_is_xpu": False, "_is_npu": False}
         flags.update(platform)
         with patch.multiple(BASE, **flags):
-            return processor._fast_image_processor_device(_Processor())
+            return processor._resolve_mm_preprocessing_device(_Processor())
 
     def test_device_follows_the_instance_base_gpu_id(self):
         self.assertEqual(self._device(_make(base_gpu_id=3)), "cuda:3")
@@ -89,8 +100,300 @@ class TestFastImageProcessorDevice(CustomTestCase):
 
         processor = _make(base_gpu_id=3)
         with patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=True):
-            device = processor._fast_image_processor_device(Glm4vProcessor())
+            device = processor._resolve_mm_preprocessing_device(Glm4vProcessor())
         self.assertIsNone(device)
+
+    def test_class_default_replaces_the_serving_gpu_on_cuda_platforms(self):
+        self.assertIsNone(_StubProcessor.mm_preprocessing_device)
+        self.assertEqual(self._device(_make(base_gpu_id=3)), "cuda:3")
+        self.assertEqual(
+            self._device(_make(_CpuDefaultProcessor, base_gpu_id=3)), "cpu"
+        )
+        self.assertEqual(
+            self._device(_make(_Cuda1DefaultProcessor, base_gpu_id=3)), "cuda:1"
+        )
+
+    def test_class_default_yields_to_cpu_xpu_and_npu_platforms(self):
+        processor = _make(_Cuda1DefaultProcessor, base_gpu_id=3)
+        self.assertEqual(self._device(processor, _is_cpu=True), "cpu")
+        self.assertEqual(self._device(processor, _is_xpu=True), "xpu")
+        with patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=True):
+            self.assertEqual(processor._mm_preprocessing_device_choice(), "npu")
+
+    def test_the_choice_is_pure_and_applies_no_npu_patches(self):
+        """The constructor sizes the worker pool from the choice, so it must
+        not import or apply the NPU processor patches; those run on the first
+        processor call through `_resolve_mm_preprocessing_device`."""
+        processor = _make(base_gpu_id=3)
+        with (
+            patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=True),
+            patch.object(
+                BaseMultimodalProcessor, "_apply_npu_processor_patches"
+            ) as patches,
+        ):
+            self.assertEqual(processor._mm_preprocessing_device_choice(), "npu")
+            self.assertFalse(patches.called)
+            processor._resolve_mm_preprocessing_device(_Processor())
+            self.assertTrue(patches.called)
+
+    def test_invalid_server_setting_is_rejected(self):
+        from sglang.srt.arg_groups.validation_hook import (
+            validate_mm_preprocessing_device,
+        )
+
+        for bad in ("cpuu", "gpu", ""):
+            with self.subTest(setting=bad):
+                cfg = SimpleNamespace(mm_preprocessing_device=bad, device="cuda")
+                with self.assertRaisesRegex(ValueError, "mm-preprocessing-device"):
+                    validate_mm_preprocessing_device(cfg)
+        with self.assertRaisesRegex(ValueError, "requires --device=cuda"):
+            validate_mm_preprocessing_device(
+                SimpleNamespace(mm_preprocessing_device="cuda", device="cpu")
+            )
+        for ok in ("auto", "cpu", "cuda"):
+            validate_mm_preprocessing_device(
+                SimpleNamespace(mm_preprocessing_device=ok, device="cuda")
+            )
+
+    def test_server_cpu_wins_over_the_class_default(self):
+        processor = _make(
+            _Cuda1DefaultProcessor, base_gpu_id=3, mm_preprocessing_device="cpu"
+        )
+        self.assertEqual(self._device(processor), "cpu")
+
+    def test_server_cuda_is_the_serving_gpu_and_wins_over_the_class_default(self):
+        processor = _make(
+            _CpuDefaultProcessor, base_gpu_id=3, mm_preprocessing_device="cuda"
+        )
+        self.assertEqual(self._device(processor), "cuda:3")
+
+    def test_server_cpu_wins_over_the_platform(self):
+        processor = _make(base_gpu_id=3, mm_preprocessing_device="cpu")
+        self.assertEqual(self._device(processor, _is_xpu=True), "cpu")
+
+    def test_server_auto_defers_to_class_default_then_platform(self):
+        self.assertEqual(ServerArgs(model_path="dummy").mm_preprocessing_device, "auto")
+        auto = dict(base_gpu_id=3, mm_preprocessing_device="auto")
+        self.assertEqual(self._device(_make(_CpuDefaultProcessor, **auto)), "cpu")
+        self.assertEqual(self._device(_make(**auto)), "cuda:3")
+
+
+class _FastImageProcessor:
+    pass
+
+
+def _fast_path_processor(cls=_StubProcessor, **fields):
+    processor = _make(cls, base_gpu_id=0, **fields)
+    processor.disable_fast_image_processor = False
+    processor._processor = SimpleNamespace(image_processor=_FastImageProcessor())
+    return processor
+
+
+@contextmanager
+def _gpu_platform():
+    with (
+        patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=False),
+        patch(f"{BASE}.BaseImageProcessor", _FastImageProcessor),
+    ):
+        yield
+
+
+class TestPreprocessingCompetesWithTheScheduler(CustomTestCase):
+    def _competes(self, processor):
+        with _gpu_platform():
+            competes = processor._preprocessing_competes_with_the_scheduler()
+            workers = processor._resolve_auto_mm_processor_worker_num()
+        return competes, workers
+
+    def test_fast_processor_on_the_serving_gpu_competes(self):
+        self.assertEqual(self._competes(_fast_path_processor()), (True, 1))
+
+    def test_class_cpu_default_does_not_compete(self):
+        processor = _fast_path_processor(_CpuDefaultProcessor)
+        self.assertEqual(self._competes(processor), (False, 2))
+
+    def test_server_cpu_does_not_compete(self):
+        processor = _fast_path_processor(mm_preprocessing_device="cpu")
+        self.assertEqual(self._competes(processor), (False, 2))
+
+    def test_server_cuda_competes_despite_a_class_cpu_default(self):
+        processor = _fast_path_processor(
+            _CpuDefaultProcessor, mm_preprocessing_device="cuda"
+        )
+        self.assertEqual(self._competes(processor), (True, 1))
+
+    def test_pil_backend_never_competes(self):
+        processor = _fast_path_processor()
+        processor.disable_fast_image_processor = True
+        self.assertEqual(self._competes(processor), (False, 2))
+
+    def test_the_choice_override_is_what_counts(self):
+        """A subclass that places the work itself reports it via the choice."""
+
+        class PlacesOnTheGpu(_CpuDefaultProcessor):
+            def _mm_preprocessing_device_choice(self):
+                return "cuda:0"
+
+        processor = _fast_path_processor(PlacesOnTheGpu)
+        self.assertEqual(self._competes(processor), (True, 1))
+
+    def test_a_class_placing_its_own_call_is_sized_for_the_platform(self):
+        """Neither the server setting nor a class default reaches the fast
+        processor call of a class with its own ``process_mm_data``, so the
+        worker count assumes the platform device (the serving GPU here)."""
+
+        class OwnPlacement(_CpuDefaultProcessor):
+            def process_mm_data(self, *args, **kwargs):
+                raise NotImplementedError
+
+        processor = _fast_path_processor(OwnPlacement, mm_preprocessing_device="cpu")
+        self.assertTrue(processor._places_preprocessing_itself())
+        self.assertEqual(self._competes(processor), (True, 1))
+        self.assertFalse(_fast_path_processor()._places_preprocessing_itself())
+
+
+class _Feature:
+    def __init__(self, events):
+        self.events = events
+
+    def to(self, device):
+        self.events.append(("copy", device))
+        return self
+
+
+class TestProcessMmDataDevice(CustomTestCase):
+    """The device the HF processor call actually receives."""
+
+    def _harness(self, cls=_StubProcessor, **fields):
+        events = []
+        feature = _Feature(events)
+
+        class Processor:
+            image_processor = _FastImageProcessor()
+            tokenizer = SimpleNamespace(bos_token=None)
+
+            def __call__(self, **kwargs):
+                events.append(("call", kwargs.get("device"), sorted(kwargs)))
+                return {"pixel_values": feature}
+
+        processor = _make(cls, base_gpu_id=0, **fields)
+        processor.mm_feature_transport = "cpu"
+        processor.precompute_hash_before_cpu_transfer = False
+        processor._processor = Processor()
+        processor._tokenizer = processor._processor.tokenizer
+        processor._tokenizer_auto_adds_specials = False
+        processor.disable_fast_image_processor = False
+        processor.image_config = {}
+        processor.video_config = {}
+        processor.audio_config = {}
+        processor.FEATURE_NAMES = ["pixel_values"]
+        return processor, events
+
+    @contextmanager
+    def _cuda_pool_spy(self):
+        with (
+            _gpu_platform(),
+            patch(f"{BASE}.torch.cuda.device", return_value=nullcontext()),
+            patch(f"{BASE}.torch.cuda.MemPool", return_value="pool") as mem_pool,
+            patch(f"{BASE}.torch.cuda.use_mem_pool", return_value=nullcontext()),
+            patch(f"{BASE}.torch.Tensor", _Feature),
+        ):
+            yield mem_pool
+
+    def _call_device(self, events):
+        (call,) = [event for event in events if event[0] == "call"]
+        return call[1], call[2]
+
+    def test_unpinned_call_goes_to_the_serving_gpu_through_the_pool(self):
+        processor, events = self._harness()
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", images=["image"])
+        self.assertEqual(self._call_device(events)[0], "cuda:0")
+        self.assertTrue(mem_pool.called)
+
+    def test_class_cpu_default_reaches_the_call_and_skips_the_pool(self):
+        processor, events = self._harness(_CpuDefaultProcessor)
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", images=["image"])
+        self.assertEqual(self._call_device(events)[0], "cpu")
+        self.assertFalse(mem_pool.called)
+        self.assertIn(("copy", "cpu"), events)
+
+    def test_server_cpu_reaches_the_call_and_skips_the_pool(self):
+        processor, events = self._harness(mm_preprocessing_device="cpu")
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", images=["image"])
+        self.assertEqual(self._call_device(events)[0], "cpu")
+        self.assertFalse(mem_pool.called)
+
+    def test_server_cuda_reaches_the_call_over_a_class_cpu_default(self):
+        processor, events = self._harness(
+            _CpuDefaultProcessor, mm_preprocessing_device="cuda"
+        )
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", images=["image"])
+        self.assertEqual(self._call_device(events)[0], "cuda:0")
+        self.assertTrue(mem_pool.called)
+
+    def test_video_only_request_takes_the_same_device(self):
+        """The device is a top-level kwarg of the whole call, so video moves too."""
+        processor, events = self._harness(mm_preprocessing_device="cpu")
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", videos=["video"])
+        device, kwargs = self._call_device(events)
+        self.assertEqual(device, "cpu")
+        self.assertIn("videos", kwargs)
+        self.assertNotIn("images", kwargs)
+        self.assertFalse(mem_pool.called)
+
+    def test_pil_backend_passes_no_device(self):
+        processor, events = self._harness(mm_preprocessing_device="cpu")
+        processor.disable_fast_image_processor = True
+        with self._cuda_pool_spy() as mem_pool:
+            processor.process_mm_data("t", images=["image"])
+        device, kwargs = self._call_device(events)
+        self.assertIsNone(device)
+        self.assertNotIn("device", kwargs)
+        self.assertFalse(mem_pool.called)
+
+
+class TestGpuImageDecodeFollowsThePlacement(CustomTestCase):
+    def _decode(self, processor):
+        with patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=False):
+            return processor._resolve_gpu_image_decode()
+
+    def test_server_cpu_turns_gpu_decode_off(self):
+        self.assertTrue(_StubProcessor.gpu_image_decode)
+        self.assertFalse(self._decode(_make(mm_preprocessing_device="cpu")))
+
+    def test_class_cpu_default_turns_gpu_decode_off(self):
+        self.assertFalse(self._decode(_make(_CpuDefaultProcessor)))
+        # The server setting outranks the class default in both directions.
+        self.assertTrue(
+            self._decode(_make(_CpuDefaultProcessor, mm_preprocessing_device="cuda"))
+        )
+
+    def test_other_placements_keep_the_class_default(self):
+        class NoGpuDecode(_StubProcessor):
+            gpu_image_decode = False
+
+        for setting in ("auto", "cuda"):
+            with self.subTest(setting=setting):
+                self.assertTrue(self._decode(_make(mm_preprocessing_device=setting)))
+                self.assertFalse(
+                    self._decode(_make(NoGpuDecode, mm_preprocessing_device=setting))
+                )
+
+    def test_load_single_item_uses_the_instance_mode(self):
+        image = SimpleNamespace(mode="RGB")
+        with patch(f"{BASE}.load_image", return_value=(image, None)) as load_image:
+            _StubProcessor._load_single_item(
+                "data", Modality.IMAGE, gpu_image_decode=False
+            )
+            _StubProcessor._load_single_item("data", Modality.IMAGE)
+        self.assertEqual(
+            [call.args[1] for call in load_image.call_args_list], [False, True]
+        )
 
 
 class TestFastImageProcessorMemoryPool(CustomTestCase):


### PR DESCRIPTION
## Motivation

The first image request can create a persistent CUDA context in the tokenizer process on the same GPU as the model. On a nearly full GPU, this additional memory use can make later text requests OOM even though they fit before the image request.

This PR lets operators keep the base fast image/video preprocessing path on CPU, avoiding that path's CUDA context without switching to the PIL processor backend. The default remains unchanged.

## Modifications

Add `--mm-preprocessing-device {auto,cpu,cuda}`. The choice controls the base fast-processor device, JPEG GPU decode and associated worker sizing. `cpu` disables the base JPEG GPU decoder. When either the explicit option or a processor class override selects CPU, video processor placement is updated before choosing a CUDA memory pool; `cuda` requires a CUDA server. `auto` retains platform behavior and honors a processor class's device override on CUDA.

This is not a guarantee that the entire tokenizer process avoids CUDA: custom processor paths may choose their own device, Kimi wrappers ignore the base device keyword, and CUDA IPC/VMM feature transports allocate on GPU independently. No model processor default changes.

## Accuracy Tests

Author CPU validation at `7732c8a72e`: 150 tests and 11 subtests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `3fac6bfca7` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

CPU tests exercise device resolution, CLI/programmatic validation, worker sizing, image/video calls and JPEG decoding choices. A fake fast processor records the device passed by the real base processing method; the CPU cases must avoid its CUDA memory-pool branch. Custom production processors and model outputs are not exercised.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/multimodal/test_processor_device_selection.py
```

The CPU run also covers `test_base_processor_image_decode.py`, `test_mm_process_config.py` and `test_kimi_k25.py`.

Author-observed failure on GLM-5.3-Flash TP2 at memory fraction 0.99: four cold 4k-token requests fit before an image request and OOMed afterward, when the tokenizer CUDA context occupied about 1.1 GB. Logs for that serving observation are not attached to this PR.

## Speed Tests and Profiling

CPU placement trades preprocessing latency for GPU headroom. No benchmark was run for this exact diff; the existing `auto` choice remains the default.

## Checklist

- [x] Format changed code and add CPU regression coverage.
- [x] Document placement scope and exceptions.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282214260](https://github.com/sgl-project/sglang/actions/runs/34282214260)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282213826](https://github.com/sgl-project/sglang/actions/runs/34282213826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282214101](https://github.com/sgl-project/sglang/actions/runs/34282214101)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
