### PR TITLE
[RL] Flag the from_numpy sincos position tables as not weight-checked

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -249,6 +249,7 @@ class Learnable2DInterpPosEmbDivided_fixed(nn.Module):
             .unsqueeze(1),
             persistent=False,
         )
+        self.time_weight._skip_weight_check = True
 
         self.reset_parameters()
 

--- a/python/sglang/srt/models/kimi_k3_vl.py
+++ b/python/sglang/srt/models/kimi_k3_vl.py
@@ -228,6 +228,7 @@ class Learnable2DInterpPosEmbDividedFixed(nn.Module):
             .unsqueeze(1),
             persistent=False,
         )
+        self.time_weight._skip_weight_check = True
 
     def position_embeddings(
         self,

--- a/python/sglang/srt/models/minicpmv.py
+++ b/python/sglang/srt/models/minicpmv.py
@@ -304,6 +304,7 @@ class Resampler2_5(BaseResampler):
         )
         pos_embed = torch.from_numpy(pos_embed_arr).float().to(device)
         self.register_buffer("pos_embed", pos_embed, persistent=False)
+        self.pos_embed._skip_weight_check = True
 
     def _adjust_pos_cache(
         self, tgt_sizes: torch.Tensor, device: torch.types.Device
@@ -429,6 +430,7 @@ class Resampler4_5(BaseResampler):
         )
         pos_embed = torch.from_numpy(pos_embed_arr).float().to(device)
         self.register_buffer("pos_embed", pos_embed, persistent=False)
+        self.pos_embed._skip_weight_check = True
 
     def _adjust_pos_cache(
         self, tgt_sizes: torch.Tensor, device: torch.types.Device
@@ -458,6 +460,7 @@ class Resampler4_5(BaseResampler):
             .to(device)
         )
         self.register_buffer("temporal_pos_embed", pos_embed, persistent=False)
+        self.temporal_pos_embed._skip_weight_check = True
 
     def _adjust_temporal_pos_cache(
         self, max_temporal_size: int, device: torch.types.Device = "cpu"


### PR DESCRIPTION
## Motivation

`--check-weight-update-equal` (the RL weight checker) resets every parameter and buffer to random values, runs one weight sync, then compares each tensor against a pre-reset snapshot. That contract assumes every checked tensor is rewritten by the sync.

Kimi-K2.5 / Kimi-K3-VL `vision_tower.patch_embed.pos_emb.time_weight` and MiniCPM-V `pos_embed` / `temporal_pos_embed` break it: they are sincos tables registered with `persistent=False` and built with `torch.from_numpy`, which ignores the construction device context (`device_loading_context` moves only parameters), so they stay on the CPU. No checkpoint and no weight sync carries them, yet the checker enumerates `named_buffers()` and none of the hard-coded skip patterns match their names — once reset, nothing can restore them.

On `main` the failure is masked by an aliasing accident: the snapshot is `param.detach().cpu()`, and for a CPU tensor `.cpu()` returns the tensor itself, so reset moves the snapshot too and the compare is vacuously green. Any snapshot that makes a real copy (as sgl-project/sglang#37649 / sglang-miles does after #36561) exposes the mismatch on every Kimi-K2.5 sync check:

```text
name=vision_tower.patch_embed.pos_emb.time_weight max_abs_err=1.836 mean_abs_err=0.479 num_exceed=4608
```

## Modifications

Mark the tables with the checker's existing per-tensor `_skip_weight_check` flag at their definition, the way kv-cache `k_scale` / `v_scale` are marked: `kimi_k25.py`, `kimi_k3_vl.py` (`time_weight`), `minicpmv.py` (`pos_embed` ×2, `temporal_pos_embed`). Five lines; the checker is untouched. Non-persistent buffers that are derived from weights and refreshed after a sync keep being checked, which is why this does not filter on `state_dict` membership.

Same change as sgl-project/sglang#37649 (sglang-miles), cherry-picked.

## Validation

Kimi-K2.5 RL E2E on radixark/miles main with this change pinned via `ci-sglang-pr`: **passes** — https://github.com/radixark/miles/actions/runs/33677325425 (fails on `time_weight` at sglang-miles head without it, run 33611520660). Separate follow-up: `time_weight` living on the CPU will fail on real video inputs.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829398825](https://github.com/sgl-project/sglang/actions/runs/34829398825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829398514](https://github.com/sgl-project/sglang/actions/runs/34829398514)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829398750](https://github.com/sgl-project/sglang/actions/runs/34829398750)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->