### PR TITLE
【Fix】(hicache nixl): chunk oversized hybrid-pool transfers

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, List, Optional
 
 import torch
@@ -521,6 +521,38 @@ class HiCacheNixl(HiCacheStorage):
             return [], [], 0
         return key_strs, list(zip(ptr_list, size_list)), key_multiplier
 
+    def _chunk_transfer(self, transfer: PoolTransfer) -> List[PoolTransfer]:
+        """Split an oversized bounce-buffer transfer into <=128-key chunks.
+
+        The pre-registered bounce buffer holds ``STORAGE_BATCH_SIZE`` slots, so
+        a non-zero-copy hybrid pool whose batch exceeds that would otherwise be
+        dropped wholesale by ``_prepare_pool_transfer``. Zero-copy pools have no
+        per-batch cap and pass through as a single chunk. Malformed transfers
+        (``host_indices`` missing or the wrong length) pass through intact so
+        ``_prepare_pool_transfer`` rejects them before any partial I/O is issued.
+        """
+        keys = transfer.keys or []
+        ctx = self._hybrid_pool_ctx.get(transfer.name)
+        if ctx is None or ctx.is_zero_copy or len(keys) <= STORAGE_BATCH_SIZE:
+            return [transfer]
+
+        page_size = getattr(ctx.host_pool, "page_size", 1) or 1
+        host_indices = transfer.host_indices
+        if host_indices is None or host_indices.numel() != len(keys) * page_size:
+            return [transfer]
+
+        chunks: List[PoolTransfer] = []
+        for start in range(0, len(keys), STORAGE_BATCH_SIZE):
+            end = min(start + STORAGE_BATCH_SIZE, len(keys))
+            chunks.append(
+                replace(
+                    transfer,
+                    keys=keys[start:end],
+                    host_indices=host_indices[start * page_size : end * page_size],
+                )
+            )
+        return chunks
+
     def _prepare_pool_transfer(
         self, transfer: PoolTransfer, for_write: bool
     ) -> tuple[Optional[HostKVCache], List[str], List[tuple], List[int], int]:
@@ -943,6 +975,34 @@ class HiCacheNixl(HiCacheStorage):
             for i in range(0, len(results), key_multiplier)
         ]
 
