### PR TITLE
[DCP] flashmla: reject decode context parallelism

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -206,6 +206,18 @@ def create_flex_attention_backend(runner):
 
 @register_attention_backend("flashmla")
 def create_flashmla_backend(runner):
+    if get_parallel().dcp_enabled:
+        _, decode_backend = attention_backends_of(resolved_view(runner.server_args))
+        if decode_backend == "flashmla":
+            raise ValueError(
+                "flashmla cannot serve decode context parallelism: it builds its "
+                "decode block table straight off the DCP-widened req_to_token "
+                "with the global seq_lens, so the rows name widened pages rather "
+                "than this rank's physical ones and the kernel is told to read "
+                "the whole sequence out of one shard. Select cutedsl_mla, "
+                "tokenspeed_mla or trtllm_mla for decode; flashmla stays "
+                "available for prefill via --prefill-attention-backend."
+            )
     from sglang.srt.layers.attention.flashmla_backend import FlashMLABackend
 
     return FlashMLABackend(runner)

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -108,10 +108,6 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         # only; draft-side instances must not allocate it.
         self.is_draft_runner = model_runner.is_draft_worker
 
-        # get dcp info
-        self.dcp_world_size = get_parallel().attn_dcp_size
-        self.dcp_rank = get_parallel().attn_dcp_rank
-
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -440,9 +436,6 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
 
         reshape_q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
         if self.is_fp8_kvcache:
-            assert self.dcp_world_size == 1, (
-                "FlashMLA does not support DCP for FP8 kv cache"
-            )
             if layer.k_scale is not None:
                 q_scale = layer.k_scale
                 descale_q = layer.k_scale.reshape(1)
@@ -492,6 +485,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
             # TODO uniform output for forward_decode and forward_extend to
             # return tuple instead of single output
             # decode context parallel needs lse to correct attn_output via online softmax
+            # Not reached for the target decode backend under DCP, which
+            # create_flashmla_backend refuses; the draft path runs on a replicated
+            # pool. The LSE half is here, the rank-local page table is not.
             if get_parallel().dcp_enabled:
                 return o, lse
             return o

--- a/test/registered/dcp/test_flashmla_dcp_guard.py
+++ b/test/registered/dcp/test_flashmla_dcp_guard.py
@@ -1,0 +1,90 @@
+"""``flashmla`` must refuse decode context parallelism at construction time.
+
+The backend builds its decode block table straight off ``req_to_token`` with
+the batch's GLOBAL ``seq_lens`` (``create_flashmla_kv_indices_triton``, and
+``cache_seqlens=forward_batch.seq_lens`` into the kernel). Under DCP the pool
+is widened -- ``kv_cache_configurator`` allocates
+``max_total_num_tokens * dcp_size`` at ``page_size * dcp_size`` -- so those
+rows name widened pages rather than this rank's physical ones, and the kernel
+is told to read the whole sequence out of one shard. bf16 carried no guard at
+all and computed silently wrong output; the fp8 branch carried an assert whose
+message blamed the dtype rather than the missing page table.
+
+Prefill is untouched: ``ForwardMode.EXTEND`` delegates to the
+FlashInferMLA parent, which does have a DCP path. So the refusal keys on
+flashmla being the DECODE backend, mirroring
+``create_trtllm_mla_backend``'s DCP-with-speculative-decoding check.
+
+Usage:
+    python -m pytest test_flashmla_dcp_guard.py -v
+    python test_flashmla_dcp_guard.py
+"""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.attention import attention_registry as registry
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+BACKEND_MODULE = "sglang.srt.layers.attention.flashmla_backend"
+SENTINEL = object()
+
+
+def _call(*, dcp_size, decode_backend, prefill_backend="flashmla"):
+    """Run the factory with the topology and backend split faked out.
+
+    ``resolved_view`` needs a real ServerArgs to resolve overrides and the
+    happy path needs a real ModelRunner, so both are stubbed; the factory's
+    own branch is what is under test. The backend module is injected into
+    ``sys.modules`` rather than patched in place so the test does not depend
+    on something else having imported it (it pulls in sgl_kernel, which a
+    CPU runner has no reason to load).
+    """
+    parallel = SimpleNamespace(dcp_enabled=dcp_size > 1, dcp_size=dcp_size, dcp_rank=0)
+    runner = SimpleNamespace(server_args=SimpleNamespace())
+    stub = types.ModuleType(BACKEND_MODULE)
+    stub.FlashMLABackend = lambda _runner: SENTINEL
+    with (
+        patch.object(registry, "get_parallel", return_value=parallel),
+        patch.object(registry, "resolved_view", side_effect=lambda sa: sa),
+        patch.object(
+            registry,
+            "attention_backends_of",
+            return_value=(prefill_backend, decode_backend),
+        ),
+        patch.dict(sys.modules, {BACKEND_MODULE: stub}),
+    ):
+        return registry.create_flashmla_backend(runner)
+
+
+class TestFlashMLARejectsDcpDecode(CustomTestCase):
+    def test_dcp_decode_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            _call(dcp_size=4, decode_backend="flashmla")
+        # The message has to name the page table, not the KV dtype: the fp8
+        # assert this replaces sent readers after a dtype problem instead.
+        self.assertIn("decode context parallelism", str(ctx.exception))
+        self.assertIn("block table", str(ctx.exception))
+
+    def test_dcp_disabled_is_allowed(self):
+        self.assertIs(_call(dcp_size=1, decode_backend="flashmla"), SENTINEL)
+
+    def test_prefill_only_under_dcp_is_allowed(self):
+        # EXTEND runs through the FlashInferMLA parent, which has a DCP path,
+        # so a split config that only prefills on flashmla must still build.
+        self.assertIs(_call(dcp_size=4, decode_backend="cutedsl_mla"), SENTINEL)
+
+    def test_dcp_size_two_also_raises(self):
+        # dcp_size 2 and 4 take different owner-rule paths; neither is served.
+        with self.assertRaises(ValueError):
+            _call(dcp_size=2, decode_backend="flashmla")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`flashmla` cannot serve decode context parallelism, and the only guard that exists blames the
KV dtype. Measured on 4x H20, DeepSeek-V2-Lite, bf16, `--page-size 64`, GSM8K 200q/5-shot:

