### PR TITLE
[Fix] Handle Ollama chat inputs and context limits

### DIFF
--- a/python/sglang/srt/entrypoints/ollama/serving.py
+++ b/python/sglang/srt/entrypoints/ollama/serving.py
@@ -7,7 +7,7 @@ internal format and return Ollama-compatible responses.
 
 import time
 from datetime import datetime, timezone
-from typing import AsyncIterator, Union
+from typing import AsyncIterator, Optional, Union
 
 import orjson
 from fastapi import Request
@@ -27,6 +27,8 @@ from sglang.srt.entrypoints.ollama.protocol import (
 )
 from sglang.srt.managers.io_struct import GenerateReqInput
 
+_DEFAULT_MAX_NEW_TOKENS = 2048
+
 
 class OllamaServing:
     """Handler for Ollama-compatible API endpoints."""
@@ -38,7 +40,9 @@ class OllamaServing:
         """Get current timestamp in Ollama format."""
         return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
-    def _convert_options_to_sampling_params(self, options: dict = None) -> dict:
+    def _convert_options_to_sampling_params(
+        self, options: dict = None, prompt_length: Optional[int] = None
+    ) -> dict:
         """Convert Ollama options to SGLang sampling params."""
         sampling_params = {}
 
@@ -61,9 +65,26 @@ class OllamaServing:
         # Set a reasonable default for max_new_tokens if not specified
         # Ollama users typically expect longer responses than SGLang's default (128)
         if "max_new_tokens" not in sampling_params:
-            sampling_params["max_new_tokens"] = 2048
+            sampling_params["max_new_tokens"] = (
+                self._get_default_max_new_tokens(prompt_length)
+                if prompt_length is not None
+                else _DEFAULT_MAX_NEW_TOKENS
+            )
 
         return sampling_params
+
+    def _get_default_max_new_tokens(self, prompt_length: int) -> int:
+        """Return the Ollama default that fits in the model context."""
+        context_len = getattr(self.tokenizer_manager, "context_len", None)
+        model_config = getattr(self.tokenizer_manager, "model_config", None)
+        if context_len is None:
+            context_len = getattr(model_config, "context_len", None)
+        if context_len is None:
+            return _DEFAULT_MAX_NEW_TOKENS
+
+        num_reserved_tokens = getattr(self.tokenizer_manager, "num_reserved_tokens", 0)
+        remaining_tokens = context_len - prompt_length - num_reserved_tokens
+        return max(0, min(_DEFAULT_MAX_NEW_TOKENS, remaining_tokens))
 
     async def handle_chat(
         self, request: OllamaChatRequest, raw_request: Request
@@ -81,10 +102,13 @@ class OllamaServing:
             messages,
             tokenize=True,
             add_generation_prompt=True,
+            return_dict=False,
         )
 
         # Convert options to sampling params
