### PR TITLE
[Fix] Reasoning parser: treat template-opened reasoning that ends on EOS as content (glm45)

### DIFF
--- a/docs/docs/advanced_features/separate_reasoning.mdx
+++ b/docs/docs/advanced_features/separate_reasoning.mdx
@@ -60,6 +60,12 @@ SGLang supports parsing reasoning content out from "normal" content for reasonin
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Uses special thinking delimiters. Also requires `--tool-call-parser kimi_k2` for tool use.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>[GLM-4.5 / 4.6 / 5.x](https://huggingface.co/zai-org/GLM-5.2)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`<think>` … `</think>`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`glm45`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The chat template opens `<think>` for the model. Output that ends on EOS without `</think>` is returned as content (see below). For tool use, also specify `--tool-call-parser glm45` or `glm47`.</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>[GPT OSS](https://huggingface.co/openai/gpt-oss-120b)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`&lt;|channel|&gt;analysis&lt;|message|&gt;` … `&lt;|end|&gt;`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`gpt-oss`</td>
@@ -89,6 +95,11 @@ SGLang supports parsing reasoning content out from "normal" content for reasonin
 
 **GPT OSS:**
 - GPT OSS: Uses special `<|channel|>analysis<|message|>` and `<|end|>` tags
+
+**GLM-4.5 Family (GLM-4.5 / 4.6 / 5.x):**
+- The chat template opens `<think>` for the model, so the output normally starts inside the reasoning block and closes it with `</think>` before the answer.
+- When the model skips thinking, it writes the answer straight away and ends on EOS without ever emitting `</think>`. The `glm45` parser returns that output as `content` (`finish_reason` is `stop`), while a block cut by `max_tokens` (`finish_reason` is `length`) stays `reasoning_content`. In streaming mode the text is streamed as `reasoning_content` and re-emitted as `content` once the stream finishes.
+- Set `"chat_template_kwargs": {"skipped_think_as_content": false}` to disable this per request (or server-wide via `--default-chat-template-kwargs`); `true` enables it for other parsers built on the same `<think>` framing.
 
 
 ## Usage

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1915,7 +1915,9 @@ class OpenAIServingChat(OpenAIServingBase):
                         tokenizer=self.tokenizer_manager.tokenizer,
                         tool_call_parser_active=self._tool_call_parsing_active(request),
                     )
-                    reasoning_text, text = parser.parse_non_stream(text)
+                    reasoning_text, text = parser.parse_non_stream(
+                        text, finish_reason=finish_reason
+                    )
                 except Exception as e:
                     logger.error(f"Reasoning parsing error: {e}")
                     return self.create_error_response(
@@ -2258,7 +2260,9 @@ class OpenAIServingChat(OpenAIServingBase):
         reasoning_parser = reasoning_parser_dict[index]
         reasoning_text, normal_text = reasoning_parser.parse_stream_chunk(delta)
         if finish_reason_type is not None and finish_reason_type != "abort":
-            end_reasoning_text, end_normal_text = reasoning_parser.parse_stream_end()
+            end_reasoning_text, end_normal_text = reasoning_parser.parse_stream_end(
+                content["meta_info"]["finish_reason"]
+            )
             if end_reasoning_text:
                 reasoning_text = (reasoning_text or "") + end_reasoning_text
             if end_normal_text:

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -675,6 +675,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 tokenizer,
                 output_logprobs=output_logprobs,
                 require_reasoning=require_reasoning,
+                finish_reason=meta_info.get("finish_reason") if meta_info else None,
             )
 
             if meta_info is not None:
@@ -806,6 +807,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         output_logprobs: Optional[list] = None,
         *,
         require_reasoning: bool,
+        finish_reason: Union[str, dict[str, Any], None] = None,
     ):
         chat_tools = self._response_tools_to_chat_tools(request)
         if self.reasoning_parser:
@@ -825,7 +827,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                     and request.tool_choice != "none"
                 ),
             )
-            reasoning_content, content = reasoning_parser.parse_non_stream(final_output)
+            reasoning_content, content = reasoning_parser.parse_non_stream(
+                final_output, finish_reason=finish_reason
+            )
         else:
             reasoning_content = None
             content = final_output