- `--tp-size 4`, no DCP: accuracy 0.335, server healthy.
- `--tp-size 4 --dcp-size 2` (and `4`): the first decode step aborts.

```
File ".../deepseek_common/attention_forward_methods/forward_mla.py", line 758,
  in forward_absorb_core
    attn_output = self.attn_mqa(
File ".../layers/attention/flashmla_backend.py", line 543, in forward_decode
    self.token_to_kv_pool.set_kv_buffer(
File ".../mem_cache/memory_pool.py", line 4203, in set_kv_buffer
AssertionError: MLATokenToKVPool.set_kv_buffer has no DCP-aware write path. Under
--dcp-size > 1 the MLA write must go through set_mla_kv_buffer, whose kernel resolves
the owner rule; reaching the combined-row door means an attention backend took a write
path that never declared which loc space it emits.
```

This is bf16, so the FP8 assert is never reached — the dtype was never what stood in the way.

**Why it is not one missing assert.** `forward_absorb_core` routes by backend name:

```python
if self.current_attention_backend in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS:
    ...
    elif is_dcp_mla_decode_phase(forward_batch):
        attn_output, lse = self.attn_mqa_for_dcp_decode(   # query all-gathered, LSE returned
            q_nope_out, k_nope, k_nope, forward_batch, q_rope=q_pe, k_rope=k_pe, ...
        )
    ...
else:
    q = torch.cat([q_nope_out, q_pe], dim=-1)
    k = torch.cat([k_nope, k_pe], dim=-1)
    attn_output = self.attn_mqa(q, k, ...)                 # flashmla lands here
```

`FORWARD_ABSORB_CORE_ATTENTION_BACKENDS` (`deepseek_common/utils.py`) lists `fa3`, `fa4`, `dsa`,
`nsa`, `flashinfer`, `cutlass_mla`, `trtllm_mla`, `cutedsl_mla`, `tokenspeed_mla`, `ascend`,
`intel_xpu` — not `flashmla`. Every part of the MLA DCP decode path lives inside that branch:
the query all-gather, `attn_mqa_for_dcp_decode`, the `(o, lse)` return the cross-rank merge
consumes, and the DCP-aware `set_mla_kv_buffer` write. flashmla takes the pre-concatenated
branch, so under DCP it writes a combined row through a door that cannot resolve the owner rule.

