### PR TITLE
[AMD] perf(sgl-kernel) use the ROCm block_quota default for the MLA page_first KV write-back

### DIFF
--- a/python/sglang/kernels/aot/python/sgl_kernel/kvcacheio.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/kvcacheio.py
@@ -12,7 +12,7 @@ _is_hip = is_hip()
 
 
 def _default_mla_block_quota() -> int:
-    """CU (block) quota for the MLA page_first KV gather kernel.
+    """CU (block) quota for the MLA page_first KV transfer kernels.
 
     Defaults to 16 on ROCm / 2 on CUDA. Override with the
     SGLANG_HICACHE_BLOCK_QUOTA environment variable to tune how many CUs the
@@ -326,9 +326,11 @@ def transfer_kv_all_layer_mla_lf_pf(
     item_size: int,
     dst_layout_dim: int,
     num_layers: int,
-    block_quota: int = 2,
+    block_quota: Optional[int] = None,
     num_warps_per_block: int = 16 if _is_hip else 32,
 ):
+    if block_quota is None:
+        block_quota = _default_mla_block_quota()
     torch.ops.sgl_kernel.transfer_kv_all_layer_mla_lf_pf.default(
         src_layers,
         dst,


### PR DESCRIPTION
## Motivation

#30024 added `_default_mla_block_quota()` (16 on ROCm, 2 on CUDA) and wired it into
the MLA page_first *load* entry points. The write-back half of the same path kept
the CUDA-tuned `block_quota: int = 2`, so two adjacent methods of one host-pool
class resolve to different quotas:

```python
# MHATokenToKOnlyPoolHost
transfer_kv_per_layer_mla_pf_lf(...)   # load:       resolved -> 16  (#30024)
transfer_kv_all_layer_mla_lf_pf(...)   # write-back: block_quota = 2
```

## Modifications

One file, `kernels/aot/python/sgl_kernel/kvcacheio.py`: widen
`transfer_kv_all_layer_mla_lf_pf`'s `block_quota` to `Optional[int] = None` and
resolve it through the existing `_default_mla_block_quota()`

## Accuracy Tests

Every transfer below is checked bitwise against a `torch` gather before timing.

## Speed Tests and Profiling

### Bandwidth

M3 geometry after TP4 (88431 tokens, random gather), bitwise-checked against a
torch gather before timing, 7 rounds, 0.0-2.6% spread. Median GB/s:

| element_size | bq=2 | bq=4 | bq=8 | **bq=16** | bq=32 | bq=64 | bq=128 | bq16/bq2 |
|---|---|---|---|---|---|---|---|---|
| 256 | 12.58 | 25.00 | 49.84 | **47.86** | 53.81 | 55.37 | 55.61 | **3.80x** |
| 512 | 23.84 | 47.36 | 48.31 | **53.28** | 55.53 | 55.71 | 55.28 | **2.23x** |
| 576 | 26.05 | 46.55 | 44.85 | **49.84** | 51.03 | 51.04 | 50.93 | **1.91x** |
| 1152 | 30.76 | 42.51 | 49.68 | **53.51** | 54.61 | 54.25 | 53.50 | **1.74x** |

3.80x at M3's element size (256 B), 1.74x at the largest shape. The gain falls off
with element size because a fixed two-block cap costs proportionally more when each
item is small. `bq=2` is worst at every shape.

### Interference with a concurrent forward pass

Upstream annotates this parameter `# can be tuned for less interference`. That
accounts for how many CUs the transfer holds, not for how long: `bq=2` holds 8x
fewer workgroups but stays resident 3.6x longer. **gemm**: bf16 4096x8192x8192
matmul, CU bound, stands in for prefill. **hbm**: large bf16 streaming
elementwise, bandwidth bound, stands in for decode attention.

| bq | transfer GB/s | gemm fwd | gemm interference | hbm interference |
|---|---|---|---|---|
| 2 | 13.8 | 735.1 ms | 24.61 ms/GB | 1.04 ms/GB |
| 4 | 27.0 | 709.6 ms | 4.83 ms/GB | 0.52 ms/GB |
| 8 | 53.6 | 699.2 ms | -3.21 ms/GB | -0.10 ms/GB |
| **16** | 49.6 | **703.3 ms** | **0.00 ms/GB** | **0.50 ms/GB** |
| 32 | 54.6 | 702.7 ms | -0.53 ms/GB | 11.38 ms/GB |
| 64 | 55.8 | 702.5 ms | -0.68 ms/GB | 14.03 ms/GB |

Solo gemm 703.3 ms, hbm 713.3 ms, so anything within ~0.5 ms/GB of zero is noise. It is also why 16
and not more: 32 and 64 cost 11.38 and 14.03 ms/GB where 16 costs 0.50, for 10%
and 13% more bandwidth.

### End to end: MiniMax-M3 TP4 on MI355X

| conc | stock TPM | hit | patched TPM | hit | delta |
|---|---|---|---|---|---|
| 5 | 369,417 | 0.8245 | 371,216 | 0.8245 | **+0.5%** |
| 10 | 786,912 | 0.8579 | 854,536 | 0.8632 | **+8.6%** |
| 15 | 693,449 | 0.8483 | 761,465 | 0.8528 | **+9.8%** |



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33710475234](https://github.com/sgl-project/sglang/actions/runs/33710475234)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33710475139](https://github.com/sgl-project/sglang/actions/runs/33710475139)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33710475245](https://github.com/sgl-project/sglang/actions/runs/33710475245)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->