### PR TITLE
[Examples] Use tp_size in save_sharded_state Engine example

### DIFF
--- a/examples/runtime/engine/save_sharded_state.py
+++ b/examples/runtime/engine/save_sharded_state.py
@@ -8,8 +8,8 @@ Example usage:
 
 python save_sharded_state.py \
     --model-path /path/to/load \
-    --quantization deepspeedfp \
-    --tensor-parallel-size 8 \
+    --quantization fp8 \
+    --tp-size 8 \
     --output /path/to/save
 
 Then, the model can be loaded with
@@ -17,8 +17,8 @@ Then, the model can be loaded with
 llm = Engine(
     model_path="/path/to/save",
     load_format="sharded_state",
-    quantization="deepspeedfp",
-    tensor_parallel_size=8,
+    quantization="fp8",
+    tp_size=8,
 )
 """
 


### PR DESCRIPTION
## Summary

`examples/runtime/engine/save_sharded_state.py` documents loading with:

```python
llm = Engine(
    ...
    tensor_parallel_size=8,
)
```

`Engine(**kwargs)` constructs `ServerArgs(**kwargs)`. The dataclass field is `tp_size` (CLI exposes `--tp-size` with alias `--tensor-parallel-size`). There is no `tensor_parallel_size` Python kwarg, so the documented Engine call raises `TypeError: ServerArgs.__init__() got an unexpected keyword argument 'tensor_parallel_size'`.

Also replaces invalid `quantization="deepspeedfp"` / `--quantization deepspeedfp` with `fp8` (present in `QUANTIZATION_CHOICES`); `deepspeedfp` is not accepted by argparse choices on current `main`.

Aligned with the sibling fix in `save_remote_state.py` (`tp_size` / `--tp-size`).

## How verified / repro

On `sgl-project/sglang` `main`:

1. Docstring in `examples/runtime/engine/save_sharded_state.py` uses `tensor_parallel_size=8` and `quantization="deepspeedfp"`.
2. In `python/sglang/srt/server_args.py`, field is `tp_size` with `aliases=["--tensor-parallel-size"]`; no `tensor_parallel_size` field.
3. `python/sglang/srt/entrypoints/engine.py` `Engine.__init__` builds `ServerArgs(**kwargs)` (unless `server_args=` is passed).
4. `deepspeedfp` is absent from `QUANTIZATION_CHOICES`; `fp8` is present.
5. Minimal check:

```python
from sglang.srt.server_args import ServerArgs
ServerArgs(model_path="x", tp_size=8)  # ok
# ServerArgs(model_path="x", tensor_parallel_size=8)  # TypeError
```

One-file change only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33621954194](https://github.com/sgl-project/sglang/actions/runs/33621954194)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33621953858](https://github.com/sgl-project/sglang/actions/runs/33621953858)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->