### PR TITLE
[AMD] [GLM-5.3-Flash Day 0] Enable FP8 and Quark MXFP4 MoE on gfx950

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -282,10 +282,13 @@ class AiterRunnerCore(MoeRunnerCore):
             # `SGLANG_USE_AITER_MOE_GU_ITLV=0` to switch to SEPARATED, which
             # matches the layout produced by `Mxfp4MoEMethod` (gpt-oss
             # MXFP4) and the gptoss_fp4 tuned FlyDSL kernels.
-            extra["gate_mode"] = (
-                GateMode.INTERLEAVE.value
-                if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
-                else GateMode.SEPARATED.value
+            extra.setdefault(
+                "gate_mode",
+                (
+                    GateMode.INTERLEAVE.value
+                    if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
+                    else GateMode.SEPARATED.value
+                ),
             )
             extra["swiglu_limit"] = quant_info.swiglu_limit
         if self.config.no_combine:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1619,6 +1619,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight.data = shuffle_weight(
                     layer.w2_weight.contiguous(), (16, 16)
                 )
+                layer._aiter_gate_up_interleaved = False
             return
         elif self.use_mxfp8:
             self._process_mxfp8_moe_weights(
@@ -1657,6 +1658,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight.data = shuffle_weight(
                     layer.w2_weight.contiguous(), (16, 16)
                 )
+                layer._aiter_gate_up_interleaved = False
         elif _use_aiter:
             # Pre-shuffle weights
             t = shuffle_weight(layer.w13_weight, (16, 16))
@@ -1665,6 +1667,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             t = shuffle_weight(layer.w2_weight, (16, 16))
             layer.w2_weight.copy_(t)
             del t
+            layer._aiter_gate_up_interleaved = False
         elif _is_cpu:
             assert (
                 _is_cpu_amx_available
@@ -2345,6 +2348,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 requires_grad=False,
             )
             torch.cuda.empty_cache()
+            layer._aiter_gate_up_interleaved = False
 
             # ROCm (_use_aiter): using column-wise scaling
             layer.w13_weight_scale1 *= layer.w13_weight_scale.unsqueeze(-1)
@@ -2744,6 +2748,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             quant_type = AiterQuantType.PER_TOKEN
             w13_scale = layer.w13_weight_scale1
             w2_scale = layer.w2_weight_scale1
+
+        fused_moe_kwargs = None
+        gate_up_interleaved = getattr(layer, "_aiter_gate_up_interleaved", None)
+        if (
+            gate_up_interleaved is not None
+            and (self.moe_runner_config.swiglu_limit or 0.0) > 0
+        ):
+            from aiter.ops.flydsl.moe_common import GateMode
+
+            fused_moe_kwargs = {
+                "gate_mode": (
+                    GateMode.INTERLEAVE.value
+                    if gate_up_interleaved
+                    else GateMode.SEPARATED.value
+                )
+            }
+
         return AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,
@@ -2754,6 +2775,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             swiglu_limit=self.moe_runner_config.swiglu_limit or 0.0,
             hidden_pad=getattr(layer, "hidden_pad", 0),
             intermediate_pad=getattr(layer, "intermediate_pad", 0),
+            fused_moe_kwargs=fused_moe_kwargs,
         )
 
 

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -38,12 +38,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_is_shuffle_moe_mxfp4 = is_gfx95_supported()
-
 __all__ = ["QuarkW4A4MXFp4MoE"]
 
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_is_gfx95 = is_gfx95_supported()
+_is_shuffle_moe_mxfp4 = _use_aiter and _is_gfx95
 if _use_aiter:
     from aiter.ops.shuffle import moe_shuffle_scale, moe_shuffle_weight, shuffle_weight
     from aiter.utility.fp4_utils import e8m0_shuffle
@@ -203,6 +203,8 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             is_concat=True,
             is_packed=True,
         )
+        layer.hidden_pad = 0
+        layer.intermediate_pad = w13_up_dim // 2 - intermediate_size_per_partition
 
         # Add the quantization method used (per tensor/grouped/channel)
         # to ensure the weight scales are loaded in properly
@@ -821,6 +823,11 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         layer.w2_weight = torch.nn.Parameter(qw2_weight, requires_grad=False)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not getattr(self, "_owns_moe_runner", False):
+            raise RuntimeError(
+                "Quark MXFP4 weight preshuffling requires an owned AITER runner."
+            )
+
         if (
             not self.is_checkpoint_mxfp4_serialized
             or self.dequantization_config is not None
@@ -891,15 +898,19 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         )
 
         self.moe_runner_config = moe_runner_config
+        self._owns_moe_runner = False
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto() and get_moe_a2a_backend().supports_aiter():
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            self._owns_moe_runner = True
         else:
