### PR TITLE
Prevent scheduler crashes when Mamba checkpoint slots run out

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
@@ -54,6 +56,9 @@ if TYPE_CHECKING:
         UnifiedRadixCache,
         UnifiedTreeNode,
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 class MambaComponent(TreeComponent):
@@ -492,12 +497,35 @@ class MambaComponent(TreeComponent):
 
     def _alloc_mamba_slot(self) -> torch.Tensor:
         """Allocate one mamba pool slot, evicting if necessary."""
+        slot = self._try_alloc_mamba_slot()
+        assert slot is not None, "Can not alloc mamba cache"
+        return slot
+
+    def _try_alloc_mamba_slot(self) -> Optional[torch.Tensor]:
+        """Allocate one mamba pool slot, evicting if necessary; None when the
+        pool has no free or evictable slot."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
             self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
-            assert slot is not None, "Can not alloc mamba cache"
         return slot
+
+    _last_skip_log_time = 0.0
+
+    def _log_skipped_checkpoint(self, req: Req) -> None:
+        now = time.monotonic()
+        if now - MambaComponent._last_skip_log_time < 1.0:
+            return
+        MambaComponent._last_skip_log_time = now
+        allocator = self.cache.req_to_token_pool.mamba_allocator
+        logger.info(
+            "mamba checkpoint skipped for rid=%s: no free or evictable slot "
+            "(available=%d evictable=%d of %d)",
+            req.rid,
+            allocator.available_size(),
+            self.tree_core.mamba_evictable_size(),
+            getattr(allocator, "size", -1),
+        )
 
     @property
     def int8_ckpt_pool(self):
@@ -572,9 +600,17 @@ class MambaComponent(TreeComponent):
             if cache_len is None:
                 return 0
             # Donate the mamba index to the radix cache instead of copying.
+            # An unfinished request's checkpoint is an optimization: when the
+            # pool has no free or evictable slot (every slot is held by running
+            # requests or locked for a pending host backup), skip this stash
+            # instead of failing; the request keeps its own state and the next
+            # stash retries.
             if self.int8_ckpt_pool is not None:
                 if self.cache.enable_mamba_extra_buffer:
-                    new_slot = self._alloc_mamba_slot()
+                    new_slot = self._try_alloc_mamba_slot()
+                    if new_slot is None:
+                        self._log_skipped_checkpoint(req)
+                        return 0
                     src_active = (
                         self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                             req, new_slot
@@ -587,14 +623,20 @@ class MambaComponent(TreeComponent):
                         req.kv.mamba_pool_idx.view(-1)
                     )
             elif self.cache.enable_mamba_extra_buffer:
-                new_slot = self._alloc_mamba_slot()
+                new_slot = self._try_alloc_mamba_slot()
+                if new_slot is None:
+                    self._log_skipped_checkpoint(req)
+                    return 0
                 mamba_value_donated = (
                     self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                         req, new_slot
                     )
                 )
             else:
-                mamba_value_donated = self._alloc_mamba_slot()
+                mamba_value_donated = self._try_alloc_mamba_slot()
+                if mamba_value_donated is None:
+                    self._log_skipped_checkpoint(req)
+                    return 0
                 # mamba_pool is a pure PHYSICAL store; translate both slot ids
                 # virtual->physical (identity for the non-unified memory pool) first.
                 translate = self.cache.req_to_token_pool.translate_mamba_indices

--- a/test/registered/unit/mem_cache/test_mamba_component_pool_exhaustion.py
+++ b/test/registered/unit/mem_cache/test_mamba_component_pool_exhaustion.py
@@ -1,0 +1,75 @@
+"""An exhausted unified mamba pool skips the unfinished-request checkpoint
+instead of asserting; with a free slot the request's checkpoint slot is
+donated and the free slot replaces it, as before."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams
+from sglang.srt.mem_cache.unified_cache.components.mamba_component import (
+    MambaComponent,
+)
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _component(*, slot):
+    comp = object.__new__(MambaComponent)
+    allocator = MagicMock()
+    allocator.alloc.return_value = slot
+    allocator.available_size.return_value = 0
+    allocator.size = 28
+    pool = SimpleNamespace(
+        mamba_allocator=allocator,
+        mamba_ckpt_pool=None,
+        donate_mamba_ping_pong_slot=MagicMock(return_value=torch.tensor([3])),
+    )
+    comp.cache = SimpleNamespace(
+        req_to_token_pool=pool,
+        enable_mamba_extra_buffer=True,
+        evict_for_alloc=MagicMock(),
+    )
+    comp.tree_core = SimpleNamespace(mamba_evictable_size=lambda: 0)
+    return comp, allocator
+
+
+def _req():
+    return SimpleNamespace(
+        rid="r1",
+        kv=SimpleNamespace(mamba_last_track_seqlen=4096, mamba_pool_idx=None),
+    )
+
+
+class TestMambaPoolExhaustion(CustomTestCase):
+    def test_unfinished_checkpoint_skipped_when_pool_exhausted(self):
+        comp, allocator = _component(slot=None)
+        params = InsertParams(prev_prefix_len=0, chunked=True, priority=0)
+        cache_len = comp.prepare_for_caching_req(
+            req=_req(), insert_params=params, token_ids_len=4096, is_finished=False
+        )
+        self.assertEqual(cache_len, 0)
+        self.assertIsNone(params.mamba_value)
+        comp.cache.evict_for_alloc.assert_called_once()
+        self.assertEqual(allocator.alloc.call_count, 2)
+
+    def test_unfinished_checkpoint_donated_when_replacement_slot_available(self):
+        comp, allocator = _component(slot=torch.tensor([7]))
+        params = InsertParams(prev_prefix_len=0, chunked=True, priority=0)
+        cache_len = comp.prepare_for_caching_req(
+            req=_req(), insert_params=params, token_ids_len=4096, is_finished=False
+        )
+        self.assertEqual(cache_len, 4096)
+        self.assertTrue(torch.equal(params.mamba_value, torch.tensor([3])))
+        comp.cache.evict_for_alloc.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Concurrent long prompts can crash the scheduler when an optional intermediate Mamba-state checkpoint needs a replacement slot and the unified cache has no free or evictable slot. The failure is `AssertionError: Can not alloc mamba cache`, rather than a request waiting for capacity.

