### PR TITLE
[AMD] [GLM-5.3-Flash Day 0] Honor fused and per-expert names in quark `exclude`

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -55,6 +55,29 @@ def should_ignore_layer(
     # proj_name = qkv_proj
     proj_name = layer_name.split(".")[-1]
 
+    # Some checkpoints serialize an ALREADY-FUSED module and list that exact
+    # fused name in `exclude`. OneNexus/GLM-5.3-Flash-MXFP4 does: its vision
+    # tower ships visual.blocks.N.attn.qkv_proj as one tensor and all 125 such
+    # names appear verbatim in quantization_config.exclude. The packed-mapping
+    # expansion below rewrites that to q_proj/k_proj/v_proj, none of which are
+    # in `exclude`, so the layer is quantized while the checkpoint holds it
+    # unpacked. Honor a direct match before expanding.
+    if check_equal_or_regex_match(layer_name=layer_name, targets=ignore):
+        return True
+
+    # MoE exclusions may likewise be written PER EXPERT while SGLang fuses a
+    # layer's experts into a single FusedMoE module. The same checkpoint lists
+    # model.layers.{3,5,6}.mlp.experts.{0..287}.{down,gate,up}_proj -- 1728
+    # entries -- but the module is named model.layers.N.mlp.experts, which
+    # matches none of them, so those BF16 experts get loaded as MXFP4.
+    if layer_name.endswith(".experts"):
+        expert_prefix = layer_name + "."
+        if any(
+            isinstance(target, str) and target.startswith(expert_prefix)
+            for target in ignore
+        ):
+            return True
+
     # Fused layers like gate_up_proj or qkv_proj will not be fused
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that

--- a/test/registered/unit/layers/quantization/test_quark_utils.py
+++ b/test/registered/unit/layers/quantization/test_quark_utils.py
@@ -8,7 +8,10 @@ import unittest
 
 import torch
 
-from sglang.srt.layers.quantization.quark.utils import e8m0_to_f32
+from sglang.srt.layers.quantization.quark.utils import (
+    e8m0_to_f32,
+    should_ignore_layer,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -64,6 +67,80 @@ class TestE8M0ToF32(CustomTestCase):
         self.assertEqual(out[0].item(), 1.0)
         self.assertEqual(out[1].item(), 128.0)
         self.assertTrue(torch.isnan(out[2]).item())
+
+
+QKV_MAPPING = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+
+
+class TestShouldIgnoreLayerFusedNames(CustomTestCase):
+    """`exclude` entries that name an ALREADY-FUSED module, or name MoE experts
+    individually, must still exclude the module SGLang actually builds.
+
+    Both shapes occur in OneNexus/GLM-5.3-Flash-MXFP4. Getting either wrong is
+    not a silent accuracy loss -- the weights fail to load, because an
+    MXFP4-packed parameter (2 values per byte) meets an unpacked BF16 weight:
+    `param_data.shape=(128, 512), loaded_weight.shape=(128, 1024)`.
+    """
+
+    # ---- Bug-catchers: must FAIL on unfixed code ---------------------------
+
+    def test_directly_excluded_fused_qkv_is_ignored(self):
+        # The checkpoint serializes one fused qkv tensor and excludes that exact
+        # name. Expanding to q/k/v_proj first finds nothing and quantizes it.
+        name = "visual.blocks.0.attn.qkv_proj"
+        self.assertTrue(
+            should_ignore_layer(name, ignore=[name], fused_mapping=QKV_MAPPING)
+        )
+
+    def test_per_expert_excludes_ignore_the_fused_moe_module(self):
+        # SGLang builds one FusedMoE named ...mlp.experts; the checkpoint
+        # excludes each expert separately.
+        layer = "model.layers.6.mlp.experts"
+        ignore = [
+            f"{layer}.{i}.{proj}"
+            for i in range(3)
+            for proj in ("down_proj", "gate_proj", "up_proj")
+        ]
+        self.assertTrue(
+            should_ignore_layer(layer, ignore=ignore, fused_mapping=QKV_MAPPING)
+        )
+
+    # ---- Guards: behavior that must NOT change -----------------------------
+
+    def test_unexcluded_fused_qkv_still_expands(self):
+        # With no direct match, the packed expansion must still decide, and an
+        # empty ignore list must not start excluding everything.
+        self.assertFalse(
+            should_ignore_layer(
+                "model.layers.0.self_attn.qkv_proj",
+                ignore=[],
+                fused_mapping=QKV_MAPPING,
+            )
+        )
+
+    def test_shard_level_excludes_still_work(self):
+        # The original path: shards named individually, module named fused.
+        name = "model.layers.0.self_attn.qkv_proj"
+        ignore = [
+            "model.layers.0.self_attn.q_proj",
+            "model.layers.0.self_attn.k_proj",
+            "model.layers.0.self_attn.v_proj",
+        ]
+        self.assertTrue(
+            should_ignore_layer(name, ignore=ignore, fused_mapping=QKV_MAPPING)
+        )
+
+    def test_unrelated_moe_layer_is_not_ignored(self):
+        # Only the layer whose experts are excluded may be excluded: a prefix
+        # test must not match a different layer index.
+        ignore = ["model.layers.6.mlp.experts.0.down_proj"]
+        self.assertFalse(
+            should_ignore_layer(
+                "model.layers.7.mlp.experts",
+                ignore=ignore,
+                fused_mapping=QKV_MAPPING,
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`OneNexus/GLM-5.3-Flash-MXFP4` cannot be loaded on this branch. Weight loading aborts with

```
AssertionError: param_data.shape=torch.Size([128, 512]),
                loaded_weight.shape=torch.Size([128, 1024])
```

in `load_qkv_weight`. The 2× width is the signature of an **MXFP4-packed parameter** (two values per byte) meeting an **unpacked BF16 weight** — i.e. a layer the checkpoint excluded from quantization got quantized anyway.

## Root cause

`should_ignore_layer()` only consults `exclude` *after* rewriting a fused module name into its shards. This checkpoint uses two exclusion shapes that never survive that rewrite:

**1. Already-fused modules named directly.** The vision tower ships `visual.blocks.N.attn.qkv_proj` as a single tensor, and all **125** such names appear verbatim in `quantization_config.exclude`. Expanding to `q_proj`/`k_proj`/`v_proj` matches nothing, so the module is quantized while the checkpoint holds it unpacked.

**2. Per-expert MoE excludes.** The checkpoint lists `model.layers.{3,5,6}.mlp.experts.{0..287}.{down,gate,up}_proj` — **1728 entries** — but SGLang builds one `FusedMoE` named `model.layers.N.mlp.experts`, which matches none of them. Those three layers' routed experts are BF16 in the checkpoint (the model card documents this) and were being loaded as MXFP4.

Measured on the checkpoint, confirming both the exclusion shape and which layers it covers:

```
exclude entries total                     2552
  ... mentioning "experts"                1860
  ... per-expert (experts.<N>.<proj>)     1728   -> layers 3, 5 and 6 only
  ... mentioning "visual"                  125
```

and the tensors themselves:

```
layers.5.mlp.experts.0.down_proj.weight   BF16   (4096, 2048)     no weight_scale
layers.7.mlp.experts.0.down_proj.weight   U8     (4096, 1024)     + weight_scale
```

At TP8 that is 2048/8 = **256** versus 1024/8 = **128** — exactly the assertion above.

## Fix

Check `exclude` for a direct match before expanding packed mappings, and treat a fused `...experts` module as excluded when the checkpoint excludes its experts individually. Both run *before* the existing expansion, so the shard-level path is unchanged.

The per-expert rule is exact for this checkpoint, where exclusion is whole-layer (288 experts × 3 projections). It would not be for a checkpoint that excluded only *some* experts of a layer — SGLang's fused representation cannot express that at all, so there is no correct behavior to preserve there.

## Verification

8× MI355X (gfx950), ROCm 7.2.4, with the six open **[AMD] [GLM-5.3-Flash Day 0]** PRs applied (#37530, #37563, #37573, #37626, #37629, #37653):

- **without** this change: weight loading aborts as above
- **with** it: all 120 shards load and the server answers `/v1/models`

## Tests

Added to `test/registered/unit/layers/quantization/test_quark_utils.py`, in that file's existing bug-catcher style. Proven non-vacuous — run against the unpatched function:

```
== UNFIXED (branch HEAD)
   directly excluded fused qkv            want=True  got=False FAIL
   per-expert excludes -> fused MoE       want=True  got=False FAIL
   unexcluded fused qkv still expands     want=False got=False PASS
   shard-level excludes still work        want=True  got=True  PASS
   unrelated MoE layer not ignored        want=False got=False PASS
== FIXED (this PR)
   all five PASS
```

The three guards cover the behavior that must **not** change: an empty `ignore` list must not start excluding everything, the original shard-level path must still work, and a per-expert prefix must not match a different layer index.

## Note

None of the six Day-0 PRs touch `quark/utils.py`, so this gap is not covered by them.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33696764690](https://github.com/sgl-project/sglang/actions/runs/33696764690)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33696764505](https://github.com/sgl-project/sglang/actions/runs/33696764505)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33696764681](https://github.com/sgl-project/sglang/actions/runs/33696764681)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->