### PR TITLE
[Fix] Reject unsupported xgrammar pattern and length combinations

### DIFF
--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -58,6 +58,68 @@ logger = logging.getLogger(__name__)
 MAX_ROLLBACK_TOKENS = 200
 
 
+def has_xgrammar_unsupported_pattern_length_combination(schema: dict) -> bool:
+    """Whether a schema combines ``pattern`` with a string length bound.
+
+    XGrammar can compile both keywords independently, but currently drops the
+    length bound when they occur in the same string schema. Rejecting this
+    combination prevents constrained decoding from silently violating the
+    input schema.
+    """
+
+    schema_array_keywords = ("allOf", "anyOf", "oneOf", "prefixItems")
+    schema_keywords = (
+        "additionalItems",
+        "additionalProperties",
+        "contains",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    )
+    schema_map_keywords = (
+        "$defs",
+        "dependentSchemas",
+        "definitions",
+        "patternProperties",
+        "properties",
+    )
+
+    def check_schema(obj) -> bool:
+        if not isinstance(obj, dict):
+            return False
+
+        if "pattern" in obj and ("minLength" in obj or "maxLength" in obj):
+            return True
+
+        for key in schema_keywords:
+            value = obj.get(key)
+            if isinstance(value, dict) and check_schema(value):
+                return True
+            if isinstance(value, list) and any(check_schema(item) for item in value):
+                return True
+
+        for key in schema_array_keywords:
+            value = obj.get(key)
+            if isinstance(value, list) and any(check_schema(item) for item in value):
+                return True
+
+        for key in schema_map_keywords:
+            value = obj.get(key)
+            if isinstance(value, dict) and any(
+                check_schema(item) for item in value.values()
+            ):
+                return True
+
+        return False
+
+    return check_schema(schema)
+
+
 def _allocate_token_bitmask(vocab_size: int, batch_size: int) -> torch.Tensor:
     # Pin where pinning exists, so the later H2D can be a genuine non_blocking
     # copy (a pageable source silently downgrades it).  MPS torch has no
@@ -339,6 +401,14 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
                 # Note: This builtin JSON grammar includes *all* valid JSON (including, for example, arrays at the root)
                 ctx = self.grammar_compiler.compile_builtin_json_grammar()
             else:
+                schema = json.loads(key_string)
+                if isinstance(
+                    schema, dict
+                ) and has_xgrammar_unsupported_pattern_length_combination(schema):
+                    raise RuntimeError(
+                        "JSON schema combines pattern with minLength or maxLength, "
+                        "which xgrammar cannot enforce together"
+                    )
                 ctx = self.grammar_compiler.compile_json_schema(
                     schema=key_string, any_whitespace=self.any_whitespace
                 )

--- a/test/registered/unit/constrained/test_xgrammar_pattern_length.py
+++ b/test/registered/unit/constrained/test_xgrammar_pattern_length.py
@@ -1,0 +1,92 @@
+"""Unit tests for xgrammar pattern and string-length schema combinations."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.constrained.base_grammar_backend import InvalidGrammarObject
+from sglang.srt.constrained.xgrammar_backend import (
+    XGrammarGrammarBackend,
+    has_xgrammar_unsupported_pattern_length_combination,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestXGrammarPatternLengthCombination(unittest.TestCase):
+    def test_rejects_pattern_with_min_length(self):
+        schema = {
+            "type": "string",
+            "pattern": "^[a-z]+$",
+            "minLength": 5,
+        }
+
+        self.assertTrue(has_xgrammar_unsupported_pattern_length_combination(schema))
+
+    def test_rejects_pattern_with_max_length(self):
+        schema = {
+            "type": "string",
+            "pattern": "^[a-z]+$",
+            "maxLength": 5,
+        }
+
+        self.assertTrue(has_xgrammar_unsupported_pattern_length_combination(schema))
+
+    def test_rejects_nested_combination(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[a-z]+$",
+                        "minLength": 5,
+                    },
+                }
+            },
+        }
+
+        self.assertTrue(has_xgrammar_unsupported_pattern_length_combination(schema))
+
+    def test_allows_each_keyword_individually(self):
+        self.assertFalse(
+            has_xgrammar_unsupported_pattern_length_combination(
+                {"type": "string", "pattern": "^[a-z]+$"}
+            )
+        )
+        self.assertFalse(
+            has_xgrammar_unsupported_pattern_length_combination(
+                {"type": "string", "minLength": 5}
+            )
+        )
+        self.assertFalse(
+            has_xgrammar_unsupported_pattern_length_combination(
+                {"type": "string", "maxLength": 5}
+            )
+        )
+
+    def test_does_not_confuse_property_names_with_schema_keywords(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string", "minLength": 5},
+            },
+        }
+
+        self.assertFalse(has_xgrammar_unsupported_pattern_length_combination(schema))
+
+    def test_dispatch_returns_invalid_grammar_without_compiling(self):
+        backend = object.__new__(XGrammarGrammarBackend)
+        backend.grammar_compiler = MagicMock()
+
+        result = backend.dispatch_json(
+            '{"type":"string","pattern":"^[a-z]+$","minLength":5}'
+        )
+
+        self.assertIsInstance(result, InvalidGrammarObject)
+        backend.grammar_compiler.compile_json_schema.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37707. With xgrammar, a JSON Schema that combines `pattern` with
`minLength` can compile successfully while the length constraint is silently
dropped. This can produce structured output that violates the requested
schema.

## Modifications

- Detect `pattern` combined with `minLength` or `maxLength` before xgrammar
  compilation, including nested schema positions.
- Return the existing `InvalidGrammarObject` path with a clear error instead
  of silently weakening the constraint.
- Preserve schemas that use each keyword independently.
- Add CPU unit tests for nested schemas, false-positive property names, and
  admission rejection before compilation.

This is intentionally limited to the combination reported in #37707 and is a
narrow complement to the broader unsupported-keyword handling proposed in
#28804.

## Validation

- Reproduced the issue with xgrammar 0.2.1: `pattern + minLength` accepted a
  two-character value despite `minLength: 5`, while `minLength` alone rejected
  it.
- Focused xgrammar unit tests passed: 6 passed.
- `pre-commit run --files ...` passed for all changed files.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33722424728](https://github.com/sgl-project/sglang/actions/runs/33722424728)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33722424508](https://github.com/sgl-project/sglang/actions/runs/33722424508)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33722424766](https://github.com/sgl-project/sglang/actions/runs/33722424766)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->