### PR TITLE
[Docs] Remove obsolete --hybrid-kvcache-ratio from server arguments

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -3468,16 +3468,5 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>N/A</td>
     </tr>
 
-
-
-
-        <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--hybrid-kvcache-ratio`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Mix ratio in [0,1] between uniform and hybrid kv buffers (0.0 = pure uniform: swa_size / full_size = 1)(1.0 = pure hybrid: swa_size / full_size = local_attention_size / context_length)</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Optional[float]</td>
-    </tr>
-
-
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

`--hybrid-kvcache-ratio` was removed from the server CLI in #16399, but `docs/docs/advanced_features/server_arguments.mdx` still documents it under **Deprecated arguments**. This PR deletes that obsolete table row only.

The replacement flag `--swa-full-tokens-ratio` is already documented in the Memory and scheduling section of the same page (and lives in `python/sglang/srt/server_args.py` as `swa_full_tokens_ratio`).

## Repro

On current `main`:

```bash
# Docs still list the removed flag
rg -n 'hybrid-kvcache-ratio' docs/docs/advanced_features/server_arguments.mdx

# No matching CLI field / argparse entry in server_args.py
rg -n 'hybrid_kvcache' python/sglang/srt/server_args.py
# (empty)

# Replacement is present in both docs and code
rg -n 'swa-full-tokens-ratio|swa_full_tokens_ratio' docs/docs/advanced_features/server_arguments.mdx python/sglang/srt/server_args.py
```

## Change

- Remove the `--hybrid-kvcache-ratio` row from the Deprecated arguments table in `server_arguments.mdx`.
- Do not re-add the flag; no other files changed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33599921319](https://github.com/sgl-project/sglang/actions/runs/33599921319)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33599921032](https://github.com/sgl-project/sglang/actions/runs/33599921032)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->