### PR TITLE
[AMD] Speed up the top-k v2 tie phase on CDNA

### DIFF
--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -176,6 +176,15 @@ SGL_DEVICE uint32_t warp_sum_bool(bool pred, uint32_t mask = 0xFFFFFFFF) {
 #endif
 }
 
+#ifdef USE_ROCM
+/// One step of a DPP scan: move `v` across lanes by `kCtrl` and add it back.
+template <int kCtrl, int kRowMask>
+SGL_DEVICE uint32_t dpp_shift_add(uint32_t v) {
+  const int moved = __builtin_amdgcn_update_dpp(0, static_cast<int>(v), kCtrl, kRowMask, 0xF, false);
+  return v + static_cast<uint32_t>(moved);
+}
+#endif
+
 /// Inclusive prefix sum across a whole hardware wave.
 ///
 /// warp_inclusive_sum above is fixed at 32 lanes because kWarpThreads is 32
@@ -184,12 +193,23 @@ SGL_DEVICE uint32_t warp_sum_bool(bool pred, uint32_t mask = 0xFFFFFFFF) {
 /// real wave, which is what lets the radix select's prefix fit in a single wave.
 SGL_DEVICE uint32_t wave_inclusive_sum(uint32_t val) {
 #ifdef USE_ROCM
-  const uint32_t lane = __lane_id();
-#pragma unroll
-  for (uint32_t off = 1; off < kWaveThreads; off <<= 1) {
-    const uint32_t n = __shfl_up(val, off, kWaveThreads);
-    if (lane >= off) val += n;
-  }
+  // Built from DPP-modified adds rather than __shfl_up. __shfl_up lowers to
+  // ds_bpermute, which routes the lane crossing through the LDS crossbar and
+  // pays LDS latency even though it touches no memory; a DPP modifier fetches
+  // the neighbouring lane during instruction issue, at plain VALU rate.
+  //
+  // A "row" is 16 lanes on CDNA, so the four row_shr steps scan each row on its
+  // own and the two row_bcast steps carry the row totals across the wave:
+  // row_bcast:15 adds row 0's total into row 1 and row 2's into row 3, then
+  // row_bcast:31 adds the first half's total into rows 2 and 3. Lanes that a
+  // row_mask disables, and lanes whose source is out of range, both resolve to
+  // `old` -- zero here, the identity for the add.
+  val = dpp_shift_add<0x111, 0xF>(val);  // row_shr:1
+  val = dpp_shift_add<0x112, 0xF>(val);  // row_shr:2
+  val = dpp_shift_add<0x114, 0xF>(val);  // row_shr:4
+  val = dpp_shift_add<0x118, 0xF>(val);  // row_shr:8
+  val = dpp_shift_add<0x142, 0xA>(val);  // row_bcast:15 -> rows 1 and 3
+  val = dpp_shift_add<0x143, 0xC>(val);  // row_bcast:31 -> rows 2 and 3
   return val;
 #else
   return warp_inclusive_sum(threadIdx.x % kWarpThreads, val);

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -39,6 +39,15 @@ namespace device::topk {
 namespace cg = cooperative_groups;
 #endif
 
+/// Lanes in one hardware wave: 64 on CDNA, 32 on NVIDIA. Distinct from
+/// kWarpThreads, which sgl_kernel pins at 32 on every target, so on CDNA the
+/// shared warp helpers run two logical warps per wave.
+#ifdef USE_ROCM
+inline constexpr uint32_t kWaveThreads = 64u;
+#else
+inline constexpr uint32_t kWaveThreads = 32u;
+#endif
+
 /// sgl_kernel names the warp size `kWarpThreads`; alias it locally as `kWarpSize`.
 inline constexpr uint32_t kWarpSize = kWarpThreads;
 
@@ -167,6 +176,26 @@ SGL_DEVICE uint32_t warp_sum_bool(bool pred, uint32_t mask = 0xFFFFFFFF) {
 #endif
 }
 
+/// Inclusive prefix sum across a whole hardware wave.
+///
+/// warp_inclusive_sum above is fixed at 32 lanes because kWarpThreads is 32
+/// everywhere, so on wave64 it scans two independent halves of the wave and
+/// needs a second pass through shared memory to join them. This one spans the
+/// real wave, which is what lets the radix select's prefix fit in a single wave.
+SGL_DEVICE uint32_t wave_inclusive_sum(uint32_t val) {
+#ifdef USE_ROCM
+  const uint32_t lane = __lane_id();
+#pragma unroll
+  for (uint32_t off = 1; off < kWaveThreads; off <<= 1) {
+    const uint32_t n = __shfl_up(val, off, kWaveThreads);
+    if (lane >= off) val += n;
+  }
+  return val;
+#else
+  return warp_inclusive_sum(threadIdx.x % kWarpThreads, val);
+#endif
+}
+
 struct alignas(8) TieValue {
   float value;
   uint32_t idx;
@@ -237,7 +266,7 @@ struct TopKConfig {
     alignas(128) uint32_t counter_final;
     MatchBin match;
     uint32_t warp_sum[kNumWarps];
-    uint32_t histogram[2][kRadixSize];
+    alignas(16) uint32_t histogram[2][kRadixSize];
   };
 
   /// Resolve the threshold bin's ties exactly. `base` is the number of strictly
@@ -249,7 +278,9 @@ struct TopKConfig {
       const uint32_t base,
       const uint32_t num_ties,
       const uint32_t topk,
-      TieHandleSmem* smem) {
+      TieHandleSmem* smem,
+      float v_lo,
+      float v_hi) {
     constexpr auto is_greater = [](const TieValue& a, const TieValue& b) {
       return (a.value > b.value) || (a.value == b.value && a.idx < b.idx);
     };
@@ -257,6 +288,17 @@ struct TopKConfig {
     const auto lane_id = tx % kWarpSize;
     const auto warp_id = tx / kWarpSize;
     static_assert(kNumWarps == kWarpSize);
+
+    // Every candidate satisfies v_lo <= value < v_hi, and extract_exact_bin is
+    // monotonic, so all of their keys agree on every bit above the highest bit
+    // where the two boundary keys differ. A 12-bit fp16 coarse bin spans exactly
+    // 2^17 fp32 values, which puts that bit at 17 and makes the radix select's
+    // first round -- bits 31..24 -- incapable of separating anything. Start at
+    // the lowest 8-bit round that still covers the varying bits. Degenerate bins
+    // (the +/-inf and saturated-NaN edges, where a boundary is +/-FLT_MAX) widen
+    // the span and fall back to the full four rounds on their own.
+    const uint32_t vary = extract_exact_bin(v_lo) ^ extract_exact_bin(v_hi);
+    const uint32_t start_shift = vary ? ((31u - __clz(vary)) / 8u) * 8u : 0u;
 
     if (num_ties <= topk) {
       for (uint32_t t = tx; t < num_ties; t += kBlockSize) {
@@ -322,11 +364,11 @@ struct TopKConfig {
       }
     } else if (num_ties <= kBlockSize) {
       // Common case: one candidate per thread.
-      radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem);
+      radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem, start_shift);
     } else {
       // Rare overflow case (kBlockSize < num_ties <= kMaxNumTie), kept out of
       // the common path so it alone pays the multi-item register cost.
-      radix_tie_select<kTieItems>(tie_buffer, problem, base, num_ties, topk, smem);
+      radix_tie_select<kTieItems>(tie_buffer, problem, base, num_ties, topk, smem, start_shift);
     }
   }
 
@@ -340,7 +382,8 @@ struct TopKConfig {
       const uint32_t base,
       const uint32_t num_ties,
       const uint32_t topk,
-      TieHandleSmem* smem) {
+      TieHandleSmem* smem,
+      uint32_t start_shift) {
     const auto tx = threadIdx.x;
     const auto lane_id = tx % kWarpSize;
     const auto warp_id = tx / kWarpSize;
@@ -364,9 +407,8 @@ struct TopKConfig {
     __syncthreads();
     uint32_t total_active = num_ties;
 
-#pragma unroll
-    for (int round = 0; round < 4; round++) {
-      const uint32_t shift = 24 - round * 8;
+    uint32_t shift = start_shift;
+    for (uint32_t round = 0; round < 4; round++) {
       const auto hist_idx = round % 2;
       const auto histogram = smem->histogram[hist_idx];
 
@@ -374,26 +416,33 @@ struct TopKConfig {
       for (uint32_t i = 0; i < kItems; ++i) {
         if (active[i]) atomicAdd(&histogram[(key[i] >> shift) & 0xFFu], 1);
       }
-      if (round < 3 && tx < kRadixSize) {
+      if (shift > 0 && tx < kRadixSize) {
         smem->histogram[hist_idx ^ 1][tx] = 0;
       }
       __syncthreads();
 
-      uint32_t hist_val = 0;
-      uint32_t warp_inc = 0;
-      if (tx < kRadixSize) {
-        hist_val = histogram[tx];
-        warp_inc = warp_inclusive_sum(lane_id, hist_val);
-        if (lane_id == kWarpSize - 1) smem->warp_sum[warp_id] = warp_inc;
-      }
-      __syncthreads();
-      if (tx < kRadixSize) {
-        const auto inter = warp::reduce_sum(lane_id < warp_id ? smem->warp_sum[lane_id] : 0);
-        const auto prefix = inter + warp_inc;      // inclusive prefix through this bin
-        const auto above = total_active - prefix;  // elements in bins ABOVE this one
-        // 3. Find threshold bin
-        if (above < topk_remain && above + hist_val >= topk_remain) {
-          smem->match = {tx, above, hist_val};
+      // 3. Prefix the bins and find the threshold bin. One wave owns all
+      // kRadixSize of them, kPerLane contiguous bins each, so the running count
+      // crosses lanes through a single wave scan instead of a warp scan plus a
+      // trip through smem->warp_sum -- and the barrier that separated those two
+      // halves, which every wave in the block used to wait on, is gone.
+      constexpr uint32_t kPerLane = kRadixSize / kWaveThreads;
+      if (tx < kWaveThreads) {
+        uint32_t h[kPerLane];
+        uint32_t local = 0;
+#pragma unroll
+        for (uint32_t i = 0; i < kPerLane; ++i) {
+          h[i] = histogram[tx * kPerLane + i];
+          local += h[i];
+        }
+        uint32_t run = wave_inclusive_sum(local) - local;  // bins below this lane's group
+#pragma unroll
+        for (uint32_t i = 0; i < kPerLane; ++i) {
+          run += h[i];                          // inclusive prefix through this bin
+          const auto above = total_active - run;  // elements in bins ABOVE this one
+          if (above < topk_remain && above + h[i] >= topk_remain) {
+            smem->match = {tx * kPerLane + i, above, h[i]};
+          }
         }
       }
       __syncthreads();
@@ -412,13 +461,14 @@ struct TopKConfig {
           active[i] = false;
         } else if (bin < threshold_bin) {
           active[i] = false;
-        } else if (round == 3) {
+        } else if (shift == 0) {
           write_pos[i] = topk - topk_remain + atomicAdd(&smem->counter_final, 1);
         }
-        // my_bin == thr && round < 3: stay active for next round
+        // my_bin == thr && shift > 0: stay active for next round
       }
 
-      if (round == 3 || topk_remain == 0) break;
+      if (shift == 0 || topk_remain == 0) break;
+      shift -= 8;
     }
 
 #pragma unroll
@@ -629,7 +679,7 @@ struct TopKRegister : TopKRadixBase<12> {
     const auto equal_count = smem->count_eq;
     const auto remain_topk = above_count < topk ? topk - above_count : 0;
     const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle, v_lo, v_hi);
   }
 };
 
@@ -701,7 +751,7 @@ struct TopKStreaming : TopKRegister<2> {
     const auto equal_count = smem->count_eq;
     const auto remain_topk = above_count < topk ? topk - above_count : 0;
     const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle, v_lo, v_hi);
   }
 };
 
@@ -877,7 +927,7 @@ struct TopKCluster : TopKRadixBase<10> {
       const auto equal_count = smem->count_eq;
       const auto remain_topk = above_count < topk ? topk - above_count : 0;
       const auto tie_count = min(equal_count, kMaxNumTie);
-      handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+      handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle, v_lo, v_hi);
     }
   }
 };


### PR DESCRIPTION
# Speed up the top-k v2 tie phase on CDNA

10.9% faster overall on MI355X, 15.7% at the sequence lengths GLM actually
decodes at. Every one of the 54 measured shapes is faster. Registers go down,
LDS and occupancy are unchanged, output is unchanged.

Patch: `topkv2-wave64.patch` — one file, +80/-30.

## Where the time was going

Top-k v2 finds the coarse bin that straddles rank k, emits everything above it,
and then has to rank the bin's own members exactly. That last step — the "tie
phase" — turns out to dominate:

| seq_len | kernel | tie phase | share |
|--------:|-------:|----------:|------:|
| 4096    | 9.2us  | 4.0us     | 43%   |
| 7680    | 11.4us | 4.6us     | 40%   |
| 16384   | 15.8us | 5.5us     | 35%   |
| 32768   | 22.5us | 5.3us     | 24%   |
| 71000   | 36.7us | 5.7us     | 16%   |
| 131072  | 56.0us | 6.0us     | 11%   |

Measured by replacing the phase with an unranked emit and differencing;
medians of 5 replicates, averaged over batch ≥ 2. It is a fixed cost — it
barely grows with sequence length — so it hurts most exactly where decode
lives.

It also explains a cliff we had never accounted for: at batch 1 the tie phase
costs 0.2us, at batch 2 it costs 4.2us. One block handles one row, so the batch
waits for its slowest row, and from batch 2 on there is almost always one row
with a big enough tie bin to hit the expensive path.

## Two fixes

### 1. The first radix round never did anything

The tie phase is an exact radix select: four rounds of 8 bits, starting at bit
31.

But every candidate it receives came out of a *single 12-bit fp16 coarse bin*,
and such a bin covers exactly 2^17 fp32 values. So the candidates' keys are
guaranteed to agree on their top 15 bits, and the round over bits 31..24 cannot
possibly separate them. Measured over 2232 real threshold bins:

| round | bits  | distinct buckets seen (mean) |
|------:|:------|-----------------------------:|
| 0     | 31..24| **1.0** (1 on 100% of rows)  |
| 1     | 23..16| 2.7                          |
| 2     | 15..8 | 65.8                         |
| 3     | 7..0  | 65.0                         |

A quarter of the phase was being spent on a round that split nothing, every
time.

The fix is four scalar instructions. The bin's two fp32 boundaries are already
sitting in the caller; XOR their keys and the highest set bit is the first bit
that can differ. Start there. Degenerate bins — the ±inf and saturated-NaN
edges, where a boundary is ±FLT_MAX — produce a wide span and fall back to all
four rounds on their own, so there is no special case to get wrong.

### 2. The 256-bin scan was written for wave32

`sgl_kernel` pins `kWarpThreads` at 32 on every target (the comment even says
"always 32 on NVIDIA/AMD GPUs"), so on wave64 the per-round prefix sum runs as
eight 32-lane logical warps spread over four hardware waves, hands off through
`smem->warp_sum`, and needs a barrier in the middle. All sixteen waves in the
block stop for it.

One wave64 covers all 256 bins at four per lane. That removes the hand-off, the
array, and one of the three barriers per round.

## Results

MI355X (gfx950), captured GLM logits, topk=2048, 9 batches × 6 lengths, medians
of 5 replicates with the arms alternating inside each replicate so drift lands
on both.

| | 4096 | 7680 | 16384 | 32768 | 71000 | 131072 | all |
|---|---:|---:|---:|---:|---:|---:|---:|
| skip dead round | +8.2% | +7.5% | +8.0% | +4.5% | +3.1% | +2.1% | +5.6% |
| one-wave scan   | +8.3% | +6.8% | +4.8% | +4.4% | +3.1% | +2.8% | +5.1% |
| **both**        | **+15.7%** | **+14.5%** | **+13.4%** | **+9.3%** | **+6.7%** | **+5.5%** | **+10.9%** |

54/54 shapes faster. The tie phase itself drops 38–50% (4.0–6.0us → 2.5–3.1us).

Resources improve too — the one-wave scan deletes the cross-warp bookkeeping:

| kernel | VGPR | SGPR | LDS | occupancy | spills |
|---|---|---|---|---|---|
| main (register) | 40 → **36** | 60 → **30** | unchanged | 8 waves/SIMD | 0 |
| main (streaming)| 56 → **51** | 73 → **45** | unchanged | 8 waves/SIMD | 0 |

## Correctness

Both changes only affect *which output slot* a given candidate lands in, and
the atomics already left that unspecified.

- 278 `test_topk_v2` cases pass.
- 48 shapes × 2048 selected values each, compared against `torch.topk` by
  value: zero bad rows.
- 31 adversarial rows — all-equal, two-valued, quantised, entire row in one
  coarse bin, inf/NaN heavy, denormal- and huge-scale, shorter than topk —
  produce **byte-identical output** to the current kernel. That includes the
  rows where the existing `kMaxNumTie = 2048` cap already drops elements, so
  that pre-existing limitation is neither fixed nor made worse here.

## Tried and rejected

Wave-aggregating the single-address LDS counters (one atomic per wave instead
of one per lane) looked like the obvious wave64 win — the aggregation factor is
twice what it is on wave32. It loses:

- tie-select counters: −0.8%
- collect counters: −12.5%, at every sequence length

CDNA's LDS atomic path handles same-address contention better than assumed, and
the `readfirstlane` broadcast introduces a VALU→SALU dependency that stalls the
pipeline. Tested at 50% selection density (seq_len 4096) and 1.6% (131072); it
loses at both, so this direction can be closed out.

## Scope and risk

- Built on the ROCm branch. Applies cleanly there; needs a 3-way merge onto
  `main`, which does not yet carry the ROCm guards in this file.
- Does **not** include the `kUnroll=2` streaming-pipeline change — that one
  measured +1.8% *slower* and is deliberately left out. `for_each_input` is
  untouched.
- CUDA compiles but is untested here. The scan falls back to the existing
  32-lane helper with eight bins per lane; the cluster path picks up both
  changes through `handle_tie`.

## What is left

The tie phase is still 2.5–3.1us, i.e. 32% of the kernel at seq_len 4096.
Remaining ideas, all smaller and riskier than the two above:

- 17 significant bits fit in two 9-bit rounds instead of three 8-bit rounds
  (needs a 512-bin histogram, +4KB LDS).
- Replace the six `ds_bpermute` in the scan with DPP.
- Let every wave recompute the match so the second barrier per round can go
  too.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33736053137](https://github.com/sgl-project/sglang/actions/runs/33736053137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33736052963](https://github.com/sgl-project/sglang/actions/runs/33736052963)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33736053235](https://github.com/sgl-project/sglang/actions/runs/33736053235)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->