### PR TITLE
[Scheduler] Stop waiting-queue scan after exhausted chunk budget

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3634,9 +3634,30 @@ class Scheduler(
             prefill_tile_block_m=prefill_tile_block_m,
         )
 
+        skip_waiting_admission = False
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
+            post_chunk_budget_state = adder.budget_state()
+            # NO_TOKEN takes precedence over chunk exhaustion in budget_state().
+            chunk_budget_exhausted = (
+                self.dllm_config is None
+                and adder.rem_chunk_tokens is not None
+                and adder.rem_chunk_tokens <= 0
+            )
+            skip_waiting_admission = (
+                post_chunk_budget_state == AddReqResult.OTHER or chunk_budget_exhausted
+            )
+            if (
+                skip_waiting_admission
+                and post_chunk_budget_state == AddReqResult.NO_TOKEN
+            ):
+                if self.enable_hierarchical_cache:
+                    running_batch.batch_is_full = len(adder.can_run_list) > 0 or (
+                        not running_batch.is_empty()
+                    )
+                else:
+                    running_batch.batch_is_full = True
 
         if self.enable_lora:
             running_loras = {
@@ -3651,11 +3672,12 @@ class Scheduler(
                     running_batch.reqs,
                 )
 
+        waiting_reqs = () if skip_waiting_admission else self.waiting_queue
         mamba_allocator = getattr(self.req_to_token_pool, "mamba_allocator", None)
         if mamba_allocator is not None:
-            mamba_allocator.alloc_group_begin(len(self.waiting_queue))
+            mamba_allocator.alloc_group_begin(len(waiting_reqs))
         # Get requests from the waiting queue to a new prefill batch
-        for req in self.waiting_queue:
+        for req in waiting_reqs:
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
 

--- a/test/registered/unit/managers/test_scheduler_chunk_budget.py
+++ b/test/registered/unit/managers/test_scheduler_chunk_budget.py
@@ -1,0 +1,181 @@
+"""Regression tests for waiting admission after resuming a chunked request."""
+
+import unittest
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.utils.common import Range
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _RecordingPrefillAdder(PrefillAdder):
+    instances: ClassVar[list["_RecordingPrefillAdder"]] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__class__.instances.append(self)
+
+    def add_one_req(self, req, **kwargs):
+        self.can_run_list.append(req)
+        return AddReqResult.CONTINUE
+
+
+def _make_scheduler(waiting_req, chunked_req, available_tokens):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.grammar_manager = MagicMock()
+    scheduler.enable_hierarchical_cache = False
+    scheduler.enable_hicache_storage = False
+    scheduler.enable_priority_preemption = False
+    scheduler.enable_priority_scheduling = False
+    scheduler.is_hybrid_swa = False
+    scheduler.min_free_slots_delayer = None
+    scheduler.waiting_queue = [waiting_req]
+    scheduler.chunked_req = chunked_req
+    scheduler.get_num_allocatable_reqs = MagicMock(return_value=8)
+    scheduler.policy = MagicMock()
+    scheduler.chunked_prefill_size = 4
+    scheduler.enable_dynamic_chunking = False
+    scheduler.tp_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            attn_backend=SimpleNamespace(), prefill_aware_swa=False
+        )
+    )
+    scheduler.page_size = 1
+    scheduler.tree_cache = MagicMock()
+    scheduler.tree_cache.supports_mamba.return_value = False
+    scheduler.tree_cache.evictable_size.return_value = 0
+    scheduler.token_to_kv_pool_allocator = MagicMock()
+    scheduler.token_to_kv_pool_allocator.available_size.return_value = available_tokens
+    scheduler.new_token_ratio_tracker = SimpleNamespace(current=1.0)
+    scheduler.max_prefill_tokens = 32
+    scheduler.is_mixed_chunk = False
+    scheduler.priority_scheduling_preemption_threshold = 0
+    scheduler.max_prefill_bs = 8
+    scheduler.max_running_requests = 8
+    scheduler.dllm_config = None
+    scheduler.enable_lora = False
+    scheduler.req_to_token_pool = SimpleNamespace(mamba_allocator=MagicMock())
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
+    scheduler.truncation_align_size = None
+    scheduler.model_config = MagicMock()
+    scheduler.enable_overlap = False
+    scheduler.spec_algorithm = MagicMock()
+    scheduler.load_inquirer = MagicMock()
+    return scheduler
+
+
+class TestSchedulerChunkBudget(CustomTestCase):
+    def setUp(self):
+        _RecordingPrefillAdder.instances.clear()
+
+    def _run_scheduler(self, chunk_tokens, available_tokens=128):
+        chunked_req = MagicMock()
+        chunked_req.full_untruncated_fill_ids = list(range(chunk_tokens))
+        chunked_req.prefix_indices = []
+        chunked_req.sampling_params.max_new_tokens = 1
+        chunked_req.retracted_stain = False
+        chunked_req.kv.holds_mamba = False
+        chunked_req.inflight_middle_chunks = 0
+        chunked_req.set_extend_range.side_effect = lambda start, end: setattr(
+            chunked_req, "extend_range", Range(start, end)
+        )
+        waiting_req = MagicMock()
+        running_batch = MagicMock()
+        running_batch.reqs = []
+        running_batch.batch_is_full = False
+        running_batch.is_empty.return_value = True
+        scheduler = _make_scheduler(waiting_req, chunked_req, available_tokens)
+
+        batch = MagicMock()
+        batch.return_logprob = False
+        batch.input_embeds = None
+        with (
+            patch(
+                "sglang.srt.managers.scheduler.PrefillAdder",
+                _RecordingPrefillAdder,
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.ScheduleBatch.init_new",
+                return_value=batch,
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.PrefillStats.from_adder",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.get_memory",
+                return_value=SimpleNamespace(enable_flexkv=False),
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.get_schedule",
+                return_value=SimpleNamespace(prefill_max_requests=None),
+            ),
+            patch(
+                "sglang.srt.managers.schedule_policy.is_dsa_prefill_cp_in_seq_split",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_policy.is_prefill_context_parallel_enabled",
+                return_value=False,
+            ),
+        ):
+            Scheduler._get_new_batch_prefill_raw(
+                scheduler,
+                prefill_delayer_single_pass=None,
+                running_batch=running_batch,
+            )
+
+        return (
+            scheduler,
+            running_batch,
+            waiting_req,
+            _RecordingPrefillAdder.instances[-1],
+        )
+
+    def test_waiting_queue_not_scanned_after_resumed_chunk_exhausts_budget(self):
+        scheduler, _, waiting_req, adder = self._run_scheduler(chunk_tokens=4)
+
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+        waiting_req.init_next_round_input.assert_not_called()
+        scheduler.req_to_token_pool.mamba_allocator.alloc_group_begin.assert_called_once_with(
+            0
+        )
+        self.assertEqual(len(adder.can_run_list), 1)
+        self.assertEqual(scheduler.waiting_queue, [waiting_req])
+
+    def test_waiting_queue_scanned_when_resumed_chunk_leaves_budget(self):
+        scheduler, _, waiting_req, adder = self._run_scheduler(chunk_tokens=2)
+
+        self.assertEqual(adder.rem_chunk_tokens, 2)
+        waiting_req.init_next_round_input.assert_called_once()
+        scheduler.req_to_token_pool.mamba_allocator.alloc_group_begin.assert_called_once_with(
+            1
+        )
+        self.assertEqual(len(adder.can_run_list), 2)
+        self.assertEqual(scheduler.waiting_queue, [])
+
+    def test_total_token_exhaustion_marks_batch_full_without_scanning(self):
+        scheduler, running_batch, waiting_req, adder = self._run_scheduler(
+            chunk_tokens=4,
+            available_tokens=6,
+        )
+
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+        self.assertEqual(adder.rem_total_tokens, 0)
+        waiting_req.init_next_round_input.assert_not_called()
+        self.assertTrue(running_batch.batch_is_full)
+        self.assertEqual(scheduler.waiting_queue, [waiting_req])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #35642.

