### PR TITLE
fix(glm5): support speculative mixed batches with DP attention

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -310,13 +310,16 @@ def sparse_attention_fwd_kernel_v1(
     D = dim
     D_tail = tail_dim
 
-    if head_kv > 64:
-        assert head_kv % 64 == 0, "head_kv should be a multiple of 64"
-        REPLICATE_H = head_kv // 64
+    heads_per_block = 32 if threads == 128 else 64
+    if head_kv > heads_per_block:
+        assert head_kv % heads_per_block == 0, (
+            f"head_kv should be a multiple of {heads_per_block}"
+        )
+        REPLICATE_H = head_kv // heads_per_block
     else:
         REPLICATE_H = 1
 
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    H_per_block = padded_H if REPLICATE_H == 1 else heads_per_block
 
     @T.prim_func
     def main(
@@ -336,7 +339,6 @@ def sparse_attention_fwd_kernel_v1(
             KV_shared = T.alloc_shared([BI, D], dtype)
             if has_tail:
                 K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
-            O_shared = T.alloc_shared([H_per_block, D], dtype)
             mask = T.alloc_fragment([BI], "bool")
 
             acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
@@ -357,7 +359,9 @@ def sparse_attention_fwd_kernel_v1(
             q_i = s_i
             max_kv_i = q_i
 
-            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+            H0 = g_i * padded_H + (
+                0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * heads_per_block
+            )
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -423,7 +427,6 @@ def sparse_attention_fwd_kernel_v1(
             for h_i in T.Parallel(H_per_block):
                 sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
 
-            T.copy(acc_o, O_shared)
             T.copy(acc_o, Output[b_i, s_i, H0:H1, :])
 
     return main
@@ -1393,7 +1396,24 @@ def tilelang_sparse_fwd(
             if tail_dim == 0
             else sparse_attention_fwd_kernel_v2
         )
-        kernel = kernel_factory(num_heads, d_v, tail_dim, topk, sm_scale=sm_scale)
+        # Workstation/consumer Blackwell (SM 12.x) exposes a much smaller
+        # opt-in shared-memory budget than datacenter Blackwell.  The default
+        # 64-row, 2-stage tile requires over 200 KiB and cannot launch there.
+        small_blackwell_tile = (
+            torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12
+        )
+        kernel = kernel_factory(
+            num_heads,
+            d_v,
+            tail_dim,
+            topk,
+            sm_scale=sm_scale,
+            block_I=32 if small_blackwell_tile else 64,
+            # CUDA 13.3 adds enough bookkeeping to put the one-stage kernel
+            # just over SM12's 99 KiB opt-in ceiling (103424 vs 101376 B).
+            num_stages=0 if small_blackwell_tile else 2,
+            threads=128 if small_blackwell_tile else 256,
+        )
         out = kernel(q.unsqueeze(0), kv.unsqueeze(0), indices.unsqueeze(0))  # type: ignore
     return out
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
@@ -93,9 +93,9 @@ class IndexerKPool(MultiPlatformOp):
             f"index_topk ({self.index_topk}) must be divisible by "
             f"index_kpool ({self.index_kpool})"
         )
-        assert (
-            64 % self.index_kpool == 0
-        ), f"index_kpool ({self.index_kpool}) must divide page_size (64)"
+        assert 64 % self.index_kpool == 0, (
+            f"index_kpool ({self.index_kpool}) must divide page_size (64)"
+        )
 
         self.index_kpool_compress_ape = nn.Parameter(
             torch.zeros(self.index_kpool, self.head_dim, dtype=torch.float32)
@@ -898,9 +898,9 @@ class IndexerKPool(MultiPlatformOp):
         total_k_rows = plan.ragged_total_k_rows
 
         n_real = seq_lens_expanded.shape[0]
-        assert (
-            n_real <= total_q
-        ), f"plan has more real rows ({n_real}) than q_fp8 ({total_q})"
+        assert n_real <= total_q, (
+            f"plan has more real rows ({n_real}) than q_fp8 ({total_q})"
+        )
 
         if total_k_rows > 0:
             k_u8 = plan.ragged_k_u8
@@ -1308,22 +1308,55 @@ class IndexerKPool(MultiPlatformOp):
         buf = pool.get_index_k_with_scale_buffer(layer_id=layer_id)
 
         def _compress_write() -> None:
+            score = self._compute_gate_score_if_missing(x, gate_score_maybe)
+            real_num_tokens = getattr(forward_batch, "num_token_non_padded_cpu", None)
+            if real_num_tokens is None:
+                real_num_tokens = key.shape[0]
+            assert 0 <= real_num_tokens <= key.shape[0], (
+                "DSA KPool target-verify real token count is outside the "
+                f"physical input: real={real_num_tokens}, physical={key.shape[0]}"
+            )
+            ragged_verify_layout = getattr(
+                getattr(forward_batch, "spec_info", None),
+                "ragged_verify_layout",
+                None,
+            )
+            assert ragged_verify_layout is None, (
+                "DSA KPool target-verify fixed-width write plan cannot consume "
+                "ragged EAGLE groups"
+            )
+            assert real_num_tokens % num_draft_tokens == 0, (
+                "DSA KPool target-verify real token count must contain complete "
+                f"draft groups: real={real_num_tokens}, draft={num_draft_tokens}"
+            )
+            real_batch = real_num_tokens // num_draft_tokens
+            assert real_batch <= plan.req.shape[0], (
+                "DSA KPool target-verify real request count is outside the "
+                f"write plan: real={real_batch}, physical={plan.req.shape[0]}"
+            )
+            # MLP sync can append physical token rows after DSA metadata and its
+            # write plan have been built. Trim both token-domain inputs [B*N, ...]
+            # and request-domain plan inputs [B, ...] to the logical verify batch.
             kpool_write_tail_and_maybe_compress(
                 pool=pool,
                 buf=buf,
-                key=key,
-                score=self._compute_gate_score_if_missing(x, gate_score_maybe),
+                key=key[:real_num_tokens],
+                score=score[:real_num_tokens],
                 tail_k=tail_k_buf,
                 tail_score=tail_score_buf,
                 ape=self.index_kpool_compress_ape,
-                req_pool_indices=plan.req,
-                write_start=plan.write_start,
-                tail_logical_start=plan.tail_logical_start,
-                write_loc=plan.write_loc,
-                out_cache_loc=forward_batch.out_cache_loc,
+                req_pool_indices=plan.req[:real_batch],
+                write_start=plan.write_start[:real_batch],
+                tail_logical_start=plan.tail_logical_start[:real_batch],
+                write_loc=plan.write_loc[:real_batch],
+                out_cache_loc=forward_batch.out_cache_loc[:real_num_tokens],
                 num_draft_tokens=num_draft_tokens,
                 round_scale=self.scale_fmt is not None,
-                effective_n_per_batch=plan.effective_n_per_batch,
+                effective_n_per_batch=(
+                    plan.effective_n_per_batch[:real_batch]
+                    if plan.effective_n_per_batch is not None
+                    else None
+                ),
             )
 
         if enable_dual_stream:

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -235,6 +235,29 @@ class MambaAttnBackendBase(AttentionBackend):
                         device=forward_batch.input_ids.device,
                     )
 
+                # MLP sync can pad an eager verify into a larger physical
+                # request bucket. Preserve those request rows for collective
+                # shape compatibility, but make their query ranges empty so
+                # recurrent kernels only consume the logical token prefix.
+                if _real_bs is not None and _real_bs < bs:
+                    if query_start_loc.shape[0] < _real_bs + 1:
+                        raise RuntimeError(
+                            "target-verify query_start_loc does not cover all real "
+                            f"requests: qsl_rows={query_start_loc.shape[0]}, "
+                            f"real_bs={_real_bs}, padded_bs={bs}"
+                        )
+                    logical_end = query_start_loc[_real_bs]
+                    padded_query_start_loc = torch.empty(
+                        (bs + 1,),
+                        dtype=query_start_loc.dtype,
+                        device=query_start_loc.device,
+                    )
+                    padded_query_start_loc[: _real_bs + 1] = query_start_loc[
+                        : _real_bs + 1
+                    ]
+                    padded_query_start_loc[_real_bs + 1 :] = logical_end
+                    query_start_loc = padded_query_start_loc
+
                 if self.topk > 1:
                     retrieve_next_token = forward_batch.spec_info.retrieve_next_token
                     retrieve_next_sibling = (

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -111,11 +111,7 @@ class RadixLinearAttention(nn.Module):
                 )
             return output
 
-        # Target verify rebuilds query_start_loc from the physical padded input,
-        # unlike ordinary extend where it retains the logical sequence ends.
-        should_trim_padded_extend = (
-            is_extend and not forward_batch.forward_mode.is_target_verify()
-        )
+        should_trim_padded_extend = is_extend
         real_num_tokens = (
             getattr(forward_batch, "num_token_non_padded_cpu", None)
             if should_trim_padded_extend
@@ -159,6 +155,22 @@ def _linear_attention_with_output_impl(
     """Run linear attention on the real prefix and initialize physical padding."""
     real_num_tokens = min(forward_batch.num_token_non_padded_cpu, mixed_qkv.shape[0])
 
+    physical_num_tokens = mixed_qkv.shape[0]
+
+    def _real_token_prefix(tensor: torch.Tensor) -> torch.Tensor:
+        # Linear-attention gates use both token-major [T, ...] and batched
+        # [1, T, ...] layouts. Narrow the axis that represents the same
+        # physical token rows as mixed_qkv.
+        if tensor.shape[0] == physical_num_tokens:
+            return tensor[:real_num_tokens]
+        if tensor.ndim > 1 and tensor.shape[1] == physical_num_tokens:
+            return tensor[:, :real_num_tokens]
+        raise AssertionError(
+            "linear-attention input has no physical token axis: "
+            f"tensor_shape={tuple(tensor.shape)}, "
+            f"physical_num_tokens={physical_num_tokens}"
+        )
+
     original_out_cache_loc = forward_batch.out_cache_loc
     # Keep the original ForwardBatch object and only narrow cache locations for
     # this backend call so model/backend state is still written to the same batch.
@@ -169,8 +181,8 @@ def _linear_attention_with_output_impl(
             layer=attention_layer,
             forward_batch=forward_batch,
             mixed_qkv=mixed_qkv[:real_num_tokens],
-            a=a[:real_num_tokens],
-            b=b[:real_num_tokens],
+            a=_real_token_prefix(a),
+            b=_real_token_prefix(b),
             linear_attn_output=logical_output,
         )
     finally:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3496,17 +3496,6 @@ class Scheduler(
             running_batch = prefill_plan.running_batch
 
         need_mlp_sync = self.require_mlp_sync
-        if (
-            need_mlp_sync
-            and not self.spec_algorithm.is_none()
-            and not get_spec().speculative_skip_dp_mlp_sync
-        ):
-            # NOTE: This branch makes sure prefill and decode batches will not be mixed when spec and dp-attn is enabled.
-            # Before merging the new batch into running batch:
-            # 1. All new batches are none -> need_mlp_sync remains true (sync is needed for decode batch).
-            # 2. All new batches are some (prefill / idle) -> we do not need prepare mlp sync one more time.
-            new_batch = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(new_batch)
-            need_mlp_sync = new_batch is None
 
         if new_batch is not None:
             # Run prefill first if possible

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -278,7 +278,6 @@ def _local_prefill_cuda_graph_vote(
     prefill_graph_runner,
     coordinated_prefill: bool,
     breakable_prefill: bool,
-    spec_algorithm: SpeculativeAlgorithm,
     model_config,
 ) -> bool:
     """This rank's vote for the prefill graph (min-reduced across dp
@@ -305,7 +304,6 @@ def _local_prefill_cuda_graph_vote(
         # decode->extend conversion eligibility; needs the captured-graph
         # prefill runner, not the eager fallback.
         and isinstance(prefill_graph_runner, PrefillCudaGraphRunner)
-        and spec_algorithm.is_none()
         and not local_batch.return_logprob
         # Grammar FSMs advance through the decode result path only.
         and not local_batch.has_grammar
@@ -401,7 +399,6 @@ def prepare_mlp_sync_batch_raw(
         prefill_graph_runner=prefill_graph_runner,
         coordinated_prefill=coordinated_prefill,
         breakable_prefill=breakable_prefill,
-        spec_algorithm=model_runner.spec_algorithm,
         model_config=model_runner.model_config,
     )
 
@@ -561,8 +558,8 @@ class SchedulerDPAttnAdapter:
         all falling to eager."""
         if batch is None or not batch.forward_mode.is_decode():
             return batch
-        # Global triggers from the gather. This rank's own eligibility (spec/
-        # TBO/CP/logprob/replayability) is folded into the min-reduced vote:
+        # Global triggers from the gather. This rank's own eligibility
+        # (TBO/CP/logprob/replayability) is folded into the min-reduced vote:
         # if it failed, can_run_dp_prefill_cuda_graph is already False.
         if not batch.is_extend_in_batch:
             return batch

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1512,7 +1512,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     def _pad_inputs_to_size(self, model_runner: ModelRunner, num_tokens, bs):
         # padding
         self._original_num_tokens = self.positions.shape[0]
-        self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
+        if self.input_ids is not None:
+            self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
         if self.input_embeds is not None:
             # Keep token-aligned inputs consistent after padding.
             self.input_embeds = self._pad_tensor_to_size(self.input_embeds, num_tokens)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1540,7 +1540,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 self.seq_lens_cpu, bs, value=seq_len_fill_value
             )
 
-        self.out_cache_loc = self._pad_tensor_to_size(self.out_cache_loc, num_tokens)
+        # Chunked speculative prefills can reserve KV slots for the whole
+        # request while positions/input_ids only describe the current chunk.
+        # Keep the token-aligned cache locations to the active chunk before DP
+        # padding; otherwise a short first chunk produces a negative pad size.
+        self.out_cache_loc = self._pad_tensor_to_size(
+            self.out_cache_loc[: self._original_num_tokens], num_tokens
+        )
         if self.encoder_lens is not None:
             self.encoder_lens = self._pad_tensor_to_size(self.encoder_lens, bs)
         self.positions = self._pad_tensor_to_size(self.positions, num_tokens)

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -112,17 +112,29 @@ def _resolve_eagle_aux_hidden_state(
         )
 
     if spec_algorithm.is_eagle3():
-        config.eagle_use_aux_hidden_state = True
-        try:
-            eagle_config = getattr(draft_model_config.hf_config, "eagle_config", None)
-            config.eagle_use_aux_hidden_state = eagle_config.get(
-                "use_aux_hidden_state", True
+        eagle_config = getattr(draft_model_config.hf_config, "eagle_config", None)
+        draft_architectures = set(
+            getattr(draft_model_config.hf_config, "architectures", None) or []
+        )
+        is_glm5_native_nextn = (
+            "Glm5NextForConditionalGenerationNextN" in draft_architectures
+            or getattr(draft_model_config.hf_config, "model_type", None) == "glm5_next"
+        ) and eagle_config is None
+
+        # GLM-5.3's native MTP head consumes the final H-wide target state. It
+        # has no EAGLE3 aux-state projection; applying EAGLE3's generic fallback
+        # would incorrectly concatenate three target states into a 3H tensor.
+        config.eagle_use_aux_hidden_state = not is_glm5_native_nextn
+        if eagle_config is not None:
+            getter = (
+                eagle_config.get
+                if isinstance(eagle_config, dict)
+                else lambda key, default=None: getattr(eagle_config, key, default)
             )
-            config.eagle_aux_hidden_state_layer_ids = eagle_config[
-                "eagle_aux_hidden_state_layer_ids"
-            ]
-        except Exception:
-            config.eagle_aux_hidden_state_layer_ids = None
+            config.eagle_use_aux_hidden_state = getter("use_aux_hidden_state", True)
+            config.eagle_aux_hidden_state_layer_ids = getter(
+                "eagle_aux_hidden_state_layer_ids", None
+            )
 
 
 def _resolve_dflash_aux_hidden_state(

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -21,9 +21,6 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from safetensors.torch import load_file
-from torch import nn
-from transformers import PretrainedConfig
-
 from sglang.kernels.ops.layernorm.fused_eh_norm import fused_eh_norm
 from sglang.srt.configs.model_config import is_deepseek_dsa
 from sglang.srt.distributed import get_pp_group
@@ -62,6 +59,8 @@ from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV3ForC
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.runtime_context import get_model, get_parallel, get_spec
 from sglang.srt.utils import BumpAllocator, add_prefix, is_cuda, is_npu
+from torch import nn
+from transformers import PretrainedConfig
 
 
 def _gather_dsa_topk_indices_for_cp(
@@ -174,21 +173,37 @@ class DeepseekModelNextN(nn.Module):
             self.cp_size = get_parallel().attn_cp_size
         else:
             self.cp_size = None
-        self.decoder = DeepseekV2DecoderLayer(
+        self.decoder = self._build_decoder(
+            config,
+            quant_config=quant_config,
+            moe_quant_config_override=moe_quant_config_override,
+            prefix=add_prefix(layer_name, prefix),
+            alt_stream=self.alt_stream,
+        )
+
+        self.shared_head = nn.Module()
+        self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def _build_decoder(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig],
+        moe_quant_config_override: Optional[QuantizationConfig],
+        prefix: str,
+        alt_stream: Optional[torch.cuda.Stream],
+    ) -> nn.Module:
+        return DeepseekV2DecoderLayer(
             config,
             0,
             quant_config=quant_config,
             moe_quant_config_override=moe_quant_config_override,
             is_nextn=True,
-            prefix=add_prefix(layer_name, prefix),
-            alt_stream=self.alt_stream,
+            prefix=prefix,
+            alt_stream=alt_stream,
             skip_rope=config.qk_rope_head_dim == 0,
             dsa_enable_prefill_cp=self.dsa_enable_prefill_cp,
             mla_enable_prefill_cp=self.mla_enable_prefill_cp,
         )
-
-        self.shared_head = nn.Module()
-        self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(
         self,
@@ -364,7 +379,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
 
         nextn_quant_config = self._resolve_nextn_quant_config(config, quant_config)
 
-        self.model = DeepseekModelNextN(
+        self.model = self._build_nextn_model(
             config, nextn_quant_config, prefix=add_prefix("model", prefix)
         )
         self.lm_head = ParallelLMHead(
@@ -375,6 +390,14 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             use_attn_tp_group=get_parallel().enable_dp_lm_head,
         )
         self.logits_processor = LogitsProcessor(config)
+
+    def _build_nextn_model(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str,
+    ) -> DeepseekModelNextN:
+        return DeepseekModelNextN(config, quant_config, prefix=prefix)
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -21,6 +21,9 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from safetensors.torch import load_file
+from torch import nn
+from transformers import PretrainedConfig
+
 from sglang.kernels.ops.layernorm.fused_eh_norm import fused_eh_norm
 from sglang.srt.configs.model_config import is_deepseek_dsa
 from sglang.srt.distributed import get_pp_group
@@ -59,8 +62,6 @@ from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV3ForC
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.runtime_context import get_model, get_parallel, get_spec
 from sglang.srt.utils import BumpAllocator, add_prefix, is_cuda, is_npu
-from torch import nn
-from transformers import PretrainedConfig
 
 
 def _gather_dsa_topk_indices_for_cp(
@@ -118,7 +119,7 @@ class DeepseekModelNextN(nn.Module):
             logger.warning(
                 "Overriding DeepseekV3ForCausalLMNextN quant config for modelopt_fp4 Deepseek model."
             )
-            quant_config = None
+            quant_config = self._resolve_modelopt_nextn_quant_config(quant_config)
 
         self.vocab_size = config.vocab_size
 
@@ -183,6 +184,11 @@ class DeepseekModelNextN(nn.Module):
 
         self.shared_head = nn.Module()
         self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def _resolve_modelopt_nextn_quant_config(
+        self, quant_config: QuantizationConfig
+    ) -> Optional[QuantizationConfig]:
+        return None
 
     def _build_decoder(
         self,

--- a/python/sglang/srt/models/glm5_next_nextn.py
+++ b/python/sglang/srt/models/glm5_next_nextn.py
@@ -13,12 +13,48 @@
 # ==============================================================================
 
 import logging
+from copy import copy
 
-from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
-from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+import torch
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.models.deepseek_nextn import (
+    DeepseekModelNextN,
+    DeepseekV3ForCausalLMNextN,
+)
+from sglang.srt.models.glm5_next import (
+    Glm5NextDecoderLayer,
+    Glm5NextForConditionalGeneration,
+)
 from sglang.srt.models.utils import WeightsMapper
+from torch import nn
+from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
+
+
+class Glm5NextModelNextN(DeepseekModelNextN):
+    def _build_decoder(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None,
+        moe_quant_config_override: QuantizationConfig | None,
+        prefix: str,
+        alt_stream: torch.cuda.Stream | None,
+    ) -> nn.Module:
+        # The published NextN block uses GLM's DSA/MoE layer but deliberately
+        # omits the target model's mHC parameters. Build that layer with mHC
+        # disabled instead of inheriting DeepSeek's decoder implementation.
+        decoder_config = copy(config)
+        decoder_config.mhc = False
+        return Glm5NextDecoderLayer(
+            config=decoder_config,
+            layer_id=config.num_hidden_layers,
+            quant_config=quant_config,
+            moe_quant_config_override=moe_quant_config_override,
+            is_nextn=True,
+            prefix=prefix,
+            alt_stream=alt_stream,
+        )
 
 
 class Glm5NextForConditionalGenerationNextN(DeepseekV3ForCausalLMNextN):
@@ -58,6 +94,21 @@ class Glm5NextForConditionalGenerationNextN(DeepseekV3ForCausalLMNextN):
             quant_config=quant_config,
             prefix=prefix,
         )
+        self.hot_token_id = None
+
+    def _build_nextn_model(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> Glm5NextModelNextN:
+        return Glm5NextModelNextN(config, quant_config, prefix=prefix)
+
+    def set_embed(self, embed):
+        del self.model.embed_tokens.weight
+        self.model.embed_tokens.weight = embed
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
 
     def load_weights(self, weights):
         if not hasattr(self, "fuse_qkv_a_proj"):

--- a/python/sglang/srt/models/glm5_next_nextn.py
+++ b/python/sglang/srt/models/glm5_next_nextn.py
@@ -33,6 +33,15 @@ logger = logging.getLogger(__name__)
 
 
 class Glm5NextModelNextN(DeepseekModelNextN):
+    def _resolve_modelopt_nextn_quant_config(
+        self, quant_config: QuantizationConfig
+    ) -> QuantizationConfig:
+        # GLM-5.3's native MTP block keeps attention/shared projections in BF16
+        # via ModelOpt's ignore rules, but its routed experts remain NVFP4.  The
+        # generic DeepSeek drafter drops ModelOpt quantization entirely, which
+        # allocates unpacked BF16 expert tensors at twice the checkpoint width.
+        return quant_config
+
     def _build_decoder(
         self,
         config: PretrainedConfig,

--- a/python/sglang/srt/models/glm5_next_nextn.py
+++ b/python/sglang/srt/models/glm5_next_nextn.py
@@ -16,6 +16,9 @@ import logging
 from copy import copy
 
 import torch
+from torch import nn
+from transformers import PretrainedConfig
+
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.models.deepseek_nextn import (
     DeepseekModelNextN,
@@ -26,13 +29,23 @@ from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
 )
 from sglang.srt.models.utils import WeightsMapper
-from torch import nn
-from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 
 
 class Glm5NextModelNextN(DeepseekModelNextN):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        # Keep the draft KV pool on the same logical layer-numbering origin as
+        # GLM's published MTP decoder (the layer after the target stack).
+        self.start_layer = config.num_hidden_layers
+        self.end_layer = self.start_layer + 1
+        super().__init__(config, quant_config, prefix)
+
     def _resolve_modelopt_nextn_quant_config(
         self, quant_config: QuantizationConfig
     ) -> QuantizationConfig:

--- a/python/sglang/srt/models/glm5_next_nextn.py
+++ b/python/sglang/srt/models/glm5_next_nextn.py
@@ -95,6 +95,10 @@ class Glm5NextForConditionalGenerationNextN(DeepseekV3ForCausalLMNextN):
             prefix=prefix,
         )
         self.hot_token_id = None
+        # Native MTP checkpoints do not store a separate output head. EAGLE3's
+        # initialization path must share both target tensors, just as NEXTN's
+        # EAGLE path already does.
+        self.load_lm_head_from_target = True
 
     def _build_nextn_model(
         self,

--- a/test/registered/unit/layers/attention/test_hybrid_linear_attn_metadata.py
+++ b/test/registered/unit/layers/attention/test_hybrid_linear_attn_metadata.py
@@ -1,0 +1,123 @@
+"""CPU coverage for eager hybrid-linear metadata after MLP-sync padding."""
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    MambaAttnBackendBase,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _ReqToTokenPool:
+    def get_mamba_indices(self, req_pool_indices):
+        return req_pool_indices.clone()
+
+    def translate_mamba_indices(self, mamba_indices):
+        return mamba_indices
+
+
+def _backend():
+    backend = object.__new__(MambaAttnBackendBase)
+    backend.device = torch.device("cpu")
+    backend.topk = 1
+    backend.req_to_token_pool = _ReqToTokenPool()
+    return backend
+
+
+def _target_verify_batch(
+    *,
+    draft_token_num: int,
+    physical_tokens: int,
+    original_batch_size: int = 1,
+    ragged_query_start_loc=None,
+):
+    ragged_layout = (
+        None
+        if ragged_query_start_loc is None
+        else SimpleNamespace(qo_indptr_device=ragged_query_start_loc)
+    )
+    return SimpleNamespace(
+        batch_size=physical_tokens // draft_token_num,
+        _original_batch_size=original_batch_size,
+        req_pool_indices=torch.tensor(
+            list(range(17, 17 + original_batch_size))
+            + [0] * (physical_tokens // draft_token_num - original_batch_size)
+        ),
+        mamba_track_indices=None,
+        mamba_track_mask=None,
+        extend_start_loc=None,
+        extend_seq_lens=None,
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        spec_info=SimpleNamespace(
+            draft_token_num=draft_token_num,
+            ragged_verify_layout=ragged_layout,
+        ),
+        input_ids=torch.arange(physical_tokens),
+        num_token_non_padded_cpu=(
+            original_batch_size * draft_token_num
+            if ragged_query_start_loc is None
+            else int(ragged_query_start_loc[-1])
+        ),
+    )
+
+
+class TestHybridLinearAttentionMetadata(CustomTestCase):
+    def test_eager_target_verify_collapses_mlp_sync_padding_rows(self):
+        forward_batch = _target_verify_batch(draft_token_num=4, physical_tokens=8)
+
+        metadata = _backend()._forward_metadata(forward_batch)
+
+        self.assertEqual(metadata.query_start_loc.tolist(), [0, 4, 4])
+        self.assertEqual(metadata.mamba_cache_indices.tolist(), [17, -1])
+        self.assertEqual(
+            int(metadata.query_start_loc[-1]),
+            forward_batch.num_token_non_padded_cpu,
+        )
+        self.assertEqual(
+            metadata.query_start_loc.shape[0] - 1,
+            metadata.mamba_cache_indices.shape[0],
+        )
+
+    def test_eager_target_verify_preserves_unpadded_request_domain(self):
+        forward_batch = _target_verify_batch(draft_token_num=6, physical_tokens=6)
+
+        metadata = _backend()._forward_metadata(forward_batch)
+
+        self.assertEqual(metadata.query_start_loc.tolist(), [0, 6])
+        self.assertEqual(metadata.mamba_cache_indices.tolist(), [17])
+
+    def test_eager_target_verify_preserves_real_requests_before_padding(self):
+        forward_batch = _target_verify_batch(
+            draft_token_num=4,
+            physical_tokens=16,
+            original_batch_size=2,
+        )
+
+        metadata = _backend()._forward_metadata(forward_batch)
+
+        self.assertEqual(metadata.query_start_loc.tolist(), [0, 4, 8, 8, 8])
+        self.assertEqual(metadata.mamba_cache_indices.tolist(), [17, 18, -1, -1])
+
+    def test_eager_ragged_verify_pads_only_the_request_domain(self):
+        forward_batch = _target_verify_batch(
+            draft_token_num=4,
+            physical_tokens=8,
+            ragged_query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        )
+
+        metadata = _backend()._forward_metadata(forward_batch)
+
+        self.assertEqual(metadata.query_start_loc.tolist(), [0, 3, 3])
+        self.assertEqual(metadata.mamba_cache_indices.tolist(), [17, -1])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/layers/test_dsa_indexer_kpool_padding.py
+++ b/test/registered/unit/layers/test_dsa_indexer_kpool_padding.py
@@ -1,0 +1,130 @@
+"""CPU regression coverage for DSA KPool target-verify padding."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer_kpool, kpool_fp8_index
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSAIndexerKPoolTargetVerifyPadding(CustomTestCase):
+    @staticmethod
+    def _indexer(num_tokens: int):
+        indexer = object.__new__(dsa_indexer_kpool.IndexerKPool)
+        indexer.index_kpool_compress_ape = torch.empty(4, 128)
+        indexer.scale_fmt = None
+        indexer._get_q_k_bf16 = MagicMock(
+            return_value=(
+                torch.randn(num_tokens, 2, 128),
+                torch.randn(num_tokens, 128),
+                torch.randn(num_tokens, 128),
+            )
+        )
+        indexer._compute_gate_score_if_missing = MagicMock(
+            return_value=torch.randn(num_tokens, 128)
+        )
+        return indexer
+
+    @staticmethod
+    def _pool():
+        pool = MagicMock()
+        pool.get_compress_tail_buffers.return_value = (
+            torch.empty(1, 12, 128),
+            torch.empty(1, 12, 128),
+        )
+        pool.get_index_k_with_scale_buffer.return_value = torch.empty(1)
+        return pool
+
+    def test_cache_write_drops_mlp_sync_padding_tokens(self):
+        indexer = self._indexer(num_tokens=8)
+        pool = self._pool()
+        plan = SimpleNamespace(
+            num_draft_tokens=6,
+            req=torch.tensor([17, 99]),
+            write_start=torch.tensor([23, 0], dtype=torch.int32),
+            tail_logical_start=torch.tensor([19, 0], dtype=torch.int32),
+            write_loc=torch.tensor([[29], [-1]]),
+            effective_n_per_batch=torch.tensor([6, 0], dtype=torch.int32),
+        )
+        metadata = SimpleNamespace(attn_metadata=SimpleNamespace(kpool_write_plan=plan))
+        forward_batch = SimpleNamespace(
+            num_token_non_padded_cpu=6,
+            spec_info=SimpleNamespace(ragged_verify_layout=None),
+            out_cache_loc=torch.arange(8) + 100,
+        )
+
+        with (
+            patch.object(dsa_indexer_kpool, "is_cuda", return_value=True),
+            patch.object(dsa_indexer_kpool, "get_token_to_kv_pool", return_value=pool),
+            patch.object(
+                kpool_fp8_index, "kpool_write_tail_and_maybe_compress"
+            ) as write,
+        ):
+            result = indexer._forward_cuda_target_verify(
+                x=torch.randn(8, 64),
+                q_lora=torch.randn(8, 32),
+                positions=torch.arange(8),
+                forward_batch=forward_batch,
+                layer_id=7,
+                act_quant=MagicMock(),
+                metadata=metadata,
+                enable_dual_stream=False,
+                return_indices=False,
+            )
+
+        self.assertIsNone(result)
+        kwargs = write.call_args.kwargs
+        self.assertEqual(kwargs["key"].shape, (6, 128))
+        self.assertEqual(kwargs["score"].shape, (6, 128))
+        torch.testing.assert_close(kwargs["out_cache_loc"], torch.arange(6) + 100)
+        torch.testing.assert_close(kwargs["req_pool_indices"], torch.tensor([17]))
+        torch.testing.assert_close(
+            kwargs["write_start"], torch.tensor([23], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            kwargs["tail_logical_start"], torch.tensor([19], dtype=torch.int32)
+        )
+        torch.testing.assert_close(kwargs["write_loc"], torch.tensor([[29]]))
+        torch.testing.assert_close(
+            kwargs["effective_n_per_batch"],
+            torch.tensor([6], dtype=torch.int32),
+        )
+
+    def test_cache_write_rejects_ragged_groups(self):
+        indexer = self._indexer(num_tokens=4)
+        pool = self._pool()
+        plan = SimpleNamespace(num_draft_tokens=3)
+        metadata = SimpleNamespace(attn_metadata=SimpleNamespace(kpool_write_plan=plan))
+        forward_batch = SimpleNamespace(
+            num_token_non_padded_cpu=4,
+            out_cache_loc=torch.arange(4),
+            spec_info=SimpleNamespace(ragged_verify_layout=object()),
+        )
+
+        with (
+            patch.object(dsa_indexer_kpool, "is_cuda", return_value=True),
+            patch.object(dsa_indexer_kpool, "get_token_to_kv_pool", return_value=pool),
+            self.assertRaisesRegex(AssertionError, "fixed-width write plan"),
+        ):
+            indexer._forward_cuda_target_verify(
+                x=torch.randn(4, 64),
+                q_lora=torch.randn(4, 32),
+                positions=torch.arange(4),
+                forward_batch=forward_batch,
+                layer_id=7,
+                act_quant=MagicMock(),
+                metadata=metadata,
+                enable_dual_stream=False,
+                return_indices=False,
+            )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/layers/test_radix_linear_attention.py
+++ b/test/registered/unit/layers/test_radix_linear_attention.py
@@ -56,13 +56,29 @@ class _TargetVerifyMode:
         return True
 
 
-class _PhysicalAttentionBackend:
-    def forward(self, *, layer, forward_batch, mixed_qkv, a, b):
-        del layer, forward_batch
-        assert mixed_qkv.shape[0] == 5
-        assert a.shape[0] == 5
-        assert b.shape[0] == 5
-        return torch.full((1, 5, 2, 4), 9.0)
+class _TargetVerifyAttentionBackend:
+    def __init__(self):
+        self.forward_metadata = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 3, 3], dtype=torch.int32),
+            mamba_cache_indices=torch.tensor([17, -1], dtype=torch.int32),
+        )
+
+    def forward(
+        self, *, layer, forward_batch, mixed_qkv, a, b, linear_attn_output=None
+    ):
+        del layer
+        assert mixed_qkv.shape[0] == 3
+        assert a.shape == (1, 3, 8)
+        assert b.shape == (1, 3, 2)
+        assert int(self.forward_metadata.query_start_loc[-1]) == mixed_qkv.shape[0]
+        assert (
+            self.forward_metadata.query_start_loc.shape[0] - 1
+            == self.forward_metadata.mamba_cache_indices.shape[0]
+        )
+        assert forward_batch.spec_info.draft_token_num == 3
+        assert linear_attn_output is not None
+        linear_attn_output.fill_(9.0)
+        return linear_attn_output
 
 
 class TestRadixLinearAttentionPadding(CustomTestCase):
@@ -106,7 +122,7 @@ class TestRadixLinearAttentionPadding(CustomTestCase):
         torch.testing.assert_close(output[:, 3:], torch.zeros((1, 2, 2, 4)))
         self.assertIs(forward_batch.out_cache_loc, original_out_cache_loc)
 
-    def test_target_verify_keeps_physical_rows_matching_its_metadata(self):
+    def test_target_verify_drops_mlp_sync_padding_and_restores_output_shape(self):
         layer = radix_linear_attention.RadixLinearAttention(
             layer_id=0,
             num_q_heads=1,
@@ -121,6 +137,7 @@ class TestRadixLinearAttentionPadding(CustomTestCase):
             forward_mode=_TargetVerifyMode(),
             num_token_non_padded_cpu=3,
             out_cache_loc=original_out_cache_loc,
+            spec_info=SimpleNamespace(draft_token_num=3),
         )
 
         with (
@@ -132,17 +149,18 @@ class TestRadixLinearAttentionPadding(CustomTestCase):
             patch.object(
                 radix_linear_attention,
                 "get_attn_backend",
-                return_value=_PhysicalAttentionBackend(),
+                return_value=_TargetVerifyAttentionBackend(),
             ),
         ):
             output = layer.forward(
                 forward_batch=forward_batch,
                 mixed_qkv=torch.zeros((5, 8)),
-                a=torch.zeros((5, 2)),
-                b=torch.zeros((5, 2)),
+                a=torch.zeros((1, 5, 8)),
+                b=torch.zeros((1, 5, 2)),
             )
 
-        torch.testing.assert_close(output, torch.full((1, 5, 2, 4), 9.0))
+        torch.testing.assert_close(output[:, :3], torch.full((1, 3, 2, 4), 9.0))
+        torch.testing.assert_close(output[:, 3:], torch.zeros((1, 2, 2, 4)))
         self.assertIs(forward_batch.out_cache_loc, original_out_cache_loc)
 
     def test_eager_backend_failure_restores_out_cache_loc(self):

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -82,6 +82,22 @@ class _FakeReq:
 
 
 class TestMergeBatchOutOfPlace(unittest.TestCase):
+    def test_spec_decode_to_extend_uses_pending_bonus_token_as_input(self):
+        req = _FakeReq("spec", origin_len=3, output_len=2)
+        batch = ScheduleBatch(reqs=[req])
+        batch.spec_algorithm = SpeculativeAlgorithm.EAGLE
+        batch.enable_overlap = True
+        batch.forward_mode = ForwardMode.DECODE
+        batch.chunked_req = object()
+        batch.prefill_stats = object()
+
+        batch.convert_decode_to_extend()
+
+        self.assertEqual(batch.forward_mode, ForwardMode.EXTEND)
+        self.assertEqual(batch.prefix_lens, [3])
+        self.assertEqual(req.extend_range, Range(4, 5))
+        self.assertIs(batch.decoding_reqs, batch.reqs)
+
     def test_merge_batch_rebinds_lists_without_mutating_either_side(self):
         """merge_batch must build new list objects; no field of either side may be mutated in place."""
         self_batch = make_schedule_batch(

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -94,7 +94,9 @@ class TestMergeBatchOutOfPlace(unittest.TestCase):
         batch.convert_decode_to_extend()
 
         self.assertEqual(batch.forward_mode, ForwardMode.EXTEND)
-        self.assertEqual(batch.prefix_lens, [3])
+        # The last output token is the pending bonus token replayed as the
+        # one-token extend input, so the preceding four tokens are the prefix.
+        self.assertEqual(batch.prefix_lens, [4])
         self.assertEqual(req.extend_range, Range(4, 5))
         self.assertIs(batch.decoding_reqs, batch.reqs)
 

--- a/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
@@ -66,6 +66,41 @@ def test_draft_worker_does_not_budget_itself():
     assert config.eagle_draft_num_layers is None
 
 
+def test_glm5_native_nextn_does_not_enable_generic_eagle3_aux_capture():
+    kwargs = _resolve_kwargs()
+    kwargs["spec_algorithm"].is_eagle3.return_value = True
+    kwargs["model_config"].hf_config = SimpleNamespace(
+        architectures=["Glm5NextForConditionalGenerationNextN"],
+        eagle_config=None,
+    )
+
+    config = spec_aux_hidden_state.resolve_spec_aux_hidden_state_config(
+        **kwargs, is_draft_worker=False
+    )
+
+    assert not config.eagle_use_aux_hidden_state
+    assert config.eagle_aux_hidden_state_layer_ids is None
+
+
+def test_glm5_eagle3_checkpoint_config_can_explicitly_request_aux_capture():
+    kwargs = _resolve_kwargs()
+    kwargs["spec_algorithm"].is_eagle3.return_value = True
+    kwargs["model_config"].hf_config = SimpleNamespace(
+        architectures=["Glm5NextForConditionalGenerationNextN"],
+        eagle_config={
+            "use_aux_hidden_state": True,
+            "eagle_aux_hidden_state_layer_ids": [7],
+        },
+    )
+
+    config = spec_aux_hidden_state.resolve_spec_aux_hidden_state_config(
+        **kwargs, is_draft_worker=False
+    )
+
+    assert config.eagle_use_aux_hidden_state
+    assert config.eagle_aux_hidden_state_layer_ids == [7]
+
+
 @pytest.mark.parametrize(
     ("target_model_type", "draft_architecture", "expected"),
     [

--- a/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
+++ b/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
@@ -118,6 +118,24 @@ class TestMlpSyncPadUnpad(CustomTestCase):
             fb.input_embeds, torch.tensor([[1.0, 1.0, 1.0, 1.0], [0, 0, 0, 0]])
         )
 
+    def test_chunked_prefill_trims_reserved_cache_locations_before_padding(self):
+        fb = ForwardBatch(
+            forward_mode=ForwardMode.EXTEND,
+            batch_size=1,
+            input_ids=torch.tensor([11, 12]),
+            req_pool_indices=torch.tensor([5]),
+            seq_lens=torch.tensor([2]),
+            out_cache_loc=torch.tensor([20, 21, 22]),
+            seq_lens_sum=2,
+            positions=torch.tensor([0, 1]),
+            seq_lens_cpu=torch.tensor([2]),
+            lora_ids=[None],
+        )
+
+        fb._pad_inputs_to_size(_mock_model_runner(), num_tokens=4, bs=1)
+
+        torch.testing.assert_close(fb.out_cache_loc, torch.tensor([20, 21, 0, 0]))
+
     def test_dp_cuda_graph_batch_size_uses_raw_request_counts(self):
         fb = SimpleNamespace(original_global_num_tokens_cpu=[3, 11, 7])
         self.assertEqual(DecodeCudaGraphRunner._max_dp_batch_size(fb), 11)

--- a/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
+++ b/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
@@ -96,6 +96,28 @@ class TestMlpSyncPadUnpad(CustomTestCase):
 
         self.assertIsNone(spec_info.hidden_states)
 
+    def test_embedding_only_target_verify_can_be_padded(self):
+        fb = ForwardBatch(
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            batch_size=1,
+            input_ids=None,
+            input_embeds=torch.ones(1, 4),
+            req_pool_indices=torch.tensor([5]),
+            seq_lens=torch.tensor([7]),
+            out_cache_loc=torch.tensor([0]),
+            seq_lens_sum=7,
+            positions=torch.tensor([6]),
+            seq_lens_cpu=torch.tensor([7]),
+            lora_ids=[None],
+        )
+
+        fb._pad_inputs_to_size(_mock_model_runner(), num_tokens=2, bs=1)
+
+        self.assertIsNone(fb.input_ids)
+        torch.testing.assert_close(
+            fb.input_embeds, torch.tensor([[1.0, 1.0, 1.0, 1.0], [0, 0, 0, 0]])
+        )
+
     def test_dp_cuda_graph_batch_size_uses_raw_request_counts(self):
         fb = SimpleNamespace(original_global_num_tokens_cpu=[3, 11, 7])
         self.assertEqual(DecodeCudaGraphRunner._max_dp_batch_size(fb), 11)

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -1,15 +1,16 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
-from torch import nn
-
 from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
 )
+from sglang.srt.models.glm5_next_nextn import Glm5NextModelNextN
 from sglang.test.ci.ci_register import register_cpu_ci
+from torch import nn
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -86,6 +87,39 @@ def test_glm5_next_dflash_maps_target_layers_to_capture_points():
     assert model.capture_aux_hidden_states
     assert model.model.dflash_capture
     assert model.model.layers_to_capture == [6, 15, 25, 34, 43]
+
+
+def test_glm5_nextn_builds_glm_decoder_layer(monkeypatch):
+    decoder = object()
+    decoder_cls = MagicMock(return_value=decoder)
+    monkeypatch.setattr(
+        "sglang.srt.models.glm5_next_nextn.Glm5NextDecoderLayer", decoder_cls
+    )
+    model = Glm5NextModelNextN.__new__(Glm5NextModelNextN)
+    config = SimpleNamespace(num_hidden_layers=45, mhc=True)
+
+    actual = model._build_decoder(
+        config,
+        quant_config=None,
+        moe_quant_config_override=None,
+        prefix="model.decoder",
+        alt_stream=None,
+    )
+
+    assert actual is decoder
+    decoder_cls.assert_called_once()
+    call = decoder_cls.call_args.kwargs
+    assert call["config"] is not config
+    assert not call["config"].mhc
+    assert call | {"config": config} == {
+        "config": config,
+        "layer_id": 45,
+        "quant_config": None,
+        "moe_quant_config_override": None,
+        "is_nextn": True,
+        "prefix": "model.decoder",
+        "alt_stream": None,
+    }
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -122,5 +122,12 @@ def test_glm5_nextn_builds_glm_decoder_layer(monkeypatch):
     }
 
 
+def test_glm5_nextn_preserves_modelopt_quantization_for_routed_experts():
+    model = Glm5NextModelNextN.__new__(Glm5NextModelNextN)
+    quant_config = MagicMock()
+
+    assert model._resolve_modelopt_nextn_quant_config(quant_config) is quant_config
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -4,13 +4,15 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from torch import nn
+
+from sglang.srt.models.deepseek_nextn import DeepseekModelNextN
 from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
 )
 from sglang.srt.models.glm5_next_nextn import Glm5NextModelNextN
 from sglang.test.ci.ci_register import register_cpu_ci
-from torch import nn
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -127,6 +129,14 @@ def test_glm5_nextn_preserves_modelopt_quantization_for_routed_experts():
     quant_config = MagicMock()
 
     assert model._resolve_modelopt_nextn_quant_config(quant_config) is quant_config
+
+
+def test_glm5_nextn_exposes_logical_draft_layer_range(monkeypatch):
+    monkeypatch.setattr(DeepseekModelNextN, "__init__", lambda *args, **kwargs: None)
+    model = Glm5NextModelNextN(SimpleNamespace(num_hidden_layers=45))
+
+    assert model.start_layer == 45
+    assert model.end_layer == 46
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

> **Stacked on #36507. Review only the commits above `xinyuan/glm-5.3-flash-support`. This PR will be rebased onto `main` after #36507 merges.**

I am happy to split this into smaller PRs or have the relevant commits folded directly into #36507, whichever is easiest for maintainers to review and land.

GLM-5.3-Flash cannot currently combine EAGLE speculative decoding, mixed chunked-prefill/decode batches, and DP attention unless DP MLP synchronization is bypassed. This prevents the normal synchronized path from serving mixed workloads.

This PR enables that combination without setting `--speculative-skip-dp-mlp-sync`. It also addresses the native NextN and mHC auxiliary-hidden-state failures described in #36829.

No existing open PR was found for this specific combination.

## Modifications

- Remove the blanket scheduler rejection for speculative mixed DP-attention batches.
- Convert mixed decode rows into the one-token extend representation expected by the target model.
- Trim MLP-sync padding before target verification and DSA KPool indexing.
- Implement the native GLM-5.3 NextN decoder and auxiliary-hidden-state contract.
- Preserve NVFP4 quantization for the NextN expert layer.
- Align the NextN KV-cache layer range.
- When running on SM120-class GPUs, use a smaller TileLang DSA tile that fits within their shared-memory limit. Other GPUs, including B200, keep the existing tile settings.
- Support embedding-only target batches during DP padding.
- Trim whole-request speculative KV reservations to the active chunk before DP padding.
- Add focused regression coverage for the scheduler, DP padding, DSA KPool, hybrid linear attention, NextN, and auxiliary-hidden-state paths.

## Accuracy Tests

Tested `LibertAIDAI/GLM-5.3-Flash-NVFP4` on 4x NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs (SM120) with:

- `--tp-size 4 --dp-size 4 --enable-dp-attention`
- `--enable-mixed-chunk --chunked-prefill-size 512` (resolved to 128)
- EAGLE with 5 steps, top-k 1, and 6 draft tokens
- TileLang DSA prefill and decode backends
- Marlin target and speculative MoE backends
- `speculative_skip_dp_mlp_sync=False`

Results:

- A greedy basic request for `The capital of France is` returned the expected continuation beginning with `Paris` and generated all 32 requested tokens.
- Four 192-token decode requests were started, followed by four long chunked prefills generating 32 tokens each.
- All eight overlapping requests returned HTTP 200 across all four DP ranks.
- The server remained healthy after completion with no scheduler exceptions.

Evidence that speculative decoding was active:

| Request | DP rank | Output tokens | Spec accept rate | Average accepted length | Correct / proposed drafts | Verify calls |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Basic generation | 2 | 32 | 0.257 | 2.286 | 18 / 70 | 14 |

The four overlapping 192-token decode requests ran on DP ranks 3, 0, 1, and 2 and reported speculative acceptance rates of 0.475, 0.255, 1.000, and 0.212 respectively. The four requests that began as long chunked prefills also entered speculative decode and reported rates of 0.967, 1.000, 1.000, and 1.000. These fields are emitted from EAGLE verification; the basic request's 70 proposed drafts and 14 verify calls confirm that the request did not fall back to ordinary decoding.

Test coverage:

- Focused unit suite before the final upstream rebase: 38 passed.
- The updated `test_mlp_sync_pad_unpad.py`, including the final chunked-prefill KV-reservation regression: 8 passed.
- All repository pre-commit hooks pass on the rebased stack.

## Speed Tests and Profiling

This is a correctness and compatibility change. No controlled before/after performance benchmark was run because the previous configuration rejected or crashed on the target workload.

During the functional concurrency test, the four long prefills completed in 22.45-22.46 seconds and the four concurrent 192-token decodes completed in 23.65-24.91 seconds. These figures include the tested workload's contention and are provided as a smoke-test reference, not a performance claim.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused unit tests for the modified paths.
- [x] No documentation update is required; this fixes an existing runtime configuration and does not add a user-facing option.
- [x] Provide model-output accuracy and end-to-end workload results above.
- [x] Provide the available timing observations and explain why no comparative speed benchmark applies.
- [x] Follow the SGLang code-style guidance.