@@ -2239,7 +2243,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     )
                     if flush:
                         end_reasoning, end_normal = (
-                            reasoning_parser_obj.parse_stream_end()
+                            reasoning_parser_obj.parse_stream_end(finish_reason)
                         )
                         if end_reasoning:
                             reasoning_chunk = (reasoning_chunk or "") + end_reasoning

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 from sglang.srt.entrypoints.openai.encoding_dsv4 import dsml_token as dsv4_dsml_token
 from sglang.srt.entrypoints.openai.encoding_dsv4 import eos_token as dsv4_eos_token
@@ -75,6 +75,7 @@ class BaseReasoningFormatDetector:
         thinks_internally: bool = False,
         reasoning_default: str = "always",
         force_nonempty_content: bool = False,
+        skipped_think_as_content: bool = False,
     ):
         self.think_start_token = think_start_token
         self.think_end_token = think_end_token
@@ -92,6 +93,15 @@ class BaseReasoningFormatDetector:
 
         self._force_nonempty_content = force_nonempty_content
         self._accumulated_reasoning = ""
+
+        # Reasoning the template opened but the model never closed is the
+        # answer when generation stopped on its own (EOS), and truncated
+        # thinking when it was cut (max_tokens or a stop string). Only the
+        # caller knows which, via set_finish_reason(). Only meaningful for
+        # detectors on the base detect_and_parse()/finish() paths.
+        self.skipped_think_as_content = skipped_think_as_content
+        self._finish_reason: Optional[str] = None
+        self._finish_matched: Any = None
 
         self.continue_final_message = continue_final_message
         if self.continue_final_message:
@@ -112,6 +122,30 @@ class BaseReasoningFormatDetector:
         if self._force_nonempty_content and not ret.normal_text:
             ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
         return ret
+
+    def set_finish_reason(
+        self, finish_reason: Union[str, Mapping[str, Any], None]
+    ) -> None:
+        """Record how generation ended before the final parse: the engine's
+        finish_reason dict ({"type": "stop", "matched": <token id | stop str>})
+        or just its type. None keeps the finish-reason-agnostic behaviour."""
+        if isinstance(finish_reason, Mapping):
+            self._finish_reason = finish_reason.get("type")
+            self._finish_matched = finish_reason.get("matched")
+        else:
+            self._finish_reason = finish_reason
+            self._finish_matched = None
+
+    def _skipped_thinking(self) -> bool:
+        return (
+            self.skipped_think_as_content
+            and self._finish_reason == "stop"
+            # A user stop string also reports "stop" but cut the model off; only
+            # its own EOS token (matched is an id, not a str) says it chose to answer.
+            and not isinstance(self._finish_matched, str)
+            # A block the client's assistant prefix opened is not the template's.
+            and self.think_start_token not in self.previous_content
+        )
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         """
@@ -152,6 +186,8 @@ class BaseReasoningFormatDetector:
                 return StreamingParseResult(
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
+            if self._skipped_thinking():
+                return StreamingParseResult(normal_text=processed_text)
             # Assume reasoning was truncated before end token
             return StreamingParseResult(reasoning_text=processed_text)
 
@@ -179,7 +215,7 @@ class BaseReasoningFormatDetector:
             Streams reasoning content as it arrives
         """
         ret = self._parse_streaming_increment_impl(new_text)
-        if self._force_nonempty_content:
+        if self._force_nonempty_content or self.skipped_think_as_content:
             if self._in_reasoning:
                 self._accumulated_reasoning += ret.reasoning_text
             else:
@@ -303,6 +339,17 @@ class BaseReasoningFormatDetector:
             if normal_text:
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
+
+        if self._skipped_thinking():
+            # The trace already streamed as reasoning; re-emit it whole as the
+            # answer. Only a held-back tail still needs to complete that
+            # stream -- a block that never streamed is emitted once, as content.
+            normal_text = self._accumulated_reasoning + buffer
+            self._accumulated_reasoning = ""
+            return StreamingParseResult(
+                normal_text=normal_text,
+                reasoning_text=buffer if self.stream_reasoning else "",
+            )
 
         if buffer:
             return StreamingParseResult(reasoning_text=buffer)
