### PR TITLE
fix: restore missing get_component_forced_attn_backend import in minimax_h3

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -54,6 +54,7 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
 from sglang.multimodal_gen.runtime.layers.attention.selector import (
     claim_deferred_component_attn_backend,
     get_attn_backend,
+    get_component_forced_attn_backend,
     get_global_forced_attn_backend,
 )
 from sglang.multimodal_gen.runtime.layers.linear import (


### PR DESCRIPTION
## Motivation

`main` is currently red on `lint`: `ruff` reports an undefined name in `minimax_h3.py`.

```
F821 Undefined name `get_component_forced_attn_backend`
   --> python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py:717:44
    |
717 |         self._selected_attention_backend = get_component_forced_attn_backend()
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is a semantic merge conflict between two diffusion PRs that do not textually conflict:

- #36907 (`62c470697`) dropped `get_component_forced_attn_backend` from the `selector` import block in `minimax_h3.py`, because its last call site there was replaced by `claim_deferred_component_attn_backend()`.
- #34893 (`4b329482e`) was branched before that and added a **new** call site in `MiniMaxH3Attention.__init__`. It was green on its own branch, where the import still existed. The two edits sit in different hunks, so the merge succeeded and left the call without its import.

This is not only a lint failure: the call is in `MiniMaxH3Attention.__init__`, so constructing a MiniMax-H3 model raises `NameError` at runtime.

## Modifications

Restore the `get_component_forced_attn_backend` import. One line, no behavior change beyond making the existing call resolve.

## Accuracy Test

No functional change — the imported symbol is the one the call site already expects (`selector.get_component_forced_attn_backend`, unchanged).

## Checklist

Reproduced the CI failure locally with the pre-commit rule set and confirmed the fix clears it:

```
$ ruff check --select=F401,F821,UP037 python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
# before: Found 1 error (F821)
# after:  All checks passed!
```

Full `pre-commit run` on the changed file passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33605814745](https://github.com/sgl-project/sglang/actions/runs/33605814745)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33605814389](https://github.com/sgl-project/sglang/actions/runs/33605814389)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33605814710](https://github.com/sgl-project/sglang/actions/runs/33605814710)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->