### PR TITLE
[AMD][CI] Migrate paged decode tests to dense KV views

### DIFF
--- a/test/registered/kernels/test_lean_attention.py
+++ b/test/registered/kernels/test_lean_attention.py
@@ -197,13 +197,13 @@ def _run_pair_fp8(H_Q, H_KV, D, B, S, fp8_dtype, dev="cuda", seed=0):
 def _run_pair_paged(
     H_Q, H_KV, D, B, S, page_size, dev="cuda", dt=torch.float16, seed=0
 ):
-    """Standard vs Lean on dense 3-D KV views with page-aware addressing.
+    """Standard vs Lean on dense 3-D KV views with ``page_size > 1``.
 
     The KV cache uses the current ``[row, head, dim]`` kernel contract and is
-    addressed through scattered row ids in ``kv_indices`` (a permutation), so
-    the kernel's page-aware address math (``kv_loc // page_size`` /
-    ``kv_loc % page_size``) is genuinely exercised. Both arms read the identical
-    buffer + indices, so their outputs must agree. Returns (o_std, o_lean).
+    addressed through scattered row ids in ``kv_indices`` (a permutation). This
+    exercises the kernel specialization for multi-row pages, but not the retired
+    4-D paged-buffer layout. Both arms read the identical buffer + indices, so
+    their outputs must agree. Returns (o_std, o_lean).
     """
     torch.manual_seed(seed)
     D_V = D
@@ -224,7 +224,7 @@ def _run_pair_paged(
     )
 
     kv_indptr = torch.arange(0, (B + 1) * S, step=S, device=dev, dtype=torch.int32)
-    # Scatter slots across pages so page_id/tok_in_p vary within every BLOCK_N tile.
+    # Use noncontiguous slot ids while running the page_size > 1 specialization.
     kv_indices = torch.randperm(tot, device=dev).to(torch.int32)
     q = torch.randn(B, H_Q, D, dtype=dt, device=dev)
     num_kv_splits = torch.full((B,), MAX_KV_SPLITS, dtype=torch.int32, device=dev)
@@ -317,10 +317,9 @@ class TestLeanAttentionParity(CustomTestCase):
                         )
 
     def test_paged_kv_parity(self):
-        # Lean must read a dense 3-D KV view with page_size > 1 the same way the
-        # standard kernel does. Guards the page-aware address math (kv_loc //
-        # page_size, kv_loc % page_size); a regression would scramble reads and
-        # drop cos well below 1.
+        # Lean must read the current dense 3-D KV view with page_size > 1 the
+        # same way the standard kernel does. This covers that specialization,
+        # not the retired 4-D paged-buffer layout.
         for name, H_Q, H_KV, D in GQA_SHAPES:
             for page_size in (16, 64):
                 with self.subTest(model=name, page_size=page_size):

--- a/test/registered/kernels/test_lean_attention.py
+++ b/test/registered/kernels/test_lean_attention.py
@@ -197,12 +197,13 @@ def _run_pair_fp8(H_Q, H_KV, D, B, S, fp8_dtype, dev="cuda", seed=0):
 def _run_pair_paged(
     H_Q, H_KV, D, B, S, page_size, dev="cuda", dt=torch.float16, seed=0
 ):
-    """Standard vs Lean on a **paged** 4-D KV buffer ``[num_pages, page_size, head, dim]``.
+    """Standard vs Lean on dense 3-D KV views with page-aware addressing.
 
-    The KV cache is stored in pages and addressed through scattered slot ids in ``kv_indices``
-    (a permutation), so the kernel's page-aware address math (``kv_loc // page_size`` /
-    ``kv_loc % page_size``) is genuinely exercised — not the contiguous fast path. Both arms read
-    the identical buffer + indices, so their outputs must agree. Returns (o_std, o_lean).
+    The KV cache uses the current ``[row, head, dim]`` kernel contract and is
+    addressed through scattered row ids in ``kv_indices`` (a permutation), so
+    the kernel's page-aware address math (``kv_loc // page_size`` /
+    ``kv_loc % page_size``) is genuinely exercised. Both arms read the identical
+    buffer + indices, so their outputs must agree. Returns (o_std, o_lean).
     """
     torch.manual_seed(seed)
     D_V = D
@@ -214,9 +215,13 @@ def _run_pair_paged(
     )
     num_pages = tot // page_size
 
