### PR TITLE
[MLX] Support Hunyuan on Apple Silicon (#32521)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/__init__.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/__init__.py
@@ -34,6 +34,7 @@ from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
 )
 from sglang.srt.hardware_backend.mlx.kv_cache.layout import MlxModelCacheLayout
 from sglang.srt.hardware_backend.mlx.kv_cache.model_patching import (
+    attention_has_extended_contract,
     find_attention_layers,
     get_num_layers,
     patch_model_attention,
@@ -43,6 +44,7 @@ __all__ = [
     "BatchedDecodeContext",
     "clear_context",
     "AttentionOffsetCache",
+    "attention_has_extended_contract",
     "ContiguousAttentionKVCache",
     "find_attention_layers",
     "get_attention_scale",

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
@@ -229,10 +229,14 @@ class MLXAttentionWrapper(nn.Module):
             self, "_sink_kwargs", {} if sinks is None else {"sinks": sinks}
         )
 
-    def __call__(self, x: mx.array, mask: Any = None, cache: Any = None) -> mx.array:
+    def __call__(
+        self, x: mx.array, mask: Any = None, cache: Any = None, *args, **kwargs
+    ):
+        # Forward extra args the inner module takes (Hunyuan passes a shared-KV
+        # state positionally) so delegation matches its contract.
         ctx = get_context()
         if ctx is None:
-            return self._inner(x, mask=mask, cache=cache)
+            return self._inner(x, mask, cache, *args, **kwargs)
         return self._batched_decode(x, ctx)
 
     def _batched_decode(self, x: mx.array, ctx: BatchedDecodeContext) -> mx.array:

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/model_patching.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/model_patching.py
@@ -1,5 +1,6 @@
 """Model introspection and attention patching."""
 
+import inspect
 import logging
 from typing import Any
 
@@ -39,6 +40,29 @@ def find_attention_layers(model: Any) -> tuple[list[Any], list[str | None]]:
             return layer_list, attn_attrs
         raise ValueError(f"No attention attribute in layer type {type(layer_list[0])}")
     return layer_list, []
+
+
+def attention_has_extended_contract(
+    layer_list: list[Any], attn_attrs: list[str | None]
+) -> bool:
+    """Whether any attention module is called with more than ``(x, mask, cache)``
+    (e.g. Hunyuan threads a shared-KV tuple positionally)."""
+    for layer, attr in zip(layer_list, attn_attrs):
+        if attr is None:
+            continue
+        attn = getattr(layer, attr)
+        inner = attn._inner if isinstance(attn, MLXAttentionWrapper) else attn
+        try:
+            positional = [
+                p
+                for p in inspect.signature(inner.__call__).parameters.values()
+                if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+            ]
+        except (TypeError, ValueError):
+            continue
+        if len(positional) > 3:
+            return True
+    return False
 
 
 def patch_model_attention(model: Any) -> int:

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -49,6 +49,7 @@ from sglang.srt.hardware_backend.mlx.kv_cache import (
     MlxModelCacheLayout,
     PoolBackedAttentionKVCache,
     WindowedAttentionKVCache,
+    attention_has_extended_contract,
     clear_context,
     find_attention_layers,
     get_head_dim,
@@ -161,6 +162,7 @@ class MlxModelRunner:
     _enable_sampling = False
     _sanitize_nan = False
     _deterministic_seeding = False
+    _decode_delegates_to_model = False
 
     def __init__(
         self,
@@ -232,6 +234,18 @@ class MlxModelRunner:
             attn_attrs,
             # Per-layer sliding windows (container convention, e.g. gpt-oss).
             layer_window_sizes=get_layer_window_sizes(self.model),
+        )
+        # Extended-contract attention (e.g. Hunyuan) delegates decode.
+        self._decode_delegates_to_model = attention_has_extended_contract(
+            layer_list, attn_attrs
+        )
+        logger.info(
+            "MLX decode path: %s",
+            (
+                "native per-request (extended attention contract)"
+                if self._decode_delegates_to_model
+                else "batched shared-pool"
+            ),
         )
         if self._cache_layout.num_attention_layers == 0:
             raise RuntimeError("MLX model has no supported attention layers")
@@ -1573,6 +1587,10 @@ class MlxModelRunner:
             last_logits = self._decode_with_hybrid_batching(
                 caches, batched_input, list(req_ids)
             )
+        elif self._decode_delegates_to_model:
+            last_logits = self._decode_with_native_cache(
+                caches, [batched_input[i : i + 1] for i in range(len(req_ids))]
+            )
         else:
             last_logits = self._decode_with_batched_attention(
                 caches, batched_input, list(req_ids)
@@ -1630,6 +1648,10 @@ class MlxModelRunner:
         if self._cache_layout.has_auxiliary_state:
             last_logits = self._decode_with_hybrid_batching(
                 caches, batched_input, prev.req_ids
+            )
+        elif self._decode_delegates_to_model:
+            last_logits = self._decode_with_native_cache(
+                caches, [batched_input[i : i + 1] for i in range(len(prev.req_ids))]
             )
         else:
             last_logits = self._decode_with_batched_attention(

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -243,6 +243,14 @@ def supports_cuda_vmm_feature_transport(model_config: ModelConfig) -> bool:
 
 
 def get_resolved_model_impl(model_config: ModelConfig) -> ModelImpl:
+    # MLX serves via mlx_lm.load(), so there is no sglang/Transformers impl to
+    # resolve here; resolving would import the model's auto_map and crash (e.g.
+    # Hunyuan). Local import keeps the MLX backend off this module's import path.
+    from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+    if use_mlx():
+        return ModelImpl.SGLANG
+
     resolved_model_impl = getattr(model_config, "_resolved_model_impl", None)
     if resolved_model_impl is not None:
         return resolved_model_impl

--- a/test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py
@@ -1,0 +1,123 @@
+import importlib.util
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+# Registered on the CPU suite but skipped wherever mlx is absent; runs for real
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, which the
+# macOS CI lane (pr-test-mlx.yml) only dispatches via a gated workflow_dispatch.
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+
+# hunyuan architecture (HunYuanForCausalLM), served on the MLX backend through
+# mlx_lm's own hunyuan implementation; the SGLang MLX backend does not require
+# any srt/models file for it. This is a black-box correctness guard for the
+# served model.
+#
+# Default is the MLX-community 4-bit repo so the test is portable. Override with
+# SGLANG_MLX_TEST_MODEL to point at a local copy, e.g.
+#   SGLANG_MLX_TEST_MODEL=models/Hunyuan-7B-Instruct-4bit
+MODEL_PATH = os.environ.get(
+    "SGLANG_MLX_TEST_MODEL", "mlx-community/Hunyuan-7B-Instruct-4bit"
+)
+
+# mem-fraction is tuned conservatively for a 24 GB Apple Silicon machine.
+MEM_FRACTION_STATIC = os.environ.get("SGLANG_MLX_TEST_MEM_FRACTION", "0.7")
+
+
+@unittest.skipUnless(_HAS_MLX, "requires mlx (Apple Silicon only)")
+class TestHunyuanMlxCorrectness(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "1",
+                "--disable-radix-cache",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                MEM_FRACTION_STATIC,
+                "--max-running-requests",
+                "1",
+                "--context-length",
+                "2048",
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process is not None:
+            kill_process_tree(cls.process.pid)
+
+    def _chat(self, messages, max_tokens=32, temperature=0):
+        resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": MODEL_PATH,
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+
+    def test_basic_generation_nonempty(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "Say hello briefly."},
+            ],
+            max_tokens=16,
+        )
+        self.assertIsInstance(text, str)
+        self.assertGreater(len(text), 0)
+
+    def test_simple_arithmetic(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "What is 2+2? Reply with just the number."},
+            ],
+            max_tokens=8,
+        )
+        self.assertIn("4", text)
+
+    def test_simple_fact(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "What is the capital of France? One word."},
+            ],
+            max_tokens=8,
+        )
+        self.assertIn("Paris", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Serve `hunyuan` on the Apple Silicon MLX backend. This completes the `hunyuan.py` item on the Apple Device Support roadmap (#19137) and fixes #32521 (only the `_decode_with_native_cache` path)

Two independent things block Hunyuan today, both hit only on `SGLANG_USE_MLX=1`:

1. **Startup crash in architecture resolution.** On the MLX backend the model is served entirely by `mlx_lm.load()`; no sglang/Transformers model class is used. But `get_resolved_model_impl()` (called from `kv_cache_builder.build_kv_cache` and `Scheduler.init_chunked_prefill`) still resolves the architecture. For a repo whose HF arch name is not in sglang's native registry, resolution falls into `resolve_transformers_arch`, which imports the repo's remote `auto_map`. `mlx-community/Hunyuan-7B-Instruct-4bit` declares `architectures: ["HunYuanForCausalLM"]` (sglang registers `HunYuanMoEV1ForCausalLM` / `HunYuanDenseV1ForCausalLM`, not that name), and its `config.json` `auto_map` points `AutoModel` at `modeling_hunyuan.HunyuanModel`, which does not exist in the repo (the class is `HunYuanModel`). The import fails and startup crashes. The existing MLX models (qwen2_moe, qwen3_moe, gpt_oss) avoid this only because their arch names happen to be registered.

2. **Decode cannot run Hunyuan's attention.** The MLX decode path always runs through the batched, hand-rolled `_decode_with_batched_attention`, which re-implements attention (q/k/v proj, qk-norm, RoPE, SDPA) for the standard `attn(x, mask, cache) -> array` contract. Hunyuan's decoder layer instead calls `self_attn(x, mask, cache, shared_kv_states)` and returns `(out, kv_states)` (CLA plumbing), and applies qk-norm under `query_layernorm`/`key_layernorm` after RoPE. So the hand-rolled path both raises (`TypeError` / tuple-unpack) and would be numerically wrong even if it did not.

The fix keeps the change minimal and general: Route models whose attention does not match the standard contract through the existing per-request path that delegates to the model's own forward. That is correct for any `mlx-lm` model. Standard models are untouched.

## Modifications

Under `python/sglang/srt/`:

- **`model_loader/utils.py`**: `get_resolved_model_impl()` returns `ModelImpl.SGLANG` immediately when `use_mlx()`. On MLX there is no sglang/Transformers impl to resolve, so the guard skips the resolution (and the crashing `auto_map` import) for every MLX model. This is behavior-preserving for the models that work today, whose archs resolve to `SGLANG` anyway, and it future-proofs any `mlx-community` repo whose arch name is not registered. 

- **`hardware_backend/mlx/kv_cache/attention_wrapper.py`**: `MLXAttentionWrapper.__call__` accepts and forwards `*args, **kwargs`. When no batched-decode context is set (prefill / delegate path) it now calls `self._inner(x, mask, cache, *args, **kwargs)` and returns the inner module's result verbatim, so decoder layers that pass extra positional state (Hunyuan's shared-KV tuple) and expect a tuple back work unchanged. No effect on standard models, which pass no extra args.

- **`hardware_backend/mlx/kv_cache/model_patching.py`**: new `attention_has_extended_contract(layer_list, attn_attrs)`. It inspects each layer's inner-attention call signature and returns `True` if any takes more than `(x, mask, cache)`. Placed next to the other attention-discovery helpers (`find_attention_layers`, etc.).

- **`hardware_backend/mlx/kv_cache/__init__.py`**: re-export `attention_has_extended_contract` (same as `find_attention_layers`).

- **`hardware_backend/mlx/model_runner.py`**: compute `self._decode_delegates_to_model` once at load via the contract check, and in both `decode_batch_start` and `decode_batch_start_chained` route those models' decode through the existing `_decode_with_native_cache` (per-request; delegates to the model's own forward, so any `mlx-lm` model is correct) instead of `_decode_with_batched_attention`. Standard models keep the fast batched path unchanged. A class-level `_decode_delegates_to_model = False` default (alongside the existing test defaults) keeps decode routing well-defined for runners built via `object.__new__` in unit tests. One `logger.info` reports the selected decode path.

