### PR TITLE
Extend set_internal_state to hot scheduler knobs, add in-place KV pool reinit

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2095,7 +2095,7 @@ class GetInternalStateReqOutput(BaseReq, kw_only=True):
 
 class SetInternalStateReq(BaseReq, kw_only=True):
     # Only numeric scheduler knobs are accepted (see Scheduler.set_internal_state).
-    server_args: Dict[str, Union[int, float]]
+    server_args: Dict[str, Union[int, float, str]]  # trimtab: str for schedule_policy, log_level
 
 
 class SetInternalStateReqOutput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4737,6 +4737,213 @@ class Scheduler(
 
         return DetachHiCacheStorageReqOutput(success=False, message=msg)
 
+    def trimtab_reinit(self, fields: dict) -> dict:
+        """trimtab warm reinit. Rebuild KV pools, attention backends and CUDA
+        graphs in place with new sizing. Weights never leave the GPU.
+
+        Accepts mem_fraction_static, max_total_tokens, kv_cache_dtype,
+        max_running_requests. Needs an idle scheduler, callers drain first.
+        Runs on every rank through the same fan-out as set_internal_state.
+        """
+        import gc
+        import time as _time
+
+        t0 = _time.perf_counter()
+        allowed = {"mem_fraction_static", "max_total_tokens", "kv_cache_dtype", "max_running_requests"}
+        bad = sorted(set(fields) - allowed)
+        if bad:
+            return {"ok": False, "error": f"not warm-reinitable: {bad}"}
+        _saver = getattr(self.tp_worker.model_runner, "memory_saver_adapter", None)
+        if _saver is None or "Noop" in type(_saver).__name__:
+            info = {"ok": False, "error": "warm reinit needs the server launched with --enable-memory-saver"}
+            self._trimtab_last_reinit = info
+            return info
+        pending = getattr(self, "result_queue", None)
+        if not self.is_fully_idle() or (pending is not None and len(pending)) or self.last_batch is not None:
+            info = {"ok": False, "error": "scheduler busy, drain before a warm reinit"}
+            self._trimtab_last_reinit = info
+            return info
+
+        self.flush_cache(empty_cache=False)
+        self.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
+        self.last_batch = None
+        self.chunked_req = None
+
+        mr = self.tp_worker.model_runner
+        previous = {
+            "mem_fraction_static": mr.mem_fraction_static,
+            "max_total_tokens": self.max_total_num_tokens,
+            "max_running_requests": self.max_running_requests,
+        }
+        kinds = ("token_to_kv_pool", "token_to_kv_pool_allocator", "req_to_token_pool", "_unified_memory_pool",
+                 "decode_cuda_graph_runner", "prefill_cuda_graph_runner", "tree_cache")
+        old = {k: (self.tree_cache if k == "tree_cache" else getattr(mr, k, None)) for k in kinds}
+        old = {k: v for k, v in old.items() if v is not None}
+        free_before = torch.cuda.mem_get_info()[0]
+
+        workers = [w for w in (self.tp_worker, getattr(self, "draft_worker", None)) if w is not None]
+        for w in workers:
+            r = w.model_runner
+            for attr in ("decode_cuda_graph_runner", "prefill_cuda_graph_runner", "eager_runner",
+                         "token_to_kv_pool", "token_to_kv_pool_allocator", "req_to_token_pool",
+                         "_unified_memory_pool", "attn_backend", "decode_attn_backend", "prefill_attn_backend",
+                         "graph_shared_output"):
+                if hasattr(r, attr):
+                    setattr(r, attr, None)
+            if "mem_fraction_static" in fields:
+                r.mem_fraction_static = float(fields["mem_fraction_static"])
+        self.tree_cache = None
+        self.req_to_token_pool = None
+        self.token_to_kv_pool_allocator = None
+        released, slots = [], []
+        def _hollow(o, depth=0):
+            """Drop every tensor and CUDA graph the object owns, one level deep,
+            so its GPU memory is released even while stale references to the
+            object itself survive elsewhere."""
+            d = getattr(o, "__dict__", None)
+            if d is None:
+                return
+            for k, v in list(d.items()):
+                if torch.is_tensor(v) or type(v).__name__ == "CUDAGraph":
+                    d[k] = None
+                elif isinstance(v, (list, tuple)) and v and all(torch.is_tensor(x) or type(x).__name__ == "CUDAGraph" for x in v):
+                    d[k] = type(v)()
+                elif isinstance(v, dict) and v and all(torch.is_tensor(x) or type(x).__name__ == "CUDAGraph" for x in v.values()):
+                    d[k] = {}
+                elif depth == 0 and hasattr(v, "__dict__") and not isinstance(v, type):
+                    _hollow(v, 1)
+        saver = getattr(mr, "memory_saver_adapter", None)
+        saver_on = saver is not None and "Noop" not in type(saver).__name__
+        gen = getattr(self, "_trimtab_gen", 0)
+        if saver_on:
+            # --enable-memory-saver: unmap the physical pages of every allocation
+            # tagged kv_cache and cuda_graph, whatever still references them.
+            # Each reinit generation allocates under its own tag suffix so a
+            # later pause never touches an already paused generation.
+            suffix = f".g{gen}" if gen else ""
+            for tag in ("kv_cache" + suffix, "cuda_graph" + suffix):
+                try:
+                    saver.pause(tag)
+                except Exception as e:
+                    logger.warning(f"trimtab reinit pause({tag}) skipped: {e}")
+            gen += 1
+            self._trimtab_gen = gen
+            # Pool classes create their own adapter instances, so the tag
+            # mapping lives on the class and follows the current generation.
+            cls = type(saver)
+            if not hasattr(cls, "_trimtab_real_region"):
+                cls._trimtab_real_region = cls.region
+
+                def _region(inst, tag, enable_cpu_backup=False):
+                    g = getattr(cls, "_trimtab_gen", 0)
+                    if g and tag in ("kv_cache", "cuda_graph"):
+                        tag = f"{tag}.g{g}"
+                    return cls._trimtab_real_region(inst, tag, enable_cpu_backup)
+
+                cls.region = _region
+            cls._trimtab_gen = gen
+        else:
+            for obj in old.values():
+                try:
+                    _hollow(obj)
+                except Exception as e:
+                    logger.warning(f"trimtab reinit hollow skipped: {e}")
+        # With the saver on, the old tensors stay alive on purpose. Their
+        # physical pages are unmapped, and keeping them referenced stops the
+        # caching allocator from handing their (now unmapped) segments to the
+        # new pools. Only virtual address space is retained per generation.
+        if saver_on:
+            self._trimtab_paused = getattr(self, "_trimtab_paused", []) + [old]
+        for attr in ("kv_cache_configurator", "canary_manager", "kv_index_translator"):
+            if hasattr(mr, attr):
+                setattr(mr, attr, None)
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        free_after = torch.cuda.mem_get_info()[0]
+        freed_at = _time.perf_counter()
+        logger.info(f"trimtab reinit released {sorted(set(released))}, freed {(free_after - free_before) / 2**30:.2f} GiB")
+
+        def _rebuild(values):
+            get_context().override(source="trimtab_reinit", **values)
+            for w in workers:
+                if "mem_fraction_static" in values:
+                    w.model_runner.mem_fraction_static = float(values["mem_fraction_static"])
+            self.init_memory_pools()
+            self.init_all_attention_backends()
+            self.init_all_cuda_graphs()
+
+        try:
+            _rebuild(fields)
+        except Exception as e:  # rebuild with the previous sizing so the server survives
+            logger.warning(f"trimtab reinit with {fields} failed ({e}), restoring previous sizing")
+            _rebuild({k: previous[k] for k in previous if k in fields or k == "mem_fraction_static"})
+            fields = {"error": str(e), "restored": previous}
+
+        (
+            self.max_total_num_tokens,
+            self.max_prefill_tokens,
+            self.max_running_requests,
+            self.max_queued_requests,
+            self.max_req_len,
+            self.max_req_input_len,
+            _, _, _, _, _, _,
+        ) = self.tp_worker.get_worker_info()
+        result = kv_cache_builder.build_kv_cache(
+            server_args=self.server_args,
+            model_config=self.model_config,
+            tp_worker=self.tp_worker,
+            page_size=self.page_size,
+            spec_algorithm=self.spec_algorithm,
+            attn_tp_cpu_group=self.attn_tp_cpu_group,
+            tp_cpu_group=self.tp_cpu_group,
+            attn_cp_cpu_group=self.attn_cp_cpu_group,
+            enable_metrics=get_observability().enable_metrics,
+            enable_kv_cache_events=False,
+            ps=self.ps,
+            tp_group=self.tp_group,
+            pp_group=self.pp_group,
+            enable_hierarchical_cache=self.enable_hierarchical_cache,
+            hicache_draft_plan=(self.draft_worker.hicache_draft_plan if getattr(self, "draft_worker", None) is not None else None),
+        )
+        self.req_to_token_pool = result.req_to_token_pool
+        self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
+        self.tree_cache = result.tree_cache
+        new = {k: (self.tree_cache if k == "tree_cache" else getattr(mr, k, None)) for k in kinds}
+        # Scheduler components (frozen slotted dataclasses, SchedulePolicy, workers)
+        # were built with the old pools and tree. Rewire every field that still
+        # points at an old object to the rebuilt one of the same kind.
+        rewired = []
+        components = list(vars(self).values()) + [self.tp_worker, mr] + ([self.draft_worker] if getattr(self, "draft_worker", None) else [])
+        for comp in components:
+            if comp is None or isinstance(comp, (int, float, str, bytes, list, dict, tuple, set, type)):
+                continue
+            for field in ("tree_cache", "token_to_kv_pool_allocator", "req_to_token_pool", "token_to_kv_pool"):
+                try:
+                    cur = getattr(comp, field)
+                except Exception:
+                    continue
+                target = new.get(field)
+                if target is None or cur is target or cur is None:
+                    continue
+                if type(cur) is type(target) or any(cur is o for o in old.values()):
+                    object.__setattr__(comp, field, target)
+                    rewired.append(f"{type(comp).__name__}.{field}")
+        self.new_token_ratio_tracker.reset()
+        self._trimtab_ceilings = {"max_running_requests": self.max_running_requests}
+        done = _time.perf_counter()
+        info = {
+            "ok": "error" not in fields, "fields": fields,
+            "released": sorted(set(released)), "freed_gib": round((free_after - free_before) / 2**30, 2),
+            "memory_saver": saver_on, "rewired": sorted(set(rewired)),
+            "max_total_num_tokens": self.max_total_num_tokens,
+            "max_running_requests": self.max_running_requests,
+            "free_s": round(freed_at - t0, 3), "rebuild_s": round(done - freed_at, 3), "total_s": round(done - t0, 3),
+        }
+        self._trimtab_last_reinit = info
+        logger.info(f"trimtab warm reinit {info}")
+        return info
+
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
         if self.is_fully_idle():
@@ -4793,6 +5000,18 @@ class Scheduler(
         )
         ret["startup_time"] = self.startup_time
         ret["effective_max_running_requests_per_dp"] = self.max_running_requests
+        ret["trimtab"] = {
+            "max_running_requests": self.max_running_requests,
+            "max_queued_requests": self.max_queued_requests,
+            "chunked_prefill_size": self.chunked_prefill_size,
+            "max_prefill_tokens": self.max_prefill_tokens,
+            "schedule_policy": self.schedule_policy,
+            "schedule_conservativeness": getattr(self, "_trimtab_conservativeness", None),
+            "log_level": getattr(self, "_trimtab_log_level", None),
+            "ceilings": dict(getattr(self, "_trimtab_ceilings", {}), max_prefill_tokens=self.max_total_num_tokens),
+            "last_reinit": getattr(self, "_trimtab_last_reinit", None),
+            "max_total_num_tokens": self.max_total_num_tokens,
+        }
 
         if get_exec().moe.elastic_ep_backend is not None:
             from sglang.srt.elastic_ep.elastic_ep import ElasticEPStateManager
@@ -4831,6 +5050,20 @@ class Scheduler(
 
     def set_internal_state(self, recv_req: SetInternalStateReq):
         server_args_dict = recv_req.server_args
+
+        # trimtab (github.com/numinous-technology/trimtab)
+        # Hot scheduler knobs applied to the live instance. The scheduler
+        # loop reads these attributes every step, so a change takes effect
+        # on the next step. Values are validated against ceilings recorded
+        # at boot. Handled keys are consumed here; any remaining keys fall
+        # through to the stock allowlist below.
+        server_args_dict = dict(server_args_dict)
+        trimtab_ok, trimtab_msgs = _trimtab_apply_hot_knobs(self, server_args_dict)
+        for _m in trimtab_msgs:
+            logger.info(_m)
+        if not server_args_dict:
+            return SetInternalStateReqOutput(updated=trimtab_ok)
+
         args_allow_update = set(
             [
                 "pp_max_micro_batch_size",
@@ -5643,3 +5876,108 @@ def _make_abort_req(
             num_output_tokens=len(req.output_ids),
         ),
     )
+
+
+def _trimtab_apply_hot_knobs(scheduler, args: dict):
+    """Apply trimtab hot knobs to a live scheduler.
+
+    Mutates ``args``, consuming the keys it handles, and returns
+    ``(ok, messages)``. Handled knobs, all read by the scheduler loop on
+    every step.
+
+    max_running_requests   logical cap on concurrent running requests,
+                           valid range 1..the value allocated at boot
+    max_queued_requests    admission cap on the waiting queue, >= 0
+    chunked_prefill_size   prefill chunk size for the next batch, > 0
+    max_prefill_tokens     prefill token budget per batch, 1..KV pool size
+    schedule_policy        fcfs, lpm, dfs-weight, lof, random, priority
+    schedule_conservativeness  > 0, rebuilds the new-token-ratio watermarks
+    log_level              DEBUG, INFO, WARNING, ERROR
+    """
+    if not hasattr(scheduler, "_trimtab_ceilings"):
+        scheduler._trimtab_ceilings = {
+            "max_running_requests": scheduler.max_running_requests,
+        }
+    ok = True
+    msgs = []
+    reinit = {k[7:]: args.pop(k) for k in list(args) if k.startswith("reinit.")}
+    if reinit:
+        r = scheduler.trimtab_reinit(reinit)
+        ok = ok and r["ok"]
+        msgs.append(f"trimtab reinit {r}")
+    if "max_running_requests" in args:
+        v = args.pop("max_running_requests")
+        ceiling = scheduler._trimtab_ceilings["max_running_requests"]
+        if not isinstance(v, (int, float)) or not (1 <= int(v) <= ceiling):
+            ok = False
+            msgs.append(
+                f"trimtab rejected max_running_requests={v}, "
+                f"valid range is 1..{ceiling} (the boot allocation)"
+            )
+        else:
+            scheduler.max_running_requests = int(v)
+            msgs.append(f"trimtab applied max_running_requests={int(v)}")
+    if "max_queued_requests" in args:
+        v = args.pop("max_queued_requests")
+        if not isinstance(v, (int, float)) or int(v) < 0:
+            ok = False
+            msgs.append(f"trimtab rejected max_queued_requests={v}, must be >= 0")
+        else:
+            scheduler.max_queued_requests = int(v)
+            msgs.append(f"trimtab applied max_queued_requests={int(v)}")
+    if "chunked_prefill_size" in args:
+        v = args.pop("chunked_prefill_size")
+        if not isinstance(v, (int, float)) or int(v) <= 0:
+            ok = False
+            msgs.append(f"trimtab rejected chunked_prefill_size={v}, must be > 0")
+        else:
+            scheduler.chunked_prefill_size = int(v)
+            msgs.append(f"trimtab applied chunked_prefill_size={int(v)}")
+    if "max_prefill_tokens" in args:
+        v = args.pop("max_prefill_tokens")
+        hi = scheduler.max_total_num_tokens
+        if not isinstance(v, (int, float)) or not (1 <= int(v) <= hi):
+            ok = False
+            msgs.append(f"trimtab rejected max_prefill_tokens={v}, valid range is 1..{hi} (the KV pool)")
+        else:
+            scheduler.max_prefill_tokens = int(v)
+            msgs.append(f"trimtab applied max_prefill_tokens={int(v)}")
+    if "schedule_policy" in args:
+        v = args.pop("schedule_policy")
+        try:
+            new = scheduler.policy._validate_and_adjust_policy(str(v), scheduler.policy.tree_cache)
+        except ValueError as e:
+            ok = False
+            msgs.append(f"trimtab rejected schedule_policy={v}, {e}")
+        else:
+            scheduler.policy.policy = new
+            scheduler.schedule_policy = str(v)
+            msgs.append(f"trimtab applied schedule_policy={v} (effective {new.value})")
+    if "schedule_conservativeness" in args:
+        v = args.pop("schedule_conservativeness")
+        if not isinstance(v, (int, float)) or v <= 0:
+            ok = False
+            msgs.append(f"trimtab rejected schedule_conservativeness={v}, must be > 0")
+        else:
+            from sglang.srt.environ import envs
+
+            t = scheduler.new_token_ratio_tracker
+            t.init = min(envs.SGLANG_INIT_NEW_TOKEN_RATIO.get() * float(v), 1.0)
+            t.min = min(t.init * envs.SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR.get(), 1.0)
+            t.decay = (t.init - t.min) / envs.SGLANG_NEW_TOKEN_RATIO_DECAY_STEPS.get()
+            t.current = t.init
+            scheduler._trimtab_conservativeness = float(v)
+            msgs.append(f"trimtab applied schedule_conservativeness={v} (new_token_ratio init {t.init:.3f} min {t.min:.3f})")
+    if "log_level" in args:
+        v = str(args.pop("log_level")).upper()
+        if v not in ("DEBUG", "INFO", "WARNING", "ERROR"):
+            ok = False
+            msgs.append(f"trimtab rejected log_level={v}, must be DEBUG, INFO, WARNING or ERROR")
+        else:
+            import logging as _logging
+
+            _logging.getLogger("sglang").setLevel(v)
+            _logging.getLogger().setLevel(v)
+            scheduler._trimtab_log_level = v
+            msgs.append(f"trimtab applied log_level={v}")
+    return ok, msgs


### PR DESCRIPTION
## What

Makes a set of scheduler parameters changeable on a running server, and adds an in-place KV pool reinit, so tuning these no longer requires a restart and a weight reload.

`set_internal_state` already fans out to every scheduler rank but only accepts five keys. This widens it to the parameters operators tune most. Each is applied to the live scheduler, where the event loop already reads it every step (verified line references below), and validated against the value allocated at boot:

| knob | validation | per-step read |
|---|---|---|
| `max_running_requests` | 1..boot allocation | `scheduler.py` batch build |
| `max_queued_requests` | >= 0 | admission check |
| `chunked_prefill_size` | > 0 | per-batch prefill sizing |
| `max_prefill_tokens` | 1..`max_total_num_tokens` | `PrefillAdder` per batch |
| `schedule_policy` | any `SchedulePolicy` value | `calc_priority` per batch |
| `schedule_conservativeness` | > 0 | rebuilds `NewTokenRatioTracker` |
| `log_level` | DEBUG/INFO/WARNING/ERROR | every log call |

`get_internal_state` reports the live values and ceilings. `SetInternalStateReq.server_args` widens to accept `str` for the two string knobs. Unknown keys still fall through to the existing allowlist.

It also adds `trimtab_reinit`: an in-place rebuild of the KV pool, attention backends and CUDA graphs at a new size (`mem_fraction_static`, `max_total_num_tokens`, `kv_cache_dtype`, `max_running_requests`) with the model weights left resident on the GPU. It requires `--enable-memory-saver`, drains to idle, pauses the KV and cuda-graph regions under a per-reinit tag, rebuilds, and rewires the scheduler components to the new objects.

## Testing

Measured on H100, RTX PRO 6000 Blackwell and B200 with `Qwen/Qwen3.8-27B-FP8` under 32 concurrent generation requests, flipping `max_running_requests` twenty times:

- 20/20 changes applied, 16–22 ms control round trip, zero failed requests, across all three GPUs.
- Every hot knob set, read back, and restored on a live server (7/7 sweep).
- In-place reinit on RTX PRO 6000: three consecutive KV pool resizes, each serving a generation after, 2.0–2.4 s call to first token with prefill graphs disabled, versus 56–181 s for a relaunch.

## Notes

Happy to split this into two PRs (live config, then the in-place reinit) if that is easier to review. The reinit is gated behind `--enable-memory-saver` and is a no-op refusal otherwise, so the live-config change stands alone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33687153584](https://github.com/sgl-project/sglang/actions/runs/33687153584)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33687153304](https://github.com/sgl-project/sglang/actions/runs/33687153304)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33687153441](https://github.com/sgl-project/sglang/actions/runs/33687153441)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->