### PR TITLE
[Docs] Prefer --smg-grpc-mode over deprecated --grpc-mode in Model Gateway

### DIFF
--- a/docs/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs/docs/advanced_features/sgl_model_gateway.mdx
@@ -189,7 +189,7 @@ python -m sglang_router.launch_server \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --tp-size 1 \
   --dp-size 8 \
-  --grpc-mode \
+  --smg-grpc-mode \
   --log-level debug \
   --router-prometheus-port 10001 \
   --router-tool-call-parser llama \
@@ -222,7 +222,7 @@ Use SRT gRPC workers to unlock the highest throughput and access native reasonin
 # Workers expose gRPC endpoints
 python -m sglang.launch_server \
   --model meta-llama/Llama-3.1-8B-Instruct \
-  --grpc-mode \
+  --smg-grpc-mode \
   --port 20000
 
 # Router
@@ -2268,7 +2268,7 @@ gRPC mode provides the highest performance for SGLang workers:
 # Start workers in gRPC mode
 python -m sglang.launch_server \
   --model meta-llama/Llama-3.1-8B-Instruct \
-  --grpc-mode \
+  --smg-grpc-mode \
   --port 20000
 
 # Configure gateway for gRPC
@@ -2806,7 +2806,7 @@ python -m sglang_router.launch_router \
 
 ### gRPC Connection Issues
 
-Ensure workers are started with `--grpc-mode` and verify `--model-path` or `--tokenizer-path` is provided to the router.
+Ensure workers are started with `--smg-grpc-mode` and verify `--model-path` or `--tokenizer-path` is provided to the router.
 
 ### Tokenizer Loading Failures
 


### PR DESCRIPTION
## Summary
- Update Model Gateway docs to launch SRT workers with `--smg-grpc-mode` instead of the deprecated `--grpc-mode` alias (same legacy SMG gRPC behavior).

## Local repro
```bash
# Code: --grpc-mode is deprecated and remaps to smg_grpc_mode
rg -n 'grpc-mode|smg.grpc|smg_grpc_mode' \
  python/sglang/srt/server_args.py \
  python/sglang/srt/arg_groups/serving_hook.py

# Expect serving_hook.py warning:
#   --grpc-mode is deprecated ... Use --smg-grpc-mode for the legacy SMG gRPC server

# Docs before: Model Gateway examples/troubleshooting use --grpc-mode
rg -n 'grpc-mode|smg-grpc-mode' docs/docs/advanced_features/sgl_model_gateway.mdx

# Docs after this PR: those paths use --smg-grpc-mode
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33625562571](https://github.com/sgl-project/sglang/actions/runs/33625562571)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33625562568](https://github.com/sgl-project/sglang/actions/runs/33625562568)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->