### PR TITLE
[AMD] perf(kernel): tune JIT HiCache transfer block_quota for ROCm

### DIFF
--- a/python/sglang/kernels/ops/kvcache/hicache.py
+++ b/python/sglang/kernels/ops/kvcache/hicache.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_hip_runtime,
+    load_jit,
+    make_cpp_args,
+)
 from sglang.kernels.kernel_api_logging import debug_kernel_api
 
 if TYPE_CHECKING:
@@ -11,6 +16,11 @@ if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 DEFAULT_BLOCK_QUOTA = 2
+DEFAULT_BLOCK_QUOTA_HIP = 8
+
+
+def _default_hicache_block_quota() -> int:
+    return DEFAULT_BLOCK_QUOTA_HIP if is_hip_runtime() else DEFAULT_BLOCK_QUOTA
 
 
 @cache_once
@@ -77,7 +87,7 @@ def can_use_hicache_jit_kernel(
         return False
     try:
         unroll = unroll or _default_unroll(element_size)
-        block_quota = block_quota or DEFAULT_BLOCK_QUOTA
+        block_quota = block_quota or _default_hicache_block_quota()
         _jit_hicache_module(
             element_size=element_size,
             unroll=unroll,
@@ -143,7 +153,7 @@ def transfer_hicache_one_layer(
     k_cache_dst = k_cache_dst.view(-1, element_dim)
     v_cache_dst = v_cache_dst.view(-1, element_dim)
     element_size = element_dim * k_cache_dst.element_size()
-    block_quota = block_quota or DEFAULT_BLOCK_QUOTA
+    block_quota = block_quota or _default_hicache_block_quota()
     unroll = unroll or _default_unroll(element_size)
     module = _jit_hicache_module(
         element_size=element_size,
@@ -179,7 +189,7 @@ def transfer_hicache_all_layer(
         assert kv_cache_dst_stride_bytes == kv_cache_src_stride_bytes
         element_size = kv_cache_dst_stride_bytes
 
-    block_quota = block_quota or DEFAULT_BLOCK_QUOTA
+    block_quota = block_quota or _default_hicache_block_quota()
     unroll = unroll or _default_unroll(element_size)
     module = _jit_hicache_module(
         element_size=element_size,
@@ -212,7 +222,7 @@ def transfer_hicache_one_layer_mla(
     cache_src = cache_src.view(-1, element_dim)
     cache_dst = cache_dst.view(-1, element_dim)
     element_size = element_dim * cache_dst.element_size()
-    block_quota = block_quota or DEFAULT_BLOCK_QUOTA
+    block_quota = block_quota or _default_hicache_block_quota()
     unroll = unroll or _default_unroll(element_size)
     module = _jit_hicache_module(
         element_size=element_size,
@@ -243,7 +253,7 @@ def transfer_hicache_all_layer_mla(
         assert cache_dst_stride_bytes == cache_src_stride_bytes
         element_size = cache_dst_stride_bytes
 
-    block_quota = block_quota or DEFAULT_BLOCK_QUOTA
+    block_quota = block_quota or _default_hicache_block_quota()
     unroll = unroll or _default_unroll(element_size)
     module = _jit_hicache_module(
         element_size=element_size,


### PR DESCRIPTION
## Motivation

`python/sglang/kernels/ops/kvcache/hicache.py` uses `DEFAULT_BLOCK_QUOTA = 2` on
every platform. On CDNA that caps host->device at 24 GB/s where the same kernel
reaches 55 GB/s at `block_quota = 8`. This patch resolves to 8 on ROCm and
leaves 2 everywhere else; CUDA is bit-for-bit unchanged. JIT-side counterpart of
#30024, which did the same for the AOT kernel.

## Modifications

One file, `python/sglang/kernels/ops/kvcache/hicache.py`. Adds
`DEFAULT_BLOCK_QUOTA_HIP = 8` and a call-time resolver
`_default_hicache_block_quota()`, and uses it at the five `hicache.cuh` entry
points (`can_use_hicache_jit_kernel`, `transfer_hicache_one_layer`,
`transfer_hicache_all_layer`, and the two MLA variants).

The three staged-write-back entry points are a different template
(`staged_write_back.cuh`) and were not measured, so they keep
`DEFAULT_BLOCK_QUOTA`. No in-tree caller passes `block_quota` explicitly.

## Accuracy Tests

The kernel moves the same bytes to the same destinations for any `block_quota`.
Every transfer in the benchmark below is bitwise-checked against a `torch`
gather before timing.

## Speed Tests and Profiling

### Bandwidth

Geometry taken from MiniMax-M3 after TP4 (88431 tokens, random gather indices),
7 shuffled rounds, 0.0-0.3% spread across rounds. Host->device, median GB/s:

| element_size | unroll | bq=2 | bq=4 | **bq=8** | bq=16 | bq=32 | bq=64 |
|---|---|---|---|---|---|---|---|
| 128 | 4 | 16.56 | 32.43 | **43.85** | 43.74 | 45.24 | 45.66 |
| 256 | 4 | 24.43 | 45.62 | **54.34** | 52.92 | 54.96 | 54.82 |
| 512 | 4 | 24.93 | 46.47 | **54.73** | 52.81 | 55.10 | 55.20 |
| 1024 | 2 | 24.80 | 46.37 | **55.46** | 54.79 | 56.01 | 56.31 |
| 1152 | 1 | 23.53 | 44.68 | **54.54** | 55.36 | 55.95 | 56.47 |

`bq=2` is the worst value at every shape and gives up 55-64% of achievable
bandwidth; `bq=8` reaches 96-99% of the best measured value and going past it
buys at most 4%. Device->host is 1.02-1.45x and never regresses.

### Interference with a concurrent forward pass

Upstream annotates this parameter with `# can be tuned for less interference`.
That premise accounts for how many CUs the transfer holds, not for how long:
`bq=2` holds 4x fewer workgroups but stays resident 2.2x longer because its
bandwidth is lower (one 4.1 GB load, 168 ms vs 76 ms). Measured against two
concurrent forward-pass proxies, each timed on its own stream and normalised per
byte moved (`interference = (t_concurrent - t_solo) / GB`, 4.01 GB per load, 7
rounds). **gemm**: bf16 4096x8192x8192 matmul, compute/CU bound, stands in for
prefill. **hbm**: large bf16 streaming elementwise, HBM-bandwidth bound, stands
in for decode attention.

| bq | transfer GB/s | gemm fwd | gemm interference | hbm fwd | hbm interference |
|---|---|---|---|---|---|
| 2 | 24.3 | 217.9 ms | 15.38 ms/GB | 224.1 ms | 2.60 ms/GB |
| 4 | 45.6 | 189.1 ms | 8.20 ms/GB | 218.8 ms | 1.29 ms/GB |
| **8** | 54.0 | **183.2 ms** | **6.73 ms/GB** | **217.2 ms** | **0.88 ms/GB** |
| 16 | 52.3 | 184.3 ms | 7.00 ms/GB | 224.4 ms | 2.69 ms/GB |
| 32 | 54.5 | 186.1 ms | 7.44 ms/GB | 256.1 ms | 10.60 ms/GB |
| 64 | 54.2 | 196.2 ms | 9.96 ms/GB | 265.2 ms | 12.86 ms/GB |

Solo: gemm 156.3 ms, hbm 213.6 ms. `bq=2 -> 8` cuts interference by 56% and 66%,
and 8 is the minimum of both curves; `bq=32` / `bq=64` are 12x and 14.6x worse
than 8 on the bandwidth-bound proxy.

### End to end: MiniMax-M3 TP4 on MI355X

Two arms one `block_quota` apart, each on a freshly booted server, radix
dataset, 300 s per point, `POST /flush_cache` before every point. Cache hit
ratio is matched to within 0.7 points across all four rungs:

| concurrency | bq=2 TPM | bq=8 TPM | tpot bq=2 / bq=8 |
|---|---|---|---|
| 15 | 5,574,054 | 5,537,165 | 21.7 / 19.9 ms |
| 25 | 6,836,329 | 7,491,941 | 29.9 / 25.9 ms |
| 35 | 6,367,051 | 7,000,006 | 45.8 / 37.3 ms |
| 45 | 6,446,586 | 6,783,900 | 49.1 / 38.9 ms |

Same volume of data moved, +10% throughput, and the decode-latency margin widens
with concurrency (0.917x -> 0.792x). On a stress config with a smaller KV pool
(`--hicache-size 120`), throughput at concurrency 5/10/15 is +17.9% / +58.3% /
+22.9%.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33710494451](https://github.com/sgl-project/sglang/actions/runs/33710494451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33710494264](https://github.com/sgl-project/sglang/actions/runs/33710494264)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33710494400](https://github.com/sgl-project/sglang/actions/runs/33710494400)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->