### PR TITLE
Report which prefill phases consume GPU memory before an OOM

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1339,6 +1339,14 @@ class Envs:
     # Eager forward wraps the ForwardBatch's own tensors instead of copying them
     # into the CUDA graph buffer registry (no per-iter device-to-device copy).
     SGLANG_EAGER_INPUT_NO_COPY = EnvBool(False)
+    # Directory for allocator-history forensics snapshots (unset = disabled).
+    # Snapshots map damaged addresses to the allocation site of the block a
+    # captured CUDA graph still writes through.
+    SGLANG_MEM_FORENSICS_DIR = EnvStr(None)
+    SGLANG_MEM_FORENSICS_MAX_ENTRIES = EnvInt(300000)
+    # Log per-phase device-memory peaks for extend forwards (see
+    # utils/extend_mem_profile.py). Host-side counters only; no device sync.
+    SGLANG_EXTEND_MEM_PROFILE = EnvBool(False)
 
     # ===================================================================
     # Tokenizer, request state, embeddings, and reasoning controls

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -50,6 +50,7 @@ from sglang.srt.state_capturer.indexer_topk import (
 from sglang.srt.utils import (
     add_prefix,
     ceil_align,
+    extend_mem_profile,
     get_bool_env_var,
     get_device_module,
     is_cuda,
@@ -250,6 +251,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and not is_neox_style
         )
         self.alt_stream = alt_stream
+        if not extend_mem_profile.ENABLED:
+            self.forward_cuda = self._forward_cuda_impl
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         if self.dsa_enable_prefill_cp:
             self.cp_size = get_parallel().attn_cp_size
@@ -1498,6 +1501,24 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         )
 
     def forward_cuda(
+        self,
+        x: torch.Tensor,
+        q_lora: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        return_indices: bool = True,
+    ) -> Optional[torch.Tensor]:
+        # Reached only when the profiler is enabled: __init__ rebinds
+        # forward_cuda straight to _forward_cuda_impl otherwise (BaseFusedOp
+        # resolves its dispatch target with getattr, so the instance binding
+        # wins and decode skips this wrapper layer).
+        with extend_mem_profile.phase("mla:indexer"):
+            return self._forward_cuda_impl(
+                x, q_lora, positions, forward_batch, layer_id, return_indices
+            )
+
+    def _forward_cuda_impl(
         self,
         x: torch.Tensor,
         q_lora: torch.Tensor,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -90,6 +90,7 @@ from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_buffer, get_exec, get_parallel, get_spec
 from sglang.srt.utils import (
+    extend_mem_profile,
     get_bool_env_var,
     is_cuda,
     is_gfx95_supported,
@@ -2035,12 +2036,13 @@ class DeepseekSparseAttnBackend(
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
-                    layer,
-                    cache_loc,
-                    k,
-                    k_rope,
-                )
+                with extend_mem_profile.phase("mla:kv-write"):
+                    self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
 
         # Use MHA kernel if in MHA_ONE_SHOT mode
         if self.use_mha:
@@ -2246,14 +2248,15 @@ class DeepseekSparseAttnBackend(
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)
             if topk_transform_method == TopkTransformMethod.RAGGED:
                 page_table_1 = topk_indices
-            return self._forward_flashinfer_sparse_mla(
-                q_all=q_all,
-                kv_cache=kv_cache,
-                page_table_1=page_table_1,
-                seq_lens=metadata.dsa_cache_seqlens_int32,
-                sm_scale=layer.scaling,
-                skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
-            )
+            with extend_mem_profile.phase("mla:sparse-attn"):
+                return self._forward_flashinfer_sparse_mla(
+                    q_all=q_all,
+                    kv_cache=kv_cache,
+                    page_table_1=page_table_1,
+                    seq_lens=metadata.dsa_cache_seqlens_int32,
+                    sm_scale=layer.scaling,
+                    skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
+                )
         elif dsa_impl == "flashmla_kv":
             if q_rope is not None:
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -19,7 +19,7 @@ from sglang.srt.layers.attention.linear.utils import (
     build_verify_intermediate_state_indices,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
-from sglang.srt.utils import is_cpu, is_cuda, is_npu
+from sglang.srt.utils import extend_mem_profile, is_cpu, is_cuda, is_npu
 from sglang.srt.utils.common import is_gfx95_supported, rank0_log
 
 # KDA always uses the triton causal_conv1d_fn (no CUDA override).
@@ -833,20 +833,21 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 self.forward_metadata.conv_states_mask_indices
             ] = mixed_qkv[self.forward_metadata.track_conv_indices]
 
-        # Depthwise conv is channel-independent, so one packed call over the
-        # full qkv width matches the decode path and saves two kernel launches.
-        qkv = causal_conv1d_fn(
-            mixed_qkv.transpose(0, 1),
-            layer.conv_weights,
-            layer.bias,
-            activation="silu",
-            conv_states=conv_states,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
-        q, k, v = qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
+        with extend_mem_profile.phase("kda:conv"):
+            # Depthwise conv is channel-independent, so one packed call over the
+            # full qkv width matches the decode path and saves two kernel launches.
+            qkv = causal_conv1d_fn(
+                mixed_qkv.transpose(0, 1),
+                layer.conv_weights,
+                layer.bias,
+                activation="silu",
+                conv_states=conv_states,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
+            q, k, v = qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
 
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
@@ -857,31 +858,32 @@ class KDAAttnBackend(MambaAttnBackendBase):
             a = a.unflatten(-1, (-1, layer.head_k_dim))
 
         track_ssm = self.forward_metadata.has_mamba_track_mask
-        core_attn_out = self.kernel_dispatcher.extend(
-            q=q,
-            k=k,
-            v=v,
-            g=a,
-            beta=b,
-            ssm_states=ssm_states,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            A_log=layer.A_log,
-            dt_bias=layer.dt_bias,
-            lower_bound=layer.lower_bound,
-            beta_is_raw=gate_was_flat,
-            extend_seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-            # draft_extend_v2 must stay rollback-able, so kernels that commit state
-            # in place (e.g. FlashKDA) must not run for it.
-            is_spec_decode=forward_batch.forward_mode.is_draft_extend_v2(),
-            return_intermediate_states=track_ssm,
-            # Which global chunk rows of h the track snapshot will read; lets
-            # kernels that cannot materialize per-chunk states (NVIDIA KDA) take the
-            # fast path when the snapshot only needs the final state.
-            track_ssm_h_src=(
-                self.forward_metadata.track_ssm_h_src if track_ssm else None
-            ),
-        )
+        with extend_mem_profile.phase("kda:extend"):
+            core_attn_out = self.kernel_dispatcher.extend(
+                q=q,
+                k=k,
+                v=v,
+                g=a,
+                beta=b,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                A_log=layer.A_log,
+                dt_bias=layer.dt_bias,
+                lower_bound=layer.lower_bound,
+                beta_is_raw=gate_was_flat,
+                extend_seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+                # draft_extend_v2 must stay rollback-able, so kernels that commit state
+                # in place (e.g. FlashKDA) must not run for it.
+                is_spec_decode=forward_batch.forward_mode.is_draft_extend_v2(),
+                return_intermediate_states=track_ssm,
+                # Which global chunk rows of h the track snapshot will read; lets
+                # kernels that cannot materialize per-chunk states (NVIDIA KDA) take the
+                # fast path when the snapshot only needs the final state.
+                track_ssm_h_src=(
+                    self.forward_metadata.track_ssm_h_src if track_ssm else None
+                ),
+            )
         if track_ssm:
             # Snapshot the SSM state at the last track-aligned chunk boundary
             # from the kernel's per-chunk states (h) / final states into the

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -48,7 +48,7 @@ from sglang.srt.runtime_context import (
     get_server_args,
     get_serving,
 )
-from sglang.srt.utils import flatten_nested_list, print_warning_once
+from sglang.srt.utils import extend_mem_profile, flatten_nested_list, print_warning_once
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
 from sglang.utils import logger
 
@@ -430,14 +430,14 @@ def embed_mm_inputs(
         items = [
             item for item in item_flatten_list if item.is_modality(modality=modality)
         ]
+        # "image", "video", etc
+        modality_id = modality.name.lower()
         embedder = (
             None
             if data_embedding_func_mapping is None
             else data_embedding_func_mapping.get(modality, None)
         )
         if embedder is None:
-            # "image", "video", etc
-            modality_id = modality.name.lower()
             embedder = getattr(multimodal_model, f"get_{modality_id}_feature", None)
         if len(items) != 0:
             assert embedder is not None, f"no embedding method found for {modality}"
@@ -459,16 +459,17 @@ def embed_mm_inputs(
                     flatten_nested_list([item.offsets for item in mm_items])
                 )
 
-            embedding, mask, input_ids = get_embedding_and_mask(
-                data_embedding_func=embedder,
-                embedding_items=items,
-                placeholder_tensor=placeholder_tensor,
-                input_ids=input_ids,
-                items_size=items_size,
-                prefix_length=extend_prefix_lens,
-                extend_length=extend_seq_lens,
-                items_offset_list=items_offsets,
-            )
+            with extend_mem_profile.phase(f"mm-embed:{modality_id}"):
+                embedding, mask, input_ids = get_embedding_and_mask(
+                    data_embedding_func=embedder,
+                    embedding_items=items,
+                    placeholder_tensor=placeholder_tensor,
+                    input_ids=input_ids,
+                    items_size=items_size,
+                    prefix_length=extend_prefix_lens,
+                    extend_length=extend_seq_lens,
+                    items_offset_list=items_offsets,
+                )
 
             if use_deepstack.get(modality, None) and embedding is not None:
                 embedding, deepstack_embedding = (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -347,6 +347,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
     resolve_image_processor_backend,
 )
+from sglang.srt.utils.mem_forensics import maybe_dump_memory_forensics
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -1846,6 +1847,10 @@ class Scheduler(
         # Triton kernel device-load is a lazy first-use at serving time.
         triton_load_watch.install()
         triton_load_watch.mark_serving_started()
+
+        # Snapshot allocator state while every capture-era block is still
+        # alive; damaged addresses at runtime resolve against this dump.
+        maybe_dump_memory_forensics("ready")
 
         if use_mlx():
             # MLX overlap uses mx.async_eval for CPU/GPU overlap,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -96,6 +96,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
+    ForwardMode,
     PPProxyTensors,
 )
 from sglang.srt.model_executor.forward_context import (
@@ -215,6 +216,7 @@ from sglang.srt.state_capturer.routed_experts import (
 from sglang.srt.utils import (
     cpu_has_amx_support,
     enable_show_time_cost,
+    extend_mem_profile,
     get_available_gpu_memory,
     is_host_cpu_arm64,
     is_npu,
@@ -225,6 +227,7 @@ from sglang.srt.utils import (
     slow_rank_detector,
 )
 from sglang.srt.utils.device_timer import device_timer_ctx
+from sglang.srt.utils.mem_forensics import maybe_start_memory_forensics
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
@@ -269,6 +272,37 @@ def _prefill_cuda_graph_allows_context_parallel(
         bool(getattr(prefill_runner, "enable_cp_v2_bcg_capture", False))
         and is_cp_v2_active(forward_batch)
     )
+
+
+def extend_mem_profile_tokens(forward_batch: ForwardBatch) -> int:
+    """Real token count of a genuine prefill extend for the extend memory
+    profiler; 0 for anything else, so only such extends are recorded.
+
+    Genuine means the batch was built as ``ForwardMode.EXTEND``. MIXED,
+    TARGET_VERIFY, SPLIT_PREFILL, DLLM_EXTEND, decode and idle batches return
+    0, and so does a batch that ``prepare_mlp_sync_batch`` converted to
+    EXTEND for DP MAX_LEN padding (an idle hybrid-SSM rank running a
+    fabricated request, or decode rows padded to 1-token extends): those
+    keep their original mode in ``_original_forward_mode``, and the idle
+    conversion deliberately overwrites ``num_token_non_padded_cpu`` with the
+    peer's padded length, so neither the converted mode nor that count can
+    be trusted on its own.
+
+    The count comes from before padding: ``_original_num_tokens`` is the
+    pre-padding token count recorded by ``_pad_inputs_to_size``; when no
+    padding ran, ``num_token_non_padded_cpu`` is the batch's own count.
+    """
+    mode = forward_batch._original_forward_mode
+    if mode is None:
+        mode = forward_batch.forward_mode
+    if mode != ForwardMode.EXTEND:
+        return 0
+    num_tokens = forward_batch._original_num_tokens
+    if num_tokens is None:
+        num_tokens = forward_batch.num_token_non_padded_cpu
+    if num_tokens is None:
+        num_tokens = forward_batch.input_ids.numel()
+    return int(num_tokens)
 
 
 @dataclass
@@ -432,6 +466,10 @@ class ModelRunner:
         # Get available memory before model loading.
         # Stored for later use by alloc_memory_pool().
         self.init_torch_distributed()
+
+        # Allocator-history recording must begin before any lazily created
+        # buffer that a captured CUDA graph may later reference.
+        maybe_start_memory_forensics()
 
         # Init forward stream for overlap schedule
         self.forward_stream = torch.get_device_module(self.device).Stream()
@@ -1838,9 +1876,7 @@ class ModelRunner:
                 can_run_graph = True
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.
-                ret = self.eager_runner.execute(
-                    forward_batch, pp_proxy_tensors=pp_proxy_tensors
-                )
+                ret = self._execute_eager(forward_batch, pp_proxy_tensors)
 
             if (
                 forward_batch.global_num_tokens_cpu is not None
@@ -1849,6 +1885,20 @@ class ModelRunner:
                 forward_batch.post_forward_mlp_sync_batch(ret)
 
             return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+
+    def _execute_eager(self, forward_batch: ForwardBatch, pp_proxy_tensors):
+        """Run the eager forward, under the extend memory profiler only when
+        it was enabled at import. Disabled cost: this method call and one
+        module-constant check; the token helper is not evaluated."""
+        if not extend_mem_profile.ENABLED:
+            return self.eager_runner.execute(
+                forward_batch, pp_proxy_tensors=pp_proxy_tensors
+            )
+        # end() runs on the exception path too (fail-open).
+        with extend_mem_profile.record(extend_mem_profile_tokens(forward_batch)):
+            return self.eager_runner.execute(
+                forward_batch, pp_proxy_tensors=pp_proxy_tensors
+            )
 
     def _preprocess_logits(
         self,

--- a/python/sglang/srt/utils/extend_mem_profile.py
+++ b/python/sglang/srt/utils/extend_mem_profile.py
@@ -1,0 +1,319 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Hook-local caching-allocator allocation deltas plus the whole-extend
+allocated peak, for eager extend (prefill) forwards.
+
+Enabled by ``SGLANG_EXTEND_MEM_PROFILE=1``, read once at import into
+:data:`ENABLED`. When it is unset, :func:`phase` and :func:`record` are
+module-level functions that return one shared inert context object and the
+module touches nothing else; the model runner and the per-layer hooks check
+:data:`ENABLED` before doing any work of their own.
+
+What is measured: all numbers are ``torch.cuda`` caching-allocator counters
+(``memory_allocated`` / ``max_memory_allocated``), i.e. bytes the allocator
+has handed out to tensors on the current device. They do not include
+allocator-cached-but-free segments, memory taken directly from the driver by
+libraries (cuBLAS / NCCL / FlashInfer workspaces, kernel scratch outside the
+allocator), or anything on other devices. Reading the counters is host-side
+bookkeeping, so no device synchronization is added.
+
+Usage: ``record(num_tokens)`` as a context manager around one extend forward
+(``begin``/``end`` are the explicit form), ``phase(tag)`` as a context manager
+around any sub-step (an attention backend's kernels, the multimodal embedding
+step). Only extends with at least ``min_tokens`` real tokens are recorded.
+
+* A phase's value is a hook-local allocation delta: ``max_memory_allocated``
+  during its body minus ``memory_allocated`` at its entry. Each phase is
+  measured against its own entry live set, so the values of different phases
+  are not additive and are not disjoint parts of the extend peak: tensors a
+  phase leaves alive (a conv output consumed by the next kernel) are inside
+  the later phases' baselines, not their deltas. Repeated tags (one per
+  decoder layer) keep their maximum; a nested phase's delta is folded into
+  its enclosing phase.
+* The whole-extend allocated peak is ``max_memory_allocated`` over the whole
+  extend minus ``memory_allocated`` at ``begin``. The allocator keeps one
+  device-wide peak counter, which every phase entry resets, so the extend
+  peak is folded together from the counter's value at every reset point and
+  at ``end``; allocations made outside any phase still count towards it.
+
+``end`` logs one line with the extend peak and the largest phase deltas.
+Phases whose delta or retained delta reaches ``LARGE_PHASE_BYTES`` are logged
+immediately, so an OOM later in the same extend does not lose them. A phase
+that still retains that much after it ends also requests an allocator-history
+snapshot through :mod:`sglang.srt.utils.mem_forensics`, which writes one when
+``SGLANG_MEM_FORENSICS_DIR`` is set and is a no-op otherwise.
+
+The profiler is fail-open: an exception raised by the profiled code always
+propagates unchanged (the context manager calls ``end`` on all exits), and an
+allocator query that fails inside the profiler disables profiling for the
+rest of that extend with one warning instead of raising.
+
+State is module-global and the peak counter is per device. The profiler
+assumes serialized forward calls on the current device (speculative decoding
+builds a draft runner next to the target runner in the same process; their
+forwards do not overlap); it is not thread-safe, and allocations made by
+another thread or stream on the same device during a phase are attributed to
+that phase.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+LARGE_PHASE_BYTES = 256 * 2**20
+DEFAULT_MIN_TOKENS = 1024
+
+# Bound once at import: the hooks read this constant, never the environment.
+ENABLED: bool = envs.SGLANG_EXTEND_MEM_PROFILE.get()
+
+_active: bool = False
+_num_tokens: int = 0
+_base: int = 0
+_peak: int = 0  # highest allocator value observed so far in this extend
+_phase_peaks: Dict[str, int] = {}
+_open_phases: List[_Phase] = []
+_extend_count: int = 0
+
+
+def enabled() -> bool:
+    return ENABLED
+
+
+def _disable(where: str, exc: BaseException) -> None:
+    """Fail open: stop profiling this extend rather than raise from the profiler."""
+    global _active
+    _active = False
+    _open_phases.clear()
+    logger.warning(
+        "extend-mem-profile disabled for the rest of this extend: %s failed: %r",
+        where,
+        exc,
+    )
+
+
+def _observe_peak() -> int:
+    """Fold the device-wide peak counter into the extend peak and return it."""
+    global _peak
+    peak = torch.cuda.max_memory_allocated()
+    if peak > _peak:
+        _peak = peak
+    return peak
+
+
+def begin(num_tokens: int, min_tokens: int = DEFAULT_MIN_TOKENS) -> None:
+    """Start recording one extend forward of ``num_tokens`` real tokens."""
+    global _active, _num_tokens, _base, _peak, _phase_peaks
+    _active = False
+    _open_phases.clear()
+    if not ENABLED or num_tokens < min_tokens:
+        return
+    try:
+        if not torch.cuda.is_available():
+            return
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+    except Exception as exc:
+        _disable("begin", exc)
+        return
+    _num_tokens = num_tokens
+    _base = base
+    _peak = base
+    _phase_peaks = {}
+    _active = True
+
+
+def end() -> None:
+    """Finish the current extend and log its summary line. Never raises."""
+    global _active, _extend_count
+    if not _active:
+        return
+    try:
+        _extend_count += 1
+        _observe_peak()  # allocations since the last phase reset
+        peak = _peak - _base
+        live_now = torch.cuda.memory_allocated()
+        free_b, _ = torch.cuda.mem_get_info()
+        top = sorted(_phase_peaks.items(), key=lambda kv: kv[1], reverse=True)[:8]
+        phases = ", ".join(f"{k}={v / 2**20:.0f}MiB" for k, v in top)
+        logger.info(
+            "extend-mem-profile #%d tokens=%d extend_alloc_peak=%.0fMiB "
+            "live_at_entry=%.2fGiB live_after=%.2fGiB device_free_now=%.2fGiB "
+            "top_phase_alloc_deltas[%s]",
+            _extend_count,
+            _num_tokens,
+            peak / 2**20,
+            _base / 2**30,
+            live_now / 2**30,
+            free_b / 2**30,
+            phases,
+        )
+    except Exception as exc:
+        _disable("end", exc)
+    finally:
+        _active = False
+        _open_phases.clear()
+
+
+class _NoopScope:
+    """Shared inert context object handed out whenever nothing is recorded."""
+
+    __slots__ = ()
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+_NOOP_SCOPE = _NoopScope()
+
+
+class _ExtendScope:
+    __slots__ = ("num_tokens", "min_tokens")
+
+    def __init__(self, num_tokens: int, min_tokens: int):
+        self.num_tokens = num_tokens
+        self.min_tokens = min_tokens
+
+    def __enter__(self) -> None:
+        begin(self.num_tokens, self.min_tokens)
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        end()
+        return False
+
+
+class _Phase:
+    __slots__ = ("tag", "before", "peak")
+
+    def __init__(self, tag: str):
+        self.tag = tag
+        self.before = -1  # entry not completed: exit records nothing
+        self.peak = 0  # highest allocator value attributable to this phase
+
+    def __enter__(self) -> None:
+        if not _active:
+            return None
+        try:
+            # What accumulated since the last reset belongs to the enclosing
+            # phases (and the whole extend); fold it in before resetting.
+            outer_peak = _observe_peak()
+            for outer in _open_phases:
+                if outer_peak > outer.peak:
+                    outer.peak = outer_peak
+            before = torch.cuda.memory_allocated()
+            torch.cuda.reset_peak_memory_stats()
+        except Exception as exc:
+            _disable(f"phase {self.tag} entry", exc)
+            return None
+        self.before = before
+        self.peak = before
+        _open_phases.append(self)
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self.before < 0 or not _active:
+            return False
+        try:
+            self._finish()
+        except Exception as e:
+            _disable(f"phase {self.tag} exit", e)
+        return False
+
+    def _finish(self) -> None:
+        peak_abs = max(self.peak, _observe_peak())
+        if _open_phases and _open_phases[-1] is self:
+            _open_phases.pop()
+        for outer in _open_phases:
+            if peak_abs > outer.peak:
+                outer.peak = peak_abs
+        peak = peak_abs - self.before
+        prev = _phase_peaks.get(self.tag)
+        if prev is None or peak > prev:
+            _phase_peaks[self.tag] = peak
+        # Report large phases immediately: an OOM later in the same extend
+        # would otherwise take the numbers with it.
+        live_after = torch.cuda.memory_allocated()
+        retained = live_after - self.before
+        if peak >= LARGE_PHASE_BYTES or retained >= LARGE_PHASE_BYTES:
+            free_b, _ = torch.cuda.mem_get_info()
+            logger.info(
+                "extend-mem-profile phase %s alloc_delta=%.0fMiB retained=%.0fMiB "
+                "live_after=%.2fGiB device_free=%.2fGiB",
+                self.tag,
+                peak / 2**20,
+                retained / 2**20,
+                live_after / 2**30,
+                free_b / 2**30,
+            )
+        if retained >= LARGE_PHASE_BYTES:
+            # A phase that leaves this much behind is the question the
+            # profiler exists to answer; when allocator history is being
+            # recorded (SGLANG_MEM_FORENSICS_DIR), snapshot it with stacks.
+            from sglang.srt.utils.mem_forensics import maybe_dump_memory_forensics
+
+            maybe_dump_memory_forensics(f"retained-{self.tag}")
+
+
+def _record_enabled(num_tokens: int, min_tokens: int = DEFAULT_MIN_TOKENS):
+    """``record`` when enabled: context manager for one extend forward,
+    ``begin`` on entry and ``end`` on every exit (normal or exception).
+    Returns the shared no-op object below ``min_tokens``."""
+    if num_tokens < min_tokens:
+        return _NOOP_SCOPE
+    return _ExtendScope(num_tokens, min_tokens)
+
+
+def _record_disabled(num_tokens: int, min_tokens: int = DEFAULT_MIN_TOKENS):
+    """``record`` when disabled: the shared no-op object, nothing else."""
+    return _NOOP_SCOPE
+
+
+def _phase_enabled(tag: str):
+    """``phase`` when enabled: context manager recording the hook-local
+    allocation delta of the enclosed step under ``tag``; the shared no-op
+    object outside an active extend."""
+    return _Phase(tag) if _active else _NOOP_SCOPE
+
+
+def _phase_disabled(tag: str):
+    """``phase`` when disabled: the shared no-op object, nothing else."""
+    return _NOOP_SCOPE
+
+
+def _bind(enabled_flag: bool) -> None:
+    """Select the enabled or disabled ``record`` / ``phase`` entry points.
+    Called once at import from the env; tests call it to flip the profiler
+    without re-importing. Hooks look the functions up on the module at call
+    time, so rebinding here is enough."""
+    global ENABLED, record, phase, _active
+    ENABLED = bool(enabled_flag)
+    _active = False
+    _open_phases.clear()
+    record = _record_enabled if ENABLED else _record_disabled
+    phase = _phase_enabled if ENABLED else _phase_disabled
+
+
+record = _record_disabled
+phase = _phase_disabled
+_bind(ENABLED)

--- a/python/sglang/srt/utils/mem_forensics.py
+++ b/python/sglang/srt/utils/mem_forensics.py
@@ -1,0 +1,163 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Allocator-history forensics for CUDA-graph buffer lifetime debugging.
+
+When ``SGLANG_MEM_FORENSICS_DIR`` names a directory, the model runner starts
+CUDA caching-allocator history recording (with Python allocation stacks)
+during initialization, and each scheduler writes one
+``torch.cuda.memory._snapshot`` pickle tagged ``ready`` when it reaches its
+event loop, after every CUDA graph capture has completed. Failure handlers
+may call :func:`maybe_dump_memory_forensics` with their own tag for a second
+snapshot. Mapping a corrupted tensor's ``data_ptr`` onto the ``ready``
+snapshot names the allocation site of a block a captured graph recorded.
+
+Recording is started once per process and left active. The allocator keeps
+one process-wide history recorder, so another feature that calls
+``torch.cuda.memory._record_memory_history`` itself (the ``MEM`` activity of
+the torch profiler, the CUDA graph runner's capture-debug path) stops or
+reconfigures it. A dump therefore checks the snapshot for history entries
+first: when there are none, it re-arms recording with the configured
+parameters, writes nothing, and leaves the tag unconsumed, so the next
+request for that tag writes a snapshot whose history starts at the re-arm.
+Limitation: the first request after another profiler stopped recording only
+re-arms, and the snapshot that follows carries no history from before that
+point. Both entry points return without touching ``torch.cuda`` unless the
+directory variable is set, and dump failures are logged and never raised, so
+the original failure path of a caller is preserved even on a faulted CUDA
+context.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import threading
+import time
+
+import torch
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_started = False
+_dumped_tags: set[str] = set()
+
+
+def memory_forensics_enabled() -> bool:
+    return bool(envs.SGLANG_MEM_FORENSICS_DIR.get())
+
+
+def _rank_label() -> str:
+    try:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            return str(torch.distributed.get_rank())
+    except Exception:
+        pass
+    return "na"
+
+
+def _start_recording() -> None:
+    torch.cuda.memory._record_memory_history(
+        enabled="all",
+        context="all",
+        stacks="python",
+        max_entries=envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.get(),
+    )
+
+
+def _snapshot_has_history(snapshot) -> bool:
+    return any(snapshot.get("device_traces") or [])
+
+
+def maybe_start_memory_forensics() -> None:
+    """Begin allocator-history recording once per process when enabled."""
+    global _started
+    if not memory_forensics_enabled():
+        return
+    with _lock:
+        if _started:
+            return
+        try:
+            if not torch.cuda.is_available():
+                return
+            _start_recording()
+        except Exception:
+            logger.exception("Memory forensics recording failed to start")
+            return
+        _started = True
+        logger.info(
+            "Memory forensics recording started (dir=%s, max_entries=%d)",
+            envs.SGLANG_MEM_FORENSICS_DIR.get(),
+            envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.get(),
+        )
+
+
+def maybe_dump_memory_forensics(tag: str) -> None:
+    """Write one snapshot pickle per (process, tag).
+
+    The snapshot is written to a temporary file and moved into place
+    atomically; the tag is consumed only after a successful write, so a
+    transient failure does not suppress a later retry. A snapshot without
+    history entries is not written: recording is re-armed instead and the
+    tag stays unconsumed (see the module docstring). File names embed the
+    distributed rank, the PID, and a nanosecond timestamp, so concurrent
+    data-parallel replicas, restarts, and multiple servers sharing the
+    directory cannot collide.
+    """
+    if not _started:
+        return
+    with _lock:
+        if tag in _dumped_tags:
+            return
+        out_dir = envs.SGLANG_MEM_FORENSICS_DIR.get()
+        path = os.path.join(
+            out_dir,
+            f"mem-forensics-{tag}-rank{_rank_label()}"
+            f"-pid{os.getpid()}-{time.time_ns()}.pickle",
+        )
+        try:
+            snapshot = torch.cuda.memory._snapshot()
+            if not _snapshot_has_history(snapshot):
+                # Another memory profiler stopped the process-wide recorder.
+                # Re-arm now and defer the dump: the next request for this
+                # tag writes a snapshot with history from this point on.
+                _start_recording()
+                logger.warning(
+                    "Memory forensics snapshot %r deferred: allocator history "
+                    "was not being recorded (another memory profiler stopped "
+                    "it); recording re-armed, the next request for this tag "
+                    "writes a snapshot.",
+                    tag,
+                )
+                return
+            os.makedirs(out_dir, exist_ok=True)
+            tmp_path = path + ".tmp"
+            try:
+                with open(tmp_path, "wb") as file:
+                    pickle.dump(snapshot, file)
+                os.replace(tmp_path, path)
+            except BaseException:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except Exception:
+            logger.exception("Memory forensics dump failed for tag %r", tag)
+            return
+        _dumped_tags.add(tag)
+        logger.info("Memory forensics snapshot written: %s", path)

--- a/test/registered/unit/managers/test_mm_embed_mapped_embedder.py
+++ b/test/registered/unit/managers/test_mm_embed_mapped_embedder.py
@@ -1,0 +1,129 @@
+"""embed_mm_inputs with a per-modality embedder mapping (Kimi-VL style).
+
+Regression for the extend-memory-profile tag: the tag must follow the modality
+whether the embedder comes from ``data_embedding_func_mapping`` or from the
+model's ``get_<modality>_feature`` fallback, and must not go stale between
+modalities.
+"""
+
+from unittest import mock
+
+import pytest
+import torch
+from torch import nn
+
+from sglang.srt.managers import mm_utils
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.utils import extend_mem_profile
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-b-test-cpu")
+
+IMAGE_PAD = 100
+AUDIO_PAD = 200
+HIDDEN = 4
+
+
+def _item(modality, pad_value, offsets, embedding):
+    return MultimodalDataItem(
+        modality=modality,
+        pad_value=pad_value,
+        offsets=offsets,
+        precomputed_embeddings=embedding,
+    )
+
+
+def _inputs():
+    # 8 tokens: image placeholders at [0, 2], audio placeholders at [4, 5].
+    input_ids = torch.tensor([IMAGE_PAD] * 3 + [3] + [AUDIO_PAD] * 2 + [5, 7])
+    image = torch.full((3, HIDDEN), 1.0)
+    audio = torch.full((2, HIDDEN), 2.0)
+    mm_inputs = MultimodalInputs(
+        mm_items=[
+            _item(Modality.IMAGE, IMAGE_PAD, [(0, 2)], image),
+            _item(Modality.AUDIO, AUDIO_PAD, [(4, 5)], audio),
+        ]
+    )
+    return input_ids, image, audio, mm_inputs
+
+
+class _PhaseSpy:
+    def __init__(self):
+        self.tags = []
+
+    def __call__(self, tag):
+        self.tags.append(tag)
+        return extend_mem_profile._NOOP_SCOPE
+
+
+def _run(input_ids, mm_inputs, **kwargs):
+    embedding = nn.Embedding(16, HIDDEN)
+    spy = _PhaseSpy()
+    with mock.patch.object(extend_mem_profile, "phase", spy):
+        input_embeds, _ = mm_utils.embed_mm_inputs(
+            mm_inputs_list=[mm_inputs],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[input_ids.numel()],
+            input_ids=input_ids.clone(),
+            input_embedding=embedding,
+            **kwargs,
+        )
+    return input_embeds, embedding, spy.tags
+
+
+def _assert_scattered(input_embeds, embedding, input_ids, image, audio):
+    torch.testing.assert_close(input_embeds[0:3], image)
+    torch.testing.assert_close(input_embeds[4:6], audio)
+    text = embedding(input_ids.clamp(max=15))
+    torch.testing.assert_close(input_embeds[3], text[3])
+    torch.testing.assert_close(input_embeds[6:8], text[6:8])
+
+
+def test_mapped_embedders_for_every_modality():
+    input_ids, image, audio, mm_inputs = _inputs()
+    input_embeds, embedding, tags = _run(
+        input_ids,
+        mm_inputs,
+        multimodal_model=None,
+        data_embedding_func_mapping={
+            Modality.IMAGE: mock.Mock(name="image_embedder"),
+            Modality.AUDIO: mock.Mock(name="audio_embedder"),
+        },
+    )
+    _assert_scattered(input_embeds, embedding, input_ids, image, audio)
+    # Audio follows video in Modality.all(); its tag must be its own.
+    assert tags == ["mm-embed:image", "mm-embed:audio"]
+
+
+def test_mixed_mapped_and_model_fallback_embedders():
+    input_ids, image, audio, mm_inputs = _inputs()
+    model = mock.Mock(spec=["get_image_feature"])
+    input_embeds, embedding, tags = _run(
+        input_ids,
+        mm_inputs,
+        multimodal_model=model,
+        data_embedding_func_mapping={Modality.AUDIO: mock.Mock(name="audio")},
+    )
+    _assert_scattered(input_embeds, embedding, input_ids, image, audio)
+    assert tags == ["mm-embed:image", "mm-embed:audio"]
+
+
+def test_missing_embedder_still_asserts_by_modality():
+    input_ids, _, _, mm_inputs = _inputs()
+    with pytest.raises(AssertionError, match="AUDIO"):
+        _run(
+            input_ids,
+            mm_inputs,
+            multimodal_model=mock.Mock(spec=["get_image_feature"]),
+            data_embedding_func_mapping=None,
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/model_executor/test_extend_mem_profile_gate.py
+++ b/test/registered/unit/model_executor/test_extend_mem_profile_gate.py
@@ -1,0 +1,226 @@
+"""Which eager forwards the extend memory profiler records.
+
+Covers the mode/token predicate (``extend_mem_profile_tokens``) against
+ForwardBatch-like objects shaped the way ``prepare_mlp_sync_batch`` leaves
+them, and the ModelRunner eager call site: ``record`` must be entered only for
+a genuine prefill extend with enough real tokens, and nothing profiler-related
+may run when the profiler is disabled.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.model_runner import (
+    ModelRunner,
+    extend_mem_profile_tokens,
+)
+from sglang.srt.utils import extend_mem_profile
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _batch(
+    mode,
+    *,
+    original_mode=None,
+    original_num_tokens=None,
+    non_padded=None,
+    input_ids=0,
+):
+    """ForwardBatch-like object with the fields the predicate reads."""
+    return SimpleNamespace(
+        forward_mode=mode,
+        _original_forward_mode=original_mode,
+        _original_num_tokens=original_num_tokens,
+        num_token_non_padded_cpu=non_padded,
+        input_ids=torch.zeros(input_ids, dtype=torch.int64),
+    )
+
+
+def plain_extend(tokens=4096):
+    # No DP padding: the count is the batch's own token count.
+    return _batch(ForwardMode.EXTEND, non_padded=tokens, input_ids=tokens)
+
+
+def padded_extend(real=3000, padded=4096):
+    # A real extend rank under DP MAX_LEN: input_ids padded to the peer's
+    # length, mode unchanged, pre-padding count recorded.
+    return _batch(
+        ForwardMode.EXTEND,
+        original_num_tokens=real,
+        non_padded=real,
+        input_ids=padded,
+    )
+
+
+def idle_hybrid_converted(peer_tokens=4096):
+    # Idle hybrid-SSM rank converted to EXTEND with a fabricated request:
+    # forward_batch_info overwrites num_token_non_padded_cpu with the peer's
+    # padded length and pads input_ids to it; positions had 0 rows.
+    return _batch(
+        ForwardMode.EXTEND,
+        original_mode=ForwardMode.IDLE,
+        original_num_tokens=0,
+        non_padded=peer_tokens,
+        input_ids=peer_tokens,
+    )
+
+
+def decode_converted(bs=8, peer_tokens=4096):
+    # Decode rows padded to 1-token extends next to a prefill peer.
+    return _batch(
+        ForwardMode.EXTEND,
+        original_mode=ForwardMode.DECODE,
+        original_num_tokens=bs,
+        non_padded=bs,
+        input_ids=peer_tokens,
+    )
+
+
+def mixed(tokens=4096):
+    return _batch(ForwardMode.MIXED, non_padded=tokens, input_ids=tokens)
+
+
+def target_verify(reqs=256, draft=4):
+    return _batch(
+        ForwardMode.TARGET_VERIFY, non_padded=reqs * draft, input_ids=reqs * draft
+    )
+
+
+def decode(bs=256):
+    return _batch(ForwardMode.DECODE, non_padded=bs, input_ids=bs)
+
+
+def idle():
+    return _batch(ForwardMode.IDLE, non_padded=0, input_ids=0)
+
+
+class ExtendMemProfileTokensTest(unittest.TestCase):
+    def test_plain_extend_reports_its_token_count(self):
+        self.assertEqual(extend_mem_profile_tokens(plain_extend(4096)), 4096)
+
+    def test_padded_extend_reports_the_pre_padding_count(self):
+        self.assertEqual(
+            extend_mem_profile_tokens(padded_extend(real=3000, padded=4096)), 3000
+        )
+
+    def test_idle_hybrid_rank_converted_to_extend_is_excluded(self):
+        # The review's case: idle Mamba/KDA rank paired with a 4096-token
+        # prefill must not be profiled as a 4096-token extend.
+        self.assertEqual(extend_mem_profile_tokens(idle_hybrid_converted(4096)), 0)
+
+    def test_decode_rows_converted_to_extend_are_excluded(self):
+        self.assertEqual(extend_mem_profile_tokens(decode_converted()), 0)
+
+    def test_mixed_is_excluded(self):
+        self.assertEqual(extend_mem_profile_tokens(mixed(4096)), 0)
+
+    def test_target_verify_is_excluded(self):
+        self.assertEqual(extend_mem_profile_tokens(target_verify(256, 4)), 0)
+
+    def test_decode_and_idle_are_excluded(self):
+        self.assertEqual(extend_mem_profile_tokens(decode()), 0)
+        self.assertEqual(extend_mem_profile_tokens(idle()), 0)
+
+    def test_falls_back_to_input_ids_without_any_count(self):
+        batch = _batch(ForwardMode.EXTEND, input_ids=2048)
+        self.assertEqual(extend_mem_profile_tokens(batch), 2048)
+
+
+class _RecordSpy:
+    """Stands in for extend_mem_profile.record: remembers each call and
+    whether the returned scope was entered."""
+
+    def __init__(self):
+        self.calls = []
+        self.entered = []
+
+    def __call__(self, num_tokens, min_tokens=extend_mem_profile.DEFAULT_MIN_TOKENS):
+        self.calls.append(num_tokens)
+        if num_tokens < min_tokens:
+            return extend_mem_profile._NOOP_SCOPE
+        spy = self
+
+        class _Scope:
+            def __enter__(self_inner):
+                spy.entered.append(num_tokens)
+
+            def __exit__(self_inner, *exc):
+                return False
+
+        return _Scope()
+
+
+def _runner():
+    runner = ModelRunner.__new__(ModelRunner)
+    runner.eager_runner = SimpleNamespace(
+        execute=mock.Mock(side_effect=lambda fb, pp_proxy_tensors=None: ("out", fb))
+    )
+    return runner
+
+
+class ModelRunnerEagerGateTest(unittest.TestCase):
+    def setUp(self):
+        self._was_enabled = extend_mem_profile.ENABLED
+
+    def tearDown(self):
+        extend_mem_profile._bind(self._was_enabled)
+
+    def test_record_is_entered_only_for_the_qualifying_extend(self):
+        extend_mem_profile._bind(True)
+        runner = _runner()
+        spy = _RecordSpy()
+        batches = [
+            plain_extend(4096),
+            idle_hybrid_converted(4096),
+            decode_converted(),
+            mixed(4096),
+            target_verify(256, 4),
+            decode(256),
+            idle(),
+            plain_extend(512),  # genuine extend, below min_tokens
+        ]
+        with mock.patch.object(extend_mem_profile, "record", spy):
+            for batch in batches:
+                out = runner._execute_eager(batch, None)
+                self.assertEqual(out, ("out", batch))
+        self.assertEqual(runner.eager_runner.execute.call_count, len(batches))
+        self.assertEqual(spy.calls, [4096, 0, 0, 0, 0, 0, 0, 512])
+        self.assertEqual(spy.entered, [4096])
+
+    def test_disabled_runner_never_touches_the_profiler(self):
+        extend_mem_profile._bind(False)
+        runner = _runner()
+        batch = plain_extend(4096)
+        with (
+            mock.patch.object(extend_mem_profile, "record") as record,
+            mock.patch(
+                "sglang.srt.model_executor.model_runner.extend_mem_profile_tokens"
+            ) as tokens,
+        ):
+            out = runner._execute_eager(batch, None)
+        self.assertEqual(out, ("out", batch))
+        runner.eager_runner.execute.assert_called_once_with(
+            batch, pp_proxy_tensors=None
+        )
+        self.assertFalse(record.called)
+        self.assertFalse(tokens.called)
+
+    def test_exception_from_execute_propagates_through_the_scope(self):
+        extend_mem_profile._bind(True)
+        runner = _runner()
+        runner.eager_runner.execute.side_effect = RuntimeError("CUDA out of memory")
+        spy = _RecordSpy()
+        with mock.patch.object(extend_mem_profile, "record", spy):
+            with self.assertRaises(RuntimeError):
+                runner._execute_eager(plain_extend(4096), None)
+        self.assertEqual(spy.entered, [4096])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_extend_mem_profile.py
+++ b/test/registered/unit/utils/test_extend_mem_profile.py
@@ -1,0 +1,356 @@
+"""Unit tests for the env-gated extend memory profiler (hook-local
+caching-allocator allocation deltas plus the whole-extend allocated peak)."""
+
+import contextlib
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.utils import extend_mem_profile, mem_forensics
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+MiB = 2**20
+LOGGER = "sglang.srt.utils.extend_mem_profile"
+
+
+class FakeAllocator:
+    """Host-side stand-in for the CUDA caching allocator's counters."""
+
+    def __init__(self, allocated: int = 0):
+        self.allocated = allocated
+        self.peak = allocated
+        self.reset_calls = 0
+        self.fail_mem_get_info = False
+        self.fail_max_memory_allocated = False
+
+    def alloc(self, nbytes: int) -> None:
+        self.allocated += nbytes
+        self.peak = max(self.peak, self.allocated)
+
+    def free(self, nbytes: int) -> None:
+        self.allocated -= nbytes
+
+    def memory_allocated(self) -> int:
+        return self.allocated
+
+    def max_memory_allocated(self) -> int:
+        if self.fail_max_memory_allocated:
+            raise RuntimeError("allocator stats unavailable")
+        return self.peak
+
+    def reset_peak_memory_stats(self) -> None:
+        self.reset_calls += 1
+        self.peak = self.allocated
+
+    def mem_get_info(self):
+        if self.fail_mem_get_info:
+            raise RuntimeError("cudaMemGetInfo failed")
+        return (4 * 2**30, 8 * 2**30)
+
+    @contextlib.contextmanager
+    def patched(self):
+        with (
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(torch.cuda, "memory_allocated", self.memory_allocated),
+            mock.patch.object(
+                torch.cuda, "max_memory_allocated", self.max_memory_allocated
+            ),
+            mock.patch.object(
+                torch.cuda, "reset_peak_memory_stats", self.reset_peak_memory_stats
+            ),
+            mock.patch.object(torch.cuda, "mem_get_info", self.mem_get_info),
+        ):
+            yield
+
+
+@contextlib.contextmanager
+def profiler(enabled: bool):
+    """Flip the import-time binding for one test and restore it after."""
+    was = extend_mem_profile.ENABLED
+    extend_mem_profile._bind(enabled)
+    try:
+        yield
+    finally:
+        extend_mem_profile._bind(was)
+
+
+class ExtendMemProfileTest(unittest.TestCase):
+    def setUp(self):
+        # Isolation between tests only; the tests below assert the module
+        # leaves _active False on its own after every exit path.
+        extend_mem_profile._active = False
+        extend_mem_profile._phase_peaks = {}
+        extend_mem_profile._open_phases.clear()
+        extend_mem_profile._extend_count = 0
+
+    def test_disabled_entry_points_are_noops(self):
+        with profiler(False):
+            self.assertFalse(extend_mem_profile.enabled())
+            self.assertFalse(extend_mem_profile.ENABLED)
+            with (
+                mock.patch.object(torch.cuda, "reset_peak_memory_stats") as reset,
+                mock.patch.object(torch.cuda, "memory_allocated") as allocated,
+                mock.patch.object(mem_forensics, "maybe_dump_memory_forensics") as dump,
+            ):
+                extend_mem_profile.begin(4096)
+                self.assertFalse(extend_mem_profile._active)
+                with extend_mem_profile.phase("layer"):
+                    pass
+                with self.assertNoLogs(LOGGER):
+                    extend_mem_profile.end()
+                with self.assertNoLogs(LOGGER):
+                    with extend_mem_profile.record(4096):
+                        with extend_mem_profile.phase("layer"):
+                            pass
+        self.assertFalse(reset.called)
+        self.assertFalse(allocated.called)
+        self.assertFalse(dump.called)
+        self.assertEqual(extend_mem_profile._phase_peaks, {})
+        self.assertEqual(extend_mem_profile._extend_count, 0)
+
+    def test_disabled_binding_is_the_plain_noop_functions(self):
+        # Disabled hot path: module-level functions that return the shared
+        # object without reading the env or any module state.
+        with profiler(False):
+            self.assertIs(extend_mem_profile.phase, extend_mem_profile._phase_disabled)
+            self.assertIs(
+                extend_mem_profile.record, extend_mem_profile._record_disabled
+            )
+            with mock.patch("os.getenv") as getenv:
+                self.assertIs(
+                    extend_mem_profile.phase("a"), extend_mem_profile._NOOP_SCOPE
+                )
+                self.assertIs(
+                    extend_mem_profile.record(4096), extend_mem_profile._NOOP_SCOPE
+                )
+            self.assertFalse(getenv.called)
+        with profiler(True):
+            self.assertIs(extend_mem_profile.phase, extend_mem_profile._phase_enabled)
+            self.assertIs(extend_mem_profile.record, extend_mem_profile._record_enabled)
+
+    def test_inactive_scopes_are_one_shared_object(self):
+        with profiler(False):
+            self.assertIs(extend_mem_profile.phase("a"), extend_mem_profile.phase("b"))
+            self.assertIs(extend_mem_profile.phase("a"), extend_mem_profile._NOOP_SCOPE)
+            self.assertIs(
+                extend_mem_profile.record(4096), extend_mem_profile._NOOP_SCOPE
+            )
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            # Enabled but below min_tokens: still the shared no-op.
+            self.assertIs(
+                extend_mem_profile.record(1023), extend_mem_profile._NOOP_SCOPE
+            )
+            # Outside an active extend: still the shared no-op.
+            self.assertIs(extend_mem_profile.phase("a"), extend_mem_profile._NOOP_SCOPE)
+            with extend_mem_profile.record(4096):
+                self.assertIsInstance(
+                    extend_mem_profile.phase("a"), extend_mem_profile._Phase
+                )
+
+    def test_small_extends_and_missing_cuda_stay_silent(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            extend_mem_profile.begin(1023)
+            self.assertFalse(extend_mem_profile._active)
+            with mock.patch.object(torch.cuda, "is_available", return_value=False):
+                extend_mem_profile.begin(4096)
+            self.assertFalse(extend_mem_profile._active)
+        self.assertEqual(alloc.reset_calls, 0)
+
+    def test_phase_deltas_are_recorded_and_summarized(self):
+        alloc = FakeAllocator(allocated=10 * MiB)
+        with profiler(True), alloc.patched():
+            extend_mem_profile.begin(4096)
+            self.assertTrue(extend_mem_profile._active)
+            self.assertEqual(extend_mem_profile._base, 10 * MiB)
+
+            with extend_mem_profile.phase("attn"):
+                alloc.alloc(30 * MiB)
+                alloc.free(30 * MiB)
+            with extend_mem_profile.phase("attn"):
+                alloc.alloc(20 * MiB)
+                alloc.free(20 * MiB)
+            with extend_mem_profile.phase("mlp"):
+                alloc.alloc(5 * MiB)
+                alloc.free(5 * MiB)
+            with self.assertLogs(LOGGER, level="INFO") as logs:
+                extend_mem_profile.end()
+
+        # Repeated tags keep their maximum; below-threshold phases log nothing
+        # until the summary line.
+        self.assertEqual(
+            extend_mem_profile._phase_peaks, {"attn": 30 * MiB, "mlp": 5 * MiB}
+        )
+        self.assertEqual(len(logs.output), 1)
+        line = logs.output[0]
+        self.assertIn("extend-mem-profile #1 tokens=4096 extend_alloc_peak=30MiB", line)
+        self.assertIn("top_phase_alloc_deltas[attn=30MiB, mlp=5MiB]", line)
+        self.assertFalse(extend_mem_profile._active)
+
+    def test_whole_extend_peak_includes_unwrapped_allocations(self):
+        alloc = FakeAllocator(allocated=10 * MiB)
+        with profiler(True), alloc.patched():
+            with self.assertLogs(LOGGER, level="INFO") as logs:
+                with extend_mem_profile.record(4096):
+                    # Allocated and freed outside any phase, before the first
+                    # phase resets the device-wide counter.
+                    alloc.alloc(100 * MiB)
+                    alloc.free(100 * MiB)
+                    with extend_mem_profile.phase("attn"):
+                        alloc.alloc(30 * MiB)
+                        alloc.free(30 * MiB)
+                    # Again after the last phase, seen only by end().
+                    alloc.alloc(120 * MiB)
+                    alloc.free(120 * MiB)
+        self.assertEqual(extend_mem_profile._phase_peaks, {"attn": 30 * MiB})
+        self.assertIn("tokens=4096 extend_alloc_peak=120MiB", logs.output[-1])
+        self.assertFalse(extend_mem_profile._active)
+
+    def test_phase_deltas_are_hook_local_not_disjoint_parts_of_the_peak(self):
+        # kda:conv retains its outputs, kda:extend then adds a workspace on
+        # top of them: the extend peak holds both, each delta holds one, and
+        # peak minus a delta is not "everything else".
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            with self.assertLogs(LOGGER, level="INFO") as logs:
+                with extend_mem_profile.record(4096):
+                    with extend_mem_profile.phase("kda:conv"):
+                        alloc.alloc(100 * MiB)  # q/k/v outputs, kept alive
+                    with extend_mem_profile.phase("kda:extend"):
+                        alloc.alloc(60 * MiB)  # workspace
+                        alloc.free(60 * MiB)
+                    alloc.free(100 * MiB)
+        self.assertEqual(
+            extend_mem_profile._phase_peaks,
+            {"kda:conv": 100 * MiB, "kda:extend": 60 * MiB},
+        )
+        self.assertIn("extend_alloc_peak=160MiB", logs.output[-1])
+
+    def test_nested_phase_delta_folds_into_outer_phase(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            with self.assertLogs(LOGGER, level="INFO") as logs:
+                with extend_mem_profile.record(4096):
+                    with extend_mem_profile.phase("outer"):
+                        alloc.alloc(50 * MiB)  # outer's own transient
+                        alloc.free(50 * MiB)
+                        alloc.alloc(30 * MiB)  # live across the inner phase
+                        with extend_mem_profile.phase("inner"):
+                            alloc.alloc(40 * MiB)
+                            alloc.free(40 * MiB)
+                        alloc.free(30 * MiB)
+        # The inner reset must not erase outer's earlier 50 MiB, and the
+        # inner peak (30 live + 40) counts towards outer as 70 MiB.
+        self.assertEqual(
+            extend_mem_profile._phase_peaks, {"outer": 70 * MiB, "inner": 40 * MiB}
+        )
+        self.assertIn("extend_alloc_peak=70MiB", logs.output[-1])
+        self.assertEqual(extend_mem_profile._open_phases, [])
+
+    def test_phase_is_recorded_when_body_raises(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            extend_mem_profile.begin(4096)
+            with self.assertRaises(RuntimeError):
+                with extend_mem_profile.phase("attn"):
+                    alloc.alloc(7 * MiB)
+                    raise RuntimeError("out of memory")
+        self.assertEqual(extend_mem_profile._phase_peaks, {"attn": 7 * MiB})
+        self.assertEqual(extend_mem_profile._open_phases, [])
+
+    def test_exception_in_recorded_extend_unwinds_and_propagates_original(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            with self.assertRaises(RuntimeError) as raised:
+                with extend_mem_profile.record(4096):
+                    self.assertTrue(extend_mem_profile._active)
+                    with extend_mem_profile.phase("attn"):
+                        alloc.alloc(7 * MiB)
+                        raise RuntimeError("CUDA out of memory")
+            self.assertEqual(str(raised.exception), "CUDA out of memory")
+            self.assertFalse(extend_mem_profile._active)
+            self.assertEqual(extend_mem_profile._open_phases, [])
+            # The following decode/extend does not attribute work to this
+            # extend.
+            self.assertIs(
+                extend_mem_profile.phase("attn"), extend_mem_profile._NOOP_SCOPE
+            )
+
+    def test_profiler_failure_never_replaces_original_exception(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            with (
+                self.assertRaises(RuntimeError) as raised,
+                self.assertLogs(LOGGER, level="WARNING") as logs,
+            ):
+                with extend_mem_profile.record(4096):
+                    with extend_mem_profile.phase("attn"):
+                        # A CUDA error makes the allocator/device queries in
+                        # the profiler fail while the original error unwinds.
+                        alloc.fail_max_memory_allocated = True
+                        alloc.fail_mem_get_info = True
+                        raise RuntimeError("original CUDA error")
+        self.assertEqual(str(raised.exception), "original CUDA error")
+        self.assertFalse(extend_mem_profile._active)
+        self.assertEqual(extend_mem_profile._open_phases, [])
+        self.assertTrue(any("disabled for the rest" in line for line in logs.output))
+
+    def test_profiler_failure_without_body_error_is_contained(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            alloc.fail_mem_get_info = True
+            with self.assertLogs(LOGGER, level="WARNING"):
+                with extend_mem_profile.record(4096):
+                    with extend_mem_profile.phase("big"):
+                        alloc.alloc(300 * MiB)  # crosses the immediate-log threshold
+                    # Disabled for the rest of the extend after the failure.
+                    self.assertFalse(extend_mem_profile._active)
+        self.assertFalse(extend_mem_profile._active)
+
+    def test_large_transient_phase_is_logged_immediately(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            extend_mem_profile.begin(4096)
+            with (
+                mock.patch.object(mem_forensics, "maybe_dump_memory_forensics") as dump,
+                self.assertLogs(LOGGER, level="INFO") as logs,
+            ):
+                with extend_mem_profile.phase("kda:extend"):
+                    alloc.alloc(extend_mem_profile.LARGE_PHASE_BYTES)
+                    alloc.free(extend_mem_profile.LARGE_PHASE_BYTES)
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn(
+            "extend-mem-profile phase kda:extend alloc_delta=256MiB retained=0MiB",
+            logs.output[0],
+        )
+        # Nothing was retained, so no allocator snapshot is requested.
+        self.assertFalse(dump.called)
+
+    def test_retaining_phase_requests_forensics_snapshot(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            extend_mem_profile.begin(4096)
+            with (
+                mock.patch.object(mem_forensics, "maybe_dump_memory_forensics") as dump,
+                self.assertLogs(LOGGER, level="INFO") as logs,
+            ):
+                with extend_mem_profile.phase("mm-embed:image"):
+                    alloc.alloc(300 * MiB)
+        self.assertIn("alloc_delta=300MiB retained=300MiB", logs.output[0])
+        dump.assert_called_once_with("retained-mm-embed:image")
+
+    def test_phase_outside_begin_end_is_noop(self):
+        alloc = FakeAllocator()
+        with profiler(True), alloc.patched():
+            with extend_mem_profile.phase("attn"):
+                alloc.alloc(300 * MiB)
+        self.assertEqual(extend_mem_profile._phase_peaks, {})
+        self.assertEqual(alloc.reset_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_mem_forensics.py
+++ b/test/registered/unit/utils/test_mem_forensics.py
@@ -1,0 +1,200 @@
+"""Unit tests for allocator-history forensics gating and dump lifecycle."""
+
+import os
+import pickle
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import mem_forensics
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+LOGGER = "sglang.srt.utils.mem_forensics"
+WITH_HISTORY = {"segments": [], "device_traces": [[{"action": "alloc"}]]}
+NO_HISTORY = {"segments": [], "device_traces": [[], []]}
+
+
+class MemForensicsTest(unittest.TestCase):
+    def setUp(self):
+        mem_forensics._started = False
+        mem_forensics._dumped_tags = set()
+
+    def test_disabled_without_directory(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override(None):
+            with mock.patch.object(
+                torch.cuda.memory, "_record_memory_history"
+            ) as record:
+                mem_forensics.maybe_start_memory_forensics()
+        self.assertFalse(record.called)
+        self.assertFalse(mem_forensics._started)
+
+    def test_start_records_once_with_configured_parameters(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
+            with envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(1234):
+                with (
+                    mock.patch.object(torch.cuda, "is_available", return_value=True),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
+                    mem_forensics.maybe_start_memory_forensics()
+                    mem_forensics.maybe_start_memory_forensics()
+        self.assertEqual(record.call_count, 1)
+        self.assertEqual(record.call_args.kwargs["enabled"], "all")
+        self.assertEqual(record.call_args.kwargs["context"], "all")
+        self.assertEqual(record.call_args.kwargs["stacks"], "python")
+        self.assertEqual(record.call_args.kwargs["max_entries"], 1234)
+        self.assertTrue(mem_forensics._started)
+
+    def test_start_failure_is_contained_and_not_marked_started(self):
+        with envs.SGLANG_MEM_FORENSICS_DIR.override("/tmp/forensics"):
+            with (
+                mock.patch.object(torch.cuda, "is_available", return_value=True),
+                mock.patch.object(
+                    torch.cuda.memory,
+                    "_record_memory_history",
+                    side_effect=RuntimeError("driver"),
+                ),
+            ):
+                mem_forensics.maybe_start_memory_forensics()
+        self.assertFalse(mem_forensics._started)
+
+    def test_dump_writes_one_snapshot_per_tag(self):
+        snapshot = WITH_HISTORY
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=snapshot
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+            names = sorted(os.listdir(out_dir))
+            self.assertEqual(len(names), 2)
+            self.assertEqual(
+                sorted(name.split("-")[2] for name in names),
+                ["corruption", "ready"],
+            )
+            for name in names:
+                self.assertIn(f"pid{os.getpid()}", name)
+                self.assertTrue(name.endswith(".pickle"))
+            with open(os.path.join(out_dir, names[0]), "rb") as file:
+                self.assertEqual(pickle.load(file), snapshot)
+        # History was present, so nothing was re-armed.
+        self.assertFalse(record.called)
+
+    def test_dump_is_noop_before_start(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+
+    def test_failed_dump_never_raises_and_allows_retry(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with mock.patch.object(
+                    torch.cuda.memory,
+                    "_snapshot",
+                    side_effect=RuntimeError("faulted context"),
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+                self.assertEqual(os.listdir(out_dir), [])
+                with mock.patch.object(
+                    torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("corruption")
+            names = os.listdir(out_dir)
+            self.assertEqual(len(names), 1)
+
+    def test_failed_write_leaves_no_partial_file(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                    ),
+                    mock.patch.object(pickle, "dump", side_effect=OSError("disk full")),
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+            self.assertNotIn("ready", mem_forensics._dumped_tags)
+
+    def test_dump_without_history_rearms_and_defers_to_next_request(self):
+        # Sequence from the review: a MEM torch profile ran and stopped the
+        # process-wide recorder, then a retained phase asks for a snapshot.
+        with tempfile.TemporaryDirectory() as out_dir:
+            with (
+                envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir),
+                envs.SGLANG_MEM_FORENSICS_MAX_ENTRIES.override(4321),
+            ):
+                mem_forensics._started = True
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                    self.assertLogs(LOGGER, level="WARNING") as logs,
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
+                # Re-armed with the configured parameters, nothing written,
+                # tag still open.
+                self.assertEqual(record.call_count, 1)
+                self.assertEqual(record.call_args.kwargs["enabled"], "all")
+                self.assertEqual(record.call_args.kwargs["stacks"], "python")
+                self.assertEqual(record.call_args.kwargs["max_entries"], 4321)
+                self.assertEqual(os.listdir(out_dir), [])
+                self.assertNotIn("retained-kda:extend", mem_forensics._dumped_tags)
+                self.assertTrue(any("re-armed" in line for line in logs.output))
+                # The next request for the same tag finds history and writes.
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=WITH_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory, "_record_memory_history"
+                    ) as record,
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("retained-kda:extend")
+                self.assertFalse(record.called)
+                names = os.listdir(out_dir)
+                self.assertEqual(len(names), 1)
+                self.assertIn("retained-kda:extend", names[0])
+            self.assertIn("retained-kda:extend", mem_forensics._dumped_tags)
+
+    def test_rearm_failure_is_contained_and_keeps_tag_open(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            with envs.SGLANG_MEM_FORENSICS_DIR.override(out_dir):
+                mem_forensics._started = True
+                with (
+                    mock.patch.object(
+                        torch.cuda.memory, "_snapshot", return_value=NO_HISTORY
+                    ),
+                    mock.patch.object(
+                        torch.cuda.memory,
+                        "_record_memory_history",
+                        side_effect=RuntimeError("driver"),
+                    ),
+                    self.assertLogs(LOGGER, level="ERROR"),
+                ):
+                    mem_forensics.maybe_dump_memory_forensics("ready")
+            self.assertEqual(os.listdir(out_dir), [])
+            self.assertNotIn("ready", mem_forensics._dumped_tags)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The allocation that fails during an image or long-prompt prefill may follow the operation that consumed the available memory. Whole-forward peaks do not identify that phase.

## Modifications

Add opt-in `SGLANG_EXTEND_MEM_PROFILE=1` counters around multimodal embedding, KDA, KV writes, sparse attention and indexing, with whole-extend peaks and immediate large-delta logging. This PR includes #37169's allocator-history recorder and will be rebased to remove that dependency after it merges.

Record only qualifying eager EXTEND batches with at least 1,024 real tokens. Disabled entry points make no CUDA calls. Diagnostic failures preserve the original exception. Counters cover PyTorch allocator memory; phase deltas are not additive, and profiling assumes serialized forwards on the current device. This diagnoses memory growth; it does not reduce allocations.

## Accuracy Tests

Author CPU validation at `69c59624ad`: 38 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `a60410e873` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

Author CPU tests passed 38 cases across `test_extend_mem_profile.py`, `test_mem_forensics.py`, `test_extend_mem_profile_gate.py` and `test_mm_embed_mapped_embedder.py`. They cover accounting, disabled behavior, snapshot requests, exception cleanup and real call-site placement. GPU profiling hooks were not exercised in this isolated PR test.

## Speed Tests and Profiling

Disabled by default. No disabled-path overhead benchmark was run. Tensor values are unchanged.

## Checklist

- [x] Format changed code and retain CPU regressions.
- [x] Document the stacked dependency and counter limitations.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282223343](https://github.com/sgl-project/sglang/actions/runs/34282223343)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282222494](https://github.com/sgl-project/sglang/actions/runs/34282222494)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282223215](https://github.com/sgl-project/sglang/actions/runs/34282223215)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
