### PR TITLE
Distributed: dispatch GroupCoordinator.broadcast to PyNccl during graph capture

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1467,6 +1467,12 @@ class GroupCoordinator:
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
             return input_
+        # torch.distributed work events abort HIP graph capture; PyNccl is
+        # enabled exactly inside graph_capture() (see the mode table there).
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is not None and not pynccl_comm.disabled:
+            pynccl_comm.broadcast(input_, src=src)
+            return input_
         # Broadcast.
         torch.distributed.broadcast(
             input_, src=self.ranks[src], group=self.device_group


### PR DESCRIPTION
# Distributed: dispatch `GroupCoordinator.broadcast` to PyNccl during graph capture

`GroupCoordinator` keeps two NCCL paths and `graph_capture()` documents which one
each mode may use: PyNccl is enabled exactly inside the capture context, while
`torch.distributed` collectives must stay out of captured graphs, because
`ProcessGroupNCCL`'s watchdog queries work events on the capturing stream and
HIP rejects that outright. `_all_reduce_in_place` and `_reduce_scatter_tensor`
already honour the table with an `if pynccl_comm is not None and not
pynccl_comm.disabled` dispatch; `broadcast` was the one collective that did not,
so the first broadcast issued inside capture aborted every rank on ROCm:

```
HIP error: operation not permitted on an event last recorded in a capturing stream
```

That broadcast is DSpark's per-step TP sync (`spec_tp_sync.py`), which is why
speculative decoding never came up on ROCm with the default in-graph proposal --
the only workaround was `SGLANG_DSPARK_FOLDED_PROPOSAL=0` (eager proposal head).
This PR adds the same dispatch to `broadcast`. The incoming `src` is the
group-local rank, which is exactly what `PyNcclCommunicator.broadcast` takes
(its rank is `dist.get_rank(group)`), so no translation is needed; the
`torch.distributed` branch keeps its `self.ranks[src]` mapping for the eager
path. `pynccl_comm.disabled` is only ever cleared by `change_state(enable=True)`
inside `graph_capture()`, so every eager caller (`mm_utils`, `dsa_cache_layer_split`,
`world_size == 1`, coordinators without PyNccl) is unchanged. The EAGLE verify
broadcasts in `eagle_utils.py` run inside capture on CUDA and now take the
documented PyNccl path as well, same values, one less contract violation.
`dsa_indexer.py` already calls `pynccl_comm.broadcast(..., src=0)` directly, so
the semantics are in-tree precedent.

## Performance
8x MI350X (gfx950), TP8, DeepSeek-V4-Flash-0731 (fp4 experts / fp8 dense),
`--attention-backend dsv4 --page-size 256 --kv-cache-dtype fp8_e4m3
--enforce-shared-experts-fusion`, bs=1, input 24000, output 250, greedy. The
PR does not change any kernel; it makes the speculative configuration bootable
on ROCm, so the comparison is target-only vs the now-working DSPARK config on
the same boot family.

| config | decode tok/s | accept length |
|---|---|---|
| target-only (baseline; DSPARK aborts capture) | 130 | -- |
| DSPARK block 4, eager proposal (`SGLANG_DSPARK_FOLDED_PROPOSAL=0`, prior workaround) | 237 | 3.08 |
| **DSPARK block 4, default in-graph proposal (this PR)** | **256** | 3.08 |

## Accuracy
GSM8K, 200 examples, parallel 32, greedy, same harness for both:
target-only 0.945 / 0.910 (mean 0.928); DSPARK with this PR 0.965 / 0.935 /
0.905 / 0.900 / 0.900 (mean 0.921) -- parity within the harness's ~+/-3 pt
run-to-run spread. Full-set (1319) later in the same campaign: 0.915 for both.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33681024404](https://github.com/sgl-project/sglang/actions/runs/33681024404)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33683214727](https://github.com/sgl-project/sglang/actions/runs/33683214727)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33681024544](https://github.com/sgl-project/sglang/actions/runs/33681024544)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->