### PR TITLE
feat: support video input for Kimi K2.5 models

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -271,9 +271,9 @@ class Learnable2DInterpPosEmbDivided_fixed(nn.Module):
             if t == 1:
                 pos_emb_3d = pos_emb_2d
             else:
-                pos_emb_3d = (
-                    pos_emb_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[0:t]
-                )
+                pos_emb_3d = pos_emb_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[
+                    0:t
+                ].to(pos_emb_2d)
 
             pos_embs.append(pos_emb_3d.reshape(-1, pos_emb_3d.shape[-1]))
 

--- a/python/sglang/srt/multimodal/processors/kimi_k25.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k25.py
@@ -10,6 +10,7 @@ from PIL import Image
 
 from sglang.kernels.ops.mm.process import normalize_and_patchify
 from sglang.srt.managers.schedule_batch import (
+    Modality,
     MultimodalProcessorOutput,
 )
 from sglang.srt.models.kimi_k25 import KimiK25ForConditionalGeneration
@@ -23,6 +24,7 @@ from sglang.srt.multimodal.processors.kimi_common import KimiGridMMDataMixin
 from sglang.srt.multimodal.transport.cuda_ipc import (
     DEFER_CUDA_IPC_FEATURE_RECONSTRUCTION_KEY,
 )
+from sglang.srt.utils.common import load_video
 
 # ---------------------------------------------------------------------------
 # GPU image preprocessing utilities (resize, pad, normalize, patchify on CUDA)
@@ -373,6 +375,7 @@ class KimiGPUProcessorWrapper:
         self._fixed_output_tokens = fixed_output_tokens
         self._image_mean = image_mean
         self._image_std = image_std
+        self._media_proc_cfg = hf_processor.media_processor.media_proc_cfg
         self._gpu_norm_tensors = None
 
         # Explicitly expose attributes that base class process_mm_data needs:
@@ -386,11 +389,131 @@ class KimiGPUProcessorWrapper:
     def __call__(self, text=None, images=None, **kwargs):
         # process_mm_data passes images via kwargs["images"]
         images = images or kwargs.pop("images", None)
+        videos = kwargs.pop("videos", None)
         original_input_ids = kwargs.pop("sglang_original_input_ids", None)
 
+        if videos:
+            return self._video_call(text, images, videos)
         if images and torch.cuda.is_available():
             return self._gpu_call(text, images, original_input_ids)
         return self._cpu_call(text, images, original_input_ids, **kwargs)
