### PR TITLE
fix(tokenizer): keep generic TokenizersBackend when re-resolve fails (GLM-5.3)

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -546,9 +546,22 @@ def get_tokenizer(
                 type(tokenizer).__name__ == _TOKENIZERS_BACKEND
                 and tokenizer_backend != "fastokens"
             ):
-                tokenizer = _resolve_tokenizers_backend(
-                    tokenizer_name, *args, **common_kwargs
-                )
+                try:
+                    tokenizer = _resolve_tokenizers_backend(
+                        tokenizer_name, *args, **common_kwargs
+                    )
+                except Exception as e:
+                    # Some checkpoints (e.g. GLM-5.3) declare
+                    # tokenizer_class=TokenizersBackend with no auto_map, so the
+                    # slow-class retry inside _resolve_tokenizers_backend cannot
+                    # find a concrete class and raises. The generic fast
+                    # TokenizersBackend instance is fully functional (vocab +
+                    # added tokens); keep it as-is instead of failing to load
+                    # the tokenizer entirely.
+                    logger.warning(
+                        "TokenizersBackend re-resolve failed (%s); "
+                        "keeping the generic fast TokenizersBackend", e
+                    )
 
         return _apply_post_load_fixes(tokenizer, tokenizer_name, tokenizer_revision)
     except Exception as e:


### PR DESCRIPTION
## 问题

transformers v5 对无 tokenizer mapping 的 model_type 回退到通用 `TokenizersBackend` 类。GLM-5.3（zai-org/GLM-5.3）的 tokenizer_config.json 声明 `"tokenizer_class": "TokenizersBackend"` 且没有 auto_map。`_resolve_tokenizers_backend` 的 `use_fast=False` 重试找不到具体 slow tokenizer 类并抛 ValueError，导致 checkpoint 完全无法服务：

```
ValueError: Couldn't instantiate the backend tokenizer from one of:
(1) a tokenizers library serialization file,
(2) a slow tokenizer instance to convert or
(3) an equivalent slow tokenizer class to instantiate and convert.
You need to have sentencepiece or tiktoken installed to convert a slow
tokenizer to a fast one.
```

（sentencepiece/tiktoken 已安装；真实原因是 tokenizer_config 未声明具体类且无 auto_map。）

## 修复

re-resolve 失败时保留通用 fast `TokenizersBackend` 实例（vocab + added_tokens 完整可用）并打 warning，而不是让 tokenizer 加载整体失败。

## 验证（2026-09-02，B300 8×TP 生产）

- 修复前：GLM-5.3 FP8 checkpoint 启动即报上述 ValueError
- 修复后：tokenizer 正常加载（154856 vocab）、chat/completions 端到端 200、reasoning parser（glm45）正常工作

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33649831594](https://github.com/sgl-project/sglang/actions/runs/33649831594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33649831153](https://github.com/sgl-project/sglang/actions/runs/33649831153)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33649831270](https://github.com/sgl-project/sglang/actions/runs/33649831270)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->