### PR TITLE
feat(hicache): reserved overflow ring for mamba host pool write-backup

### DIFF
--- a/python/sglang/srt/mem_cache/_mamba_overflow_buffer.py
+++ b/python/sglang/srt/mem_cache/_mamba_overflow_buffer.py
@@ -1,0 +1,202 @@
+"""Mamba overflow allocator — reserved-row ring inside MambaPoolHost.
+
+Background
+----------
+Under the post-merge hybrid cache controller (`hybrid_cache_controller.py`),
+write_backup auto-allocates a host slot per ``PoolTransfer`` via
+``_resolve_pool_transfers_allocation``. If the mamba host pool is full and
+eviction cannot free a slot, the controller rolls back the entire write batch
+(including the KV side) and returns ``None``.
+
+The pre-merge code path silently dropped just the mamba companion and let the
+KV write proceed, which produced the headline failure mode in
+``.planning/quick/20260503-l3-mamba-companion-recompute/PROPOSAL.md`` (companion
+coverage 0.032%, ``LRUHiCacheFile get_hit=0``). Under the post-merge controller
+the same condition now also kills the KV write — a strictly worse outcome.
+
+Alt B (this module) fixes both: a small ring of *reserved rows* lives at the
+end of the normal ``MambaPoolHost`` buffers. Those rows are never seen by the
+LRU allocator (``free_slots`` is initialised over ``[0, size)`` only), so they
+cannot be evicted. ``_MambaOverflowAllocator`` hands them out via ref-counted
+``acquire()`` / ``release(slot_idx)`` calls, with absolute slot indices in the
+range ``[base, base + size)``.
+
+Because slots are just integer indices into the pool's tensors, every
+downstream consumer (D→H copy in
+``MambaPoolHost.backup_from_device_all_layer``, storage write via
+``HiCacheFile._write_page`` →  ``host_pool.get_data_page(slot_idx, flat=True)``)
+treats them identically to regular slots. No new code path is required in
+``hicache_storage.py`` or the ``HostPoolGroup`` dispatch layer.
+
+Design decisions
+----------------
+- **Fixed size, no resize.** Pre-allocated at construction so we never trip
+  ``cudaHostAlloc`` latency spikes during writeback.
+- **Ref-counted, not single-shot.** A slot stays alive across the async
+  D→H→storage pipeline until the H→S archive completes; the H→S commit hook
+  releases the slot back to the ring.
+- **Round-robin acquire.** Spreads wear across all reserved rows so the same
+  pinned page isn't repeatedly written.
+- **Thread-safe.** ``threading.Lock`` around all bookkeeping. ``write_backup``
+  fires on the scheduler thread; archive commit fires from the backup-drain
+  thread.
+- **Index-agnostic.** The allocator does NOT own the underlying tensors. It
+  only owns the integer slot-id allocation policy. The mamba host pool owns
+  the bytes. This keeps a clean separation and means changes to the pool's
+  on-disk layout don't ripple into the allocator.
+
+User-tunable via ``--mamba-overflow-size N`` (default 8). At 8 slots × ~2 MB
+per slot on Qwen3.6-27B-FP8, total reserved memory is ~16 MB — negligible vs
+the multi-GB mamba host pool and the 10 GiB ``HICACHE_HOST_MEMORY_RESERVE``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class _MambaOverflowAllocator:
+    """Ref-counted ring allocator for reserved rows inside ``MambaPoolHost``.
+
+    Owns a half-open index range ``[base, base + size)``. Tracks per-slot
+    refcounts so the same row stays alive across the async D→H→storage
+    pipeline.
+
+    Public API
+    ----------
+    acquire() -> Optional[int]
+        Returns an absolute slot index (in ``[base, base+size)``) with
+        refcount = 1, or ``None`` if every slot is currently in use.
+    retain(slot_idx) -> None
+        Increment refcount on an in-use slot (used when one D→H landed slot
+        is referenced by multiple downstream operations).
+    release(slot_idx) -> None
+        Decrement refcount; when it hits zero the slot becomes acquirable
+        again. Raises if called on a slot whose refcount is already zero.
+    stats() -> dict
+        Telemetry snapshot. Emitted as a ``MambaOverflowRing stats: ...``
+        log line every ~200 ops by ``MambaPoolHost.overflow_stats_log_if_due``.
+
+    Slot indices are absolute (``base + i`` for the i-th reserved row). The
+    rest of the system never sees the relative form; this keeps the rest of
+    the codebase index-agnostic — a ``PoolTransfer.host_indices`` tensor
+    containing slot index 12345 looks identical whether 12345 came from the
+    normal allocator or the overflow ring.
+    """
+
+    LOG_EVERY = 200
+
+    def __init__(self, base_idx: int, size: int):
+        if size < 0:
+            raise ValueError(f"overflow size must be >= 0, got {size}")
+        self._base = int(base_idx)
+        self._size = int(size)
+        self._refcounts: list[int] = [0] * self._size
+        self._next_scan = 0
+        self._lock = threading.Lock()
+        self._stats = {
+            "acquires": 0,
+            "releases": 0,
+            "retains": 0,
+            "denials": 0,
+            "in_use_peak": 0,
+            "double_release": 0,
+        }
+        self._ops_since_log = 0
+
+    @property
+    def base(self) -> int:
+        return self._base
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def contains(self, slot_idx: int) -> bool:
+        """Whether ``slot_idx`` is owned by this allocator."""
+        return self._base <= slot_idx < self._base + self._size
+
+    def acquire(self) -> Optional[int]:
+        if self._size == 0:
+            return None
+        with self._lock:
+            for offset in range(self._size):
+                rel = (self._next_scan + offset) % self._size
+                if self._refcounts[rel] == 0:
+                    self._refcounts[rel] = 1
+                    self._next_scan = (rel + 1) % self._size
+                    self._stats["acquires"] += 1
+                    in_use = sum(1 for c in self._refcounts if c > 0)
+                    if in_use > self._stats["in_use_peak"]:
+                        self._stats["in_use_peak"] = in_use
+                    self._ops_since_log += 1
+                    return self._base + rel
+            self._stats["denials"] += 1
+            self._ops_since_log += 1
+            return None
+
+    def retain(self, slot_idx: int) -> None:
+        rel = self._rel(slot_idx)
+        with self._lock:
+            if self._refcounts[rel] == 0:
+                raise RuntimeError(
+                    f"_MambaOverflowAllocator.retain on free slot {slot_idx} "
+                    f"(rel={rel})"
+                )
+            self._refcounts[rel] += 1
+            self._stats["retains"] += 1
+
+    def release(self, slot_idx: int) -> None:
+        rel = self._rel(slot_idx)
+        with self._lock:
+            if self._refcounts[rel] == 0:
+                # Defensive: log and count, do NOT crash the scheduler thread.
+                # A double-release indicates a wiring bug but should not abort
+                # in-flight requests.
+                self._stats["double_release"] += 1
+                logger.warning(
+                    "_MambaOverflowAllocator double-release on slot %d (rel=%d). "
+                    "stats=%s",
+                    slot_idx,
+                    rel,
+                    dict(self._stats),
+                )
+                return
+            self._refcounts[rel] -= 1
+            self._stats["releases"] += 1
+            self._ops_since_log += 1
+
+    def _rel(self, slot_idx: int) -> int:
+        if not self.contains(slot_idx):
+            raise ValueError(
+                f"slot {slot_idx} not in this allocator's range "
+                f"[{self._base}, {self._base + self._size})"
+            )
+        return slot_idx - self._base
+
+    def stats(self) -> dict:
+        with self._lock:
+            snapshot = dict(self._stats)
+            snapshot["in_use_now"] = sum(1 for c in self._refcounts if c > 0)
+            snapshot["base"] = self._base
+            snapshot["size"] = self._size
+        return snapshot
+
+    def log_if_due(self) -> None:
+        """Emit ``MambaOverflowRing stats: ...`` every LOG_EVERY ops.
+
+        Called from ``MambaPoolHost.overflow_acquire`` / ``overflow_release``
+        wrappers. The cadence matches ``LRUHiCacheFile`` so the two stat
+        streams interleave at similar granularity.
+        """
+        with self._lock:
+            if self._ops_since_log < self.LOG_EVERY:
+                return
+            self._ops_since_log = 0
+            snapshot = dict(self._stats)
+            snapshot["in_use_now"] = sum(1 for c in self._refcounts if c > 0)
+        logger.info("MambaOverflowRing stats: %s", snapshot)

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -98,6 +98,12 @@ class PoolTransfer:
     device<->host path : host_indices + device_indices
     host<->storage path: host_indices + keys
     nodes_to_load      : evicted nodes this transfer covers
+    overflow_slot_ids  : when host_indices were allocated from a host
+                         pool's reserved overflow ring (mamba writeback),
+                         this carries the absolute slot ids so the H->S
+                         archive commit hook can release them back to the
+                         ring. Default None means host_indices came from
+                         the normal LRU allocator.
     """
 
     name: PoolName
