### PR TITLE
[Docs] Use tp_size in save_remote_state Engine example

### DIFF
--- a/examples/runtime/engine/save_remote_state.py
+++ b/examples/runtime/engine/save_remote_state.py
@@ -8,14 +8,14 @@ Example usage:
 
 python save_remote_state.py \
     --model-path /path/to/load \
-    --tensor-parallel-size 8 \
+    --tp-size 8 \
     --remote-model-save-url [protocol]://[host]:[port]/[model_name] \
 
 Then, the model can be loaded with
 
 llm = Engine(
     model_path="[protocol]://[host]:[port]/[model_name]",
-    tensor_parallel_size=8,
+    tp_size=8,
 )
 """
 


### PR DESCRIPTION
## Summary

`examples/runtime/engine/save_remote_state.py` docstring is out of date vs `ServerArgs` / `Engine` on `main`:

1. `Engine(..., tensor_parallel_size=8)` is invalid — `Engine(**kwargs)` builds `ServerArgs`, whose field is `tp_size`.
2. CLI example updated to the primary flag `--tp-size` (`--tensor-parallel-size` remains a documented alias).

Docs/example-only. Does not touch `save_sharded_state.py` (open #37363 on that file for quantization).

## What drifted

On `main` (`fe3d4b9bbbff744d056dda122ea9157c2932a2bd`):

Docstring:

```
llm = Engine(
    model_path="...",
    tensor_parallel_size=8,
)
```

Code (`python/sglang/srt/server_args.py`):

```
tp_size: A[
    int,
    Arg(
        help="The tensor parallelism size.",
        aliases=["--tensor-parallel-size"],
    ),
    NS("parallel"),
] = 1
```

`Engine.__init__` does `ServerArgs(**kwargs)`, so the kwarg must be `tp_size`.

## Test plan

- [x] Confirmed `tp_size` is the ServerArgs field; `--tensor-parallel-size` is CLI alias only
- [x] Confirmed `Engine(**kwargs)` constructs ServerArgs from kwargs
- [x] Confirmed no equivalent OPEN PR for `save_remote_state.py`
- [ ] Docstring examples use `--tp-size` / `tp_size=8`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33609675412](https://github.com/sgl-project/sglang/actions/runs/33609675412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33609675152](https://github.com/sgl-project/sglang/actions/runs/33609675152)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->