### PR TITLE
[Fix] Flush buffered Harmony output at stream end

### DIFF
--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -48,7 +48,7 @@ class GptOssDetector(BaseFormatDetector):
         # Parse with HarmonyParser
         events = self.harmony_parser.parse(text)
         # Flush buffer for complete parsing
-        events += self.harmony_parser.parse("")
+        events += self.harmony_parser.finish()
 
         tool_indices = self._get_tool_indices(tools)
         calls = []
@@ -72,6 +72,33 @@ class GptOssDetector(BaseFormatDetector):
 
         normal_text = " ".join(normal_parts).strip()
         return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        """Flush HarmonyParser state when the output stream ends."""
+        events = self.harmony_parser.finish()
+        if not events:
+            self._buffer = ""
+            return StreamingParseResult(normal_text="", calls=[])
+
+        tool_indices = getattr(self, "_tool_indices", self._get_tool_indices(tools))
+        calls = []
+        normal_parts = []
+        tool_index = max(self.current_tool_id, 0)
+        for event in events:
+            if event.event_type == "tool_call":
+                tool_call = self._extract_tool_call_from_event(
+                    event.raw_text if event.raw_text else event.content,
+                    tool_indices,
+                    tool_index,
+                )
+                if tool_call:
+                    calls.append(tool_call)
+                    tool_index += 1
+            elif event.event_type == "normal":
+                normal_parts.append(event.content)
+
+        self._buffer = ""
+        return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]

--- a/python/sglang/srt/parser/harmony_parser.py
+++ b/python/sglang/srt/parser/harmony_parser.py
@@ -198,6 +198,75 @@ class CanonicalStrategy:
 
         return events, ""
 
+    def finish(self, text: str) -> List[Event]:
+        """Flush text that cannot form a complete channel block."""
+        events, remaining = self.parse(text)
+        events = [event for event in events if event.content]
+        if remaining:
+            event = self._flush_remaining(remaining)
+            if event is not None:
+                events.append(event)
+        return events
+
+    def _flush_remaining(self, text: str) -> Optional[Event]:
+        tokens = list(iter_tokens(text))
+        channel_pos = next(
+            (index for index, token in enumerate(tokens) if token.type == "CHANNEL"),
+            None,
+        )
+        if channel_pos is None:
+            if text.strip() and not self._is_standalone_structural_token(text):
+                return Event("normal", text)
+            return None
+
+        channel_token = tokens[channel_pos]
+        message_pos = next(
+            (
+                index
+                for index in range(channel_pos + 1, len(tokens))
+                if tokens[index].type == "MESSAGE"
+            ),
+            None,
+        )
+
+        if message_pos is not None:
+            channel_header = text[channel_token.end : tokens[message_pos].start]
+            channel_type = self._extract_channel_type(channel_header)
+            content_start = tokens[message_pos].end
+        else:
+            channel_text = text[channel_token.end :]
+            match = re.match(
+                r"\s*(analysis|commentary|final)", channel_text, re.IGNORECASE
+            )
+            if match is None:
+                return None
+            channel_type = match.group(1).lower()
+            content_start = channel_token.end + match.end()
+
+        if channel_type is None:
+            return None
+
+        content_end = len(text)
+        if message_pos is not None:
+            for token in tokens[message_pos + 1 :]:
+                if token.type in (
+                    "START",
+                    "CHANNEL",
+                    "MESSAGE",
+                    "END",
+                    "CALL",
+                    "RETURN",
+                ):
+                    content_end = token.start
+                    break
+
+        content = text[content_start:content_end]
+        if not content:
+            return None
+
+        event_type = "reasoning" if channel_type == "analysis" else "normal"
+        return Event(event_type, content.lstrip() if message_pos is None else content)
+
     def _parse_partial_analysis(
         self, text: str, tokens: List[Token], start_pos: int
     ) -> Optional[Tuple[Event, str]]:
@@ -497,6 +566,38 @@ class TextStrategy:
             events.append(Event("normal", emit))
         return events, hold
 
