### PR TITLE
fix(disaggregation): align GLM DSA tails with KV-owned request slots

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1457,7 +1457,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             def _dsa_tail_payload():
                 return get_dsa_tail_state_indices(
                     self.token_to_kv_pool,
-                    decode_req.req.req_pool_idx,
+                    decode_req.req.kv.req_pool_idx,
                     seq_len,
                 )
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1247,7 +1247,7 @@ class SchedulerDisaggregationPrefillMixin:
             def _dsa_tail_payload():
                 return get_dsa_tail_state_indices(
                     self.token_to_kv_pool_allocator.get_kvcache(),
-                    req.req_pool_idx,
+                    req.kv.req_pool_idx,
                     seq_len,
                 )
 

--- a/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
@@ -1650,8 +1650,14 @@ def kpool_write_tail_and_maybe_compress(
     assert bn % num_draft_tokens == 0
     bs = bn // num_draft_tokens
     max_closed_pools = kpool_max_closed_pools(num_draft_tokens, pool.index_kpool)
+    assert req_pool_indices.shape == (bs,), req_pool_indices.shape
+    assert write_start.shape == (bs,), write_start.shape
+    assert tail_logical_start.shape == (bs,), tail_logical_start.shape
     assert write_loc.shape == (bs, max_closed_pools), write_loc.shape
     assert write_loc.stride(1) == 1, write_loc.stride()
+    assert out_cache_loc.numel() >= bn, (out_cache_loc.shape, bn)
+    if effective_n_per_batch is not None:
+        assert effective_n_per_batch.shape == (bs,), effective_n_per_batch.shape
 
     key = key.contiguous()
     score = score.contiguous()

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -97,6 +97,13 @@ from sglang.srt.utils.common import (
 logger = logging.getLogger(__name__)
 
 
+def _req_slot_capacity(req_to_token_pool: ReqToTokenPool) -> int:
+    """Return the non-padding request-slot domain of a request table."""
+    capacity = int(req_to_token_pool.req_to_token.shape[0]) - 1
+    assert capacity >= 0, "req_to_token must include its padding row"
+    return capacity
+
+
 def _should_elide_dsa_index_k(*, is_draft_worker: bool) -> bool:
     memory_config = get_memory()
     return (
@@ -1225,7 +1232,7 @@ class KVCacheConfigurator:
         elif self.use_mla_backend and is_dsa_model and not self.mambaish_config:
             token_to_kv_pool = self._build_dsa_kv_pool(
                 max_total_num_tokens=sizes.max_total_num_tokens,
-                max_running_requests=sizes.max_running_requests,
+                req_to_token_pool=req_to_token_pool,
             )
         elif self.use_mla_backend and not self.mambaish_config:
             assert not is_dsa_model
@@ -1515,7 +1522,7 @@ class KVCacheConfigurator:
         return token_to_kv_pool
 
     def _build_dsa_kv_pool(
-        self, *, max_total_num_tokens: int, max_running_requests: int
+        self, *, max_total_num_tokens: int, req_to_token_pool: ReqToTokenPool
     ) -> KVCache:
         from sglang.srt.layers.cp.utils import get_glm_dsa_cp_layer_shard_info
 
@@ -1573,7 +1580,12 @@ class KVCacheConfigurator:
                 self.model_config.hf_config
             ),
             tail_extra_slots=(max_speculative_num_draft_tokens() or 0),
-            max_running_requests=max_running_requests,
+            # KPool tails are indexed by req_pool_idx, not by the number of
+            # requests admitted to execution.  Disaggregated decode reserves
+            # additional in-transfer rows in DecodeReqToTokenPool, so size the
+            # tails for that complete slot domain (excluding padding row 0,
+            # which DSATokenToKVPool adds back).
+            max_running_requests=_req_slot_capacity(req_to_token_pool),
             **pool_kwargs,
         )
         return token_to_kv_pool
@@ -1804,7 +1816,7 @@ class KVCacheConfigurator:
                 if dsa_index_kpool > 1:
                     extra_args.update(
                         tail_extra_slots=(max_speculative_num_draft_tokens() or 0),
-                        max_running_requests=(req_to_token_pool.req_to_token.shape[0]),
+                        max_running_requests=_req_slot_capacity(req_to_token_pool),
                     )
         quant_method = self._build_mha_quant_method(
             num_layers=len(full_attention_layer_ids)

--- a/test/registered/kernels/test_dsa_kpool_multi_pool.py
+++ b/test/registered/kernels/test_dsa_kpool_multi_pool.py
@@ -105,7 +105,14 @@ class TestDsaKpoolMultiPool(CustomTestCase):
             ),
         )
 
