### PR TITLE
[chore] Add .git-blame-ignore-revs for the black -> ruff-format reformat (#37210)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Skipped by `git blame`. Enable locally:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# [CI][RFC] Replace black-jupyter with ruff-format (#37210)
+28262c20df6f2945c1b1cd7b27b0faef59cb0438


### PR DESCRIPTION
### What

Adds `.git-blame-ignore-revs` listing the squash commit of #37210 (`28262c20df6f2945c1b1cd7b27b0faef59cb0438`), which reformatted 1409 Python files and one notebook when the pre-commit formatter moved from `black-jupyter` to `ruff-format`.

Without this, `git blame` on any of those files attributes every line to the reformat instead of to the commit that last changed behaviour.

### How to use it

GitHub applies this file automatically in its web blame view. Locally it is opt-in, once per clone:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

### Why the SHA is added in a separate PR

`main` is squash-merged, so #37210's pre-merge SHAs never land on `main` — the entry has to be the post-squash SHA, which only exists after that PR merged. Worth knowing for the next mass reformat: an ignore-revs entry naming a commit that isn't in the repo does **not** error, it is silently inert, so a pre-squash or placeholder SHA would look correct while doing nothing. (A non-hex placeholder is worse: `git blame` then fails outright with `fatal: invalid object name`.)

### Verification that the reformat was semantics-preserving

Checked before #37210 merged, and re-confirmed that its squash commit is byte-identical to the verified tree:

- All 1409 changed `.py` files parse to an identical AST (`ast.dump`, attributes excluded — so every node, operator and literal *value* is compared, which also proves no docstring was re-indented or re-wrapped).
- The notebook's 11 code cells are likewise AST-identical; its only change is `f"{i+1}"` → `f"{i + 1}"`.
- The `COMMENT` token stream is unchanged across all 1409 files, so nothing was dropped or reflowed away — including `# noqa` / `# type: ignore` pragmas, which an AST comparison alone would not catch.

One byte-level change worth recording: `python/sglang/srt/models/qwen2_classification.py` lost its UTF-8 BOM. CPython's source-encoding detection handles the file either way.

### Follow-up (not in this PR)

The contribution guide could mention the `git config` line above so the skip is on by default for new contributors. Happy to add it here instead if reviewers prefer it bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33709076148](https://github.com/sgl-project/sglang/actions/runs/33709076148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33709075975](https://github.com/sgl-project/sglang/actions/runs/33709075975)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->