+    def finish(self, text: str) -> List[Event]:
+        """Flush text that was held while waiting for a text-format marker."""
+        events, remaining = self.parse(text)
+        if not remaining:
+            return events
+
+        if remaining.strip().lower() in {"analysis", "commentary"}:
+            return events
+
+        match = re.match(
+            r"^\s*(?:assistant\s*)?(analysis|commentary)(.*)$",
+            remaining,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if match:
+            content = match.group(2)
+            if content:
+                event_type = (
+                    "reasoning" if match.group(1).lower() == "analysis" else "normal"
+                )
+                events.append(Event(event_type, content.strip()))
+            return events
+
+        match = re.match(
+            r"^\s*assistantfinal(.*)$", remaining, re.IGNORECASE | re.DOTALL
+        )
+        if match and match.group(1):
+            events.append(Event("normal", match.group(1).strip()))
+        elif remaining.strip():
+            events.append(Event("normal", remaining))
+        return events
+
 
 class HarmonyParser:
     """Facade for parsing Harmony format, switching between strategies."""
@@ -512,6 +613,9 @@ class HarmonyParser:
         )
 
     def parse(self, chunk: str) -> List[Event]:
+        if not chunk:
+            return self.finish()
+
         self._buffer += chunk
 
         if self.strategy is None:
@@ -538,7 +642,26 @@ class HarmonyParser:
 
         self._buffer = remaining
 
-        # Filter events for streaming case
+        return self._filter_events(events, buffer_has_call_token)
+
+    def finish(self) -> List[Event]:
+        """Flush buffered text once no more stream chunks will arrive."""
+        if not self._buffer:
+            return []
+
+        buffered_text = self._buffer
+        if self.strategy is None:
+            events = [Event("normal", buffered_text)]
+        else:
+            events = self.strategy.finish(buffered_text)
+
+        self._buffer = ""
+        return self._filter_events(events, buffered_text.rstrip().endswith("<|call|>"))
+
+    def _filter_events(
+        self, events: List[Event], buffer_has_call_token: bool
+    ) -> List[Event]:
+        """Filter commentary filler from parsed events."""
         filtered_events = []
         for event in events:
             should_filter = False

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -768,9 +768,13 @@ class GptOssDetector(BaseReasoningFormatDetector):
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         events = self.parser.parse(text)
-        # Flush the buffer for one-shot parsing
-        events += self.parser.parse("")
+        events += self.parser.finish()
 
+        return self._events_to_result(events)
+
+    def _events_to_result(
+        self, events, apply_force_nonempty_content: bool = True
+    ) -> StreamingParseResult:
         reasoning_text = "".join(
             [e.content for e in events if e.event_type == "reasoning"]
         )
@@ -784,32 +788,25 @@ class GptOssDetector(BaseReasoningFormatDetector):
         normal_text = "".join(normal_parts)
         # Tool call events preserve raw text with structural markers
 
+        result = StreamingParseResult(
+            normal_text=normal_text,
+            reasoning_text=reasoning_text,
+        )
+        return (
+            self._maybe_apply_force_nonempty_content(result)
+            if apply_force_nonempty_content
+            else result
+        )
+
+    def finish(self) -> StreamingParseResult:
+        """Flush HarmonyParser state when the output stream ends."""
         return self._maybe_apply_force_nonempty_content(
-            StreamingParseResult(
-                normal_text=normal_text,
-                reasoning_text=reasoning_text,
-            )
+            self._events_to_result(self.parser.finish())
         )
 
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         events = self.parser.parse(new_text)
-
-        reasoning_text = "".join(
-            [e.content for e in events if e.event_type == "reasoning"]
-        )
-        normal_parts = []
-        for e in events:
-            if e.event_type == "normal":
-                normal_parts.append(e.content)
-            elif e.event_type == "tool_call":
-                # Use raw_text to preserve structural markers for function call detector
-                normal_parts.append(e.raw_text if e.raw_text else e.content)
-        normal_text = "".join(normal_parts)
-
-        return StreamingParseResult(
-            normal_text=normal_text,
-            reasoning_text=reasoning_text,
-        )
+        return self._events_to_result(events, apply_force_nonempty_content=False)
 
 
 class MiniMaxAppendThinkDetector(BaseReasoningFormatDetector):

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2850,6 +2850,19 @@ class TestGptOssDetector(unittest.TestCase):
         )
         self.assertFalse(self.detector.has_tool_call("no tool call here"))
 
+    def test_finish_flushes_incomplete_final(self):
+        """Flush final text held by HarmonyParser when the stream ends."""
+        self.detector.parse_streaming_increment(
+            "<|start|>assistant<|channel|>final The answer",
+            self.tools,
+        )
+
+        result = self.detector.finish(self.tools)
+
+        self.assertEqual(result.normal_text, "The answer")
+        self.assertEqual(result.calls, [])
+        self.assertEqual(self.detector.finish(self.tools).normal_text, "")
+
     def test_get_model_structural_tag(self):
         import xgrammar as xgr
 

