### PR TITLE
[Examples] Fix llava_video USAGE path to frontend_language

### DIFF
--- a/examples/frontend_language/usage/llava_video/srt_example_llava_v.sh
+++ b/examples/frontend_language/usage/llava_video/srt_example_llava_v.sh
@@ -3,15 +3,15 @@
 ##### USAGE #####
 #    - First node:
 #      ```sh
-#      bash examples/usage/llava_video/srt_example_llava_v.sh K 0 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
+#      bash examples/frontend_language/usage/llava_video/srt_example_llava_v.sh K 0 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
 #      ```
 #    - Second node:
 #      ```sh
-#      bash examples/usage/llava_video/srt_example_llava_v.sh K 1 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
+#      bash examples/frontend_language/usage/llava_video/srt_example_llava_v.sh K 1 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
 #      ```
 #    - The K node:
 #      ```sh
-#      bash examples/usage/llava_video/srt_example_llava_v.sh K K-1 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
+#      bash examples/frontend_language/usage/llava_video/srt_example_llava_v.sh K K-1 YOUR_VIDEO_PATH YOUR_MODEL_PATH FRAMES_PER_VIDEO
 #      ```
 
 


### PR DESCRIPTION
## Summary
- The USAGE comments in `examples/frontend_language/usage/llava_video/srt_example_llava_v.sh` tell users to run `bash examples/usage/llava_video/srt_example_llava_v.sh ...`.
- That path does not exist on `main` (`examples/usage/` only has unrelated scripts). The real location is `examples/frontend_language/usage/llava_video/`.
- Update all three USAGE examples to the correct path so copy-paste from repo root works.

## Drift
Wrong (main): `bash examples/usage/llava_video/srt_example_llava_v.sh ...`
Correct: `bash examples/frontend_language/usage/llava_video/srt_example_llava_v.sh ...`

## Repro
```bash
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/examples/frontend_language/usage/llava_video/srt_example_llava_v.sh | grep -n examples/usage/llava_video
ls examples/usage/llava_video 2>&1 || true
ls examples/frontend_language/usage/llava_video/srt_example_llava_v.sh
```

## Test plan
- [x] Verified on default branch via raw/API (no full clone)
- [x] Confirmed no equivalent open PR for this USAGE path fix
- [ ] CI / docs-only review

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33705474776](https://github.com/sgl-project/sglang/actions/runs/33705474776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33705474389](https://github.com/sgl-project/sglang/actions/runs/33705474389)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->