### PR TITLE
[CI] Drop stale torch-sys link paths from the cargo target cache

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -309,6 +309,16 @@ setup_cargo_cache() {
         mkdir -p "${CARGO_TARGET_DIR}"
     fi
 
+    local build_dir torch_lib
+    for build_dir in "${CARGO_TARGET_DIR}"/*/build/torch-sys-*; do
+        [ -f "${build_dir}/output" ] || continue
+        torch_lib="$(sed -n '/^cargo:libtorch_lib=/{s///p;q;}' "${build_dir}/output")"
+        if [ -n "${torch_lib}" ] && [ ! -d "${torch_lib}" ]; then
+            echo "torch-sys cached a libtorch dir that is gone (${torch_lib}); forcing a rebuild"
+            rm -rf "${build_dir}" "${build_dir%/build/*}/.fingerprint/${build_dir##*/}"
+        fi
+    done
+
     mark_step_done "${FUNCNAME[0]}"
 }
 


### PR DESCRIPTION
`base-c-test-4-gpu-gb300` is the only stage that still compiles the Rust extensions during install (aarch64 has no prebuild), and it fails at `Install dependencies`:

```
/usr/bin/ld: cannot find -ltorch_cuda / -ltorch_python / -ltorch_cpu / -ltorch / -lc10
error: could not compile `sglang-radix-tree`
```

Failure examples: [job 100502807553](https://github.com/sgl-project/sglang/actions/runs/33707711018/job/100502807553) and [job 100502807711](https://github.com/sgl-project/sglang/actions/runs/33707711018/job/100502807711).

torch is a build-system requirement, so PEP 517 build isolation installs it under `/root/.cache/uv/builds-v0/.tmpXXXX/` and torch-sys bakes that absolute path into the shared cargo target dir. uv deletes the temp tree when the build ends, but cargo's build-script fingerprint doesn't know the path was ephemeral and never re-runs the script, so the next job relinks against a directory that is gone. Confirmed on both GB300 runners, each holding a different dead path.

`setup_cargo_cache` now drops a cached torch-sys entry whose recorded libtorch dir no longer exists, so the script re-runs against the current build env.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33710664140](https://github.com/sgl-project/sglang/actions/runs/33710664140)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33710664227](https://github.com/sgl-project/sglang/actions/runs/33710664227)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33710664290](https://github.com/sgl-project/sglang/actions/runs/33710664290)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->