### PR TITLE
[MLX] Delegate batched decode to the model's attention (#32521)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
@@ -179,6 +179,42 @@ def clear_context() -> None:
     _thread_local.batched_ctx = None
 
 
+class BatchedPoolCache:
+    """mlx-lm cache adapter for one attention layer in one batched decode step.
+
+    ``offset`` carries per-request RoPE positions; ``update_and_fetch`` writes
+    each new K/V to its pool slot and returns the right-padded batched K/V.
+    """
+
+    def __init__(self, layer_caches, ctx: BatchedDecodeContext, window: int | None):
+        self._layer_caches = layer_caches
+        self._ctx = ctx
+        self._window = window
+        self.offset = ctx.offsets
+
+    @property
+    def state(self):
+        return ()
+
+    def update_and_fetch(self, keys: mx.array, values: mx.array):
+        B, n_kv_heads, _, head_dim = keys.shape
+        pad_sizes, _ = self._ctx.decode_padding(self._window)
+        all_k = []
+        all_v = []
+        for i in range(B):
+            self._layer_caches[i].write_token(keys[i : i + 1], values[i : i + 1])
+            k_all, v_all = self._layer_caches[i].get_kv(self._window)
+            pad = pad_sizes[i]
+            if pad > 0:
+                k_pad = mx.zeros((1, n_kv_heads, pad, head_dim), dtype=k_all.dtype)
+                v_pad = mx.zeros((1, n_kv_heads, pad, head_dim), dtype=v_all.dtype)
+                k_all = mx.concatenate([k_all, k_pad], axis=2)
+                v_all = mx.concatenate([v_all, v_pad], axis=2)
+            all_k.append(k_all)
+            all_v.append(v_all)
+        return mx.concatenate(all_k, axis=0), mx.concatenate(all_v, axis=0)
+
+
 class MLXAttentionWrapper(nn.Module):
     """Wraps an mlx-lm Attention for batched decode (BS>1).
 
@@ -229,11 +265,31 @@ class MLXAttentionWrapper(nn.Module):
             self, "_sink_kwargs", {} if sinks is None else {"sinks": sinks}
         )
 
-    def __call__(self, x: mx.array, mask: Any = None, cache: Any = None) -> mx.array:
+    def __call__(
+        self, x: mx.array, mask: Any = None, cache: Any = None, *args, **kwargs
+    ):
+        # Forward extra args the inner module takes (Hunyuan passes a shared-KV
+        # state positionally) so delegation matches its contract.
         ctx = get_context()
         if ctx is None:
-            return self._inner(x, mask=mask, cache=cache)
-        return self._batched_decode(x, ctx)
+            return self._inner(x, mask, cache, *args, **kwargs)
+        if ctx.aot.rope is not None and self._window_size is None:
+            # The fused AOT RoPE+scatter kernel owns the RoPE step, so it needs
+            # the hand-rolled path.
+            return self._batched_decode(x, ctx)
+        return self._delegated_decode(x, ctx, *args, **kwargs)
+
+    def _delegated_decode(
+        self, x: mx.array, ctx: BatchedDecodeContext, *args, **kwargs
+    ):
+        # The module runs its own q/k/v, norms, RoPE and SDPA; we own only the
+        # KV pool and batching, handed to it as a BatchedPoolCache.
+        window = self._window_size
+        cache_idx = ctx.attention_pool_index_by_layer[self._layer_idx]
+        layer_caches = ctx.attention_layer_caches[cache_idx]
+        _, attn_mask = ctx.decode_padding(window)
+        cache = BatchedPoolCache(layer_caches, ctx, window)
+        return self._inner(x, attn_mask, cache, *args, **kwargs)
 
     def _batched_decode(self, x: mx.array, ctx: BatchedDecodeContext) -> mx.array:
         inner = self._inner

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -243,6 +243,14 @@ def supports_cuda_vmm_feature_transport(model_config: ModelConfig) -> bool:
 
 
 def get_resolved_model_impl(model_config: ModelConfig) -> ModelImpl:
+    # MLX serves via mlx_lm.load(), so there is no sglang/Transformers impl to
+    # resolve here; resolving would import the model's auto_map and crash (e.g.
+    # Hunyuan). Local import keeps the MLX backend off this module's import path.
+    from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+
+    if use_mlx():
+        return ModelImpl.SGLANG
+
     resolved_model_impl = getattr(model_config, "_resolved_model_impl", None)
     if resolved_model_impl is not None:
         return resolved_model_impl

--- a/test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py
@@ -1,0 +1,123 @@
+import importlib.util
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+# Registered on the CPU suite but skipped wherever mlx is absent; runs for real
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, which the
+# macOS CI lane (pr-test-mlx.yml) only dispatches via a gated workflow_dispatch.
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+
+# hunyuan architecture (HunYuanForCausalLM), served on the MLX backend through
+# mlx_lm's own hunyuan implementation; the SGLang MLX backend does not require
+# any srt/models file for it. This is a black-box correctness guard for the
+# served model.
+#
+# Default is the MLX-community 4-bit repo so the test is portable. Override with
+# SGLANG_MLX_TEST_MODEL to point at a local copy, e.g.
+#   SGLANG_MLX_TEST_MODEL=models/Hunyuan-7B-Instruct-4bit
+MODEL_PATH = os.environ.get(
+    "SGLANG_MLX_TEST_MODEL", "mlx-community/Hunyuan-7B-Instruct-4bit"
+)
+
+# mem-fraction is tuned conservatively for a 24 GB Apple Silicon machine.
+MEM_FRACTION_STATIC = os.environ.get("SGLANG_MLX_TEST_MEM_FRACTION", "0.7")
+
+
+@unittest.skipUnless(_HAS_MLX, "requires mlx (Apple Silicon only)")
+class TestHunyuanMlxCorrectness(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "1",
+                "--disable-radix-cache",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                MEM_FRACTION_STATIC,
+                "--max-running-requests",
+                "1",
+                "--context-length",
+                "2048",
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process is not None:
+            kill_process_tree(cls.process.pid)
+
+    def _chat(self, messages, max_tokens=32, temperature=0):
+        resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": MODEL_PATH,
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+
+    def test_basic_generation_nonempty(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "Say hello briefly."},
+            ],
+            max_tokens=16,
+        )
+        self.assertIsInstance(text, str)
+        self.assertGreater(len(text), 0)
+
+    def test_simple_arithmetic(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "What is 2+2? Reply with just the number."},
+            ],
+            max_tokens=8,
+        )
+        self.assertIn("4", text)
+
+    def test_simple_fact(self):
+        text = self._chat(
+            [
+                {"role": "system", "content": "You are a concise assistant."},
+                {"role": "user", "content": "What is the capital of France? One word."},
+            ],
+            max_tokens=8,
+        )
+        self.assertIn("Paris", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -1321,6 +1321,24 @@ if _HAS_MLX:
             self.o_proj = FakeProjection(4)
             self.rope = lambda x, offset=None: x
 
+        def __call__(self, x, mask=None, cache=None):
+            # Minimal mlx-lm attention contract so the delegate decode path can
+            # drive this stub.
+            B, L, _ = x.shape
+            hd = self.head_dim
+            q = self.q_proj(x).reshape(B, L, -1, hd).transpose(0, 2, 1, 3)
+            k = self.k_proj(x).reshape(B, L, -1, hd).transpose(0, 2, 1, 3)
+            v = self.v_proj(x).reshape(B, L, -1, hd).transpose(0, 2, 1, 3)
+            offset = cache.offset if cache is not None else 0
+            q = self.rope(q, offset=offset)
+            k = self.rope(k, offset=offset)
+            if cache is not None:
+                k, v = cache.update_and_fetch(k, v)
+            out = mx.fast.scaled_dot_product_attention(
+                q, k, v, scale=self.scale, mask=mask
+            )
+            return self.o_proj(out.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
     class ProjectionOnlyMixer(nn.Module):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
## Motivation
Fixes #32521

Hunyuan (`HunYuanForCausalLM`) cannot be served on the MLX (Apple Silicon) backend today. There are two blockers:

1. **Architecture resolution crashes.** `get_resolved_model_impl` resolves a sglang/Transformers implementation for the model, which imports the model's `auto_map`. Hunyuan's `auto_map` names a class that does not resolve, so startup raises before serving begins. On MLX there is no sglang or Transformers model class to resolve at all, since the model is served through `mlx_lm.load()`.
2. **Batched decode cannot reproduce Hunyuan's attention.** The MLX batched decode path re-implements each model's attention math by hand. It assumes a fixed contract (bare-array return, `q_norm`/`k_norm` names, norm-before-RoPE) that Hunyuan does not follow: Hunyuan returns a shared-KV state alongside the output and applies qk-norm after RoPE. The hand-rolled path silently produces wrong results for it.

This PR fixes both: it skips architecture resolution on MLX, and it makes batched decode delegate the attention math to the model itself, so any model (from the supported list) that follows mlx-lm's cache protocol is served correctly by construction.

## Modifications

**`python/sglang/srt/model_loader/utils.py`**
- `get_resolved_model_impl` returns `ModelImpl.SGLANG` immediately when the MLX backend is active, before any HF architecture resolution. This avoids importing the model's `auto_map`, which is what crashes for Hunyuan.

**`python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py`**
- `MLXAttentionWrapper.__call__` gains `*args, **kwargs` and forwards them to the wrapped module. Hunyuan's attention takes a shared-KV state positionally and returns it, so delegation must pass extra arguments through and return the module's own arity.
- Decode routing in `__call__`: with no batched-decode context set it calls the inner module directly (prefill); with a context set and the opt-in fused AOT RoPE plus pool-scatter kernel active on a full-attention layer it uses the existing hand-rolled `_batched_decode` (that kernel must own the RoPE step); otherwise it uses the new `_delegated_decode`, which is the default.
- New `_delegated_decode`: hands the module `(x, mask, cache)`, where `cache` is a `BatchedPoolCache` and `mask` is the layer's decode-padding mask from the existing `ctx.decode_padding(window)`. The module runs its own q/k/v projections, norms, RoPE and SDPA, so no attention math is re-implemented here.
- New `BatchedPoolCache`: an mlx-lm cache-protocol adapter for one attention layer in one batched decode step. `offset` carries the per-request RoPE positions as an array. `update_and_fetch` writes each request's new K/V to its per-request pool slot through the existing `write_token`/`get_kv`, then returns the right-padded batched K/V for a single SDPA call. `state` returns an empty tuple.
- `_batched_decode` (the hand-rolled path) is unchanged. It remains only for the opt-in AOT kernel path.

**`test/registered/unit/hardware_backend/mlx/test_attention_patching.py`**
- The `FakeAttention` test stub gains a minimal callable `__call__` implementing the mlx-lm attention contract (q/k/v projection, RoPE at `cache.offset`, `cache.update_and_fetch`, SDPA, `o_proj`). 

**`test/registered/mlx/models_e2e/test_hunyuan_mlx_correctness.py`** (new test)
-  It mirrors the existing qwen2_moe e2e test and needs no `srt/models` file.

## Accuracy Tests

Tested on Apple M4 Pro (16-core GPU), 24 GB unified memory, macOS 27.0; torch 2.13.0, mlx 0.32.2, mlx-lm 0.31.3. Greedy output is token-for-token identical to raw `mlx_lm`

## Speed Tests and Profiling

Measured on Apple Silicon (M4 Pro, 24 GB) with `mlx-community/Hunyuan-7B-Instruct-4bit`, 128 output tokens per request, distinct prompts (no shared prefix), greedy. mlx_lm.server is run with `--decode-concurrency 32`. Aggregate completion throughput (total output tokens divided by wall time), in tokens per second:

| Concurrency | SGLang (this branch) | mlx_lm.server |
| --- | --- | --- |
| 1 | 54 | 46 |
| 4 | 114 | 104 |
| 8 | 117 | 110 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33721121118](https://github.com/sgl-project/sglang/actions/runs/33721121118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33721120865](https://github.com/sgl-project/sglang/actions/runs/33721120865)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33721121005](https://github.com/sgl-project/sglang/actions/runs/33721121005)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->