### PR TITLE
[Feature] Add TextSeal watermarking support

### DIFF
--- a/benchmark/textseal/generate_samples.py
+++ b/benchmark/textseal/generate_samples.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import argparse
+import concurrent.futures
+import json
+from pathlib import Path
+
+import requests
+
+PROMPTS = [
+    f"Write a detailed explanation of topic {index}, using several paragraphs and concrete examples."
+    for index in range(50)
+]
+
+
+def _generate_sample(args, index: int, prompt: str, watermarked: bool):
+    headers = {"X-SGLang-Watermark": "textseal"} if watermarked else {}
+    response = requests.post(
+        args.base_url + "/v1/completions",
+        headers=headers,
+        json={
+            "model": args.model,
+            "prompt": prompt,
+            "temperature": 0.8,
+            "top_p": 0.95,
+            "max_tokens": args.max_tokens,
+            "seed": 20260901 + index,
+        },
+        timeout=300,
+    )
+    response.raise_for_status()
+    body = response.json()
+    return {
+        "prompt_index": index,
+        "watermarked": watermarked,
+        "text": body["choices"][0]["text"],
+        "completion_tokens": body["usage"]["completion_tokens"],
+        "model": args.model,
+        "seed": 20260901 + index,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    parser.add_argument("--model", default="Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--max-concurrency", type=int, default=8)
+    args = parser.parse_args()
+
+    jobs = [
+        (index, prompt, watermarked)
+        for index, prompt in enumerate(PROMPTS)
+        for watermarked in (False, True)
+    ]
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.max_concurrency
+    ) as executor:
+        records = executor.map(
+            lambda job: _generate_sample(args, *job),
+            jobs,
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as output:
+        for record in records:
+            output.write(json.dumps(record) + "\n")
+            output.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/textseal/run_latency.py
+++ b/benchmark/textseal/run_latency.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+METRICS = (
+    "median_tpot_ms",
+    "mean_tpot_ms",
+    "median_ttft_ms",
+    "mean_ttft_ms",
+    "output_throughput",
+    "request_throughput",
+)
+
+
+def _run_trial(base_url: str, output: Path, watermarked: bool):
+    command = [
+        sys.executable,
+        "-m",
+        "sglang.benchmark.serving",
+        "--backend",
+        "sglang-oai-chat",
+        "--base-url",
+        base_url,
+        "--model",
+        MODEL,
+        "--dataset-name",
+        "random",
+        "--random-input-len",
+        "128",
+        "--random-output-len",
+        "256",
+        "--random-range-ratio",
+        "1.0",
+        "--num-prompts",
+        "100",
+        "--max-concurrency",
+        "8",
+        "--warmup-requests",
+        "16",
+        "--temperature",
+        "0.8",
+        "--top-p",
+        "0.95",
+        "--extra-request-body",
+        json.dumps({"temperature": 0.8, "top_p": 0.95}),
+        "--seed",
+        "20260901",
+        "--output-file",
+        str(output),
+    ]
+    if watermarked:
+        command.extend(["--header", "X-SGLang-Watermark=textseal"])
+    subprocess.run(command, check=True)
+    return json.loads(output.read_text().splitlines()[-1])
+
+
+def _percent_change(baseline: float, textseal: float) -> float:
+    return (textseal - baseline) / baseline * 100
+
+
+def _summarize_metric(pairs, metric: str):
+    baseline = [pair[f"baseline_{metric}"] for pair in pairs]
+    textseal = [pair[f"textseal_{metric}"] for pair in pairs]
+    changes = [pair[f"{metric}_change_percent"] for pair in pairs]
+    return {
+        "baseline_mean": statistics.mean(baseline),
+        "baseline_median": statistics.median(baseline),
+        "baseline_stdev": statistics.stdev(baseline),
+        "textseal_mean": statistics.mean(textseal),
+        "textseal_median": statistics.median(textseal),
+        "textseal_stdev": statistics.stdev(textseal),
+        "paired_change_mean_percent": statistics.mean(changes),
+        "paired_change_median_percent": statistics.median(changes),
+        "paired_change_stdev_percent": statistics.stdev(changes),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    pairs = []
+    for pair_index in range(5):
+        results = {}
+        order = (False, True) if pair_index % 2 == 0 else (True, False)
+        for watermarked in order:
+            name = "textseal" if watermarked else "baseline"
+            output = args.output_dir / f"pair-{pair_index + 1}-{name}.jsonl"
+            results[name] = _run_trial(args.base_url, output, watermarked)
+        pair = {"pair": pair_index + 1}
+        for metric in METRICS:
+            baseline = results["baseline"][metric]
+            textseal = results["textseal"][metric]
+            pair[f"baseline_{metric}"] = baseline
+            pair[f"textseal_{metric}"] = textseal
+            pair[f"{metric}_change_percent"] = _percent_change(baseline, textseal)
+        pairs.append(pair)
+
+    regressions = [pair["median_tpot_ms_change_percent"] for pair in pairs]
+    report = {
+        "model": MODEL,
+        "pairs": pairs,
+        "metric_summaries": {
+            metric: _summarize_metric(pairs, metric) for metric in METRICS
+        },
+        "median_paired_tpot_regression_percent": statistics.median(regressions),
+        "mean_paired_tpot_regression_percent": statistics.mean(regressions),
+        "stdev_paired_tpot_regression_percent": statistics.stdev(regressions),
+        "accepted": statistics.median(regressions) < 5.0,
+    }
+    report_path = args.output_dir / "summary.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/textseal/validate_detection.py
+++ b/benchmark/textseal/validate_detection.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+import json
+import statistics
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+from transformers import AutoTokenizer
+
+PINNED_TEXTSEAL_COMMIT = "c60d0d1da2e59f09a698438e218a07ee779b4616"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_official_detector(checkout: Path):
+    package = checkout / "textseal" / "watermarking"
+    textseal_package = types.ModuleType("textseal")
+    textseal_package.__path__ = [str(checkout / "textseal")]
+    watermarking_package = types.ModuleType("textseal.watermarking")
+    watermarking_package.__path__ = [str(package)]
+    sys.modules["textseal"] = textseal_package
+    sys.modules["textseal.watermarking"] = watermarking_package
+
+    config_module = _load_module("textseal.watermarking.config", package / "config.py")
+    _load_module("textseal.watermarking.core", package / "core.py")
+    detector_module = _load_module(
+        "textseal.watermarking.detector", package / "detector.py"
+    )
+    return config_module.WatermarkConfig, detector_module.TextSealDetector
+
+
+def _load_config(path: Path):
+    data = json.loads(path.read_text())
+    return data["providers"]["textseal"]
+
+
+def _load_texts(path: Path, watermarked: bool):
+    texts = []
+    with path.open() as source:
+        for line in source:
+            record = json.loads(line)
+            if record["watermarked"] is watermarked:
+                texts.append(record["text"])
+    return texts
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples", type=Path, required=True)
+    parser.add_argument("--watermark-config", type=Path, required=True)
+    parser.add_argument("--model", default="Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--textseal-checkout", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    commit = subprocess.run(
+        [
+            "git",
+            "-c",
+            f"safe.directory={args.textseal_checkout.resolve()}",
+            "rev-parse",
+            "HEAD",
+        ],
+        cwd=args.textseal_checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if commit != PINNED_TEXTSEAL_COMMIT:
+        raise RuntimeError(f"expected TextSeal {PINNED_TEXTSEAL_COMMIT}, got {commit}")
+
+    WatermarkConfig, TextSealDetector = _load_official_detector(args.textseal_checkout)
+    watermark_config = _load_config(args.watermark_config)
+    config = WatermarkConfig(
+        watermark_type="textseal",
+        secret_key=int(watermark_config["key_a"]),
+        secret_key_b=int(watermark_config["key_b"]),
+        ngram=watermark_config.get("ngram", 2),
+        mixing_alpha=watermark_config.get("mixing_probability", 0.5),
+        scoring_method="v2",
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    detector = TextSealDetector(tokenizer, config, scoring_method="v2")
+
+    positive = detector.detect_batch(_load_texts(args.samples, True))
+    negative = detector.detect_batch(_load_texts(args.samples, False))
+    report = {
+        "textseal_commit": commit,
+        "model": args.model,
+        "scoring_method": "v2",
+        "threshold": 0.01,
+        "positive_samples": len(positive),
+        "negative_samples": len(negative),
+        "detection_rate": statistics.mean(item["detected"] for item in positive),
+        "false_positive_rate": statistics.mean(item["detected"] for item in negative),
+        "positive_median_p_value": statistics.median(
+            item["p_value"] for item in positive
+        ),
+        "negative_median_p_value": statistics.median(
+            item["p_value"] for item in negative
+        ),
+        "positive_scored_tokens": [item["n_tokens"] for item in positive],
+        "negative_scored_tokens": [item["n_tokens"] for item in negative],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -924,6 +924,7 @@
             "pages": [
               "docs/advanced_features/overview",
               "docs/advanced_features/server_arguments",
+              "docs/advanced_features/textseal_watermarking",
               "docs/advanced_features/session_radix_cache",
               "docs/advanced_features/hyperparameter_tuning",
               "docs/advanced_features/attention_backend",

--- a/docs/docs/advanced_features/textseal_watermarking.mdx
+++ b/docs/docs/advanced_features/textseal_watermarking.mdx
@@ -1,0 +1,80 @@
+---
+title: "TextSeal Watermarking"
+metatags:
+    description: "Configure request-controlled TextSeal generation-time watermarking in SGLang."
+---
+
+SGLang supports server-configured, request-controlled TextSeal generation-time watermarking. Secret keys are loaded from a local JSON file at startup and are never accepted in request bodies, headers, or command-line values.
+
+## Configuration
+
+Create a file readable only by the server account:
+
+```json
+{
+  "providers": {
+    "textseal": {
+      "enabled": true,
+      "key_a": "REPLACE_WITH_DECIMAL_KEY_A",
+      "key_b": "REPLACE_WITH_DECIMAL_KEY_B",
+      "ngram": 2,
+      "mixing_probability": 0.5
+    }
+  }
+}
+```
+
+Replace both placeholders with distinct decimal integer strings. Restrict permissions to the server account and rotate keys by replacing the file and restarting the server. SGLang validates the file during startup and redacts key values from configuration representations and errors.
+
+Launch a supported server:
+
+```bash
+sglang serve --model-path Qwen/Qwen2.5-0.5B-Instruct \
+  --watermark-config /run/secrets/sglang-watermark.json \
+  --disable-cuda-graph \
+  --sampling-backend pytorch
+```
+
+## Requests
+
+Enable TextSeal with a header:
+
+```bash
+curl http://127.0.0.1:30000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'X-SGLang-Watermark: textseal' \
+  -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","messages":[{"role":"user","content":"Explain photosynthesis."}],"temperature":0.8}'
+```
+
+Disable watermarking with `X-SGLang-Watermark: off`. HTTP request bodies cannot select watermark providers or configuration.
+
+## Supported Modes
+
+The initial implementation supports text generation through native `/generate`, `/v1/chat/completions`, and `/v1/completions`, including streaming, with TP size 1 and the PyTorch or FlashInfer sampler. Temperature must be nonzero and effective sampling support should contain multiple tokens.
+
+Beam search, speculative decoding, multimodal requests, disaggregated serving, TP greater than 1, other sampling backends, and CUDA graphs are rejected with `watermark_unsupported_mode`. Dynamically collapsed top-p or min-p support emits its sole admissible token for that step.
+
+## Errors
+
+Watermark request failures use HTTP 400 and one of these stable codes: `watermark_invalid_request`, `watermark_provider_unknown`, `watermark_disabled`, or `watermark_unsupported_mode`.
+
+## Provenance And Detection
+
+The generation core is adapted from Meta TextSeal v0.2.0 at commit `c60d0d1da2e59f09a698438e218a07ee779b4616`, licensed under Apache-2.0. Detection remains an offline operation using the official TextSeal detector and its heavier scientific dependencies.
+
+Generate matched samples and run detection from an environment containing that exact upstream checkout:
+
+```bash
+python benchmark/textseal/generate_samples.py --output artifacts/textseal/samples.jsonl
+PYTHONPATH=/path/to/textseal python benchmark/textseal/validate_detection.py \
+  --samples artifacts/textseal/samples.jsonl \
+  --watermark-config /run/secrets/sglang-watermark.json \
+  --textseal-checkout /path/to/textseal \
+  --output artifacts/textseal/detection.json
+```
+
+Run five interleaved latency pairs against the same capable server:
+
+```bash
+python benchmark/textseal/run_latency.py --output-dir artifacts/textseal/latency
+```

--- a/python/sglang/kernels/ops/sampling/textseal_selector.py
+++ b/python/sglang/kernels/ops/sampling/textseal_selector.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_BLOCK_SIZE = 8192
+_M = tl.constexpr(8191)
+_P2 = tl.constexpr(100000007)
+_P3 = tl.constexpr(500001713)
+_P4 = tl.constexpr(15485863)
+_MIXING_PRIME = tl.constexpr(40499)
+_MIXING_SHIFT = tl.constexpr(13)
+
+
+@triton.jit
+def _textseal_partial_argmax_kernel(
+    probs,
+    token_ids,
+    weighted_contexts,
+    keys,
+    partial_scores,
+    partial_token_ids,
+    vocab_size: tl.constexpr,
+    num_splits: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    split = tl.program_id(1)
+    offsets = split * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < vocab_size
+    row_offsets = row * vocab_size + offsets
+    candidate_probs = tl.load(probs + row_offsets, mask=in_bounds, other=0.0).to(
+        tl.float32
+    )
+    out_offset = row * num_splits + split
+
+    if tl.max(candidate_probs, axis=0) > 0.0:
+        candidate_token_ids = tl.load(
+            token_ids + row_offsets, mask=in_bounds, other=0
+        ).to(tl.int64)
+        weighted_context = tl.load(weighted_contexts + row).to(tl.int64)
+        key = tl.load(keys + row).to(tl.int64)
+        hashed = (weighted_context + _P2 * candidate_token_ids + _P3 * key) * _P4
+        hashed = hashed * _MIXING_PRIME
+        hashed = hashed ^ (hashed >> _MIXING_SHIFT)
+        hashed = hashed % _M
+        hashed = tl.where(hashed < 0, hashed + _M, hashed)
+        uniform_scores = hashed.to(tl.float32) / _M
+        is_candidate = in_bounds & (candidate_probs > 0.0)
+        safe_probs = tl.where(is_candidate, candidate_probs, 1.0)
+        selection_scores = tl.where(
+            is_candidate,
+            tl.log(uniform_scores + 1e-30) / safe_probs,
+            -float("inf"),
+        )
+        local_index = tl.argmax(selection_scores, axis=0, tie_break_left=True)
+        best_score = tl.max(selection_scores, axis=0)
+        best_token_id = tl.load(
+            token_ids + row * vocab_size + split * BLOCK_SIZE + local_index
+        )
+        tl.store(partial_scores + out_offset, best_score)
+        tl.store(partial_token_ids + out_offset, best_token_id)
+    else:
+        tl.store(partial_scores + out_offset, -float("inf"))
+        tl.store(partial_token_ids + out_offset, 0)
+
+
+@triton.jit
+def _textseal_finalize_argmax_kernel(
+    partial_scores,
+    partial_token_ids,
+    output_token_ids,
+    num_splits: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_splits
+    scores = tl.load(
+        partial_scores + row * num_splits + offsets,
+        mask=mask,
+        other=-float("inf"),
+    )
+    split = tl.argmax(scores, axis=0, tie_break_left=True)
+    token_id = tl.load(partial_token_ids + row * num_splits + split)
+    tl.store(output_token_ids + row, token_id)
+
+
+def select_textseal_tokens_triton(
+    effective_probs: torch.Tensor,
+    token_ids: torch.Tensor,
+    weighted_contexts: torch.Tensor,
+    keys: torch.Tensor,
+) -> torch.Tensor:
+    if effective_probs.ndim != 2:
+        raise ValueError("effective_probs must be a 2D tensor")
+    if effective_probs.dtype != torch.float32:
+        raise ValueError("effective_probs must use float32")
+    if not effective_probs.is_cuda:
+        raise ValueError("TextSeal Triton selection requires CUDA tensors")
+    if token_ids.shape != effective_probs.shape or token_ids.dtype != torch.int64:
+        raise ValueError("token_ids must be int64 and match effective_probs")
+    batch_size, vocab_size = effective_probs.shape
+    if (
+        weighted_contexts.shape != (batch_size,)
+        or weighted_contexts.dtype != torch.int64
+    ):
+        raise ValueError("weighted_contexts must be int64 with one value per row")
+    if keys.shape != (batch_size,) or keys.dtype != torch.int64:
+        raise ValueError("keys must be int64 with one value per row")
+    if not all(
+        tensor.is_cuda and tensor.is_contiguous()
+        for tensor in (effective_probs, token_ids, weighted_contexts, keys)
+    ):
+        raise ValueError("TextSeal Triton inputs must be contiguous CUDA tensors")
+
+    output_token_ids = torch.empty(
+        batch_size, dtype=torch.int32, device=effective_probs.device
+    )
+    if batch_size == 0:
+        return output_token_ids
+
+    num_splits = triton.cdiv(vocab_size, _BLOCK_SIZE)
+    partial_scores = torch.empty(
+        (batch_size, num_splits), dtype=torch.float32, device=effective_probs.device
+    )
+    partial_token_ids = torch.empty(
+        (batch_size, num_splits), dtype=torch.int32, device=effective_probs.device
+    )
+    _textseal_partial_argmax_kernel[(batch_size, num_splits)](
+        effective_probs,
+        token_ids,
+        weighted_contexts,
+        keys,
+        partial_scores,
+        partial_token_ids,
+        vocab_size=vocab_size,
+        num_splits=num_splits,
+        BLOCK_SIZE=_BLOCK_SIZE,
+        num_warps=8,
+    )
+    _textseal_finalize_argmax_kernel[(batch_size,)](
+        partial_scores,
+        partial_token_ids,
+        output_token_ids,
+        num_splits=num_splits,
+        BLOCK_SIZE=triton.next_power_of_2(num_splits),
+        num_warps=1,
+    )
+    return output_token_ids

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -26,8 +26,11 @@ logger = logging.getLogger(__name__)
 
 def check_server_args(server_args: Any):
     from sglang.srt.arg_groups.lora_hook import check_lora_server_args
+    from sglang.srt.sampling.watermark import load_watermark_config
 
     cfg = resolving_view(server_args)
+
+    load_watermark_config(cfg.watermark_config)
 
     # Check parallel size constraints
     if cfg.ep_join_mode != "scale":

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -110,7 +110,10 @@ from sglang.srt.entrypoints.openai.serving_tokenize import (
 from sglang.srt.entrypoints.openai.serving_transcription import (
     OpenAIServingTranscription,
 )
-from sglang.srt.entrypoints.request_headers import apply_header_overrides
+from sglang.srt.entrypoints.request_headers import (
+    apply_header_overrides,
+    apply_watermark_request,
+)
 from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -907,6 +910,7 @@ if os.environ.get("DUMPER_SERVER_PORT") == "reuse":
 )
 async def generate_request(obj: GenerateReqInput, request: Request):
     """Handle a generate request."""
+    apply_watermark_request(obj, request.headers)
     if envs.SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES.get():
         apply_header_overrides(obj, request.headers)
     if obj.stream:

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -12,6 +12,7 @@ from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
+from sglang.srt.entrypoints.request_headers import apply_watermark_request
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.observability.req_time_stats import monotonic_time
 from sglang.srt.server_args import ServerArgs
@@ -94,6 +95,9 @@ class OpenAIServingBase(ABC):
                 request, raw_request
             )
 
+            if isinstance(adapted_request, GenerateReqInput):
+                apply_watermark_request(adapted_request, raw_request.headers)
+
             if isinstance(adapted_request, (GenerateReqInput, EmbeddingReqInput)):
                 # Only set timing fields if adapted_request supports them
                 adapted_request.received_time = received_time
@@ -108,6 +112,19 @@ class OpenAIServingBase(ABC):
                     adapted_request, processed_request, raw_request
                 )
         except HTTPException as e:
+            if (
+                isinstance(e.detail, dict)
+                and {
+                    "code",
+                    "message",
+                }
+                <= e.detail.keys()
+            ):
+                return self.create_error_response(
+                    message=e.detail["message"],
+                    err_type=e.detail["code"],
+                    status_code=e.status_code,
+                )
             return self.create_error_response(
                 message=e.detail, err_type=str(e.status_code), status_code=e.status_code
             )

--- a/python/sglang/srt/entrypoints/request_headers.py
+++ b/python/sglang/srt/entrypoints/request_headers.py
@@ -6,6 +6,11 @@ This mechanism allows upstream callers to leave the body opaque
 
 from fastapi import HTTPException
 
+from sglang.srt.sampling.watermark import (
+    WatermarkRequestError,
+    parse_watermark_header,
+)
+
 # request header -> (target attribute, value type)
 _HEADER_OVERRIDES = {
     "x-override-rid": ("rid", str),
@@ -31,3 +36,14 @@ def apply_header_overrides(obj, headers) -> None:
             raise HTTPException(
                 status_code=400, detail=f"invalid {header} header {value!r}: {e}"
             ) from e
+
+
+def apply_watermark_request(obj, headers) -> None:
+    """Apply the request watermark selected by the watermark header."""
+    try:
+        obj.watermark = parse_watermark_header(headers.get("x-sglang-watermark"))
+    except WatermarkRequestError as error:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": error.code, "message": str(error)},
+        ) from error

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -19,6 +19,11 @@ from sglang.srt.layers.logprob_processor import (
 from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.srt.sampling.watermark import (
+    WatermarkBatchInfo,
+    deterministic_key_a_mask,
+    select_textseal_tokens,
+)
 from sglang.srt.utils.async_probe import sanitize_nan_logits
 from sglang.srt.utils.common import (
     get_bool_env_var,
@@ -289,6 +294,46 @@ class Sampler(nn.Module):
         Used for standard sampling with flashinfer/pytorch backends.
         Handles both simple (direct multinomial) and complex (top-k/top-p/min-p) cases.
         """
+        if sampling_info.watermark is not None:
+            if sampling_info.watermark.all_enabled:
+                return sample_textseal_from_probs(
+                    probs,
+                    sampling_info.top_ks,
+                    sampling_info.top_ps,
+                    sampling_info.min_ps,
+                    sampling_info.watermark,
+                    positions,
+                    sampling_info.watermark_max_top_k,
+                )
+            ordinary_token_ids = self._sample_from_probs_ordinary(
+                probs, sampling_info, positions, simple_sampling_case
+            )
+            enabled_indices = torch.nonzero(
+                sampling_info.watermark.enabled, as_tuple=True
+            )[0]
+            watermark_token_ids = sample_textseal_from_probs(
+                probs[enabled_indices],
+                sampling_info.top_ks[enabled_indices],
+                sampling_info.top_ps[enabled_indices],
+                sampling_info.min_ps[enabled_indices],
+                sampling_info.watermark.filter(enabled_indices),
+                positions[enabled_indices],
+                sampling_info.watermark_max_top_k,
+            )
+            return ordinary_token_ids.index_copy(
+                0, enabled_indices, watermark_token_ids
+            )
+        return self._sample_from_probs_ordinary(
+            probs, sampling_info, positions, simple_sampling_case
+        )
+
+    def _sample_from_probs_ordinary(
+        self,
+        probs: torch.Tensor,
+        sampling_info: SamplingBatchInfo,
+        positions: torch.Tensor,
+        simple_sampling_case: bool,
+    ) -> torch.Tensor:
         if simple_sampling_case:
             batch_next_token_ids = sampling_from_probs_torch(
                 probs,
@@ -640,6 +685,65 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     probs_idx = probs_idx.to(torch.int32)
     batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
     return batch_next_token_ids
+
+
+def build_effective_probs(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+    min_ps: torch.Tensor,
+) -> torch.Tensor:
+    probs_sort, probs_idx = _build_effective_probs_sorted(probs, top_ks, top_ps, min_ps)
+    return torch.zeros_like(probs).scatter(1, probs_idx, probs_sort)
+
+
+def _build_effective_probs_sorted(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+    min_ps: torch.Tensor,
+    max_top_k: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if max_top_k is not None and max_top_k < probs.shape[-1]:
+        probs_sort, probs_idx = torch.topk(
+            probs, k=max_top_k, dim=-1, largest=True, sorted=True
+        )
+    else:
+        probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    positions = torch.arange(probs_sort.shape[-1], device=probs.device).view(1, -1)
+    keep = positions < top_ks.view(-1, 1)
+    keep &= (probs_sum - probs_sort) <= top_ps.view(-1, 1)
+    keep &= probs_sort >= probs_sort[:, :1] * min_ps.view(-1, 1)
+    probs_sort = torch.where(keep, probs_sort, 0.0)
+    probs_sort = probs_sort / probs_sort.sum(dim=-1, keepdim=True)
+    return probs_sort, probs_idx
+
+
+def sample_textseal_from_probs(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+    min_ps: torch.Tensor,
+    watermark: WatermarkBatchInfo,
+    positions: torch.Tensor,
+    max_top_k: int,
+) -> torch.Tensor:
+    effective_probs, token_ids = _build_effective_probs_sorted(
+        probs, top_ks, top_ps, min_ps, max_top_k
+    )
+    use_key_a = deterministic_key_a_mask(
+        watermark.nonces, positions, watermark.mixing_probabilities
+    )
+    return select_textseal_tokens(
+        effective_probs,
+        watermark.contexts,
+        watermark.key_a,
+        watermark.key_b,
+        use_key_a,
+        token_ids=token_ids,
+        ngrams=watermark.ngrams,
+    )
 
 
 def top_k_top_p_min_p_sampling_from_logits_ascend(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -62,6 +62,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.multimodal.mm_utils import has_valid_data
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.sampling.watermark import WatermarkRequestConfig
 from sglang.srt.utils import ImageData, VideoData
 from sglang.srt.utils.field_validators import validate_optional_list_i64_1d_2d
 from sglang.srt.utils.msgpack_utils import dec_hook, enc_hook, ext_hook
@@ -222,6 +223,9 @@ class GenerateReqInput:
     video_config: Optional[Dict[str, Any]] = None
     # The sampling_params. See descriptions below.
     sampling_params: Optional[Union[List[Dict[str, Any]], Dict[str, Any]]] = None
+    # Runtime type: Optional[Union[WatermarkRequestConfig, List[Optional[WatermarkRequestConfig]]]].
+    # Typed as Any because watermark selection comes exclusively from the HTTP header.
+    watermark: Any = None
     # Whether to return logprobs.
     return_logprob: Optional[Union[List[bool], bool]] = None
     # If return logprobs, the start location in the prompt for returning logprobs.
@@ -555,6 +559,7 @@ class GenerateReqInput:
         self._normalize_video_data(num)
         self._normalize_audio_data(num)
         self._normalize_sampling_params(num)
+        self._normalize_watermark(num)
         self._normalize_logprob_params(num)
         self._normalize_return_hidden_states(num)
         self._normalize_custom_logit_processor(num)
@@ -694,6 +699,16 @@ class GenerateReqInput:
             self.sampling_params = [self.sampling_params] * num
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num
+
+    def _normalize_watermark(self, num):
+        if isinstance(self.watermark, list):
+            if len(self.watermark) != self.batch_size:
+                raise ValueError(
+                    "The length of watermark should be equal to the batch size."
+                )
+            self.watermark = self.watermark * self.parallel_sample_num
+        else:
+            self.watermark = [self.watermark] * num
 
     def _normalize_rid(self, num):
         """Normalize request IDs for batch processing."""
@@ -897,6 +912,7 @@ class GenerateReqInput:
                 else None
             ),
             sampling_params=self.sampling_params[i],
+            watermark=self.watermark[i],
             return_logprob=self.return_logprob[i],
             logprob_start_len=self.logprob_start_len[i],
             top_logprobs_num=self.top_logprobs_num[i],
@@ -980,6 +996,7 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     token_type_ids: Optional[List[int]]
     # The sampling parameters
     sampling_params: SamplingParams
+    watermark: Optional[WatermarkRequestConfig] = None
     # Whether to return the logprobs
     return_logprob: bool
     # If return logprobs, the start location in the prompt for returning logprobs.

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -102,6 +102,12 @@ def resolve_forward_inputs(batch: ScheduleBatch, future_map: FutureMap) -> None:
                     future_map.output_tokens_buf,
                     batch.mix_running_indices,
                 )
+            if batch.sampling_info.watermark is not None:
+                batch.sampling_info.watermark = (
+                    batch.sampling_info.watermark.advance_contexts(
+                        decode_gpu, row_start=len(batch.reqs) - decode_gpu.shape[0]
+                    )
+                )
             batch.input_ids = torch.cat([prefill_gpu, decode_gpu])
         else:
             batch.input_ids = prefill_gpu
@@ -112,6 +118,10 @@ def resolve_forward_inputs(batch: ScheduleBatch, future_map: FutureMap) -> None:
         if _DEBUG_ASSERT:
             _assert_nonneg_and_invalidate(
                 batch.input_ids, future_map.output_tokens_buf, batch.req_pool_indices
+            )
+        if batch.sampling_info.watermark is not None:
+            batch.sampling_info.watermark = (
+                batch.sampling_info.watermark.advance_contexts(batch.input_ids)
             )
 
     # Only the overlap path relays spec extras through the future_map; the

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -140,6 +140,7 @@ from sglang.srt.observability.req_time_stats import (
 )
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.sampling.watermark import WatermarkRequestConfig
 from sglang.srt.utils import flatten_nested_list
 from sglang.srt.utils.token_sequence_matcher import TokenSequenceMatcher
 
@@ -910,6 +911,7 @@ class Req(ReqDllmMixin):
         origin_input_text: str,
         origin_input_ids: array[int],
         sampling_params: SamplingParams,
+        watermark: Optional[WatermarkRequestConfig] = None,
         return_logprob: bool = False,
         top_logprobs_num: int = 0,
         dllm_config: Optional[DllmConfig] = None,
@@ -1008,6 +1010,7 @@ class Req(ReqDllmMixin):
                 "__req__": self
             }
         self.sampling_params = sampling_params
+        self.watermark = watermark
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
         self.return_hidden_states_mode = get_return_hidden_states_mode(
@@ -3286,6 +3289,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
+        if not self.enable_overlap:
+            self.sampling_info.refresh_watermark_contexts(self.reqs)
         # Decode embeds the last output token via embed_tokens; clear the stale
         # prefill-time tensor so it doesn't leak into ForwardBatch.
         self.input_embeds = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -39,11 +39,13 @@ from sglang.srt.runtime_context import (
     get_model,
     get_observability,
     get_parallel,
+    get_resources,
     get_schedule,
     get_serving,
     get_spec,
     publish,
 )
+from sglang.srt.sampling.watermark import load_watermark_config
 
 from sglang.srt.utils.common import suppress_noisy_warnings  # isort: skip
 
@@ -446,6 +448,7 @@ class Scheduler(
 
         # Parse args
         self.server_args = server_args
+        self.init_watermark_registry()
         self.nccl_port = port_args.nccl_port
         self.schedule_policy = get_schedule().schedule_policy
         self.enable_priority_scheduling = get_schedule().enable_priority_scheduling
@@ -701,6 +704,11 @@ class Scheduler(
 
         self.is_initializing = False
         self.init_startup_timing_summary()
+
+    def init_watermark_registry(self) -> None:
+        get_resources().watermark_registry = load_watermark_config(
+            get_serving().watermark_config
+        )
 
     def init_startup_timing_begin(self) -> None:
         self.scheduler_startup_begin = time.perf_counter()
@@ -2625,6 +2633,7 @@ class Scheduler(
                 recv_req.input_text,
                 recv_req.input_ids,
                 recv_req.sampling_params,
+                watermark=recv_req.watermark,
                 return_logprob=recv_req.return_logprob,
                 top_logprobs_num=recv_req.top_logprobs_num,
                 token_ids_logprob=recv_req.token_ids_logprob,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -143,6 +143,10 @@ from sglang.srt.runtime_context import (
     get_spec,
 )
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.sampling.watermark import (
+    WatermarkRequestError,
+    load_watermark_config,
+)
 from sglang.srt.server_args import (
     PortArgs,
     ServerArgs,
@@ -414,6 +418,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Parse args
         self.server_args = server_args
         assert_published(server_args, role="tokenizer")
+        self.init_watermark_registry()
         self.startup_time: Optional[Dict[str, Any]] = None
         self.elastic_worker_count = get_parallel().dp_size
         self.elastic_pending_ep_size = None
@@ -464,6 +469,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.cuda_vmm_feature_transport = CudaVmmFeatureTransport(
             self.server_args, self.mm_processor
         )
+
+    def init_watermark_registry(self):
+        self.watermark_registry = load_watermark_config(get_serving().watermark_config)
 
     def init_model_config(self):
         server_args = self.server_args
@@ -776,6 +784,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Normalize the request
         obj.normalize_batch_and_arguments()
+        self._validate_watermark_requests(obj)
         self._set_default_priority(obj)
         if (
             isinstance(obj, GenerateReqInput)
@@ -834,6 +843,54 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # path are left untouched (pop is a no-op).
             self._discard_pending_req_states(obj)
             raise
+
+    def _validate_watermark_requests(self, obj) -> None:
+        if not isinstance(obj, GenerateReqInput):
+            return
+        requests = (
+            [obj] if obj.is_single else [obj[index] for index in range(obj.batch_size)]
+        )
+        for request in requests:
+            request_config = request.watermark
+            if request_config is None:
+                continue
+            self.watermark_registry.resolve_request(request_config)
+            self._validate_watermark_mode(request)
+
+    def _validate_watermark_mode(self, request: GenerateReqInput) -> None:
+        sampling_params = request.sampling_params
+        unsupported_reason = None
+        if not self.is_generation:
+            unsupported_reason = "watermark requires a generation model"
+        elif not get_device().device.startswith("cuda"):
+            unsupported_reason = "watermark currently requires a CUDA device"
+        elif request.contains_mm_input():
+            unsupported_reason = "watermark does not support multimodal input"
+        elif self.disaggregation_mode != DisaggregationMode.NULL:
+            unsupported_reason = "watermark does not support disaggregated execution"
+        elif get_parallel().tp_size != 1:
+            unsupported_reason = "watermark currently requires tensor parallel size 1"
+        elif get_spec().speculative_algorithm:
+            unsupported_reason = "watermark does not support speculative decoding"
+        elif get_exec().dllm.dllm_algorithm is not None:
+            unsupported_reason = "watermark does not support diffusion language models"
+        elif sampling_params.get("beam_width", 1) > 1:
+            unsupported_reason = "watermark does not support beam search"
+        elif sampling_params.get("temperature", 1.0) == 0:
+            unsupported_reason = "watermark does not support greedy sampling"
+        elif sampling_params.get("top_k") == 1:
+            unsupported_reason = "watermark does not support single-token support"
+        elif get_exec().kernel.sampling_backend not in ("flashinfer", "pytorch"):
+            unsupported_reason = "watermark requires the flashinfer or pytorch sampler"
+        elif not get_exec().graph.disable_cuda_graph:
+            unsupported_reason = (
+                "watermark currently requires CUDA graphs to be disabled"
+            )
+
+        if unsupported_reason is not None:
+            raise WatermarkRequestError(
+                "watermark_unsupported_mode", unsupported_reason
+            )
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool
@@ -1381,6 +1438,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 input_ids=input_ids_arr,
                 mm_inputs=mm_inputs,
                 sampling_params=sampling_params,
+                watermark=obj.watermark,
                 return_logprob=obj.return_logprob,
                 logprob_start_len=obj.logprob_start_len,
                 top_logprobs_num=obj.top_logprobs_num,

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -579,6 +579,8 @@ class Resources(_FlagGroupBase):
     tcp_store: Any = None
     # Trace verbosity; the accessor seeds it lazily from SGLANG_TRACE_LEVEL.
     trace_level: Any = None
+    # Secret-owning watermark provider registry, initialized once per process.
+    watermark_registry: Any = None
 
 
 class ForwardFlags:

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -12,10 +12,15 @@ from sglang.srt.constrained.base_grammar_backend import (
     GrammarMask,
     GrammarRow,
 )
-from sglang.srt.runtime_context import get_exec
+from sglang.srt.runtime_context import get_exec, get_resources
 from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
 from sglang.srt.sampling.penaltylib.repetition_penalty import apply_scaling_penalties
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.srt.sampling.watermark import (
+    WatermarkBatchInfo,
+    WatermarkRequestConfig,
+    build_watermark_batch_info,
+)
 from sglang.srt.utils.common import is_pin_memory_available
 
 if TYPE_CHECKING:
@@ -77,12 +82,15 @@ class SamplingBatchInfo:
     # Per-request flag for returning sparse sampling support metadata.
     return_sampling_masks: Optional[List[bool]] = None
     sampling_mask_max_top_k: int = 0
+    watermark_max_top_k: int = 0
 
     # Device
     device: str = "cuda"
 
     # Handle logit bias
     logit_bias: Optional[torch.Tensor] = None
+
+    watermark: Optional[WatermarkBatchInfo] = None
 
     @classmethod
     def from_schedule_batch(cls, batch: ScheduleBatch, vocab_size: int):
@@ -148,6 +156,14 @@ class SamplingBatchInfo:
         return_sampling_masks = [r.return_sampling_mask for r in reqs]
         sampling_mask_max_top_k = max(
             (r.sampling_params.top_k for r in reqs if r.return_sampling_mask),
+            default=0,
+        )
+        watermark_max_top_k = max(
+            (
+                r.sampling_params.top_k
+                for r in reqs
+                if isinstance(r.watermark, WatermarkRequestConfig)
+            ),
             default=0,
         )
 
@@ -216,26 +232,66 @@ class SamplingBatchInfo:
             logit_bias=logit_bias,
             return_sampling_masks=return_sampling_masks,
             sampling_mask_max_top_k=sampling_mask_max_top_k,
+            watermark_max_top_k=watermark_max_top_k,
         )
         ret.adjusted_from_schedule_batch(batch, vocab_size)
         return ret
 
     # placeholder for override
     def adjusted_from_schedule_batch(self, batch: ScheduleBatch, vocab_size: int):
-        pass
+        registry = get_resources().watermark_registry
+        if registry is None:
+            if any(
+                isinstance(request.watermark, WatermarkRequestConfig)
+                for request in batch.reqs
+            ):
+                raise RuntimeError("watermark registry is not initialized")
+            return
+        self.watermark = build_watermark_batch_info(
+            batch.reqs, registry, device=batch.device
+        )
 
     # placeholder for override
-    def adjusted_merge_batch(self, other: SamplingBatchInfo):
-        pass
+    def adjusted_merge_batch(
+        self,
+        other: SamplingBatchInfo,
+        *,
+        self_len: int,
+        other_len: int,
+    ):
+        if self.watermark is None:
+            if other.watermark is None:
+                return
+            disabled = WatermarkBatchInfo.disabled(
+                self_len,
+                context_width=other.watermark.contexts.shape[1],
+                device=other.watermark.contexts.device,
+            )
+            self.watermark = disabled.merge(other.watermark)
+            return
+        if other.watermark is None:
+            disabled = WatermarkBatchInfo.disabled(
+                other_len,
+                context_width=self.watermark.contexts.shape[1],
+                device=self.watermark.contexts.device,
+            )
+            self.watermark = self.watermark.merge(disabled)
+            return
+        self.watermark = self.watermark.merge(other.watermark)
 
     # placeholder for override
     def adjusted_filter_batch(
         self, keep_indices: List[int], keep_indices_device: torch.Tensor
     ):
-        pass
+        if self.watermark is not None:
+            self.watermark = self.watermark.filter(keep_indices_device)
 
     def __len__(self):
         return len(self.temperatures)
+
+    def refresh_watermark_contexts(self, requests) -> None:
+        if self.watermark is not None:
+            self.watermark = self.watermark.refresh_contexts(requests)
 
     def update_regex_vocab_mask(self):
         if not self.grammars:
@@ -469,8 +525,15 @@ class SamplingBatchInfo:
         self.need_top_p_sampling |= other.need_top_p_sampling
         self.need_top_k_sampling |= other.need_top_k_sampling
         self.need_min_p_sampling |= other.need_min_p_sampling
+        self.watermark_max_top_k = max(
+            self.watermark_max_top_k, other.watermark_max_top_k
+        )
 
-        self.adjusted_merge_batch(other)
+        self.adjusted_merge_batch(
+            other,
+            self_len=self_len,
+            other_len=other_len,
+        )
 
     def copy_for_forward(self):
         # Accumulate the penalty into a pre-allocated buffer to get rid of the dependency of `penalizer_orchestrator` later

--- a/python/sglang/srt/sampling/watermark/__init__.py
+++ b/python/sglang/srt/sampling/watermark/__init__.py
@@ -1,0 +1,41 @@
+from sglang.srt.sampling.watermark.batch import (
+    WatermarkBatchInfo,
+    build_watermark_batch_info,
+)
+from sglang.srt.sampling.watermark.config import (
+    TextSealConfig,
+    WatermarkConfigError,
+    WatermarkRegistry,
+    load_watermark_config,
+)
+from sglang.srt.sampling.watermark.request import (
+    WatermarkRequestConfig,
+    WatermarkRequestError,
+    parse_watermark_header,
+)
+from sglang.srt.sampling.watermark.textseal import (
+    context_from_token_ids,
+    deterministic_key_a_mask,
+    prf_dual,
+    prf_uniform,
+    request_nonce,
+    select_textseal_tokens,
+)
+
+__all__ = [
+    "TextSealConfig",
+    "WatermarkBatchInfo",
+    "WatermarkConfigError",
+    "WatermarkRegistry",
+    "WatermarkRequestConfig",
+    "WatermarkRequestError",
+    "build_watermark_batch_info",
+    "context_from_token_ids",
+    "deterministic_key_a_mask",
+    "load_watermark_config",
+    "parse_watermark_header",
+    "prf_dual",
+    "prf_uniform",
+    "request_nonce",
+    "select_textseal_tokens",
+]

--- a/python/sglang/srt/sampling/watermark/batch.py
+++ b/python/sglang/srt/sampling/watermark/batch.py
@@ -1,0 +1,196 @@
+from collections.abc import Sequence
+from typing import Any
+
+import msgspec
+import torch
+
+from sglang.srt.sampling.watermark.config import WatermarkRegistry
+from sglang.srt.sampling.watermark.request import WatermarkRequestConfig
+from sglang.srt.sampling.watermark.textseal import (
+    context_from_token_ids,
+    request_nonce,
+)
+
+
+class WatermarkBatchInfo(msgspec.Struct, frozen=True, kw_only=True):
+    enabled: torch.Tensor
+    all_enabled: bool
+    key_a: torch.Tensor
+    key_b: torch.Tensor
+    mixing_probabilities: torch.Tensor
+    ngrams: torch.Tensor
+    contexts: torch.Tensor
+    nonces: torch.Tensor
+
+    @classmethod
+    def disabled(
+        cls,
+        batch_size: int,
+        *,
+        context_width: int,
+        device: torch.device | str,
+    ) -> "WatermarkBatchInfo":
+        return cls(
+            enabled=torch.zeros(batch_size, dtype=torch.bool, device=device),
+            all_enabled=False,
+            key_a=torch.zeros(batch_size, dtype=torch.long, device=device),
+            key_b=torch.zeros(batch_size, dtype=torch.long, device=device),
+            mixing_probabilities=torch.zeros(
+                batch_size, dtype=torch.float, device=device
+            ),
+            ngrams=torch.ones(batch_size, dtype=torch.int32, device=device),
+            contexts=torch.zeros(
+                (batch_size, context_width), dtype=torch.long, device=device
+            ),
+            nonces=torch.zeros(batch_size, dtype=torch.long, device=device),
+        )
+
+    def advance_contexts(
+        self, token_ids: torch.Tensor, *, row_start: int = 0
+    ) -> "WatermarkBatchInfo":
+        contexts = self.contexts.clone()
+        contexts[row_start:] = torch.cat(
+            (contexts[row_start:, 1:], token_ids.long().view(-1, 1)), dim=1
+        )
+        return WatermarkBatchInfo(
+            enabled=self.enabled,
+            all_enabled=self.all_enabled,
+            key_a=self.key_a,
+            key_b=self.key_b,
+            mixing_probabilities=self.mixing_probabilities,
+            ngrams=self.ngrams,
+            contexts=contexts,
+            nonces=self.nonces,
+        )
+
+    def refresh_contexts(self, requests: Sequence[Any]) -> "WatermarkBatchInfo":
+        contexts = torch.zeros_like(self.contexts)
+        for row, request in enumerate(requests):
+            if not self.enabled[row]:
+                continue
+            ngram = int(self.ngrams[row].item())
+            token_ids = request.origin_input_ids + request.output_ids
+            contexts[row, -ngram:] = context_from_token_ids(
+                token_ids, ngram, device=contexts.device
+            )
+        return WatermarkBatchInfo(
+            enabled=self.enabled,
+            all_enabled=self.all_enabled,
+            key_a=self.key_a,
+            key_b=self.key_b,
+            mixing_probabilities=self.mixing_probabilities,
+            ngrams=self.ngrams,
+            contexts=contexts,
+            nonces=self.nonces,
+        )
+
+    def filter(self, keep_indices: torch.Tensor) -> "WatermarkBatchInfo":
+        return WatermarkBatchInfo(
+            enabled=self.enabled[keep_indices],
+            all_enabled=self.all_enabled,
+            key_a=self.key_a[keep_indices],
+            key_b=self.key_b[keep_indices],
+            mixing_probabilities=self.mixing_probabilities[keep_indices],
+            ngrams=self.ngrams[keep_indices],
+            contexts=self.contexts[keep_indices],
+            nonces=self.nonces[keep_indices],
+        )
+
+    def merge(self, other: "WatermarkBatchInfo") -> "WatermarkBatchInfo":
+        context_width = max(self.contexts.shape[1], other.contexts.shape[1])
+        return WatermarkBatchInfo(
+            enabled=torch.cat((self.enabled, other.enabled)),
+            all_enabled=self.all_enabled and other.all_enabled,
+            key_a=torch.cat((self.key_a, other.key_a)),
+            key_b=torch.cat((self.key_b, other.key_b)),
+            mixing_probabilities=torch.cat(
+                (self.mixing_probabilities, other.mixing_probabilities)
+            ),
+            ngrams=torch.cat((self.ngrams, other.ngrams)),
+            contexts=torch.cat(
+                (
+                    _left_pad_contexts(self.contexts, context_width),
+                    _left_pad_contexts(other.contexts, context_width),
+                )
+            ),
+            nonces=torch.cat((self.nonces, other.nonces)),
+        )
+
+
+def _left_pad_contexts(contexts: torch.Tensor, width: int) -> torch.Tensor:
+    if contexts.shape[1] == width:
+        return contexts
+    padding = torch.zeros(
+        (contexts.shape[0], width - contexts.shape[1]),
+        dtype=contexts.dtype,
+        device=contexts.device,
+    )
+    return torch.cat((padding, contexts), dim=1)
+
+
+def build_watermark_batch_info(
+    requests: Sequence[Any],
+    registry: WatermarkRegistry,
+    *,
+    device: torch.device | str,
+) -> WatermarkBatchInfo | None:
+    if not any(
+        isinstance(request.watermark, WatermarkRequestConfig) for request in requests
+    ):
+        return None
+
+    configs = [
+        (
+            registry.resolve_request(request.watermark)
+            if isinstance(request.watermark, WatermarkRequestConfig)
+            else None
+        )
+        for request in requests
+    ]
+    max_ngram = max(config.ngram for config in configs if config is not None)
+    contexts = torch.zeros((len(requests), max_ngram), dtype=torch.long, device=device)
+    for row, (request, config) in enumerate(zip(requests, configs)):
+        if config is None:
+            continue
+        token_ids = request.origin_input_ids + request.output_ids
+        contexts[row, -config.ngram :] = context_from_token_ids(
+            token_ids, config.ngram, device=device
+        )
+
+    return WatermarkBatchInfo(
+        enabled=torch.tensor(
+            [config is not None for config in configs],
+            dtype=torch.bool,
+            device=device,
+        ),
+        all_enabled=all(config is not None for config in configs),
+        key_a=torch.tensor(
+            [config.key_a if config is not None else 0 for config in configs],
+            dtype=torch.long,
+            device=device,
+        ),
+        key_b=torch.tensor(
+            [config.key_b if config is not None else 0 for config in configs],
+            dtype=torch.long,
+            device=device,
+        ),
+        mixing_probabilities=torch.tensor(
+            [
+                config.mixing_probability if config is not None else 0.0
+                for config in configs
+            ],
+            dtype=torch.float,
+            device=device,
+        ),
+        ngrams=torch.tensor(
+            [config.ngram if config is not None else 1 for config in configs],
+            dtype=torch.int32,
+            device=device,
+        ),
+        contexts=contexts,
+        nonces=torch.tensor(
+            [request_nonce(request.rid) for request in requests],
+            dtype=torch.long,
+            device=device,
+        ),
+    )

--- a/python/sglang/srt/sampling/watermark/config.py
+++ b/python/sglang/srt/sampling/watermark/config.py
@@ -1,0 +1,156 @@
+import json
+import math
+from pathlib import Path
+from typing import Any, Optional
+
+import msgspec
+
+from sglang.srt.sampling.watermark.request import (
+    WatermarkRequestConfig,
+    WatermarkRequestError,
+)
+
+_INT64_MIN = -(1 << 63)
+_INT64_MAX = (1 << 63) - 1
+
+
+class WatermarkConfigError(ValueError):
+    pass
+
+
+class TextSealConfig(msgspec.Struct, frozen=True, kw_only=True):
+    key_a: int
+    key_b: int
+    ngram: int = 1
+    mixing_probability: float = 0.5
+
+    def __repr__(self) -> str:
+        return (
+            "TextSealConfig(key_a=<redacted>, key_b=<redacted>, "
+            f"ngram={self.ngram!r}, "
+            f"mixing_probability={self.mixing_probability!r})"
+        )
+
+
+class WatermarkRegistry(msgspec.Struct, frozen=True, kw_only=True):
+    textseal: Optional[TextSealConfig] = None
+
+    @property
+    def textseal_enabled(self) -> bool:
+        return self.textseal is not None
+
+    def resolve_request(self, request: WatermarkRequestConfig) -> TextSealConfig:
+        if request.provider != "textseal":
+            raise WatermarkRequestError(
+                "watermark_provider_unknown", "unknown watermark provider"
+            )
+        if not self.textseal_enabled:
+            raise WatermarkRequestError(
+                "watermark_disabled", "requested watermark provider is disabled"
+            )
+        assert self.textseal is not None
+        return self.textseal
+
+    def __repr__(self) -> str:
+        return f"WatermarkRegistry(textseal_enabled={self.textseal_enabled!r})"
+
+
+def load_watermark_config(path: Optional[str]) -> WatermarkRegistry:
+    if path is None:
+        return WatermarkRegistry()
+
+    config_path = Path(path).expanduser().resolve()
+    if not config_path.is_file():
+        raise WatermarkConfigError("watermark config must be a readable regular file")
+
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise WatermarkConfigError("failed to read watermark config JSON") from error
+
+    return _parse_watermark_config(raw)
+
+
+def _parse_watermark_config(raw: Any) -> WatermarkRegistry:
+    root = _require_object(raw, "watermark config")
+    _reject_unknown_fields(root, {"providers"}, "watermark config")
+    providers = _require_object(root.get("providers"), "providers")
+    _reject_unknown_fields(providers, {"textseal"}, "providers")
+
+    textseal = providers.get("textseal")
+    if textseal is None:
+        return WatermarkRegistry()
+    textseal = _require_object(textseal, "TextSeal provider")
+    _reject_unknown_fields(
+        textseal,
+        {"enabled", "key_a", "key_b", "ngram", "mixing_probability"},
+        "TextSeal provider",
+    )
+
+    enabled = textseal.get("enabled")
+    if not isinstance(enabled, bool):
+        raise WatermarkConfigError("TextSeal enabled must be a boolean")
+    if not enabled:
+        return WatermarkRegistry()
+
+    return WatermarkRegistry(textseal=_parse_textseal_config(textseal))
+
+
+def _parse_textseal_config(raw: dict[str, Any]) -> TextSealConfig:
+    key_a = _parse_secret_integer(raw.get("key_a"), "key_a")
+    key_b = _parse_secret_integer(raw.get("key_b"), "key_b")
+    if key_a == key_b:
+        raise WatermarkConfigError("TextSeal keys must be distinct")
+
+    ngram = raw.get("ngram", 1)
+    if isinstance(ngram, bool) or not isinstance(ngram, int) or not 1 <= ngram <= 10:
+        raise WatermarkConfigError("TextSeal ngram must be an integer in [1, 10]")
+
+    mixing_probability = raw.get("mixing_probability", 0.5)
+    if isinstance(mixing_probability, bool) or not isinstance(
+        mixing_probability, (int, float)
+    ):
+        raise WatermarkConfigError(
+            "TextSeal mixing_probability must be a finite number in [0, 1]"
+        )
+    mixing_probability = float(mixing_probability)
+    if not math.isfinite(mixing_probability) or not 0 <= mixing_probability <= 1:
+        raise WatermarkConfigError(
+            "TextSeal mixing_probability must be a finite number in [0, 1]"
+        )
+
+    return TextSealConfig(
+        key_a=key_a,
+        key_b=key_b,
+        ngram=ngram,
+        mixing_probability=mixing_probability,
+    )
+
+
+def _parse_secret_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise WatermarkConfigError(f"TextSeal {field} must be a signed 64-bit integer")
+    if isinstance(value, str):
+        try:
+            value = int(value, 10)
+        except ValueError as error:
+            raise WatermarkConfigError(
+                f"TextSeal {field} must be a signed 64-bit integer"
+            ) from error
+    if not isinstance(value, int) or not _INT64_MIN <= value <= _INT64_MAX:
+        raise WatermarkConfigError(f"TextSeal {field} must be a signed 64-bit integer")
+    return value
+
+
+def _require_object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise WatermarkConfigError(f"{field} must be a JSON object")
+    return value
+
+
+def _reject_unknown_fields(
+    value: dict[str, Any], allowed: set[str], field: str
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise WatermarkConfigError(f"{field} contains unknown fields: {unknown!r}")

--- a/python/sglang/srt/sampling/watermark/request.py
+++ b/python/sglang/srt/sampling/watermark/request.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+import msgspec
+
+
+class WatermarkRequestConfig(msgspec.Struct, frozen=True, kw_only=True):
+    provider: str
+
+
+class WatermarkRequestError(ValueError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def parse_watermark_header(value: Optional[str]) -> Optional[WatermarkRequestConfig]:
+    if value is None:
+        return None
+
+    value = value.strip()
+    if value == "off":
+        return None
+
+    if value != "textseal":
+        if value.split(";", 1)[0] not in {"off", "textseal"}:
+            raise WatermarkRequestError(
+                "watermark_provider_unknown", "unknown watermark provider"
+            )
+        raise WatermarkRequestError(
+            "watermark_invalid_request", "invalid watermark request header"
+        )
+
+    return WatermarkRequestConfig(provider="textseal")

--- a/python/sglang/srt/sampling/watermark/textseal.py
+++ b/python/sglang/srt/sampling/watermark/textseal.py
@@ -1,0 +1,163 @@
+"""TextSeal generation core adapted from Meta TextSeal v0.2.0.
+
+Source: facebookresearch/textseal commit c60d0d1da2e59f09a698438e218a07ee779b4616,
+Apache-2.0. SGLang adds batched keys, deterministic key choice, and
+effective-support inputs.
+"""
+
+import hashlib
+from collections.abc import Sequence
+
+import torch
+
+_PRIMES = [
+    10000019,
+    10000247,
+    10000439,
+    10000643,
+    10000747,
+    10000867,
+    10000993,
+    10001213,
+    10001357,
+    10001501,
+]
+_P2 = 100000007
+_P3 = 500001713
+_P4 = 15485863
+_M = 8191
+_MIXING_PRIME = 40499
+_MIXING_SHIFT = 13
+_KEY_CHOICE_DOMAIN = 0x53474C545854534C
+
+
+def _weighted_sum(contexts: torch.Tensor) -> torch.Tensor:
+    primes = torch.tensor(
+        _PRIMES[: contexts.shape[-1]], dtype=torch.long, device=contexts.device
+    )
+    return (contexts.long() * primes).sum(dim=-1)
+
+
+def _weighted_sum_by_ngram(
+    contexts: torch.Tensor, ngrams: torch.Tensor
+) -> torch.Tensor:
+    width = contexts.shape[-1]
+    context_positions = (
+        torch.arange(width, device=contexts.device).view(1, -1)
+        - width
+        + ngrams.view(-1, 1)
+    )
+    primes = torch.tensor(_PRIMES[:width], dtype=torch.long, device=contexts.device)
+    weights = primes[context_positions.clamp_min(0)]
+    weights = torch.where(context_positions >= 0, weights, 0)
+    return (contexts.long() * weights).sum(dim=-1)
+
+
+def _expand_rows(value: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    while value.ndim < target.ndim:
+        value = value.unsqueeze(-1)
+    return value
+
+
+def _hash(
+    weighted_contexts: torch.Tensor,
+    token_ids: torch.Tensor,
+    secret_keys: int | torch.Tensor,
+) -> torch.Tensor:
+    weighted_contexts = _expand_rows(weighted_contexts, token_ids)
+    if isinstance(secret_keys, int):
+        secret_keys = torch.full_like(token_ids, secret_keys, dtype=torch.long)
+    else:
+        secret_keys = _expand_rows(secret_keys.to(token_ids.device).long(), token_ids)
+    hashed = (weighted_contexts + _P2 * token_ids.long() + _P3 * secret_keys) * _P4
+    hashed = hashed * _MIXING_PRIME
+    hashed = hashed ^ (hashed >> _MIXING_SHIFT)
+    return hashed % _M
+
+
+def prf_uniform(
+    contexts: torch.Tensor,
+    token_ids: torch.Tensor,
+    secret_keys: int | torch.Tensor,
+) -> torch.Tensor:
+    token_ids = token_ids.to(contexts.device)
+    return _hash(_weighted_sum(contexts), token_ids, secret_keys).float() / _M
+
+
+def prf_dual(
+    contexts: torch.Tensor,
+    token_ids: torch.Tensor,
+    key_a: int | torch.Tensor,
+    key_b: int | torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    weighted_contexts = _weighted_sum(contexts)
+    token_ids = token_ids.to(contexts.device)
+    return (
+        _hash(weighted_contexts, token_ids, key_a).float() / _M,
+        _hash(weighted_contexts, token_ids, key_b).float() / _M,
+    )
+
+
+def request_nonce(request_id: str) -> int:
+    digest = hashlib.blake2b(
+        request_id.encode("utf-8"), digest_size=8, person=b"SGLTextSeal"
+    ).digest()
+    return int.from_bytes(digest, "little", signed=True)
+
+
+def deterministic_key_a_mask(
+    nonces: torch.Tensor,
+    positions: torch.Tensor,
+    mixing_probabilities: torch.Tensor,
+) -> torch.Tensor:
+    contexts = nonces.long().view(-1, 1)
+    scores = prf_uniform(contexts, positions.long(), _KEY_CHOICE_DOMAIN)
+    return scores < mixing_probabilities
+
+
+def context_from_token_ids(
+    token_ids: Sequence[int], ngram: int, *, device: torch.device | str
+) -> torch.Tensor:
+    tail = list(token_ids[-ngram:])
+    return torch.tensor(
+        [0] * (ngram - len(tail)) + tail,
+        dtype=torch.long,
+        device=device,
+    )
+
+
+def select_textseal_tokens(
+    effective_probs: torch.Tensor,
+    contexts: torch.Tensor,
+    key_a: torch.Tensor,
+    key_b: torch.Tensor,
+    use_key_a: torch.Tensor,
+    token_ids: torch.Tensor | None = None,
+    ngrams: torch.Tensor | None = None,
+) -> torch.Tensor:
+    weighted_contexts = (
+        _weighted_sum(contexts)
+        if ngrams is None
+        else _weighted_sum_by_ngram(contexts, ngrams)
+    )
+    keys = torch.where(use_key_a, key_a, key_b)
+    if effective_probs.is_cuda and token_ids is not None:
+        from sglang.kernels.ops.sampling.textseal_selector import (
+            select_textseal_tokens_triton,
+        )
+
+        return select_textseal_tokens_triton(
+            effective_probs,
+            token_ids,
+            weighted_contexts,
+            keys,
+        )
+
+    if token_ids is None:
+        token_ids = torch.arange(
+            effective_probs.shape[-1], device=effective_probs.device
+        ).expand_as(effective_probs)
+    uniform_scores = _hash(weighted_contexts, token_ids, keys).float() / _M
+    selection_scores = torch.log(uniform_scores + 1e-30) / (effective_probs + 1e-30)
+    selected_indices = torch.argmax(selection_scores, dim=-1, keepdim=True)
+    return torch.gather(token_ids, -1, selected_indices).reshape(-1).to(torch.int32)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1322,6 +1322,11 @@ class ServerArgs:
         "Set admin API key for sensitive management endpoints (e.g. /clear_hicache_storage_backend). When set, admin endpoints require this key and do NOT accept --api-key.",
         NS("serving"),
     ] = None
+    watermark_config: A[
+        Optional[str],
+        "Path to the server-side watermark configuration JSON file.",
+        NS("serving"),
+    ] = None
     served_model_name: A[
         Optional[str],
         "Override the model name returned by the v1/models endpoint in OpenAI API server.",

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -295,6 +295,7 @@ class Session:
             origin_input_ids=input_ids,
             origin_input_ids_unpadded=input_ids_unpadded,
             sampling_params=req.sampling_params,
+            watermark=req.watermark,
             lora_id=req.lora_id,
             session=self,
             custom_logit_processor=req.custom_logit_processor,

--- a/test/registered/jit/test_textseal_selector.py
+++ b/test/registered/jit/test_textseal_selector.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.sampling.textseal_selector import (
+    select_textseal_tokens_triton,
+)
+from sglang.srt.sampling.watermark.textseal import (
+    _weighted_sum_by_ngram,
+    select_textseal_tokens,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class TestTextSealSelector(CustomTestCase):
+    def test_matches_reference_across_split_boundaries(self) -> None:
+        """Blockwise selection must preserve dense hash-score argmax semantics."""
+        generator = torch.Generator().manual_seed(7)
+        batch_size = 5
+        vocab_size = 16_397
+        probs = torch.rand(batch_size, vocab_size, generator=generator)
+        probs, token_ids = probs.sort(dim=-1, descending=True)
+        support_lengths = torch.tensor([1, 8_191, 8_192, 8_193, vocab_size])
+        is_candidate = torch.arange(vocab_size).view(1, -1) < support_lengths.view(
+            -1, 1
+        )
+        probs = torch.where(is_candidate, probs, 0.0)
+        probs = probs / probs.sum(dim=-1, keepdim=True)
+
+        contexts = torch.tensor(
+            [
+                [0, 0, 0, 0],
+                [1, -2, 3, -4],
+                [2**31 - 1, -(2**31), 17, -29],
+                [10**12, -(10**12), 97, -101],
+                [-(2**40), 2**39, -(2**38), 2**37],
+            ],
+            dtype=torch.int64,
+        )
+        ngrams = torch.tensor([1, 2, 3, 4, 4], dtype=torch.int32)
+        key_a = torch.tensor([0, 741852963, -(2**40), 2**39, -17])
+        key_b = torch.tensor([963852741, -31, 2**40, -(2**39), 19])
+        use_key_a = torch.tensor([True, False, True, False, True])
+
+        expected = select_textseal_tokens(
+            probs,
+            contexts,
+            key_a,
+            key_b,
+            use_key_a,
+            token_ids=token_ids,
+            ngrams=ngrams,
+        )
+        weighted_contexts = _weighted_sum_by_ngram(contexts, ngrams)
+        keys = torch.where(use_key_a, key_a, key_b)
+        actual = select_textseal_tokens_triton(
+            probs.cuda(),
+            token_ids.cuda(),
+            weighted_contexts.cuda(),
+            keys.cuda(),
+        ).cpu()
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/openai_server/features/test_textseal.py
+++ b/test/registered/openai_server/features/test_textseal.py
@@ -1,0 +1,122 @@
+import json
+import os
+import tempfile
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+class TestTextSealEndpoints(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        )
+        json.dump(
+            {
+                "providers": {
+                    "textseal": {
+                        "enabled": True,
+                        "key_a": "741852963",
+                        "key_b": "963852741",
+                        "ngram": 2,
+                        "mixing_probability": 0.5,
+                    }
+                }
+            },
+            cls.config_file,
+        )
+        cls.config_file.close()
+        cls.process = popen_launch_server(
+            MODEL,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--disable-cuda-graph",
+                "--attention-backend",
+                "triton",
+                "--sampling-backend",
+                "pytorch",
+                "--watermark-config",
+                cls.config_file.name,
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        os.unlink(cls.config_file.name)
+
+    def _request(self, endpoint, payload, *, stream, header=True):
+        payload = {**payload, "stream": stream, "temperature": 0.8, "max_tokens": 8}
+        headers = {"X-SGLang-Watermark": "textseal"} if header else {}
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + endpoint,
+            json=payload,
+            headers=headers,
+            stream=stream,
+            timeout=60,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        if stream:
+            chunks = [line for line in response.iter_lines() if line]
+            self.assertTrue(any(line.startswith(b"data:") for line in chunks))
+        else:
+            self.assertTrue(response.json()["choices"])
+
+    def test_chat_and_completions_streaming_and_non_streaming(self):
+        cases = [
+            (
+                "/v1/chat/completions",
+                {
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "Say hello."}],
+                },
+            ),
+            (
+                "/v1/completions",
+                {
+                    "model": MODEL,
+                    "prompt": "The capital of France is",
+                },
+            ),
+        ]
+        for endpoint, payload in cases:
+            for stream in (False, True):
+                with self.subTest(endpoint=endpoint, stream=stream):
+                    self._request(endpoint, payload, stream=stream)
+
+    def test_stable_header_errors(self):
+        payload = {
+            "model": MODEL,
+            "prompt": "Hello",
+            "temperature": 0.8,
+            "max_tokens": 2,
+        }
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/v1/completions",
+            json=payload,
+            headers={"X-SGLang-Watermark": "textseal;key_a=do-not-log"},
+            timeout=60,
+        )
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertEqual(body["type"], "watermark_invalid_request")
+        self.assertNotIn("do-not-log", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/watermark/test_batch_info.py
+++ b/test/registered/unit/sampling/watermark/test_batch_info.py
@@ -1,0 +1,162 @@
+import unittest
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.overlap_utils import resolve_forward_inputs
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.sampling.watermark import (
+    TextSealConfig,
+    WatermarkRegistry,
+    WatermarkRequestConfig,
+    build_watermark_batch_info,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _request(rid, prompt, output, watermarked=False):
+    return SimpleNamespace(
+        rid=rid,
+        origin_input_ids=array("q", prompt),
+        output_ids=array("q", output),
+        watermark=(
+            WatermarkRequestConfig(provider="textseal") if watermarked else None
+        ),
+    )
+
+
+class TestWatermarkBatchInfo(CustomTestCase):
+    def setUp(self):
+        self.registry = WatermarkRegistry(
+            textseal=TextSealConfig(key_a=11, key_b=12, ngram=2)
+        )
+
+    def test_ordinary_batch_has_no_attachment(self):
+        requests = [_request("ordinary", [1, 2], [])]
+        self.assertIsNone(
+            build_watermark_batch_info(requests, self.registry, device="cpu")
+        )
+
+    def test_constructs_prompt_and_generated_contexts(self):
+        requests = [
+            _request("a", [1], [2, 3], True),
+            _request("b", [4], []),
+            _request("c", [5, 6], [7], True),
+        ]
+        info = build_watermark_batch_info(requests, self.registry, device="cpu")
+
+        self.assertEqual(info.enabled.tolist(), [True, False, True])
+        self.assertFalse(info.all_enabled)
+        self.assertEqual(info.contexts.tolist(), [[2, 3], [0, 0], [6, 7]])
+        self.assertEqual(info.ngrams.tolist(), [2, 1, 2])
+        self.assertEqual(info.key_a.tolist(), [11, 0, 11])
+
+    def test_filter_reorder_and_merge_preserve_alignment(self):
+        first = build_watermark_batch_info(
+            [
+                _request("a", [1, 2], [], True),
+                _request("b", [3, 4], []),
+            ],
+            self.registry,
+            device="cpu",
+        )
+        filtered = first.filter(torch.tensor([1, 0]))
+        self.assertEqual(filtered.enabled.tolist(), [False, True])
+        self.assertEqual(filtered.contexts.tolist(), [[0, 0], [1, 2]])
+
+        second = build_watermark_batch_info(
+            [_request("c", [5], [6, 7], True)],
+            self.registry,
+            device="cpu",
+        )
+        self.assertTrue(second.all_enabled)
+        merged = filtered.merge(second)
+        self.assertFalse(merged.all_enabled)
+        self.assertEqual(merged.enabled.tolist(), [False, True, True])
+        self.assertEqual(
+            merged.contexts.tolist(),
+            [[0, 0], [1, 2], [6, 7]],
+        )
+
+        requests = [
+            _request("b", [3, 4], [8]),
+            _request("a", [1, 2], [9], True),
+            _request("c", [5], [6, 7, 10], True),
+        ]
+        refreshed = merged.refresh_contexts(requests)
+        self.assertEqual(
+            refreshed.contexts.tolist(),
+            [[0, 0], [2, 9], [7, 10]],
+        )
+
+    def test_merge_preserves_unwatermarked_rows_in_both_orders(self):
+        """Mixed batch merges must retain one watermark row per request."""
+        marked = build_watermark_batch_info(
+            [_request("marked", [1, 2], [], True)],
+            self.registry,
+            device="cpu",
+        )
+
+        ordinary_first = SimpleNamespace(watermark=None)
+        SamplingBatchInfo.adjusted_merge_batch(
+            ordinary_first,
+            SimpleNamespace(watermark=marked),
+            self_len=2,
+            other_len=1,
+        )
+        self.assertEqual(
+            ordinary_first.watermark.enabled.tolist(), [False, False, True]
+        )
+        self.assertEqual(
+            ordinary_first.watermark.contexts.tolist(), [[0, 0], [0, 0], [1, 2]]
+        )
+
+        marked_first = SimpleNamespace(watermark=marked)
+        SamplingBatchInfo.adjusted_merge_batch(
+            marked_first,
+            SimpleNamespace(watermark=None),
+            self_len=1,
+            other_len=2,
+        )
+        self.assertEqual(marked_first.watermark.enabled.tolist(), [True, False, False])
+        self.assertEqual(
+            marked_first.watermark.contexts.tolist(), [[1, 2], [0, 0], [0, 0]]
+        )
+
+    def test_overlap_relay_advances_context_with_current_decode_token(self):
+        """Delayed request output IDs must not leave watermark context one token behind."""
+        requests = [
+            _request("a", [1], [2, 3], True),
+            _request("b", [5], [6, 7], True),
+        ]
+        sampling_info = SimpleNamespace(
+            watermark=build_watermark_batch_info(requests, self.registry, device="cpu")
+        )
+        no_spec = SimpleNamespace(is_none=lambda: True)
+        batch = SimpleNamespace(
+            prefill_input_ids_cpu=None,
+            input_ids=None,
+            req_pool_indices=torch.tensor([1, 3]),
+            sampling_info=sampling_info,
+            enable_overlap=False,
+            spec_algorithm=no_spec,
+        )
+        future_map = SimpleNamespace(
+            output_tokens_buf=torch.tensor([0, 8, 0, 9]), spec_algo=no_spec
+        )
+
+        resolve_forward_inputs(batch, future_map)
+
+        self.assertEqual(batch.input_ids.tolist(), [8, 9])
+        self.assertEqual(
+            batch.sampling_info.watermark.contexts.tolist(),
+            [[3, 8], [7, 9]],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/watermark/test_config.py
+++ b/test/registered/unit/sampling/watermark/test_config.py
@@ -1,0 +1,110 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.srt.sampling.watermark import (
+    WatermarkConfigError,
+    load_watermark_config,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+_SECRET_A = "741852963"
+_SECRET_B = "963852741"
+
+
+class TestWatermarkConfig(CustomTestCase):
+    def test_loads_textseal_config(self):
+        registry = self._load(
+            {
+                "providers": {
+                    "textseal": {
+                        "enabled": True,
+                        "key_a": _SECRET_A,
+                        "key_b": _SECRET_B,
+                        "ngram": 2,
+                        "mixing_probability": 0.25,
+                    }
+                }
+            }
+        )
+
+        config = registry.textseal
+        self.assertEqual(config.key_a, int(_SECRET_A))
+        self.assertEqual(config.key_b, int(_SECRET_B))
+        self.assertEqual(config.ngram, 2)
+        self.assertEqual(config.mixing_probability, 0.25)
+        self.assertNotIn(_SECRET_A, repr(config))
+        self.assertNotIn(_SECRET_B, repr(registry))
+
+    def test_none_and_disabled_are_empty(self):
+        self.assertFalse(load_watermark_config(None).textseal_enabled)
+        registry = self._load({"providers": {"textseal": {"enabled": False}}})
+        self.assertFalse(registry.textseal_enabled)
+
+    def test_rejects_invalid_configuration_without_leaking_keys(self):
+        invalid_configs = [
+            {"providers": {"unknown": {}}},
+            {
+                "providers": {
+                    "textseal": {
+                        "enabled": True,
+                        "key_a": _SECRET_A,
+                        "key_b": _SECRET_B,
+                        "unexpected": _SECRET_A,
+                    }
+                }
+            },
+            {
+                "providers": {
+                    "textseal": {
+                        "enabled": True,
+                        "key_a": _SECRET_A,
+                        "key_b": _SECRET_A,
+                    }
+                }
+            },
+        ]
+
+        for config in invalid_configs:
+            with self.subTest(config=config):
+                with self.assertRaises(WatermarkConfigError) as context:
+                    self._load(config)
+                message = str(context.exception)
+                self.assertNotIn(_SECRET_A, message)
+                self.assertNotIn(_SECRET_B, message)
+
+    def test_rejects_malformed_json_without_echoing_contents(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "watermark.json"
+            path.write_text('{"secret":"741852963"', encoding="utf-8")
+            with self.assertRaisesRegex(
+                WatermarkConfigError, "failed to read watermark config JSON"
+            ) as context:
+                load_watermark_config(str(path))
+        self.assertNotIn(_SECRET_A, str(context.exception))
+
+    def test_server_args_validation_rejects_malformed_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "watermark.json"
+            path.write_text('{"secret":"741852963"', encoding="utf-8")
+            server_args = ServerArgs(model_path="dummy", watermark_config=str(path))
+            server_args.resolve_once()
+            with self.assertRaises(WatermarkConfigError) as context:
+                server_args.check_server_args()
+        self.assertNotIn(_SECRET_A, str(context.exception))
+
+    def _load(self, value):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "watermark.json"
+            path.write_text(json.dumps(value), encoding="utf-8")
+            return load_watermark_config(str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/watermark/test_request.py
+++ b/test/registered/unit/sampling/watermark/test_request.py
@@ -1,0 +1,93 @@
+import unittest
+from types import SimpleNamespace
+
+from starlette.datastructures import Headers
+
+from sglang.srt.entrypoints.request_headers import apply_watermark_request
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.sampling.watermark import (
+    TextSealConfig,
+    WatermarkRegistry,
+    WatermarkRequestConfig,
+    WatermarkRequestError,
+    parse_watermark_header,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestWatermarkRequest(CustomTestCase):
+    def test_header_contract(self):
+        self.assertIsNone(parse_watermark_header(None))
+        self.assertIsNone(parse_watermark_header(" off "))
+        self.assertEqual(
+            parse_watermark_header("textseal"),
+            WatermarkRequestConfig(provider="textseal"),
+        )
+
+    def test_rejects_unknown_provider_and_malformed_header(self):
+        cases = [
+            ("unknown", "watermark_provider_unknown"),
+            ("textseal;key_a=741852963", "watermark_invalid_request"),
+            ("textseal;profile=default", "watermark_invalid_request"),
+        ]
+        for value, code in cases:
+            with self.subTest(value=value):
+                with self.assertRaises(WatermarkRequestError) as context:
+                    parse_watermark_header(value)
+                self.assertEqual(context.exception.code, code)
+                self.assertNotIn("741852963", str(context.exception))
+
+    def test_http_request_uses_only_header(self):
+        request = SimpleNamespace(
+            watermark={"provider": "textseal", "key_a": "741852963"}
+        )
+        apply_watermark_request(request, Headers())
+        self.assertIsNone(request.watermark)
+
+        apply_watermark_request(request, Headers({"x-sglang-watermark": "textseal"}))
+        self.assertEqual(request.watermark.provider, "textseal")
+
+    def test_batch_normalization_and_splitting(self):
+        request = GenerateReqInput(
+            text=["first", "second"],
+            watermark=[
+                WatermarkRequestConfig(provider="textseal"),
+                None,
+            ],
+        )
+        request.normalize_batch_and_arguments()
+
+        self.assertEqual(request[0].watermark.provider, "textseal")
+        self.assertIsNone(request[1].watermark)
+
+    def test_registry_resolves_request_errors_without_secrets(self):
+        config = TextSealConfig(key_a=741852963, key_b=963852741)
+        registry = WatermarkRegistry(textseal=config)
+        request = WatermarkRequestConfig(provider="textseal")
+        self.assertIs(registry.resolve_request(request), config)
+
+        cases = [
+            (
+                WatermarkRegistry(),
+                request,
+                "watermark_disabled",
+            ),
+            (
+                registry,
+                WatermarkRequestConfig(provider="unknown"),
+                "watermark_provider_unknown",
+            ),
+        ]
+        for candidate_registry, candidate_request, code in cases:
+            with self.subTest(code=code):
+                with self.assertRaises(WatermarkRequestError) as context:
+                    candidate_registry.resolve_request(candidate_request)
+                self.assertEqual(context.exception.code, code)
+                self.assertNotIn("741852963", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/watermark/test_sampler.py
+++ b/test/registered/unit/sampling/watermark/test_sampler.py
@@ -1,0 +1,161 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.sampler import (
+    Sampler,
+    build_effective_probs,
+    sample_textseal_from_probs,
+)
+from sglang.srt.sampling.watermark import (
+    WatermarkBatchInfo,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _watermark(enabled=(True, True)):
+    return WatermarkBatchInfo(
+        enabled=torch.tensor(enabled),
+        all_enabled=all(enabled),
+        key_a=torch.tensor([741852963, 741852963]),
+        key_b=torch.tensor([963852741, 963852741]),
+        mixing_probabilities=torch.tensor([1.0, 0.0]),
+        ngrams=torch.tensor([2, 2], dtype=torch.int32),
+        contexts=torch.tensor([[1, 2], [2, 1]]),
+        nonces=torch.tensor([11, 12]),
+    )
+
+
+class TestTextSealSampler(CustomTestCase):
+    def test_no_attachment_uses_only_ordinary_path(self):
+        sampler = MagicMock()
+        sampler._sample_from_probs_ordinary.return_value = torch.tensor([3, 4])
+        sampling_info = SimpleNamespace(watermark=None)
+
+        selected = Sampler._sample_from_probs(
+            sampler,
+            torch.tensor([[0.6, 0.4], [0.4, 0.6]]),
+            sampling_info,
+            torch.tensor([1, 1]),
+            False,
+        )
+
+        torch.testing.assert_close(selected, torch.tensor([3, 4]))
+        sampler._sample_from_probs_ordinary.assert_called_once()
+
+    def test_mixed_batch_overwrites_only_enabled_rows(self):
+        sampler = MagicMock()
+        sampler._sample_from_probs_ordinary.return_value = torch.tensor([3, 4])
+        watermark = _watermark(enabled=(True, False))
+        sampling_info = SimpleNamespace(
+            watermark=watermark,
+            top_ks=torch.tensor([4, 4]),
+            top_ps=torch.ones(2),
+            min_ps=torch.zeros(2),
+            watermark_max_top_k=4,
+        )
+        with patch(
+            "sglang.srt.layers.sampler.sample_textseal_from_probs",
+            return_value=torch.tensor([1]),
+        ) as textseal_sampler:
+            selected = Sampler._sample_from_probs(
+                sampler,
+                torch.full((2, 4), 0.25),
+                sampling_info,
+                torch.tensor([1, 1]),
+                False,
+            )
+
+        torch.testing.assert_close(selected, torch.tensor([1, 4]))
+        self.assertEqual(textseal_sampler.call_args.args[0].shape, (1, 4))
+
+    def test_fully_watermarked_batch_skips_ordinary_sampler(self):
+        sampler = MagicMock()
+        sampling_info = SimpleNamespace(
+            watermark=_watermark(),
+            top_ks=torch.tensor([4, 4]),
+            top_ps=torch.ones(2),
+            min_ps=torch.zeros(2),
+            watermark_max_top_k=4,
+        )
+        with patch(
+            "sglang.srt.layers.sampler.sample_textseal_from_probs",
+            return_value=torch.tensor([1, 2]),
+        ):
+            selected = Sampler._sample_from_probs(
+                sampler,
+                torch.full((2, 4), 0.25),
+                sampling_info,
+                torch.tensor([1, 1]),
+                False,
+            )
+
+        torch.testing.assert_close(selected, torch.tensor([1, 2]))
+        sampler._sample_from_probs_ordinary.assert_not_called()
+
+    def test_effective_support_matches_top_k_top_p_min_p(self):
+        probs = torch.tensor([[0.4, 0.3, 0.2, 0.1], [0.5, 0.2, 0.2, 0.1]])
+        effective = build_effective_probs(
+            probs,
+            torch.tensor([3, 4]),
+            torch.tensor([0.65, 1.0]),
+            torch.tensor([0.0, 0.5]),
+        )
+        torch.testing.assert_close(effective[0], torch.tensor([4 / 7, 3 / 7, 0.0, 0.0]))
+        torch.testing.assert_close(effective[1], torch.tensor([1.0, 0.0, 0.0, 0.0]))
+
+    def test_textseal_selection_uses_effective_support(self):
+        probs = torch.tensor([[0.55, 0.25, 0.15, 0.05], [0.6, 0.1, 0.2, 0.1]])
+        selected = sample_textseal_from_probs(
+            probs,
+            torch.tensor([4, 4]),
+            torch.ones(2),
+            torch.zeros(2),
+            _watermark(),
+            torch.tensor([4, 9]),
+            4,
+        )
+        self.assertEqual(selected.tolist(), [0, 1])
+
+    def test_collapsed_support_returns_only_admissible_token(self):
+        selected = sample_textseal_from_probs(
+            torch.tensor([[0.6, 0.4], [0.6, 0.4]]),
+            torch.tensor([1, 2]),
+            torch.ones(2),
+            torch.zeros(2),
+            _watermark(),
+            torch.tensor([1, 1]),
+            2,
+        )
+        self.assertEqual(selected[0].item(), 0)
+
+    def test_finite_top_k_bounds_textseal_candidates(self):
+        """Finite top-k must avoid passing the full vocabulary to selection."""
+        probs = torch.tensor([[0.05, 0.4, 0.1, 0.3, 0.15], [0.3, 0.1, 0.2, 0.05, 0.35]])
+        with patch(
+            "sglang.srt.layers.sampler.select_textseal_tokens",
+            return_value=torch.tensor([1, 4]),
+        ) as selector:
+            sample_textseal_from_probs(
+                probs,
+                torch.tensor([2, 2]),
+                torch.ones(2),
+                torch.zeros(2),
+                _watermark(),
+                torch.tensor([1, 1]),
+                2,
+            )
+
+        effective_probs = selector.call_args.args[0]
+        token_ids = selector.call_args.kwargs["token_ids"]
+        self.assertEqual(effective_probs.shape, (2, 2))
+        torch.testing.assert_close(token_ids, torch.tensor([[1, 3], [4, 0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/watermark/test_textseal.py
+++ b/test/registered/unit/sampling/watermark/test_textseal.py
@@ -1,0 +1,131 @@
+import unittest
+
+import torch
+
+from sglang.srt.sampling.watermark import (
+    context_from_token_ids,
+    deterministic_key_a_mask,
+    prf_dual,
+    prf_uniform,
+    request_nonce,
+    select_textseal_tokens,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestTextSealCore(CustomTestCase):
+    def test_pinned_upstream_dual_key_vectors(self):
+        contexts = torch.tensor([[1, 2], [2, 1], [0, 7]], dtype=torch.long)
+        token_ids = torch.tensor(
+            [[0, 1, 17, 8191], [0, 1, 17, 8191], [0, 1, 17, 8191]],
+            dtype=torch.long,
+        )
+        expected_a = torch.tensor(
+            [
+                [0.9306555986, 0.1497985572, 0.1714076400, 0.1441826373],
+                [0.1108533740, 0.1986326426, 0.6988157630, 0.2518618107],
+                [0.4537907541, 0.2308631390, 0.2098644823, 0.0665364414],
+            ]
+        )
+        expected_b = torch.tensor(
+            [
+                [0.3291417360, 0.7209131718, 0.0850933939, 0.9232084155],
+                [0.8423879743, 0.9981687069, 0.7058967352, 0.0708094239],
+                [0.3026492596, 0.4627029598, 0.1153705269, 0.8742522001],
+            ]
+        )
+
+        actual_a, actual_b = prf_dual(contexts, token_ids, 741852963, 963852741)
+        torch.testing.assert_close(actual_a, expected_a, rtol=0, atol=1e-7)
+        torch.testing.assert_close(actual_b, expected_b, rtol=0, atol=1e-7)
+
+    def test_pinned_upstream_signed_overflow_vectors(self):
+        cases = [
+            ([1], 0, 0, 0.3553900719),
+            (
+                [9223372036854775807],
+                2147483647,
+                9223372036854775807,
+                0.4679526389,
+            ),
+            ([-1, 2], -7, -9223372036854775808, 0.9518983960),
+        ]
+        for context, token_id, key, expected in cases:
+            with self.subTest(context=context, token_id=token_id, key=key):
+                actual = prf_uniform(
+                    torch.tensor([context]), torch.tensor([token_id]), key
+                )
+                self.assertAlmostEqual(actual.item(), expected, places=7)
+
+    def test_selector_matches_pinned_upstream_expression(self):
+        contexts = torch.tensor([[1, 2], [2, 1]], dtype=torch.long)
+        probs = torch.tensor([[0.55, 0.25, 0.15, 0.05], [0.6, 0.0, 0.3, 0.1]])
+        key_a = torch.tensor([741852963, 741852963])
+        key_b = torch.tensor([963852741, 963852741])
+
+        selected_a = select_textseal_tokens(
+            probs, contexts, key_a, key_b, torch.tensor([True, True])
+        )
+        selected_b = select_textseal_tokens(
+            probs, contexts, key_a, key_b, torch.tensor([False, False])
+        )
+        self.assertEqual(selected_a.tolist(), [0, 2])
+        self.assertEqual(selected_b.tolist(), [1, 0])
+
+    def test_mixed_ngram_selector_matches_independent_rows(self):
+        contexts = torch.tensor([[0, 0, 1, 2], [3, 4, 5, 6]])
+        probs = torch.tensor([[0.55, 0.25, 0.15, 0.05], [0.6, 0.0, 0.3, 0.1]])
+        key_a = torch.tensor([741852963, 741852963])
+        key_b = torch.tensor([963852741, 963852741])
+        use_key_a = torch.tensor([True, False])
+
+        mixed = select_textseal_tokens(
+            probs,
+            contexts,
+            key_a,
+            key_b,
+            use_key_a,
+            ngrams=torch.tensor([2, 4]),
+        )
+        independent = torch.cat(
+            [
+                select_textseal_tokens(
+                    probs[row : row + 1],
+                    contexts[row : row + 1, -ngram:],
+                    key_a[row : row + 1],
+                    key_b[row : row + 1],
+                    use_key_a[row : row + 1],
+                )
+                for row, ngram in enumerate((2, 4))
+            ]
+        )
+
+        torch.testing.assert_close(mixed, independent)
+
+    def test_context_padding_and_deterministic_key_choice(self):
+        self.assertEqual(
+            context_from_token_ids([7], 3, device="cpu").tolist(), [0, 0, 7]
+        )
+        self.assertEqual(
+            context_from_token_ids([1, 2, 3, 4], 3, device="cpu").tolist(),
+            [2, 3, 4],
+        )
+        nonces = torch.tensor([request_nonce("a"), request_nonce("b")])
+        positions = torch.tensor([11, 11])
+        probabilities = torch.tensor([0.5, 0.5])
+        first = deterministic_key_a_mask(nonces, positions, probabilities)
+        second = deterministic_key_a_mask(nonces, positions, probabilities)
+        self.assertTrue(torch.equal(first, second))
+        self.assertFalse(
+            deterministic_key_a_mask(nonces, positions, torch.zeros(2)).any()
+        )
+        self.assertTrue(
+            deterministic_key_a_mask(nonces, positions, torch.ones(2)).all()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

Add opt-in TextSeal watermarking to SGLang text generation. The implementation embeds statistically detectable evidence during sampling while preserving the ordinary sampling path when watermarking is disabled.

## Modifications

- Added secure TextSeal configuration with key redaction and request-header support.
- Propagated watermark configuration through HTTP, OpenAI, tokenization, scheduling, and sampling layers.
- Added batched watermark state management for filtering, merging, and context updates.
- Implemented PyTorch and Triton token selectors using pinned TextSeal arithmetic.
- Added bounded `torch.topk` candidate construction to avoid sorting the full vocabulary.
- Added admission checks for unsupported execution modes.
- Added benchmark, sample-generation, and official-detector validation tools.
- Added unit, JIT, and OpenAI endpoint tests.
- Added TextSeal documentation.

The initial implementation supports native `/generate`, `/v1/chat/completions`, and `/v1/completions`, including streaming. It currently requires TP=1, nonzero temperature, and disabled CUDA graphs. Speculative decoding and disaggregated serving are rejected.

## Accuracy Tests

The official TextSeal v2 detector from pinned commit `c60d0d1da2e59f09a698438e218a07ee779b4616` was run against 50 watermarked and 50 baseline generations from `Qwen/Qwen2.5-0.5B-Instruct`.

| Metric | Result |
| --- | ---: |
| Watermarked detection rate | 50/50 (100%) |
| Baseline false-positive rate | 0/50 (0%) |
| Positive median p-value | `4.33e-11` |
| Negative median p-value | `0.5163` |
| Detection threshold | `0.01` |

Additional validation:

- OpenAI endpoint tests: **2 passed**, covering chat/completions and streaming/non-streaming requests.
- TextSeal sampler tests: **7 passed**.
- Fixed arithmetic vectors validate parity with the pinned upstream implementation.
- Batch lifecycle tests cover filtering, merging, and context updates.
- The non-watermarked path remains separate and covered by existing sampling tests.

## Speed Tests and Profiling

Test environment:

- GPU: NVIDIA Tesla T4
- Model: `Qwen/Qwen2.5-0.5B-Instruct`
- Five alternating baseline/TextSeal pairs
- 100 prompts per trial
- Concurrency: 8
- Output length: 400 tokens
- Triton attention, PyTorch sampling, TP=1, CUDA graphs disabled

| Metric | Baseline | TextSeal | Paired change |
| --- | ---: | ---: | ---: |
| Median TPOT, mean across pairs | 22.30 ms | 23.78 ms | **+6.67%** |
| Output throughput | 339.94 token/s | 318.28 token/s | **-6.37%** |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->