### PR TITLE
[Fix] Treat whitespace-only content as empty in reasoning fallback

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -109,7 +109,7 @@ class BaseReasoningFormatDetector:
     def _maybe_apply_force_nonempty_content(
         self, ret: StreamingParseResult
     ) -> StreamingParseResult:
-        if self._force_nonempty_content and not ret.normal_text:
+        if self._force_nonempty_content and not ret.normal_text.strip():
             ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
         return ret
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -41,6 +41,23 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
         self.assertEqual(result.normal_text, text)
         self.assertEqual(result.reasoning_text, "")
 
+    def test_force_nonempty_content_treats_whitespace_as_empty(self):
+        """Whitespace-only content must not block the reasoning-to-content rescue."""
+        for detector_class in (Qwen3Detector, DeepSeekR1Detector, Glm45Detector):
+            with self.subTest(detector=detector_class.__name__):
+                detector = detector_class(force_nonempty_content=True)
+                text = (
+                    detector.think_start_token
+                    + "The answer is 42."
+                    + detector.think_end_token
+                    + " \n"
+                )
+
+                result = detector.detect_and_parse(text)
+
+                self.assertEqual(result.normal_text, "The answer is 42.")
+                self.assertEqual(result.reasoning_text, " \n")
+
     def test_detect_and_parse_with_start_token(self):
         """Test parsing text starting with think token."""
         text = "<think>This is reasoning"


### PR DESCRIPTION
## Motivation

Fixes #37652. When `force_nonempty_content` is enabled, a whitespace-only tail after a reasoning block currently prevents the reasoning text from being promoted to normal content.

## Modifications

- Treat whitespace-only `normal_text` as empty in the shared reasoning fallback.
- Add CPU-only regression coverage for Qwen3, DeepSeek-R1, and GLM-4.5 detectors.

## Accuracy Tests

- `pre-commit run --files python/sglang/srt/parser/reasoning_parser.py test/registered/unit/parser/test_reasoning_parser.py` passed.


## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33720229916](https://github.com/sgl-project/sglang/actions/runs/33720229916)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33720229742](https://github.com/sgl-project/sglang/actions/runs/33720229742)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33720229798](https://github.com/sgl-project/sglang/actions/runs/33720229798)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->