### PR TITLE
[Docs] Remove stale examples from runtime README

### DIFF
--- a/examples/runtime/README.md
+++ b/examples/runtime/README.md
@@ -6,8 +6,6 @@ The below examples will mostly need you to start a server in a separate terminal
 
 * `lora.py`: An example how to use LoRA adapters.
 * `multimodal_embedding.py`: An example how perform [multi modal embedding](https://huggingface.co/Alibaba-NLP/gme-Qwen2-VL-2B-Instruct).
-* `openai_batch_chat.py`: An example how to process batch requests for chat completions.
-* `openai_batch_complete.py`: An example how to process batch requests for text completions.
 * **`openai_chat_with_response_prefill.py`**:
   An example that demonstrates how to [prefill a response](https://eugeneyan.com/writing/prompting/#prefill-claudes-responses) using the OpenAI API by enabling the `continue_final_message` parameter.
   When enabled, the final (partial) assistant message is removed and its content is used as a prefill so that the model continues that message rather  than starting a new turn. See [Anthropic's prefill example](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response#example-structured-data-extraction-with-prefilling) for more context.
@@ -22,7 +20,6 @@ The `engine` folder contains that examples that show how to use [Offline Engine 
 * `embedding.py`: An example how to extract embeddings.
 * `launch_engine.py`: An example how to launch the Engine.
 * `offline_batch_inference_eagle.py`: An example how to perform speculative decoding using [EAGLE](https://docs.sglang.io/advanced_features/speculative_decoding.html).
-* `offline_batch_inference_torchrun.py`: An example how to perform inference using [torchrun](https://pytorch.org/docs/stable/elastic/run.html).
 * `offline_batch_inference_vlm.py`: An example how to use VLMs with the engine.
 * `offline_batch_inference.py`: An example how to use the engine to perform inference on a batch of examples.
 
@@ -36,7 +33,6 @@ The `hidden_states` folder contains examples on how to extract hidden states usi
 ## Multimodal
 
 SGLang supports multimodal inputs for various model architectures. The `multimodal` folder contains examples showing how to use urls, files or encoded data to make requests to multimodal models. Examples include querying the [Llava-OneVision](multimodal/llava_onevision_server.py) model (image, multi-image, video), Llava-backed [Qwen-Llava](multimodal/qwen_llava_server.py) and [Llama3-Llava](multimodal/llama3_llava_server.py) models (image, multi-image), and Mistral AI's [Pixtral](multimodal/pixtral_server.py) (image, multi-image).
-
 
 ## Token In, Token Out
 


### PR DESCRIPTION
## Summary

`examples/runtime/README.md` still listed three example scripts that are no longer present on `main`:

- `openai_batch_chat.py`
- `openai_batch_complete.py`
- `offline_batch_inference_torchrun.py`

A recursive Contents/tree listing of `examples/runtime/` on current `main` has no matches for those paths (they are not under another directory either). This PR drops those stale README entries so the documented examples match the tree.

## Test plan

- [x] Confirmed the three paths are absent via `git/trees?recursive=1` on `sgl-project/sglang@main`
- [x] Remaining README entries still resolve under `examples/runtime/` / `engine/` / `hidden_states/` / `multimodal/` / `token_in_token_out/`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33591919820](https://github.com/sgl-project/sglang/actions/runs/33591919820)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33591919673](https://github.com/sgl-project/sglang/actions/runs/33591919673)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->