-            # TODO(cwan): refactor other backends
-            pass
+            raise NotImplementedError(
+                "Quark MXFP4 MoE currently requires the AITER runner; "
+                f"got {moe_runner_backend.value!r}."
+            )
 
     def apply_weights(
         self,
@@ -926,6 +937,12 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             from aiter.ops.flydsl.moe_common import GateMode
 
             _fused_moe_kwargs = {"gate_mode": GateMode.INTERLEAVE.value}
+        elif _is_gfx95:
+            from aiter.ops.flydsl.moe_common import GateMode
+
+            # Quark checkpoints store gate and up projections as separate
+            # contiguous row ranges. Keep that ordering for correctness.
+            _fused_moe_kwargs = {"gate_mode": GateMode.SEPARATED.value}
         else:
             _fused_moe_kwargs = None
 
@@ -936,6 +953,9 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             expert_mask=layer.dispatcher.expert_mask_gpu,
+            hidden_pad=getattr(layer, "hidden_pad", 0),
+            intermediate_pad=getattr(layer, "intermediate_pad", 0),
+            swiglu_limit=self.moe_runner_config.swiglu_limit or 0.0,
             fused_moe_kwargs=_fused_moe_kwargs,
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/test/manual/test_glm53_flash_moe_checkpoint.py
+++ b/test/manual/test_glm53_flash_moe_checkpoint.py
@@ -1,0 +1,527 @@
+"""Checkpoint-driven MoE validation for GLM-5.3-Flash.
+
+This test loads selected expert tensors, never the model. Set:
+
+  GLM53_FLASH_FP8_PATH=/path/to/zai-org/GLM-5.3-Flash
+  GLM53_FLASH_MXFP4_PATH=/path/to/GLM-5.3-Flash-Quark-MXFP4-AttnFP8
+"""
+
+import json
+import os
+import re
+import struct
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+from aiter.ops.flydsl.moe_common import GateMode
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.triton.quant import dynamic_mxfp4_quant
+from aiter.utility.fp4_utils import e8m0_shuffle
+from safetensors import safe_open
+
+from sglang.kernels.ops.layernorm import mhc
+from sglang.srt.layers.moe.moe_runner.aiter import (
+    AiterMoeQuantInfo,
+    AiterQuantType,
+    AiterRunnerCore,
+    AiterRunnerInput,
+)
+from sglang.srt.layers.quantization.fp8_utils import dequant_mxfp4
+from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestGLM53FlashMoECheckpoint(CustomTestCase):
+    hidden_size = 4096
+    intermediate_size = 2048
+    num_experts = 288
+    swiglu_limit = 10.0
+    target = re.compile(
+        r"^model\.language_model\.layers\.(?:[3-9]|[1-3][0-9]|4[0-4])"
+        r"\.mlp\.experts\.\d+\.(?:gate_proj|up_proj|down_proj)\.weight$"
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        source = os.environ.get("GLM53_FLASH_FP8_PATH")
+        quantized = os.environ.get("GLM53_FLASH_MXFP4_PATH")
+        if not source or not quantized:
+            raise unittest.SkipTest(
+                "set GLM53_FLASH_FP8_PATH and GLM53_FLASH_MXFP4_PATH"
+            )
+        cls.source = Path(source)
+        cls.quantized = Path(quantized)
+        cls.source_map, cls.source_headers = cls._read_headers(cls.source)
+        cls.quantized_map, cls.quantized_headers = cls._read_headers(cls.quantized)
+        config = json.loads((cls.quantized / "config.json").read_text())
+        text_config = config.get("text_config", config)
+        cls.rms_eps = text_config["rms_norm_eps"]
+        cls.hc_eps = text_config["hc_eps"]
+        cls.sinkhorn_iters = text_config["hc_sinkhorn_iters"]
+        cls.runner = AiterRunnerCore(
+            SimpleNamespace(
+                no_combine=False,
+                activation="silu",
+                gemm1_alpha=None,
+                gemm1_clamp_limit=None,
+            )
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "runner"):
+            del cls.runner
+        torch.cuda.empty_cache()
+        super().tearDownClass()
+
+    @staticmethod
+    def _read_headers(root):
+        weight_map = json.loads((root / "model.safetensors.index.json").read_text())[
+            "weight_map"
+        ]
+        headers = {}
+        for filename in sorted(set(weight_map.values())):
+            with (root / filename).open("rb") as stream:
+                size = struct.unpack("<Q", stream.read(8))[0]
+                header = json.loads(stream.read(size))
+            header.pop("__metadata__", None)
+            headers.update(header)
+        return weight_map, headers
+
+    @staticmethod
+    def _load(root, weight_map, name, device="cuda"):
+        with safe_open(root / weight_map[name], framework="pt", device=device) as shard:
+            return shard.get_tensor(name)
+
+    @classmethod
+    def _expert_names(cls, layer, expert):
+        base = f"model.language_model.layers.{layer}.mlp.experts.{expert}"
+        return {
+            projection: (
+                f"{base}.{projection}.weight",
+                f"{base}.{projection}.weight_scale",
+            )
+            for projection in ("gate_proj", "up_proj", "down_proj")
+        }
+
+    @classmethod
+    def _load_expert_bank(cls, layer, experts):
+        weights = {"gate_proj": [], "up_proj": [], "down_proj": []}
+        scales = {"gate_proj": [], "up_proj": [], "down_proj": []}
+        for expert in experts:
+            for projection, (weight_name, scale_name) in cls._expert_names(
+                layer, expert
+            ).items():
+                weights[projection].append(
+                    cls._load(cls.quantized, cls.quantized_map, weight_name)
+                )
+                scales[projection].append(
+                    cls._load(cls.quantized, cls.quantized_map, scale_name)
+                )
+
+        w13_raw = torch.cat(
+            [
+                torch.stack(weights["gate_proj"]),
+                torch.stack(weights["up_proj"]),
+            ],
+            dim=1,
+        )
+        s13_raw = torch.cat(
+            [
+                torch.stack(scales["gate_proj"]),
+                torch.stack(scales["up_proj"]),
+            ],
+            dim=1,
+        )
+        w2_raw = torch.stack(weights["down_proj"])
+        s2_raw = torch.stack(scales["down_proj"])
+        return {
+            "w13_raw": w13_raw,
+            "s13_raw": s13_raw,
+            "w2_raw": w2_raw,
+            "s2_raw": s2_raw,
+            "w13": shuffle_weight(w13_raw.contiguous(), (16, 16)),
+            "w2": shuffle_weight(w2_raw.contiguous(), (16, 16)),
+            "s13": e8m0_shuffle(s13_raw.view(-1, s13_raw.shape[-1])).view_as(s13_raw),
+            "s2": e8m0_shuffle(s2_raw.view(-1, s2_raw.shape[-1])).view_as(s2_raw),
+        }
+
+    @classmethod
+    def _dequant(cls, weight, scale):
+        experts, rows, packed = weight.shape
+        blocks = packed // 16
+        return dequant_mxfp4(
+            weight.view(experts, rows, blocks, 16),
+            scale,
+            torch.bfloat16,
+        )
+
+    @classmethod
+    def _quant_dequant_activation(cls, activation):
+        quantized, scale = dynamic_mxfp4_quant(activation)
+        tokens, packed = quantized.shape
+        blocks = packed // 16
+        return dequant_mxfp4(
+            quantized.view(1, tokens, blocks, 16),
+            scale.view(1, tokens, blocks),
+            torch.bfloat16,
+        ).squeeze(0)
+
+    @classmethod
+    def _torch_routed(cls, hidden, ids, weights, bank):
+        w13 = cls._dequant(bank["w13_raw"], bank["s13_raw"])
+        w2 = cls._dequant(bank["w2_raw"], bank["s2_raw"])
+        hidden = cls._quant_dequant_activation(hidden)
+        output = torch.zeros_like(hidden)
+        for token in range(hidden.shape[0]):
+            for route in range(ids.shape[1]):
+                expert = int(ids[token, route])
+                gate = F.linear(
+                    hidden[token].float(),
+                    w13[expert, : cls.intermediate_size].float(),
+                ).clamp(max=cls.swiglu_limit)
+                up = F.linear(
+                    hidden[token].float(),
+                    w13[expert, cls.intermediate_size :].float(),
+                ).clamp(-cls.swiglu_limit, cls.swiglu_limit)
+                activated = cls._quant_dequant_activation(
+                    (F.silu(gate) * up).unsqueeze(0).bfloat16()
+                ).squeeze(0)
+                expert_output = F.linear(activated.float(), w2[expert].float())
+                output[token] += (expert_output * weights[token, route]).to(
+                    output.dtype
+                )
+        return output
+
+    @classmethod
+    def _aiter_routed(cls, hidden, ids, weights, bank):
+        w13 = bank["w13"].view(torch.float4_e2m1fn_x2)
+        w2 = bank["w2"].view(torch.float4_e2m1fn_x2)
+        w13.is_shuffled = True
+        w2.is_shuffled = True
+        quant_info = AiterMoeQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            quant_type=AiterQuantType.PER_1X32,
+            w13_scale=bank["s13"],
+            w2_scale=bank["s2"],
+            swiglu_limit=cls.swiglu_limit,
+            fused_moe_kwargs={"gate_mode": GateMode.SEPARATED.value},
+        )
+        runner_input = AiterRunnerInput(
+            hidden_states=hidden,
+            topk_ids=ids.to(torch.int32),
+            topk_weights=weights.to(torch.float32),
+            quant_type=AiterQuantType.PER_1X32,
+        )
+        return cls.runner.run(runner_input, quant_info, {}).hidden_states
+
+    @staticmethod
+    def _assert_numerics(actual, expected):
+        actual_float = actual.float()
+        expected_float = expected.float()
+        cosine = F.cosine_similarity(
+            actual_float.flatten().unsqueeze(0),
+            expected_float.flatten().unsqueeze(0),
+        ).item()
+        relative_l2 = (
+            torch.linalg.vector_norm(actual_float - expected_float)
+            / torch.linalg.vector_norm(expected_float).clamp(min=1e-12)
+        ).item()
+        if cosine <= 0.98 or relative_l2 >= 0.20:
+            raise AssertionError(
+                f"MoE mismatch: cosine={cosine:.6f}, relative_l2={relative_l2:.6f}"
+            )
+        if not torch.isfinite(actual).all():
+            raise AssertionError("MoE output contains non-finite values")
+
+    def test_checkpoint_precision_boundary_and_shapes(self):
+        targets = {
+            name
+            for name, metadata in self.quantized_headers.items()
+            if self.target.fullmatch(name) and metadata["dtype"] == "U8"
+        }
+        self.assertEqual(len(targets), 42 * self.num_experts * 3)
+
+        for name in targets:
+            metadata = self.quantized_headers[name]
+            scale = self.quantized_headers[f"{name}_scale"]
+            projection = name.rsplit(".", 2)[-2]
+            if projection in ("gate_proj", "up_proj"):
+                self.assertEqual(metadata["shape"], [2048, 2048])
+                self.assertEqual(scale["shape"], [2048, 128])
+            else:
+                self.assertEqual(metadata["shape"], [4096, 1024])
+                self.assertEqual(scale["shape"], [4096, 64])
+            self.assertEqual(scale["dtype"], "U8")
+
+        shared_targets = [
+            name
+            for name, metadata in self.quantized_headers.items()
+            if ".mlp.shared_experts." in name
+            and not ".layers.45." in name
+            and name.endswith(".weight")
+            and metadata["dtype"] == "U8"
+        ]
+        self.assertEqual(len(shared_targets), 42 * 3)
+        for name in shared_targets:
+            self.assertEqual(
+                self.quantized_headers[f"{name}_scale"]["dtype"], "U8"
+            )
+
+        preserved_mtp = [
+            name
+            for name, metadata in self.quantized_headers.items()
+            if ".layers.45.mlp." in name
+            and (
+                ".experts." in name or ".shared_experts." in name
+            )
+            and name.endswith(".weight")
+            and metadata["dtype"] == "F8_E4M3"
+        ]
+        self.assertEqual(
+            len(preserved_mtp), (self.num_experts + 1) * 3
+        )
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+        "requires one gfx950 GPU",
+    )
+    def test_real_experts_match_dequantized_oracle(self):
+        for layer in (3, 4, 11, 22, 43, 44):
+            for expert in (0, 143, 287):
+                with self.subTest(layer=layer, expert=expert):
+                    bank = self._load_expert_bank(layer, [expert])
+                    generator = torch.Generator(device="cuda")
+                    generator.manual_seed(layer * 1000 + expert)
+                    hidden = (
+                        torch.randn(
+                            4,
+                            self.hidden_size,
+                            generator=generator,
+                            device="cuda",
+                            dtype=torch.bfloat16,
+                        )
+                        * 0.5
+                    )
+                    ids = torch.zeros((4, 1), device="cuda", dtype=torch.int64)
+                    weights = torch.ones((4, 1), device="cuda", dtype=torch.float32)
+                    expected = self._torch_routed(hidden, ids, weights, bank)
+                    actual = self._aiter_routed(hidden, ids, weights, bank)
+                    self._assert_numerics(actual, expected)
+                    del bank
+
+    @classmethod
+    def _load_shared_mxfp4(cls, layer):
+        base = f"model.language_model.layers.{layer}.mlp.shared_experts"
+        tensors = {}
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            weight_name = f"{base}.{projection}.weight"
+            scale_name = f"{base}.{projection}.weight_scale"
+            weight = cls._load(cls.quantized, cls.quantized_map, weight_name)
+            scale = cls._load(cls.quantized, cls.quantized_map, scale_name)
+            rows, packed = weight.shape
+            blocks = packed // 16
+            tensors[projection] = cls._dequant(
+                weight.view(1, rows, packed),
+                scale.view(1, rows, blocks),
+            ).squeeze(0)
+        return tensors
+
+    @classmethod
+    def _shared_output(cls, hidden, shared):
+        gate = F.linear(hidden.float(), shared["gate_proj"].float()).clamp(
+            max=cls.swiglu_limit
+        )
+        up = F.linear(hidden.float(), shared["up_proj"].float()).clamp(
+            -cls.swiglu_limit, cls.swiglu_limit
+        )
+        return F.linear(
+            F.silu(gate) * up, shared["down_proj"].float()
+        ).bfloat16()
+
+    @classmethod
+    def _load_ffn_mhc(cls, layer):
+        base = f"model.language_model.layers.{layer}"
+        fn = cls._load(cls.quantized, cls.quantized_map, f"{base}.hc_ffn_fn").float()
+        scale = cls._load(
+            cls.quantized, cls.quantized_map, f"{base}.hc_ffn_scale"
+        ).float()
+        bias = cls._load(
+            cls.quantized, cls.quantized_map, f"{base}.hc_ffn_base"
+        ).float()
+        norm = cls._load(
+            cls.quantized,
+            cls.quantized_map,
+            f"{base}.post_attention_layernorm.weight",
+        ).bfloat16()
+        return fn, scale, bias, norm
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+        "requires one gfx950 GPU",
+    )
+    def test_real_top8_plus_shared_output_contract(self):
+        layer = 11
+        bank = self._load_expert_bank(layer, list(range(8)))
+        hidden = (
+            torch.randn(2, self.hidden_size, device="cuda", dtype=torch.bfloat16) * 0.5
+        )
+        ids = torch.arange(8, device="cuda", dtype=torch.int64).repeat(2, 1)
+        weights = torch.rand(2, 8, device="cuda", dtype=torch.float32)
+        weights /= weights.sum(dim=-1, keepdim=True)
+        routed_ref = self._torch_routed(hidden, ids, weights, bank)
+        routed = self._aiter_routed(hidden, ids, weights, bank)
+        self._assert_numerics(routed, routed_ref)
+
+        shared = self._load_shared_mxfp4(layer)
+        shared_output = self._shared_output(hidden, shared)
+        combined = (routed + shared_output).bfloat16()
+        combined_ref = (routed_ref + shared_output).bfloat16()
+        self.assertEqual(combined.shape, (2, self.hidden_size))
+        self.assertEqual(combined.dtype, torch.bfloat16)
+        self._assert_numerics(combined, combined_ref)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+        "requires one gfx950 GPU",
+    )
+    def test_real_mhc_moe_mhc_joint_flow(self):
+        for layer in (3, 4, 43, 44):
+            with self.subTest(layer=layer):
+                fn, scale, bias, norm = self._load_ffn_mhc(layer)
+                bank = self._load_expert_bank(layer, list(range(8)))
+                shared = self._load_shared_mxfp4(layer)
+                generator = torch.Generator(device="cuda")
+                generator.manual_seed(5000 + layer)
+                residual = (
+                    torch.randn(
+                        2,
+                        4,
+                        self.hidden_size,
+                        generator=generator,
+                        device="cuda",
+                        dtype=torch.bfloat16,
+                    )
+                    * 0.1
+                )
+                residual_flat = residual.reshape(2, 4 * self.hidden_size)
+
+                post_ref, comb_ref, moe_input_ref = mhc._mhc_pre_torch(
+                    residual,
+                    fn,
+                    scale,
+                    bias,
+                    self.rms_eps,
+                    self.hc_eps,
+                    self.hc_eps,
+                    2.0,
+                    self.sinkhorn_iters,
+                )
+                moe_input_ref = (
+                    moe_input_ref.float()
+                    * torch.rsqrt(
+                        moe_input_ref.float().square().mean(dim=-1, keepdim=True)
+                        + self.rms_eps
+                    )
+                    * norm.float()
+                ).bfloat16()
+
+                moe_input, h_res, h_post, norm_fused = mhc.hc_pre(
+                    residual_flat,
+                    fn,
+                    scale,
+                    bias,
+                    hc_mult=4,
+                    rms_eps=self.rms_eps,
+                    hc_eps=self.hc_eps,
+                    sinkhorn_iters=self.sinkhorn_iters,
+                    out_norm_weight=norm,
+                    out_norm_eps=self.rms_eps,
+                )
+                if not norm_fused:
+                    moe_input = (
+                        moe_input.float()
+                        * torch.rsqrt(
+                            moe_input.float().square().mean(
+                                dim=-1, keepdim=True
+                            )
+                            + self.rms_eps
+                        )
+                        * norm.float()
+                    ).bfloat16()
+                torch.testing.assert_close(
+                    moe_input, moe_input_ref, atol=2e-2, rtol=2e-2
+                )
+
+                ids = torch.arange(8, device="cuda", dtype=torch.int64).repeat(2, 1)
+                weights = torch.rand(
+                    2,
+                    8,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.float32,
+                )
+                weights /= weights.sum(dim=-1, keepdim=True)
+                routed_ref = self._torch_routed(moe_input_ref, ids, weights, bank)
+                routed = self._aiter_routed(moe_input, ids, weights, bank)
+                shared_ref = self._shared_output(moe_input_ref, shared)
+                shared_actual = self._shared_output(moe_input, shared)
+                moe_output_ref = (routed_ref + shared_ref).bfloat16()
+                moe_output = (routed + shared_actual).bfloat16()
+                self._assert_numerics(moe_output, moe_output_ref)
+
+                joint_ref = mhc._mhc_post_torch(
+                    moe_output_ref, residual, post_ref, comb_ref
+                ).reshape(2, 4 * self.hidden_size)
+                joint = mhc.hc_post(
+                    moe_output,
+                    residual_flat,
+                    h_post,
+                    h_res,
+                    hc_mult=4,
+                )
+                self.assertEqual(joint.shape, residual_flat.shape)
+                self.assertEqual(joint.dtype, torch.bfloat16)
+                self._assert_numerics(joint, joint_ref)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+        "requires one gfx950 GPU",
+    )
+    def test_mhc_moe_mhc_zero_token_contract(self):
+        fn, scale, bias, norm = self._load_ffn_mhc(3)
+        bank = self._load_expert_bank(3, [0])
+        residual = torch.empty(
+            0, 4 * self.hidden_size, device="cuda", dtype=torch.bfloat16
+        )
+        moe_input, h_res, h_post, norm_fused = mhc.hc_pre(
+            residual,
+            fn,
+            scale,
+            bias,
+            hc_mult=4,
+            rms_eps=self.rms_eps,
+            hc_eps=self.hc_eps,
+            sinkhorn_iters=self.sinkhorn_iters,
+            out_norm_weight=norm,
+            out_norm_eps=self.rms_eps,
+        )
+        self.assertFalse(norm_fused)
+        moe_output = self._aiter_routed(
+            moe_input,
+            torch.empty((0, 1), device="cuda", dtype=torch.int64),
+            torch.empty((0, 1), device="cuda", dtype=torch.float32),
+            bank,
+        )
+        joint = mhc.hc_post(moe_output, residual, h_post, h_res, hc_mult=4)
+        self.assertEqual(joint.shape, (0, 4 * self.hidden_size))
+        self.assertEqual(joint.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/manual/test_glm53_flash_moe_checkpoint.py
+++ b/test/manual/test_glm53_flash_moe_checkpoint.py
@@ -151,6 +151,59 @@ class TestGLM53FlashMoECheckpoint(CustomTestCase):
         }
 
     @classmethod
