### PR TITLE
[AMD] Deepen the top-k v2 streaming load pipeline on ROCm

### DIFF
--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -435,6 +435,25 @@ struct TopKConfig {
 template <uint32_t kHistBits_>
 struct TopKRadixBase : TopKConfig {
   static constexpr uint32_t kVecSize = 4;
+#ifdef USE_ROCM
+  // Vectors each thread keeps in flight across a full-length pass over the input.
+  //
+  // Both of the streaming path's passes are a dependent chain of
+  // load -> classify -> LDS atomic, and the grid is one block per row, so at
+  // decode batch sizes only a fraction of the CUs are occupied and there is no
+  // other resident work to hide the load latency behind. Holding a second
+  // vector in flight before either is consumed fills that gap; 2 measured best
+  // on gfx950 for the same loop shape in the legacy kernel, 4 and 8 spend the
+  // registers without buying more overlap.
+  //
+  // kUnroll == 1 reduces the loop below to the original single-vector pipeline
+  // element for element, which is what CUDA keeps: there the register paths
+  // already cover the seq_len range that matters, and the streaming path only
+  // runs where the occupancy is high enough to hide the latency anyway.
+  static constexpr uint32_t kUnroll = 2;
+#else
+  static constexpr uint32_t kUnroll = 1;
+#endif
   static constexpr uint32_t kHistBits = kHistBits_;
   static constexpr uint32_t kHistSize = 1 << kHistBits;
   using vec_t = AlignedVector<float, kVecSize>;
@@ -468,17 +487,39 @@ struct TopKRadixBase : TopKConfig {
     const auto tx = threadIdx.x;
     const uint32_t num_full = seq_len / kVecSize;  // fully-in-bounds vectors
 
-    vec_t next_vec;
+    // The kUnroll vectors a thread owns in one trip stay kBlockSize apart, so
+    // every load is still the same coalesced 16B access as the depth-1 version;
+    // only the issue order changes. The set of (value, index) pairs handed to
+    // `fn` is identical -- the order is not, which the callers do not depend on
+    // (they classify into LDS counters / atomically-slotted buffers).
+    constexpr uint32_t kStep = kUnroll * kBlockSize;
+    vec_t next_vec[kUnroll];
     uint32_t vi = tx;
-    if (vi < num_full) next_vec.load(in, vi);
-    while (vi < num_full) {
-      const auto cur = next_vec;
-      const auto base = vi * kVecSize;
-      vi += kBlockSize;
-      if (vi < num_full) next_vec.load(in, vi);
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j) {
-        fn(cur[j], base + j);
+    for (uint32_t k = 0; k < kUnroll; ++k) {
+      if (vi + k * kBlockSize < num_full) next_vec[k].load(in, vi + k * kBlockSize);
+    }
+    while (vi < num_full) {
+      vec_t cur[kUnroll];
+#pragma unroll
+      for (uint32_t k = 0; k < kUnroll; ++k) {
+        cur[k] = next_vec[k];
+      }
+      const uint32_t cur_vi = vi;
+      vi += kStep;
+#pragma unroll
+      for (uint32_t k = 0; k < kUnroll; ++k) {
+        if (vi + k * kBlockSize < num_full) next_vec[k].load(in, vi + k * kBlockSize);
+      }
+#pragma unroll
+      for (uint32_t k = 0; k < kUnroll; ++k) {
+        const uint32_t vik = cur_vi + k * kBlockSize;
+        if (vik >= num_full) break;
+        const auto base = vik * kVecSize;
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+          fn(cur[k][j], base + j);
+        }
       }
     }
 


### PR DESCRIPTION
## Motivation

On ROCm, the top-k v2 streaming kernel reads the input one 16B vector at a time. Each
iteration is load -> classify -> LDS atomic, so the next load cannot start until the
previous one lands. The grid is one block per row, so at decode batch sizes most CUs sit
idle and there is no other work to hide that load latency behind.

Keeping a second vector in flight fills the gap. This is the same change that helped the
legacy AOT top-k kernel (`elementwise/topk.cu`) on gfx950.

## Modifications

One file: `python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh`.

- Add `TopKRadixBase::kUnroll`, set to 2 under `USE_ROCM` and 1 otherwise.
- Rewrite the `for_each_input` load loop to carry `kUnroll` vectors instead of one.

The vectors a thread owns in one trip stay `kBlockSize` apart, so every load is the same
coalesced 16B access as before; only the issue order changes. `kUnroll == 1` reduces to
the original loop element for element, so CUDA builds are unchanged by construction.

**Scope.** `for_each_input` is only reached from `TopKStreaming` on ROCm (`TopKCluster` is
`#ifndef USE_ROCM`). Streaming is selected when `seq_len > 16384`; below that the register
paths (`Register2` <= 8192, `Register4` <= 16384) hold the row in registers and already
issue all loads up front. So this affects long-context decode and long ragged prefill
rows only.

## Accuracy Tests

The set of `(value, index)` pairs handed to `fn` is unchanged; only the order changes, and
callers do not depend on order (they classify into LDS counters / atomically-slotted
buffers).

Verified by lifting the loop verbatim into a host harness and comparing the produced
multiset against the pre-change loop for `kUnroll` in {1, 2, 4}, block sizes 8/16/32/64,
and `seq_len` 0..4000, including full-coverage checks. All identical.

## Speed Tests and Profiling

Not yet measured on v2 -- pending a >16K-context run, since shorter sequences never reach
this path. The depth-2 shape was measured best on gfx950 in the legacy AOT kernel for the
same loop; 4 and 8 spent registers without buying more overlap.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33619138389](https://github.com/sgl-project/sglang/actions/runs/33619138389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33619137950](https://github.com/sgl-project/sglang/actions/runs/33619137950)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33619138090](https://github.com/sgl-project/sglang/actions/runs/33619138090)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->