-    # 4-D paged KV buffers [num_pages, page_size, head, dim] (the shared-pool layout).
-    k = torch.randn(num_pages, page_size, H_KV, D, dtype=dt, device=dev)
-    v = torch.randn(num_pages, page_size, H_KV, D_V, dtype=dt, device=dev)
+    # Build page-shaped storage, then expose the dense per-layer view used by the pool.
+    k = torch.randn(num_pages, page_size, H_KV, D, dtype=dt, device=dev).view(
+        tot, H_KV, D
+    )
+    v = torch.randn(num_pages, page_size, H_KV, D_V, dtype=dt, device=dev).view(
+        tot, H_KV, D_V
+    )
 
     kv_indptr = torch.arange(0, (B + 1) * S, step=S, device=dev, dtype=torch.int32)
     # Scatter slots across pages so page_id/tok_in_p vary within every BLOCK_N tile.
@@ -312,9 +317,10 @@ class TestLeanAttentionParity(CustomTestCase):
                         )
 
     def test_paged_kv_parity(self):
-        # Lean must read a paged 4-D KV buffer the same way the standard kernel does. Guards
-        # the page-aware address math (kv_loc // page_size, kv_loc % page_size); a regression
-        # to the contiguous-only form would scramble reads and drop cos well below 1.
+        # Lean must read a dense 3-D KV view with page_size > 1 the same way the
+        # standard kernel does. Guards the page-aware address math (kv_loc //
+        # page_size, kv_loc % page_size); a regression would scramble reads and
+        # drop cos well below 1.
         for name, H_Q, H_KV, D in GQA_SHAPES:
             for page_size in (16, 64):
                 with self.subTest(model=name, page_size=page_size):

--- a/test/registered/unit/layers/attention/test_mla_decode_forced_splits.py
+++ b/test/registered/unit/layers/attention/test_mla_decode_forced_splits.py
@@ -80,9 +80,10 @@ def _inputs(seq_lens, head_num, page_size, max_kv_splits, seed):
         )
     else:
         n_pages = (n_slots + page_size - 1) // page_size
+        # Build by page, then expose the dense 3-D per-layer view used by decode.
         pool = torch.randn(
             n_pages, page_size, 1, LK, dtype=torch.bfloat16, device=dev, generator=gen
-        )
+        ).view(n_pages * page_size, 1, LK)
         n_slots = n_pages * page_size
 
     kv_indptr = torch.zeros(batch + 1, dtype=torch.int32, device=dev)


### PR DESCRIPTION
## What went wrong

Attention keeps information from earlier tokens in a KV cache so that it can reuse that information when generating the next token.

Tests can organize this cache into pages. #34602 changed the shape passed to the shared attention code:

```text
Before: [pages, rows per page, attention heads, values]
Now:    [all rows, attention heads, values]
```

Here, `all rows = pages x rows per page`.

Two AMD tests still passed the old four-dimensional shape:

- `test_lean_attention.py::test_paged_kv_parity`
- `test_mla_decode_forced_splits.py::test_tuned_matches_stock`

The shared input check rejects those shapes immediately:

- `[1024, 16, 4, 128]`
- `[257, 64, 1, 576]`

This means the tests fail before they reach the Lean Attention or MLA forced-split calculations. The error does not show that either calculation is wrong; it shows that the test data is still using the retired shape.

The failure was first associated with #37151, but the CI history and code path show that this shape mismatch predates #37151 and comes from the test fixtures not being updated with #34602.

## What this PR changes

This PR changes only how those two tests present their KV-cache data:

- The tests still create the same page-shaped random data.
- `.view(...)` combines the first two dimensions into one `all rows` dimension.
- This is a zero-copy view: it does not copy, reorder, or change any values.
- No production code or attention kernel is changed.

## Why the tests are still useful

The tests still use page sizes greater than one and shuffled cache-row IDs, so they run the current dense-storage kernel specialization with those settings. They do not claim to validate the retired four-dimensional storage layout. The MLA test also still compares forced-split decoding with the normal decoding path; only its input shape is updated.

## Validation

- Local pre-commit checks passed on `3a611ba3f6a0f4df7d255f95663f0b83e0926ba8`.
- GitHub lint: [run](https://github.com/sgl-project/sglang/actions/runs/33733950843)
- Focused AMD MI35X: [workflow run](https://github.com/sgl-project/sglang/actions/runs/33733966550), [target job](https://github.com/sgl-project/sglang/actions/runs/33733966550/job/100580196004)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33733951373](https://github.com/sgl-project/sglang/actions/runs/33733951373)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33733951231](https://github.com/sgl-project/sglang/actions/runs/33733951231)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33733951422](https://github.com/sgl-project/sglang/actions/runs/33733951422)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->