### PR TITLE
[RL] Flag the from_numpy sincos position tables as not weight-checked

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -249,6 +249,7 @@ class Learnable2DInterpPosEmbDivided_fixed(nn.Module):
             .unsqueeze(1),
             persistent=False,
         )
+        self.time_weight._skip_weight_check = True
 
         self.reset_parameters()
 

--- a/python/sglang/srt/models/kimi_k3_vl.py
+++ b/python/sglang/srt/models/kimi_k3_vl.py
@@ -228,6 +228,7 @@ class Learnable2DInterpPosEmbDividedFixed(nn.Module):
             .unsqueeze(1),
             persistent=False,
         )
+        self.time_weight._skip_weight_check = True
 
     def position_embeddings(
         self,

--- a/python/sglang/srt/models/minicpmv.py
+++ b/python/sglang/srt/models/minicpmv.py
@@ -304,6 +304,7 @@ class Resampler2_5(BaseResampler):
         )
         pos_embed = torch.from_numpy(pos_embed_arr).float().to(device)
         self.register_buffer("pos_embed", pos_embed, persistent=False)
+        self.pos_embed._skip_weight_check = True
 
     def _adjust_pos_cache(
         self, tgt_sizes: torch.Tensor, device: torch.types.Device
@@ -429,6 +430,7 @@ class Resampler4_5(BaseResampler):
         )
         pos_embed = torch.from_numpy(pos_embed_arr).float().to(device)
         self.register_buffer("pos_embed", pos_embed, persistent=False)
+        self.pos_embed._skip_weight_check = True
 
     def _adjust_pos_cache(
         self, tgt_sizes: torch.Tensor, device: torch.types.Device
@@ -458,6 +460,7 @@ class Resampler4_5(BaseResampler):
             .to(device)
         )
         self.register_buffer("temporal_pos_embed", pos_embed, persistent=False)
+        self.temporal_pos_embed._skip_weight_check = True
 
     def _adjust_temporal_pos_cache(
         self, max_temporal_size: int, device: torch.types.Device = "cpu"


### PR DESCRIPTION
## Motivation

Since #36561 every `--check-weight-update-equal` run of Kimi-K2.5 fails on one tensor:

```text
check tensor equality failed:
name=vision_tower.patch_embed.pos_emb.time_weight max_abs_err=1.836 mean_abs_err=0.479 num_exceed=4608
```

`time_weight` is a sincos table registered with `persistent=False` and built with `torch.from_numpy`, which ignores the construction device context; `device_loading_context` moves only parameters, so the buffer stays on the CPU. No checkpoint and no weight sync carries it, yet the checker enumerates `named_buffers()`, resets it and compares it — and nothing can restore a randomized copy. Its name matches none of the hard-coded skip patterns.

This was hidden while the snapshot was `param.detach().cpu()`: for a CPU tensor `.cpu()` returns the tensor itself, so the snapshot aliased the live buffer and reset moved both sides at once — the check was vacuously green. The arena copy in #36561 removed the alias and surfaced the real mismatch.

Bisect: the Kimi-K2.5 E2E on radixark/miles passes with sglang-miles pinned before #36561 and fails at its head, with the same miles code and image.

## Modifications

Mark the affected tables with the checker's existing per-tensor `_skip_weight_check` flag at their definition, the way kv-cache `k_scale`/`v_scale` are marked:

- `kimi_k25.py`, `kimi_k3_vl.py`: `time_weight`
- `minicpmv.py`: `pos_embed` (2 sites), `temporal_pos_embed` — same `from_numpy` construction, `device` defaults to `"cpu"` and two call sites pass none

Five lines, checker untouched. Non-persistent buffers that are derived from weights and refreshed after every sync (Inkling `_w2_lin` / `_a_cat` / `_w1_delta`, GGUF dequant caches) stay checked: the compare is what proves that refresh ran. A blanket skip of non-persistent buffers would lose that, which is why this does not filter on `state_dict` membership.

## Validation

- radixark/miles Kimi-K2.5 E2E (`test_kimi_k25_2layer_ci.py`) on radixark/miles main with `ci-sglang-pr` pinned to this commit (`cca4cad`, identical model lines): **passes** — https://github.com/radixark/miles/actions/runs/33677325425. Same test at sglang-miles head without the fix fails on `time_weight` (run 33611520660).
- Not executed: MiniCPM-V has no weight-check E2E; its flags follow from the identical construction.

Separate follow-up, not in this PR: `time_weight` living on the CPU will fail on real video inputs (device mismatch in the vision forward).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33677891133](https://github.com/sgl-project/sglang/actions/runs/33677891133)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33677890791](https://github.com/sgl-project/sglang/actions/runs/33677890791)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33677891016](https://github.com/sgl-project/sglang/actions/runs/33677891016)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->