+    def _load_fp8_expert_bank(cls, layer, expert, shared=False):
+        if shared:
+            base = f"model.language_model.layers.{layer}.mlp.shared_experts"
+        else:
+            base = f"model.language_model.layers.{layer}.mlp.experts.{expert}"
+        tensors = {}
+        scales = {}
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            tensors[projection] = cls._load(
+                cls.source,
+                cls.source_map,
+                f"{base}.{projection}.weight",
+            )
+            scales[projection] = cls._load(
+                cls.source,
+                cls.source_map,
+                f"{base}.{projection}.weight_scale_inv",
+            )
+        w13 = torch.cat([tensors["gate_proj"], tensors["up_proj"]], dim=0).unsqueeze(0)
+        s13 = torch.cat([scales["gate_proj"], scales["up_proj"]], dim=0).unsqueeze(0)
+        return {
+            "w13": shuffle_weight(w13.contiguous(), (16, 16)),
+            "w2": shuffle_weight(
+                tensors["down_proj"].unsqueeze(0).contiguous(), (16, 16)
+            ),
+            "s13": s13,
+            "s2": scales["down_proj"].unsqueeze(0),
+            "gate": tensors["gate_proj"].float()
+            * scales["gate_proj"]
+            .repeat_interleave(128, dim=0)
+            .repeat_interleave(128, dim=1)
+            .float(),
+            "up": tensors["up_proj"].float()
+            * scales["up_proj"]
+            .repeat_interleave(128, dim=0)
+            .repeat_interleave(128, dim=1)
+            .float(),
+            "down": tensors["down_proj"].float()
+            * scales["down_proj"]
+            .repeat_interleave(128, dim=0)
+            .repeat_interleave(128, dim=1)
+            .float(),
+        }
+
+    @staticmethod
+    def _quant_dequant_fp8_activation(activation):
+        tokens, width = activation.shape
+        groups = activation.float().view(tokens, width // 128, 128)
+        scale = groups.abs().amax(dim=-1).clamp(min=1e-12) / 448.0
+        quantized = (groups / scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+        return (quantized.float() * scale.unsqueeze(-1)).reshape(tokens, width)
+
+    @classmethod
     def _dequant(cls, weight, scale):
         experts, rows, packed = weight.shape
         blocks = packed // 16
@@ -280,6 +333,61 @@ class TestGLM53FlashMoECheckpoint(CustomTestCase):
             and metadata["dtype"] == "F8_E4M3"
         ]
         self.assertEqual(len(preserved_mtp), (self.num_experts + 1) * 3)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+        "requires one gfx950 GPU",
+    )
+    def test_source_block_fp8_routed_shared_and_mtp_experts(self):
+        cases = (
+            (3, 0, False),
+            (43, 287, False),
+            (3, 0, True),
+            (45, 0, False),
+            (45, 0, True),
+        )
+        for layer, expert, shared in cases:
+            with self.subTest(layer=layer, expert=expert, shared=shared):
+                bank = self._load_fp8_expert_bank(layer, expert, shared=shared)
+                generator = torch.Generator(device="cuda")
+                generator.manual_seed(layer * 1000 + expert + int(shared))
+                hidden = (
+                    torch.randn(
+                        2,
+                        self.hidden_size,
+                        generator=generator,
+                        device="cuda",
+                        dtype=torch.bfloat16,
+                    )
+                    * 0.5
+                )
+                hidden_qdq = self._quant_dequant_fp8_activation(hidden)
+                gate = F.linear(hidden_qdq, bank["gate"]).clamp(max=self.swiglu_limit)
+                up = F.linear(hidden_qdq, bank["up"]).clamp(
+                    -self.swiglu_limit, self.swiglu_limit
+                )
+                activated = self._quant_dequant_fp8_activation(
+                    (F.silu(gate) * up).bfloat16()
+                )
+                expected = F.linear(activated, bank["down"]).bfloat16()
+
+                quant_info = AiterMoeQuantInfo(
+                    w13_weight=bank["w13"],
+                    w2_weight=bank["w2"],
+                    quant_type=AiterQuantType.PER_128X128,
+                    w13_scale=bank["s13"],
+                    w2_scale=bank["s2"],
+                    swiglu_limit=self.swiglu_limit,
+                    fused_moe_kwargs={"gate_mode": GateMode.SEPARATED.value},
+                )
+                runner_input = AiterRunnerInput(
+                    hidden_states=hidden,
+                    topk_ids=torch.zeros((2, 1), device="cuda", dtype=torch.int32),
+                    topk_weights=torch.ones((2, 1), device="cuda", dtype=torch.float32),
+                    quant_type=AiterQuantType.PER_128X128,
+                )
+                actual = self.runner.run(runner_input, quant_info, {}).hidden_states
+                self._assert_numerics(actual, expected)
 
     @unittest.skipUnless(
         torch.cuda.is_available() and is_hip() and is_gfx95_supported(),

--- a/test/manual/test_glm53_flash_moe_checkpoint.py
+++ b/test/manual/test_glm53_flash_moe_checkpoint.py
@@ -269,23 +269,17 @@ class TestGLM53FlashMoECheckpoint(CustomTestCase):
         ]
         self.assertEqual(len(shared_targets), 42 * 3)
         for name in shared_targets:
