### PR TITLE
[Docs] Fix --log-requests-level typo in observability docs

### DIFF
--- a/docs/docs/advanced_features/observability.mdx
+++ b/docs/docs/advanced_features/observability.mdx
@@ -15,7 +15,7 @@ See [Production Metrics](../references/production_metrics) and [Production Reque
 ## Logging
 
 By default, SGLang does not log any request contents. You can log them by using `--log-requests`.
-You can control the verbosity by using `--log-request-level`.
+You can control the verbosity by using `--log-requests-level`.
 See [Logging](./server_arguments#logging) for more details.
 
 You can change verbosity at runtime:


### PR DESCRIPTION
## Summary

`docs/docs/advanced_features/observability.mdx` told users to control request-log verbosity with `--log-request-level`, but the live CLI flag (from `ServerArgs.log_requests_level` in `python/sglang/srt/server_args.py`) is `--log-requests-level`. The same spelling already appears in `docs/docs/advanced_features/server_arguments.mdx` and in the `--log-requests` help text.

`--log-request-level` is not a registered option and is not an unambiguous argparse abbreviation of `--log-requests-level` (several `--log-requests*` flags share the `--log-request` prefix).

This PR updates the observability guide to `--log-requests-level`.

## Test plan

- [x] Confirmed `log_requests_level` → `--log-requests-level` in `server_args.py` on `main`
- [x] Confirmed `server_arguments.mdx` already documents `--log-requests-level`
- [x] Confirmed `--log-request-level` does not uniquely abbreviate any live flag
- [x] Diff is a one-line docs typo fix in `observability.mdx` only

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33593701090](https://github.com/sgl-project/sglang/actions/runs/33593701090)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33593700945](https://github.com/sgl-project/sglang/actions/runs/33593700945)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->