### PR TITLE
[Docs] Prefer --flashinfer-allreduce-fusion-backend over deprecated enable flag

### DIFF
--- a/docs/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -89,7 +89,7 @@ import { GLM5Deployment } from '/src/snippets/autoregressive/glm-5-deployment.js
   </tbody>
 </table>
 
-- **B200 (FP8)**: Use `--ep 1 --attention-backend dsa --dsa-decode-backend trtllm --dsa-prefill-backend trtllm --moe-runner-backend flashinfer_trtllm --enable-flashinfer-allreduce-fusion` for optimized DSA and MoE backends on Blackwell. Also add `--quantization fp8` for FP8 weight quantization.
+- **B200 (FP8)**: Use `--ep 1 --attention-backend dsa --dsa-decode-backend trtllm --dsa-prefill-backend trtllm --moe-runner-backend flashinfer_trtllm --flashinfer-allreduce-fusion-backend auto` for optimized DSA and MoE backends on Blackwell. Also add `--quantization fp8` for FP8 weight quantization.
 
 - **AMD GPUs**: Use `--dsa-prefill-backend tilelang --dsa-decode-backend tilelang` for the DSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). EAGLE speculative decoding is not currently supported on AMD for GLM-5.
 - For other configuration tips (MTP, DSA kernel, Context Parallel, HiSparse, NVFP4, Index Cache), see the [DeepSeek-V3.2 cookbook page](../DeepSeek/DeepSeek-V3_2). GLM-5 and DeepSeek-V3.2 share the same model structure, so the optimization techniques are common.
@@ -113,7 +113,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --enable-flashinfer-allreduce-fusion \
+  --flashinfer-allreduce-fusion-backend auto \
   --mem-fraction-static 0.85 \
   --host 0.0.0.0 \
   --port 30000

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -138,7 +138,7 @@ This section provides deployment configurations optimized for different hardware
 - To speed up weight loading for this large model, add `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'` to the launch command.
 - **CUDA IPC Transport**: Add `SGLANG_USE_CUDA_IPC_TRANSPORT=1` as an environment variable to use CUDA IPC for transferring multimodal features, significantly improving TTFT (Time To First Token). Note: this consumes additional memory proportional to image size, so you may need to lower `--mem-fraction-static` or `--max-running-requests`.
 - **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300.
-- **B200 (FP8)**: Add `--enable-flashinfer-allreduce-fusion` for optimized throughput on Blackwell.
+- **B200 (FP8)**: Add `--flashinfer-allreduce-fusion-backend auto` for optimized throughput on Blackwell.
 - For processing large images or videos, you may need to lower `--mem-fraction-static` to leave room for image feature tensors.
 - Hardware requirements:
     - **BF16**: ~397B parameters require ~800GB of GPU memory for weights.
@@ -1011,7 +1011,7 @@ python3 -m sglang.launch_server \
   --kv-cache-dtype fp8_e4m3 \
   --mamba-ssm-dtype bfloat16 \
   --attention-backend flashinfer \
