### PR TITLE
[Docs] Align optimistic prefill and tensor dump CLI names in server arguments

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -2989,12 +2989,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
     </tr>
-        <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--debug-tensor-dump-inject`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Inject the outputs from jax as the input of every layer.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
   </tbody>
 </table>
 
@@ -3064,8 +3058,8 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-retries`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill retries that will skip the bootstrap wait.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-attempts`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill forward passes that skip the bootstrap wait.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>


### PR DESCRIPTION
## Summary

`docs/docs/advanced_features/server_arguments.mdx` is out of date vs `python/sglang/srt/server_args.py` on `main`:

1. `--optimistic-prefill-retries` is documented, but the live field is `optimistic_prefill_attempts` (`--optimistic-prefill-attempts`). Help text is updated to the current field description.
2. `--debug-tensor-dump-inject` is still listed, but that CLI field was deleted. Remaining dump flags (`output-folder` / `layers` / `input-file`) are unchanged.

Docs-only, same file. Does not touch `--hybrid-kvcache-ratio` (open #37556).

## What drifted

On `main` (`fe3d4b9bbbff744d056dda122ea9157c2932a2bd`):

Docs (`server_arguments.mdx`):

```
`--optimistic-prefill-retries`
Number of optimistic prefill retries that will skip the bootstrap wait.
Default: `0`
```

```
`--debug-tensor-dump-inject`
Inject the outputs from jax as the input of every layer.
Default: `False`
```

Code (`python/sglang/srt/server_args.py`):

```
optimistic_prefill_attempts: A[
    int,
    "Number of optimistic prefill forward passes that skip the bootstrap wait.",
    NS("disagg"),
] = 0
```

Debug tensor dump fields are only `debug_tensor_dump_output_folder`, `debug_tensor_dump_layers`, and `debug_tensor_dump_input_file`. There is no `debug_tensor_dump_inject` and no `optimistic_prefill_retries` alias.

## Test plan

- [x] Confirmed `optimistic_prefill_attempts` is the live field (default `0`); no retries alias in `server_args.py`
- [x] Confirmed debug-tensor-dump CLI is only `output-folder` / `layers` / `input-file`
- [ ] Docs preview of Server Arguments shows `--optimistic-prefill-attempts` and no longer lists `--debug-tensor-dump-inject`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33608426469](https://github.com/sgl-project/sglang/actions/runs/33608426469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33608426253](https://github.com/sgl-project/sglang/actions/runs/33608426253)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->