### PR TITLE
feat(cache): support direct external cache linkers without HiCache

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -420,6 +420,7 @@ class Scheduler(
     # Class-level default so on_idle's stall gate works even if a fork
     # overrides init_load_publisher (which would otherwise not set it).
     _last_stall_publish_ts: float = float("-inf")
+    enable_async_cache_io: bool = False
 
     def __init__(
         self,
@@ -591,6 +592,11 @@ class Scheduler(
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
+        self.enable_async_cache_io = (
+            self.enable_hierarchical_cache
+            or self.tree_cache.has_external_cache_io()
+            or get_memory().enable_flexkv
+        )
         if self.enable_hierarchical_cache:
             cache_controller = self.tree_cache.cache_controller
             if cache_controller is not None:
@@ -3100,8 +3106,8 @@ class Scheduler(
                 direction * recv_req.priority < direction * candidate_req.priority
             )
             if abort_existing_req:
-                if self.enable_hicache_storage:
-                    # Release prefetch events associated with the request
+                if self.enable_async_cache_io:
+                    # Release external lookup/prefetch state for the request.
                     self.tree_cache.release_aborted_request(candidate_req.rid)
                 self.waiting_queue.pop(idx)
                 self.beam_coordinator.retire_group(candidate_req)
@@ -3131,8 +3137,8 @@ class Scheduler(
         for req in self.waiting_queue:
             entry_time = req.time_stats.wait_queue_entry_time
             if 0 < entry_time < deadline:
-                if self.enable_hicache_storage:
-                    # Release prefetch events associated with the request
+                if self.enable_async_cache_io:
+                    # Release external lookup/prefetch state for the request.
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     _make_abort_req(
@@ -3289,7 +3295,7 @@ class Scheduler(
                 req, self.req_to_metadata_buffer_idx_allocator
             )
             req.pending_bootstrap = False
-        if self.enable_hicache_storage:
+        if self.enable_async_cache_io:
             self.tree_cache.release_aborted_request(req.rid)
         release_kv_cache(req, self.tree_cache, is_insert=False)
 
@@ -3549,7 +3555,7 @@ class Scheduler(
             for req in ready_grammar_requests:
                 self._add_request_to_queue(req)
 
-        if self.enable_hierarchical_cache or get_memory().enable_flexkv:
+        if self.enable_async_cache_io:
             self.tree_cache.check_hicache_events()
             if self.enable_hicache_storage:
                 self._retry_missed_storage_prefetches()
@@ -3723,7 +3729,7 @@ class Scheduler(
 
             if res != AddReqResult.CONTINUE:
                 if res == AddReqResult.NO_TOKEN:
-                    if self.enable_hierarchical_cache:
+                    if self.enable_async_cache_io:
                         # Set batch_is_full after making sure there are requests that can be served
                         running_batch.batch_is_full = len(adder.can_run_list) > 0 or (
                             not running_batch.is_empty()
@@ -3787,7 +3793,7 @@ class Scheduler(
             self.chunked_req is None or len(can_run_list) != 1
         )
 
-        if self.enable_hierarchical_cache:
+        if self.enable_async_cache_io:
             # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
             new_batch.hicache_consumer_index = (
                 self.tree_cache.ready_to_load_host_cache()
@@ -4625,6 +4631,9 @@ class Scheduler(
                         # (buffer-mode unified tree only).
                         idle &= tc.buffer_pipeline.is_idle()
 
+            if self.tree_cache.has_external_cache_io():
+                idle &= not self.tree_cache.has_pending_external_cache_io()
+
         return idle
 
     def _pp_microbatches_drained(self) -> bool:
@@ -4996,8 +5005,8 @@ class Scheduler(
             # We still need to send something back to TokenizerManager to clean up the state.
             req = self.waiting_queue.pop(i)
             self.beam_coordinator.retire_group(req)
-            if self.enable_hicache_storage:
-                # to release prefetch events associated with the request
+            if self.enable_async_cache_io:
+                # Release external lookup/prefetch state for the request.
                 self.tree_cache.release_aborted_request(req.rid)
             self.ipc_channels.send_to_tokenizer.send_output(_make_abort_req(req), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
@@ -5029,7 +5038,7 @@ class Scheduler(
             for req in self.dllm_manager.pop_aborted_reqs(
                 recv_req.abort_all, recv_req.rid
             ):
-                if self.enable_hicache_storage:
+                if self.enable_async_cache_io:
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     _make_abort_req(req), req
@@ -5050,7 +5059,7 @@ class Scheduler(
             for req in self.disagg_prefill_bootstrap_queue.queue:
                 if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort bootstrap queue request. {req.rid=}")
-                    if self.enable_hicache_storage:
+                    if self.enable_async_cache_io:
                         self.tree_cache.release_aborted_request(req.rid)
 
                     if hasattr(req.disagg_kv_sender, "abort"):

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -451,6 +451,19 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         """
         raise NotImplementedError()
 
+    def has_external_cache_io(self) -> bool:
+        """Whether this cache drives asynchronous I/O outside its device pool.
+
+        This capability is intentionally independent of HiCache.  Direct cache
+        linkers do not allocate a native host tier, but still need the scheduler
+        to poll completions and start queued loads.
+        """
+        return False
+
+    def has_pending_external_cache_io(self) -> bool:
+        """Whether external cache work must drain before the cache is idle."""
+        return False
+
     def take_events(self):
         return [] if self.kv_events is None else self.kv_events.take()
 

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -104,6 +104,9 @@ class PoolTransfer:
     host_indices: Optional[torch.Tensor] = None
     device_indices: Optional[torch.Tensor] = None
     keys: Optional[List[str]] = None
+    # Backend-owned, stable binary keys for a direct external-cache linker.
+    # ``keys`` remains the SGLang SHA chain used by existing storage backends.
+    linker_keys: Optional[List[bytes]] = None
     hit_policy: PoolHitPolicy = PoolHitPolicy.ALL_PAGES
     nodes_to_load: Optional[List[Any]] = None
     indices_from_pool: Optional[PoolName] = None

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1641,6 +1641,13 @@ class _PlainKvStrategy(StackStrategy):
             return False
         return components == {ComponentType.FULL}
 
+    def build_direct_linker_pool_group(self, *, kvcache, params, page_size):
+        from sglang.srt.mem_cache.hybrid_cache.linker_pool_assembler import (
+            _build_plain_kv_device_pool_group,
+        )
+
+        return _build_plain_kv_device_pool_group(kvcache, page_size)
+
     def build(
         self,
         *,

--- a/python/sglang/srt/mem_cache/hybrid_cache/linker_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/linker_pool_assembler.py
@@ -361,6 +361,71 @@ def _build_dsa_device_pool_group(kvcache: Any, page_size: int) -> DevicePoolGrou
     return DevicePoolGroup(entries, num_layers, page_size, rank_replicated=True)
 
 
+def _build_plain_kv_device_pool_group(kvcache: Any, page_size: int) -> DevicePoolGroup:
+    """Expose a standard MHA K/V pool without allocating mirror buffers."""
+    from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+    # Specialized subclasses add scale buffers, VMM ownership, page-major
+    # layouts, or no-op storage.  Exposing only their K/V lists would silently
+    # omit required state, so V1 accepts the canonical pool class exactly.
+    if type(kvcache) is not MHATokenToKVPool:
+        raise ValueError(
+            "The direct external linker V1 plain-KV adapter only supports "
+            f"the standard MHATokenToKVPool, got {type(kvcache).__name__}."
+        )
+    if hasattr(kvcache, "quant_method") and kvcache.is_quantized_kv_cache:
+        raise ValueError(
+            "The direct external linker V1 does not support quantized KV pools."
+        )
+    if getattr(kvcache, "post_capture_active", False):
+        raise ValueError(
+            "The direct external linker V1 does not support post-capture VMM pools."
+        )
+    if kvcache.page_size != page_size:
+        raise ValueError(
+            "MHA KV page size must match the tree page size: "
+            f"{kvcache.page_size} != {page_size}."
+        )
+    if len(kvcache.k_buffer) != len(kvcache.v_buffer) or not kvcache.k_buffer:
+        raise ValueError("MHA KV pool must expose one K and V tensor per layer.")
+
+    buffers = [*kvcache.k_buffer, *kvcache.v_buffer]
+    reference = buffers[0]
+    if any(
+        buffer.shape != reference.shape
+        or buffer.stride() != reference.stride()
+        or buffer.dtype != reference.dtype
+        or buffer.device != reference.device
+        or not buffer.is_contiguous()
+        for buffer in buffers
+    ):
+        raise ValueError(
+            "The direct external linker V1 requires homogeneous contiguous K/V tensors."
+        )
+
+    total_slots = kvcache.size + page_size
+    first_rows = reference.shape[0]
+    if first_rows * page_size == total_slots:
+        rows_are_pages = True
+    elif first_rows == total_slots:
+        rows_are_pages = False
+    else:
+        raise ValueError(
+            "MHA KV tensor rows do not match the token-pool page geometry."
+        )
+    identity = {layer: layer for layer in range(kvcache.layer_num)}
+    entry = DevicePoolEntry(
+        name=PoolName.KV,
+        indices_from_pool=PoolName.KV,
+        device_pool=kvcache,
+        components=[kvcache.k_buffer, kvcache.v_buffer],
+        layer_mapping=identity,
+        page_size=page_size,
+        rows_are_pages=rows_are_pages,
+    )
+    return DevicePoolGroup([entry], kvcache.layer_num, page_size)
+
+
 def resolve_hybrid_device_pool_group(
     *,
     kvcache: Any,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -335,6 +335,9 @@ def build_kv_cache(
             tp_size=ps.tp_size,
             tp_rank=ps.tp_rank,
             tp_group=tp_group,
+            dp_rank=ps.dp_rank,
+            attn_dp_rank=ps.attn_dp_rank,
+            attn_cp_rank=ps.attn_cp_rank,
         )
     )
 

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -22,6 +22,7 @@ from sglang.srt.runtime_context import get_disagg, get_memory, get_serving
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,9 @@ class TreeCacheBuildContext:
     tp_group: Any
     full_tokens_per_layer: Optional[int] = None
     is_dsa: bool = False
+    dp_rank: Optional[int] = None
+    attn_dp_rank: int = 0
+    attn_cp_rank: int = 0
 
 
 RadixCacheFactory = Callable[[TreeCacheBuildContext], BasePrefixCache]
@@ -149,6 +153,27 @@ def _create_unified_radix_cache(
     params: CacheInitParams,
 ) -> BasePrefixCache:
     """Initialize a UnifiedRadixCache with proper components and optional HiCache."""
+    cache = create_unified_radix_cache_without_hicache(ctx)
+    if (
+        ctx.enable_hierarchical_cache
+        or get_disagg().disaggregation_decode_retraction_backup == "host_pool"
+    ):
+        cache.init_hicache(server_args, params)
+        ctx.tp_worker.register_hicache_layer_transfer_counter(
+            cache.cache_controller.layer_done_counter
+        )
+    return cache
+
+
+def create_unified_radix_cache_without_hicache(
+    ctx: TreeCacheBuildContext,
+) -> UnifiedRadixCache:
+    """Build the standard unified radix cache without a native host tier.
+
+    External backends use this helper so component selection remains centralized
+    while HiCache construction is kept an explicit, mutually exclusive step.
+    """
+    params = ctx.params
     if get_disagg().disaggregation_decode_retraction_backup == "host_pool":
         if ctx.is_hybrid_ssm:
             raise ValueError("Host-pool retraction does not support Mamba models.")
@@ -184,16 +209,7 @@ def _create_unified_radix_cache(
         params.component_registry_override = {
             ComponentType.MAMBA: MlxAuxiliaryStateComponent,
         }
-    cache = UnifiedRadixCache(params)
-    if (
-        ctx.enable_hierarchical_cache
-        or get_disagg().disaggregation_decode_retraction_backup == "host_pool"
-    ):
-        cache.init_hicache(server_args, params)
-        ctx.tp_worker.register_hicache_layer_transfer_counter(
-            cache.cache_controller.layer_done_counter
-        )
-    return cache
+    return UnifiedRadixCache(params)
 
 
 def create_tree_cache(ctx: TreeCacheBuildContext) -> BasePrefixCache:

--- a/python/sglang/srt/mem_cache/rust_tree_core/adapter.py
+++ b/python/sglang/srt/mem_cache/rust_tree_core/adapter.py
@@ -54,6 +54,7 @@ from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
     InsertStepResult,
     NodeId,
     RadixCacheWalkResult,
+    RollbackExternalLoadResult,
     UnifiedTreeCoreInterface,
 )
 from sglang.srt.runtime_context import get_exec, mamba_cache_chunk_size
@@ -817,6 +818,33 @@ class RustUnifiedTreeCore(UnifiedTreeCoreInterface):
 
     def get_hash_values(self, node_id: NodeId) -> list[str]:
         return self._binding.get_hash_values(node_id)
+
+    def set_linker_key_codec(self, codec) -> None:
+        raise RuntimeError(
+            "Direct linker key sidecars are not supported by the Rust tree core."
+        )
+
+    def get_last_linker_key_value(self, node_id: NodeId) -> Optional[bytes]:
+        raise RuntimeError(
+            "Direct linker key sidecars are not supported by the Rust tree core."
+        )
+
+    def get_linker_key_values(self, node_id: NodeId) -> list[bytes]:
+        raise RuntimeError(
+            "Direct linker key sidecars are not supported by the Rust tree core."
+        )
+
+    def rollback_external_load(
+        self,
+        anchor_node_id: NodeId,
+        inserted_node_id: NodeId,
+        adopted_ranges,
+        lock_params: DecLockRefParams,
+        expected_full_slots: Optional[torch.Tensor],
+    ) -> RollbackExternalLoadResult:
+        raise RuntimeError(
+            "Queued direct-linker rollback is not supported by the Rust tree core."
+        )
 
     def snapshot_buffer_backup(
         self, node_id: NodeId, pass_prefix_keys: bool

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
@@ -19,7 +19,10 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
 from sglang.srt.mem_cache.hybrid_cache.linker_pool_assembler import (
     resolve_hybrid_device_pool_group,
 )
-from sglang.srt.mem_cache.unified_cache.unified_cache_linker import UnifiedCacheLinker
+from sglang.srt.mem_cache.unified_cache.unified_cache_linker import (
+    LinkerCancelOutcome,
+    UnifiedCacheLinker,
+)
 from sglang.srt.runtime_context import get_memory, get_model
 from sglang.srt.utils import freeze_gc, get_device_module
 
@@ -160,6 +163,7 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
                 self.layer_done_counter
             )
         self.pending_loads: dict[str, list[PoolTransfer]] = {}
+        self.submitted_load_rids: set[str] = set()
         self.gc_frozen = False
         self.load_queue: Queue[
             tuple[int, dict[str, list[PoolTransfer]], object] | None
@@ -236,11 +240,28 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
     def cancel_queued_load(self, rid: str) -> bool:
         return self.pending_loads.pop(rid, None) is not None
 
+    def cancel_request(self, rid: str) -> LinkerCancelOutcome:
+        if self.cancel_queued_load(rid):
+            return LinkerCancelOutcome.QUEUED_LOAD_CANCELLED
+        if rid in self.submitted_load_rids:
+            return LinkerCancelOutcome.SUBMITTED_LOAD_RETAINED
+        return LinkerCancelOutcome.NOT_FOUND
+
+    def has_pending_operations(self) -> bool:
+        return bool(
+            self.pending_loads
+            or self.submitted_load_rids
+            or not self.completed_loads.empty()
+            or not self.offload_results.empty()
+        )
+
     def num_completed_loads(self) -> int:
         return self.completed_loads.qsize()
 
     def pop_completed_load(self) -> list[str]:
-        return self.completed_loads.get_nowait()
+        rids = self.completed_loads.get_nowait()
+        self.submitted_load_rids.difference_update(rids)
+        return rids
 
     def freeze_gc_once(self) -> None:
         if self.gc_frozen:
@@ -256,6 +277,7 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
         self.freeze_gc_once()
         pending = self.pending_loads
         self.pending_loads = {}
+        self.submitted_load_rids.update(pending)
 
         counter_index = self.layer_done_counter.update_producer()
         ready_event = device_module.Event()
@@ -403,6 +425,7 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
             except Empty:
                 break
         self.layer_done_counter.reset()
+        self.submitted_load_rids.clear()
 
     def close(self) -> None:
         self.reset()

--- a/python/sglang/srt/mem_cache/unified_cache/unified_cache_linker.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_cache_linker.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, NamedTuple
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Literal, NamedTuple, Optional, Protocol
 
 import torch
 
@@ -48,10 +50,43 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
 
+@dataclass(frozen=True)
+class LinkerKeyDomain:
+    """Inputs that namespace KV content beyond its token sequence."""
+
+    cache_salt: Optional[str]
+    extra_key: Optional[str]
+
+
+class LinkerKeyCodec(Protocol):
+    """Backend-owned incremental codec for stable external page keys."""
+
+    codec_id: str
+
+    def extend_pages(
+        self,
+        *,
+        parent_key: Optional[bytes],
+        page_tokens: Sequence[int],
+        page_size: int,
+        key_domain: LinkerKeyDomain,
+    ) -> list[bytes]: ...
+
+
+class LinkerCancelOutcome(str, Enum):
+    """Terminal state observed while releasing one request's linker work."""
+
+    LOOKUP_RELEASED = "lookup_released"
+    QUEUED_LOAD_CANCELLED = "queued_load_cancelled"
+    SUBMITTED_LOAD_RETAINED = "submitted_load_retained"
+    NOT_FOUND = "not_found"
+
+
 class UnifiedCacheLinker(ABC):
     """External KV store reached directly from the device pools."""
 
     layer_done_counter: object
+    key_codec: Optional[LinkerKeyCodec] = None
 
     @abstractmethod
     def lookup(self, rid: str, transfers: list[PoolTransfer]) -> list[int]:
@@ -82,6 +117,21 @@ class UnifiedCacheLinker(ABC):
     @abstractmethod
     def cancel_queued_load(self, rid: str) -> bool:
         """Cancel a load that has not started yet."""
+
+    def cancel_request(self, rid: str) -> LinkerCancelOutcome:
+        """Release lookup/queued state while retaining submitted DMA guards.
+
+        The default preserves compatibility with linkers that only implement
+        ``cancel_queued_load``.  New backends should override this method so a
+        lookup ticket and a submitted load are distinguishable.
+        """
+        if self.cancel_queued_load(rid):
+            return LinkerCancelOutcome.QUEUED_LOAD_CANCELLED
+        return LinkerCancelOutcome.NOT_FOUND
+
+    def has_pending_operations(self) -> bool:
+        """Return backend work not otherwise represented by wrapper state."""
+        return False
 
     @abstractmethod
     def num_completed_loads(self) -> int:
@@ -122,6 +172,7 @@ class ExternalCacheHitMarker(NamedTuple):
 
     prefix_key: RadixKey
     tail_hashes: list[str]
+    tail_linker_keys: Optional[list[bytes]]
     device_hit_len: int
 
 
@@ -129,6 +180,19 @@ class _PendingOffload(NamedTuple):
     lock_node_id: NodeId
     lock_params: DecLockRefParams
     publish_node_ids: list[NodeId]
+
+
+@dataclass
+class PendingExternalLoad:
+    """Tree transaction retained until an external H2D reaches completion."""
+
+    rid: str
+    inserted_node: NodeId
+    anchor_node: NodeId
+    adopted_ranges: dict
+    allocated_component_slots: dict[PoolName, torch.Tensor]
+    lock_params: DecLockRefParams
+    phase: Literal["queued", "submitted"] = "queued"
 
 
 class UnifiedCacheLinkerWrapper:
@@ -144,12 +208,19 @@ class UnifiedCacheLinkerWrapper:
         # rid -> what match found, consumed by the next init_load_back.
         self.hit_markers: dict[str, ExternalCacheHitMarker] = {}
         # Loads in flight, each pinning its inserted endpoint until DMA completes.
-        self.pending_loads: dict[str, tuple[NodeId, DecLockRefParams]] = {}
+        self.pending_loads: dict[str, PendingExternalLoad] = {}
         # Offloads in flight, each holding a lock on its node until it lands.
         self.pending_offloads: list[_PendingOffload] = []
 
         cache.tree_core.enable_external_cache_linker = True
         cache.write_through_threshold = 1
+        if cache_linker.key_codec is not None:
+            set_codec = getattr(cache.tree_core, "set_linker_key_codec", None)
+            if set_codec is None:
+                raise RuntimeError(
+                    "This tree core does not support linker-owned key sidecars."
+                )
+            set_codec(cache_linker.key_codec)
 
     @property
     def layer_done_counter(self) -> object:
@@ -158,9 +229,24 @@ class UnifiedCacheLinkerWrapper:
     def has_hit(self, rid: str) -> bool:
         return rid in self.hit_markers
 
+    def has_pending_io(self) -> bool:
+        return bool(
+            self.hit_markers
+            or self.pending_loads
+            or self.pending_offloads
+            or self.cache_linker.has_pending_operations()
+        )
+
     # ---- match: probe the remote store and report host_hit_length ----
 
     def match(self, key: RadixKey, req: Req, result: MatchResult) -> MatchResult:
+        # Cache-aware scheduling can probe a waiting request once for priority
+        # and again for admission.  A lookup ticket pins external blocks, so
+        # replace any unconsumed probe instead of leaking it or asking the
+        # backend to accept a duplicate request ID.
+        if req.rid in self.hit_markers:
+            self.release_request(req.rid)
+
         cache = self.cache
         page = cache.page_size
         device_hit_len = int(result.device_indices.numel())
@@ -170,6 +256,9 @@ class UnifiedCacheLinkerWrapper:
         tail_hashes = self._tail_hashes(key, result, device_hit_len)
         if not tail_hashes:
             return result
+        tail_linker_keys = self._tail_linker_keys(key, result, device_hit_len)
+        if self.cache_linker.key_codec is not None and tail_linker_keys is None:
+            return result
 
         lookup_transfers = []
         for component in cache._components_tuple:
@@ -178,16 +267,25 @@ class UnifiedCacheLinkerWrapper:
             )
             if transfer is None:
                 return result
+            self._set_transfer_linker_keys(transfer, tail_linker_keys)
             lookup_transfers.append(transfer)
         by_pool = {transfer.name: transfer for transfer in lookup_transfers}
 
         # Tail-relative: page 0 of `tail_hashes` is the first uncached page.
-        hit_pages = self._sync_restorable_prefix(
-            self.cache_linker.lookup(req.rid, lookup_transfers),
-            num_pages=len(tail_hashes),
-            device_hit_pages=0,
-        )
+        local_restorable = self.cache_linker.lookup(req.rid, lookup_transfers)
+        try:
+            hit_pages = self._sync_restorable_prefix(
+                local_restorable,
+                num_pages=len(tail_hashes),
+                device_hit_pages=0,
+            )
+        except BaseException:
+            self.cache_linker.cancel_request(req.rid)
+            raise
         if hit_pages == 0:
+            # A rank can hold a local lookup ticket even when the TP/CP
+            # intersection is empty.  No hit marker will own that ticket.
+            self.cache_linker.cancel_request(req.rid)
             return result
         hit_tokens = hit_pages * page
 
@@ -203,6 +301,11 @@ class UnifiedCacheLinkerWrapper:
         self.hit_markers[req.rid] = ExternalCacheHitMarker(
             prefix_key=key[: device_hit_len + hit_tokens],
             tail_hashes=list(tail_hashes[:hit_pages]),
+            tail_linker_keys=(
+                list(tail_linker_keys[:hit_pages])
+                if tail_linker_keys is not None
+                else None
+            ),
             device_hit_len=device_hit_len,
         )
         return result._replace(
@@ -255,6 +358,56 @@ class UnifiedCacheLinkerWrapper:
             page_size=page,
         )
 
+    def _tail_linker_keys(
+        self, key: RadixKey, result: MatchResult, device_hit_len: int
+    ) -> Optional[list[bytes]]:
+        codec = self.cache_linker.key_codec
+        if codec is None:
+            return None
+
+        parent_key = None
+        if device_hit_len > 0:
+            parent_key = self.cache.tree_core.get_last_linker_key_value(
+                result.last_device_node
+            )
+            if parent_key is None:
+                return None
+
+        page = self.cache.page_size
+        tail_len = (len(key) - device_hit_len) // page * page
+        if tail_len == 0:
+            return []
+        linker_keys = codec.extend_pages(
+            parent_key=parent_key,
+            page_tokens=list(key[device_hit_len : device_hit_len + tail_len]),
+            page_size=page,
+            key_domain=LinkerKeyDomain(
+                cache_salt=key.cache_salt,
+                extra_key=key.extra_key,
+            ),
+        )
+        expected = tail_len // page
+        if len(linker_keys) != expected or any(
+            not isinstance(linker_key, bytes) for linker_key in linker_keys
+        ):
+            raise RuntimeError(
+                f"Linker key codec {codec.codec_id!r} returned "
+                f"{len(linker_keys)} keys for {expected} pages."
+            )
+        return linker_keys
+
+    @staticmethod
+    def _set_transfer_linker_keys(
+        transfer: PoolTransfer, linker_keys: Optional[Sequence[bytes]]
+    ) -> None:
+        if linker_keys is None:
+            return
+        if transfer.keys is None or len(transfer.keys) != len(linker_keys):
+            raise RuntimeError(
+                f"External linker key count does not match {transfer.name} transfer."
+            )
+        transfer.linker_keys = list(linker_keys)
+
     # ---- init_load_back: remote -> device, then insert ----
 
     def load_back(self, req: Req) -> tuple[torch.Tensor, NodeId]:
@@ -266,23 +419,28 @@ class UnifiedCacheLinkerWrapper:
 
         device_hit_len = hit.device_hit_len
         tail_hashes = hit.tail_hashes
+        tail_linker_keys = hit.tail_linker_keys
         prefix_len = device_hit_len + len(tail_hashes) * cache.page_size
 
         # Build per-component linker transfers.
         component_transfers: list[tuple[TreeComponent, PoolTransfer]] = []
         for component in cache._components_tuple:
-            transfer = component.build_external_linker_transfer(
-                LinkerTransferPhase.LOAD, None, tail_hashes
-            )
-            if transfer is None:
-                self._update_load(
-                    ExternalLinkerLoadPhase.ABORT,
-                    req,
-                    component_transfers,
-                    prefix_len,
+            try:
+                transfer = component.build_external_linker_transfer(
+                    LinkerTransferPhase.LOAD, None, tail_hashes
                 )
+            except BaseException:
+                self._abort_prepared_load(req, component_transfers, prefix_len)
+                raise
+            if transfer is None:
+                self._abort_prepared_load(req, component_transfers, prefix_len)
                 return empty_indices, req.last_node
             component_transfers.append((component, transfer))
+            try:
+                self._set_transfer_linker_keys(transfer, tail_linker_keys)
+            except BaseException:
+                self._abort_prepared_load(req, component_transfers, prefix_len)
+                raise
 
         full_transfer = component_transfers[0][1]
         assert full_transfer.name == PoolName.KV
@@ -341,7 +499,13 @@ class UnifiedCacheLinkerWrapper:
             canonical_full=canonical_tail,
         )
 
-        self._queue_load(req.rid, insert_result.last_device_node, load_transfers)
+        self._queue_load(
+            req.rid,
+            insert_result.last_device_node,
+            load_transfers,
+            anchor_node=req.last_node,
+            adopted_ranges=insert_result.adopted_ranges or {},
+        )
 
         node = cache.resolve_node_handle(insert_result.last_device_node)
         while node.id != req.last_node:
@@ -349,22 +513,63 @@ class UnifiedCacheLinkerWrapper:
             node = node.parent
         return canonical_tail, insert_result.last_device_node
 
+    def _abort_prepared_load(
+        self,
+        req: Req,
+        component_transfers: list[tuple[TreeComponent, PoolTransfer]],
+        prefix_len: int,
+    ) -> None:
+        try:
+            self._update_load(
+                ExternalLinkerLoadPhase.ABORT,
+                req,
+                component_transfers,
+                prefix_len,
+            )
+        finally:
+            # ``hit`` has already been popped, so no tree marker remains to
+            # own the backend's lookup ticket after preparation fails.
+            self.cache_linker.cancel_request(req.rid)
+
     def _queue_load(
-        self, rid: str, node_id: NodeId, transfers: list[PoolTransfer]
+        self,
+        rid: str,
+        node_id: NodeId,
+        transfers: list[PoolTransfer],
+        *,
+        anchor_node: Optional[NodeId] = None,
+        adopted_ranges: Optional[dict] = None,
     ) -> None:
         if not transfers:
+            self.cache_linker.cancel_request(rid)
             return
         assert rid not in self.pending_loads
         lock_params = self.cache.inc_lock_ref(node_id).to_dec_params()
+        pending = PendingExternalLoad(
+            rid=rid,
+            inserted_node=node_id,
+            anchor_node=node_id if anchor_node is None else anchor_node,
+            adopted_ranges={} if adopted_ranges is None else adopted_ranges,
+            allocated_component_slots={
+                transfer.name: transfer.device_indices
+                for transfer in transfers
+                if getattr(transfer, "device_indices", None) is not None
+            },
+            lock_params=lock_params,
+        )
         try:
             queued = self.cache_linker.load(rid, transfers)
         except BaseException:
-            self.cache.dec_lock_ref(node_id, lock_params)
+            try:
+                self.cache_linker.cancel_request(rid)
+            finally:
+                self._rollback_pending_load(pending)
             raise
         if not queued:
-            self.cache.dec_lock_ref(node_id, lock_params)
+            self.cache_linker.cancel_request(rid)
+            self._rollback_pending_load(pending)
             raise RuntimeError(f"Failed to queue the linker load for rid={rid!r}.")
-        self.pending_loads[rid] = (node_id, lock_params)
+        self.pending_loads[rid] = pending
 
     def _update_load(
         self,
@@ -405,8 +610,17 @@ class UnifiedCacheLinkerWrapper:
                 )
                 if not keys:
                     continue
+                linker_keys = None
+                if transfer.linker_keys is not None:
+                    _, linker_keys = self._select_adopted_pages(
+                        transfer.device_indices,
+                        ranges,
+                        prefix_len,
+                        transfer.linker_keys,
+                    )
                 transfer.device_indices = indices
                 transfer.keys = keys
+                transfer.linker_keys = linker_keys
                 component_canonical, _ = self._select_adopted_pages(
                     canonical_full, ranges, prefix_len
                 )
@@ -428,8 +642,8 @@ class UnifiedCacheLinkerWrapper:
         indices: torch.Tensor,
         ranges: Sequence[tuple[int, int]],
         prefix_len: int,
-        keys: Sequence[str] | None = None,
-    ) -> tuple[torch.Tensor, list[str]]:
+        keys: Sequence | None = None,
+    ) -> tuple[torch.Tensor, list]:
         page = self.cache.page_size
         coverage_start = prefix_len - len(indices)
         pages = indices.reshape(-1, page)
@@ -473,6 +687,9 @@ class UnifiedCacheLinkerWrapper:
                 LinkerTransferPhase.OFFLOAD, node, None
             )
             if transfer is not None:
+                if self.cache_linker.key_codec is not None:
+                    linker_keys = cache.tree_core.get_linker_key_values(node_id)
+                    self._set_transfer_linker_keys(transfer, linker_keys)
                 transfers.append(transfer)
 
         lock_params = cache.inc_lock_ref(node_id).to_dec_params()
@@ -517,8 +734,8 @@ class UnifiedCacheLinkerWrapper:
     def drain_loads(self, finish_count: int) -> None:
         for _ in range(finish_count):
             for rid in self.cache_linker.pop_completed_load():
-                node_id, lock_params = self.pending_loads.pop(rid)
-                self.cache.dec_lock_ref(node_id, lock_params)
+                pending = self.pending_loads.pop(rid)
+                self.cache.dec_lock_ref(pending.inserted_node, pending.lock_params)
 
     def take_completed_offloads(self, finish_count: int) -> list[bool]:
         assert finish_count <= len(self.pending_offloads)
@@ -536,7 +753,12 @@ class UnifiedCacheLinkerWrapper:
             self.cache.dec_lock_ref(pending.lock_node_id, pending.lock_params)
 
     def start_layer_wise_loading(self) -> int:
-        return self.cache_linker.start_layer_wise_loading()
+        consumer_index = self.cache_linker.start_layer_wise_loading()
+        if consumer_index >= 0:
+            for pending in self.pending_loads.values():
+                if pending.phase == "queued":
+                    pending.phase = "submitted"
+        return consumer_index
 
     # ---- lifecycle ----
 
@@ -546,8 +768,8 @@ class UnifiedCacheLinkerWrapper:
         self._release_pending_locks()
 
     def _release_pending_locks(self) -> None:
-        for node_id, lock_params in self.pending_loads.values():
-            self.cache.dec_lock_ref(node_id, lock_params)
+        for pending in self.pending_loads.values():
+            self.cache.dec_lock_ref(pending.inserted_node, pending.lock_params)
         self.pending_loads.clear()
         for pending in self.pending_offloads:
             for node_id in pending.publish_node_ids:
@@ -560,11 +782,38 @@ class UnifiedCacheLinkerWrapper:
 
     def release_request(self, rid: str) -> None:
         self.hit_markers.pop(rid, None)
-        # TODO: Roll back the published tree and component state atomically before
-        # canceling; otherwise the tree may retain device slots that were never loaded.
-        if self.cache_linker.cancel_queued_load(rid):
-            node_id, lock_params = self.pending_loads.pop(rid)
-            self.cache.dec_lock_ref(node_id, lock_params)
+        outcome = self.cache_linker.cancel_request(rid)
+        if outcome is LinkerCancelOutcome.QUEUED_LOAD_CANCELLED:
+            pending = self.pending_loads.pop(rid)
+            if pending.phase != "queued":
+                raise RuntimeError(f"Linker cancelled submitted load for rid={rid!r}.")
+            self._rollback_pending_load(pending)
+        elif outcome is LinkerCancelOutcome.SUBMITTED_LOAD_RETAINED:
+            pending = self.pending_loads.get(rid)
+            if pending is None or pending.phase != "submitted":
+                raise RuntimeError(
+                    f"Linker retained unknown submitted load for rid={rid!r}."
+                )
+        elif (
+            outcome is LinkerCancelOutcome.LOOKUP_RELEASED and rid in self.pending_loads
+        ):
+            raise RuntimeError(f"Linker lost queued load state for rid={rid!r}.")
+        elif outcome is LinkerCancelOutcome.NOT_FOUND and rid in self.pending_loads:
+            raise RuntimeError(f"Linker lost pending load state for rid={rid!r}.")
+
+    def _rollback_pending_load(self, pending: PendingExternalLoad) -> None:
+        """Undo tree adoption before releasing the transaction's node lock."""
+        try:
+            if pending.adopted_ranges:
+                self.cache.rollback_external_load(
+                    anchor_node=pending.anchor_node,
+                    inserted_node=pending.inserted_node,
+                    adopted_ranges=pending.adopted_ranges,
+                    allocated_component_slots=pending.allocated_component_slots,
+                    lock_params=pending.lock_params,
+                )
+        finally:
+            self.cache.dec_lock_ref(pending.inserted_node, pending.lock_params)
 
     def close(self) -> None:
         self.cache_linker.close()

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -63,6 +63,10 @@ from sglang.srt.mem_cache.unified_cache.components import (
     TreeComponent,
     get_and_increase_time_counter,
 )
+from sglang.srt.mem_cache.unified_cache.unified_cache_linker import (
+    LinkerKeyCodec,
+    LinkerKeyDomain,
+)
 from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
     BufferBackupSnapshot,
     BufferBackupState,
@@ -75,6 +79,7 @@ from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
     InsertStepResult,
     NodeId,
     RadixCacheWalkResult,
+    RollbackExternalLoadResult,
     UnifiedTreeCoreInterface,
 )
 from sglang.srt.mem_cache.utils import (
@@ -122,6 +127,8 @@ class UnifiedTreeNode:
         self.last_access_time = get_and_increase_time_counter()
         self.creation_time = get_and_increase_time_counter()
         self.hash_value = None
+        # Stable binary page keys owned by the active direct-cache linker.
+        self.linker_key_values: Optional[list[bytes]] = None
         # Namespace-aware hashes used only for external KV events.
         self.event_hash_value: Optional[list[str]] = None
         self.hit_count = 0
@@ -400,6 +407,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.enable_hicache = False
         self.enable_storage = False
         self.enable_external_cache_linker = False
+        self.linker_key_codec: Optional[LinkerKeyCodec] = None
         self.write_through_threshold = 256
         self.is_write_back = False
         self.has_swa_host_pool = False
@@ -451,6 +459,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.root_node.key = RadixKey(array("q"), None)
         self.root_node.component_data[BASE_COMPONENT_TYPE].value = []
         self.root_node.hash_value = []
+        self.root_node.linker_key_values = []
         for ct in self.component_types:
             self.root_node.component_data[ct].lock_ref = 1
 
@@ -520,6 +529,53 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     def get_hash_values(self, node_id: NodeId) -> list[str]:
         """The hash values owned by this node, excluding its ancestors."""
         return self.node_by_id(node_id).hash_value or []
+
+    def set_linker_key_codec(self, codec: LinkerKeyCodec) -> None:
+        """Install one active linker codec and populate existing node sidecars."""
+        if self.linker_key_codec is not None and self.linker_key_codec is not codec:
+            raise RuntimeError("A different linker key codec is already installed.")
+        self.linker_key_codec = codec
+        stack = [self.root_node]
+        while stack:
+            node = stack.pop()
+            if node is not self.root_node and node.linker_key_values is None:
+                node.linker_key_values = self._compute_linker_key_values(node)
+            stack.extend(node.children.values())
+
+    def get_last_linker_key_value(self, node_id: NodeId) -> Optional[bytes]:
+        values = self.node_by_id(node_id).linker_key_values
+        return values[-1] if values else None
+
+    def get_linker_key_values(self, node_id: NodeId) -> list[bytes]:
+        values = self.node_by_id(node_id).linker_key_values
+        return list(values) if values is not None else []
+
+    def _compute_linker_key_values(self, node: UnifiedTreeNode) -> list[bytes]:
+        codec = self.linker_key_codec
+        if codec is None:
+            return []
+        assert node.parent is not None and node.key is not None
+        parent_values = node.parent.linker_key_values
+        if parent_values is None:
+            raise RuntimeError("Missing parent linker key sidecar.")
+        values = codec.extend_pages(
+            parent_key=parent_values[-1] if parent_values else None,
+            page_tokens=list(node.key),
+            page_size=self.page_size,
+            key_domain=LinkerKeyDomain(
+                cache_salt=node.key.cache_salt,
+                extra_key=node.key.extra_key,
+            ),
+        )
+        expected = len(node.key) // self.page_size
+        if len(values) != expected or any(
+            not isinstance(value, bytes) for value in values
+        ):
+            raise RuntimeError(
+                f"Linker key codec {codec.codec_id!r} returned {len(values)} "
+                f"keys for {expected} pages."
+            )
+        return values
 
     def snapshot_buffer_backup(
         self, node_id: NodeId, pass_prefix_keys: bool
@@ -894,6 +950,96 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         prefix_chunks.reverse()
         return torch.cat(prefix_chunks)
 
+    def rollback_external_load(
+        self,
+        anchor_node_id: NodeId,
+        inserted_node_id: NodeId,
+        adopted_ranges: dict[ComponentType, list[tuple[int, int]]],
+        lock_params: DecLockRefParams,
+        expected_full_slots: Optional[torch.Tensor],
+    ) -> RollbackExternalLoadResult:
+        """Remove FULL values installed by a queued external load.
+
+        V1 intentionally supports only the homogeneous FULL component.  Each
+        adopted interval must cover complete radix nodes; a partial-node rollback
+        would risk discarding valid KV owned by an earlier request and therefore
+        fails closed.
+        """
+        unsupported = set(adopted_ranges) - {BASE_COMPONENT_TYPE}
+        if unsupported:
+            raise RuntimeError(
+                f"External-load rollback does not support components {unsupported}."
+            )
+
+        anchor = self.node_by_id(anchor_node_id)
+        node = self.node_by_id(inserted_node_id)
+        path = []
+        while node is not anchor:
+            if node is self.root_node:
+                raise RuntimeError("External-load rollback anchor is not an ancestor.")
+            path.append(node)
+            node = node.parent
+        path.reverse()
+
+        anchor_depth = 0
+        node = anchor
+        while node is not self.root_node:
+            anchor_depth += len(node.key)
+            node = node.parent
+
+        ranges = adopted_ranges.get(BASE_COMPONENT_TYPE, [])
+        selected = []
+        cursor = anchor_depth
+        for node in path:
+            end = cursor + len(node.key)
+            overlaps = any(start < end and cursor < stop for start, stop in ranges)
+            if overlaps:
+                covered = any(start <= cursor and end <= stop for start, stop in ranges)
+                if not covered:
+                    raise RuntimeError(
+                        "Queued external load adopted only part of a radix node."
+                    )
+                value = node.component_data[BASE_COMPONENT_TYPE].value
+                if value is None:
+                    raise RuntimeError("Queued external-load node is already evicted.")
+                selected.append((node, value))
+            cursor = end
+
+        selected_slots = [value for _, value in selected]
+        actual = (
+            torch.cat(selected_slots)
+            if selected_slots
+            else self._empty_match_result.device_indices
+        )
+        if expected_full_slots is not None and not torch.equal(
+            actual, expected_full_slots.to(actual.device)
+        ):
+            raise RuntimeError(
+                "Queued external-load slot ownership changed before rollback."
+            )
+
+        result = RollbackExternalLoadResult()
+        skipped = lock_params.skip_lock_node_ids.setdefault(BASE_COMPONENT_TYPE, set())
+        for node, value in selected:
+            cd = node.component_data[BASE_COMPONENT_TYPE]
+            if cd.lock_ref != 1:
+                raise RuntimeError(
+                    "Queued external-load node is referenced outside its transaction."
+                )
+            # Consume this transaction's path lock here.  The normal dec call
+            # skips these now-tombstoned nodes and releases the remaining path.
+            cd.lock_ref -= 1
+            skipped.add(node.id)
+            self.component_protected_size_[BASE_COMPONENT_TYPE] -= len(value)
+            cd.value = None
+            node.external_cache_stored = False
+            result.device_frees[BASE_COMPONENT_TYPE].append(value)
+            result.tracker[BASE_COMPONENT_TYPE] += len(value)
+            self.evictable_device_leaves.discard(node)
+            self._update_evictable_leaf_sets(node.parent)
+            self.kv_events.record_remove(node, medium=StorageMedium.GPU)
+        return result
+
     def _touch_node(self, node: UnifiedTreeNode):
         node.last_access_time = get_and_increase_time_counter()
         if node != self.root_node:
@@ -1183,6 +1329,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
         )
+        split_pages = split_len // self.page_size
+        if child.linker_key_values is not None:
+            new_node.linker_key_values = child.linker_key_values[:split_pages]
+            child.linker_key_values = child.linker_key_values[split_pages:]
         new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
             child.event_hash_value, split_len, self.page_size
         )
@@ -1232,6 +1382,8 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.component_evictable_size_[BASE_COMPONENT_TYPE] += len(value)
         if self.enable_storage or self.enable_external_cache_linker:
             new_node.hash_value = compute_node_hash_values(new_node, self.page_size)
+        if self.linker_key_codec is not None:
+            new_node.linker_key_values = self._compute_linker_key_values(new_node)
 
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(parent)

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -72,6 +72,12 @@ class DecSwaLockOnlyResult(BaseEvictionResult):
     pass
 
 
+class RollbackExternalLoadResult(BaseEvictionResult):
+    """Device slots detached while cancelling a queued external load."""
+
+    pass
+
+
 class RadixCacheWalkResult(msgspec.Struct, frozen=True, kw_only=True):
     """Flat (slot, position, prev-slot) rows emitted by the KV-canary walk."""
 
@@ -195,6 +201,21 @@ class UnifiedTreeCoreInterface(ABC):
     @abstractmethod
     def get_hash_values(self, node_id: NodeId) -> list[str]:
         """The hash values owned by this node, excluding its ancestors."""
+        ...
+
+    @abstractmethod
+    def set_linker_key_codec(self, codec) -> None:
+        """Install the active direct-linker page-key codec."""
+        ...
+
+    @abstractmethod
+    def get_last_linker_key_value(self, node_id: NodeId) -> Optional[bytes]:
+        """Return the last linker key on a node, if present."""
+        ...
+
+    @abstractmethod
+    def get_linker_key_values(self, node_id: NodeId) -> list[bytes]:
+        """Return linker keys owned by a node, excluding ancestors."""
         ...
 
     @abstractmethod
@@ -385,6 +406,18 @@ class UnifiedTreeCoreInterface(ABC):
         self, from_node_id: NodeId, until_node_id: NodeId
     ) -> torch.Tensor:
         """Concatenate FULL device values from from_node up to (exclusive) until_node."""
+        ...
+
+    @abstractmethod
+    def rollback_external_load(
+        self,
+        anchor_node_id: NodeId,
+        inserted_node_id: NodeId,
+        adopted_ranges: dict[ComponentType, list[tuple[int, int]]],
+        lock_params: DecLockRefParams,
+        expected_full_slots: Optional[torch.Tensor],
+    ) -> RollbackExternalLoadResult:
+        """Detach ranges adopted by a queued, never-submitted external load."""
         ...
 
     @abstractmethod

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -350,7 +350,25 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def init_cache_linker(self, cache_linker: UnifiedCacheLinker) -> None:
         """Attach an external KV store directly to the device pools."""
+        if (
+            getattr(self, "cache_controller", None) is not None
+            or getattr(self, "host_pool_group", None) is not None
+            or getattr(self, "_storage_attachment", None) is not None
+            or getattr(self, "buffer_pipeline", None) is not None
+            or getattr(self, "enable_storage", False)
+        ):
+            raise RuntimeError(
+                "A direct cache linker is mutually exclusive with native HiCache."
+            )
+        if self.linker is not None:
+            raise RuntimeError("A direct cache linker is already attached.")
         self.linker = UnifiedCacheLinkerWrapper(self, cache_linker)
+
+    def has_external_cache_io(self) -> bool:
+        return self.linker is not None
+
+    def has_pending_external_cache_io(self) -> bool:
+        return self.linker is not None and self.linker.has_pending_io()
 
     def reset(self) -> None:
         if self.linker is not None:
@@ -385,6 +403,10 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def init_hicache(self, server_args: ServerArgs, params: CacheInitParams) -> None:
         """Initialize HiCache infrastructure."""
+        if self.linker is not None:
+            raise RuntimeError(
+                "Native HiCache is mutually exclusive with a direct cache linker."
+            )
         self.host_memory_mode = get_memory().hicache_host_memory_mode
         if self.host_memory_mode == "buffer_only":
             # TODO(Jialin): Extend buffer-only state handoff to Mamba in a
@@ -797,6 +819,25 @@ class UnifiedRadixCache(BasePrefixCache):
         if self.disable:
             return DecLockRefResult()
         return self.tree_core.dec_lock_ref(node_id, params, skip_swa)
+
+    def rollback_external_load(
+        self,
+        *,
+        anchor_node: NodeId,
+        inserted_node: NodeId,
+        adopted_ranges: dict,
+        allocated_component_slots: dict[PoolName, torch.Tensor],
+        lock_params: DecLockRefParams,
+    ) -> None:
+        """Detach and free slots from a queued direct-linker transaction."""
+        result = self.tree_core.rollback_external_load(
+            anchor_node,
+            inserted_node,
+            adopted_ranges,
+            lock_params,
+            allocated_component_slots.get(PoolName.KV),
+        )
+        self._free_values(result.device_frees, result.host_frees)
 
     def _dec_req_lock(self, req: Req, *, skip_swa: bool = False) -> None:
         """Release the tree lock a request holds on its last_node, honoring the

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -571,6 +571,15 @@ class StreamingSession(BasePrefixCache):
     def check_hicache_events(self):
         return self.inner.check_hicache_events()
 
+    def has_external_cache_io(self) -> bool:
+        return self.inner.has_external_cache_io()
+
+    def has_pending_external_cache_io(self) -> bool:
+        return self.inner.has_pending_external_cache_io()
+
+    def release_host_resources(self) -> None:
+        self.inner.release_host_resources()
+
     def take_events(self):
         return self.inner.take_events()
 

--- a/test/registered/unit/managers/test_scheduler_timeouts.py
+++ b/test/registered/unit/managers/test_scheduler_timeouts.py
@@ -86,6 +86,17 @@ class TestWaitingTimeout(CustomTestCase):
         self.assertEqual(len(s.waiting_queue), 1)
         s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
 
+    def test_external_cache_state_is_released_for_timed_out_request(self):
+        stale = _req("stale", wait_entry=time.perf_counter() - 10)
+        s = _scheduler([stale])
+        s.enable_async_cache_io = True
+        s.tree_cache = MagicMock()
+
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1.0):
+            s._abort_on_waiting_timeout()
+
+        s.tree_cache.release_aborted_request.assert_called_once_with("stale")
+
     def test_disabled_timeout_is_a_no_op(self):
         s = _scheduler([_req("stale", wait_entry=time.perf_counter() - 100)])
         with envs.SGLANG_REQ_WAITING_TIMEOUT.override(0):

--- a/test/registered/unit/mem_cache/test_linker_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_linker_pool_assembler.py
@@ -117,6 +117,7 @@ class TestDevicePoolGroup(CustomTestCase):
         transfer = PoolTransfer(
             name=PoolName.KV,
             keys=["a", "b"],
+            linker_keys=[b"a", b"b"],
             device_indices=torch.tensor([0, 1, 4, 5]),
             hit_policy=PoolHitPolicy.TRAILING_PAGES,
         )
@@ -128,6 +129,8 @@ class TestDevicePoolGroup(CustomTestCase):
         )
         self.assertEqual(resolved[0].host_indices.tolist(), [0, 1, 4, 5])
         self.assertEqual(resolved[1].host_indices.tolist(), [100, 101, 104, 105])
+        self.assertEqual(resolved[0].linker_keys, [b"a", b"b"])
+        self.assertEqual(resolved[1].linker_keys, [b"a", b"b"])
         self.assertTrue(
             all(item.hit_policy == PoolHitPolicy.ALL_PAGES for item in resolved)
         )
@@ -159,6 +162,81 @@ class TestDevicePoolGroup(CustomTestCase):
 
 
 class TestHybridDevicePoolAssembler(CustomTestCase):
+    def test_plain_mha_exposes_original_kv_tensors(self):
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        kvcache = MHATokenToKVPool.__new__(MHATokenToKVPool)
+        kvcache.page_size = 2
+        kvcache.size = 6
+        kvcache.layer_num = 2
+        kvcache.k_buffer = [torch.zeros((8, 3)) for _ in range(2)]
+        kvcache.v_buffer = [torch.zeros((8, 3)) for _ in range(2)]
+
+        group = resolve_hybrid_device_pool_group(
+            kvcache=kvcache,
+            page_size=2,
+            params=SimpleNamespace(),
+            components={ComponentType.FULL},
+        )
+
+        self.assertEqual(set(group.entry_map), {PoolName.KV})
+        self.assertEqual(group.num_layers, 2)
+        self.assertEqual(
+            group.entry_map[PoolName.KV].get_hybrid_pool_buffer(),
+            [*kvcache.k_buffer, *kvcache.v_buffer],
+        )
+
+    def test_plain_mha_rejects_specialized_pool_subclasses(self):
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        class SpecializedPool(MHATokenToKVPool):
+            pass
+
+        kvcache = SpecializedPool.__new__(SpecializedPool)
+        with self.assertRaisesRegex(ValueError, "standard MHATokenToKVPool"):
+            resolve_hybrid_device_pool_group(
+                kvcache=kvcache,
+                page_size=2,
+                params=SimpleNamespace(),
+                components={ComponentType.FULL},
+            )
+
+    @staticmethod
+    def _plain_mha_pool():
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        kvcache = MHATokenToKVPool.__new__(MHATokenToKVPool)
+        kvcache.page_size = 2
+        kvcache.size = 6
+        kvcache.layer_num = 1
+        kvcache.k_buffer = [torch.zeros((8, 3))]
+        kvcache.v_buffer = [torch.zeros((8, 3))]
+        return kvcache
+
+    def test_plain_mha_rejects_quantized_pool(self):
+        kvcache = self._plain_mha_pool()
+        kvcache.quant_method = object()
+
+        with self.assertRaisesRegex(ValueError, "quantized KV pools"):
+            resolve_hybrid_device_pool_group(
+                kvcache=kvcache,
+                page_size=2,
+                params=SimpleNamespace(),
+                components={ComponentType.FULL},
+            )
+
+    def test_plain_mha_rejects_post_capture_vmm_pool(self):
+        kvcache = self._plain_mha_pool()
+        kvcache.post_capture_active = True
+
+        with self.assertRaisesRegex(ValueError, "post-capture VMM pools"):
+            resolve_hybrid_device_pool_group(
+                kvcache=kvcache,
+                page_size=2,
+                params=SimpleNamespace(),
+                components={ComponentType.FULL},
+            )
+
     def test_deepseek_v4_maps_sparse_sidecars(self):
         from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
             DeepSeekV4LayerItem,

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -5,12 +5,14 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.mem_cache.registry import (
     _RADIX_CACHE_REGISTRY,
     TreeCacheBuildContext,
     create_tree_cache,
+    create_unified_radix_cache_without_hicache,
     default_radix_cache_factory,
     get_radix_cache_factory,
     register_radix_cache_backend,
@@ -121,6 +123,24 @@ class TestCreateTreeCacheRouting(_RegistryIsolationMixin, CustomTestCase):
 
         factory.assert_called_once()
         self.assertIs(result, cache)
+
+    def test_unified_helper_does_not_initialize_hicache(self):
+        ctx = _make_ctx(self, enable_hierarchical_cache=True)
+        ctx.params = SimpleNamespace(
+            req_to_token_pool=SimpleNamespace(),
+            component_registry_override=None,
+            tree_components=None,
+        )
+        cache = MagicMock(name="unified_cache")
+        with patch(
+            "sglang.srt.mem_cache.unified_radix_cache.UnifiedRadixCache",
+            return_value=cache,
+        ) as cache_cls:
+            result = create_unified_radix_cache_without_hicache(ctx)
+
+        self.assertIs(result, cache)
+        cache_cls.assert_called_once_with(ctx.params)
+        cache.init_hicache.assert_not_called()
 
     def test_unknown_backend_raises(self):
         with self.assertRaises(ValueError):

--- a/test/registered/unit/mem_cache/test_unified_cache_linker.py
+++ b/test/registered/unit/mem_cache/test_unified_cache_linker.py
@@ -1,10 +1,12 @@
+from array import array
 from types import SimpleNamespace
 
 import pytest
 import torch
 
-from sglang.srt.mem_cache.base_prefix_cache import InsertResult
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefParams, InsertResult
 from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache.cache_action import (
     ReplaceWriteThroughOnNodeSplit,
 )
@@ -16,8 +18,14 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
     LinkerTransferPhase,
 )
 from sglang.srt.mem_cache.unified_cache.unified_cache_linker import (
+    LinkerCancelOutcome,
+    PendingExternalLoad,
     UnifiedCacheLinker,
     UnifiedCacheLinkerWrapper,
+)
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import (
+    UnifiedTreeCore,
+    UnifiedTreeNode,
 )
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -126,6 +134,137 @@ def test_restorable_prefix_intersects_sparse_rank_results():
     assert hit_pages == 2
 
 
+def test_empty_rank_intersection_releases_local_lookup_ticket():
+    cancellations = []
+
+    class _TicketLinker(_FakeLinker):
+        def cancel_request(self, rid):
+            cancellations.append(rid)
+            return LinkerCancelOutcome.LOOKUP_RELEASED
+
+    class _Component:
+        def build_external_linker_transfer(self, phase, node, keys):
+            assert phase == LinkerTransferPhase.LOOKUP
+            return PoolTransfer(name=PoolName.KV, keys=["hash"])
+
+    linker = _TicketLinker()
+    linker.restorable = [1]
+    cache = _cache_for_wrapper(
+        page_size=2,
+        _components_tuple=(_Component(),),
+        _all_reduce_attn_groups=lambda mask, op: mask.zero_(),
+    )
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    wrapper._tail_hashes = lambda key, result, device_hit_len: ["hash"]
+    result = SimpleNamespace(device_indices=torch.tensor([], dtype=torch.int64))
+
+    matched = wrapper.match(
+        RadixKey(array("q", [1, 2])), SimpleNamespace(rid="rid"), result
+    )
+
+    assert matched is result
+    assert cancellations == ["rid"]
+    assert wrapper.hit_markers == {}
+
+
+def test_repeated_match_releases_unconsumed_lookup_ticket():
+    cancellations = []
+
+    class _TicketLinker(_FakeLinker):
+        def cancel_request(self, rid):
+            cancellations.append(rid)
+            return LinkerCancelOutcome.LOOKUP_RELEASED
+
+    cache = _cache_for_wrapper(page_size=2)
+    wrapper = UnifiedCacheLinkerWrapper(cache, _TicketLinker())
+    wrapper.hit_markers["rid"] = object()
+    result = SimpleNamespace(device_indices=torch.tensor([0, 1]))
+
+    matched = wrapper.match(
+        RadixKey(array("q", [1, 2])), SimpleNamespace(rid="rid"), result
+    )
+
+    assert matched is result
+    assert cancellations == ["rid"]
+    assert wrapper.hit_markers == {}
+
+
+def test_load_allocation_failure_releases_lookup_ticket():
+    cancellations = []
+
+    class _TicketLinker(_FakeLinker):
+        def cancel_request(self, rid):
+            cancellations.append(rid)
+            return LinkerCancelOutcome.LOOKUP_RELEASED
+
+    class _NoCapacityComponent:
+        def build_external_linker_transfer(self, phase, node, keys):
+            assert phase == LinkerTransferPhase.LOAD
+            return None
+
+    empty = torch.tensor([], dtype=torch.int64)
+    cache = _cache_for_wrapper(
+        page_size=2,
+        tree_core=SimpleNamespace(
+            enable_external_cache_linker=False,
+            empty_match_result=SimpleNamespace(device_indices=empty),
+        ),
+        _components_tuple=(_NoCapacityComponent(),),
+    )
+    wrapper = UnifiedCacheLinkerWrapper(cache, _TicketLinker())
+    wrapper.hit_markers["rid"] = SimpleNamespace(
+        prefix_key=RadixKey(array("q", [1, 2])),
+        tail_hashes=["hash"],
+        tail_linker_keys=None,
+        device_hit_len=0,
+    )
+
+    indices, node = wrapper.load_back(SimpleNamespace(rid="rid", last_node=7))
+
+    assert indices is empty
+    assert node == 7
+    assert cancellations == ["rid"]
+    assert wrapper.hit_markers == {}
+
+
+def test_linker_codec_extends_only_the_device_miss_tail():
+    calls = []
+
+    class _Codec:
+        codec_id = "unit-codec"
+
+        def extend_pages(self, *, parent_key, page_tokens, page_size, key_domain):
+            calls.append((parent_key, page_tokens, page_size, key_domain))
+            return [bytes(page) for page in zip(*[iter(page_tokens)] * page_size)]
+
+    linker = _FakeLinker()
+    linker.key_codec = _Codec()
+    tree_core = SimpleNamespace(
+        enable_external_cache_linker=False,
+        set_linker_key_codec=lambda codec: calls.append(("installed", codec)),
+        get_last_linker_key_value=lambda node_id: b"parent",
+    )
+    cache = _cache_for_wrapper(page_size=2, tree_core=tree_core)
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    key = RadixKey(
+        array("q", [1, 2, 3, 4, 5, 6]),
+        extra_key="adapter-a",
+        cache_salt="tenant-a",
+    )
+
+    values = wrapper._tail_linker_keys(
+        key, SimpleNamespace(last_device_node=9), device_hit_len=2
+    )
+
+    assert values == [b"\x03\x04", b"\x05\x06"]
+    parent_key, tokens, page_size, domain = calls[1]
+    assert parent_key == b"parent"
+    assert tokens == [3, 4, 5, 6]
+    assert page_size == 2
+    assert domain.cache_salt == "tenant-a"
+    assert domain.extra_key == "adapter-a"
+
+
 def test_async_offload_pins_node_until_completion():
     class _Component:
         def build_external_linker_transfer(self, phase, node, keys):
@@ -207,12 +346,21 @@ def test_release_request_cancels_queued_load():
     linker = _FakeLinker()
     lock_params = object()
     unlocks = []
+    rollbacks = []
     cache = _cache_for_wrapper(
-        dec_lock_ref=lambda node, params: unlocks.append((node, params))
+        dec_lock_ref=lambda node, params: unlocks.append((node, params)),
+        rollback_external_load=lambda **kwargs: rollbacks.append(kwargs),
     )
     wrapper = UnifiedCacheLinkerWrapper(cache, linker)
     wrapper.hit_markers["rid"] = object()
-    wrapper.pending_loads["rid"] = (7, lock_params)
+    wrapper.pending_loads["rid"] = PendingExternalLoad(
+        rid="rid",
+        inserted_node=7,
+        anchor_node=3,
+        adopted_ranges={ComponentType.FULL: [(4, 8)]},
+        allocated_component_slots={PoolName.KV: torch.tensor([10, 11, 12, 13])},
+        lock_params=lock_params,
+    )
     linker.queued_loads["rid"] = [object()]
 
     wrapper.release_request("rid")
@@ -221,6 +369,71 @@ def test_release_request_cancels_queued_load():
     assert wrapper.pending_loads == {}
     assert "rid" not in linker.queued_loads
     assert unlocks == [(7, lock_params)]
+    assert rollbacks[0]["anchor_node"] == 3
+    assert rollbacks[0]["inserted_node"] == 7
+
+
+def test_release_request_retains_submitted_load_until_completion():
+    class _SubmittedLinker(_FakeLinker):
+        def cancel_request(self, rid):
+            assert rid in self.queued_loads
+            return LinkerCancelOutcome.SUBMITTED_LOAD_RETAINED
+
+    linker = _SubmittedLinker()
+    unlocks = []
+    cache = _cache_for_wrapper(
+        inc_lock_ref=lambda node: SimpleNamespace(to_dec_params=lambda: object()),
+        dec_lock_ref=lambda node, params: unlocks.append(node),
+    )
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    wrapper._queue_load("rid", 7, [PoolTransfer(name=PoolName.KV)])
+    wrapper.start_layer_wise_loading()
+
+    wrapper.release_request("rid")
+
+    assert wrapper.pending_loads["rid"].phase == "submitted"
+    assert unlocks == []
+
+    linker.completed_loads.append(["rid"])
+    wrapper.drain_loads(1)
+    assert unlocks == [7]
+
+
+def test_tree_rollback_tombstones_adopted_full_nodes_and_returns_slots():
+    core = UnifiedTreeCore.__new__(UnifiedTreeCore)
+    root = UnifiedTreeNode((ComponentType.FULL,))
+    root.key = RadixKey(array("q"))
+    root.component_data[ComponentType.FULL].value = []
+    anchor = UnifiedTreeNode((ComponentType.FULL,))
+    anchor.key = RadixKey(array("q", [1, 2]))
+    anchor.parent = root
+    anchor.component_data[ComponentType.FULL].value = torch.tensor([1, 2])
+    inserted = UnifiedTreeNode((ComponentType.FULL,))
+    inserted.key = RadixKey(array("q", [3, 4]))
+    inserted.parent = anchor
+    inserted.component_data[ComponentType.FULL].value = torch.tensor([10, 11])
+    inserted.component_data[ComponentType.FULL].lock_ref = 1
+    core.root_node = root
+    core._node_arena = {node.id: node for node in (root, anchor, inserted)}
+    core.component_protected_size_ = {ComponentType.FULL: 2}
+    core.evictable_device_leaves = {inserted}
+    core._update_evictable_leaf_sets = lambda node: None
+    core.kv_events = SimpleNamespace(record_remove=lambda *args, **kwargs: None)
+    lock_params = DecLockRefParams()
+
+    result = core.rollback_external_load(
+        anchor.id,
+        inserted.id,
+        {ComponentType.FULL: [(2, 4)]},
+        lock_params,
+        torch.tensor([10, 11]),
+    )
+
+    assert inserted.component_data[ComponentType.FULL].value is None
+    assert inserted.component_data[ComponentType.FULL].lock_ref == 0
+    assert lock_params.skip_lock_node_ids[ComponentType.FULL] == {inserted.id}
+    assert result.device_frees[ComponentType.FULL][0].tolist() == [10, 11]
+    result.device_frees.clear()
 
 
 def test_failed_offload_rolls_back_split_fragments():
@@ -352,7 +565,14 @@ def test_close_quiesces_backend_before_releasing_pending_loads():
         dec_lock_ref=lambda node_id, params: events.append(("unlock", node_id))
     )
     wrapper = UnifiedCacheLinkerWrapper(cache, linker)
-    wrapper.pending_loads["rid"] = (7, object())
+    wrapper.pending_loads["rid"] = PendingExternalLoad(
+        rid="rid",
+        inserted_node=7,
+        anchor_node=7,
+        adopted_ranges={},
+        allocated_component_slots={},
+        lock_params=object(),
+    )
 
     wrapper.close()
 
@@ -408,6 +628,7 @@ def test_component_commit_keeps_only_adopted_pages():
     full = PoolTransfer(
         name=PoolName.KV,
         keys=["a", "b", "c", "d"],
+        linker_keys=[b"a", b"b", b"c", b"d"],
         device_indices=torch.tensor([100, 101, 102, 103, 104, 105, 106, 107]),
     )
     canonical_tail = torch.tensor([10, 11, 102, 103, 14, 15, 106, 107])
@@ -435,6 +656,7 @@ def test_component_commit_keeps_only_adopted_pages():
 
     assert filtered == [full, swa]
     assert full.keys == ["b", "d"]
+    assert full.linker_keys == [b"b", b"d"]
     assert full.device_indices.tolist() == [102, 103, 106, 107]
     assert swa.keys == ["b", "d"]
     assert swa.device_indices.tolist() == [202, 203, 206, 207]


### PR DESCRIPTION
## Motivation

Enable a registered direct external-cache linker to drive asynchronous KV I/O without enabling or allocating SGLang HiCache host L2. This is the SGLang half of the Dynamo KVBM integration.

Companion Dynamo change: https://github.com/ai-dynamo/dynamo/pull/14180

This PR is intentionally a draft. It depends on the companion Dynamo PR and on an owner-backed rcommu host-memory provider that has not been submitted yet.

## Modifications

- Add generic external-cache I/O capabilities and use them for scheduler polling, load start, admission retry, abort cleanup, and idle detection.
- Add linker-owned binary page-key sidecars, including node split handling and a fail-closed Rust-tree path.
- Make queued loads transactional so cancellation rolls back adopted radix ranges, GPU slots, lookup tickets, and node locks; retain submitted loads until completion.
- Expose a no-HiCache unified-cache factory and a zero-copy plain-MHA device-pool adapter, while rejecting quantized, VMM, and unsupported hybrid layouts.
- Preserve compatibility for Mooncake direct-linker submitted cancellation and StreamingSession capability forwarding.

## Accuracy Tests

No model-forward semantics are changed. CPU unit coverage passes; end-to-end GPU/rcommu restore validation is pending the owner-provider dependency.

- `PYTHONPATH=python python -m pytest -q test/registered/unit/managers/test_scheduler_timeouts.py test/registered/unit/mem_cache/test_linker_pool_assembler.py test/registered/unit/mem_cache/test_registry.py test/registered/unit/mem_cache/test_unified_cache_linker.py` — 59 passed.

## Speed Tests and Profiling

Not measured in this draft. The data path is zero-copy at the Python boundary; KVBM owns native G1/G2 transfers.

## Checklist

- [x] Format the changed files with pre-commit.
- [x] Add CPU unit tests for the new lifecycle and rollback behavior.
- [ ] Add integration documentation after the cross-repository API is accepted.
- [ ] Run GPU accuracy and performance validation after the owner-backed provider lands.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33616743375](https://github.com/sgl-project/sglang/actions/runs/33616743375)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33616743134](https://github.com/sgl-project/sglang/actions/runs/33616743134)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33616743181](https://github.com/sgl-project/sglang/actions/runs/33616743181)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->