### PR TITLE
[HiCache] Keep kernel host buffers in one registration

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -237,6 +237,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
                 registration_granularity_bytes=self.layer_num * self.item_bytes,
+                require_single_registration=True,
             )
         elif self.layout == "page_first_direct":
             self.kv_buffer = alloc_func(
@@ -246,6 +247,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
                 registration_granularity_bytes=self.layer_num * self.item_bytes,
+                require_single_registration=False,
             )
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
@@ -642,6 +644,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
                 registration_granularity_bytes=(self.layer_num * self.state_page_bytes),
+                require_single_registration=True,
             )
         elif self.layout == "page_first_direct":
             self.kv_buffer = alloc_func(
@@ -651,6 +654,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
                 registration_granularity_bytes=(self.layer_num * self.state_page_bytes),
+                require_single_registration=False,
             )
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -122,7 +122,9 @@ def get_allocator_type() -> str:
 
 
 def _cuda_host_register(
-    buffer: torch.Tensor, registration_granularity_bytes: int | None = None
+    buffer: torch.Tensor,
+    registration_granularity_bytes: int | None = None,
+    require_single_registration: bool = False,
 ) -> None:
     # Avoid oversized cudaHostRegister calls on large host pools.
     cudart = torch.cuda.cudart()
@@ -131,11 +133,10 @@ def _cuda_host_register(
     chunk_limit_bytes = (
         max(envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB.get(), 1) * 1024**3
     )
-    # Preserve the legacy single-call behavior unless the caller provides a
-    # copy granularity. Splitting an unknown page-first layout at an arbitrary
-    # byte offset can make one cudaMemcpyBatchAsync span two registrations.
+    # Kernel pointer arithmetic requires one device alias for the full buffer:
+    # adjacent host registrations are not guaranteed adjacent device aliases.
     chunk_bytes = total
-    if registration_granularity_bytes is not None:
+    if registration_granularity_bytes is not None and not require_single_registration:
         if registration_granularity_bytes <= 0:
             raise ValueError(
                 "registration_granularity_bytes must be positive, got "
@@ -158,11 +159,19 @@ def _cuda_host_register(
             ptr = base + offset
             rc = int(cudart.cudaHostRegister(ptr, size, 0))
             if rc != 0:
+                kernel_hint = (
+                    " Kernel-backed page_first HiCache requires one contiguous "
+                    "host registration; use page_first_direct/direct if this "
+                    "allocation is too large for the runtime."
+                    if require_single_registration
+                    else ""
+                )
                 raise RuntimeError(
                     f"cudaHostRegister failed (rc={rc}, "
                     f"{cudart.cudaGetErrorString(rc)}) at offset={offset} size={size} "
                     f"(total={total}, chunk_limit={chunk_bytes}); host buffer is not "
                     f"pinned and device transfers may silently return stale data."
+                    f"{kernel_hint}"
                 )
             registered_ranges.append((ptr, size))
             offset += size
@@ -225,6 +234,7 @@ def alloc_with_host_register(
     pin_memory: bool,
     allocator: HostTensorAllocator,
     registration_granularity_bytes: int | None = None,
+    require_single_registration: bool = False,
 ) -> torch.Tensor:
     """
     Allocate tensor and register host memory with cudaHostRegister.
@@ -232,7 +242,11 @@ def alloc_with_host_register(
     """
     buffer = allocator.allocate(dims, dtype=dtype, device=device)
     if pin_memory:
-        _cuda_host_register(buffer, registration_granularity_bytes)
+        _cuda_host_register(
+            buffer,
+            registration_granularity_bytes,
+            require_single_registration,
+        )
     return buffer
 
 
@@ -243,6 +257,7 @@ def alloc_with_pin_memory(
     pin_memory: bool,
     allocator: None,
     registration_granularity_bytes: int | None = None,
+    require_single_registration: bool = False,
 ) -> torch.Tensor:
     """
     Allocate tensor using PyTorch's built-in pin_memory flag.

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -174,6 +174,7 @@ class DSAIndexerPoolHost(HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
                 registration_granularity_bytes=self.indexer_layout_dim,
+                require_single_registration=self.layout == "page_first",
             )
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -149,6 +149,7 @@ class MambaPoolHost(HostKVCache):
                 registration_granularity_bytes=(
                     int(np.prod(dims[1:])) * dtype.itemsize
                 ),
+                require_single_registration=self.layout == "page_first",
             )
 
         if self.layout in ["page_first", "page_first_direct"]:

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -199,6 +199,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                 if self.layout in ("page_first", "page_first_direct")
                 else None
             ),
+            require_single_registration=self.layout == "page_first",
         )
         return buffer
 
@@ -804,6 +805,7 @@ class MHATokenToKOnlyPoolHost(HostKVCache):
                 if self.layout in ("page_first", "page_first_direct")
                 else None
             ),
+            require_single_registration=self.layout == "page_first",
         )
 
     def get_hybrid_pool_buffer(self):
@@ -1128,6 +1130,7 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
             pin_memory=self.pin_memory,
             allocator=self.allocator,
             registration_granularity_bytes=self.page_size * self._k_layout_dim(),
+            require_single_registration=self.layout == "page_first",
         )
         v_buffer = alloc_func(
             v_dims,
@@ -1136,6 +1139,7 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
             pin_memory=self.pin_memory,
             allocator=self.allocator,
             registration_granularity_bytes=self.page_size * self._v_layout_dim(),
+            require_single_registration=self.layout == "page_first",
         )
         return (k_buffer, v_buffer)
 

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -211,6 +211,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 if self.layout in ("page_first", "page_first_direct")
                 else None
             ),
+            require_single_registration=self.layout == "page_first",
         )
         return buffer
 

--- a/test/registered/unit/mem_cache/test_hicache_host_register.py
+++ b/test/registered/unit/mem_cache/test_hicache_host_register.py
@@ -99,6 +99,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     host.indexer_layout_dim,
                 )
+                self.assertEqual(
+                    alloc.call_args.kwargs["require_single_registration"],
+                    layout == "page_first",
+                )
 
     def test_page_first_direct_mla_uses_page_registration_granularity(self):
         pool = MLATokenToKVPoolHost.__new__(MLATokenToKVPoolHost)
@@ -121,6 +125,7 @@ class TestHiCacheHostRegister(unittest.TestCase):
             alloc.call_args.kwargs["registration_granularity_bytes"],
             pool.page_size * pool.layer_num * pool.kv_cache_dim * pool.dtype.itemsize,
         )
+        self.assertFalse(alloc.call_args.kwargs["require_single_registration"])
 
     def test_page_first_direct_mha_uses_page_registration_granularity(self):
         pool = MHATokenToKVPoolHost.__new__(MHATokenToKVPoolHost)
@@ -148,6 +153,34 @@ class TestHiCacheHostRegister(unittest.TestCase):
             * pool.head_dim
             * pool.dtype.itemsize,
         )
+        self.assertFalse(alloc.call_args.kwargs["require_single_registration"])
+
+    def test_page_first_mha_and_mla_require_single_registration(self):
+        cases = (
+            (MHATokenToKVPoolHost, mha_pool_host, {"head_num": 2, "head_dim": 4}),
+            (MLATokenToKVPoolHost, mla_pool_host, {"kv_cache_dim": 5}),
+        )
+        for pool_cls, pool_module, attributes in cases:
+            with self.subTest(pool=pool_cls.__name__):
+                pool = pool_cls.__new__(pool_cls)
+                pool.__dict__.update(
+                    layout="page_first",
+                    size=8,
+                    layer_num=3,
+                    page_size=2,
+                    dtype=torch.float16,
+                    device_pool=SimpleNamespace(device="cuda"),
+                    device="cpu",
+                    pin_memory=True,
+                    allocator=object(),
+                    **attributes,
+                )
+                alloc = mock.Mock(return_value=object())
+
+                with mock.patch.dict(pool_module.ALLOC_MEMORY_FUNCS, {"cuda": alloc}):
+                    pool.init_kv_buffer()
+
+                self.assertTrue(alloc.call_args.kwargs["require_single_registration"])
 
     def test_mamba_page_layouts_use_per_buffer_page_granularity(self):
         for layout in ("page_first", "page_first_direct"):
@@ -184,6 +217,13 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         3 * 2 * 2 * torch.float32.itemsize,
                     ],
                 )
+                self.assertEqual(
+                    [
+                        call.kwargs["require_single_registration"]
+                        for call in alloc.call_args_list
+                    ],
+                    [layout == "page_first"] * 3,
+                )
 
     def test_deepseek_v4_page_layouts_use_page_registration_granularity(self):
         for layout in ("page_first", "page_first_direct"):
@@ -210,6 +250,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                 self.assertEqual(
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     3 * 11,
+                )
+                self.assertEqual(
+                    alloc.call_args.kwargs["require_single_registration"],
+                    layout == "page_first",
                 )
 
             with self.subTest(pool="state", layout=layout):
@@ -243,6 +287,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     2 * 2 * 3,
                 )
+                self.assertEqual(
+                    alloc.call_args.kwargs["require_single_registration"],
+                    layout == "page_first",
+                )
 
     def test_k_only_mha_page_layouts_use_page_registration_granularity(self):
         for layout in ("page_first", "page_first_direct"):
@@ -271,6 +319,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                 self.assertEqual(
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     pool.page_size * pool.layout_dim,
+                )
+                self.assertEqual(
+                    alloc.call_args.kwargs["require_single_registration"],
+                    layout == "page_first",
                 )
 
     def test_asymmetric_mha_page_layouts_use_native_page_granularities(self):
@@ -306,6 +358,13 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         pool.page_size * pool._k_layout_dim(),
                         pool.page_size * pool._v_layout_dim(),
                     ],
+                )
+                self.assertEqual(
+                    [
+                        call.kwargs["require_single_registration"]
+                        for call in alloc.call_args_list
+                    ],
+                    [layout == "page_first"] * 2,
                 )
 
     def test_unregister_releases_every_registered_chunk_once(self):
@@ -372,6 +431,45 @@ class TestHiCacheHostRegister(unittest.TestCase):
             _cuda_host_register(buffer)
 
         self.assertEqual(cudart.registrations, [(base, total, 0)])
+
+    def test_kernel_addressing_forces_single_registration(self):
+        gib = 1024**3
+        base = 0x10000000
+        total = 2 * gib + 17
+        cudart = _FakeCudart()
+
+        with (
+            mock.patch.object(
+                envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB,
+                "get",
+                return_value=1,
+            ),
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            _cuda_host_register(
+                _FakeBuffer(base, total),
+                registration_granularity_bytes=gib,
+                require_single_registration=True,
+            )
+
+        self.assertEqual(cudart.registrations, [(base, total, 0)])
+
+    def test_kernel_registration_failure_recommends_direct_mode(self):
+        buffer = _FakeBuffer(0x10000000, 1024)
+        cudart = _FakeCudart(fail_on_registration=1)
+
+        with (
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "use page_first_direct/direct",
+            ),
+        ):
+            _cuda_host_register(
+                buffer,
+                registration_granularity_bytes=256,
+                require_single_registration=True,
+            )
 
     def test_registration_boundaries_honor_page_copy_granularity(self):
         mib = 1024**2


### PR DESCRIPTION
## Summary

Kernel-backed `page_first` HiCache pools derive one device-visible base pointer and use base-plus-offset addressing across the full buffer. Independently registered adjacent host ranges are not guaranteed to receive adjacent device aliases.

Require one complete host registration for `page_first` buffers. Keep the existing aligned chunked registration for `page_first_direct`, where each transfer address is interpreted independently. If a complete registration fails, report the compatible `page_first_direct/direct` fallback.

## Hardware validation

MI355X / ROCm 7.2, two adjacent 4 MiB host ranges:

- Registered separately: host delta `4 MiB`, device-alias delta `-80 MiB`
- Registered together: host delta `4 MiB`, device-alias delta `4 MiB`

This confirms that base-plus-offset addressing is valid within one registration but cannot be extrapolated across independent registrations.

## Tests

- Host registration and pool propagation: **14 passed, 14 subtests passed**
- Adjacent host-pool regression matrix: **43 passed, 1 skipped, 14 subtests passed**
- All applicable pre-commit hooks passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33619293569](https://github.com/sgl-project/sglang/actions/runs/33619293569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33619293352](https://github.com/sgl-project/sglang/actions/runs/33619293352)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33619293453](https://github.com/sgl-project/sglang/actions/runs/33619293453)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->