### PR TITLE
fix(glm4v): align mRoPE mask with final input IDs

### DIFF
--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -109,7 +109,7 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
             hf_config=self.hf_config,
             image_grid_thw=getattr(ret, "image_grid_thw", None),
             video_grid_thw=getattr(ret, "video_grid_thw", None),
-            attention_mask=getattr(ret, "attention_mask", None),
+            attention_mask=None,
         )
         mrope_positions = mrope_positions.squeeze(1)
 

--- a/test/registered/unit/multimodal/test_glm4v_processor.py
+++ b/test/registered/unit/multimodal/test_glm4v_processor.py
@@ -1,0 +1,57 @@
+"""CPU regression tests for the GLM-V multimodal processor."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import torch
+
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultiModalProcessorOutput,
+)
+from sglang.srt.multimodal.processors.glm4v import Glm4vImageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestGlm4vImageProcessor(unittest.IsolatedAsyncioTestCase):
+    async def test_mrope_uses_final_ids_when_processor_mask_is_stale(self):
+        processor = object.__new__(Glm4vImageProcessor)
+        processor.hf_config = SimpleNamespace(
+            image_token_id=101,
+            video_start_token_id=102,
+            video_end_token_id=103,
+            vision_config=SimpleNamespace(spatial_merge_size=1),
+        )
+        processor.mm_tokens = SimpleNamespace(image_token_id=101, video_token_id=None)
+
+        processor.load_mm_data = AsyncMock(
+            return_value=BaseMultiModalProcessorOutput(input_text="")
+        )
+        final_input_ids = torch.tensor([7, 101, 101, 8], dtype=torch.long)
+        processor.process_and_combine_mm_data_async = AsyncMock(
+            return_value=(
+                [],
+                final_input_ids,
+                SimpleNamespace(
+                    image_grid_thw=torch.tensor([[1, 1, 2]], dtype=torch.long),
+                    video_grid_thw=None,
+                    attention_mask=torch.ones((1, 3), dtype=torch.long),
+                ),
+            )
+        )
+
+        output = await processor.process_mm_data_async(
+            image_data=[],
+            input_text="",
+            request_obj=SimpleNamespace(video_data=[]),
+        )
+
+        self.assertEqual(output.input_ids, final_input_ids.tolist())
+        self.assertEqual(output.mrope_positions.shape, (3, 4))
+        self.assertEqual(output.mrope_position_delta.shape, (1, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #37097

## Motivation

With `SGLANG_MM_AVOID_RETOKENIZE` enabled, the GLM-V processor can restore the
client's exact pretokenized `input_ids` after the HF processor has computed an
`attention_mask` from decode-and-retokenize text. A noncanonical token sequence
can therefore leave the mask shorter than the final IDs, causing
`get_rope_index_glm4v` to raise `IndexError` during multimodal preprocessing.

## Modifications

- Stop forwarding the processor-generated `attention_mask` at the single-
  sequence GLM-V mRoPE call site. The helper already builds an all-ones mask
  from the final `input_ids` when the mask is `None`.
- Add a CPU regression test with a final four-token sequence and a stale
  three-token processor mask.

## Duplicate-work check

- No open upstream PR was found for #37097 or the focused MRoPE/retokenization
  search.
- The same one-line fix is present in #36833's `nanjiangwill:codex/glm53-vlm-processor`
  branch, after `nanjiangwill/sglang#1` was merged into that branch. However,
  #36833 targets the separate, diverged `sglang-miles-glm53next` integration
  branch rather than current `main`; this PR applies the focused fix and
  regression coverage to upstream `main`.

## Validation

- `git diff --check`
- `PYTHONPATH=python .venv/bin/python` focused pytest run for
  `test_glm4v_processor.py` and `test_processor_async_call_sites.py`: 7 passed
  (the host needed a local torchvision operator compatibility shim).
- `.venv/bin/pre-commit run --files python/sglang/srt/multimodal/processors/glm4v.py test/registered/unit/multimodal/test_glm4v_processor.py`: passed
- No model-output or performance evaluation is applicable; this is a CPU-side
  multimodal preprocessing fix.

## AI assistance

AI assistance was used to investigate the issue, implement the focused change,
and prepare the regression test. The submitting contributor should review and
be able to explain every changed line.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33620382641](https://github.com/sgl-project/sglang/actions/runs/33620382641)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33620382363](https://github.com/sgl-project/sglang/actions/runs/33620382363)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33620382477](https://github.com/sgl-project/sglang/actions/runs/33620382477)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->