### PR TITLE
Retry queued prefills when Mamba cache capacity may have recovered

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3711,8 +3711,16 @@ class Scheduler(
             if self.enable_hicache_storage:
                 self._retry_missed_storage_prefetches()
 
-        if self.enable_priority_preemption or self.is_hybrid_swa:
-            # Reset batch_is_full to try preemption with a prefill adder.
+        if (
+            self.enable_priority_preemption
+            or self.is_hybrid_swa
+            or (self.is_hybrid_ssm and self.tree_cache.supports_mamba())
+        ):
+            # batch_is_full is otherwise cleared only when the running batch
+            # shrinks. Preemption, SWA eviction and mamba-aware radix
+            # eviction (cached recurrent states of finished requests become
+            # evictable while the batch is unchanged) can all admit a request
+            # before that, so re-run admission every round.
             running_batch.batch_is_full = False
 
         if (

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
@@ -1,6 +1,7 @@
 """Gating of the per-round batch_is_full reset in _get_new_batch_prefill_raw:
-cleared for hybrid SWA and for hybrid SSM with a mamba-aware radix cache,
-kept for hybrid SSM without mamba cache support and for a plain cache."""
+cleared for hybrid SWA and for a hybrid SSM model with a mamba-aware cache,
+kept for a hybrid SSM model whose cache lacks mamba support and for a model
+that is neither hybrid SSM nor hybrid SWA (no preemption in any case)."""
 
 import unittest
 from types import SimpleNamespace
@@ -61,7 +62,7 @@ class TestHybridSsmAdmissionLatch(CustomTestCase):
             self._latch_after_round(_scheduler(is_hybrid_ssm=False, is_hybrid_swa=True))
         )
 
-    def test_plain_cache_keeps_latch(self):
+    def test_non_hybrid_model_keeps_latch(self):
         self.assertTrue(self._latch_after_round(_scheduler(is_hybrid_ssm=False)))
 
 

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
@@ -1,0 +1,69 @@
+"""Gating of the per-round batch_is_full reset in _get_new_batch_prefill_raw:
+cleared for hybrid SWA and for hybrid SSM with a mamba-aware radix cache,
+kept for hybrid SSM without mamba cache support and for a plain cache."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _scheduler(
+    *, is_hybrid_ssm: bool, is_hybrid_swa: bool = False, supports_mamba: bool = True
+) -> Scheduler:
+    s = Scheduler.__new__(Scheduler)
+    s.grammar_manager = MagicMock()
+    s.grammar_manager.has_waiting_grammars.return_value = False
+    s.enable_hierarchical_cache = False
+    s.enable_hicache_storage = False
+    s.enable_priority_preemption = False
+    s.is_hybrid_swa = is_hybrid_swa
+    s.is_hybrid_ssm = is_hybrid_ssm
+    s.tree_cache = SimpleNamespace(supports_mamba=lambda: supports_mamba)
+    s.waiting_queue = []
+    s.chunked_req = None
+    return s
+
+
+class TestHybridSsmAdmissionLatch(CustomTestCase):
+    def _latch_after_round(self, s):
+        running_batch = SimpleNamespace(batch_is_full=True, reqs=[])
+        with patch(
+            "sglang.srt.managers.scheduler.get_memory",
+            return_value=SimpleNamespace(enable_flexkv=False),
+        ):
+            ret, rb = Scheduler._get_new_batch_prefill_raw(
+                s, prefill_delayer_single_pass=None, running_batch=running_batch
+            )
+        self.assertIsNone(ret)
+        return rb.batch_is_full
+
+    def test_hybrid_ssm_with_mamba_radix_cache_resets_latch(self):
+        self.assertFalse(self._latch_after_round(_scheduler(is_hybrid_ssm=True)))
+
+    def test_hybrid_ssm_without_mamba_cache_keeps_latch(self):
+        self.assertTrue(
+            self._latch_after_round(
+                _scheduler(is_hybrid_ssm=True, supports_mamba=False)
+            )
+        )
+
+    def test_hybrid_swa_resets_latch(self):
+        self.assertFalse(
+            self._latch_after_round(_scheduler(is_hybrid_ssm=False, is_hybrid_swa=True))
+        )
+
+    def test_plain_cache_keeps_latch(self):
+        self.assertTrue(self._latch_after_round(_scheduler(is_hybrid_ssm=False)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py
@@ -25,6 +25,7 @@ def _scheduler(
     s.grammar_manager.has_waiting_grammars.return_value = False
     s.enable_hierarchical_cache = False
     s.enable_hicache_storage = False
+    s.enable_unified_cache_external_linker = False
     s.enable_priority_preemption = False
     s.is_hybrid_swa = is_hybrid_swa
     s.is_hybrid_ssm = is_hybrid_ssm

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
@@ -1,5 +1,7 @@
-"""A waiting request refused with NO_TOKEN is retried on the next round on a
-hybrid SSM radix cache, and stays latched out on a plain cache."""
+"""With a PrefillAdder stand-in that refuses every request with NO_TOKEN, a
+hybrid SSM model with a mamba-aware cache re-offers the waiting request each
+round; a model that is neither hybrid SSM nor hybrid SWA offers it once and
+keeps batch_is_full set."""
 
 import unittest
 from types import SimpleNamespace
@@ -116,7 +118,7 @@ class TestHybridSsmAdmissionRetry(CustomTestCase):
         calls, _ = self._rounds(_scheduler(is_hybrid_ssm=True), 3)
         self.assertEqual(calls, 3)
 
-    def test_plain_cache_latches_after_one_refusal(self):
+    def test_non_hybrid_model_latches_after_one_refusal(self):
         calls, latched = self._rounds(_scheduler(is_hybrid_ssm=False), 3)
         self.assertEqual(calls, 1)
         self.assertTrue(latched)

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
@@ -1,0 +1,126 @@
+"""A waiting request refused with NO_TOKEN is retried on the next round on a
+hybrid SSM radix cache, and stays latched out on a plain cache."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_policy import AddReqResult
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _RefusingAdder:
+    """PrefillAdder stand-in: every add_one_req is refused with NO_TOKEN."""
+
+    calls = 0
+
+    def __init__(self, *args, **kwargs):
+        self.can_run_list = []
+        self.new_chunked_req = None
+        self.rem_mamba_slots = None
+
+    def chunk_budget_exhausted(self):
+        return False
+
+    def add_chunked_req(self, req):
+        return req
+
+    def preempt_to_schedule(self, req):
+        return False
+
+    def add_one_req(self, req, **kwargs):
+        _RefusingAdder.calls += 1
+        return AddReqResult.NO_TOKEN
+
+
+def _req():
+    return SimpleNamespace(
+        rid="r1",
+        beam_group=None,
+        session=None,
+        lora_id=None,
+        init_next_round_input=MagicMock(),
+        kv=SimpleNamespace(
+            holds_mamba=False, mamba_cow_src_index=None, mamba_needs_clear=False
+        ),
+    )
+
+
+def _scheduler(*, is_hybrid_ssm: bool) -> Scheduler:
+    s = Scheduler.__new__(Scheduler)
+    s.grammar_manager = MagicMock()
+    s.grammar_manager.has_waiting_grammars.return_value = False
+    s.enable_hierarchical_cache = False
+    s.enable_hicache_storage = False
+    s.enable_priority_preemption = False
+    s.is_hybrid_swa = False
+    s.is_hybrid_ssm = is_hybrid_ssm
+    s.tree_cache = SimpleNamespace(
+        supports_mamba=lambda: True,
+        req_to_token_pool=SimpleNamespace(),
+    )
+    s.waiting_queue = [_req()]
+    s.chunked_req = None
+    s.min_free_slots_delayer = None
+    s.get_num_allocatable_reqs = lambda *args, **kwargs: 1
+    s.policy = MagicMock()
+    s.chunked_prefill_size = 4096
+    s.enable_dynamic_chunking = False
+    s.tp_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(attn_backend=SimpleNamespace())
+    )
+    s.page_size = 1
+    s.token_to_kv_pool_allocator = MagicMock()
+    s.new_token_ratio_tracker = SimpleNamespace(current=1.0)
+    s.max_prefill_tokens = 4096
+    s.is_mixed_chunk = False
+    s.priority_scheduling_preemption_threshold = 0
+    s.max_prefill_bs = 1
+    s.max_running_requests = 4
+    s.dllm_config = None
+    s.enable_lora = False
+    s.lora_drainer = None
+    s.req_to_token_pool = SimpleNamespace()
+    s.disaggregation_mode = DisaggregationMode.NULL
+    s.truncation_align_size = None
+    return s
+
+
+class TestHybridSsmAdmissionRetry(CustomTestCase):
+    def _rounds(self, s, n):
+        running_batch = SimpleNamespace(batch_is_full=False, reqs=[])
+        _RefusingAdder.calls = 0
+        with patch("sglang.srt.managers.scheduler.PrefillAdder", _RefusingAdder), patch(
+            "sglang.srt.managers.scheduler.get_memory",
+            return_value=SimpleNamespace(enable_flexkv=False),
+        ), patch(
+            "sglang.srt.managers.scheduler.get_schedule",
+            return_value=SimpleNamespace(prefill_max_requests=None),
+        ):
+            for _ in range(n):
+                ret, running_batch = Scheduler._get_new_batch_prefill_raw(
+                    s, prefill_delayer_single_pass=None, running_batch=running_batch
+                )
+                self.assertIsNone(ret)
+        return _RefusingAdder.calls, running_batch.batch_is_full
+
+    def test_hybrid_ssm_retries_admission_every_round(self):
+        calls, _ = self._rounds(_scheduler(is_hybrid_ssm=True), 3)
+        self.assertEqual(calls, 3)
+
+    def test_plain_cache_latches_after_one_refusal(self):
+        calls, latched = self._rounds(_scheduler(is_hybrid_ssm=False), 3)
+        self.assertEqual(calls, 1)
+        self.assertTrue(latched)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
@@ -62,6 +62,7 @@ def _scheduler(*, is_hybrid_ssm: bool) -> Scheduler:
     s.grammar_manager.has_waiting_grammars.return_value = False
     s.enable_hierarchical_cache = False
     s.enable_hicache_storage = False
+    s.enable_unified_cache_external_linker = False
     s.enable_priority_preemption = False
     s.is_hybrid_swa = False
     s.is_hybrid_ssm = is_hybrid_ssm

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
@@ -85,6 +85,7 @@ def _scheduler(*, is_hybrid_ssm: bool) -> Scheduler:
     s.new_token_ratio_tracker = SimpleNamespace(current=1.0)
     s.max_prefill_tokens = 4096
     s.is_mixed_chunk = False
+    s.processed_tokens_counter = 0
     s.priority_scheduling_preemption_threshold = 0
     s.max_prefill_bs = 1
     s.max_running_requests = 4

--- a/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
+++ b/test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
@@ -101,12 +101,16 @@ class TestHybridSsmAdmissionRetry(CustomTestCase):
     def _rounds(self, s, n):
         running_batch = SimpleNamespace(batch_is_full=False, reqs=[])
         _RefusingAdder.calls = 0
-        with patch("sglang.srt.managers.scheduler.PrefillAdder", _RefusingAdder), patch(
-            "sglang.srt.managers.scheduler.get_memory",
-            return_value=SimpleNamespace(enable_flexkv=False),
-        ), patch(
-            "sglang.srt.managers.scheduler.get_schedule",
-            return_value=SimpleNamespace(prefill_max_requests=None),
+        with (
+            patch("sglang.srt.managers.scheduler.PrefillAdder", _RefusingAdder),
+            patch(
+                "sglang.srt.managers.scheduler.get_memory",
+                return_value=SimpleNamespace(enable_flexkv=False),
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.get_schedule",
+                return_value=SimpleNamespace(prefill_max_requests=None),
+            ),
         ):
             for _ in range(n):
                 ret, running_batch = Scheduler._get_new_batch_prefill_raw(


### PR DESCRIPTION
## Motivation

A hybrid SSM server can leave requests queued even after Mamba-state capacity becomes available. Once admission marks the running batch as full, the scheduler does not retry while that batch remains unchanged. Cached states can become evictable during that time, so a previous capacity failure is not a valid reason to stop checking.

Author observation on GLM-5.3-Flash, TP2, request limit 4 and Mamba pool 28: a fourth distinct-prefix request stayed queued throughout the other three requests' decode. This PR retries admission for hybrid SSM models whose cache supports Mamba state. It does not bypass the capacity checks or enlarge the pool.

## Modifications

Clear the full-batch admission latch each scheduler round for that configuration, alongside the existing hybrid-SWA and priority-preemption resets. Other configurations retain their existing behavior.

## Accuracy Tests

Author CPU validation at `464c747ef3`: 6 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `7624e35482` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

The CPU tests check which model/cache combinations reset the latch. A three-round scheduler test supplies one waiting request and a fake admission helper that always returns `NO_TOKEN`: the patched hybrid-SSM case attempts admission three times; unpatched main attempts it once. The non-hybrid case remains at one attempt. This proves retry behavior, not successful allocation with a real cache.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_latch.py test/registered/unit/managers/test_scheduler_hybrid_ssm_admission_retry.py
```

## Speed Tests and Profiling

Author-reported serving probes used four distinct-prefix requests at 8k, 18k, 28k and 38k prompt lengths. The 18k case previously stayed at three active requests and reached four in two subsequent runs. The later build also contained a separate checkpoint fix, so this is not an isolated A/B.

Repeated admission checks add work when a request remains inadmissible. That overhead was not measured.

## Checklist

- [x] Format changed code and add CPU regression coverage.
- [x] Distinguish scheduler tests from integration observations.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282235107](https://github.com/sgl-project/sglang/actions/runs/34282235107)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282232687](https://github.com/sgl-project/sglang/actions/runs/34282232687)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282233357](https://github.com/sgl-project/sglang/actions/runs/34282233357)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->