@@ -675,6 +722,7 @@ class Glm45Detector(BaseReasoningFormatDetector):
         continue_final_message: bool = False,
         previous_content: str = "",
         reasoning_default: str = "enable_thinking",
+        skipped_think_as_content: bool = True,
     ):
         think_excluded_tokens = [
             "<tool_call>",
@@ -695,6 +743,7 @@ class Glm45Detector(BaseReasoningFormatDetector):
             force_nonempty_content=force_nonempty_content,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            skipped_think_as_content=skipped_think_as_content,
         )
 
 
@@ -709,8 +758,8 @@ class Ling3Detector(Glm45Detector):
 
     If non-streaming output only contains reasoning text and no tool call, Ling3
     moves that text into normal content as a client-experience fallback. Streaming
-    parsing still emits reasoning increments as they arrive because this parser
-    does not receive a final end-of-generation signal.
+    parsing still emits reasoning increments as they arrive; the base finish()
+    re-emits them as content once the stream ends.
     """
 
     def __init__(
@@ -2019,8 +2068,19 @@ class ReasoningParser:
 
         self.detector = detector_class(**kwargs)
 
-    def parse_non_stream(self, full_text: str) -> Tuple[Optional[str], Optional[str]]:
+        # Set as an attribute rather than a ctor kwarg so every detector can be
+        # toggled per request, whichever arguments its __init__ happens to take.
+        skipped_think_as_content = chat_template_kwargs.get("skipped_think_as_content")
+        if isinstance(skipped_think_as_content, bool):
+            self.detector.skipped_think_as_content = skipped_think_as_content
+
+    def parse_non_stream(
+        self,
+        full_text: str,
+        finish_reason: Union[str, Mapping[str, Any], None] = None,
+    ) -> Tuple[Optional[str], Optional[str]]:
         """Non-streaming call: one-time parsing"""
+        self.detector.set_finish_reason(finish_reason)
         ret = self.detector.detect_and_parse(full_text)
         return ret.reasoning_text, ret.normal_text
 
@@ -2044,8 +2104,11 @@ class ReasoningParser:
         ret = self.detector.parse_streaming_increment(chunk_text)
         return ret.reasoning_text, ret.normal_text
 
-    def parse_stream_end(self) -> Tuple[Optional[str], Optional[str]]:
+    def parse_stream_end(
+        self, finish_reason: Union[str, Mapping[str, Any], None] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
         """Streaming call: flush any detector-specific buffered state once
         the stream ends."""
+        self.detector.set_finish_reason(finish_reason)
         ret = self.detector.finish()
         return ret.reasoning_text, ret.normal_text

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -3298,6 +3298,82 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(msg.content, "")
         self.assertEqual(msg.reasoning_content, "42")
 
+    # --- glm45: template-opened <think> that never closes ---
+
+    SKIPPED_THINK_ANSWER = '```json\n{"kind": "tool", "operation": "alerts"}\n```'
+
+    def _setup_glm45(self):
+        self.tm.server_args.reasoning_parser = "glm45"
+        self.chat.reasoning_parser = "glm45"
+        self.template_manager.reasoning_config = ReasoningToggleConfig(
+            toggle_param="enable_thinking", default_enabled=True
+        )
+
+    def test_build_chat_response_glm45_stop_without_think_end_is_content(self):
+        """GLM's template opens <think> for the model. Output that ends on EOS
+        without ever closing it is the model skipping thinking and answering
+        directly, so it is content; a max_tokens cut stays reasoning."""
+        self._setup_glm45()
+        answer = self.SKIPPED_THINK_ANSWER
+        req = ChatCompletionRequest(
+            model="zai-org/GLM-5.2",
+            messages=[{"role": "user", "content": "Hi?"}],
+        )
+        for finish, expected in (
+            ({"type": "stop", "matched": 154827}, (answer, None)),
+            ({"type": "length", "length": 20}, ("", answer)),
+            ({"type": "stop", "matched": "\n\n"}, ("", answer)),
+        ):
+            with self.subTest(finish_reason=finish):
+                ret_item = {
+                    "text": answer,
+                    "meta_info": {
+                        "id": f"chatcmpl-{uuid.uuid4()}",
+                        "prompt_tokens": 10,
+                        "completion_tokens": 20,
+                        "weight_version": "default",
+                        "finish_reason": finish,
+                    },
+                    "index": 0,
+                }
+                response = self.chat._build_chat_response(req, [ret_item], created=0)
+                msg = response.choices[0].message
+                self.assertEqual((msg.content, msg.reasoning_content), expected)
+
+    def test_process_reasoning_stream_glm45_reemits_skipped_think_on_stop(self):
+        """Streaming cannot know the block will never close, so it streams the
+        text as reasoning; the finishing step re-emits it as content on stop
+        and leaves it as reasoning on a max_tokens cut."""
+        self._setup_glm45()
+        answer = self.SKIPPED_THINK_ANSWER
+        head, tail = answer[:10], answer[10:]
+        req = ChatCompletionRequest(
+            model="zai-org/GLM-5.2",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+        )
+        for finish, expected_delta in (
+            ({"type": "stop", "matched": 154827}, answer),
+            ({"type": "length", "length": 20}, ""),
+            ({"type": "stop", "matched": "\n\n"}, ""),
+        ):
+            with self.subTest(finish_reason=finish):
+                parsers = {}
+                reasoning, delta = self.chat._process_reasoning_stream(
+                    0, head, parsers, {"meta_info": {}}, req, None
+                )
+                self.assertEqual((reasoning, delta), (head, ""))
+                reasoning, delta = self.chat._process_reasoning_stream(
+                    0,
+                    tail,
+                    parsers,
+                    {"meta_info": {"finish_reason": finish}},
+                    req,
+                    finish["type"],
+                )
+                self.assertEqual(reasoning, tail)
+                self.assertEqual(delta, expected_delta)
+
     # --- poolside_v1 (Laguna-XS.2) regression tests ---
 
     def test_poolside_v1_enable_thinking_dispatch(self):

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -913,6 +913,29 @@ class EnginePassthroughTestCase(CustomTestCase):
 
         self.assertTrue(parser_cls.call_args.kwargs["force_reasoning"])
 
+    def test_skipped_think_answer_is_a_message_item_on_stop(self):
+        """Mirrors the chat path: GLM output that ends on EOS without closing
+        the template-opened <think> is the answer, not a reasoning item."""
+        serving = make_serving()
+        serving.reasoning_parser = "glm45"
+        serving.tool_call_parser = None
+        answer = '```json\n{"kind": "tool", "operation": "alerts"}\n```'
+        for finish, item_type in (
+            ({"type": "stop", "matched": 154827}, "message"),
+            ({"type": "length", "length": 20}, "reasoning"),
+            ({"type": "stop", "matched": "\n\n"}, "reasoning"),
+        ):
+            with self.subTest(finish_reason=finish):
+                items = serving._make_response_output_items(
+                    ResponsesRequest(model="x", input="hi", store=False),
+                    answer,
+                    tokenizer=Mock(),
+                    require_reasoning=True,
+                    finish_reason=finish,
+                )
+                self.assertEqual(items[0].type, item_type)
+                self.assertEqual(items[0].content[0].text, answer)
+
     def test_require_reasoning_false_without_reasoning_parser(self):
         serving = make_serving()
         serving.reasoning_parser = None

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -208,6 +208,28 @@ class NonHarmonyStreamTestCase(CustomTestCase):
         )
         self.assertEqual(streamed, "Answer<|e")
 
+    def test_skipped_think_answer_streams_as_output_text_on_stop(self):
+        """GLM output that ends on EOS without closing the template-opened
+        <think> streams live as reasoning and is re-emitted as output text
+        when the stream finishes, so the answer reaches the client."""
+        serving = make_serving()
+        serving.reasoning_parser = "glm45"
+        serving.tool_call_parser = None
+
+        request = ResponsesRequest(model="x", input="hi", stream=True, store=False)
+        answer = '```json\n{"kind": "tool", "operation": "alerts"}\n```'
+        fixture = StreamFixture(serving, request, require_reasoning=True)
+        events = fixture.run(
+            [engine_chunk(answer[:10], 4), engine_chunk(answer, 9, finish=True)]
+        )
+
+        streamed = "".join(
+            p["delta"]
+            for ev, p in zip(event_types(events), event_payloads(events))
+            if ev == "response.output_text.delta"
+        )
+        self.assertEqual(streamed, answer)
+
 
 class MultiToolCallStreamingOrderTestCase(CustomTestCase):
     """The wire order of message / function_call items across tool-call deltas."""

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -530,6 +530,270 @@ class TestLing3Detector(CustomTestCase):
         self.assertEqual(result.normal_text, "")
 
 
+class TestSkippedThinkAsContent(CustomTestCase):
+    """Template-opened reasoning (GLM-4.5 family) that ends with a natural stop
+    before any </think> is the model's answer, not truncated reasoning: the
+    template already emitted <think>, so the model skipped thinking and wrote
+    the answer straight away. finish_reason is the only signal that separates
+    this from a max_tokens cut."""
+
+    ANSWER = '```json\n{"kind": "tool", "operation": "alerts"}\n```'
+
+    def _detector(self, **kwargs):
+        return Glm45Detector(force_reasoning=True, **kwargs)
+
+    def test_stop_without_think_end_is_content(self):
+        detector = self._detector()
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.normal_text, self.ANSWER)
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_length_without_think_end_stays_reasoning(self):
+        detector = self._detector()
+        detector.set_finish_reason("length")
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.reasoning_text, self.ANSWER)
+        self.assertEqual(result.normal_text, "")
+
+    def test_unknown_finish_reason_stays_reasoning(self):
+        """Callers that do not know how generation ended (/separate_reasoning)
+        keep today's behaviour."""
+        detector = self._detector()
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.reasoning_text, self.ANSWER)
+        self.assertEqual(result.normal_text, "")
+
+    def test_abort_without_think_end_stays_reasoning(self):
+        detector = self._detector()
+        detector.set_finish_reason("abort")
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.reasoning_text, self.ANSWER)
+        self.assertEqual(result.normal_text, "")
+
+    def test_engine_finish_reason_dict_with_eos_token_is_content(self):
+        detector = self._detector()
+        detector.set_finish_reason({"type": "stop", "matched": 154827})
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.normal_text, self.ANSWER)
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_user_stop_string_inside_reasoning_stays_reasoning(self):
+        """A user stop sequence also reports finish_reason "stop", but it cut
+        the model off; only the model's own EOS says it chose to answer."""
+        detector = self._detector()
+        detector.set_finish_reason({"type": "stop", "matched": "\n\n"})
+        result = detector.detect_and_parse("half a thought")
+        self.assertEqual(result.reasoning_text, "half a thought")
+        self.assertEqual(result.normal_text, "")
+
+    def test_client_opened_think_in_continue_final_message_stays_reasoning(self):
+        """With continue_final_message the block was opened by the client's
+        assistant prefix, not by the template, so the premise does not hold."""
+        detector = Glm45Detector(
+            continue_final_message=True, previous_content="<think>half a"
+        )
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse(" thought")
+        self.assertEqual(result.reasoning_text, " thought")
+        self.assertEqual(result.normal_text, "")
+
+    def test_stop_with_tool_call_keeps_tool_split(self):
+        detector = self._detector()
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse("need a tool<tool_call>get_weather")
+        self.assertEqual(result.reasoning_text, "need a tool")
+        self.assertEqual(result.normal_text, "<tool_call>get_weather")
+
+    def test_stop_with_closed_reasoning_unchanged(self):
+        detector = self._detector()
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse("thinking</think>The answer is 42.")
+        self.assertEqual(result.reasoning_text, "thinking")
+        self.assertEqual(result.normal_text, "The answer is 42.")
+
+    def test_stop_strips_echoed_think_start(self):
+        detector = self._detector()
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse("<think>" + self.ANSWER)
+        self.assertEqual(result.normal_text, self.ANSWER)
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_flag_off_keeps_reasoning_on_stop(self):
+        detector = self._detector(skipped_think_as_content=False)
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.reasoning_text, self.ANSWER)
+        self.assertEqual(result.normal_text, "")
+
+    def test_default_off_for_other_detectors(self):
+        """Qwen3 writes its own <think></think> pair when it skips thinking, so
+        an unclosed block there is a real truncation; the rule stays opt-in."""
+        detector = Qwen3Detector(force_reasoning=True)
+        detector.set_finish_reason("stop")
+        result = detector.detect_and_parse(self.ANSWER)
+        self.assertEqual(result.reasoning_text, self.ANSWER)
+        self.assertEqual(result.normal_text, "")
+
+    def test_ling3_inherits_glm45_default(self):
+        self.assertTrue(Ling3Detector().skipped_think_as_content)
+
+    # --- streaming: reasoning streams live, finish() re-emits it as content ---
+
+    def _stream(self, detector, text, size):
+        reasoning, normal = "", ""
+        for i in range(0, len(text), size):
+            ret = detector.parse_streaming_increment(text[i : i + size])
+            reasoning += ret.reasoning_text
+            normal += ret.normal_text
+        return reasoning, normal
+
+    def test_streaming_stop_reemits_reasoning_as_content(self):
+        for size in (1, 5, 13):
+            with self.subTest(chunk=size):
+                detector = self._detector()
+                reasoning, normal = self._stream(detector, self.ANSWER, size)
+                self.assertEqual(reasoning, self.ANSWER)
+                self.assertEqual(normal, "")
+                detector.set_finish_reason("stop")
+                end = detector.finish()
+                self.assertEqual(end.normal_text, self.ANSWER)
+                self.assertEqual(end.reasoning_text, "")
+
+    def test_streaming_stop_flushes_held_back_tail_to_both_fields(self):
+        """A trailing slice that could start </think> is held back while
+        streaming; on stop it completes the reasoning stream and the re-emitted
+        content alike."""
+        detector = self._detector()
+        reasoning, _ = self._stream(detector, "answer <", 100)
+        self.assertEqual(reasoning, "answer ")
+        detector.set_finish_reason("stop")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "answer <")
+        self.assertEqual(end.reasoning_text, "<")
+
+    def test_streaming_length_flushes_reasoning_only(self):
+        detector = self._detector()
+        self._stream(detector, "answer <", 100)
+        detector.set_finish_reason("length")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
+        self.assertEqual(end.reasoning_text, "<")
+
+    def test_streaming_stop_no_stream_reasoning_emits_content_once(self):
+        detector = self._detector(stream_reasoning=False)
+        reasoning, normal = self._stream(detector, self.ANSWER, 5)
+        self.assertEqual((reasoning, normal), ("", ""))
+        detector.set_finish_reason("stop")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, self.ANSWER)
+        self.assertEqual(end.reasoning_text, "")
+
+    def test_streaming_tool_call_then_stop_does_not_reemit(self):
+        detector = self._detector()
+        reasoning, normal = self._stream(detector, "need a tool<tool_call>x", 7)
+        self.assertEqual(reasoning, "need a tool")
+        self.assertEqual(normal, "<tool_call>x")
+        detector.set_finish_reason("stop")
+        end = detector.finish()
+        self.assertEqual((end.normal_text, end.reasoning_text), ("", ""))
+
+    def test_streaming_closed_think_then_stop_does_not_reemit(self):
+        detector = self._detector()
+        reasoning, normal = self._stream(detector, "thinking</think>answer", 4)
+        self.assertEqual(reasoning, "thinking")
+        self.assertEqual(normal, "answer")
+        detector.set_finish_reason("stop")
+        end = detector.finish()
+        self.assertEqual((end.normal_text, end.reasoning_text), ("", ""))
+
+    def test_streaming_user_stop_string_flushes_reasoning_only(self):
+        detector = self._detector()
+        self._stream(detector, "half a thought <", 100)
+        detector.set_finish_reason({"type": "stop", "matched": "\n\n"})
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
+        self.assertEqual(end.reasoning_text, "<")
+
+    def test_streaming_flag_off_stop_flushes_reasoning(self):
+        detector = self._detector(skipped_think_as_content=False)
+        self._stream(detector, "answer <", 100)
+        detector.set_finish_reason("stop")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
+        self.assertEqual(end.reasoning_text, "<")
+
+    # --- ReasoningParser: finish_reason plumbing and chat_template_kwargs ---
+
+    def _request(self, **chat_template_kwargs):
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionMessageUserParam,
+            ChatCompletionRequest,
+        )
+
+        return ChatCompletionRequest(
+            model="test",
+            messages=[ChatCompletionMessageUserParam(role="user", content="Hi")],
+            chat_template_kwargs=chat_template_kwargs or None,
+        )
+
+    def test_parse_non_stream_takes_finish_reason(self):
+        parser = ReasoningParser("glm45", force_reasoning=True)
+        self.assertEqual(
+            parser.parse_non_stream(self.ANSWER, finish_reason="stop"),
+            ("", self.ANSWER),
+        )
+        self.assertEqual(
+            parser.parse_non_stream(self.ANSWER, finish_reason="length"),
+            (self.ANSWER, ""),
+        )
+        self.assertEqual(parser.parse_non_stream(self.ANSWER), (self.ANSWER, ""))
+
+    def test_parse_stream_end_takes_finish_reason(self):
+        parser = ReasoningParser("glm45", force_reasoning=True)
+        self.assertEqual(parser.parse_stream_chunk(self.ANSWER), (self.ANSWER, ""))
+        self.assertEqual(
+            parser.parse_stream_end(finish_reason="stop"), ("", self.ANSWER)
+        )
+
+    def test_parser_takes_engine_finish_reason_dict(self):
+        parser = ReasoningParser("glm45", force_reasoning=True)
+        self.assertEqual(
+            parser.parse_non_stream(
+                self.ANSWER, finish_reason={"type": "stop", "matched": [154827]}
+            ),
+            ("", self.ANSWER),
+        )
+        self.assertEqual(
+            parser.parse_non_stream(
+                "half a thought", finish_reason={"type": "stop", "matched": "\n\n"}
+            ),
+            ("half a thought", ""),
+        )
+
+    def test_chat_template_kwargs_opt_out(self):
+        parser = ReasoningParser(
+            "glm45",
+            force_reasoning=True,
+            request=self._request(skipped_think_as_content=False),
+        )
+        self.assertEqual(
+            parser.parse_non_stream(self.ANSWER, finish_reason="stop"),
+            (self.ANSWER, ""),
+        )
+
+    def test_chat_template_kwargs_opt_in_for_other_detectors(self):
+        parser = ReasoningParser(
+            "qwen3",
+            force_reasoning=True,
+            request=self._request(skipped_think_as_content=True),
+        )
+        self.assertEqual(
+            parser.parse_non_stream(self.ANSWER, finish_reason="stop"),
+            ("", self.ANSWER),
+        )
+
+
 class TestHunyuanDetector(CustomTestCase):
     """Test cases for Hunyuan detector with tool interruption support."""
 


