### PR TITLE
Reserve a fixed 8 GiB for VLM runtime under post-capture KV sizing

### DIFF
--- a/python/sglang/srt/arg_groups/memory_hook.py
+++ b/python/sglang/srt/arg_groups/memory_hook.py
@@ -364,9 +364,7 @@ def adjust_mem_fraction_for_vlm(server_args: Any, model_config, gpu_mem=None):
         declare_resolution(
             server_args,
             "adjust_mem_fraction_for_vlm",
-            mem_fraction_static=round(
-                cfg.mem_fraction_static - 8 * 1024 / gpu_mem, 3
-            ),
+            mem_fraction_static=round(cfg.mem_fraction_static - 8 * 1024 / gpu_mem, 3),
         )
         return
 

--- a/python/sglang/srt/arg_groups/memory_hook.py
+++ b/python/sglang/srt/arg_groups/memory_hook.py
@@ -278,7 +278,7 @@ def handle_gpu_memory_settings(server_args: Any, gpu_mem):
             and not cfg.language_model_only
             and cfg.disaggregation_mode != "decode"
         ):
-            adjust_mem_fraction_for_vlm(server_args, model_config)
+            adjust_mem_fraction_for_vlm(server_args, model_config, gpu_mem)
 
     # If symm mem is enabled and prealloc size is not set, set it to 4GB
     if cfg.enable_symm_mem and not envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.is_set():
@@ -349,10 +349,25 @@ def reserve_for_deepep_a2a_mb(server_args: Any) -> float:
     return 0.0
 
 
-def adjust_mem_fraction_for_vlm(server_args: Any, model_config):
+def adjust_mem_fraction_for_vlm(server_args: Any, model_config, gpu_mem=None):
     cfg = resolving_view(server_args)
     vision_config = getattr(model_config.hf_config, "vision_config", None)
     if vision_config is None:
+        return
+
+    if post_capture_kv_sizing_planned(server_args):
+        # Post-capture sizing measures real free memory after graph capture, so
+        # reserve a fixed 8 GiB for VLM runtime allocations instead of the
+        # capacity-scaled heuristic below.
+        if gpu_mem is None:
+            return
+        declare_resolution(
+            server_args,
+            "adjust_mem_fraction_for_vlm",
+            mem_fraction_static=round(
+                cfg.mem_fraction_static - 8 * 1024 / gpu_mem, 3
+            ),
+        )
         return
 
     # roughly reduce the mem_fraction_static base on params of Vit


### PR DESCRIPTION
## Motivation

Post-capture KV sizing measures free memory after graph capture, so the capacity-scaled ViT heuristic mis-sizes VLM headroom there: it scales with total GPU memory rather than with what VLM runtime allocations (image processing, encoder transients) actually need. On large-memory GPUs it strands double-digit GiB that could back the KV cache.

## Modifications

- On the post-capture sizing path, reserve a fixed 8 GiB for VLM runtime allocations instead of applying the capacity-scaled factor.
- The reserve is routed through `adjust_mem_fraction_for_vlm` (now taking `gpu_mem`), keeping that function the single seam for VLM memory headroom so integrations whose encoders bound their own memory can override it in one place.
- Explicit `--mem-fraction-static` values, the legacy sizing path's heuristic, and text-only / PD-decode engines are unchanged.

Verified on an internal TP=4 deployment: the derived fraction and KV capacity match the intended fixed reserve, and an encoder-bounded integration overriding the seam reclaims it cleanly.

## Original commits

- `71238b1c67`
- `80ee123f2eec`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33702814716](https://github.com/sgl-project/sglang/actions/runs/33702814716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33784312654](https://github.com/sgl-project/sglang/actions/runs/33784312654)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33702814643](https://github.com/sgl-project/sglang/actions/runs/33702814643)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->