### PR TITLE
[Bugfix] Key CUDA graph dedup signatures on kernel function identity

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
+++ b/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
@@ -107,6 +107,7 @@ def kernel_node_payload(node):
     params = checkCudaErrors(cuda_drv.cuGraphKernelNodeGetParams(node))
     return (
         kernel_name(params),
+        (int(params.kern), int(params.func)),
         (int(params.gridDimX), int(params.gridDimY), int(params.gridDimZ)),
         (int(params.blockDimX), int(params.blockDimY), int(params.blockDimZ)),
         int(params.sharedMemBytes),


### PR DESCRIPTION
## Motivation

`cudaGraphExecUpdate` keeps the exec's originally instantiated values for launch attributes that `cuGraphKernelNodeGetAttribute` cannot read back (e.g. `CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION`) and reports success instead of `cudaGraphExecUpdateErrorAttributesChanged`. We root-caused a deterministic hang on GB300 to this: updating an exec from a cuBLASLt kernel captured with preferred cluster (4,1,1) to a variant without fallback-cluster support launches it under 4-CTA clusters and deadlocks in an mbarrier wait.

The dedup registry keys exec groups on kernel name + geometry + queryable attributes, but names are not identities: JIT compilers (triton, `torch.compile`) can emit different kernels with identical names from different modules, so an exec-update could still cross functions whose capture-only attributes differ.

## Modifications

Add the kernel/function handles to `kernel_node_payload` so only launches of the same loaded function share a graph exec. One-line diff; dedup coverage is unchanged for real workloads since repeated captures of the same kernel reuse the same handles.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Verified on GB300: same-kernel captures still produce equal signatures (dedup preserved); two modules loaded from identical PTX (same name/geometry, different functions) now produce different signatures.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33684248365](https://github.com/sgl-project/sglang/actions/runs/33684248365)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33684248154](https://github.com/sgl-project/sglang/actions/runs/33684248154)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33684248469](https://github.com/sgl-project/sglang/actions/runs/33684248469)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->