### PR TITLE
Fix int32 offset overflow in kpool gather kernel

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
@@ -81,7 +81,8 @@ def _gather_index_k_scale_prefix_into_kernel(
     token_id = tl.program_id(0)
     page_idx = token_id // PAGE_SIZE
     token_offset_in_page = token_id % PAGE_SIZE
-    page = tl.load(page_indices_ptr + page_idx)
+    # Use int64 because page offsets can overflow int32 for large index buffers.
+    page = tl.load(page_indices_ptr + page_idx).to(tl.int64)
 
     offs = tl.arange(0, BLOCK_D)
     mask = offs < HEAD_DIM


### PR DESCRIPTION
## Motivation

Large index buffers can produce page offsets that overflow int32.

## Modifications

Cast the loaded page index to int64 before calculating buffer offsets.

## Accuracy Tests

Not applicable; this fixes address calculation without changing intended outputs.

- `python -m py_compile python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py`
- CUDA test not run locally because `torch` is unavailable.

## Speed Tests and Profiling

Not run; no material performance impact is expected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33690351756](https://github.com/sgl-project/sglang/actions/runs/33690351756)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33690351471](https://github.com/sgl-project/sglang/actions/runs/33690351471)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33690351846](https://github.com/sgl-project/sglang/actions/runs/33690351846)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->