### PR TITLE
Fix stale Scheduler attribute reads that break --enable-pdmux

### DIFF
--- a/python/sglang/srt/multiplex/multiplexing_mixin.py
+++ b/python/sglang/srt/multiplex/multiplexing_mixin.py
@@ -37,7 +37,7 @@ class SchedulerMultiplexMixin:
 
         # for pd_multiplexing, Init stream_groups, exclude normal stream for prefill only and decode only
         self.pdmux_config = load_pdmux_config(get_disagg().pdmux_config_path)
-        initialize_stream_groups(self.gpu_id, self.pdmux_config)
+        initialize_stream_groups(self.ps.gpu_id, self.pdmux_config)
         self.stream_groups = get_stream_groups()
         self.sm_counts = get_sm_counts()
         self.real_sm_group_num = len(self.stream_groups)
@@ -214,7 +214,7 @@ class SchedulerMultiplexMixin:
                     )
 
                     self.tp_cpu_group.allreduce(flags, dist.ReduceOp.SUM).wait()
-                    if flags.item() == self.tp_size:
+                    if flags.item() == self.ps.tp_size:
                         self.process_batch_result(
                             self.split_prefill_batch, prefill_result
                         )


### PR DESCRIPTION
## Problem

PD multiplexing cannot start on any model. `SchedulerMultiplexMixin` reads
`self.gpu_id` and `self.tp_size`, but both live on the `ParallelState` object
the scheduler builds as `self.ps`, so each read raises `AttributeError`.

The first one fires inside `Scheduler.__init__` → `init_pdmux()`, before any
kernel runs:

File "sglang/srt/managers/scheduler.py", line 540, in init
    self.init_pdmux()
File "sglang/srt/multiplex/multiplexing_mixin.py", line 40, in init_pdmux
    initialize_stream_groups(self.gpu_id, self.pdmux_config)
AttributeError: 'Scheduler' object has no attribute 'gpu_id'

Fixing only that exposes the second, at `multiplexing_mixin.py:217` in
`event_loop_pdmux`, which fires on the first batch — the scheduler dies again and
the startup warmup request times out.

This is not model- or hardware-specific: `--enable-pdmux` fails at startup on
every configuration.

## Fix

Two reads, `self.gpu_id` → `self.ps.gpu_id` and `self.tp_size` →
`self.ps.tp_size`.

`self.ps` is assigned at `scheduler.py:503` and `init_pdmux()` is called at
`:540`, so it is available at both sites. The scheduler already reads these
values through `self.ps` everywhere else (`:755`, `:962`, `:989`, `:1479`), and
there is no plain `self.gpu_id` / `self.tp_size` assignment on `Scheduler` — this
looks like drift left behind when those attributes moved onto `ParallelState`.

I checked the rest of the module for the same drift: of the 19 `self.<attr>`
reads under `srt/multiplex/`, these two were the only ones missing from
`Scheduler`, and no other file there reads either name.

## Verification

1× RTX PRO 5000 Blackwell (sm_120, 110 SM), dense `Qwen3ForCausalLM` FP8
checkpoint, `--enable-pdmux` with a `manual_divisions` pdmux config.

Before: scheduler raises during startup, server never becomes healthy.

After:

PD-Multiplexing enabled with 3 stream groups, sm_counts (prefill_sm, decode_sm): [(110, 0), (86, 24), (0, 110)]

a decode CUDA graph is captured per stream group, `/health` goes green, and real
requests are served with correct output.

## Note (separate issue, not fixed here)

`pdmux_context.get_arch_constraints` has no entry above compute capability 9, so
`divide_sm()` raises `ValueError: Unsupported compute capability: 12.0` on
Blackwell. It can be bypassed with `manual_divisions`, which is what the
verification above used, so it does not block this fix. I have not touched it
because the right `(min_per_part, multiple)` values for Blackwell need someone
who knows the green-context granularity — I only have an empirical observation
(on this 110-SM card, requesting decode 14/16/18/20 all yield ~17 effective SMs
and 22/24 both yield ~26, measured by timing a fixed GEMM per stream). Happy to
file that separately.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33731581159](https://github.com/sgl-project/sglang/actions/runs/33731581159)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33731580932](https://github.com/sgl-project/sglang/actions/runs/33731580932)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33731581311](https://github.com/sgl-project/sglang/actions/runs/33731581311)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->