### PR TITLE
Converge the two SWA predicates, and stop conditioning the capture sink on the pool

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1192,11 +1192,14 @@ class AiterAttnBackend(AttentionBackend):
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
             self.cuda_graph_swa_out_cache_loc[n:].zero_()
-            self.cuda_graph_swa_out_cache_loc[:n].copy_(
-                self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                    forward_batch.out_cache_loc
+            if in_capture:
+                self.cuda_graph_swa_out_cache_loc[:n].zero_()
+            else:
+                self.cuda_graph_swa_out_cache_loc[:n].copy_(
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        forward_batch.out_cache_loc
+                    )
                 )
-            )
             self.forward_metadata.swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[
                 :n
             ]

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -494,6 +494,18 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info = forward_batch.spec_info
         out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
 
+        # Refill the SWA write-target buffer (bound as a metadata view in
+        # _bind_metadata_buffers) from the live out_cache_loc before replay.
+        if self.use_sliding_window_kv_pool and out_cache_loc is not None:
+            n = out_cache_loc.shape[0]
+            self.cuda_graph_swa_out_cache_loc[n:].zero_()
+            if in_capture:
+                self.cuda_graph_swa_out_cache_loc[:n].zero_()
+            else:
+                self.cuda_graph_swa_out_cache_loc[:n].copy_(
+                    self.kv_index_translator.sliding_window_write_loc_for(out_cache_loc)
+                )
+
         if in_capture:
             num_tokens = forward_batch.positions.numel()
             seq_lens_cpu = seq_lens.cpu()
@@ -537,7 +549,6 @@ class FlashAttentionBackend(AttentionBackend):
                 spec_info=spec_info,
                 seq_lens_cpu=seq_lens_cpu,
                 out_cache_loc=out_cache_loc,
-                in_capture=True,
             )
 
             if forward_mode.is_decode_or_idle() and spec_info is None:
@@ -2754,7 +2765,6 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: Optional[torch.Tensor] = None,
-        in_capture: bool = False,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
@@ -2771,20 +2781,6 @@ class FlashAttentionBackend(AttentionBackend):
         device = seq_lens.device
         metadata = None
         metadata_expand = None
-
-        # Refill the SWA write-target buffer (bound as a metadata view in
-        # _bind_metadata_buffers) from the live out_cache_loc before replay.
-        if self.use_sliding_window_kv_pool and out_cache_loc is not None:
-            n = out_cache_loc.shape[0]
-            self.cuda_graph_swa_out_cache_loc[n:].zero_()
-            if in_capture and self.kv_index_translator.is_translating:
-                # A capture batch never went through `init_new`, so there is no
-                # rebound write loc; zeros are the page-0 sink.
-                self.cuda_graph_swa_out_cache_loc[:n].zero_()
-            else:
-                self.cuda_graph_swa_out_cache_loc[:n].copy_(
-                    self.kv_index_translator.sliding_window_write_loc_for(out_cache_loc)
-                )
 
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -842,10 +842,7 @@ class FlashInferAttnBackend(AttentionBackend):
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
             self.cuda_graph_swa_out_cache_loc[n:].zero_()
