### PR TITLE
[Mamba] Warn when prefix-cache checkpoint capacity is insufficient

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -164,6 +164,45 @@ MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP = 1
 MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_BUFFER = 1
 
 
+def _warn_if_mamba_checkpoint_capacity_is_insufficient(
+    *,
+    token_capacity: int,
+    chunked_prefill_size: Optional[int],
+    max_mamba_cache_size: Optional[int],
+) -> None:
+    """Warn when the KV budget can hold more prefill checkpoints than Mamba slots.
+
+    A chunked-prefill handoff can donate one Mamba prefix checkpoint. This is
+    therefore a conservative capacity estimate rather than a prediction of a
+    particular workload's cache occupancy.
+    """
+    if (
+        token_capacity <= 0
+        or chunked_prefill_size is None
+        or chunked_prefill_size <= 0
+        or max_mamba_cache_size is None
+        or max_mamba_cache_size <= 0
+    ):
+        return
+
+    estimated_checkpoint_demand = math.ceil(token_capacity / chunked_prefill_size)
+    if estimated_checkpoint_demand <= max_mamba_cache_size:
+        return
+
+    logger.warning(
+        "Hybrid Mamba prefix-cache checkpoint capacity may be insufficient: "
+        "the KV cache can hold up to %d checkpoint(s) for %d tokens at "
+        "chunked_prefill_size=%d, but max_mamba_cache_size=%d. Prefix-cache "
+        "branch reuse may degrade under LRU pressure. Consider increasing "
+        "--max-mamba-cache-size, adjusting --mamba-full-memory-ratio when the "
+        "Mamba pool is auto-sized, or increasing --chunked-prefill-size.",
+        estimated_checkpoint_demand,
+        token_capacity,
+        chunked_prefill_size,
+        max_mamba_cache_size,
+    )
+
+
 def _pp_local_per_request_bytes(
     total_bytes: int,
     layer_ids: list[int],
@@ -2138,6 +2177,13 @@ class KVCacheConfigurator:
 
         capped_by_mamba = False
         if self.mambaish_config is not None:
+            if not get_memory().disable_radix_cache:
+                _warn_if_mamba_checkpoint_capacity_is_insufficient(
+                    token_capacity=token_capacity,
+                    chunked_prefill_size=get_schedule().chunked_prefill_size,
+                    max_mamba_cache_size=get_schedule().max_mamba_cache_size,
+                )
+
             ratio = self._calculate_mamba_ratio()
             mamba_cap = get_schedule().max_mamba_cache_size // ratio
             if mamba_cap < max_num_reqs:

--- a/test/registered/unit/mem_cache/test_mamba_checkpoint_capacity_warning.py
+++ b/test/registered/unit/mem_cache/test_mamba_checkpoint_capacity_warning.py
@@ -1,0 +1,78 @@
+"""CPU-only tests for the hybrid Mamba checkpoint-capacity warning."""
+
+import unittest
+from unittest import mock
+
+from sglang.srt.mem_cache.kv_cache_configurator import (
+    _warn_if_mamba_checkpoint_capacity_is_insufficient,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMambaCheckpointCapacityWarning(unittest.TestCase):
+    @staticmethod
+    def _warn(*, token_capacity, chunked_prefill_size, max_mamba_cache_size):
+        with mock.patch(
+            "sglang.srt.mem_cache.kv_cache_configurator.logger.warning"
+        ) as warning:
+            _warn_if_mamba_checkpoint_capacity_is_insufficient(
+                token_capacity=token_capacity,
+                chunked_prefill_size=chunked_prefill_size,
+                max_mamba_cache_size=max_mamba_cache_size,
+            )
+        return warning
+
+    def test_warns_when_checkpoint_demand_exceeds_pool(self):
+        warning = self._warn(
+            token_capacity=433_919,
+            chunked_prefill_size=2_048,
+            max_mamba_cache_size=165,
+        )
+
+        warning.assert_called_once()
+        message = warning.call_args.args[0]
+        self.assertIn("checkpoint capacity may be insufficient", message)
+        self.assertEqual(warning.call_args.args[1:], (212, 433_919, 2_048, 165))
+
+    def test_rounds_checkpoint_demand_up(self):
+        warning = self._warn(
+            token_capacity=8_193,
+            chunked_prefill_size=8_192,
+            max_mamba_cache_size=1,
+        )
+
+        warning.assert_called_once()
+        self.assertEqual(warning.call_args.args[1], 2)
+
+    def test_does_not_warn_when_capacity_is_sufficient(self):
+        warning = self._warn(
+            token_capacity=16_384,
+            chunked_prefill_size=8_192,
+            max_mamba_cache_size=2,
+        )
+
+        warning.assert_not_called()
+
+    def test_does_not_warn_when_chunked_prefill_is_disabled(self):
+        warning = self._warn(
+            token_capacity=433_919,
+            chunked_prefill_size=-1,
+            max_mamba_cache_size=1,
+        )
+
+        warning.assert_not_called()
+
+    def test_does_not_warn_without_a_mamba_pool(self):
+        warning = self._warn(
+            token_capacity=433_919,
+            chunked_prefill_size=2_048,
+            max_mamba_cache_size=None,
+        )
+
+        warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Refs #36935.

Hybrid Mamba prefix caching may create more chunked-prefill checkpoint
positions than the Mamba state pool can retain. Under sustained LRU pressure,
branch reuse can silently degrade. The existing startup message reports
max-running-requests limits, but it does not surface this checkpoint-capacity
condition.

## Modifications

- Add a startup warning when `ceil(max_total_num_tokens / chunked_prefill_size)` exceeds `max_mamba_cache_size`.
- Skip the estimate when radix caching is disabled, chunked prefill is disabled, or the Mamba pool is unconfigured.
- Add CPU-only tests for the threshold, rounding, and guard cases.

This PR is intentionally limited to observability. It does not change
checkpoint creation, LRU policy, or cache behavior.

## Validation

- `pre-commit run --files python/sglang/srt/mem_cache/kv_cache_configurator.py test/registered/unit/mem_cache/test_mamba_checkpoint_capacity_warning.py` passed.
- `python -m py_compile python/sglang/srt/mem_cache/kv_cache_configurator.py test/registered/unit/mem_cache/test_mamba_checkpoint_capacity_warning.py` passed.


## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required for this observability-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33618880886](https://github.com/sgl-project/sglang/actions/runs/33618880886)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33618880630](https://github.com/sgl-project/sglang/actions/runs/33618880630)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33618880822](https://github.com/sgl-project/sglang/actions/runs/33618880822)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->