### PR TITLE
[Docs] Fix SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK default

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -318,8 +318,8 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of dispatched tokens on each GPU for --moe-a2a-backend=flashinfer</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`"1024"`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of dispatched tokens on each GPU for --moe-a2a-backend=flashinfer. When unset, defaults to <code>max(chunked_prefill_size, 4096)</code>.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_DEEPEP_LL_COMBINE_SEND_NUM_SMS`</td>


### PR DESCRIPTION
## Summary
- Correct the documented default for `SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK` in `docs/docs/references/environment_variables.mdx`.
- Docs previously listed default `"1024"`, but the runtime treats the env as unset (`EnvInt(None)`) and falls back to `max(chunked_prefill_size, 4096)` for `--moe-a2a-backend=flashinfer`.
- Default column: `"1024"` → `Not set`; description notes the unset fallback.

## Repro / verification
1. Docs (before): `docs/docs/references/environment_variables.mdx` lists default `` `"1024"` `` for `SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK`.
2. `python/sglang/srt/environ.py`:
   ```python
   SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(None)
   ```
3. `python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py` (when unset):
   ```python
   cps = get_schedule().chunked_prefill_size
   default_max_tokens = max(cps if cps and cps > 0 else 4096, 4096)
   configured_max_tokens = (
       envs.SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
   )
   self.max_num_tokens = (
       configured_max_tokens
       if configured_max_tokens is not None
       else default_max_tokens
   )
   ```
4. After this PR, the env-var table matches that behavior (`Not set` → `max(chunked_prefill_size, 4096)`).

## Test plan
- [ ] Confirm table default column shows `Not set`
- [ ] Confirm description mentions unset → `max(chunked_prefill_size, 4096)` for `--moe-a2a-backend=flashinfer`
- [ ] Spot-check against `environ.py` / `flashinfer.py` on current `main`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33703906432](https://github.com/sgl-project/sglang/actions/runs/33703906432)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33703906172](https://github.com/sgl-project/sglang/actions/runs/33703906172)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->