### PR TITLE
Warm up real serving paths before the first user request

### DIFF
--- a/python/sglang/srt/entrypoints/warmup.py
+++ b/python/sglang/srt/entrypoints/warmup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 import tqdm
@@ -125,6 +125,379 @@ async def voice_chat(disaggregation_mode: str, tokenizer_manager: TokenizerManag
             generate_req_input.bootstrap_host = FAKE_BOOTSTRAP_HOST
 
         await tokenizer_manager.generate_request(generate_req_input, None).__anext__()
+
+
+# Concurrent requests per serving_coverage cohort on one DP rank. The cohort
+# exists to drain through every batch size, so it tracks max_running_requests,
+# capped so the warmup stays bounded on deployments that allow hundreds of
+# running requests.
+_SERVING_COVERAGE_MAX_COHORT = 8
+
+# With data parallelism every phase runs once per DP rank (each rank is its own
+# scheduler with its own kernels). Ranks run concurrently in windows of this
+# size so tokenizer-side in-flight requests stay bounded at
+# window * cohort even on wide deployments.
+_SERVING_COVERAGE_MAX_CONCURRENT_DP_RANKS = 8
+
+# Longest decode any phase asks for; the prompt budget reserves room for it.
+_SERVING_COVERAGE_MAX_DECODE = 320
+
+_SERVING_COVERAGE_TEXT_PROMPTS = [
+    "The history of the Roman Empire begins with the founding of",
+    "In Python, a list comprehension is a compact way to",
+    "Photosynthesis is the process by which plants convert",
+    "To make a simple tomato sauce, start by heating olive oil and",
+    "The three laws of motion formulated by Newton describe how",
+    "A binary search tree is a data structure in which each node",
+    "The water cycle describes how water evaporates from the surface,",
+    "Machine learning models are trained by adjusting parameters to",
+]
+
+_SERVING_COVERAGE_SAMPLING_PROMPTS = [
+    "Write two sentences about the ocean at night.",
+    "List three uses for a paperclip.",
+    "Describe a quiet morning in a small town.",
+    "Give a short tip for learning a new language.",
+]
+
+# Non-greedy sampling paths: top-p, top-k, min-p and a penalizer.
+_SERVING_COVERAGE_SAMPLING_VARIANTS = [
+    {"temperature": 0.8, "top_p": 0.95},
+    {"temperature": 1.0, "top_p": 0.9, "top_k": 40},
+    {"temperature": 0.7, "top_k": 20, "min_p": 0.05},
+    {"temperature": 0.6, "top_p": 0.95, "repetition_penalty": 1.05},
+]
+
+
+def _serving_coverage_budget(max_req_input_len: Optional[int]):
+    """Prompt and decode token budgets for one request, ``(max_prompt, max_decode)``.
+
+    ``max_req_input_len`` is the engine's input limit; prompt plus decode
+    never exceed it: the prompt budget reserves the decode budget and, when
+    the limit leaves room, 64 tokens of headroom for the chat template. Any
+    positive limit clamps; a short-context model gets shorter prompts and
+    shorter decodes, never unclamped requests. ``None`` (limit unknown)
+    disables clamping; the real ``TokenizerManager`` always publishes the
+    limit.
+    """
+    limit = int(max_req_input_len or 0)
+    if limit <= 0:
+        return None, _SERVING_COVERAGE_MAX_DECODE
+    if limit >= 1024:
+        max_decode = _SERVING_COVERAGE_MAX_DECODE
+    else:
+        max_decode = max(limit // 4, 1)
+    headroom = 64 if limit >= 256 else 0
+    max_prompt = max(limit - max_decode - headroom, 1)
+    return max_prompt, max_decode
+
+
+async def _gather_all(coros):
+    """Run every coroutine to completion, then raise the first failure.
+
+    ``asyncio.gather`` alone re-raises the first exception while its siblings
+    keep running; a phase that "failed" would then return with requests still
+    in flight, and anything armed after the phase (the serving-started mark)
+    would see their kernel loads as late. Waiting for all of them keeps a
+    phase's completion meaningful.
+    """
+    import asyncio
+
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    failures = [r for r in results if isinstance(r, BaseException)]
+    if failures:
+        if len(failures) > 1:
+            logger.debug(
+                "serving_coverage: %d of %d requests failed; first: %r",
+                len(failures),
+                len(results),
+                failures[0],
+            )
+        raise failures[0]
+
+
+def _serving_coverage_phases(
+    disaggregation_mode: str, tokenizer_manager: TokenizerManager
+):
+    """Build the serving_coverage phases as ``(name, coroutine function)`` pairs.
+
+    Every phase issues genuine requests through ``generate_request`` and
+    drains them, so the specializations loaded are exactly the ones serving
+    will use. Phase order matters: the greedy phases come first so the
+    sampling phase only adds the sampling kernels on top of already-loaded
+    decode shapes. With ``dp_size > 1`` each phase body runs once per DP
+    rank (``routed_dp_rank``), ranks concurrently in bounded windows, so
+    every rank sees the same shapes a single-rank deployment would.
+    """
+    import itertools
+
+    from sglang.srt.runtime_context import get_parallel, get_schedule
+
+    schedule = get_schedule()
+    cap = _SERVING_COVERAGE_MAX_COHORT
+    max_running = max(1, min(int(schedule.max_running_requests or cap), cap))
+    chunk = int(schedule.chunked_prefill_size or 0)
+    if chunk <= 0:
+        chunk = 4096
+    dp_size = int(get_parallel().dp_size or 1)
+    ranks = list(range(dp_size)) if dp_size > 1 else [None]
+
+    max_prompt, max_decode = _serving_coverage_budget(
+        getattr(tokenizer_manager, "max_req_input_len", None)
+        or getattr(tokenizer_manager, "context_len", None)
+    )
+    if max_prompt is None:
+        logger.warning(
+            "serving_coverage: input limit unknown; prompt lengths are not clamped"
+        )
+    vocab_size = getattr(
+        getattr(tokenizer_manager, "model_config", None), "vocab_size", None
+    )
+    id_high = min(2**16, int(vocab_size)) if vocab_size else 2**16
+    # Text prompts need a tokenizer; --skip-tokenizer-init leaves none. They
+    # are not clamped (the template adds tokens the warmup cannot count), so
+    # they also need a prompt budget that fits a short sentence plus template.
+    has_tokenizer = getattr(tokenizer_manager, "tokenizer", None) is not None
+    text_ok = has_tokenizer and (max_prompt is None or max_prompt >= 32)
+    if has_tokenizer and not text_ok:
+        logger.info(
+            "serving_coverage: skipping text and image phases: the prompt "
+            "budget (%d tokens) is too small for a text prompt",
+            max_prompt,
+        )
+    rooms = itertools.count()
+
+    def _ids(n):
+        n = max(n, 1)
+        if max_prompt is not None:
+            n = min(n, max_prompt)
+        return np.random.randint(id_high, size=[n]).tolist()
+
+    def _request(rank, input_ids=None, text=None, image_data=None, max_new_tokens=48):
+        req = GenerateReqInput(
+            input_ids=input_ids,
+            text=text,
+            image_data=image_data,
+            sampling_params={
+                "max_new_tokens": min(max_new_tokens, max_decode),
+                "temperature": 0.0,
+                "ignore_eos": True,
+            },
+        )
+        if rank is not None:
+            req.routed_dp_rank = rank
+        if disaggregation_mode != "null":
+            # Distinct rooms: cohort requests are in flight concurrently.
+            req.bootstrap_room = next(rooms)
+            req.bootstrap_host = FAKE_BOOTSTRAP_HOST
+        return req
+
+    async def _run(req):
+        async for _ in tokenizer_manager.generate_request(req, None):
+            pass
+
+    async def _gather(reqs):
+        await _gather_all(_run(r) for r in reqs)
+
+    def _per_rank(body):
+        """Wrap ``body(rank)`` so the phase covers every DP rank."""
+
+        async def phase():
+            window = _SERVING_COVERAGE_MAX_CONCURRENT_DP_RANKS
+            for start in range(0, len(ranks), window):
+                await _gather_all(body(r) for r in ranks[start : start + window])
+
+        return phase
+
+    def _fits(tokens):
+        return max_prompt is None or tokens <= max_prompt
+
+    phases = []
+
+    async def _cohort(rank):
+        # Staggered decode lengths so the requests finish at different steps
+        # and the running batch shrinks one request at a time; staggered
+        # prompt lengths straddle the chunk boundary so chunked prefills
+        # coexist with decode.
+        await _gather(
+            _request(
+                rank,
+                input_ids=_ids(chunk // 2 + (chunk // max_running) * i + 64 * i),
+                max_new_tokens=32 + 40 * i,
+            )
+            for i in range(max_running)
+        )
+
+    phases.append(("cohort", _per_rank(_cohort)))
+
+    if _fits(chunk + 64):
+
+        async def _cold_cohort(rank):
+            # Every request longer than one chunk, so the number of concurrent
+            # multi-chunk extends reaches max_running.
+            await _gather(
+                _request(
+                    rank,
+                    input_ids=_ids(chunk + 64 + 256 * i),
+                    max_new_tokens=16 + 24 * i,
+                )
+                for i in range(max_running)
+            )
+
+        phases.append(("cold-cohort", _per_rank(_cold_cohort)))
+    else:
+        logger.info(
+            "serving_coverage: skipping cold-cohort phase: prompts are clamped "
+            "to %d tokens, which cannot exceed one chunked-prefill chunk (%d)",
+            max_prompt,
+            chunk,
+        )
+
+    chunk_lengths = [
+        tokens
+        for tokens in (chunk, chunk + 64, 2 * chunk, 2 * chunk + 64, 3 * chunk + 64)
+        if _fits(tokens)
+    ]
+    if chunk_lengths:
+
+        async def _chunk_multiples(rank):
+            # Exact chunk multiples and one-block-past-a-multiple, alone.
+            for tokens in chunk_lengths:
+                await _run(_request(rank, input_ids=_ids(tokens), max_new_tokens=4))
+
+        phases.append(("chunk-multiples", _per_rank(_chunk_multiples)))
+    else:
+        logger.info(
+            "serving_coverage: skipping chunk-multiples phase: prompts are "
+            "clamped to %d tokens, below one chunked-prefill chunk (%d)",
+            max_prompt,
+            chunk,
+        )
+
+    async def _short_prompts(rank):
+        # Chat-turn sized prompts, alone and as a cohort, plus one long decode.
+        for tokens in (16, 48, 128, 320, 768):
+            await _run(_request(rank, input_ids=_ids(tokens), max_new_tokens=16))
+        await _gather(
+            _request(rank, input_ids=_ids(24 + 40 * i), max_new_tokens=24 + 16 * i)
+            for i in range(max_running)
+        )
+        await _run(_request(rank, input_ids=_ids(32), max_new_tokens=256))
+
+    phases.append(("short-prompts", _per_rank(_short_prompts)))
+
+    if text_ok:
+
+        async def _natural_text(rank):
+            # Random token ids rarely yield accepted speculative drafts, so
+            # the verify shapes that accepted drafts produce are left to real
+            # text; natural prompts exercise the drafter on text it can
+            # predict.
+            prompts = _SERVING_COVERAGE_TEXT_PROMPTS
+            for text in prompts[:2]:
+                await _run(_request(rank, text=text, max_new_tokens=192))
+            await _gather(
+                _request(
+                    rank,
+                    text=prompts[(2 + i) % len(prompts)],
+                    max_new_tokens=96 + 32 * i,
+                )
+                for i in range(max_running)
+            )
+
+        phases.append(("natural-text", _per_rank(_natural_text)))
+
+    async def _sampling(rank):
+        # The phases above decode greedily; the sampling kernels are built or
+        # loaded on the first non-greedy request otherwise.
+        prompts = _SERVING_COVERAGE_SAMPLING_PROMPTS
+        variants = _SERVING_COVERAGE_SAMPLING_VARIANTS
+
+        def _sampled(i, max_new_tokens):
+            if text_ok:
+                req = _request(
+                    rank, text=prompts[i % len(prompts)], max_new_tokens=max_new_tokens
+                )
+            else:
+                req = _request(
+                    rank, input_ids=_ids(32 + 8 * i), max_new_tokens=max_new_tokens
+                )
+            req.sampling_params.update(variants[i % len(variants)])
+            return req
+
+        for i in range(len(variants)):
+            await _run(_sampled(i, 48))
+        await _gather(_sampled(i, 40 + 8 * i) for i in range(max_running))
+
+    phases.append(("sampling", _per_rank(_sampling)))
+
+    mm_tokens = getattr(
+        getattr(tokenizer_manager, "mm_processor", None), "mm_tokens", None
+    )
+    image_token = getattr(mm_tokens, "image_token", None)
+    if isinstance(image_token, list):
+        image_token = image_token[0] if image_token else None
+    if image_token and text_ok:
+
+        async def _image(rank):
+            import base64
+            import io
+
+            from PIL import Image
+
+            buf = io.BytesIO()
+            Image.new("RGB", (64, 64), (128, 64, 32)).save(buf, format="PNG")
+            data_url = (
+                "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+            )
+            await _run(
+                _request(
+                    rank,
+                    text=f"{image_token} Describe the image.",
+                    image_data=[data_url],
+                    max_new_tokens=8,
+                )
+            )
+
+        phases.append(("image", _per_rank(_image)))
+
+    return phases
+
+
+@warmup("serving_coverage")
+async def serving_coverage(
+    disaggregation_mode: str, tokenizer_manager: TokenizerManager
+):
+    """Drive the real serving path before ready so lazy kernel loads land now.
+
+    Triton loads a specialization's cubin at first launch, outside the torch
+    allocator; on a deployment whose pools hold nearly all device memory a
+    first use minutes into serving can fail in ``cuModuleLoadData``.
+    Hand-rolled prewarms miss real specializations, so this warmup issues
+    genuine requests instead (see ``_serving_coverage_phases``):
+
+    * a cohort of up to ``max_running_requests`` concurrent requests with
+      staggered lengths, and a cold cohort with every prompt longer than one
+      chunked-prefill chunk,
+    * single prefills at exact chunk multiples,
+    * short prompts and one long decode,
+    * natural-text prompts (accepted speculative drafts widen verify batches
+      in ways random token ids never do),
+    * non-greedy sampling variants (the sampling kernels are otherwise built
+      on the first sampled request),
+    * one image request when the model is multimodal.
+
+    Prompt and decode lengths are clamped to the engine's input limit; phases
+    whose shapes cannot fit are skipped with a log line. With data
+    parallelism every phase runs once per DP rank. Each phase is best-effort:
+    a failure logs, its requests are still drained, and serving proceeds.
+    """
+    for name, fn in _serving_coverage_phases(disaggregation_mode, tokenizer_manager):
+        try:
+            await fn()
+            logger.info("serving_coverage warmup phase done: %s", name)
+        except Exception:
+            logger.exception("serving_coverage warmup phase failed: %s", name)
 
 
 @warmup("prefill_shapes")

--- a/python/sglang/srt/entrypoints/warmup.py
+++ b/python/sglang/srt/entrypoints/warmup.py
@@ -386,6 +386,29 @@ def _serving_coverage_phases(
 
     phases.append(("short-prompts", _per_rank(_short_prompts)))
 
+    if _fits(chunk + 64):
+
+        async def _cached_prefix(rank):
+            # A completed multi-chunk request publishes recurrent checkpoints.
+            # Reusing it exercises slot copy-on-write, which cold requests and
+            # short natural prompts do not necessarily reach during warmup.
+            prefix = _ids(chunk + 64)
+            await _run(_request(rank, input_ids=list(prefix), max_new_tokens=4))
+            await _run(_request(rank, input_ids=list(prefix), max_new_tokens=4))
+            await _gather(
+                _request(rank, input_ids=list(prefix), max_new_tokens=4)
+                for _ in range(max_running)
+            )
+
+        phases.append(("cached-prefix", _per_rank(_cached_prefix)))
+    else:
+        logger.info(
+            "serving_coverage: skipping cached-prefix phase: prompts are "
+            "clamped to %d tokens, below the checkpoint warmup length (%d + 64)",
+            max_prompt,
+            chunk,
+        )
+
     if text_ok:
 
         async def _natural_text(rank):
@@ -481,6 +504,8 @@ async def serving_coverage(
       chunked-prefill chunk,
     * single prefills at exact chunk multiples,
     * short prompts and one long decode,
+    * completed multi-chunk prefixes reused alone and concurrently (recurrent
+      slot copy-on-write otherwise first runs on a real cached request),
     * natural-text prompts (accepted speculative drafts widen verify batches
       in ways random token ids never do),
     * non-greedy sampling variants (the sampling kernels are otherwise built

--- a/test/registered/unit/entrypoints/test_serving_coverage_warmup.py
+++ b/test/registered/unit/entrypoints/test_serving_coverage_warmup.py
@@ -1,0 +1,476 @@
+"""Unit tests for the serving_coverage warmup, no server, no model."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.entrypoints import warmup as warmup_module
+from sglang.srt.entrypoints.warmup import (
+    _SERVING_COVERAGE_MAX_COHORT,
+    _SERVING_COVERAGE_MAX_DECODE,
+    _SERVING_COVERAGE_SAMPLING_VARIANTS,
+    _gather_all,
+    _serving_coverage_budget,
+    _serving_coverage_phases,
+    _warmup_registry,
+    serving_coverage,
+)
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+MOD = "sglang.srt.entrypoints.warmup"
+CHUNK = 256
+MAX_RUNNING = 3
+# A production-sized input limit: clamping is always on, never binding here.
+INPUT_LIMIT = 65536
+
+
+class FakeTokenizerManager:
+    """Records every request handed to generate_request and its concurrency."""
+
+    def __init__(
+        self,
+        image_token=None,
+        tokenizer=object(),
+        max_req_input_len=INPUT_LIMIT,
+    ):
+        self.max_req_input_len = max_req_input_len
+        self.model_config = SimpleNamespace(vocab_size=32000)
+        self.tokenizer = tokenizer
+        self.mm_processor = (
+            SimpleNamespace(mm_tokens=SimpleNamespace(image_token=image_token))
+            if image_token is not None
+            else None
+        )
+        self.requests = []
+        self.max_in_flight = 0
+        self._in_flight = 0
+
+    async def generate_request(self, req, request):
+        self.requests.append(req)
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        await asyncio.sleep(0)
+        self._in_flight -= 1
+        yield {}
+
+
+def _phases(tokenizer_manager, disaggregation_mode="null"):
+    return dict(_serving_coverage_phases(disaggregation_mode, tokenizer_manager))
+
+
+def _prompt_lens(requests):
+    return [len(r.input_ids) for r in requests]
+
+
+class _PublishedConfig(unittest.IsolatedAsyncioTestCase):
+    """The warmup reads the published schedule/parallel bags, like production."""
+
+    max_running_requests = MAX_RUNNING
+    chunked_prefill_size = CHUNK
+    dp_size = 1
+
+    def setUp(self):
+        override = get_context().override_server_args(
+            max_running_requests=self.max_running_requests,
+            chunked_prefill_size=self.chunked_prefill_size,
+            dp_size=self.dp_size,
+        )
+        override.install()
+        self.addCleanup(override.restore)
+
+
+class TestServingCoveragePhases(_PublishedConfig):
+    def test_is_registered_under_its_warmup_name(self):
+        self.assertIs(_warmup_registry["serving_coverage"], serving_coverage)
+
+    def test_phase_families_and_order(self):
+        names = [
+            name for name, _ in _serving_coverage_phases("null", FakeTokenizerManager())
+        ]
+        self.assertEqual(
+            names,
+            [
+                "cohort",
+                "cold-cohort",
+                "chunk-multiples",
+                "short-prompts",
+                "natural-text",
+                "sampling",
+            ],
+        )
+
+    async def test_cohort_issues_max_running_requests_concurrently(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+
+        self.assertEqual(len(tm.requests), MAX_RUNNING)
+        self.assertEqual(tm.max_in_flight, MAX_RUNNING)
+        self.assertEqual(len(set(_prompt_lens(tm.requests))), MAX_RUNNING)
+        self.assertEqual(
+            len({r.sampling_params["max_new_tokens"] for r in tm.requests}),
+            MAX_RUNNING,
+        )
+        for req in tm.requests:
+            self.assertEqual(req.sampling_params["temperature"], 0.0)
+            self.assertTrue(req.sampling_params["ignore_eos"])
+            self.assertIsNone(req.routed_dp_rank)
+
+    async def test_cold_cohort_prompts_all_exceed_one_chunk(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cold-cohort"]()
+
+        self.assertEqual(len(tm.requests), MAX_RUNNING)
+        self.assertEqual(tm.max_in_flight, MAX_RUNNING)
+        for n in _prompt_lens(tm.requests):
+            self.assertGreater(n, CHUNK)
+
+    async def test_chunk_multiple_prefills_present(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["chunk-multiples"]()
+
+        lens = _prompt_lens(tm.requests)
+        for expected in (CHUNK, 2 * CHUNK, CHUNK + 64, 2 * CHUNK + 64, 3 * CHUNK + 64):
+            self.assertIn(expected, lens)
+        # Single prefills, one at a time.
+        self.assertEqual(tm.max_in_flight, 1)
+
+    async def test_short_prompts_and_one_long_decode(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["short-prompts"]()
+
+        lens = _prompt_lens(tm.requests)
+        for expected in (16, 48, 128, 320, 768):
+            self.assertIn(expected, lens)
+        self.assertEqual(tm.max_in_flight, MAX_RUNNING)
+        long_decodes = [
+            r for r in tm.requests if r.sampling_params["max_new_tokens"] == 256
+        ]
+        self.assertEqual(len(long_decodes), 1)
+
+    async def test_natural_text_requests_carry_text(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["natural-text"]()
+
+        self.assertGreaterEqual(len(tm.requests), 1 + MAX_RUNNING)
+        for req in tm.requests:
+            self.assertIsNone(req.input_ids)
+            self.assertIsInstance(req.text, str)
+            self.assertTrue(req.text)
+
+    def test_natural_text_is_skipped_without_a_tokenizer(self):
+        phases = _phases(FakeTokenizerManager(tokenizer=None))
+        self.assertNotIn("natural-text", phases)
+        self.assertIn("sampling", phases)
+
+    async def test_sampling_phase_sets_non_greedy_params(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["sampling"]()
+
+        self.assertEqual(
+            len(tm.requests), len(_SERVING_COVERAGE_SAMPLING_VARIANTS) + MAX_RUNNING
+        )
+        for req in tm.requests:
+            params = req.sampling_params
+            self.assertGreater(params["temperature"], 0.0)
+            self.assertTrue(
+                {"top_p", "top_k", "min_p"} & set(params),
+                f"no sampling knob in {params}",
+            )
+
+    async def test_sampling_phase_falls_back_to_ids_without_a_tokenizer(self):
+        tm = FakeTokenizerManager(tokenizer=None)
+        await _phases(tm)["sampling"]()
+        for req in tm.requests:
+            self.assertIsNone(req.text)
+            self.assertIsNotNone(req.input_ids)
+
+    async def test_image_phase_only_when_the_processor_has_an_image_token(self):
+        self.assertNotIn("image", _phases(FakeTokenizerManager()))
+        self.assertNotIn("image", _phases(FakeTokenizerManager(image_token="")))
+
+        tm = FakeTokenizerManager(image_token="<image>")
+        phases = _phases(tm)
+        self.assertIn("image", phases)
+        await phases["image"]()
+
+        self.assertEqual(len(tm.requests), 1)
+        req = tm.requests[0]
+        self.assertIn("<image>", req.text)
+        self.assertEqual(len(req.image_data), 1)
+        self.assertTrue(req.image_data[0].startswith("data:image/png;base64,"))
+
+    async def test_image_token_list_uses_its_first_entry(self):
+        tm = FakeTokenizerManager(image_token=["<img>", "<img_end>"])
+        await _phases(tm)["image"]()
+        self.assertIn("<img>", tm.requests[0].text)
+
+    async def test_disaggregation_gives_concurrent_requests_distinct_rooms(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm, disaggregation_mode="prefill")["cohort"]()
+
+        rooms = [r.bootstrap_room for r in tm.requests]
+        self.assertEqual(len(set(rooms)), MAX_RUNNING)
+        for req in tm.requests:
+            self.assertEqual(req.bootstrap_host, FAKE_BOOTSTRAP_HOST)
+
+    async def test_token_ids_stay_inside_the_vocabulary(self):
+        tm = FakeTokenizerManager()
+        tm.model_config.vocab_size = 100
+        await _phases(tm)["short-prompts"]()
+        for req in tm.requests:
+            self.assertLess(max(req.input_ids), 100)
+
+    async def test_a_failing_phase_does_not_abort_the_others(self):
+        ran = []
+
+        async def boom():
+            raise RuntimeError("phase failure")
+
+        async def ok():
+            ran.append("ok")
+
+        with patch(
+            f"{MOD}._serving_coverage_phases",
+            return_value=[("boom", boom), ("ok", ok)],
+        ):
+            # The module names its logger by file path, so pass the object.
+            with self.assertLogs(warmup_module.logger, level="ERROR") as cm:
+                await serving_coverage("null", FakeTokenizerManager())
+
+        self.assertEqual(ran, ["ok"])
+        self.assertTrue(any("boom" in line for line in cm.output))
+
+    async def test_full_warmup_drives_every_phase(self):
+        tm = FakeTokenizerManager(image_token="<image>")
+        await serving_coverage("null", tm)
+
+        self.assertTrue(any(r.image_data for r in tm.requests))
+        self.assertTrue(any(r.text and not r.image_data for r in tm.requests))
+        self.assertTrue(any(r.sampling_params["temperature"] > 0 for r in tm.requests))
+        self.assertEqual(tm.max_in_flight, MAX_RUNNING)
+        for req in tm.requests:
+            if req.input_ids is not None:
+                self.assertLessEqual(len(req.input_ids), INPUT_LIMIT - 384)
+            self.assertLessEqual(
+                req.sampling_params["max_new_tokens"], _SERVING_COVERAGE_MAX_DECODE
+            )
+
+
+class TestCohortCap(_PublishedConfig):
+    max_running_requests = 1000
+
+    async def test_cohort_is_capped(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+        self.assertEqual(len(tm.requests), _SERVING_COVERAGE_MAX_COHORT)
+
+
+class TestUnresolvedMaxRunning(_PublishedConfig):
+    max_running_requests = None
+
+    async def test_unresolved_max_running_requests_uses_the_cap(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+        self.assertEqual(len(tm.requests), _SERVING_COVERAGE_MAX_COHORT)
+
+
+class TestGatherWaitsForSiblings(unittest.IsolatedAsyncioTestCase):
+    async def test_a_failing_request_does_not_return_before_its_peers(self):
+        finished = []
+
+        async def fails_at_once():
+            raise ValueError("rejected")
+
+        async def slow(i):
+            for _ in range(3):
+                await asyncio.sleep(0)
+            finished.append(i)
+
+        with self.assertRaisesRegex(ValueError, "rejected"):
+            await _gather_all([fails_at_once(), slow(1), slow(2), slow(3)])
+
+        # The failure surfaced only after every sibling had drained.
+        self.assertEqual(sorted(finished), [1, 2, 3])
+
+    async def test_all_successes_raise_nothing(self):
+        async def ok():
+            return 1
+
+        await _gather_all([ok(), ok()])
+
+
+class TestPromptClamping(_PublishedConfig):
+    def test_budget_reserves_the_decode_length(self):
+        self.assertEqual(_serving_coverage_budget(None), (None, 320))
+        self.assertEqual(_serving_coverage_budget(0), (None, 320))
+        self.assertEqual(_serving_coverage_budget(65536), (65536 - 384, 320))
+        self.assertEqual(_serving_coverage_budget(1024), (640, 320))
+        # Below 1024 the decode shrinks too, so prompt + decode still fits.
+        self.assertEqual(_serving_coverage_budget(512), (320, 128))
+        # Below 256 there is no template headroom; the budgets still fit.
+        self.assertEqual(_serving_coverage_budget(64), (48, 16))
+        self.assertEqual(_serving_coverage_budget(8), (6, 2))
+        self.assertEqual(_serving_coverage_budget(4), (3, 1))
+        self.assertEqual(_serving_coverage_budget(1), (1, 1))
+        for limit in (2, 4, 8, 64, 200, 255, 256, 512, 1023, 1024, 4096):
+            max_prompt, max_decode = _serving_coverage_budget(limit)
+            self.assertGreaterEqual(max_prompt, 1, limit)
+            self.assertGreaterEqual(max_decode, 1, limit)
+            self.assertLessEqual(max_prompt + max_decode, limit, limit)
+
+    async def test_tiny_limits_skip_text_phases_and_still_fit(self):
+        # Text and image prompts are not clamped (the template adds tokens the
+        # warmup cannot count), so below a 32-token prompt budget those phases
+        # are skipped and the sampling phase falls back to token ids.
+        for limit in (4, 8, 24):
+            with self.subTest(limit=limit):
+                tm = FakeTokenizerManager(max_req_input_len=limit, image_token="<img>")
+                max_prompt, max_decode = _serving_coverage_budget(limit)
+                with self.assertLogs(warmup_module.logger, level="INFO") as cm:
+                    phases = _phases(tm)
+                self.assertNotIn("natural-text", phases)
+                self.assertNotIn("image", phases)
+                self.assertIn("sampling", phases)
+                self.assertTrue(any("text and image" in line for line in cm.output))
+                await serving_coverage("null", tm)
+                self.assertTrue(tm.requests)
+                for req in tm.requests:
+                    self.assertIsNone(req.text)
+                    self.assertGreaterEqual(len(req.input_ids), 1)
+                    self.assertLessEqual(len(req.input_ids), max_prompt)
+                    self.assertLessEqual(
+                        len(req.input_ids) + req.sampling_params["max_new_tokens"],
+                        limit,
+                    )
+
+    async def test_a_32_token_budget_keeps_text_phases(self):
+        tm = FakeTokenizerManager(max_req_input_len=64, image_token="<img>")
+        phases = _phases(tm)
+        self.assertIn("natural-text", phases)
+        self.assertIn("image", phases)
+
+    async def test_prompts_and_decodes_are_clamped_at_1024(self):
+        tm = FakeTokenizerManager(max_req_input_len=1024)
+        max_prompt, max_decode = _serving_coverage_budget(1024)
+        phases = _phases(tm)
+        # chunk (256) + 64 fits in 640, so the multi-chunk phases survive.
+        self.assertIn("cold-cohort", phases)
+        self.assertIn("chunk-multiples", phases)
+
+        await serving_coverage("null", tm)
+
+        self.assertTrue(tm.requests)
+        for req in tm.requests:
+            if req.input_ids is not None:
+                self.assertLessEqual(len(req.input_ids), max_prompt)
+            self.assertLessEqual(req.sampling_params["max_new_tokens"], max_decode)
+            self.assertLessEqual(
+                len(req.input_ids or []) + req.sampling_params["max_new_tokens"],
+                1024,
+            )
+        # Something was actually clamped: the 768-token short prompt and the
+        # 3*chunk+64 = 832 prefill both exceed the 640 budget.
+        self.assertIn(max_prompt, _prompt_lens(r for r in tm.requests if r.input_ids))
+
+    async def test_a_zero_input_limit_never_means_unclamped(self):
+        # A limit that leaves no headroom above 1024 used to compute a prompt
+        # budget of 0 and read it as "do not clamp".
+        tm = FakeTokenizerManager(max_req_input_len=1024)
+        await _phases(tm)["short-prompts"]()
+        self.assertTrue(all(len(r.input_ids) <= 640 for r in tm.requests))
+
+
+class TestOneTokenChunk(_PublishedConfig):
+    chunked_prefill_size = 1
+
+    async def test_no_request_has_an_empty_prompt(self):
+        # chunk // 2 is 0 with a one-token chunk; every prompt still has a token.
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+        self.assertTrue(tm.requests)
+        self.assertTrue(all(len(r.input_ids) >= 1 for r in tm.requests))
+
+
+class TestPhasesThatCannotFitAreSkipped(_PublishedConfig):
+    chunked_prefill_size = 4096
+
+    def test_multi_chunk_phases_are_skipped_with_a_reason(self):
+        tm = FakeTokenizerManager(max_req_input_len=1024)
+        with self.assertLogs(warmup_module.logger, level="INFO") as cm:
+            phases = _phases(tm)
+        self.assertNotIn("cold-cohort", phases)
+        self.assertNotIn("chunk-multiples", phases)
+        self.assertIn("cohort", phases)
+        self.assertIn("short-prompts", phases)
+        skipped = [line for line in cm.output if "skipping" in line]
+        self.assertEqual(len(skipped), 2)
+        self.assertTrue(all("640" in line and "4096" in line for line in skipped))
+
+    async def test_remaining_phases_still_fit(self):
+        tm = FakeTokenizerManager(max_req_input_len=1024)
+        await _phases(tm)["cohort"]()
+        for req in tm.requests:
+            self.assertLessEqual(len(req.input_ids), 640)
+
+
+class TestDataParallelCoverage(_PublishedConfig):
+    dp_size = 3
+
+    async def test_every_dp_rank_gets_the_full_cohort(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+
+        self.assertEqual(len(tm.requests), self.dp_size * MAX_RUNNING)
+        by_rank = {}
+        for req in tm.requests:
+            by_rank.setdefault(req.routed_dp_rank, []).append(req)
+        self.assertEqual(set(by_rank), set(range(self.dp_size)))
+        for rank, reqs in by_rank.items():
+            self.assertEqual(len(reqs), MAX_RUNNING, rank)
+            self.assertEqual(len(set(_prompt_lens(reqs))), MAX_RUNNING, rank)
+        # Ranks run concurrently: the whole fan-out is in flight at once.
+        self.assertEqual(tm.max_in_flight, self.dp_size * MAX_RUNNING)
+
+    async def test_single_prefill_phases_stay_alone_per_rank(self):
+        tm = FakeTokenizerManager()
+        await _phases(tm)["chunk-multiples"]()
+        # Concurrency across ranks never exceeds one request per rank.
+        self.assertLessEqual(tm.max_in_flight, self.dp_size)
+        for rank in range(self.dp_size):
+            lens = _prompt_lens(r for r in tm.requests if r.routed_dp_rank == rank)
+            self.assertIn(CHUNK, lens)
+            self.assertIn(2 * CHUNK, lens)
+
+    async def test_sampling_and_short_prompts_cover_every_rank(self):
+        tm = FakeTokenizerManager()
+        phases = _phases(tm)
+        await phases["short-prompts"]()
+        await phases["sampling"]()
+        ranks = {r.routed_dp_rank for r in tm.requests}
+        self.assertEqual(ranks, set(range(self.dp_size)))
+        sampled = [r for r in tm.requests if r.sampling_params["temperature"] > 0]
+        self.assertEqual({r.routed_dp_rank for r in sampled}, set(range(self.dp_size)))
+
+
+class TestWideDataParallelWindows(_PublishedConfig):
+    dp_size = 20
+
+    async def test_ranks_run_in_bounded_windows(self):
+        from sglang.srt.entrypoints.warmup import (
+            _SERVING_COVERAGE_MAX_CONCURRENT_DP_RANKS as WINDOW,
+        )
+
+        tm = FakeTokenizerManager()
+        await _phases(tm)["cohort"]()
+        self.assertEqual(len(tm.requests), self.dp_size * MAX_RUNNING)
+        self.assertEqual({r.routed_dp_rank for r in tm.requests}, set(range(20)))
+        self.assertLessEqual(tm.max_in_flight, WINDOW * MAX_RUNNING)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/test_serving_coverage_warmup.py
+++ b/test/registered/unit/entrypoints/test_serving_coverage_warmup.py
@@ -99,9 +99,34 @@ class TestServingCoveragePhases(_PublishedConfig):
                 "cold-cohort",
                 "chunk-multiples",
                 "short-prompts",
+                "cached-prefix",
                 "natural-text",
                 "sampling",
             ],
+        )
+
+    async def test_cached_prefix_is_published_before_reuse(self):
+        class CacheAwareManager(FakeTokenizerManager):
+            completed = set()
+
+            async def generate_request(self, req, request):
+                prefix = tuple(req.input_ids)
+                if self.requests:
+                    assert prefix in self.completed, (
+                        "reuse started before prefill drained"
+                    )
+                async for response in super().generate_request(req, request):
+                    yield response
+                self.completed.add(prefix)
+
+        tm = CacheAwareManager()
+        await _phases(tm)["cached-prefix"]()
+        self.assertEqual(len(tm.requests), 2 + MAX_RUNNING)
+        self.assertEqual(len(tm.completed), 1)
+        self.assertEqual(len(next(iter(tm.completed))), CHUNK + 64)
+        self.assertEqual(tm.max_in_flight, MAX_RUNNING)
+        self.assertEqual(
+            len({id(req.input_ids) for req in tm.requests}), len(tm.requests)
         )
 
     async def test_cohort_issues_max_running_requests_concurrently(self):
@@ -405,10 +430,11 @@ class TestPhasesThatCannotFitAreSkipped(_PublishedConfig):
             phases = _phases(tm)
         self.assertNotIn("cold-cohort", phases)
         self.assertNotIn("chunk-multiples", phases)
+        self.assertNotIn("cached-prefix", phases)
         self.assertIn("cohort", phases)
         self.assertIn("short-prompts", phases)
         skipped = [line for line in cm.output if "skipping" in line]
-        self.assertEqual(len(skipped), 2)
+        self.assertEqual(len(skipped), 3)
         self.assertTrue(all("640" in line and "4096" in line for line in skipped))
 
     async def test_remaining_phases_still_fit(self):


### PR DESCRIPTION
## Motivation

A server can report ready before it has compiled the kernels needed for ordinary sampled chats, larger prompt batches or images. The first matching user request then pays the compilation or device-load cost. The general warmup does not cover all of these request shapes.

This PR adds an opt-in startup warmup that exercises those serving paths before readiness. An author-observed GLM-5.3-Flash deployment spent about 75 seconds compiling FlashInfer sampling during its first sampled chat; that observation motivates the sampling phase, but no GPU receipt for this PR revision is attached.

## Modifications

`--warmups serving_coverage` sends and fully consumes requests through the tokenizer manager: concurrent cohorts, cold prompts crossing prefill-chunk boundaries, short and natural-text prompts, a completed cache seed followed by replay and concurrent prefix reuse, non-greedy sampling variants, and a generated image when a compatible processor is available. Natural text exercises speculative decoding shapes that random token IDs may not reach.

Token-ID requests respect the configured prompt/decode budget and vocabulary bounds. DP requests are routed to each rank in bounded windows; disaggregated requests receive distinct bootstrap rooms. Text and image inputs are not token-count-clamped. Phase failures are logged and later phases continue, so this is warmup coverage, not a readiness correctness gate. No scheduler, model-forward or kernel implementation changes.

## Accuracy Tests

Author CPU validation at `d6b59f4f9f`: 33 tests and 3 subtests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `805c1fd55d` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

The CPU tests replace request generation with recording async iterators. They verify each phase's requests are consumed, cohort concurrency and limits, chunk-relative lengths, natural-text/image eligibility, sampling parameters and token-ID fallback, DP routing, unique bootstrap rooms, budget handling, failure propagation, and seed-before-replay ordering with independent request token lists.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/entrypoints/test_serving_coverage_warmup.py
```

This validates request construction and orchestration; it does not demonstrate complete kernel coverage on every model or GPU.

## Speed Tests and Profiling

Opt-in only. Compilation and warmup work move into startup; startup duration for this revision was not measured. The request-handler code is unchanged.

## Checklist

- [x] Format changed code and add CPU regression coverage.
- [ ] Attach exact-revision GPU warmup and startup-duration measurements.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282223153](https://github.com/sgl-project/sglang/actions/runs/34282223153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282223152](https://github.com/sgl-project/sglang/actions/runs/34282223152)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282223176](https://github.com/sgl-project/sglang/actions/runs/34282223176)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