That also makes the `if get_parallel().dcp_enabled: return o, lse` line #14194 left in
`forward_decode` unreachable: its caller on this path is `self.attn_mqa`, which expects a single
tensor, not a tuple.

**The read path is wrong one layer down, too.** Even with dispatch and the write fixed, the
block table would still be built from the DCP-widened `req_to_token` with the batch's global
`seq_lens` — `init_forward_metadata` (all three branches), `_apply_decode_target_verify_metadata`,
and `cache_seqlens=forward_batch.seq_lens` in `forward_decode`. Compared against the rank-local
table `create_mla_kv_page_table_for_dcp` already builds for the trtllm_mla family
(`global_len=512`, physical page 64, `bs=2`):

```
dcp_size=2:  width today=8 pages, rank-local truth=4;  cache_seqlens today=512, truth=256
dcp_size=4:  width today=8 pages, rank-local truth=2;  cache_seqlens today=512, truth=128

dcp_size=4, fragmented pool, req0 widened pages [44, 46]:
  rank 0..3 needs [44, 46], today gives [176, 177]   (176 == 44*256//64)
```

Width and `cache_seqlens` are global in every layout I measured; the page ids additionally
diverge once the widened pool is fragmented (on a freshly allocated pool they happen to
coincide, verified at `dcp_size` 2 and 4).

This PR only makes the refusal honest and complete: one startup error that names the real gap,
instead of an FP8-only assert plus an AssertionError from inside the KV pool. Wiring flashmla
into the DCP decode path is follow-up work that has to touch the model-side dispatch, not just
this backend.

### Relation to #29760

Part of #29736.

The roadmap frames the flashmla FP8 item as "lift the `dcp_world_size == 1` assert", and
#29760 implements exactly that: drop the assert and mirror the bf16 `return o, lse` into
the FP8 branch, on the stated grounds that this involves "no kernel or memory layout
changes". The FP8 branch does need that tuple return — on `main` it is `o, _ =
flash_mla_with_kvcache(...)` followed by a bare `return o.view(...)`, so lifting the assert
alone would hand the DCP merge a non-tuple.

But the memory layout is where the problem is. Under DCP the pool is widened (the allocator
branch above) and _neither_ branch builds a rank-local page table, so mirroring bf16 into
FP8 inherits the bf16 gap rather than avoiding it.

@Aiziyou918 agreed and handed the page-table work over
([comment](https://github.com/sgl-project/sglang/pull/29760#issuecomment-5522520326)): _"the
page-table / local seq_lens issue you pointed out makes sense, and I agree that it should be
resolved before we fully enable FlashMLA + DCP [...] I'm happy for you to own the page-table
fix."_ The order we settled on:

1. refuse the currently unsafe flashmla + DCP path (this PR),
2. add the rank-local page table and rank-local `seq_lens`,
3. re-enable DCP and keep #29760's FP8 tuple-return fix, validated across bf16/FP8 and
   `dcp_size` 2/4.

On #29760's GSM8K numbers (0.955 vs 0.960 at `--tp-size 4 --dcp-size 2
--disable-radix-cache`): the fresh-pool result above accounts for the page ids coinciding in
that setup, but not for the accuracy holding — reading `global_len` tokens where the rank owns
half of them dilutes the softmax over keys outside the sequence even if those pages are
zero-filled. The likeliest explanation is that decode for DeepSeek-V4-Flash does not resolve to
`FlashMLABackend` at all. Either way it does not change this PR: the row width and
`cache_seqlens` are global on every layout I measured. Discussed with @Aiziyou918
[here](https://github.com/sgl-project/sglang/pull/29760#issuecomment-5550834989).

## Modifications

`python/sglang/srt/layers/attention/attention_registry.py`

- `create_flashmla_backend` now raises when DCP is enabled **and** `flashmla` is the
  resolved _decode_ backend, with a message that names the page table rather than the
  dtype. This mirrors `create_trtllm_mla_backend`'s existing
  DCP-with-speculative-decoding refusal, in the same place and the same style.
- The check keys on the decode backend, not on `dcp_enabled` alone, because prefill is
  not affected. `FlashMLABackend.forward_extend` hands `ForwardMode.EXTEND` straight to
  `super().forward_extend` — the `FlashInferMLAAttnBackend` parent, which does have a DCP
  path via `update_local_kv_lens_for_dcp` — and only handles target_verify /
  draft_extend_v2 itself. So `--prefill-attention-backend flashmla
