### PR TITLE
[NPU] Fix MTP draft loading for ModelSlim W8A8 checkpoints: dequantize int8 MTP weights

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -15,7 +15,9 @@
 """Inference-only Qwen3_5 MTP model."""
 
 import copy
+import json
 import logging
+import os
 from contextlib import ExitStack
 from typing import Iterable, Optional, Tuple
 
@@ -80,6 +82,41 @@ def _mtp_quant_config(quant_config):
         ):
             return None
     return quant_config
+
+
+def _load_mtp_w8a8_dequant_scales(model_path: str) -> dict:
+    """Per-row int8 dequant scales for W8A8 MTP weights, keyed by the
+    original checkpoint weight name.
+
+    On NPU the MTP draft runs unquantized (quant_config=None) while
+    ModelSlim checkpoints may store the MTP projections as W8A8 (int8 +
+    per-row weight_scale). Without dequantization the raw int8 codes are
+    copied into the bf16 parameters and the draft model is numerically
+    broken (spec-decode accept rate collapses to ~0).
+    """
+    scales: dict = {}
+    try:
+        index_file = os.path.join(
+            model_path, "quant_model_weights.safetensors.index.json"
+        )
+        if not os.path.exists(index_file):
+            return scales
+        with open(index_file) as f:
+            weight_map = json.load(f)["weight_map"]
+        from safetensors import safe_open
+
+        for key in weight_map:
+            if not key.startswith("mtp.") or not key.endswith(".weight_scale"):
+                continue
+            with safe_open(
+                os.path.join(model_path, weight_map[key]),
+                framework="pt",
+                device="cpu",
+            ) as f:
+                scales[key[: -len("_scale")]] = f.get_tensor(key)
+    except Exception as e:
+        logger.warning("MTP draft: failed to load W8A8 scales: %s", e)
+    return scales
 
 
 class Qwen3_5ForCausalLMMTP(nn.Module):
@@ -321,6 +358,13 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        mtp_w8a8_scales = (
+            _load_mtp_w8a8_dequant_scales(
+                get_spec().speculative_draft_model_path or get_model().model_path
+            )
+            if self.quant_config is None
+            else {}
+        )
 
         for name, loaded_weight in weights:
             # The last-stage MTP draft cannot share the target embedding on PP0.
@@ -346,6 +390,18 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             # Only process MTP branch weights
             if "mtp" not in name:
                 continue
+
+            orig_ckpt_name = name
+            if (
+                self.quant_config is None
+                and loaded_weight.dtype == torch.int8
+                and orig_ckpt_name in mtp_w8a8_scales
+            ):
+                w8a8_scale = mtp_w8a8_scales[orig_ckpt_name]
+                if w8a8_scale.shape[0] == loaded_weight.shape[0]:
+                    loaded_weight = (
+                        loaded_weight.to(torch.float32) * w8a8_scale.to(torch.float32)
+                    ).to(getattr(self.config, "torch_dtype", torch.bfloat16))
 
             if name.startswith("mtp."):
                 # Remove the mtp. prefix for processing