### PR DESCRIPTION
## Motivation

Fixes #37645.

GLM-4.5 / 4.6 / 5.x chat templates open the reasoning block for the model: with thinking enabled the generation prompt ends in `<|assistant|><think>`, so the model only ever emits `</think>` and the answer. When the model decides to skip thinking, it writes the answer straight away and stops on EOS without ever emitting `</think>`.

The `glm45` detector (via `BaseReasoningFormatDetector`) has no way to tell that apart from a `max_tokens` cut: both are "reasoning started, no end token", and both land in the branch that assumes truncation. The complete, valid answer is returned as `reasoning_content`, `content` is `""`, `finish_reason` is `stop`. Clients that read `content` see an empty successful response and typically retry the whole context.

Measured on a production GLM-5.2 deployment (sglang, `--reasoning-parser glm45`, non-stream, no tools, ~119k chat completions over two days):

| empty `content`, non-empty `reasoning_content`, no tool call | count | prompt tokens |
|---|---|---|
| `finish_reason=length`, `</think>` never emitted (true truncation) | 2023 | 31.5M |
| `finish_reason=stop`, `</think>` never emitted (skipped thinking) | 700 | 35.8M |
| `finish_reason=stop`, `</think>` emitted, empty answer | 1 | 415 |

In every `stop` case `reasoning_content` held the final answer verbatim (a JSON payload the caller asked for), not a trace. `finish_reason` separates the two populations exactly. Note that the existing opt-in `force_nonempty_content` cannot be used here: it swaps on any empty content and would return the 2023 truncated traces as answers.

