### PR TITLE
[2/N] Quantization Refactor: drive the method registry from a string spec table

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -3,173 +3,166 @@
 # Adapted from https://raw.githubusercontent.com/vllm-project/vllm/v0.5.5/vllm/model_executor/layers/quantization/__init__.py
 from __future__ import annotations
 
-from typing import Dict, Type
+import importlib
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Type
 
-from sglang.srt.layers.quantization.auto_round import AutoRoundConfig
-from sglang.srt.layers.quantization.awq import (
-    AWQConfig,
-    AWQCPUConfig,
-    AWQMarlinConfig,
-    AWQXPUConfig,
-)
-from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.quantization.bitsandbytes import BitsAndBytesConfig
-from sglang.srt.layers.quantization.blockwise_int8 import BlockInt8Config
-from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
-    CompressedTensorsConfig,
-)
-from sglang.srt.layers.quantization.fp8 import Fp8Config
-from sglang.srt.layers.quantization.gguf import GGUFConfig
-from sglang.srt.layers.quantization.gptq import (
-    CPUGPTQConfig,
-    GPTQAscendConfig,
-    GPTQMarlinConfig,
-    GPTQXPUConfig,
-)
-from sglang.srt.layers.quantization.humming import HummingConfig
-from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
-from sglang.srt.layers.quantization.modelopt_quant import (
-    ModelOptFp4Config,
-    ModelOptFp8Config,
-    ModelOptMixedPrecisionConfig,
-)
-from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
-from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
-from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
-from sglang.srt.layers.quantization.npu_mxfp4 import Mxfp4W4A8Config
-from sglang.srt.layers.quantization.npu_mxfp4_w4a4 import Mxfp4W4A4Config
-from sglang.srt.layers.quantization.nvfp4_online import NvFp4OnlineConfig
-from sglang.srt.layers.quantization.petit import PetitNvFp4Config
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
-from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
-from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
-from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
-from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
-from sglang.srt.platforms import current_platform
-from sglang.srt.utils import (
-    cpu_has_amx_support,
-    is_cpu,
-    is_cuda,
-    is_gfx95_supported,
-    is_mps,
-    is_npu,
-    is_xpu,
+from sglang.srt.layers.quantization.registry import (
+    CPU_SUPPORTED_METHOD_SPECS,
+    PLATFORM_OVERRIDE_SPECS,
+    QUANTIZATION_METHOD_SPECS,
+    all_config_class_specs,
 )
 
-_is_gfx95_supported = is_gfx95_supported()
+if TYPE_CHECKING:
+    from sglang.srt.layers.quantization.base_config import QuantizationConfig
 
-# Base quantization methods
-BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
-    "fp8": Fp8Config,
-    "mxfp8": Fp8Config,
-    "blockwise_int8": BlockInt8Config,
-    "modelopt": ModelOptFp8Config,  # Auto-detect, defaults to FP8
-    "modelopt_fp8": ModelOptFp8Config,
-    "modelopt_fp4": ModelOptFp4Config,
-    "nvfp4_online": NvFp4OnlineConfig,
-    "modelopt_mixed": ModelOptMixedPrecisionConfig,
-    "w8a8_int8": W8A8Int8Config,
-    "w8a8_fp8": W8A8Fp8Config,
-    "awq": AWQConfig,
-    "awq_marlin": AWQMarlinConfig,
-    "bitsandbytes": BitsAndBytesConfig,
-    "gguf": GGUFConfig,
-    "gptq_marlin": GPTQMarlinConfig,
-    "moe_wna16": MoeWNA16Config,
-    "compressed-tensors": CompressedTensorsConfig,
-    "w4afp8": W4AFp8Config,
-    "petit_nvfp4": PetitNvFp4Config,
-    "quark": QuarkConfig,
-    "quark_mxfp4": QuarkConfig,
-    "auto-round": AutoRoundConfig,
-    "auto-round-int8": W8A8Int8Config,
-    "modelslim": ModelSlimConfig,
-    "quark_int4fp8_moe": QuarkInt4Fp8Config,
-    "humming": HummingConfig,
-    "mxfp_w4a8": Mxfp4W4A8Config,
-}
+# Importing this package used to import all 28 config modules, so asking
+# "which methods exist" -- or resolving any single one of them -- pulled in
+# every third-party quantization dependency. Resolution of a spec to its config
+# class is deferred to first use instead, which is why the tables below are
+# lazy mappings rather than plain dicts. Keep this module's own imports free of
+# torch and of any config module.
 
 
-# On XPU the OCP-MoE `Mxfp4Config` path is served by the sgl-kernel-xpu grouped
-# GEMM, which consumes the packed e2m1 + ue8m0 g32 checkpoint layout directly.
-# Other backends without that kernel keep the existing "unknown quantization
-# method" error rather than falling through to a bf16 upcast.
-if is_cpu() or is_cuda() or _is_gfx95_supported or is_xpu():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "mxfp4": Mxfp4Config,
-        }
+def _resolve_spec(spec: str) -> Type["QuantizationConfig"]:
+    module_path, _, class_name = spec.rpartition(":")
+    return getattr(importlib.import_module(module_path), class_name)
+
+
+def _platform_conditions() -> Dict[str, Callable[[], bool]]:
+    from sglang.srt.utils import (
+        is_cpu,
+        is_cuda,
+        is_gfx95_supported,
+        is_mps,
+        is_npu,
+        is_xpu,
+    )
+
+    return {
+        "mxfp4_capable": lambda: (
+            is_cpu() or is_cuda() or is_gfx95_supported() or is_xpu()
+        ),
+        "npu": is_npu,
+        "cpu": is_cpu,
+        "xpu": is_xpu,
+        "mps": is_mps,
+    }
+
+
+def _active_method_specs() -> Dict[str, str]:
+    """Base specs with this platform's overrides applied, in table order."""
+    conditions = _platform_conditions()
+    unknown = [c for c, _ in PLATFORM_OVERRIDE_SPECS if c not in conditions]
+    if unknown:
+        raise KeyError(
+            f"PLATFORM_OVERRIDE_SPECS names condition(s) {unknown} that "
+            f"_platform_conditions() does not define; add them there. "
+            f"Known conditions: {sorted(conditions)}"
+        )
+    specs = dict(QUANTIZATION_METHOD_SPECS)
+    for condition, overrides in PLATFORM_OVERRIDE_SPECS:
+        if conditions[condition]():
+            specs.update(overrides)
+    return specs
+
+
+class _LazyMethodMap(Mapping):
+    """Maps method name -> config class, importing a config on first lookup.
+
+    Reads like the plain dict it replaces (`in`, `[...]`, `.keys()`,
+    `.items()`, `[*...]`), and preserves its iteration order. Membership tests
+    and key iteration resolve nothing; `[...]` resolves the one entry asked
+    for, and only `.items()` / `.values()` force every config module to
+    import.
+    """
+
+    def __init__(self, specs_factory: Callable[[], Dict[str, str]]) -> None:
+        self._specs_factory = specs_factory
+        self._specs: Optional[Dict[str, str]] = None
+        self._resolved: Dict[str, Type["QuantizationConfig"]] = {}
+
+    @property
+    def specs(self) -> Dict[str, str]:
+        if self._specs is None:
+            self._specs = self._specs_factory()
+        return self._specs
+
+    def __getitem__(self, name: str) -> Type["QuantizationConfig"]:
+        if name not in self._resolved:
+            self._resolved[name] = _resolve_spec(self.specs[name])
+        return self._resolved[name]
+
+    def __contains__(self, name: object) -> bool:
+        # Must not fall through to __getitem__: `Mapping.__contains__` would
+        # import a config module just to answer a membership test, and would
+        # let an ImportError escape a check expected to be exception-free.
+        return name in self.specs
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.specs)
+
+    def __len__(self) -> int:
+        return len(self.specs)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({list(self.specs)!r})"
+
+
+# Base quantization methods, plus this platform's overrides.
+BASE_QUANTIZATION_METHODS: Mapping[str, Type["QuantizationConfig"]] = _LazyMethodMap(
+    _active_method_specs
+)
+
+# Subset of the above supported on CPU with AMX.
+CPU_QUANTIZATION_METHODS: Mapping[str, Type["QuantizationConfig"]] = _LazyMethodMap(
+    lambda: dict(CPU_SUPPORTED_METHOD_SPECS)
+)
+
+QUANTIZATION_METHODS = BASE_QUANTIZATION_METHODS
+
+_CONFIG_CLASS_SPECS = all_config_class_specs()
+
+
+def __getattr__(name: str) -> object:
+    """Serve the config classes the package has always re-exported.
+
+    Keeps `from sglang.srt.layers.quantization import Fp8Config` (and every
+    other `*Config`) working now that they are no longer imported eagerly.
+    Unknown names must raise `AttributeError` so `from ... import <submodule>`
+    still falls through to the import machinery.
+    """
+    if name == "QuantizationConfig":
+        from sglang.srt.layers.quantization.base_config import QuantizationConfig
+
+        return QuantizationConfig
+    spec = _CONFIG_CLASS_SPECS.get(name)
+    if spec is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return _resolve_spec(spec)
+
+
+def __dir__() -> list[str]:
+    return sorted(
+        [*globals(), *_CONFIG_CLASS_SPECS, "QuantizationConfig"],
     )
 
 