+    def _contiguous_page_results(
+        self,
+        raw_results: List[bool],
+        key_multiplier: int,
+        expected_pages: int,
+        pool_name: PoolName,
+    ) -> List[bool]:
+        """Collapse a chunk's component results to a contiguous page prefix.
+
+        ``raw_results`` is one boolean per storage component (``key_multiplier``
+        per page) for a single NIXL transfer. Pages must form a contiguous
+        success prefix — the first failed page invalidates every page after it.
+        """
+        page_results = list(self._page_results(raw_results, key_multiplier))
+        if len(page_results) != expected_pages:
+            logger.error(
+                "HiCacheNixl: hybrid pool %s page result length mismatch: "
+                "expected %s pages, got %s",
+                pool_name,
+                expected_pages,
+                len(page_results),
+            )
+            return [False] * expected_pages
+        if False in page_results:
+            first_failure = page_results.index(False)
+            page_results[first_failure:] = [False] * (expected_pages - first_failure)
+        return page_results
+
     def batch_get_v2(
         self,
         transfers: List[PoolTransfer],
@@ -950,35 +1010,47 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
-            host_pool, key_strs, host_buffers, page_offsets, key_multiplier = (
-                self._prepare_pool_transfer(transfer, for_write=False)
-            )
-            if host_pool is None or not key_strs:
-                results[transfer.name] = [False] * len(transfer.keys or [])
-                continue
+            pool_results: List[bool] = []
+            total_pages = len(transfer.keys or [])
+            for chunk in self._chunk_transfer(transfer):
+                host_pool, key_strs, host_buffers, page_offsets, key_multiplier = (
+                    self._prepare_pool_transfer(chunk, for_write=False)
+                )
+                batch_pages = len(chunk.keys or [])
+                if host_pool is None or not key_strs:
+                    pool_results.extend([False] * batch_pages)
+                    break
 
-            start_time = time.perf_counter()
-            transfer_results = self._batch_xfer(
-                key_strs, key_strs, host_buffers, "READ"
-            )
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._log_xfer_stats(
-                f"batch_get_v2[{transfer.name}]",
-                len(transfer.keys or []),
-                transfer.host_indices,
-                [size for _, size in host_buffers],
-                elapsed_ms,
-            )
-            ctx = self._hybrid_pool_ctx[transfer.name]
-            page_results = self._page_results(transfer_results, key_multiplier)
-            if not ctx.is_zero_copy:
-                for ok, page_offset, data_page in zip(
-                    page_results, page_offsets, ctx.bounce_get
-                ):
-                    if not ok:
-                        break
-                    host_pool.set_from_flat_data_page(page_offset, data_page)
-            results[transfer.name] = page_results
+                start_time = time.perf_counter()
+                transfer_results = self._batch_xfer(
+                    key_strs, key_strs, host_buffers, "READ"
+                )
+                elapsed_ms = (time.perf_counter() - start_time) * 1000
+                self._log_xfer_stats(
+                    f"batch_get_v2[{transfer.name}]",
+                    batch_pages,
+                    chunk.host_indices,
+                    [size for _, size in host_buffers],
+                    elapsed_ms,
+                )
+                ctx = self._hybrid_pool_ctx[transfer.name]
+                chunk_page_results = self._contiguous_page_results(
+                    transfer_results, key_multiplier, batch_pages, transfer.name
+                )
+                if not ctx.is_zero_copy:
+                    for ok, page_offset, data_page in zip(
+                        chunk_page_results, page_offsets, ctx.bounce_get
+                    ):
+                        if not ok:
+                            break
+                        host_pool.set_from_flat_data_page(page_offset, data_page)
+                pool_results.extend(chunk_page_results)
+                if not all(chunk_page_results):
+                    break
+
+            if len(pool_results) < total_pages:
+                pool_results.extend([False] * (total_pages - len(pool_results)))
+            results[transfer.name] = pool_results
         return results
 
     def batch_set_v2(
@@ -988,26 +1060,37 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
-            _, key_strs, host_buffers, _, key_multiplier = self._prepare_pool_transfer(
-                transfer, for_write=True
-            )
-            if not key_strs:
-                results[transfer.name] = [False] * len(transfer.keys or [])
-                continue
+            pool_results: List[bool] = []
+            total_pages = len(transfer.keys or [])
+            for chunk in self._chunk_transfer(transfer):
+                _, key_strs, host_buffers, _, key_multiplier = (
+                    self._prepare_pool_transfer(chunk, for_write=True)
+                )
+                batch_pages = len(chunk.keys or [])
+                if not key_strs:
+                    pool_results.extend([False] * batch_pages)
+                    break
 
-            start_time = time.perf_counter()
-            transfer_results = self._batch_xfer(
-                key_strs, key_strs, host_buffers, "WRITE"
-            )
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._log_xfer_stats(
-                f"batch_set_v2[{transfer.name}]",
-                len(transfer.keys or []),
-                transfer.host_indices,
-                [size for _, size in host_buffers],
-                elapsed_ms,
-            )
-            results[transfer.name] = self._page_results(
-                transfer_results, key_multiplier
-            )
+                start_time = time.perf_counter()
+                transfer_results = self._batch_xfer(
+                    key_strs, key_strs, host_buffers, "WRITE"
+                )
+                elapsed_ms = (time.perf_counter() - start_time) * 1000
+                self._log_xfer_stats(
+                    f"batch_set_v2[{transfer.name}]",
+                    batch_pages,
+                    chunk.host_indices,
+                    [size for _, size in host_buffers],
+                    elapsed_ms,
+                )
+                chunk_page_results = self._contiguous_page_results(
+                    transfer_results, key_multiplier, batch_pages, transfer.name
+                )
+                pool_results.extend(chunk_page_results)
+                if not all(chunk_page_results):
+                    break
+
+            if len(pool_results) < total_pages:
+                pool_results.extend([False] * (total_pages - len(pool_results)))
+            results[transfer.name] = pool_results
         return results

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -15,6 +15,7 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.hicache_storage import (
+    STORAGE_BATCH_SIZE,
     HiCacheStorageConfig,
     PoolName,
     PoolTransfer,
@@ -686,6 +687,114 @@ class TestNixlUnified(CustomTestCase):
         self.assertEqual(get_results[PoolName.SWA], [True])
         self.assertTrue(torch.equal(mamba_pool.get_data_page(0), expected_mamba))
         self.assertTrue(torch.equal(swa_pool.get_data_page(0), expected_swa))
+
+    def test_batch_set_v2_chunks_oversized_bounce_transfer(self):
+        """An oversized non-zero-copy transfer must be chunked, not dropped.
+
+        The pre-registered bounce buffer holds only STORAGE_BATCH_SIZE slots, so
+        a hybrid-pool transfer larger than that was previously rejected wholesale
+        by _prepare_pool_transfer and reported all-False for every page. The fix
+        splits it into STORAGE_BATCH_SIZE-key sub-transfers so each fits the
+        bounce buffer.
+        """
+        n = STORAGE_BATCH_SIZE * 2 + 44
+        pool = MockHybridPool(num_pages=n, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.MAMBA)
+
+        chunk_sizes = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            chunk_sizes.append(len(key_strs))
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        keys = [f"p{i}" for i in range(n)]
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    keys=keys,
+                    host_indices=torch.arange(n, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.MAMBA], [True] * n)
+        self.assertEqual(
+            chunk_sizes,
+            [STORAGE_BATCH_SIZE, STORAGE_BATCH_SIZE, n - 2 * STORAGE_BATCH_SIZE],
+        )
+
+    def test_batch_get_v2_stops_after_first_failed_chunk(self):
+        """A failed chunk must truncate the result to a contiguous prefix.
+
+        Pages form a radix-cache prefix, so once a chunk fails no later page can
+        be a valid hit. The v2 loop must stop issuing transfers after the first
+        failed chunk and pad the result so a True never follows a False.
+        """
+        n = STORAGE_BATCH_SIZE * 2 + 44
+        pool = MockHybridPool(num_pages=n, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.MAMBA)
+
+        call_count = {"count": 0}
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            call_count["count"] += 1
+            # Chunk 1 succeeds, chunk 2 fails, chunk 3 would succeed if the loop
+            # kept going -- that must not happen.
+            return [call_count["count"] != 2] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        keys = [f"p{i}" for i in range(n)]
+        results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    keys=keys,
+                    host_indices=torch.arange(n, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(call_count["count"], 2)
+        self.assertEqual(
+            results[PoolName.MAMBA],
+            [True] * STORAGE_BATCH_SIZE + [False] * (n - STORAGE_BATCH_SIZE),
+        )
+
+    def test_batch_set_v2_rejects_malformed_transfer_atomically(self):
+        """A transfer whose host_indices don't match len(keys)*page_size must be
+        rejected as a whole before any partial I/O is issued.
+
+        Chunking must not slice a malformed host_indices into "valid-looking"
+        sub-chunks that get transferred against the wrong pages.
+        """
+        n = STORAGE_BATCH_SIZE * 2 + 44
+        page_size = 2
+        pool = MockHybridPool(num_pages=n, page_size=page_size, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.MAMBA)
+
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append(len(key_strs))
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        keys = [f"p{i}" for i in range(n)]
+        # Correct length is n * page_size == 600; pass only n == 300.
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    keys=keys,
+                    host_indices=torch.arange(n, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(calls, [])
+        self.assertEqual(results[PoolName.MAMBA], [False] * n)
 
 
 @unittest.skipUnless(hasattr(os, "O_DIRECT"), "O_DIRECT not available on this platform")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The NIXL HiCache backend pre-registers a fixed-size bounce buffer (STORAGE_BATCH_SIZE = 128 slots) for non-zero-copy hybrid pools (Mamba temporal/conv and other component pools). batch_set_v2 /      
  batch_get_v2 handed the entire transfer to _prepare_pool_transfer, which rejected any batch larger than 128 keys with a hard check and returned empty. The caller then reported every page as False —  
  so for long sequences or large prefill batches, pages beyond 128 were silently neither written to nor read from storage, degrading the cache hit rate with no error surfaced.                          
                                                                                                                                                                                                         
  This PR splits an oversized transfer into STORAGE_BATCH_SIZE-bounded sub-transfers so each fits the pre-registered bounce buffer, and hardens the result handling so partial failures are surfaced     
  correctly.

```shell
[2026-09-02 06:40:48 TP3] HiCacheNixl: hybrid pool deepseek_v4_c128 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP0] Prefill batch, #new-seq: 2, #new-token: 16384, #cached-token: 0, full token usage: 0.17, swa token usage: 0.07, #running-req: 2, #queue-req: 12, #pending-token: 562934, cuda graph: False, input throughput (token/s): 20907.51
E0902 06:40:48.854561   11946 gds_backend.cpp:79] GDS path-mode requires a unique devId per file (devId=1 already registered)
E0902 06:40:48.854619   11946 nixl_agent.cpp:545] registerMem: registration failed for the specified or all potential backends
[2026-09-02 06:40:48 TP0] Failed to register memory of type FILE: NIXL_ERR_BACKEND
[2026-09-02 06:40:48 TP0] HiCacheNixl: hybrid pool deepseek_v4_c4 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP0] HiCacheNixl: hybrid pool deepseek_v4_c4_indexer batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP0] HiCacheNixl: hybrid pool deepseek_v4_c128 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP3] HiCacheNixl: hybrid pool deepseek_v4_c4 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP3] HiCacheNixl: hybrid pool deepseek_v4_c4_indexer batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP3] HiCacheNixl: hybrid pool deepseek_v4_c128 batch size 220 exceeds bounce buffer capacity 128
E0902 06:40:48.858354   11946 gds_backend.cpp:79] GDS path-mode requires a unique devId per file (devId=1 already registered)
E0902 06:40:48.858378   11946 nixl_agent.cpp:545] registerMem: registration failed for the specified or all potential backends
[2026-09-02 06:40:48 TP0] Failed to register memory of type FILE: NIXL_ERR_BACKEND
[2026-09-02 06:40:48 TP2] HiCacheNixl: hybrid pool deepseek_v4_c4 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP2] HiCacheNixl: hybrid pool deepseek_v4_c4_indexer batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP2] HiCacheNixl: hybrid pool deepseek_v4_c128 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP1] HiCacheNixl: hybrid pool deepseek_v4_c4 batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP1] HiCacheNixl: hybrid pool deepseek_v4_c4_indexer batch size 220 exceeds bounce buffer capacity 128
[2026-09-02 06:40:48 TP1] HiCacheNixl: hybrid pool deepseek_v4_c128 batch size 220 exceeds bounce buffer capacity 128
E0902 06:40:48.873074   11947 gds_backend.cpp:79] GDS path-mode requires a unique devId per file (devId=1 already registered)
E0902 06:40:48.873115   11947 nixl_agent.cpp:545] registerMem: registration failed for the specified or all potential backends
[2026-09-02 06:40:48 TP0] Failed to register memory of type FILE: NIXL_ERR_BACKEND
E0902 06:40:48.884233   11947 gds_backend.cpp:79] GDS path-mode requires a unique devId per file (devId=1 already registered)
```
In fact, there are two separate issues here. The first issue can be resolved by this PR: https://github.com/sgl-project/sglang/pull/34362.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Chunk oversized bounce-backed transfers. Add _chunk_transfer, which splits a non-zero-copy hybrid-pool transfer into ≤STORAGE_BATCH_SIZE-key chunks and slices host_indices on the same page_size    
  boundary. Zero-copy pools (which have no per-batch cap) and malformed transfers pass through as a single chunk.                                                                                        
 - Normalize results to a contiguous page prefix. Add _contiguous_page_results to collapse per-component transfer results into page-level results, validate the result length, and force the first      
  failed page to invalidate every later page (matching radix-cache prefix semantics — no True after a False).                                                                                            
 - Stop early and pad on failure. Rewrite batch_get_v2 / batch_set_v2 to iterate the chunks, break out after the first failed chunk (no further transfers issued), and pad the result list to the total 
  page count so callers always get one boolean per requested page.                                                                                                                                       
 - Reject malformed transfers atomically. A host_indices length that doesn't match len(keys) * page_size now passes through intact so _prepare_pool_transfer rejects the whole operation before any     
  partial I/O is issued, instead of being sliced into "valid-looking" sub-chunks that transfer against the wrong pages.                                                                                  
 - Add unit tests (test/registered/unit/mem_cache/test_hicache_nixl_storage.py) covering oversized-transfer chunking, early-stop on the first failed chunk, and atomic rejection of malformed transfers.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```shell
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     200
Benchmark duration (s):                  148.17
Total input tokens:                      12565716
Total input text tokens:                 12565716
Total generated tokens:                  204800
Total generated tokens (retokenized):    204372
Request throughput (req/s):              1.35
Input token throughput (tok/s):          84804.77
Output token throughput (tok/s):         1382.17
Peak output token throughput (tok/s):    4742.00
Peak concurrent requests:                32
Total token throughput (tok/s):          86186.95
Concurrency:                             15.74
Accept length:                           5.68
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11660.11
Median E2E Latency (ms):                 11680.31
P90 E2E Latency (ms):                    13882.87
P95 E2E Latency (ms):                    14687.89
P99 E2E Latency (ms):                    15243.95
---------------Time to First Token----------------
Mean TTFT (ms):                          4623.98
Median TTFT (ms):                        4224.56
P90 TTFT (ms):                           7519.52
P95 TTFT (ms):                           8356.49
P99 TTFT (ms):                           9560.67
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.88
Median TPOT (ms):                        6.90
P90 TPOT (ms):                           9.33
P95 TPOT (ms):                           9.89
P99 TPOT (ms):                           11.72
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.88
Median ITL (ms):                         3.38
P90 ITL (ms):                            4.36
P95 ITL (ms):                            31.75
P99 ITL (ms):                            108.70
Max ITL (ms):                            2823.19
----------------Cache Hit Details-----------------
Total prompt tokens:                     12565716
Total cached tokens:                     11282688
  Device:                                1635072
  Host:                                  1933824
  Storage (HiCacheFile):                 7713792
Cache hit rate:                          89.8%
  Device:                                14.5%
  Host:                                  17.1%
  Storage (HiCacheFile):                 68.4%
-------------Cache Hit TTFT by Source-------------
Category                    Count       Mean     Median        P90        P95        P99
Device-only hit TTFT           29    4345.06    4138.51    7057.64    7207.26    8589.78
Host-only hit TTFT             33    4396.77    3869.30    7468.39    7829.24    8356.82
Device+Host hit TTFT            0       0.00       0.00       0.00       0.00       0.00
Storage hit TTFT              138    4736.93    4512.05    7614.47    8385.93    9563.87
```
It work normally
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33704719302](https://github.com/sgl-project/sglang/actions/runs/33704719302)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33704719214](https://github.com/sgl-project/sglang/actions/runs/33704719214)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33704719441](https://github.com/sgl-project/sglang/actions/runs/33704719441)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->