--- a/test/registered/unit/parser/test_harmony_parser.py
+++ b/test/registered/unit/parser/test_harmony_parser.py
@@ -309,6 +309,38 @@ class TestHarmonyParser(CustomTestCase):
         self.assertIsInstance(self.parser.strategy, TextStrategy)
         self.assertEqual(len(events2), 1)
 
+    def test_finish_flushes_incomplete_final_without_message(self):
+        """Flush a final response whose channel omits the message marker."""
+        answer = "<|start|>assistant<|channel|>final The answer is 42."
+
+        events = self.parser.parse(answer)
+        events.extend(self.parser.finish())
+
+        self.assertEqual(
+            "".join(event.content for event in events if event.event_type == "normal"),
+            "The answer is 42.",
+        )
+        self.assertEqual(self.parser.finish(), [])
+
+    def test_finish_flushes_plain_text(self):
+        """Flush plain text held before a parser strategy can be selected."""
+        self.assertEqual(self.parser.parse("plain response"), [])
+
+        events = self.parser.finish()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_type, "normal")
+        self.assertEqual(events[0].content, "plain response")
+
+    def test_empty_parse_flushes_buffer(self):
+        """Keep parse(\"\") compatible with existing end-of-stream callers."""
+        self.parser.parse("<|start|>assistant<|channel|>final The answer")
+
+        events = self.parser.parse("")
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].content, "The answer")
+
     def test_streaming_commentary_filler(self):
         """Test that 'commentary' filler is filtered in streaming case."""
         # Test when commentary arrives as a separate chunk after <|call|>

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1219,6 +1219,17 @@ class TestGptOssDetector(CustomTestCase):
         self.assertIn("reasoning part", all_reasoning)
         self.assertIn("answer", all_normal)
 
+    def test_finish_flushes_incomplete_final(self):
+        """Flush final text held by HarmonyParser when the stream ends."""
+        self.detector.parse_streaming_increment(
+            "<|start|>assistant<|channel|>final The answer"
+        )
+
+        result = self.detector.finish()
+
+        self.assertEqual(result.normal_text, "The answer")
+        self.assertEqual(result.reasoning_text, "")
+
 
 class TestMiniMaxAppendThinkDetector(CustomTestCase):
     """Test cases for MiniMaxAppendThinkDetector."""


### PR DESCRIPTION
## Motivation

Fixes #37650. `HarmonyParser` can retain the final response when a stream ends
before a structural marker arrives, causing the response to be silently
dropped. This affects incomplete canonical final blocks and unframed text,
and the same parser is used by GPT-OSS reasoning and function-call handling.

## Modifications

- Add an explicit `HarmonyParser.finish()` path for canonical and text-format
  buffers.
- Keep `parse("")` compatible with existing end-of-stream callers.
- Flush GPT-OSS reasoning and function-call detector state through the parser's
  end-of-stream path.
- Add focused CPU regression tests for incomplete final text, plain text, and
  detector-level flushing.

## Accuracy Tests

This is a parser end-of-stream fix; it does not change model weights or
sampling. No model evaluation was run. The focused parser and detector tests
cover the affected output-boundary behavior.

## Validation

- `PYTHONPATH=python python/.venv/bin/python -m pytest test/registered/unit/parser/test_harmony_parser.py -q` — 46 passed.
- `PYTHONPATH=python python/.venv/bin/python -m pytest test/registered/unit/parser/test_reasoning_parser.py -q` — 122 passed.
- `PYTHONPATH=python python/.venv/bin/python -m pytest test/registered/unit/function_call/test_function_call_parser.py -k GptOssDetector -q` — 3 passed, 241 deselected.
- `pre-commit run --files python/sglang/srt/parser/harmony_parser.py python/sglang/srt/parser/reasoning_parser.py python/sglang/srt/function_call/gpt_oss_detector.py test/registered/unit/parser/test_harmony_parser.py test/registered/unit/parser/test_reasoning_parser.py test/registered/unit/function_call/test_function_call_parser.py` — passed.
- `git diff --check origin/main...HEAD` — passed.


## Duplicate-work check

No open PR was found for the exact end-of-stream buffering issue when this work
started. Open PR #10576 addresses GPT-OSS tool calls ending with `<|return|>`;
this PR handles buffered output when the stream ends before a required marker
and does not duplicate that behavior.

AI assistance was used during implementation. The submitting contributor is
responsible for reviewing and understanding every changed line and the
validation results before merge.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33724846962](https://github.com/sgl-project/sglang/actions/runs/33724846962)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33724846775](https://github.com/sgl-project/sglang/actions/runs/33724846775)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33724847047](https://github.com/sgl-project/sglang/actions/runs/33724847047)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->