### PR TITLE
fix(gateway): don't register a worker with no model identity under IGW

### DIFF
--- a/sgl-model-gateway/src/core/steps/worker/local/create_worker.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/create_worker.rs
@@ -74,12 +74,36 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
         }
 
         // Determine model_id: config > served_model_name > model_path > UNKNOWN_MODEL_ID
-        let model_id = config
+        let discovered_model_id = config
             .model_id
             .clone()
             .or_else(|| final_labels.get("served_model_name").cloned())
-            .or_else(|| final_labels.get("model_path").cloned())
-            .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
+            .or_else(|| final_labels.get("model_path").cloned());
+
+        // In IGW mode routing selects workers by model name, so a worker whose
+        // identity we never learned can never be picked: registering it under
+        // UNKNOWN_MODEL_ID hides a lost worker behind a healthy-looking entry
+        // that nothing later corrects, because the service-discovery resync
+        // only re-submits pods with no registered worker at all. Failing here
+        // leaves the pod unregistered, which is the state that resync retries.
+        // Outside IGW the model filter is off and an unnamed worker still
+        // serves, so the fallback stays for backends that expose no metadata.
+        let model_id = match discovered_model_id {
+            Some(model_id) => model_id,
+            None if app_context.router_config.enable_igw => {
+                return Err(WorkflowError::StepFailed {
+                    step_id: StepId::new("create_worker"),
+                    message: format!(
+                        "Worker {} has no model identity: /model_info and /server_info \
+                         did not answer, and IGW routing cannot select a worker whose \
+                         model is unknown. Leaving it unregistered for the \
+                         service-discovery resync to retry.",
+                        config.url
+                    ),
+                });
+            }
+            None => UNKNOWN_MODEL_ID.to_string(),
+        };
 
         if model_id != UNKNOWN_MODEL_ID {
             debug!("Using model_id: {}", model_id);

--- a/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
@@ -284,12 +284,28 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
                 // /server_info reports the launch configuration; /model_info
                 // reports the model the worker is serving now. Both are read
                 // here, and a failure of one does not lose the other.
-                let server_info = get_server_info(&config.url, config.api_key.as_deref())
+                // Neither call failing is fatal here: the step is declared
+                // optional so that a slow worker still reaches create_worker.
+                // But swallowing them silently leaves an operator with no way
+                // to tell a worker that answered from one that never did, so
+                // each failure is logged.
+                let server_info = match get_server_info(&config.url, config.api_key.as_deref())
                     .await
-                    .ok();
-                let model_info = get_model_info(&config.url, config.api_key.as_deref())
-                    .await
-                    .ok();
+                {
+                    Ok(info) => Some(info),
+                    Err(e) => {
+                        warn!("/server_info failed for {}: {}", config.url, e);
+                        None
+                    }
+                };
+                let model_info = match get_model_info(&config.url, config.api_key.as_deref()).await
+                {
+                    Ok(info) => Some(info),
+                    Err(e) => {
+                        warn!("/model_info failed for {}: {}", config.url, e);
+                        None
+                    }
+                };
 
                 // Identity comes from /model_info, which a weight update moves;
                 // /server_info answers the launch record and is the fallback for
@@ -358,10 +374,16 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
 
                 // If no model name discovered yet, try /v1/models as fallback
                 if !labels.contains_key("model_path") && !labels.contains_key("served_model_name") {
-                    if let Ok(model_name) =
-                        get_model_name_from_v1_models(&config.url, config.api_key.as_deref()).await
+                    match get_model_name_from_v1_models(&config.url, config.api_key.as_deref())
+                        .await
                     {
-                        labels.insert("served_model_name".to_string(), model_name);
+                        Ok(model_name) => {
+                            labels.insert("served_model_name".to_string(), model_name);
+                        }
+                        Err(e) => warn!(
+                            "no model identity discovered for {}: /v1/models also failed: {}",
+                            config.url, e
+                        ),
                     }
                 }
 

--- a/sgl-model-gateway/src/core/steps/worker/local/mod.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/mod.rs
@@ -361,3 +361,84 @@ pub fn create_worker_update_workflow_data(
         updated_workers: None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! What `create_worker` does when metadata discovery found no model name.
+    //!
+    //! `discover_metadata` is declared `FailureAction::ContinueNextStep`, so a
+    //! worker whose `/model_info` and `/server_info` never answered still
+    //! reaches `create_worker` with empty labels. Under IGW that worker cannot
+    //! be routed to -- `get_by_model` selects by name -- and the service
+    //! discovery resync will not revisit it, because it only re-submits pods
+    //! that have no registered worker at all. Refusing is what keeps it in the
+    //! state the resync retries.
+
+    use std::{collections::HashMap, sync::Arc};
+
+    use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowInstanceId, WorkflowResult};
+
+    use super::*;
+    use crate::{app_context::AppContext, core::ConnectionMode};
+
+    /// A worker config with a url and nothing else: no `model_id`, which is
+    /// what Kubernetes service discovery builds.
+    fn worker_data_without_identity() -> LocalWorkerWorkflowData {
+        LocalWorkerWorkflowData {
+            config: serde_json::from_value(serde_json::json!({
+                "url": "http://worker-that-never-answered:30000"
+            }))
+            .expect("a url-only worker config should deserialize"),
+            connection_mode: Some(ConnectionMode::Http),
+            discovered_labels: HashMap::new(),
+            dp_info: None,
+            workers: None,
+            final_labels: HashMap::new(),
+            detected_runtime_type: None,
+            app_context: None,
+            actual_workers: None,
+        }
+    }
+
+    async fn app_context(enable_igw: bool) -> Arc<AppContext> {
+        let config = RouterConfig {
+            enable_igw,
+            ..RouterConfig::default()
+        };
+        Arc::new(
+            AppContext::from_config(config, 60)
+                .await
+                .expect("a default AppContext should build"),
+        )
+    }
+
+    /// Runs the real step, not a scripted stand-in. No network is involved:
+    /// empty `discovered_labels` is what a failed discovery leaves behind.
+    async fn create_worker_without_identity(enable_igw: bool) -> WorkflowResult<StepResult> {
+        let mut data = worker_data_without_identity();
+        data.app_context = Some(app_context(enable_igw).await);
+        let mut context = WorkflowContext::new(WorkflowInstanceId::new(), data);
+        CreateLocalWorkerStep.execute(&mut context).await
+    }
+
+    #[tokio::test]
+    async fn igw_refuses_a_worker_with_no_model_identity() {
+        let error = create_worker_without_identity(true)
+            .await
+            .expect_err("IGW cannot route to an unnamed worker, so it must not register one");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("no model identity"),
+            "the failure has to name its cause, or an operator sees only a failed \
+             AddWorker; got {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn without_igw_an_unnamed_worker_still_registers() {
+        create_worker_without_identity(false)
+            .await
+            .expect("outside IGW the model filter is off, so an unnamed worker still serves");
+    }
+}