Under `test/`:

- **`registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py`**: new black-box smoke test, a near-copy of `test_qwen2_moe_mlx_correctness.py`. It launches the server with `SGLANG_USE_MLX=1` and asserts non-empty generation, `2+2 -> "4"`, and capital-of-France `-> "Paris"`. Registered via `register_cpu_ci` + `register_mlx_ci` and gated by `@skipUnless(_HAS_MLX)`, so it runs for real only on Apple Silicon. Default model `mlx-community/Hunyuan-7B-Instruct-4bit`, overridable with `SGLANG_MLX_TEST_MODEL`.

Orthogonal and not addressed here: with this 4-bit repo the model's EOS token can leak into the streamed text (the server does not stop on it). That is a stop-token/tokenizer detail, separate from this change.

## Accuracy Tests

Serving affects model output, so verified token-for-token against unpatched `mlx-lm`.

```
# Token-exact: SGLang MLX greedy output == raw mlx_lm greedy output, plus batched==solo isolation
SGLANG_MLX_TEST_MODEL=mlx-community/Hunyuan-7B-Instruct-4bit \
  pytest test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py -q
#   2 passed

# New Hunyuan smoke test
pytest test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py -q
#   3 passed

# No regression across the MLX unit suite
pytest test/registered/unit/hardware_backend/mlx/ -q
#   223 passed, 2 skipped
```

Tested on Apple M4 Pro (16-core GPU), 24 GB unified memory, macOS 27.0; torch 2.13.0, mlx 0.32.2, mlx-lm 0.31.3.

## Speed Tests and Profiling

Observed ~55 tok/s decode for `Hunyuan-7B-Instruct-4bit` on the machine above. Its decode throughput at 12 concurrent was still only ~40-57 tok/s, i.e. no better than single-stream. We would have to start making changes to the batched-decode method asap.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33702090118](https://github.com/sgl-project/sglang/actions/runs/33702090118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33702089863](https://github.com/sgl-project/sglang/actions/runs/33702089863)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33702090048](https://github.com/sgl-project/sglang/actions/runs/33702090048)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->