### PR TITLE
[sgl-kernel] Add sm_110a and sm_121a gencodes to infllm_ops on aarch64 + CUDA 13

### DIFF
--- a/python/sglang/kernels/aot/CMakeLists.txt
+++ b/python/sglang/kernels/aot/CMakeLists.txt
@@ -520,6 +520,17 @@ endif()
 list(APPEND INFLLM_FLASH_CUDA_FLAGS "-gencode=arch=compute_90,code=sm_90")
 if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
     list(APPEND INFLLM_FLASH_CUDA_FLAGS "-gencode=arch=compute_120a,code=sm_120a")
+    # Match the main sgl-kernel arch list: on aarch64 with CUDA 13+ the
+    # Blackwell parts are sm_110a (Thor) and sm_121a (GB10 / DGX Spark).
+    # sm_120a code does not run on sm_121, and this module ships no PTX to
+    # JIT from, so without these gencodes infllm_ops has no usable kernel on
+    # those devices even though common_ops does.
+    if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        list(APPEND INFLLM_FLASH_CUDA_FLAGS
+            "-gencode=arch=compute_110a,code=sm_110a"
+            "-gencode=arch=compute_121a,code=sm_121a"
+        )
+    endif()
 endif()
 
 set(INFLLM_FLASH_SOURCES


### PR DESCRIPTION
## Motivation

`infllm_ops` builds with its own `INFLLM_FLASH_CUDA_FLAGS` list in
`python/sglang/kernels/aot/CMakeLists.txt`, and that list stops at `sm_120a`. The main
sgl-kernel flag list already adds `sm_110a` and `sm_121a` on aarch64 with CUDA 13+, so on
the aarch64 wheel `common_ops` carries `sm_121a` cubins while `infllm_ops` does not.

`sm_120a` code does not run on `sm_121`, and the module embeds no PTX to JIT from, so on
a GB10 (DGX Spark) there is no usable code object in this module at all. Checked against
`sgl_kernel-0.3.21-cp310-abi3-manylinux2014_aarch64.whl`:

```
$ cuobjdump --list-elf infllm_ops.*.so | grep -o 'sm_[0-9]*a\?' | sort -u
sm_120a
sm_90
$ cuobjdump --list-elf common_ops.abi3.so | grep -o 'sm_[0-9]*a\?' | sort -u
sm_100 sm_110a sm_120a sm_121a sm_90
$ cuobjdump --list-ptx infllm_ops.*.so
cuobjdump info : No PTX file found to extract
```

## Modifications

Mirror the aarch64 + CUDA 13 branch of the main flag list inside the `infllm_ops`
block, so the two arch lists stay in step: add `-gencode=arch=compute_110a,code=sm_110a`
and `-gencode=arch=compute_121a,code=sm_121a` under the same
`CUDA_VERSION >= 13.0 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64"` condition.

One file, 11 lines, gencode list only. No kernel source changes.

## Accuracy Tests

Not applicable, no numerics change. The vendored kernels are the existing
`flash_fwd_split_*_bf16_sm80.cu` sources compiled for two more targets, the same way
`sm_120a` is already produced from them.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide (CMake only).
- [ ] Add unit tests: none, build configuration change.
- [x] Update documentation as needed: none needed.

## Notes

Not build-verified on my side (sgl-kernel from source is a multi-hour build on this
box). The change copies an existing branch of the same file verbatim, so the risk is
confined to compile time for two extra targets.

Related: there is a second, separate problem with this module on the same wheel. It is
built without `USE_SABI` (the only extension in the file that is), so the installed file
is `infllm_ops.cpython-310-aarch64-linux-gnu.so` inside an `abi3` wheel and fails the
Python ABI check on 3.12. I have filed that as an issue rather than folding it in here,
since the right fix (per-Python build vs. dropping the `abi3` tag) is a packaging
decision. Link: #37640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34170220373](https://github.com/sgl-project/sglang/actions/runs/34170220373)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34170220050](https://github.com/sgl-project/sglang/actions/runs/34170220050)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34170220265](https://github.com/sgl-project/sglang/actions/runs/34170220265)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->