### PR TITLE
[Parser] Detect the Spark-X2.5 tool-call parser instead of falling back to glm45

### DIFF
--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -342,6 +342,20 @@ def _is_glm47(ctx):
     )
 
 
+def _is_spark25(ctx):
+    # Spark-X2.5 uses the GLM-style <arg_key>/<arg_value> tool-call body, but
+    # emits it on one line with no newline between the tags, which
+    # Glm4MoeDetector does not parse. Its template is distinctive: DeepSeek
+    # style sentence markers with <|Bot|> / <|Tool|> role tags, which no other
+    # supported template uses. Check the template text rather than the vocab
+    # so it does not depend on which markers the tokenizer registers as tokens.
+    return (
+        ctx.has_text("<|Bot|>")
+        and ctx.has_text("<tool_call>")
+        and ctx.has_text("<arg_key>")
+    )
+
+
 def _is_xml_kv_tool_call(ctx):
     # Structural signature for the GLM-4.5 / GLM-4.6 style tool-call format
     # (`<tool_call>name<arg_key>k</arg_key>\n<arg_value>v</arg_value>...</tool_call>`).
@@ -525,6 +539,9 @@ TOOL_CALL_PARSER_RULES = (
     DetectionRule(name="deepseek_v32", value="deepseekv32", predicate=_is_deepseek_v32),
     DetectionRule(name="deepseek_v31", value="deepseekv31", predicate=_is_deepseek_v31),
     DetectionRule(name="lfm2", value="lfm2", predicate=_is_lfm2),
+    # Before the GLM rules and the generic xml_kv fallback: Spark shares the
+    # <arg_key> body but needs its own parser (see _is_spark25).
+    DetectionRule(name="spark25", value="spark25", predicate=_is_spark25),
     DetectionRule(name="glm47", value="glm47", predicate=_is_glm47),
     DetectionRule(name="glm45", value="glm45", predicate=_is_glm45),
     DetectionRule(name="minicpm5", value="minicpm5", predicate=_is_minicpm5),

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -574,10 +574,25 @@ class TestToolCallParserDetection(unittest.TestCase):
         self.assertEqual(rp, "qwen3")
         self.assertEqual(tcp, "qwen")
 
+    def test_spark_x25_detects_spark25_tool_call_parser(self):
+        # Regression for #37608: the official Spark-X2.5 template was resolved
+        # to glm45 through the generic xml_kv fallback, and Glm4MoeDetector
+        # cannot parse its single-line <arg_key>/<arg_value> calls.
+        _, tcp = self._detect_all("XHToken/Spark-X2.5-4B")
+        self.assertEqual(tcp, "spark25")
+
     def test_tool_call_parser_rule_values_via_snippets(self):
         """Table-driven: verify tool-call rule values differ from reasoning where expected."""
         cases = [
             # (name, template, vocab, expected_tool_call)
+            (
+                "spark25_bot_role_tags_one_line_xml_kv",
+                "<｜start▁of▁sentence｜><|Bot|></think>"
+                "<tool_call>{{ name }}<arg_key>{{ k }}</arg_key>"
+                "<arg_value>{{ v }}</arg_value></tool_call>",
+                ["<tool_call>", "<arg_key>", "<arg_value>"],
+                "spark25",
+            ),
             (
                 "qwen_maps_from_qwen3_config",
                 "{% set enable_thinking = enable_thinking if enable_thinking is defined else true %}",
@@ -744,6 +759,15 @@ class TestToolCallParserDetection(unittest.TestCase):
                     template, _DummyTokenizer(vocab), config, force
                 )
                 self.assertEqual(result, expected)
+
+    def test_spark25_rule_precedes_glm_and_xml_kv_fallback(self):
+        # Spark-X2.5 carries the same <arg_key> body as GLM, so it must be
+        # matched before both the glm rules and the generic xml_kv fallback,
+        # which would otherwise claim it for glm45 (#37608).
+        rule_index = {rule.name: i for i, rule in enumerate(TOOL_CALL_PARSER_RULES)}
+        self.assertLess(rule_index["spark25"], rule_index["glm47"])
+        self.assertLess(rule_index["spark25"], rule_index["glm45"])
+        self.assertLess(rule_index["spark25"], rule_index["xml_kv_tool_call"])
 
     def test_glm45_rule_precedes_xml_kv_fallback(self):
         # The specific GLM-4.5 family check must run before the generic


### PR DESCRIPTION
## Motivation

Fixes #37608.

`--tool-call-parser auto` resolves the official Spark-X2.5 template to `glm45`.
`TOOL_CALL_PARSER_RULES` has no spark25 rule, so the generic `xml_kv_tool_call`
fallback claims any template whose tokenizer carries `<arg_key>` / `<arg_value>`.
Spark emits the same GLM-style body on one line with no newline between the tags,
which `Glm4MoeDetector` does not parse, so auto mode silently picks a parser that
cannot read the model's tool calls. `--tool-call-parser spark25` works, but the
dedicated detector exists and auto should find it.

## Modifications

- `template_detection.py`: add `_is_spark25`, keyed on the `<|Bot|>` role tag that
  only the Spark template uses (checked as template text rather than vocab, so it
  does not depend on which markers the tokenizer registers), and place the rule ahead
  of `glm47`, `glm45` and the `xml_kv_tool_call` fallback.
- `test_template_manager.py`: a snippet row in the tool-call rule table, a
  rule-ordering check, and a real-tokenizer regression against
  `XHToken/Spark-X2.5-4B` next to the existing Qwen3 one.

With the reporter's reproducer, the matching rules are now
`[spark25, xml_kv_tool_call, qwen]` and `auto` resolves to `spark25`.

## Accuracy Tests

Not applicable, parser selection only.

```
test_template_manager.py -k "spark25_rule or tool_call_parser_rule_values or glm45_rule_precedes or poolside_s21 or glm45_requires"
5 passed, 23 subtests passed
test_template_manager.py -k "spark_x25_detects or qwen3_detects_qwen_tool"
2 passed
test_template_manager.py (offline part)
41 passed, 56 subtests passed
```

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide.
- [x] Add unit tests.
- [x] Update documentation as needed: none needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34170219416](https://github.com/sgl-project/sglang/actions/runs/34170219416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34170219341](https://github.com/sgl-project/sglang/actions/runs/34170219341)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34170219426](https://github.com/sgl-project/sglang/actions/runs/34170219426)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->