This PR skips that unfinished-request checkpoint when the pool is exhausted. The request keeps its KV indices and continues without inserting a new checkpoint; successful checkpoint allocation behaves as before.

## Modifications

- Use a non-asserting allocation attempt for unfinished-request checkpoints and return through the existing zero-length cache-insertion path if eviction cannot supply a slot.
- Log the skipped checkpoint at most once per second, including free, evictable and total slots.
- Keep the asserting allocation contract for other callers. The legacy Mamba cache is unchanged.

## Accuracy Tests

Author CPU validation at `0f68190978`: 2 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `a17aa1b0bd` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

The CPU regression forces allocation to fail after eviction and checks that the method returns zero without donating or copying the request's state. A second case supplies a replacement slot and checks the original donation behavior. The exhausted case raises on the unpatched main branch.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/mem_cache/test_mamba_component_pool_exhaustion.py
```

Author-reported hardware reproduction: GLM-5.3-Flash, TP2, unified radix cache with a HiCache Mamba tier, `--max-mamba-cache-size 28`. Four concurrent cold 95k-token prompts asserted before the change and completed afterward, with `available=0 evictable=0 of 28` in the skip log. Hardware logs are not attached to this PR.

## Speed Tests and Profiling

No isolated speed benchmark. Successful allocations add a `None` check; the fallback applies only when allocation remains exhausted.

## Checklist

- [x] Format changed code and add CPU regression coverage.
- [x] Describe the hardware reproduction and evidence limitation.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282231673](https://github.com/sgl-project/sglang/actions/runs/34282231673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282231491](https://github.com/sgl-project/sglang/actions/runs/34282231491)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282231749](https://github.com/sgl-project/sglang/actions/runs/34282231749)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->