### PR TITLE
[unified-memory] Speculative decoding on the unified memory pool: translate every read and write path

### DIFF
--- a/python/sglang/kernels/jit/csrc/attention/fused_fp8_qkv_kv_cache.cuh
+++ b/python/sglang/kernels/jit/csrc/attention/fused_fp8_qkv_kv_cache.cuh
@@ -24,6 +24,8 @@ struct FusedQkvParams {
   int64_t q_stride;
   int64_t k_stride;
   int64_t v_stride;
+  int64_t k_cache_stride;  // elements between consecutive cache slots
+  int64_t v_cache_stride;
   uint32_t num_tokens;
   uint32_t q_dim;
   uint32_t kv_dim;
@@ -76,12 +78,12 @@ __global__ void fused_fp8_qkv_kv_cache_kernel(const __grid_constant__ FusedQkvPa
   }
   quant_row<T, kVecN>(
       static_cast<const T*>(params.k) + static_cast<size_t>(token) * params.k_stride,
-      static_cast<fp8_e4m3_t*>(params.k_cache) + static_cast<size_t>(slot) * params.kv_dim,
+      static_cast<fp8_e4m3_t*>(params.k_cache) + static_cast<size_t>(slot) * params.k_cache_stride,
       params.kv_dim,
       inv_k);
   quant_row<T, kVecN>(
       static_cast<const T*>(params.v) + static_cast<size_t>(token) * params.v_stride,
-      static_cast<fp8_e4m3_t*>(params.v_cache) + static_cast<size_t>(slot) * params.kv_dim,
+      static_cast<fp8_e4m3_t*>(params.v_cache) + static_cast<size_t>(slot) * params.v_cache_stride,
       params.kv_dim,
       inv_v);
 
@@ -133,7 +135,10 @@ struct FusedFp8QkvKvCache {
 
     TensorMatcher({N, Dkv}).with_strides({SK, 1}).with_dtype<T>().with_device(device).verify(k);
     TensorMatcher({N, Dkv}).with_strides({SV, 1}).with_dtype<T>().with_device(device).verify(v);
-    TensorMatcher({S, Dkv}).with_dtype<fp8_e4m3_t>().with_device(device).verify(k_cache).verify(v_cache);
+    auto SKC = SymbolicSize{"k_cache_stride"};
+    auto SVC = SymbolicSize{"v_cache_stride"};
+    TensorMatcher({S, Dkv}).with_strides({SKC, 1}).with_dtype<fp8_e4m3_t>().with_device(device).verify(k_cache);
+    TensorMatcher({S, Dkv}).with_strides({SVC, 1}).with_dtype<fp8_e4m3_t>().with_device(device).verify(v_cache);
     TensorMatcher({N}).with_dtype<int32_t, int64_t>(idx_dtype).with_device(device).verify(cache_loc);
     TensorMatcher({1}).with_dtype<fp32_t>().with_device(device).verify(k_scale).verify(v_scale);
 
@@ -156,12 +161,16 @@ struct FusedFp8QkvKvCache {
     const uint32_t kv_dim = static_cast<uint32_t>(Dkv.unwrap());
     const int64_t k_stride = SK.unwrap();
     const int64_t v_stride = SV.unwrap();
+    const int64_t k_cache_stride = SKC.unwrap();
+    const int64_t v_cache_stride = SVC.unwrap();
     RuntimeCheck(num_tokens > 0, "fused_fp8_qkv_kv_cache: num_tokens must be > 0, got ", num_tokens);
 
     auto fits = [&](int vec) {
       const int in_bytes = vec * static_cast<int>(sizeof(T));
       bool ok = kv_dim % vec == 0 && k_stride % vec == 0 && v_stride % vec == 0 && aligned(k.data_ptr(), in_bytes) &&
                 aligned(v.data_ptr(), in_bytes);
+      ok = ok && k_cache_stride % vec == 0 && v_cache_stride % vec == 0 && aligned(k_cache.data_ptr(), vec) &&
+           aligned(v_cache.data_ptr(), vec);
       if (quantize_q) {
         ok = ok && q_dim % vec == 0 && q_stride % vec == 0 && aligned(q_ptr, in_bytes);
       }
@@ -182,6 +191,8 @@ struct FusedFp8QkvKvCache {
         .q_stride = q_stride,
         .k_stride = k_stride,
         .v_stride = v_stride,
+        .k_cache_stride = k_cache_stride,
+        .v_cache_stride = v_cache_stride,
         .num_tokens = num_tokens,
         .q_dim = q_dim,
         .kv_dim = kv_dim,

--- a/python/sglang/kernels/jit/csrc/kv_canary/canary_common.cuh
+++ b/python/sglang/kernels/jit/csrc/kv_canary/canary_common.cuh
@@ -12,7 +12,7 @@ namespace canary {
 // Device-side handle for one real-KV source.
 struct RealKvSourceHandle {
   const uint8_t* tensor;     // raw uint8 byte pointer to the source tensor
-  int32_t row_stride_bytes;  // tensor.shape[1] in bytes (may exceed page_size * num_bytes_per_token)
+  int32_t row_stride_bytes;  // tensor.stride(0) in bytes (may exceed page_size * num_bytes_per_token)
   int32_t page_size;
   int32_t num_bytes_per_token;
   int32_t read_bytes;
@@ -37,8 +37,8 @@ SGL_DEVICE uint64_t splitmix64_mix3(uint64_t a, uint64_t b, uint64_t c) {
 //     tensor[slot_idx // page_size,
 //            (slot_idx % page_size) * num_bytes_per_token + byte_offset]
 //
-// row_stride_bytes is the dim-1 size of the underlying tensor in bytes (which may exceed
-// page_size * num_bytes_per_token; trailing bytes are skipped).
+// row_stride_bytes is the dim-0 stride of the underlying tensor in bytes (which may exceed
+// page_size * num_bytes_per_token; the remaining bytes are skipped).
 SGL_DEVICE void real_kv_load_uint4(
     const RealKvSourceHandle& src, int64_t slot_idx, int64_t byte_offset, uint64_t& word_lo, uint64_t& word_hi) {
   const int64_t row = slot_idx / src.page_size;

--- a/python/sglang/kernels/jit/csrc/kv_canary/canary_verify.cuh
+++ b/python/sglang/kernels/jit/csrc/kv_canary/canary_verify.cuh
@@ -204,25 +204,33 @@ struct CanaryVerifyKernel {
     // CUDA. real_kv_source_params is a small CPU int32 table of length kMaxRealKvSources * 3.
     SymbolicSize N_real_kv_rows_0 = {"real_kv_rows_0"};
     SymbolicSize N_real_kv_cols_0 = {"real_kv_cols_0"};
+    SymbolicSize N_real_kv_stride_0 = {"real_kv_stride_0"};
     TensorMatcher({N_real_kv_rows_0, N_real_kv_cols_0})
+        .with_strides({N_real_kv_stride_0, 1})
         .with_dtype<uint8_t>()
         .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_0);
     SymbolicSize N_real_kv_rows_1 = {"real_kv_rows_1"};
     SymbolicSize N_real_kv_cols_1 = {"real_kv_cols_1"};
+    SymbolicSize N_real_kv_stride_1 = {"real_kv_stride_1"};
     TensorMatcher({N_real_kv_rows_1, N_real_kv_cols_1})
+        .with_strides({N_real_kv_stride_1, 1})
         .with_dtype<uint8_t>()
         .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_1);
     SymbolicSize N_real_kv_rows_2 = {"real_kv_rows_2"};
     SymbolicSize N_real_kv_cols_2 = {"real_kv_cols_2"};
+    SymbolicSize N_real_kv_stride_2 = {"real_kv_stride_2"};
     TensorMatcher({N_real_kv_rows_2, N_real_kv_cols_2})
+        .with_strides({N_real_kv_stride_2, 1})
         .with_dtype<uint8_t>()
         .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_2);
     SymbolicSize N_real_kv_rows_3 = {"real_kv_rows_3"};
     SymbolicSize N_real_kv_cols_3 = {"real_kv_cols_3"};
+    SymbolicSize N_real_kv_stride_3 = {"real_kv_stride_3"};
     TensorMatcher({N_real_kv_rows_3, N_real_kv_cols_3})
+        .with_strides({N_real_kv_stride_3, 1})
         .with_dtype<uint8_t>()
         .with_device<kDLGPU>(device_)
         .verify(real_kv_buf_3);
@@ -271,7 +279,7 @@ struct CanaryVerifyKernel {
     tvm::ffi::TensorView source_bufs[kMaxRealKvSources] = {real_kv_buf_0, real_kv_buf_1, real_kv_buf_2, real_kv_buf_3};
     for (int s = 0; s < kMaxRealKvSources; ++s) {
       p.sources[s].tensor = static_cast<const uint8_t*>(source_bufs[s].data_ptr());
-      p.sources[s].row_stride_bytes = static_cast<int32_t>(source_bufs[s].size(1));
+      p.sources[s].row_stride_bytes = static_cast<int32_t>(source_bufs[s].stride(0));
       p.sources[s].page_size = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldPageSize];
       p.sources[s].num_bytes_per_token = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldNumBytesPerToken];
       p.sources[s].read_bytes = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldReadBytes];

--- a/python/sglang/kernels/jit/csrc/kv_canary/canary_write.cuh
+++ b/python/sglang/kernels/jit/csrc/kv_canary/canary_write.cuh
@@ -250,25 +250,33 @@ inline void canary_write_step_cuda(
 
   SymbolicSize N_real_kv_rows_0 = {"real_kv_rows_0"};
   SymbolicSize N_real_kv_cols_0 = {"real_kv_cols_0"};
+  SymbolicSize N_real_kv_stride_0 = {"real_kv_stride_0"};
   TensorMatcher({N_real_kv_rows_0, N_real_kv_cols_0})
+      .with_strides({N_real_kv_stride_0, 1})
       .with_dtype<uint8_t>()
       .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_0);
   SymbolicSize N_real_kv_rows_1 = {"real_kv_rows_1"};
   SymbolicSize N_real_kv_cols_1 = {"real_kv_cols_1"};
+  SymbolicSize N_real_kv_stride_1 = {"real_kv_stride_1"};
   TensorMatcher({N_real_kv_rows_1, N_real_kv_cols_1})
+      .with_strides({N_real_kv_stride_1, 1})
       .with_dtype<uint8_t>()
       .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_1);
   SymbolicSize N_real_kv_rows_2 = {"real_kv_rows_2"};
   SymbolicSize N_real_kv_cols_2 = {"real_kv_cols_2"};
+  SymbolicSize N_real_kv_stride_2 = {"real_kv_stride_2"};
   TensorMatcher({N_real_kv_rows_2, N_real_kv_cols_2})
+      .with_strides({N_real_kv_stride_2, 1})
       .with_dtype<uint8_t>()
       .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_2);
   SymbolicSize N_real_kv_rows_3 = {"real_kv_rows_3"};
   SymbolicSize N_real_kv_cols_3 = {"real_kv_cols_3"};
+  SymbolicSize N_real_kv_stride_3 = {"real_kv_stride_3"};
   TensorMatcher({N_real_kv_rows_3, N_real_kv_cols_3})
+      .with_strides({N_real_kv_stride_3, 1})
       .with_dtype<uint8_t>()
       .with_device<kDLGPU>(device_)
       .verify(real_kv_buf_3);
@@ -329,7 +337,7 @@ inline void canary_write_step_cuda(
   tvm::ffi::TensorView source_bufs[kMaxRealKvSources] = {real_kv_buf_0, real_kv_buf_1, real_kv_buf_2, real_kv_buf_3};
   for (int s = 0; s < kMaxRealKvSources; ++s) {
     p.sources[s].tensor = static_cast<const uint8_t*>(source_bufs[s].data_ptr());
-    p.sources[s].row_stride_bytes = static_cast<int32_t>(source_bufs[s].size(1));
+    p.sources[s].row_stride_bytes = static_cast<int32_t>(source_bufs[s].stride(0));
     p.sources[s].page_size = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldPageSize];
     p.sources[s].num_bytes_per_token = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldNumBytesPerToken];
     p.sources[s].read_bytes = params[s * kRealKvSourceFieldsPerEntry + kRealKvSourceFieldReadBytes];

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -85,7 +85,6 @@ def create_mla_kv_page_table_for_dcp(
     v2p_ptr,  # in: [num_pages + 1] int64 -- virtual->physical page table
     req_to_token_stride: tl.constexpr,
     block_table_stride: tl.constexpr,
-    mult,  # runtime: kernel_page_multiplier of the target sub-pool
     PHYSICAL_PAGE_SIZE: tl.constexpr,
     DCP_SIZE: tl.constexpr,
     DCP_RANK: tl.constexpr,
@@ -97,7 +96,8 @@ def create_mla_kv_page_table_for_dcp(
     ``HAS_V2P`` picks the id space the emitted page number is in: the
     DCP-collapsed page IS physical on a static pool, and still VIRTUAL under
     the unified memory pool, where it takes one more gather through ``v2p_ptr``
-    and a ``mult`` scale to reach the per-layer views.
+    to reach the per-layer views. No scale: under the token-major views a
+    physical page IS the kernel-facing page.
     """
     req = tl.program_id(0)
     page_block = tl.program_id(1)
@@ -118,7 +118,7 @@ def create_mla_kv_page_table_for_dcp(
         # 0, the reserved padding page.
         pages = tl.where(virtual_locs < 0, 0, pages)
         physical = tl.load(v2p_ptr + pages, mask=mask, other=0)
-        pages = tl.maximum(physical * mult, 0)
+        pages = tl.maximum(physical, 0)
     tl.store(
         block_kv_indices_ptr + req * block_table_stride + page_offsets,
         pages.to(tl.int32),

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -69,27 +69,24 @@ if _is_cuda:
 def canonicalize_stride(tensor: torch.Tensor) -> torch.Tensor:
     """
     Adjust degenerate strides for a tensor, make it canonical.
+    Only size-1 dims whose stride collides with the next dim are rewritten;
+    every other stride is kept, so non-contiguous KV views keep their addressing.
     """
     sizes = tensor.size()
     strides = tensor.stride()
     ndim = tensor.dim()
 
-    need_fix = any(
-        sizes[i] == 1 and strides[i] == strides[i + 1] for i in range(ndim - 1)
-    )
-
-    if not need_fix:
-        return tensor
-
-    # canonicalize the stride
     # Example:
     # - shape: [num_pages, 1, 64, 128]
     # - stride: [8192, 128, 128, 1] (wrong!)
     # Gives new stride: [8192, 8192, 128 ,1] (correct!)
-    new_strides = [0] * ndim
-    new_strides[-1] = 1
+    new_strides = list(strides)
     for i in range(ndim - 2, -1, -1):
-        new_strides[i] = new_strides[i + 1] * sizes[i + 1]
+        if sizes[i] == 1 and strides[i] == strides[i + 1]:
+            new_strides[i] = new_strides[i + 1] * sizes[i + 1]
+
+    if new_strides == list(strides):
+        return tensor
 
     return tensor.as_strided(sizes, new_strides)
 

--- a/python/sglang/kernels/ops/kv_canary/verify.py
+++ b/python/sglang/kernels/ops/kv_canary/verify.py
@@ -55,22 +55,23 @@ class RealKvSource:
     num_bytes_per_token``. Trailing bytes of each row are ignored by the canary; this is exactly how the
     abstraction accommodates pools whose per-row layout interleaves canary-relevant bytes with other metadata
     (layer-split storage, K/V interleaving, ...). When ``page_size == 1`` the pattern
-    collapses to the simple ``tensor[slot_idx, :num_bytes_per_token]`` case.
+    collapses to the simple ``tensor[slot_idx, :num_bytes_per_token]`` case. Dim 0 may be a per-layer
+    view into a larger buffer: the kernel steps rows by ``tensor.stride(0)`` instead of ``shape[1]``.
 
     A pool may expose multiple RealKvSource instances per (canary buffer × K/V half) — the launch wrappers
     iterate the source list and fold each into the running real_kv_hash via splitmix64 (one int64 fingerprint
     per slot, regardless of source count).
 
     Pool patchers construct sources by:
-    - viewing / reshaping the underlying KV layer into the canonical [num_rows, dim1_bytes] form (no stage-copy
-      needed when the underlying storage is already row-major contiguous on dim 0),
+    - viewing the underlying KV layer as [num_rows, dim1_bytes] (a view, never a stage-copy: a copy would
+      fingerprint a stale snapshot instead of the live pool),
     - choosing ``page_size`` and ``num_bytes_per_token`` so that the access pattern above lands on the bytes
       the canary should fingerprint,
     - leaving any per-row padding / non-canary bytes in the trailing portion of each row (they will simply be
       skipped).
 
     16-byte alignment precondition: the CUDA fold kernel issues 128-bit aligned loads, so ``read_bytes``,
-    ``num_bytes_per_token``, and the row stride (``tensor.shape[1]`` in bytes) must all be positive
+    ``num_bytes_per_token``, and the row stride (``tensor.stride(0)`` in bytes) must all be positive
     multiples of 16. There is no "skip this source" sentinel — callers omit the source from their
     ``real_kv_sources`` tuple entirely (factory helpers return an empty tuple in that case).
 
@@ -113,12 +114,12 @@ class RealKvSource:
             raise ValueError(
                 f"kv-canary: RealKvSource.tensor must be at least 2-D, got shape {tuple(self.tensor.shape)}"
             )
-        row_stride_bytes = int(self.tensor.shape[1]) * self.tensor.element_size()
+        row_stride_bytes = int(self.tensor.stride(0)) * self.tensor.element_size()
         if row_stride_bytes % 16 != 0:
             raise ValueError(
-                f"kv-canary: RealKvSource.tensor dim-1 byte width must be a multiple of 16, "
+                f"kv-canary: RealKvSource.tensor row stride must be a multiple of 16 bytes, "
                 f"got {row_stride_bytes} bytes (shape={tuple(self.tensor.shape)}, "
-                f"dtype={self.tensor.dtype})"
+                f"strides={tuple(self.tensor.stride())}, dtype={self.tensor.dtype})"
             )
 
 

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -17,7 +17,7 @@ One gather-and-translate: for each request row, read the virtual ids out of
 `req_to_token` and convert each to the id the kernels can use.
 
     page(b, c)  = req_to_token[req[b], c * ps] // ps        -- the VIRTUAL page
-    entry(b, c) = clamp(v2p[page(b, c)] * multiplier, 0)    -- kernel-facing
+    entry(b, c) = clamp(v2p[page(b, c)], 0)                 -- the PHYSICAL page
 
 Two delivery forms over that one formula:
 
@@ -70,7 +70,6 @@ def build_kv_read_indices_kernel(
     out_ptr,  # out: int32
     req_stride,  # runtime: req_to_token row stride (elements)
     out_stride,  # runtime: uniform row stride, used when row_starts is null
-    mult,  # runtime: kernel_page_multiplier of the target sub-pool
     item_stride,  # runtime: items one program advances per loop trip
     PAGE_SIZE: tl.constexpr,
     EMIT_PER_TOKEN: tl.constexpr,
@@ -109,7 +108,7 @@ def build_kv_read_indices_kernel(
         # Triton's `//` truncates toward zero, so `-1 // ps` is 0 for ps > 1 but
         # -1 at ps == 1, which would read one element BEFORE `v2p`.
         vpage = tl.where(tok < 0, 0, tok // PAGE_SIZE)
-        entry = tl.maximum(tl.load(v2p_ptr + vpage, mask=mask, other=0) * mult, 0)
+        entry = tl.maximum(tl.load(v2p_ptr + vpage, mask=mask, other=0), 0)
         if EMIT_PER_TOKEN:
             value = entry * PAGE_SIZE + pos % PAGE_SIZE
         else:
@@ -126,7 +125,6 @@ def _launch(
     req_pool_indices: torch.Tensor,
     seq_lens: torch.Tensor,
     v2p: torch.Tensor,
-    multiplier: int,
     page_size: int,
     max_items: int,
     out: torch.Tensor,
@@ -149,7 +147,6 @@ def _launch(
         out,
         req_to_token.stride(0),
         out_stride,
-        multiplier,
         item_programs * _BLOCK_ITEMS,
         PAGE_SIZE=page_size,
         EMIT_PER_TOKEN=emit_per_token,
@@ -165,13 +162,12 @@ def _entries(
     req: int,
     page_cols: torch.Tensor,
     v2p: torch.Tensor,
-    multiplier: int,
     page_size: int,
 ) -> torch.Tensor:
     """The formula above, in torch. The allocator's unit tests run on CPU, so
     without this the Triton kernel would have no coverage there."""
     tok = req_to_token[req, page_cols * page_size].to(torch.int64)
-    return (v2p[torch.where(tok < 0, 0, tok // page_size)] * multiplier).clamp(min=0)
+    return v2p[torch.where(tok < 0, 0, tok // page_size)].clamp(min=0)
 
 
 def build_kv_read_table(
@@ -180,7 +176,6 @@ def build_kv_read_table(
     req_pool_indices: torch.Tensor,
     seq_lens: torch.Tensor,
     v2p: torch.Tensor,
-    multiplier: int,
     page_size: int,
     max_pages: int,
     out: torch.Tensor,
@@ -217,7 +212,6 @@ def build_kv_read_table(
                 req=int(req_pool_indices[b]),
                 page_cols=cols[:live],
                 v2p=v2p,
-                multiplier=multiplier,
                 page_size=page_size,
             ).to(torch.int32)
         return out
@@ -227,7 +221,6 @@ def build_kv_read_table(
         req_pool_indices=req_pool_indices,
         seq_lens=seq_lens,
         v2p=v2p,
-        multiplier=multiplier,
         page_size=page_size,
         max_items=max_pages,
         out=out,
@@ -246,7 +239,6 @@ def build_kv_read_table_packed(
     seq_lens: torch.Tensor,
     v2p: torch.Tensor,
     indptr: torch.Tensor,
-    multiplier: int,
     page_size: int,
     max_tokens: int,
     out: torch.Tensor,
@@ -286,7 +278,6 @@ def build_kv_read_table_packed(
                 req=int(req_pool_indices[b]),
                 page_cols=pos // page_size,
                 v2p=v2p,
-                multiplier=multiplier,
                 page_size=page_size,
             )
             start = int(indptr[b])
@@ -298,7 +289,6 @@ def build_kv_read_table_packed(
         req_pool_indices=req_pool_indices,
         seq_lens=seq_lens,
         v2p=v2p,
-        multiplier=multiplier,
         page_size=page_size,
         max_items=max_tokens,
         out=out,

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -71,6 +71,7 @@ def build_kv_read_indices_kernel(
     req_stride,  # runtime: req_to_token row stride (elements)
     out_stride,  # runtime: uniform row stride, used when row_starts is null
     item_stride,  # runtime: items one program advances per loop trip
+    seq_len_delta,  # runtime: verify widening added to every row's live prefix
     PAGE_SIZE: tl.constexpr,
     EMIT_PER_TOKEN: tl.constexpr,
     OUT_INT64: tl.constexpr,
@@ -78,7 +79,7 @@ def build_kv_read_indices_kernel(
 ):
     bid = tl.program_id(0)
     req = tl.load(req_pool_indices_ptr + bid).to(tl.int64)
-    seqlen = tl.load(seq_lens_ptr + bid)
+    seqlen = tl.load(seq_lens_ptr + bid) + seq_len_delta
     # Derived here, not on the host: one elementwise op there costs a whole
     # launch, which a captured graph then replays every step.
     if EMIT_PER_TOKEN:
@@ -132,6 +133,7 @@ def _launch(
     row_starts: Optional[torch.Tensor],
     kv_start_idx: Optional[torch.Tensor],
     emit_per_token: bool,
+    seq_len_delta: int = 0,
 ) -> None:
     bs = int(req_pool_indices.numel())
     item_programs = min(
@@ -148,6 +150,7 @@ def _launch(
         req_to_token.stride(0),
         out_stride,
         item_programs * _BLOCK_ITEMS,
+        seq_len_delta,
         PAGE_SIZE=page_size,
         EMIT_PER_TOKEN=emit_per_token,
         OUT_INT64=out.dtype == torch.int64,
@@ -179,12 +182,17 @@ def build_kv_read_table(
     page_size: int,
     max_pages: int,
     out: torch.Tensor,
+    seq_len_delta: int = 0,
 ) -> torch.Tensor:
     """Fill ``out``'s live prefix with PAGE TABLE entries.
 
     ``out`` is caller-owned (fresh zeros for the eager path, the module's
     capture-stable buffer for replay) and only its ``[:bs, :max_pages]``
     region's live prefix is written -- never rebound, never tail-cleared.
+
+    ``seq_len_delta`` widens every row's live prefix -- the whole-sequence
+    verify contract (draft KV read back from the pool). ``max_pages`` must
+    already cover the delta; columns past it are never launched.
     """
     bs = int(req_pool_indices.numel())
     assert out.dtype == torch.int32, (
@@ -205,7 +213,7 @@ def build_kv_read_table(
     if not req_to_token.is_cuda:
         cols = torch.arange(max_pages, device=req_to_token.device)
         for b in range(bs):
-            n_pages = (int(seq_lens[b]) + page_size - 1) // page_size
+            n_pages = (int(seq_lens[b]) + seq_len_delta + page_size - 1) // page_size
             live = min(n_pages, max_pages)
             out[b, :live] = _entries(
                 req_to_token=req_to_token,
@@ -228,6 +236,7 @@ def build_kv_read_table(
         row_starts=None,
         kv_start_idx=None,
         emit_per_token=False,
+        seq_len_delta=seq_len_delta,
     )
     return out
 

--- a/python/sglang/kernels/ops/memory/virtual_slot.py
+++ b/python/sglang/kernels/ops/memory/virtual_slot.py
@@ -203,13 +203,13 @@ def write_loc_to_kernel_id_kernel(
     out_ptr,  # out: [N] int64 — kernel-facing ids
     N,  # runtime: live element count
     W,  # runtime: lanes to write; [N, W) get 0
-    stride,  # runtime: pool_page_size * kernel_page_multiplier
+    stride,  # runtime: pool_page_size (a physical id IS the kernel id)
     PAGE_SIZE: tl.constexpr,
     DCP_SIZE: tl.constexpr,
     DCP_RANK: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """``kernel_id(t) = v2p[t // ps] * ps * mult + t % ps``, clamped at 0.
+    """``kernel_id(t) = v2p[t // ps] * ps + t % ps``, clamped at 0.
 
     Under DCP the incoming id is WIDENED: ``loc % dcp_size`` names its owner
     and ``loc // dcp_size`` is the row. Ids this rank does not own resolve to

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -272,13 +272,14 @@ def handle_unified_memory_pool(server_args: Any) -> None:
         "audited for the unified pool's virtual/kernel-facing loc translation. Got "
         f"--speculative-algorithm={cfg.speculative_algorithm!r}."
     )
+    assert cfg.speculative_eagle_topk in (None, 1), (
+        "--enable-unified-memory supports a linear draft chain only "
+        "(--speculative-eagle-topk in {None, 1}); tree verify relocates "
+        "accepted tokens one at a time inside the target pool, which the "
+        "unified pool's page-granular move_kv_cache cannot express. Got "
+        f"--speculative-eagle-topk={cfg.speculative_eagle_topk!r}."
+    )
     if cfg.speculative_algorithm == "DSPARK":
-        assert cfg.speculative_eagle_topk in (None, 1), (
-            "--enable-unified-memory + DSPARK supports a linear draft "
-            "chain only (--speculative-eagle-topk in {None, 1}); tree "
-            "verify is not audited for the unified pool. Got "
-            f"--speculative-eagle-topk={cfg.speculative_eagle_topk!r}."
-        )
         _assert_spec_verify_backends(server_args, algorithm="DSPARK")
     assert not cfg.enable_two_batch_overlap, (
         "--enable-unified-memory does not support --enable-two-batch-overlap: "

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -196,6 +196,48 @@ def handle_cache_compatibility(server_args: Any) -> None:
         raise ValueError("--swa-full-tokens-ratio should be in range (0, 1.0].")
 
 
+# Backends whose speculative verify id rails are translation-audited for
+# the unified pool.
+_SPEC_VERIFY_AUDITED_BACKENDS = frozenset(
+    {
+        "triton",
+        "trtllm_mla",
+        "cutedsl_mla",
+        "tokenspeed_mla",
+        "flashmla",
+        "flashinfer",
+        "fa3",
+    }
+)
+
+
+def _assert_spec_verify_backends(server_args: Any, *, algorithm: str) -> None:
+    """Refuse spec backends whose verify id rails are not translation-audited.
+
+    Checks the target's prefill/decode pair AND the draft worker's own
+    backend: the latter resolves from `--speculative-draft-attention-backend`
+    before inheriting the target's, so it can be unaudited on its own."""
+    from sglang.srt.arg_groups.overrides import attention_backends_of
+
+    allowed = _SPEC_VERIFY_AUDITED_BACKENDS
+    backends = set(attention_backends_of(resolved_view(server_args)))
+    backends.discard(None)
+    assert backends <= allowed, (
+        f"--enable-unified-memory + {algorithm} requires spec-verify-audited "
+        f"attention backends {sorted(allowed)} for both prefill "
+        f"and decode; got {sorted(backends)}. Other backends do "
+        "not translate speculative verify indices to the unified "
+        "pool's kernel-facing space yet."
+    )
+    draft_backend = resolving_view(server_args).speculative_draft_attention_backend
+    assert draft_backend is None or draft_backend in allowed, (
+        f"--enable-unified-memory + {algorithm} requires the draft worker on a "
+        f"spec-verify-audited backend {sorted(allowed)}; got "
+        f"--speculative-draft-attention-backend={draft_backend!r}. Leave it "
+        "unset to inherit the target's."
+    )
+
+
 def handle_unified_memory_pool(server_args: Any) -> None:
 
     cfg = resolving_view(server_args)
@@ -237,18 +279,7 @@ def handle_unified_memory_pool(server_args: Any) -> None:
             "verify is not audited for the unified pool. Got "
             f"--speculative-eagle-topk={cfg.speculative_eagle_topk!r}."
         )
-        # Both roles: verify routes to either backend depending on
-        # --speculative-attention-mode.
-        spec_allowed = {"triton", "trtllm_mla", "cutedsl_mla", "tokenspeed_mla"}
-        spec_backends = set(attention_backends_of(resolved_view(server_args)))
-        spec_backends.discard(None)
-        assert spec_backends <= spec_allowed, (
-            "--enable-unified-memory + DSPARK requires spec-verify-audited "
-            f"attention backends {sorted(spec_allowed)} for both prefill "
-            f"and decode; got {sorted(spec_backends)}. flashinfer / fa3 do "
-            "not translate speculative verify indices to the unified "
-            "pool's kernel-facing space yet."
-        )
+        _assert_spec_verify_backends(server_args, algorithm="DSPARK")
     assert not cfg.enable_two_batch_overlap, (
         "--enable-unified-memory does not support --enable-two-batch-overlap: "
         "TBO's replay split hands each child a view without the pre-translate "

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -331,7 +331,7 @@ def _validate_unified_memory_dcp(server_args: Any) -> None:
 
 
 def handle_page_major_kv_layout(server_args: Any):
-    # The unified pool stores state in the page-major envelope-strided layout, so
+    # The unified pool stores state in the page-major envelope layout, so
     # enabling it implies --enable-page-major-kv-layout — routing it through the
     # single page-major path + stride-aware Triton asserts (set before the guard).
 
@@ -359,17 +359,18 @@ def handle_page_major_kv_layout(server_args: Any):
     assert unified_memory_supported_for_model(
         model_config, use_mla_backend=use_mla_backend(server_args)
     ), (
-        "--enable-unified-memory requires uniform K/V rows "
-        "(head_dim == v_head_dim); this model has "
+        "--enable-unified-memory does not yet admit asymmetric K/V rows "
+        "(head_dim != v_head_dim); this model has "
         f"head_dim={model_config.head_dim}, "
         f"v_head_dim={model_config.v_head_dim}, "
         f"swa_head_dim={model_config.swa_head_dim}, "
-        f"swa_v_head_dim={model_config.swa_v_head_dim}. The unified "
-        "pool's per-layer views require a uniform row width; run "
-        "this model without --enable-unified-memory."
+        f"swa_v_head_dim={model_config.swa_v_head_dim}. The token-major "
+        "views can hold them, but the backends' write and read paths are "
+        "not audited for it; run this model without --enable-unified-memory."
     )
     # Allow-list. Every backend below reads through the translator, so what
-    # gates one is only whether its kernels can address the per-layer views:
+    # gates one is only whether its kernels address the per-layer views by
+    # their strides (the slot stride is the whole entry, not one row):
     #   * MLA models: the full paged MLA family, incl. flashmla (ps=64
     #     snap). cutlass_mla stays rejected (never exercised).
     #   * MHA/SWA models: fa3 / fa4 / flashinfer / trtllm_mha alongside
@@ -402,9 +403,8 @@ def handle_page_major_kv_layout(server_args: Any):
         "--enable-page-major-kv-layout: the resolved attention backends "
         f"{sorted(backends)} are not in the allowed set "
         f"{sorted(allowed_full)} for this configuration (unified memory "
-        "allows the per-layer-view families; plain page-major keeps the "
-        "envelope-strided views only Triton reads). Pass a compatible "
-        "--attention-backend."
+        "allows the stride-aware per-layer-view families). Pass a "
+        "compatible --attention-backend."
     )
     # The Mamba/KDA state is stored in envelope-strided views; only
     # stride-audited kernels may read it (Stage 4 audit, per slot):

--- a/python/sglang/srt/kv_canary/pool_patcher/buffer_alloc.py
+++ b/python/sglang/srt/kv_canary/pool_patcher/buffer_alloc.py
@@ -67,11 +67,10 @@ def make_row_source(
     layer_buffer: torch.Tensor,
     read_bytes: int,
 ) -> Tuple[RealKvSource, ...]:
-    contiguous = layer_buffer.contiguous()
-    num_slots = int(contiguous.shape[0])
+    num_slots = int(layer_buffer.shape[0])
     if num_slots == 0 or read_bytes == 0:
         return ()
-    flat = contiguous.view(torch.uint8).reshape(num_slots, -1)
+    flat = layer_buffer.view(torch.uint8).view(num_slots, -1)
     num_bytes_per_token = int(flat.shape[1])
     clipped = _clip_read_bytes_aligned(
         requested=read_bytes, num_bytes_per_token=num_bytes_per_token

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -264,6 +264,7 @@ class AiterAttnBackend(AttentionBackend):
         self.kv_cache_dtype = model_runner.kv_cache_dtype
 
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.kv_index_translator = model_runner.kv_index_translator
 
         self.use_mla = model_runner.model_config.attention_arch == AttentionArch.MLA
 
@@ -1432,10 +1433,10 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 kv_indices, kv_indptr, qo_indptr, _ = (
                     forward_batch.spec_info.generate_attn_arg_prefill(
-                        forward_batch.req_pool_indices,
-                        forward_batch.seq_lens,
-                        forward_batch.seq_lens_sum,
-                        self.req_to_token,
+                        req_pool_indices=forward_batch.req_pool_indices,
+                        paged_kernel_lens=forward_batch.seq_lens,
+                        paged_kernel_lens_sum=forward_batch.seq_lens_sum,
+                        translator=self.kv_index_translator,
                     )
                 )
                 self.forward_metadata = ForwardMetadata(
@@ -3329,6 +3330,7 @@ class AiterIndicesUpdaterPrefill:
         self.kv_last_page_len = attn_backend.kv_last_page_len
         self.qo_indptr = attn_backend.qo_indptr
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.kv_index_translator = model_runner.kv_index_translator
         self.update = self.update_single_wrapper
 
         self.kv_indices = None
@@ -3401,10 +3403,10 @@ class AiterIndicesUpdaterPrefill:
         else:
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
                 spec_info.generate_attn_arg_prefill(
-                    req_pool_indices,
-                    paged_kernel_lens,
-                    paged_kernel_lens_sum,
-                    self.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    paged_kernel_lens=paged_kernel_lens,
+                    paged_kernel_lens_sum=paged_kernel_lens_sum,
+                    translator=self.kv_index_translator,
                 )
             )
 
@@ -3418,6 +3420,7 @@ class AiterMlaIndicesUpdaterPrefill:
 
         # Buffers and wrappers
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.kv_index_translator = model_runner.kv_index_translator
         self.update = self.update_single_wrapper
 
         self.kv_indptr = None
@@ -3479,10 +3482,10 @@ class AiterMlaIndicesUpdaterPrefill:
         else:
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
                 spec_info.generate_attn_arg_prefill(
-                    req_pool_indices,
-                    kv_lens,
-                    kv_lens_sum,
-                    self.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    paged_kernel_lens=kv_lens,
+                    paged_kernel_lens_sum=kv_lens_sum,
+                    translator=self.kv_index_translator,
                 )
             )
 

--- a/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
@@ -33,6 +33,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
     TRTLLMMLAMultiStepDraftBackend,
 )
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
+from sglang.srt.mem_cache.layout.page_major import paged_row_view
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import is_flashinfer_available
 
@@ -226,7 +227,7 @@ class CuteDslMLABackend(TRTLLMMLABackend):
             query = query.unsqueeze(1)
 
         k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
+        kv_cache = paged_row_view(k_cache, self.page_size).unsqueeze(1)
 
         metadata = (
             getattr(forward_batch, "decode_trtllm_mla_metadata", None)

--- a/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
@@ -209,9 +209,7 @@ class CuteDslMLABackend(TRTLLMMLABackend):
             assert k is not None and k_rope is not None
             self.token_to_kv_pool.set_mla_kv_buffer(
                 layer,
-                KVWriteLoc.for_batch(
-                    forward_batch, self._kv_write_loc(forward_batch)
-                ),
+                KVWriteLoc.for_batch(forward_batch, self._kv_write_loc(forward_batch)),
                 k,
                 k_rope,
             )

--- a/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutedsl_mla_backend.py
@@ -34,6 +34,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
 )
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
 from sglang.srt.mem_cache.layout.page_major import paged_row_view
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import is_flashinfer_available
 
@@ -207,7 +208,12 @@ class CuteDslMLABackend(TRTLLMMLABackend):
         if query is None and save_kv_cache:
             assert k is not None and k_rope is not None
             self.token_to_kv_pool.set_mla_kv_buffer(
-                layer, self._kv_write_loc(forward_batch), k, k_rope
+                layer,
+                KVWriteLoc.for_batch(
+                    forward_batch, self._kv_write_loc(forward_batch)
+                ),
+                k,
+                k_rope,
             )
 
         if query is not None:

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -460,6 +460,10 @@ class FlashAttentionBackend(AttentionBackend):
         return self.token_to_kv_pool.full_to_swa_index_mapping
 
     def draft_extend_metadata_captured_in_graph(self) -> bool:
+        # A translating backend rebuilds out of graph: the captured gather
+        # would bake raw req_to_token (virtual) ids into the page table.
+        if self.kv_index_translator.is_translating:
+            return False
         return (
             not self.use_sliding_window_kv_pool
             or self.token_to_kv_pool.full_to_swa_index_mapping is not None
@@ -3084,18 +3088,44 @@ class FlashAttentionBackend(AttentionBackend):
             max_seq_pages = (
                 metadata.max_seq_len_k + self.page_size - 1
             ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            if self.use_sliding_window_kv_pool and metadata.swa_page_table is not None:
-                swa_page_indices = self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                    page_indices
+            if self.kv_index_translator.reads_are_translated:
+                # The translator writes kernel-facing page ids straight into
+                # the captured tables; `sliding_window_out` fills the swa twin
+                # in the same pass.
+                self.kv_index_translator.fill_read_table(
+                    out=metadata.page_table,
+                    sliding_window_out=(
+                        metadata.swa_page_table
+                        if self.use_sliding_window_kv_pool
+                        and metadata.swa_page_table is not None
+                        else None
+                    ),
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    seq_len_delta=self._spec_read_seq_len_delta(
+                        forward_mode, spec_info
+                    ),
                 )
-                metadata.swa_page_table[:, :max_seq_pages].copy_(
-                    swa_page_indices // self.page_size
+            else:
+                page_indices = self.req_to_token[
+                    req_pool_indices[:, None],
+                    self.draft_extend_metadata["strided_indices"][:max_seq_pages],
+                ]
+                if (
+                    self.use_sliding_window_kv_pool
+                    and metadata.swa_page_table is not None
+                ):
+                    swa_page_indices = (
+                        self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                            page_indices
+                        )
+                    )
+                    metadata.swa_page_table[:, :max_seq_pages].copy_(
+                        swa_page_indices // self.page_size
+                    )
+                metadata.page_table[:, :max_seq_pages].copy_(
+                    page_indices // self.page_size
                 )
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
 
         else:
             raise ValueError(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1289,7 +1289,11 @@ class FlashAttentionBackend(AttentionBackend):
                     v_scale = v_descale if self.kv_cache_is_mxfp8 else layer.v_scale
                     self.token_to_kv_pool.set_kv_buffer(
                         layer,
-                        KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                        KVWriteLoc.for_batch(
+                            forward_batch,
+                            cache_loc,
+                            swa_loc=self.forward_metadata.swa_out_cache_loc,
+                        ),
                         k,
                         v,
                         k_scale,
@@ -1820,7 +1824,11 @@ class FlashAttentionBackend(AttentionBackend):
                     v_scale = v_descale if self.kv_cache_is_mxfp8 else layer.v_scale
                     self.token_to_kv_pool.set_kv_buffer(
                         layer,
-                        KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                        KVWriteLoc.for_batch(
+                            forward_batch,
+                            cache_loc,
+                            swa_loc=self.forward_metadata.swa_out_cache_loc,
+                        ),
                         k,
                         v,
                         k_scale,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1172,21 +1172,24 @@ class FlashAttentionBackend(AttentionBackend):
         *,
         head_group_num: int = 1,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        key_cache, value_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
-        return (
-            key_cache.view(
+        key_cache, value_cache = self.token_to_kv_pool.get_paged_kv_buffer(
+            layer.layer_id
+        )
+        if head_group_num != 1:
+            # Reinterpret each page's heads as `head_group_num` pseudo-pages.
+            key_cache = key_cache.view(
                 -1,
                 self.page_size,
                 layer.tp_k_head_num // head_group_num,
                 layer.head_dim,
-            ),
-            value_cache.view(
+            )
+            value_cache = value_cache.view(
                 -1,
                 self.page_size,
                 layer.tp_v_head_num // head_group_num,
                 layer.v_head_dim,
-            ),
-        )
+            )
+        return key_cache, value_cache
 
     def prepare_paged_mha_query(
         self,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2939,32 +2939,20 @@ class FlashAttentionBackend(AttentionBackend):
                     geometry = build_ragged_target_verify_geometry(
                         seq_lens=seq_lens, layout=padded
                     )
-                    metadata.cache_seqlens_int32.copy_(geometry.cache_seqlens_int32)
                     metadata.cu_seqlens_q.copy_(geometry.cu_seqlens_q)
+                    # Per-row verify lens; the builder re-derives
+                    # cache_seqlens from them at delta 0.
+                    verify_lens = geometry.cache_seqlens_int32
+                    verify_delta = 0
                 else:
-                    metadata.cache_seqlens_int32.copy_(
-                        (seq_lens + self.speculative_num_draft_tokens)
-                    )
+                    verify_lens = seq_lens
+                    verify_delta = self.speculative_num_draft_tokens
 
                 # Page table built on-device (self-guards on cache_seqlens);
                 # max_seq_len_k left unset -- unread here (scheduler_metadata is
                 # normal-decode-only).
-                metadata.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-                )
-                has_swa = self.use_sliding_window_kv_pool
-                build_trtllm_mha_page_table(
-                    req_to_token=self.req_to_token,
-                    req_pool_indices=req_pool_indices,
-                    cache_seqlens=metadata.cache_seqlens_int32,
-                    page_table=metadata.page_table,
-                    page_size=self.page_size,
-                    swa_page_table=metadata.swa_page_table if has_swa else None,
-                    full_to_swa=(
-                        self.token_to_kv_pool.full_to_swa_index_mapping
-                        if has_swa
-                        else None
-                    ),
+                self._set_decode_page_metadata(
+                    metadata, req_pool_indices, verify_lens, verify_delta
                 )
             else:
                 # When topk > 1, we need two specific target verify metadata, and then merge states

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -701,6 +701,31 @@ class FlashAttentionBackend(AttentionBackend):
             m.max_seq_len_k = self.max_context_len
         self.forward_metadata = m
 
+    def _spec_read_seq_len_delta(
+        self, forward_mode: ForwardMode, spec_info: Optional[SpecInput]
+    ) -> int:
+        """Columns past ``seq_lens`` this mode's whole-sequence read covers —
+        the translated table's fill must reach ``cache_seqlens``. Takes the
+        two fields rather than a ForwardBatch: the captured build slices its
+        batch and has none.
+
+        Zero for the prefix-only shapes: normal decode/extend, the topk>1
+        split (drafts read via the expand metadata), draft-extend whose lens
+        already include the window, and draft-extend's idle batch. The ragged
+        verify layout's per-row lens are bounded by the draft window, so its
+        upper bound rides the same delta."""
+        if spec_info is None:
+            return 0
+        if forward_mode.is_target_verify() and self.topk <= 1:
+            return self.speculative_num_draft_tokens
+        if (
+            forward_mode.is_decode_or_idle()
+            and self.topk <= 1
+            and self.speculative_num_steps > 0
+        ):
+            return self.speculative_step_id + 1
+        return 0
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
         metadata = FlashAttentionMetadata()
@@ -1084,7 +1109,15 @@ class FlashAttentionBackend(AttentionBackend):
             self.kv_index_translator.is_translating and metadata.page_table is not None
         )
         if _unified_read:
-            kv_view = self.kv_index_translator.index_table_for_batch(forward_batch)
+            delta = self._spec_read_seq_len_delta(
+                forward_batch.forward_mode, forward_batch.spec_info
+            )
+            if delta:
+                kv_view = self.kv_index_translator.widened_index_table(
+                    forward_batch, seq_len_delta=delta
+                )
+            else:
+                kv_view = self.kv_index_translator.index_table_for_batch(forward_batch)
             metadata.page_table = kv_view.ids
             if self.use_sliding_window_kv_pool:
                 metadata.swa_page_table = kv_view.sliding_window_ids

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -707,7 +707,8 @@ class FlashAttentionBackend(AttentionBackend):
         """Columns past ``seq_lens`` this mode's whole-sequence read covers —
         the translated table's fill must reach ``cache_seqlens``. Takes the
         two fields rather than a ForwardBatch: the captured build slices its
-        batch and has none.
+        batch and has none. Now read by both builds, so eager and replay
+        widen identically.
 
         Zero for the prefix-only shapes: normal decode/extend, the topk>1
         split (drafts read via the expand metadata), draft-extend whose lens
@@ -2797,13 +2798,11 @@ class FlashAttentionBackend(AttentionBackend):
                     # Page table built on-device (self-guards on cache_seqlens);
                     # max_seq_len_k left unset -- unread here (scheduler_metadata
                     # is normal-decode-only).
-                    # Spec is asserted off under the unified pool, so this
-                    # captured view is always the passthrough (req_to_token).
                     self._set_decode_page_metadata(
                         metadata,
                         req_pool_indices,
                         seq_lens,
-                        self.speculative_step_id + 1,
+                        self._spec_read_seq_len_delta(forward_mode, spec_info),
                     )
 
                 else:
@@ -2904,7 +2903,10 @@ class FlashAttentionBackend(AttentionBackend):
                         else self.max_context_len
                     )
                     self._set_decode_page_metadata(
-                        metadata, req_pool_indices, seq_lens, 0
+                        metadata,
+                        req_pool_indices,
+                        seq_lens,
+                        self._spec_read_seq_len_delta(forward_mode, spec_info),
                     )
 
                 self._maybe_update_local_attn_metadata_for_replay(

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1337,7 +1337,11 @@ class FlashInferAttnBackend(AttentionBackend):
                 assert v is not None
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        cache_loc,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
+                    ),
                     k,
                     v,
                     *self._kv_write_scales(layer),
@@ -1439,7 +1443,11 @@ class FlashInferAttnBackend(AttentionBackend):
             if save_kv_cache:
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        cache_loc,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
+                    ),
                     k,
                     v,
                     *self._kv_write_scales(layer),
@@ -1471,7 +1479,11 @@ class FlashInferAttnBackend(AttentionBackend):
             if save_kv_cache:
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        cache_loc,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
+                    ),
                     k,
                     v,
                     *self._kv_write_scales(layer),

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -2191,6 +2191,7 @@ class FlashInferIndicesUpdaterPrefill:
                         paged_kernel_lens=paged_kernel_lens,
                         paged_kernel_lens_sum=paged_kernel_lens_sum,
                         translator=translator,
+                        sliding_window=use_swa_source,
                         kv_start_idx=kv_start_idx,
                     )
                 )
@@ -2201,6 +2202,7 @@ class FlashInferIndicesUpdaterPrefill:
                         paged_kernel_lens=paged_kernel_lens,
                         paged_kernel_lens_sum=paged_kernel_lens_sum,
                         translator=translator,
+                        sliding_window=use_swa_source,
                     )
                 )
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -2187,20 +2187,20 @@ class FlashInferIndicesUpdaterPrefill:
             if spec_info.spec_input_type == SpecInputType.DFLASH_VERIFY:
                 kv_indices, kv_indptr, qo_indptr, custom_mask = (
                     spec_info.generate_attn_arg_prefill(
-                        req_pool_indices,
-                        paged_kernel_lens,
-                        paged_kernel_lens_sum,
-                        self.req_to_token,
+                        req_pool_indices=req_pool_indices,
+                        paged_kernel_lens=paged_kernel_lens,
+                        paged_kernel_lens_sum=paged_kernel_lens_sum,
+                        translator=translator,
                         kv_start_idx=kv_start_idx,
                     )
                 )
             else:
                 kv_indices, kv_indptr, qo_indptr, custom_mask = (
                     spec_info.generate_attn_arg_prefill(
-                        req_pool_indices,
-                        paged_kernel_lens,
-                        paged_kernel_lens_sum,
-                        self.req_to_token,
+                        req_pool_indices=req_pool_indices,
+                        paged_kernel_lens=paged_kernel_lens,
+                        paged_kernel_lens_sum=paged_kernel_lens_sum,
+                        translator=translator,
                     )
                 )
 

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -49,6 +49,7 @@ from sglang.srt.utils import (
     is_flashinfer_available,
     next_power_of_2,
 )
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.flashinfer_mla_backend import (
@@ -708,9 +709,13 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             assert v is not None
             if save_kv_cache:
                 if k_rope is not None:
-                    self.token_to_kv_pool.set_mla_kv_buffer(layer, cache_loc, k, k_rope)
+                    self.token_to_kv_pool.set_mla_kv_buffer(
+                        layer, KVWriteLoc.for_batch(forward_batch, cache_loc), k, k_rope
+                    )
                 else:
-                    self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+                    self.token_to_kv_pool.set_kv_buffer(
+                        layer, KVWriteLoc.for_batch(forward_batch, cache_loc), k, v
+                    )
         if q_rope is not None:
             q = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
             q_rope = q_rope.view(
@@ -779,14 +784,14 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 if k_rope is not None:
                     self.token_to_kv_pool.set_mla_kv_buffer(
                         layer,
-                        cache_loc,
+                        KVWriteLoc.for_batch(forward_batch, cache_loc),
                         k,
                         k_rope,
                     )
                 else:
                     self.token_to_kv_pool.set_kv_buffer(
                         layer,
-                        cache_loc,
+                        KVWriteLoc.for_batch(forward_batch, cache_loc),
                         k,
                         v,
                     )

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -32,6 +32,7 @@ from sglang.srt.layers.dcp import (
     update_local_kv_lens_for_dcp,
 )
 from sglang.srt.layers.dcp.planner import plan_dcp_decode_metadata
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -49,7 +50,6 @@ from sglang.srt.utils import (
     is_flashinfer_available,
     next_power_of_2,
 )
-from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.flashinfer_mla_backend import (

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -1078,10 +1078,10 @@ class FlashInferMLAIndicesUpdaterPrefill:
         elif fast_verify_plan_kwargs is not None:
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
                 spec_info.generate_attn_arg_prefill(
-                    req_pool_indices,
-                    paged_kernel_lens,
-                    paged_kernel_lens_sum,
-                    self.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    paged_kernel_lens=paged_kernel_lens,
+                    paged_kernel_lens_sum=paged_kernel_lens_sum,
+                    translator=self.attn_backend.kv_index_translator,
                     kv_indices_buf=fast_verify_plan_kwargs["kv_indices_buf"],
                 )
             )
@@ -1090,10 +1090,10 @@ class FlashInferMLAIndicesUpdaterPrefill:
             # TODO: Support topk > 1 with custom mask
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
                 spec_info.generate_attn_arg_prefill(
-                    req_pool_indices,
-                    paged_kernel_lens,
-                    paged_kernel_lens_sum,
-                    self.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    paged_kernel_lens=paged_kernel_lens,
+                    paged_kernel_lens_sum=paged_kernel_lens_sum,
+                    translator=self.attn_backend.kv_index_translator,
                 )
             )
 

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -199,17 +199,25 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
 
             max_seqlen_pad = triton.cdiv(eager_max_k + self.num_draft_tokens, PAGE_SIZE)
             block_kv_indices = self._eager_block_kv_indices(bs, max_seqlen_pad)
-            create_flashmla_kv_indices_triton[
-                (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
-            ](
-                self.req_to_token,
-                forward_batch.req_pool_indices,
-                seq_lens,
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                block_kv_indices.stride(0),
-            )
+            if self.kv_index_translator.is_translating:
+                assert self.page_size == PAGE_SIZE
+                self.kv_index_translator.fill_read_table(
+                    out=block_kv_indices,
+                    req_pool_indices=forward_batch.req_pool_indices,
+                    seq_lens=seq_lens,
+                )
+            else:
+                create_flashmla_kv_indices_triton[
+                    (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
+                ](
+                    self.req_to_token,
+                    forward_batch.req_pool_indices,
+                    seq_lens,
+                    None,
+                    block_kv_indices,
+                    self.req_to_token.stride(0),
+                    block_kv_indices.stride(0),
+                )
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
                 self.num_draft_tokens * self.num_q_heads,
@@ -231,17 +239,25 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
 
             max_seqlen_pad = triton.cdiv(eager_max_k + window, PAGE_SIZE)
             block_kv_indices = self._eager_block_kv_indices(bs, max_seqlen_pad)
-            create_flashmla_kv_indices_triton[
-                (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
-            ](
-                self.req_to_token,
-                forward_batch.req_pool_indices,
-                seq_lens_k,
-                None,
-                block_kv_indices,
-                self.req_to_token.stride(0),
-                block_kv_indices.stride(0),
-            )
+            if self.kv_index_translator.is_translating:
+                assert self.page_size == PAGE_SIZE
+                self.kv_index_translator.fill_read_table(
+                    out=block_kv_indices,
+                    req_pool_indices=forward_batch.req_pool_indices,
+                    seq_lens=seq_lens_k,
+                )
+            else:
+                create_flashmla_kv_indices_triton[
+                    (bs, get_num_kv_index_blocks_flashmla(max_seqlen_pad, PAGE_SIZE))
+                ](
+                    self.req_to_token,
+                    forward_batch.req_pool_indices,
+                    seq_lens_k,
+                    None,
+                    block_kv_indices,
+                    self.req_to_token.stride(0),
+                    block_kv_indices.stride(0),
+                )
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens_k,
                 window * self.num_q_heads,

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -19,6 +19,7 @@ from sglang.kernels.ops.attention.utils import (
 from sglang.kernels.ops.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.layers.attention.flashinfer_mla_backend import FlashInferMLAAttnBackend
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
+from sglang.srt.mem_cache.layout.page_major import paged_view
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel, get_spec
 
@@ -462,7 +463,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             reshape_q_fp8 = reshape_q_fp8_2d.reshape(q_shape)
             o, _ = flash_mla_with_kvcache(
                 q=reshape_q_fp8,
-                k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
+                k_cache=paged_view(k_cache, PAGE_SIZE),
                 block_table=self.forward_metadata.block_kv_indices[:bs],
                 cache_seqlens=forward_batch.seq_lens.to(torch.int32),
                 head_dim_v=self.kv_lora_rank,
@@ -479,7 +480,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             # todo: need check all causal True or False?
             o, lse = flash_mla_with_kvcache(
                 q=reshape_q,
-                k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
+                k_cache=paged_view(k_cache, PAGE_SIZE),
                 block_table=self.forward_metadata.block_kv_indices[:bs],
                 cache_seqlens=forward_batch.seq_lens.to(torch.int32),
                 head_dim_v=self.kv_lora_rank,
@@ -553,7 +554,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 reshape_q_fp8 = reshape_q_fp8_2d.reshape(q_shape)
                 o, _ = flash_mla_with_kvcache(
                     q=reshape_q_fp8,
-                    k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
+                    k_cache=paged_view(k_cache, PAGE_SIZE),
                     block_table=self.forward_metadata.block_kv_indices[:bs],
                     cache_seqlens=cache_seqlens,
                     head_dim_v=self.kv_lora_rank,
@@ -567,7 +568,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             else:
                 o, _ = flash_mla_with_kvcache(
                     q=reshape_q,
-                    k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
+                    k_cache=paged_view(k_cache, PAGE_SIZE),
                     block_table=self.forward_metadata.block_kv_indices[:bs],
                     cache_seqlens=cache_seqlens,
                     head_dim_v=self.kv_lora_rank,

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -20,6 +20,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.layers.attention.flashinfer_mla_backend import FlashInferMLAAttnBackend
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
 from sglang.srt.mem_cache.layout.page_major import paged_view
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel, get_spec
 
@@ -432,7 +433,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             if save_kv_cache:
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    cache_loc,
+                    KVWriteLoc.for_batch(forward_batch, cache_loc),
                     k,
                     v,
                 )
@@ -515,7 +516,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             if k is not None:
                 assert v is not None
                 if save_kv_cache:
-                    self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+                    self.token_to_kv_pool.set_kv_buffer(
+                        layer, KVWriteLoc.for_batch(forward_batch, cache_loc), k, v
+                    )
 
             bs = forward_batch.batch_size
             k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)

--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -404,9 +404,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         if save_kv_cache:
             self.token_to_kv_pool.set_mla_kv_buffer(
                 layer,
-                KVWriteLoc.for_batch(
-                    forward_batch, self._kv_write_loc(forward_batch)
-                ),
+                KVWriteLoc.for_batch(forward_batch, self._kv_write_loc(forward_batch)),
                 k,
                 k_rope,
             )

--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
     TRTLLMMLAMultiStepDraftBackend,
 )
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
+from sglang.srt.mem_cache.layout.page_major import paged_row_view
 from sglang.srt.runtime_context import (
     get_parallel,
     get_resources,
@@ -411,7 +412,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
             query = query.unsqueeze(1)
 
         k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
+        kv_cache = paged_row_view(k_cache, self.page_size).unsqueeze(1)
         metadata = (
             getattr(forward_batch, "decode_trtllm_mla_metadata", None)
             or self.forward_decode_metadata

--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -50,6 +50,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
 )
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
 from sglang.srt.mem_cache.layout.page_major import paged_row_view
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.runtime_context import (
     get_parallel,
     get_resources,
@@ -289,7 +290,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         k_pe_fp8 = k_fp8[:, 0:1, layer.qk_nope_head_dim :]
         self.token_to_kv_pool.set_mla_kv_buffer(
             layer.attn_mha,
-            forward_batch.out_cache_loc,
+            KVWriteLoc.for_batch(forward_batch),
             kv_a_fp8.unsqueeze(1),
             k_pe_fp8,
         )
@@ -402,7 +403,12 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
 
         if save_kv_cache:
             self.token_to_kv_pool.set_mla_kv_buffer(
-                layer, self._kv_write_loc(forward_batch), k, k_rope
+                layer,
+                KVWriteLoc.for_batch(
+                    forward_batch, self._kv_write_loc(forward_batch)
+                ),
+                k,
+                k_rope,
             )
 
         query = q.view(-1, layer.tp_q_head_num, layer.head_dim)

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1564,9 +1564,9 @@ class TritonAttnBackend(AttentionBackend):
         else:
             # Save KV cache first (must do this before unified kernel)
             if save_kv_cache:
-                loc_info = KVWriteLoc(
-                    forward_batch.out_cache_loc,
-                    self.forward_metadata.swa_out_cache_loc,
+                loc_info = KVWriteLoc.for_batch(
+                    forward_batch,
+                    swa_loc=self.forward_metadata.swa_out_cache_loc,
                     full_loc=self.forward_metadata.out_cache_loc_full_physical,
                 )
                 if layer.k_scale is None:
@@ -2152,9 +2152,9 @@ class TritonAttnBackend(AttentionBackend):
                     # pool, refreshed into a capture-stable buffer before replay —
                     # translating inside set_kv_buffer would be captured and replay
                     # a stale v2p. None (-> raw loc) for static pools.
-                    KVWriteLoc(
-                        forward_batch.out_cache_loc,
-                        self.forward_metadata.swa_out_cache_loc,
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
                         full_loc=self.forward_metadata.out_cache_loc_full_physical,
                     ),
                     k,
@@ -2164,9 +2164,9 @@ class TritonAttnBackend(AttentionBackend):
                 self._set_kv_buffer(
                     forward_batch,
                     layer,
-                    KVWriteLoc(
-                        forward_batch.out_cache_loc,
-                        self.forward_metadata.swa_out_cache_loc,
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
                         full_loc=self.forward_metadata.out_cache_loc_full_physical,
                     ),
                     k,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -42,6 +42,7 @@ from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     KVCacheAttentionAccessKind,
 )
 from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.mem_cache.layout.page_major import paged_view
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -1403,12 +1404,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 k_cache_raw, v_cache_raw, layer, layer.head_dim
             )
         else:
-            k_cache = k_cache_raw.view(
-                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
-            )
-            v_cache = v_cache_raw.view(
-                -1, self.page_size, layer.tp_v_head_num, layer.head_dim
-            )
+            k_cache = paged_view(k_cache_raw, self.page_size)
+            v_cache = paged_view(v_cache_raw, self.page_size)
 
         kv_cache = (k_cache, v_cache)
         # sink: additional value per head in the denominator of the softmax.

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -1263,7 +1263,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if save_kv_cache and k is not None:
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                    KVWriteLoc.for_batch(
+                        forward_batch,
+                        cache_loc,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
+                    ),
                     k,
                     v,
                     *self._kv_write_scales(layer),
@@ -1367,7 +1371,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 else:
                     self.token_to_kv_pool.set_kv_buffer(
                         layer,
-                        KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                        KVWriteLoc.for_batch(
+                            forward_batch,
+                            cache_loc,
+                            swa_loc=self.forward_metadata.swa_out_cache_loc,
+                        ),
                         k,
                         v,
                         layer.k_scale,

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -53,6 +53,7 @@ from sglang.srt.layers.attention.flashinfer_mla_backend import (
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
 from sglang.srt.layers.dcp.layout import get_dcp_lens
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
+from sglang.srt.mem_cache.layout.page_major import paged_row_view
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -1368,7 +1369,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         # Prepare KV cache inline
         k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
+        kv_cache = paged_row_view(k_cache, self.page_size).unsqueeze(1)
 
         # Get metadata
         metadata = (
@@ -1558,7 +1559,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             bs = forward_batch.batch_size
 
             k_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-            kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
+            kv_cache = paged_row_view(k_cache, self.page_size).unsqueeze(1)
 
             q = q.to(self.data_type)
 

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -54,6 +54,7 @@ from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_ver
 from sglang.srt.layers.dcp.layout import get_dcp_lens
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
 from sglang.srt.mem_cache.layout.page_major import paged_row_view
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -1321,7 +1322,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     )
                 if query is None:
                     self.token_to_kv_pool.set_mla_kv_buffer(
-                        layer, self._decode_kernel_loc, k, k_rope
+                        layer,
+                        KVWriteLoc.for_batch(forward_batch, self._decode_kernel_loc),
+                        k,
+                        k_rope,
                     )
             else:
                 # eager (or static pool): out_cache_loc is kernel-facing.
@@ -1341,7 +1345,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     )
                 if query is None:
                     self.token_to_kv_pool.set_mla_kv_buffer(
-                        layer, forward_batch.out_cache_loc, k, k_rope
+                        layer, KVWriteLoc.for_batch(forward_batch), k, k_rope
                     )
 
         # Prepare query tensor inline (already built when the fused save-KV
@@ -1513,11 +1517,14 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
             if self._decode_kernel_loc is not None:
                 self.token_to_kv_pool.set_mla_kv_buffer(
-                    layer, self._decode_kernel_loc, k, k_rope
+                    layer,
+                    KVWriteLoc.for_batch(forward_batch, self._decode_kernel_loc),
+                    k,
+                    k_rope,
                 )
             else:
                 self.token_to_kv_pool.set_mla_kv_buffer(
-                    layer, forward_batch.out_cache_loc, k, k_rope
+                    layer, KVWriteLoc.for_batch(forward_batch), k, k_rope
                 )
 
         # TODO refactor to avoid code duplication

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -396,7 +396,6 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             v2p,
             self.req_to_token.stride(0),
             block_kv_indices.stride(0),
-            self.kv_index_translator.full_page_multiplier,
             PHYSICAL_PAGE_SIZE=self.page_size,
             DCP_SIZE=parallel.dcp_size,
             DCP_RANK=parallel.dcp_rank,

--- a/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_hybrid_swa.py
@@ -304,10 +304,6 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         return self.swa_attn_allocator.translate_kv_loc_for_kernel(kv_indices, out=out)
 
     @property
-    def kernel_page_multiplier(self) -> int:
-        return self.full_attn_allocator.kernel_page_multiplier
-
-    @property
     def full_v2p_page_table(self) -> torch.Tensor:
         """Page-level virtual->physical table of the full sub-pool."""
         return self.full_attn_allocator.virtual_to_physical
@@ -316,15 +312,6 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
     def full_p2v_page_table(self) -> torch.Tensor:
         """Page-level physical->virtual table of the full sub-pool."""
         return self.full_attn_allocator.physical_to_virtual
-
-    def translate_kv_loc_for_kernel(
-        self,
-        loc: torch.Tensor,
-        *,
-        out: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Full-pool virtual TOKEN ids -> kernel-facing ids."""
-        return self.full_attn_allocator.translate_kv_loc_for_kernel(loc, out=out)
 
     def translate_write_loc_for_kernel(
         self,
@@ -338,10 +325,6 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         return self.full_attn_allocator.translate_write_loc_for_kernel(
             loc, out=out, out_width=out_width
         )
-
-    @property
-    def swa_kernel_page_multiplier(self) -> int:
-        return self.swa_attn_allocator.kernel_page_multiplier
 
     @property
     def swa_v2p_page_table(self) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/allocator/unified_mamba.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_mamba.py
@@ -231,29 +231,16 @@ class UnifiedMambaTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return result
 
     @property
-    def kernel_page_multiplier(self) -> int:
-        return self.full_attn_allocator.kernel_page_multiplier
-
-    @property
     def full_v2p_page_table(self) -> torch.Tensor:
         """Page-level virtual->physical table of the full sub-pool. Kernels that
         build the MLA block table straight from req_to_token gather through this,
-        then scale by `kernel_page_multiplier` to reach the per-page block."""
+        The kernel id is the physical token id; there is no per-page scale."""
         return self.full_attn_allocator.virtual_to_physical
 
     @property
     def full_p2v_page_table(self) -> torch.Tensor:
         """Page-level physical->virtual table of the full sub-pool."""
         return self.full_attn_allocator.physical_to_virtual
-
-    def translate_kv_loc_for_kernel(
-        self,
-        loc: torch.Tensor,
-        *,
-        out: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Full-pool virtual TOKEN ids -> kernel-facing ids."""
-        return self.full_attn_allocator.translate_kv_loc_for_kernel(loc, out=out)
 
     def translate_write_loc_for_kernel(
         self,

--- a/python/sglang/srt/mem_cache/allocator/unified_sub_pool.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_sub_pool.py
@@ -254,14 +254,15 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self.entry_bytes = spec.entry_bytes()
         self.min_slot_index = unified_buffer.min_slot_index(sub_pool_name)
         self.is_id_owner = is_id_owner
-        # Kernel-facing page-stride scale, from the spec that owns the layout;
-        # `kernel_page_multiplier=` overrides it only for tests.
-        self.kernel_page_multiplier = (
-            spec.blocks_per_page()
-            if kernel_page_multiplier is None
-            else kernel_page_multiplier
+        # Kernel-facing ids are the physical token ids: the token-major views
+        # step slots by the whole entry, so there is no per-page block scale.
+        # The kwarg is accepted (and must be 1) until the plumbing is removed.
+        assert kernel_page_multiplier in (None, 1), (
+            f"kernel_page_multiplier must be 1 (token-major views); got "
+            f"{kernel_page_multiplier}"
         )
-        # Zero page envelopes on hand-out -- see _maybe_zero_pages.
+        self.kernel_page_multiplier = 1
+        # Zero page envelopes on hand-out — see _maybe_zero_pages.
         self._zero_pages_on_alloc = isinstance(kvcache, UnifiedMLATokenToKVPool)
         # Overlap mode: `free` drops a wait_stream(forward_stream) barrier so its
         # v2p writes + move kernel serialize after the in-flight forward.
@@ -982,14 +983,15 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         *,
         out: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Virtual token ids -> kernel-facing ids:
+        """Virtual token ids -> kernel-facing ids, which under the token-major
+        views are the physical token ids:
 
-            kernel_id(t) = (t // ps) * (ps * kernel_page_multiplier) + t % ps
+            kernel_id(t) = v2p[t // ps] * ps + t % ps
 
-        Internal machinery (compaction, in-flight write sets) MUST keep using
-        `translate_kv_loc`: kernel-facing ids are for kernels only. Tombstones (-1)
-        clamp to kernel-facing id 0, the page-0 sink. int64 out; a consumer whose
-        kernel ABI wants int32 narrows where it fills that buffer.
+        (`kernel_page_multiplier` is pinned to 1, so this equals
+        `translate_kv_loc`.) Tombstones (-1) clamp to id 0, the page-0 sink.
+        int64 out; a consumer whose kernel ABI wants int32 narrows where it
+        fills that buffer.
         """
         with record_function("MultiEndedAlloc.translate_kv_loc_for_kernel"):
             return self._translate_loc_fused(virt_tokens, dcp_size=1, out=out)

--- a/python/sglang/srt/mem_cache/allocator/unified_sub_pool.py
+++ b/python/sglang/srt/mem_cache/allocator/unified_sub_pool.py
@@ -230,7 +230,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         need_sort: bool = False,
         forward_stream: Optional[torch.cuda.Stream] = None,
         lazy_compaction: bool = False,
-        kernel_page_multiplier: Optional[int] = None,
     ):
         spec = unified_buffer.spec(sub_pool_name)
         max_slots = unified_buffer.max_slots(sub_pool_name)
@@ -254,14 +253,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self.entry_bytes = spec.entry_bytes()
         self.min_slot_index = unified_buffer.min_slot_index(sub_pool_name)
         self.is_id_owner = is_id_owner
-        # Kernel-facing ids are the physical token ids: the token-major views
-        # step slots by the whole entry, so there is no per-page block scale.
-        # The kwarg is accepted (and must be 1) until the plumbing is removed.
-        assert kernel_page_multiplier in (None, 1), (
-            f"kernel_page_multiplier must be 1 (token-major views); got "
-            f"{kernel_page_multiplier}"
-        )
-        self.kernel_page_multiplier = 1
         # Zero page envelopes on hand-out — see _maybe_zero_pages.
         self._zero_pages_on_alloc = isinstance(kvcache, UnifiedMLATokenToKVPool)
         # Overlap mode: `free` drops a wait_stream(forward_stream) barrier so its
@@ -918,6 +909,16 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
 
     # -- translate (virtual TOKEN ids -> physical TOKEN ids) --
 
+    # TODO(unified-memory): fold this onto the fused path. Under the token-major
+    # views `translate_kv_loc`, `translate_kv_loc_for_kernel` and
+    # `_translate_loc_fused(dcp_size=1)` all compute the same id; only the
+    # implementation differs (one Triton launch vs several torch ops). Two things
+    # stop it being a rename: `write_loc_to_kernel_ids` flat-addresses and asserts
+    # contiguity, while callers pass strided slices (flashattention_backend hands
+    # `page_table[:bs, :max_seq_len]`); and the fused path sends a negative loc to
+    # the page-0 sink where this one lets the v2p index wrap, so the swap is a fix
+    # and needs a red-first test. Retarget `translate_kv_loc_for_kernel`'s caller
+    # only AFTER that -- first would strip the -1 handling the SWA path relies on.
     def translate_kv_loc(
         self,
         virt_tokens: torch.Tensor,
@@ -949,33 +950,26 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         virt_tokens: torch.Tensor,
         out: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        # Tombstone-safety clamp: a tombstoned v2p entry (-1) must not reach
-        # `k_buffer[-1]` (illegal access under captured graph replay). Clamping to
-        # 0 routes it to physical slot 0, reserved sink space holding no real data.
+        # Tombstoned v2p entries (-1) clamp to physical slot 0.
         ps = self.pool_page_size
-        if ps == 1:
-            if out is not None:
-                # `index_select(out=out)` forbids index/out aliasing, but the
-                # canonical caller passes `out=kv_indices` in place.
-                tmp = torch.index_select(self.virtual_to_physical, 0, virt_tokens)
-                tmp = torch.clamp_min(tmp, 0)
-                out.copy_(tmp)
-                return out
-            result = torch.index_select(self.virtual_to_physical, 0, virt_tokens)
-            return torch.clamp_min(result, 0)
-        # ps > 1: page math. `virt_pages`/`offsets` are fresh, so they
-        # cannot alias `out` -- `index_select(out=out)` is safe.
-        virt_pages = virt_tokens // ps
-        offsets = virt_tokens % ps
-        if out is not None:
-            torch.index_select(self.virtual_to_physical, 0, virt_pages, out=out)
+        pages = virt_tokens if ps == 1 else virt_tokens // ps
+        offsets = None if ps == 1 else virt_tokens % ps
+        if out is None:
+            phys = self.virtual_to_physical[pages]
+            ids = phys if offsets is None else phys * ps + offsets
+            return ids.clamp_(min=0)
+        if pages.dtype != torch.int64:
+            pages = pages.to(torch.int64)
+        if pages is virt_tokens:
+            # `take(out=out)` forbids index/out aliasing, but the canonical
+            # caller translates in place: translate(loc, out=loc).
+            out.copy_(torch.take(self.virtual_to_physical, pages))
+        else:
+            torch.take(self.virtual_to_physical, pages, out=out)
+        if offsets is not None:
             out.mul_(ps)
             out.add_(offsets)
-            out.clamp_(min=0)  # tombstoned page: -1*ps + offset in [-ps, -1]
-            return out
-        phys_pages = self.virtual_to_physical[virt_pages]
-        result = phys_pages * ps + offsets
-        return torch.clamp_min(result, 0)
+        return out.clamp_(min=0)
 
     def translate_kv_loc_for_kernel(
         self,
@@ -988,8 +982,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
 
             kernel_id(t) = v2p[t // ps] * ps + t % ps
 
-        (`kernel_page_multiplier` is pinned to 1, so this equals
-        `translate_kv_loc`.) Tombstones (-1) clamp to id 0, the page-0 sink.
+        (Identical to `translate_kv_loc`: the kernel id IS the physical id.) Tombstones (-1) clamp to id 0, the page-0 sink.
         int64 out; a consumer whose kernel ABI wants int32 narrows where it
         fills that buffer.
         """
@@ -1021,7 +1014,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             loc=loc,
             v2p=self.virtual_to_physical,
             page_size=self.pool_page_size,
-            stride=self.pool_page_size * self.kernel_page_multiplier,
+            stride=self.pool_page_size,
             dcp_size=dcp_size,
             dcp_rank=dcp_rank,
             out=out,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -70,7 +70,6 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     MLATokenToKVPoolFP4,
     NoOpMHATokenToKVPool,
-    PageMajorMHATokenToKVPool,
     ReqToTokenPool,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
@@ -1177,18 +1176,9 @@ class KVCacheConfigurator:
         is_dsv4_model: bool,
         req_to_token_pool: ReqToTokenPool,
     ) -> KVCache:
-        # Page-granularity envelope layout for the MHA-shaped (full / SWA) pools,
-        # selected by swapping in the PageMajorMHATokenToKVPool subclass. The
-        # default keeps upstream's per-layer layout. The Mamba state pool is routed
-        # separately via `mamba_envelope_layout` on the req-to-token pool above.
-        enable_page_major = get_memory().enable_page_major_kv_layout
-        if self.is_draft_worker and get_memory().enable_unified_memory:
-            # Page-major is a target-pool layout choice; the draft backend
-            # reads the plain per-layer contiguous layout.
-            enable_page_major = False
-        mha_pool_class = (
-            PageMajorMHATokenToKVPool if enable_page_major else MHATokenToKVPool
-        )
+        # The page-granularity envelope layout lives in the unified pool; the
+        # plain pools keep upstream's per-layer layout.
+        mha_pool_class = MHATokenToKVPool
 
         if is_dsv4_model:
             token_to_kv_pool = self._build_dsv4_kv_pool(
@@ -1279,12 +1269,6 @@ class KVCacheConfigurator:
                 quant_method = self._build_mha_quant_method(
                     num_layers=self.layer_info.num_effective_layers
                 )
-                if quant_method is not None and is_float4_e2m1fn_x2(
-                    self.kv_cache_dtype
-                ):
-                    assert not enable_page_major, (
-                        "page-major KV layout is not supported with fp4 KV cache"
-                    )
                 token_to_kv_pool = self._build_mha_kv_pool(
                     max_total_num_tokens=sizes.max_total_num_tokens,
                     mha_pool_class=mha_pool_class,

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -245,6 +245,7 @@ class KVIndexTranslator:
         seq_lens: torch.Tensor,
         max_pages: Optional[int] = None,
         into: Optional[KVReadTables] = None,
+        seq_len_delta: int = 0,
     ) -> KVIndexTable:
         """The one per-batch entry point.
 
@@ -253,6 +254,10 @@ class KVIndexTranslator:
         returns the table WHOLE, so a caller needing a stable pointer (a
         captured graph bakes it) passes its own tables in ``into``;
         ``into=None`` allocates of width ``max_pages`` instead.
+
+        ``seq_len_delta`` widens every row's live prefix -- the whole-sequence
+        verify contract (draft KV read back from the pool). An eager caller's
+        ``max_pages`` must already cover the delta.
         """
         if not self.is_translating or self.defer_read_translate:
             return KVIndexTable(
@@ -296,6 +301,7 @@ class KVIndexTranslator:
             page_size=self.page_size,
             max_pages=width,
             out=out_full,
+            seq_len_delta=seq_len_delta,
         )
         if out_swa is not None:
             build_kv_read_table(
@@ -306,6 +312,7 @@ class KVIndexTranslator:
                 page_size=self.page_size,
                 max_pages=width,
                 out=out_swa,
+                seq_len_delta=seq_len_delta,
             )
         return KVIndexTable(
             ids=out_full,
@@ -323,6 +330,7 @@ class KVIndexTranslator:
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         sliding_window_out: Optional[torch.Tensor] = None,
+        seq_len_delta: int = 0,
     ) -> None:
         """`build_index_table(into=...)` for a caller that owns a bare block
         table rather than a KVReadTables: the page-table consumers read that
@@ -347,6 +355,7 @@ class KVIndexTranslator:
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             into=KVReadTables(full=out, sliding_window=sliding_window_out),
+            seq_len_delta=seq_len_delta,
         )
 
     def index_table_for_batch(self, forward_batch) -> KVIndexTable:
@@ -391,6 +400,30 @@ class KVIndexTranslator:
         them.
         """
         return self._full_v2p_table
+
+    def widened_index_table(self, forward_batch, *, seq_len_delta: int) -> KVIndexTable:
+        """Whole-sequence-verify view: every row's live prefix widened by
+        `seq_len_delta` columns (the drafts are read back from the pool).
+        Not memoized -- verify is one consumer, and the batch's memoized
+        prefix table stays valid for the others."""
+        max_pages = None
+        if self.is_translating:
+            slc = forward_batch.seq_lens_cpu
+            if (
+                forward_batch.seq_lens_sum is not None
+                and slc is not None
+                and slc.numel() > 0
+            ):
+                max_seq = int(slc.max()) + seq_len_delta
+            else:
+                max_seq = self.req_to_token.shape[1]
+            max_pages = max(-(-max_seq // self.page_size), 1)
+        return self.build_index_table(
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            max_pages=max_pages,
+            seq_len_delta=seq_len_delta,
+        )
 
     def bind_and_verify_backends(self, backends) -> None:
         """Boot: make every reachable backend carry THIS translator.

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -432,7 +432,9 @@ class KVIndexTranslator:
 
     def rebind_write_loc(self, forward_batch) -> None:
         """Phase 1 of the WRITE contract: translate the batch's write loc to
-        FULL-side kernel-facing ids, once, at ForwardBatch construction.
+        FULL-side kernel-facing ids exactly once, at ForwardBatch
+        construction, and mark the batch's loc kernel-facing. On non-unified
+        pools the allocation is already physical / kernel-facing.
 
         REBIND, never mutate: the translate returns a FRESH tensor, so the
         ScheduleBatch's aliased tensor stays VIRTUAL for the radix / accept /
@@ -440,12 +442,14 @@ class KVIndexTranslator:
         the batch for `fill_capture_write_loc`.
         """
         self._index_table_memo = None
-        if not self.is_translating or forward_batch.out_cache_loc is None:
+        if forward_batch.out_cache_loc is None:
             return
         forward_batch.out_cache_loc_virtual = forward_batch.out_cache_loc
-        forward_batch.out_cache_loc = self._translate_write_full(
-            forward_batch.out_cache_loc
-        )
+        if self.is_translating:
+            forward_batch.out_cache_loc = self._translate_write_full(
+                forward_batch.out_cache_loc
+            )
+        forward_batch.out_cache_loc_id_space = "kernel"
 
     def fill_capture_write_loc(
         self,

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -19,8 +19,7 @@ A KV slot can be named in three id spaces:
     slot even after the pool moves data around.
   * **physical** - where that slot sits in the pool right now.
   * **kernel-facing** - what a kernel can index the per-layer K/V tensors
-    with. Same as physical on a plain pool; under the unified pool it is the
-    physical page scaled by the per-page block count.
+    with. Under the token-major views, it is the same as physical id.
 
 All three coincide on a plain pool, so nothing here does any work there.
 
@@ -129,8 +128,7 @@ class KVIndexTranslator:
             alloc = token_to_kv_pool_allocator
             self._full_v2p_table = alloc.full_v2p_page_table
             self._full_p2v_table = alloc.full_p2v_page_table
-            self._full_page_multiplier = alloc.kernel_page_multiplier
-            self._translate_full = alloc.translate_kv_loc_for_kernel
+            self._translate_full = alloc.translate_kv_loc
             # The WRITE loc is the one id that arrives DCP-WIDENED: read indices
             # are collapsed by the DCP index kernels, `out_cache_loc` still
             # carries the owner rule in `loc % dcp_size`. Identity with the read
@@ -141,21 +139,17 @@ class KVIndexTranslator:
             self.defer_read_translate = get_parallel().attn_dcp_size > 1
             if isinstance(alloc, UnifiedSWATokenToKVPoolAllocator):
                 self._swa_v2p_table = alloc.swa_v2p_page_table
-                self._swa_page_multiplier = alloc.swa_kernel_page_multiplier
                 self._swa_write_loc_from_full = self._swa_write_loc_unified
             else:
                 self._swa_v2p_table = None
-                self._swa_page_multiplier = 1
                 self._swa_write_loc_from_full = None
         else:
             self._full_v2p_table = None
             self._full_p2v_table = None
-            self._full_page_multiplier = 1
             self._translate_full = None
             self._translate_write_full = None
             self.defer_read_translate = False
             self._swa_v2p_table = None
-            self._swa_page_multiplier = 1
             # `translate_loc_from_full_to_swa` is abstract on `BaseSWAKVPool`,
             # which is also what the backends' `_resolve_swa_kv_pool` keys on.
             self._swa_write_loc_from_full = (
@@ -237,11 +231,6 @@ class KVIndexTranslator:
             seq_lens=seq_lens,
             v2p=self._swa_v2p_table if sliding_window else self._full_v2p_table,
             indptr=indptr,
-            multiplier=(
-                self._swa_page_multiplier
-                if sliding_window
-                else self._full_page_multiplier
-            ),
             page_size=self.page_size,
             max_tokens=total_tokens,
             out=out,
@@ -304,7 +293,6 @@ class KVIndexTranslator:
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             v2p=self._full_v2p_table,
-            multiplier=self._full_page_multiplier,
             page_size=self.page_size,
             max_pages=width,
             out=out_full,
@@ -315,7 +303,6 @@ class KVIndexTranslator:
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
                 v2p=self._swa_v2p_table,
-                multiplier=self._swa_page_multiplier,
                 page_size=self.page_size,
                 max_pages=width,
                 out=out_swa,
@@ -405,11 +392,6 @@ class KVIndexTranslator:
         """
         return self._full_v2p_table
 
-    @property
-    def full_page_multiplier(self) -> int:
-        """Scales a physical page into the id space the per-layer views use."""
-        return self._full_page_multiplier
-
     def bind_and_verify_backends(self, backends) -> None:
         """Boot: make every reachable backend carry THIS translator.
 
@@ -495,16 +477,15 @@ class KVIndexTranslator:
         return self._swa_write_loc_from_full(out_cache_loc)
 
     def _swa_write_loc_unified(self, kernel_loc: torch.Tensor) -> torch.Tensor:
-        """Sliding-window write loc, derived pointwise from FULL-side
-        kernel-facing values (phase 2 of the write contract).
+        """Sliding-window write loc, derived pointwise from FULL-side physical
+        values (phase 2 of the write contract).
         """
-        full_stride = self.page_size * self._full_page_multiplier
-        offset = kernel_loc % full_stride  # == virtual_token % page_size
+        ps = self.page_size
+        offset = kernel_loc % ps  # == virtual_token % page_size
         # An unmapped physical page reads back as -1; clamp it rather than let
         # the gather wrap onto the v2p table's last element.
-        virt_page = self._full_p2v_table[kernel_loc // full_stride].clamp_(min=0)
-        swa_stride = self.page_size * self._swa_page_multiplier
-        return (self._swa_v2p_table[virt_page] * swa_stride + offset).clamp_(min=0)
+        virt_page = self._full_p2v_table[kernel_loc // ps].clamp_(min=0)
+        return (self._swa_v2p_table[virt_page] * ps + offset).clamp_(min=0)
 
     # -- token-level translate surface (the mixin / local-attn consumers) ------
 

--- a/python/sglang/srt/mem_cache/layout/page_major.py
+++ b/python/sglang/srt/mem_cache/layout/page_major.py
@@ -54,14 +54,18 @@ def align_entry_bytes(num_bytes: int) -> int:
 def paged_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:
     """``[slots, ...]`` -> ``[slots // page_size, page_size, ...]``, as a view.
 
-    Splitting dim 0 never copies: the slot stride becomes dim 1's stride, so a
-    strided per-layer view keeps addressing ``slot * stride(0)``.
+    Built with ``as_strided``, not ``view``: dim 1 must carry the slot stride
+    at every page size, and ``view`` gives a size-1 dim (``page_size == 1``)
+    the row stride instead, which differs from the slot stride whenever the
+    per-layer view is strided.
     """
     num_slots = int(flat.shape[0])
     assert num_slots % page_size == 0, (num_slots, page_size)
-    out = flat.view(num_slots // page_size, page_size, *flat.shape[1:])
-    assert out.stride(1) == flat.stride(0)
-    return out
+    slot_stride = flat.stride(0)
+    return flat.as_strided(
+        (num_slots // page_size, page_size, *flat.shape[1:]),
+        (slot_stride * page_size, slot_stride, *flat.stride()[1:]),
+    )
 
 
 def paged_row_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/layout/page_major.py
+++ b/python/sglang/srt/mem_cache/layout/page_major.py
@@ -1,23 +1,33 @@
-"""Page-granularity envelope (page-major, layer-major within a page) cache views.
+"""Page-granularity envelope (page-major, token-major within a page) cache views.
 
 A pool of this layout keeps all layers of all slots in one contiguous byte
-buffer. The buffer is split into pages of ``page_size`` slots; within a page,
-each layer's K and V (or each Mamba conv/temporal tensor) are grouped together:
+buffer, split into pages of ``page_size`` slots. Within a page the slots follow
+one another, and one slot's ENTRY holds every part of that token -- K and V of
+every layer for MHA, the latent row of every layer for MLA -- at a fixed byte
+offset:
 
-    page bytes = [L0_K * ps | L0_V * ps | L1_K * ps | L1_V * ps | ...]
+    page bytes  = [ entry(slot 0) | entry(slot 1) | ... | entry(slot ps-1) ]
+    entry bytes = [ K_0 | V_0 | K_1 | V_1 | ... ]  (MHA)
+                  [ lat_0 | lat_1 | ... ]           (MLA)
 
-Across pages the layout is envelope-major (one ``page_bytes`` block per page).
-At ``page_size == 1`` a page is a single slot, so the within-page block is the
-per-slot ``[L0_K | L0_V | L1_K | L1_V | ...]`` envelope (token-granularity).
+Every per-layer view is therefore a flat ``(num_pages * page_size, *row_shape)``
+tensor with slot stride ``entry_bytes`` and storage offset
+``anchor + part offset``, indexed by the PHYSICAL token id
+``page * page_size + slot``. Parts may differ in row width (K vs V); only their
+offsets differ, never the stride.
 
-These builders produce per-layer views into a raw ``uint8`` buffer; they hold
-no allocator/ownership state. ``anchor_bytes`` is the byte offset of the
-pool's region inside the raw buffer (0 for a standalone pool).
+These builders produce views into a raw ``uint8`` buffer; they hold no
+allocator/ownership state. ``anchor_bytes`` is the byte offset of the pool's
+region inside the raw buffer (0 for a standalone pool).
 """
 
 from typing import List, Sequence, Tuple
 
+import msgspec
 import torch
+
+ENTRY_ALIGN_BYTES = 32
+ROW_ALIGN_BYTES = 16
 
 
 def _prod(shape: Sequence[int]) -> int:
@@ -25,6 +35,20 @@ def _prod(shape: Sequence[int]) -> int:
     for s in shape:
         out *= int(s)
     return out
+
+
+def _contiguous_strides(shape: Sequence[int]) -> Tuple[int, ...]:
+    strides = []
+    acc = 1
+    for s in reversed(shape):
+        strides.append(acc)
+        acc *= int(s)
+    return tuple(reversed(strides))
+
+
+def align_entry_bytes(num_bytes: int) -> int:
+    """Round a slot's byte sum up to the entry alignment."""
+    return -(-num_bytes // ENTRY_ALIGN_BYTES) * ENTRY_ALIGN_BYTES
 
 
 def paged_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:
@@ -45,149 +69,121 @@ def paged_row_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:
     return paged_view(flat.view(int(flat.shape[0]), -1), page_size)
 
 
-def mha_entry_bytes(
-    *, layer_num: int, head_num: int, head_dim: int, v_head_dim: int, itemsize: int
-) -> int:
-    """Bytes occupied by one slot across all layers (K and V)."""
-    k_row_bytes = head_num * head_dim * itemsize
-    v_row_bytes = head_num * v_head_dim * itemsize
-    return layer_num * (k_row_bytes + v_row_bytes)
+class DensePart(msgspec.Struct, frozen=True, kw_only=True):
+    """One row family inside the entry: ``layer_num`` rows of ``row_shape``,
+    layer ``l`` at ``offset_bytes + l * layer_stride_bytes``."""
+
+    name: str
+    offset_bytes: int
+    layer_stride_bytes: int
+    layer_num: int
+    row_shape: Tuple[int, ...]
+    dtype: torch.dtype
+
+    def row_bytes(self) -> int:
+        return _prod(self.row_shape) * self.dtype.itemsize
+
+    def layer_offset_bytes(self, layer: int) -> int:
+        return self.offset_bytes + layer * self.layer_stride_bytes
 
 
-def build_mha_views(
-    raw: torch.Tensor,
-    *,
-    layer_num: int,
-    head_num: int,
-    head_dim: int,
-    v_head_dim: int,
-    store_dtype: torch.dtype,
-    page_size: int,
-    num_pages: int,
-    anchor_bytes: int = 0,
-) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-    """Per-layer K/V views over ``raw`` for uniform-row MHA.
+class DenseEntryLayout(msgspec.Struct, frozen=True, kw_only=True):
+    """Byte layout of one slot's entry; ``entry_bytes`` is the slot stride of
+    every view built over it."""
 
-    The page envelope ``[L0_K*ps | L0_V*ps | L1_K*ps | ...]`` is a uniform
-    array of ``2*layer_num`` row-blocks when K and V rows are equally wide, so
-    it is a valid paged pool under
+    entry_bytes: int
+    parts: Tuple[DensePart, ...]
 
-        kernel_id(t) = (t // ps) * (ps * 2 * layer_num) + t % ps
+    def __post_init__(self):
+        self.validate()
 
-    with layer ``l``'s K at block ``2l`` and its V at block ``2l+1``. Each view
-    is a contiguous ``(num_pages * 2 * layer_num * ps, head_num, head_dim)``.
+    def part(self, name: str) -> DensePart:
+        for p in self.parts:
+            if p.name == name:
+                return p
+        raise KeyError(f"no part {name!r} in {[p.name for p in self.parts]}")
 
-    Views overlap by ``ps`` rows per block, safe because an id always resolves
-    inside its own block; the last view runs ``(2*layer_num - 1) * ps`` rows
-    past the envelope, so ``raw`` needs ``UnifiedKVPool.view_tail_pad_bytes``.
-    """
-    assert head_dim == v_head_dim, (
-        f"build_mha_views requires uniform rows (head_dim == v_head_dim); "
-        f"got head_dim={head_dim}, v_head_dim={v_head_dim}. Asymmetric-KV "
-        "models cannot use the unified pool (screened out at startup)."
-    )
-    itemsize = store_dtype.itemsize
-    row_elems = head_num * head_dim
-    row_bytes = row_elems * itemsize
-    blocks = 2 * layer_num
-    page_bytes = page_size * blocks * row_bytes
-    n_rows = num_pages * blocks * page_size
-    assert anchor_bytes % itemsize == 0
-    last_view_end = (
-        anchor_bytes + (blocks - 1) * page_size * row_bytes + n_rows * row_bytes
-    )
-    assert last_view_end <= raw.numel() * raw.itemsize, (
-        f"build_mha_views: block {blocks - 1}'s view ends at byte "
-        f"{last_view_end} but the raw buffer holds only "
-        f"{raw.numel() * raw.itemsize} bytes; allocate the tail pad "
-        f"(one page envelope = {page_bytes} B) via view_tail_pad_bytes"
-    )
-
-    as_dtype_view = raw.view(store_dtype)
-    k_buffer: List[torch.Tensor] = []
-    v_buffer: List[torch.Tensor] = []
-    for layer in range(layer_num):
-        k_base_bytes = anchor_bytes + (2 * layer) * page_size * row_bytes
-        v_base_bytes = k_base_bytes + page_size * row_bytes
-        for base_bytes, out in ((k_base_bytes, k_buffer), (v_base_bytes, v_buffer)):
-            assert base_bytes % itemsize == 0
-            out.append(
-                torch.as_strided(
-                    as_dtype_view,
-                    size=(n_rows, head_num, head_dim),
-                    stride=(row_elems, head_dim, 1),
-                    storage_offset=base_bytes // itemsize,
-                )
+    def validate(self) -> None:
+        assert self.entry_bytes % ENTRY_ALIGN_BYTES == 0, (
+            f"entry_bytes={self.entry_bytes} is not a multiple of {ENTRY_ALIGN_BYTES}"
+        )
+        spans = []
+        for p in self.parts:
+            row = p.row_bytes()
+            assert (
+                p.offset_bytes % ROW_ALIGN_BYTES == 0
+                and p.layer_stride_bytes % ROW_ALIGN_BYTES == 0
+                and row % ROW_ALIGN_BYTES == 0
+            ), (
+                f"part {p.name!r}: offset {p.offset_bytes}, layer stride "
+                f"{p.layer_stride_bytes} and row {row} B must all be multiples of "
+                f"{ROW_ALIGN_BYTES} (vector stores)"
             )
-    return k_buffer, v_buffer
+            for l in range(p.layer_num):
+                lo = p.layer_offset_bytes(l)
+                assert 0 <= lo and lo + row <= self.entry_bytes, (
+                    f"part {p.name!r} layer {l} spans [{lo}, {lo + row}) outside "
+                    f"the {self.entry_bytes}-byte entry"
+                )
+                spans.append((lo, lo + row, p.name, l))
+        spans.sort()
+        for a, b in zip(spans, spans[1:]):
+            assert a[1] <= b[0], (
+                f"parts overlap: {a[2]}[{a[3]}] [{a[0]}, {a[1]}) and "
+                f"{b[2]}[{b[3]}] [{b[0]}, {b[1]})"
+            )
 
 
-def mla_entry_bytes(*, layer_num: int, kv_cache_dim: int, itemsize: int) -> int:
-    """Bytes occupied by one MLA slot across all layers (single latent row, no V)."""
-    return layer_num * kv_cache_dim * itemsize
-
-
-def build_mla_views(
+def build_dense_views(
     raw: torch.Tensor,
     *,
-    layer_num: int,
-    kv_cache_dim: int,
-    store_dtype: torch.dtype,
+    layout: DenseEntryLayout,
+    part: DensePart,
     page_size: int,
     num_pages: int,
     anchor_bytes: int = 0,
 ) -> List[torch.Tensor]:
-    """Per-layer views over ``raw`` for MLA in the page-major layout.
-
-    The page envelope is ``[L0_latent * ps | L1_latent * ps | ...]``. Because all
-    MLA layers share one uniform row size (``kv_cache_dim``), the envelope is
-    itself a valid paged pool under a re-numbered index space: folding the
-    layer offset ``l * ps * kv_cache_dim`` into each view's storage_offset makes
-    every per-layer view a plain CONTIGUOUS ``(num_pages * layer_num * ps, 1,
-    kv_cache_dim)`` tensor, addressed by the layer-independent kernel-facing id
-
-        kernel_id(t) = (t // ps) * (ps * layer_num) + t % ps      (t = physical token)
-
-    so one shared block table (entry = page * layer_num) serves every layer, and
-    kernels that require ``.view(-1, page_size, kv_cache_dim)`` (trtllm/cutlass/
-    flashmla) work on the views natively.
-
-    The views overlap each other (view ``l+1`` is view ``l`` shifted by ``ps``
-    rows); that is safe because layer ``l`` is only ever indexed at kernel-facing ids,
-    which always resolve to layer-``l`` bytes relative to view ``l``'s origin.
-    Layer ``layer_num-1``'s view extends ``(layer_num-1) * ps`` rows past the
-    last page envelope, so ``raw`` must carry at least one extra page envelope
-    of tail padding (``UnifiedKVPool``'s ``view_tail_pad_bytes``).
+    """Per-layer views of one part: ``(num_pages * page_size, *row_shape)`` with
+    slot stride ``layout.entry_bytes``, indexed by the physical token id
+    ``page * page_size + slot`` (``paged_view`` regroups them by page).
     """
-    itemsize = store_dtype.itemsize
-    row_bytes = kv_cache_dim * itemsize
-    page_bytes = page_size * layer_num * row_bytes
-    n_rows = num_pages * layer_num * page_size
-    assert anchor_bytes % itemsize == 0
-    last_view_end = (
-        anchor_bytes + (layer_num - 1) * page_size * row_bytes + (n_rows * row_bytes)
+    itemsize = part.dtype.itemsize
+    assert layout.entry_bytes % itemsize == 0 and anchor_bytes % itemsize == 0
+    n_rows = num_pages * page_size
+    end = anchor_bytes + n_rows * layout.entry_bytes
+    assert end <= raw.numel() * raw.itemsize, (
+        f"build_dense_views: {n_rows} slots of {layout.entry_bytes} B end at byte "
+        f"{end} but the raw buffer holds only {raw.numel() * raw.itemsize} bytes"
     )
-    assert last_view_end <= raw.numel() * raw.itemsize, (
-        f"build_mla_views: layer {layer_num - 1}'s view ends at byte "
-        f"{last_view_end} but the raw buffer holds only "
-        f"{raw.numel() * raw.itemsize} bytes; allocate the tail pad "
-        f"(one page envelope = {page_bytes} B) via view_tail_pad_bytes"
-    )
-
-    as_dtype_view = raw.view(store_dtype)
+    as_dtype_view = raw.view(part.dtype)
+    stride = (layout.entry_bytes // itemsize, *_contiguous_strides(part.row_shape))
     views: List[torch.Tensor] = []
-    for layer in range(layer_num):
-        base_bytes = anchor_bytes + layer * page_size * row_bytes
+    for layer in range(part.layer_num):
+        base_bytes = anchor_bytes + part.layer_offset_bytes(layer)
         assert base_bytes % itemsize == 0
         views.append(
             torch.as_strided(
                 as_dtype_view,
-                size=(n_rows, 1, kv_cache_dim),
-                stride=(kv_cache_dim, kv_cache_dim, 1),
+                size=(n_rows, *part.row_shape),
+                stride=stride,
                 storage_offset=base_bytes // itemsize,
             )
         )
     return views
+
+
+def mha_entry_bytes(
+    *, layer_num: int, head_num: int, head_dim: int, v_head_dim: int, itemsize: int
+) -> int:
+    """Bytes occupied by one slot across all layers (K and V), aligned."""
+    k_row_bytes = head_num * head_dim * itemsize
+    v_row_bytes = head_num * v_head_dim * itemsize
+    return align_entry_bytes(layer_num * (k_row_bytes + v_row_bytes))
+
+
+def mla_entry_bytes(*, layer_num: int, kv_cache_dim: int, itemsize: int) -> int:
+    """Bytes occupied by one MLA slot across all layers (latent rows), aligned."""
+    return align_entry_bytes(layer_num * kv_cache_dim * itemsize)
 
 
 def mamba_entry_bytes(

--- a/python/sglang/srt/mem_cache/layout/page_major.py
+++ b/python/sglang/srt/mem_cache/layout/page_major.py
@@ -27,6 +27,24 @@ def _prod(shape: Sequence[int]) -> int:
     return out
 
 
+def paged_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:
+    """``[slots, ...]`` -> ``[slots // page_size, page_size, ...]``, as a view.
+
+    Splitting dim 0 never copies: the slot stride becomes dim 1's stride, so a
+    strided per-layer view keeps addressing ``slot * stride(0)``.
+    """
+    num_slots = int(flat.shape[0])
+    assert num_slots % page_size == 0, (num_slots, page_size)
+    out = flat.view(num_slots // page_size, page_size, *flat.shape[1:])
+    assert out.stride(1) == flat.stride(0)
+    return out
+
+
+def paged_row_view(flat: torch.Tensor, page_size: int) -> torch.Tensor:
+    """``[slots, ...]`` -> ``[slots // page_size, page_size, row_elems]``, as a view."""
+    return paged_view(flat.view(int(flat.shape[0]), -1), page_size)
+
+
 def mha_entry_bytes(
     *, layer_num: int, head_num: int, head_dim: int, v_head_dim: int, itemsize: int
 ) -> int:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -62,6 +62,7 @@ from sglang.srt.mem_cache.kv_vmm_backing import KvVmmBufferOwner
 from sglang.srt.mem_cache.layout.page_major import (
     build_page_major_mamba_views,
     mamba_entry_bytes,
+    paged_view,
 )
 from sglang.srt.mem_cache.utils import (
     get_mla_kv_buffer_triton,
@@ -1795,6 +1796,17 @@ class KVCache(abc.ABC):
     @abc.abstractmethod
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError()
+
+    def get_paged_kv_buffer(
+        self, layer_id: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Per-layer K/V as ``[num_pages, page_size, ...]`` views of the flat
+        buffers; no copy, the slot stride is kept."""
+        k_buffer, v_buffer = self.get_kv_buffer(layer_id)
+        return (
+            paged_view(k_buffer, self.page_size),
+            paged_view(v_buffer, self.page_size),
+        )
 
     @abc.abstractmethod
     def set_kv_buffer(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1660,7 +1660,7 @@ class KVWriteLoc:
         *,
         swa_loc: Optional[torch.Tensor] = None,
         full_loc: Optional[torch.Tensor] = None,
-    ) -> "KVWriteLoc":
+    ) -> KVWriteLoc:
         """A write loc derived from the batch's ``out_cache_loc`` (or a slice /
         alias of it), carrying the batch's id space."""
         return cls(
@@ -1836,9 +1836,7 @@ class KVCache(abc.ABC):
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError()
 
-    def get_paged_kv_buffer(
-        self, layer_id: int
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    def get_paged_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """Per-layer K/V as ``[num_pages, page_size, ...]`` views of the flat
         buffers; no copy, the slot stride is kept."""
         k_buffer, v_buffer = self.get_kv_buffer(layer_id)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -85,7 +85,6 @@ from sglang.srt.utils import (
     next_power_of_2,
 )
 from sglang.srt.utils.async_probe import (
-    maybe_detect_kernel_facing_loc,
     maybe_detect_oob,
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -1722,10 +1721,6 @@ class KVCache(abc.ABC):
     ):
         self.size = size
         self.page_size = page_size
-        # Row-blocks one page holds in this pool's kernel-facing id space; >1
-        # only for the unified pool's per-layer views, and then a write loc must
-        # have been translated into that space first.
-        self.kernel_page_blocks = 1
         self.dtype = dtype
         self.device = device
         if dtype in (torch.float8_e5m2, torch.float8_e4m3fn, torch.float8_e4m3fnuz):
@@ -2441,9 +2436,6 @@ class MHATokenToKVPool(KVCache):
         # Catch stale slot ids here instead of as illegal-addr / silent KV
         # corruption in the store_kvcache write (gated on SGLANG_ENABLE_ASYNC_ASSERT).
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA)")
-        maybe_detect_kernel_facing_loc(
-            loc, self.page_size, self.kernel_page_blocks, "set_kv_buffer (MHA)"
-        )
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id
         )
@@ -4269,9 +4261,7 @@ class MLATokenToKVPool(KVCache):
 
     # Has the WRITE loc arriving here already had the DCP owner rule resolved?
     # False: this pool takes a WIDENED loc. The unified pool resolves it in
-    # `KVIndexTranslator.rebind_write_loc` and flips this. Not derivable from
-    # `kernel_page_blocks`: that is `layer_num`, so a rank owning one
-    # full-attention layer is translated with blocks_per_page 1.
+    # `KVIndexTranslator.rebind_write_loc` and flips this.
     write_loc_is_dcp_resolved = False
 
     @property
@@ -4303,9 +4293,6 @@ class MLATokenToKVPool(KVCache):
     ):
         loc, _, _ = unwrap_write_loc(loc_info)
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
-        maybe_detect_kernel_facing_loc(
-            loc, self.page_size, self.kernel_page_blocks, "set_kv_buffer (MLA)"
-        )
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id
         )
@@ -4388,9 +4375,6 @@ class MLATokenToKVPool(KVCache):
             0,
             (self.size + self.page_size) * self._write_loc_dcp_span,
             "set_mla_kv_buffer (MLA)",
-        )
-        maybe_detect_kernel_facing_loc(
-            loc, self.page_size, self.kernel_page_blocks, "set_mla_kv_buffer (MLA)"
         )
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2125,7 +2125,7 @@ class MHATokenToKVPool(KVCache):
         )
         self.data_strides = torch.tensor(
             [
-                np.prod(x.shape[1:]) * x.dtype.itemsize
+                x.stride(0) * x.dtype.itemsize  # slot stride: views may be strided
                 for x in slot_move_pointer_buffers
             ],
             device=self.device,
@@ -2481,6 +2481,8 @@ class MHATokenToKVPool(KVCache):
                 cache_k.stride(1),
                 cache_v.stride(0),
                 cache_v.stride(1),
+                self.k_buffer[layer_id - self.start_layer].stride(0),
+                self.v_buffer[layer_id - self.start_layer].stride(0),
             )
             return
 
@@ -3019,7 +3021,7 @@ class NoOpMHATokenToKVPool(MHATokenToKVPool):
         self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
         self.data_strides = torch.tensor(
             [
-                np.prod(x.shape[1:]) * x.dtype.itemsize
+                x.stride(0) * x.dtype.itemsize  # slot stride: views may be strided
                 for x in self.k_buffer + self.v_buffer
             ],
             device=self.device,
@@ -3405,7 +3407,7 @@ class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
         self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
         self.data_strides = torch.tensor(
             [
-                np.prod(x.shape[1:]) * x.dtype.itemsize
+                x.stride(0) * x.dtype.itemsize  # slot stride: views may be strided
                 for x in self.k_buffer + self.v_buffer
             ],
             device=self.device,
@@ -5096,6 +5098,8 @@ def masked_set_kv_buffer_kernel(
     k_stride_H: tl.constexpr,
     v_stride_B: tl.constexpr,
     v_stride_H: tl.constexpr,
+    k_buffer_stride: tl.constexpr,
+    v_buffer_stride: tl.constexpr,
 ):
     pid = tl.program_id(0)
     if pid >= N:
@@ -5117,10 +5121,10 @@ def masked_set_kv_buffer_kernel(
         col = idx % D
 
         key = tl.load(k_ptr + pid * k_stride_B + row * k_stride_H + col, mask=mask)
-        tl.store(k_buffer_ptr + loc * H * D + idx, key, mask=mask)
+        tl.store(k_buffer_ptr + loc * k_buffer_stride + idx, key, mask=mask)
 
         value = tl.load(v_ptr + pid * v_stride_B + row * v_stride_H + col, mask=mask)
-        tl.store(v_buffer_ptr + loc * H * D + idx, value, mask=mask)
+        tl.store(v_buffer_ptr + loc * v_buffer_stride + idx, value, mask=mask)
 
 
 class MHATokenToKOnlyPool(KVCache):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1641,11 +1641,34 @@ class KVWriteLoc:
     loc into its sub-pool, mirroring ``swa_kv_pool`` / ``full_kv_pool``);
     ``loc`` is the generic fallback. Bundling them lets a backend issue one
     ``set_kv_buffer`` call regardless of pool type.
+
+    ``id_space`` says if the kernel will accept locs: ``"kernel"`` implies
+    rebound by the translator, or physical by allocation, ``"virtual"``
+    otherwise. The kernel refuses a ``"virtual"`` loc.
     """
 
     loc: torch.Tensor
     swa_loc: Optional[torch.Tensor] = None
     full_loc: Optional[torch.Tensor] = None
+    id_space: str = "virtual"
+
+    @classmethod
+    def for_batch(
+        cls,
+        forward_batch,
+        loc: Optional[torch.Tensor] = None,
+        *,
+        swa_loc: Optional[torch.Tensor] = None,
+        full_loc: Optional[torch.Tensor] = None,
+    ) -> "KVWriteLoc":
+        """A write loc derived from the batch's ``out_cache_loc`` (or a slice /
+        alias of it), carrying the batch's id space."""
+        return cls(
+            forward_batch.out_cache_loc if loc is None else loc,
+            swa_loc,
+            full_loc,
+            id_space=forward_batch.out_cache_loc_id_space,
+        )
 
     def __post_init__(self):
         # swa_loc / full_loc are resolved once at metadata-init from the full
@@ -1662,6 +1685,11 @@ def unwrap_write_loc(loc_info):
     if isinstance(loc_info, KVWriteLoc):
         return loc_info.loc, loc_info.swa_loc, loc_info.full_loc
     return loc_info, None, None
+
+
+def write_loc_id_space(loc_info) -> str:
+    """``id_space`` of a ``KVWriteLoc``; a bare loc declares nothing (virtual)."""
+    return loc_info.id_space if isinstance(loc_info, KVWriteLoc) else "virtual"
 
 
 class KvBufferDesc:
@@ -1779,6 +1807,22 @@ class KVCache(abc.ABC):
     def get_kv_buffer_shape(self) -> Tuple[torch.Size, torch.Size]:
         k_buffer, v_buffer = self.get_kv_buffer(self.start_layer)
         return k_buffer.shape, v_buffer.shape
+
+    # Unified pools reset this.
+    requires_translated_write_loc = False
+
+    def _check_write_loc_space(self, loc_info, where: str) -> None:
+        if not self.requires_translated_write_loc:
+            return
+        if not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
+            return
+        space = write_loc_id_space(loc_info)
+        assert space == "kernel", (
+            f"{where}: write loc is {space!r}, not kernel-facing. Producers hand "
+            "the pool KVWriteLoc.for_batch(forward_batch, ...) after "
+            "KVIndexTranslator.rebind_write_loc, or KVWriteLoc(loc, "
+            "id_space='kernel') for ids they translated themselves."
+        )
 
     @abc.abstractmethod
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
@@ -2433,6 +2477,7 @@ class MHATokenToKVPool(KVCache):
         dcp_kv_mask: Optional[torch.Tensor] = None,
     ):
         loc, _, _ = unwrap_write_loc(loc_info)
+        self._check_write_loc_space(loc_info, "set_kv_buffer (MHA)")
         # Catch stale slot ids here instead of as illegal-addr / silent KV
         # corruption in the store_kvcache write (gated on SGLANG_ENABLE_ASYNC_ASSERT).
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA)")
@@ -3915,7 +3960,7 @@ class HybridLinearKVPool(KVCache):
     def set_kv_buffer(
         self,
         layer: RadixAttention,
-        loc: torch.Tensor,
+        loc_info,
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
         k_scale: float = 1.0,
@@ -3925,10 +3970,13 @@ class HybridLinearKVPool(KVCache):
         # Write-location info lives in the metadata (`KVWriteLoc`). `full_loc` is the
         # unified pool's pre-translated PHYSICAL loc (None for a static pool, where
         # `loc` is already physical) — either way the pool writes a PHYSICAL loc.
-        loc, _, full_loc = unwrap_write_loc(loc)
+        loc, _, full_loc = unwrap_write_loc(loc_info)
         layer_id = self._transfer_full_attention_id(layer.layer_id)
+        write_loc = KVWriteLoc(
+            full_loc if full_loc is not None else loc,
+            id_space=write_loc_id_space(loc_info),
+        )
         if not self.use_mla:
-            write_loc = full_loc if full_loc is not None else loc
             self.full_kv_pool.set_kv_buffer(
                 layer,
                 write_loc,
@@ -3940,9 +3988,6 @@ class HybridLinearKVPool(KVCache):
                 dcp_kv_mask=dcp_kv_mask,
             )
         else:
-            # Mirror the MHA branch: `full_loc` is the unified pool's
-            # pre-translated (kernel-facing) loc; None for a static pool.
-            write_loc = full_loc if full_loc is not None else loc
             with self._transfer_id_context(layer):
                 self.full_kv_pool.set_kv_buffer(
                     layer,
@@ -3984,13 +4029,15 @@ class HybridLinearKVPool(KVCache):
     def set_mla_kv_buffer(
         self,
         layer: RadixAttention,
-        loc: torch.Tensor,
+        loc_info,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
         assert self.use_mla, "set_mla_kv_buffer called when use_mla is False"
         with self._transfer_id_context(layer):
-            self.full_kv_pool.set_mla_kv_buffer(layer, loc, cache_k_nope, cache_k_rope)
+            self.full_kv_pool.set_mla_kv_buffer(
+                layer, loc_info, cache_k_nope, cache_k_rope
+            )
 
     def get_mla_kv_buffer(
         self,
@@ -4292,6 +4339,7 @@ class MLATokenToKVPool(KVCache):
         layer_id_override: Optional[int] = None,
     ):
         loc, _, _ = unwrap_write_loc(loc_info)
+        self._check_write_loc_space(loc_info, "set_kv_buffer (MLA)")
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id
@@ -4364,11 +4412,13 @@ class MLATokenToKVPool(KVCache):
     def set_mla_kv_buffer(
         self,
         layer: RadixAttention,
-        loc: torch.Tensor,
+        loc_info,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
         layer_id_override: Optional[int] = None,
     ):
+        loc, _, _ = unwrap_write_loc(loc_info)
+        self._check_write_loc_space(loc_info, "set_mla_kv_buffer (MLA)")
         # loc is widened under DCP unless the pool declares it resolved.
         maybe_detect_oob(
             loc,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1914,9 +1914,8 @@ class MHATokenToKVPool(KVCache):
         self.use_native_move_kv_cache = envs.SGLANG_NATIVE_MOVE_KV_CACHE.get()
         if kv_cache_layout is not None:
             # Explicit physical-layout selector wins over the platform default.
-            # This is a label only; layouts that change buffer identity (e.g. the
-            # page-granularity envelope) live in a dedicated pool subclass
-            # (PageMajorMHATokenToKVPool) rather than in branches here.
+            # This is a label only; the page-granularity envelope layout lives in
+            # the unified pool.
             self.use_hnd = False
             self.kv_cache_layout = kv_cache_layout
         elif self.use_hnd:
@@ -2518,8 +2517,8 @@ class MHATokenToKVPool(KVCache):
         cache_v: torch.Tensor,
     ):
         # Per-layer physical write into K/V buffer ``layer_idx``. Override for
-        # layouts that change buffer identity (e.g. PageMajorMHATokenToKVPool's
-        # 4-D strided views). ``loc`` and the cache tensors are already dtype-cast
+        # layouts that change buffer identity. ``loc`` and the cache tensors
+        # are already dtype-cast
         # and viewed as ``store_dtype`` by ``set_kv_buffer``.
         if self.kv_cache_layout == "vectorized_5d":
             # Late-import to keep the NHD path import-clean.
@@ -2924,7 +2923,7 @@ class MHATokenToKVPool(KVCache):
 
     def _move_kv_cache_impl(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         # Physical move strategy. Override for layouts that change buffer
-        # identity (e.g. PageMajorMHATokenToKVPool always uses the native move).
+        # identity (the unified pool moves whole page envelopes).
         if self.use_native_move_kv_cache:
             move_kv_cache_native(self.k_buffer, self.v_buffer, tgt_loc, src_loc)
             if getattr(self, "k_scale_buffer", None) is not None:
@@ -3237,78 +3236,6 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
 
             self.k_scale_buffer[layer_id - self.start_layer][loc] = cache_k_fp4_sf
             self.v_scale_buffer[layer_id - self.start_layer][loc] = cache_v_fp4_sf
-
-
-class PageMajorMHATokenToKVPool(MHATokenToKVPool):
-    """MHA pool with the page-major page-granularity envelope layout.
-
-    NON-CONSTRUCTIBLE: the strided 4-D view builder and its write kernel are
-    gone, and ServerArgs rejects the static page-major arm at boot. The class
-    stays as the seat for the per-layer-view reimplementation.
-    """
-
-    def __init__(
-        self,
-        *args,
-        kv_cache_layout: Optional[str] = None,
-        enable_kv_cache_copy: bool = False,
-        **kwargs,
-    ):
-        assert kv_cache_layout in (
-            None,
-            "page_major_layer_major",
-        ), f"PageMajorMHATokenToKVPool fixes its layout; got {kv_cache_layout!r}"
-        # The tiled copy kernel assumes stride == row bytes, which the strided 4-D
-        # views violate, so the copy path is never available here regardless of
-        # what the caller requested (the spec-decode call sites pass
-        # enable_kv_cache_copy=True). Always fall back to the native move.
-        super().__init__(
-            *args,
-            kv_cache_layout="page_major_layer_major",
-            enable_kv_cache_copy=False,
-            **kwargs,
-        )
-
-    def _create_buffers(self):
-        raise NotImplementedError(
-            "PageMajorMHATokenToKVPool: the strided 4-D envelope views were "
-            "removed; the static-pool page-major layout is temporarily "
-            "unsupported (ServerArgs rejects it at startup). "
-            "--enable-unified-memory provides the page-major layout with "
-            "per-layer views."
-        )
-
-    # The methods below assume the per-layer contiguous 3-D layout. The 4-D
-    # strided envelope views have no per-layer contiguous region (their bytes are
-    # interleaved layer-major within each page) and index page-major, not
-    # token-major. Inheriting them would silently mis-index; fail loudly instead.
-
-    def get_contiguous_buf_infos(self):
-        raise NotImplementedError(
-            "page-major layout has no per-layer contiguous regions; KV transfer / "
-            "disaggregation is unsupported (TODO: expose the single _raw buffer "
-            "with a page-aware transfer scheme)."
-        )
-
-    def get_cpu_copy(self, indices, mamba_indices=None, req_pool_index=None):
-        raise NotImplementedError(
-            "CPU offloading is unsupported under the page-major layout "
-            "(TODO: split token ids into page/slot for the 4-D index)."
-        )
-
-    def load_cpu_copy(
-        self, kv_cache_cpu, indices, mamba_indices=None, req_pool_index=None
-    ):
-        raise NotImplementedError(
-            "CPU offloading is unsupported under the page-major layout "
-            "(TODO: split token ids into page/slot for the 4-D index)."
-        )
-
-    def set_kv_buffer_prefix_valid(self, *args, **kwargs):
-        raise NotImplementedError(
-            "prefix-valid commit is unsupported under the page-major layout "
-            "(_set_kv_buffer_prefix_valid_impl assumes 3-D contiguous + row_dim)."
-        )
 
 
 class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
@@ -3749,8 +3676,7 @@ class HybridLinearKVPool(KVCache):
                 TokenToKVPoolClass = NPUMHATokenToKVPool
                 quant_method_kwarg = {}
             elif full_kv_pool_class is not None:
-                # Caller-selected MHA layout variant (e.g. the page-major
-                # PageMajorMHATokenToKVPool). NPU / out-of-tree classes keep
+                # Caller-selected MHA pool class. NPU / out-of-tree classes keep
                 # priority since they don't understand alternate layouts.
                 TokenToKVPoolClass = full_kv_pool_class
             else:

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -37,8 +37,10 @@ from sglang.kernels.ops.kvcache.zero_pages import zero_pages
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.layout.page_major import (
-    build_mha_views,
-    build_mla_views,
+    DenseEntryLayout,
+    DensePart,
+    align_entry_bytes,
+    build_dense_views,
     build_page_major_mamba_views,
 )
 from sglang.srt.mem_cache.memory_pool import (
@@ -106,19 +108,6 @@ class SubPoolSpec(ABC):
         """Storage dtype (informational). Multi-dtype subclasses return the dominant buffer's."""
         raise NotImplementedError
 
-    def view_tail_pad_bytes(self, page_size: int) -> int:
-        """Bytes this sub-pool's views reach PAST its last page envelope."""
-        return 0
-
-    def blocks_per_page(self) -> int:
-        """Row-blocks one page holds in this sub-pool's kernel-facing id space.
-
-        The page envelope is a uniform array of equally wide row-blocks, so a
-        kernel-facing id is the physical page scaled by this count (see
-        `MultiEndedAllocator.translate_kv_loc_for_kernel`). 1 means the kernel-facing ids are the physical ones.
-        """
-        return 1
-
 
 @dataclass(frozen=True, kw_only=True)
 class MHASubPoolSpec(SubPoolSpec):
@@ -146,29 +135,45 @@ class MHASubPoolSpec(SubPoolSpec):
         return self.head_num * self.v_head_dim * self.store_dtype.itemsize
 
     def entry_bytes(self) -> int:
-        return self.layer_num * (self.k_row_bytes() + self.v_row_bytes())
+        return align_entry_bytes(
+            self.layer_num * (self.k_row_bytes() + self.v_row_bytes())
+        )
 
-    # Page-major byte math: within a page block K/V group per layer
-    # [L0_K*ps | L0_V*ps | L1_K*ps | ...]; at ps==1 this collapses to the per-slot envelope.
+    # Token-major entry: [K_0 | V_0 | K_1 | V_1 | ...] per slot; a page is
+    # page_size such entries back to back.
 
     def page_bytes(self, page_size: int) -> int:
         return page_size * self.entry_bytes()
 
-    def layer_k_offset_in_page(self, layer_id: int, page_size: int) -> int:
-        return layer_id * page_size * (self.k_row_bytes() + self.v_row_bytes())
+    def layer_k_offset_in_entry(self, layer_id: int) -> int:
+        return layer_id * (self.k_row_bytes() + self.v_row_bytes())
 
-    def layer_v_offset_in_page(self, layer_id: int, page_size: int) -> int:
-        return (
-            self.layer_k_offset_in_page(layer_id, page_size)
-            + page_size * self.k_row_bytes()
+    def layer_v_offset_in_entry(self, layer_id: int) -> int:
+        return self.layer_k_offset_in_entry(layer_id) + self.k_row_bytes()
+
+    def layout(self) -> DenseEntryLayout:
+        layer_stride = self.k_row_bytes() + self.v_row_bytes()
+        return DenseEntryLayout(
+            entry_bytes=self.entry_bytes(),
+            parts=(
+                DensePart(
+                    name="k",
+                    offset_bytes=0,
+                    layer_stride_bytes=layer_stride,
+                    layer_num=self.layer_num,
+                    row_shape=(self.head_num, self.head_dim),
+                    dtype=self.store_dtype,
+                ),
+                DensePart(
+                    name="v",
+                    offset_bytes=self.k_row_bytes(),
+                    layer_stride_bytes=layer_stride,
+                    layer_num=self.layer_num,
+                    row_shape=(self.head_num, self.v_head_dim),
+                    dtype=self.store_dtype,
+                ),
+            ),
         )
-
-    def view_tail_pad_bytes(self, page_size: int) -> int:
-        return page_size * self.entry_bytes()
-
-    def blocks_per_page(self) -> int:
-        """Row-blocks per page in the kernel-facing id space (one K + one V per layer)."""
-        return 2 * self.layer_num
 
     def get_dtype(self) -> torch.dtype:
         return self.store_dtype
@@ -201,16 +206,26 @@ class MLASubPoolSpec(SubPoolSpec):
     def kv_cache_dim(self) -> int:
         return self.kv_lora_rank + self.qk_rope_head_dim
 
+    def row_bytes(self) -> int:
+        return self.kv_cache_dim * self.store_dtype.itemsize
+
     def entry_bytes(self) -> int:
-        return self.layer_num * self.kv_cache_dim * self.store_dtype.itemsize
+        return align_entry_bytes(self.layer_num * self.row_bytes())
 
-    def view_tail_pad_bytes(self, page_size: int) -> int:
-        return page_size * self.entry_bytes()
-
-    def blocks_per_page(self) -> int:
-        """One latent row per layer, so L blocks per page (MHA has 2L: a K
-        block and a V block per layer)."""
-        return self.layer_num
+    def layout(self) -> DenseEntryLayout:
+        return DenseEntryLayout(
+            entry_bytes=self.entry_bytes(),
+            parts=(
+                DensePart(
+                    name="kv",
+                    offset_bytes=0,
+                    layer_stride_bytes=self.row_bytes(),
+                    layer_num=self.layer_num,
+                    row_shape=(1, self.kv_cache_dim),
+                    dtype=self.store_dtype,
+                ),
+            ),
+        )
 
     def get_dtype(self) -> torch.dtype:
         return self.store_dtype
@@ -292,10 +307,10 @@ def _reserved_floor_bytes(sub_pool_specs: List[SubPoolSpec], page_size: int) -> 
 
 class UnifiedKVPool:
     """One physical `uint8` byte buffer shared by N sub-pools, each exposing
-    per-layer views over its own byte range (contiguous per layer for KV,
-    strided for the Mamba state). Two END pools (one grow-up, one grow-down)
-    own the buffer's ends; optional "float" MIDDLE pools live between their
-    frontiers. Allocators keep byte ranges disjoint; no usage tracking here.
+    per-layer strided views over its own byte range. Two END pools (one
+    grow-up, one grow-down) own the buffer's ends; optional "float" MIDDLE
+    pools live between their frontiers. Allocators keep byte ranges disjoint;
+    no usage tracking here.
     """
 
     def __init__(
@@ -343,13 +358,8 @@ class UnifiedKVPool:
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
             enable=enable_memory_saver
         )
-        self.view_tail_pad_bytes = max(
-            spec.view_tail_pad_bytes(page_size) for spec in sub_pool_specs
-        )
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-            self._raw = torch.empty(
-                total_bytes + self.view_tail_pad_bytes, dtype=torch.uint8, device=device
-            )
+            self._raw = torch.empty(total_bytes, dtype=torch.uint8, device=device)
         if envs.SGLANG_DEBUG_POISON_POOL.get():
             # Debug: bf16-NaN-fill so NaN-unsafe reads of never-written bytes
             # fail deterministically.
@@ -364,7 +374,7 @@ class UnifiedKVPool:
         self._max_slots: Dict[str, int] = {}
         self._anchor_bytes: Dict[str, int] = {}
         self._min_slot_index: Dict[str, int] = {}
-        # MHA: (k_buffer, v_buffer); MLA: [per-layer per-layer views];
+        # MHA: (k_buffer, v_buffer); MLA: [per-layer views];
         # Mamba: (conv_state_list, temporal_state)
         self._mha_views: Dict[str, Tuple[List[torch.Tensor], List[torch.Tensor]]] = {}
         self._mla_views: Dict[str, List[torch.Tensor]] = {}
@@ -487,21 +497,20 @@ class UnifiedKVPool:
         page_size: int,
     ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
         num_pages = max_slots // page_size
-        _assert_kernel_id_bound(
-            sub_pool_name=spec.name,
-            n_rows=num_pages * spec.blocks_per_page() * page_size,
+        _assert_kernel_id_bound(sub_pool_name=spec.name, n_rows=num_pages * page_size)
+        layout = spec.layout()
+        k_views, v_views = (
+            build_dense_views(
+                self._raw,
+                layout=layout,
+                part=layout.part(name),
+                page_size=page_size,
+                num_pages=num_pages,
+                anchor_bytes=anchor_bytes,
+            )
+            for name in ("k", "v")
         )
-        return build_mha_views(
-            self._raw,
-            layer_num=spec.layer_num,
-            head_num=spec.head_num,
-            head_dim=spec.head_dim,
-            v_head_dim=spec.v_head_dim,
-            store_dtype=spec.store_dtype,
-            page_size=page_size,
-            num_pages=num_pages,
-            anchor_bytes=anchor_bytes,
-        )
+        return k_views, v_views
 
     def _build_mla_views(
         self,
@@ -511,15 +520,12 @@ class UnifiedKVPool:
         page_size: int,
     ) -> List[torch.Tensor]:
         num_pages = max_slots // page_size
-        _assert_kernel_id_bound(
-            sub_pool_name=spec.name,
-            n_rows=num_pages * spec.blocks_per_page() * page_size,
-        )
-        return build_mla_views(
+        _assert_kernel_id_bound(sub_pool_name=spec.name, n_rows=num_pages * page_size)
+        layout = spec.layout()
+        return build_dense_views(
             self._raw,
-            layer_num=spec.layer_num,
-            kv_cache_dim=spec.kv_cache_dim,
-            store_dtype=spec.store_dtype,
+            layout=layout,
+            part=layout.part("kv"),
             page_size=page_size,
             num_pages=num_pages,
             anchor_bytes=anchor_bytes,
@@ -541,16 +547,13 @@ class UnifiedKVPool:
 
 
 class UnifiedMHATokenToKVPool(MHATokenToKVPool):
-    """MHA KV pool whose per-layer `k_buffer`/`v_buffer` are `build_mha_views`
-    views into a `UnifiedKVPool` (requires uniform K/V rows).
+    """MHA KV pool whose per-layer `k_buffer`/`v_buffer` are token-major views
+    into a `UnifiedKVPool` (see `build_dense_views`).
 
-    Views are contiguous `(n_rows, head_num, head_dim)`; locs are
-
-        kernel_id(t) = (t // ps) * (ps * 2 * layer_num) + t % ps
-
-    which is layer- and K/V-independent, each view's storage_offset folding in
-    its block origin (layer l's K at block 2l, V at 2l+1). `move_kv_cache` is
-    the exception: compaction passes REAL physical token ids.
+    Each view is a strided `(num_pages * ps, head_num, head_dim)` tensor whose
+    slot stride is the whole entry, indexed by the PHYSICAL token id; K and V
+    of every layer sit at fixed offsets inside that entry, so K and V rows may
+    differ in width. `move_kv_cache` relocates whole page envelopes.
     """
 
     def __init__(
@@ -573,7 +576,7 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
         self._v_views = v_views
         self._num_pages = max_slots // page_size
         self._page_bytes = page_size * spec.entry_bytes()
-        view_rows = self._num_pages * spec.blocks_per_page() * page_size
+        view_rows = self._num_pages * page_size
 
         super().__init__(
             size=view_rows - page_size,
@@ -591,7 +594,6 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
             enable_kv_cache_copy=False,
             kv_cache_layout="page_major",
         )
-        self.kernel_page_blocks = spec.blocks_per_page()
 
     def _create_buffers(self):
         self.k_buffer = self._k_views
@@ -605,9 +607,8 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
         return 0, 0  # UnifiedKVPool logs the total; per-sub-pool would double-count
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
-        """Relocate slots by whole page envelope.
-        `tgt_loc`/`src_loc` are REAL physical token ids, not kernel-facing ids.
-        """
+        """Relocate slots by whole page envelope (`tgt_loc`/`src_loc` are
+        physical token ids)."""
         if tgt_loc.numel() == 0:
             return
         # The envelope view below starts at byte 0, so this sub-pool must be
@@ -647,21 +648,15 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
 
 
 class UnifiedMLATokenToKVPool(MLATokenToKVPool):
-    """MLA KV pool whose per-layer `kv_buffer` entries are kernel-facing views into a
-    `UnifiedKVPool` (see `build_mla_views`).
+    """MLA KV pool whose per-layer `kv_buffer` entries are token-major views
+    into a `UnifiedKVPool` (see `build_dense_views`).
 
-    Loc-space contract: every loc this pool receives through the KVCache API
-    (`set_kv_buffer` / `set_mla_kv_buffer` / `get_mla_kv_buffer`, and the
-    kv_indices consumed by attention kernels reading `get_key_buffer` /
-    `get_value_buffer`) is a kernel-facing id — the `translate_kv_loc_for_kernel` output
-
-        kernel_id(t) = (t // ps) * (ps * layer_num) + t % ps
-
-    which is layer-independent (the layer offset is folded into each view's
-    storage_offset), so the stock `MLATokenToKVPool` read/write methods work on
-    the views unmodified. The ONE exception is `move_kv_cache`: the allocator's
-    compaction calls it with REAL physical token ids, and it is overridden to
-    relocate whole page envelopes on the raw buffer.
+    Every loc this pool receives through the KVCache API is a PHYSICAL token
+    id (`translate_kv_loc` of the virtual id). Each view is a strided
+    `(num_pages * ps, 1, kv_cache_dim)` tensor whose slot stride is the whole
+    entry, the layer offset folded into its storage_offset, so the stock
+    `MLATokenToKVPool` read/write methods work on the views unmodified.
+    `move_kv_cache` relocates whole page envelopes on the raw buffer.
     """
 
     def __init__(
@@ -685,10 +680,10 @@ class UnifiedMLATokenToKVPool(MLATokenToKVPool):
         max_slots = unified_buffer.max_slots(sub_pool_name)
         self._num_pages = max_slots // page_size
         self._page_bytes = page_size * spec.entry_bytes()
-        self._view_rows = self._num_pages * spec.blocks_per_page() * page_size
+        self._view_rows = self._num_pages * page_size
 
         super().__init__(
-            # OOB checks bound locs by `size + page_size`; kernel-facing ids run to
+            # OOB checks bound locs by `size + page_size`; physical ids run to
             # `_view_rows` (page 0 is the reserved padding sink).
             size=self._view_rows - page_size,
             page_size=page_size,
@@ -699,7 +694,6 @@ class UnifiedMLATokenToKVPool(MLATokenToKVPool):
             device=unified_buffer.device,
             enable_memory_saver=False,  # buffer owned by UnifiedKVPool
         )
-        self.kernel_page_blocks = spec.blocks_per_page()
 
     def _create_buffers(self):
         self.kv_buffer = self._kv_views
@@ -720,9 +714,9 @@ class UnifiedMLATokenToKVPool(MLATokenToKVPool):
         ``raw_ptr + physical_page_id * page_envelope_bytes``.
 
         The transfer item is the whole page envelope (all layers of one page)
-        rather than a per-layer region, because the per-layer per-layer views
-        overlap and index in kernel-facing ids. Both sides must therefore build the
-        pool with identical specs.
+        rather than a per-layer region: the layers interleave inside each
+        slot's entry. Both sides must therefore build the pool with identical
+        specs.
         """
         # The address formula omits the anchor; a nonzero one would mis-address.
         assert self._unified_buffer.anchor_bytes(self._sub_pool_name) == 0
@@ -732,8 +726,8 @@ class UnifiedMLATokenToKVPool(MLATokenToKVPool):
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         """Relocate whole page envelopes.
 
-        `tgt_loc`/`src_loc` are REAL physical token ids (NOT kernel-facing ids): both
-        compaction paths expand page ids into page-major-ordered token runs
+        `tgt_loc`/`src_loc` are physical token ids: both compaction paths
+        expand page ids into page-major-ordered token runs
         (`pages[:, None] * ps + offsets`), relied on here to recover the page
         lists. One contiguous envelope copy replaces the per-layer strided moves.
         """
@@ -1362,15 +1356,13 @@ def init_unified_mamba_pools(
     if use_mla_backend:
         logger.info(
             "[unified-memory-pool]   full_layers=%d, mamba_layers=%d, kv_lora_rank=%d, "
-            "qk_rope_head_dim=%d, page_size=%d (per-layer views, kernel_page_multiplier=%d, "
-            "view_tail_pad=%d B)",
+            "qk_rope_head_dim=%d, page_size=%d (token-major views, entry_bytes=%d B)",
             len(full_attention_layer_ids),
             len(mamba_layer_ids),
             kv_lora_rank,
             qk_rope_head_dim,
             page_size,
-            len(full_attention_layer_ids),
-            shared_pool.view_tail_pad_bytes,
+            full_spec.entry_bytes(),
         )
     else:
         logger.info(
@@ -1382,8 +1374,7 @@ def init_unified_mamba_pools(
             head_dim,
             page_size,
             is_draft_worker,
-            "per-layer views, kernel_page_multiplier=%d, view_tail_pad=%d B"
-            % (full_spec.blocks_per_page(), shared_pool.view_tail_pad_bytes),
+            "token-major views, entry_bytes=%d B" % full_spec.entry_bytes(),
         )
     logger.info(
         "[unified-memory-pool]   total_bytes=%d, max_total_num_tokens=%d, max_mamba_cache_size=%d, "
@@ -1786,12 +1777,8 @@ def init_unified_swa_pools(
     logger.info("[unified-memory-pool] UNIFIED MEMORY POOL ENABLED -- path=SWA hybrid")
     logger.info(
         "[unified-memory-pool]   %s",
-        "per-layer views, kernel_page_multiplier full=%d swa=%d, view_tail_pad=%d B"
-        % (
-            full_spec.blocks_per_page(),
-            swa_spec.blocks_per_page(),
-            shared_pool.view_tail_pad_bytes,
-        ),
+        "token-major views, entry_bytes full=%d swa=%d B"
+        % (full_spec.entry_bytes(), swa_spec.entry_bytes()),
     )
     logger.info(
         "[unified-memory-pool]   full_layers=%d, swa_layers=%d, head_num=%d, head_dim=%d, "

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -1516,12 +1516,12 @@ class UnifiedSWAKVPool(SWAKVPool):
         return  # no-op in shared mode (the swa-side v2p IS the mapping)
 
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
-        """Virtual token ids -> swa kernel-facing ids (int64)."""
+        """Virtual token ids -> swa-physical token ids (int64)."""
         assert self._swa_allocator is not None, (
             "UnifiedSWAKVPool.translate_loc_from_full_to_swa called before "
             "attach_allocators"
         )
-        return self._swa_allocator.translate_kv_loc_for_kernel(kv_indices)
+        return self._swa_allocator.translate_kv_loc(kv_indices)
 
     def get_state_buf_infos(self):
         return self.swa_kv_pool.get_contiguous_buf_infos()

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -46,10 +46,12 @@ from sglang.srt.mem_cache.layout.page_major import (
 from sglang.srt.mem_cache.memory_pool import (
     HybridLinearKVPool,
     HybridReqToTokenPool,
+    KVWriteLoc,
     MambaPool,
     MHATokenToKVPool,
     MLATokenToKVPool,
     unwrap_write_loc,
+    write_loc_id_space,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -556,6 +558,8 @@ class UnifiedMHATokenToKVPool(MHATokenToKVPool):
     differ in width. `move_kv_cache` relocates whole page envelopes.
     """
 
+    requires_translated_write_loc = True
+
     def __init__(
         self,
         *,
@@ -658,6 +662,8 @@ class UnifiedMLATokenToKVPool(MLATokenToKVPool):
     `MLATokenToKVPool` read/write methods work on the views unmodified.
     `move_kv_cache` relocates whole page envelopes on the raw buffer.
     """
+
+    requires_translated_write_loc = True
 
     def __init__(
         self,
@@ -1563,6 +1569,7 @@ class UnifiedSWAKVPool(SWAKVPool):
         (pre-translated once per forward by the attention backend); never translates here.
         """
         loc, swa_loc, full_loc = unwrap_write_loc(loc_info)
+        id_space = write_loc_id_space(loc_info)
         layer_id = layer.layer_id
         pool_layer_id, is_swa = self.layers_mapping[layer_id]
         if is_swa:
@@ -1574,7 +1581,7 @@ class UnifiedSWAKVPool(SWAKVPool):
             )
             self.swa_kv_pool.set_kv_buffer(
                 None,
-                swa_loc,
+                KVWriteLoc(swa_loc, id_space=id_space),
                 cache_k,
                 cache_v,
                 k_scale,
@@ -1589,7 +1596,7 @@ class UnifiedSWAKVPool(SWAKVPool):
             full_loc = loc
         self.full_kv_pool.set_kv_buffer(
             None,
-            full_loc,
+            KVWriteLoc(full_loc, id_space=id_space),
             cache_k,
             cache_v,
             k_scale,

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -801,6 +801,7 @@ class CPUGraphRunner:
 
         forward_batch = ForwardBatch(
             forward_mode=self.capture_forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -420,6 +420,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # DSV4-NPU only: per-pool slot bundle from DSV4NPUTokenToKVPoolAllocator,
     # consumed by the Ascend backend for PA_ND block tables. None elsewhere.
     out_cache_loc_dsv4: Optional[DSV4OutCacheLoc] = None
+    # Id space of `out_cache_loc`: "kernel" once a pool's write door may take it,
+    # set by KVIndexTranslator.rebind_write_loc; capture-time batches declare it.
+    out_cache_loc_id_space: str = "virtual"
     # The indices to track mamba state with
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     # The mask to track mamba state if needed

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -596,6 +596,7 @@ class BaseRunner(ABC):
 
         forward_batch = ForwardBatch(
             forward_mode=capture_forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=batch_size,
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -982,6 +982,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         forward_batch = ForwardBatch(
             forward_mode=self.capture_forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1343,6 +1343,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         with torch.device(self.device):
             forward_batch = ForwardBatch(
                 forward_mode=ForwardMode.EXTEND,
+                out_cache_loc_id_space="kernel",
                 batch_size=bs,
                 input_ids=_slot("input_ids"),
                 input_embeds=(
@@ -1626,6 +1627,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         static_forward_batch = ForwardBatch(
             forward_mode=pcg_forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=input_ids,
             input_embeds=input_embeds,

--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -345,6 +345,7 @@ class FalconH1HybridAttentionDecoderLayer(nn.Module):
                 layer_id=self.layer_id,
                 forward_batch=forward_batch,
                 mup_vector=self.mup_vector,
+                use_triton_causal_conv=forward_batch.forward_mode.is_target_verify(),
             )
             mamba_hidden_states = mamba_hidden_states * self.ssm_out_multiplier
 

--- a/python/sglang/srt/models/inkling_common/attn.py
+++ b/python/sglang/srt/models/inkling_common/attn.py
@@ -149,6 +149,17 @@ def _rel_proj_kernel_eligible(r: torch.Tensor) -> bool:
     )
 
 
+def _is_slot_major_nhd(buf: torch.Tensor, head_dim: int) -> bool:
+    """[slot, head, head_dim] with a contiguous (head, head_dim) row; the slot
+    stride may exceed head * head_dim (strided pool views)."""
+    return (
+        buf.dim() == 3
+        and buf.shape[-1] == head_dim
+        and buf.stride(2) == 1
+        and buf.stride(1) == head_dim
+    )
+
+
 class RelLogitsProj(nn.Module):
     def __init__(self, d_rel: int, rel_extent: int, *, deterministic: bool = False):
         super().__init__()
@@ -439,15 +450,18 @@ class InklingAttention(nn.Module):
         k_buf = pool.get_key_buffer(self.layer_id)
         v_buf = pool.get_value_buffer(self.layer_id)
         # The fused store writes raw bf16 into an NHD [slot, head, head_dim]
-        # buffer indexed by loc. Take it only for that exact layout: FP8/MXFP8
-        # (non-bf16) and HND/vectorized_5d (4D/5D, paged (page, head) index)
-        # pools keep the backend store, which owns their quant + layout. conv +
-        # windows + qk-norm stay fused regardless.
+        # buffer indexed by loc, stepping slots by the buffer's own stride (so
+        # strided per-layer pool views qualify). Take it only for that layout:
+        # FP8/MXFP8 (non-bf16) and HND/vectorized_5d (4D/5D, paged (page, head)
+        # index) pools keep the backend store, which owns their quant + layout.
+        # conv + windows + qk-norm stay fused regardless.
         do_bf16_store = (
             k_buf.dtype == torch.bfloat16
-            and k_buf.dim() == 3
-            and k_buf.shape[-1] == self.head_dim
-            and k_buf.is_contiguous()
+            and v_buf.dtype == torch.bfloat16
+            and _is_slot_major_nhd(k_buf, self.head_dim)
+            and _is_slot_major_nhd(v_buf, self.head_dim)
+            and k_buf.stride(0) == v_buf.stride(0)
+            and k_buf.stride(0) % 8 == 0
         )
         sfk = sfv = None
         do_mxfp8_store = False
@@ -458,12 +472,10 @@ class InklingAttention(nn.Module):
             do_mxfp8_store = (
                 k_buf.dtype == torch.float8_e4m3fn
                 and v_buf.dtype == torch.float8_e4m3fn
-                and k_buf.dim() == 3
-                and v_buf.dim() == 3
-                and k_buf.shape[-1] == self.head_dim
-                and v_buf.shape[-1] == self.head_dim
-                and k_buf.is_contiguous()
-                and v_buf.is_contiguous()
+                and _is_slot_major_nhd(k_buf, self.head_dim)
+                and _is_slot_major_nhd(v_buf, self.head_dim)
+                and k_buf.stride(0) == v_buf.stride(0)
+                and k_buf.stride(0) % 32 == 0
                 and sfk.dim() == 5
                 and sfv.dim() == 5
                 and getattr(pool, "page_size", 0) == 128
@@ -556,12 +568,10 @@ class InklingAttention(nn.Module):
         do_bf16_store = (
             k_buf.dtype == torch.bfloat16
             and v_buf.dtype == torch.bfloat16
-            and k_buf.dim() == 3
-            and v_buf.dim() == 3
-            and k_buf.shape[-1] == self.head_dim
-            and v_buf.shape[-1] == self.head_dim
-            and k_buf.is_contiguous()
-            and v_buf.is_contiguous()
+            and _is_slot_major_nhd(k_buf, self.head_dim)
+            and _is_slot_major_nhd(v_buf, self.head_dim)
+            and k_buf.stride(0) == v_buf.stride(0)
+            and k_buf.stride(0) % 8 == 0
         )
         sfk = sfv = None
         do_mxfp8_store = False
@@ -572,12 +582,10 @@ class InklingAttention(nn.Module):
             do_mxfp8_store = (
                 k_buf.dtype == torch.float8_e4m3fn
                 and v_buf.dtype == torch.float8_e4m3fn
-                and k_buf.dim() == 3
-                and v_buf.dim() == 3
-                and k_buf.shape[-1] == self.head_dim
-                and v_buf.shape[-1] == self.head_dim
-                and k_buf.is_contiguous()
-                and v_buf.is_contiguous()
+                and _is_slot_major_nhd(k_buf, self.head_dim)
+                and _is_slot_major_nhd(v_buf, self.head_dim)
+                and k_buf.stride(0) == v_buf.stride(0)
+                and k_buf.stride(0) % 32 == 0
                 and sfk.dim() == 5
                 and sfv.dim() == 5
                 and getattr(pool, "page_size", 0) == 128
@@ -675,12 +683,10 @@ class InklingAttention(nn.Module):
         do_bf16_store = (
             k_buf.dtype == torch.bfloat16
             and v_buf.dtype == torch.bfloat16
-            and k_buf.dim() == 3
-            and v_buf.dim() == 3
-            and k_buf.shape[-1] == self.head_dim
-            and v_buf.shape[-1] == self.head_dim
-            and k_buf.is_contiguous()
-            and v_buf.is_contiguous()
+            and _is_slot_major_nhd(k_buf, self.head_dim)
+            and _is_slot_major_nhd(v_buf, self.head_dim)
+            and k_buf.stride(0) == v_buf.stride(0)
+            and k_buf.stride(0) % 8 == 0
         )
         sfk = sfv = None
         do_mxfp8_store = False
@@ -691,12 +697,10 @@ class InklingAttention(nn.Module):
             do_mxfp8_store = (
                 k_buf.dtype == torch.float8_e4m3fn
                 and v_buf.dtype == torch.float8_e4m3fn
-                and k_buf.dim() == 3
-                and v_buf.dim() == 3
-                and k_buf.shape[-1] == self.head_dim
-                and v_buf.shape[-1] == self.head_dim
-                and k_buf.is_contiguous()
-                and v_buf.is_contiguous()
+                and _is_slot_major_nhd(k_buf, self.head_dim)
+                and _is_slot_major_nhd(v_buf, self.head_dim)
+                and k_buf.stride(0) == v_buf.stride(0)
+                and k_buf.stride(0) % 32 == 0
                 and sfk.dim() == 5
                 and sfv.dim() == 5
                 and getattr(pool, "page_size", 0) == 128

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -32,6 +32,7 @@ from sglang.kernels.ops.layernorm.norm import (
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.layout.page_major import paged_view
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
@@ -346,12 +347,8 @@ def create_fused_set_kv_buffer_arg(
             key_cache = k_buffer
             value_cache = v_buffer
         else:
-            key_cache = k_buffer.view(
-                -1, page_size, layer.tp_k_head_num, layer.qk_head_dim
-            )
-            value_cache = v_buffer.view(
-                -1, page_size, layer.tp_v_head_num, layer.v_head_dim
-            )
+            key_cache = paged_view(k_buffer, page_size)
+            value_cache = paged_view(v_buffer, page_size)
         return {
             "v": value.view(-1, layer.tp_v_head_num, layer.v_head_dim),
             "k_scale": layer.k_scale,

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -126,15 +126,20 @@ class DFlashVerifyInput(SpecInput):
 
     def generate_attn_arg_prefill(
         self,
+        *,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
-        req_to_token: torch.Tensor,
+        translator: KVIndexTranslator,
         kv_start_idx: Optional[torch.Tensor] = None,
         kv_indices_buf: Optional[torch.Tensor] = None,
+        sliding_window: bool = False,
     ):
+        """CSR verify args, gathered straight into the packed stream. The lens
+        are widened here and handed to the translator, so nothing materializes
+        a ``[bs, max_pages]`` rectangle to repack from."""
         device = req_pool_indices.device
-        bs = len(req_pool_indices)
+        bs = req_pool_indices.numel()
 
         layout = self.ragged_verify_layout
         if layout is not None and layout.bs != bs:
@@ -172,14 +177,14 @@ class DFlashVerifyInput(SpecInput):
                 dtype=torch.int32,
                 device=device,
             )
-        create_flashinfer_kv_indices_triton[(bs,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            kv_start_idx,
-            kv_indices,
-            req_to_token.size(1),
+        translator.fill_packed_read_stream(
+            req_pool_indices=req_pool_indices,
+            seq_lens=paged_kernel_lens,
+            indptr=cum_kv_seq_len,
+            total_tokens=paged_kernel_lens_sum + kv_indices_extra,
+            out=kv_indices,
+            kv_start_idx=kv_start_idx,
+            sliding_window=sliding_window,
         )
         mask = self.custom_mask
         if mask is not None:

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -2128,6 +2128,7 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=block_ids.flatten(),
             req_pool_indices=batch.req_pool_indices,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -350,6 +350,7 @@ class DraftBlockProposer:
         empty_long = torch.empty((0,), dtype=torch.int64, device=device)
         idle_batch = ForwardBatch(
             forward_mode=ForwardMode.IDLE,
+            out_cache_loc_id_space="kernel",
             batch_size=0,
             input_ids=empty_long,
             req_pool_indices=empty_long,
@@ -419,6 +420,7 @@ class DraftBlockProposer:
         draft_num_tokens = bs * query_token_num
         draft_forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=draft_block_ids.flatten(),
             req_pool_indices=batch.req_pool_indices,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -512,16 +512,19 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(
+                batch, on_publish, pp_proxy_tensors=pp_proxy_tensors
+            )
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
     def _forward_prefill(
-        self, batch: ScheduleBatch, on_publish
+        self, batch: ScheduleBatch, on_publish, pp_proxy_tensors=None
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_idle():
             if get_parallel().enable_dp_attention:
@@ -531,7 +534,9 @@ class DSparkWorkerV2(BaseSpecWorker):
             return self._decode_idle_result(on_publish=on_publish)
 
         batch_output = self.target_worker.forward_batch_generation(
-            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
         )
         # BCG replay skips model-side Python, so re-evaluate the same pure predicate.
         target_hidden_is_projected = (

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -426,6 +426,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
 
         forward_batch = ForwardBatch(
             forward_mode=ForwardMode.DECODE,
+            out_cache_loc_id_space="kernel",
             batch_size=num_seqs,
             input_ids=None,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -414,6 +414,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         forward_batch = ForwardBatch(
             forward_mode=self.forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import torch
 
-from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -81,13 +81,18 @@ class EagleVerifyInput(SpecInput):
 
     def generate_attn_arg_prefill(
         self,
+        *,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
-        req_to_token: torch.Tensor,
+        translator: KVIndexTranslator,
+        sliding_window: bool = False,
     ):
+        """CSR verify args, gathered straight into the packed stream. The lens
+        are widened here and handed to the translator, so nothing materializes
+        a ``[bs, max_pages]`` rectangle to repack from."""
         device = req_pool_indices.device
-        batch_size = len(req_pool_indices)
+        batch_size = req_pool_indices.numel()
         qo_indptr = torch.arange(
             0,
             (1 + batch_size) * self.draft_token_num,
@@ -102,19 +107,15 @@ class EagleVerifyInput(SpecInput):
         paged_kernel_lens = paged_kernel_lens + self.draft_token_num
         cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
 
-        kv_indices = torch.empty(
-            paged_kernel_lens_sum + self.draft_token_num * batch_size,
-            dtype=torch.int32,
-            device=device,
-        )
-        create_flashinfer_kv_indices_triton[(batch_size,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            None,
-            kv_indices,
-            req_to_token.size(1),
+        total_tokens = paged_kernel_lens_sum + self.draft_token_num * batch_size
+        kv_indices = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        translator.fill_packed_read_stream(
+            req_pool_indices=req_pool_indices,
+            seq_lens=paged_kernel_lens,
+            indptr=cum_kv_seq_len,
+            total_tokens=total_tokens,
+            out=kv_indices,
+            sliding_window=sliding_window,
         )
         mask_numel = (
             paged_kernel_lens_sum * self.draft_token_num
@@ -352,11 +353,15 @@ class EagleDraftExtendInput(SpecInput):
 
     def generate_attn_arg_prefill(
         self,
+        *,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: Optional[int],
-        req_to_token: torch.Tensor,
+        translator: KVIndexTranslator,
+        sliding_window: bool = False,
     ):
+        """Draft-extend CSR args. The lens already include the window, so
+        unlike verify nothing is widened here."""
         device = req_pool_indices.device
         bs = self.num_correct_drafts.numel()
         # Constant num_tokens_per_req qo layout (required for cuda-graph capture).
@@ -377,13 +382,12 @@ class EagleDraftExtendInput(SpecInput):
             paged_kernel_lens_sum, dtype=torch.int32, device=device
         )
 
-        create_flashinfer_kv_indices_triton[(bs,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            None,
-            kv_indices,
-            req_to_token.size(1),
+        translator.fill_packed_read_stream(
+            req_pool_indices=req_pool_indices,
+            seq_lens=paged_kernel_lens,
+            indptr=cum_kv_seq_len,
+            total_tokens=paged_kernel_lens_sum,
+            out=kv_indices,
+            sliding_window=sliding_window,
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -300,6 +300,7 @@ class FrozenKVMTPCudaGraphRunner(DecodeCudaGraphRunner):
 
         forward_batch = ForwardBatch(
             forward_mode=ForwardMode.DECODE,
+            out_cache_loc_id_space="kernel",
             batch_size=expanded_bs,
             input_ids=None,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -745,7 +745,11 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         )
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ):
         # Mirrors EAGLEWorkerV2.forward_batch_generation; the only frozen-specific
         # change is the idle draft-input (FrozenKVMTPDraftInput + recurrent hidden
@@ -753,7 +757,9 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             # Target prefill (frozen is never standalone -> capture FULL hidden).
             batch_output = self.target_worker.forward_batch_generation(
-                batch, capture_hidden_mode=CaptureHiddenMode.FULL
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
             )
 
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -331,6 +331,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         # Forward batch
         forward_batch = ForwardBatch(
             forward_mode=self.forward_mode,
+            out_cache_loc_id_space="kernel",
             batch_size=bs,
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -982,7 +982,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         )
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             # Target prefill
@@ -992,7 +996,9 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 else CaptureHiddenMode.FULL
             )
             batch_output = self.target_worker.forward_batch_generation(
-                batch, capture_hidden_mode=target_capture_mode
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=target_capture_mode,
             )
 
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import torch
 
-from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 
 
@@ -58,12 +58,17 @@ class NgramVerifyInput(SpecInput):
 
     def generate_attn_arg_prefill(
         self,
+        *,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
-        req_to_token: torch.Tensor,
+        translator: KVIndexTranslator,
+        sliding_window: bool = False,
     ):
-        bs = len(req_pool_indices)
+        """CSR verify args, gathered straight into the packed stream. The lens
+        are widened here and handed to the translator, so nothing materializes
+        a ``[bs, max_pages]`` rectangle to repack from."""
+        bs = req_pool_indices.numel()
 
         cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=self.device)
 
@@ -75,20 +80,16 @@ class NgramVerifyInput(SpecInput):
             * self.draft_token_num
         )
 
-        kv_indices = torch.empty(
-            paged_kernel_lens_sum + self.draft_token_num * bs,
-            dtype=torch.int32,
-            device=self.device,
-        )
+        total_tokens = paged_kernel_lens_sum + self.draft_token_num * bs
+        kv_indices = torch.empty(total_tokens, dtype=torch.int32, device=self.device)
 
-        create_flashinfer_kv_indices_triton[(bs,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            None,
-            kv_indices,
-            req_to_token.size(1),
+        translator.fill_packed_read_stream(
+            req_pool_indices=req_pool_indices,
+            seq_lens=paged_kernel_lens,
+            indptr=cum_kv_seq_len,
+            total_tokens=total_tokens,
+            out=kv_indices,
+            sliding_window=sliding_window,
         )
 
         # Pad custom_mask when CUDA graph pads batch size beyond the actual number of requests.

--- a/python/sglang/srt/speculative/uno_worker_v2.py
+++ b/python/sglang/srt/speculative/uno_worker_v2.py
@@ -414,8 +414,11 @@ class UnoWorkerV2(BaseSpecWorker):
         self,
         batch: ScheduleBatch,
         on_publish,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
-        result = self.target_worker.forward_batch_generation(batch)
+        result = self.target_worker.forward_batch_generation(
+            batch, pp_proxy_tensors=pp_proxy_tensors
+        )
         if not isinstance(result.next_token_ids, torch.Tensor):
             raise RuntimeError("UNO target prefill returned no sampled seed tensor.")
 
@@ -775,12 +778,15 @@ class UnoWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         del grammar_barrier
         self._validate_batch(batch)
 
         if batch.forward_mode == ForwardMode.EXTEND:
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(
+                batch, on_publish, pp_proxy_tensors=pp_proxy_tensors
+            )
 
         if batch.forward_mode == ForwardMode.DECODE:
             return self._forward_decode(batch, on_publish)

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -141,27 +141,6 @@ def maybe_detect_oob(indices: Optional[torch.Tensor], low: int, high: int, msg: 
     )
 
 
-def maybe_detect_kernel_facing_loc(
-    indices: Optional[torch.Tensor], page_size: int, blocks_per_page: int, msg: str
-):
-    """Async check that a write loc is in the pool's KERNEL-FACING id space.
-
-    A kernel-facing id is `phys_page * (page_size * blocks_per_page) + offset`
-    with `offset < page_size`, so its remainder modulo the page stride is
-    below page_size; a VIRTUAL id satisfies that only in the first block.
-    Vacuous at blocks_per_page 1. Virtual ids are in range for the OOB probe,
-    so this is the only check that separates them.
-    """
-    if blocks_per_page <= 1 or not envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
-        return
-    if indices is None or indices.numel() == 0:
-        return
-    torch._assert_async(
-        (indices % (page_size * blocks_per_page) < page_size).all(),
-        f"write loc outside the kernel-facing id space (virtual ids?): {msg}",
-    )
-
-
 def maybe_detect_page_aligned(
     indices: Optional[torch.Tensor], page_size: int, msg: str
 ):

--- a/test/registered/dcp/test_trtllm_mla_family_dcp_metadata.py
+++ b/test/registered/dcp/test_trtllm_mla_family_dcp_metadata.py
@@ -229,7 +229,6 @@ class TestDcpBlockTableIdSpace(CustomTestCase):
     PAGE_SIZE = 64
     DCP_SIZE = 4
     DCP_RANK = 2
-    MULTIPLIER = 3
     # Virtual page per request, deliberately not the identity so a missing
     # gather cannot coincide with the right answer.
     VIRTUAL_PAGES = [[5, 2, 9], [7, 0, 4], [1, 8, 6]]
@@ -277,7 +276,7 @@ class TestDcpBlockTableIdSpace(CustomTestCase):
             )
         return block_kv_indices.cpu(), local_seq_lens.cpu(), req_to_token.cpu()
 
-    def _reference(self, req_to_token, local_seq_lens, v2p, multiplier):
+    def _reference(self, req_to_token, local_seq_lens, v2p):
         """What each live entry must be, derived from the id-space definition."""
         rows = []
         for req in range(local_seq_lens.numel()):
@@ -290,7 +289,7 @@ class TestDcpBlockTableIdSpace(CustomTestCase):
                 if v2p is None:
                     row.append(collapsed_page)
                 else:
-                    row.append(max(int(v2p[collapsed_page]) * multiplier, 0))
+                    row.append(max(int(v2p[collapsed_page]), 0))
             rows.append(row)
         return rows
 
@@ -302,9 +301,9 @@ class TestDcpBlockTableIdSpace(CustomTestCase):
             self.assertTrue((table[req, len(row) :] == -1).all())
 
     def test_static_pool_entries_are_the_collapsed_page(self):
-        translator = SimpleNamespace(full_v2p_table=None, full_page_multiplier=1)
+        translator = SimpleNamespace(full_v2p_table=None)
         table, local_lens, req_to_token = self._fill(translator)
-        self._assert_matches(table, self._reference(req_to_token, local_lens, None, 1))
+        self._assert_matches(table, self._reference(req_to_token, local_lens, None))
 
     def test_unified_pool_entries_go_through_the_page_table(self):
         num_pages = 1 + max(max(p) for p in self.VIRTUAL_PAGES)
@@ -314,25 +313,21 @@ class TestDcpBlockTableIdSpace(CustomTestCase):
             dtype=torch.int64,
             device="cuda",
         )
-        translator = SimpleNamespace(
-            full_v2p_table=v2p, full_page_multiplier=self.MULTIPLIER
-        )
+        translator = SimpleNamespace(full_v2p_table=v2p)
         table, local_lens, req_to_token = self._fill(translator)
-        expected = self._reference(req_to_token, local_lens, v2p.cpu(), self.MULTIPLIER)
+        expected = self._reference(req_to_token, local_lens, v2p.cpu())
         self._assert_matches(table, expected)
         # And it is genuinely a translation, not an accident of the fixture.
-        static = self._reference(req_to_token, local_lens, None, 1)
+        static = self._reference(req_to_token, local_lens, None)
         self.assertNotEqual(expected, static)
 
     def test_freed_page_lands_on_the_padding_sink(self):
         # A tombstoned (-1) v2p row must clamp to entry 0, the reserved
-        # padding page, rather than scale -1 into a wild block id.
+        # padding page, rather than emit -1 as a block id.
         num_pages = 1 + max(max(p) for p in self.VIRTUAL_PAGES)
         v2p = torch.arange(num_pages, dtype=torch.int64, device="cuda")
         v2p[self.VIRTUAL_PAGES[0][0]] = -1
-        translator = SimpleNamespace(
-            full_v2p_table=v2p, full_page_multiplier=self.MULTIPLIER
-        )
+        translator = SimpleNamespace(full_v2p_table=v2p)
         table, _, _ = self._fill(translator)
         self.assertEqual(int(table[0, 0]), 0)
 

--- a/test/registered/kernel/mem_cache/test_masked_set_kv_buffer_strided.py
+++ b/test/registered/kernel/mem_cache/test_masked_set_kv_buffer_strided.py
@@ -1,0 +1,82 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""``masked_set_kv_buffer_kernel`` must step destination slots by the buffer's
+own stride. The unified pool's per-layer K/V buffers are strided views (slot
+stride > head_num * head_dim), so a hardcoded ``loc * H * D`` would write into
+the wrong slot without any error.
+
+    python -m pytest test/registered/unit/mem_cache/test_masked_set_kv_buffer_strided.py -v
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import masked_set_kv_buffer_kernel
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class TestMaskedSetKvBufferStrided(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
+    def test_writes_land_at_slot_stride(self):
+        torch.manual_seed(0)
+        N, H, D = 16, 4, 64
+        slots = N + 8
+        E = 2 * H * D + 128  # slot stride wider than one K row
+        device = "cuda"
+        backing_k = torch.zeros(slots * E, dtype=torch.bfloat16, device=device)
+        backing_v = torch.zeros_like(backing_k)
+        k_buffer = backing_k.as_strided((slots, H, D), (E, D, 1))
+        v_buffer = backing_v.as_strided((slots, H, D), (E, D, 1), H * D)
+        cache_k = torch.randn(N, H, D, dtype=torch.bfloat16, device=device)
+        cache_v = torch.randn(N, H, D, dtype=torch.bfloat16, device=device)
+        loc = torch.randperm(slots, device=device)[:N]
+        mask = torch.arange(N, device=device) % 3 != 0
+
+        masked_set_kv_buffer_kernel[(N,)](
+            cache_k,
+            cache_v,
+            k_buffer,
+            v_buffer,
+            loc,
+            mask,
+            N,
+            H,
+            D,
+            128,
+            cache_k.stride(0),
+            cache_k.stride(1),
+            cache_v.stride(0),
+            cache_v.stride(1),
+            k_buffer.stride(0),
+            v_buffer.stride(0),
+        )
+
+        ref_k = torch.zeros_like(k_buffer)
+        ref_v = torch.zeros_like(v_buffer)
+        ref_k[loc[mask]] = cache_k[mask]
+        ref_v[loc[mask]] = cache_v[mask]
+        torch.testing.assert_close(k_buffer, ref_k, rtol=0, atol=0)
+        torch.testing.assert_close(v_buffer, ref_v, rtol=0, atol=0)
+        # Nothing outside the two views was touched.
+        gap_k = backing_k.view(slots, E)[:, H * D :]
+        gap_v = backing_v.view(slots, E)[:, : H * D]
+        self.assertTrue(bool((gap_k == 0).all()) and bool((gap_v == 0).all()))
+        self.assertTrue(bool((backing_v.view(slots, E)[:, 2 * H * D :] == 0).all()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/kvcache/test_fused_fp8_qkv_kv_cache.py
+++ b/test/registered/kernels/ops/kvcache/test_fused_fp8_qkv_kv_cache.py
@@ -85,6 +85,49 @@ def test_fused_fp8_qkv_kv_cache(
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "hkv,head_dim,extra", [(8, 128, 1024), (2, 64, 128), (1, 128, 32)]
+)
+@pytest.mark.parametrize("num_tokens", [1, 7, 64])
+def test_fused_fp8_qkv_kv_cache_strided_cache(num_tokens, dtype, hkv, head_dim, extra):
+    """Caches that are strided views (slot stride > kv_dim), like the unified
+    pool's per-layer views: rows land at ``slot * stride(0)`` and bytes outside
+    the view are never touched."""
+    torch.manual_seed(0)
+    device = "cuda"
+    kv_dim = hkv * head_dim
+    total_slots = num_tokens + 4
+    slot_stride = kv_dim + extra  # fp8: elements == bytes
+    backing_k = torch.zeros(total_slots, slot_stride, dtype=FP8, device=device)
+    backing_v = torch.zeros_like(backing_k)
+    k_cache = backing_k[:, :kv_dim].view(total_slots, hkv, head_dim)
+    v_cache = backing_v[:, extra:].view(total_slots, hkv, head_dim)
+    assert not k_cache.is_contiguous() and k_cache.stride(0) == slot_stride
+
+    k = torch.randn(num_tokens, hkv, head_dim, dtype=dtype, device=device)
+    v = torch.randn(num_tokens, hkv, head_dim, dtype=dtype, device=device)
+    cache_loc = torch.randperm(total_slots, device=device)[:num_tokens]
+
+    assert fused_fp8_qkv_kv_cache(None, k, v, k_cache, v_cache, cache_loc) is None
+
+    loc = cache_loc.long()
+    k_ref = _ref_quant(k.reshape(num_tokens, kv_dim).float(), 1.0)
+    v_ref = _ref_quant(v.reshape(num_tokens, kv_dim).float(), 1.0)
+    torch.testing.assert_close(
+        _bytes(k_cache.reshape(total_slots, kv_dim)[loc]), _bytes(k_ref), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        _bytes(v_cache.reshape(total_slots, kv_dim)[loc]), _bytes(v_ref), rtol=0, atol=0
+    )
+    untouched = torch.ones(total_slots, dtype=torch.bool, device=device)
+    untouched[loc] = False
+    assert (backing_k[:, kv_dim:].view(torch.uint8) == 0).all()
+    assert (backing_v[:, :extra].view(torch.uint8) == 0).all()
+    assert (backing_k[untouched].view(torch.uint8) == 0).all()
+    assert (backing_v[untouched].view(torch.uint8) == 0).all()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/test/registered/unit/layers/attention/test_flashattention_graph_metadata.py
+++ b/test/registered/unit/layers/attention/test_flashattention_graph_metadata.py
@@ -77,5 +77,43 @@ class TestFlashAttentionGraphMetadata(CustomTestCase):
         self.assertEqual(backend.forward_metadata.max_seq_len_k, 16)
 
 
+class TestSpecReadSeqLenDelta(CustomTestCase):
+    """The mode -> seq_len_delta map IS the widening the whole-sequence spec
+    reads apply to cache_seqlens; a drift silently truncates the verify or
+    draft tail of the translated read table (the metadata builders widen
+    cache_seqlens while the source fill stays prefix-only)."""
+
+    def _backend(self, *, topk=1, num_steps=3, step_id=1, num_draft=4):
+        b = FlashAttentionBackend.__new__(FlashAttentionBackend)
+        b.topk = topk
+        b.speculative_num_steps = num_steps
+        b.speculative_step_id = step_id
+        b.speculative_num_draft_tokens = num_draft
+        return b
+
+    def test_mode_to_delta_map(self):
+        b = self._backend()
+        spec = object()
+        # Verify reads [prefix + drafts]; draft decode step i reads
+        # [prefix + i + 1] (both write the drafts into the pool first).
+        self.assertEqual(b._spec_read_seq_len_delta(ForwardMode.TARGET_VERIFY, spec), 4)
+        self.assertEqual(b._spec_read_seq_len_delta(ForwardMode.DECODE, spec), 2)
+        # Prefix-only shapes stay un-widened.
+        self.assertEqual(
+            b._spec_read_seq_len_delta(ForwardMode.DRAFT_EXTEND_V2, spec), 0
+        )
+        self.assertEqual(b._spec_read_seq_len_delta(ForwardMode.DECODE, None), 0)
+        self.assertEqual(b._spec_read_seq_len_delta(ForwardMode.EXTEND, spec), 0)
+        # Draft-extend's idle batch carries no live draft chain.
+        idle = self._backend(num_steps=0)
+        self.assertEqual(idle._spec_read_seq_len_delta(ForwardMode.IDLE, spec), 0)
+        # topk>1 reads the drafts via the expand metadata - prefix only.
+        tree = self._backend(topk=2)
+        self.assertEqual(
+            tree._spec_read_seq_len_delta(ForwardMode.TARGET_VERIFY, spec), 0
+        )
+        self.assertEqual(tree._spec_read_seq_len_delta(ForwardMode.DECODE, spec), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/layers/attention/test_verify_widening_is_wired.py
+++ b/test/registered/unit/layers/attention/test_verify_widening_is_wired.py
@@ -1,0 +1,317 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""A widened verify table must reach the kernel that reads past seq_lens.
+
+BUG REGRESSION, two shapes. A whole-sequence verify reads
+`[committed prefix | drafts]` back out of the pool, so a page-table consumer
+has to build its read table with `seq_len_delta` set. Both shapes are a
+widening that is computed but cannot arrive.
+
+FIRST: the widened table is bound to a local and then the UN-widened per-batch
+view is handed on instead -- the widening dropped on the floor. Nothing fails
+loudly: a dead store compiles, type-checks, and at page_size 256 the un-widened
+`ceil(seq/ps)` columns still happen to cover the few draft tokens. Only at
+page_size 1, where every draft token needs its own column, do the drafts read
+stale entries -- observed as accept length collapsing (6.20 -> 1.37) and, on a
+run that kept its accept length, wrong tokens (gsm8k 0.905 -> 0.730).
+
+SECOND, and invisible to the first guard: the eager verify path widens
+correctly while the CAPTURED path -- the one a cuda-graph replay runs -- builds
+its table with no `seq_len_delta` at all. There is no dead store to find. The
+replayed verify reads a table filled only to `seq_lens` while the CSR builder
+widened the lens by `draft_token_num`, so every row's draft tail is stale.
+
+Both guards are structural, because both failures are: a widened table nothing
+reads, and a captured build that never widens, each mean the widening cannot
+reach a kernel. That is cheap to check exactly, and it stays red for the whole
+class of rewiring mistakes rather than the one spelling each bug took.
+
+Scope note: this guards the PAGE-TABLE consumers (fa3 and the MLA family),
+which gather from a rectangle whose live prefix can fall short. The CSR
+consumers gather through `fill_packed_read_stream` from already-widened lens,
+so they materialize no table to under-fill and no widening to drop.
+
+    python -m pytest test/registered/unit/layers/attention/test_verify_widening_is_wired.py -v
+"""
+
+import ast
+import pathlib
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+# Every backend that builds a read table through the KV-index translator.
+_BACKEND_DIR = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "python"
+    / "sglang"
+    / "srt"
+    / "layers"
+    / "attention"
+)
+_WIDENING_CALL = "widened_index_table"
+
+
+def _dead_widenings(path: pathlib.Path):
+    """(function, variable, lineno) for each widened table that is never read.
+
+    A widening lands in one of two shapes. Bound to a LOCAL, it has to be read
+    again in the same function or it went nowhere. PUBLISHED to an attribute
+    (`self.spec_kv_view = ...`, how the flashinfer backends hand the table to
+    updaters that take no table argument) it escapes the function, so the
+    consumption to look for is a read of that attribute somewhere in the
+    module -- an attribute nothing loads is the same dead store wearing a
+    different spelling.
+    """
+    tree = ast.parse(path.read_text())
+    attr_loads = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load)
+    }
+    dead = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        locals_, published = {}, {}
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                func = node.value.func
+                if isinstance(func, ast.Attribute) and func.attr == _WIDENING_CALL:
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            locals_[target.id] = node.lineno
+                        elif isinstance(target, ast.Attribute):
+                            published[target.attr] = node.lineno
+        if not locals_ and not published:
+            continue
+        loaded = {
+            n.id
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
+        for name, lineno in locals_.items():
+            if name not in loaded:
+                dead.append((fn.name, name, lineno))
+        for name, lineno in published.items():
+            if name not in attr_loads:
+                dead.append((fn.name, f"self.{name}", lineno))
+    return sorted(dead, key=lambda d: d[2])
+
+
+# The captured/replay builders. A backend reaches them per cuda-graph replay,
+# so a build here that does not widen truncates every replayed verify.
+_CAPTURED_BUILDERS = ("out_graph", "cuda_graph_metadata")
+_BUILD_CALL = "build_index_table"
+
+
+def _table_builders(tree: ast.Module):
+    """`build_index_table`, plus this module's own helpers that forward a
+    `seq_len_delta` to it.
+
+    A captured builder need not call the translator directly -- it may slice
+    its batch to `bs` first and go through a helper. That hop must not be a
+    place the delta can be dropped, so the helper is held to the same rule as
+    the call it wraps.
+    """
+    builders = {_BUILD_CALL}
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == _BUILD_CALL
+                and any(kw.arg == "seq_len_delta" for kw in node.keywords)
+            ):
+                builders.add(fn.name)
+                break
+    return builders
+
+
+def _unwidened_captured_builds(path: pathlib.Path):
+    """(function, lineno) for each captured-path build that omits the delta."""
+    tree = ast.parse(path.read_text())
+    builders = _table_builders(tree)
+    found = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not any(marker in fn.name for marker in _CAPTURED_BUILDERS):
+            continue
+        if fn.name in builders:
+            continue  # the helper itself; its own call carries the delta
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in builders:
+                if not any(kw.arg == "seq_len_delta" for kw in node.keywords):
+                    found.append((fn.name, node.lineno))
+    return found
+
+
+class TestVerifyWideningIsWired(unittest.TestCase):
+    def test_widened_table_is_consumed(self):
+        """A widened table that is never read cannot reach a kernel, so the
+        verify tail silently falls back to the un-widened prefix."""
+        offenders = []
+        for path in sorted(_BACKEND_DIR.glob("*.py")):
+            if _WIDENING_CALL not in path.read_text():
+                continue
+            for fn, name, lineno in _dead_widenings(path):
+                offenders.append(f"{path.name}:{lineno} {fn}() -> '{name}'")
+        self.assertEqual(
+            offenders,
+            [],
+            "widened verify table computed but never read (the updater gets the "
+            "un-widened view, truncating the draft tail at page_size 1): "
+            + "; ".join(offenders),
+        )
+
+    def test_captured_build_widens_like_the_eager_one(self):
+        """A backend that widens its EAGER verify read must widen the CAPTURED
+        one by the same delta, or every cuda-graph replay truncates the draft
+        tail while the CSR builder still widens the lens."""
+        offenders = []
+        for path in sorted(_BACKEND_DIR.glob("*.py")):
+            if _WIDENING_CALL not in path.read_text():
+                continue
+            for fn, lineno in _unwidened_captured_builds(path):
+                offenders.append(f"{path.name}:{lineno} {fn}()")
+        self.assertEqual(
+            offenders,
+            [],
+            "captured verify build omits seq_len_delta while the eager path "
+            "widens (replay reads a stale draft tail): " + "; ".join(offenders),
+        )
+
+    def test_guard_detects_an_unwidened_captured_build(self):
+        """The detector must catch the shape it guards."""
+        src = (
+            "class B:\n"
+            "    def init_forward_metadata_out_graph(self, fb):\n"
+            "        kv_view = self.t.build_index_table(\n"
+            "            req_pool_indices=fb.req_pool_indices, seq_lens=fb.seq_lens\n"
+            "        )\n"
+            "        self.u.update(kv_view=kv_view)\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(
+                _unwidened_captured_builds(tmp),
+                [("init_forward_metadata_out_graph", 3)],
+            )
+        finally:
+            tmp.unlink()
+
+    def test_guard_accepts_a_widened_captured_build(self):
+        """...and must NOT fire once the delta is passed, else it is unfixable."""
+        src = (
+            "class B:\n"
+            "    def init_forward_metadata_out_graph(self, fb):\n"
+            "        kv_view = self.t.build_index_table(\n"
+            "            seq_lens=fb.seq_lens, seq_len_delta=4\n"
+            "        )\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(_unwidened_captured_builds(tmp), [])
+        finally:
+            tmp.unlink()
+
+    def test_guard_detects_an_unwidened_helper_hop(self):
+        """A captured builder that reaches the translator through a helper
+        must still carry the delta across the hop."""
+        src = (
+            "class B:\n"
+            "    def _spec_table(self, seq_lens, seq_len_delta):\n"
+            "        return self.t.build_index_table(\n"
+            "            seq_lens=seq_lens, seq_len_delta=seq_len_delta\n"
+            "        )\n"
+            "    def init_forward_metadata_out_graph(self, fb):\n"
+            "        self.kv_view = self._spec_table(seq_lens=fb.seq_lens)\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(
+                _unwidened_captured_builds(tmp),
+                [("init_forward_metadata_out_graph", 7)],
+            )
+        finally:
+            tmp.unlink()
+
+    def test_guard_detects_a_published_widening_nothing_reads(self):
+        """Publishing to an attribute is only a consumption if something reads
+        the attribute back -- otherwise it is a dead store with extra steps."""
+        src = (
+            "class B:\n"
+            "    def init_forward_metadata(self, fb):\n"
+            "        self.spec_kv_view = self.t.widened_index_table(fb, 4)\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(
+                _dead_widenings(tmp),
+                [("init_forward_metadata", "self.spec_kv_view", 3)],
+            )
+        finally:
+            tmp.unlink()
+
+    def test_guard_accepts_a_published_widening_that_is_read(self):
+        """...and must NOT fire once a consumer reads it, else it is unfixable."""
+        src = (
+            "class B:\n"
+            "    def init_forward_metadata(self, fb):\n"
+            "        self.spec_kv_view = self.t.widened_index_table(fb, 4)\n"
+            "class U:\n"
+            "    def call_begin_forward(self):\n"
+            "        return self.backend.spec_kv_view\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(_dead_widenings(tmp), [])
+        finally:
+            tmp.unlink()
+
+    def test_guard_detects_a_dead_widening(self):
+        """The detector itself must catch the shape it guards -- otherwise it
+        would pass green forever after a refactor of the walk above."""
+        src = (
+            "class B:\n"
+            "    def init_forward_metadata(self, fb):\n"
+            "        kv_view = self.t.index_table_for_batch(fb)\n"
+            "        index_table = self.t.widened_index_table(fb, seq_len_delta=4)\n"
+            "        self.u.update(kv_view=kv_view)\n"
+        )
+        tmp = pathlib.Path(self.id().replace(".", "_") + ".py")
+        tmp.write_text(src)
+        try:
+            self.assertEqual(
+                _dead_widenings(tmp), [("init_forward_metadata", "index_table", 4)]
+            )
+        finally:
+            tmp.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_full_loc_fast_path.py
+++ b/test/registered/unit/mem_cache/test_full_loc_fast_path.py
@@ -170,7 +170,7 @@ class TestUnifiedSWATombstoneClamp(unittest.TestCase):
         return pool
 
     def test_tombstoned_id_lands_on_sink(self):
-        for ps, mult in ((1, 1), (4, 1), (4, 6)):
+        for ps, mult in ((1, 1), (4, 1)):
             v2p = torch.tensor([0, -1, 2], dtype=torch.int64)
             pool = self._make_bare_pool(ps, v2p, multiplier=mult)
             # Virtual ids covering the tombstoned page (index 1) and a live one.
@@ -297,7 +297,6 @@ class TestMlaWriteDoorsUnderDcp(unittest.TestCase):
         pool = object.__new__(MLATokenToKVPool)
         pool.size = 64
         pool.page_size = 1
-        pool.kernel_page_blocks = 1
         pool.start_layer = 0
         pool.dtype = torch.float16
         pool.store_dtype = torch.float16

--- a/test/registered/unit/mem_cache/test_full_loc_fast_path.py
+++ b/test/registered/unit/mem_cache/test_full_loc_fast_path.py
@@ -30,10 +30,10 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 
-def _loc_info(virtual_loc, swa_phys=None, full_phys=None):
+def _loc_info(virtual_loc, swa_phys=None, full_phys=None, id_space="virtual"):
     from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 
-    return KVWriteLoc(virtual_loc, swa_phys, full_phys)
+    return KVWriteLoc(virtual_loc, swa_phys, full_phys, id_space=id_space)
 
 
 class _RecordingPool:
@@ -41,9 +41,17 @@ class _RecordingPool:
 
     def __init__(self):
         self.calls = []
+        self.spaces = []
 
-    def set_kv_buffer(self, layer, loc, cache_k, cache_v, *args, **kwargs):
+    def set_kv_buffer(self, layer, loc_info, cache_k, cache_v, *args, **kwargs):
+        from sglang.srt.mem_cache.memory_pool import (
+            unwrap_write_loc,
+            write_loc_id_space,
+        )
+
+        loc, _, _ = unwrap_write_loc(loc_info)
         self.calls.append((loc, kwargs))
+        self.spaces.append(write_loc_id_space(loc_info))
 
 
 class TestUnifiedSWARouting(unittest.TestCase):
@@ -229,6 +237,23 @@ class TestHybridLinearFullLocRouting(unittest.TestCase):
                         # is already physical, so write it directly.
                         self.assertIs(forwarded, loc)
                     self.assertNotIn("already_physical", kwargs)
+
+    def test_forwards_the_id_space(self):
+        # The sub-pool decides on the marker, so the composite must pass it
+        # through unchanged in both directions.
+        for space in ("kernel", "virtual"):
+            pool = self._make_bare_pool()
+            pool.set_kv_buffer(
+                types.SimpleNamespace(layer_id=0),
+                _loc_info(
+                    torch.tensor([1, 2]),
+                    full_phys=torch.tensor([5, 6]),
+                    id_space=space,
+                ),
+                torch.zeros(2, 4, 8),
+                torch.zeros(2, 4, 8),
+            )
+            self.assertEqual(pool.full_kv_pool.spaces, [space])
 
 
 class _RecordingMLAPool(_RecordingPool):

--- a/test/registered/unit/mem_cache/test_full_loc_fast_path.py
+++ b/test/registered/unit/mem_cache/test_full_loc_fast_path.py
@@ -160,7 +160,7 @@ class TestUnifiedSWATombstoneClamp(unittest.TestCase):
     buffer base.
     """
 
-    def _make_bare_pool(self, page_size, v2p, multiplier=1):
+    def _make_bare_pool(self, page_size, v2p):
         from sglang.srt.mem_cache.allocator.unified_sub_pool import MultiEndedAllocator
         from sglang.srt.mem_cache.unified_memory_pool import UnifiedSWAKVPool
 
@@ -172,23 +172,21 @@ class TestUnifiedSWATombstoneClamp(unittest.TestCase):
         swa_allocator.page_size = page_size
         swa_allocator.pool_page_size = page_size
         swa_allocator.virtual_to_physical = v2p
-        swa_allocator.kernel_page_multiplier = multiplier
         pool = object.__new__(UnifiedSWAKVPool)
         pool._swa_allocator = swa_allocator
         return pool
 
     def test_tombstoned_id_lands_on_sink(self):
-        for ps, mult in ((1, 1), (4, 1)):
+        for ps in (1, 4):
             v2p = torch.tensor([0, -1, 2], dtype=torch.int64)
-            pool = self._make_bare_pool(ps, v2p, multiplier=mult)
+            pool = self._make_bare_pool(ps, v2p)
             # Virtual ids covering the tombstoned page (index 1) and a live one.
             kv_indices = torch.tensor([0, ps, 2 * ps], dtype=torch.int64)
             out = pool.translate_loc_from_full_to_swa(kv_indices)
             self.assertEqual(out.dtype, torch.int64)
             self.assertTrue(
                 bool((out >= 0).all().item()),
-                f"tombstoned swa id stayed negative at page_size={ps}, "
-                f"multiplier={mult}: {out}",
+                f"tombstoned swa id stayed negative at page_size={ps}: {out}",
             )
             self.assertEqual(int(out[1].item()), 0)
 

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -13,15 +13,34 @@
 # ==============================================================================
 """KVIndexTranslator -- the read-path id translator.
 
-CPU-only: these exercise the builder's pure-torch reference path, not the
-Triton kernel.
+Covers, CPU-only (the builder's pure-torch reference path; GPU parity of the
+Triton kernel is a later CUDA CI pin):
+  - strict passthrough: a non-unified source returns the SAME req_to_token /
+    req_pool_indices objects -- zero tensor ops, no copies (the property that
+    makes backend re-pointing byte-identical for every non-unified server);
+  - static SWA pools keep their legacy full->swa mapping on the view;
+  - the read table matches the hand formula
+        entry[b, c] = clamp(v2p[req_to_token[req[b], c*ps] // ps] * mult, 0)
+    over the REAL SWA composite's tables (full AND swa, ps in {1, 4},
+    multiplier in {1, 2L}), with the swa table built from VIRTUAL ids;
+  - sink routing: dead lanes (seq_len 0), -1 req_to_token entries, and
+    tombstoned v2p pages all read entry 0;
+  - the capture contract: buffers are zero-filled and idempotent; a refresh
+    updates ONLY the live prefix (stale tails and rows beyond bs keep prior
+    contents); the returned table is the WHOLE buffer (pointer-stable);
+  - the eager-view memo: a single source-resident slot keyed by batch
+    identity (same batch shares one build; the next batch replaces it; a
+    dead batch never matches);
+  - the two-phase write contract: the rebind touches only the full side, and
+    the sliding-window write loc derives POINTWISE from the kernel-facing values
+    (pads, slices, and fresh copies included), for both pool families.
+
+    python -m pytest test/registered/unit/mem_cache/test_kv_index_translator.py -v
 """
 
-from sglang.srt.runtime_context import publish, reset_context
-from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 import unittest
 from types import SimpleNamespace
@@ -29,10 +48,10 @@ from types import SimpleNamespace
 import torch
 from test_multi_ended_allocator import _FakeUnifiedSWAKVPool
 
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator, KVReadTables
 from sglang.srt.mem_cache.allocator.unified_hybrid_swa import (
     UnifiedSWATokenToKVPoolAllocator,
 )
-from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator, KVReadTables
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.unified_memory_pool import MHASubPoolSpec, UnifiedKVPool
 
@@ -41,7 +60,7 @@ _FULL_L = 2
 _SWA_L = 3
 
 
-def _build_composite(ps, collapse=False, n_full_pages=16, n_swa_pages=8):
+def _build_composite(ps, n_full_pages=16, n_swa_pages=8):
     full_spec = MHASubPoolSpec(
         name="full",
         layer_num=_FULL_L,
@@ -78,11 +97,6 @@ def _build_composite(ps, collapse=False, n_full_pages=16, n_swa_pages=8):
         need_sort=False,
         forward_stream=None,
     )
-    if collapse:
-        # The multiplier-1 arm, where kernel-facing ids ARE the physical ones.
-        # No unified sub-pool reports 1 today, so pin the regime here.
-        allocator.full_attn_allocator.kernel_page_multiplier = 1
-        allocator.swa_attn_allocator.kernel_page_multiplier = 1
     # The fake IS the runner's token_to_kv_pool, and the real UnifiedSWAKVPool
     # carries the pool-level full->swa translate, so the fake must too.
     kvcache.translate_loc_from_full_to_swa = allocator.translate_loc_from_full_to_swa
@@ -117,15 +131,10 @@ def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, mult, ps, wi
 
 
 class TestPassthrough(unittest.TestCase):
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
-
     def test_non_unified_returns_same_objects(self):
-        """Strict passthrough: no copy, no branch. Any tensor op on the
-        non-unified path breaks byte-identity for every static-pool server."""
+        """The strict-passthrough property: no copy, no branch, the exact
+        tensors backends read today. A regression here (any tensor op on the
+        non-unified path) breaks byte-identity for every static-pool server."""
         req_to_token = torch.arange(64, dtype=torch.int64).reshape(4, 16)
         src = KVIndexTranslator(
             req_to_token=req_to_token,
@@ -152,7 +161,7 @@ class TestPassthrough(unittest.TestCase):
 
 def _alloc_and_fill(allocator, ps, lens):
     """Allocate per-request virtual runs and write them into a fake
-    req_to_token."""
+    req_to_token; returns (req_to_token, req_pool_indices, seq_lens)."""
     width = 16 * ps
     req_to_token = torch.full((len(lens), width), -1, dtype=torch.int64)
     for r, n in enumerate(lens):
@@ -168,20 +177,15 @@ def _alloc_and_fill(allocator, ps, lens):
 
 
 class TestReadTableBuild(unittest.TestCase):
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
 
-    def test_read_table_matches_reference_across_multipliers(self):
-        """Both read tables must equal the independent per-element derivation,
-        across page sizes and both multiplier regimes (MLA=1, MHA=2L); the swa
-        table agreeing over VIRTUAL ids proves it is never chained through
-        full-physical."""
+    def test_read_table_matches_reference(self):
+        """The load-bearing formula pin: full AND swa read tables equal
+        the independent per-element derivation across page sizes (kernel-facing
+        ids are the physical ones: multiplier 1). The swa table agreeing with
+        a formula over VIRTUAL ids is also the never-chained-through-
+        full-physical proof."""
         for ps in (1, 4):
-            for collapse in (True, False):
-                allocator = _build_composite(ps, collapse=collapse)
+            for allocator in (_build_composite(ps),):
                 full_mult = allocator.kernel_page_multiplier
                 swa_mult = allocator.swa_kernel_page_multiplier
                 req_to_token, rows, seq_lens = _alloc_and_fill(
@@ -226,8 +230,10 @@ class TestReadTableBuild(unittest.TestCase):
                 )
 
     def test_packed_stream_equals_the_rectangle_it_replaces(self):
-        """The two builders must agree element for element:
-        packed[indptr[b] + p] == ids[b, p // ps] * ps + p % ps."""
+        """The packed builder and the rectangle must agree element for element:
+        packed[indptr[b] + p] == ids[b, p // ps] * ps + p % ps. Consumers that
+        plan over the stream and consumers that read the page table have to see
+        the same KV, so a change to either builder alone turns this red."""
         for ps in (1, 4):
             allocator = _build_composite(ps)
             req_to_token, rows, seq_lens = _alloc_and_fill(
@@ -258,9 +264,9 @@ class TestReadTableBuild(unittest.TestCase):
                     )
 
     def test_sink_routing(self):
-        """Dead lanes, -1 slots inside the live prefix, and tombstoned v2p
-        pages must ALL read entry 0; one wild entry is a captured-graph OOB
-        read at replay."""
+        """Dead lanes (seq_len 0), -1 slots inside the live prefix, and
+        tombstoned v2p pages must ALL read entry 0 -- one wild entry is a
+        captured-graph OOB read at replay."""
         ps = 4
         allocator = _build_composite(ps)
         req_to_token, rows, seq_lens = _alloc_and_fill(
@@ -288,16 +294,13 @@ class TestBuildInto(unittest.TestCase):
     FULL-side read-table entries -- the trtllm_mla / flashmla consumption route
     (their rows ARE the read table's rows)."""
 
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
-
     def test_prefix_filled_tail_sentinel_preserved_width_capped(self):
-        """The -1 tail sentinel belongs to the backend, and a table padded
-        WIDER than the req_to_token page span (trtllm's LCM alignment) must be
-        capped rather than trip the builder's width assert."""
+        """Three contracts in one batch: entries equal the read-table formula,
+        lanes past each row's live pages keep the backend's -1 sentinel
+        (prefix-only -- a tail write scatters the trtllm sentinel contract),
+        and a table padded WIDER than the req_to_token page span (trtllm's
+        LCM alignment) is capped instead of tripping the builder's width
+        assert."""
         ps = 4
         allocator = _build_composite(ps)
         full_mult = allocator.kernel_page_multiplier
@@ -331,8 +334,8 @@ class TestBuildInto(unittest.TestCase):
             )
 
     def test_passthrough_source_refuses(self):
-        """Callers dispatch on `reads_are_translated`; a passthrough source has
-        no v2p to build from and must fail loud, not fill garbage."""
+        """Callers dispatch on `enabled`; a passthrough source has no v2p to
+        build from and must fail loud, not fill garbage."""
         src = KVIndexTranslator(
             req_to_token=torch.zeros((2, 4), dtype=torch.int64),
             token_to_kv_pool_allocator=SimpleNamespace(),
@@ -352,24 +355,21 @@ class TestPoolOwnership(unittest.TestCase):
     """A runner only gets the kernel-facing id space when the pool IT reads and
     writes is the one the allocator's ids address.
 
-    Guarded shape: a runner handed a SHARED allocator while owning a SEPARATE
-    KV buffer sized to the allocator's SLOT count. Probing the allocator alone
-    reports "unified" for that runner, so its indices would be mapped into the
-    composite's kernel-facing space (ids up to num_pages * multiplier) and used
-    to address a buffer with only num_slots rows.
+    Guarded shape: a runner handed a SHARED allocator (one slot index space,
+    one req_to_token) while owning a SEPARATE KV buffer sized to the
+    allocator's SLOT count. Probing the allocator alone reports "unified" for
+    that runner, so its indices would be mapped into the composite's
+    kernel-facing space (kernel-facing ids up to num_pages * multiplier) and then used
+    to address a buffer with only num_slots rows -- out of bounds on both the
+    read gather and the KV store.
     """
 
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
-
     def test_real_factory_bundle_satisfies_the_ownership_identity(self):
-        """The guard rests on `allocator.get_kvcache() is token_to_kv_pool`, so
-        a factory returning a pool the allocator does not hold would silently
-        disable the unified path for EVERY model. Pinned against the real
-        factory, not this file's own construction."""
+        """The guard rests on `allocator.get_kvcache() is token_to_kv_pool`
+        holding for a REAL target bundle. If a factory ever returned a pool
+        the allocator does not hold, the guard would silently disable the
+        unified path for EVERY model -- so pin it against the real factory
+        rather than against this file's own construction."""
         from sglang.srt.mem_cache.unified_memory_pool import init_unified_swa_pools
 
         bundle = init_unified_swa_pools(
@@ -419,9 +419,9 @@ class TestPoolOwnership(unittest.TestCase):
         self.assertFalse(src.is_translating)
 
     def test_disabled_source_is_strict_passthrough(self):
-        """Such a runner must see RAW virtual ids: they index its own pool
-        directly, and a translate here is the out-of-bounds bug the ownership
-        identity exists to prevent."""
+        """Consequence of the guard: such a runner must see RAW virtual ids on
+        the read table -- they index its own pool directly. A translate here is
+        the out-of-bounds bug the ownership identity exists to prevent."""
         alloc = _build_composite(ps=1)
         req_to_token = torch.arange(16, dtype=torch.int32, device=_DEV).view(2, 8)
         src = KVIndexTranslator(
@@ -446,12 +446,6 @@ class TestPoolOwnership(unittest.TestCase):
 
 
 class TestCaptureContract(unittest.TestCase):
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
-
     def test_caller_owned_table_is_returned_whole_and_filled_prefix_only(self):
         ps = 4
         allocator = _build_composite(ps)
@@ -476,17 +470,16 @@ class TestCaptureContract(unittest.TestCase):
             into=tables,
         )
         self.assertIs(view.ids, cap, "the caller's table comes back WHOLE")
-        want = allocator.full_v2p_page_table[req_to_token[1, ::ps][:2] // ps] * (
-            2 * _FULL_L
-        )
+        want = allocator.full_v2p_page_table[req_to_token[1, ::ps][:2] // ps]
         self.assertTrue(torch.equal(cap[0, :2], want.to(torch.int32)))
         self.assertTrue(bool((cap[0, 2:] == 7).all()), "stale tail was cleared")
         self.assertTrue(bool((cap[1:] == 7).all()), "rows beyond bs were touched")
 
     def test_row_ids_not_reallocated_across_builds(self):
-        """`row_ids` is one arange sized from the request pool and sliced per
-        build; a per-build `torch.arange` would be correct but costs an
-        allocation and a launch on every replay prep."""
+        """`row_ids` is a constant arange sized once from the request pool, so
+        builds at different batch sizes hand back slices of ONE buffer. A
+        per-build `torch.arange` would be correct but would spend an allocation
+        and a launch on every replay prep."""
         allocator = _build_composite(1)
         req_to_token, rows, seq_lens = _alloc_and_fill(allocator, 1, lens=[4, 2, 3])
         src = _make_source(allocator, req_to_token, 1)
@@ -531,15 +524,10 @@ class _FakeForwardBatch:
 
 
 class TestViewMemo(unittest.TestCase):
-    """The eager view is memoized ON THE SOURCE in a single slot keyed by batch
-    identity, so per-batch state stays out of the ForwardBatch while one
-    metadata build's many consumers still share one table build."""
-
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
+    """The eager view is memoized ON THE SOURCE in a single slot keyed by
+    batch identity -- per-batch state stays out of the ForwardBatch (it does
+    not scale with the number of id spaces), and one metadata build's many
+    consumers still share one table build."""
 
     def _fb(self, allocator, ps, lens):
         req_to_token, rows, seq_lens = _alloc_and_fill(allocator, ps, lens=lens)
@@ -595,16 +583,12 @@ class TestViewMemo(unittest.TestCase):
 
 
 class TestWriteLoc(unittest.TestCase):
-    """The two-phase write contract: `rebind_write_loc` rebinds the full side
-    once at ForwardBatch construction, and the sliding-window write loc derives
-    POINTWISE from the full-side values -- pads, slices, and fresh copies
-    included -- with no handover and no stored per-forward state."""
-
-    def setUp(self):
-        # The code under test reads its config from the bags.
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="tokenizer")
+    """The two-phase write contract: phase 1 (`rebind_write_loc`) rebinds the
+    full side once at ForwardBatch construction; phase 2 derives the
+    sliding-window write loc on demand, POINTWISE from the full-side
+    values. Value-based derivation is the property under test: pads, slices,
+    and fresh copies of the loc must all derive correctly with no handover
+    and no stored per-forward state."""
 
     def _built(self, ps=1, n=4):
         allocator = _build_composite(ps)
@@ -631,8 +615,10 @@ class TestWriteLoc(unittest.TestCase):
             self.assertTrue(torch.equal(virt, keep))
 
     def test_swa_write_loc_round_trips_from_full_side(self):
-        """Derived property: `field(full(t)) == swa(t)` for any virtual run t,
-        across page sizes and multipliers."""
+        """The derived property behind phase 2: for any virtual run t,
+        deriving from the kernel-facing full-side values must equal the direct
+        virtual->swa translate — `field(full(t)) == swa(t)` across page sizes
+        and multipliers."""
         for ps in (1, 4, 64):
             src, _, rows, seq_lens, _, want_full, want_swa = self._built(
                 ps=ps, n=3 * ps
@@ -641,14 +627,29 @@ class TestWriteLoc(unittest.TestCase):
             self.assertTrue(torch.equal(got, want_swa))
 
     def test_pad_lanes_derive_to_sink(self):
-        """The DP pad appends zeros, and kernel-facing 0 is the reserved
-        padding slot in every id space, so pad lanes derive to swa slot 0 with
-        no `num_live` bookkeeping."""
+        """The DP pad appends zeros; kernel-facing 0 is the reserved padding slot in
+        every id space, so pad lanes must derive to swa slot 0 with no
+        `num_live` bookkeeping."""
         src, _, rows, seq_lens, _, want_full, want_swa = self._built(n=3)
         padded = torch.cat([want_full, want_full.new_zeros(2)])
         got = self._field(src, rows, seq_lens, padded)
         self.assertTrue(torch.equal(got[:3], want_swa))
         self.assertTrue(bool((got[3:] == 0).all()), "pad lanes must land on slot 0")
+
+    def test_slice_and_copy_derive_pointwise_without_handover(self):
+        """REGRESSION (design): the retired identity-resolver refused any
+        tensor it had not been handed -- a TBO child's re-padded slice or a
+        registry's fresh copy raised. Value-based derivation must accept
+        both, pointwise, with no adopt/handover call."""
+        src, _, rows, seq_lens, _, want_full, want_swa = self._built(n=4)
+        padded = torch.cat([want_full, want_full.new_zeros(2)])
+        # TBO-child shape: a slice crossing the pad boundary.
+        got = self._field(src, rows, seq_lens, padded[2:6])
+        self.assertTrue(torch.equal(got[:2], want_swa[2:4]))
+        self.assertTrue(bool((got[2:] == 0).all()))
+        # Registry shape: a fresh equal-value copy.
+        got2 = self._field(src, rows, seq_lens, want_full.clone())
+        self.assertTrue(torch.equal(got2, want_swa))
 
     def test_tombstoned_swa_page_clamps_to_sink(self):
         src, allocator, rows, seq_lens, virt, want_full, _ = self._built(ps=1, n=2)

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -48,10 +48,10 @@ from types import SimpleNamespace
 import torch
 from test_multi_ended_allocator import _FakeUnifiedSWAKVPool
 
-from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator, KVReadTables
 from sglang.srt.mem_cache.allocator.unified_hybrid_swa import (
     UnifiedSWATokenToKVPoolAllocator,
 )
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator, KVReadTables
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.unified_memory_pool import MHASubPoolSpec, UnifiedKVPool
 
@@ -177,7 +177,6 @@ def _alloc_and_fill(allocator, ps, lens):
 
 
 class TestReadTableBuild(unittest.TestCase):
-
     def test_read_table_matches_reference(self):
         """The load-bearing formula pin: full AND swa read tables equal
         the independent per-element derivation across page sizes (kernel-facing

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -20,9 +20,9 @@ Triton kernel is a later CUDA CI pin):
     makes backend re-pointing byte-identical for every non-unified server);
   - static SWA pools keep their legacy full->swa mapping on the view;
   - the read table matches the hand formula
-        entry[b, c] = clamp(v2p[req_to_token[req[b], c*ps] // ps] * mult, 0)
-    over the REAL SWA composite's tables (full AND swa, ps in {1, 4},
-    multiplier in {1, 2L}), with the swa table built from VIRTUAL ids;
+        entry[b, c] = clamp(v2p[req_to_token[req[b], c*ps] // ps], 0)
+    over the REAL SWA composite's tables (full AND swa, ps in {1, 4}), with
+    the swa table built from VIRTUAL ids;
   - sink routing: dead lanes (seq_len 0), -1 req_to_token entries, and
     tombstoned v2p pages all read entry 0;
   - the capture contract: buffers are zero-filled and idempotent; a refresh
@@ -116,7 +116,7 @@ def _make_source(allocator, req_to_token, ps):
     )
 
 
-def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, mult, ps, width):
+def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, ps, width):
     """Independent python derivation of the read-table formula."""
     bs = req_pool_indices.numel()
     out = torch.zeros((bs, width), dtype=torch.int32)
@@ -126,7 +126,7 @@ def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, mult, ps, wi
         for c in range(min(n_pages, width)):
             tok = int(req_to_token[req, c * ps])
             page = 0 if tok < 0 else tok // ps
-            out[b, c] = max(int(v2p[page]) * mult, 0)
+            out[b, c] = max(int(v2p[page]), 0)
     return out
 
 
@@ -186,8 +186,6 @@ class TestReadTableBuild(unittest.TestCase):
         full-physical proof."""
         for ps in (1, 4):
             for allocator in (_build_composite(ps),):
-                full_mult = allocator.kernel_page_multiplier
-                swa_mult = allocator.swa_kernel_page_multiplier
                 req_to_token, rows, seq_lens = _alloc_and_fill(
                     allocator, ps, lens=[5 * ps, 2 * ps, 3 * ps - 1]
                 )
@@ -207,7 +205,6 @@ class TestReadTableBuild(unittest.TestCase):
                     rows,
                     seq_lens,
                     allocator.full_v2p_page_table,
-                    full_mult,
                     ps,
                     width,
                 )
@@ -216,17 +213,16 @@ class TestReadTableBuild(unittest.TestCase):
                     rows,
                     seq_lens,
                     allocator.swa_v2p_page_table,
-                    swa_mult,
                     ps,
                     width,
                 )
                 self.assertTrue(
                     torch.equal(view.ids, want_full),
-                    f"full read table off-formula (ps={ps}, mult={full_mult})",
+                    f"full read table off-formula (ps={ps})",
                 )
                 self.assertTrue(
                     torch.equal(view.sliding_window_ids, want_swa),
-                    f"swa read table off-formula (ps={ps}, mult={swa_mult})",
+                    f"swa read table off-formula (ps={ps})",
                 )
 
     def test_packed_stream_equals_the_rectangle_it_replaces(self):
@@ -303,7 +299,6 @@ class TestBuildInto(unittest.TestCase):
         assert."""
         ps = 4
         allocator = _build_composite(ps)
-        full_mult = allocator.kernel_page_multiplier
         lens = [5, 2 * ps + 1, 1]
         req_to_token, rows, seq_lens = _alloc_and_fill(allocator, ps, lens=lens)
         src = _make_source(allocator, req_to_token, ps)
@@ -318,7 +313,6 @@ class TestBuildInto(unittest.TestCase):
             rows,
             seq_lens,
             allocator.full_v2p_page_table,
-            full_mult,
             ps,
             width_pages,
         )
@@ -595,7 +589,7 @@ class TestWriteLoc(unittest.TestCase):
         req_to_token, rows, seq_lens = _alloc_and_fill(allocator, ps, lens=[max(n, 1)])
         src = _make_source(allocator, req_to_token, ps)
         virt = allocator.alloc(-(-n // ps) * ps)[:n]
-        want_full = allocator.translate_kv_loc_for_kernel(virt)
+        want_full = allocator.translate_kv_loc(virt)
         want_swa = allocator.translate_loc_from_full_to_swa(virt)
         return src, allocator, rows, seq_lens, virt, want_full, want_swa
 

--- a/test/registered/unit/mem_cache/test_kv_stride_hygiene.py
+++ b/test/registered/unit/mem_cache/test_kv_stride_hygiene.py
@@ -1,0 +1,137 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""KV-cache row addressing must come from tensor strides, not shapes.
+
+A per-layer KV buffer may be a strided view into a larger buffer (slot stride
+larger than ``head_num * head_dim``). Every helper that computes a slot address
+must then use ``stride(0)``; deriving it from ``prod(shape[1:])`` silently
+addresses the wrong slot, and ``.contiguous()`` silently snapshots instead of
+aliasing the live pool. These tests pin the stride-derived behaviour on views
+that differ from contiguous buffers.
+
+CPU-only.
+
+    python -m pytest test/registered/unit/mem_cache/test_kv_stride_hygiene.py -v
+"""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.utils import canonicalize_stride
+from sglang.kernels.ops.kv_canary.verify import RealKvSource
+from sglang.srt.kv_canary.pool_patcher.buffer_alloc import make_row_source
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _strided_rows(num_rows: int, row_elems: int, slot_elems: int, dtype, *, offset=0):
+    """A [num_rows, row_elems] view whose row stride is ``slot_elems`` (> row_elems)."""
+    backing = torch.zeros(num_rows * slot_elems + offset, dtype=dtype)
+    view = backing.as_strided((num_rows, row_elems), (slot_elems, 1), offset)
+    assert not view.is_contiguous()
+    return backing, view
+
+
+class TestCanonicalizeStride(unittest.TestCase):
+    def test_degenerate_head_dim_is_fixed(self):
+        t = torch.empty(4 * 64 * 128).as_strided((4, 1, 64, 128), (8192, 128, 128, 1))
+        out = canonicalize_stride(t)
+        self.assertEqual(tuple(out.stride()), (8192, 8192, 128, 1))
+        self.assertEqual(out.data_ptr(), t.data_ptr())
+
+    def test_strided_view_without_degenerate_dims_is_untouched(self):
+        ps, H, D, E = 4, 8, 128, 8 * 128 + 512  # slot stride wider than a row
+        t = torch.empty(3 * ps * E).as_strided((3, ps, H, D), (ps * E, E, D, 1))
+        self.assertIs(canonicalize_stride(t), t)
+
+    def test_strided_view_keeps_non_degenerate_strides(self):
+        # Degenerate head dim on a strided view: only that stride is rewritten.
+        ps, D, E = 4, 128, 2048
+        t = torch.empty(3 * ps * E).as_strided((3, 1, ps, D), (ps * E, E, E, 1))
+        out = canonicalize_stride(t)
+        self.assertEqual(tuple(out.stride()), (ps * E, ps * E, E, 1))
+        for p in range(3):
+            for s in range(ps):
+                self.assertEqual(out[p, 0, s].data_ptr(), t[p, 0, s].data_ptr())
+
+    def test_single_head_with_distinct_strides_is_untouched(self):
+        ps, D, E = 4, 128, 2048
+        t = torch.empty(3 * ps * E).as_strided((3, ps, 1, D), (ps * E, E, D, 1))
+        self.assertIs(canonicalize_stride(t), t)
+
+
+class TestRealKvSourceStrides(unittest.TestCase):
+    def test_accepts_strided_rows(self):
+        _, view = _strided_rows(8, 64, 96, torch.uint8)
+        src = RealKvSource(
+            tensor=view, page_size=1, num_bytes_per_token=64, read_bytes=16
+        )
+        self.assertEqual(src.tensor.stride(0), 96)
+
+    def test_rejects_unaligned_row_stride(self):
+        _, view = _strided_rows(8, 64, 72, torch.uint8)
+        with self.assertRaisesRegex(ValueError, "row stride must be a multiple of 16"):
+            RealKvSource(
+                tensor=view, page_size=1, num_bytes_per_token=64, read_bytes=16
+            )
+
+
+class TestMakeRowSourceAliases(unittest.TestCase):
+    def test_strided_layer_view_is_aliased_not_copied(self):
+        N, H, D, E = 6, 2, 16, 2 * 16 + 32  # bf16 elems; slot stride wider than a row
+        backing = torch.zeros(N * E, dtype=torch.bfloat16)
+        layer = backing.as_strided((N, H, D), (E, D, 1))
+        (src,) = make_row_source(layer_buffer=layer, read_bytes=16)
+        self.assertEqual(src.tensor.data_ptr(), layer.data_ptr())
+        self.assertEqual(tuple(src.tensor.shape), (N, H * D * 2))
+        self.assertEqual(src.tensor.stride(0), E * 2)
+        layer[3, 1, 0] = 1.0  # a later pool write must be visible to the canary
+        written = src.tensor[3, D * 2 : D * 2 + 2].view(torch.bfloat16)[0]
+        self.assertNotEqual(int(written), 0)
+
+    def test_non_viewable_layout_raises_instead_of_snapshotting(self):
+        layer = torch.zeros(4, 16, 2, dtype=torch.bfloat16).transpose(1, 2)
+        with self.assertRaises(RuntimeError):
+            make_row_source(layer_buffer=layer, read_bytes=16)
+
+
+class TestDataStridesFollowViews(unittest.TestCase):
+    def test_data_strides_use_stride0(self):
+        # K and V of both layers share one slot of E elements.
+        L, N, H, D, E = 2, 5, 2, 16, 2 * (2 * 16) + 64
+        itemsize = 2
+        backing = torch.zeros(N * E, dtype=torch.float16)
+        pool = MHATokenToKVPool.__new__(MHATokenToKVPool)
+        pool.device = "cpu"
+        pool.k_buffer = [
+            backing.as_strided((N, H, D), (E, D, 1), l * 2 * H * D) for l in range(L)
+        ]
+        pool.v_buffer = [
+            backing.as_strided((N, H, D), (E, D, 1), (l * 2 + 1) * H * D)
+            for l in range(L)
+        ]
+        pool._init_data_ptrs_and_strides()
+        self.assertEqual(pool.data_strides.tolist(), [E * itemsize] * (2 * L))
+        self.assertNotEqual(E * itemsize, H * D * itemsize)
+        self.assertEqual(
+            pool.data_ptrs.tolist(),
+            [x.data_ptr() for x in pool.k_buffer + pool.v_buffer],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_kv_stride_hygiene.py
+++ b/test/registered/unit/mem_cache/test_kv_stride_hygiene.py
@@ -32,6 +32,7 @@ import torch
 from sglang.kernels.ops.attention.utils import canonicalize_stride
 from sglang.kernels.ops.kv_canary.verify import RealKvSource
 from sglang.srt.kv_canary.pool_patcher.buffer_alloc import make_row_source
+from sglang.srt.mem_cache.layout.page_major import paged_row_view, paged_view
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -107,6 +108,47 @@ class TestMakeRowSourceAliases(unittest.TestCase):
         layer = torch.zeros(4, 16, 2, dtype=torch.bfloat16).transpose(1, 2)
         with self.assertRaises(RuntimeError):
             make_row_source(layer_buffer=layer, read_bytes=16)
+
+
+class TestPagedView(unittest.TestCase):
+    def test_contiguous_matches_plain_view(self):
+        N, ps, H, D = 12, 4, 2, 16
+        flat = torch.zeros(N, H, D)
+        out = paged_view(flat, ps)
+        self.assertEqual(tuple(out.shape), (N // ps, ps, H, D))
+        self.assertEqual(out.stride(), flat.view(-1, ps, H, D).stride())
+        self.assertEqual(out.data_ptr(), flat.data_ptr())
+
+    def test_strided_slots_keep_their_stride(self):
+        N, ps, H, D, E = 12, 4, 2, 16, 2 * 16 + 96
+        flat = torch.zeros(N * E).as_strided((N, H, D), (E, D, 1))
+        out = paged_view(flat, ps)
+        self.assertEqual(tuple(out.stride()), (ps * E, E, D, 1))
+        for t in range(N):
+            self.assertEqual(out[t // ps, t % ps].data_ptr(), flat[t].data_ptr())
+        rows = paged_row_view(flat, ps)
+        self.assertEqual(tuple(rows.shape), (N // ps, ps, H * D))
+        self.assertEqual(tuple(rows.stride()), (ps * E, E, 1))
+
+    def test_rejects_partial_pages(self):
+        with self.assertRaises(AssertionError):
+            paged_view(torch.zeros(10, 2, 16), 4)
+
+    def test_pool_accessor_returns_views(self):
+        N, ps, H, D, E = 8, 2, 2, 16, 2 * (2 * 16) + 32
+        backing = torch.zeros(N * E, dtype=torch.float16)
+        pool = MHATokenToKVPool.__new__(MHATokenToKVPool)
+        pool.page_size = ps
+        pool.start_layer = 0
+        pool.layer_transfer_counter = None
+        pool.is_quantized_kv_cache = False
+        pool.dtype = pool.store_dtype = torch.float16
+        pool.k_buffer = [backing.as_strided((N, H, D), (E, D, 1), 0)]
+        pool.v_buffer = [backing.as_strided((N, H, D), (E, D, 1), H * D)]
+        k, v = pool.get_paged_kv_buffer(0)
+        self.assertEqual(tuple(k.shape), (N // ps, ps, H, D))
+        self.assertEqual(tuple(k.stride()), (ps * E, E, D, 1))
+        self.assertEqual(v.data_ptr(), pool.v_buffer[0].data_ptr())
 
 
 class TestDataStridesFollowViews(unittest.TestCase):

--- a/test/registered/unit/mem_cache/test_layout_compat.py
+++ b/test/registered/unit/mem_cache/test_layout_compat.py
@@ -11,29 +11,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""``move_kv_cache_native`` -- the stock per-layer 3-D move static-pool
-compaction rides on -- must stay byte-exact. CPU-only.
+"""Unit tests for the page-major envelope byte layout.
 
-The page-major envelope layout and the per-layer views over it are covered by
-``test_unified_mha_views.py``, which pins the view addressing against the
-envelope formula byte for byte.
+The subject here is the ENVELOPE — the byte layout the unified pool stores its
+KV in — pinned through ``MHASubPoolSpec``'s offset math. The 3-D per-layer views
+the pool exposes over the same bytes are covered by
+``test_unified_mha_views.py``, which also pins the view addressing
+against the envelope formula byte for byte.
+
+Verifies that:
+1. ``MHASubPoolSpec.layer_k_offset_in_entry`` / ``layer_v_offset_in_entry``
+   math matches the token-major entry, independent of the page size.
+2. ``move_kv_cache_native`` (the stock per-layer 3-D move) stays byte-exact.
+
+CPU-only — no GPU / Triton needed.
+
+    python -m pytest test/registered/unit/mem_cache/test_layout_compat.py -v
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=9, suite="base-a-test-cpu")
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 import unittest
 
 import torch
 
 from sglang.srt.mem_cache.memory_pool import move_kv_cache_native
+from sglang.srt.mem_cache.unified_memory_pool import MHASubPoolSpec
+
+_DEV = "cpu"
+
+
+def _make_mha_spec(name, grow, layer_num=2, head_num=2, head_dim=4):
+    return MHASubPoolSpec(
+        name=name,
+        layer_num=layer_num,
+        head_num=head_num,
+        head_dim=head_dim,
+        store_dtype=torch.float16,
+        grow_direction=grow,
+    )
+
+
+class TestMHASpecLayerOffsets(unittest.TestCase):
+    """Verify ``layer_k_offset_in_entry`` / ``layer_v_offset_in_entry`` math."""
+
+    def test_offsets_match_token_major_entry(self):
+        spec = _make_mha_spec("full", "up", layer_num=3, head_num=2, head_dim=4)
+        # Layer L's K sits at L * (k_row + v_row) inside the slot's entry and
+        # its V right after that K. The page size never enters: a page is
+        # page_size entries back to back.
+        k_row = spec.k_row_bytes()
+        v_row = spec.v_row_bytes()
+        layout = spec.layout()
+        self.assertEqual(layout.entry_bytes, spec.entry_bytes())
+        for L in range(spec.layer_num):
+            self.assertEqual(spec.layer_k_offset_in_entry(L), L * (k_row + v_row))
+            self.assertEqual(
+                spec.layer_v_offset_in_entry(L), L * (k_row + v_row) + k_row
+            )
+            self.assertEqual(
+                layout.part("k").layer_offset_bytes(L), spec.layer_k_offset_in_entry(L)
+            )
+            self.assertEqual(
+                layout.part("v").layer_offset_bytes(L), spec.layer_v_offset_in_entry(L)
+            )
+
+    def test_page_bytes(self):
+        spec = _make_mha_spec("full", "up", layer_num=3, head_num=2, head_dim=4)
+        # page_bytes = page_size * entry_bytes (preserved invariant)
+        for ps in [1, 8, 64, 256]:
+            self.assertEqual(spec.page_bytes(ps), ps * spec.entry_bytes())
 
 
 class TestMoveKVCacheNative(unittest.TestCase):
     def test_move_kv_cache_3d_path_unchanged(self):
         """The stock per-layer 3-D move must relocate exactly the named token
-        rows, byte-identically; compaction on static pools rides on it."""
+        rows, byte-identically — compaction on static pools rides on it."""
         k = [torch.zeros((32, 2, 4), dtype=torch.float16) for _ in range(2)]
         v = [torch.zeros((32, 2, 4), dtype=torch.float16) for _ in range(2)]
         for L in range(2):

--- a/test/registered/unit/mem_cache/test_multi_ended_allocator.py
+++ b/test/registered/unit/mem_cache/test_multi_ended_allocator.py
@@ -1700,16 +1700,13 @@ class TestPagedMultiEndedAllocator(unittest.TestCase):
             "v2p_page[virt_pages] * page_size + offsets.",
         )
 
-        # The composite emits KERNEL-FACING ids, not the physical token ids this
-        # helper returns; they coincide only at multiplier 1, which nothing uses.
-        swa_mult = allocator.swa_kernel_page_multiplier
-        self.assertEqual(swa_mult, 2 * swa_spec.layer_num)
+        # The composite emits the swa sub-pool's PHYSICAL token ids (the
+        # kernel-facing id space of the token-major views).
         composite_out = allocator.translate_loc_from_full_to_swa(v_tokens)
-        expected_kernel = swa_phys_pages_direct * (PS * swa_mult) + offsets_in
         self.assertTrue(
-            bool((composite_out.long() == expected_kernel.long()).all().item()),
+            bool((composite_out.long() == expected.long()).all().item()),
             "REGRESSION: translate_loc_from_full_to_swa must emit the swa "
-            "sub-pool's kernel-facing ids (phys_page * ps * blocks_per_page + offset).",
+            "sub-pool's physical token ids (phys_page * ps + offset).",
         )
 
 
@@ -2304,16 +2301,16 @@ class TestSWACompositeKernelIdSurface(unittest.TestCase):
         )
 
     def test_full_kernel_translate_matches_formula(self):
-        """Both sides scale by their OWN sub-pool's block count, and the full
-        kernel id follows v2p[t // ps] * (ps * mult) + t % ps."""
-        mult = 2 * self.FULL_L
+        """Kernel-facing ids ARE the physical token ids under the token-major
+        views, so both sides pin at multiplier 1 and the id follows
+        v2p[t // ps] * ps + t % ps."""
         a = self._build()
-        self.assertEqual(a.kernel_page_multiplier, 2 * self.FULL_L)
-        self.assertEqual(a.swa_kernel_page_multiplier, 2 * self.SWA_L)
+        self.assertEqual(a.kernel_page_multiplier, 1)
+        self.assertEqual(a.swa_kernel_page_multiplier, 1)
         v = a.alloc(3 * self.PS)
         self.assertIsNotNone(v)
         v2p = a.full_attn_allocator.virtual_to_physical
-        expected = v2p[v // self.PS] * (self.PS * mult) + v % self.PS
+        expected = v2p[v // self.PS] * self.PS + v % self.PS
         self.assertTrue(torch.equal(a.translate_kv_loc_for_kernel(v), expected))
         # The PHYSICAL translate must stay unscaled -- compaction and the byte
         # machinery depend on it staying in physical space.
@@ -2428,8 +2425,8 @@ class TestPs64MLACompositeFeasibility(unittest.TestCase):
 
     def test_construction_alloc_and_kernel_formula(self):
         a = self._build()
-        # MLA: one latent row per layer, so the spec reports LAYERS blocks.
-        self.assertEqual(a.kernel_page_multiplier, self.LAYERS)
+        # Token-major views: the kernel id is the physical token id.
+        self.assertEqual(a.kernel_page_multiplier, 1)
         v = a.alloc(2 * self.PS)
         self.assertIsNotNone(v, "2-page alloc infeasible at ps=64")
         # Page-aligned virtual run (page-granular allocator invariant).
@@ -2437,7 +2434,7 @@ class TestPs64MLACompositeFeasibility(unittest.TestCase):
         # The kernel translate follows the affine formula at ps=64, and every id
         # fits int32 (the canonical narrows on store).
         v2p = a.full_v2p_page_table
-        want = v2p[v // self.PS] * (self.PS * self.LAYERS) + v % self.PS
+        want = v2p[v // self.PS] * self.PS + v % self.PS
         got = a.translate_kv_loc_for_kernel(v)
         self.assertTrue(torch.equal(got, want), "kernel-facing formula broke at ps=64")
         self.assertTrue(bool((got < 2**31).all().item()))

--- a/test/registered/unit/mem_cache/test_multi_ended_allocator.py
+++ b/test/registered/unit/mem_cache/test_multi_ended_allocator.py
@@ -2248,9 +2248,10 @@ class TestO3FusedAllocBind(unittest.TestCase):
 
 
 class TestSWACompositeKernelIdSurface(unittest.TestCase):
-    """The SWA composite's kernel-facing id surface. Attention backends probe for
-    `translate_kv_loc_for_kernel` / `full_v2p_page_table`, and every id must
-    follow `kernel_id(t) = v2p[t // ps] * (ps * mult) + t % ps`."""
+    """The SWA composite's id surface: both translates follow
+    `phys(t) = v2p[t // ps] * ps + t % ps` over their own side's v2p table,
+    and the raw v2p tables are exposed unwrapped.
+    """
 
     def setUp(self):
         # The code under test reads its config from the bags.
@@ -2300,58 +2301,52 @@ class TestSWACompositeKernelIdSurface(unittest.TestCase):
             forward_stream=None,
         )
 
-    def test_full_kernel_translate_matches_formula(self):
-        """Kernel-facing ids ARE the physical token ids under the token-major
-        views, so both sides pin at multiplier 1 and the id follows
-        v2p[t // ps] * ps + t % ps."""
+    def test_composite_exposes_raw_v2p_tables(self):
         a = self._build()
-        self.assertEqual(a.kernel_page_multiplier, 1)
-        self.assertEqual(a.swa_kernel_page_multiplier, 1)
+        self.assertIs(a.full_v2p_page_table, a.full_attn_allocator.virtual_to_physical)
+        self.assertIs(a.swa_v2p_page_table, a.swa_attn_allocator.virtual_to_physical)
+
+    def test_full_translate_matches_formula(self):
+        a = self._build()
         v = a.alloc(3 * self.PS)
         self.assertIsNotNone(v)
         v2p = a.full_attn_allocator.virtual_to_physical
         expected = v2p[v // self.PS] * self.PS + v % self.PS
-        self.assertTrue(torch.equal(a.translate_kv_loc_for_kernel(v), expected))
-        # The PHYSICAL translate must stay unscaled -- compaction and the byte
-        # machinery depend on it staying in physical space.
-        phys = v2p[v // self.PS] * self.PS + v % self.PS
-        self.assertTrue(torch.equal(a.translate_kv_loc(v), phys))
+        self.assertTrue(torch.equal(a.translate_kv_loc(v), expected))
 
-    def test_kernel_translate_accepts_an_int32_page_table(self):
-        """Regression: fa3 passes its own page table, which is int32 and 2-D, so
-        the gather must not require an int64 index."""
+    def test_translate_accepts_an_int32_page_table(self):
+        """REGRESSION: fa3 translates its own page table, which is int32 and
+        2-D. A gather that requires an int64 index (`torch.take`) crashes the
+        scheduler there while every int64 caller stays green. Both page sizes:
+        at ps == 1 the index IS the caller's tensor, at ps > 1 it is derived."""
         for ps in (1, 4):
             with self.subTest(page_size=ps):
                 self.PS = ps
-                mult = 2 * self.FULL_L
                 a = self._build()
                 v = a.alloc(4 * ps)
                 self.assertIsNotNone(v)
                 v2p = a.full_attn_allocator.virtual_to_physical
-                expected = v2p[v // ps] * (ps * mult) + v % ps
+                expected = v2p[v // ps] * ps + v % ps
                 page_table = v.to(torch.int32).view(2, -1)
-                got = a.translate_kv_loc_for_kernel(page_table)
+                got = a.translate_kv_loc(page_table)
                 self.assertEqual(got.shape, page_table.shape)
                 self.assertTrue(torch.equal(got.reshape(-1), expected))
                 # `out=` takes the same int32 index; the buffer stays int64.
                 dst = torch.empty(page_table.shape, dtype=torch.int64, device=_DEV)
-                a.translate_kv_loc_for_kernel(page_table, out=dst)
+                a.translate_kv_loc(page_table, out=dst)
                 self.assertTrue(torch.equal(dst.reshape(-1), expected))
 
-    def test_swa_translate_scales_page_stride(self):
-        mult = 2 * self.SWA_L
+    def test_swa_translate_matches_formula(self):
         a = self._build()
         v = a.alloc(3 * self.PS)
         self.assertIsNotNone(v)
         v2p_swa = a.swa_attn_allocator.virtual_to_physical
-        expected = v2p_swa[v // self.PS] * (self.PS * mult) + v % self.PS
+        expected = v2p_swa[v // self.PS] * self.PS + v % self.PS
         self.assertTrue(torch.equal(a.translate_loc_from_full_to_swa(v), expected))
 
-    def test_swa_kernel_tombstone_still_lands_on_sink(self):
-        """The scaled stride must not break the tombstone clamp: a tombstoned
-        page's ids (v2p == -1 -> -stride + offset, negative for every in-page
-        offset) still land on the sink, never negative."""
-        mult = 2 * self.SWA_L
+    def test_swa_tombstone_still_lands_on_sink(self):
+        """A tombstoned page's ids (v2p == -1 -> -ps + offset, negative for
+        every in-page offset) still land on the sink, never negative."""
         a = self._build()
         v = a.alloc(2 * self.PS)
         self.assertIsNotNone(v)
@@ -2425,8 +2420,6 @@ class TestPs64MLACompositeFeasibility(unittest.TestCase):
 
     def test_construction_alloc_and_kernel_formula(self):
         a = self._build()
-        # Token-major views: the kernel id is the physical token id.
-        self.assertEqual(a.kernel_page_multiplier, 1)
         v = a.alloc(2 * self.PS)
         self.assertIsNotNone(v, "2-page alloc infeasible at ps=64")
         # Page-aligned virtual run (page-granular allocator invariant).
@@ -2435,7 +2428,7 @@ class TestPs64MLACompositeFeasibility(unittest.TestCase):
         # fits int32 (the canonical narrows on store).
         v2p = a.full_v2p_page_table
         want = v2p[v // self.PS] * self.PS + v % self.PS
-        got = a.translate_kv_loc_for_kernel(v)
+        got = a.translate_kv_loc(v)
         self.assertTrue(torch.equal(got, want), "kernel-facing formula broke at ps=64")
         self.assertTrue(bool((got < 2**31).all().item()))
 
@@ -3030,7 +3023,7 @@ class TestDcpWidening(unittest.TestCase):
                 self.assertTrue(
                     torch.equal(
                         written[owned],
-                        a.translate_kv_loc_for_kernel(ids[owned] // dcp_size),
+                        a.translate_kv_loc(ids[owned] // dcp_size),
                     )
                 )
                 # ...and the rest go to the sink the write kernels skip.

--- a/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
+++ b/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
@@ -18,7 +18,9 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.layout.page_major import (
-    build_mla_views,
+    DenseEntryLayout,
+    DensePart,
+    build_dense_views,
     build_page_major_mamba_views,
     mamba_entry_bytes,
     mla_entry_bytes,
@@ -31,29 +33,34 @@ register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 class TestMLAEnvelopeTransferAddressing(CustomTestCase):
     def test_page_envelope_matches_per_layer_views(self):
-        """Every (page, layer, slot) row written through the MLA views
-        must land at raw_ptr + page * page_envelope_bytes + layer-block offset,
-        i.e. inside the page's transfer envelope."""
+        """Every (page, layer, slot) row written through the MLA views must
+        land at raw_ptr + page * page_envelope_bytes + slot * entry_bytes +
+        layer * row_bytes, i.e. inside the page's transfer envelope."""
         layer_num, page_size, kv_dim, num_pages = 3, 4, 8, 6
         store_dtype = torch.bfloat16
         row_bytes = kv_dim * store_dtype.itemsize
-        page_bytes = page_size * layer_num * row_bytes
-        self.assertEqual(
-            page_bytes,
-            page_size
-            * mla_entry_bytes(
-                layer_num=layer_num,
-                kv_cache_dim=kv_dim,
-                itemsize=store_dtype.itemsize,
+        entry_bytes = mla_entry_bytes(
+            layer_num=layer_num, kv_cache_dim=kv_dim, itemsize=store_dtype.itemsize
+        )
+        page_bytes = page_size * entry_bytes
+        layout = DenseEntryLayout(
+            entry_bytes=entry_bytes,
+            parts=(
+                DensePart(
+                    name="kv",
+                    offset_bytes=0,
+                    layer_stride_bytes=row_bytes,
+                    layer_num=layer_num,
+                    row_shape=(1, kv_dim),
+                    dtype=store_dtype,
+                ),
             ),
         )
-        # +1 page envelope of tail pad, as UnifiedKVPool allocates for MLA.
-        raw = torch.zeros((num_pages + 1) * page_bytes, dtype=torch.uint8)
-        views = build_mla_views(
+        raw = torch.zeros(num_pages * page_bytes, dtype=torch.uint8)
+        views = build_dense_views(
             raw,
-            layer_num=layer_num,
-            kv_cache_dim=kv_dim,
-            store_dtype=store_dtype,
+            layout=layout,
+            part=layout.part("kv"),
             page_size=page_size,
             num_pages=num_pages,
             anchor_bytes=0,
@@ -62,14 +69,10 @@ class TestMLAEnvelopeTransferAddressing(CustomTestCase):
         for page in range(num_pages):
             for layer in range(layer_num):
                 for off in range(page_size):
-                    kernel_id = page * layer_num * page_size + off
+                    token = page * page_size + off
                     val = torch.randn(kv_dim, dtype=store_dtype)
-                    views[layer][kernel_id, 0] = val
-                    start = (
-                        page * page_bytes
-                        + layer * page_size * row_bytes
-                        + off * row_bytes
-                    )
+                    views[layer][token, 0] = val
+                    start = page * page_bytes + off * entry_bytes + layer * row_bytes
                     got = raw[start : start + row_bytes].view(store_dtype)
                     self.assertTrue(torch.equal(got, val), (page, layer, off))
 

--- a/test/registered/unit/mem_cache/test_unified_handout_zeroing.py
+++ b/test/registered/unit/mem_cache/test_unified_handout_zeroing.py
@@ -17,7 +17,7 @@ from sglang.srt.mem_cache.unified_memory_pool import (
 BF16_NAN = 0x7FC1  # LE bf16 NaN bit pattern, as SGLANG_DEBUG_POISON_POOL fills
 
 
-def _build(device, page_size=1, kernel_page_multiplier=None):
+def _build(device, page_size=1):
     """A tiny MLA+mamba unified pool + full-side allocator.
 
     Mirrors init_unified_mamba_pools' construction just enough for the
@@ -61,9 +61,6 @@ def _build(device, page_size=1, kernel_page_multiplier=None):
         device=device,
         is_id_owner=True,
         page_size=page_size,
-        kernel_page_multiplier=(
-            layer_num if kernel_page_multiplier is None else kernel_page_multiplier
-        ),
     )
     return buf, kvcache, allocator
 
@@ -113,12 +110,11 @@ class TestUnifiedHandoutZeroing(unittest.TestCase):
         pages2 = self._phys_pages(allocator, out2)
         self.assertTrue((env[pages2] == 0).all().item())
 
-    def test_zeroing_enabled_for_single_layer_multiplier(self):
-        # A shard owning exactly ONE full-attention MLA layer has
-        # kernel_page_multiplier == 1 but its pool is still
-        # UnifiedMLATokenToKVPool with the same NaN-unsafe partial-page
-        # reads — zeroing must key on the pool type, not on multiplier > 1.
-        buf, kvcache, allocator = _build("cuda", kernel_page_multiplier=1)
+    def test_zeroing_keys_on_pool_type(self):
+        # UnifiedMLATokenToKVPool has NaN-unsafe partial-page reads whatever
+        # its geometry — zeroing must key on the pool type, not on any
+        # id-space scale.
+        buf, kvcache, allocator = _build("cuda")
         self.assertTrue(allocator._zero_pages_on_alloc)
         self._poison(buf)
         out = allocator.alloc(8)

--- a/test/registered/unit/mem_cache/test_unified_mha_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mha_views.py
@@ -516,11 +516,8 @@ class TestFactoryViews(unittest.TestCase):
             need_sort=False,
         )
 
-    def test_factory_pins_unit_multipliers(self):
+    def test_factory_builds_per_layer_views(self):
         b = self._bundle()
-        alloc = b.token_to_kv_pool_allocator
-        self.assertEqual(alloc.kernel_page_multiplier, 1)
-        self.assertEqual(alloc.swa_kernel_page_multiplier, 1)
         # Sub-pools expose stock 3-D per-layer views.
         self.assertEqual(b.token_to_kv_pool.full_kv_pool.k_buffer[0].dim(), 3)
         self.assertEqual(b.token_to_kv_pool.swa_kv_pool.k_buffer[0].dim(), 3)

--- a/test/registered/unit/mem_cache/test_unified_mha_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mha_views.py
@@ -11,19 +11,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""MHA K/V views for the unified memory pool (uniform-row hybrid models), CPU-only.
+"""MHA K/V views for the unified memory pool (token-major dense views).
+
+Covers, CPU-only (pure torch — no GPU / Triton kernels):
+  - `MHASubPoolSpec.layout()`: K and V of every layer sit at fixed offsets
+    inside one slot entry, K and V rows may differ in width, alignment is
+    enforced at construction;
+  - `build_dense_views` addressing: view_l[t] for PHYSICAL token t must land
+    exactly at the byte the envelope formula assigns to (page, slot, layer,
+    K|V) — cross-checked against an independent 4-D (page, slot) description;
+  - K and V of one token share ONE id (the per-layer origin shift does the
+    disambiguation), with no aliasing across the 2L views;
+  - a too-short buffer and misaligned rows fail loud at construction.
 
 Addressing law under test:
 
-    kernel_id(t) = (t // ps) * (ps * 2L) + t % ps
-    K of layer l at block 2l, V at block 2l+1; blocks are ps rows of
-    head_num*head_dim elements, at offsets identical to
-    MHASubPoolSpec.layer_k/v_offset_in_page when rows are uniform.
+    byte(t, l, K) = t * entry_bytes + l * (k_row + v_row)
+    byte(t, l, V) = byte(t, l, K) + k_row
+    t = page * page_size + slot      (the physical token id IS the kernel id)
+
+    python -m pytest test/registered/unit/mem_cache/test_unified_mha_views.py -v
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 import unittest
 from types import SimpleNamespace
@@ -31,7 +43,12 @@ from types import SimpleNamespace
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.layout.page_major import build_mha_views
+from sglang.srt.mem_cache.layout.page_major import (
+    ENTRY_ALIGN_BYTES,
+    build_dense_views,
+    mha_entry_bytes,
+    paged_view,
+)
 from sglang.srt.mem_cache.unified_memory_pool import (
     MHASubPoolSpec,
     UnifiedKVPool,
@@ -40,17 +57,23 @@ from sglang.srt.mem_cache.unified_memory_pool import (
 
 _DEV = "cpu"
 # `set_kv_buffer` dispatches on the PLATFORM (memory_pool._is_cuda, resolved at
-# import), not on the tensors it is handed, so cases driving it build there.
+# import), not on the tensors it is handed, so cases driving it must build on
+# the platform's device. The rest of this file is byte arithmetic, so CPU.
 _STORE_DEV = "cuda" if torch.cuda.is_available() else "cpu"
 
-# Geometry kept tiny so every byte offset is hand-checkable.
+# Small-but-nontrivial MHA geometry: L=2 layers, H=2 heads, D=4, so every byte
+# offset is hand-checkable. One entry = 2 layers x (K row + V row) = 64 B.
 _L = 2
 _H = 2
 _D = 4
-_ROW = _H * _D  # row elements
 _DTYPE = torch.bfloat16
 _ITEM = _DTYPE.itemsize
-_BLOCKS = 2 * _L
+_K_ROW = _H * _D * _ITEM
+_V_ROW = _H * _D * _ITEM
+_ENTRY = mha_entry_bytes(
+    layer_num=_L, head_num=_H, head_dim=_D, v_head_dim=_D, itemsize=_ITEM
+)
+assert _ENTRY == _L * (_K_ROW + _V_ROW)  # no alignment pad at this geometry
 
 
 def _mha_spec(head_dim=_D, v_head_dim=None, layer_num=_L, grow="down"):
@@ -65,150 +88,240 @@ def _mha_spec(head_dim=_D, v_head_dim=None, layer_num=_L, grow="down"):
     )
 
 
-def _kernel_id(t, ps):
-    return (t // ps) * (ps * _BLOCKS) + t % ps
+def _make_raw(ps, num_pages, entry=_ENTRY, short=0):
+    n = num_pages * ps * entry - short
+    return torch.zeros(n, dtype=torch.uint8, device=_DEV)
 
 
-def _make_raw(ps, num_pages, pad_pages=1):
-    page_bytes = ps * _BLOCKS * _ROW * _ITEM
-    raw = torch.zeros(
-        (num_pages + pad_pages) * page_bytes, dtype=torch.uint8, device=_DEV
+def _build_views(raw, ps, num_pages, head_dim=_D, v_head_dim=None, layer_num=_L):
+    layout = _mha_spec(head_dim, v_head_dim, layer_num).layout()
+    kw = dict(layout=layout, page_size=ps, num_pages=num_pages)
+    return (
+        build_dense_views(raw, part=layout.part("k"), **kw),
+        build_dense_views(raw, part=layout.part("v"), **kw),
     )
-    return raw
 
 
-def _build_views(raw, ps, num_pages, head_dim=_D, v_head_dim=_D, layer_num=_L):
-    return build_mha_views(
-        raw,
-        layer_num=layer_num,
+def _reference_paged_views(
+    raw, *, page_size, num_pages, anchor_bytes=0, head_dim=_D, v_head_dim=_D
+):
+    """Independent 4-D description of the token-major envelope: per-layer
+    ``(num_pages, page_size, head_num, head_dim)`` views addressed by
+    ``(page, slot)``, so the flat builder's addressing can be cross-checked
+    against a second, independently derived description of the same bytes."""
+    k_row = _H * head_dim * _ITEM
+    v_row = _H * v_head_dim * _ITEM
+    entry = mha_entry_bytes(
+        layer_num=_L,
         head_num=_H,
         head_dim=head_dim,
         v_head_dim=v_head_dim,
-        store_dtype=_DTYPE,
-        page_size=ps,
-        num_pages=num_pages,
+        itemsize=_ITEM,
     )
-
-
-def _reference_strided_views(raw, *, page_size, num_pages, anchor_bytes=0):
-    """Independent 4-D strided description of the same page-major envelope,
-    addressed by ``(page, slot)`` -- the oracle for the view builder."""
-    k_row_bytes = _ROW * _ITEM
-    v_row_bytes = _ROW * _ITEM
-    page_bytes = page_size * _L * (k_row_bytes + v_row_bytes)
     as_dtype_view = raw.view(_DTYPE)
-    k_stride = (page_bytes // _ITEM, k_row_bytes // _ITEM, _D, 1)
-    v_stride = (page_bytes // _ITEM, v_row_bytes // _ITEM, _D, 1)
-    shape = (num_pages, page_size, _H, _D)
     k_views, v_views = [], []
     for layer in range(_L):
-        k_base = anchor_bytes + layer * page_size * (k_row_bytes + v_row_bytes)
-        v_base = k_base + page_size * k_row_bytes
-        k_views.append(
-            torch.as_strided(
-                as_dtype_view,
-                size=shape,
-                stride=k_stride,
-                storage_offset=k_base // _ITEM,
+        k_base = anchor_bytes + layer * (k_row + v_row)
+        v_base = k_base + k_row
+        parts = ((k_base, head_dim, k_views), (v_base, v_head_dim, v_views))
+        for base, dim, out in parts:
+            out.append(
+                torch.as_strided(
+                    as_dtype_view,
+                    size=(num_pages, page_size, _H, dim),
+                    stride=(page_size * entry // _ITEM, entry // _ITEM, dim, 1),
+                    storage_offset=base // _ITEM,
+                )
             )
-        )
-        v_views.append(
-            torch.as_strided(
-                as_dtype_view,
-                size=shape,
-                stride=v_stride,
-                storage_offset=v_base // _ITEM,
-            )
-        )
     return k_views, v_views
 
 
 class TestMHASpecSurface(unittest.TestCase):
-    def test_asymmetric_rows_refused_by_the_view_builder(self):
-        """ServerArgs screens asymmetric-KV models out of
-        --enable-unified-memory; this guards a caller reaching the builder."""
+    def test_layout_parts_match_spec_offsets(self):
+        """The spec's offset helpers and its layout descriptor are two
+        derivations of the entry; they must agree, and the page size never
+        enters (a page is page_size entries back to back)."""
         spec = _mha_spec()
-        raw = torch.zeros(1 << 16, dtype=torch.uint8)
-        with self.assertRaises(AssertionError):
-            build_mha_views(
-                raw,
-                layer_num=spec.layer_num,
-                head_num=spec.head_num,
-                head_dim=6,
-                v_head_dim=4,
-                store_dtype=spec.store_dtype,
-                page_size=1,
-                num_pages=4,
+        layout = spec.layout()
+        self.assertEqual(layout.entry_bytes, spec.entry_bytes())
+        for l in range(_L):
+            self.assertEqual(spec.layer_k_offset_in_entry(l), l * (_K_ROW + _V_ROW))
+            self.assertEqual(
+                spec.layer_v_offset_in_entry(l), l * (_K_ROW + _V_ROW) + _K_ROW
             )
+            self.assertEqual(
+                layout.part("k").layer_offset_bytes(l), spec.layer_k_offset_in_entry(l)
+            )
+            self.assertEqual(
+                layout.part("v").layer_offset_bytes(l), spec.layer_v_offset_in_entry(l)
+            )
+
+    def test_entry_bytes_matches_layout_helper_and_is_aligned(self):
+        spec = _mha_spec()
+        self.assertEqual(
+            spec.entry_bytes(),
+            mha_entry_bytes(
+                layer_num=_L, head_num=_H, head_dim=_D, v_head_dim=_D, itemsize=_ITEM
+            ),
+        )
+        # 48 B of rows round up to one 64 B entry; the parts still fit inside.
+        padded = MHASubPoolSpec(
+            name="full",
+            layer_num=1,
+            head_num=1,
+            head_dim=16,
+            v_head_dim=8,
+            store_dtype=_DTYPE,
+            grow_direction="down",
+        )
+        self.assertEqual(padded.entry_bytes(), ENTRY_ALIGN_BYTES * 2)
+        self.assertEqual(padded.entry_bytes() % ENTRY_ALIGN_BYTES, 0)
+        padded.layout()  # validates
+
+    def test_asymmetric_rows_are_admitted(self):
+        """K and V are two parts of one entry at their own offsets; they no
+        longer have to be the same kind of row (the MiMoV2 shape, scaled)."""
+        spec = _mha_spec(head_dim=8, v_head_dim=4)
+        layout = spec.layout()
+        self.assertEqual(layout.part("k").row_bytes(), _H * 8 * _ITEM)
+        self.assertEqual(layout.part("v").row_bytes(), _H * 4 * _ITEM)
+        self.assertEqual(layout.part("v").offset_bytes, _H * 8 * _ITEM)
+
+    def test_misaligned_rows_fail_loud(self):
+        """A row that is not a multiple of 16 B would break the vector stores
+        every write kernel issues, so the layout refuses it at construction."""
+        with self.assertRaises(AssertionError):
+            _mha_spec(head_dim=6, v_head_dim=6).layout()
 
 
 class TestMHAViews(unittest.TestCase):
-    def test_view_shapes_are_stock_mha(self):
+    def test_view_shapes_and_strides(self):
         ps, num_pages = 4, 6
         k_views, v_views = _build_views(_make_raw(ps, num_pages), ps, num_pages)
-        n_rows = num_pages * _BLOCKS * ps
+        n_rows = num_pages * ps
         self.assertEqual(len(k_views), _L)
         self.assertEqual(len(v_views), _L)
         for v in (*k_views, *v_views):
-            # The stock MHATokenToKVPool per-layer signature: 3-D, packed rows.
+            # The stock MHATokenToKVPool per-layer signature: 3-D, one row per
+            # physical token, the slot stride being the whole entry.
             self.assertEqual(tuple(v.shape), (n_rows, _H, _D))
-            self.assertEqual(v.stride(), (_ROW, _D, 1))
+            self.assertEqual(v.stride(), (_ENTRY // _ITEM, _D, 1))
+        for l in range(_L):
+            self.assertEqual(
+                (v_views[l].storage_offset() - k_views[l].storage_offset()) * _ITEM,
+                _K_ROW,
+            )
 
-    def test_addressing_matches_strided_reference(self):
-        """Cross-readback both ways: a write through the strided oracle at
-        (page, slot) must read back through the view at kernel_id(t)."""
+    def test_addressing_matches_paged_reference(self):
+        """Cross-readback: bytes written through the reference (page, slot)
+        views must be read back through the flat views at t = page*ps+slot,
+        for both K and V of every layer — and vice versa."""
         for ps in (1, 4):
             num_pages = 5
             raw = _make_raw(ps, num_pages)
-            sk, sv = _reference_strided_views(raw, page_size=ps, num_pages=num_pages)
+            sk, sv = _reference_paged_views(raw, page_size=ps, num_pages=num_pages)
             dk, dv = _build_views(raw, ps, num_pages)
             probes = [(0, 0, 0), (1, 1, ps - 1), (4, 0, ps // 2), (3, 1, 0)]
-            # strided-write -> view-read
             for p, l, s in probes:
                 t = p * ps + s
-                d = _kernel_id(t, ps)
                 sk[l][p, s] = float(p * 100 + l * 10 + s + 1)
                 sv[l][p, s] = float(p * 100 + l * 10 + s + 2)
                 self.assertTrue(
-                    torch.all(dk[l][d] == float(p * 100 + l * 10 + s + 1)),
+                    torch.all(dk[l][t] == float(p * 100 + l * 10 + s + 1)),
                     f"K (p={p}, l={l}, s={s}, ps={ps}) view readback off-formula",
                 )
                 self.assertTrue(
-                    torch.all(dv[l][d] == float(p * 100 + l * 10 + s + 2)),
+                    torch.all(dv[l][t] == float(p * 100 + l * 10 + s + 2)),
                     f"V (p={p}, l={l}, s={s}, ps={ps}) view readback off-formula",
                 )
-            # view-write -> strided-read
             for p, l, s in probes:
                 t = p * ps + s
-                d = _kernel_id(t, ps)
-                dk[l][d] = float(p * 100 + l * 10 + s + 3)
-                dv[l][d] = float(p * 100 + l * 10 + s + 4)
-                self.assertTrue(
-                    torch.all(sk[l][p, s] == float(p * 100 + l * 10 + s + 3))
-                )
-                self.assertTrue(
-                    torch.all(sv[l][p, s] == float(p * 100 + l * 10 + s + 4))
-                )
+                dk[l][t] = float(p * 100 + l * 10 + s + 3)
+                dv[l][t] = float(p * 100 + l * 10 + s + 4)
+                want_k = float(p * 100 + l * 10 + s + 3)
+                want_v = float(p * 100 + l * 10 + s + 4)
+                self.assertTrue(torch.all(sk[l][p, s] == want_k))
+                self.assertTrue(torch.all(sv[l][p, s] == want_v))
 
-    def test_k_and_v_share_one_kernel_id_without_aliasing(self):
-        """One kernel-facing id, 2L distinct cells (K and V of every layer): writes
-        through all 2L views at the SAME id must not clobber each other."""
+    def test_byte_addresses_match_envelope_formula(self):
+        """The per-layer view's byte address for token ``t``, layer ``l`` must
+        equal the hand-computed envelope formula. Independent of any view
+        builder — this is the raw layout contract every envelope consumer
+        (moves, sizing, transfer math) relies on."""
+        for ps in (1, 4):
+            num_pages = 5
+            dk, dv = _build_views(_make_raw(ps, num_pages), ps, num_pages)
+            for t in (0, 1, ps, 3 * ps + (ps - 1), 4 * ps):
+                for l in range(_L):
+                    expected_k = t * _ENTRY + l * (_K_ROW + _V_ROW)
+                    expected_v = expected_k + _K_ROW
+                    got_k = (dk[l].storage_offset() + t * dk[l].stride(0)) * _ITEM
+                    got_v = (dv[l].storage_offset() + t * dv[l].stride(0)) * _ITEM
+                    self.assertEqual(got_k, expected_k, f"K t={t} l={l} ps={ps}")
+                    self.assertEqual(got_v, expected_v, f"V t={t} l={l} ps={ps}")
+
+    def test_k_and_v_share_one_id_without_aliasing(self):
+        """One id, 2L distinct cells (K and V of every layer): writes through
+        all 2L views at the SAME id must not clobber each other."""
         ps, num_pages = 4, 4
         dk, dv = _build_views(_make_raw(ps, num_pages), ps, num_pages)
         t = 2 * ps + 1  # page 2, slot 1
-        d = _kernel_id(t, ps)
         for l in range(_L):
-            dk[l][d] = float(2 * l + 1)
-            dv[l][d] = float(2 * l + 2)
+            dk[l][t] = float(2 * l + 1)
+            dv[l][t] = float(2 * l + 2)
         for l in range(_L):
-            self.assertTrue(torch.all(dk[l][d] == float(2 * l + 1)))
-            self.assertTrue(torch.all(dv[l][d] == float(2 * l + 2)))
+            self.assertTrue(torch.all(dk[l][t] == float(2 * l + 1)))
+            self.assertTrue(torch.all(dv[l][t] == float(2 * l + 2)))
 
-    def test_missing_tail_pad_fails_loud(self):
+    def test_asymmetric_views_address_their_own_rows(self):
+        head_dim, v_head_dim = 8, 4
+        k_row, v_row = _H * head_dim * _ITEM, _H * v_head_dim * _ITEM
+        entry = mha_entry_bytes(
+            layer_num=_L,
+            head_num=_H,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            itemsize=_ITEM,
+        )
+        ps, num_pages = 4, 3
+        raw = _make_raw(ps, num_pages, entry=entry)
+        dk, dv = _build_views(raw, ps, num_pages, head_dim, v_head_dim)
+        self.assertEqual(tuple(dk[0].shape[1:]), (_H, head_dim))
+        self.assertEqual(tuple(dv[0].shape[1:]), (_H, v_head_dim))
+        t = 2 * ps + 3
+        for l in range(_L):
+            dk[l][t] = float(l + 1)
+            dv[l][t] = float(l + 11)
+        flat = raw.view(_DTYPE)
+        for l in range(_L):
+            k0 = (t * entry + l * (k_row + v_row)) // _ITEM
+            v0 = k0 + k_row // _ITEM
+            self.assertTrue(torch.all(flat[k0 : k0 + k_row // _ITEM] == float(l + 1)))
+            self.assertTrue(torch.all(flat[v0 : v0 + v_row // _ITEM] == float(l + 11)))
+
+    def test_views_fill_the_buffer_exactly(self):
+        """No tail pad: the last view's last byte is the buffer's last byte."""
         ps, num_pages = 2, 4
-        raw = _make_raw(ps, num_pages, pad_pages=0)
+        raw = _make_raw(ps, num_pages)
+        _, dv = _build_views(raw, ps, num_pages)
+        last = dv[_L - 1]
+        end = (last.storage_offset() + (last.shape[0] - 1) * last.stride(0)) * _ITEM
+        self.assertEqual(end + _V_ROW, raw.numel())
+
+    def test_short_buffer_fails_loud(self):
+        ps, num_pages = 2, 4
         with self.assertRaises(AssertionError):
-            _build_views(raw, ps, num_pages)
+            _build_views(_make_raw(ps, num_pages, short=1), ps, num_pages)
+
+    def test_paged_view_regroups_by_page(self):
+        ps, num_pages = 4, 3
+        dk, _ = _build_views(_make_raw(ps, num_pages), ps, num_pages)
+        paged = paged_view(dk[1], ps)
+        self.assertEqual(
+            tuple(paged.stride()), (ps * _ENTRY // _ITEM, _ENTRY // _ITEM, _D, 1)
+        )
+        for t in range(num_pages * ps):
+            self.assertEqual(paged[t // ps, t % ps].data_ptr(), dk[1][t].data_ptr())
 
 
 # ---- pool level ----
@@ -243,16 +356,27 @@ def _make_pool(ps=1, full_spec=None, device=_DEV):
 
 
 class TestUnifiedKVPoolViews(unittest.TestCase):
-    def test_every_mha_sub_pool_is_per_layer_contiguous(self):
+    def test_every_mha_sub_pool_is_a_slot_strided_view(self):
         """The unified pool has ONE MHA layout: both sub-pools come back as
-        stock 3-D per-layer views, whatever their page size."""
+        3-D per-layer views whose slot stride is their own entry."""
         for ps in (1, 4):
             pool = _make_pool(ps=ps)
-            for name in ("full", "swa"):
+            for name, spec in (("full", _mha_spec()), ("swa", _swa_spec())):
                 k, v = pool.mha_views_for(name)
-                self.assertEqual(k[0].dim(), 3, f"{name} K at ps={ps}")
-                self.assertEqual(v[0].dim(), 3, f"{name} V at ps={ps}")
-                self.assertTrue(k[0].is_contiguous())
+                for t in (k[0], v[0], k[-1], v[-1]):
+                    self.assertEqual(t.dim(), 3, f"{name} at ps={ps}")
+                    self.assertEqual(t.stride(0) * _ITEM, spec.entry_bytes())
+
+    def test_raw_is_exactly_the_budget(self):
+        """The views end at the last slot, so the pool allocates exactly the
+        byte budget: no tail pad, nothing to under-allocate."""
+        for ps in (1, 4):
+            kv = _make_pool(ps)
+            self.assertEqual(
+                kv._raw.numel(),
+                _mha_spec().entry_bytes() * _N_FULL
+                + _swa_spec().entry_bytes() * _N_SWA,
+            )
 
 
 def _layer(l):
@@ -270,21 +394,23 @@ def _make_pool_and_kv(ps, device=_DEV):
 
 
 class TestUnifiedMHATokenToKVPool(unittest.TestCase):
-    def test_size_is_view_row_bound(self):
+    def test_size_is_slot_bound(self):
         """`size` drives BOTH the python OOB check and the store kernel's
-        device-side size_limit; it must be the view row bound, not slot count."""
+        device-side size_limit; `size + page_size` must be the view row count."""
         for ps in (1, 4):
             unified_kv, pool_under_test = _make_pool_and_kv(ps)
-            n_rows = (unified_kv.max_slots("full") // ps) * _BLOCKS * ps
+            n_rows = (unified_kv.max_slots("full") // ps) * ps
             self.assertEqual(pool_under_test.size, n_rows - ps)
+            self.assertEqual(pool_under_test.k_buffer[0].shape[0], n_rows)
 
     def test_stock_write_lands_on_envelope_truth(self):
-        """Byte-identity: the inherited `set_kv_buffer` at kernel-facing locs must
-        produce the same bytes as writes through the strided oracle."""
+        """Byte-identity: the pool's stock inherited `set_kv_buffer` at physical
+        token ids must produce exactly the bytes that direct writes through
+        the reference (page, slot) views produce at the same cells — pins the
+        whole write path (loc -> strided view -> raw bytes) end to end."""
         for ps in (1, 4):
             kv, pool = _make_pool_and_kv(ps, device=_STORE_DEV)
-            # An independent strided view of the SAME sub-pool region.
-            sk, sv = _reference_strided_views(
+            sk, sv = _reference_paged_views(
                 kv._raw,
                 page_size=ps,
                 num_pages=kv.max_slots("full") // ps,
@@ -295,20 +421,10 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
                 toks = torch.tensor(
                     [p * ps + s for (p, s) in probes], device=_STORE_DEV
                 )
-                kernel_locs = (toks // ps) * (ps * _BLOCKS) + toks % ps
-                k = torch.full(
-                    (len(probes), _H, _D),
-                    float(l + 1),
-                    dtype=_DTYPE,
-                    device=_STORE_DEV,
-                )
-                v = torch.full(
-                    (len(probes), _H, _D),
-                    float(l + 101),
-                    dtype=_DTYPE,
-                    device=_STORE_DEV,
-                )
-                pool.set_kv_buffer(_layer(l), kernel_locs, k, v)
+                shape = (len(probes), _H, _D)
+                k = torch.full(shape, float(l + 1), dtype=_DTYPE, device=_STORE_DEV)
+                v = torch.full(shape, float(l + 101), dtype=_DTYPE, device=_STORE_DEV)
+                pool.set_kv_buffer(_layer(l), toks, k, v)
                 for p, s in probes:
                     self.assertTrue(
                         torch.all(sk[l][p, s] == float(l + 1)),
@@ -320,13 +436,13 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
                     )
 
     def test_move_kv_cache_relocates_whole_envelopes(self):
-        """Compaction hands PHYSICAL token runs, not kernel-facing ids; the
-        override must relocate exactly the page envelopes those runs name."""
+        """Compaction hands PHYSICAL token runs. The override must relocate
+        exactly the page envelopes those runs name."""
         ps = 4
         kv, pool = _make_pool_and_kv(ps)
-        live = kv._raw.numel() - kv.view_tail_pad_bytes
+        live = kv._raw.numel()
         seed = (torch.arange(live, dtype=torch.float32) % 251).to(torch.uint8)
-        kv._raw[:live] = seed
+        kv._raw[:] = seed
         page_bytes = ps * _mha_spec().entry_bytes()
 
         src_pages, tgt_pages = torch.tensor([5, 6]), torch.tensor([2, 3])
@@ -340,13 +456,14 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
                 sp * page_bytes : (sp + 1) * page_bytes
             ]
         self.assertTrue(
-            torch.equal(kv._raw[:live], want),
+            torch.equal(kv._raw, want),
             "envelope move did not relocate exactly the named pages",
         )
 
     def test_transfer_entry_points_fail_loud(self):
-        """PD / CPU-copy entry points assume per-layer buffers indexed by TOKEN
-        id and would silently mis-index the row space, so each must raise."""
+        """PD / CPU-copy entry points assume per-layer contiguous buffers;
+        against the strided views they would silently mis-index. Every one of
+        them must raise."""
         _, pool = _make_pool_and_kv(1)
         with self.assertRaises(NotImplementedError):
             pool.get_contiguous_buf_infos()
@@ -358,8 +475,10 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
             pool.set_kv_buffer_prefix_valid()
 
     def test_hnd_env_cannot_hijack_layout(self):
-        """SGLANG_USE_HND_KVCACHE must not flip this pool's layout: HND indexes
-        4-D while the per-layer views are 3-D, so the pinned label has to win."""
+        """SGLANG_USE_HND_KVCACHE=1 used to flip the inherited env-driven
+        layout selector, putting the pool in a mode whose code paths do not
+        match its buffers (HND indexes 4-D; the per-layer views are 3-D). The
+        pinned label must win."""
         with envs.SGLANG_USE_HND_KVCACHE.override(True):
             _, pool = _make_pool_and_kv(1)
             self.assertFalse(pool.use_hnd)
@@ -367,27 +486,13 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
 
 
 class TestFactoryViews(unittest.TestCase):
-    def setUp(self):
-        # `KVIndexTranslator.__init__` asks the parallel context for
-        # `attn_dcp_size`, which is a quotient of the configured leaves and is
-        # computed at publish. A bare process has none, so state one the way a
-        # real process does.
-        from sglang.srt.runtime_context import publish, reset_context
-        from sglang.srt.server_args import ServerArgs
-
-        reset_context()
-        self.addCleanup(reset_context)
-        publish(ServerArgs(model_path="dummy"), role="test")
-
-    """Over the real SWA factory: matching kernel-facing multipliers in the
-    composite allocator, and a rebind that emits both write locs."""
-
-    # _swa_factory geometry: L_full = L_swa = 2, uniform 8/8 dims, ps = 1.
-    FULL_MULT = 4  # 2 * L_full
-    SWA_MULT = 4  # 2 * L_swa
+    """The real SWA factory builds the sub-pools and the composite allocator.
+    End-to-end over that factory, kernel-facing ids are the physical ones and
+    the rebind must emit BOTH write locs."""
 
     def _bundle(self):
-        # Kept tiny so the per-layer views build on CPU.
+        # Self-contained tiny SWA-factory bundle (L_full = L_swa = 2, uniform
+        # 8/8 dims, ps = 1) — small enough that per-layer views build on CPU.
         from sglang.srt.mem_cache.unified_memory_pool import init_unified_swa_pools
 
         return init_unified_swa_pools(
@@ -410,28 +515,28 @@ class TestFactoryViews(unittest.TestCase):
             need_sort=False,
         )
 
-    def test_factory_wires_matching_multipliers(self):
+    def test_factory_pins_unit_multipliers(self):
         b = self._bundle()
-        pool = b.unified_memory_pool
         alloc = b.token_to_kv_pool_allocator
-        self.assertEqual(alloc.kernel_page_multiplier, self.FULL_MULT)
-        self.assertEqual(alloc.swa_kernel_page_multiplier, self.SWA_MULT)
+        self.assertEqual(alloc.kernel_page_multiplier, 1)
+        self.assertEqual(alloc.swa_kernel_page_multiplier, 1)
         # Sub-pools expose stock 3-D per-layer views.
         self.assertEqual(b.token_to_kv_pool.full_kv_pool.k_buffer[0].dim(), 3)
         self.assertEqual(b.token_to_kv_pool.swa_kv_pool.k_buffer[0].dim(), 3)
-        self.assertGreater(pool.view_tail_pad_bytes, 0)
 
-    def test_rebind_emits_kernel_facing_full_and_build_derives_swa(self):
-        """rebind_write_loc rebinds out_cache_loc to FULL-kernel-facing ids, and
-        the SWA write loc is derived pointwise from those kernel-facing values."""
+    def test_rebind_emits_physical_full_and_build_derives_swa(self):
+        """End-to-end over the real factory: rebind_write_loc rebinds
+        out_cache_loc to FULL-side physical ids (phase 1), and the per-batch
+        build derives the SWA write loc pointwise from those values (phase 2)
+        — both checked against the v2p tables over the VIRTUAL ids."""
         from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 
         b = self._bundle()
         alloc = b.token_to_kv_pool_allocator
         v = alloc.alloc(4)
         self.assertIsNotNone(v)
-        expected_full = alloc.full_v2p_page_table[v] * self.FULL_MULT  # ps=1
-        expected_swa = alloc.swa_v2p_page_table[v] * self.SWA_MULT
+        expected_full = alloc.full_v2p_page_table[v]  # ps=1
+        expected_swa = alloc.swa_v2p_page_table[v]
 
         class _FB:
             pass

--- a/test/registered/unit/mem_cache/test_unified_mha_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mha_views.py
@@ -49,6 +49,7 @@ from sglang.srt.mem_cache.layout.page_major import (
     mha_entry_bytes,
     paged_view,
 )
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.unified_memory_pool import (
     MHASubPoolSpec,
     UnifiedKVPool,
@@ -424,7 +425,7 @@ class TestUnifiedMHATokenToKVPool(unittest.TestCase):
                 shape = (len(probes), _H, _D)
                 k = torch.full(shape, float(l + 1), dtype=_DTYPE, device=_STORE_DEV)
                 v = torch.full(shape, float(l + 101), dtype=_DTYPE, device=_STORE_DEV)
-                pool.set_kv_buffer(_layer(l), toks, k, v)
+                pool.set_kv_buffer(_layer(l), KVWriteLoc(toks, id_space="kernel"), k, v)
                 for p, s in probes:
                     self.assertTrue(
                         torch.all(sk[l][p, s] == float(l + 1)),

--- a/test/registered/unit/mem_cache/test_unified_mha_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mha_views.py
@@ -315,14 +315,22 @@ class TestMHAViews(unittest.TestCase):
             _build_views(_make_raw(ps, num_pages, short=1), ps, num_pages)
 
     def test_paged_view_regroups_by_page(self):
-        ps, num_pages = 4, 3
-        dk, _ = _build_views(_make_raw(ps, num_pages), ps, num_pages)
-        paged = paged_view(dk[1], ps)
-        self.assertEqual(
-            tuple(paged.stride()), (ps * _ENTRY // _ITEM, _ENTRY // _ITEM, _D, 1)
-        )
-        for t in range(num_pages * ps):
-            self.assertEqual(paged[t // ps, t % ps].data_ptr(), dk[1][t].data_ptr())
+        """BUG REGRESSION at page_size 1: a `view`-built split gives the size-1
+        slot dim the ROW stride, not the entry stride, so the paged view
+        misreported the slot stride of every MHA/SWA layer at ps=1."""
+        num_pages = 3
+        for ps in (1, 4):
+            dk, _ = _build_views(_make_raw(ps, num_pages), ps, num_pages)
+            paged = paged_view(dk[1], ps)
+            self.assertEqual(
+                tuple(paged.stride()),
+                (ps * _ENTRY // _ITEM, _ENTRY // _ITEM, _D, 1),
+                ps,
+            )
+            for t in range(num_pages * ps):
+                self.assertEqual(
+                    paged[t // ps, t % ps].data_ptr(), dk[1][t].data_ptr(), (ps, t)
+                )
 
 
 # ---- pool level ----

--- a/test/registered/unit/mem_cache/test_unified_mla_block_table.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_block_table.py
@@ -145,6 +145,39 @@ class TestBlockTable(unittest.TestCase):
         v2p[0] = 0  # page 0 is the reserved sink
         return req_to_token, req_pool_indices, seq_lens, v2p
 
+    def test_seq_len_delta_matches_widened_lens(self):
+        """The kernel's ``seq_len_delta`` equals building with ``seq_lens + k``
+        (the two spellings of verify widening), and genuinely widens: the
+        widened columns overwrite the -1 sentinel the plain build leaves."""
+        from sglang.kernels.ops.kvcache.kv_read_table import build_kv_read_table
+
+        for page_size in (1, 32):
+            rt, rpi, sl, v2p = self._make_batch(page_size)
+            delta = page_size + 1
+            max_pages = int((sl.max().item() + delta + page_size - 1) // page_size)
+
+            def fill(seq_lens, seq_len_delta):
+                out = torch.full(
+                    (rpi.shape[0], max_pages), -1, dtype=torch.int32, device=_DEV
+                )
+                build_kv_read_table(
+                    req_to_token=rt,
+                    req_pool_indices=rpi,
+                    seq_lens=seq_lens.to(torch.int64),
+                    v2p=v2p,
+                    page_size=page_size,
+                    max_pages=max_pages,
+                    out=out,
+                    seq_len_delta=seq_len_delta,
+                )
+                return out
+
+            widened = fill(sl, delta)
+            by_lens = fill(sl + delta, 0)
+            plain = fill(sl, 0)
+            self.assertTrue(torch.equal(widened, by_lens), f"ps={page_size}")
+            self.assertFalse(torch.equal(widened, plain), f"ps={page_size}")
+
     def test_static_kernel_matches_reference(self):
         """The stripped (id-space-free) flashmla kernel is byte-identical to the
         plain token//ps reference -- guards the v2p-arg removal itself."""

--- a/test/registered/unit/mem_cache/test_unified_mla_block_table.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_block_table.py
@@ -58,11 +58,10 @@ register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
 
 _HAS_CUDA = torch.cuda.is_available()
 _DEV = "cuda"
-_MULT = 1  # kernel-facing ids are the physical ones
 
 
 def _fill_block_table(
-    req_to_token, req_pool_indices, seq_lens, page_size, *, v2p, mult
+    req_to_token, req_pool_indices, seq_lens, page_size, *, v2p
 ):
     """The unified route: canonical builder into a -1-filled block table
     (exactly what KVIndexTranslator.build_into does for trtllm_mla/flashmla)."""
@@ -76,7 +75,6 @@ def _fill_block_table(
         req_pool_indices=req_pool_indices,
         seq_lens=seq_lens.to(torch.int64),
         v2p=v2p,
-        multiplier=mult,
         page_size=page_size,
         max_pages=max_blocks,
         out=out,
@@ -108,7 +106,7 @@ def _fill_block_table_static(req_to_token, req_pool_indices, seq_lens, page_size
     return out
 
 
-def _reference(req_to_token, req_pool_indices, seq_lens, page_size, *, v2p, mult):
+def _reference(req_to_token, req_pool_indices, seq_lens, page_size, *, v2p):
     """Python reference: virtual token -> virtual page -> physical page -> kernel id."""
     bs = req_pool_indices.shape[0]
     max_blocks = (int(seq_lens.max().item()) + page_size - 1) // page_size
@@ -118,7 +116,7 @@ def _reference(req_to_token, req_pool_indices, seq_lens, page_size, *, v2p, mult
         row = req_to_token[int(req_pool_indices[r].item())]
         virt_pages = row[: n_pages * page_size : page_size] // page_size
         pages = v2p[virt_pages.long()] if v2p is not None else virt_pages.long()
-        ref[r, :n_pages] = pages * mult
+        ref[r, :n_pages] = pages
     return ref
 
 
@@ -155,7 +153,7 @@ class TestBlockTable(unittest.TestCase):
         for page_size in (1, 32, 64):
             rt, rpi, sl, _ = self._make_batch(page_size)
             got = _fill_block_table_static(rt, rpi, sl, page_size)
-            want = _reference(rt, rpi, sl, page_size, v2p=None, mult=1)
+            want = _reference(rt, rpi, sl, page_size, v2p=None)
             self.assertTrue(
                 torch.equal(got.long(), want), f"page_size={page_size}: {got} != {want}"
             )
@@ -163,8 +161,8 @@ class TestBlockTable(unittest.TestCase):
     def test_block_table_matches_reference(self):
         for page_size in (1, 32, 64):
             rt, rpi, sl, v2p = self._make_batch(page_size)
-            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
-            want = _reference(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
+            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p)
+            want = _reference(rt, rpi, sl, page_size, v2p=v2p)
             self.assertTrue(
                 torch.equal(got.long(), want),
                 f"page_size={page_size}:\ngot ={got}\nwant={want}",
@@ -179,12 +177,12 @@ class TestBlockTable(unittest.TestCase):
         """
         for page_size in (1, 64):
             rt, rpi, sl, v2p = self._make_batch(page_size)
-            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=1).long()
-            want = _reference(rt, rpi, sl, page_size, v2p=v2p, mult=1)
+            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p).long()
+            want = _reference(rt, rpi, sl, page_size, v2p=v2p)
             self.assertTrue(torch.equal(got, want), f"page_size={page_size}")
             # ... and the v2p permutation is non-trivial here, so a skipped
             # translation would be visibly different rather than accidentally equal.
-            virtual = _reference(rt, rpi, sl, page_size, v2p=None, mult=1)
+            virtual = _reference(rt, rpi, sl, page_size, v2p=None)
             self.assertFalse(
                 torch.equal(want, virtual),
                 "test batch degenerated: v2p is the identity on the pages used",
@@ -196,7 +194,7 @@ class TestBlockTable(unittest.TestCase):
         trtllm/flashmla block-table contract)."""
         page_size = 64
         rt, rpi, sl, v2p = self._make_batch(page_size)
-        got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
+        got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p)
         for r in range(got.shape[0]):
             n_pages = (int(sl[r].item()) + page_size - 1) // page_size
             self.assertTrue(
@@ -205,21 +203,20 @@ class TestBlockTable(unittest.TestCase):
             )
 
     def test_agrees_with_token_level_translate(self):
-        """The flashinfer updaters translate TOKEN ids with
-        `translate_kv_loc_for_kernel`; the trtllm path builds PAGE ids in-kernel. Both
-        must address the same kernel-facing page block."""
+        """The flashinfer updaters translate TOKEN ids with `translate_kv_loc`;
+        the trtllm path builds PAGE ids in-kernel. Both must address the same
+        physical page."""
         page_size = 64
         rt, rpi, sl, v2p = self._make_batch(page_size)
         block_table = _fill_block_table(
-            rt, rpi, sl, page_size, v2p=v2p, mult=_MULT
+            rt, rpi, sl, page_size, v2p=v2p
         ).long()
         for r in range(rt.shape[0]):
             n = int(sl[r].item())
             virt_tokens = rt[r, :n].long()
-            # translate_kv_loc_for_kernel's formula, applied to token ids.
+            # translate_kv_loc's formula, applied to token ids.
             kernel_tokens = (
-                v2p[virt_tokens // page_size] * (page_size * _MULT)
-                + virt_tokens % page_size
+                v2p[virt_tokens // page_size] * page_size + virt_tokens % page_size
             )
             # The block-table entry scaled by page_size must be the kernel-facing id of
             # each page's first token.
@@ -243,7 +240,7 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
     (no source flag) stays byte-identical to the pre-translator kernel.
     """
 
-    def _run(self, page_size, *, v2p, mult, bs=5, max_ctx=2048):
+    def _run(self, page_size, *, v2p, bs=5, max_ctx=2048):
         from sglang.kernels.ops.attention.metadata import normal_decode_set_metadata
         from sglang.kernels.ops.kvcache.kv_read_table import (
             build_kv_read_table,
@@ -281,7 +278,6 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
                 req_pool_indices=rpi,
                 seq_lens=cache_seqlens,
                 v2p=v2p_full,
-                multiplier=mult,
                 page_size=page_size,
                 max_pages=max_pages,
                 out=page_table,
@@ -302,7 +298,7 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
             )
         torch.cuda.synchronize()
         want = _reference(
-            rt, rpi, sl, page_size, v2p=(v2p_full if v2p else None), mult=mult
+            rt, rpi, sl, page_size, v2p=(v2p_full if v2p else None)
         )
         return page_table, want, sl
 
@@ -320,27 +316,26 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
     def test_identity_when_hooks_absent(self):
         """Static pool: no v2p, multiplier 1 -> byte-identical to pre-change."""
         for page_size in (1, 64):
-            got, want, sl = self._run(page_size, v2p=False, mult=1)
+            got, want, sl = self._run(page_size, v2p=False)
             self._assert_live_prefix(got, want, sl, page_size)
 
     def test_translated_mapping_ps1_fast_path(self):
-        got, want, sl = self._run(1, v2p=True, mult=_MULT)
+        got, want, sl = self._run(1, v2p=True)
         self._assert_live_prefix(got, want, sl, 1)
 
     def test_translated_mapping_general_path(self):
-        got, want, sl = self._run(64, v2p=True, mult=_MULT)
+        got, want, sl = self._run(64, v2p=True)
         self._assert_live_prefix(got, want, sl, 64)
 
     def test_single_full_attention_layer(self):
         """multiplier 1 with a real v2p: the gather alone is the translation."""
         for page_size in (1, 64):
-            got, want, sl = self._run(page_size, v2p=True, mult=1)
+            got, want, sl = self._run(page_size, v2p=True)
             self._assert_live_prefix(got, want, sl, page_size)
             virtual = _reference(
                 *TestBlockTable._make_batch(self, page_size)[:3],
                 page_size,
                 v2p=None,
-                mult=1,
             )
             self.assertFalse(
                 torch.equal(want, virtual),

--- a/test/registered/unit/mem_cache/test_unified_mla_block_table.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_block_table.py
@@ -60,9 +60,7 @@ _HAS_CUDA = torch.cuda.is_available()
 _DEV = "cuda"
 
 
-def _fill_block_table(
-    req_to_token, req_pool_indices, seq_lens, page_size, *, v2p
-):
+def _fill_block_table(req_to_token, req_pool_indices, seq_lens, page_size, *, v2p):
     """The unified route: canonical builder into a -1-filled block table
     (exactly what KVIndexTranslator.build_into does for trtllm_mla/flashmla)."""
     from sglang.kernels.ops.kvcache.kv_read_table import build_kv_read_table
@@ -208,9 +206,7 @@ class TestBlockTable(unittest.TestCase):
         physical page."""
         page_size = 64
         rt, rpi, sl, v2p = self._make_batch(page_size)
-        block_table = _fill_block_table(
-            rt, rpi, sl, page_size, v2p=v2p
-        ).long()
+        block_table = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p).long()
         for r in range(rt.shape[0]):
             n = int(sl[r].item())
             virt_tokens = rt[r, :n].long()
@@ -297,9 +293,7 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
                 None,
             )
         torch.cuda.synchronize()
-        want = _reference(
-            rt, rpi, sl, page_size, v2p=(v2p_full if v2p else None)
-        )
+        want = _reference(rt, rpi, sl, page_size, v2p=(v2p_full if v2p else None))
         return page_table, want, sl
 
     def _assert_live_prefix(self, got, want, sl, page_size):

--- a/test/registered/unit/mem_cache/test_unified_mla_block_table.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_block_table.py
@@ -15,10 +15,11 @@
 memory pool (Kimi-Linear).
 
 `req_to_token` holds VIRTUAL token ids, while the per-layer MLA views are
-contiguous (`build_mla_views`). The paged MLA backends therefore need their
-page-level block table filled with kernel-facing page ids:
+token-major (`build_dense_views`), indexed by the physical token id. The paged
+MLA backends therefore need their page-level block table filled with physical
+page ids:
 
-    kernel_page(virtual_page) = v2p[virtual_page] * layer_num
+    kernel_page(virtual_page) = v2p[virtual_page]
 
 Since the read-path translator, ONE builder computes that formula for every
 family — `build_index_table` (the canonical) — and the backends only
@@ -57,7 +58,7 @@ register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
 
 _HAS_CUDA = torch.cuda.is_available()
 _DEV = "cuda"
-_LAYERS = 24  # K3 MLA full-attention layer count
+_MULT = 1  # kernel-facing ids are the physical ones
 
 
 def _fill_block_table(
@@ -162,22 +163,19 @@ class TestBlockTable(unittest.TestCase):
     def test_block_table_matches_reference(self):
         for page_size in (1, 32, 64):
             rt, rpi, sl, v2p = self._make_batch(page_size)
-            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_LAYERS)
-            want = _reference(rt, rpi, sl, page_size, v2p=v2p, mult=_LAYERS)
+            got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
+            want = _reference(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
             self.assertTrue(
                 torch.equal(got.long(), want),
                 f"page_size={page_size}:\ngot ={got}\nwant={want}",
             )
 
     def test_single_full_attention_layer_still_maps_v2p(self):
-        """A config with exactly ONE full-attention layer (e.g. a PP rank owning a
-        single MLA layer) has `kernel_page_multiplier == 1`, but its req_to_token
-        still holds VIRTUAL ids. The kernel-facing id collapses onto the physical id, so
-        the v2p gather alone IS the whole translation -- it must not be skipped.
-
-        Regression guard for detecting the unified pool via `multiplier > 1`:
-        that predicate treats this config as a static pool and leaves the block
-        table in virtual id space.
+        """The kernel-facing id IS the physical id, so the v2p gather alone is
+        the whole translation -- it must not be skipped. Regression guard for
+        detecting the unified pool via `multiplier > 1`: that predicate would
+        treat every unified pool as static and leave the block table in
+        virtual id space.
         """
         for page_size in (1, 64):
             rt, rpi, sl, v2p = self._make_batch(page_size)
@@ -198,7 +196,7 @@ class TestBlockTable(unittest.TestCase):
         trtllm/flashmla block-table contract)."""
         page_size = 64
         rt, rpi, sl, v2p = self._make_batch(page_size)
-        got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_LAYERS)
+        got = _fill_block_table(rt, rpi, sl, page_size, v2p=v2p, mult=_MULT)
         for r in range(got.shape[0]):
             n_pages = (int(sl[r].item()) + page_size - 1) // page_size
             self.assertTrue(
@@ -213,14 +211,14 @@ class TestBlockTable(unittest.TestCase):
         page_size = 64
         rt, rpi, sl, v2p = self._make_batch(page_size)
         block_table = _fill_block_table(
-            rt, rpi, sl, page_size, v2p=v2p, mult=_LAYERS
+            rt, rpi, sl, page_size, v2p=v2p, mult=_MULT
         ).long()
         for r in range(rt.shape[0]):
             n = int(sl[r].item())
             virt_tokens = rt[r, :n].long()
             # translate_kv_loc_for_kernel's formula, applied to token ids.
             kernel_tokens = (
-                v2p[virt_tokens // page_size] * (page_size * _LAYERS)
+                v2p[virt_tokens // page_size] * (page_size * _MULT)
                 + virt_tokens % page_size
             )
             # The block-table entry scaled by page_size must be the kernel-facing id of
@@ -326,11 +324,11 @@ class TestFa3MetadataBlockTable(unittest.TestCase):
             self._assert_live_prefix(got, want, sl, page_size)
 
     def test_translated_mapping_ps1_fast_path(self):
-        got, want, sl = self._run(1, v2p=True, mult=_LAYERS)
+        got, want, sl = self._run(1, v2p=True, mult=_MULT)
         self._assert_live_prefix(got, want, sl, 1)
 
     def test_translated_mapping_general_path(self):
-        got, want, sl = self._run(64, v2p=True, mult=_LAYERS)
+        got, want, sl = self._run(64, v2p=True, mult=_MULT)
         self._assert_live_prefix(got, want, sl, 64)
 
     def test_single_full_attention_layer(self):

--- a/test/registered/unit/mem_cache/test_unified_mla_gpu_parity.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_gpu_parity.py
@@ -43,7 +43,7 @@ _DTYPE = torch.bfloat16
 
 
 def _kernel_id(t: torch.Tensor, ps: int) -> torch.Tensor:
-    return (t // ps) * (ps * _L) + t % ps
+    return t  # token-major views: the kernel id is the physical token id
 
 
 def _make_pools(ps: int, n_tokens: int = 4096):

--- a/test/registered/unit/mem_cache/test_unified_mla_gpu_parity.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_gpu_parity.py
@@ -46,6 +46,13 @@ def _kernel_id(t: torch.Tensor, ps: int) -> torch.Tensor:
     return t  # token-major views: the kernel id is the physical token id
 
 
+def _marked(loc: torch.Tensor):
+    # The unified doors take a KVWriteLoc that declares its id space.
+    from sglang.srt.mem_cache.memory_pool import KVWriteLoc
+
+    return KVWriteLoc(loc, id_space="kernel")
+
+
 def _make_pools(ps: int, n_tokens: int = 4096):
     from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
     from sglang.srt.mem_cache.unified_memory_pool import (
@@ -129,7 +136,7 @@ class TestUnifiedMLAPoolGPUParity(unittest.TestCase):
             layer = types.SimpleNamespace(layer_id=l)
             nope = torch.randn(n_loc, 1, _LORA, dtype=_DTYPE, device=_DEV)
             rope = torch.randn(n_loc, 1, _ROPE, dtype=_DTYPE, device=_DEV)
-            unified.set_mla_kv_buffer(layer, _kernel_id(locs, ps), nope, rope)
+            unified.set_mla_kv_buffer(layer, _marked(_kernel_id(locs, ps)), nope, rope)
             ref.set_mla_kv_buffer(layer, locs, nope, rope)
         torch.cuda.synchronize()
         self._assert_parity(unified, ref, locs, ps)
@@ -150,7 +157,7 @@ class TestUnifiedMLAPoolGPUParity(unittest.TestCase):
             for l in (0, _L // 2, _L - 1):
                 layer = types.SimpleNamespace(layer_id=l)
                 k = torch.randn(n_loc, 1, _D, dtype=_DTYPE, device=_DEV)
-                unified.set_kv_buffer(layer, _kernel_id(locs, ps), k, None)
+                unified.set_kv_buffer(layer, _marked(_kernel_id(locs, ps)), k, None)
                 ref.set_kv_buffer(layer, locs, k, None)
             torch.cuda.synchronize()
             self._assert_parity(unified, ref, locs, ps, layers=(0, _L // 2, _L - 1))
@@ -164,11 +171,34 @@ class TestUnifiedMLAPoolGPUParity(unittest.TestCase):
             layer = types.SimpleNamespace(layer_id=3)
             nope = torch.randn(n_loc, 1, _LORA, dtype=_DTYPE, device=_DEV)
             rope = torch.randn(n_loc, 1, _ROPE, dtype=_DTYPE, device=_DEV)
-            unified.set_mla_kv_buffer(layer, _kernel_id(locs, ps), nope, rope)
+            unified.set_mla_kv_buffer(layer, _marked(_kernel_id(locs, ps)), nope, rope)
             got_nope, got_rope = unified.get_mla_kv_buffer(layer, _kernel_id(locs, ps))
             torch.cuda.synchronize()
             torch.testing.assert_close(got_nope, nope, rtol=0, atol=0)
             torch.testing.assert_close(got_rope, rope, rtol=0, atol=0)
+
+    def test_move_kv_cache_page_envelope_gpu(self):
+        for ps in (1, 64):
+            unified, ref, max_tokens = _make_pools(ps)
+            num_pages = max_tokens // ps
+            n_loc = ps  # one full page of tokens
+            src_page, dst_page = num_pages - 2, 2
+            src_t = torch.arange(ps, device=_DEV, dtype=torch.int64) + src_page * ps
+            dst_t = torch.arange(ps, device=_DEV, dtype=torch.int64) + dst_page * ps
+            torch.manual_seed(17)
+            for l in range(_L):
+                layer = types.SimpleNamespace(layer_id=l)
+                k = torch.randn(n_loc, 1, _D, dtype=_DTYPE, device=_DEV)
+                unified.set_kv_buffer(layer, _marked(_kernel_id(src_t, ps)), k, None)
+            before = [
+                unified.get_key_buffer(l)[_kernel_id(src_t, ps)].clone()
+                for l in range(_L)
+            ]
+            unified.move_kv_cache(dst_t, src_t)
+            torch.cuda.synchronize()
+            for l in range(_L):
+                got = unified.get_key_buffer(l)[_kernel_id(dst_t, ps)]
+                torch.testing.assert_close(got, before[l], rtol=0, atol=0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_unified_mla_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_views.py
@@ -11,26 +11,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""MLA views for the unified memory pool (MLA-hybrid-Mamba, Kimi K3), CPU-only.
+"""MLA views for the unified memory pool (MLA-hybrid-Mamba, Kimi K3).
 
-Addressing law under test: the (page, layer, slot) cell sits at envelope byte
-offset `p*(L*ps*D) + l*(ps*D) + s*D`, reached through the kernel-facing id
-`(t // ps) * (ps * L) + t % ps`.
+Covers, CPU-only (pure torch — no GPU / Triton kernels):
+  - `MLASubPoolSpec` byte math (aligned entry, one latent row per layer);
+  - `build_dense_views` addressing: view_l[t] for PHYSICAL token t must land
+    at the envelope byte `t * entry_bytes + l * row_bytes`, the per-layer
+    views must not alias at equal ids, and a short buffer must fail loud;
+  - `UnifiedKVPool` MLA plumbing: the allocation is exactly the budget and
+    the reserved sink floor covers the whole page-0 envelope;
+  - `UnifiedMLATokenToKVPool`: buffer wiring, V-as-prefix-slice, and the
+    page-envelope `move_kv_cache` (physical token ids, page-major runs);
+  - `MultiEndedAllocator.translate_kv_loc_for_kernel`: identical to the
+    physical translate, tombstone clamp to the sink, `out=` contract, the
+    pinned multiplier, and correctness across eager compaction.
 
-GPU parity of the read/write kernels (set_mla_kv_buffer TMA path etc.) lives in
-`test_unified_mla_gpu_parity.py`.
+GPU parity of the actual read/write kernels (set_mla_kv_buffer TMA path etc.)
+lives in the server-level tests, not here.
+
+    python -m pytest test/registered/unit/mem_cache/test_unified_mla_views.py -v
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 import unittest
 
 import torch
 
+from sglang.srt.mem_cache.layout.page_major import (
+    ENTRY_ALIGN_BYTES,
+    build_dense_views,
+    mla_entry_bytes,
+)
 from sglang.srt.mem_cache.allocator.unified_sub_pool import MultiEndedAllocator
-from sglang.srt.mem_cache.layout.page_major import build_mla_views
 from sglang.srt.mem_cache.unified_memory_pool import (
     MambaSubPoolSpec,
     MLASubPoolSpec,
@@ -40,14 +55,18 @@ from sglang.srt.mem_cache.unified_memory_pool import (
 
 _DEV = "cpu"
 
-# Geometry kept tiny so every byte offset is hand-checkable; real K3 is
-# L=24, D=576 (=512+64).
+# Small-but-nontrivial MLA geometry: L=3 layers, D=8 (=6+2), so every byte
+# offset is hand-checkable. Real K3 is L=24, D=576 (=512+64). 3 rows x 16 B
+# = 48 B of payload round up to one 64 B entry.
 _L = 3
 _LORA = 6
 _ROPE = 2
 _D = _LORA + _ROPE
 _DTYPE = torch.bfloat16
 _ITEM = _DTYPE.itemsize
+_ROW = _D * _ITEM
+_ENTRY = mla_entry_bytes(layer_num=_L, kv_cache_dim=_D, itemsize=_ITEM)
+_E_ELEMS = _ENTRY // _ITEM
 
 
 def _mla_spec(grow="down", layer_num=_L):
@@ -87,11 +106,27 @@ def _make_unified(page_size=1, n_full_tokens=64, n_mamba_slots=8):
     return pool, full, mamba
 
 
-def _kernel_id(t, ps, layer_num):
-    return (t // ps) * (ps * layer_num) + t % ps
+def _build_views(raw, ps, num_pages):
+    layout = _mla_spec().layout()
+    return build_dense_views(
+        raw, layout=layout, part=layout.part("kv"), page_size=ps, num_pages=num_pages
+    )
 
 
 class TestMLASubPoolSpec(unittest.TestCase):
+    def test_entry_bytes_and_dim(self):
+        spec = _mla_spec()
+        self.assertEqual(spec.kv_cache_dim, _D)
+        self.assertEqual(spec.row_bytes(), _ROW)
+        self.assertEqual(spec.entry_bytes(), _ENTRY)
+        self.assertGreaterEqual(spec.entry_bytes(), _L * _ROW)
+        self.assertEqual(spec.entry_bytes() % ENTRY_ALIGN_BYTES, 0)
+        self.assertEqual(spec.get_dtype(), _DTYPE)
+        layout = spec.layout()
+        self.assertEqual(layout.entry_bytes, _ENTRY)
+        for l in range(_L):
+            self.assertEqual(layout.part("kv").layer_offset_bytes(l), l * _ROW)
+
     def test_rejects_nonpositive_dims(self):
         with self.assertRaises(AssertionError):
             MLASubPoolSpec(
@@ -105,79 +140,54 @@ class TestMLASubPoolSpec(unittest.TestCase):
 
 
 class TestMLAViews(unittest.TestCase):
-    def _make_raw(self, ps, num_pages, pad_pages=1):
-        page_bytes = ps * _L * _D * _ITEM
-        raw = torch.zeros(
-            (num_pages + pad_pages) * page_bytes, dtype=torch.uint8, device=_DEV
-        )
-        return raw, page_bytes
+    def _make_raw(self, ps, num_pages, short=0):
+        n = num_pages * ps * _ENTRY - short
+        return torch.zeros(n, dtype=torch.uint8, device=_DEV)
 
     def test_view_addressing_matches_envelope_formula(self):
         for ps in (1, 4):
             num_pages = 6
-            raw, _ = self._make_raw(ps, num_pages)
-            views = build_mla_views(
-                raw,
-                layer_num=_L,
-                kv_cache_dim=_D,
-                store_dtype=_DTYPE,
-                page_size=ps,
-                num_pages=num_pages,
-            )
+            raw = self._make_raw(ps, num_pages)
+            views = _build_views(raw, ps, num_pages)
             self.assertEqual(len(views), _L)
-            n_rows = num_pages * _L * ps
+            n_rows = num_pages * ps
             for v in views:
                 self.assertEqual(tuple(v.shape), (n_rows, 1, _D))
-                # contiguous in the (row, dim) sense: .view(-1, ps, D) legality
-                self.assertEqual(v.stride(0), _D)
-                self.assertEqual(v.stride(2), 1)
+                self.assertEqual(v.stride(), (_E_ELEMS, _D, 1))
             flat = raw.view(_DTYPE)
             for p, l, s in [(0, 0, 0), (1, 2, ps - 1), (4, 1, ps // 2), (5, 2, 0)]:
                 t = p * ps + s
                 marker = float(p * 100 + l * 10 + s + 1)
-                views[l][_kernel_id(t, ps, _L)] = marker
-                # envelope formula, in elements
-                elem = p * (_L * ps * _D) + l * (ps * _D) + s * _D
+                views[l][t] = marker
+                elem = t * _E_ELEMS + l * _D  # envelope formula, in elements
                 self.assertTrue(
                     torch.all(flat[elem : elem + _D] == marker),
                     f"(p={p}, l={l}, s={s}, ps={ps}) landed off-formula",
                 )
 
     def test_views_do_not_alias_across_layers(self):
-        ps = 4
-        num_pages = 4
-        raw, _ = self._make_raw(ps, num_pages)
-        views = build_mla_views(
-            raw,
-            layer_num=_L,
-            kv_cache_dim=_D,
-            store_dtype=_DTYPE,
-            page_size=ps,
-            num_pages=num_pages,
-        )
+        ps, num_pages = 4, 4
+        views = _build_views(self._make_raw(ps, num_pages), ps, num_pages)
         t = 2 * ps + 1  # page 2, slot 1
-        d = _kernel_id(t, ps, _L)
         for l in range(_L):
-            views[l][d] = float(l + 1)
+            views[l][t] = float(l + 1)
         for l in range(_L):
-            self.assertTrue(torch.all(views[l][d] == float(l + 1)))
+            self.assertTrue(torch.all(views[l][t] == float(l + 1)))
 
-    def test_missing_tail_pad_fails_loud(self):
-        ps = 2
-        num_pages = 4
-        raw, _ = self._make_raw(ps, num_pages, pad_pages=0)
+    def test_short_buffer_fails_loud(self):
+        ps, num_pages = 2, 4
         with self.assertRaises(AssertionError):
-            build_mla_views(
-                raw,
-                layer_num=_L,
-                kv_cache_dim=_D,
-                store_dtype=_DTYPE,
-                page_size=ps,
-                num_pages=num_pages,
-            )
+            _build_views(self._make_raw(ps, num_pages, short=1), ps, num_pages)
 
 
 class TestUnifiedKVPoolMLA(unittest.TestCase):
+    def test_raw_is_exactly_the_budget(self):
+        pool, full, mamba = _make_unified(page_size=4)
+        total = full.entry_bytes() * 64 + mamba.entry_bytes() * 8
+        self.assertEqual(pool.max_slots("full"), total // full.entry_bytes())
+        self.assertEqual(pool.max_slots("mamba"), total // mamba.entry_bytes())
+        self.assertEqual(pool._raw.numel(), total)
+
     def test_reserved_floor_covers_page0_envelope(self):
         ps = 4
         pool, full, mamba = _make_unified(page_size=ps)
@@ -194,6 +204,7 @@ class TestUnifiedKVPoolMLA(unittest.TestCase):
         views = pool.mla_views_for("full")
         self.assertEqual(len(views), _L)
         self.assertIs(pool.mla_spec("full"), full)
+        self.assertEqual(views[0].stride(0) * _ITEM, full.entry_bytes())
 
 
 class TestUnifiedMLATokenToKVPool(unittest.TestCase):
@@ -211,6 +222,7 @@ class TestUnifiedMLATokenToKVPool(unittest.TestCase):
         pool, kv_pool = self._make(ps=1)
         self.assertEqual(len(kv_pool.kv_buffer), _L)
         self.assertEqual(kv_pool.get_kv_size_bytes(), 0)
+        self.assertEqual(kv_pool.size, pool.max_slots("full") - 1)
         k = kv_pool.get_key_buffer(1)
         v = kv_pool.get_value_buffer(1)
         self.assertEqual(k.shape[-1], _D)
@@ -220,24 +232,15 @@ class TestUnifiedMLATokenToKVPool(unittest.TestCase):
         self.assertTrue(torch.all(v[7] == 2.5))
 
     def test_move_kv_cache_moves_page_envelopes(self):
-        """Whole page envelopes relocate, in raw bytes and (at ps=4) as read
-        back through the per-layer views at the destination kernel ids."""
         for ps in (1, 4):
             pool, kv_pool = self._make(ps=ps)
             num_pages = pool.max_slots("full") // ps
-            page_bytes = ps * _L * _D * _ITEM
+            page_bytes = ps * pool.mla_spec("full").entry_bytes()
             env = pool._raw[: num_pages * page_bytes].view(num_pages, page_bytes)
-            src_pages = torch.tensor([num_pages - 2, num_pages - 4, num_pages - 3])
-            dst_pages = torch.tensor([2, 3, 5])
+            src_pages = torch.tensor([num_pages - 2, num_pages - 4])
+            dst_pages = torch.tensor([2, 3])
             env[src_pages[0]] = 7
             env[src_pages[1]] = 9
-            if ps == 4:
-                # write through the views at src, expect it at dst after the move
-                for l in range(_L):
-                    for s in range(ps):
-                        kv_pool.kv_buffer[l][
-                            _kernel_id(int(src_pages[2]) * ps + s, ps, _L)
-                        ] = float(l * ps + s + 1)
             # page-major token runs, exactly how compaction expands pages
             offsets = torch.arange(ps, dtype=torch.int64)
             src_t = (src_pages[:, None] * ps + offsets).reshape(-1)
@@ -245,15 +248,27 @@ class TestUnifiedMLATokenToKVPool(unittest.TestCase):
             kv_pool.move_kv_cache(dst_t, src_t)
             self.assertTrue(torch.all(env[dst_pages[0]] == 7), f"ps={ps}")
             self.assertTrue(torch.all(env[dst_pages[1]] == 9), f"ps={ps}")
-            if ps == 4:
-                for l in range(_L):
-                    for s in range(ps):
-                        got = kv_pool.kv_buffer[l][
-                            _kernel_id(int(dst_pages[2]) * ps + s, ps, _L)
-                        ]
-                        self.assertTrue(
-                            torch.all(got == float(l * ps + s + 1)), f"(l={l}, s={s})"
-                        )
+
+    def test_move_then_readback(self):
+        ps = 4
+        pool, kv_pool = self._make(ps=ps)
+        num_pages = pool.max_slots("full") // ps
+        src_page, dst_page = num_pages - 3, 5
+        # write through the views at src, expect it at dst after the move
+        for l in range(_L):
+            for s in range(ps):
+                kv_pool.kv_buffer[l][src_page * ps + s] = float(l * ps + s + 1)
+        offsets = torch.arange(ps, dtype=torch.int64)
+        kv_pool.move_kv_cache(
+            (torch.tensor([dst_page])[:, None] * ps + offsets).reshape(-1),
+            (torch.tensor([src_page])[:, None] * ps + offsets).reshape(-1),
+        )
+        for l in range(_L):
+            for s in range(ps):
+                got = kv_pool.kv_buffer[l][dst_page * ps + s]
+                self.assertTrue(
+                    torch.all(got == float(l * ps + s + 1)), f"(l={l}, s={s})"
+                )
 
 
 class _FakeKVCache:
@@ -265,7 +280,7 @@ class _FakeKVCache:
 
 
 class TestTranslateKvLocForKernel(unittest.TestCase):
-    def _build(self, ps=1, n_full_tokens=64, multiplier=_L):
+    def _build(self, ps=1, n_full_tokens=64, multiplier=None):
         pool, full, mamba = _make_unified(page_size=ps, n_full_tokens=n_full_tokens)
         full_alloc = MultiEndedAllocator(
             kvcache=_FakeKVCache(pool.max_slots("full")),
@@ -287,33 +302,20 @@ class TestTranslateKvLocForKernel(unittest.TestCase):
         mamba_alloc.bind_peer(full_alloc)
         return full_alloc
 
-    def test_kernel_id_matches_formula(self):
-        """kernel id = (phys // ps) * (ps * multiplier) + phys % ps, across
-        page sizes, the multiplier-1 physical fallback, and eager compaction."""
-        for ps, multiplier in ((1, _L), (4, _L), (1, 1)):
-            with self.subTest(page_size=ps, multiplier=multiplier):
-                alloc = self._build(ps=ps, multiplier=multiplier)
-                a = alloc.alloc(4 * ps)
-                b = alloc.alloc(4 * ps)
-                c = alloc.alloc(4 * ps)
-                self.assertIsNotNone(c)
-
-                def check(virt):
-                    phys = alloc.translate_kv_loc(virt)
-                    expected = (phys // ps) * (ps * multiplier) + phys % ps
-                    self.assertTrue(
-                        torch.all(alloc.translate_kv_loc_for_kernel(virt) == expected)
-                    )
-
-                for virt in (a, b, c):
-                    check(virt)
-                alloc.free(b)  # eager compaction relocates survivors
-                for virt in (a, c):
-                    check(virt)
+    def test_kernel_id_is_the_physical_id(self):
+        for ps in (1, 4):
+            alloc = self._build(ps=ps)
+            v = alloc.alloc(3 * ps)
+            self.assertIsNotNone(v)
+            phys = alloc.translate_kv_loc(v)
+            kernel = alloc.translate_kv_loc_for_kernel(v)
+            self.assertTrue(torch.equal(kernel, phys), f"ps={ps}")
+            v2p = alloc.virtual_to_physical
+            self.assertTrue(torch.equal(kernel, v2p[v // ps] * ps + v % ps))
 
     def test_tombstone_clamps_to_sink(self):
         alloc = self._build(ps=1)
-        # never-allocated virtual ids -> v2p == -1 -> kernel-facing id 0
+        # never-allocated virtual ids -> v2p == -1 -> id 0
         virt = torch.tensor([alloc.min_slot_index + 1], dtype=torch.int64)
         kernel = alloc.translate_kv_loc_for_kernel(virt)
         self.assertTrue(torch.all(kernel == 0))
@@ -332,6 +334,26 @@ class TestTranslateKvLocForKernel(unittest.TestCase):
             x = v.clone()
             alloc.translate_kv_loc_for_kernel(x, out=x)
             self.assertTrue(torch.all(x == no_out))
+
+    def test_multiplier_is_pinned_to_one(self):
+        self.assertEqual(self._build(ps=1).kernel_page_multiplier, 1)
+        self.assertEqual(self._build(ps=1, multiplier=1).kernel_page_multiplier, 1)
+        with self.assertRaises(AssertionError):
+            self._build(ps=1, multiplier=_L)
+
+    def test_kernel_id_follows_compaction(self):
+        alloc = self._build(ps=1)
+        a = alloc.alloc(4)
+        b = alloc.alloc(4)
+        c = alloc.alloc(4)
+        self.assertIsNotNone(c)
+        alloc.free(b)  # eager compaction relocates survivors
+        for run in (a, c):
+            self.assertTrue(
+                torch.equal(
+                    alloc.translate_kv_loc_for_kernel(run), alloc.translate_kv_loc(run)
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_unified_mla_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_views.py
@@ -40,12 +40,13 @@ import unittest
 
 import torch
 
+from sglang.srt.mem_cache.allocator.unified_sub_pool import MultiEndedAllocator
 from sglang.srt.mem_cache.layout.page_major import (
     ENTRY_ALIGN_BYTES,
     build_dense_views,
     mla_entry_bytes,
+    paged_row_view,
 )
-from sglang.srt.mem_cache.allocator.unified_sub_pool import MultiEndedAllocator
 from sglang.srt.mem_cache.unified_memory_pool import (
     MambaSubPoolSpec,
     MLASubPoolSpec,
@@ -163,6 +164,24 @@ class TestMLAViews(unittest.TestCase):
                 self.assertTrue(
                     torch.all(flat[elem : elem + _D] == marker),
                     f"(p={p}, l={l}, s={s}, ps={ps}) landed off-formula",
+                )
+
+    def test_paged_row_view_keeps_the_slot_stride(self):
+        """BUG REGRESSION at page_size 1: the paged MLA backends hand the
+        kernels `paged_row_view(kv)`, whose dim 1 must carry the entry stride
+        at every page size; a `view`-built split gave the size-1 slot dim the
+        row stride instead."""
+        num_pages = 3
+        for ps in (1, 4):
+            views = _build_views(self._make_raw(ps, num_pages), ps, num_pages)
+            paged = paged_row_view(views[1], ps)
+            self.assertEqual(tuple(paged.shape), (num_pages, ps, _D), ps)
+            self.assertEqual(tuple(paged.stride()), (ps * _E_ELEMS, _E_ELEMS, 1), ps)
+            for t in range(num_pages * ps):
+                self.assertEqual(
+                    paged[t // ps, t % ps].data_ptr(),
+                    views[1][t].data_ptr(),
+                    (ps, t),
                 )
 
     def test_views_do_not_alias_across_layers(self):

--- a/test/registered/unit/mem_cache/test_unified_mla_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_views.py
@@ -22,9 +22,9 @@ Covers, CPU-only (pure torch — no GPU / Triton kernels):
     the reserved sink floor covers the whole page-0 envelope;
   - `UnifiedMLATokenToKVPool`: buffer wiring, V-as-prefix-slice, and the
     page-envelope `move_kv_cache` (physical token ids, page-major runs);
-  - `MultiEndedAllocator.translate_kv_loc_for_kernel`: identical to the
-    physical translate, tombstone clamp to the sink, `out=` contract, the
-    pinned multiplier, and correctness across eager compaction.
+  - `MultiEndedAllocator.translate_kv_loc`: the v2p formula, tombstone clamp
+    to the sink, `out=` contract, int32 2-D page tables, and correctness
+    across eager compaction.
 
 GPU parity of the actual read/write kernels (set_mla_kv_buffer TMA path etc.)
 lives in the server-level tests, not here.
@@ -279,8 +279,8 @@ class _FakeKVCache:
         self.buf[dst_loc] = self.buf[src_loc].clone()
 
 
-class TestTranslateKvLocForKernel(unittest.TestCase):
-    def _build(self, ps=1, n_full_tokens=64, multiplier=None):
+class TestTranslateKvLoc(unittest.TestCase):
+    def _build(self, ps=1, n_full_tokens=64):
         pool, full, mamba = _make_unified(page_size=ps, n_full_tokens=n_full_tokens)
         full_alloc = MultiEndedAllocator(
             kvcache=_FakeKVCache(pool.max_slots("full")),
@@ -289,7 +289,6 @@ class TestTranslateKvLocForKernel(unittest.TestCase):
             device=_DEV,
             is_id_owner=True,
             page_size=ps,
-            kernel_page_multiplier=multiplier,
         )
         mamba_alloc = MultiEndedAllocator(
             kvcache=_FakeKVCache(pool.max_slots("mamba")),
@@ -302,46 +301,53 @@ class TestTranslateKvLocForKernel(unittest.TestCase):
         mamba_alloc.bind_peer(full_alloc)
         return full_alloc
 
-    def test_kernel_id_is_the_physical_id(self):
+    def test_translate_matches_v2p_formula(self):
         for ps in (1, 4):
             alloc = self._build(ps=ps)
             v = alloc.alloc(3 * ps)
             self.assertIsNotNone(v)
-            phys = alloc.translate_kv_loc(v)
-            kernel = alloc.translate_kv_loc_for_kernel(v)
-            self.assertTrue(torch.equal(kernel, phys), f"ps={ps}")
             v2p = alloc.virtual_to_physical
-            self.assertTrue(torch.equal(kernel, v2p[v // ps] * ps + v % ps))
+            want = v2p[v // ps] * ps + v % ps
+            self.assertTrue(torch.equal(alloc.translate_kv_loc(v), want), f"ps={ps}")
 
     def test_tombstone_clamps_to_sink(self):
         alloc = self._build(ps=1)
         # never-allocated virtual ids -> v2p == -1 -> id 0
         virt = torch.tensor([alloc.min_slot_index + 1], dtype=torch.int64)
-        kernel = alloc.translate_kv_loc_for_kernel(virt)
-        self.assertTrue(torch.all(kernel == 0))
+        self.assertTrue(torch.all(alloc.translate_kv_loc(virt) == 0))
 
     def test_out_matches_and_aliases(self):
         for ps in (1, 4):
             alloc = self._build(ps=ps)
             v = alloc.alloc(2 * ps)
             self.assertIsNotNone(v)
-            no_out = alloc.translate_kv_loc_for_kernel(v)
+            no_out = alloc.translate_kv_loc(v)
             out = torch.empty_like(v)
-            ret = alloc.translate_kv_loc_for_kernel(v, out=out)
+            ret = alloc.translate_kv_loc(v, out=out)
             self.assertIs(ret, out)
             self.assertTrue(torch.all(out == no_out))
             # canonical in-place aliasing: translate(x, out=x)
             x = v.clone()
-            alloc.translate_kv_loc_for_kernel(x, out=x)
+            alloc.translate_kv_loc(x, out=x)
             self.assertTrue(torch.all(x == no_out))
 
-    def test_multiplier_is_pinned_to_one(self):
-        self.assertEqual(self._build(ps=1).kernel_page_multiplier, 1)
-        self.assertEqual(self._build(ps=1, multiplier=1).kernel_page_multiplier, 1)
-        with self.assertRaises(AssertionError):
-            self._build(ps=1, multiplier=_L)
+    def test_accepts_an_int32_2d_page_table(self):
+        """fa3 translates its own page table, which is int32 and 2-D; a gather
+        that needs a 1-D int64 index would crash the scheduler there."""
+        for ps in (1, 4):
+            alloc = self._build(ps=ps)
+            v = alloc.alloc(4 * ps)
+            self.assertIsNotNone(v)
+            want = alloc.translate_kv_loc(v)
+            page_table = v.to(torch.int32).view(2, -1)
+            got = alloc.translate_kv_loc(page_table)
+            self.assertEqual(got.shape, page_table.shape)
+            self.assertTrue(torch.equal(got.reshape(-1), want))
+            dst = torch.empty(page_table.shape, dtype=torch.int64)
+            alloc.translate_kv_loc(page_table, out=dst)
+            self.assertTrue(torch.equal(dst.reshape(-1), want))
 
-    def test_kernel_id_follows_compaction(self):
+    def test_translate_follows_compaction(self):
         alloc = self._build(ps=1)
         a = alloc.alloc(4)
         b = alloc.alloc(4)
@@ -350,9 +356,7 @@ class TestTranslateKvLocForKernel(unittest.TestCase):
         alloc.free(b)  # eager compaction relocates survivors
         for run in (a, c):
             self.assertTrue(
-                torch.equal(
-                    alloc.translate_kv_loc_for_kernel(run), alloc.translate_kv_loc(run)
-                )
+                torch.equal(alloc.translate_kv_loc(run), alloc.virtual_to_physical[run])
             )
 
 

--- a/test/registered/unit/mem_cache/test_unified_npool_sweep.py
+++ b/test/registered/unit/mem_cache/test_unified_npool_sweep.py
@@ -221,16 +221,14 @@ class TestFloatViews(unittest.TestCase):
         self.assertEqual(len(k_views), spec.layer_num)
         self.assertEqual(len(v_views), spec.layer_num)
         num_pages = pool.max_slots("swa") // page_size
-        blocks = 2 * spec.layer_num  # K at block 2l, V at 2l+1
-        n_rows = num_pages * blocks * page_size
+        n_rows = num_pages * page_size
         for k in (*k_views, *v_views):
-            # Stock 3-D per-layer MHA signature; the row index is the
-            # kernel-facing id, each view's storage_offset folding in its block
-            # origin (see `build_mha_views`).
+            # 3-D per-layer views indexed by the physical token id; the slot
+            # stride is the whole entry (see `build_dense_views`).
             self.assertEqual(tuple(k.shape), (n_rows, spec.head_num, spec.head_dim))
+            self.assertEqual(k.stride(0) * k.element_size(), spec.entry_bytes())
         # Round-trip: a float view is a real strided window into _raw.
-        slot = pool.min_slot_index("swa")
-        row = (slot // page_size) * (page_size * blocks) + slot % page_size
+        row = pool.min_slot_index("swa")
         pattern = (
             torch.arange(spec.head_num * spec.head_dim, dtype=torch.float32)
             .reshape(spec.head_num, spec.head_dim)

--- a/test/registered/unit/mem_cache/test_write_loc_id_space.py
+++ b/test/registered/unit/mem_cache/test_write_loc_id_space.py
@@ -75,12 +75,20 @@ def _batch(loc):
 
 def _unified_mha_pool(ps=1):
     full = MHASubPoolSpec(
-        name="full", layer_num=_L, head_num=_H, head_dim=_D,
-        store_dtype=_DTYPE, grow_direction="down",
+        name="full",
+        layer_num=_L,
+        head_num=_H,
+        head_dim=_D,
+        store_dtype=_DTYPE,
+        grow_direction="down",
     )
     swa = MHASubPoolSpec(
-        name="swa", layer_num=_L, head_num=_H, head_dim=_D,
-        store_dtype=_DTYPE, grow_direction="up",
+        name="swa",
+        layer_num=_L,
+        head_num=_H,
+        head_dim=_D,
+        store_dtype=_DTYPE,
+        grow_direction="up",
     )
     kv = UnifiedKVPool(
         total_bytes=full.entry_bytes() * 32 + swa.entry_bytes() * 16,
@@ -165,8 +173,14 @@ class TestUnifiedDoorsRefuseUnmarkedLocs(unittest.TestCase):
 
     def test_plain_pool_ignores_the_marker(self):
         pool = MHATokenToKVPool(
-            size=8, page_size=1, head_num=_H, head_dim=_D, dtype=_DTYPE,
-            layer_num=1, device=_DEV, enable_memory_saver=False,
+            size=8,
+            page_size=1,
+            head_num=_H,
+            head_dim=_D,
+            dtype=_DTYPE,
+            layer_num=1,
+            device=_DEV,
+            enable_memory_saver=False,
         )
         loc = torch.tensor([2], dtype=torch.int64, device=_DEV)
         k, v = self._kv(1)

--- a/test/registered/unit/mem_cache/test_write_loc_id_space.py
+++ b/test/registered/unit/mem_cache/test_write_loc_id_space.py
@@ -1,0 +1,209 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The write-loc id-space marker.
+
+Under the token-major views a virtual id is in range and, by value, the same
+kind of integer as a physical one, so the unified pools cannot tell a skipped
+rebind from a translated loc. The marker is the contract that replaces that
+probe: `rebind_write_loc` marks the batch's loc kernel-facing, backends carry
+the mark through `KVWriteLoc.for_batch`, composites forward it, and the unified
+write doors refuse an unmarked loc (under SGLANG_ENABLE_ASYNC_ASSERT).
+
+    python -m pytest test/registered/unit/mem_cache/test_write_loc_id_space.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
+from sglang.srt.mem_cache.memory_pool import (
+    KVWriteLoc,
+    MHATokenToKVPool,
+    write_loc_id_space,
+)
+from sglang.srt.mem_cache.unified_memory_pool import (
+    MHASubPoolSpec,
+    UnifiedKVPool,
+    UnifiedMHATokenToKVPool,
+    init_unified_swa_pools,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+# `set_kv_buffer` dispatches on the platform, so the pools that get written live
+# on the platform's device; the marker logic itself is device-free.
+_DEV = "cuda" if torch.cuda.is_available() else "cpu"
+_L, _H, _D = 2, 2, 8
+_DTYPE = torch.float16
+
+
+def _plain_translator():
+    return KVIndexTranslator(
+        req_to_token=torch.zeros((1, 4), dtype=torch.int64),
+        token_to_kv_pool_allocator=SimpleNamespace(),
+        token_to_kv_pool=SimpleNamespace(),
+        page_size=1,
+        device="cpu",
+    )
+
+
+def _translating_translator(v2p):
+    src = _plain_translator()
+    src.is_translating = True
+    src._translate_write_full = lambda t, out=None: v2p[t.to(torch.int64)]
+    return src
+
+
+def _batch(loc):
+    return SimpleNamespace(out_cache_loc=loc, out_cache_loc_id_space="virtual")
+
+
+def _unified_mha_pool(ps=1):
+    full = MHASubPoolSpec(
+        name="full", layer_num=_L, head_num=_H, head_dim=_D,
+        store_dtype=_DTYPE, grow_direction="down",
+    )
+    swa = MHASubPoolSpec(
+        name="swa", layer_num=_L, head_num=_H, head_dim=_D,
+        store_dtype=_DTYPE, grow_direction="up",
+    )
+    kv = UnifiedKVPool(
+        total_bytes=full.entry_bytes() * 32 + swa.entry_bytes() * 16,
+        sub_pool_specs=[full, swa],
+        device=_DEV,
+        enable_memory_saver=False,
+        page_size=ps,
+    )
+    return UnifiedMHATokenToKVPool(
+        unified_buffer=kv, sub_pool_name="full", page_size=ps, enable_alt_stream=False
+    )
+
+
+class TestRebindMarksTheBatch(unittest.TestCase):
+    def test_non_translating_pool_marks_kernel_without_rebinding(self):
+        loc = torch.tensor([3, 5], dtype=torch.int64)
+        fb = _batch(loc)
+        _plain_translator().rebind_write_loc(fb)
+        self.assertIs(fb.out_cache_loc, loc)  # physical by allocation: untouched
+        self.assertEqual(fb.out_cache_loc_id_space, "kernel")
+
+    def test_translating_pool_rebinds_and_marks_kernel(self):
+        v2p = torch.tensor([7, 6, 5, 4], dtype=torch.int64)
+        loc = torch.tensor([1, 2], dtype=torch.int64)
+        fb = _batch(loc)
+        _translating_translator(v2p).rebind_write_loc(fb)
+        self.assertTrue(torch.equal(fb.out_cache_loc, v2p[loc]))
+        self.assertEqual(fb.out_cache_loc_id_space, "kernel")
+
+    def test_no_loc_stays_virtual(self):
+        fb = _batch(None)
+        _translating_translator(torch.arange(4)).rebind_write_loc(fb)
+        self.assertEqual(fb.out_cache_loc_id_space, "virtual")
+
+
+class TestKVWriteLocCarriesTheSpace(unittest.TestCase):
+    def test_for_batch_copies_the_batch_space_and_default_loc(self):
+        fb = _batch(torch.tensor([1, 2]))
+        self.assertEqual(KVWriteLoc.for_batch(fb).id_space, "virtual")
+        fb.out_cache_loc_id_space = "kernel"
+        info = KVWriteLoc.for_batch(fb, swa_loc=torch.tensor([9, 9]))
+        self.assertIs(info.loc, fb.out_cache_loc)
+        self.assertEqual(info.id_space, "kernel")
+        sliced = KVWriteLoc.for_batch(fb, fb.out_cache_loc[:1])
+        self.assertEqual(sliced.id_space, "kernel")
+
+    def test_bare_and_default_are_virtual(self):
+        self.assertEqual(write_loc_id_space(torch.tensor([1])), "virtual")
+        self.assertEqual(write_loc_id_space(KVWriteLoc(torch.tensor([1]))), "virtual")
+        self.assertEqual(
+            write_loc_id_space(KVWriteLoc(torch.tensor([1]), id_space="kernel")),
+            "kernel",
+        )
+
+
+class TestUnifiedDoorsRefuseUnmarkedLocs(unittest.TestCase):
+    def _kv(self, n=2):
+        k = torch.ones((n, _H, _D), dtype=_DTYPE, device=_DEV)
+        return k, k * 2
+
+    def test_unified_mha_door(self):
+        pool = _unified_mha_pool()
+        layer = SimpleNamespace(layer_id=0)
+        loc = torch.tensor([3, 4], dtype=torch.int64, device=_DEV)
+        k, v = self._kv()
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(True):
+            with self.assertRaisesRegex(AssertionError, "not kernel-facing"):
+                pool.set_kv_buffer(layer, loc, k, v)
+            with self.assertRaisesRegex(AssertionError, "not kernel-facing"):
+                pool.set_kv_buffer(layer, KVWriteLoc(loc), k, v)
+            pool.set_kv_buffer(layer, KVWriteLoc(loc, id_space="kernel"), k, v)
+        self.assertTrue(torch.all(pool.k_buffer[0][3] == 1))
+        self.assertTrue(torch.all(pool.v_buffer[0][4] == 2))
+
+    def test_check_is_gated_by_the_async_assert_env(self):
+        pool = _unified_mha_pool()
+        loc = torch.tensor([3], dtype=torch.int64, device=_DEV)
+        k, v = self._kv(1)
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(False):
+            pool.set_kv_buffer(SimpleNamespace(layer_id=1), loc, k, v)
+        self.assertTrue(torch.all(pool.k_buffer[1][3] == 1))
+
+    def test_plain_pool_ignores_the_marker(self):
+        pool = MHATokenToKVPool(
+            size=8, page_size=1, head_num=_H, head_dim=_D, dtype=_DTYPE,
+            layer_num=1, device=_DEV, enable_memory_saver=False,
+        )
+        loc = torch.tensor([2], dtype=torch.int64, device=_DEV)
+        k, v = self._kv(1)
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(True):
+            pool.set_kv_buffer(SimpleNamespace(layer_id=0), loc, k, v)
+        self.assertTrue(torch.all(pool.k_buffer[0][2] == 1))
+
+    def test_swa_composite_forwards_the_space(self):
+        b = init_unified_swa_pools(
+            device=_DEV,
+            kv_cache_dtype=_DTYPE,
+            head_num=_H,
+            head_dim=_D,
+            v_head_dim=_D,
+            swa_head_num=_H,
+            swa_head_dim=_D,
+            swa_v_head_dim=_D,
+            page_size=1,
+            start_layer=0,
+            end_layer=4,
+            swa_attention_layer_ids=[1, 3],
+            full_attention_layer_ids=[0, 2],
+            full_max_total_num_tokens=64,
+            swa_max_total_num_tokens=32,
+            enable_memory_saver=False,
+            need_sort=False,
+        )
+        pool = b.token_to_kv_pool
+        loc = torch.tensor([2, 3], dtype=torch.int64, device=_DEV)
+        k, v = self._kv()
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(True):
+            for layer_id in (0, 1):  # a full layer and a swa layer
+                layer = SimpleNamespace(layer_id=layer_id)
+                with self.assertRaisesRegex(AssertionError, "not kernel-facing"):
+                    pool.set_kv_buffer(layer, KVWriteLoc(loc, loc), k, v)
+                pool.set_kv_buffer(layer, KVWriteLoc(loc, loc, id_space="kernel"), k, v)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_unified_out_cache_loc_rebind.py
+++ b/test/registered/unit/model_executor/test_unified_out_cache_loc_rebind.py
@@ -73,15 +73,13 @@ def _armed_source(v2p, swa_map):
     # The WRITE loc has its own translate because under DCP it arrives widened;
     # at dcp_size == 1 it is the read translate, so arm it with the same fake.
     src._translate_write_full = src._translate_full
-    # Phase 2 derives from kernel-facing values through p2v + the swa v2p; arm
-    # the inverse of the fake v2p (ps=1, both multipliers 1: kernel == physical,
-    # and the expected swa loc for virtual t is swa_map[t]).
+    # Phase 2 derives from physical values through p2v + the swa v2p; arm the
+    # inverse of the fake v2p (ps=1, so the expected swa loc for virtual t is
+    # swa_map[t]).
     p2v = torch.zeros(int(v2p.max()) + 1, dtype=torch.int64)
     p2v[v2p] = torch.arange(v2p.numel(), dtype=torch.int64)
     src._full_p2v_table = p2v
     src._swa_v2p_table = swa_map
-    src._full_page_multiplier = 1
-    src._swa_page_multiplier = 1
     return src
 
 

--- a/test/registered/unit/model_executor/test_unified_out_cache_loc_rebind.py
+++ b/test/registered/unit/model_executor/test_unified_out_cache_loc_rebind.py
@@ -151,26 +151,6 @@ class TestPadComposesWithDerivation(CustomTestCase):
         sub = src._swa_write_loc_unified(fb.out_cache_loc[1:5])
         self.assertTrue(torch.equal(sub, loc[1:5]))
 
-    def test_the_probe_separates_kernel_facing_from_virtual_ids(self):
-        """A skipped rebind is the failure mode this contract has no other
-        guard against: virtual ids stay inside the OOB probe's bounds (they are
-        `blocks_per_page` times SMALLER than a kernel-facing id), so the store lands on
-        the wrong slots and only the output is wrong. The kernel-facing probe
-        is what separates them -- the in-page offset of a kernel-facing id is always
-        below page_size, and a virtual id's is not unless it happens to fall in
-        the first block."""
-        for page_size, blocks in ((1, 8), (4, 6)):
-            with self.subTest(page_size=page_size, blocks=blocks):
-                stride = page_size * blocks
-                virt = torch.arange(1, 2 * stride, dtype=torch.int64)
-                kernel = (virt // page_size) * stride + virt % page_size
-                in_space = kernel % stride < page_size
-                self.assertTrue(bool(in_space.all()), "kernel-facing ids must pass")
-                # Virtual ids pass only in the first block; that is why the
-                # probe needs a batch, not one id, to be conclusive.
-                caught = ~(virt % stride < page_size)
-                self.assertTrue(bool(caught.any()), "virtual ids must be caught")
-
     def test_empty_loc_rebinds_to_empty(self):
         src = _armed_source(
             torch.arange(8, dtype=torch.int64), torch.arange(8, dtype=torch.int64)

--- a/test/registered/unit/server_args/test_page_major_backend_allowlist.py
+++ b/test/registered/unit/server_args/test_page_major_backend_allowlist.py
@@ -13,12 +13,16 @@
 # ==============================================================================
 """`--enable-page-major-kv-layout` full-attention backend allowlist.
 
-`handle_page_major_kv_layout` gates two ways, because the per-layer views the
-unified pool exposes are all the allowlisted backends can read: an MLA arm
-(`build_mla_views`), an MHA/SWA arm (`build_mha_views`), and no page-major arm
-at all without the unified pool. `fa3` is the resolved default on pre-Blackwell
-hosts, so its absence from an arm makes `--enable-unified-memory` fail to boot
-under its own default configuration.
+Two-way gate (see `_handle_page_major_kv_layout`), because the unified pool
+exposes per-layer views and nothing else:
+  * unified-memory MLA models allow the whole wired
+    paged MLA family -- `fa3`, `flashinfer`'s MLA backend, `trtllm_mla` with
+    its `cutedsl_mla` / `tokenspeed_mla` subclasses, and `flashmla` (ps=64
+    snap);
+  * unified-memory MHA/SWA models allow `fa3` /
+    `fa4` / `flashinfer` / `trtllm_mha` alongside Triton;
+  * plain `--enable-page-major-kv-layout` without the unified pool keeps the
+    envelope-strided 4-D views only the stride-aware Triton kernels read.
 
 The same handler screens the pool itself: the MHA/SWA per-layer views need
 uniform K/V rows, so an asymmetric-K/V model (MiMoV2: head_dim 192 !=

--- a/test/registered/unit/server_args/test_page_major_backend_allowlist.py
+++ b/test/registered/unit/server_args/test_page_major_backend_allowlist.py
@@ -24,12 +24,19 @@ exposes per-layer views and nothing else:
   * plain `--enable-page-major-kv-layout` without the unified pool keeps the
     envelope-strided 4-D views only the stride-aware Triton kernels read.
 
-The same handler screens the pool itself: the MHA/SWA per-layer views need
-uniform K/V rows, so an asymmetric-K/V model (MiMoV2: head_dim 192 !=
-v_head_dim 128) is rejected on EVERY backend, Triton included. MLA models are
-exempt -- their sub-pool keeps one latent row per layer, and real MLA configs
-(Kimi-Linear: head_dim 72, v_head_dim 128) report asymmetric dims while running
-the unified pool today.
+The same handler also screens the pool itself: asymmetric K/V rows are not
+admitted yet, so an asymmetric-K/V model (MiMoV2: head_dim 192 != v_head_dim
+128) cannot run `--enable-unified-memory` at all and is rejected on EVERY
+backend, Triton included. MLA models are exempt -- their sub-pool keeps
+one latent row per layer, and several MLA configs (Kimi-Linear: head_dim 72,
+v_head_dim 128) report asymmetric dims while running the unified pool today.
+
+Pinned here so no arm silently widens to an unwired backend (`cutlass_mla`,
+`aiter`) and no arm silently narrows: `fa3` is the resolved default on
+pre-Blackwell hosts, so its absence from an arm makes `--enable-unified-memory`
+fail to boot under its own default configuration.
+
+    python -m pytest test/registered/unit/server_args/test_page_major_backend_allowlist.py -v
 """
 
 import unittest
@@ -98,7 +105,7 @@ class TestPageMajorBackendAllowlist(unittest.TestCase):
         "tokenspeed_mla",
         "flashmla",
     )
-    # Wired for the per-layer MHA/SWA views (uniform-row models).
+    # Wired for the per-layer MHA/SWA views.
     PER_LAYER_VIEW_MHA_BACKENDS = ("fa3", "fa4", "flashinfer", "trtllm_mha")
     # MLA-family kernels that must never leak into the MHA arm.
     MLA_ONLY_BACKENDS = ("trtllm_mla", "cutedsl_mla", "tokenspeed_mla", "flashmla")
@@ -110,8 +117,8 @@ class TestPageMajorBackendAllowlist(unittest.TestCase):
         the MLA nor the MHA arm can narrow away."""
         for use_mla in (True, False):
             self.assertTrue(_accepts("triton", use_mla=use_mla))
-        # The uniform-row screen is a property of the model, not of the
-        # backend, so it rejects even Triton.
+        # Asymmetric K/V rows are not admitted yet; that is a property of the
+        # model, not of the backend, so the screen rejects even Triton.
         self.assertFalse(_accepts("triton", use_mla=False, has_asymmetric_kv=True))
 
     def test_per_layer_view_mla_backends_allowed_under_unified_mla(self):
@@ -121,11 +128,11 @@ class TestPageMajorBackendAllowlist(unittest.TestCase):
                 f"{backend} should be allowed with the unified-memory MLA pool",
             )
 
-    def test_per_layer_view_mha_backends_allowed_for_uniform_row_models(self):
+    def test_per_layer_view_mha_backends_allowed_under_unified_mha(self):
         for backend in self.PER_LAYER_VIEW_MHA_BACKENDS:
             self.assertTrue(
                 _accepts(backend, use_mla=False),
-                f"{backend} should be allowed for a uniform-row MHA model",
+                f"{backend} should be allowed with the unified-memory MHA pool",
             )
 
     def test_mla_only_backends_rejected_for_mha(self):
@@ -136,7 +143,8 @@ class TestPageMajorBackendAllowlist(unittest.TestCase):
             )
 
     def test_asymmetric_kv_mha_model_cannot_use_unified_memory(self):
-        """The rejection is the POOL's, not a backend's, so it must fire on
+        """head_dim != v_head_dim (MiMoV2): not admitted under the unified pool
+        yet. The rejection is the POOL's, not a backend's, so it must fire on
         every backend -- Triton included."""
         for backend in ("triton",) + self.PER_LAYER_VIEW_MHA_BACKENDS:
             self.assertFalse(

--- a/test/registered/unit/server_args/test_unified_memory_spec_gate.py
+++ b/test/registered/unit/server_args/test_unified_memory_spec_gate.py
@@ -108,11 +108,16 @@ class TestUnifiedMemorySpecGate(unittest.TestCase):
         for backend in ("fa4", "trtllm_mha"):
             self.assertFalse(_accepts("DSPARK", backend=backend))
 
-    def test_dspark_refused_tree_topk(self):
-        """Tree verify needs a per-token move inside the target pool, which
-        the unified pool's page-granular `move_kv_cache` cannot express."""
+    def test_tree_drafting_refused(self):
+        """Tree verify needs a per-token move inside the TARGET pool, which
+        the unified pool's page-granular `move_kv_cache` cannot express.
+        DSPARK is the only admitted algorithm today, so it is the only one
+        that can demonstrate the rule; the check itself is unconditional, so
+        it keeps holding as further arms are admitted."""
         for topk in (2, 4, 8):
             self.assertFalse(_accepts("DSPARK", topk=topk))
+        # The shape knob must not disturb spec-off.
+        self.assertTrue(_accepts(None, topk=None))
 
     def test_draft_backend_is_audited_too(self):
         """The draft worker runs its OWN forward on its OWN backend, resolved

--- a/test/registered/unit/server_args/test_unified_memory_spec_gate.py
+++ b/test/registered/unit/server_args/test_unified_memory_spec_gate.py
@@ -1,0 +1,149 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""`--enable-unified-memory` speculative-decoding allow-list.
+
+One audited arm today: DSPARK, a chain draft whose draft KV lives in a pool of
+its own. Its verify runs on the backends whose spec paths build their read
+tables through the KV-index translator -- the MLA verify family plus
+`flashmla` / `flashinfer` / `fa3`. Everything else stays refused until its
+verify id rails are audited.
+
+Pinned so no arm silently widens to an unaudited algorithm, tree shape, or
+backend. The backend set in particular is a claim about code that exists: a
+backend listed here MUST have a translated spec path, or a unified run on it
+reads the pool with virtual ids and silently returns wrong tokens.
+
+    python -m pytest test/registered/unit/server_args/test_unified_memory_spec_gate.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.arg_groups.kv_cache_hook import handle_unified_memory_pool
+from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _accepts(
+    algorithm: str | None,
+    *,
+    topk: int | None = 1,
+    backend: str | None = "triton",
+    draft_backend: str | None = None,
+) -> bool:
+    """Run just `handle_unified_memory_pool` against a minimal stand-in.
+
+    ServerArgs' real constructor pulls in a model config; this exercises the
+    single handler under test with the fields it reads (disaggregation off, so
+    only the speculative / cache / dcp / cuda-graph checks run).
+    """
+    sa = ServerArgs.__new__(ServerArgs)
+    for name, value in {
+        "enable_unified_memory": True,
+        "disaggregation_mode": "null",
+        "speculative_algorithm": algorithm,
+        "speculative_eagle_topk": topk,
+        "speculative_draft_attention_backend": draft_backend,
+        "enable_hierarchical_cache": False,
+        "enable_lmcache": False,
+        "dcp_size": 1,
+        "cuda_graph_config": None,
+        "attention_backend": backend,
+        "prefill_attention_backend": None,
+        "decode_attention_backend": None,
+    }.items():
+        object.__setattr__(sa, name, value)
+    object.__setattr__(
+        sa,
+        "_model_config",
+        SimpleNamespace(is_hybrid_swa=True, attention_arch=AttentionArch.MHA),
+    )
+    try:
+        handle_unified_memory_pool(sa)
+        return True
+    except AssertionError:
+        return False
+
+
+class TestUnifiedMemorySpecGate(unittest.TestCase):
+    # Backends whose speculative verify path builds through the translator.
+    AUDITED_BACKENDS = (
+        "triton",
+        "trtllm_mla",
+        "cutedsl_mla",
+        "tokenspeed_mla",
+        "flashmla",
+        "flashinfer",
+        "fa3",
+    )
+    # Algorithms with no audited unified-pool verify rails.
+    UNAUDITED_ALGORITHMS = ("EAGLE", "EAGLE3", "DFLASH", "NGRAM", "STANDALONE")
+
+    def test_dspark_admitted_on_every_audited_backend(self):
+        """Each entry is a claim that the backend's spec verify path
+        translates. Adding one here without the code is how a unified run
+        silently reads the pool with virtual ids."""
+        for backend in self.AUDITED_BACKENDS:
+            self.assertTrue(
+                _accepts("DSPARK", backend=backend),
+                f"DSPARK should pass on verify-audited backend {backend}",
+            )
+
+    def test_dspark_refused_on_unaudited_backends(self):
+        """fa4 and trtllm_mha have no translated spec verify path."""
+        for backend in ("fa4", "trtllm_mha"):
+            self.assertFalse(_accepts("DSPARK", backend=backend))
+
+    def test_dspark_refused_tree_topk(self):
+        """Tree verify needs a per-token move inside the target pool, which
+        the unified pool's page-granular `move_kv_cache` cannot express."""
+        for topk in (2, 4, 8):
+            self.assertFalse(_accepts("DSPARK", topk=topk))
+
+    def test_draft_backend_is_audited_too(self):
+        """The draft worker runs its OWN forward on its OWN backend, resolved
+        from `--speculative-draft-attention-backend` before it falls back to
+        inheriting the target's. Checking only the target therefore leaves an
+        unaudited backend reachable: every target arm can be audited while the
+        draft translates nothing. Unset must still inherit and pass."""
+        self.assertTrue(_accepts("DSPARK", draft_backend=None))
+        for draft_backend in self.AUDITED_BACKENDS:
+            self.assertTrue(
+                _accepts("DSPARK", draft_backend=draft_backend),
+                f"audited draft backend {draft_backend} should pass",
+            )
+        for draft_backend in ("fa4", "trtllm_mha", "torch_native"):
+            self.assertFalse(
+                _accepts("DSPARK", draft_backend=draft_backend),
+                f"unaudited draft backend {draft_backend} must be refused",
+            )
+
+    def test_spec_off_admitted(self):
+        """The gate constrains only speculative configurations; spec-off must
+        keep booting."""
+        self.assertTrue(_accepts(None))
+
+    def test_unaudited_algorithms_refused(self):
+        """Every other algorithm stays out until its verify id rails are
+        audited -- on every backend."""
+        for algorithm in self.UNAUDITED_ALGORITHMS:
+            for backend in ("triton", "fa3"):
+                self.assertFalse(_accepts(algorithm, backend=backend))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_spec_worker_forward_signature.py
+++ b/test/registered/unit/spec/test_spec_worker_forward_signature.py
@@ -1,0 +1,131 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Every spec worker takes the call the scheduler makes.
+
+BUG REGRESSION. `Scheduler.run_batch` drives whichever V2 spec worker
+`SpeculativeAlgorithm.create_worker` installed, and on the non-overlap branch it
+passes `pp_proxy_tensors=` unconditionally. Three workers never grew the
+parameter -- DSpark, frozen-KV MTP and multi-layer EAGLE -- so any run on a
+non-overlap schedule died with
+
+    TypeError: DSparkWorkerV2.forward_batch_generation() got an unexpected
+               keyword argument 'pp_proxy_tensors'
+
+on BOTH the baseline and the unified arm (eval_571 lost the whole Kimi x DSPARK
+cell that way; Kimi pins normal scheduling, so it takes that branch every time).
+
+The worker set is DERIVED from `create_worker`'s own `return` statements, so a
+worker added later is covered without editing this file -- a hand-kept list
+would pass forever while the new worker drifted.
+
+    python -m pytest test/registered/unit/spec/test_spec_worker_forward_signature.py -v
+"""
+
+import ast
+import pathlib
+import unittest
+
+import sglang.srt.speculative.spec_info as spec_info
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# What Scheduler.run_batch passes on the non-overlap spec branch, beyond the
+# positional batch. Keep in sync with scheduler.py's call, not with any worker.
+_SCHEDULER_KWARGS = ("pp_proxy_tensors",)
+
+
+def _worker_classes():
+    """(class_name, module_path) for every worker `create_worker` can return.
+
+    AST rather than import: several worker modules pull in compiled kernels that
+    are absent on a CPU box, and a skip here would be a silent coverage hole in
+    exactly the guard that is supposed to be un-skippable.
+    """
+    tree = ast.parse(pathlib.Path(spec_info.__file__).read_text())
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "create_worker"
+    )
+    modules = {
+        alias.name: node.module
+        for node in ast.walk(fn)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    returned = [
+        node.value.id
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Name)
+    ]
+    return [(name, modules[name]) for name in returned if name in modules]
+
+
+def _forward_params(module_path: str, class_name: str):
+    root = pathlib.Path(spec_info.__file__).parents[3]
+    src = root / (module_path.replace(".", "/") + ".py")
+    tree = ast.parse(src.read_text())
+    cls = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == class_name
+    )
+    fn = next(
+        (
+            n
+            for n in cls.body
+            if isinstance(n, ast.FunctionDef) and n.name == "forward_batch_generation"
+        ),
+        None,
+    )
+    if fn is None:
+        return None
+    args = fn.args
+    names = {a.arg for a in args.args} | {a.arg for a in args.kwonlyargs}
+    if args.kwarg is not None:
+        names.add("**")
+    return names
+
+
+class TestSpecWorkerForwardSignature(CustomTestCase):
+    def test_every_worker_accepts_the_scheduler_call(self):
+        workers = _worker_classes()
+        self.assertGreaterEqual(
+            len(workers), 5, "create_worker's return set failed to resolve"
+        )
+        missing = []
+        for class_name, module_path in workers:
+            params = _forward_params(module_path, class_name)
+            if params is None:
+                # Inherits forward_batch_generation from a base; the base is
+                # itself a worker the scheduler drives, so nothing to pin here.
+                continue
+            if "**" in params:
+                continue
+            for kwarg in _SCHEDULER_KWARGS:
+                if kwarg not in params:
+                    missing.append(f"{class_name}.forward_batch_generation({kwarg}=)")
+        self.assertEqual(
+            missing,
+            [],
+            "these spec workers cannot bind the call Scheduler.run_batch makes, "
+            "so every non-overlap spec run on them dies with a TypeError: "
+            + ", ".join(missing),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #40331**, the last of the seven PRs split out of #38592. Those seven
> carry the unified memory pool's layout work; this PR builds the speculative
> rails on top of them. #40331 is not merged yet, so the diff against `main` shows
> the union of all of it — 22 commits, 75 files, +3491/−1482. **This PR's own
> contribution is 11 commits, 16 files, +851/−157, starting at `1d9a5225a6`.**
> Please review only those, on top of #40331; the diff shrinks on its own as the
> stack lands.
>
> **The stack below this PR**, in review and merge order:
>
> | # | PR | what it does |
> |---|---|---|
> | 1 | #40326 | derive KV row addresses from strides, not shapes |
> | 2 | #40327 | build paged KV views through one helper |
> | 3 | #38592 | **token-major layout** — the core of the series |
> | 4 | #40328 | give the write loc an explicit id space |
> | 5 | #40329 | remove the kernel-page multiplier plumbing |
> | 6 | #40330 | fold the kernel translate onto `translate_kv_loc` |
> | 7 | #40331 | stride the write-loc kernel, then fold the last translate |

## Motivation

Under `--enable-unified-memory` a KV slot has three names: the **virtual** id the
scheduler allocates, the **physical** id where it currently sits, and the
**kernel-facing** id an attention kernel may index a per-layer view with. A
non-speculative forward already routes every read and write through
`KVIndexTranslator`, so those three stay consistent.

Speculative decoding did not. Verify reads a **widened** window — the request's
live prefix plus the draft tokens being checked — and several backends built that
window's page table straight from `req_to_token` rows, or from a captured graph's
persistent buffer, without translating. On a plain pool that is invisible, since
all three id spaces coincide. On the unified pool it silently reads the wrong KV,
and because speculative decoding *rejects* wrong tokens rather than crashing, it
surfaces as degraded output rather than as a failure.

That is why `--enable-unified-memory` currently refuses every speculative
algorithm except DSPARK, and DSPARK only on Triton.

## Modifications

Every speculative read and write path now goes through `KVIndexTranslator`, and
the backends that were excluded only because they did not are admitted.

The translator gains the widening the verify window needs — a `seq_len_delta` on
both index-table builders and a `widened_index_table()` view — so a verify read
resolves the live prefix *and* the draft tail in one translated table. The
speculative info types then gather their CSR arguments through that table instead
of assembling page tables themselves.

Each backend is converted on its own terms: flashmla's eager spec branches,
flashinfer's verify gather (which must come from the sliding-window id space, not
the full one), and fa3's four distinct paths — eager reads, the captured source
build, the captured verify page table, and the draft-extend rebuild. fa3 is four
commits rather than one so each stays an independent bisect point.

With those in place the allow-list admits **flashmla, flashinfer and fa3** for
DSPARK verify alongside Triton, and the per-arm tree-drafting refusals collapse
into one unconditional `speculative_eagle_topk in (None, 1)` check next to the
algorithm allow-list, so a future arm inherits the rule instead of repeating it.

One prerequisite fix rides along; it is described under *Notes for reviewers*.

## Accuracy Tests

The DSpark draft used for validation loads with
`--speculative-draft-load-format dummy` — random weights — so every proposal is
rejected and accept length is pinned at 1.00 by construction. **These runs check
that the rails are functionally correct, not that speculative decoding is fast or
accurate with a real drafter.**

That makes accuracy the only usable signal: a translation bug on the verify read
path also yields rejected tokens and also reads 1.00, so it is invisible in
throughput. What a broken rail corrupts is the **target's own output**, because
speculative decoding is lossless only when verify is correct.

Model families exercised. The verify rails are scored on the MLA hybrid
(Kimi-Linear-48B-A3B) with DSPARK on every admitted backend — Triton, fa3,
flashinfer, and flashmla as the verify target — against a spec-off control on the
same backend. The gated-deltanet hybrid (Qwen3.5-9B), the sliding-window hybrid
(gpt-oss-20b) and the Mamba hybrid (Falcon-H1-7B) run spec-off as unified-vs-
baseline controls of the ordinary read path. A broader grid over
`cache × schedule × page size` adds the tri-pool hybrid (Inkling and
Inkling-Small) and dense Llama-3.1-8B as a non-hybrid control.

GSM8K at n=200, unified against a baseline on the same model, backend and
configuration, so every delta isolates the pool:

- verify rails: median **−0.50 pt**, spread sd 2.31 pt
- broader spec-off grid: median **+0.50 pt**, spread sd 2.03 pt

Both spreads sit under the **measured** same-arm floor of ±2.9 pt, obtained by
running two identical configurations against each other rather than assuming the
binomial. Against the PR this one is based on, the per-configuration shift is
**+0.00 pt** — this PR moves no score.

The widest single deviation is −6.5 pt, on gpt-oss-20b with fa3. It is not a
regression: in that same configuration the **baseline arm alone spans 7.0 pt**
across two backends (0.530 on Triton against 0.600 on fa3), so the gap between
arms is smaller than the scatter within one of them. gpt-oss is the lowest-scoring
and widest-spread model in the set.

## Speed Tests and Profiling

Serving benchmark, unified against baseline on the same matrix. Median inter-token
latency:

- product configuration: **+0.43%**
- verify-rails probe at `page_size 1`: **+1.24%**

Against the PR this one is based on, the per-configuration shift is **−0.03 pp**
— this PR adds no measurable cost of its own; both figures are the unified pool's
standing overhead, and the product-configuration number is slightly lower here
than on the base PR.

The gap between those two numbers is page size, not speculation. Pooling both
runs and splitting by page size gives +1.29% at 1, +0.87% at 64, +0.42% at 128
and +0.12% at 256 — a clean falloff consistent with work proportional to
`seq_len / page_size`, which is the number of page-table entries the
virtual-to-physical translate touches per forward. The probe pins `page_size 1`
deliberately, as the worst case for translation; product configurations run 64
to 256.

With a dummy draft these numbers only show the rails add no per-step cost; they
are not a speculative-decoding speedup measurement.

## Notes for reviewers

**One commit has no reachable path on this branch, deliberately.** It gates the
Falcon-H1 causal-conv on `forward_mode.is_target_verify()`, fixing an assertion
that fires on `main` whenever a speculative algorithm reaches a Falcon-H1 target
verify without the page-major layout flag set. Reaching it here needs a
speculative algorithm running on Falcon, and the DSpark draft used for validation
has a `mask_token_id` beyond Falcon's vocabulary, which `resolve_runtime_config`
refuses — so this branch cannot pair them. The line is correct and cheap, and it
becomes live once the chain-drafting algorithms are admitted in the follow-up.
Flagged rather than left for a reviewer to find as an untested line.

**The verify rails are validated on an MLA host only.** The draft checkpoint
available for validation pins a minimum depth, a minimum vocabulary and a hidden
width that only Kimi-Linear satisfies; gpt-oss, Falcon-H1 and Qwen3.5 each fail a
different one. So all four admitted backends are exercised, but the MHA and
sliding-window spec-verify paths are not reachable with it. Those two host kinds
are covered spec-off only.

**Not yet validated:** aiter, fa4, trtllm_mla, cutedsl_mla and tokenspeed_mla are
admitted under `--enable-unified-memory` and supported by this change, but not
exercised on SM100-class or ROCm hardware; the same holds for trtllm_mha's SM100
kernels and for `--dcp-size > 1`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35474187377](https://github.com/sgl-project/sglang/actions/runs/35474187377)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35474187327](https://github.com/sgl-project/sglang/actions/runs/35474187327)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35474187382](https://github.com/sgl-project/sglang/actions/runs/35474187382)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->