### PR TITLE
[Fix] Respect Spark2.5 attention gate activation mode

### DIFF
--- a/python/sglang/srt/configs/spark2_5.py
+++ b/python/sglang/srt/configs/spark2_5.py
@@ -23,6 +23,7 @@ class Spark2_5Config(PretrainedConfig):
         rope_parameters: Optional[dict[str, Any]] = None,
         layer_types: list[str] = None,
         tie_word_embeddings: Optional[bool] = None,
+        gate_attn_act_mode: str = "sigmoid",
         **kwargs,
     ) -> None:
         self.hidden_size = hidden_size
@@ -32,6 +33,7 @@ class Spark2_5Config(PretrainedConfig):
         self.num_hidden_layers = num_hidden_layers
         self.head_dim = head_dim
         self.headwise_attn_output_gate = headwise_attn_output_gate
+        self.gate_attn_act_mode = gate_attn_act_mode
         self.sliding_window = sliding_window
         self.vocab_size = vocab_size
         self.rms_norm_eps = rms_norm_eps

--- a/python/sglang/srt/models/spark2_5.py
+++ b/python/sglang/srt/models/spark2_5.py
@@ -2,6 +2,7 @@ import logging
 from typing import Iterable, Optional, Tuple, Union
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.distributed import get_pp_group
@@ -40,6 +41,15 @@ logger = logging.getLogger(__name__)
 # SGLang assumes exclusive
 def _get_attention_sliding_window_size(config):
     return config.sliding_window - 1
+
+
+def _apply_gate_activation(gate: torch.Tensor, mode: str) -> torch.Tensor:
+    gate = gate.float()
+    if mode == "sigmoid":
+        return torch.sigmoid(gate)
+    if mode == "silu":
+        return F.silu(gate)
+    raise ValueError(f"Unsupported gate_attn_act_mode: {mode}")
 
 
 class Spark2_5MLP(nn.Module):
@@ -96,6 +106,7 @@ class Spark2_5Attention(nn.Module):
         layer_type: str = "sliding_attention",
         headwise_attn_output_gate: bool = True,
         prefix: str = "",
+        gate_attn_act_mode: str = "sigmoid",
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -126,6 +137,9 @@ class Spark2_5Attention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.partial_rotary_factor = partial_rotary_factor
         self.headwise_attn_output_gate = headwise_attn_output_gate
+        if gate_attn_act_mode not in ("sigmoid", "silu"):
+            raise ValueError(f"Unsupported gate_attn_act_mode: {gate_attn_act_mode}")
+        self.gate_attn_act_mode = gate_attn_act_mode
 
         self.q_k_v_proj = QKVParallelLinear(
             hidden_size,
@@ -197,7 +211,7 @@ class Spark2_5Attention(nn.Module):
 
         if self.headwise_attn_output_gate:
             g, _ = self.g_proj(hidden_states)
-            g = torch.sigmoid(g.float()).to(attn_output.dtype)
+            g = _apply_gate_activation(g, self.gate_attn_act_mode).to(attn_output.dtype)
             gate_output = attn_output.view(
                 attn_output.shape[0],
                 self.num_heads,
@@ -249,6 +263,7 @@ class Spark2_5DecoderLayer(nn.Module):
             headwise_attn_output_gate=getattr(
                 config, "headwise_attn_output_gate", True
             ),
+            gate_attn_act_mode=getattr(config, "gate_attn_act_mode", "sigmoid"),
             prefix=add_prefix("self_attn", prefix),
         )
 

--- a/test/registered/unit/models/test_spark2_5.py
+++ b/test/registered/unit/models/test_spark2_5.py
@@ -1,0 +1,35 @@
+"""CPU tests for Spark2.5 attention output-gate activation selection."""
+
+import pytest
+import torch
+
+from sglang.srt.configs.spark2_5 import Spark2_5Config
+from sglang.srt.models.spark2_5 import _apply_gate_activation
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_config_preserves_gate_activation_mode():
+    assert Spark2_5Config(gate_attn_act_mode="silu").gate_attn_act_mode == "silu"
+
+
+def test_gate_activation_sigmoid_matches_reference():
+    gate = torch.tensor([-2.0, 0.0, 2.0], dtype=torch.float16)
+
+    actual = _apply_gate_activation(gate, "sigmoid")
+
+    torch.testing.assert_close(actual, torch.sigmoid(gate.float()))
+
+
+def test_gate_activation_silu_matches_reference():
+    gate = torch.tensor([-2.0, 0.0, 2.0], dtype=torch.float16)
+
+    actual = _apply_gate_activation(gate, "silu")
+
+    torch.testing.assert_close(actual, torch.nn.functional.silu(gate.float()))
+
+
+def test_gate_activation_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="Unsupported gate_attn_act_mode: gelu"):
+        _apply_gate_activation(torch.ones(1), "gelu")


### PR DESCRIPTION
## Motivation

Fixes #37639. Spark2.5 attention output gating currently always applies
`sigmoid`, even when a checkpoint declares a different supported
`gate_attn_act_mode`. This makes future `silu` checkpoints diverge silently
from the reference implementation.

## Modifications

- Read `gate_attn_act_mode` from the Spark2.5 config.
- Support the reference `sigmoid` and `silu` activations.
- Raise a clear error for unsupported activation modes.
- Add CPU unit coverage for both modes and invalid configuration.

The existing `sigmoid` default preserves the behavior of currently released
Spark2.5 checkpoints.

## Validation

- Focused Spark2.5 CPU tests added.

Full model/GPU validation was not available in this environment.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33722427014](https://github.com/sgl-project/sglang/actions/runs/33722427014)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33722426984](https://github.com/sgl-project/sglang/actions/runs/33722426984)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33722427092](https://github.com/sgl-project/sglang/actions/runs/33722427092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->