-    def _run_compress_case(self, effective_n: int, expected_closed_pools: int):
+    def _run_compress_case(
+        self,
+        effective_n: int,
+        expected_closed_pools: int,
+        *,
+        req_pool_idx: int = 0,
+        req_pool_size: int = 1,
+    ):
         torch.manual_seed(42)
         pool = self._pool()
         num_draft_tokens = self.NUM_DRAFT_TOKENS
@@ -120,7 +127,11 @@ class TestDsaKpoolMultiPool(CustomTestCase):
             self.POOL_SIZE, INDEX_HEAD_DIM, dtype=torch.float32, device="cuda"
         )
         tail_k_initial = torch.randn(
-            1, tail_size, INDEX_HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+            req_pool_size,
+            tail_size,
+            INDEX_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device="cuda",
         )
         tail_score_initial = torch.randn_like(tail_k_initial)
 
@@ -128,8 +139,8 @@ class TestDsaKpoolMultiPool(CustomTestCase):
         tail_score_expected = tail_score_initial.clone()
         for i in range(num_draft_tokens):
             physical_slot = (write_start_value + i) % tail_size
-            tail_k_expected[0, physical_slot] = key[i]
-            tail_score_expected[0, physical_slot] = score[i]
+            tail_k_expected[req_pool_idx, physical_slot] = key[i]
+            tail_score_expected[req_pool_idx, physical_slot] = score[i]
 
         expected_cache = self._empty_cache()
         dummy_chunk = torch.zeros(
@@ -142,8 +153,11 @@ class TestDsaKpoolMultiPool(CustomTestCase):
             chunk_score=dummy_chunk,
             tail_k=tail_k_expected,
             tail_score=tail_score_expected,
-            req_pool_idx=torch.zeros(
-                expected_closed_pools, dtype=torch.int64, device="cuda"
+            req_pool_idx=torch.full(
+                (expected_closed_pools,),
+                req_pool_idx,
+                dtype=torch.int64,
+                device="cuda",
             ),
             n_from_tail=torch.full(
                 (expected_closed_pools,),
@@ -177,7 +191,9 @@ class TestDsaKpoolMultiPool(CustomTestCase):
             tail_k=tail_k_actual,
             tail_score=tail_score_actual,
             ape=ape,
-            req_pool_indices=torch.zeros(1, dtype=torch.int64, device="cuda"),
+            req_pool_indices=torch.tensor(
+                [req_pool_idx], dtype=torch.int64, device="cuda"
+            ),
             write_start=torch.tensor(
                 [write_start_value], dtype=torch.int32, device="cuda"
             ),
@@ -208,6 +224,13 @@ class TestDsaKpoolMultiPool(CustomTestCase):
     def test_effective_n_only_compresses_accepted_pools(self):
         self._run_compress_case(effective_n=2, expected_closed_pools=1)
 
+    def test_pd_decode_high_request_slot_writes_its_own_tail(self):
+        self._run_compress_case(
+            effective_n=self.NUM_DRAFT_TOKENS,
+            expected_closed_pools=2,
+            req_pool_idx=96,
+            req_pool_size=97,
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/disaggregation/test_decode_req_to_token_pool.py
+++ b/test/registered/unit/disaggregation/test_decode_req_to_token_pool.py
@@ -7,6 +7,8 @@ from sglang.srt.disaggregation.decode import (
     DecodeReqToTokenPool,
     HybridMambaDecodeReqToTokenPool,
 )
+from sglang.srt.mem_cache.kv_cache_configurator import _req_slot_capacity
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -49,6 +51,31 @@ def test_hybrid_decode_pool_initializes_aux_cache_contract():
     )
 
     assert pool.schedulable_token_capacity(17) == 17
+
+
+def test_kpool_slot_capacity_covers_decode_preallocation_rows():
+    pool = DecodeReqToTokenPool(
+        size=32,
+        max_context_len=8,
+        device="cpu",
+        enable_memory_saver=False,
+        pre_alloc_size=64,
+    )
+
+    assert pool.req_to_token.shape[0] == 97
+    assert _req_slot_capacity(pool) == 96
+
+
+def test_kpool_slot_capacity_counts_padding_row_once():
+    pool = ReqToTokenPool(
+        size=32,
+        max_context_len=8,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+
+    assert pool.req_to_token.shape[0] == 33
+    assert _req_slot_capacity(pool) == 32
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_dsa_tail_req_pool_idx.py
+++ b/test/registered/unit/disaggregation/test_dsa_tail_req_pool_idx.py
@@ -1,0 +1,142 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+
+from sglang.srt.disaggregation.base.conn import StateType
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSATailReqPoolIndex(unittest.TestCase):
+    def test_decode_preallocation_uses_kv_owned_req_pool_idx(self):
+        req = SimpleNamespace(
+            rid="decode-dsa-tail",
+            priority=0,
+            origin_input_ids=[1, 2, 3],
+            output_ids=[],
+            finished_reason=None,
+            return_logprob=False,
+            sampling_params=SimpleNamespace(max_new_tokens=1),
+            kv=SimpleNamespace(req_pool_idx=3, cache_protected_len=0),
+            time_stats=MagicMock(),
+        )
+        receiver = MagicMock()
+        decode_req = SimpleNamespace(
+            req=req,
+            waiting_for_input=True,
+            kv_receiver=receiver,
+            metadata_buffer_index=-1,
+            is_rebootstrap=False,
+        )
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.pp_size = 1
+        queue.queue = [decode_req]
+        queue.pending_reqs = []
+        queue.retracted_queue = []
+        queue.num_reserved_decode_tokens = 0
+        queue._num_published_destinations = 0
+        queue._resolve_pending_reqs = MagicMock()
+        queue._update_handshake_waiters = MagicMock()
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+        queue._allocatable_token_budgets = MagicMock(return_value=1024)
+        queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
+        queue._pre_alloc_fill_len = MagicMock(return_value=3)
+        queue._pre_alloc = MagicMock(return_value=torch.arange(3))
+        queue.req_to_token_pool = SimpleNamespace(
+            available_size=lambda: 1,
+            req_to_token=torch.arange(64).reshape(8, 8),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = MagicMock()
+        queue.req_to_metadata_buffer_idx_allocator.available_size.return_value = 1
+        queue.req_to_metadata_buffer_idx_allocator.alloc.return_value = 0
+        queue.token_to_kv_pool_allocator = MagicMock()
+        queue.token_to_kv_pool_allocator.page_size = 1
+        queue.token_to_kv_pool_allocator.translate_kv_indices_for_transfer.side_effect = (
+            lambda indices: indices
+        )
+        queue.token_to_kv_pool = MagicMock()
+        queue.token_to_kv_pool.page_size = 1
+        queue.transfer_queue = SimpleNamespace(enable_staging=False)
+        queue.kv_manager = SimpleNamespace(
+            kv_args=SimpleNamespace(state_types=[StateType.DSA_TAIL])
+        )
+        queue.scheduler = SimpleNamespace(
+            running_batch=SimpleNamespace(reqs=[]),
+            enable_priority_scheduling=False,
+            enable_hisparse=False,
+            enable_decode_hicache=False,
+            server_args=SimpleNamespace(disaggregation_decode_enable_radix_cache=False),
+        )
+
+        expected_tail = np.array([31, 32], dtype=np.int32)
+        with patch(
+            "sglang.srt.disaggregation.decode.get_dsa_tail_state_indices",
+            return_value=expected_tail,
+        ) as get_tail:
+            preallocated, failed = queue.pop_preallocated()
+
+        self.assertEqual(preallocated, [decode_req])
+        self.assertEqual(failed, [])
+        get_tail.assert_called_once_with(queue.token_to_kv_pool, 3, 3)
+        state_indices = receiver.send_metadata.call_args.args[2]
+        np.testing.assert_array_equal(state_indices[0], expected_tail)
+
+    def test_prefill_final_send_uses_kv_owned_req_pool_idx(self):
+        sender = MagicMock()
+        sender.should_send_kv_chunk.return_value = True
+        req = SimpleNamespace(
+            rid="prefill-dsa-tail",
+            origin_input_ids=[1, 2, 3, 4],
+            extend_range=SimpleNamespace(end=4),
+            start_send_idx=0,
+            disagg_decode_prefix_len=0,
+            kv=SimpleNamespace(req_pool_idx=5),
+            disagg_kv_sender=sender,
+        )
+        pool = MagicMock()
+        allocator = MagicMock()
+        allocator.page_size = 1
+        allocator.get_kvcache.return_value = pool
+        allocator.translate_kv_indices_for_transfer.side_effect = (
+            lambda indices: indices
+        )
+        scheduler = SimpleNamespace(
+            token_to_kv_pool_allocator=allocator,
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.arange(64).reshape(8, 8)
+            ),
+            disagg_metadata_buffers=MagicMock(),
+            disagg_prefill_bootstrap_queue=SimpleNamespace(
+                kv_manager=SimpleNamespace(
+                    kv_args=SimpleNamespace(state_types=[StateType.DSA_TAIL])
+                )
+            ),
+            enable_staging=False,
+            disagg_prefill_pending_chunk_rids={req.rid},
+        )
+
+        expected_tail = np.array([51], dtype=np.int32)
+        with patch(
+            "sglang.srt.disaggregation.prefill.get_dsa_tail_state_indices",
+            return_value=expected_tail,
+        ) as get_tail:
+            SchedulerDisaggregationPrefillMixin.send_kv_chunk(
+                scheduler, req, last_chunk=True
+            )
+
+        get_tail.assert_called_once_with(pool, 5, 4)
+        state_indices = sender.send.call_args.args[1]
+        np.testing.assert_array_equal(state_indices[0], expected_tail)
+        self.assertEqual(req.start_send_idx, 4)
+        self.assertNotIn(req.rid, scheduler.disagg_prefill_pending_chunk_rids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PR #37094 moved request-slot ownership from `Req.req_pool_idx` to
`ReqKvInfo.req_pool_idx`. The GLM DSA tail state-transfer closures in prefill and
decode still read the old request-owned field.

Disaggregated decode also reserves request-table rows for in-flight transfers.
For example, `max_running_requests=32` with 64 pre-allocation rows produces 96
usable request slots plus padding row 0. The DSA tail pool was still sized from
`max_running_requests`, so a valid high request slot such as 96 could index past
the allocated 33-row tail tensor.

## Modifications

- Read the DSA tail slot from `req.kv.req_pool_idx` on both prefill and decode.
- Derive DSA tail capacity from the complete non-padding request-table domain,
  including disaggregated decode pre-allocation rows.
- Apply the same padding-row accounting to hybrid DSA KPool construction.
- Add shape assertions at the KPool tail write boundary.
- Add CPU contract tests for KV-owned slot propagation and request-table
  capacity, plus a CUDA regression that writes and compresses request slot 96.

## Relationship to the GLM-5.3 EAGLE padding fixes

This is independent of issue #37585 and PRs #37587 / #37588:

- #37587 trims MLP-sync padding at the generic hybrid/radix-linear target-verify
  boundary.
- #37588 trims padded EAGLE groups inside the GLM DSA indexer KPool.
- This PR handles PD/disaggregation state-transfer slot ownership and tail-table
  capacity. It does not change target-verify token padding and does not close
  #37585.

The changes can therefore be reviewed and merged independently on
`xinyuan/glm-5.3-flash-support`.

## Accuracy Tests

No model accuracy benchmark was run because this changes request-slot routing
and allocation rather than model numerics. Targeted contract and CUDA kernel
regressions passed.

Validation ran in Kubernetes Pod `glm53-dsa-slot-pr-649159cc` in
`dev-cluster/hank`, using image
`iaas-gpu-cn-beijing.cr.volces.com/serving/sglang@sha256:f6742cd1bf0448d83f36b9597c8c68aced9b10a4726873b7ac80e38748e89b27`
and source commit `649159cc504c6cceadf74eb6cc8223ad9a68c1c0`.

```bash
python3 -m pytest -q \
  test/registered/unit/disaggregation/test_decode_req_to_token_pool.py \
  test/registered/unit/disaggregation/test_dsa_tail_req_pool_idx.py
# 7 passed

python3 -m pytest -q \
  test/registered/kernels/test_dsa_kpool_multi_pool.py
# 4 passed
```

The Pod completed with exit code 0 and was deleted after evidence collection.

## Speed Tests and Profiling

Not applicable. This PR does not add work to the steady-state attention or DSA
kernel path; the additional checks are Python-side launch-contract assertions.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

AI assistance was used to help investigate, implement, and draft this change.
The submitter reviewed the code and validation evidence before opening the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33632978182](https://github.com/sgl-project/sglang/actions/runs/33632978182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33632978006](https://github.com/sgl-project/sglang/actions/runs/33632978006)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33632978131](https://github.com/sgl-project/sglang/actions/runs/33632978131)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->