### PR TITLE
[mem_cache] Add session_ids to KV cache events for disaggregated routing

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -279,6 +279,7 @@ class BlockStored(KVCacheEvent):
     block_size: int
     lora_id: Optional[int]
     medium: Optional[str] = None
+    session_ids: Optional[list[str]] = None
 
 
 class BlockStoredWithMetadata(BlockStored, tag="BlockStored", kw_only=True):
@@ -294,6 +295,7 @@ class BlockStoredWithMetadata(BlockStored, tag="BlockStored", kw_only=True):
 class BlockRemoved(KVCacheEvent):
     block_hashes: list[int]
     medium: Optional[str] = None
+    session_ids: Optional[list[str]] = None
 
 
 class AllBlocksCleared(KVCacheEvent):

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -79,6 +79,10 @@ class InsertParams:
     priority: int = 0
     track_adopted_ranges: bool = False
 
+    # Session id for KV event reporting (available at insert time, before
+    # register_session_ref writes session_ids onto ComponentData).
+    session_id: Optional[str] = None
+
 
 @dataclasses.dataclass
 class InsertResult:

--- a/python/sglang/srt/mem_cache/events.py
+++ b/python/sglang/srt/mem_cache/events.py
@@ -47,6 +47,19 @@ class KVCacheEventRecorder:
         self.page_size = page_size
         self._queue: list = []
 
