### PR TITLE
Fix unified SWA: size a non-owner's v2p by the id space it must address

### DIFF
--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -333,12 +333,9 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         ) // self.pool_page_size
         self.entry_bytes_per_page = self.entry_bytes * self.pool_page_size
 
-        # v2p is indexed by VIRTUAL page id, p2v by PHYSICAL page id, and for a
-        # non-owner the two counts are unrelated: it consumes ids minted by the
-        # composite's owner, whose per-page byte cost -- and so page count --
-        # depends on its own layer share. Either side can be the larger. Sizing
-        # v2p by this pool's page count leaves the top of the shared id space
-        # off the end of the table whenever the owner has more pages.
+        # v2p is indexed by VIRTUAL page id, p2v by PHYSICAL page id. A
+        # non-owner consumes the owner's ids, so its v2p spans the owner's
+        # count; the two are unrelated and either can be the larger.
         self.num_virtual_ids = (
             self.num_pages if virtual_num_pages is None else virtual_num_pages
         )
@@ -3219,8 +3216,8 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             need_sort=need_sort,
             forward_stream=forward_stream,
             lazy_compaction=lazy_compaction,
-            # `alloc` binds the virtual pages full mints, so the swa side has to
-            # be able to address full's whole id space, not just its own pages.
+            # swa binds the virtual pages full mints, so it must address
+            # full's whole id space.
             virtual_num_pages=self.full_attn_allocator.num_virtual_ids,
         )
         self._wire_peers()

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -267,6 +267,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         sub_pool_name: str,
         device: str,
         is_id_owner: bool,
+        virtual_num_pages: Optional[int] = None,
         page_size: int = 1,
         shards_under_dcp: bool = False,
         need_sort: bool = False,
@@ -332,10 +333,18 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         ) // self.pool_page_size
         self.entry_bytes_per_page = self.entry_bytes * self.pool_page_size
 
-        # v2p / p2v sized by PAGES. Page 0 is the padding anchor; trailing row is
-        # the -1 sentinel.
+        # v2p is indexed by VIRTUAL page id, p2v by PHYSICAL page id, and for a
+        # non-owner the two counts are unrelated: it consumes ids minted by the
+        # composite's owner, whose per-page byte cost -- and so page count --
+        # depends on its own layer share. Either side can be the larger. Sizing
+        # v2p by this pool's page count leaves the top of the shared id space
+        # off the end of the table whenever the owner has more pages.
+        self.num_virtual_ids = (
+            self.num_pages if virtual_num_pages is None else virtual_num_pages
+        )
+        # Page 0 is the padding anchor; the trailing row is the -1 sentinel.
         self.virtual_to_physical = torch.full(
-            (self.num_pages + 1,),
+            (self.num_virtual_ids + 1,),
             -1,
             dtype=torch.int64,
             device=device,
@@ -346,8 +355,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             dtype=torch.int64,
             device=device,
         )
-        # Back-compat alias (count of virtual PAGES) consulted by is_slot_allocated.
-        self.num_virtual_ids = self.num_pages
 
         # Chain neighbours: `low_peer` toward byte 0, `high_peer` toward
         # `total_bytes`. Ends have one (`bind_peer`), float middles have both.
@@ -540,7 +547,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
     def is_slot_allocated(self, slot: int) -> bool:
         """Whether the PAGE containing this virtual id is in use."""
         virt_page = slot // self.page_size
-        if virt_page < 0 or virt_page >= self.num_pages:
+        if virt_page < 0 or virt_page >= self.num_virtual_ids:
             return False
         return int(self.virtual_to_physical[virt_page].item()) != -1
 
@@ -3212,6 +3219,9 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             need_sort=need_sort,
             forward_stream=forward_stream,
             lazy_compaction=lazy_compaction,
+            # `alloc` binds the virtual pages full mints, so the swa side has to
+            # be able to address full's whole id space, not just its own pages.
+            virtual_num_pages=self.full_attn_allocator.num_virtual_ids,
         )
         self._wire_peers()
 

--- a/test/registered/attention/test_gemma4_unified_swa_virtual_ids.py
+++ b/test/registered/attention/test_gemma4_unified_swa_virtual_ids.py
@@ -29,11 +29,8 @@ churn past `swa.num_pages`. `--max-total-tokens 60000` puts that within one
 200-example GSM8K run; at this model's default budget the swa table is 3.8M
 entries and it would take dozens.
 
