### PR TITLE
[Examples] Add --chat-template to offline VLM batch inference

### DIFF
--- a/examples/runtime/engine/offline_batch_inference_vlm.py
+++ b/examples/runtime/engine/offline_batch_inference_vlm.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python offline_batch_inference_vlm.py --model-path Qwen/Qwen2-VL-7B-Instruct
+python offline_batch_inference_vlm.py --model-path Qwen/Qwen2-VL-7B-Instruct --chat-template qwen2-vl
 """
 
 import argparse
@@ -16,7 +16,7 @@ def main(
 ):
     vlm = sgl.Engine(**dataclasses.asdict(server_args))
 
-    conv = chat_templates[server_args.chat_template].copy()
+    conv = chat_templates[server_args.chat_template or "qwen2-vl"].copy()
     image_token = conv.image_token
 
     image_url = "https://github.com/sgl-project/sglang/blob/main/examples/assets/example_image.png?raw=true"


### PR DESCRIPTION
## What drifted
`examples/runtime/engine/offline_batch_inference_vlm.py` Usage is:

```
python offline_batch_inference_vlm.py --model-path Qwen/Qwen2-VL-7B-Instruct
```

The script does `chat_templates[server_args.chat_template]`. `ServerArgs.chat_template` defaults to `None`, so the published command raises `KeyError: None`. `--chat-template` is a real CLI flag; builtin template `qwen2-vl` exists.

## Local repro
```bash
gh api repos/sgl-project/sglang/contents/examples/runtime/engine/offline_batch_inference_vlm.py \
  -H 'Accept: application/vnd.github.raw' | nl -ba | sed -n '1,20p'

gh api repos/sgl-project/sglang/contents/python/sglang/srt/server_args.py \
  -H 'Accept: application/vnd.github.raw' | nl -ba | sed -n '1335,1339p'
```

Running the published command fails at:

```
conv = chat_templates[server_args.chat_template].copy()
# KeyError: None
```

## Change
- Usage: add `--chat-template qwen2-vl`
- Lookup: `server_args.chat_template or "qwen2-vl"` so this Qwen2-VL example does not crash if the flag is omitted

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33699613617](https://github.com/sgl-project/sglang/actions/runs/33699613617)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33699613433](https://github.com/sgl-project/sglang/actions/runs/33699613433)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->