--- a/test/registered/unit/models/test_qwen3_5_mtp_w8a8_dequant.py
+++ b/test/registered/unit/models/test_qwen3_5_mtp_w8a8_dequant.py
@@ -1,0 +1,159 @@
+"""CPU coverage for W8A8 dequantization of MTP weights on the unquantized
+(NPU) draft path.
+
+On NPU the MTP draft is forced to ``quant_config=None`` while ModelSlim
+checkpoints may store the MTP projections as W8A8 (int8 + per-row
+``weight_scale``). Without dequantization the raw int8 codes are copied
+into the bf16 parameters and the draft model is numerically broken
+(spec-decode accept rate collapses to ~0). These tests cover scale
+discovery and the ``load_weights`` dequant branch without an NPU.
+"""
+
+import json
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.srt.models import qwen3_5_mtp
+from sglang.srt.models.qwen3_5_mtp import (
+    Qwen3_5ForCausalLMMTP,
+    _load_mtp_w8a8_dequant_scales,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+Q_PROJ = "mtp.layers.0.self_attn.q_proj"
+
+
+def _write_ckpt(tmp_path, tensors):
+    save_file(tensors, str(tmp_path / "shard_00001.safetensors"))
+    index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {name: "shard_00001.safetensors" for name in tensors},
+    }
+    (tmp_path / "quant_model_weights.safetensors.index.json").write_text(
+        json.dumps(index)
+    )
+    return str(tmp_path)
+
+
+def _stub_model(monkeypatch, ckpt, quant_config=None):
+    """Bypass __init__ (needs runtime context); set only what load_weights reads."""
+    model = Qwen3_5ForCausalLMMTP.__new__(Qwen3_5ForCausalLMMTP)
+    torch.nn.Module.__init__(model)
+    model.quant_config = quant_config
+    model.config = SimpleNamespace(torch_dtype=torch.bfloat16)
+    monkeypatch.setattr(
+        qwen3_5_mtp,
+        "get_spec",
+        lambda: SimpleNamespace(speculative_draft_model_path=ckpt),
+    )
+    monkeypatch.setattr(
+        qwen3_5_mtp, "get_model", lambda: SimpleNamespace(model_path=ckpt)
+    )
+    return model
+
+
+class _CaptureParam:
+    def __init__(self):
+        self.calls = []
+
+    def weight_loader(self, param, loaded_weight, shard_id):
+        self.calls.append((shard_id, loaded_weight))
+
+
+def test_scale_discovery_keys_by_weight_name(tmp_path):
+    q = torch.randint(-127, 128, (16, 8), dtype=torch.int8)
+    s = (torch.rand(16, 1) * 0.01 + 0.001).float()
+    ckpt = _write_ckpt(
+        tmp_path,
+        {
+            f"{Q_PROJ}.weight": q,
+            f"{Q_PROJ}.weight_scale": s,
+            # FLOAT (unquantized) MTP tensors carry no scale
+            "mtp.fc.weight": torch.randn(8, 32, dtype=torch.bfloat16),
+            # non-mtp scales must be ignored
+            "model.language_model.layers.0.mlp.gate_proj.weight_scale": torch.rand(
+                4, 1
+            ),
+        },
+    )
+    scales = _load_mtp_w8a8_dequant_scales(ckpt)
+    assert list(scales) == [f"{Q_PROJ}.weight"]
+    assert torch.equal(scales[f"{Q_PROJ}.weight"], s)
+
+
+def test_scale_discovery_without_index(tmp_path):
+    assert _load_mtp_w8a8_dequant_scales(str(tmp_path)) == {}
+
+
+def test_scale_discovery_missing_shard_does_not_raise(tmp_path):
+    (tmp_path / "quant_model_weights.safetensors.index.json").write_text(
+        json.dumps(
+            {"weight_map": {f"{Q_PROJ}.weight_scale": "missing.safetensors"}}
+        )
+    )
+    assert _load_mtp_w8a8_dequant_scales(str(tmp_path)) == {}
+
+
+def test_load_weights_dequantizes_int8_mtp_projection(monkeypatch, tmp_path):
+    q = torch.randint(-127, 128, (16, 8), dtype=torch.int8)
+    s = (torch.rand(16, 1) * 0.01 + 0.001).float()
+    ckpt = _write_ckpt(
+        tmp_path, {f"{Q_PROJ}.weight": q, f"{Q_PROJ}.weight_scale": s}
+    )
+    model = _stub_model(monkeypatch, ckpt)
+    capture = _CaptureParam()
+    model.named_parameters = lambda *a, **k: [
+        ("model.layers.0.qkv_proj.weight", capture)
+    ]
+
+    model.load_weights(iter([(f"{Q_PROJ}.weight", q.clone())]))
+
+    assert len(capture.calls) == 1
+    shard_id, loaded = capture.calls[0]
+    assert shard_id == "q"
+    assert loaded.dtype == torch.bfloat16
+    expected = (q.float() * s.float()).to(torch.bfloat16)
+    assert torch.equal(loaded, expected)
+
+
+def test_load_weights_passes_int8_through_when_quantized(monkeypatch, tmp_path):
+    q = torch.randint(-127, 128, (16, 8), dtype=torch.int8)
+    s = (torch.rand(16, 1) * 0.01 + 0.001).float()
+    ckpt = _write_ckpt(
+        tmp_path, {f"{Q_PROJ}.weight": q, f"{Q_PROJ}.weight_scale": s}
+    )
+    model = _stub_model(monkeypatch, ckpt, quant_config=SimpleNamespace())
+    capture = _CaptureParam()
+    model.named_parameters = lambda *a, **k: [
+        ("model.layers.0.qkv_proj.weight", capture)
+    ]
+
+    model.load_weights(iter([(f"{Q_PROJ}.weight", q.clone())]))
+
+    shard_id, loaded = capture.calls[0]
+    assert shard_id == "q"
+    assert loaded.dtype == torch.int8
+    assert torch.equal(loaded, q)
+
+
+def test_load_weights_scale_shape_mismatch_is_noop(monkeypatch, tmp_path):
+    q = torch.randint(-127, 128, (16, 8), dtype=torch.int8)
+    s = (torch.rand(4, 1) * 0.01 + 0.001).float()  # wrong row count
+    ckpt = _write_ckpt(
+        tmp_path, {f"{Q_PROJ}.weight": q, f"{Q_PROJ}.weight_scale": s}
+    )
+    model = _stub_model(monkeypatch, ckpt)
+    capture = _CaptureParam()
+    model.named_parameters = lambda *a, **k: [
+        ("model.layers.0.qkv_proj.weight", capture)
+    ]
+
+    model.load_weights(iter([(f"{Q_PROJ}.weight", q.clone())]))
+
+    _, loaded = capture.calls[0]
+    assert loaded.dtype == torch.int8
+    assert torch.equal(loaded, q)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Serving a ModelSlim-quantized Qwen3.5/3.8 checkpoint (main model `W8A8_DYNAMIC`) with MTP speculative decoding on NPU produces a numerically broken draft model: every drafted token is rejected (`accept len: 1.02, accept rate: 0.01`), so the full draft cost is paid for nothing (~15 tok/s vs 56 tok/s on the same 2-card server with a working draft).