+
+    @staticmethod
+    def _format_timestamp(seconds: float, mode: str) -> str:
+        total_ms = max(0, round(seconds * 1000))
+        hours, rem_ms = divmod(total_ms, 3_600_000)
+        minutes, rem_ms = divmod(rem_ms, 60_000)
+        secs, millis = divmod(rem_ms, 1000)
+        if mode == "hh:mm:ss.fff":
+            return f"{hours:02d}:{minutes:02d}:{secs:02d}.{millis:03d}"
+        if mode == "mm:ss.fff":
+            total_minutes = hours * 60 + minutes
+            return f"{total_minutes:02d}:{secs:02d}.{millis:03d}"
+        if mode == "mm:ss":
+            total_minutes = hours * 60 + minutes
+            return f"{total_minutes:02d}:{secs:02d}"
+        raise ValueError(f"Unsupported Kimi video timestamp mode: {mode}")
+
+    def _decode_video_chunks(self, video):
+        total_frames = len(video)
+        if total_frames <= 0:
+            raise ValueError("Kimi video input contains no frames")
+        source_fps = float(video.avg_fps)
+        if source_fps <= 0:
+            raise ValueError(f"Kimi video input has invalid fps: {source_fps}")
+
+        sample_fps = min(float(self._media_proc_cfg["sample_fps"]), source_fps)
+        sampled_nframes = max(round(total_frames * sample_fps / source_fps), 1)
+        max_frames = self._media_proc_cfg.get("max_num_frames_each_video")
+        if max_frames is not None:
+            sampled_nframes = min(sampled_nframes, int(max_frames))
+        frame_indices = (
+            np.linspace(0, total_frames - 1, sampled_nframes).round().astype(int)
+        )
+        sampled_frames = video.get_frames_at(frame_indices.tolist())
+
+        chunk_size = int(self._media_proc_cfg["temporal_merge_kernel_size"])
+        timestamp_mode = self._media_proc_cfg["timestamp_mode"]
+        chunks = []
+        prompts = []
+        for start in range(0, sampled_nframes, chunk_size):
+            frames = [
+                Image.fromarray(frame.astype("uint8"))
+                for frame in sampled_frames[start : start + chunk_size]
+            ]
+            chunks.append({"type": "video_chunk", "video_chunk": frames})
+            timestamp = self._format_timestamp(
+                float(frame_indices[start]) / source_fps, timestamp_mode
+            )
+            prompts.append(
+                self._hf_processor.media_processor.make_chunk_prompt(timestamp)
+            )
+        return chunks, "".join(prompts)
+
+    def _video_call(self, text, images, videos):
+        """Use Kimi's native temporal chunks with SGLang's decoded videos."""
+        if isinstance(text, (list, tuple)) and text and isinstance(text[0], int):
+            input_text = self.tokenizer.decode(text)
+        elif isinstance(text, torch.Tensor):
+            input_text = self.tokenizer.decode(text.flatten().tolist())
+        else:
+            input_text = text[0] if isinstance(text, list) else text
+
+        image_tag = "<|media_begin|>image<|media_content|><|media_pad|><|media_end|>"
+        video_placeholder = self._hf_processor.video_placeholder
+        decoded_videos = [self._decode_video_chunks(video) for video in videos]
+
+        image_iter = iter(images or [])
+        video_iter = iter(decoded_videos)
+        ordered_medias = []
+        expanded_parts = []
+        cursor = 0
+        visual_pattern = re.compile(
+            f"({re.escape(image_tag)}|{re.escape(video_placeholder)})"
+        )
+        for match in visual_pattern.finditer(input_text):
+            expanded_parts.append(input_text[cursor : match.start()])
+            marker = match.group(0)
+            if marker == image_tag:
+                image = next(image_iter)
+                ordered_medias.append({"type": "image", "image": image})
+                expanded_parts.append(marker)
+            else:
+                chunks, prompt = next(video_iter)
+                ordered_medias.extend(chunks)
+                expanded_parts.append(prompt)
+            cursor = match.end()
+        expanded_parts.append(input_text[cursor:])
+        expanded_text = "".join(expanded_parts)
+
+        try:
+            next(image_iter)
+            raise ValueError("Kimi image data has no matching prompt placeholder")
+        except StopIteration:
+            pass
+        try:
+            next(video_iter)
+            raise ValueError("Kimi video data has no matching prompt placeholder")
+        except StopIteration:
+            pass
+
+        vision_inputs = self.media_processor.preprocess(
+            ordered_medias, return_tensors="pt"
+        )
+        text_inputs = self.tokenizer(expanded_text, return_tensors="pt")
+        grid_thws = vision_inputs["grid_thws"]
+        chunk_token_counts = [
+            (int(grid[-2]) * int(grid[-1])) // (self._merge_kernel_size**2)
+            for grid in grid_thws
+        ]
+        text_inputs["input_ids"] = _expand_image_token_ids(
+            text_inputs["input_ids"], self._image_token_id, chunk_token_counts
+        )
+        out = {**text_inputs, **vision_inputs}
+        grid_thws = out.pop("grid_thws", None)
+        if grid_thws is not None:
+            out["image_grid_thw"] = grid_thws
+        return out
 
     def _prepare_input_ids(self, input_text, resize_configs, original_input_ids):
         if original_input_ids is not None:
@@ -518,12 +641,36 @@ class KimiK2_5VLImageProcessor(KimiGridMMDataMixin, SGLangBaseProcessor):
     auto_mm_io_worker_num = 16
     supports_mm_processor_concurrency = True
 
+    @classmethod
+    def _load_single_item(
+        cls,
+        data,
+        modality: Modality,
+        frame_count_limit=None,
+        audio_sample_rate=None,
+        discard_alpha_channel=True,
+    ):
+        # Kimi's CPU vision preprocessor consumes PIL frames. Avoid enabling
+        # torchcodec's optional CUDA decoder only to transfer them back to CPU.
+        if modality == Modality.VIDEO:
+            return load_video(data, use_gpu=False)
+        return super()._load_single_item(
+            data,
+            modality,
+            frame_count_limit,
+            audio_sample_rate,
+            discard_alpha_channel,
+        )
+
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         mm_tokens = MultimodalSpecialTokens(
             image_token="<|media_pad|>",
+            video_token="<|kimi_k25_video_placeholder|>",
             # TODO: could we convert in MultimodalSpecialTokens?
             image_token_id=hf_config.media_placeholder_token_id,
+            video_token_id=hf_config.media_placeholder_token_id,
             image_token_regex=re.compile(r"(?:<\|media_pad\|>)+"),
+            video_token_regex=re.compile(r"<\|kimi_k25_video_placeholder\|>"),
         ).build(_processor)
 
         media_proc_cfg = _processor.media_processor.media_proc_cfg
@@ -552,6 +699,24 @@ class KimiK2_5VLImageProcessor(KimiGridMMDataMixin, SGLangBaseProcessor):
         *args,
         **kwargs,
     ):
