### PR TITLE
Support NEXTN with HiCache in the PD decode radix cache

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -147,13 +147,14 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
     if cfg.speculative_algorithm is not None:
         assert cfg.speculative_algorithm in (
             "EAGLE",
+            "NEXTN",
             "DSPARK",
         ), (
-            f"Only EAGLE and DSPARK speculative algorithms are supported for {model_arch}"
+            f"Only EAGLE, NEXTN, and DSPARK speculative algorithms are supported for {model_arch}"
         )
-        if cfg.speculative_algorithm == "EAGLE":
+        if cfg.speculative_algorithm in ("EAGLE", "NEXTN"):
             assert cfg.speculative_eagle_topk == 1, (
-                f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
+                f"Only EAGLE/NEXTN speculative decoding with topk == 1 is supported for {model_arch}"
             )
 
 

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -86,11 +86,13 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
                     "--disaggregation-decode-enable-radix-cache is incompatible "
                     "with --disaggregation-transfer-backend fake"
                 )
-            if cfg.speculative_algorithm is not None:
+            spec_algorithm = (cfg.speculative_algorithm or "").upper()
+            # NEXTN is resolved to EAGLE after this validation hook runs.
+            if spec_algorithm and spec_algorithm not in ("EAGLE", "NEXTN"):
                 raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache is incompatible "
-                    "with speculative decoding "
-                    f"(--speculative-algorithm {cfg.speculative_algorithm})"
+                    "--disaggregation-decode-enable-radix-cache supports "
+                    "speculative decoding only for EAGLE and NEXTN, but got "
+                    f"--speculative-algorithm {cfg.speculative_algorithm}"
                 )
 
             if resolved_view(server_args).enable_dp_attention:

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -129,9 +129,19 @@ class BaseKVSender(ABC):
     ): ...
 
     @abstractmethod
-    def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
+    def init(
+        self,
+        num_kv_indices: int,
+        aux_index: Optional[int] = None,
+        num_request_pages: Optional[int] = None,
+        send_page_offset: int = 0,
+    ):
         """
         Set req's index metadata locally or notify the decoder server about the kv indices length and aux index.
+
+        ``num_request_pages`` and ``send_page_offset`` locate this sender's page
+        stream inside the whole request. They differ from ``num_kv_indices`` when
+        the decode server already owns a cached prefix.
         """
         ...
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1195,6 +1195,8 @@ class CommonKVSender(BaseKVSender):
         self._transfer_num_state_indices = 0
         # inner state
         self.curr_idx = 0
+        self.num_request_pages = 0
+        self.send_page_offset = 0
         self.init_time: Optional[float] = None
         if self.kv_mgr.is_dummy_cp_rank:
             # Non-authoritative CP ranks are dummy participants.
@@ -1240,9 +1242,19 @@ class CommonKVSender(BaseKVSender):
         except Exception as e:
             logger.error(f"Failed to register prefill dp_rank: {e}")
 
-    def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
+    def init(
+        self,
+        num_kv_indices: int,
+        aux_index: Optional[int] = None,
+        num_request_pages: Optional[int] = None,
+        send_page_offset: int = 0,
+    ):
         self.num_kv_indices = num_kv_indices
         self.aux_index = aux_index
+        self.num_request_pages = (
+            num_kv_indices if num_request_pages is None else num_request_pages
+        )
+        self.send_page_offset = send_page_offset
         logger.debug(
             f"CommonKVSender init with num_kv_indices: {num_kv_indices} and aux_index: {aux_index}"
         )
@@ -1297,7 +1309,8 @@ class CommonKVSender(BaseKVSender):
                 self.kv_mgr,
                 kv_indices,
                 index_slice,
-                total_pages=self.num_kv_indices,
+                total_pages=self.num_request_pages,
+                page_offset=self.send_page_offset,
             )
         elif self.kv_mgr.is_dummy_cp_rank:
             if not is_last_chunk:

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -68,6 +68,8 @@ class FakeKVSender(BaseKVSender):
         self,
         kv_indices: list[int],
         aux_index: Optional[int] = None,
