### PR TITLE
[Examples] Fix Usage filename in offline_batch_inference_qwen_1m.py

### DIFF
--- a/examples/runtime/engine/offline_batch_inference_qwen_1m.py
+++ b/examples/runtime/engine/offline_batch_inference_qwen_1m.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python3 offline_batch_inference.py
+python3 offline_batch_inference_qwen_1m.py
 """
 
 from urllib.request import urlopen


### PR DESCRIPTION
## Summary
- Fix the Usage docstring in `examples/runtime/engine/offline_batch_inference_qwen_1m.py` so it uses this script's own filename instead of `offline_batch_inference.py`.

## Repro
1. Open `examples/runtime/engine/offline_batch_inference_qwen_1m.py` on `main`.
2. Observe the module docstring Usage line:
   ```
   python3 offline_batch_inference.py
   ```
3. There is no `offline_batch_inference.py` next to this file; following Usage fails / points at the wrong script.
4. Correct command is:
   ```
   python3 offline_batch_inference_qwen_1m.py
   ```

## Test plan
- [ ] Confirm Usage matches the filename `offline_batch_inference_qwen_1m.py`
- [ ] Confirm only the Usage line changed (one-line docstring fix)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33711374259](https://github.com/sgl-project/sglang/actions/runs/33711374259)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33711374001](https://github.com/sgl-project/sglang/actions/runs/33711374001)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->