-  --enable-flashinfer-allreduce-fusion \
+  --flashinfer-allreduce-fusion-backend auto \
   --mem-fraction-static 0.8 \
   --stream-interval 50 \
   --scheduler-recv-interval 10 \

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1814,7 +1814,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-flashinfer-allreduce-fusion`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable FlashInfer allreduce fusion with Residual RMSNorm.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>Deprecated.</strong> Use <code>--flashinfer-allreduce-fusion-backend=auto</code> instead. Legacy alias that enables FlashInfer allreduce fusion with Residual RMSNorm.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>

--- a/docs/src/snippets/autoregressive/glm-5-deployment.jsx
+++ b/docs/src/snippets/autoregressive/glm-5-deployment.jsx
@@ -177,7 +177,7 @@ export const GLM5Deployment = () => {
         cmd += ' \\\n  --dsa-decode-backend trtllm';
         cmd += ' \\\n  --dsa-prefill-backend trtllm';
         cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm';
-        cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+        cmd += ' \\\n  --flashinfer-allreduce-fusion-backend auto';
         cmd += ' \\\n  --enable-dp-lm-head';
         cmd += ' \\\n  --disable-radix-cache';
         cmd += ' \\\n  --max-prefill-tokens 32768';
@@ -221,7 +221,7 @@ export const GLM5Deployment = () => {
       cmd += ' \\\n  --dsa-decode-backend trtllm';
       cmd += ' \\\n  --dsa-prefill-backend trtllm';
       cmd += ' \\\n  --moe-runner-backend flashinfer_trtllm';
-      cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+      cmd += ' \\\n  --flashinfer-allreduce-fusion-backend auto';
     }
 
     if (hardware === 'b300' && effectiveQuant === 'fp8') {
@@ -232,7 +232,7 @@ export const GLM5Deployment = () => {
 
     // H200 FP8: flashinfer allreduce fusion.
     if (hardware === 'h200' && effectiveQuant === 'fp8') {
-      cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+      cmd += ' \\\n  --flashinfer-allreduce-fusion-backend auto';
     }
 
     cmd += ` \\\n  --mem-fraction-static ${memFraction}`;

--- a/docs/src/snippets/autoregressive/minimax-m25-deployment.jsx
+++ b/docs/src/snippets/autoregressive/minimax-m25-deployment.jsx
@@ -115,7 +115,7 @@ export const MiniMaxM25Deployment = () => {
     }
 
     if (useAllreduceFusion) {
-      cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      cmd += ` \\\n  --flashinfer-allreduce-fusion-backend auto`;
     }
 
     if (isAMD) {

--- a/docs/src/snippets/autoregressive/minimax-m27-deployment.jsx
+++ b/docs/src/snippets/autoregressive/minimax-m27-deployment.jsx
@@ -200,7 +200,7 @@ export const MiniMaxM27Deployment = () => {
     }
 
     if (useAllreduceFusion) {
-      cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+      cmd += ' \\\n  --flashinfer-allreduce-fusion-backend auto';
     }
 
     return cmd;

--- a/docs/src/snippets/autoregressive/qwen35-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen35-deployment.jsx
@@ -427,7 +427,7 @@ export const Qwen35Deployment = () => {
     // fusion flag instead, handled in the AMD backend block below.
     const amdGpu = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
     if (quantization !== 'fp4' && hardware !== 'xeon' && !amdGpu) {
-      cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
+      cmd += ` \\\n  --flashinfer-allreduce-fusion-backend auto`;
     }
 
     // H200 FP8-specific optimizations


### PR DESCRIPTION
## Summary
- Teach the current `--flashinfer-allreduce-fusion-backend auto` flag in GLM/Qwen/MiniMax cookbooks and deployment snippets instead of the deprecated `--enable-flashinfer-allreduce-fusion` alias.
- Mark `--enable-flashinfer-allreduce-fusion` as deprecated in the server arguments reference (points to `--flashinfer-allreduce-fusion-backend=auto`).
- Leave `--enforce-disable-flashinfer-allreduce-fusion` unchanged.

## Local repro
```bash
# Code: old enable flag is deprecated and maps to backend=auto
rg -n 'enable-flashinfer-allreduce-fusion|flashinfer-allreduce-fusion-backend' \
  python/sglang/srt/server_args.py \
  python/sglang/srt/arg_groups/serving_hook.py

# Expect in server_args.py help:
#   (Deprecated: use --flashinfer-allreduce-fusion-backend=auto)
# Expect in serving_hook.py:
#   "--enable-flashinfer-allreduce-fusion is deprecated."
#   flashinfer_allreduce_fusion_backend="auto"

# Docs before: cookbooks/snippets recommend --enable-flashinfer-allreduce-fusion
rg -n 'enable-flashinfer-allreduce-fusion' \
  docs/cookbook/autoregressive/GLM/GLM-5.mdx \
  docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx \
  docs/src/snippets/autoregressive/

# Docs after this PR: those paths use --flashinfer-allreduce-fusion-backend auto;
# server_arguments.mdx marks the enable flag Deprecated.
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33618548051](https://github.com/sgl-project/sglang/actions/runs/33618548051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33618547878](https://github.com/sgl-project/sglang/actions/runs/33618547878)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->