### PR TITLE
[Scheduler] Start non-leader ranks from an empty list in the DP-attention request broadcast

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -167,8 +167,15 @@ class SchedulerRequestReceiver:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
             else:
-                work_reqs = None
-                control_reqs = None
+                # The requests reach every rank in two hops: along attn_tp from
+                # the leader, then along attn_cp from each attn_tp_rank 0. In
+                # the first hop the source of every attn_cp_rank != 0 slice is
+                # a rank that has nothing yet, and broadcast_pyobj reads
+                # len(data) on the source, so it must hold a list rather than
+                # None. It broadcasts an empty payload, and the second hop
+                # replaces it with the real requests (#37590).
+                work_reqs = []
+                control_reqs = []
 
             work_reqs = attn_cp_tp_broadcast_pyobj(work_reqs)
 

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -762,7 +762,11 @@ class SchedulerPPMixin:
                 self.ps.pp_rank * self.ps.tp_size + dp_offset,
             )
         else:
-            data = None
+            # Same two-hop fan-out as SchedulerRequestReceiver: the attn_tp
+            # hop runs first, and its source in an attn_cp_rank != 0 slice has
+            # nothing yet. broadcast_pyobj reads len(data) on the source, so
+            # start from an empty list and let the attn_cp hop fill it in.
+            data = []
 
         data = attn_cp_tp_broadcast_pyobj(data)
         return data

--- a/test/registered/unit/managers/test_request_receiver_dp_attention.py
+++ b/test/registered/unit/managers/test_request_receiver_dp_attention.py
@@ -1,0 +1,100 @@
+# Regression for #37590: with DP attention and both attn_tp_size > 1 and
+# attn_cp_size > 1, the first broadcast hop runs along attn_tp, so its source
+# in every attn_cp_rank != 0 slice is a rank that holds no requests yet.
+# broadcast_pyobj reads len(data) on the source, which raised
+# "object of type NoneType has no len()" and killed the scheduler.
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.scheduler_components.request_receiver import (
+    SchedulerRequestReceiver,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+MOD = "sglang.srt.managers.scheduler_components.request_receiver"
+LEADER_REQS = ["req-a", "req-b"]
+
+
+def _fake_broadcast_pyobj(data, rank, dist_group, src=0, **_):
+    # Mirror the real function on the source rank: it serializes data, so it
+    # must be a list. Non-source ranks receive the list held by the leader.
+    if rank == src:
+        len(data)
+        return data
+    return list(LEADER_REQS)
+
+
+def _receiver(attn_tp_rank, attn_cp_rank, attn_tp_size=2, attn_cp_size=2):
+    def group(rank):
+        return SimpleNamespace(rank=rank, ranks=[0], cpu_group=object())
+
+    return SchedulerRequestReceiver(
+        recv_from_tokenizer=None,
+        recv_from_rpc=None,
+        recv_skipper=None,
+        input_blocker=None,
+        mm_receiver=None,
+        ps=SimpleNamespace(
+            pp_rank=0,
+            tp_size=attn_tp_size * attn_cp_size,
+            attn_tp_rank=attn_tp_rank,
+            attn_cp_rank=attn_cp_rank,
+            attn_tp_size=attn_tp_size,
+            attn_cp_size=attn_cp_size,
+            attn_dp_rank=0,
+        ),
+        tp_group=group(0),
+        tp_cpu_group=group(0),
+        attn_tp_group=group(attn_tp_rank),
+        attn_tp_cpu_group=group(attn_tp_rank),
+        attn_cp_group=group(attn_cp_rank),
+        attn_cp_cpu_group=group(attn_cp_rank),
+        world_group=group(0),
+        server_args=SimpleNamespace(),
+        model_config=SimpleNamespace(is_multimodal=False),
+        max_recv_per_poll=-1,
+        stream_output=lambda *args, **kwargs: None,
+        get_last_batch=lambda: None,
+    )
+
+
+class TestDpAttentionRequestBroadcast(unittest.TestCase):
+    def _run(self, receiver, recv_reqs):
+        parallel = SimpleNamespace(
+            enable_dp_attention=True,
+            enable_dp_attention_local_control_broadcast=False,
+        )
+        with (
+            patch(f"{MOD}.get_parallel", return_value=parallel),
+            patch(f"{MOD}.is_ep_scale_joiner", return_value=False),
+            patch(f"{MOD}.broadcast_pyobj", side_effect=_fake_broadcast_pyobj),
+        ):
+            return receiver._broadcast_reqs_across_ranks(recv_reqs)
+
+    def test_attn_tp_source_in_nonzero_cp_slice_does_not_crash(self):
+        # attn_tp_rank 0 in attn_cp slice 1: the source of the first hop for
+        # its slice, holding nothing. This is the rank that raised TypeError.
+        receiver = _receiver(attn_tp_rank=0, attn_cp_rank=1)
+        self.assertEqual(self._run(receiver, None), LEADER_REQS)
+
+    def test_plain_follower_receives_leader_requests(self):
+        receiver = _receiver(attn_tp_rank=1, attn_cp_rank=1)
+        self.assertEqual(self._run(receiver, None), LEADER_REQS)
+
+    def test_leader_still_splits_and_forwards_its_own_requests(self):
+        receiver = _receiver(attn_tp_rank=0, attn_cp_rank=0)
+        # The receiver is a frozen slots dataclass, so stub the split on the
+        # class rather than the instance.
+        with patch.object(
+            SchedulerRequestReceiver,
+            "_split_work_and_control_reqs",
+            lambda self, reqs: (["work"], ["ctrl"]),
+        ):
+            self.assertEqual(self._run(receiver, ["work", "ctrl"]), ["work", "ctrl"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37590.

With DP attention and both `attn_tp_size > 1` and `attn_cp_size > 1`, every
scheduler dies on its first `recv_requests()` with
`TypeError: object of type 'NoneType' has no len()`.

The requests fan out in two hops: along attn_tp from the leader, then along attn_cp
from each `attn_tp_rank == 0`. Only the combined leader holds a list; every other
rank sets `work_reqs` and `control_reqs` to `None`. But the attn_tp hop runs first,
and its source in every `attn_cp_rank != 0` slice is a rank that has nothing yet.
`broadcast_pyobj` reads `len(data)` on the source, so that rank crashes before the
attn_cp hop can deliver anything.

## Modifications

- `request_receiver.py`: start non-leaders from an empty list instead of `None`. The
  first hop then broadcasts an empty payload in those slices and the second hop
  replaces it with the leader's requests, so every rank ends with the same list and
  the collective structure is unchanged.
- `scheduler_pp_mixin.py`: `_pp_recv_pyobj_from_prev_stage` has the same shape and
  gets the same change.
- New unit test driving `_broadcast_reqs_across_ranks` with a fake `broadcast_pyobj`
  that mirrors the real contract on the source rank. The `attn_tp_rank 0 /
  attn_cp_rank 1` case raises the TypeError on main and passes with this change.

I do not have a multi-GPU setup that can run attn_tp > 1 with attn_cp > 1, so the
end-to-end check is the unit test plus the reporter's analysis; the change is
confined to the initial value on non-leader ranks.

## Accuracy Tests

Not applicable, request routing only.

## Speed Tests and Profiling

Not applicable. One extra empty broadcast per non-leader slice on the first hop.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide.
- [x] Add unit tests.
- [x] Update documentation as needed: none needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34170218277](https://github.com/sgl-project/sglang/actions/runs/34170218277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34170218179](https://github.com/sgl-project/sglang/actions/runs/34170218179)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34170218279](https://github.com/sgl-project/sglang/actions/runs/34170218279)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->