### PR TITLE
[Bugfix] Break InternVL tile-grid ties on area, not block count

### DIFF
--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -163,18 +163,21 @@ class InternVLProcessor(BaseMultimodalProcessor):
         # Find closest ratio
         best_ratio_diff = float("inf")
         best_ratio = (1, 1)
+        area = W * H
 
         for x, y in target_ratios:
             target_ar = x / y
             diff = abs(aspect_ratio - target_ar)
-            blocks = x * y
-            best_blocks = best_ratio[0] * best_ratio[1]
 
             if diff < best_ratio_diff:
                 best_ratio_diff = diff
                 best_ratio = (x, y)
-            elif diff == best_ratio_diff and blocks > best_blocks:
-                best_ratio = (x, y)
+            elif diff == best_ratio_diff:
+                # Only move to a larger grid when the image actually has the
+                # pixels to fill it. Preferring more blocks unconditionally
+                # sends a 448x448 image to a 3x3 grid.
+                if area > 0.5 * image_size * image_size * x * y:
+                    best_ratio = (x, y)
 
         target_w, target_h = image_size * best_ratio[0], image_size * best_ratio[1]
         blocks = best_ratio[0] * best_ratio[1]


### PR DESCRIPTION
## Motivation

`InternVLProcessor.dynamic_preprocess` picks a much larger tile grid than the image
warrants, so InternVL and InternS1 requests spend several times the image tokens they
should. A 448x448 image with a 448 tile size should be a single tile. It currently
becomes a 3x3 grid, ten tiles with the thumbnail, and 2560 tokens instead of 512.

The cause is the tie-break. When several candidate grids have the same aspect-ratio
error, this copy prefers whichever has more blocks:

```python
elif diff == best_ratio_diff and blocks > best_blocks:
    best_ratio = (x, y)
```

For any square image every square grid ties at `diff == 0`, so it always walks up to
the largest one `max_num` allows.

This repository already contains the correct implementation. `srt/multimodal/internvl_utils.py`
has `find_closest_aspect_ratio`, taken verbatim from OpenGVLab upstream, which breaks
the same tie on whether the image actually has the pixels to fill the larger grid:

```python
elif ratio_diff == best_ratio_diff:
    if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
        best_ratio = ratio
```

The two diverged when #9795 rewrote preprocessing for the GPU path.

## Modifications

Bring the tie-break in `processors/internvl.py` back in line with `internvl_utils.py`
and OpenGVLab. Also drops the two loop-local variables that become dead once the
block-count comparison is gone.

## Credit

**This is a reland of #11181 by @coco-alen**, which diagnosed this same bug and proposed
this same fix in October 2025. It was closed on 2026-08-11 by the stale bot after 255
days with no review, with the note "Reopen it if the work is still relevant" -- it was
never rejected on merit. The approach and the diagnosis are theirs. This reland is
rebased onto current main, where the affected code has since moved, and removes the
now-dead locals.

## Accuracy Tests

Comparing the two tie-breaks over common image shapes, at `image_size=448`, `max_num=12`,
tile counts including the thumbnail and 256 tokens per tile:

| image | after this PR | before this PR |
|---|---|---|
| 448 x 448 | (1,1) 2 tiles, 512 tok | (3,3) 10 tiles, 2560 tok |
| 500 x 500 | (1,1) 2 tiles, 512 tok | (3,3) 10 tiles, 2560 tok |
| 896 x 896 | (2,2) 5 tiles, 1280 tok | (3,3) 10 tiles, 2560 tok |
| 1344 x 448 | (3,1) 4 tiles, 1024 tok | (6,2) 13 tiles, 3328 tok |
| 1024 x 1024 | (3,3) 10 tiles | unchanged |
| 1920 x 1080 | (4,2) 9 tiles | unchanged |
| 640 x 480 | (4,3) 13 tiles | unchanged |
| 2048 x 2048 | (3,3) 10 tiles | unchanged |
| 1280 x 720 | (4,2) 9 tiles | unchanged |
| 3000 x 2000 | (3,2) 7 tiles | unchanged |

Four of ten shapes change, all of them toward the grid `internvl_utils.py` and upstream
already choose. Larger images are unaffected, which is the expected shape of this fix:
it only stops small images being blown up.

The original PR reported a throughput improvement from 10.18 to 23.35 req/s on InternVL3.
I have not reproduced that number, since I do not have the hardware; the tile counts above
are what I verified directly.

## Checklist

- [x] Format your code according to Format code with pre-commit
- [ ] Add unit tests according to Run and add unit tests
- [x] Follow the SGLang code style guidance

On tests: I could not run the existing suite for this module locally, so rather than ship
an unexercised test I have left it out. Happy to add one that pins the tile grid for a
square image if you would like it -- say the word and I will push it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33689147179](https://github.com/sgl-project/sglang/actions/runs/33689147179)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33689146819](https://github.com/sgl-project/sglang/actions/runs/33689146819)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33689147187](https://github.com/sgl-project/sglang/actions/runs/33689147187)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->