### PR TITLE
[CI] Install lmms-eval from PyPI, drop human-eval install, add clone token fallback

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -128,6 +128,11 @@ jobs:
 
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(inputs.install_timeout) }}
+        env:
+          # The checkout above does not persist the job token because fork code
+          # runs here; a public-read-only PAT keeps github.com clones off the
+          # anonymous per-IP rate limit. Unset secret -> empty -> anonymous.
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_CI_CLONE }}
         run: |
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
@@ -236,6 +241,8 @@ jobs:
 
       - name: Install dependencies (diffusion)
         timeout-minutes: 20
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_CI_CLONE }}
         run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -129,9 +129,8 @@ jobs:
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(inputs.install_timeout) }}
         env:
-          # The checkout above does not persist the job token because fork code
-          # runs here; a public-read-only PAT keeps github.com clones off the
-          # anonymous per-IP rate limit. Unset secret -> empty -> anonymous.
+          # Public-read-only PAT: the checkout above leaves no job token for the
+          # install script's github.com clones. Unset -> anonymous.
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_CI_CLONE }}
         run: |
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -763,9 +763,8 @@ install_extra_deps() {
     fi
 
     if [ "$IS_BLACKWELL" != "1" ]; then
-        git_clone_with_retry https://github.com/EvolvingLMMs-Lab/lmms-eval.git lmms-eval "--branch v0.5"
-        $PIP_CMD install -e lmms-eval/ $PIP_INSTALL_SUFFIX
-        # lmms-eval v0.5 pulls antlr4-python3-runtime==4.7.2, clobbering the
+        $PIP_CMD install "lmms_eval==0.5.0" $PIP_INSTALL_SUFFIX
+        # lmms_eval 0.5.0 pulls antlr4-python3-runtime==4.7.2, clobbering the
         # 4.9.3 that sgl-eval's latex2sympy2_extended needs (4.7.2 ImportError
         # at sgl-eval import). Pin it back so the nightly sgl-eval path works.
         $PIP_CMD install "antlr4-python3-runtime==4.9.3" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
@@ -782,14 +781,6 @@ install_test_tools() {
     [ -e "${HOME}/.cache/sglang" ] && [ ! -d "${HOME}/.cache/sglang" ] && rm -f "${HOME}/.cache/sglang"
     mkdir -p "${HOME}/.cache/sglang/"
     mv python/kernels.lock "${HOME}/.cache/sglang/" || true
-
-    # Install human-eval (subshell keeps cd local)
-    $PIP_CMD install "setuptools==70.0.0" $PIP_INSTALL_SUFFIX
-    [ -d human-eval ] || git_clone_with_retry https://github.com/merrymercy/human-eval.git human-eval
-    (
-        cd human-eval
-        $PIP_CMD install -e . --no-build-isolation $PIP_INSTALL_SUFFIX
-    )
 
     mark_step_done "${FUNCNAME[0]}"
 }

--- a/scripts/ci/utils/git_clone_with_retry.sh
+++ b/scripts/ci/utils/git_clone_with_retry.sh
@@ -10,10 +10,14 @@ _git_with_github_auth() {
 
   local repo_root
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-  # Persisted by actions/checkout; absent under persist-credentials: false, and
-  # the clone then stays anonymous by design.
+  # Persisted by actions/checkout; absent under persist-credentials: false, where
+  # a workflow may instead hand over a public-read-only token via GH_TOKEN.
   local header
   header="$(git -C "$repo_root" config --local --get http.https://github.com/.extraheader 2>/dev/null || true)"
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [ -z "$header" ] && [ -n "$token" ]; then
+    header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$token" | base64 | tr -d '\n')"
+  fi
 
   local rc=0
   if [ -z "$header" ]; then


### PR DESCRIPTION
Follow-up to #37647. Removes the per-job GitHub clones from the CUDA install hot path: `lmms_eval==0.5.0` from PyPI (same content as the `v0.5` tag; only `models/chat/async_openai.py` differs, which CI does not use) and no more `human-eval` clone (only `test/manual/eval` uses it; `pip install human-eval` from PyPI is API-compatible, as the docs already say). The clone helper also accepts a `GH_TOKEN` fallback so `rerun-test.yml`, which deliberately runs with `persist-credentials: false`, can authenticate the remaining gdrcopy clone via a public-read-only PAT stored as `GH_PAT_FOR_CI_CLONE`; with the secret unset it stays anonymous as today.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33693494246](https://github.com/sgl-project/sglang/actions/runs/33693494246)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33693493438](https://github.com/sgl-project/sglang/actions/runs/33693493438)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33693493540](https://github.com/sgl-project/sglang/actions/runs/33693493540)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->