### PR TITLE
[CI] bot-cherry-pick: use a workflow-scoped push token and retry the push

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -49,11 +49,40 @@ jobs:
             exit 1
           fi
 
+      - name: Verify push credential
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_CHERRY_PICK_PUSH }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::warning::GH_PAT_FOR_CHERRY_PICK_PUSH is not set; falling back to GITHUB_TOKEN. Pushes are then subject to GitHub's pre-receive workflow scan (see the checkout step) and may be rejected."
+            exit 0
+          fi
+          if [[ "$(gh api "repos/${GITHUB_REPOSITORY}" --jq .permissions.push)" != "true" ]]; then
+            echo "::error::GH_PAT_FOR_CHERRY_PICK_PUSH cannot push to ${GITHUB_REPOSITORY}. Grant it Contents: Write and Workflows: Write, or unset the secret to fall back to GITHUB_TOKEN."
+            exit 1
+          fi
+          echo "OK: GH_PAT_FOR_CHERRY_PICK_PUSH can push to ${GITHUB_REPOSITORY}."
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # actions/checkout persists this token as
+          # `http.https://github.com/.extraheader`, and that header overrides any
+          # credential embedded in a push URL -- so whatever is set here is what
+          # `git push` below authenticates with, and it is the only place a
+          # different push credential can be selected.
+          #
+          # GITHUB_TOKEN can never hold the `workflow` capability (`permissions:`
+          # has no `workflows` key), so every push it makes forces a server-side
+          # scan for workflow-file changes. That scan intermittently times out and
+          # rejects the push even when no workflow file is touched:
+          # https://github.com/actions/checkout/issues/2287. A token that already
+          # carries the capability has been reported to avoid it; that is what
+          # GH_PAT_FOR_CHERRY_PICK_PUSH is for. It is deliberately separate from
+          # GH_PAT_FOR_CHERRY_PICK, which opens the PR and is scoped read-only on
+          # contents. When it is unset, this falls back to today's behaviour.
+          token: ${{ secrets.GH_PAT_FOR_CHERRY_PICK_PUSH || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -199,7 +228,28 @@ jobs:
         env:
           NEW_BRANCH: ${{ steps.cherry_pick.outputs.new_branch }}
         run: |
-          git push origin "$NEW_BRANCH"
+          # Retry: the pre-receive workflow scan described on the checkout step
+          # fails by timing out, which is transient. A permission denial is not,
+          # so stop on it rather than burning the remaining attempts.
+          PUSH_LOG="${RUNNER_TEMP}/push.log"
+          for attempt in 1 2 3 4; do
+            if git push origin "$NEW_BRANCH" > "$PUSH_LOG" 2>&1; then
+              cat "$PUSH_LOG"
+              exit 0
+            fi
+            cat "$PUSH_LOG"
+            if grep -qiE 'denied|403|not authorized' "$PUSH_LOG"; then
+              echo "::error::Push of ${NEW_BRANCH} was denied. This is a credential problem, not a transient one: check that the checkout token has Contents: Write on ${GITHUB_REPOSITORY}."
+              exit 1
+            fi
+            if [[ "$attempt" -lt 4 ]]; then
+              DELAY=$(( attempt * 60 ))
+              echo "::warning::Push of ${NEW_BRANCH} failed (attempt ${attempt}/4); retrying in ${DELAY}s."
+              sleep "$DELAY"
+            fi
+          done
+          echo "::error::Failed to push ${NEW_BRANCH} after 4 attempts; no branch was created and no PR was opened. Re-run this workflow, or cherry-pick and push by hand."
+          exit 1
 
       - name: Create Pull Request
         id: create_pr


### PR DESCRIPTION
## Problem

`bot-cherry-pick.yml` fails at **Push branch**. All three attempts of [run 33694637604](https://github.com/sgl-project/sglang/actions/runs/33694637604) (23:21, 23:31, 23:40 UTC) were rejected with:

```
! [remote rejected] cherry-pick/718bd39fe0-to-v0.5.19-e5732296
  (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

The message names a scope, but the cause is a **timeout**, not a permission denial. The cherry-picked commit `718bd39fe0` touches only `python/sglang/srt/...` and tests — no `.github/` files at all. GitHub's pre-receive scan simply failed to determine that in time and failed closed.

The scan runs on every push this job makes because `GITHUB_TOKEN` can never carry the `workflow` capability — `permissions:` has no `workflows` key. This is an [open GitHub-side bug](https://github.com/actions/checkout/issues/2287), reported since Oct 2025 across `actions/checkout` v4/v5/v6, `GITHUB_TOKEN`, App tokens and PATs, and reproduced by other projects ([tt-metal#32354](https://github.com/tenstorrent/tt-metal/issues/32354), [cli/cli#13635](https://github.com/cli/cli/issues/13635)). It flips on and off with no local trigger, which is why this workflow ran fine for months and then failed on every attempt of one dispatch.

Ruled out as causes:
- **Divergence from `main`** — the last *successful* run (Aug 20, `release/v0.5.18`) pushed off a branch **151** commits behind `main` with the same **21** differing workflow files; the failing one was only **87** behind.
- **Rulesets** — `main-hard-protections` is scoped to `refs/heads/main`, so it never applies to `cherry-pick/**`.
- **Ref/repo growth** — 1506 heads but only 3 `cherry-pick/*` (they get cleaned up); workflow count moved 103 → 107 between the two runs.

## Changes

**1. Select the push credential on the checkout step.** `actions/checkout` persists its token as `http.https://github.com/.extraheader`, and that header overrides credentials embedded in a push URL. Verified empirically — with a valid token in the URL and a bogus extraheader the push is rejected, and with a bogus token in the URL and a valid extraheader it succeeds. So `git push https://x-access-token:$PAT@github.com/...` would silently keep authenticating as `GITHUB_TOKEN`; the checkout step is the only place this can be changed.

**2. A new, dedicated secret — `GH_PAT_FOR_CHERRY_PICK_PUSH`.** Deliberately *not* the existing `GH_PAT_FOR_CHERRY_PICK`: #25926 provisioned that one as `Contents: Read` / `Pull requests: Write` on purpose, so "a leak can't push commits to the repo, only open PRs". Widening it would undo that. The new secret falls back to `GITHUB_TOKEN` via `secrets.X || secrets.GITHUB_TOKEN`, so **until an admin provisions it this workflow behaves exactly as it does today** — the change cannot regress anything on merge.

**3. Retry the push with backoff (60s/120s/180s), bailing out immediately on a permission denial.** Denials are not transient and shouldn't burn the remaining attempts or produce a misleading "just re-run it" message.

**4. A pre-flight `Verify push credential` step**, following the precedent at `.github/workflows/diffusion-ci-gt-gen.yml:76`. If the secret is set but can't push, the job fails in seconds with an actionable message instead of after checkout + fetch + cherry-pick have all succeeded.

## Admin follow-up (not required to merge)

Create repo secret `GH_PAT_FOR_CHERRY_PICK_PUSH` with:

| Permission | Level |
|---|---|
| Contents | Write |
| Workflows | Write |
| Metadata | Read (default) |

`Workflows: Write` is the part that matters here and is **separate from** `Contents: Write` — granting only the latter will make pushes work but leaves the scan (and this bug) in place.

## Known limitations

- **The token swap is the best-evidenced remedy, not a proven one.** [actions/checkout#2287](https://github.com/actions/checkout/issues/2287) reports a workflow-scoped PAT fixing exactly this; [cli/cli#13635](https://github.com/cli/cli/issues/13635) reports an App token *with* `Workflows: write` still hitting the timeout. That is why the retry loop is here too, and why the secret is optional.
- **The retry alone would not have rescued run 33694637604** — that outage spanned at least 20 minutes and three separate job attempts. Retry covers short blips; the token is the attempt at a real fix.
- **The push credential is persisted for the whole job.** That is inherent to the mechanism (see change 1) — `persist-credentials: false` would disable the very thing that makes the fix work. The marginal exposure over today is the `workflow` capability, in a job that cherry-picks caller-supplied SHAs onto release branches. Flagging it explicitly for reviewers rather than burying it.

## Test plan

- [ ] Merge (safe: no-op until the secret exists), then dispatch against a benign merged commit and confirm the fallback path still behaves as today.
- [ ] Admin creates `GH_PAT_FOR_CHERRY_PICK_PUSH` with the permissions above.
- [ ] Re-dispatch: confirm `Verify push credential` prints OK, the branch pushes, and the PR opens and triggers `pr-test.yml`.
- [ ] Negative check: temporarily set the secret to a read-only PAT and confirm the job fails at `Verify push credential`, not at `Push branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFHtJ49txxW8Wrhf97B85y

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829408145](https://github.com/sgl-project/sglang/actions/runs/34829408145)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829407948](https://github.com/sgl-project/sglang/actions/runs/34829407948)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->