### PR TITLE
[CPU] Fall back to no_buffer mamba radix cache on CPU

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -545,6 +545,11 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
 def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
     """Whether ``model_arch`` supports the extra_buffer strategy on the
     configured linear-attention backend (pure read)."""
+    # The CPU backend has no FLA: linear_attn_backend still resolves to
+    # "triton", but the Triton path rolls back to the CPU kernels, which
+    # implement no_buffer only.
+    if get_platform().is_cpu:
+        return False
     if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS:
         return view.linear_attn_backend == "triton"
     return False

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1776,6 +1776,7 @@ _PLATFORM_PROBES: Dict[str, str] = {
     "is_npu": "is_npu",
     "is_xpu": "is_xpu",
     "is_musa": "is_musa",
+    "is_cpu": "is_cpu",
     "is_sm90": "is_sm90_supported",
     "is_sm100": "is_sm100_supported",
     "is_sm100_or_sm110": "is_sm100_or_sm110_supported",

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -5,6 +5,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 
+import contextlib
 import dataclasses
 import json
 import os
@@ -2217,6 +2218,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             supports_mamba_cache_extra_buffer,
         )
 
+        # Every expectation below is a non-CPU one; a CPU host resolves to
+        # no_buffer, which the tail of this test covers explicitly.
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(override_platform(is_cpu=False))
+
         def _view(arch, layer_types=None, **kw):
             hf = SimpleNamespace(architectures=[arch])
             if layer_types is not None:
@@ -2329,6 +2336,23 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 "Qwen3_5MoeForConditionalGeneration",
             )
         )