After a resumed chunk consumes the current chunk budget, the scheduler still scans the waiting queue. That allows prefix-cache matching and host-cache load-back side effects even though no waiting request can be admitted.

This is an updated and tested alternative to #35645. The control-flow handling is based on the work by @imReese; the commit credits them as co-author.

## Modifications

- Recheck the prefill budget after adding a resumed chunked request.
- Skip waiting-request admission when the chunk budget is exhausted while preserving the resumed chunk in the runnable batch.
- Preserve `batch_is_full` behavior when `NO_TOKEN` takes precedence over chunk exhaustion.
- Avoid Mamba waiting-request preallocation for a skipped queue.
- Add scheduler-level CPU regression coverage for exhausted, partially available, and simultaneously exhausted chunk/total-token budgets.

## Accuracy Tests

This change does not modify model computation or output values.

- Focused CPU unit module using the actual `Scheduler` and `PrefillAdder`: 3 tests passed.
- The same tests were run against the pre-fix scheduler method: the two exhaustion cases failed because `waiting_req.init_next_round_input()` was called once, confirming the regression coverage.
- `python3 -m py_compile python/sglang/srt/managers/scheduler.py test/registered/unit/managers/test_scheduler_chunk_budget.py`
- `ruff check test/registered/unit/managers/test_scheduler_chunk_budget.py`
- `black --check python/sglang/srt/managers/scheduler.py test/registered/unit/managers/test_scheduler_chunk_budget.py`
- `isort --check-only test/registered/unit/managers/test_scheduler_chunk_budget.py`

## Speed Tests and Profiling

No benchmark was run. The change removes unnecessary waiting-queue cache matching and possible host-cache load-back work from scheduling passes with an exhausted chunk budget.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable: no user-facing behavior or configuration changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to model outputs; focused scheduler regression tests are included above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33703212432](https://github.com/sgl-project/sglang/actions/runs/33703212432)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33703212212](https://github.com/sgl-project/sglang/actions/runs/33703212212)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33703212401](https://github.com/sgl-project/sglang/actions/runs/33703212401)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->