### PR TITLE
[Fix] Spark2.5 MLP use exact GELU to match reference

### DIFF
--- a/python/sglang/srt/models/spark2_5.py
+++ b/python/sglang/srt/models/spark2_5.py
@@ -67,7 +67,7 @@ class Spark2_5MLP(nn.Module):
             prefix=add_prefix("down_proj", prefix),
             reduce_results=reduce_results,
         )
-        self.act_fn = GeluAndMul()
+        self.act_fn = GeluAndMul("none")
 
     def forward(
         self,


### PR DESCRIPTION
## Problem

`Spark2_5MLP` ([spark2_5.py:70](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/spark2_5.py#L70)) constructed `GeluAndMul()` with no arguments, which selects the default `approximate="tanh"` ([activation.py:224](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/activation.py#L224)) — the tanh-approximation of GELU.

The official Spark-X2.5 reference uses **exact** GELU:
- [config.json](https://huggingface.co/XHToken/Spark-X2.5-4B/blob/main/config.json) sets `hidden_act: "gelu"` (exact, not `gelu_pytorch_tanh`).
- [modeling_spark.py:126-129](https://huggingface.co/XHToken/Spark-X2.5-4B/blob/main/modeling_spark.py#L126) hard-asserts `hidden_act == "gelu"` and uses `ACT2FN["gelu"]`, which maps to `torch.nn.functional.gelu` without the tanh approximation.

This causes every Spark2.5 MLP block to diverge numerically from the reference (max abs diff ~4.7e-4 per activation, per the issue repro).

## Fix

`GeluAndMul("none")` selects the existing exact fused path (`gelu_and_mul`, activation.py:234), matching the reference. This is the same explicit selection already used by `gemma.py` for its `hidden_act="gelu"` models.

```diff
-        self.act_fn = GeluAndMul()
+        self.act_fn = GeluAndMul("none")
```

## Why this is the root-cause fix

The mismatch is a single zero-argument default. `GeluAndMul` has only two valid modes (`"tanh"` / `"none"`), and the reference forces exact `gelu`. There is no conditional or config-driven path — Spark2.5 always wants exact, so the explicit `"none"` is correct unconditionally.

## Verification

- Confirmed `hidden_act: "gelu"` in the upstream config.json.
- Confirmed `modeling_spark.py` raises on any non-`"gelu"` value and uses `ACT2FN["gelu"]` (exact).
- `GeluAndMul("none")` routes to `gelu_and_mul` (exact fused kernel); `GeluAndMul()` (tanh) routes to `gelu_tanh_and_mul`.
- No existing tests touch the Spark2.5 MLP activation path, so no regressions expected.

CPU repro from the issue (max abs diff drops to 0 with this change):
```python
import torch, torch.nn.functional as F
x = torch.linspace(-5, 5, 20001, dtype=torch.float32)
assert torch.equal(F.gelu(x, approximate="none"), F.gelu(x))      # exact == reference
assert not torch.equal(F.gelu(x, approximate="tanh"), F.gelu(x)) # tanh != reference
```

Fixes #37609

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33664297814](https://github.com/sgl-project/sglang/actions/runs/33664297814)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33664296836](https://github.com/sgl-project/sglang/actions/runs/33664296836)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33664297031](https://github.com/sgl-project/sglang/actions/runs/33664297031)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->