## Modifications

- `BaseReasoningFormatDetector`: new `skipped_think_as_content` flag (default `False`) and `set_finish_reason()`, which takes the engine's finish-reason dict (`{"type", "matched"}`) or just the type. When the flag is on and generation ended on the model's own EOS (`type == "stop"` and `matched` is a token id, not a user stop string) while still inside a never-closed reasoning block with no tool call, the text is the answer:
  - non-stream: the truncation branch of `_detect_and_parse_impl` returns it as `normal_text`;
  - stream: nothing is held back; the text streams as `reasoning_content` as before and `finish()` re-emits the accumulated block as `normal_text` (same shape as the `force_nonempty_content` / Kimi-K3 handling, #34187). A held-back partial-marker tail still completes the reasoning stream. Under `stream_reasoning=False` the block is emitted once, as content.
  - `length` / `abort` / unknown finish reason / a user stop string matched inside the block / a block opened by the client's own assistant prefix under `continue_final_message`: unchanged, stays `reasoning_content`.
- `Glm45Detector`: `skipped_think_as_content=True` by default. The template itself opens `<think>`, so an EOS inside the block is unambiguous. `Ling3Detector` inherits it. No other detector changes its default.
- `ReasoningParser`: `parse_non_stream(text, finish_reason=None)` and `parse_stream_end(finish_reason=None)` forward the signal; `chat_template_kwargs["skipped_think_as_content"]` (`true`/`false`) toggles the flag per request or server-wide via `--default-chat-template-kwargs`, for any detector using the base parse paths.
- `serving_chat.py` / `serving_responses.py`: pass the engine finish-reason dict that is already in scope at the four parse call sites (non-stream + stream, chat + responses). `/separate_reasoning` and other callers pass nothing and keep today's behaviour.
- Docs: `separate_reasoning.mdx` gains a GLM row in the parser table and a "GLM-4.5 Family" note.

Known limit of the heuristic: genuine thinking that degenerates into an EOS without `</think>` is indistinguishable from skipped thinking. In the measured traffic every `stop` case carried the final answer, and the per-request opt-out covers deployments where that does not hold. `force_nonempty_content` semantics are untouched; streaming now accumulates the reasoning text whenever the flag is on, as that flag already does.

## Accuracy Tests

Not applicable (no model forward changes). Unit tests:

- `test/registered/unit/parser/test_reasoning_parser.py` — `TestSkippedThinkAsContent` (26 tests, 3 subtests): non-stream `stop` / `length` / `abort` / no finish reason / engine dict with EOS id / user stop string / `continue_final_message` prefix / tool interruption / closed block / echoed `<think>` / flag off / other detectors stay off / Ling3 inherits; streaming re-emit across chunk sizes 1/5/13, held-back tail flushes to both fields, `length` and user stop string flush reasoning only, `stream_reasoning=False` emits content once, tool call and closed block never re-emit, flag off; `ReasoningParser` plumbing (type and dict) and `chat_template_kwargs` opt-out / opt-in.
- `test/registered/unit/entrypoints/openai/test_serving_chat.py` — `_build_chat_response` and `_process_reasoning_stream` with `glm45`: EOS `stop` vs `length` vs user stop string.
- `test/registered/unit/entrypoints/openai/test_serving_responses.py`, `test_serving_responses_stream.py` — `_make_response_output_items` item type, and the streamed `response.output_text.delta` for a skipped-think answer.

```
pytest test/registered/unit/parser                                  382 passed
pytest test/registered/unit/entrypoints/openai/test_serving_chat.py test_serving_responses.py test_serving_responses_stream.py
                                                                    154 passed (5 pre-existing failures unrelated: missing uvicorn in the local env)
```

## Speed Tests and Profiling

Not applicable: one attribute read on the truncation branch; streaming accumulates the reasoning text only when the flag is on (as `force_nonempty_content` already does).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33674956183](https://github.com/sgl-project/sglang/actions/runs/33674956183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33674955863](https://github.com/sgl-project/sglang/actions/runs/33674955863)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33674956224](https://github.com/sgl-project/sglang/actions/runs/33674956224)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