-if is_npu():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "gptq": GPTQAscendConfig,
-            # On NPU, `mxfp4` means single-level W4A4 MXFP4 for dense LLM (the
-            # upstream `Mxfp4Config` OCP-MoE path is only registered on
-            # cpu/cuda/hip above, so there is no collision here).
-            "mxfp4": Mxfp4W4A4Config,
-        }
-    )
-
-
-if is_cpu():
-    # Plain GPTQ is CUDA-only in name: the kernel is gone, but the Intel AMX
-    # path below is untouched. `get_quantization_config` rejects anything
-    # missing from this registry before it can consult CPU_QUANTIZATION_METHODS,
-    # so the key has to exist here for the CPU path to stay reachable.
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "gptq": CPUGPTQConfig,
-        }
-    )
-
-
-if is_xpu():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "gptq": GPTQXPUConfig,
-            "awq": AWQXPUConfig,
-        }
-    )
-
-
-if is_mps():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "mlx_q4": MlxQuantizationConfig,
-            "mlx_q8": MlxQuantizationConfig,
-        }
-    )
-
-# subset of above quant methods, supported on CPU
-CPU_QUANTIZATION_METHODS = {
-    "fp8": Fp8Config,
-    "w8a8_int8": W8A8Int8Config,
-    "compressed-tensors": CompressedTensorsConfig,
-    "awq": AWQCPUConfig,
-    "gptq": CPUGPTQConfig,
-    "mxfp4": Mxfp4Config,
-    "auto-round": AutoRoundConfig,
-}
-
-QUANTIZATION_METHODS = {**BASE_QUANTIZATION_METHODS}
-
-
-def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
+def get_quantization_config(quantization: str) -> Type["QuantizationConfig"]:
     if quantization not in QUANTIZATION_METHODS:
         raise ValueError(
             f"Invalid quantization method: {quantization}. "
             f"Available methods: {list(QUANTIZATION_METHODS.keys())}"
         )
