### PR TITLE
[AMD][CI] Run ROCm 7.0 shadow tests every two days

### DIFF
--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -2,7 +2,7 @@ name: Nightly Test (AMD ROCm 7.0)
 
 on:
   schedule:
-    - cron: '30 17 * * *'
+    - cron: '30 17 */2 * *'
   push:
     branches:
       - main

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -6,11 +6,11 @@ run-name: ${{ (inputs.target_stage || inputs.target_stage_select) && (inputs.pr_
 on:
   schedule:
     # ROCm 7.0 rollback shadow. pr-test-amd-rocm720.yml is the PR gate; this
-    # workflow now only proves ROCm 7.0 still works, so it fires once a day
+    # workflow now only proves ROCm 7.0 still works, so it fires every two days
     # alongside nightly-test-amd.yml and chases coverage rather than latency:
     # no matrix parallelism caps, no stage fast-fail (the `schedule` escape in
     # each job's `if`), and continue-on-error via check-changes.
-    - cron: '30 17 * * *'
+    - cron: '30 17 */2 * *'
   workflow_dispatch:
     inputs:
       target_stage_select:


### PR DESCRIPTION
## Motivation

The ROCm 7.0 PR and nightly workflows serve as rollback-shadow coverage and do not need to run daily. Reduce CI runner usage while retaining regular compatibility coverage.

## Modifications

- Change the ROCm 7.0 PR test schedule from daily to every two days.
- Change the ROCm 7.0 nightly test schedule from daily to every two days.
- Keep the existing start time unchanged at 17:30 UTC.
- Update the PR workflow comment to reflect the new cadence.

## Accuracy Tests

N/A — this change does not affect model outputs.

## Speed Tests and Profiling

N/A — this change only updates CI schedules.

## Checklist

- [x] Verified the workflow changes with `git diff --check`.
- [x] No unit tests, documentation, accuracy tests, or benchmarks are required for this schedule-only change.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33612643150](https://github.com/sgl-project/sglang/actions/runs/33612643150)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33612642826](https://github.com/sgl-project/sglang/actions/runs/33612642826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->