### PR TITLE
[Examples] Fix Usage filenames in quick_start examples

### DIFF
--- a/examples/frontend_language/quick_start/azure_openai_example_chat.py
+++ b/examples/frontend_language/quick_start/azure_openai_example_chat.py
@@ -1,7 +1,7 @@
 """
 Usage:
 export AZURE_OPENAI_API_KEY=sk-******
-python3 openai_example_chat.py
+python3 azure_openai_example_chat.py
 """
 
 import os

--- a/examples/frontend_language/quick_start/openai_example_n.py
+++ b/examples/frontend_language/quick_start/openai_example_n.py
@@ -1,7 +1,7 @@
 """
 Usage:
 export OPENAI_API_KEY=sk-******
-python3 openai_example_chat.py
+python3 openai_example_n.py
 """
 
 import sglang as sgl

--- a/examples/frontend_language/quick_start/openai_example_o1.py
+++ b/examples/frontend_language/quick_start/openai_example_o1.py
@@ -1,7 +1,7 @@
 """
 Usage:
 export OPENAI_API_KEY=sk-******
-python3 openai_example_chat.py
+python3 openai_example_o1.py
 """
 
 import sglang as sgl

--- a/examples/frontend_language/quick_start/openrouter_example_chat.py
+++ b/examples/frontend_language/quick_start/openrouter_example_chat.py
@@ -1,7 +1,7 @@
 """
 Usage:
 export OPENROUTER_API_KEY=sk-******
-python3 together_example_chat.py
+python3 openrouter_example_chat.py
 """
 
 import os


### PR DESCRIPTION
## Summary
Four `examples/frontend_language/quick_start/*.py` files have copy-pasted `Usage:` lines that name a different script. Running the documented command therefore executes the wrong file (or fails if that sibling is not on `PYTHONPATH` as expected).

| File | Wrong Usage | Fixed |
|------|-------------|--------|
| `azure_openai_example_chat.py` | `python3 openai_example_chat.py` | `python3 azure_openai_example_chat.py` |
| `openai_example_n.py` | `python3 openai_example_chat.py` | `python3 openai_example_n.py` |
| `openai_example_o1.py` | `python3 openai_example_chat.py` | `python3 openai_example_o1.py` |
| `openrouter_example_chat.py` | `python3 together_example_chat.py` | `python3 openrouter_example_chat.py` |

## Repro (main @ 81b0e498)
```bash
for f in azure_openai_example_chat.py openai_example_n.py openai_example_o1.py openrouter_example_chat.py; do
  echo "=== $f ==="
  curl -sL "https://raw.githubusercontent.com/sgl-project/sglang/main/examples/frontend_language/quick_start/$f" | head -5
done
```
Observed:
- `azure_openai_example_chat.py` → `python3 openai_example_chat.py`
- `openai_example_n.py` → `python3 openai_example_chat.py`
- `openai_example_o1.py` → `python3 openai_example_chat.py`
- `openrouter_example_chat.py` → `python3 together_example_chat.py`

Correct siblings (`openai_example_chat.py`, `together_example_chat.py`, `orcarouter_example_chat.py`) already document their own filenames.

## Test plan
- [x] Diff is Usage docstring only (4 one-line renames)
- [x] Filename in Usage matches the file basename
- [ ] CI / example lint as configured for this repo

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33712636184](https://github.com/sgl-project/sglang/actions/runs/33712636184)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33712635973](https://github.com/sgl-project/sglang/actions/runs/33712635973)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->