### PR TITLE
[Docs] Drop deprecated --prefill-round-robin-balance from PD disaggregation

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -678,7 +678,7 @@ do
         --moe-a2a-backend deepep --enable-dp-attention --deepep-mode low_latency --enable-dp-lm-head \
         --cuda-graph-bs 2 4 6 8 10 12 14 16 18 20 22 24 26 28 --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 8192 \
         --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4  \
-        --prefill-round-robin-balance --disable-shared-experts-fusion --dtype bfloat16 --tokenizer-worker-num 4 \
+        --disable-shared-experts-fusion --dtype bfloat16 --tokenizer-worker-num 4 \
        	--load-balance-method round_robin
         NODE_RANK=$i
         break


### PR DESCRIPTION
## Summary

The ASCEND DeepSeek multi-node decode example in `docs/docs/advanced_features/pd_disaggregation.mdx` still passes `--prefill-round-robin-balance`. That flag is registered as a `DeprecatedAction` no-op in `python/sglang/srt/server_args.py` (prints a deprecation warning and does not store a value). Round-robin balancing is configured with `--load-balance-method round_robin`, which the example already uses.

This docs-only change removes the deprecated flag from that example and leaves `--load-balance-method round_robin` in place.

## Test plan

- [x] Confirmed `--prefill-round-robin-balance` is `DeprecatedAction` on `main`
- [x] Confirmed `--load-balance-method` includes `round_robin`
- [x] Example still documents `--load-balance-method round_robin`
- [ ] Docs preview of PD Disaggregation no longer shows `--prefill-round-robin-balance`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33717909127](https://github.com/sgl-project/sglang/actions/runs/33717909127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33717908821](https://github.com/sgl-project/sglang/actions/runs/33717908821)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->