### PR DESCRIPTION
Fixes #37554.

## Motivation

Under IGW, a worker whose metadata discovery failed is registered as `model_id: "unknown"`, stays healthy, takes no traffic for the life of the router process, and is never corrected.

Kubernetes service discovery submits an `AddWorker` as soon as a pod has an IP, which is before a starting engine can answer `/model_info` or `/server_info`. `discover_metadata` is `FailureAction::ContinueNextStep`, so that worker still reaches `create_worker`, which falls back to `UNKNOWN_MODEL_ID` and registers it.

Under IGW that worker is unreachable: `select_pd_pair` and the regular router both narrow candidates with `worker_registry.get_by_model(model_id)`, so `"unknown"` is never a candidate for any named model. It is also never corrected — the service-discovery resync only re-submits pods for which no worker is registered at all, and this one is registered, while `tracked_pods` deduplicates the later watch events. `--service-discovery` enables IGW automatically, so every discovery-driven deployment is in that mode.

The visible result is a router serving on a fraction of its fleet with every pod `Ready`, `/workers` reporting `is_healthy: true`, and no log line saying a metadata call failed. We hit this in production after an engine rollout: routing to roughly 40% of the workers for hours, cleared by a router restart.

This path became reachable when `ContinueNextStep` started being honoured (#37249, wfaas 1.0.2). Before that the workflow deadlocked at `discover_metadata` instead, which lost the worker too but did so visibly and left the resync able to recover it.

## Modifications

**`create_worker.rs` — refuse, when and only when IGW is on.** An unregistered pod is the one state the resync retries, so the worker is picked up with its real `model_id` as soon as it answers. Outside IGW the model filter is off and an unnamed worker still serves, so the `UNKNOWN_MODEL_ID` fallback stays for backends that expose no metadata endpoints (the case #25293 addressed). The error names its cause, so a failed `AddWorker` is readable.

**`discover_metadata.rs` — log each failed metadata call.** The step keeps swallowing its HTTP errors: it is optional by design, and making it fail would burn its 3 × 10 s of retries before reaching the check above without changing the outcome. What was missing was any record that the call failed, which is why the incident was invisible.

**Tests** — two, over the real `CreateLocalWorkerStep` rather than a stand-in, one per IGW mode. No network: empty `discovered_labels` is exactly what a failed discovery leaves behind.

## Accuracy Tests

Not applicable — router-only change, no model forward path touched.

## Speed Tests and Profiling

Not applicable to the serving path. The one behavioural cost is on the failure path: a refused `AddWorker` is retried on each resync tick until the worker answers, where before it succeeded once and left a dead entry.

## Verification

- `cargo test -p sgl-model-gateway --lib`: 394 passed, 0 failed.
- Negative control: with `create_worker.rs` reverted to `main`, `igw_refuses_a_worker_with_no_model_identity` fails. The test exercises the change.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Behaviour measured on an isolated canary, two router deployments differing only in this commit, against the same stub workers with the same injected metadata hang:

  | | without this change | with it |
  |---|---|---|
  | while metadata hangs | 2 workers, both `model_id: "unknown"`, both healthy | 0 workers registered |
  | once the workers answer | still `"unknown"` (2 min 34 s observed) | registered with their real `model_id` within 18 s |

  The 18 s is one `--service-discovery-resync-secs 10` tick plus the `AddWorker` that follows it.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation — no user-facing flag or behaviour to document; the change removes a silent failure mode.
- [x] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35675648539](https://github.com/sgl-project/sglang/actions/runs/35675648539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35675648259](https://github.com/sgl-project/sglang/actions/runs/35675648259)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->