--decode-attention-backend cutedsl_mla` under DCP stays a valid config.
- Keying on the resolved decode backend is also _narrower_ than the assert it replaces.
  Two call sites build `FlashMLABackend` directly rather than through the registry —
  `speculative/draft_utils.py` and `FlashMLAMultiStepDraftBackend` — and both are draft
  side. Per `docs/docs/advanced_features/dcp.mdx`, the draft KV cache is replicated on every
  DCP rank and draft steps deliberately skip DCP metadata, so global `seq_lens` is
  _correct_ there and must not be refused. The dropped assert read the process-global
  `attn_dcp_size`, so it would fire on that legitimate replicated path too.

`python/sglang/srt/layers/attention/flashmla_backend.py`

- Drop the FP8-only `assert self.dcp_world_size == 1`, now subsumed and reported
  earlier with an accurate reason.
- Drop `self.dcp_world_size` / `self.dcp_rank`. That assert was the only reader of
  `dcp_world_size`; `dcp_rank` had none.
- Keep the bf16 `if get_parallel().dcp_enabled: return o, lse` and note in a comment
  that it is the half already in place — the cross-rank merge knows this backend's
  natural-log LSE base (#33065) — so the follow-up only has to supply the page table.
  Not dead code: the draft path above still reaches it.

`test/registered/dcp/test_flashmla_dcp_guard.py` (new)

- `register_cpu_ci(est_time=10, suite="base-a-test-cpu")`; no GPU needed.
- Four cases: DCP decode raises, DCP disabled builds, prefill-only under DCP builds,
  `dcp_size=2` also raises (2 and 4 take different owner-rule paths).
- The backend module is injected into `sys.modules` as a stub rather than patched in
  place, so the test does not depend on anything else having imported
  `flashmla_backend` (it pulls in `sgl_kernel`, which a CPU runner has no reason to
  load).

No behavior change for `dcp_size == 1`, i.e. every existing flashmla deployment.

## Accuracy Tests

No model outputs change, and this is exhaustive rather than sampled:

- The removed assert's condition was `self.dcp_world_size == 1`. Under `dcp_size == 1`
  it was always true, so it never raised and never touched output.
- The two dropped `__init__` attributes had no other readers:
  `grep -n 'dcp_world_size\|dcp_rank' flashmla_backend.py` returns 3 hits, all removed
  here.
- The new refusal sits inside `if get_parallel().dcp_enabled:`, which is `False` when
  `dcp_size == 1`.

There is no remaining path on which `dcp_size == 1` behavior can differ, so every
existing flashmla deployment is byte-identical.

The e2e accuracy comparison for the configuration this PR _rejects_ belongs to the
follow-up that makes it correct.

## Speed Tests and Profiling

Not applicable — one branch on a factory function at startup, nothing on the forward
path.

## Verification performed

- `python3 test/registered/dcp/test_flashmla_dcp_guard.py` — 4/4 OK, run twice: once in
  a CUDA-less container (matching a CPU runner) and once with a GPU visible. Both green.
- `python3 test/registered/dcp/test_dcp_layout_unit.py` — 17/17 OK, no regression.
- `attention_registry` and `flashmla_backend` both import cleanly; no dangling
  references to `dcp_world_size` / `dcp_rank` remain in `flashmla_backend.py`.
- The wrong-page-table numbers above come from a probe run on 1x H20 against
  `create_mla_kv_page_table_for_dcp`, the rank-local table the trtllm_mla family already
  builds. Repro script available on request.
- Page-table probe re-run across `dcp_size` in {2, 4} x pool layout in {fresh, fragmented}:
  width and `cache_seqlens` diverge from the rank-local truth in all four; page ids diverge
  in the two fragmented ones and coincide in the two fresh ones.
- Environment: 8x NVIDIA H20 (SM90, 96GB), driver 570.86.15, torch 2.13.0+cu130,
  sglang-kernel 0.4.6.post1.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

On documentation: `docs/docs/advanced_features/dcp.mdx` does not currently enumerate
which MLA backends serve DCP decode, and `flashmla` is not mentioned in it at all, so
there is no support matrix to amend. Happy to add a short "MLA backend DCP support"
section if reviewers would like one.