+        num_request_pages: Optional[int] = None,
+        send_page_offset: int = 0,
     ):
         logger.debug(
             f"FakeKVSender init with kv_indices: {kv_indices}, aux_index: {aux_index}"

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -374,11 +374,18 @@ class PrefillBootstrapQueue:
         # Base of the staging chunk grid (suffix-relative send coordinates).
         req.disagg_decode_prefix_len = decode_prefix_len
         num_kv_indices_to_send = num_kv_indices - decode_prefix_len
-        num_pages = kv_to_page_num(
-            num_kv_indices_to_send,
-            self.scheduler.token_to_kv_pool_allocator.page_size,
+        page_size = self.scheduler.token_to_kv_pool_allocator.page_size
+        assert decode_prefix_len % page_size == 0, (
+            f"decode_prefix_len ({decode_prefix_len}) must be page aligned, "
+            f"page_size={page_size}, rid={req.rid}"
         )
-        req.disagg_kv_sender.init(num_pages, req.metadata_buffer_index)
+        num_pages = kv_to_page_num(num_kv_indices_to_send, page_size)
+        req.disagg_kv_sender.init(
+            num_pages,
+            req.metadata_buffer_index,
+            num_request_pages=kv_to_page_num(num_kv_indices, page_size),
+            send_page_offset=decode_prefix_len // page_size,
+        )
         req.pending_bootstrap = False
         return True
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -710,6 +710,7 @@ def filter_kv_indices_for_cp_rank(
     kv_indices: np.ndarray,
     index_slice: slice,
     total_pages: Optional[int] = None,
+    page_offset: int = 0,
 ) -> Tuple[np.ndarray, slice]:
     """Filters kv_indices and index_slice for the current CP rank."""
     if total_pages is None:
@@ -721,19 +722,20 @@ def filter_kv_indices_for_cp_rank(
         return kv_indices, index_slice
 
     rank_start, rank_end = _get_cp_rank_page_bounds(total_pages, cp_rank, cp_size)
-    chunk_start = index_slice.start if index_slice.start is not None else 0
-    chunk_end = index_slice.stop if index_slice.stop is not None else total_pages
+    local_start = index_slice.start if index_slice.start is not None else 0
+    chunk_start = page_offset + local_start
+    chunk_end = chunk_start + len(kv_indices)
     first_pos = max(rank_start, chunk_start) - chunk_start
     last_pos = min(rank_end, chunk_end) - chunk_start
 
     if last_pos <= first_pos:
         new_kv_indices = kv_indices[:0]
-        new_index_slice = slice(chunk_start, chunk_start)
+        new_index_slice = slice(local_start, local_start)
     else:
         new_kv_indices = kv_indices[first_pos:last_pos]
         new_index_slice = slice(
-            chunk_start + first_pos,
-            chunk_start + last_pos,
+            local_start + first_pos,
+            local_start + last_pos,
         )
     return new_kv_indices, new_index_slice
 

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -259,17 +259,18 @@ def build_kv_cache(
                     "window attention (SWA) models requires the unified radix "
                     "tree (set SGLANG_ENABLE_UNIFIED_RADIX_TREE=1)."
                 )
-            if enable_hierarchical_cache:
+            is_deepseek_v4 = getattr(model_config, "is_deepseek_v4_arch", False)
+            if enable_hierarchical_cache and not is_deepseek_v4:
                 raise ValueError(
                     "--disaggregation-decode-enable-radix-cache with sliding "
                     "window attention (SWA) models currently supports only "
                     "device-resident cache and is incompatible with "
                     "--enable-hierarchical-cache."
                 )
-            if getattr(model_config, "is_deepseek_v4_arch", False):
+            if is_deepseek_v4 and not enable_hierarchical_cache:
                 raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache does not support "
-                    "DeepSeek-V4 (DSA) compressed KV (c4/c128/indexer) yet."
+                    "--disaggregation-decode-enable-radix-cache with "
+                    "DeepSeek-V4 requires --enable-hierarchical-cache."
                 )
             if getattr(model_config, "is_hybrid_swa_compress", False):
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3198,7 +3198,7 @@ class ServerArgs:
     ] = None
     disaggregation_decode_enable_radix_cache: A[
         bool,
-        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse, speculative decoding, and --disaggregation-transfer-backend fake.",
+        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse and --disaggregation-transfer-backend fake. With speculative decoding, only EAGLE and NEXTN are supported.",
         NS("disagg"),
     ] = False
     disaggregation_decode_enable_offload_kvcache: A[

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -32,6 +32,7 @@ from sglang.srt.disaggregation.mooncake.conn import (
 )
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
+    filter_kv_indices_for_cp_rank,
     get_dsv4_c128_state_indices,
     setup_state_kv_args,
 )
@@ -145,6 +146,27 @@ class TestDisaggregationWire(unittest.TestCase):
 
 
 class TestCPReplicatedStateTransfer(unittest.TestCase):
+    def test_prefix_hit_keeps_cp_partition_request_relative(self):
+        suffix_pages = np.arange(100, 108, dtype=np.int32)
+        expected = {
+            0: ([], slice(0, 0)),
+            1: ([100, 101, 102, 103], slice(0, 4)),
+            2: ([104, 105, 106, 107], slice(4, 8)),
+        }
+
+        for cp_rank, (pages, destination_slice) in expected.items():
+            with self.subTest(cp_rank=cp_rank):
+                manager = SimpleNamespace(attn_cp_rank=cp_rank, attn_cp_size=3)
+                actual_pages, actual_slice = filter_kv_indices_for_cp_rank(
+                    manager,
+                    suffix_pages,
+                    slice(0, 8),
+                    total_pages=12,
+                    page_offset=4,
+                )
+                self.assertEqual(actual_pages.tolist(), pages)
+                self.assertEqual(actual_slice, destination_slice)
+
     def test_only_nonzero_cp_ranks_without_layer_split_skip_state(self):
         cases = [
             (1, 0, False, False),

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -804,6 +804,50 @@ class TestLoadBalanceMethod(unittest.TestCase):
 
         self.assertFalse(resolution_result(server_args, "disable_radix_cache"))
 
+    def test_pd_decode_radix_cache_allows_nextn(self):
+        server_args = self._load_balance_args(
+            disaggregation_mode="decode",
+            disaggregation_decode_enable_radix_cache=True,
+            disaggregation_transfer_backend="nixl",
+            speculative_algorithm="NEXTN",
+        )
+
+        self.assertFalse(resolution_result(server_args, "disable_radix_cache"))
+
+    def test_pd_decode_radix_cache_rejects_other_speculative_algorithms(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            disaggregation_mode="decode",
+            disaggregation_decode_enable_radix_cache=True,
+            disaggregation_transfer_backend="nixl",
+            speculative_algorithm="DSPARK",
+        )
+
+        with self.assertRaisesRegex(ValueError, "only for EAGLE and NEXTN"):
+            handle_pd_disaggregation(server_args)
+
+
+class TestDeepSeekV4Args(unittest.TestCase):
+    def test_accepts_nextn_before_alias_resolution(self):
+        from sglang.srt.arg_groups.deepseek_v4_hook import (
+            apply_deepseek_v4_defaults,
+        )
+
+        server_args = ServerArgs(
+            model_path="dummy",
+            max_running_requests=32,
+            speculative_algorithm="NEXTN",
+            speculative_eagle_topk=1,
+        )
+        with (
+            patch(
+                "sglang.srt.arg_groups.deepseek_v4_hook.get_platform",
+                return_value=SimpleNamespace(is_hip=False),
+            ),
+            patch("sglang.srt.arg_groups.deepseek_v4_hook.run_post_process_pass"),
+        ):
+            apply_deepseek_v4_defaults(server_args, "DeepseekV4ForCausalLM")
+
 
 class TestSkipTokenizerInit(unittest.TestCase):
     def test_skip_tokenizer_worker_counts(self):


### PR DESCRIPTION
# Title

Support NEXTN with HiCache in the PD decode radix cache

## Motivation

The PD decode-side radix cache currently rejects all speculative decoding and rejects DeepSeek-V4 HiCache during KV-cache construction. This prevents reusing a prefix that is already resident on Decode when serving DeepSeek-V4-Flash with NEXTN.

Related to #27666.

## Modifications

- Allow the validated EAGLE/NEXTN path with the PD decode-side radix cache while continuing to reject speculative algorithms with unsupported draft-state layouts.
- Accept the raw `NEXTN` alias in the DeepSeek-V4 argument hook before it is normalized to EAGLE.
- Allow DeepSeek-V4 decode radix caching only with HiCache; retain the existing restrictions for other SWA and hybrid SSM layouts.
- Keep CP ownership request-relative when only the suffix after a Decode prefix hit is transferred. The sender now carries the full request page count and suffix page offset.
- Update the CLI help and add focused regression coverage to the existing server-argument and disaggregation-wire test modules.

## Accuracy Tests

DeepSeek-V4-Flash, PD Prefill TP4+CP4 / Decode TP8, FP8 KV, HiCache, NEXTN (2 steps, top-k 1, 3 draft tokens), NIXL/UCX TCP:

- SGLang `GSM8KMixin/run_eval` 5-shot completion protocol
- 194/200 correct: **97.0%**
- Wilson 95% CI: **[93.61%, 98.62%]**
- 200/200 parsed, 200/200 requests succeeded, no retries
- All 200 completions ended with `finish_reason=stop`

This is an absolute accuracy gate, not a matched model-quality comparison.
The GPU accuracy and speed runs used community base `83bd2c473f173404216f6d9851ad7a95c1e3c565` plus this compatibility patch. The PR commit was subsequently rebased onto current community `main`; the post-rebase commit passed the CPU tests listed below.

## Speed Tests and Profiling

Matched A/B/A test with 36,959 input tokens, 36,608 Decode-cached tokens, 64 output tokens, concurrency 16, and NIXL/UCX restricted to TCP over `eth0`:

| Metric | Radix hit mean | Forced-miss | Improvement |
|---|---:|---:|---:|
| Mean TTFT | 31.395 s | 44.227 s | **29.01%** |
| Mean TPOT | 140.993 ms | 146.145 ms | **3.53%** |
| Mean E2E | 40.277 s | 53.434 s | **24.62%** |

All 96 measured requests and 96 cache-prime requests succeeded. The benefit is expected when KV transfer is the bottleneck; the same workload showed no clear improvement on the available default RDMA path.

## Tests

On the exact rebased commit, using the SGLang runtime image:

```text
python3 -m pytest -q \
  test/registered/unit/server_args/test_server_args.py \
  test/registered/unit/disaggregation/test_disaggregation_wire.py

221 passed, 33 subtests passed
```

`python3 scripts/lint/check_registered_tests.py` also passed.

## Checklist

- [ ] Format the code with the repository-pinned pre-commit environment (environment installation was unavailable during local preparation).
- [x] Add unit tests according to the Run and add unit tests guide.
- [x] Update the CLI documentation for the supported combinations.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33761295367](https://github.com/sgl-project/sglang/actions/runs/33761295367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33761295254](https://github.com/sgl-project/sglang/actions/runs/33761295254)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33761295411](https://github.com/sgl-project/sglang/actions/runs/33761295411)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->