### PR TITLE
[Perf] Use set membership for id-existence check in _sort_tool_message_run

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -735,12 +735,13 @@ class OpenAIServingChat(OpenAIServingBase):
         if len(run) < 2:
             return run
         call_ids = [tc.get("id") for tc in tool_calls]
-        if any(call_id is None for call_id in call_ids) or len(set(call_ids)) != len(
+        call_id_set = set(call_ids)
+        if any(call_id is None for call_id in call_ids) or len(call_id_set) != len(
             call_ids
         ):
             return run
         result_ids = [message.get("tool_call_id") for message in run]
-        if any(result_id not in call_ids for result_id in result_ids) or len(
+        if any(result_id not in call_id_set for result_id in result_ids) or len(
             set(result_ids)
         ) != len(result_ids):
             return run


### PR DESCRIPTION
## Motivation

`_sort_tool_message_run` (added in #37320) validates each tool result's id against the preceding assistant `tool_calls` with `result_id not in call_ids` where `call_ids` is a list, so validating a contiguous run of n results costs Θ(n²). This runs synchronously on the tokenizer event loop via `_apply_jinja_template` → `_canonicalize_tool_message_order`, and the validation is paid even for text-only runs that the function then returns unchanged. A large agent history (tens of thousands of tool results) blocks the event loop for seconds.

## Modifications

Build `call_id_set = set(call_ids)` once and use it for the existence check. No behavior change: the same runs are sorted or returned untouched; `set(call_ids)` was already computed here for the duplicate check.

## Benchmark

Reversed, valid, text-only run of 25,600 tool results, calling the method directly (CPU):

| | before | after |
|---|---:|---:|
| `_sort_tool_message_run` | 4.042 s | 0.011 s |

## Tests

`pytest test/registered/unit/entrypoints/openai/test_serving_chat.py -k canonicalize` — 3 passed (existing #37320 coverage for sorted media runs, unassociable runs, and text-only runs).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35703389885](https://github.com/sgl-project/sglang/actions/runs/35703389885)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35703389565](https://github.com/sgl-project/sglang/actions/runs/35703389565)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35703389696](https://github.com/sgl-project/sglang/actions/runs/35703389696)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->