### PR TITLE
[XPU] Enable GPT-OSS MXFP4

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -108,7 +108,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
 }
 
 
-if is_cpu() or is_cuda() or _is_gfx95_supported:
+if is_cpu() or is_cuda() or is_xpu() or _is_gfx95_supported:
     BASE_QUANTIZATION_METHODS.update(
         {
             "mxfp4": Mxfp4Config,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -66,7 +66,6 @@ from sglang.srt.utils import (
     round_up,
     set_weight_attrs,
     use_intel_amx_backend,
-    use_intel_xpu_backend,
 )
 from sglang.srt.utils.common import get_bool_env_var
 from sglang.srt.utils.custom_op import register_custom_op
@@ -1588,8 +1587,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             return StandardCombineInput(hidden_states=output)
 
         if is_xpu():
-            if not use_intel_xpu_backend():
-                raise RuntimeError("MXFP4 on Intel XPU requires SGLANG_USE_SGL_XPU=1.")
             assert TopKOutputChecker.format_is_standard(topk_output)
             from sgl_kernel import fused_experts
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -61,10 +61,12 @@ from sglang.srt.utils import (
     is_gfx95_supported,
     is_hip,
     is_triton_kernels_available,
+    is_xpu,
     next_power_of_2,
     round_up,
     set_weight_attrs,
     use_intel_amx_backend,
+    use_intel_xpu_backend,
 )
 from sglang.srt.utils.common import get_bool_env_var
 from sglang.srt.utils.custom_op import register_custom_op
@@ -615,6 +617,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
+        if is_xpu():
+            return
+
         if self.use_marlin and not self.use_mega_moe:
             from sglang.srt.layers.quantization.marlin_utils import (
                 check_moe_marlin_supports_layer,
@@ -1382,6 +1387,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
+        if is_xpu():
+            return
+
         moe_runner_backend = get_moe_runner_backend()
         if moe_runner_backend.is_auto():
             # Must match apply() priority: _use_aiter before use_triton_kernels.
@@ -1577,6 +1585,32 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     topk_output,
                     self.moe_runner_config,
                 )
+            return StandardCombineInput(hidden_states=output)
+
+        if is_xpu():
+            if not use_intel_xpu_backend():
+                raise RuntimeError("MXFP4 on Intel XPU requires SGLANG_USE_SGL_XPU=1.")
+            assert TopKOutputChecker.format_is_standard(topk_output)
+            from sgl_kernel import fused_experts
+
+            topk_weights, topk_ids, _ = topk_output
+            output = fused_experts(
+                x,
+                layer.w13_weight.view(torch.int8),
+                layer.w2_weight.view(torch.int8),
+                topk_weights,
+                topk_ids,
+                b1=getattr(layer, "w13_weight_bias", None),
+                b2=getattr(layer, "w2_weight_bias", None),
+                use_mxfp4_w4a16=True,
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                activation=self.moe_runner_config.activation,
+                routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
+                gemm1_alpha=self.moe_runner_config.gemm1_alpha,
+                gemm1_limit=self.moe_runner_config.gemm1_clamp_limit,
+                swiglu_limit=self.moe_runner_config.swiglu_limit,
+            )
             return StandardCombineInput(hidden_states=output)
 
         if self.use_marlin:

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -229,34 +229,8 @@ class GptOssSparseMoeBlock(nn.Module):
                 != "mxfp4"
             }
             if quant_config_name == "mxfp4" and is_xpu():
-                # gpt-oss-120b-dedicated fix (deliberately scoped to this
-                # model, not a shared Mxfp4MoEMethod/quantization change):
-                # SGLang's XPU MXFP4 MoE kernel
-                # (sgl_kernel.fused_experts(..., use_mxfp4_w4a16=True) ->
-                # moe_grouped_mm_nt_xe20_w4a16) requires each rank's
-                # intermediate size to be a multiple of the MXFP4 group size
-                # (mxfp4_block=32). This model's `intermediate_size=2880`
-                # isn't evenly divisible into a 32-aligned chunk for every
-                # `tp_size`/`ep_size` combo (e.g. `tp_size=8`: `2880/8=360`,
-                # `360/32=11.25`), which used to crash `FusedMoE`'s weight
-                # loader with a tensor-shape mismatch as soon as
-                # `intermediate_size // moe_tp_size` came out unaligned.
-                #
-                # `_load_mxfp4_experts_weights` below already computes each
-                # rank's *loaded* shard width with exactly this alignment
-                # (`per_rank_intermediate_size = ceil(intermediate_size /
-                # mxfp4_block / moe_tp_size) * mxfp4_block`) when slicing the
-                # checkpoint. The mismatch was that `FusedMoE.__init__`
-                # allocates its weight/scale/bias buffers from the *raw*
-                # `intermediate_size // moe_tp_size` (no rounding). Passing
-                # an already-padded `intermediate_size` here (matching the
-                # loader's own formula) makes the two agree, so the buffer is
-                # always >= what the loader ever tries to write into it.
-                # `_load_mxfp4_experts_weights` still slices the real
-                # checkpoint using the unpadded `self.config.intermediate_size`,
-                # so the extra padded rows/columns are simply left at their
-                # zero-initialized default and contribute nothing through
-                # down_proj -- real (unpadded) experts are unaffected.
+                # Keep GPT-OSS XPU MXFP4 shards 32-aligned so FusedMoE's
+                # buffers match the padded checkpoint slices.
                 mxfp4_block = 32
                 moe_tp_size = get_parallel().moe_tp_size
                 intermediate_size_block = config.intermediate_size // mxfp4_block

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -82,6 +82,7 @@ from sglang.srt.utils import (
     is_flashinfer_available,
     is_hip,
     is_npu,
+    is_xpu,
     make_layers,
 )
 from sglang.srt.utils.custom_op import register_custom_op
@@ -217,6 +218,7 @@ class GptOssSparseMoeBlock(nn.Module):
         self.top_k = config.num_experts_per_tok
         experts_type = get_moe_impl_class(quant_config)
         extra_kwargs = {}
+        moe_intermediate_size = config.intermediate_size
         if experts_type.__name__ == "FusedMoE":
             quant_config_name = (
                 quant_config.get_name() if quant_config is not None else None
@@ -226,6 +228,45 @@ class GptOssSparseMoeBlock(nn.Module):
                 "use_weight_loader_fused": quant_config_name
                 != "mxfp4"
             }
+            if quant_config_name == "mxfp4" and is_xpu():
+                # gpt-oss-120b-dedicated fix (deliberately scoped to this
+                # model, not a shared Mxfp4MoEMethod/quantization change):
+                # SGLang's XPU MXFP4 MoE kernel
+                # (sgl_kernel.fused_experts(..., use_mxfp4_w4a16=True) ->
+                # moe_grouped_mm_nt_xe20_w4a16) requires each rank's
+                # intermediate size to be a multiple of the MXFP4 group size
+                # (mxfp4_block=32). This model's `intermediate_size=2880`
+                # isn't evenly divisible into a 32-aligned chunk for every
+                # `tp_size`/`ep_size` combo (e.g. `tp_size=8`: `2880/8=360`,
+                # `360/32=11.25`), which used to crash `FusedMoE`'s weight
+                # loader with a tensor-shape mismatch as soon as
+                # `intermediate_size // moe_tp_size` came out unaligned.
+                #
+                # `_load_mxfp4_experts_weights` below already computes each
+                # rank's *loaded* shard width with exactly this alignment
+                # (`per_rank_intermediate_size = ceil(intermediate_size /
+                # mxfp4_block / moe_tp_size) * mxfp4_block`) when slicing the
+                # checkpoint. The mismatch was that `FusedMoE.__init__`
+                # allocates its weight/scale/bias buffers from the *raw*
+                # `intermediate_size // moe_tp_size` (no rounding). Passing
+                # an already-padded `intermediate_size` here (matching the
+                # loader's own formula) makes the two agree, so the buffer is
+                # always >= what the loader ever tries to write into it.
+                # `_load_mxfp4_experts_weights` still slices the real
+                # checkpoint using the unpadded `self.config.intermediate_size`,
+                # so the extra padded rows/columns are simply left at their
+                # zero-initialized default and contribute nothing through
+                # down_proj -- real (unpadded) experts are unaffected.
+                mxfp4_block = 32
+                moe_tp_size = get_parallel().moe_tp_size
+                intermediate_size_block = config.intermediate_size // mxfp4_block
+                per_rank_intermediate_size_block = math.ceil(
+                    intermediate_size_block / moe_tp_size
+                )
+                per_rank_intermediate_size = (
+                    per_rank_intermediate_size_block * mxfp4_block
+                )
+                moe_intermediate_size = per_rank_intermediate_size * moe_tp_size
 
         self.experts = experts_type(
             num_experts=config.num_local_experts
@@ -233,7 +274,7 @@ class GptOssSparseMoeBlock(nn.Module):
             top_k=config.num_experts_per_tok,
             layer_id=layer_id,
             hidden_size=config.hidden_size,
-            intermediate_size=config.intermediate_size,
+            intermediate_size=moe_intermediate_size,
             quant_config=quant_config,
             activation=self.activation,
             gemm1_alpha=self.gemm1_alpha,


### PR DESCRIPTION
## Motivation

Enable MXFP4 inference for GPT-OSS-120B on Intel XPU.

## Modifications

- Register MXFP4 quantization on XPU and require the Intel XPU kernel backend.
- Route MXFP4 MoE execution through the XPU fused-experts kernel.
- Pad the GPT-OSS intermediate size for MXFP4 tensor-parallel shards so the loader and allocated buffers agree.

## Accuracy Tests

Not run (requires an Intel XPU runtime and GPT-OSS-120B weights).

## Speed Tests and Profiling

Not run.

## Checklist

- [x] Run isort and Ruff checks on the modified Python files.
- [x] Run syntax compilation on the modified Python files.
- [ ] Run unit tests.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33667698703](https://github.com/sgl-project/sglang/actions/runs/33667698703)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33667698279](https://github.com/sgl-project/sglang/actions/runs/33667698279)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33667698530](https://github.com/sgl-project/sglang/actions/runs/33667698530)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->