+        video_data = getattr(request_obj, "video_data", None) or []
+        if video_data:
+            base_output = await self.load_mm_data(
+                prompt=input_text,
+                image_data=image_data,
+                video_data=video_data,
+                multimodal_tokens=self.mm_tokens,
+            )
+            mm_items, input_ids, _ = await self.process_and_combine_mm_data_async(
+                base_output,
+                self.mm_tokens,
+            )
+            return MultimodalProcessorOutput(
+                input_ids=input_ids.tolist(),
+                mm_items=mm_items,
+                im_token_id=self.mm_tokens.image_token_id,
+            )
+
         expected_image_count = len(image_data or [])
         placeholder_count = self.count_image_placeholders(
             input_text, self.mm_tokens.image_token_id

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -28,6 +28,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.models.kimi_k3 import KimiK3ForConditionalGeneration
 from sglang.srt.models.kimi_k25 import (
     KimiK25ForConditionalGeneration,
+    Learnable2DInterpPosEmbDivided_fixed,
     mm_projection_auto,
 )
 from sglang.srt.models.kimi_vl_moonvit import tpool_patch_merger
@@ -108,6 +109,28 @@ def _image_item(feature, grid_thw):
         feature=feature,
         model_specific_data={"image_grid_thw": torch.tensor(grid_thw)},
     )
+
+
+def test_kimi_temporal_position_buffer_matches_learned_embedding_placement():
+    position_embedding = Learnable2DInterpPosEmbDivided_fixed(
+        height=2,
+        width=2,
+        num_frames=4,
+        dim=8,
+    )
+    position_embedding.weight = nn.Parameter(
+        position_embedding.weight.to(dtype=torch.bfloat16)
+    )
+    hidden_states = torch.zeros(8, 8, dtype=torch.bfloat16)
+
+    output = position_embedding(
+        hidden_states,
+        grid_thws=torch.tensor([[2, 2, 2]]),
+    )
+
+    assert position_embedding.time_weight.dtype == torch.float32
+    assert output.dtype == position_embedding.weight.dtype
+    assert output.device == position_embedding.weight.device
 
 
 def test_kimi_gpu_preprocess_batches_only_source_compatible_images():
@@ -230,6 +253,35 @@ def test_kimi_expansion_matches_the_base_retokenize_avoidance_rebuild():
             ids, image_token_id=7, image_token_counts=counts
         )
         assert wrapper.flatten().tolist() == expected
+
+
+def test_kimi_video_chunks_expand_to_grid_token_counts():
+    wrapper = KimiGPUProcessorWrapper.__new__(KimiGPUProcessorWrapper)
+    wrapper._image_token_id = 7
+    wrapper._merge_kernel_size = 2
+    wrapper._hf_processor = SimpleNamespace(video_placeholder="<video>")
+    wrapper._decode_video_chunks = Mock(
+        return_value=([{"type": "video_chunk"}, {"type": "video_chunk"}], "chunks")
+    )
+    wrapper.media_processor = SimpleNamespace(
+        preprocess=Mock(
+            return_value={
+                "pixel_values": torch.zeros(1),
+                "grid_thws": torch.tensor([[4, 46, 26], [4, 20, 20]]),
+            }
+        )
+    )
+    wrapper.tokenizer = Mock(
+        return_value={"input_ids": torch.tensor([[1, 7, 2, 7, 3]])}
+    )
+
+    output = wrapper._video_call("before<video>after", images=[], videos=["video"])
+
+    # MoonViT pools over time, then spatially merges each 2x2 patch group.
+    expected_chunk_tokens = [46 * 26 // 4, 20 * 20 // 4]
+    assert output["input_ids"].shape[1] == 3 + sum(expected_chunk_tokens)
+    assert output["input_ids"].eq(7).sum().item() == sum(expected_chunk_tokens)
+    assert output["image_grid_thw"].tolist() == [[4, 46, 26], [4, 20, 20]]
 
 
 def test_kimi_cpu_fallback_keeps_the_request_tokens():


### PR DESCRIPTION
## Summary

- load and sample video inputs for Kimi K2.5 using the model processor's native temporal chunks and timestamp prompts
- expand each temporal chunk placeholder to the vision-token count derived from its output grid
- align the non-persistent temporal position buffer with the learned position embedding's device and dtype

## Problem

Video requests were not handled by the Kimi multimodal processor. Enabling that path exposed two failures: temporal position embeddings could mix CPU and accelerator tensors, and one placeholder token per temporal chunk did not match the number of embeddings returned by the vision encoder.

## Tests

- added CPU regression coverage for temporal-buffer placement
- added CPU regression coverage for grid-derived video chunk token expansion
- formatting, AST, Ruff, import sorting, codespell, and lint checks pass
- end-to-end `video_url` request with the public Big Buck Bunny sample returns a correct video description

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33659244644](https://github.com/sgl-project/sglang/actions/runs/33659244644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33659244267](https://github.com/sgl-project/sglang/actions/runs/33659244267)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33659244670](https://github.com/sgl-project/sglang/actions/runs/33659244670)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->