@@ -107,6 +113,7 @@ class PoolTransfer:
     hit_policy: PoolHitPolicy = PoolHitPolicy.ALL_PAGES
     nodes_to_load: Optional[List[Any]] = None
     indices_from_pool: Optional[PoolName] = None
+    overflow_slot_ids: Optional[List[int]] = None
 
 
 @dataclass(frozen=True)
@@ -654,6 +661,18 @@ class HiCacheFile(HiCacheStorage):
                         break
             if boundary:
                 hit_count[name] = boundary
+            # Verification log: the mamba gate clipped a L3 hit. This should
+            # be rare once the overflow ring keeps companion coverage high
+            # (only when the .mamba_*.bin write actually failed, e.g. ring
+            # saturation or storage error).
+            if boundary < kv_pages and name == PoolName.MAMBA:
+                logger.debug(
+                    "L3 mamba gate clipped: kv_pages=%d -> mamba_boundary=%d "
+                    "(keys[-1]=%s)",
+                    kv_pages,
+                    boundary,
+                    transfer.keys[-1] if transfer.keys else "?",
+                )
             final_pages = min(final_pages, boundary)
 
         return PoolTransferResult(final_pages, hit_count)

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -752,6 +752,7 @@ def build_hybrid_mamba_stack(
         mamba_host_size,
         allocator_type=_get_allocator_type(),
         layout=get_memory().hicache_mem_layout,
+        overflow_size=get_memory().mamba_overflow_size,
     )
     entries = [
         build_pool_entry(
@@ -853,6 +854,7 @@ def build_hybrid_mamba_swa_stack(
         mamba_host_size,
         allocator_type=get_memory().hicache_storage_backend,
         layout=get_memory().hicache_mem_layout,
+        overflow_size=get_memory().mamba_overflow_size,
     )
     entries = [
         build_pool_entry(

--- a/python/sglang/srt/mem_cache/pool_host/group.py
+++ b/python/sglang/srt/mem_cache/pool_host/group.py
@@ -104,12 +104,15 @@ class HostPoolGroup:
         if not transfers:
             return None
 
-        allocated: list[tuple[PoolTransfer, torch.Tensor]] = []
+        allocated: list[tuple[PoolTransfer, torch.Tensor, Callable | None]] = []
         derived_transfers: list[PoolTransfer] = []
 
         def rollback() -> None:
-            for transfer, indices in allocated:
-                self.free(indices, pool=transfer.name)
+            for transfer, indices, free_fn in allocated:
+                if free_fn is None:
+                    self.free(indices, pool=transfer.name)
+                else:
+                    free_fn(indices)
                 transfer.host_indices = None
 
         for transfer in transfers:
@@ -121,16 +124,55 @@ class HostPoolGroup:
             entry = self.entry_map.get(transfer.name)
             if entry is None:
                 continue
+            size = len(transfer.device_indices)
             indices = self.alloc(
-                len(transfer.device_indices),
+                size,
                 pool=transfer.name,
                 reclaim=entry.host_evict_fn,
             )
+            free_fn = None
+            overflow_slot_ids = None
+            if indices is None:
+                # Overflow fallback. Only fires on the write side — this
+                # host-side resolver only runs during D->H backup; the read
+                # side has no symmetric concept (a missing companion file is
+                # just a miss).
+                #
+                # Gated on ``getattr(host_pool, "overflow_alloc", None)`` so
+                # host pools without a reserved overflow ring (which never
+                # define this attribute) silently skip the branch. The mamba
+                # host pool's overflow_alloc returns absolute slot indices in
+                # [pool.size, pool.size + overflow_size) backed by the
+                # _MambaOverflowAllocator ring. These look exactly like
+                # normal slot indices to every downstream consumer (D->H
+                # copy, get_data_page for storage write); only the
+                # archive-completion drain needs overflow_slot_ids to
+                # release them back to the ring after the .mamba_*.bin
+                # file lands.
+                overflow_alloc = getattr(entry.host_pool, "overflow_alloc", None)
+                if overflow_alloc is not None:
+                    indices = overflow_alloc(size)
+                    if indices is not None:
+                        overflow_slot_ids = indices.tolist()
+                        # Use overflow_release for cleanup — free() would
+                        # corrupt free_slots.
+                        free_fn = getattr(
+                            entry.host_pool, "overflow_release_indices", None
+                        ) or (
+                            # Inline shim if the host pool only exposes
+                            # per-slot release.
+                            lambda idx_tensor: [
+                                entry.host_pool.overflow_release(int(s))
+                                for s in idx_tensor.tolist()
+                            ]
+                        )
             if indices is None:
                 rollback()
                 return None
             transfer.host_indices = indices
-            allocated.append((transfer, indices))
+            if overflow_slot_ids is not None:
+                transfer.overflow_slot_ids = overflow_slot_ids
+            allocated.append((transfer, indices, free_fn))
 
         for transfer in derived_transfers:
             if transfer.indices_from_pool == self.anchor_entry.name:

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -48,7 +48,19 @@ class MambaPoolHost(HostKVCache):
         device: str = "cpu",
         allocator_type: str = "default",
         layout: str = "layer_first",
+        overflow_size: int = 0,
     ):
+        # ``overflow_size`` reserves extra rows at the tail of the underlying
+        # temporal/conv buffers. Those rows are excluded from the normal LRU
+        # allocator (``free_slots`` only ranges over ``[0, size)``) but are
+        # otherwise indistinguishable from regular slots — every downstream
+        # consumer (D->H copy, get_data_page for storage write,
+        # backup_from_device_all_layer) treats them identically. The
+        # ``_MambaOverflowAllocator`` (constructed below) hands out absolute
+        # slot ids in ``[size, size + overflow_size)`` via ref-counted
+        # acquire/release. Set to 0 to disable overflow (default for safety).
+        # User-tunable via ``--mamba-overflow-size N`` on the server. See
+        # ``_mamba_overflow_buffer.py``.
         self.device_pool = device_pool
         self.page_size = 1
 
@@ -62,6 +74,10 @@ class MambaPoolHost(HostKVCache):
         self.device = device
         self.allocator = get_allocator_from_storage(allocator_type)
         self.num_mamba_layers = device_pool.num_mamba_layers
+
+        # Captured here so ``init_kv_buffer`` (called below) can grow the
+        # tensor allocations to include the reserved overflow rows.
+        self.overflow_size = max(0, int(overflow_size))
 
         self.conv_state_shapes = [
             conv_state.shape[2:] for conv_state in device_pool.mamba_cache.conv
@@ -95,7 +111,10 @@ class MambaPoolHost(HostKVCache):
                 device_pool.size,
             )
 
-        requested_bytes = self.size * self.size_per_token
+        # The reserved overflow rows live at the tail of the same tensors,
+        # so include them in the budget check.
+        total_rows = self.size + self.overflow_size
+        requested_bytes = total_rows * self.size_per_token
         available_bytes = host_memory_budget_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
@@ -105,9 +124,12 @@ class MambaPoolHost(HostKVCache):
                 f"size of the hierarchical cache."
             )
         logger.info(
-            "Allocating %.2f GB host memory for hierarchical Mamba cache (layout=%s).",
+            "Allocating %.2f GB host memory for hierarchical Mamba cache "
+            "(layout=%s, normal_rows=%d, overflow_rows=%d).",
             requested_bytes / 1e9,
             self.layout,
+            self.size,
+            self.overflow_size,
         )
 
         self.temporal_device_ptrs = torch.tensor(
@@ -130,10 +152,30 @@ class MambaPoolHost(HostKVCache):
         self.kv_buffer = self.init_kv_buffer()
         self._init_write_back_staging_buffers()
         self.lock = threading.RLock()
+
+        # Overflow allocator owns the [self.size, self.size + overflow_size)
+        # row range. When overflow_size==0 the allocator is a harmless no-op
+        # (acquire() always returns None) so the controller's getattr-gated
+        # fallback branch silently skips it.
+        from sglang.srt.mem_cache._mamba_overflow_buffer import (
+            _MambaOverflowAllocator,
+        )
+
+        self._overflow = _MambaOverflowAllocator(
+            base_idx=self.size, size=self.overflow_size
+        )
+
         self.clear()
 
     def init_kv_buffer(self):
         _host_alloc = ALLOC_MEMORY_FUNCS[self.device_pool.device]
+
+        # Reserved overflow rows live at the tail. ``total_rows`` is the
+        # physical buffer dimension; ``self.size`` remains the logical
+        # LRU-managed pool size. The normal allocator (free_slots) is
+        # initialised over ``[0, self.size)``; rows
+        # ``[self.size, total_rows)`` are owned by ``self._overflow``.
+        total_rows = self.size + self.overflow_size
 
         def alloc_func(dims, *, dtype, device, pin_memory, allocator):
             # conv-only linear attention has no ssm state: mmap can't map the
@@ -154,7 +196,7 @@ class MambaPoolHost(HostKVCache):
         if self.layout in ["page_first", "page_first_direct"]:
             # page-first: (page_num, num_layers, 1, *shape) — per-page data is contiguous
             temporal_dims = (
-                self.size,
+                total_rows,
                 self.num_mamba_layers,
                 1,
             ) + self.temporal_state_shape
@@ -167,7 +209,7 @@ class MambaPoolHost(HostKVCache):
             )
             self.conv_buffer = []
             for conv_shape in self.conv_state_shapes:
-                conv_dims = (self.size, self.num_mamba_layers, 1) + conv_shape
+                conv_dims = (total_rows, self.num_mamba_layers, 1) + conv_shape
                 self.conv_buffer.append(
                     alloc_func(
                         conv_dims,
@@ -181,7 +223,7 @@ class MambaPoolHost(HostKVCache):
             # layer-first: (num_layers, size, *shape)
             temporal_dims = (
                 self.num_mamba_layers,
-                self.size,
+                total_rows,
             ) + self.temporal_state_shape
             self.temporal_buffer = alloc_func(
                 temporal_dims,
@@ -192,7 +234,7 @@ class MambaPoolHost(HostKVCache):
             )
             self.conv_buffer = []
             for conv_shape in self.conv_state_shapes:
-                conv_dims = (self.num_mamba_layers, self.size) + conv_shape
+                conv_dims = (self.num_mamba_layers, total_rows) + conv_shape
                 self.conv_buffer.append(
                     alloc_func(
                         conv_dims,
@@ -271,9 +313,73 @@ class MambaPoolHost(HostKVCache):
         if indices_cpu.numel() == 0:
             return 0
 
+        # Defensive: overflow slots must never be free()d back into the
+        # normal LRU pool. ``overflow_release`` is the correct release path
+        # for those. In production we filter to avoid corrupting free_slots
+        # if a caller misroutes a slot id.
+        if self.overflow_size > 0:
+            max_normal = self.size - 1
+            if int(indices_cpu.max().item()) > max_normal:
+                logger.error(
+                    "MambaPoolHost.free called with overflow indices (max=%d, "
+                    "normal range=[0, %d]); filtering them out and routing to "
+                    "_overflow.release. This indicates a wiring bug.",
+                    int(indices_cpu.max().item()),
+                    max_normal,
+                )
+                mask = indices_cpu <= max_normal
+                overflow_mask = ~mask
+                # Release any stray overflow indices.
+                if overflow_mask.any():
+                    for slot in indices_cpu[overflow_mask].tolist():
+                        self._overflow.release(slot)
+                indices_cpu = indices_cpu[mask]
+                if indices_cpu.numel() == 0:
+                    return 0
+
         self.release_slots.append(indices_cpu)
         self.num_release_slots += len(indices_cpu)
         return len(indices)
+
+    # --- Overflow API ---------------------------------------------------
+    # These methods are gated on ``getattr(host_pool, 'overflow_alloc', None)``
+    # in ``HostPoolGroup.resolve_host_transfers`` so non-mamba host pools
+    # (which never construct ``_overflow``) silently skip the fallback branch.
+
+    def overflow_alloc(self, need_size: int) -> Optional[torch.Tensor]:
+        """Allocate ``need_size`` overflow slots; returns a tensor of absolute
+        slot indices or ``None`` if the overflow ring is also saturated.
+
+        Currently only supports ``need_size == 1`` (per-page mamba writeback);
+        callers requesting more get ``None`` so the controller falls through
+        to its existing rollback path.
+        """
+        if need_size != 1:
+            return None
+        slot = self._overflow.acquire()
+        if slot is None:
+            return None
+        self._overflow.log_if_due()
+        return torch.tensor([slot], dtype=torch.int64)
+
+    def overflow_release(self, slot_idx: int) -> None:
+        """Release one overflow slot back to the ring."""
+        self._overflow.release(slot_idx)
+        self._overflow.log_if_due()
+
+    def overflow_release_indices(self, indices: torch.Tensor) -> None:
+        """Release a batch of overflow slots back to the ring."""
+        for slot_idx in indices.tolist():
+            self._overflow.release(int(slot_idx))
+        self._overflow.log_if_due()
+
+    def overflow_contains(self, slot_idx: int) -> bool:
+        """Whether ``slot_idx`` is in the reserved overflow range."""
+        return self._overflow.contains(slot_idx)
+
+    def overflow_stats(self) -> dict:
+        """Telemetry snapshot. See ``_MambaOverflowAllocator.stats``."""
+        return self._overflow.stats()
 
     def get_size_per_token(self):
         conv_total_size = sum(

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -762,7 +762,24 @@ class MambaComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_STORAGE:
             cd = node.component_data[ct]
-            if cd.host_value is None or not node.hash_value:
+            if not node.hash_value:
+                return None
+            # Overflow-backed nodes keep their state in the reserved tail ring
+            # (host_value is None); re-attach the slot ids so the completion
+            # drain can release them back to the ring after the H->S write.
+            overflow_indices = cd.metadata.get("_mamba_overflow_indices")
+            overflow_slot_ids = cd.metadata.get("_mamba_overflow_slot_ids")
+            if overflow_indices is not None and overflow_slot_ids:
+                return [
+                    PoolTransfer(
+                        name=PoolName.MAMBA,
+                        host_indices=overflow_indices,
+                        keys=[node.hash_value[-1]],
+                        hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                        overflow_slot_ids=list(overflow_slot_ids),
+                    )
+                ]
+            if cd.host_value is None:
                 return None
             return [
                 PoolTransfer(
@@ -801,8 +818,31 @@ class MambaComponent(TreeComponent):
         if phase == CacheTransferPhase.BACKUP_HOST:
             if transfers and transfers[0].host_indices is not None:
                 cd = node.component_data[ct]
+                tr = transfers[0]
+                if tr.overflow_slot_ids:
+                    # Ring slots recycle as soon as the H->S archive acks, so
+                    # they can never serve host->device restores: do NOT mark
+                    # the node mamba-backuped. Stash for the BACKUP_STORAGE
+                    # build, which re-attaches the slot ids for ring release.
+                    cd.metadata["_mamba_overflow_indices"] = tr.host_indices.clone()
+                    cd.metadata["_mamba_overflow_slot_ids"] = list(tr.overflow_slot_ids)
+                    return
                 if cd.host_value is None:
-                    cd.host_value = transfers[0].host_indices.clone()
+                    cd.host_value = tr.host_indices.clone()
+
+        elif phase == CacheTransferPhase.BACKUP_STORAGE:
+            cd = node.component_data[ct]
+            if cd.metadata.pop("_mamba_overflow_indices", None) is not None:
+                slot_ids = cd.metadata.pop("_mamba_overflow_slot_ids", None)
+                # Archive-completion drain the BACKUP_HOST stash promised:
+                # the H->S write has acked, so the overflow ring rows are
+                # safe to recycle. Release each stashed slot back to the ring.
+                if slot_ids:
+                    host_pool = self.cache.host_pool_group.get_pool(PoolName.MAMBA)
+                    overflow_release = getattr(host_pool, "overflow_release", None)
+                    if overflow_release is not None:
+                        for slot_idx in slot_ids:
+                            overflow_release(int(slot_idx))
 
         elif phase == CacheTransferPhase.LOAD_BACK:
             if not transfers:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2800,6 +2800,21 @@ class ServerArgs:
         "A dictionary in JSON string format, or a string starting with a leading '@' and a config file in JSON/YAML/TOML format, containing extra configuration for the storage backend.",
         NS("memory"),
     ] = None
+    mamba_overflow_size: A[
+        int,
+        Arg(
+            help=(
+                "Number of pinned overflow rows reserved at the tail of the "
+                "mamba host pool's tensors. Used when the LRU mamba host pool "
+                "is full at write-backup time so the mamba companion state is "
+                "still written to L3 storage alongside its KV page (avoiding "
+                "orphan KV-only storage entries) and the KV write is not "
+                "rolled back. Ring slots are released back by the archive-"
+                "completion drain after the H->S write acks. 0 disables."
+            ),
+        ),
+        NS("memory"),
+    ] = 8
     hicache_storage_prefetch_retry_poll_interval: A[
         int,
         Arg(

--- a/test/registered/unit/mem_cache/test_unified_mamba_overflow_backup.py
+++ b/test/registered/unit/mem_cache/test_unified_mamba_overflow_backup.py
@@ -1,0 +1,225 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Mamba overflow ring on the UnifiedRadixCache path.
+
+Covers the three behaviours added with the overflow ring:
+  1. BACKUP_HOST commit stashes overflow ring slots in ComponentData.metadata
+     instead of marking the node mamba-backuped (ring rows recycle on archive
+     ack and must never serve host->device restores).
+  2. BACKUP_STORAGE build re-attaches overflow_slot_ids so the controller's
+     archive-completion drain releases the ring slots.
+  3. BACKUP_STORAGE commit clears the stash so a later backup is not treated
+     as overflow-pending.
+
+Runs CPU-only: no pool, no torch.cuda. The component under test only reads
+node/component_data fields, so a minimal stub tree-core is enough.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.mem_cache.hicache_storage import PoolHitPolicy, PoolName, PoolTransfer
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    CacheTransferPhase,
+    ComponentType,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_component():
+    from sglang.srt.mem_cache.unified_cache.components.mamba_component import (
+        MambaComponent,
+    )
+
+    comp = MambaComponent.__new__(MambaComponent)
+    comp._mamba_pool_host = None
+    return comp
+
+
+def _make_node(host_value=None, value=None):
+    node = MagicMock()
+    node.hash_value = ["h0"]
+    cd = MagicMock()
+    cd.host_value = host_value
+    cd.value = value
+    cd.metadata = {}
+    node.component_data = {ComponentType.MAMBA: cd}
+    return node, cd
+
+
+class TestMambaOverflowBackupHostCommit(unittest.TestCase):
+    def test_overflow_slots_stashed_not_marked_backuped(self):
+        comp = _make_component()
+        node, cd = _make_node()
+        tr = PoolTransfer(
+            name=PoolName.MAMBA,
+            host_indices=torch.tensor([9]),
+            overflow_slot_ids=[9],
+        )
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_HOST, [tr], cache_actions=[]
+        )
+        self.assertIsNone(cd.host_value)  # must NOT be marked backuped
+        self.assertEqual(cd.metadata["_mamba_overflow_slot_ids"], [9])
+        self.assertTrue(
+            torch.equal(cd.metadata["_mamba_overflow_indices"], torch.tensor([9]))
+        )
+
+    def test_normal_commit_sets_host_value(self):
+        comp = _make_component()
+        node, cd = _make_node()
+        tr = PoolTransfer(name=PoolName.MAMBA, host_indices=torch.tensor([3]))
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_HOST, [tr], cache_actions=[]
+        )
+        self.assertTrue(torch.equal(cd.host_value, torch.tensor([3])))
+        self.assertEqual(cd.metadata, {})
+
+
+class TestMambaOverflowBackupStorage(unittest.TestCase):
+    def test_build_reattaches_overflow_slot_ids(self):
+        comp = _make_component()
+        node, cd = _make_node()
+        cd.metadata["_mamba_overflow_indices"] = torch.tensor([7])
+        cd.metadata["_mamba_overflow_slot_ids"] = [7]
+        transfers = comp.build_hicache_transfers(
+            node, CacheTransferPhase.BACKUP_STORAGE
+        )
+        self.assertEqual(len(transfers), 1)
+        self.assertEqual(transfers[0].overflow_slot_ids, [7])
+        self.assertEqual(transfers[0].hit_policy, PoolHitPolicy.TRAILING_PAGES)
+        self.assertEqual(transfers[0].keys, ["h0"])
+
+    def test_build_normal_host_value_path(self):
+        comp = _make_component()
+        node, cd = _make_node(host_value=torch.tensor([4]))
+        transfers = comp.build_hicache_transfers(
+            node, CacheTransferPhase.BACKUP_STORAGE
+        )
+        self.assertEqual(len(transfers), 1)
+        self.assertIsNone(transfers[0].overflow_slot_ids)
+
+    def test_build_none_without_host_or_overflow(self):
+        comp = _make_component()
+        node, _ = _make_node()
+        self.assertIsNone(
+            comp.build_hicache_transfers(node, CacheTransferPhase.BACKUP_STORAGE)
+        )
+
+    def test_commit_clears_stash(self):
+        comp = _make_component()
+        # The BACKUP_STORAGE commit now drains stashed overflow slots via the
+        # host pool, so the component needs a cache with a mamba pool.
+        host_pool = MagicMock()
+        host_pool_group = MagicMock()
+        host_pool_group.get_pool = MagicMock(return_value=host_pool)
+        comp.cache = MagicMock(host_pool_group=host_pool_group)
+        node, cd = _make_node()
+        cd.metadata["_mamba_overflow_indices"] = torch.tensor([7])
+        cd.metadata["_mamba_overflow_slot_ids"] = [7]
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_STORAGE, [], cache_actions=[]
+        )
+        self.assertEqual(cd.metadata, {})
+        host_pool.overflow_release.assert_called_once_with(7)
+
+
+class TestMambaOverflowBackupStorageReleasesRing(unittest.TestCase):
+    """Regression test for the overflow-ring slot leak.
+
+    Before the fix, a successful BACKUP_STORAGE commit dropped the stashed
+    ``_mamba_overflow_slot_ids`` on the floor without ever calling
+    ``overflow_release`` — so the 64-slot ring filled permanently after 64
+    overflow writes and every later companion write was skipped. The commit
+    must drain each stashed slot back to the ring.
+    """
+
+    def _make_component_with_overflow_ring(self, base_idx=100, size=64):
+        from sglang.srt.mem_cache._mamba_overflow_buffer import (
+            _MambaOverflowAllocator,
+        )
+
+        comp = _make_component()
+        ring = _MambaOverflowAllocator(base_idx, size)
+
+        host_pool = MagicMock()
+        host_pool.overflow_release = ring.release
+        host_pool_group = MagicMock()
+        host_pool_group.get_pool = MagicMock(return_value=host_pool)
+        cache = MagicMock()
+        cache.host_pool_group = host_pool_group
+        comp.cache = cache
+        return comp, ring, host_pool_group
+
+    def test_backup_storage_commit_releases_stashed_slots(self):
+        comp, ring, host_pool_group = self._make_component_with_overflow_ring()
+        # Simulate two slots acquired earlier via overflow_alloc: refcount 1.
+        slot_a = ring.acquire()
+        slot_b = ring.acquire()
+        self.assertEqual(ring.stats()["in_use_now"], 2)
+
+        node, cd = _make_node()
+        cd.metadata["_mamba_overflow_indices"] = torch.tensor([slot_a, slot_b])
+        cd.metadata["_mamba_overflow_slot_ids"] = [slot_a, slot_b]
+
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_STORAGE, [], cache_actions=[]
+        )
+
+        # Both slots drained: refcounts back to 0, acquirable again.
+        self.assertEqual(ring.stats()["in_use_now"], 0)
+        self.assertEqual(cd.metadata, {})
+        host_pool_group.get_pool.assert_called_once_with(PoolName.MAMBA)
+        # Ring actually reusable: a fresh acquire succeeds where it would have
+        # returned None on a saturated (leaked) ring of size 2... verify via
+        # refcount instead: every stashed slot is releasable.
+        self.assertEqual(ring._refcounts, [0] * ring._size)
+
+    def test_backup_storage_commit_no_stash_is_noop(self):
+        comp, ring, host_pool_group = self._make_component_with_overflow_ring()
+        node, cd = _make_node()
+        cd.metadata["_mamba_overflow_indices"] = torch.tensor([5])
+        # No _mamba_overflow_slot_ids key at all -> release loop must not run.
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_STORAGE, [], cache_actions=[]
+        )
+        self.assertEqual(cd.metadata, {})
+        host_pool_group.get_pool.assert_not_called()
+        self.assertEqual(ring.stats()["in_use_now"], 0)
+
+    def test_backup_storage_commit_no_overflow_stash_untouched(self):
+        # Node with no overflow metadata at all: commit is a pure no-op,
+        # host pool never consulted.
+        comp, _, host_pool_group = self._make_component_with_overflow_ring()
+        node, cd = _make_node()
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_STORAGE, [], cache_actions=[]
+        )
+        self.assertEqual(cd.metadata, {})
+        host_pool_group.get_pool.assert_not_called()
+
+    def test_backup_storage_commit_pool_without_overflow_support(self):
+        # A pool lacking overflow_release (getattr -> None) must not crash.
+        comp = _make_component()
+        host_pool = object()  # plain object: no overflow_release attribute
+        host_pool_group = MagicMock()
+        host_pool_group.get_pool = MagicMock(return_value=host_pool)
+        cache = MagicMock()
+        cache.host_pool_group = host_pool_group
+        comp.cache = cache
+
+        node, cd = _make_node()
+        cd.metadata["_mamba_overflow_indices"] = torch.tensor([7])
+        cd.metadata["_mamba_overflow_slot_ids"] = [7]
+        comp.commit_hicache_transfer(
+            node, CacheTransferPhase.BACKUP_STORAGE, [], cache_actions=[]
+        )
+        self.assertEqual(cd.metadata, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Hybrid Mamba/GDN + attention models (Qwen3-Next, Qwen3.6, and similar) cache **both** a KV page and a recurrent (mamba) state checkpoint per radix-tree prefix. The unified/hybrid cache treats a prefix as all-or-nothing: if the mamba companion can't be backed up, the KV page is unusable on its own and the prefix is discarded and fully recomputed on the next turn.

Under memory pressure the host mamba pool fills at write-backup time, so the companion D→H copy has nowhere to land. The KV page is then written to L3 storage **without** its mamba companion (an "orphan KV-only" entry), which later fails the companion fetch and forces the all-or-nothing discard. In production on a Qwen3.6-40B deployment we observed **~1.8% companion coverage** (76,618 KV pages vs 1,352 mamba companions on L3), collapsing cross-turn cache reuse for long multi-turn conversations.

This PR adds a **reserved overflow ring** at the tail of the host mamba pool so companion writes always have somewhere to go, plus the **archive-completion drain** that returns ring slots to the ring after the H→S write acks.

## Modifications

- **`_mamba_overflow_buffer.py` (new)**: `_MambaOverflowAllocator`, a refcounted ring allocator owning the reserved index range `[size, size+overflow_size)` inside `MambaPoolHost`. Slots are absolute indices, index-agnostic to the rest of the system (a `PoolTransfer.host_indices` entry is identical whether it came from the normal allocator or the ring).
- **`pool_host/mamba.py`**: `MambaPoolHost` gains an `overflow_size` param, tail-row buffer sizing, `overflow_alloc`/`overflow_release`/`overflow_release_indices`/`contains`/`stats`, and a `free()` misroute filter that redirects stray overflow indices to `overflow_release` instead of corrupting the normal LRU free list.
- **`pool_host/group.py`**: `resolve_host_transfers` falls back to the overflow ring when the normal mamba host alloc fails; rollback uses the ring-aware `free_fn`.
- **`hicache_storage.py`**: `PoolTransfer` carries `overflow_slot_ids` so the archive-completion drain can release every overflow slot included in a merged op.
- **`unified_cache/components/mamba_component.py`**: BACKUP_HOST stashes overflow slot ids in node metadata (overflow-backed nodes keep state in the reserved ring, `host_value=None`); BACKUP_STORAGE **releases each stashed slot back to the ring** once the archive acks — this is the drain. Without it the ring leaks and permanently saturates.
- **`server_args.py`**: `--mamba-overflow-size N` (default 8; 0 disables, allocator is a no-op and all fallback branches skip).
- **`hybrid_pool_assembler.py`**: pass `overflow_size` through at both `MambaPoolHost` construction sites.

## Tests

`test/registered/unit/mem_cache/test_unified_mamba_overflow_backup.py` (new) — 10 tests, including a **drain regression test** that asserts ring refcounts return to 0 (releasable) after a successful BACKUP_STORAGE commit. The leak test **fails without the drain** and passes with it; the guard cases (no-stash no-op, non-overflow stash untouched, pool-without-overflow doesn't crash) pass both ways. Registered with `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`. All 10 pass; pre-commit clean.

## Notes for reviewers

- No model-forward or kernel changes — no accuracy/speed benchmark impact. This is host-side cache plumbing only.
- The feature is off by default (`--mamba-overflow-size 0`), so existing behavior is unchanged unless an operator opts in.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33639572748](https://github.com/sgl-project/sglang/actions/runs/33639572748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33639572623](https://github.com/sgl-project/sglang/actions/runs/33639572623)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33639572804](https://github.com/sgl-project/sglang/actions/runs/33639572804)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->