### PR TITLE
Fix shared-memory race in MoE alignment kernel

### DIFF
--- a/python/sglang/kernels/aot/csrc/moe/moe_align_kernel.cu
+++ b/python/sglang/kernels/aot/csrc/moe/moe_align_kernel.cu
@@ -212,13 +212,14 @@ __global__ void moe_align_block_size_kernel(
   if (tid < scan_size) scan_buf[tid] = pre + offset;
   __syncthreads();
 
-  // Write prefix[0..num_experts - 1] and cumsum
+  // Write prefix[0..num_experts - 1]
   if (tid < num_experts) prefix[tid] = scan_buf[tid];
 #endif
 
   if (tid <= num_experts) {
     cumsum[tid] = prefix[tid];
   }
+  __syncthreads();
   // fill expert_ids
   const int32_t num_blocks = s_total_tokens_post_pad / block_size;
   for (int32_t i = tid; i < num_blocks; i += stride) {

--- a/python/sglang/kernels/jit/csrc/moe/moe_align_kernel.cu
+++ b/python/sglang/kernels/jit/csrc/moe/moe_align_kernel.cu
@@ -227,13 +227,14 @@ __global__ void moe_align_block_size_kernel(
   if (tid < scan_size) scan_buf[tid] = pre + offset;
   __syncthreads();
 
-  // Write prefix[0..num_experts - 1] and cumsum
+  // Write prefix[0..num_experts - 1]
   if (tid < num_experts) prefix[tid] = scan_buf[tid];
 #endif
 
   if (tid <= num_experts) {
     cumsum[tid] = prefix[tid];
   }
+  __syncthreads();
   // fill expert_ids
   const int32_t num_blocks = s_total_tokens_post_pad / block_size;
   for (int32_t i = tid; i < num_blocks; i += stride) {


### PR DESCRIPTION
## Motivation

Prevent a shared-memory race in `moe_align_block_size_kernel`. Threads write `prefix[tid] = scan_buf[tid]` for `tid < num_experts`, and later every thread reads `prefix[mid]` inside the binary search of the `expert_ids` fill loop. Without a barrier between the stores and the search, a thread can binary-search entries that another thread has not written yet and read stale data.

## Modifications

Add the missing synchronization barrier after the shared `prefix`/`cumsum` setup and before the `expert_ids` fill loop, in both the AOT and JIT CUDA implementations.

## Accuracy Tests

Not run; this is a synchronization-only fix.

## Speed Tests and Profiling

B300, CUDA 13.0, PyTorch 2.13.0+cu130. Both variants were built from source with identical flags. Medians from 31 alternating batches of 1,000 calls after 500 warmups.

| Tokens | Experts | Top-k | Block size | Baseline | Patched | Delta |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 64 | 8 | 32 | 9.193 us | 9.272 us | +0.86% |
| 256 | 160 | 8 | 128 | 9.254 us | 9.285 us | +0.33% |
| 1,024 | 256 | 8 | 128 | 10.250 us | 10.250 us | -0.01% |
| 4,096 | 256 | 8 | 128 | 20.495 us | 20.494 us | -0.00% |

## Checklist

- [x] Code is formatted.
- [ ] Unit tests were not added.
- [x] Documentation is not required.
- [x] Speed benchmark results are provided; accuracy tests were not run.
- [x] The change follows the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35636623013](https://github.com/sgl-project/sglang/actions/runs/35636623013)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35636622606](https://github.com/sgl-project/sglang/actions/runs/35636622606)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35636623151](https://github.com/sgl-project/sglang/actions/runs/35636623151)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->