+    @staticmethod
+    def _collect_session_ids(node: Any) -> Optional[list[str]]:
+        """Collect the union of session_ids from all component_data on a node."""
+        component_data = getattr(node, "component_data", None)
+        if not component_data:
+            return None
+        all_ids: set[str] = set()
+        for cd in component_data:
+            session_ids = getattr(cd, "session_ids", None)
+            if session_ids:
+                all_ids.update(session_ids)
+        return list(all_ids) if all_ids else None
+
     def enqueue(self, event) -> None:
         """Append an event, coalescing it with a compatible queue tail.
 
@@ -112,10 +125,13 @@ class KVCacheEventRecorder:
             return None
         return hash_str_to_int64(parent_hash_values[-1])
 
-    def record_store(self, node: Any, medium=None) -> None:
+    def record_store(self, node: Any, medium=None, session_id=None) -> None:
         # One BlockStored per ``page_size`` chunk.
         # ``medium`` defaults to StorageMedium.GPU but callers may override
         # for lower-tier insertions (e.g. StorageMedium.CPU for host/L2 cache).
+        # ``session_id`` may be passed from the insert path (before
+        # register_session_ref writes it onto ComponentData); other callers
+        # fall back to _collect_session_ids(node).
         if not self.enabled:
             return
         if medium is None:
@@ -123,6 +139,10 @@ class KVCacheEventRecorder:
 
         event_hash_values = self._node_event_hash_values(node)
         parent_block_hash = self._parent_block_hash(node)
+
+        session_ids = (
+            [session_id] if session_id is not None else self._collect_session_ids(node)
+        )
 
         page_index = 0
         logical_len = len(node.key)
@@ -147,6 +167,7 @@ class KVCacheEventRecorder:
                 "block_size": len(page_tokens),
                 "lora_id": None,
                 "medium": medium,
+                "session_ids": session_ids,
             }
             if node.key.cache_salt is None:
                 event = BlockStored(**event_args)
@@ -172,6 +193,8 @@ class KVCacheEventRecorder:
         # Hash values must match what was stored.
         event_hash_values = self._node_event_hash_values(node)
 
+        session_ids = self._collect_session_ids(node)
+
         block_hashes = []
         logical_len = len(node.key)
         page_index = 0
@@ -184,7 +207,13 @@ class KVCacheEventRecorder:
             page_index += 1
 
         if block_hashes:
-            self.enqueue(BlockRemoved(block_hashes=block_hashes, medium=medium))
+            self.enqueue(
+                BlockRemoved(
+                    block_hashes=block_hashes,
+                    medium=medium,
+                    session_ids=session_ids,
+                )
+            )
 
     def record_all_cleared(self) -> None:
         if not self.enabled:

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1036,7 +1036,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         node.priority = max(node.priority, state.priority)
 
         if node.evicted:
-            self._unevict_node_on_insert(node, state.value[:prefix_len])
+            self._unevict_node_on_insert(
+                node,
+                state.value[:prefix_len],
+                session_id=state.params.session_id,
+            )
             state.result.record_adopted_range(
                 BASE_COMPONENT_TYPE,
                 state.total_prefix_length,
@@ -1106,7 +1110,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 state.total_prefix_length + len(state.key),
             )
             state.target_node = self._add_new_node(
-                state.node, state.key, state.value, priority=state.priority
+                state.node,
+                state.key,
+                state.value,
+                priority=state.priority,
+                session_id=state.params.session_id,
             )
             state.is_new_leaf = True
         else:
@@ -1226,6 +1234,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         key: RadixKey,
         value: torch.Tensor,
         priority: int = 0,
+        session_id: Optional[str] = None,
     ) -> UnifiedTreeNode:
         new_node = self._new_node(priority=priority)
         new_node.parent = parent
@@ -1238,11 +1247,14 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(parent)
-        self.kv_events.record_store(new_node)
+        self.kv_events.record_store(new_node, session_id=session_id)
         return new_node
 
     def _unevict_node_on_insert(
-        self, node: UnifiedTreeNode, fresh_value: torch.Tensor
+        self,
+        node: UnifiedTreeNode,
+        fresh_value: torch.Tensor,
+        session_id: Optional[str] = None,
     ) -> None:
         """Restore an evicted node's Full device value from fresh KV indices
         during insert."""
@@ -1257,7 +1269,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self._update_duplicate_tracking(node)
         if node.parent is not None:
             self._update_evictable_leaf_sets(node.parent)
-        self.kv_events.record_store(node, medium=StorageMedium.GPU)
+        self.kv_events.record_store(
+            node, medium=StorageMedium.GPU, session_id=session_id
+        )
 
     def _update_evictable_leaf_sets(self, node: UnifiedTreeNode) -> None:
         """Update both device and host leaf sets for a node."""

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -859,6 +859,11 @@ class UnifiedRadixCache(BasePrefixCache):
             insert_params = InsertParams(
                 prev_prefix_len=req.kv.cache_protected_len,
                 priority=getattr(req, "priority", 0) or 0,
+                session_id=(
+                    self.session_refs.session_id_for_req(req)
+                    if self.enable_session_radix_cache
+                    else None
+                ),
             )
 
             # components prepare insert data + return effective cache_len
@@ -946,6 +951,11 @@ class UnifiedRadixCache(BasePrefixCache):
             prev_prefix_len=req.kv.cache_protected_len,
             chunked=chunked,
             priority=getattr(req, "priority", 0) or 0,
+            session_id=(
+                self.session_refs.session_id_for_req(req)
+                if self.enable_session_radix_cache
+                else None
+            ),
         )
         effective_cache_len = len(token_ids)
         for comp in self._components_tuple:

--- a/test/registered/unit/mem_cache/test_kv_event_session_ids.py
+++ b/test/registered/unit/mem_cache/test_kv_event_session_ids.py
@@ -1,0 +1,263 @@
+"""Unit tests for session_ids propagation in KV cache events.
+
+Covers:
+1. BlockStored / BlockRemoved wire-format round-trip with session_ids.
+2. KVCacheEventRecorder._collect_session_ids helper.
+3. record_store threads session_id from the insert path into emitted events.
+4. record_remove falls back to _collect_session_ids(node).
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import msgspec
+
+from sglang.srt.disaggregation.kv_events import (
+    BlockRemoved,
+    BlockStored,
+    KVEventBatch,
+    StorageMedium,
+)
+from sglang.srt.mem_cache.events import KVCacheEventRecorder
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _MockKey:
+    """Minimal stand-in for RadixKey with __len__ support."""
+
+    def __init__(self, token_ids, cache_salt=None):
+        self.token_ids = list(token_ids)
+        self.is_bigram = False
+        self.cache_salt = cache_salt
+
+    def __len__(self):
+        return len(self.token_ids)
+
+
+class _MockNode:
+    """Minimal stand-in for one radix tree node."""
+
+    def __init__(self, token_ids, component_data=None, cache_salt=None):
+        self.key = _MockKey(token_ids, cache_salt)
+        self.parent = None
+        self.hash_value = None
+        self.event_hash_value = None
+        self.component_data = component_data
+
+
+def _make_node(token_ids, component_data=None, cache_salt=None):
+    """Create a mock node with a root-like parent (parent.parent is None)."""
+    node = _MockNode(token_ids, component_data, cache_salt)
+    # Root-like parent: has empty hash_value and no grandparent.
+    node.parent = _MockNode([], cache_salt=None)
+    node.parent.hash_value = []
+    node.parent.event_hash_value = None
+    return node
+
+
+class TestSessionIdsWireFormat(unittest.TestCase):
+    """session_ids survives msgpack round-trip for BlockStored and BlockRemoved."""
+
+    def test_block_stored_round_trip_with_session_ids(self):
+        event = BlockStored(
+            block_hashes=[123],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=2,
+            lora_id=None,
+            medium=StorageMedium.GPU,
+            session_ids=["sess-a", "sess-b"],
+        )
+        encoded = msgspec.msgpack.encode(event)
+        decoded = msgspec.msgpack.decode(encoded, type=BlockStored)
+        self.assertEqual(decoded.session_ids, ["sess-a", "sess-b"])
+
+    def test_block_stored_default_session_ids_is_none(self):
+        event = BlockStored(
+            block_hashes=[123],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=2,
+            lora_id=None,
+        )
+        self.assertIsNone(event.session_ids)
+
+    def test_block_removed_round_trip_with_session_ids(self):
+        event = BlockRemoved(
+            block_hashes=[456],
+            medium=StorageMedium.GPU,
+            session_ids=["sess-c"],
+        )
+        encoded = msgspec.msgpack.encode(event)
+        decoded = msgspec.msgpack.decode(encoded, type=BlockRemoved)
+        self.assertEqual(decoded.session_ids, ["sess-c"])
+
+    def test_block_removed_default_session_ids_is_none(self):
+        event = BlockRemoved(block_hashes=[789])
+        self.assertIsNone(event.session_ids)
+
+    def test_kv_event_batch_preserves_session_ids(self):
+        event = BlockStored(
+            block_hashes=[123],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=2,
+            lora_id=None,
+            session_ids=["sess-a"],
+        )
+        batch = KVEventBatch(ts=1.0, events=[event])
+        round_tripped = msgspec.msgpack.decode(
+            msgspec.msgpack.encode(batch), type=KVEventBatch
+        )
+        self.assertEqual(round_tripped.events[0].session_ids, ["sess-a"])
+
+
+class TestCollectSessionIds(unittest.TestCase):
+    """_collect_session_ids gathers the union of session_ids from component_data."""
+
+    def test_no_component_data_returns_none(self):
+        node = _make_node([1, 2], component_data=None)
+        self.assertIsNone(KVCacheEventRecorder._collect_session_ids(node))
+
+    def test_empty_component_data_list_returns_none(self):
+        node = _make_node([1, 2], component_data=[])
+        self.assertIsNone(KVCacheEventRecorder._collect_session_ids(node))
+
+    def test_collects_from_single_component(self):
+        cd = SimpleNamespace(session_ids={"sess-a", "sess-b"})
+        node = _make_node([1, 2], component_data=[cd])
+        result = KVCacheEventRecorder._collect_session_ids(node)
+        self.assertEqual(set(result), {"sess-a", "sess-b"})
+
+    def test_collects_union_from_multiple_components(self):
+        cd1 = SimpleNamespace(session_ids={"sess-a"})
+        cd2 = SimpleNamespace(session_ids={"sess-b", "sess-c"})
+        cd3 = SimpleNamespace(session_ids=None)
+        node = _make_node([1, 2], component_data=[cd1, cd2, cd3])
+        result = KVCacheEventRecorder._collect_session_ids(node)
+        self.assertEqual(set(result), {"sess-a", "sess-b", "sess-c"})
+
+    def test_all_none_returns_none(self):
+        cd1 = SimpleNamespace(session_ids=None)
+        cd2 = SimpleNamespace(session_ids=None)
+        node = _make_node([1, 2], component_data=[cd1, cd2])
+        self.assertIsNone(KVCacheEventRecorder._collect_session_ids(node))
+
+
+class TestRecordStoreSessionIds(unittest.TestCase):
+    """record_store threads session_id from the insert path into events.
+
+    The hash-computation internals (_node_event_hash_values /
+    _parent_block_hash) are patched out so the tests run without native
+    hash extensions (which require little-endian Linux).
+    """
+
+    def setUp(self):
+        self.recorder = KVCacheEventRecorder(enabled=True, page_size=2)
+        # Stub hash helpers to avoid native hash dependency.
+        self._hash_patch = patch.object(
+            self.recorder, "_node_event_hash_values", return_value=["a" * 64, "b" * 64]
+        )
+        self._parent_patch = patch.object(
+            self.recorder, "_parent_block_hash", return_value=None
+        )
+        self._hash_patch.start()
+        self._parent_patch.start()
+
+    def tearDown(self):
+        self._hash_patch.stop()
+        self._parent_patch.stop()
+
+    def test_record_store_with_explicit_session_id(self):
+        node = _make_node([1, 2, 3, 4])
+        self.recorder.record_store(node, session_id="sess-1")
+        events = self.recorder.take()
+        self.assertTrue(len(events) > 0)
+        for event in events:
+            self.assertIsInstance(event, BlockStored)
+            self.assertEqual(event.session_ids, ["sess-1"])
+
+    def test_record_store_falls_back_to_collect(self):
+        cd = SimpleNamespace(session_ids={"sess-from-component"})
+        node = _make_node([1, 2, 3, 4], component_data=[cd])
+        self.recorder.record_store(node)
+        events = self.recorder.take()
+        self.assertTrue(len(events) > 0)
+        for event in events:
+            self.assertEqual(set(event.session_ids), {"sess-from-component"})
+
+    def test_record_store_no_session_id_no_component_data(self):
+        node = _make_node([1, 2], component_data=None)
+        self.recorder.record_store(node)
+        events = self.recorder.take()
+        self.assertTrue(len(events) > 0)
+        for event in events:
+            self.assertIsNone(event.session_ids)
+
+    def test_record_store_explicit_session_id_takes_precedence(self):
+        cd = SimpleNamespace(session_ids={"from-component"})
+        node = _make_node([1, 2], component_data=[cd])
+        self.recorder.record_store(node, session_id="from-insert-path")
+        events = self.recorder.take()
+        for event in events:
+            self.assertEqual(event.session_ids, ["from-insert-path"])
+
+
+class TestRecordRemoveSessionIds(unittest.TestCase):
+    """record_remove uses _collect_session_ids from node."""
+
+    def setUp(self):
+        self.recorder = KVCacheEventRecorder(enabled=True, page_size=2)
+        self._hash_patch = patch.object(
+            self.recorder, "_node_event_hash_values", return_value=["a" * 64, "b" * 64]
+        )
+        self._parent_patch = patch.object(
+            self.recorder, "_parent_block_hash", return_value=None
+        )
+        self._hash_patch.start()
+        self._parent_patch.start()
+
+    def tearDown(self):
+        self._hash_patch.stop()
+        self._parent_patch.stop()
+
+    def test_record_remove_collects_session_ids(self):
+        cd = SimpleNamespace(session_ids={"sess-remove"})
+        node = _make_node([1, 2], component_data=[cd])
+        self.recorder.record_remove(node)
+        events = self.recorder.take()
+        self.assertTrue(len(events) > 0)
+        for event in events:
+            self.assertIsInstance(event, BlockRemoved)
+            self.assertEqual(set(event.session_ids), {"sess-remove"})
+
+    def test_record_remove_no_session_ids(self):
+        node = _make_node([1, 2], component_data=None)
+        self.recorder.record_remove(node)
+        events = self.recorder.take()
+        self.assertTrue(len(events) > 0)
+        for event in events:
+            self.assertIsNone(event.session_ids)
+
+
+class TestDisabledRecorder(unittest.TestCase):
+    """Disabled recorder is a no-op for all record_* methods."""
+
+    def test_disabled_record_store(self):
+        recorder = KVCacheEventRecorder(enabled=False, page_size=2)
+        node = _make_node([1, 2])
+        recorder.record_store(node, session_id="sess-1")
+        self.assertEqual(recorder.take(), [])
+
+    def test_disabled_record_remove(self):
+        recorder = KVCacheEventRecorder(enabled=False, page_size=2)
+        node = _make_node([1, 2])
+        recorder.record_remove(node)
+        self.assertEqual(recorder.take(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  - Add `session_ids` field to `BlockStored` and `BlockRemoved` KV cache events so downstream consumers (e.g. disaggregated routers) can route blocks by session.
  - Thread `session_id` from the insert path (`InsertParams`) through `UnifiedTreeCore._add_new_node` / `_unevict_node_on_insert` into `KVCacheEventRecorder.record_store`, ensuring the session is available at event-emit time
  even before `register_session_ref` writes it onto `ComponentData`.
  - Add `_collect_session_ids` helper to gather session IDs from node `component_data` as a fallback for `record_remove` and callers that don't pass `session_id` explicitly.

  ## Test plan
  - [x] Unit tests added: `test/registered/unit/mem_cache/test_kv_event_session_ids.py` — 18 passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33740683680](https://github.com/sgl-project/sglang/actions/runs/33740683680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33740683545](https://github.com/sgl-project/sglang/actions/runs/33740683545)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33740684457](https://github.com/sgl-project/sglang/actions/runs/33740684457)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->