-        sampling_params = self._convert_options_to_sampling_params(request.options)
+        sampling_params = self._convert_options_to_sampling_params(
+            request.options, prompt_length=len(prompt_ids)
+        )
 
         # Create SGLang request with input_ids
         gen_request = GenerateReqInput(
@@ -202,7 +226,10 @@ class OllamaServing:
             return empty_response
 
         # Convert options to sampling params
-        sampling_params = self._convert_options_to_sampling_params(request.options)
+        prompt_length = len(self.tokenizer_manager.tokenizer.encode(prompt))
+        sampling_params = self._convert_options_to_sampling_params(
+            request.options, prompt_length=prompt_length
+        )
 
         # Create SGLang request
         gen_request = GenerateReqInput(

--- a/test/registered/unit/entrypoints/ollama/test_serving.py
+++ b/test/registered/unit/entrypoints/ollama/test_serving.py
@@ -1,0 +1,111 @@
+"""Unit tests for the Ollama-compatible serving handlers."""
+
+import asyncio
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
+
+from sglang.srt.entrypoints.ollama.protocol import (  # noqa: E402
+    OllamaChatRequest,
+    OllamaGenerateRequest,
+)
+from sglang.srt.entrypoints.ollama.serving import OllamaServing  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeTokenizer:
+    def __init__(self):
+        self.chat_template_kwargs = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.chat_template_kwargs = kwargs
+        return [1, 2, 3]
+
+    def encode(self, text):
+        return [1, 2, 3]
+
+
+class _FakeTokenizerManager:
+    served_model_name = "test-model"
+    context_len = 10
+    num_reserved_tokens = 1
+
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.last_request = None
+
+    def generate_request(self, request, raw_request):
+        self.last_request = request
+
+        async def _generate():
+            yield {
+                "text": "answer",
+                "meta_info": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 1,
+                },
+            }
+
+        return _generate()
+
+
+class TestOllamaServing(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer_manager = _FakeTokenizerManager()
+        self.serving = OllamaServing(self.tokenizer_manager)
+
+    def test_chat_uses_flat_input_ids_and_context_aware_default(self):
+        request = OllamaChatRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=False,
+        )
+
+        asyncio.run(self.serving.handle_chat(request, raw_request=object()))
+
+        self.assertEqual(
+            self.tokenizer_manager.tokenizer.chat_template_kwargs["return_dict"],
+            False,
+        )
+        self.assertEqual(self.tokenizer_manager.last_request.input_ids, [1, 2, 3])
+        self.assertEqual(
+            self.tokenizer_manager.last_request.sampling_params["max_new_tokens"],
+            6,
+        )
+
+    def test_generate_uses_remaining_context_for_default(self):
+        request = OllamaGenerateRequest(
+            model="test-model",
+            prompt="hello",
+            stream=False,
+        )
+
+        asyncio.run(self.serving.handle_generate(request, raw_request=object()))
+
+        self.assertEqual(
+            self.tokenizer_manager.last_request.sampling_params["max_new_tokens"],
+            6,
+        )
+
+    def test_explicit_num_predict_is_preserved(self):
+        request = OllamaGenerateRequest(
+            model="test-model",
+            prompt="hello",
+            options={"num_predict": 2},
+            stream=False,
+        )
+
+        asyncio.run(self.serving.handle_generate(request, raw_request=object()))
+
+        self.assertEqual(
+            self.tokenizer_manager.last_request.sampling_params["max_new_tokens"],
+            2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37711. The Python Ollama `/api/chat` endpoint passes the raw
`BatchEncoding` returned by the chat template into `GenerateReqInput`, which
causes requests to fail input normalization. The default `/api/generate` and
`/api/chat` completion length can also exceed the model context when the client
does not provide `num_predict`.

## Modifications

- Request a flat `list[int]` from `apply_chat_template` before constructing the
  generation request.
- Bound the default 2048-token completion by the remaining context after the
  prompt and reserved tokens.
- Preserve an explicitly supplied `num_predict` value.
- Add focused CPU unit tests for both endpoints and explicit option handling.

## Validation

- `PYTHONPATH=python python/.venv/bin/python -m pytest test/registered/unit/entrypoints/ollama/test_serving.py -q` — 3 passed.
- `pre-commit run --files python/sglang/srt/entrypoints/ollama/serving.py test/registered/unit/entrypoints/ollama/test_serving.py` — passed.
- `git diff --check origin/main...HEAD` — passed.
- No model evaluation is required: this change only fixes endpoint input
  normalization and request-length defaults.

## Duplicate-work check

No open PR was found for issue #37711 or the same Python Ollama serving path.
The open Rust Ollama endpoint PR #37440 is a separate implementation and is
not modified by this PR.

AI assistance was used during implementation. The submitting contributor has
reviewed the changed lines and the validation results.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33724930937](https://github.com/sgl-project/sglang/actions/runs/33724930937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33724930511](https://github.com/sgl-project/sglang/actions/runs/33724930511)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33724931202](https://github.com/sgl-project/sglang/actions/runs/33724931202)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->