### PR TITLE
[CI] Skip the GPU idle check on devices where NVML cannot report memory

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -2024,7 +2024,15 @@ def _collect_busy_gpu_reports(pynvml, gpu_indices: List[int]) -> List[str]:
     reports = []
     for index in gpu_indices:
         handle = pynvml.nvmlDeviceGetHandleByIndex(index)
-        used_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).used
+        try:
+            used_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).used
+        except pynvml.NVMLError:
+            # Unified-memory parts (GB10 / DGX Spark, Jetson Thor) report
+            # NVML_ERROR_NOT_SUPPORTED for the memory query, the same way
+            # nvidia-smi shows N/A for them. We cannot tell whether the
+            # device is busy, so do not treat it as busy: otherwise every
+            # test class errors in setUpClass on these machines.
+            continue
         if used_bytes < _GPU_IDLE_USED_MEMORY_THRESHOLD:
             continue
         try:


### PR DESCRIPTION
## Motivation

`_collect_busy_gpu_reports` in `python/sglang/test/test_utils.py` calls
`pynvml.nvmlDeviceGetMemoryInfo` for every visible device before each test class. On
unified-memory parts that query is not supported: a GB10 (DGX Spark) raises
`NVMLError_NotSupported` for both the v1 and v2 memory info calls, the same way
`nvidia-smi` shows `N/A` for them. The process query right below it is already wrapped
in `try/except NVMLError`; the memory query is not, so `safe_setUpClass` errors for
every test class.

Running `test/registered/unit` on a DGX Spark (GB10, sm_121, aarch64, CUDA 13) with
`SGLANG_IS_IN_CI=1`: 609 files, 341 of them fail with exactly this error in
`setUpClass`.

## Modifications

Wrap the memory query the same way the process query already is. When NVML cannot
report memory we cannot tell whether the device is busy, so it is treated as not busy
rather than blocking every test class on these machines. Nine lines, comment included.

## Accuracy Tests

Not applicable, test harness only. Three files that errored before now run:

```
batch_invariant_ops/test_batch_invariant_ops.py   6 passed
utils/test_common.py                              7 passed
configs/test_laguna_config.py                     4 passed
```

Probe on the box:

```
nvmlDeviceGetMemoryInfo     -> NVMLError_NotSupported
nvmlDeviceGetMemoryInfo v2  -> NVMLError_NotSupported
torch.cuda.mem_get_info     -> works
```

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide.
- [ ] Add unit tests: none, the change is in the test harness itself.
- [x] Update documentation as needed: none needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34170219453](https://github.com/sgl-project/sglang/actions/runs/34170219453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34170219473](https://github.com/sgl-project/sglang/actions/runs/34170219473)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34170219451](https://github.com/sgl-project/sglang/actions/runs/34170219451)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->