-    from sglang.srt.utils import is_cpu
+    from sglang.srt.platforms import current_platform
+    from sglang.srt.utils import cpu_has_amx_support, is_cpu
 
     if is_cpu() and cpu_has_amx_support():
         if quantization not in CPU_QUANTIZATION_METHODS:
             raise ValueError(
                 f"Invalid quantization method on CPU: {quantization}. "
-                f"Available methods on CPU: {list(QUANTIZATION_METHODS.keys())}"
+                f"Available methods on CPU: {list(CPU_QUANTIZATION_METHODS.keys())}"
             )
         else:
             return CPU_QUANTIZATION_METHODS[quantization]

--- a/python/sglang/srt/layers/quantization/registry.py
+++ b/python/sglang/srt/layers/quantization/registry.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Declarative registry of quantization methods.
+
+Every entry is a `"module.path:ClassName"` spec, resolved on first use by
+`sglang.srt.layers.quantization.__init__`. This module deliberately imports
+nothing: the tables can be read to answer "which methods exist" without
+pulling in torch or any config implementation.
+
+Adding a method means adding one line to the table below. Adding a new
+*platform condition* additionally means teaching `_platform_conditions()` in
+`__init__.py` about it, which is checked.
+
+A registry key is not the same thing as a `--quantization` value.
+`server_args.QUANTIZATION_CHOICES` is deliberately a *subset*: methods that
+require an already-quantized checkpoint are reachable only through the
+`quant_method` in that checkpoint's config, never from the CLI.
+`blockwise_int8` is one -- `BlockInt8LinearMethod` asserts both a
+`weight_block_size` and an int8-serialized checkpoint, and the former may only
+be set when the latter is true, so `--quantization blockwise_int8` could not
+work. Every CLI choice must appear here, but not the reverse.
+"""
+
+from __future__ import annotations
+
+# Available on every platform. Iteration order is load-bearing: the
+# `override_quantization_method` loop in `ModelConfig._verify_quantization`
+# takes the first checkpoint match, so entries must stay in this order.
+QUANTIZATION_METHOD_SPECS: dict[str, str] = {
+    "fp8": "sglang.srt.layers.quantization.fp8:Fp8Config",  # MOE + linear online quantization
+    "mxfp8": "sglang.srt.layers.quantization.fp8:Fp8Config",  # MOE + linear online quantization
+    "blockwise_int8": "sglang.srt.layers.quantization.blockwise_int8:BlockInt8Config",
+    # Modelopt has some online quantization support through ModelOptModelLoader.
+    "modelopt": "sglang.srt.layers.quantization.modelopt_quant:ModelOptFp8Config",  # auto-detect, defaults to FP8
+    "modelopt_fp8": "sglang.srt.layers.quantization.modelopt_quant:ModelOptFp8Config",
+    "modelopt_fp4": "sglang.srt.layers.quantization.modelopt_quant:ModelOptFp4Config",
+    "nvfp4_online": "sglang.srt.layers.quantization.nvfp4_online:NvFp4OnlineConfig",
+    "modelopt_mixed": "sglang.srt.layers.quantization.modelopt_quant:ModelOptMixedPrecisionConfig",
+    # Both are documented in quantization.md and support the compressed-tensors
+    # `quant_method`.
+    "w8a8_int8": "sglang.srt.layers.quantization.w8a8_int8:W8A8Int8Config",
+    "w8a8_fp8": "sglang.srt.layers.quantization.w8a8_fp8:W8A8Fp8Config",
+    "awq": "sglang.srt.layers.quantization.awq:AWQConfig",
+    "awq_marlin": "sglang.srt.layers.quantization.awq:AWQMarlinConfig",
+    "bitsandbytes": "sglang.srt.layers.quantization.bitsandbytes:BitsAndBytesConfig",
+    "gguf": "sglang.srt.layers.quantization.gguf:GGUFConfig",
+    "gptq_marlin": "sglang.srt.layers.quantization.gptq:GPTQMarlinConfig",
+    "moe_wna16": "sglang.srt.layers.quantization.moe_wna16:MoeWNA16Config",  # custom loading logic for gptq/awq checkpoints (likely untested/unused)
+    "compressed-tensors": "sglang.srt.layers.quantization.compressed_tensors.compressed_tensors:CompressedTensorsConfig",  # for Ktransformers
+    "w4afp8": "sglang.srt.layers.quantization.w4afp8:W4AFp8Config",
+    "petit_nvfp4": "sglang.srt.layers.quantization.petit:PetitNvFp4Config",
+    "quark": "sglang.srt.layers.quantization.quark.quark:QuarkConfig",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
+    "quark_mxfp4": "sglang.srt.layers.quantization.quark.quark:QuarkConfig",  # online MOE + linear quantization (incl. NVFP4 -> MXFP4 requantization)
+    "auto-round": "sglang.srt.layers.quantization.auto_round:AutoRoundConfig",
+    "auto-round-int8": "sglang.srt.layers.quantization.w8a8_int8:W8A8Int8Config",
+    "modelslim": "sglang.srt.layers.quantization.modelslim.modelslim:ModelSlimConfig",  # for NPU
+    "quark_int4fp8_moe": "sglang.srt.layers.quantization.quark_int4fp8_moe:QuarkInt4Fp8Config",
+    "humming": "sglang.srt.layers.quantization.humming:HummingConfig",
+    "mxfp_w4a8": "sglang.srt.layers.quantization.npu_mxfp4:Mxfp4W4A8Config",  # NPU W4A8 (MXFP4 weights + MXFP8 activations)
+}
+
+# Applied on top of the base table, in this order, when the named condition
+# holds. Each is a plain dict update, so an existing key keeps its position and
+# a new key appends -- matching what the imperative `.update()` calls did.
+# Condition names are evaluated in `__init__.py`; keeping them as strings is
+# what keeps this module import-free.
+PLATFORM_OVERRIDE_SPECS: tuple[tuple[str, dict[str, str]], ...] = (
+    (
+        # cpu/cuda/hip-gfx95/xpu. On XPU the OCP-MoE `Mxfp4Config` path is served
+        # by the sgl-kernel-xpu grouped GEMM, which consumes the packed e2m1 +
+        # ue8m0 g32 checkpoint layout directly. Backends without that kernel keep
+        # the existing "unknown quantization method" error rather than falling
+        # through to a bf16 upcast.
+        "mxfp4_capable",
+        {"mxfp4": "sglang.srt.layers.quantization.mxfp4:Mxfp4Config"},
+    ),
+    (
+        "npu",
+        {
+            "gptq": "sglang.srt.layers.quantization.gptq:GPTQAscendConfig",
+            # On NPU, `mxfp4` means single-level W4A4 MXFP4 for dense LLM. The
+            # upstream `Mxfp4Config` OCP-MoE path is registered only under
+            # `mxfp4_capable` (cpu/cuda/hip), so there is no collision here.
+            "mxfp4": "sglang.srt.layers.quantization.npu_mxfp4_w4a4:Mxfp4W4A4Config",
+        },
+    ),
+    (
+        # Plain GPTQ is CUDA-only in name: the kernel is gone, but the Intel AMX
+        # path in the CPU subset below is untouched. `get_quantization_config`
+        # rejects anything missing from the active table before it can consult
+        # the CPU subset, so the key has to exist here for the CPU path to stay
+        # reachable.
+        "cpu",
+        {"gptq": "sglang.srt.layers.quantization.gptq:CPUGPTQConfig"},
+    ),
+    (
+        "xpu",
+        {
+            "gptq": "sglang.srt.layers.quantization.gptq:GPTQXPUConfig",
+            "awq": "sglang.srt.layers.quantization.awq:AWQXPUConfig",
+        },
+    ),
+    (
+        "mps",
+        {
+            # Apple Silicon MLX backend -- on-the-fly quantization of fp16
+            # weights at load time via mlx.nn.quantize. Only takes effect when
+            # SGLANG_USE_MLX=1.
+            "mlx_q4": "sglang.srt.layers.quantization.mlx:MlxQuantizationConfig",  # 4 bits, group_size=64 (mlx-community default)
+            "mlx_q8": "sglang.srt.layers.quantization.mlx:MlxQuantizationConfig",  # 8 bits, group_size=64
+        },
+    ),
+)
+
+# The subset supported on CPU with AMX, with CPU-specific config classes where
+# they differ. Consulted instead of the tables above once AMX is detected.
+CPU_SUPPORTED_METHOD_SPECS: dict[str, str] = {
+    "fp8": "sglang.srt.layers.quantization.fp8:Fp8Config",
+    "w8a8_int8": "sglang.srt.layers.quantization.w8a8_int8:W8A8Int8Config",
+    "compressed-tensors": "sglang.srt.layers.quantization.compressed_tensors.compressed_tensors:CompressedTensorsConfig",
+    "awq": "sglang.srt.layers.quantization.awq:AWQCPUConfig",
+    "gptq": "sglang.srt.layers.quantization.gptq:CPUGPTQConfig",
+    "mxfp4": "sglang.srt.layers.quantization.mxfp4:Mxfp4Config",
+    "auto-round": "sglang.srt.layers.quantization.auto_round:AutoRoundConfig",
+}
+
+
+def all_method_names() -> list[str]:
+    """Every method name registered on any platform, in table order.
+
+    Spans platforms so that a caller can ask what the registry knows about
+    without being told only what today's hardware activates.
+    """
+    names = list(QUANTIZATION_METHOD_SPECS)
+    for _, overrides in PLATFORM_OVERRIDE_SPECS:
+        names.extend(name for name in overrides if name not in names)
+    names.extend(name for name in CPU_SUPPORTED_METHOD_SPECS if name not in names)
+    return names
+
+
+def all_config_class_specs() -> dict[str, str]:
+    """Config class name -> spec, for every class any table can resolve to.
+
+    Backs the package-level `__getattr__`, so `from ...quantization import
+    Fp8Config` keeps working without importing all 28 config modules.
+    """
+    specs: dict[str, str] = {}
+    tables = [QUANTIZATION_METHOD_SPECS, CPU_SUPPORTED_METHOD_SPECS]
+    tables.extend(overrides for _, overrides in PLATFORM_OVERRIDE_SPECS)
+    for table in tables:
+        for spec in table.values():
+            specs.setdefault(spec.rpartition(":")[2], spec)
+    return specs

--- a/test/registered/unit/layers/quantization/test_quantization_registry.py
+++ b/test/registered/unit/layers/quantization/test_quantization_registry.py
@@ -1,0 +1,193 @@
+"""Unit tests for the quantization method registry — CPU-only, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+import subprocess
+import sys
+import unittest
+
+from sglang.srt.layers.quantization import QUANTIZATION_METHODS
+from sglang.srt.layers.quantization.registry import (
+    CPU_SUPPORTED_METHOD_SPECS,
+    PLATFORM_OVERRIDE_SPECS,
+    QUANTIZATION_METHOD_SPECS,
+    all_config_class_specs,
+    all_method_names,
+)
+from sglang.srt.server_args import QUANTIZATION_CHOICES
+from sglang.test.test_utils import CustomTestCase
+
+
+def _every_spec():
+    """(table name, method name, spec) for every entry in every table."""
+    for name, spec in QUANTIZATION_METHOD_SPECS.items():
+        yield "base", name, spec
+    for condition, overrides in PLATFORM_OVERRIDE_SPECS:
+        for name, spec in overrides.items():
+            yield condition, name, spec
+    for name, spec in CPU_SUPPORTED_METHOD_SPECS.items():
+        yield "cpu", name, spec
+
+
+class TestSpecsResolve(CustomTestCase):
+    """Specs are strings, so a wrong module path or class name is invisible to
+    the linters and only shows up when that method is selected. Resolve all of
+    them here, including the tables this platform does not activate.
+    """
+
+    def test_every_spec_resolves_to_its_named_class(self):
+        import importlib
+
+        for table, name, spec in _every_spec():
+            with self.subTest(table=table, method=name):
+                module_path, sep, class_name = spec.rpartition(":")
+                self.assertTrue(sep, f"{spec!r} is not 'module.path:ClassName'")
+                cls = getattr(importlib.import_module(module_path), class_name, None)
+                self.assertIsNotNone(cls, f"{spec!r} does not resolve")
+                self.assertEqual(cls.__name__, class_name)
+
+    def test_config_classes_are_reachable_from_the_package_root(self):
+        # The package has always re-exported these; they now come from
+        # __getattr__ instead of eager imports.
+        import sglang.srt.layers.quantization as quantization
+
+        for class_name in all_config_class_specs():
+            with self.subTest(cls=class_name):
+                self.assertEqual(getattr(quantization, class_name).__name__, class_name)
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        # Must be AttributeError specifically: `from <pkg> import <submodule>`
+        # relies on the failure falling through to the import machinery.
+        import sglang.srt.layers.quantization as quantization
+
+        with self.assertRaises(AttributeError):
+            quantization.NotAQuantizationConfig
+
+        from sglang.srt.layers.quantization import fp8_utils  # noqa: F401
+
+
+class TestActiveTable(CustomTestCase):
+    """`ModelConfig._verify_quantization` iterates the table and takes the first
+    checkpoint match, so its order is behavior, and it reads the table through
+    `[*...]` and `.items()`.
+    """
+
+    def test_order_follows_the_spec_table(self):
+        names = [*QUANTIZATION_METHODS]
+        base = [n for n in names if n in QUANTIZATION_METHOD_SPECS]
+        self.assertEqual(base, [n for n in QUANTIZATION_METHOD_SPECS if n in names])
+
+    def test_reads_like_the_dict_it_replaced(self):
+        self.assertIn("fp8", QUANTIZATION_METHODS)
+        self.assertNotIn("no_such_method", QUANTIZATION_METHODS)
+        self.assertEqual(QUANTIZATION_METHODS["fp8"].__name__, "Fp8Config")
+        self.assertEqual([*QUANTIZATION_METHODS], list(QUANTIZATION_METHODS.keys()))
+        self.assertEqual(
+            len([*QUANTIZATION_METHODS.items()]), len(QUANTIZATION_METHODS)
+        )
+
+    def test_active_table_is_a_subset_of_the_platform_independent_names(self):
+        self.assertEqual(set(QUANTIZATION_METHODS) - set(all_method_names()), set())
+
+
+class TestCliChoicesVsRegistry(CustomTestCase):
+    """A CLI choice naming no registered method is a crash: `--quantization
+    marlin` passed argparse and then died in `get_quantization_config`. The
+    reverse is deliberate -- a method needing an already-quantized checkpoint
+    is reached through that checkpoint's `quant_method` and must not be
+    offered on the CLI -- so only one direction is asserted as an equality.
+    """
+
+    # Accepted by the CLI but not quantization methods: resolved before the
+    # registry is ever consulted.
+    SENTINELS = ("unquant",)
+
+    def test_no_choice_is_missing_from_the_registry(self):
+        registered = set(all_method_names())
+        self.assertEqual(
+            [c for c in QUANTIZATION_CHOICES if c not in registered],
+            list(self.SENTINELS),
+        )
+
+    def test_checkpoint_only_methods_stay_off_the_cli(self):
+        # blockwise_int8 is registered for checkpoint auto-detection only:
+        # BlockInt8LinearMethod asserts both a weight_block_size and an
+        # int8-serialized checkpoint, and the former may only be set when the
+        # latter holds.
+        self.assertIn("blockwise_int8", all_method_names())
+        self.assertNotIn("blockwise_int8", QUANTIZATION_CHOICES)
+
+
+class TestPlatformConditions(CustomTestCase):
+    """Override rows name their condition as a string, so a new row with an
+    unhandled name would only surface on the platform it targets.
+    """
+
+    def test_every_override_condition_has_a_handler(self):
+        from sglang.srt.layers.quantization import _platform_conditions
+
+        handlers = set(_platform_conditions())
+        named = {condition for condition, _ in PLATFORM_OVERRIDE_SPECS}
+        self.assertEqual(named - handlers, set())
+
+
+class TestImportIsLazy(CustomTestCase):
+    """Importing the package used to import all 28 config modules -- measured
+    at +1984 modules -- so every third-party quantization dependency came with
+    it. A stray top-level config import in the package `__init__`, or a
+    membership test that falls through to `__getitem__`, silently brings it all
+    back.
+    """
+
+    def test_membership_and_key_iteration_resolve_nothing(self):
+        code = (
+            "import sys;"
+            "import sglang.srt.layers.quantization as q;"
+            "assert ('fp8' in q.QUANTIZATION_METHODS) is True;"
+            "assert ('nope' in q.QUANTIZATION_METHODS) is False;"
+            "assert [*q.QUANTIZATION_METHODS] == list(q.QUANTIZATION_METHODS.keys());"
+            "print([m for m in sys.modules if m.startswith('sglang.srt.layers.quantization.')])"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        ).stdout
+        self.assertEqual(
+            sorted(eval(out.strip())),
+            ["sglang.srt.layers.quantization.registry"],
+            "`in` / key iteration must not import a config module",
+        )
+
+    def test_importing_the_package_pulls_in_no_config_module(self):
+        code = (
+            "import sys;"
+            "import sglang.srt.layers.quantization as q;"
+            "print([m for m in sys.modules if m.startswith('sglang.srt.layers.quantization.')])"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        ).stdout
+        loaded = eval(out.strip())
+        self.assertEqual(
+            sorted(loaded),
+            ["sglang.srt.layers.quantization.registry"],
+            "importing the quantization package must not import any config module",
+        )
+
+    def test_importing_server_args_pulls_in_no_quantization_module(self):
+        # server_args is imported by CLI tooling and the router; the whole
+        # quantization package costs ~1.5 s on top of what it already loads.
+        code = (
+            "import sys;"
+            "import sglang.srt.server_args;"
+            "print([m for m in sys.modules if m.startswith('sglang.srt.layers.quantization')])"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        ).stdout
+        self.assertEqual(sorted(eval(out.strip())), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`layers/quantization/__init__.py` enumerates the quantization methods three times over: an eager `from ... import <Config>` block, a base dict mapping name to class, and four imperative `if is_<platform>(): BASE_QUANTIZATION_METHODS.update({...})` blocks. Adding a method means editing all three, and what a given platform actually ends up with has to be reconstructed by reading 35 lines of conditional mutation.

The eager import block also means that importing the package at all imports every one of the 28 config modules, and with them every third-party quantization dependency, whether or not the selected method needs it. Asking the cheap question -- "is `fp8` a method this build knows about?" -- costs 1984 modules.

## Modifications

`quantization/registry.py` is new and holds the single listing, as `"module.path:ClassName"` strings:

- `QUANTIZATION_METHOD_SPECS` -- the base table. Order is preserved, because `ModelConfig._verify_quantization` iterates it and takes the first checkpoint match.
- `PLATFORM_OVERRIDE_SPECS` -- the four platform blocks as one ordered declarative table. Each row is still applied as a dict update, so an existing key keeps its position and a new key appends; the NPU/XPU shadowing of `gptq`, `awq` and `mxfp4` is now readable in one place. A row names its condition as a string, and a name `_platform_conditions()` does not define is reported as such rather than surfacing as a bare `KeyError` on the platform it targets.
- `CPU_SUPPORTED_METHOD_SPECS` -- the AMX subset.

The module imports nothing at all, so the tables can be read to answer which methods exist without pulling in torch or a config implementation.

`QUANTIZATION_METHODS` and `CPU_QUANTIZATION_METHODS` become caching lazy `Mapping`s that import a config class on first lookup, and the package serves the config classes it has always re-exported from `__getattr__` instead of eager imports. Membership tests and key iteration resolve nothing: `__contains__` reads the spec table directly rather than letting `Mapping.__contains__` fall through to `__getitem__`, which would import a config module just to answer `in`, and would let an `ImportError` escape a check that a plain dict answered without exceptions. `[...]` resolves the one entry asked for; only `.items()` and `.values()` still force everything to import.

Unknown attribute names raise `AttributeError`, so `from sglang.srt.layers.quantization import <submodule>` still falls through to the import machinery. All 33 previously re-exported names remain reachable, and `Fp8Config`, `QuantizationConfig`, `get_quantization_config` and `QUANTIZATION_METHODS` keep their import paths.

Three smaller changes in the same file. The CPU-unsupported error labelled its list "Available methods on CPU" while interpolating the full table; it now lists the CPU table. The rewrite has no place for the `DummyConfig` placeholder, which was bound to `CompressedTensorsConfig` and then unconditionally rebound by the real import ten lines below it, nor for the unused `original_isinstance`; both go. And the incidental re-exports of `is_cpu`, `is_cuda`, `is_gfx95_supported`, `is_mps`, `is_npu`, `is_xpu`, `cpu_has_amx_support` and `current_platform` from the package root are gone -- they were import artifacts rather than API, and nothing reads them from here.

### `QUANTIZATION_CHOICES` is deliberately untouched

A registry key is not a `--quantization` value, and the CLI list is a subset by design. A method that requires an already-quantized checkpoint is reachable only through that checkpoint's `quant_method`. `blockwise_int8` is one: `BlockInt8LinearMethod` asserts both a `weight_block_size` and an int8-serialized checkpoint, and the former may only be set when the latter holds, so `--quantization blockwise_int8` could not work. `registry.py` documents the asymmetry and a test pins it.

## Accuracy Tests

No accuracy run: this changes how a config class is looked up, not any numeric path. The equivalence evidence is the point instead.

- The resolved tables are identical before and after on the machine used here -- keys, values and iteration order, compared as JSON of registry key to fully-qualified class name.
- The platforms with no hardware here are covered at source level: the old imperative blocks were rebuilt from the previous `__init__.py` via AST and compared entry-for-entry against the new tables. Base 28/28, CPU 7/7, and all four override blocks match in both value and order.
- All 33 names the package previously re-exported still resolve to the same class.
- `test/registered/unit/layers/quantization/test_quantization_registry.py` is new: every spec in all four tables resolves to its named class (including the tables this platform does not activate), the config classes are reachable from the package root, an unknown attribute raises `AttributeError`, every override condition has a handler, membership and key iteration import no config module, and importing `server_args` imports nothing from this package.
- `test/registered/unit/layers/quantization`: 180 passed, and the combined failure set with `test/registered/unit/model_loader` is byte-identical to `main` on this machine (12 pre-existing, needing GPU or modelopt).
- `test/registered/unit/{server_args,cli,configs}` and `test_model_overrides.py`: 596 passed.

## Speed Tests and Profiling

No serving benchmark; nothing on a forward path changes. The import-cost change, measured on this machine as the marginal cost of importing the registry on top of `sglang.srt.server_args`:

| | added modules | added time |
| --- | --- | --- |
| before | 1984 | ~1560 ms |
| after | 3 | ~0 ms |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documented behavior or import path changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (See above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829396509](https://github.com/sgl-project/sglang/actions/runs/34829396509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829396363](https://github.com/sgl-project/sglang/actions/runs/34829396363)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829396465](https://github.com/sgl-project/sglang/actions/runs/34829396465)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->