### PR TITLE
[AMD] Skip unused TOPK v2 plan kernel on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -467,8 +467,13 @@ struct TopKKernel {
         .with_device(device_)
         .verify(metadata);
 
-    const auto batch_size = static_cast<uint32_t>(B.unwrap());
     RuntimeCheck(Bp1.unwrap() == B.unwrap() + 1, "invalid metadata shape");
+#ifdef USE_ROCM
+    // ROCm compiles out the cluster path, the only consumer of this plan.
+    (void)static_cluster_threshold;
+    return;
+#else
+    const auto batch_size = static_cast<uint32_t>(B.unwrap());
     const auto device = device_.unwrap();
     LaunchKernel(1, kBlockSize, device)(  //
         topk_plan,
@@ -476,6 +481,7 @@ struct TopKKernel {
         static_cast<PlanItem*>(metadata.data_ptr()),
         batch_size,
         static_cluster_threshold);
+#endif
   }
 
   static void transform_paged(

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -88,7 +88,9 @@ def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Ten
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
     metadata = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
-    module.topk_plan(seq_lens, metadata, static_threshold)
+    # ROCm compiles out the cluster path, the only consumer of this plan.
+    if not is_hip_runtime():
+        module.topk_plan(seq_lens, metadata, static_threshold)
     return metadata
 
 

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -88,9 +88,7 @@ def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Ten
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
     metadata = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
-    # ROCm compiles out the cluster path, the only consumer of this plan.
-    if not is_hip_runtime():
-        module.topk_plan(seq_lens, metadata, static_threshold)
+    module.topk_plan(seq_lens, metadata, static_threshold)
     return metadata
 
 


### PR DESCRIPTION
## Summary

ROCm compiles out the TOPK v2 cluster path, so its level 0/1/2 kernels do not consume plan metadata. Skip the unused `topk_plan` launch on ROCm while preserving JIT module preload and the metadata shape. Non-ROCm behavior is unchanged.

## Performance

MI355X, 1,000 iterations after 100 warmups, measured with GPU events:

| Batch | With plan launch | Without plan launch | Saved |
| ---: | ---: | ---: | ---: |
| 32 | 2.867 us | 1.616 us | **1.251 us** |
| 256 | 3.230 us | 1.726 us | **1.504 us** |

This removes one GPU kernel launch per TOPK v2 metadata build.

## Validation

- Existing `test_topk_v2.py` on MI355X: **278 passed**
- All applicable pre-commit hooks passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33631523241](https://github.com/sgl-project/sglang/actions/runs/33631523241)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33631522932](https://github.com/sgl-project/sglang/actions/runs/33631522932)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33631523144](https://github.com/sgl-project/sglang/actions/runs/33631523144)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->