+        # CPU keeps linear_attn_backend="triton" but rolls back to the CPU
+        # kernels, which implement no_buffer only.
+        with override_platform(is_cpu=True):
+            self.assertFalse(
+                supports_mamba_cache_extra_buffer(
+                    SimpleNamespace(linear_attn_backend="triton"),
+                    "Qwen3_5ForConditionalGeneration",
+                )
+            )
+            self.assertEqual(
+                _mamba_radix_cache_resolution(_view("Qwen3_5ForConditionalGeneration")),
+                {
+                    "uses_mamba_radix_cache": True,
+                    "mamba_radix_cache_strategy": "no_buffer",
+                    "disable_overlap_schedule": True,
+                },
+            )
 
     def test_qwen3_5_hybrid_coupled_declaration(self):
         from sglang.srt.arg_groups.model_overrides.qwen3_5 import (


### PR DESCRIPTION
## Motivation

Serving a hybrid mamba / linear-attention model whose architecture supports the
`extra_buffer` strategy  such as Qwen3.5 on the CPU backend (`--device cpu`,
`SGLANG_USE_CPU_ENGINE=1`) crashes during server-argument resolution with stock
flags, before any weights are loaded:

```
  File "python/sglang/srt/server_args.py", line 3697, in resolve_once
    run_resolution_pipeline(self)
  File "python/sglang/srt/arg_groups/pipeline.py", line 236, in run_resolution_pipeline
    handle_model_specific_adjustments(server_args)
  File "python/sglang/srt/arg_groups/model_hook.py", line 831, in handle_mamba_radix_cache
    validate_mamba_extra_buffer(
  File "python/sglang/srt/arg_groups/mamba_hook.py", line 104, in validate_mamba_extra_buffer
    get_platform().is_cuda
AssertionError: extra_buffer needs CUDA/MUSA/NPU/ROCm/XPU (FLA).
```

### Root cause

With the default `--mamba-radix-cache-strategy auto`,
`_mamba_radix_cache_resolution` selects `extra_buffer` whenever overlap
scheduling or paging is wanted and `supports_mamba_cache_extra_buffer` returns
`True`. That predicate checks the architecture and the linear-attention
backend, but not the platform:

```python
if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS:
    return view.linear_attn_backend == "triton"
```

On CPU `linear_attn_backend` still resolves to `"triton"`, so the check passes —
but the Triton path then rolls back to the CPU kernels:

```
python/sglang/kernels/ops/attention/fla/utils.py:223: UserWarning:
  Triton is not supported on current platform, roll back to CPU.
```

Those kernels implement `no_buffer` only. So `auto` selects a strategy the CPU
backend cannot run, and `validate_mamba_extra_buffer` then hard-asserts.

The strategy defaults to `auto` and overlap scheduling is on by default, so this
fires with stock flags. Starting one of these models on CPU today requires an
explicit opt-out — either `--mamba-radix-cache-strategy no_buffer
--disable-overlap-schedule`, or `--disable-radix-cache`.

Architectures outside `_MAMBA_EXTRA_BUFFER_ARCHS` (e.g. `Lfm2ForCausalLM`)
already resolve to `no_buffer` and are unaffected.

## Modifications

Gate the support predicate on the platform, so `auto` resolves to `no_buffer`
(disabling overlap, as that strategy already requires) on CPU. CUDA / MUSA /
NPU / ROCm / XPU are unaffected.

This mirrors #37355, which does the same for the MLX backend. Both platforms
genuinely cannot run the FLA path, so they fall back. 
Kept as a separate PR from #37355 rather than one combined predicate: the two
platforms are independent.

Also adds `is_cpu` to the platform-fact table in `runtime_context.py`.
`get_platform()` had no such fact, and `arg_groups/overrides.py` reads platform
facts exclusively through it; exposing it there makes the resolution testable
with `override_platform(is_cpu=True)` instead of patching a module global.

### Tests

Extends `test_mamba_radix_cache_resolution_pass` with a CPU case asserting that
`auto` resolves to `no_buffer` with overlap disabled, and that
`supports_mamba_cache_extra_buffer` is `False` on CPU.

The pre-existing assertions in that test expect `extra_buffer` outcomes without
pinning the platform. They passed only because `is_cpu()` requires
`SGLANG_USE_CPU_ENGINE=1`, which the `base-a-test-cpu` runners do not set — but
they failed on a real CPU-engine host. Pinned them explicitly with
`override_platform(is_cpu=False)` so the expectations no longer depend on an
ambient environment variable.

## Accuracy Tests

No forward or kernel code is touched; this only changes which mamba radix-cache
strategy `auto` selects on CPU. `no_buffer` is the existing supported CPU path,
so model outputs are unaffected. The change unblocks server startup.

Verified on an Intel Xeon 6 host (128 physical cores, 4 NUMA nodes) with
`Qwen/Qwen3.5-9B`, `--tp 4 --device cpu --attention-backend intel_amx`, radix
cache enabled, and **no** manual strategy override. Both runs are on this
branch; the only difference is reverting this commit's source files to its
parent, so nothing else varies.

Before (this commit's parent):

```
  File "python/sglang/srt/arg_groups/mamba_hook.py", line 104, in validate_mamba_extra_buffer
    get_platform().is_cuda
AssertionError: extra_buffer needs CUDA/MUSA/NPU/ROCm/XPU (FLA).
```

The run never reaches weight loading, so
this reproduces on any CPU host independent of memory or model size.

After:

```
'mamba_radix_cache_strategy': 'no_buffer', 'uses_mamba_radix_cache': True,
'disable_overlap_schedule': True
...
Mamba Cache is allocated. max_mamba_cache_size: 1643, conv_state size: 0.45GB, ssm_state size: 19.27GB
max_total_num_tokens=2874826, chunked_prefill_size=4096, context_len=8192
INFO:     Uvicorn running on http://127.0.0.1:30000
```



Unit test on the same host, where `is_cpu()` is genuinely `True`:

```
$ python -m pytest test/registered/unit/test_model_overrides.py \
    -k mamba_radix_cache_resolution -x -q
1 passed, 90 deselected
```

## Speed Tests and Profiling

No speed impact. On CPU the server previously could not start these models at
all without a manual override, and `auto` now resolves to exactly the
configuration that manual override produced. Behaviour on every other platform
is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33711951643](https://github.com/sgl-project/sglang/actions/runs/33711951643)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33711951524](https://github.com/sgl-project/sglang/actions/runs/33711951524)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33711951634](https://github.com/sgl-project/sglang/actions/runs/33711951634)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->