-            self.assertEqual(
-                self.quantized_headers[f"{name}_scale"]["dtype"], "U8"
-            )
+            self.assertEqual(self.quantized_headers[f"{name}_scale"]["dtype"], "U8")
 
         preserved_mtp = [
             name
             for name, metadata in self.quantized_headers.items()
             if ".layers.45.mlp." in name
-            and (
-                ".experts." in name or ".shared_experts." in name
-            )
+            and (".experts." in name or ".shared_experts." in name)
             and name.endswith(".weight")
             and metadata["dtype"] == "F8_E4M3"
         ]
-        self.assertEqual(
-            len(preserved_mtp), (self.num_experts + 1) * 3
-        )
+        self.assertEqual(len(preserved_mtp), (self.num_experts + 1) * 3)
 
     @unittest.skipUnless(
         torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
@@ -340,9 +334,7 @@ class TestGLM53FlashMoECheckpoint(CustomTestCase):
         up = F.linear(hidden.float(), shared["up_proj"].float()).clamp(
             -cls.swiglu_limit, cls.swiglu_limit
         )
-        return F.linear(
-            F.silu(gate) * up, shared["down_proj"].float()
-        ).bfloat16()
+        return F.linear(F.silu(gate) * up, shared["down_proj"].float()).bfloat16()
 
     @classmethod
     def _load_ffn_mhc(cls, layer):
@@ -447,9 +439,7 @@ class TestGLM53FlashMoECheckpoint(CustomTestCase):
                     moe_input = (
                         moe_input.float()
                         * torch.rsqrt(
-                            moe_input.float().square().mean(
-                                dim=-1, keepdim=True
-                            )
+                            moe_input.float().square().mean(dim=-1, keepdim=True)
                             + self.rms_eps
                         )
                         * norm.float()

--- a/test/registered/kernels/ops/moe/test_glm53_flash_quark_moe_mi35x.py
+++ b/test/registered/kernels/ops/moe/test_glm53_flash_quark_moe_mi35x.py
@@ -120,6 +120,33 @@ class TestGLM53FlashQuarkMoE(CustomTestCase):
             "s2": e8m0_shuffle(s2.view(-1, s2.shape[-1])).view_as(s2),
         }
 
+    @staticmethod
+    def _quantize_fp8_weight(weight):
+        rows, width = weight.shape
+        blocks = (
+            weight.float().view(rows // 128, 128, width // 128, 128).permute(0, 2, 1, 3)
+        )
+        scale = blocks.abs().amax(dim=(2, 3)).clamp(min=1e-12) / 448.0
+        quantized = (blocks / scale[:, :, None, None]).to(torch.float8_e4m3fn)
+        return (
+            quantized.permute(0, 2, 1, 3).reshape(rows, width),
+            scale,
+        )
+
+    @staticmethod
+    def _dequantize_fp8_weight(weight, scale):
+        return weight.float() * scale.repeat_interleave(128, dim=0).repeat_interleave(
+            128, dim=1
+        )
+
+    @staticmethod
+    def _quant_dequant_fp8_activation(activation):
+        tokens, width = activation.shape
+        groups = activation.float().view(tokens, width // 128, 128)
+        scale = groups.abs().amax(dim=-1).clamp(min=1e-12) / 448.0
+        quantized = (groups / scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+        return (quantized.float() * scale.unsqueeze(-1)).reshape(tokens, width)
+
     @classmethod
     def tearDownClass(cls):
         if hasattr(cls, "weights"):
@@ -276,6 +303,94 @@ class TestGLM53FlashQuarkMoE(CustomTestCase):
         expected = self._torch_oracle(hidden, ids, weights)
         actual = self._aiter(hidden, ids, weights)
         self._assert_numerics(actual, expected)
+
+    def test_plain_block_fp8_matches_separated_oracle(self):
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(1234)
+        gate = (
+            torch.randn(
+                self.intermediate_size,
+                self.hidden_size,
+                generator=generator,
+                device="cuda",
+                dtype=torch.bfloat16,
+            )
+            * 0.05
+        )
+        up = (
+            torch.randn(
+                self.intermediate_size,
+                self.hidden_size,
+                generator=generator,
+                device="cuda",
+                dtype=torch.bfloat16,
+            )
+            * 0.05
+        )
+        down = (
+            torch.randn(
+                self.hidden_size,
+                self.intermediate_size,
+                generator=generator,
+                device="cuda",
+                dtype=torch.bfloat16,
+            )
+            * 0.01
+        )
+        gate_q, gate_s = self._quantize_fp8_weight(gate)
+        up_q, up_s = self._quantize_fp8_weight(up)
+        down_q, down_s = self._quantize_fp8_weight(down)
+        w13_raw = torch.cat([gate_q, up_q], dim=0).unsqueeze(0)
+        w13_scale = torch.cat([gate_s, up_s], dim=0).unsqueeze(0)
+        w2_raw = down_q.unsqueeze(0)
+        w2_scale = down_s.unsqueeze(0)
+        w13 = shuffle_weight(w13_raw.contiguous(), (16, 16))
+        w2 = shuffle_weight(w2_raw.contiguous(), (16, 16))
+        quant_info = AiterMoeQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            quant_type=AiterQuantType.PER_128X128,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            swiglu_limit=self.swiglu_limit,
+            fused_moe_kwargs={"gate_mode": GateMode.SEPARATED.value},
+        )
+
+        gate_deq = self._dequantize_fp8_weight(gate_q, gate_s)
+        up_deq = self._dequantize_fp8_weight(up_q, up_s)
+        down_deq = self._dequantize_fp8_weight(down_q, down_s)
+        for tokens in (1, 8, 32):
+            with self.subTest(tokens=tokens):
+                hidden = (
+                    torch.randn(
+                        tokens,
+                        self.hidden_size,
+                        generator=generator,
+                        device="cuda",
+                        dtype=torch.bfloat16,
+                    )
+                    * 0.5
+                )
+                hidden_qdq = self._quant_dequant_fp8_activation(hidden)
+                gate_out = F.linear(hidden_qdq, gate_deq).clamp(max=self.swiglu_limit)
+                up_out = F.linear(hidden_qdq, up_deq).clamp(
+                    -self.swiglu_limit, self.swiglu_limit
+                )
+                activated = self._quant_dequant_fp8_activation(
+                    (F.silu(gate_out) * up_out).bfloat16()
+                )
+                expected = F.linear(activated, down_deq).bfloat16()
+
+                runner_input = AiterRunnerInput(
+                    hidden_states=hidden,
+                    topk_ids=torch.zeros((tokens, 1), device="cuda", dtype=torch.int32),
+                    topk_weights=torch.ones(
+                        (tokens, 1), device="cuda", dtype=torch.float32
+                    ),
+                    quant_type=AiterQuantType.PER_128X128,
+                )
+                actual = self.runner.run(runner_input, quant_info, {}).hidden_states
+                self._assert_numerics(actual, expected, max_abs=0.75)
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/moe/test_glm53_flash_quark_moe_mi35x.py
+++ b/test/registered/kernels/ops/moe/test_glm53_flash_quark_moe_mi35x.py
@@ -1,0 +1,282 @@
+"""Isolated gfx950 numerical tests for GLM-5.3-Flash Quark MoE."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+from aiter.ops.flydsl.moe_common import GateMode
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.triton.quant import dynamic_mxfp4_quant
+from aiter.utility.fp4_utils import e8m0_shuffle
+
+from sglang.srt.layers.moe.moe_runner.aiter import (
+    AiterMoeQuantInfo,
+    AiterQuantType,
+    AiterRunnerCore,
+    AiterRunnerInput,
+)
+from sglang.srt.layers.quantization.fp8_utils import dequant_mxfp4
+from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=180, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and is_hip() and is_gfx95_supported(),
+    "requires one gfx950 GPU",
+)
+class TestGLM53FlashQuarkMoE(CustomTestCase):
+    hidden_size = 4096
+    intermediate_size = 2048
+    num_experts = 9
+    swiglu_limit = 10.0
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        torch.manual_seed(7)
+        cls.weights = cls._make_mxfp4_bank()
+        cls.weights["w13_deq"] = cls._dequant(
+            cls.weights["w13_raw"], cls.weights["s13_raw"]
+        )
+        cls.weights["w2_deq"] = cls._dequant(
+            cls.weights["w2_raw"], cls.weights["s2_raw"]
+        )
+        cls.runner = AiterRunnerCore(
+            SimpleNamespace(
+                no_combine=False,
+                activation="silu",
+                gemm1_alpha=None,
+                gemm1_clamp_limit=None,
+            )
+        )
+
+    @classmethod
+    def _make_mxfp4_bank(cls):
+        gate_weights = []
+        up_weights = []
+        down_weights = []
+        gate_scales = []
+        up_scales = []
+        down_scales = []
+        for expert in range(cls.num_experts):
+            generator = torch.Generator(device="cuda")
+            generator.manual_seed(100 + expert)
+            gate = (
+                torch.randn(
+                    cls.intermediate_size,
+                    cls.hidden_size,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                * 0.05
+            )
+            up = (
+                torch.randn(
+                    cls.intermediate_size,
+                    cls.hidden_size,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                * 0.05
+            )
+            down = (
+                torch.randn(
+                    cls.hidden_size,
+                    cls.intermediate_size,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                * 0.01
+            )
+            gate_q, gate_s = dynamic_mxfp4_quant(gate)
+            up_q, up_s = dynamic_mxfp4_quant(up)
+            down_q, down_s = dynamic_mxfp4_quant(down)
+            gate_weights.append(gate_q)
+            up_weights.append(up_q)
+            down_weights.append(down_q)
+            gate_scales.append(gate_s)
+            up_scales.append(up_s)
+            down_scales.append(down_s)
+
+        w13 = torch.cat([torch.stack(gate_weights), torch.stack(up_weights)], dim=1)
+        w2 = torch.stack(down_weights)
+        s13 = torch.cat([torch.stack(gate_scales), torch.stack(up_scales)], dim=1)
+        s2 = torch.stack(down_scales)
+        return {
+            "w13_raw": w13,
+            "w2_raw": w2,
+            "s13_raw": s13,
+            "s2_raw": s2,
+            "w13": shuffle_weight(w13.contiguous(), (16, 16)),
+            "w2": shuffle_weight(w2.contiguous(), (16, 16)),
+            "s13": e8m0_shuffle(s13.view(-1, s13.shape[-1])).view_as(s13),
+            "s2": e8m0_shuffle(s2.view(-1, s2.shape[-1])).view_as(s2),
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "weights"):
+            del cls.weights
+        if hasattr(cls, "runner"):
+            del cls.runner
+        torch.cuda.empty_cache()
+        super().tearDownClass()
+
+    @classmethod
+    def _dequant(cls, weight, scale):
+        experts, rows, packed = weight.shape
+        blocks = packed // 16
+        return dequant_mxfp4(
+            weight.view(experts, rows, blocks, 16),
+            scale,
+            torch.bfloat16,
+        )
+
+    @classmethod
+    def _quant_dequant_activation(cls, activation):
+        quantized, scale = dynamic_mxfp4_quant(activation)
+        tokens, packed = quantized.shape
+        blocks = packed // 16
+        return dequant_mxfp4(
+            quantized.view(1, tokens, blocks, 16),
+            scale.view(1, tokens, blocks),
+            torch.bfloat16,
+        ).squeeze(0)
+
+    @classmethod
+    def _torch_oracle(cls, hidden_states, topk_ids, topk_weights):
+        w13 = cls.weights["w13_deq"]
+        w2 = cls.weights["w2_deq"]
+        output = torch.zeros_like(hidden_states)
+        hidden_qdq = cls._quant_dequant_activation(hidden_states)
+        for token in range(hidden_states.shape[0]):
+            for route in range(topk_ids.shape[1]):
+                expert = int(topk_ids[token, route])
+                gate = F.linear(
+                    hidden_qdq[token].float(),
+                    w13[expert, : cls.intermediate_size].float(),
+                )
+                up = F.linear(
+                    hidden_qdq[token].float(),
+                    w13[expert, cls.intermediate_size :].float(),
+                )
+                gate = gate.clamp(max=cls.swiglu_limit)
+                up = up.clamp(min=-cls.swiglu_limit, max=cls.swiglu_limit)
+                activated = F.silu(gate) * up
+                activated = cls._quant_dequant_activation(
+                    activated.unsqueeze(0).bfloat16()
+                ).squeeze(0)
+                expert_output = F.linear(activated.float(), w2[expert].float())
+                output[token] += (expert_output * topk_weights[token, route]).to(
+                    output.dtype
+                )
+        return output
+
+    @classmethod
+    def _aiter(cls, hidden_states, topk_ids, topk_weights):
+        w13 = cls.weights["w13"].view(torch.float4_e2m1fn_x2)
+        w2 = cls.weights["w2"].view(torch.float4_e2m1fn_x2)
+        w13.is_shuffled = True
+        w2.is_shuffled = True
+        quant_info = AiterMoeQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            quant_type=AiterQuantType.PER_1X32,
+            w13_scale=cls.weights["s13"],
+            w2_scale=cls.weights["s2"],
+            swiglu_limit=cls.swiglu_limit,
+            fused_moe_kwargs={"gate_mode": GateMode.SEPARATED.value},
+        )
+        runner_input = AiterRunnerInput(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids.to(torch.int32),
+            topk_weights=topk_weights.to(torch.float32),
+            quant_type=AiterQuantType.PER_1X32,
+        )
+        return cls.runner.run(runner_input, quant_info, {}).hidden_states
+
+    def _assert_numerics(self, actual, expected, max_abs=None):
+        self.assertTrue(torch.isfinite(actual).all())
+        actual_float = actual.float()
+        expected_float = expected.float()
+        cosine = F.cosine_similarity(
+            actual_float.flatten().unsqueeze(0),
+            expected_float.flatten().unsqueeze(0),
+        ).item()
+        self.assertGreater(cosine, 0.98)
+        relative_l2 = (
+            torch.linalg.vector_norm(actual_float - expected_float)
+            / torch.linalg.vector_norm(expected_float).clamp(min=1e-12)
+        ).item()
+        self.assertLess(relative_l2, 0.20)
+        if max_abs is not None:
+            self.assertLess(
+                (actual_float - expected_float).abs().max().item(),
+                max_abs,
+            )
+
+    def test_top1_and_top8_match_dequantized_oracle(self):
+        for tokens in (1, 8, 17, 32, 64, 128):
+            generator = torch.Generator(device="cuda")
+            generator.manual_seed(tokens)
+            hidden = (
+                torch.randn(
+                    tokens,
+                    self.hidden_size,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                * 0.5
+            )
+            # topk=9 models eight routed experts plus one fused shared slot.
+            for topk in (1, 8, 9):
+                with self.subTest(tokens=tokens, topk=topk):
+                    ids = torch.arange(topk, device="cuda", dtype=torch.int64).repeat(
+                        tokens, 1
+                    )
+                    weights = torch.rand(
+                        tokens,
+                        topk,
+                        generator=generator,
+                        device="cuda",
+                        dtype=torch.float32,
+                    )
+                    if topk > 1:
+                        weights /= weights.sum(dim=-1, keepdim=True)
+                    expected = self._torch_oracle(hidden, ids, weights)
+                    actual = self._aiter(hidden, ids, weights)
+                    repeated = self._aiter(hidden, ids, weights)
+                    self._assert_numerics(actual, expected, max_abs=0.75)
+                    if topk == 1:
+                        torch.testing.assert_close(actual, repeated, atol=0, rtol=0)
+                    else:
+                        # Stage-2 combines top-k routes with atomics; reduction
+                        # order may differ while remaining BF16-equivalent.
+                        torch.testing.assert_close(
+                            actual, repeated, atol=2e-2, rtol=1e-2
+                        )
+
+    def test_clamp_boundary(self):
+        hidden = torch.full(
+            (1, self.hidden_size),
+            4.0,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        ids = torch.tensor([[0]], device="cuda", dtype=torch.int64)
+        weights = torch.ones((1, 1), device="cuda", dtype=torch.float32)
+        expected = self._torch_oracle(hidden, ids, weights)
+        actual = self._aiter(hidden, ids, weights)
+        self._assert_numerics(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
+++ b/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
@@ -1,0 +1,238 @@
+"""Correctness contracts for GLM-5.3-Flash Quark MXFP4 MoE."""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.moe.moe_runner import aiter as aiter_runner
+from sglang.srt.layers.moe.moe_runner.aiter import (
+    AiterMoeQuantInfo,
+    AiterQuantType,
+    AiterRunnerCore,
+    AiterRunnerInput,
+)
+from sglang.srt.layers.quantization.quark.schemes import (
+    quark_w4a4_mxfp4_moe as quark_moe,
+)
+from sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4_moe import (
+    QuarkW4A4MXFp4MoE,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _CapturingRunner:
+    def __init__(self):
+        self.quant_info = None
+
+    def run(self, dispatch_output, quant_info):
+        self.quant_info = quant_info
+        return dispatch_output
+
+
+class TestGLM53FlashQuarkMoE(CustomTestCase):
+    def test_apply_forwards_clamp_separated_layout_and_padding(self):
+        scheme = object.__new__(QuarkW4A4MXFp4MoE)
+        scheme.moe_runner_config = SimpleNamespace(swiglu_limit=10.0)
+        scheme.runner = _CapturingRunner()
+
+        layer = SimpleNamespace(
+            w13_weight=torch.zeros((1, 4, 2), dtype=torch.uint8),
+            w2_weight=torch.zeros((1, 2, 2), dtype=torch.uint8),
+            w13_weight_scale=torch.ones((1, 4, 1), dtype=torch.uint8),
+            w2_weight_scale=torch.ones((1, 2, 1), dtype=torch.uint8),
+            hidden_pad=0,
+            intermediate_pad=128,
+            dispatcher=SimpleNamespace(expert_mask_gpu=torch.tensor([True, False])),
+        )
+        layer.w13_weight.is_shuffled = True
+        gate_mode = SimpleNamespace(
+            SEPARATED=SimpleNamespace(value="separated"),
+            INTERLEAVE=SimpleNamespace(value="interleave"),
+        )
+        fake_moe_common = types.ModuleType("aiter.ops.flydsl.moe_common")
+        fake_moe_common.GateMode = gate_mode
+
+        with (
+            patch.dict(
+                sys.modules,
+                {"aiter.ops.flydsl.moe_common": fake_moe_common},
+            ),
+            patch.object(quark_moe, "_is_gfx95", True),
+            patch.object(quark_moe, "_is_gfx1250", False),
+        ):
+            marker = object()
+            result = scheme.apply_weights(layer, marker)
+
+        self.assertIs(result, marker)
+        quant_info = scheme.runner.quant_info
+        self.assertEqual(quant_info.quant_type, AiterQuantType.PER_1X32)
+        self.assertEqual(quant_info.swiglu_limit, 10.0)
+        self.assertEqual(quant_info.hidden_pad, 0)
+        self.assertEqual(quant_info.intermediate_pad, 128)
+        self.assertEqual(quant_info.fused_moe_kwargs, {"gate_mode": "separated"})
+        self.assertIs(quant_info.expert_mask, layer.dispatcher.expert_mask_gpu)
+        self.assertTrue(quant_info.w13_weight.is_shuffled)
+        self.assertTrue(quant_info.w2_weight.is_shuffled)
+
+    def test_preshuffle_requires_owned_aiter_runner(self):
+        scheme = object.__new__(QuarkW4A4MXFp4MoE)
+        scheme._owns_moe_runner = False
+        scheme.is_checkpoint_mxfp4_serialized = True
+        scheme.dequantization_config = None
+        with self.assertRaisesRegex(RuntimeError, "owned AITER runner"):
+            scheme.process_weights_after_loading(SimpleNamespace())
+
+        scheme._owns_moe_runner = True
+        layer = nn.Module()
+        layer.w13_weight = nn.Parameter(
+            torch.zeros((1, 4, 2), dtype=torch.uint8), requires_grad=False
+        )
+        layer.w2_weight = nn.Parameter(
+            torch.zeros((1, 2, 2), dtype=torch.uint8), requires_grad=False
+        )
+        layer.w13_weight_scale = nn.Parameter(
+            torch.ones((1, 4, 1), dtype=torch.uint8), requires_grad=False
+        )
+        layer.w2_weight_scale = nn.Parameter(
+            torch.ones((1, 2, 1), dtype=torch.uint8), requires_grad=False
+        )
+        layer.dispatcher = SimpleNamespace(set_quant_config=lambda _config: None)
+
+        with (
+            patch.object(quark_moe, "_is_gfx1250", False),
+            patch.object(quark_moe, "_is_shuffle_moe_mxfp4", True),
+            patch.object(quark_moe, "e8m0_shuffle", side_effect=lambda x: x),
+            patch.object(
+                quark_moe, "shuffle_weight", side_effect=lambda x, _layout: x.clone()
+            ) as shuffle,
+        ):
+            scheme.process_weights_after_loading(layer)
+
+        self.assertEqual(shuffle.call_count, 2)
+        self.assertTrue(layer.w13_weight.is_shuffled)
+        self.assertTrue(layer.w2_weight.is_shuffled)
+
+    def test_flash_packed_shapes_for_tp_partitions(self):
+        weight_config = {"qscheme": "per_group"}
+        input_config = {"qscheme": "per_group", "is_dynamic": True}
+        for tp_size in (1, 2, 4, 8):
+            with self.subTest(tp_size=tp_size):
+                scheme = QuarkW4A4MXFp4MoE(
+                    weight_config,
+                    input_config,
+                    is_checkpoint_mxfp4_serialized=True,
+                )
+                layer = nn.Module()
+                intermediate = 2048 // tp_size
+                with patch.object(quark_moe, "_use_aiter", True):
+                    scheme.create_weights(
+                        layer,
+                        num_experts=288,
+                        hidden_size=4096,
+                        intermediate_size_per_partition=intermediate,
+                        params_dtype=torch.bfloat16,
+                        weight_loader=lambda *_args: None,
+                    )
+                self.assertEqual(
+                    tuple(layer.w13_weight.shape),
+                    (288, 2 * intermediate, 2048),
+                )
+                self.assertEqual(
+                    tuple(layer.w2_weight.shape),
+                    (288, 4096, intermediate // 2),
+                )
+                self.assertEqual(
+                    tuple(layer.w13_weight_scale.shape),
+                    (288, 2 * intermediate, 128),
+                )
+                self.assertEqual(
+                    tuple(layer.w2_weight_scale.shape),
+                    (288, 4096, intermediate // 32),
+                )
+                self.assertEqual(layer.hidden_pad, 0)
+                self.assertEqual(layer.intermediate_pad, 0)
+
+    def test_unsupported_runner_fails_during_construction(self):
+        scheme = object.__new__(QuarkW4A4MXFp4MoE)
+        backend = SimpleNamespace(
+            value="triton",
+            is_auto=lambda: False,
+            is_aiter=lambda: False,
+        )
+        with (
+            patch(
+                "sglang.srt.layers.moe.utils.get_moe_runner_backend",
+                return_value=backend,
+            ),
+            self.assertRaisesRegex(NotImplementedError, "requires the AITER"),
+        ):
+            scheme.create_moe_runner(
+                SimpleNamespace(), SimpleNamespace(swiglu_limit=10.0)
+            )
+
+    def test_explicit_gate_mode_is_not_overwritten_by_aiter(self):
+        captured = {}
+
+        def fused_moe(**kwargs):
+            captured.update(kwargs)
+            return kwargs["hidden_states"]
+
+        fake_fused_moe = types.ModuleType("aiter.fused_moe")
+        fake_fused_moe.fused_moe = fused_moe
+        fake_moe_common = types.ModuleType("aiter.ops.flydsl.moe_common")
+        fake_moe_common.GateMode = SimpleNamespace(
+            SEPARATED=SimpleNamespace(value="separated"),
+            INTERLEAVE=SimpleNamespace(value="interleave"),
+        )
+        config = SimpleNamespace(
+            no_combine=False,
+            activation="silu",
+            gemm1_alpha=None,
+            gemm1_clamp_limit=None,
+        )
+        core = AiterRunnerCore(config)
+        hidden = torch.zeros((2, 4), dtype=torch.bfloat16)
+        runner_input = AiterRunnerInput(
+            hidden_states=hidden,
+            topk_ids=torch.zeros((2, 1), dtype=torch.int32),
+            topk_weights=torch.ones((2, 1), dtype=torch.float32),
+            quant_type=AiterQuantType.PER_1X32,
+        )
+        quant_info = AiterMoeQuantInfo(
+            w13_weight=torch.zeros((1, 4, 2), dtype=torch.uint8),
+            w2_weight=torch.zeros((1, 2, 2), dtype=torch.uint8),
+            quant_type=AiterQuantType.PER_1X32,
+            swiglu_limit=10.0,
+            fused_moe_kwargs={"gate_mode": "separated"},
+        )
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "aiter.fused_moe": fake_fused_moe,
+                    "aiter.ops.flydsl.moe_common": fake_moe_common,
+                },
+            ),
+            patch.object(aiter_runner, "_aiter_quant_type", return_value="per_1x32"),
+            patch.object(aiter_runner, "_aiter_activation", return_value="swiglu"),
+        ):
+            output = core.run(runner_input, quant_info, {})
+
+        self.assertIs(output.hidden_states, hidden)
+        self.assertEqual(captured["gate_mode"], "separated")
+        self.assertEqual(captured["swiglu_limit"], 10.0)
+        self.assertEqual(captured["hidden_pad"], 0)
+        self.assertEqual(captured["intermediate_pad"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
+++ b/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
@@ -147,9 +147,14 @@ class TestGLM53FlashQuarkMoE(CustomTestCase):
         with (
             patch.object(quark_moe, "_is_gfx1250", False),
             patch.object(quark_moe, "_is_shuffle_moe_mxfp4", True),
-            patch.object(quark_moe, "e8m0_shuffle", side_effect=lambda x: x),
             patch.object(
-                quark_moe, "shuffle_weight", side_effect=lambda x, _layout: x.clone()
+                quark_moe, "e8m0_shuffle", side_effect=lambda x: x, create=True
+            ),
+            patch.object(
+                quark_moe,
+                "shuffle_weight",
+                side_effect=lambda x, _layout: x.clone(),
+                create=True,
             ) as shuffle,
         ):
             scheme.process_weights_after_loading(layer)

--- a/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
+++ b/test/registered/unit/layers/quantization/test_glm53_flash_quark_moe.py
@@ -16,6 +16,8 @@ from sglang.srt.layers.moe.moe_runner.aiter import (
     AiterRunnerCore,
     AiterRunnerInput,
 )
+from sglang.srt.layers.quantization import fp8 as fp8_module
+from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
 from sglang.srt.layers.quantization.quark.schemes import (
     quark_w4a4_mxfp4_moe as quark_moe,
 )
@@ -38,6 +40,42 @@ class _CapturingRunner:
 
 
 class TestGLM53FlashQuarkMoE(CustomTestCase):
+    def test_block_fp8_forwards_separated_layout_and_clamp(self):
+        method = object.__new__(Fp8MoEMethod)
+        method.block_quant = True
+        method.is_fp4_expert = False
+        method.moe_runner_config = SimpleNamespace(swiglu_limit=10.0)
+        layer = SimpleNamespace(
+            w13_weight=torch.zeros((1, 4, 4), dtype=torch.float8_e4m3fn),
+            w2_weight=torch.zeros((1, 4, 2), dtype=torch.float8_e4m3fn),
+            w13_weight_scale_inv=torch.ones((1, 4, 1), dtype=torch.float32),
+            w2_weight_scale_inv=torch.ones((1, 4, 1), dtype=torch.float32),
+            hidden_pad=0,
+            intermediate_pad=0,
+            _aiter_gate_up_interleaved=False,
+            dispatcher=SimpleNamespace(expert_mask_gpu=torch.tensor([True, False])),
+        )
+        gate_mode = SimpleNamespace(
+            SEPARATED=SimpleNamespace(value="separated"),
+            INTERLEAVE=SimpleNamespace(value="interleave"),
+        )
+        fake_moe_common = types.ModuleType("aiter.ops.flydsl.moe_common")
+        fake_moe_common.GateMode = gate_mode
+        with (
+            patch.dict(
+                sys.modules,
+                {"aiter.ops.flydsl.moe_common": fake_moe_common},
+            ),
+            patch.object(fp8_module, "_use_aiter", True),
+        ):
+            quant_info = method.maybe_get_hip_aiter_quant_info(layer)
+
+        self.assertIsNotNone(quant_info)
+        self.assertEqual(quant_info.quant_type, AiterQuantType.PER_128X128)
+        self.assertEqual(quant_info.swiglu_limit, 10.0)
+        self.assertEqual(quant_info.fused_moe_kwargs, {"gate_mode": "separated"})
+        self.assertIs(quant_info.expert_mask, layer.dispatcher.expert_mask_gpu)
+
     def test_apply_forwards_clamp_separated_layout_and_padding(self):
         scheme = object.__new__(QuarkW4A4MXFp4MoE)
         scheme.moe_runner_config = SimpleNamespace(swiglu_limit=10.0)


### PR DESCRIPTION
## Summary

GLM-5.3-Flash ships two gfx950 MoE checkpoint paths that share one model architecture but use different quantization contracts:

- `zai-org/GLM-5.3-Flash`: routed, shared, and MTP experts use block FP8 `[128,128]` with dynamic FP8 activations.
- `amd/GLM-5.3-Flash-Quark-MXFP4`: routed and shared experts in layers 3-44 use OCP MXFP4 1×32; MTP layer 45 remains block FP8.

Both paths load gate and up projections into separate contiguous halves and require clamped SwiGLU (`swiglu_limit=10.0`). The support branch preshuffles the weights but lets AITER infer gate/up semantics from the global interleave setting. Quark also drops clamp/padding metadata and does not make preshuffle ownership explicit.

| Contract | Before | With this PR |
| --- | --- | --- |
| block-FP8 layout | tile-only preshuffle, no physical layout metadata | records and forwards `GateMode.SEPARATED` |
| Quark MXFP4 layout | global interleave default can override checkpoint ordering | pins separated mode; AITER preserves explicit quant-method mode |
| SwiGLU | FP8 forwards the limit; Quark omits it | both forward `swiglu_limit=10.0` |
| preshuffle | Quark can preshuffle without owning the selected runner | requires an owned AITER runner |
| unsupported Quark runner | fails later with an unset runner | fails during construction |
| padding | Quark padding is not forwarded | hidden/intermediate padding is recorded and forwarded |

## Scope

Three production files:

- `fp8.py`: record block-FP8's physical gate/up ordering after AITER preshuffle and forward it with the existing clamp/scales/padding metadata.
- `quark_w4a4_mxfp4_moe.py`: own AITER preshuffle, preserve separated ordering, and forward clamp/padding metadata.
- `aiter.py`: preserve a quantization method's explicit gate mode instead of overwriting it with the global default.

Three test files cover CPU contracts, synthetic gfx950 FP8/MXFP4 numerics, and both real checkpoints. DSA, k-pool, MLA, mHC backend selection, model registration, CUDA graphs, EP/A2A, and full-model serving are untouched.

Shared experts are tested both separately and as a ninth uniform-precision expert slot. This PR validates the representation and math but does not turn on shared-expert fusion in the official launch recipe.

## Test plan

Docker: `rocm/sgl-dev:v0.5.18-rocm720-mi35x-20260901`.  
Base: `xinyuan/glm-5.3-flash-support` @ `545bd6f839`.  
Checkpoints: `zai-org/GLM-5.3-Flash@03eb536628` and `amd/GLM-5.3-Flash-Quark-MXFP4@b5688f2549`.  
The same three new test files were run in both arms; the three production files are the only variables.

| Arm | Result |
| --- | --- |
| Baseline | FP8 and MXFP4 suites fail: separated weights are consumed through the global interleave default; Quark also lacks ownership/padding/clamp handoff and early runner rejection. Synthetic and real-checkpoint numerical agreement collapses for affected expert paths. |
| This PR | CPU contracts: **6 passed**; synthetic gfx950 FP8/MXFP4: **3 passed**; dual-checkpoint validation: **6 passed**. Existing Quark regression remains green. |

Synthetic gfx950 coverage uses Flash dimensions (`hidden_size=4096`, `intermediate_size=2048`), block-FP8 and MXFP4 expert banks, token counts 1/8/17/32/64/128, top-1/top-8/top-9 routing, both activation-quantization formats, clamp-boundary inputs, deterministic top-1 output, and BF16-equivalent atomic reduction.

Checkpoint coverage verifies and executes:

- source block-FP8 routed experts, shared expert, and MTP routed/shared experts;
- AMD MXFP4 routed and shared experts plus its FP8 MTP layer;
- real expert IDs 0/143/287 across KDA/DSA-adjacent layers;
- the complete mHC-pre/MoE/mHC-post BF16 boundary, including zero tokens.

| Check | Detail |
| --- | --- |
| Registration | CPU contracts use `register_cpu_ci(suite="base-a-test-cpu")`; gfx950 numerics use `register_amd_ci(suite="stage-b-test-1-gpu-small-amd-mi35x")` |
| Formatting | file-scoped isort, Ruff, Black, syntax, and registered-test validation pass; the local whole-tree checker separately sees an unrelated ignored test file outside this PR |
| Accuracy | **not measured** — remaining attention Day-0 work must land before server-level accuracy is meaningful |
| Speed | **not measured** — fusion, overlap, EP/A2A, and tuning are outside this correctness PR |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33768400586](https://github.com/sgl-project/sglang/actions/runs/33768400586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33768400367](https://github.com/sgl-project/sglang/actions/runs/33768400367)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33768400582](https://github.com/sgl-project/sglang/actions/runs/33768400582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->