### PR TITLE
Fix Kimi-K3 required tool call close-token loops

### DIFF
--- a/python/sglang/srt/function_call/kimik3_structural_tag.py
+++ b/python/sglang/srt/function_call/kimik3_structural_tag.py
@@ -24,6 +24,9 @@ from sglang.srt.function_call.kimik3_format import (
     ARGUMENT_CLOSE,
     CALL_CLOSE,
     CALL_OPEN,
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
     THINK_CLOSE,
     THINK_OPEN,
     TOOLS_CLOSE,
@@ -40,6 +43,8 @@ _JSON_TYPES = (
     "null",
 )
 _CLOSE_TOKEN = "<|close|>"
+_OPEN_TOKEN = "<|open|>"
+_END_OF_MSG_TOKEN = "<|end_of_msg|>"
 _ARGUMENT_CLOSE_SUFFIX = ARGUMENT_CLOSE.removeprefix(_CLOSE_TOKEN)
 _JSON_TO_XTML_TYPE = {
     "string": "string",
@@ -612,12 +617,21 @@ def get_kimik3_structural_tag(
     call_tags = [_tool_call_tag(tool) for tool in selected_tools]
     tools_tag = _tool_calls_tag(call_tags, parallel_tool_calls)
     if at_least_one:
+        # Resolve marker-looking prefixes through the response-close branch.
+        # Otherwise the model can repeat the still-legal <|close|> token while
+        # MESSAGE_CLOSE and EOS are masked by required tool choice.
         suffix: Format = SequenceFormat(
             elements=[
-                AnyTextFormat(
-                    excludes=[TOOLS_OPEN, THINK_OPEN, THINK_CLOSE, CALL_OPEN]
+                OptionalFormat(content=ConstStringFormat(value=RESPONSE_OPEN)),
+                TagFormat(
+                    begin="",
+                    content=AnyTextFormat(
+                        excludes=[_OPEN_TOKEN, _CLOSE_TOKEN, _END_OF_MSG_TOKEN]
+                    ),
+                    end=RESPONSE_CLOSE,
                 ),
                 tools_tag,
+                OptionalFormat(content=ConstStringFormat(value=MESSAGE_CLOSE)),
             ]
         )
     else:

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -529,7 +529,12 @@ class KimiK3Detector(BaseReasoningFormatDetector):
     def _next_channel_idx(self, text: str, start: int = 0) -> int:
         found = [
             idx
-            for token in (RESPONSE_OPEN, self.tool_start_token)
+            for token in (
+                RESPONSE_OPEN,
+                self.tool_start_token,
+                RESPONSE_CLOSE,
+                MESSAGE_CLOSE,
+            )
             if (idx := text.find(token, start)) != -1
         ]
         return min(found) if found else -1
@@ -616,7 +621,13 @@ class KimiK3Detector(BaseReasoningFormatDetector):
 
             if not self.stream_reasoning:
                 return StreamingParseResult()
-            markers = [self.think_end_token, self.tool_start_token, RESPONSE_OPEN]
+            markers = [
+                self.think_end_token,
+                self.tool_start_token,
+                RESPONSE_OPEN,
+                RESPONSE_CLOSE,
+                MESSAGE_CLOSE,
+            ]
             if not self.stripped_think_start:
                 markers.append(self.think_start_token)
             holdback = partial_suffix_len(buf, markers)

--- a/test/registered/unit/function_call/test_kimik3_structural_tag.py
+++ b/test/registered/unit/function_call/test_kimik3_structural_tag.py
@@ -18,6 +18,8 @@ from sglang.srt.function_call.kimik3_detector import KimiK3Detector
 from sglang.srt.function_call.kimik3_format import (
     ARGUMENT_CLOSE,
     CALL_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
     THINK_CLOSE,
     TOOLS_CLOSE,
     TOOLS_OPEN,
@@ -197,10 +199,19 @@ def test_strict_schema_rejects_invalid_parameters(arguments):
 
 def test_required_allows_response_prefix_but_requires_tools():
     grammar = _grammar([_tool()], tool_choice="required")
-    response = "<|open|>response<|sep|>Checking." "<|close|>response<|sep|>"
+    response = f"{RESPONSE_OPEN}Checking.{RESPONSE_CLOSE}"
 
     assert _accepts(grammar, response + _tools_section(_valid_weather_call()))
     assert not _accepts(grammar, response)
+    assert not _accepts(grammar, _tools_section(_valid_weather_call()))
+
+
+def test_required_close_token_commits_to_response_close():
+    structural_tag = get_kimik3_structural_tag([_tool()], tool_choice="required")
+    matcher = xgr.GrammarMatcher(_TOKEN_COMPILER.compile_structural_tag(structural_tag))
+
+    assert matcher.accept_token(_CLOSE_TOKEN_ID)
+    assert not matcher.accept_token(_CLOSE_TOKEN_ID)
 
 
 def test_auto_allows_plain_response_or_multiple_tool_calls():
@@ -832,11 +843,19 @@ def test_reasoning_prefix_is_owned_by_exactly_one_layer():
     tool = _tool()
     wrapped_by_xgrammar = _grammar([tool], tool_choice="required", thinking_mode=True)
     post_reasoning_only = _grammar([tool], tool_choice="required", thinking_mode=False)
-    output = "reasoning" + THINK_CLOSE + _tools_section(_valid_weather_call())
+    output = (
+        "reasoning"
+        + THINK_CLOSE
+        + RESPONSE_CLOSE
+        + _tools_section(_valid_weather_call())
+    )
 
     assert _accepts(wrapped_by_xgrammar, output)
     assert not _accepts(post_reasoning_only, output)
-    assert _accepts(post_reasoning_only, _tools_section(_valid_weather_call()))
+    assert _accepts(
+        post_reasoning_only,
+        RESPONSE_CLOSE + _tools_section(_valid_weather_call()),
+    )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -74,6 +74,25 @@ def test_non_stream_tools_channel_passthrough() -> None:
     assert result.normal_text == f"reply{tools_channel}"
 
 
+@pytest.mark.parametrize(
+    ("marker", "content"),
+    [
+        (RESPONSE_OPEN, ""),
+        (TOOLS_OPEN, TOOLS_OPEN),
+        (RESPONSE_CLOSE, ""),
+        (MESSAGE_CLOSE, ""),
+    ],
+)
+def test_non_stream_channel_marker_implicitly_ends_reasoning(
+    marker: str, content: str
+) -> None:
+    result = KimiK3Detector(force_reasoning=True).detect_and_parse(
+        f"{THINK_OPEN}thought{marker}"
+    )
+    assert result.reasoning_text == "thought"
+    assert result.normal_text == content
+
+
 def test_non_stream_recovers_missing_think_separator() -> None:
     detector = KimiK3Detector(force_reasoning=True)
     result = detector.detect_and_parse(
@@ -141,6 +160,24 @@ def test_streaming_tools_channel_passthrough() -> None:
     reasoning, content = _stream(detector, _chunks(text, 5))
     assert reasoning == "thought"
     assert content == f"reply{tools_channel}"
+
+
+@pytest.mark.parametrize(
+    ("marker", "content"),
+    [
+        (RESPONSE_OPEN, ""),
+        (TOOLS_OPEN, TOOLS_OPEN),
+        (RESPONSE_CLOSE, ""),
+        (MESSAGE_CLOSE, ""),
+    ],
+)
+def test_streaming_channel_marker_implicitly_ends_reasoning(
+    marker: str, content: str
+) -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    reasoning, normal = _stream(detector, _chunks(f"{THINK_OPEN}thought{marker}", 3))
+    assert reasoning == "thought"
+    assert normal == content
 
 
 def test_streaming_recovers_missing_think_separator() -> None:


### PR DESCRIPTION
## Summary

- make the Kimi-K3 `tool_choice="required"` grammar commit a raw `<|close|>` prefix to `response` close instead of allowing repeated close tokens
- require the tools channel after response close, while keeping the response-open and final message-close wrappers optional
- treat `response` close and `message` close as implicit reasoning boundaries in both non-streaming and streaming parsing
- add grammar-matcher and parser regression tests for these paths

## Root cause

With required tool choice, EOS and message close are unavailable until a valid tool call has been generated. The previous grammar still allowed a raw `<|close|>` through free response text, so the model could repeatedly emit close tokens without ever entering the tools channel. The request then ran until `max_tokens` or the client-side read timeout.

Separately, Kimi-K3 can reach a response/tools/message boundary without a complete think-close marker. The reasoning parser did not recognize every such boundary, so valid downstream tool-call text could remain classified as reasoning and never reach the tool-call parser.

## Validation

- Official Kimi Vendor Verifier `dynamic_tools` suite: 20/20 runs passed, 54 tests per run (1,080 tests total) on the reported 2P2D TP8/DCP8 deployment
- Targeted checks with real xgrammar verify that a first close token commits to response close and a second raw close token is rejected
- Streaming and non-streaming parser checks cover response-open, tools-open, response-close, and message-close implicit boundaries, including markers split across 1/3/7-character chunks
- Black, isort, Ruff (`F401`, `F821`, `UP037`), compileall, and `git diff --check` pass for the changed files

The full pytest modules cannot be collected on the Windows preparation host because SGLang imports the POSIX-only `resource` module; the targeted source-loaded checks exercise the modified paths directly.

Related vLLM parser fix: https://github.com/vllm-project/vllm/pull/54314

Fixes #37430

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33612572584](https://github.com/sgl-project/sglang/actions/runs/33612572584)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33612572315](https://github.com/sgl-project/sglang/actions/runs/33612572315)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33612572533](https://github.com/sgl-project/sglang/actions/runs/33612572533)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->