-Every argument below is load-bearing and this exact configuration is the one
-that was verified red on the narrow table (score 0.16, scheduler gone) and green
-with the fix (0.865-0.880 over four runs, against 0.870 on the static pool at
-the same budget). Substituting synthetic prompts or a bigger pool made it pass
-both ways.
+Every argument below is load-bearing: a larger pool, or synthetic prompts in
+place of this eval, and the narrow table passes.
 
     python -m pytest test/registered/attention/test_gemma4_unified_swa_virtual_ids.py -v
 """
@@ -53,10 +50,8 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=65, stage="base-b", runner_config="1-gpu-large")
 
-# Healthy: 0.865-0.880 over four runs with the fix, 0.870 on the static pool at
-# the same budget. Broken: 0.05-0.21, the scheduler having died mid-run. 0.82
-# leaves ~2 sigma under the observed floor (200 examples, 1 sigma ~= 0.024) and
-# 4x over the worst failure.
+# Healthy 0.865-0.880 (static pool 0.870); a died-mid-run server scores
+# 0.05-0.21. 1 sigma over 200 examples is ~0.024.
 SCORE_THRESHOLD = 0.82
 
 
@@ -76,8 +71,8 @@ class TestGemma4UnifiedSwaVirtualIds(CustomTestCase):
                 "--disable-radix-cache",
                 "--mem-fraction-static",
                 "0.8",
-                # The small pool is the trigger, not a convenience: it is what
-                # brings `swa.num_pages` within one eval's worth of churn.
+                # The trigger: this is what brings `swa.num_pages` within one
+                # eval's worth of churn.
                 "--max-total-tokens",
                 "60000",
             ],

--- a/test/registered/attention/test_gemma4_unified_swa_virtual_ids.py
+++ b/test/registered/attention/test_gemma4_unified_swa_virtual_ids.py
@@ -1,0 +1,105 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unified memory on a hybrid sliding-window model, which nothing else covered.
+
+The unified SWA composite mints one virtual page id per allocation and binds it
+on both sides, so the swa sub-pool's `virtual_to_physical` is indexed by the
+FULL side's ids while it used to be sized by its own page count. A model with
+few full-attention layers and many sliding ones gives the id owner more pages,
+and the top of that id space then lands off the end of the swa table. On GPU
+the write is unchecked (`alloc_bind_inplace`'s `tl.store`), so the symptom
+surfaces later and elsewhere: a device-side index assert on the read in
+`_swa_write_loc_unified`, and a dead scheduler.
+
+The reachability of it is a KV-budget property, not just a model property: ids
+come off the front of the owner's free list and freed ids return to the back, so
+the cursor sweeps the owner's range over time and the failure needs cumulative
+churn past `swa.num_pages`. `--max-total-tokens 60000` puts that within one
+200-example GSM8K run; at this model's default budget the swa table is 3.8M
+entries and it would take dozens.
+
+Every argument below is load-bearing and this exact configuration is the one
+that was verified red on the narrow table (score 0.16, scheduler gone) and green
+with the fix (0.865-0.880 over four runs, against 0.870 on the static pool at
+the same budget). Substituting synthetic prompts or a bigger pool made it pass
+both ways.
+
+    python -m pytest test/registered/attention/test_gemma4_unified_swa_virtual_ids.py -v
+"""
+
+import types
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=65, stage="base-b", runner_config="1-gpu-large")
+
+# Healthy: 0.865-0.880 over four runs with the fix, 0.870 on the static pool at
+# the same budget. Broken: 0.05-0.21, the scheduler having died mid-run. 0.82
+# leaves ~2 sigma under the observed floor (200 examples, 1 sigma ~= 0.024) and
+# 4x over the worst failure.
+SCORE_THRESHOLD = 0.82
+
+
+class TestGemma4UnifiedSwaVirtualIds(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "google/gemma-4-E2B-it"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                "triton",
+                "--enable-unified-memory",
+                "--disable-radix-cache",
+                "--mem-fraction-static",
+                "0.8",
+                # The small pool is the trigger, not a convenience: it is what
+                # brings `swa.num_pages` within one eval's worth of churn.
+                "--max-total-tokens",
+                "60000",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k_survives_churn_past_the_swa_page_count(self):
+        metrics = run_eval(
+            types.SimpleNamespace(
+                base_url=self.base_url,
+                model=self.model,
+                eval_name="gsm8k",
+                num_examples=200,
+                num_threads=128,
+            )
+        )
+        self.assertGreaterEqual(metrics["score"], SCORE_THRESHOLD)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py
+++ b/test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py
@@ -18,12 +18,9 @@ gets more pages out of a shared byte budget depends on the layer split, and a
 model with few full-attention layers and many sliding ones (gemma-4: 10 and 50)
 gives the full side an order of magnitude more.
 
-The id space also rotates -- the owner hands ids out from the front of its free
-list and freed ids return to the back -- so the cursor sweeps the owner's whole
-range over time even when only a few pages are live. Sizing the swa table by
-its own pages therefore fails after enough churn rather than at once, and on
-GPU it fails as a `tl.store` past the end of the table: an unchecked write, not
-a raised index.
+Reaching an id that high takes cumulative allocation, so a narrow table fails
+after churn rather than at once -- and on GPU it fails as a `tl.store` past the
+end of the table: an unchecked write, not a raised index.
 
     python -m pytest test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py -v
 """

--- a/test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py
+++ b/test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py
@@ -1,0 +1,122 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The unified SWA composite mints one virtual page id and binds it on both
+sides, so the swa side's `virtual_to_physical` is indexed by the FULL side's
+ids. Its own page count says nothing about how wide that has to be: which side
+gets more pages out of a shared byte budget depends on the layer split, and a
+model with few full-attention layers and many sliding ones (gemma-4: 10 and 50)
+gives the full side an order of magnitude more.
+
+The id space also rotates -- the owner hands ids out from the front of its free
+list and freed ids return to the back -- so the cursor sweeps the owner's whole
+range over time even when only a few pages are live. Sizing the swa table by
+its own pages therefore fails after enough churn rather than at once, and on
+GPU it fails as a `tl.store` past the end of the table: an unchecked write, not
+a raised index.
+
+    python -m pytest test/registered/unit/mem_cache/test_unified_swa_shared_virtual_ids.py -v
+"""
+
+import unittest
+
+import torch
+from test_swa_locked_full_recover_unified import _DEV, _FakeUnifiedSWAKVPool
+
+from sglang.srt.mem_cache.multi_ended_allocator import (
+    UnifiedSWATokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.unified_memory_pool import MHASubPoolSpec, UnifiedKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _build(n_full: int, n_swa: int, full_layers: int, swa_layers: int):
+    """A composite whose sides have different per-page byte costs. `full_layers
+    < swa_layers` is the gemma-4 shape: the cheap side is the id owner and ends
+    up with far more pages than the side that has to address them."""
+    full_spec = MHASubPoolSpec(
+        name="full",
+        layer_num=full_layers,
+        head_num=2,
+        head_dim=4,
+        store_dtype=torch.float16,
+        grow_direction="up",
+    )
+    swa_spec = MHASubPoolSpec(
+        name="swa",
+        layer_num=swa_layers,
+        head_num=2,
+        head_dim=4,
+        store_dtype=torch.float16,
+        grow_direction="down",
+    )
+    pool = UnifiedKVPool(
+        total_bytes=n_full * full_spec.entry_bytes() + n_swa * swa_spec.entry_bytes(),
+        sub_pool_specs=[full_spec, swa_spec],
+        device=_DEV,
+        enable_memory_saver=False,
+    )
+    return UnifiedSWATokenToKVPoolAllocator(
+        unified_buffer=pool,
+        kvcache=_FakeUnifiedSWAKVPool(pool),
+        device=_DEV,
+        full_max_total_num_tokens=n_full,
+        swa_max_total_num_tokens=n_swa,
+        need_sort=False,
+        forward_stream=None,
+    )
+
+
+class TestSharedVirtualIdSpace(unittest.TestCase):
+    def test_swa_table_spans_the_owners_id_space(self):
+        """Static form: the table has to be wide enough before any alloc runs."""
+        for full_layers, swa_layers in ((1, 5), (5, 1), (2, 2)):
+            with self.subTest(full_layers=full_layers, swa_layers=swa_layers):
+                alloc = _build(200, 20, full_layers, swa_layers)
+                owner = alloc.full_attn_allocator
+                swa = alloc.swa_attn_allocator
+                self.assertGreaterEqual(
+                    int(swa.virtual_to_physical.shape[0]),
+                    owner.num_virtual_ids + 1,
+                    "swa v2p cannot address every id the owner can mint",
+                )
+                # p2v stays this pool's own business: it is indexed by physical id.
+                self.assertEqual(
+                    int(swa.physical_to_virtual.shape[0]), swa.num_pages + 1
+                )
+
+    def test_churn_past_the_swa_page_count_binds_cleanly(self):
+        """Dynamic form: alloc/free until the owner's cursor passes the swa
+        side's page count, which is where the narrow table used to be written
+        off the end."""
+        alloc = _build(200, 20, full_layers=1, swa_layers=5)
+        swa_pages = alloc.swa_attn_allocator.num_pages
+        highest = 0
+        for _ in range(40):
+            v = alloc.alloc(4)
+            if v is None:
+                break
+            highest = max(highest, int(v.max()) // alloc.page_size)
+            alloc.free(v)
+        self.assertGreater(
+            highest,
+            swa_pages,
+            f"churn never reached past the swa side's {swa_pages} pages, so this "
+            "test would pass on a narrow table too",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stack** — fourth of four, the top. **Depends on #37511 → #37512 → #37550** (its base branch). Two commits of its own. It is an independent bug fix that happens to sit here so the whole stack shares one CI run; it can be rebased onto `main` on request.

## Motivation

`--enable-unified-memory` on a hybrid sliding-window model dies mid-serving: a device-side index assert, the scheduler gone, and the request batch returning nothing. The same model at the same commit with the static pool is fine.

The unified SWA composite mints **one** virtual page id per allocation and binds it on both sides:

```python
new_virtual_pages = fa.free_virtual_ids[:num_pages].clone()      # the FULL side's ids
v_tokens = fa.alloc(need_size)
self.swa_attn_allocator.alloc_with_virtual(new_virtual_pages)    # bound on swa too
```

So the swa side's `virtual_to_physical` is indexed by the **full** side's ids — while it was sized by the swa side's own page count. Those two numbers are unrelated: which side gets more pages out of a shared byte budget depends on its per-page byte cost. `gemma-4-31b-it` is 10 full-attention layers to 50 sliding, so at `--mem-fraction-static 0.8` on 2×H100:

```
full  v2p len = 2,065,601
swa   v2p len =   206,561     <- indexed by ids up to 2,065,600
```

Two things make it hard to see. It needs cumulative allocation churn before an id that far up is handed out, so a fresh server passes its first eval and dies on the second. And on GPU the offending access is a **write** — `alloc_bind_inplace`'s `tl.store(v2p_ptr + v, p)`, unchecked — so the visible symptom is somewhere else entirely: the later read in `_swa_write_loc_unified` is what trips the assert. Under `CUDA_LAUNCH_BLOCKING=1` the stack resolves to that read; the CPU reference path raises `IndexError` from the write.

## Modifications

- `MultiEndedAllocator` takes `virtual_num_pages`. `virtual_to_physical` is sized by it — the id owner's count, passed down for a non-owner — while `physical_to_virtual` keeps this pool's own page count, because that one is indexed by physical id. `is_slot_allocated`'s bound moves to the virtual count for the same reason.
- The composite passes `virtual_num_pages=self.full_attn_allocator.num_virtual_ids` when building the swa side (both the 2-pool end pair and the tri-pool float).
- `test_unified_swa_shared_virtual_ids.py` (CPU): the table spans the owner's id space across three layer splits, and alloc/free churn past the swa side's page count binds cleanly.
- `test_gemma4_unified_swa_virtual_ids.py` (1 GPU, `base-b`, est 65s): the end-to-end cell that was missing — no registered test ran unified memory on a hybrid-SWA model. The existing unified e2e tests are MLA or ShortConv; the existing SWA e2e tests run the static pool.

Cost is one int64 row per id in the owner's space on the non-owner side: 16.5 MB at the gemma-4-31b shape above, against the 1.65 MB it had.

## Accuracy Tests

The failure needs two conditions, and separating them took several wrong turns:

1. **`full.num_pages > swa.num_pages`** — a property of the model, true when the full side's per-page byte cost is the lower one. Read `entry_bytes_per_page`, not the layer counts: gemma-4-E2B is 7 full to 28 sliding but 2:1 in pages.
2. **cumulative allocation churn past `swa.num_pages`** — a property of the KV budget, since only enough allocation brings an id that high into play.

Shrinking the pool makes (2) immediate, which turns a 2B model on one GPU into a one-round repro — this is what the new e2e test runs:

```
--model-path google/gemma-4-E2B-it --enable-unified-memory \
  --attention-backend triton --mem-fraction-static 0.8 \
  --disable-radix-cache --max-total-tokens 60000
```

GSM8K over 200, one GPU, 65 s wall clock:

```
main   + unified   0.05   test RED
main   + static    0.87   <- the control: the model and backend are fine
branch + unified   0.865 / 0.870 / 0.875 / 0.880   test GREEN
```

Found in the wild on the shape where the swa table is small by itself — `gemma-4-31b-it`, TP2, default budget, GSM8K over 200 alternating a side:

```
round 1   main 0.98 alive     branch 0.98 alive
round 2   main 0.00 DEAD      branch 0.98 alive
round 3   (main gone)         branch 0.98 alive
rounds 4-6                    branch 0.98, 0.98, 0.98
```

For contrast, two hybrid-SWA models that do **not** reproduce it at their default budgets:

| model | full / sliding | full pages | swa pages | runs to trigger |
|---|---|---|---|---|
| gemma-4-31b-it | 10 / 50 | 2,065,601 | 206,561 | ~3 |
| gemma-4-E2B-it | 7 / 28 | 7,576,246 | 3,788,123 | ~63 |
| gpt-oss-20b | 12 / 12 | equal | equal | never |

The unit test fails both ways round on `main`: the width check on the (1, 5) split, and the churn check with the `IndexError` the CPU reference path raises where the Triton store would not.

`test/registered/unit/mem_cache/`: 2129 passed (this branch, after rebasing onto #37550 — both changes land in the same `multi_ended_allocator.py`).

## Speed Tests and Profiling

Not a performance change. The extra table is 16.5 MB on the gemma-4-31b shape, allocated once at startup; nothing moves per step.

Since this is the top of the stack, it is also where "does unified cost anything against
the static pool" gets answered for the whole feature. Four hybrid shapes, same build,
only `--enable-unified-memory` differing -- **schedulable KV is identical**, and accuracy
and throughput are within run-to-run spread:

| model | type | KV tokens | GSM8K | tput |
|---|---|---|---|---|
| gemma-4-E2B-it (TP1) | SWA | 2913941 -> 2913939 | 0.8717 -> 0.8600 | +2.00% |
| Qwen3.5-0.8B (TP1) | 18 linear + 6 full | 5032604 -> 5032608 | 0.5400 -> 0.5350 | +1.67% |
| Kimi-Linear-48B (TP2) | MLA + KDA | 4536315 -> 4536315 | 0.9075 -> 0.9100 | -0.63% |
| Inkling-Small (TP4) | full + SWA + ShortConv | 450605 -> 450605 | 0.975 -> 0.975 | +1.21% |

Inkling matches down to the budget it is derived from (`rest=4.962 GB`,
`max_mamba_cache_size=207` on both sides), and at `--mem-fraction-static 0.9` both sides
boot with `74778` tokens, so unified needs no extra headroom. Graph memory moves in both
directions; #37512 has that column and the breakdown.

Method, because the first pass got this wrong: run a multi-GPU A/B **sequentially on the
same cards**. The TP pool is sized from the *minimum* free memory across ranks, so one
foreign 1.2 GB process on one card of one GPU set shrinks that whole side's KV -- it read
as a 22.5% Inkling regression until both sides ran on the same four cards.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — one CPU unit test and one per-PR e2e, both verified red on `main`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing surface changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes for reviewers

**The e2e test's arguments are load-bearing.** Three substitutions made it pass on `main`, so they are not tuning:

- Raising `--max-total-tokens` hides the defect — the small pool *is* condition (2).
- Synthetic short prompts at a nominal 3.7x the churn passed on `main`; the 5-shot GSM8K traffic is what reaches it.
- It cannot use `GSM8KMixin`: that path scores this model **0.155 whatever the pool**, because its chat template does not fit the model's reasoning config. Calling `run_eval` gives 0.87 on a healthy server.

Registered at `base-b`, not nightly. The lesson from the last regression in this area (#37307) was that the guard existed but was nightly-gated, so it never blocked the PR that broke it.

**One claim I could not confirm.** I described the id space as rotating — ids off the front of the owner's free list, freed ids to the back — and the code does read that way (`torch.cat([free_virtual_ids, free_v_pages])`). But probes on `alloc()` and `alloc_with_virtual` never fired during a real server run: the free list is consumed inside the Triton kernel on the `alloc_extend` path. So "churn advances the cursor" is the observed behaviour (the trigger is empirically cumulative, and the measured thresholds above bear that out), not a mechanism I have traced end to end.


---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33682091141](https://github.com/sgl-project/sglang/actions/runs/33682091141)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33682090790](https://github.com/sgl-project/sglang/actions/runs/33682090790)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33682090991](https://github.com/sgl-project/sglang/actions/runs/33682090991)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33697315211](https://github.com/sgl-project/sglang/actions/runs/33697315211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33697315009](https://github.com/sgl-project/sglang/actions/runs/33697315009)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33697315235](https://github.com/sgl-project/sglang/actions/runs/33697315235)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->