**Root cause.**

- On NPU, `_mtp_quant_config()` forces the MTP draft to `quant_config=None` when `speculative_draft_model_quantization` is unset (`qwen3_5_mtp.py`).
- These checkpoints store the MTP **projections** as W8A8: `mtp.layers.0.self_attn.q_proj.weight` is `int8` (12288, 5120) with a per-row `weight_scale` (12288, 1) and zero `weight_offset`; only norms/`fc` are `FLOAT` (per `quant_model_description.json`).
- The loader therefore copies the raw int8 codes into bf16 parameters. Verified via a live weight dump: the 6 MTP projection matrices have `absmax = 128` (the int8 code range) while correctly loaded `mtp.fc.weight` matches the checkpoint value exactly. The draft matmuls then run on garbage matrices and the target rejects every proposed token.

This is complementary to #34353: that PR covers checkpoints where **all** `mtp.*` entries are `FLOAT`; here the `mtp.*` projections are quantized, so that branch does not fire. A related loading failure is reported for compressed-tensors checkpoints in #35797.

## Modifications

`python/sglang/srt/models/qwen3_5_mtp.py`:

- Add `_load_mtp_w8a8_dequant_scales(model_path)`: reads the `mtp.*.weight_scale` entries listed in `quant_model_weights.safetensors.index.json` (the ModelSlim index), keyed by the original weight name. Fails soft (warning + empty dict) on any error, so it can never block startup.
- In `load_weights`, only when the draft runs unquantized (`quant_config is None`): if a weight's checkpoint name has a scale and the loaded tensor is `int8`, dequantize `w = q.to(f32) * scale.to(f32) -> model dtype` before name mapping / `weight_loader`. No-op otherwise (non-int8 dtype, missing scale, or scale/weight shape mismatch).

This matches vLLM-ascend behavior (MTP draft runs bf16). The change is effectively NPU-only: on CUDA the draft keeps the target's ModelSlim quant config, so the branch never fires.

## Accuracy Tests

NPU verification (Ascend 910, 2 cards, TP2, Qwen3.8-27B-W8A8, EAGLE `num_steps=3 topk=1 num_draft_tokens=4`, sgl-kernel-npu 2026.6.1, sglang 0.5.17.dev):

| Metric | Before | After | vLLM (NPU, same model) reference |
|---|---|---|---|
| draft projection absmax | 128 (raw int8 codes) | 0.35–0.96 (correct) | — |
| accept len | 1.02 | 2.98–3.38 | 2.58–3.53 |
| accept rate | 0.01 | 0.66–0.79 | per-position 0.36–0.93 |
| throughput (2 cards) | ~15 tok/s | 31–56 tok/s | accepted 3.7–55 tok/s |

- 512-token generation fully coherent (target model and mamba state commit unaffected by this change).
- New CPU unit tests (`test/registered/unit/models/test_qwen3_5_mtp_w8a8_dequant.py`, no NPU needed): scale discovery (key naming, non-MTP exclusion, missing index, missing shard) and the `load_weights` branch (exact bf16 value, pass-through with a quant config, shape-mismatch no-op).

## Speed Tests and Profiling

Same-server before/after comparison in the table above; no separate benchmark.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Related

- #34353 — all-`FLOAT` MTP case + UB-aware mamba scatter (complementary; this PR covers the W8A8 MTP case)
- #35797 — MTP weights misloaded on compressed-tensors checkpoints (same symptom family, different format)
- #25330 — UB overflow in the same NPU MTP state-commit path


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33726017268](https://github.com/sgl-project/sglang/actions/runs/33726017268)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33726017018](https://github.com/sgl-project/sglang/actions/runs/33726017018)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33726017107](https://github.com/sgl-project/sglang/actions/runs/33726017107)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->