### PR TITLE
[Docs] Prefer --smg-grpc-mode in EPD gRPC encoder example

### DIFF
--- a/docs/docs/advanced_features/epd_disaggregation.mdx
+++ b/docs/docs/advanced_features/epd_disaggregation.mdx
@@ -168,7 +168,7 @@ prefill process so it uses the gRPC receiver.
 python -m sglang.launch_server \
   --model-path Qwen/Qwen3-VL-8B-Instruct \
   --encoder-only \
-  --grpc-mode \
+  --smg-grpc-mode \
   --encoder-transfer-backend zmq_to_scheduler \
   --port 30000
 


### PR DESCRIPTION
## What drifted

In `docs/docs/advanced_features/epd_disaggregation.mdx`, the **gRPC Encoder (EPD)** example still launches the encoder with `--grpc-mode`.

On current `main`, `--grpc-mode` is a deprecated alias that folds into `--smg-grpc-mode` (`python/sglang/srt/arg_groups/serving_hook.py`). `python/sglang/srt/server_args.py` documents `--smg-grpc-mode` as the preferred flag ("Replaces the deprecated --grpc-mode"), and `python/sglang/launch_server.py` selects the encoder gRPC path when `smg_grpc_mode or grpc_mode` is set.

## Local-equivalent verification

- Confirmed on `sgl-project/sglang@main` that the EPD doc example contains `--grpc-mode`.
- Confirmed `ServerArgs.grpc_mode` help: `(Deprecated, use --smg-grpc-mode)`.
- Confirmed deprecation handler sets `smg_grpc_mode=True` when `--grpc-mode` is passed.
- Confirmed encoder launch path accepts `--smg-grpc-mode`.
- No equivalent open PR already updates this file (Model Gateway docs are covered separately).

## Change

Replace `--grpc-mode` with `--smg-grpc-mode` in the EPD gRPC encoder launch example only.

## Test plan

- [x] Diff is a one-line CLI flag rename in `epd_disaggregation.mdx`
- [x] No remaining `--grpc-mode` in that file
- [x] Flag exists on `ServerArgs` as `--smg-grpc-mode`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33718267762](https://github.com/sgl-project/sglang/actions/runs/33718267762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33718267733](https://github.com/sgl-project/sglang/actions/runs/33718267733)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->