-            if in_capture and self.kv_index_translator.is_translating:
-                # A runner-built capture batch never went through `init_new`,
-                # so there is no prepared write loc to resolve -- and zeros are the
-                # page-0 sink in every id space. Replay refills below.
+            if in_capture:
                 self.cuda_graph_swa_out_cache_loc[:n].zero_()
             else:
                 self.cuda_graph_swa_out_cache_loc[:n].copy_(

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -675,7 +675,9 @@ class TritonAttnBackend(AttentionBackend):
             out_cache_loc_full_physical = self._fill_cuda_graph_write_locs(
                 forward_batch, bs
             )
-            swa_out_cache_loc = self._fill_cuda_graph_swa_out_cache_loc(forward_batch)
+            swa_out_cache_loc = self._fill_cuda_graph_swa_out_cache_loc(
+                forward_batch, in_capture=True
+            )
             self.forward_metadata = self._build_cuda_graph_forward_metadata(
                 bs,
                 forward_mode,
@@ -696,7 +698,7 @@ class TritonAttnBackend(AttentionBackend):
             self._fill_cuda_graph_swa_out_cache_loc(forward_batch)
 
     def _fill_cuda_graph_swa_out_cache_loc(
-        self, forward_batch: ForwardBatch
+        self, forward_batch: ForwardBatch, in_capture: bool = False
     ) -> Optional[torch.Tensor]:
         """Refill the SWA write-target buffer from the batch's derived
         sliding-window write loc, returning the [:n] view (None for non-SWA /
@@ -710,12 +712,14 @@ class TritonAttnBackend(AttentionBackend):
             or out_cache_loc.shape[0] > self.cuda_graph_swa_out_cache_loc.shape[0]
         ):
             return None
-        swa_write_loc = self.kv_index_translator.sliding_window_write_loc_for(
-            out_cache_loc
-        )
         n = out_cache_loc.shape[0]
         self.cuda_graph_swa_out_cache_loc[n:].zero_()
-        self.cuda_graph_swa_out_cache_loc[:n].copy_(swa_write_loc)
+        if in_capture:
+            self.cuda_graph_swa_out_cache_loc[:n].zero_()
+        else:
+            self.cuda_graph_swa_out_cache_loc[:n].copy_(
+                self.kv_index_translator.sliding_window_write_loc_for(out_cache_loc)
+            )
         return self.cuda_graph_swa_out_cache_loc[:n]
 
     def _fill_cuda_graph_write_locs(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -885,7 +885,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ragged_layout = resolve_ragged_verify_layout(forward_batch)
             if ragged_layout is not None:
                 self._write_ragged_verify_graph_metadata(
-                    self.forward_metadata, forward_batch, ragged_layout, bs
+                    self.forward_metadata,
+                    forward_batch,
+                    ragged_layout,
+                    bs,
+                    in_capture=in_capture,
                 )
         elif forward_mode.is_draft_extend_v2():
             self.forward_metadata = self.draft_extend_metadata[bs]
@@ -918,7 +922,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ):
                 n = forward_batch.out_cache_loc.shape[0]
                 self.cuda_graph_swa_out_cache_loc[n:].zero_()
-                if in_capture and self.kv_index_translator.is_translating:
+                if in_capture:
                     self.cuda_graph_swa_out_cache_loc[:n].zero_()
                 else:
                     self.cuda_graph_swa_out_cache_loc[:n].copy_(
@@ -941,6 +945,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_batch: ForwardBatch,
         ragged_layout: RaggedVerifyLayout,
         bs: int,
+        in_capture: bool = False,
     ) -> None:
         """Eagerly rebuild the target-verify graph metadata for ragged verify.
 
@@ -968,11 +973,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
             self.cuda_graph_swa_out_cache_loc[n:].zero_()
-            self.cuda_graph_swa_out_cache_loc[:n].copy_(
-                self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                    forward_batch.out_cache_loc
+            if in_capture:
+                self.cuda_graph_swa_out_cache_loc[:n].zero_()
+            else:
+                self.cuda_graph_swa_out_cache_loc[:n].copy_(
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        forward_batch.out_cache_loc
+                    )
                 )
-            )
 
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         self._apply_cuda_graph_metadata(

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -64,11 +64,11 @@ from sglang.kernels.ops.kvcache.kv_read_table import (
     build_kv_read_table,
     build_kv_read_table_packed,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.multi_ended_allocator import (
     UnifiedMambaTokenToKVPoolAllocator,
     UnifiedSWATokenToKVPoolAllocator,
 )
-from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.runtime_context import get_parallel
 
 
@@ -154,9 +154,11 @@ class KVIndexTranslator:
             self.defer_read_translate = False
             self._swa_v2p_table = None
             self._swa_page_multiplier = 1
+            # `translate_loc_from_full_to_swa` is abstract on `BaseSWAKVPool`,
+            # which is also what the backends' `_resolve_swa_kv_pool` keys on.
             self._swa_write_loc_from_full = (
                 token_to_kv_pool.translate_loc_from_full_to_swa
-                if isinstance(token_to_kv_pool, SWAKVPool)
+                if isinstance(token_to_kv_pool, BaseSWAKVPool)
                 else None
             )
 


### PR DESCRIPTION
> **Stack** — third of four. **Depends on #37511 → #37512** (its base branch). One commit of its own; #37560 sits on top.

## Motivation

Two findings from auditing the `KVIndexTranslator` series (#35245 → #34613 → #37307). Both predate that series in effect; both were given their current form by it.

**The same question had two answers.** A backend decides "does this pool have a full→swa index mapping" through `_resolve_swa_kv_pool`, which keys on **`BaseSWAKVPool`**. The translator decided it again, for the write loc, keying on **`SWAKVPool`**:

```python
self._swa_write_loc_from_full = (
    token_to_kv_pool.translate_loc_from_full_to_swa
    if isinstance(token_to_kv_pool, SWAKVPool)   # too narrow
    else None
)
```

`translate_loc_from_full_to_swa` is an `@abstractmethod` on `BaseSWAKVPool`, so every `BaseSWAKVPool` has it. The narrow spelling drops `DeepSeekV4TokenToKVPool`, which is a `BaseSWAKVPool` and not a `SWAKVPool` — a backend that resolves such a pool as SWA passes its outer guard and then hands `None` to `copy_`.

**The capture sink was conditioned on the pool, and three backends had no sink at all.** Three sites (flashinfer, trtllm_mha, flashattention) read:

```python
if in_capture and self.kv_index_translator.is_translating:
    swa_out_cache_loc[:n].zero_()
else:
    swa_out_cache_loc[:n].copy_(sliding_window_write_loc_for(out_cache_loc))
```

Four combinations for two wanted behaviours, and only the unified one got the sink. The capture forward does write KV, so under a **static** SWA pool the `else` branch derived a real slot from a capture batch's dummy `out_cache_loc` and wrote KV there.

## Modifications

- The translator keys on `BaseSWAKVPool` — the class that declares the capability, and what `update_sliding_window_buffer` in the triton backend already used.
- All six sites that write `cuda_graph_swa_out_cache_loc` now condition on `in_capture` alone. Nothing depends on the value either way: graph capture bakes pointers, not buffer contents, and the same code refills on every replay-prep. Zeros route the capture write to slot 0, the reserved sink in every id space, whatever the pool is.
- Enumerating by the *condition* found three sites; enumerating by **who writes the buffer** found six. `triton_backend._fill_cuda_graph_swa_out_cache_loc` (called from inside the `if in_capture:` branch), `aiter_backend.init_forward_metadata_out_graph` (function-body top level, so both phases) and `trtllm_mha._write_ragged_verify_graph_metadata` had **no sink at all** -- they derived a live slot from a capture batch's dummy `out_cache_loc` and wrote KV there unconditionally. `in_capture` is threaded into the first and third; aiter already had it in scope.
- The comments were part of the problem — they said "zeros are the page-0 sink" while sitting above a branch that computes a live one. They now state why the phase is the whole condition.

## Accuracy Tests

Neither fix has an end-to-end run, because the pools whose behaviour they change are not reachable here: DSv4 (trtllm_mha rejects MLA models) and hybrid-SWA under the static pool.

What is checkable is collateral damage on the configurations that do run:

| config | result | band |
|---|---|---|
| Kimi-Linear TP2 + unified + flashinfer_mla | 0.9200 | 0.9125–0.9175 |
| Falcon-H1-1.5B + unified + fa3 | 0.7925 | 0.7625–0.7900 |
| gpt-oss-20b + unified + triton (SWA, 2 runs) | 0.950 / 0.945 | 0.9387 mean over 4 base runs |

The gpt-oss row covers the new triton sink specifically: hybrid-SWA on triton, so `_fill_cuda_graph_swa_out_cache_loc` runs on both phases. aiter is ROCm and unreachable here.

Both one question outside the band's edge, which is inside the ±2 that three runs of one unchanged server reproduce here. `test/registered/unit/mem_cache/`: 2127 passed.

## Speed Tests and Profiling

No performance effect. The sink change removes a per-capture gather on the static-SWA path (once per graph, not per step); the predicate change is an `isinstance` at construction.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — both fixes are reachable only on pools this box cannot run; a test would have to fake the pool, which the repo's style rules out.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing surface changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## A third finding, deliberately not fixed

ROCm gfx950 DeepSeek MHA FP8 (`forward_mha.py`, `forward_mha_rocm.py`) runs `filter_dcp_local_kv_indices` + `translate_dcp_read_ids` inside `forward_normal_prepare` — a per-layer method — over `page_table_1_flattened`, which is a per-step field. Both are pure functions of it, so the same tensor is recomputed once per layer.

Every clean hoist needs either a mutable field on the frozen `DSAMetadata` or module-level memo state, and the path wants ROCm gfx950 + FP8 KV + unified + DCP + prefill, none of which is reachable on this box. I would rather leave it named than ship an untested change to it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33697277863](https://github.com/sgl-project/sglang/actions/runs/33697277863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33697277668](https://github.com/sgl-project/sglang/actions/runs/33697277668)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33697277873](https://github.com/sgl-project/sglang/actions/runs/33697277873)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->