### PR TITLE
fix(hisparse): 4-18x SM120 planned-copy collapse at non-64B strides

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/hisparse.cuh
@@ -26,6 +26,14 @@ constexpr BallotMask FULL_WARP_MASK = 0xFFFFFFFFu;
 constexpr int32_t TOKEN_HIT = 0xFFFFFFFF;
 constexpr int32_t HASH_EMPTY = -1;
 
+// Planned copy's own item body (64B-aligned read + batched loads) exists only
+// where it was measured: CUDA sm120. This macro is the single arch gate, so no
+// function below carries an arch branch -- where it is undefined the body is not
+// compiled at all and copy_cache_planned_kernel falls through to copy_miss_item.
+#if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+#define SGLANG_HISPARSE_PLANNED_ALIGNED_BODY 1
+#endif
+
 // Knuth multiplicative hash for open-addressing table of size hash_size.
 __device__ __forceinline__ int hash_slot(int32_t key, int hash_size) {
   return ((uint32_t)key * 2654435761u) % (uint32_t)hash_size;
@@ -164,6 +172,113 @@ transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_
     asm volatile("st.global.cg.b64 [%0],%1;" ::"l"(dst8 + lane_id), "l"(tmp) : "memory");
   }
 }
+
+#ifdef SGLANG_HISPARSE_PLANNED_ALIGNED_BODY
+// Bulk of one item: kChunksInFlight 16B chunks per lane issued before any store.
+// `off` is how far the read base was rounded down to hit a 64B boundary, `skip ==
+// off/16` the leading chunks belonging to the previous item (loaded, never
+// stored), `last == skip + item_bytes/16` the exact end. No `volatile` and no
+// "memory" clobber on purpose: those block the very hoisting this shape is for.
+template <int kChunksInFlight>
+__device__ __forceinline__ void
+transfer_item_warp_unrolled(int32_t lane_id, const void* src_addr, void* dst_addr, int off, int skip, int last) {
+  const uint64_t* __restrict__ src = reinterpret_cast<const uint64_t*>(static_cast<const char*>(src_addr) - off);
+  uint64_t* __restrict__ dst = reinterpret_cast<uint64_t*>(static_cast<char*>(dst_addr) - off);
+  for (int j = lane_id; j < last; j += WARP_SIZE * kChunksInFlight) {
+    uint64_t lo[kChunksInFlight], hi[kChunksInFlight];
+#pragma unroll
+    for (int u = 0; u < kChunksInFlight; ++u) {
+      const int jj = j + u * WARP_SIZE;
+      if (jj < last) {
+        const uint64_t* s = src + jj * 2;
+        asm("ld.global.nc.v2.b64 {%0,%1},[%2];" : "=l"(lo[u]), "=l"(hi[u]) : "l"(s));
+      }
+    }
+#pragma unroll
+    for (int u = 0; u < kChunksInFlight; ++u) {
+      const int jj = j + u * WARP_SIZE;
+      if (jj >= skip && jj < last) {
+        uint64_t* d = dst + jj * 2;
+        asm("st.global.cg.v2.b64 [%0],{%1,%2};" ::"l"(d), "l"(lo[u]), "l"(hi[u]));
+      }
+    }
+  }
+}
+
+// Copy one item host->device with one warp, reading from a 64B-aligned base.
+// CALLED ONLY FROM copy_cache_planned_kernel's linear branch; not reachable from
+// copy_miss_item, which stays on transfer_item_warp bit for bit.
+//
+// Root cause of the 4-18x collapse it fixes: sysmem fill granularity is 64B and
+// coalescing happens only WITHIN one instruction, so a `v2.b64` load (32 lanes x
+// 16B = 512B = 8 sectors) lands on sector boundaries only if its base is 64B
+// aligned. item_size_bytes is a per-token stride, so at 656B (GLM-5.2 NVFP4 with
+// fp8_e4m3 KV) item starts cycle through offsets {16,32,48} and one 64B unit is
+// requested twice -- +1 sector in 8, i.e. +12% of traffic. The 12% is not the
+// cost; the second request queueing behind an in-flight fill of the same unit
+// is, and how much that costs is up to the SASS issue schedule. Measured at
+// grid=4 x 1024 on sm_120, same bytes/addresses/instruction count per row:
+//
+//                                   640B (off 0)  656B (off 16)   ratio
+//   misaligned, ptxas's own U=1        116.8us       1577.7us     13.51x
+//   misaligned, U=4 ld desc            116.9          537.5        4.60x
+//   misaligned, U=4 ld asc             116.9          192.3        1.64x
+//   ALIGNED,    U=4 ld asc             116.9          127.2        1.09x
+//
+// 640B is 117us under every schedule; 656B spans 8.2x, and load direction alone
+// is 2.8x. That is why H200 and per-request never collapsed: ptxas picked a
+// different order. Aligning the base is the fix because it removes the order
+// sensitivity (2.8x spread -> 1.02x) and lands on the wire ratio 704/656 =
+// 1.07x, which is the ceiling at that stride. Residual: 528B/544B stay ~1.35x
+// (33-34 chunks over 32 lanes = a second trip 3-6% occupied, which no unroll can
+// fill); not production strides.
+//
+// Scope is part of the fix -- two costs it would impose on other callers: the
+// rounded-down read is real wire traffic at any stride that is not a multiple of
+// 64, and U=4 holds 8 more 64-bit registers, which the fused swap-in kernel's
+// shared-memory LRU state has no measured budget for.
+//
+// Memory safety: reads stay in [src & ~63, src + item_size_bytes) -- `last` is
+// exact, so nothing past the item is touched, and rounding down stays within one
+// 64B unit so it cannot cross a page. Stores are bounded by `j >= skip`, so the
+// leading chunks have no store instruction at all. One precondition invisible
+// from the code: at src_loc == 0 with a base that is not 64B aligned the read
+// starts below host_cache's first byte -- still inside the allocation, since an
+// allocation base is at least 64B aligned. Production never reaches it (host
+// pool is layer_first, one page-aligned pinned allocation per layer); a
+// non-64B-aligned slice view as host_cache would.
+__device__ __forceinline__ void
+transfer_item_warp_planned(int32_t lane_id, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
+  const int total_pairs = item_size_bytes / 16;
+
+  // Rounding the read base down shifts the store address by the same `off`, so
+  // it stays 16B aligned only when off is a multiple of 16, i.e. when the stride
+  // is. A stride of 8 mod 16 keeps the unaligned base and only gets the unroll.
+  const int off = (item_size_bytes % 16 == 0) ? static_cast<int>(reinterpret_cast<uintptr_t>(src_addr) & 63) : 0;
+  const int skip = off / 16;
+  const int last = skip + total_pairs;
+  // Smallest unroll whose single trip covers the item: a warp covers 32*U chunks
+  // per trip, and a stride landing just past that pays a full round trip for a
+  // near-empty lane mask. A fixed U=2 cost 1088B 264 vs 199us this way; U=8 is
+  // noise at the lengths it fits and worse at the ones it does not.
+  if (last <= 2 * WARP_SIZE) {
+    transfer_item_warp_unrolled<2>(lane_id, src_addr, dst_addr, off, skip, last);
+  } else {
+    transfer_item_warp_unrolled<4>(lane_id, src_addr, dst_addr, off, skip, last);
+  }
+
+  // Tail: 64-bit for remaining 8-byte chunk (if item_size not multiple of 16)
+  const int tail_8B = (item_size_bytes - total_pairs * 16) / 8;
+  if (tail_8B > 0 && lane_id < tail_8B) {
+    const uint64_t* __restrict__ src8 =
+        reinterpret_cast<const uint64_t*>(static_cast<const char*>(src_addr) + total_pairs * 16);
+    uint64_t* __restrict__ dst8 = reinterpret_cast<uint64_t*>(static_cast<char*>(dst_addr) + total_pairs * 16);
+    uint64_t tmp;
+    asm volatile("ld.global.nc.b64 %0,[%1];" : "=l"(tmp) : "l"(src8 + lane_id) : "memory");
+    asm volatile("st.global.cg.b64 [%0],%1;" ::"l"(dst8 + lane_id), "l"(tmp) : "memory");
+  }
+}
+#endif  // SGLANG_HISPARSE_PLANNED_ALIGNED_BODY
 #endif
 
 __device__ __forceinline__ int popc_mask(BallotMask mask) {
@@ -876,15 +991,33 @@ __global__ __launch_bounds__(BLOCK_SIZE, 1) void copy_cache_planned_kernel(
       for (int m = m0; m < cnt; m += total_warps) {
         // Timing probe: the plan is still walked; only the bytes stay put.
         if constexpr (SkipIO) continue;
-        copy_miss_item<IsMLA, IsDsv4Layout>(
-            lane_id,
-            host_cache_k,
-            host_cache_v,
-            device_buffer_k,
-            device_buffer_v,
-            src_row[m],
-            static_cast<int64_t>(dst_row[m]),
-            item_size_bytes);
+        const int64_t src_loc = src_row[m];
+        const int64_t dst_loc = static_cast<int64_t>(dst_row[m]);
+#ifdef SGLANG_HISPARSE_PLANNED_ALIGNED_BODY
+        // Linear layout on sm120: this kernel owns its item body, so the
+        // 64B-aligned read lives here and nowhere else. `loc * item_size_bytes`
+        // is the layout contract copy_miss_item's generic path also spells out;
+        // DSv4's page-padded C4 addressing is not that, so it falls through.
+        if constexpr (!IsDsv4Layout) {
+          transfer_item_warp_planned(
+              lane_id,
+              static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes,
+              static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes,
+              item_size_bytes);
+          if constexpr (!IsMLA) {
+            transfer_item_warp_planned(
+                lane_id,
+                static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes,
+                static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes,
+                item_size_bytes);
+          }
+        } else
+#endif
+        {
+          // DSv4, plus every configuration with no aligned body (ROCm, pre-sm120).
+          copy_miss_item<IsMLA, IsDsv4Layout>(
+              lane_id, host_cache_k, host_cache_v, device_buffer_k, device_buffer_v, src_loc, dst_loc, item_size_bytes);
+        }
       }
       start += cnt;
     }

--- a/python/sglang/kernels/ops/kvcache/hisparse.py
+++ b/python/sglang/kernels/ops/kvcache/hisparse.py
@@ -417,6 +417,11 @@ def copy_cache_planned_mla(
 
     IO-only, no planning; the small fixed grid keeps the SM footprint low while
     overlapped on a side stream. The anchor's slot table stays valid (lockstep).
+
+    On sm120 the linear path copies each item through `transfer_item_warp_planned`
+    (64B-aligned read base, so no sector is requested twice); before that fix any
+    item length that was not a multiple of 64B cost 4-18x. See that function in
+    `jit/csrc/kvcacheio/hisparse.cuh`.
     """
     assert miss_src.dtype == torch.int64 and miss_dst.dtype == torch.int32
     assert miss_count.dtype == torch.int32

--- a/test/registered/kernels/ops/kvcache/test_hisparse_planned_copy.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse_planned_copy.py
@@ -1,0 +1,145 @@
+"""Guards for the planned-copy replay (`copy_cache_planned_mla`).
+
+Replay is the prefetch feature's only writer into the device buffer, and it is
+driven entirely by device-side plan tensors: a fixed grid of one-warp workers
+walks every plan row and round-robins that row's items across all workers, so
+correctness rests on three things no other registered test exercises -- the
+rotation stays a bijection onto the worker set (drop it and items vanish
+silently), `num_real_reqs` bounds the walk on the device (ignore it and a reused
+plan buffer replays the previous batch's rows), and `skip_io` walks the plan
+without writing (the timing probe must not corrupt the buffer).
+
+Item lengths are part of the contract too: on sm120 the linear path copies
+through `transfer_item_warp_planned`, which rounds the read base down to 64B and
+predicates the leading stores, so a length that is not a multiple of 64 reads
+bytes belonging to the neighbouring item. Those bytes must never reach the
+destination -- 656B and 1152B below are exactly the lengths that exercise it.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.kvcache.hisparse import copy_cache_planned_mla
+from sglang.srt.utils import is_cuda, is_npu, is_xpu
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=2, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or is_npu() or is_xpu() or not is_cuda(),
+    reason="The planned-copy kernel needs a CUDA device.",
+)
+
+DEVICE = "cuda"
+NUM_REQS = 6
+PLAN_STRIDE = 8  # top_k
+HOST_ROWS = 64
+DEV_SLOTS = NUM_REQS * PLAN_STRIDE
+NUM_BLOCKS = 2
+BLOCK_SIZE = 256
+
+
+def _buffers(item_bytes: int):
+    """Distinct byte pattern per host row, so a mis-addressed copy shows up."""
+    host = torch.empty(HOST_ROWS * item_bytes, dtype=torch.uint8, pin_memory=True)
+    host.copy_(
+        (torch.arange(HOST_ROWS * item_bytes, dtype=torch.int64) * 37 % 251).to(
+            torch.uint8
+        )
+    )
+    return host.view(HOST_ROWS, item_bytes), torch.zeros(
+        DEV_SLOTS, item_bytes, dtype=torch.uint8, device=DEVICE
+    )
+
+
+def _plan(counts: list[int], num_real: int):
+    """Plan rows with unique src rows and unique dst slots per entry."""
+    g = torch.arange(NUM_REQS * PLAN_STRIDE, dtype=torch.int64)
+    src = (g % HOST_ROWS).view(NUM_REQS, PLAN_STRIDE).to(DEVICE)
+    dst = g.view(NUM_REQS, PLAN_STRIDE).to(torch.int32).to(DEVICE)
+    cnt = torch.tensor(counts, dtype=torch.int32, device=DEVICE)
+    real = torch.tensor([num_real], dtype=torch.int32, device=DEVICE)
+    return src, dst, cnt, real
+
+
+def _expected(host, src, dst, counts: list[int], num_real: int, item_bytes: int):
+    out = torch.zeros(DEV_SLOTS, item_bytes, dtype=torch.uint8)
+    for r in range(num_real):
+        for m in range(counts[r]):
+            out[int(dst[r, m])] = host[int(src[r, m])]
+    return out
+
+
+def _replay(host, dev, src, dst, cnt, real, item_bytes, skip_io=False):
+    copy_cache_planned_mla(
+        miss_src=src,
+        miss_dst=dst,
+        miss_count=cnt,
+        num_real_reqs=real,
+        host_cache=host,
+        device_buffer=dev,
+        item_size_bytes=item_bytes,
+        num_blocks=NUM_BLOCKS,
+        block_size=BLOCK_SIZE,
+        skip_io=skip_io,
+    )
+    torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize("item_bytes", [8, 512, 656, 1152])
+def test_replay_is_byte_exact_for_ragged_rows(item_bytes: int) -> None:
+    """Every live plan entry lands byte-exactly, and nothing else is touched.
+
+    656B is the length whose 64B-aligned read reaches into the neighbouring
+    item (GLM-5.2 NVFP4 with fp8_e4m3 KV); 1152B is a multiple of 64 that needs
+    more than one unrolled trip; 8B is a single tail chunk with no 16B body.
+    """
+    counts = [3, 0, PLAN_STRIDE, 1, 5, 2]
+    host, dev = _buffers(item_bytes)
+    src, dst, cnt, real = _plan(counts, NUM_REQS)
+
+    _replay(host, dev, src, dst, cnt, real, item_bytes)
+
+    assert torch.equal(
+        dev.cpu(), _expected(host, src.cpu(), dst.cpu(), counts, NUM_REQS, item_bytes)
+    )
+
+
+def test_partial_batch_ignores_rows_beyond_num_real_reqs() -> None:
+    """`num_real_reqs` is a device-side bound; padded rows keep stale counts.
+
+    The coordinator reuses one plan buffer across batch sizes and only refills
+    the live prefix, so a replay that walked all rows would copy last batch's
+    items into this batch's slots.
+    """
+    item_bytes = 656
+    counts = [4, 2, 7, 3, 1, 5]
+    num_real = 3
+    host, dev = _buffers(item_bytes)
+    src, dst, cnt, real = _plan(counts, num_real)
+
+    _replay(host, dev, src, dst, cnt, real, item_bytes)
+
+    assert torch.equal(
+        dev.cpu(), _expected(host, src.cpu(), dst.cpu(), counts, num_real, item_bytes)
+    )
+    # The dst slots owned by the padded rows must still be zero.
+    assert not dev[num_real * PLAN_STRIDE :].any()
+
+
+def test_skip_io_moves_no_bytes() -> None:
+    """The timing probe walks the whole plan but must not write the buffer."""
+    item_bytes = 656
+    counts = [PLAN_STRIDE] * NUM_REQS
+    host, dev = _buffers(item_bytes)
+    src, dst, cnt, real = _plan(counts, NUM_REQS)
+
+    _replay(host, dev, src, dst, cnt, real, item_bytes, skip_io=True)
+
+    assert not dev.any()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

On sm120 the HiSparse planned-copy replay (`copy_cache_planned_mla`, the host→device KV
swap-in that skip layers run on a side stream) collapses **4-18x whenever the KV item size
is not a multiple of 64B**. A 512-1600B sweep in 16B steps puts every non-64B-multiple
length in that band, while every multiple of 64 is fine — so this is a length-predicated
cliff, not a gradual slowdown.

It is reachable in a real configuration today: **GLM-5.2 NVFP4 with
`--kv-cache-dtype fp8_e4m3` gives 656B items, which cost 12.1x** (1578us vs 117us for the
neighbouring 640B, same grid, same item count). DeepSeek MLA's 576B/1152B are multiples of
64 and were never affected, which is why this went unnoticed.

### Root cause

Sysmem fill granularity is 64B, and coalescing happens only *within* one instruction. One
`ld.global.nc.v2.b64` moves 32 lanes x 16B = 512B = exactly 8 sectors, so its request
boundaries land on sector boundaries **iff its base address is 64B-aligned**. Item starts
walk `(src_loc * item_size_bytes) % 64`; at 656B that offset cycles {16, 32, 48}, so one 64B
unit gets requested by two different instructions. The second request "hits" an in-flight
sysmem fill, occupies a fill/merge slot and queues behind it.

The duplicate itself is only +1 sector in 8 = **+12% traffic, which cannot arithmetically
produce 12x** — what turns 12% into 1250% is the issue order ptxas happened to pick, so the
fix is to align the read base and make the order stop mattering. Measured with bytes,
addresses, instruction counts and predicates all pinned identical, 640B is 117us under every
issue order while 656B spans 8.2x across the same orders (load direction alone is 2.8x);
after aligning, that spread collapses to 1.02x:

| item size | before | after |
|---|---|---|
| 640B (64-multiple) | 116.8us | 116.9us |
| **656B** | **1577.7us** | **127.2us (12.4x faster)** |

127.2us is the physical ceiling, not just an improvement: an item at this stride spans 11
sectors, so it must ship 704B for 656B of payload, and 704/656 = 1.07x is exactly where the
aligned body lands relative to 640B.

## Modifications

`copy_cache_planned_kernel` now owns its own item body for the linear layout, instead of
sharing one with the fused swap-in kernel:

- **`transfer_item_warp_planned`** rounds the read base down to a 64B boundary
  (`off = src & 63`), shifts the store base by the same `off`, skips the store for the
  leading `off/16` chunks (they belong to the previous item — loaded into registers, never
  written), and bounds the loads at exactly `skip + item_bytes/16` so there is no over-read
  and no tail padding. Gated on `item_size_bytes % 16 == 0`, because a non-multiple-of-16
  `off` would leave the shifted store address unaligned — that gate is correctness, not
  tuning.
- **`transfer_item_warp_unrolled<kChunksInFlight>`** issues `kChunksInFlight` 16B chunks per
  lane before any store. `kChunksInFlight` is chosen per item as the smallest unroll whose
  single trip covers it (`last <= 2*WARP_SIZE ? 2 : 4`): a warp covers `32*U` chunks per
  trip, and a stride landing just past that pays a full PCIe round trip for a nearly empty
  lane mask. A fixed U=2 pinned the whole 1040-1216B band at a flat ~260us and made three
  lengths that *are* multiples of 64 slower than before (1088B 0.74x); per-item U fixes it
  (1088B 264 → 199us). U=8 buys nothing.

Scope is deliberately narrow, and the narrowing is what the extra body is for:

- **One file-level macro** (`SGLANG_HISPARSE_PLANNED_ALIGNED_BODY`, defined only for
  `!USE_ROCM && __CUDA_ARCH__ >= 1200`) is the single arch gate. Both new functions exist
  only under it; no function carries an arch branch. With the macro off the call site
  reduces to an unconditional `copy_miss_item`, so ROCm and pre-sm120 compile and behave
  exactly as before.
- **`copy_miss_item` is byte-identical to before** (verified by extract + diff). It serves
  two callers, so a template flag on it would have left the shared helper carrying
  caller-specific behaviour; the caller-specific code lives in the caller instead.
- **DSv4 falls through to the shared path** via `if constexpr (!IsDsv4Layout)`. Its
  page-padded C4 layout is structurally immune anyway (`kValueBytes = 576 = 9x64`,
  `kPageBytes = 585x64`, `kScaleOffset = 576x64`), so there is nothing to fix and its
  addressing is not `loc * item_size_bytes`.

Three costs justify keeping this out of the shared body: neighbouring-item wire traffic at
non-64-multiple strides, reading bytes outside the logical tensor rows, and 8 extra 64-bit
registers that the fused kernel's shared-memory LRU state has no measured budget for.

Also adds `test/registered/kernels/ops/kvcache/test_hisparse_planned_copy.py` — the replay
entry point had no registered coverage at all.

## Accuracy Tests

Byte-exactness is the correctness criterion for a copy kernel, and it is checked three ways:

- **New registered test** (3 cases, 6 parametrizations, all pass): byte-exact replay for
  ragged rows at item sizes 8/512/656/1152 (656B exercises `off != 0`, i.e. the new path);
  rows beyond `num_real_reqs` are left untouched; `skip_io` moves no bytes.
- **Poison probe**, 12 configurations: everything outside the logical rows filled with
  `0xAB`, host base shifted to 16 and 48 mod 64 so row 0 also gets `off != 0` — byte-exact
  destination, **zero poison bytes copied**, untouched slots still zero.
- **`compute-sanitizer --tool memcheck`** on the shifted-base case: **0 errors**. The read
  floor is `src & ~63`; rounding down moves within one 64B unit, and any allocation base is
  at least 64B-aligned, so the rounded base never precedes the allocation. The upper bound
  is exact.
- All four JIT instantiations compile (MLA/DSv4 x skip_io), including for **sm_90** with the
  macro off, so the fallback path is covered too.

## Speed Tests and Profiling

sm120 (RTX PRO 6000, PCIe ~47 GiB/s), pinned host KV, production replay geometry
`num_blocks=4, block_size=1024`, bs=54 x 170 items, every item byte-verified against the
host source through the real JIT path:

| item size | before | after | payload BW after |
|---|---|---|---|
| 640B (64-mult) | 116.9us | 117.5us | 46.6 GiB/s |
| **656B** (GLM-5.2 NVFP4 fp8_e4m3) | **1577.7us** | **129.7us** | 43.2 GiB/s |
| 672B | ~1350 | 129.9 | 44.2 GiB/s |
| 704B (64-mult) | 129.5 | 131.9 | 45.6 GiB/s |
| 1024B (64-mult) | 186.9 | 186.9 | 46.9 GiB/s |
| 1088B (64-mult) | 200.3 | 200.8 | 46.3 GiB/s |
| 1152B (64-mult) | 209.8 | 209.6 | 47.0 GiB/s |
| 1216B (64-mult) | 223.9 | 224.0 | 46.4 GiB/s |

At any 64B-multiple stride `off == 0`, so the aligned path is bit-identical to the old one
and pays nothing — the multiples of 64 above are unchanged within noise. Across the full
512-1600B sweep every multiple of 64 now runs at 46-48 GiB/s of payload and every other
length at 44-46. **Residual, accepted:** 528B and 544B remain ~1.35x off (33-34 chunks over
32 lanes leaves a second trip 3-6% occupied, which no choice of U can fill) — still ~13x
better than before, and not production strides.

End-to-end, GLM-5.2 NVFP4 + `fp8_e4m3` KV (656B items), PD-disaggregated decode, 32k input /
1k output, single shared-prefix group through the router, clean containers differing only by
`SGLANG_DISABLE_HISPARSE_PREFETCH`. Output token throughput, tok/s:

| bs | prefetch off | prefetch on, before | prefetch on, after | after vs off | after vs before |
|---|---|---|---|---|---|
| 4 | 135.1 | 103.5 (-23.4%) | **146.8** | **+8.7%** | **+41.9%** |
| 8 | 234.0 | 151.0 (-35.5%) | **255.4** | **+9.2%** | **+69.2%** |
| 16 | 341.6 | 188.1 (-44.9%) | **355.6** | **+4.1%** | **+89.0%** |
| 32 | 457.7 | 218.4 (-52.3%) | **502.8** | **+9.8%** | **+130.2%** |
| 54 | 573.7 | 223.4 (-61.1%) | **606.5** | **+5.7%** | **+171.6%** |

The middle column is the point of this PR: **before the fix, enabling prefetch cost 23-61%
of decode throughput instead of gaining any**, and the penalty grew with batch size because
more concurrent warps amplify the queueing behind the duplicated fill. The feature was
effectively unusable at this KV item size. After the fix it delivers +4.1-9.8%, i.e.
prefetch-on is finally the faster configuration at every batch size, and the regression
against prefetch-off is gone.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33740892670](https://github.com/sgl-project/sglang/actions/runs/33740892670)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33740892847](https://github.com/sgl-project/sglang/actions/runs/33740892847)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33740892863](https://github.com/sgl-project/sglang/actions/runs/33740892863)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->