### PR TITLE
[KDA] Optimize ReplaySSM decode with pre-decayed keys and circular checkpointing

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
@@ -7,9 +7,8 @@
 # ``IS_KDA`` constexpr selects the gate path and the GDN path is bit-for-bit
 # the original (no regression to the validated GDN kernel).
 #
-# This is a STANDALONE increment: kernel + wrapper only. It is NOT yet wired
-# into the memory pool / radix cache / scheduler / backend dispatch. The caller
-# (currently the correctness test and the microbenchmark) owns the ring tensors.
+# The memory pool owns the persistent ring tensors. The backend supplies a
+# per-row cursor snapshot and force-flush decision for eager or graph replay.
 #
 # Idea (vs. ``fused_recurrent_gated_delta_rule_packed_decode`` / ``..._kda_...``):
 #   The plain packed decode reads the full recurrent state S [HV, V, K] from
@@ -53,6 +52,8 @@
 
 from __future__ import annotations
 
+import math
+
 import torch
 import triton
 import triton.language as tl
@@ -73,8 +74,10 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     g_cache,  # GDN: [num_slots, HV, L] ; KDA: [num_slots, HV, L, K] log-decay gates (fp32)
     ssm_state_indices,  # [B] physical state slot per decode row
     write_pos,  # [B] int32 per-row ring cursor (0..L-1)
+    cache_base,  # [B] int32 circular-ring logical position zero
     force_flush,  # [B] int32: !=0 forces a flush this step (radix track boundary)
     scale,
+    lower_bound,
     stride_mixed_qkv_tok: tl.constexpr,
     stride_a_tok: tl.constexpr,
     stride_b_tok: tl.constexpr,
@@ -91,10 +94,15 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     NK: tl.constexpr,
     BKT: tl.constexpr,
     MAX_CACHE_LEN: tl.constexpr,
+    CACHE_LEN_POWER_OF_TWO: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     HAS_FORCE_FLUSH: tl.constexpr,
+    CIRCULAR_REPLAY: tl.constexpr,
+    PREFIX_GATE_CACHE: tl.constexpr,
+    PREDECAYED_K_CACHE: tl.constexpr,
     IS_KDA: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
 ):
     i_v = tl.program_id(0)
     i_n = tl.program_id(1)
@@ -119,13 +127,36 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     # Per-row buffer cursor and flush flag (device-side branch, no host branch),
     # plus the set of valid (already committed) cache positions.
     b_write_pos = tl.load(write_pos + i_n).to(tl.int64)
-    b_is_flush = b_write_pos == MAX_CACHE_LEN - 1
+    b_natural_flush = b_write_pos == MAX_CACHE_LEN - 1
+    b_force_flush = False
     if HAS_FORCE_FLUSH:
         # A radix track-boundary (or any caller-forced) flush folds the partial
         # ring (the real `write_pos` entries, NOT L-1) + current token into the
         # checkpoint so an external snapshot reads an up-to-date state. cache_valid
         # below still uses the true write_pos, so only committed entries are read.
-        b_is_flush = b_is_flush | (tl.load(force_flush + i_n) != 0)
+        b_force_flush = tl.load(force_flush + i_n) != 0
+    b_is_flush = b_natural_flush | b_force_flush
+    if CIRCULAR_REPLAY:
+        b_cache_base = tl.load(cache_base + i_n).to(tl.int32)
+        if CACHE_LEN_POWER_OF_TWO:
+            physical_c = (b_cache_base + o_c) & (MAX_CACHE_LEN - 1)
+            physical_write_pos = (b_cache_base + b_write_pos) & (MAX_CACHE_LEN - 1)
+            physical_last_pos = (b_cache_base + b_write_pos - 1) & (MAX_CACHE_LEN - 1)
+        else:
+            physical_c = (b_cache_base + o_c) % MAX_CACHE_LEN
+            physical_write_pos = (b_cache_base + b_write_pos) % MAX_CACHE_LEN
+            physical_last_pos = (b_cache_base + b_write_pos - 1) % MAX_CACHE_LEN
+        b_checkpoint_history = (
+            b_natural_flush & (not b_force_flush) & (MAX_CACHE_LEN > 1)
+        )
+        b_checkpoint_full = b_force_flush | (MAX_CACHE_LEN == 1)
+    else:
+        physical_c = o_c
+        physical_write_pos = b_write_pos
+        physical_last_pos = b_write_pos - 1
+        b_checkpoint_history = False
+        b_checkpoint_full = b_is_flush
+    b_store_record = not b_checkpoint_full
     cache_valid = o_c < b_write_pos
 
     # Gate for the current token.  beta is a per-head scalar for both gate
@@ -135,18 +166,26 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     #   g = -exp(A_log) * softplus(a + dt_bias);  alpha = exp(g);  beta = sigmoid(b)
     A_log_val = tl.load(A_log + i_hv).to(tl.float32)
     b_val = tl.load(b + i_n * stride_b_tok + i_hv).to(tl.float32)
-    beta_val = tl.sigmoid(b_val).to(b.dtype.element_ty).to(tl.float32)
+    beta_val = tl.sigmoid(b_val)
+    if not PREDECAYED_K_CACHE:
+        # Preserve the upstream GDN/raw-KDA path bit for bit.  The bounded
+        # pre-decay specialization keeps beta in fp32 to match its prefix
+        # construction, but must not change existing ReplaySSM numerics.
+        beta_val = beta_val.to(b.dtype.element_ty).to(tl.float32)
     if not IS_KDA:
         a_val = tl.load(a + i_n * stride_a_tok + i_hv).to(tl.float32)
         dt_bias_val = tl.load(dt_bias + i_hv).to(tl.float32)
         x = a_val + dt_bias_val
-        softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
-        g_val = -tl.exp(A_log_val) * softplus_x
+        if USE_LOWER_BOUND:
+            g_val = lower_bound * tl.sigmoid(tl.exp(A_log_val) * x)
+        else:
+            softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
+            g_val = -tl.exp(A_log_val) * softplus_x
         alpha_val = tl.exp(g_val)
 
         # Replay decay over the committed cache, from the cached per-step gates.
         # b_replay_decay[j] = exp(sum_i g_i - cumsum_inclusive_j) = prod_{i>j} alpha_i
-        p_g_main = g_cache + (state_idx * HV + i_hv) * MAX_CACHE_LEN + o_c
+        p_g_main = g_cache + (state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_c
         b_g_all = tl.load(p_g_main, mask=cache_valid, other=0.0).to(tl.float32)
         b_g_prefix = tl.cumsum(b_g_all, axis=0)
         b_g_total = tl.sum(b_g_all, axis=0)
@@ -156,7 +195,8 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     # Cached corrected-delta vectors d (K-independent).  Layout
     # d_cache[slot, hv, L, V] -> index [V, BC] tile.
     p_d_main = d_cache + (
-        ((state_idx * HV + i_hv) * MAX_CACHE_LEN + o_c[None, :]) * V + o_v[:, None]
+        ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_c[None, :]) * V
+        + o_v[:, None]
     )
     b_d_all = tl.load(
         p_d_main, mask=mask_v[:, None] & cache_valid[None, :], other=0
@@ -208,8 +248,8 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     b_state_q = tl.zeros([BV], dtype=tl.float32)
     b_state_k = tl.zeros([BV], dtype=tl.float32)
     cur_kq = tl.zeros([1], dtype=tl.float32)
-    write_k = (not b_is_flush) and (i_v == 0) and (i_hv == i_h * (HV // H))
-    write_g_kda = IS_KDA and (not b_is_flush) and (i_v == 0)
+    write_k = b_store_record and (i_v == 0) and (i_hv == i_h * (HV // H))
+    write_g_kda = IS_KDA and b_store_record and (i_v == 0)
     for kk in range(NK):
         o_kt = kk * BKT + tl.arange(0, BKT)
         mask_kt = o_kt < K
@@ -241,7 +281,7 @@ def fused_recurrent_linear_replayssm_decode_kernel(
         )
         p_k_c = (
             k_cache
-            + ((state_idx * H + i_h) * MAX_CACHE_LEN + o_c[:, None]) * K
+            + ((state_idx * H + i_h) * MAX_CACHE_LEN + physical_c[:, None]) * K
             + o_kt[None, :]
         )
 
@@ -259,37 +299,73 @@ def fused_recurrent_linear_replayssm_decode_kernel(
             # keys and the total decay onto S0.
             p_g_c = (
                 g_cache
-                + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + o_c[:, None]) * K
+                + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_c[:, None]) * K
                 + o_kt[None, :]
             )
-            b_g_all_c = tl.load(
-                p_g_c, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
-            ).to(tl.float32)
-            b_g_prefix_c = tl.cumsum(b_g_all_c, axis=0)  # [BC, BKT]
-            b_g_total_c = tl.sum(b_g_all_c, axis=0)  # [BKT]
-            b_replay_decay_c = tl.where(
-                cache_valid[:, None],
-                tl.exp(b_g_total_c[None, :] - b_g_prefix_c),
-                0.0,
-            )  # [BC, BKT]
+            if PREFIX_GATE_CACHE:
+                # Each ring row stores the cumulative log-gate within the current
+                # window. Reading the last valid row removes the per-token scan.
+                p_g_last_c = (
+                    g_cache
+                    + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_last_pos) * K
+                    + o_kt
+                )
+                b_g_total_c = tl.load(
+                    p_g_last_c,
+                    mask=(b_write_pos > 0) & mask_kt,
+                    other=0.0,
+                ).to(tl.float32)
+                if not PREDECAYED_K_CACHE:
+                    b_g_prefix_c = tl.load(
+                        p_g_c,
+                        mask=cache_valid[:, None] & mask_kt[None, :],
+                        other=0.0,
+                    ).to(tl.float32)
+            else:
+                b_g_all_c = tl.load(
+                    p_g_c,
+                    mask=cache_valid[:, None] & mask_kt[None, :],
+                    other=0.0,
+                ).to(tl.float32)
+                b_g_prefix_c = tl.cumsum(b_g_all_c, axis=0)  # [BC, BKT]
+                b_g_total_c = tl.sum(b_g_all_c, axis=0)  # [BKT]
             b_total_decay_c = tl.exp(b_g_total_c)  # [BKT]
             b_k_all_c = tl.load(
                 p_k_c, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
             ).to(tl.float32)
-            b_k_scaled = (b_k_all_c * b_replay_decay_c).to(p_o.dtype.element_ty)
+            if PREDECAYED_K_CACHE:
+                # K_ring[j] stores K_j * exp(-prefix_j), so reconstruction
+                # needs one K-wide exp(total) instead of an LxK suffix exp.
+                b_k_scaled = (b_k_all_c * b_total_decay_c[None, :]).to(
+                    p_o.dtype.element_ty
+                )
+            else:
+                b_replay_decay_c = tl.where(
+                    cache_valid[:, None],
+                    tl.exp(b_g_total_c[None, :] - b_g_prefix_c),
+                    0.0,
+                )  # [BC, BKT]
+                b_k_scaled = (b_k_all_c * b_replay_decay_c).to(p_o.dtype.element_ty)
+
             b_h_c = b_h0_c * b_total_decay_c[None, :] + tl.dot(b_d_tc, b_k_scaled).to(
                 tl.float32
             )
+
             # KDA: current-token per-K decay folds into q/k for the readout.
             p_a_c = a + i_n * stride_a_tok + i_hv * K + o_kt
             p_dt_c = dt_bias + i_hv * K + o_kt
             b_a_c = tl.load(p_a_c, mask=mask_kt, other=0.0).to(tl.float32)
             b_dt_c = tl.load(p_dt_c, mask=mask_kt, other=0.0).to(tl.float32)
             x_c = b_a_c + b_dt_c
-            softplus_c = tl.where(
-                x_c <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x_c)), x_c
-            )
-            g_cur_c = -tl.exp(A_log_val) * softplus_c  # [BKT]
+            if USE_LOWER_BOUND:
+                g_cur_c = lower_bound * tl.sigmoid(tl.exp(A_log_val) * x_c)
+            else:
+                softplus_c = tl.where(
+                    x_c <= SOFTPLUS_THRESHOLD,
+                    tl.log(1.0 + tl.exp(x_c)),
+                    x_c,
+                )
+                g_cur_c = -tl.exp(A_log_val) * softplus_c  # [BKT]
             alpha_cur_c = tl.exp(g_cur_c)
             q_eff = q_cs * alpha_cur_c
             k_eff = k_c * alpha_cur_c
@@ -298,10 +374,22 @@ def fused_recurrent_linear_replayssm_decode_kernel(
             if write_g_kda:
                 p_cur_g = (
                     g_cache
-                    + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + b_write_pos) * K
+                    + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_write_pos) * K
                     + o_kt
                 )
-                tl.store(p_cur_g, g_cur_c, mask=mask_kt & (b_write_pos < MAX_CACHE_LEN))
+                if PREFIX_GATE_CACHE:
+                    g_store_c = tl.where(
+                        b_checkpoint_history,
+                        g_cur_c,
+                        b_g_total_c + g_cur_c,
+                    )
+                else:
+                    g_store_c = g_cur_c
+                tl.store(
+                    p_cur_g,
+                    g_store_c,
+                    mask=mask_kt & (b_write_pos < MAX_CACHE_LEN),
+                )
 
         # Read the state with the (gate-folded) q and k, accumulated across tiles.
         b_state_q += tl.sum(b_h_c * q_eff[None, :], axis=1)
@@ -310,13 +398,31 @@ def fused_recurrent_linear_replayssm_decode_kernel(
         if write_k:
             p_cur_k = (
                 k_cache
-                + ((state_idx * H + i_h) * MAX_CACHE_LEN + b_write_pos) * K
+                + ((state_idx * H + i_h) * MAX_CACHE_LEN + physical_write_pos) * K
                 + o_kt
             )
+            if PREDECAYED_K_CACHE:
+                new_total_decay_c = tl.where(
+                    b_checkpoint_history,
+                    alpha_cur_c,
+                    b_total_decay_c * alpha_cur_c,
+                )
+                k_store_c = (k_c / new_total_decay_c).to(p_cur_k.dtype.element_ty)
+            else:
+                # Preserve upstream raw KDA/GDN rounding even when the ring is
+                # wider than the activation/output dtype.
+                k_store_c = k_c.to(p_o.dtype.element_ty)
             tl.store(
                 p_cur_k,
-                k_c.to(p_o.dtype.element_ty),
+                k_store_c,
                 mask=mask_kt & (b_write_pos < MAX_CACHE_LEN),
+            )
+
+        if b_checkpoint_history:
+            tl.store(
+                p_h0_c,
+                b_h_c.to(p_h0_c.dtype.element_ty),
+                mask=mask_v[:, None] & mask_kt[None, :],
             )
 
     # Current-token output: (S . Diag(a)) q + d_cur*(k . q), with the new
@@ -330,7 +436,7 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     b_o = b_state_q + b_d_cur * tl.sum(cur_kq)
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
 
-    if b_is_flush:
+    if b_checkpoint_full:
         # Flush: fold the current token into the checkpoint, S_new = S.Diag(a) +
         # d_cur k^T, and persist it.  Re-walk K chunks to rebuild S, then apply
         # the update.  After this the ring is logically cleared (the caller
@@ -357,7 +463,7 @@ def fused_recurrent_linear_replayssm_decode_kernel(
             ).to(tl.float32)
             p_k_c = (
                 k_cache
-                + ((state_idx * H + i_h) * MAX_CACHE_LEN + o_c[:, None]) * K
+                + ((state_idx * H + i_h) * MAX_CACHE_LEN + physical_c[:, None]) * K
                 + o_kt[None, :]
             )
             if not IS_KDA:
@@ -371,24 +477,51 @@ def fused_recurrent_linear_replayssm_decode_kernel(
             else:
                 p_g_c = (
                     g_cache
-                    + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + o_c[:, None]) * K
+                    + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_c[:, None])
+                    * K
                     + o_kt[None, :]
                 )
-                b_g_all_c = tl.load(
-                    p_g_c, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
-                ).to(tl.float32)
-                b_g_prefix_c = tl.cumsum(b_g_all_c, axis=0)
-                b_g_total_c = tl.sum(b_g_all_c, axis=0)
-                b_replay_decay_c = tl.where(
-                    cache_valid[:, None],
-                    tl.exp(b_g_total_c[None, :] - b_g_prefix_c),
-                    0.0,
-                )
+                if PREFIX_GATE_CACHE:
+                    p_g_last_c = (
+                        g_cache
+                        + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_last_pos)
+                        * K
+                        + o_kt
+                    )
+                    b_g_total_c = tl.load(
+                        p_g_last_c,
+                        mask=(b_write_pos > 0) & mask_kt,
+                        other=0.0,
+                    ).to(tl.float32)
+                    if not PREDECAYED_K_CACHE:
+                        b_g_prefix_c = tl.load(
+                            p_g_c,
+                            mask=cache_valid[:, None] & mask_kt[None, :],
+                            other=0.0,
+                        ).to(tl.float32)
+                else:
+                    b_g_all_c = tl.load(
+                        p_g_c,
+                        mask=cache_valid[:, None] & mask_kt[None, :],
+                        other=0.0,
+                    ).to(tl.float32)
+                    b_g_prefix_c = tl.cumsum(b_g_all_c, axis=0)
+                    b_g_total_c = tl.sum(b_g_all_c, axis=0)
                 b_total_decay_c = tl.exp(b_g_total_c)
                 b_k_all_c = tl.load(
                     p_k_c, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
                 ).to(tl.float32)
-                b_k_scaled = (b_k_all_c * b_replay_decay_c).to(p_o.dtype.element_ty)
+                if PREDECAYED_K_CACHE:
+                    b_k_scaled = (b_k_all_c * b_total_decay_c[None, :]).to(
+                        p_o.dtype.element_ty
+                    )
+                else:
+                    b_replay_decay_c = tl.where(
+                        cache_valid[:, None],
+                        tl.exp(b_g_total_c[None, :] - b_g_prefix_c),
+                        0.0,
+                    )
+                    b_k_scaled = (b_k_all_c * b_replay_decay_c).to(p_o.dtype.element_ty)
                 b_h_c = b_h0_c * b_total_decay_c[None, :] + tl.dot(
                     b_d_tc, b_k_scaled
                 ).to(tl.float32)
@@ -397,10 +530,16 @@ def fused_recurrent_linear_replayssm_decode_kernel(
                 b_a_c = tl.load(p_a_c, mask=mask_kt, other=0.0).to(tl.float32)
                 b_dt_c = tl.load(p_dt_c, mask=mask_kt, other=0.0).to(tl.float32)
                 x_c = b_a_c + b_dt_c
-                softplus_c = tl.where(
-                    x_c <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x_c)), x_c
-                )
-                alpha_cur_c = tl.exp(-tl.exp(A_log_val) * softplus_c)  # [BKT]
+                if USE_LOWER_BOUND:
+                    g_cur_c = lower_bound * tl.sigmoid(tl.exp(A_log_val) * x_c)
+                else:
+                    softplus_c = tl.where(
+                        x_c <= SOFTPLUS_THRESHOLD,
+                        tl.log(1.0 + tl.exp(x_c)),
+                        x_c,
+                    )
+                    g_cur_c = -tl.exp(A_log_val) * softplus_c
+                alpha_cur_c = tl.exp(g_cur_c)  # [BKT]
                 b_h_new_c = (
                     b_h_c * alpha_cur_c[None, :] + b_d_cur[:, None] * k_c[None, :]
                 )
@@ -421,7 +560,9 @@ def fused_recurrent_linear_replayssm_decode_kernel(
         # (k chunks were written inside the loop; KDA's g chunks too).  GDN's
         # scalar g is appended here.
         p_cur_d = (
-            d_cache + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + b_write_pos) * V + o_v
+            d_cache
+            + ((state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_write_pos) * V
+            + o_v
         )
         tl.store(
             p_cur_d,
@@ -429,7 +570,9 @@ def fused_recurrent_linear_replayssm_decode_kernel(
             mask=mask_v & (b_write_pos < MAX_CACHE_LEN),
         )
         if (not IS_KDA) and (i_v == 0):
-            p_cur_g = g_cache + (state_idx * HV + i_hv) * MAX_CACHE_LEN + b_write_pos
+            p_cur_g = (
+                g_cache + (state_idx * HV + i_hv) * MAX_CACHE_LEN + physical_write_pos
+            )
             tl.store(p_cur_g, g_val, mask=b_write_pos < MAX_CACHE_LEN)
 
 
@@ -448,12 +591,17 @@ def fused_recurrent_linear_replayssm_decode(
     ssm_state_indices: torch.Tensor,
     write_pos: torch.Tensor,
     force_flush: torch.Tensor | None = None,
+    lower_bound: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
     block_v: int | None = None,
     num_warps: int = 1,
     num_stages: int = 3,
     nk: int = 2,
+    cache_base: torch.Tensor | None = None,
+    circular_replay: bool = False,
+    prefix_gate_cache: bool = False,
+    predecayed_k_cache: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Buffered output-only linear-attention autoregressive decode (1 token/seq).
 
@@ -471,8 +619,7 @@ def fused_recurrent_linear_replayssm_decode(
 
     Allocates nothing persistent: the caller owns the ring tensors and is
     responsible for advancing / resetting ``write_pos`` (e.g. ``(write_pos+1) %
-    L`` after each step).  This is a STANDALONE kernel; the memory-pool / cache
-    integration is a later phase.
+    L`` after each step).
     """
     if mixed_qkv.ndim != 2:
         raise ValueError(f"`mixed_qkv` must be 2D (got ndim={mixed_qkv.ndim}).")
@@ -486,16 +633,40 @@ def fused_recurrent_linear_replayssm_decode(
         raise ValueError(f"`initial_state` must be 4D (got ndim={initial_state.ndim}).")
     if not out.is_contiguous():
         raise ValueError("`out` must be contiguous.")
-    if write_pos.ndim != 1 or write_pos.dtype != torch.int32:
-        raise ValueError("`write_pos` must be a 1D int32 tensor.")
-    if force_flush is not None and (
-        force_flush.ndim != 1 or force_flush.dtype != torch.int32
+    if (
+        write_pos.ndim != 1
+        or write_pos.dtype != torch.int32
+        or not write_pos.is_contiguous()
     ):
-        raise ValueError("`force_flush` must be a 1D int32 tensor or None.")
+        raise ValueError("`write_pos` must be a contiguous 1D int32 tensor.")
+    if force_flush is not None and (
+        force_flush.ndim != 1
+        or force_flush.dtype != torch.int32
+        or not force_flush.is_contiguous()
+    ):
+        raise ValueError("`force_flush` must be a contiguous 1D int32 tensor or None.")
+    if circular_replay and (
+        cache_base is None
+        or cache_base.ndim != 1
+        or cache_base.dtype != torch.int32
+        or not cache_base.is_contiguous()
+    ):
+        raise ValueError(
+            "`cache_base` must be a contiguous 1D int32 tensor for circular replay."
+        )
 
     B = mixed_qkv.shape[0]
     num_state_slots, HV, V, K = initial_state.shape
+    if initial_state.stride()[1:] != (V * K, K, 1):
+        raise ValueError(
+            "`initial_state` must be contiguous in its [HV, V, K] inner "
+            "dimensions; an arbitrary slot stride is supported."
+        )
     qkv_dim = mixed_qkv.shape[1]
+    if qkv_dim <= HV * V or (qkv_dim - HV * V) % 2 != 0:
+        raise ValueError(
+            f"Invalid packed `mixed_qkv` last dim={qkv_dim} for HV={HV}, V={V}."
+        )
     q_dim = (qkv_dim - HV * V) // 2
     if q_dim <= 0 or q_dim % K != 0:
         raise ValueError(
@@ -506,7 +677,13 @@ def fused_recurrent_linear_replayssm_decode(
         raise ValueError(
             f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
         )
+    if tuple(b.shape) != (B, HV) or b.stride(-1) != 1:
+        raise ValueError(f"`b` must have contiguous shape {(B, HV)}.")
+    if A_log.shape[0] != HV or not A_log.is_contiguous():
+        raise ValueError(f"`A_log` must have contiguous shape {(HV,)}.")
     max_cache_len = d_cache.shape[2]
+    if max_cache_len < 1:
+        raise ValueError("ReplaySSM cache length must be at least 1.")
 
     # Gate-shape sanity: GDN scalar gate vs KDA per-K gate.
     if is_kda:
@@ -533,20 +710,28 @@ def fused_recurrent_linear_replayssm_decode(
         g_expect = (HV, max_cache_len)
 
     # Cache shape sanity (per state slot): d=(HV, L, V), k=(H, L, K).
-    if tuple(d_cache.shape[1:]) != (HV, max_cache_len, V):
+    if (
+        not d_cache.is_contiguous()
+        or not k_cache.is_contiguous()
+        or not g_cache.is_contiguous()
+    ):
+        raise ValueError("ReplaySSM ring caches must be contiguous.")
+    if tuple(d_cache.shape) != (num_state_slots, HV, max_cache_len, V):
         raise ValueError(
-            f"`d_cache` per-slot shape must be {(HV, max_cache_len, V)} "
-            f"(got {tuple(d_cache.shape[1:])})."
+            "`d_cache` shape must be "
+            f"{(num_state_slots, HV, max_cache_len, V)} "
+            f"(got {tuple(d_cache.shape)})."
         )
-    if tuple(k_cache.shape[1:]) != (H, max_cache_len, K):
+    if tuple(k_cache.shape) != (num_state_slots, H, max_cache_len, K):
         raise ValueError(
-            f"`k_cache` per-slot shape must be {(H, max_cache_len, K)} "
-            f"(got {tuple(k_cache.shape[1:])})."
+            "`k_cache` shape must be "
+            f"{(num_state_slots, H, max_cache_len, K)} "
+            f"(got {tuple(k_cache.shape)})."
         )
-    if tuple(g_cache.shape[1:]) != g_expect:
+    if tuple(g_cache.shape) != (num_state_slots, *g_expect):
         raise ValueError(
-            f"`g_cache` per-slot shape must be {g_expect} "
-            f"(got {tuple(g_cache.shape[1:])})."
+            f"`g_cache` shape must be {(num_state_slots, *g_expect)} "
+            f"(got {tuple(g_cache.shape)})."
         )
     if g_cache.dtype != torch.float32:
         raise ValueError(f"`g_cache` must be float32 (got {g_cache.dtype}).")
@@ -554,11 +739,49 @@ def fused_recurrent_linear_replayssm_decode(
         raise ValueError(
             f"`out` must have shape {(B, 1, HV, V)} (got {tuple(out.shape)})."
         )
+    if ssm_state_indices.ndim != 1 or ssm_state_indices.dtype != torch.int32:
+        raise ValueError("`ssm_state_indices` must be a 1D int32 tensor.")
     if write_pos.shape[0] != B or ssm_state_indices.shape[0] != B:
         raise ValueError(
             "`write_pos` and `ssm_state_indices` must both have length B="
             f"{B} (got {write_pos.shape[0]}, {ssm_state_indices.shape[0]})."
         )
+    if force_flush is not None and force_flush.shape[0] != B:
+        raise ValueError(f"`force_flush` must have length B={B}.")
+    if circular_replay and cache_base.shape != (B,):
+        raise ValueError(
+            f"`cache_base` must have shape {(B,)} " f"(got {tuple(cache_base.shape)})."
+        )
+    if predecayed_k_cache:
+        if not is_kda or not prefix_gate_cache or not circular_replay:
+            raise ValueError(
+                "Pre-decayed K requires KDA circular replay with prefix gates."
+            )
+        if H != HV:
+            raise ValueError("Pre-decayed K requires one K head per value head.")
+        if initial_state.dtype != torch.float32:
+            raise ValueError("Pre-decayed K requires a float32 checkpoint state.")
+        if d_cache.dtype != k_cache.dtype:
+            raise ValueError("Pre-decayed K requires matching d/k ring dtypes.")
+        if d_cache.dtype not in (mixed_qkv.dtype, torch.float32):
+            raise ValueError(
+                "Pre-decayed K d/k rings must use the activation dtype or float32."
+            )
+        if not 2 <= max_cache_len <= 16:
+            raise ValueError("Pre-decayed K requires a cache length between 2 and 16.")
+        if lower_bound is None or not math.isfinite(lower_bound) or lower_bound >= 0:
+            raise ValueError(
+                "Pre-decayed K requires a finite negative safe-gate lower bound."
+            )
+        if (max_cache_len - 1) * abs(lower_bound) > 80:
+            raise ValueError(
+                "Pre-decayed K inverse-prefix scaling is unsafe: "
+                "(cache_len - 1) * abs(lower_bound) must be <= 80."
+            )
+        if mixed_qkv.dtype == torch.float16 and k_cache.dtype != torch.float32:
+            raise ValueError(
+                "Pre-decayed K with FP16 activations requires an FP32 ring."
+            )
 
     BK = triton.next_power_of_2(K)
     if triton.cdiv(K, BK) != 1:
@@ -575,6 +798,7 @@ def fused_recurrent_linear_replayssm_decode(
     # cache / metadata loads.
     BV = block_v if block_v is not None else min(triton.next_power_of_2(V), 64)
     BC = max(16, triton.next_power_of_2(max_cache_len))
+    cache_base_arg = write_pos if cache_base is None else cache_base
 
     grid = (triton.cdiv(V, BV), B, HV)
     fused_recurrent_linear_replayssm_decode_kernel[grid](
@@ -591,8 +815,10 @@ def fused_recurrent_linear_replayssm_decode(
         g_cache=g_cache,
         ssm_state_indices=ssm_state_indices,
         write_pos=write_pos,
+        cache_base=cache_base_arg,
         force_flush=force_flush if force_flush is not None else write_pos,
         scale=scale,
+        lower_bound=0.0 if lower_bound is None else lower_bound,
         stride_mixed_qkv_tok=mixed_qkv.stride(0),
         stride_a_tok=a.stride(0),
         stride_b_tok=b.stride(0),
@@ -609,19 +835,22 @@ def fused_recurrent_linear_replayssm_decode(
         NK=nk,
         BKT=BKT,
         MAX_CACHE_LEN=max_cache_len,
+        CACHE_LEN_POWER_OF_TWO=max_cache_len & (max_cache_len - 1) == 0,
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         HAS_FORCE_FLUSH=force_flush is not None,
+        CIRCULAR_REPLAY=circular_replay,
+        PREFIX_GATE_CACHE=prefix_gate_cache,
+        PREDECAYED_K_CACHE=predecayed_k_cache,
         IS_KDA=is_kda,
+        USE_LOWER_BOUND=lower_bound is not None,
         num_warps=num_warps,
         num_stages=num_stages,
     )
     return out, initial_state
 
 
-# Backwards-compatible aliases: the original GDN-only names. Existing callers
-# (backend dispatch, tests, microbench) keep working; ``is_kda`` defaults to
-# False so these are the GDN path unchanged.
+# Backwards-compatible aliases for the original GDN-only names.
 fused_recurrent_gdn_replayssm_decode_kernel = (
     fused_recurrent_linear_replayssm_decode_kernel
 )

--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
@@ -750,7 +750,7 @@ def fused_recurrent_linear_replayssm_decode(
         raise ValueError(f"`force_flush` must have length B={B}.")
     if circular_replay and cache_base.shape != (B,):
         raise ValueError(
-            f"`cache_base` must have shape {(B,)} " f"(got {tuple(cache_base.shape)})."
+            f"`cache_base` must have shape {(B,)} (got {tuple(cache_base.shape)})."
         )
     if predecayed_k_cache:
         if not is_kda or not prefix_gate_cache or not circular_replay:

--- a/python/sglang/srt/arg_groups/attention_hook.py
+++ b/python/sglang/srt/arg_groups/attention_hook.py
@@ -327,11 +327,11 @@ def handle_linear_attn_backend(server_args: Any):
 
     # ReplaySSM buffered decode guards. Runs on Triton, or Helion for KDA.
     # cuda-graph is supported (slice 1b: CUDA-graph-safe static
-    # write-cursor buffers). The RADIX prefix cache is now supported (slice
-    # 2b: the decode kernel force-flushes the ring into temporal[slot] on
-    # the radix track boundary `seq_lens % mamba_track_interval == 0`, and
-    # the COW copy-into-slot path resets the ring cursor) -- so the
-    # --disable-radix-cache requirement is dropped.
+    # write-cursor buffers). The original GDN/raw-KDA path supports the RADIX
+    # prefix cache by force-flushing the ring at track boundaries. The bounded
+    # KDA pre-decay specialization stays inactive while Radix Cache is enabled:
+    # a temporal checkpoint and the in-place conv state must describe the same
+    # token boundary, which the current finish-time rollback cannot guarantee.
     #
     # Slice 2b only wires the no_buffer mamba scheduler strategy (the
     # default). The extra_buffer strategy donates the track snapshot via
@@ -340,6 +340,12 @@ def handle_linear_attn_backend(server_args: Any):
     # cursor of the donated/kept slot would not be reset there. Handling
     # that donation path is a follow-up; for now require no_buffer.
     if cfg.enable_linear_replayssm:
+        if cfg.enable_unified_memory:
+            raise ValueError(
+                "--enable-linear-replayssm is not supported with "
+                "--enable-unified-memory: the unified Mamba pool does not "
+                "allocate the ReplaySSM ring."
+            )
         if decode not in {"triton", "helion"}:
             raise ValueError(
                 "--enable-linear-replayssm requires Triton, or Helion for "

--- a/python/sglang/srt/configs/bailing_hybrid.py
+++ b/python/sglang/srt/configs/bailing_hybrid.py
@@ -210,6 +210,7 @@ class BailingHybridConfig(PretrainedConfig):
                 num_heads=self.num_attention_heads,
                 head_dim=self.head_dim,
                 conv_kernel_size=self.short_conv_kernel_size,
+                gate_lower_bound=self.kda_lower_bound,
             )
 
             return KimiLinearCacheParams(shape=shape, layers=self.linear_layer_ids)

--- a/python/sglang/srt/configs/kimi_linear.py
+++ b/python/sglang/srt/configs/kimi_linear.py
@@ -175,6 +175,7 @@ class KimiLinearConfig(PretrainedConfig):
             num_heads=self.linear_attn_config["num_heads"],
             head_dim=self.linear_attn_config["head_dim"],
             conv_kernel_size=self.linear_attn_config["short_conv_kernel_size"],
+            gate_lower_bound=self.linear_attn_config.get("gate_lower_bound"),
         )
 
         return KimiLinearCacheParams(shape=shape, layers=self.linear_layer_ids)

--- a/python/sglang/srt/configs/mamba_utils.py
+++ b/python/sglang/srt/configs/mamba_utils.py
@@ -13,6 +13,7 @@
 """Common config utils for mamba2 - NemotronH, FalconH1, Qwen3Next, LFM2, etc."""
 
 import logging
+import math
 from abc import ABC
 from dataclasses import dataclass, field
 from typing import List, Optional
@@ -156,6 +157,30 @@ class BaseLinearStateParams(ABC):
                 )
         return per_layer * len(self.layers)
 
+    def replayssm_decode_ring_bytes_per_req(
+        self, record_len: int, *, predecay_kda: bool = False
+    ) -> int:
+        """Per-slot bytes of the ordinary-decode ReplaySSM ring."""
+        hv, v_dim, k_dim = self.shape.temporal
+        h_k = self.shape.num_k_heads_per_tp
+        ring_dtype = (
+            self.dtype.conv
+            if predecay_kda and self.dtype.conv != torch.float16
+            else self.dtype.temporal
+        )
+        ring_b = ring_dtype.itemsize
+        fp32_b = torch.float32.itemsize
+        per_layer = (
+            hv * record_len * v_dim * ring_b
+            + h_k * record_len * k_dim * ring_b
+            + hv * record_len * (k_dim if self.is_kda else 1) * fp32_b
+        )
+        cursor_bytes = torch.int32.itemsize * (2 if predecay_kda else 1)
+        return per_layer * len(self.layers) + cursor_bytes
+
+    def supports_kda_replayssm_predecay(self, record_len: int) -> bool:
+        return False
+
     @property
     def is_kda(self) -> bool:
         """KDA per-K-channel gate vs GDN/Mamba2 per-head scalar gate. Selects
@@ -266,6 +291,7 @@ class KimiLinearStateShape:
     head_k_dim: int
     conv_kernel: int
     num_spec: int
+    gate_lower_bound: Optional[float] = None
     # Full q/k/v dimensions. Each block is TP-sharded independently.
     conv_shard_groups: Optional[List[int]] = None
     # Number of key heads after TP sharding (== runtime ``H`` the KDA packed
@@ -283,6 +309,7 @@ class KimiLinearStateShape:
         head_k_dim: Optional[int] = None,
         conv_kernel_size: int = 4,
         num_spec: int = 0,
+        gate_lower_bound: Optional[float] = None,
     ) -> "KimiLinearStateShape":
         if num_k_heads is None:
             num_k_heads = num_heads
@@ -315,6 +342,7 @@ class KimiLinearStateShape:
             head_k_dim=head_k_dim,
             conv_kernel=conv_kernel_size,
             num_spec=num_spec,
+            gate_lower_bound=gate_lower_bound,
             conv_shard_groups=[proj_size, proj_k_size, proj_k_size],
             num_k_heads_per_tp=num_k_heads_per_tp,
         )
@@ -327,3 +355,16 @@ class KimiLinearCacheParams(BaseLinearStateParams):
     @property
     def is_kda(self) -> bool:
         return True
+
+    def supports_kda_replayssm_predecay(self, record_len: int) -> bool:
+        lower_bound = self.shape.gate_lower_bound
+        local_value_heads = self.shape.temporal[0]
+        return (
+            self.shape.num_k_heads_per_tp == local_value_heads
+            and 2 <= record_len <= 16
+            and lower_bound is not None
+            and math.isfinite(lower_bound)
+            and lower_bound < 0
+            and (record_len - 1) * abs(lower_bound) <= 80
+            and self.dtype.temporal == torch.float32
+        )

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -955,6 +955,7 @@ class MambaAttnBackendBase(AttentionBackend):
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
         qsl_buf = self.query_start_loc_list[bs - 1]
+        is_target_verify = forward_mode.is_target_verify()
 
         if is_target_verify and self.topk > 1:
             if (

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -4,6 +4,8 @@ import logging
 from typing import TYPE_CHECKING, Optional, Union
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.kernels.ops.mamba.causal_conv1d_triton import PAD_SLOT_ID
 from sglang.kernels.ops.mamba.mamba_state_indices_triton import (
@@ -50,6 +52,98 @@ _validate_mamba_replay_state_indices = (
 )
 
 
+@triton.jit
+def _advance_replayssm_decode_cursor_kernel(
+    persistent_write_pos,
+    persistent_cache_base,
+    static_write_pos,
+    static_cache_base,
+    state_indices,
+    force_flush,
+    n_rows,
+    stride_indices: tl.constexpr,
+    stride_force_flush: tl.constexpr,
+    CACHE_LEN: tl.constexpr,
+    CACHE_LEN_POWER_OF_TWO: tl.constexpr,
+    HAS_FORCE_FLUSH: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    rows = tl.arange(0, BLOCK)
+    row_mask = rows < n_rows
+    slots = tl.load(state_indices + rows * stride_indices, mask=row_mask, other=-1).to(
+        tl.int64
+    )
+    valid = row_mask & (slots >= 0)
+    write_pos = tl.load(persistent_write_pos + slots, mask=valid, other=0).to(tl.int32)
+    cache_base = tl.load(persistent_cache_base + slots, mask=valid, other=0).to(
+        tl.int32
+    )
+    tl.store(static_write_pos + rows, write_pos, mask=row_mask)
+    tl.store(static_cache_base + rows, cache_base, mask=row_mask)
+
+    natural_flush = write_pos == CACHE_LEN - 1
+    forced_flush = False
+    if HAS_FORCE_FLUSH:
+        forced_flush = (
+            tl.load(
+                force_flush + rows * stride_force_flush,
+                mask=row_mask,
+                other=0,
+            )
+            != 0
+        )
+    history_flush = natural_flush & (not forced_flush) & (CACHE_LEN > 1)
+    full_flush = forced_flush | (natural_flush & (CACHE_LEN == 1))
+    next_pos = tl.where(full_flush, 0, tl.where(history_flush, 1, write_pos + 1))
+    if CACHE_LEN_POWER_OF_TWO:
+        flushed_base = (cache_base + write_pos) & (CACHE_LEN - 1)
+    else:
+        flushed_base = (cache_base + write_pos) % CACHE_LEN
+    next_base = tl.where(
+        full_flush, 0, tl.where(history_flush, flushed_base, cache_base)
+    )
+    tl.store(persistent_write_pos + slots, next_pos, mask=valid)
+    tl.store(persistent_cache_base + slots, next_base, mask=valid)
+
+
+def _advance_replayssm_predecay_cursor(
+    *,
+    persistent_write_pos: torch.Tensor,
+    persistent_cache_base: torch.Tensor,
+    static_write_pos: torch.Tensor,
+    static_cache_base: torch.Tensor,
+    state_indices: torch.Tensor,
+    cache_len: int,
+    force_flush: Optional[torch.Tensor] = None,
+) -> None:
+    n_rows = state_indices.numel()
+    if n_rows == 0:
+        return
+    if envs.SGLANG_DEBUG_MEMORY_POOL.get():
+        valid_slots = state_indices[state_indices >= 0]
+        if torch.unique(valid_slots).numel() != valid_slots.numel():
+            raise ValueError(
+                "KDA ReplaySSM requires unique non-padding state indices per step."
+            )
+    block = triton.next_power_of_2(n_rows)
+    force_flush_arg = state_indices if force_flush is None else force_flush
+    _advance_replayssm_decode_cursor_kernel[(1,)](
+        persistent_write_pos,
+        persistent_cache_base,
+        static_write_pos,
+        static_cache_base,
+        state_indices,
+        force_flush_arg,
+        n_rows,
+        stride_indices=state_indices.stride(0),
+        stride_force_flush=force_flush_arg.stride(0),
+        CACHE_LEN=cache_len,
+        CACHE_LEN_POWER_OF_TWO=cache_len & (cache_len - 1) == 0,
+        HAS_FORCE_FLUSH=force_flush is not None,
+        BLOCK=block,
+    )
+
+
 class MambaAttnBackendBase(AttentionBackend):
     # Per-slot accept lengths for the KDA fused-accept spec path; allocated only
     # by KDAAttnBackend where `_can_fuse_accept_state` holds. None everywhere
@@ -88,7 +182,14 @@ class MambaAttnBackendBase(AttentionBackend):
         # Per-bs static write-cursor / force-flush buffers for cuda-graph; None
         # unless --enable-linear-replayssm is set.
         self.replayssm_write_pos_list = None
+        self.replayssm_cache_base_list = None
         self.replayssm_force_flush_list = None
+        mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
+        self.replayssm_predecay_kda = bool(
+            mamba_pool is not None
+            and getattr(mamba_pool, "replayssm_predecay_kda", False)
+        )
+        self.replayssm_force_flush_enabled = not get_memory().disable_radix_cache
         self.query_start_loc_list = []
         self.retrieve_next_token_list = []
         self.retrieve_next_sibling_list = []
@@ -150,6 +251,7 @@ class MambaAttnBackendBase(AttentionBackend):
             mamba_cache_indices[_real_bs:] = -1
 
         replayssm_write_pos = None
+        replayssm_cache_base = None
         replayssm_force_flush = None
         if forward_batch.forward_mode.is_decode_or_idle():
             query_start_loc = torch.arange(
@@ -171,17 +273,45 @@ class MambaAttnBackendBase(AttentionBackend):
             )
             if write_pos_buf is not None:
                 slots = mamba_cache_indices.to(torch.long)
+                L = mamba_pool.linear_replayssm_cache_len
+                if self.replayssm_predecay_kda:
+                    cache_base_buf = mamba_pool.replayssm_cache_base
+                    if cache_base_buf is None:
+                        raise RuntimeError(
+                            "KDA ReplaySSM pre-decay cache base was not allocated."
+                        )
+                    replayssm_write_pos = torch.empty_like(mamba_cache_indices)
+                    replayssm_cache_base = torch.empty_like(mamba_cache_indices)
+                    if self.replayssm_force_flush_enabled:
+                        force_flush_bool = self._replayssm_track_flush_mask(
+                            forward_batch.seq_lens_cpu, bs
+                        )
+                        replayssm_force_flush = force_flush_bool.to(
+                            device=self.device, dtype=torch.int32
+                        )
+                    _advance_replayssm_predecay_cursor(
+                        persistent_write_pos=write_pos_buf,
+                        persistent_cache_base=cache_base_buf,
+                        static_write_pos=replayssm_write_pos,
+                        static_cache_base=replayssm_cache_base,
+                        state_indices=mamba_cache_indices,
+                        cache_len=L,
+                        force_flush=replayssm_force_flush,
+                    )
+                    return_metadata_cursor = True
+                else:
+                    return_metadata_cursor = False
                 # Padded rows carry slot == -1; clamp the gather in-bounds (kernel
                 # zeroes padded rows via state_idx < 0).
                 safe_slots = slots.clamp(min=0)
-                replayssm_write_pos = write_pos_buf[safe_slots].clone()
-                L = mamba_pool.linear_replayssm_cache_len
+                if not return_metadata_cursor:
+                    replayssm_write_pos = write_pos_buf[safe_slots].clone()
                 # KDA has no radix coordination: flush only on the natural write_pos
                 # == L-1 wrap. GDN adds the radix-aligned force-flush below.
                 is_kda = getattr(mamba_pool, "replayssm_is_kda", False)
                 # Force-flush on the radix track's seq_lens % mamba_track_interval
                 # == 0 boundary so the ring folds into temporal[slot] when read.
-                if not is_kda:
+                if not is_kda and not return_metadata_cursor:
                     force_flush_bool = self._replayssm_track_flush_mask(
                         forward_batch.seq_lens_cpu, bs
                     )
@@ -190,7 +320,7 @@ class MambaAttnBackendBase(AttentionBackend):
                     )
                 # Advance only valid slots, scattered over unique slots (dup-index
                 # race; padded rows clamp to 0); a forced flush -> next write_pos 0.
-                valid_mask = slots >= 0
+                valid_mask = (slots >= 0) & (not return_metadata_cursor)
                 valid_slots = slots[valid_mask]
                 if valid_slots.numel() > 0:
                     flushed = replayssm_write_pos == (L - 1)
@@ -288,6 +418,7 @@ class MambaAttnBackendBase(AttentionBackend):
             track_ssm_recompute_dst=track_ssm_recompute_dst,
             has_mamba_track_mask=has_mamba_track_mask,
             replayssm_write_pos=replayssm_write_pos,
+            replayssm_cache_base=replayssm_cache_base,
             replayssm_force_flush=replayssm_force_flush,
         )
 
@@ -486,7 +617,13 @@ class MambaAttnBackendBase(AttentionBackend):
         # Per-bs static write-cursor / force-flush buffers, captured by pointer +
         # refreshed in-place each replay; sized like state_indices_list. None when off.
         self.replayssm_write_pos_list = [] if self._replayssm_enabled() else None
-        self.replayssm_force_flush_list = [] if self._replayssm_enabled() else None
+        self.replayssm_cache_base_list = [] if self.replayssm_predecay_kda else None
+        self.replayssm_force_flush_list = (
+            []
+            if self._replayssm_enabled()
+            and (not self.replayssm_predecay_kda or self.replayssm_force_flush_enabled)
+            else None
+        )
         # int64 to match DecodeInputBuffers.mamba_track_indices + the track-save
         # kernel's int64 index load. Refreshed in-place by _replay_metadata.
         self.mamba_track_indices_buf = torch.zeros(
@@ -500,6 +637,10 @@ class MambaAttnBackendBase(AttentionBackend):
             )
             if self.replayssm_write_pos_list is not None:
                 self.replayssm_write_pos_list.append(
+                    torch.zeros((i + 1,), dtype=torch.int32, device=self.device)
+                )
+            if self.replayssm_cache_base_list is not None:
+                self.replayssm_cache_base_list.append(
                     torch.zeros((i + 1,), dtype=torch.int32, device=self.device)
                 )
             if self.replayssm_force_flush_list is not None:
@@ -589,6 +730,11 @@ class MambaAttnBackendBase(AttentionBackend):
             if self.replayssm_write_pos_list is not None
             else None
         )
+        replayssm_cache_base = (
+            self.replayssm_cache_base_list[bs - 1]
+            if self.replayssm_cache_base_list is not None
+            else None
+        )
         replayssm_force_flush = (
             self.replayssm_force_flush_list[bs - 1]
             if self.replayssm_force_flush_list is not None
@@ -604,6 +750,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
                 replayssm_write_pos=replayssm_write_pos,
+                replayssm_cache_base=replayssm_cache_base,
                 replayssm_force_flush=replayssm_force_flush,
             )
         else:
@@ -611,6 +758,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 query_start_loc=self.query_start_loc_list[bs - 1],
                 mamba_cache_indices=self.state_indices_list[bs - 1],
                 replayssm_write_pos=replayssm_write_pos,
+                replayssm_cache_base=replayssm_cache_base,
                 replayssm_force_flush=replayssm_force_flush,
             )
 
@@ -679,67 +827,95 @@ class MambaAttnBackendBase(AttentionBackend):
         # snapshot-then-advance). Skip the advance during capture: dummy slots
         # would corrupt real ring positions.
         replayssm_write_pos = None
+        replayssm_cache_base = None
         replayssm_force_flush = None
         if self.replayssm_write_pos_list is not None:
             mamba_pool = self.req_to_token_pool.mamba_pool
             write_pos_buf = mamba_pool.replayssm_write_pos
             static_wp = self.replayssm_write_pos_list[bs - 1]
-            static_ff = self.replayssm_force_flush_list[bs - 1]
+            static_cb = (
+                self.replayssm_cache_base_list[bs - 1]
+                if self.replayssm_cache_base_list is not None
+                else None
+            )
+            static_ff = (
+                self.replayssm_force_flush_list[bs - 1]
+                if self.replayssm_force_flush_list is not None
+                else None
+            )
             # Hand the full captured per-bs buffers to the kernel; it indexes per row.
             replayssm_write_pos = static_wp
+            replayssm_cache_base = static_cb
             replayssm_force_flush = static_ff
             if write_pos_buf is not None:
                 # this replay's per-row physical slots (padded rows == -1)
                 slots = mamba_indices.to(torch.long)
-                safe_slots = slots.clamp(min=0)
-                # Snapshot this step's cursor into the captured buffer in-place
-                # (copy_, never reassign the object).
-                static_wp[: len(mamba_indices)].copy_(write_pos_buf[safe_slots])
-                # Refresh the force-flush buffer in-place from this step's seq_lens
-                # (same condition as the radix track). Zeroed during capture.
-                force_flush_dev = None
-                # KDA: no radix coordination -> leave zeroed so the advance is a pure wrap.
-                is_kda = getattr(mamba_pool, "replayssm_is_kda", False)
-                if (
-                    not is_kda
-                    and forward_mode.is_decode_or_idle()
-                    and seq_lens_cpu is not None
-                ):
-                    ff_mask = self._replayssm_track_flush_mask(seq_lens_cpu, bs)
-                    force_flush_dev = ff_mask.to(device=self.device, dtype=torch.int32)
-                    static_ff.copy_(force_flush_dev)
+                if self.replayssm_predecay_kda:
+                    if static_cb is None or mamba_pool.replayssm_cache_base is None:
+                        raise RuntimeError(
+                            "KDA ReplaySSM pre-decay cache base was not initialized."
+                        )
+                    if static_ff is not None and (
+                        forward_mode.is_decode_or_idle() and seq_lens_cpu is not None
+                    ):
+                        ff_mask = self._replayssm_track_flush_mask(seq_lens_cpu, bs)
+                        static_ff.copy_(
+                            ff_mask.to(device=self.device, dtype=torch.int32)
+                        )
+                    elif static_ff is not None:
+                        static_ff.zero_()
+                    if not in_capture and forward_mode.is_decode_or_idle():
+                        _advance_replayssm_predecay_cursor(
+                            persistent_write_pos=write_pos_buf,
+                            persistent_cache_base=mamba_pool.replayssm_cache_base,
+                            static_write_pos=static_wp,
+                            static_cache_base=static_cb,
+                            state_indices=mamba_indices,
+                            cache_len=mamba_pool.linear_replayssm_cache_len,
+                            force_flush=static_ff,
+                        )
                 else:
-                    static_ff.zero_()
-                # Defense in depth: the decode-ring advance is only meaningful for
-                # decode/idle forwards (mirrors the eager path's gating). A
-                # TARGET_VERIFY replay must never advance the cursor.
-                if not in_capture and forward_mode.is_decode_or_idle():
-                    L = mamba_pool.linear_replayssm_cache_len
-                    # Advance only valid (non-padded) slots; a forced flush empties
-                    # the ring -> next write_pos 0, like the natural L-1 wrap.
-                    valid_mask = slots >= 0
-                    valid_slots = slots[valid_mask]
-                    if valid_slots.numel() > 0:
-                        cur_pos = write_pos_buf[safe_slots]
-                        flushed = cur_pos == (L - 1)
-                        if force_flush_dev is not None:
-                            flushed = flushed | (force_flush_dev != 0)
-                        next_pos = torch.where(
-                            flushed,
-                            torch.zeros_like(cur_pos),
-                            (cur_pos + 1) % L,
+                    safe_slots = slots.clamp(min=0)
+                    static_wp[: len(mamba_indices)].copy_(write_pos_buf[safe_slots])
+                    force_flush_dev = None
+                    is_kda = getattr(mamba_pool, "replayssm_is_kda", False)
+                    if (
+                        not is_kda
+                        and forward_mode.is_decode_or_idle()
+                        and seq_lens_cpu is not None
+                    ):
+                        ff_mask = self._replayssm_track_flush_mask(seq_lens_cpu, bs)
+                        force_flush_dev = ff_mask.to(
+                            device=self.device, dtype=torch.int32
                         )
-                        # Dedup; rows sharing a slot share write_pos+flush.
-                        uniq_slots, inv = torch.unique(valid_slots, return_inverse=True)
-                        next_for_valid = next_pos[valid_mask]
-                        new_vals = torch.empty(
-                            uniq_slots.shape[0],
-                            dtype=write_pos_buf.dtype,
-                            device=write_pos_buf.device,
-                        )
-                        new_vals[inv] = next_for_valid.to(write_pos_buf.dtype)
-                        write_pos_buf[uniq_slots] = new_vals
-        is_target_verify = forward_mode.is_target_verify()
+                        static_ff.copy_(force_flush_dev)
+                    else:
+                        static_ff.zero_()
+                    if not in_capture and forward_mode.is_decode_or_idle():
+                        L = mamba_pool.linear_replayssm_cache_len
+                        valid_mask = slots >= 0
+                        valid_slots = slots[valid_mask]
+                        if valid_slots.numel() > 0:
+                            cur_pos = write_pos_buf[safe_slots]
+                            flushed = cur_pos == (L - 1)
+                            if force_flush_dev is not None:
+                                flushed = flushed | (force_flush_dev != 0)
+                            next_pos = torch.where(
+                                flushed,
+                                torch.zeros_like(cur_pos),
+                                (cur_pos + 1) % L,
+                            )
+                            uniq_slots, inv = torch.unique(
+                                valid_slots, return_inverse=True
+                            )
+                            next_for_valid = next_pos[valid_mask]
+                            new_vals = torch.empty(
+                                uniq_slots.shape[0],
+                                dtype=write_pos_buf.dtype,
+                                device=write_pos_buf.device,
+                            )
+                            new_vals[inv] = next_for_valid.to(write_pos_buf.dtype)
+                            write_pos_buf[uniq_slots] = new_vals
         if forward_mode.is_decode_or_idle():
             if num_padding == 0:
                 self.query_start_loc_list[bs - 1].copy_(
@@ -800,6 +976,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 retrieve_next_sibling=self.retrieve_next_sibling_list[bs - 1],
                 retrieve_parent_token=self.retrieve_parent_token_list[bs - 1],
                 replayssm_write_pos=replayssm_write_pos,
+                replayssm_cache_base=replayssm_cache_base,
                 replayssm_force_flush=replayssm_force_flush,
             )
         else:
@@ -808,6 +985,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 mamba_cache_indices=self.state_indices_list[bs - 1],
                 mamba_track_indices=track_buf,
                 replayssm_write_pos=replayssm_write_pos,
+                replayssm_cache_base=replayssm_cache_base,
                 replayssm_force_flush=replayssm_force_flush,
             )
 

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -557,6 +557,9 @@ class KDAAttnBackend(MambaAttnBackendBase):
         replayssm_write_pos = getattr(
             self.forward_metadata, "replayssm_write_pos", None
         )
+        replayssm_cache_base = getattr(
+            self.forward_metadata, "replayssm_cache_base", None
+        )
         replayssm_force_flush = getattr(
             self.forward_metadata, "replayssm_force_flush", None
         )
@@ -755,6 +758,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 replayssm_k=replayssm_k,
                 replayssm_g=replayssm_g,
                 replayssm_write_pos=replayssm_write_pos,
+                replayssm_cache_base=replayssm_cache_base,
                 replayssm_force_flush=replayssm_force_flush,
             )
             self._track_mamba_state_decode(

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -65,39 +65,62 @@ class TritonKDAKernel(LinearAttnKernelBase):
         replayssm_k = kwargs.get("replayssm_k")
         replayssm_g = kwargs.get("replayssm_g")
         replayssm_write_pos = kwargs.get("replayssm_write_pos")
+        replayssm_cache_base = kwargs.get("replayssm_cache_base")
         replayssm_force_flush = kwargs.get("replayssm_force_flush")
-        if (
-            lower_bound is None
-            and replayssm_d is not None
-            and replayssm_k is not None
-            and replayssm_g is not None
-            and replayssm_write_pos is not None
+        replay_fields = (
+            replayssm_d,
+            replayssm_k,
+            replayssm_g,
+            replayssm_write_pos,
+        )
+        if any(value is not None for value in replay_fields) and not all(
+            value is not None for value in replay_fields
         ):
-            if lower_bound is not None:
-                raise NotImplementedError(
-                    "KDA safe gate (lower_bound) is not implemented in the "
-                    "ReplaySSM decode kernel; disable --enable-linear-replayssm."
-                )
-            K = ssm_states.shape[-1]  # ssm_states: [num_slots, HV, V, K]
-            fused_recurrent_linear_replayssm_decode(
-                mixed_qkv=mixed_qkv,
-                a=a.reshape(B, num_v_heads, K).contiguous(),
-                b=b.reshape(B, num_v_heads).contiguous(),
-                A_log=A_log.reshape(-1),
-                dt_bias=dt_bias.reshape(num_v_heads, K).contiguous(),
-                scale=scale,
-                initial_state=ssm_states,
-                d_cache=replayssm_d,
-                k_cache=replayssm_k,
-                g_cache=replayssm_g,
-                out=out,
-                ssm_state_indices=cache_indices,
-                write_pos=replayssm_write_pos,
-                force_flush=replayssm_force_flush,
-                use_qk_l2norm_in_kernel=True,
-                is_kda=True,
+            raise RuntimeError(
+                "KDA ReplaySSM received partial ring metadata; refusing to "
+                "decode from a potentially stale checkpoint."
             )
-            return out.transpose(0, 1)
+        if all(value is not None for value in replay_fields):
+            K = ssm_states.shape[-1]  # ssm_states: [num_slots, HV, V, K]
+            use_predecay = lower_bound is not None and replayssm_cache_base is not None
+            if lower_bound is not None and not use_predecay:
+                raise RuntimeError(
+                    "Bounded KDA ReplaySSM ring metadata is missing cache_base; "
+                    "native fallback would discard pending replay history."
+                )
+            else:
+                fused_recurrent_linear_replayssm_decode(
+                    mixed_qkv=mixed_qkv,
+                    a=a.reshape(B, num_v_heads, K).contiguous(),
+                    b=b.reshape(B, num_v_heads).contiguous(),
+                    A_log=A_log.reshape(-1),
+                    dt_bias=dt_bias.reshape(num_v_heads, K).contiguous(),
+                    scale=scale,
+                    initial_state=ssm_states,
+                    d_cache=replayssm_d,
+                    k_cache=replayssm_k,
+                    g_cache=replayssm_g,
+                    out=out,
+                    ssm_state_indices=cache_indices,
+                    write_pos=replayssm_write_pos,
+                    force_flush=replayssm_force_flush,
+                    lower_bound=lower_bound,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=True,
+                    block_v=16 if B == 1 else (32 if use_predecay else None),
+                    num_warps=2 if B == 1 and use_predecay else 1,
+                    num_stages=2 if use_predecay else 3,
+                    nk=1 if use_predecay else 2,
+                    cache_base=replayssm_cache_base,
+                    circular_replay=use_predecay,
+                    prefix_gate_cache=use_predecay,
+                    predecayed_k_cache=use_predecay,
+                )
+                return out.transpose(0, 1)
+        elif replayssm_cache_base is not None:
+            raise RuntimeError(
+                "KDA ReplaySSM received cache_base without a complete replay ring."
+            )
 
         # a may come in as [B, HV, K] (or [B, 1, HV*K]); b may come in as
         # [B, 1, HV]. Flatten both to the 2D shapes the kernel expects.

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -39,6 +39,10 @@ class ForwardMetadata:
     # cursor for THIS decode step (gathered from the persistent per-slot
     # buffer, then advanced once for the next step). int32, length == batch.
     replayssm_write_pos: Optional[torch.Tensor] = None
+    # Bounded KDA pre-decay: logical ring base paired with write_pos. It is a
+    # graph-static per-row snapshot; the persistent per-slot cursor is advanced
+    # exactly once outside the captured model body.
+    replayssm_cache_base: Optional[torch.Tensor] = None
     # GDN ReplaySSM (slice 2b): per-decode-row int32 flush flag for THIS decode
     # step. !=0 forces the kernel to fold the partial ring + current token into
     # the checkpoint (temporal[slot]) so the radix cache reads an up-to-date

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -117,6 +117,35 @@ def _should_elide_dsa_index_k(*, is_draft_worker: bool) -> bool:
 _is_hip = is_hip()
 
 
+def _resolve_linear_replayssm_decode(cache_params, model_config):
+    requested = get_exec().mamba.enable_linear_replayssm
+    supported_model = (
+        hybrid_gdn_config(model_config) is not None
+        or kimi_linear_config(model_config) is not None
+    )
+    replay_len = get_exec().mamba.linear_replayssm_cache_len
+    decode_backend = (
+        get_exec().mamba.linear_attn_decode_backend
+        or get_exec().mamba.linear_attn_backend
+    )
+    predecay_kda = bool(
+        requested
+        and supported_model
+        and current_platform.is_cuda()
+        and get_memory().disable_radix_cache
+        and decode_backend == "triton"
+        and cache_params.supports_kda_replayssm_predecay(replay_len)
+    )
+    bounded_kda = bool(
+        cache_params.is_kda
+        and getattr(cache_params.shape, "gate_lower_bound", None) is not None
+    )
+    ring_active = bool(
+        requested and supported_model and (not bounded_kda or predecay_kda)
+    )
+    return ring_active, predecay_kda, bounded_kda, supported_model
+
+
 def _get_dsv4_compress_state_dtypes() -> tuple[torch.dtype, torch.dtype]:
     dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
     if dtype_name in ("float32", "fp32"):
@@ -1095,6 +1124,33 @@ class KVCacheConfigurator:
                 "--enable-linear-replayssm-spec with DSPARK/DFLASH requires a KDA "
                 "(kimi_linear) model; got a non-KDA model."
             )
+        cache_params = self.mambaish_config.mamba2_cache_params
+        (
+            enable_linear_replayssm_decode_ring,
+            enable_kda_replayssm_predecay,
+            bounded_kda,
+            supported_model,
+        ) = _resolve_linear_replayssm_decode(
+            cache_params,
+            self.model_config,
+        )
+        if (
+            get_exec().mamba.enable_linear_replayssm
+            and not enable_linear_replayssm_decode_ring
+        ):
+            if not supported_model:
+                reason = "the model backend does not consume the ReplaySSM ring"
+            elif bounded_kda and not get_memory().disable_radix_cache:
+                reason = (
+                    "bounded KDA pre-decay currently requires --disable-radix-cache"
+                )
+            elif bounded_kda and not current_platform.is_cuda():
+                reason = "bounded KDA pre-decay currently requires NVIDIA CUDA"
+            else:
+                reason = "the bounded KDA shape, dtype, or backend is unsupported"
+            logger.warning(
+                "ReplaySSM is inactive because %s; keeping native decode.", reason
+            )
         req_to_token_pool = HybridReqToTokenPool(
             size=max_num_reqs,
             mamba_size=get_schedule().max_mamba_cache_size,
@@ -1102,7 +1158,7 @@ class KVCacheConfigurator:
             max_context_len=self.model_config.context_len + extra_max_context_len,
             device=self.device,
             enable_memory_saver=get_exec().features.enable_memory_saver,
-            cache_params=self.mambaish_config.mamba2_cache_params,
+            cache_params=cache_params,
             mamba_layer_ids=self._get_mamba_layer_ids_for_req_pool(),
             enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
@@ -1117,7 +1173,8 @@ class KVCacheConfigurator:
             speculative_eagle_topk=get_spec().speculative_eagle_topk,
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             start_layer=self.layer_info.start_layer,
-            enable_linear_replayssm=get_exec().mamba.enable_linear_replayssm,
+            enable_linear_replayssm=enable_linear_replayssm_decode_ring,
+            enable_kda_replayssm_predecay=enable_kda_replayssm_predecay,
             linear_replayssm_cache_len=get_exec().mamba.linear_replayssm_cache_len,
             mamba_envelope_layout=get_memory().enable_page_major_kv_layout,
             # ReplaySSM spec-verify is for linear-attn models (GDN fold or KDA
@@ -2316,14 +2373,40 @@ class KVCacheConfigurator:
         # no longer reserves the (1 + D/ratio) intermediate factor -- the whole
         # budget goes to persistent slots (K sized like non-spec), which is how the
         # freed ~9GB turns into higher max_running.
-        # The ring is not part of mamba_cache_per_req. GDN replay is fixed-size
-        # request scratch; KDA replay remains attached to each mamba slot.
-        replayssm_active = get_exec().mamba.enable_linear_replayssm_spec and (
+        # The ring is allocated per slot but is not part of mamba_cache_per_req;
+        # the solve must charge it too or num_slots is over-provisioned. GDN spec
+        # replay is fixed-size request scratch; ordinary decode and KDA spec replay
+        # remain attached to persistent mamba slots.
+        cache_params = config.mamba2_cache_params
+        replay_len = get_exec().mamba.linear_replayssm_cache_len
+        replayssm_decode_active, predecay_kda, _, _ = _resolve_linear_replayssm_decode(
+            cache_params,
+            self.model_config,
+        )
+        replayssm_spec_active = get_exec().mamba.enable_linear_replayssm_spec and (
             self.hybrid_gdn_config is not None
             or kimi_linear_config(self.model_config) is not None
         )
-        if replayssm_active:
-            record_len = get_exec().mamba.linear_replayssm_cache_len
+        # Only spec ReplaySSM replaces speculative intermediate-state buffers.
+        # Ordinary decode ReplaySSM owns a ring but does not alter MTP rollback
+        # allocation, so keep this predicate spec-only below.
+        replayssm_active = replayssm_spec_active
+        if replayssm_decode_active:
+            record_len = replay_len
+            replayssm_ring_per_req = cache_params.replayssm_decode_ring_bytes_per_req(
+                record_len=record_len,
+                predecay_kda=predecay_kda,
+            )
+        elif replayssm_spec_active:
+            # GDN sizes the fold window to the draft maximum; the KDA ring
+            # stays --linear-replayssm-cache-len long (mirrors MambaPool).
+            max_draft_tokens = max_speculative_num_draft_tokens()
+            if kimi_linear_config(self.model_config) is not None:
+                record_len = get_exec().mamba.linear_replayssm_cache_len
+            elif max_draft_tokens is not None:
+                record_len = max_draft_tokens
+            else:
+                record_len = get_exec().mamba.linear_replayssm_cache_len
             replayssm_ring_per_req = (
                 config.mamba2_cache_params.replayssm_ring_bytes_per_req(
                     record_len=record_len

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1073,13 +1073,6 @@ class MambaPool:
         self.reset_replayssm_cursors(dst_indices)
 
     def get_cpu_copy(self, indices):
-        if self.replayssm_predecay_kda:
-            wp = self.replayssm_write_pos[indices]
-            base = self.replayssm_cache_base[indices]
-            assert bool((wp == 0).all().item()) and bool((base == 0).all().item()), (
-                "CPU checkpoint transfer requires a fully flushed KDA ReplaySSM "
-                "pre-decay ring."
-            )
         current_platform.synchronize()
         conv_cpu = [
             conv[:, indices].to("cpu", non_blocking=True)
@@ -1096,18 +1089,36 @@ class MambaPool:
                 self.replayssm_cache_base[indices].to("cpu", non_blocking=True),
                 None,
             )
+            rings_cpu = tuple(
+                tensor[:, indices].to("cpu", non_blocking=True)
+                for tensor in (
+                    self.mamba_cache.replayssm_d,
+                    self.mamba_cache.replayssm_k,
+                    self.mamba_cache.replayssm_g,
+                )
+            )
             current_platform.synchronize()
-            return conv_cpu, temporal_cpu, cursors_cpu
+            return conv_cpu, temporal_cpu, cursors_cpu, rings_cpu
         current_platform.synchronize()
         return conv_cpu, temporal_cpu
 
     def load_cpu_copy(self, mamba_cache_cpu, indices):
-        # Accept historical 3-tuples, but only physical KDA cursors are restored.
-        cursors_cpu = None
-        if len(mamba_cache_cpu) == 3:
+        # Accept the legacy 2-tuple, the cursor-aware 3-tuple, and the bounded-KDA
+        # 4-tuple carrying pending ring records. Request-keyed GDN scratch is not
+        # restored with a physical checkpoint slot.
+        rings_cpu = None
+        if len(mamba_cache_cpu) == 4:
+            conv_cpu, temporal_cpu, cursors_cpu, rings_cpu = mamba_cache_cpu
+        elif len(mamba_cache_cpu) == 3:
             conv_cpu, temporal_cpu, cursors_cpu = mamba_cache_cpu
-        else:
+        elif len(mamba_cache_cpu) == 2:
             conv_cpu, temporal_cpu = mamba_cache_cpu
+            cursors_cpu = None
+        else:
+            raise ValueError(
+                "Mamba CPU state must contain 2, 3, or 4 tuple elements, "
+                f"got {len(mamba_cache_cpu)}."
+            )
         current_platform.synchronize()
         for i, conv in enumerate(self.mamba_cache.conv):
             conv[:, indices] = conv_cpu[i].to(conv.device, non_blocking=True)
@@ -1115,13 +1126,24 @@ class MambaPool:
             self.mamba_cache.temporal.device, non_blocking=True
         )
         if cursors_cpu is not None and self.replayssm_predecay_kda:
-            wp_cpu, cb_cpu, fl_cpu = cursors_cpu
+            wp_cpu, cb_cpu, _ = cursors_cpu
             self.replayssm_write_pos[indices] = wp_cpu.to(
                 self.replayssm_write_pos.device, non_blocking=True
             )
             self.replayssm_cache_base[indices] = cb_cpu.to(
                 self.replayssm_cache_base.device, non_blocking=True
             )
+            if rings_cpu is not None:
+                for tensor, tensor_cpu in zip(
+                    (
+                        self.mamba_cache.replayssm_d,
+                        self.mamba_cache.replayssm_k,
+                        self.mamba_cache.replayssm_g,
+                    ),
+                    rings_cpu,
+                    strict=True,
+                ):
+                    tensor[:, indices] = tensor_cpu.to(tensor.device, non_blocking=True)
         elif self.replayssm_predecay_kda:
             self.reset_replayssm_cursors(indices)
         current_platform.synchronize()

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -503,6 +503,7 @@ class MambaPool:
         speculative_num_draft_tokens: Optional[int] = None,
         speculative_eagle_topk: Optional[int] = None,
         enable_linear_replayssm: bool = False,
+        enable_kda_replayssm_predecay: bool = False,
         linear_replayssm_cache_len: int = 16,
         envelope_layout: bool = False,
         enable_linear_replayssm_spec: bool = False,
@@ -522,6 +523,11 @@ class MambaPool:
         self.debug_memory_pool = envs.SGLANG_DEBUG_MEMORY_POOL.get()
         self.enable_linear_replayssm = enable_linear_replayssm
         self.linear_replayssm_cache_len = linear_replayssm_cache_len
+        self.replayssm_predecay_kda = bool(
+            enable_linear_replayssm
+            and enable_kda_replayssm_predecay
+            and cache_params.supports_kda_replayssm_predecay(linear_replayssm_cache_len)
+        )
         # ReplaySSM: the decode ring (--enable-linear-replayssm) allocates the
         # chunked (d, k) records + write_pos; the spec-verify flag
         # (--enable-linear-replayssm-spec) uses compact replay for GDN and raw
@@ -626,9 +632,15 @@ class MambaPool:
                     if enable_linear_replayssm_spec and not cache_params.is_kda
                     else size + 1
                 )
-                # Decode records follow the SSM dtype. Spec-verify compact d/k
-                # records follow the activation dtype; g stays fp32.
-                ring_dtype = conv_dtype if enable_linear_replayssm_spec else ssm_dtype
+                # Spec-verify compact d/k records use the activation dtype. The
+                # bounded KDA decode ring also uses bf16 when available, matching
+                # the pre-decay kernel contract; other decode rings use SSM dtype.
+                ring_dtype = (
+                    conv_dtype
+                    if enable_linear_replayssm_spec
+                    or (self.replayssm_predecay_kda and conv_dtype != torch.float16)
+                    else ssm_dtype
+                )
                 # Fold-every-commit: one verify window, no chunked (d, k)
                 # records. KDA is the exception on both counts: its window
                 # stays L-sized (the fused verify ring-write drops
@@ -905,9 +917,15 @@ class MambaPool:
                 else None
             )
             self.replayssm_cache_base = (
-                torch.zeros((spec_state_size + 1,), dtype=torch.int32, device=device)
-                if enable_linear_replayssm_spec and not self.replayssm_spec_fold
-                else None
+                torch.zeros((size + 1,), dtype=torch.int32, device=device)
+                if self.replayssm_predecay_kda
+                else (
+                    torch.zeros(
+                        (spec_state_size + 1,), dtype=torch.int32, device=device
+                    )
+                    if enable_linear_replayssm_spec and not self.replayssm_spec_fold
+                    else None
+                )
             )
             self.replayssm_is_flush = (
                 torch.zeros((spec_state_size + 1,), dtype=torch.int8, device=device)
@@ -966,8 +984,16 @@ class MambaPool:
     def _should_fuse_slot_ops(self) -> bool:
         return self._conv_fuse_ok and not envs.SGLANG_DISABLE_FUSED_MAMBA_SLOT_OPS.get()
 
+    def reset_replayssm_cursors(self, indices) -> None:
+        """Reset cursor state keyed by physical mamba slots."""
+        if self.replayssm_write_pos is not None:
+            self.replayssm_write_pos[indices] = 0
+        if self.replayssm_predecay_kda and self.replayssm_cache_base is not None:
+            self.replayssm_cache_base[indices] = 0
+
     def clear_slots(self, indices: torch.Tensor):
         """Zero out mamba state at the given pool indices. Must run on forward stream."""
+        self.reset_replayssm_cursors(indices)
         if self._should_fuse_slot_ops():
             from sglang.srt.mem_cache.mamba_slot_fused import fused_clear_conv_slots
 
@@ -1015,6 +1041,13 @@ class MambaPool:
                 f"(write_pos==0), got {src_wp.tolist()} for src "
                 f"{src_indices.tolist()}"
             )
+            if self.replayssm_predecay_kda:
+                src_base = self.replayssm_cache_base[src_indices]
+                assert bool((src_base == 0).all().item()), (
+                    "copy_from requires a fully-flushed ReplaySSM source "
+                    f"(cache_base==0), got {src_base.tolist()} for src "
+                    f"{src_indices.tolist()}"
+                )
         if self._should_fuse_slot_ops():
             from sglang.srt.mem_cache.mamba_slot_fused import fused_copy_conv_slots
 
@@ -1036,10 +1069,17 @@ class MambaPool:
             self.mamba_cache.temporal[:, dst_indices] = self.mamba_cache.temporal[
                 :, src_indices
             ]
-        if self.replayssm_write_pos is not None:
-            self.replayssm_write_pos[dst_indices] = 0
+        # A copied physical checkpoint has no pending ordinary-decode entries.
+        self.reset_replayssm_cursors(dst_indices)
 
     def get_cpu_copy(self, indices):
+        if self.replayssm_predecay_kda:
+            wp = self.replayssm_write_pos[indices]
+            base = self.replayssm_cache_base[indices]
+            assert bool((wp == 0).all().item()) and bool((base == 0).all().item()), (
+                "CPU checkpoint transfer requires a fully flushed KDA ReplaySSM "
+                "pre-decay ring."
+            )
         current_platform.synchronize()
         conv_cpu = [
             conv[:, indices].to("cpu", non_blocking=True)
@@ -1048,14 +1088,24 @@ class MambaPool:
         temporal_cpu = self.mamba_cache.temporal[:, indices].to(
             "cpu", non_blocking=True
         )
+        # Bounded KDA cursors are keyed by physical mamba slot. GDN speculative
+        # cursors are request-keyed scratch and do not travel with checkpoints.
+        if self.replayssm_predecay_kda:
+            cursors_cpu = (
+                self.replayssm_write_pos[indices].to("cpu", non_blocking=True),
+                self.replayssm_cache_base[indices].to("cpu", non_blocking=True),
+                None,
+            )
+            current_platform.synchronize()
+            return conv_cpu, temporal_cpu, cursors_cpu
         current_platform.synchronize()
         return conv_cpu, temporal_cpu
 
     def load_cpu_copy(self, mamba_cache_cpu, indices):
-        # Accept historical 3-tuples, but request-keyed replay scratch is not
-        # restored with a physical checkpoint slot.
+        # Accept historical 3-tuples, but only physical KDA cursors are restored.
+        cursors_cpu = None
         if len(mamba_cache_cpu) == 3:
-            conv_cpu, temporal_cpu, _ = mamba_cache_cpu
+            conv_cpu, temporal_cpu, cursors_cpu = mamba_cache_cpu
         else:
             conv_cpu, temporal_cpu = mamba_cache_cpu
         current_platform.synchronize()
@@ -1064,6 +1114,16 @@ class MambaPool:
         self.mamba_cache.temporal[:, indices] = temporal_cpu.to(
             self.mamba_cache.temporal.device, non_blocking=True
         )
+        if cursors_cpu is not None and self.replayssm_predecay_kda:
+            wp_cpu, cb_cpu, fl_cpu = cursors_cpu
+            self.replayssm_write_pos[indices] = wp_cpu.to(
+                self.replayssm_write_pos.device, non_blocking=True
+            )
+            self.replayssm_cache_base[indices] = cb_cpu.to(
+                self.replayssm_cache_base.device, non_blocking=True
+            )
+        elif self.replayssm_predecay_kda:
+            self.reset_replayssm_cursors(indices)
         current_platform.synchronize()
 
     _NON_TRANSFER_STATE_FIELDS = frozenset(
@@ -1190,6 +1250,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_overlap_schedule: bool = True,
         start_layer: Optional[int] = None,
         enable_linear_replayssm: bool = False,
+        enable_kda_replayssm_predecay: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm_spec: bool = False,
@@ -1217,6 +1278,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
             enable_linear_replayssm=enable_linear_replayssm,
+            enable_kda_replayssm_predecay=enable_kda_replayssm_predecay,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             mamba_envelope_layout=mamba_envelope_layout,
             enable_linear_replayssm_spec=enable_linear_replayssm_spec,
@@ -1233,6 +1295,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         speculative_num_draft_tokens: int = None,
         speculative_eagle_topk: Optional[int] = None,
         enable_linear_replayssm: bool = False,
+        enable_kda_replayssm_predecay: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm_spec: bool = False,
@@ -1247,6 +1310,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             speculative_num_draft_tokens=speculative_num_draft_tokens,
             speculative_eagle_topk=speculative_eagle_topk,
             enable_linear_replayssm=enable_linear_replayssm,
+            enable_kda_replayssm_predecay=enable_kda_replayssm_predecay,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             envelope_layout=mamba_envelope_layout,
             enable_linear_replayssm_spec=enable_linear_replayssm_spec,
@@ -1357,8 +1421,9 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 # ring. write_pos=0 means "ring empty", so the decode kernel
                 # ignores ring contents and reads only the checkpoint state
                 # (the post-prefill state that prefill wrote into this slot).
-                if self.mamba_pool.replayssm_write_pos is not None:
-                    self.mamba_pool.replayssm_write_pos[req.kv.mamba_pool_idx] = 0
+                # ReplaySSM cursors are independent optional fields: ordinary
+                # decode owns physical write_pos, and bounded KDA also owns base.
+                self.mamba_pool.reset_replayssm_cursors(req.kv.mamba_pool_idx)
             mamba_indices.append(req.kv.mamba_pool_idx)
             if self.enable_mamba_extra_buffer:
                 if req.kv.mamba_ping_pong_track_buffer is None:

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -804,6 +804,7 @@ class UnifiedMambaPool(MambaPool):
         self.linear_replayssm_cache_len = 16
         self.replayssm_write_pos = None
         self.replayssm_is_kda = False
+        self.replayssm_predecay_kda = False
         self.enable_linear_replayssm_spec = False
         self.replayssm_spec_fold = False
         self.replayssm_cache_base = None
@@ -1061,6 +1062,7 @@ class UnifiedHybridReqToTokenPool(HybridReqToTokenPool):
         speculative_eagle_topk: Optional[int] = None,
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm: bool = False,
+        enable_kda_replayssm_predecay: bool = False,
         linear_replayssm_cache_len: int = 16,
         enable_linear_replayssm_spec: bool = False,
     ):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2720,16 +2720,20 @@ class ServerArgs:
         bool,
         "Enable the ReplaySSM buffered output-only linear-attn decode kernel. "
         "Primarily a GDN (scalar-gate) decode-bandwidth optimization (~1.2-1.5x "
-        "at batch >= 64). KDA uses its selected Triton or Helion implementation, "
-        "but its per-K gate ring is larger and ReplaySSM is typically slower "
-        "than packed KDA decode; benchmark before enabling it. Requires the "
+        "at batch >= 64). Bounded safe-gate KDA with matching Q/V head counts "
+        "uses an optimized pre-decayed ring on CUDA Triton when Radix Cache is "
+        "disabled; other KDA configurations retain the existing implementation "
+        "or native packed decode. Benchmark the target model before enabling it. "
+        "Requires the "
         "Triton linear-attn decode backend, or Helion for KDA, and "
         "--mamba-radix-cache-strategy no_buffer (the default).",
         NS("exec.mamba"),
     ] = False
     linear_replayssm_cache_len: A[
         int,
-        "Ring-buffer length L for ReplaySSM linear-attn decode. The full recurrent state is flushed to HBM every L decode steps.",
+        "Ring-buffer capacity L for ReplaySSM linear-attn decode. The recurrent "
+        "state is materialized periodically; the bounded KDA circular path keeps "
+        "the current token as the first entry of the next window.",
         NS("exec.mamba"),
     ] = 16
     # ReplaySSM spec-verify (Part B of RFC #28511): linear-attn target-verify via

--- a/test/registered/attention/unittests/kda/test_replayssm_predecay.py
+++ b/test/registered/attention/unittests/kda/test_replayssm_predecay.py
@@ -1,0 +1,373 @@
+"""Correctness tests for bounded-gate KDA ReplaySSM pre-decay decode."""
+
+from array import array
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.fla.fused_recurrent_linear_replayssm import (
+    fused_recurrent_linear_replayssm_decode,
+)
+from sglang.srt.configs.mamba_utils import (
+    KimiLinearCacheParams,
+    KimiLinearStateShape,
+    Mamba2StateDType,
+)
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    _advance_replayssm_predecay_cursor,
+)
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required"
+)
+
+
+def test_predecay_cursor_snapshot_advance_and_padding():
+    persistent_wp = torch.tensor([0, 2, 3, 0], device="cuda", dtype=torch.int32)
+    persistent_base = torch.tensor([0, 1, 2, 0], device="cuda", dtype=torch.int32)
+    static_wp = torch.zeros(3, device="cuda", dtype=torch.int32)
+    static_base = torch.zeros_like(static_wp)
+    slots = torch.tensor([1, 2, -1], device="cuda", dtype=torch.int32)
+    force_flush = torch.tensor([1, 0, 0], device="cuda", dtype=torch.int32)
+    _advance_replayssm_predecay_cursor(
+        persistent_write_pos=persistent_wp,
+        persistent_cache_base=persistent_base,
+        static_write_pos=static_wp,
+        static_cache_base=static_base,
+        state_indices=slots,
+        cache_len=4,
+        force_flush=force_flush,
+    )
+    torch.cuda.synchronize()
+    assert static_wp.tolist() == [2, 3, 0]
+    assert static_base.tolist() == [1, 2, 0]
+    assert persistent_wp.tolist() == [0, 0, 1, 0]
+    assert persistent_base.tolist() == [0, 0, 1, 0]
+
+
+def test_predecay_fresh_slot_resets_independent_cursor_fields():
+    shape = KimiLinearStateShape.create(
+        tp_world_size=1,
+        num_heads=4,
+        head_dim=8,
+        num_k_heads=4,
+        head_k_dim=8,
+        gate_lower_bound=-5.0,
+    )
+    cache_params = KimiLinearCacheParams(
+        shape=shape,
+        dtype=Mamba2StateDType(conv=torch.bfloat16, temporal=torch.float32),
+        layers=[0],
+    )
+    pool = HybridReqToTokenPool(
+        size=2,
+        mamba_size=2,
+        mamba_spec_state_size=2,
+        max_context_len=16,
+        device="cuda",
+        enable_memory_saver=False,
+        cache_params=cache_params,
+        mamba_layer_ids=[0],
+        enable_mamba_extra_buffer=False,
+        enable_linear_replayssm=True,
+        enable_kda_replayssm_predecay=True,
+        linear_replayssm_cache_len=4,
+    )
+    assert pool.mamba_pool.replayssm_cache_base is not None
+    assert pool.mamba_pool.replayssm_is_flush is None
+    req = Req(
+        rid="predecay-slot",
+        origin_input_text="",
+        origin_input_ids=array("q"),
+        sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+    )
+
+    pool.alloc([req])
+    slot = req.mamba_pool_idx
+    assert pool.mamba_pool.replayssm_write_pos[slot].item() == 0
+    assert pool.mamba_pool.replayssm_cache_base[slot].item() == 0
+    pool.mamba_pool.replayssm_write_pos[slot] = 2
+    pool.mamba_pool.replayssm_cache_base[slot] = 3
+    pool.mamba_pool.clear_slots(torch.tensor([slot], device="cuda"))
+    assert pool.mamba_pool.replayssm_write_pos[slot].item() == 0
+    assert pool.mamba_pool.replayssm_cache_base[slot].item() == 0
+
+
+def test_predecay_accepts_page_major_slot_stride():
+    batch, heads, dim, cache_len = 2, 4, 32, 4
+    replay = _allocate(batch, heads, dim, cache_len, torch.bfloat16)
+    backing = torch.zeros(batch, 2, heads, dim, dim, device="cuda", dtype=torch.float32)
+    replay["state"] = backing[:, 0]
+    assert not replay["state"].is_contiguous()
+    assert replay["state"].stride()[1:] == (dim * dim, dim, 1)
+    mixed, a, b = _inputs(batch, heads, dim, torch.bfloat16, 7000)
+    out = _decode(
+        replay,
+        mixed,
+        a,
+        b,
+        torch.zeros(heads, device="cuda"),
+        torch.zeros(heads, dim, device="cuda"),
+        torch.zeros(batch, device="cuda", dtype=torch.int32),
+        torch.zeros(batch, device="cuda", dtype=torch.int32),
+    )
+    assert torch.isfinite(out).all()
+
+
+def _inputs(batch, heads, dim, dtype, seed):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn(batch, heads, dim, generator=generator, device="cuda", dtype=dtype)
+    k = torch.randn(batch, heads, dim, generator=generator, device="cuda", dtype=dtype)
+    v = torch.randn(batch, heads, dim, generator=generator, device="cuda", dtype=dtype)
+    a = (
+        torch.randn(batch, heads, dim, generator=generator, device="cuda", dtype=dtype)
+        * 0.25
+    ).contiguous()
+    b = torch.randn(batch, heads, generator=generator, device="cuda", dtype=dtype)
+    return torch.cat((q.flatten(1), k.flatten(1), v.flatten(1)), dim=-1), a, b
+
+
+def _reference_step(mixed_qkv, a, b, a_log, dt_bias, state, lower_bound):
+    batch, heads, value_dim, key_dim = state.shape
+    width = heads * key_dim
+    q, k, v = mixed_qkv.split((width, width, heads * value_dim), dim=-1)
+    q = q.reshape(batch, heads, key_dim).float()
+    k = k.reshape(batch, heads, key_dim).float()
+    v = v.reshape(batch, heads, value_dim).float()
+    q = q / torch.sqrt(torch.sum(q * q, dim=-1, keepdim=True) + 1e-6)
+    k = k / torch.sqrt(torch.sum(k * k, dim=-1, keepdim=True) + 1e-6)
+    q = q * (key_dim**-0.5)
+    gate = lower_bound * torch.sigmoid(
+        torch.exp(a_log)[None, :, None] * (a.float() + dt_bias[None])
+    )
+    alpha = torch.exp(gate)
+    beta = torch.sigmoid(b.float())
+    decayed = state * alpha.unsqueeze(-2)
+    delta = beta.unsqueeze(-1) * (v - torch.einsum("bhvk,bhk->bhv", decayed, k))
+    state.copy_(decayed + delta.unsqueeze(-1) * k.unsqueeze(-2))
+    return torch.einsum("bhvk,bhk->bhv", state, q)
+
+
+def _allocate(batch, heads, dim, cache_len, ring_dtype):
+    generator = torch.Generator(device="cuda").manual_seed(20260821)
+    return {
+        "state": torch.randn(
+            batch,
+            heads,
+            dim,
+            dim,
+            generator=generator,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        * 0.03,
+        "d": torch.zeros(batch, heads, cache_len, dim, device="cuda", dtype=ring_dtype),
+        "k": torch.zeros(batch, heads, cache_len, dim, device="cuda", dtype=ring_dtype),
+        "g": torch.zeros(
+            batch, heads, cache_len, dim, device="cuda", dtype=torch.float32
+        ),
+        "base": torch.zeros(batch, device="cuda", dtype=torch.int32),
+    }
+
+
+def _decode(replay, mixed_qkv, a, b, a_log, dt_bias, write_pos, force_flush):
+    batch, heads, dim = a.shape
+    out = mixed_qkv.new_empty(batch, 1, heads, dim)
+    fused_recurrent_linear_replayssm_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        scale=dim**-0.5,
+        initial_state=replay["state"],
+        d_cache=replay["d"],
+        k_cache=replay["k"],
+        g_cache=replay["g"],
+        out=out,
+        ssm_state_indices=torch.arange(batch, device="cuda", dtype=torch.int32),
+        write_pos=write_pos,
+        cache_base=replay["base"],
+        force_flush=force_flush,
+        lower_bound=-5.0,
+        use_qk_l2norm_in_kernel=True,
+        is_kda=True,
+        block_v=16 if batch == 1 else 32,
+        num_warps=2 if batch == 1 else 1,
+        num_stages=2,
+        nk=1,
+        circular_replay=True,
+        prefix_gate_cache=True,
+        predecayed_k_cache=True,
+    )
+    return out
+
+
+def _advance(replay, write_pos, force_flush):
+    natural = write_pos == replay["d"].shape[2] - 1
+    forced = force_flush.bool()
+    history_flush = natural & ~forced
+    replay["base"].copy_(
+        torch.where(
+            forced,
+            torch.zeros_like(replay["base"]),
+            torch.where(
+                history_flush,
+                (replay["base"] + write_pos) % replay["d"].shape[2],
+                replay["base"],
+            ),
+        )
+    )
+    return torch.where(
+        forced,
+        torch.zeros_like(write_pos),
+        torch.where(history_flush, torch.ones_like(write_pos), write_pos + 1),
+    )
+
+
+@pytest.mark.parametrize("cache_len", [2, 3, 4, 8, 16])
+@pytest.mark.parametrize("ring_dtype", [torch.bfloat16, torch.float32])
+def test_predecay_matches_recurrence_across_wraps(cache_len, ring_dtype):
+    batch, heads, dim = 3, 4, 32
+    replay = _allocate(batch, heads, dim, cache_len, ring_dtype)
+    reference_state = replay["state"].clone()
+    cursor = torch.zeros(batch, device="cuda", dtype=torch.int32)
+    a_log = (torch.randn(heads, device="cuda") * 0.2).float().contiguous()
+    dt_bias = (torch.randn(heads, dim, device="cuda") * 0.1).float().contiguous()
+
+    for step in range(3 * cache_len + 5):
+        mixed_qkv, a, b = _inputs(batch, heads, dim, torch.bfloat16, 1000 + step)
+        expected = _reference_step(
+            mixed_qkv, a, b, a_log, dt_bias, reference_state, -5.0
+        )
+        write_pos = cursor.clone()
+        force_flush = torch.zeros_like(write_pos)
+        if step in (2, cache_len + 2):
+            force_flush[1] = 1
+        actual = _decode(
+            replay, mixed_qkv, a, b, a_log, dt_bias, write_pos, force_flush
+        )
+        torch.testing.assert_close(
+            actual[:, 0].float(),
+            expected.to(torch.bfloat16).float(),
+            atol=3e-2,
+            rtol=3e-2,
+        )
+        if force_flush.any():
+            mask = force_flush.bool()
+            torch.testing.assert_close(
+                replay["state"][mask],
+                reference_state[mask],
+                atol=5e-2,
+                rtol=3e-2,
+            )
+        cursor = _advance(replay, write_pos, force_flush)
+
+
+def test_predecay_cuda_graph_replay():
+    batch, heads, dim, cache_len = 2, 4, 32, 4
+    replay = _allocate(batch, heads, dim, cache_len, torch.bfloat16)
+    initial_state = replay["state"].clone()
+    reference_state = initial_state.clone()
+    a_log = torch.zeros(heads, device="cuda")
+    dt_bias = torch.zeros(heads, dim, device="cuda")
+    mixed, a, b = _inputs(batch, heads, dim, torch.bfloat16, 8000)
+    write_pos = torch.zeros(batch, device="cuda", dtype=torch.int32)
+    force_flush = torch.zeros_like(write_pos)
+
+    _decode(replay, mixed, a, b, a_log, dt_bias, write_pos, force_flush)
+    replay["state"].copy_(initial_state)
+    replay["d"].zero_()
+    replay["k"].zero_()
+    replay["g"].zero_()
+    replay["base"].zero_()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = _decode(replay, mixed, a, b, a_log, dt_bias, write_pos, force_flush)
+    replay["state"].copy_(initial_state)
+    replay["d"].zero_()
+    replay["k"].zero_()
+    replay["g"].zero_()
+    replay["base"].zero_()
+
+    cursor = torch.zeros_like(write_pos)
+    for step in range(9):
+        new_mixed, new_a, new_b = _inputs(
+            batch, heads, dim, torch.bfloat16, 8100 + step
+        )
+        expected = _reference_step(
+            new_mixed, new_a, new_b, a_log, dt_bias, reference_state, -5.0
+        )
+        mixed.copy_(new_mixed)
+        a.copy_(new_a)
+        b.copy_(new_b)
+        write_pos.copy_(cursor)
+        force_flush.zero_()
+        if step == 2:
+            force_flush[0] = 1
+        graph.replay()
+        torch.testing.assert_close(
+            out[:, 0].float(),
+            expected.to(torch.bfloat16).float(),
+            atol=3e-2,
+            rtol=3e-2,
+        )
+        cursor = _advance(replay, cursor, force_flush)
+
+
+@pytest.mark.parametrize(
+    ("heads", "value_heads", "lower_bound", "match"),
+    [
+        (2, 4, -5.0, "one K head"),
+        (4, 4, None, "finite negative"),
+        (4, 4, -6.0, "inverse-prefix scaling is unsafe"),
+    ],
+)
+def test_predecay_rejects_unsafe_configuration(heads, value_heads, lower_bound, match):
+    batch, dim, cache_len = 2, 32, 16
+    mixed, a, b = _inputs(batch, value_heads, dim, torch.bfloat16, 9000)
+    if heads != value_heads:
+        width = heads * dim
+        mixed = torch.cat(
+            (
+                mixed[:, :width],
+                mixed[:, value_heads * dim : value_heads * dim + width],
+                mixed[:, 2 * value_heads * dim :],
+            ),
+            dim=-1,
+        ).contiguous()
+    state = torch.zeros(batch, value_heads, dim, dim, device="cuda")
+    with pytest.raises(ValueError, match=match):
+        fused_recurrent_linear_replayssm_decode(
+            mixed_qkv=mixed,
+            a=a,
+            b=b,
+            A_log=torch.zeros(value_heads, device="cuda"),
+            dt_bias=torch.zeros(value_heads, dim, device="cuda"),
+            scale=dim**-0.5,
+            initial_state=state,
+            d_cache=torch.zeros(
+                batch, value_heads, cache_len, dim, device="cuda", dtype=torch.bfloat16
+            ),
+            k_cache=torch.zeros(
+                batch, heads, cache_len, dim, device="cuda", dtype=torch.bfloat16
+            ),
+            g_cache=torch.zeros(batch, value_heads, cache_len, dim, device="cuda"),
+            out=torch.empty(
+                batch, 1, value_heads, dim, device="cuda", dtype=torch.bfloat16
+            ),
+            ssm_state_indices=torch.arange(batch, device="cuda", dtype=torch.int32),
+            write_pos=torch.zeros(batch, device="cuda", dtype=torch.int32),
+            cache_base=torch.zeros(batch, device="cuda", dtype=torch.int32),
+            lower_bound=lower_bound,
+            is_kda=True,
+            circular_replay=True,
+            prefix_gate_cache=True,
+            predecayed_k_cache=True,
+        )

--- a/test/registered/attention/unittests/kda/test_replayssm_predecay.py
+++ b/test/registered/attention/unittests/kda/test_replayssm_predecay.py
@@ -55,9 +55,9 @@ def test_predecay_fresh_slot_resets_independent_cursor_fields():
     shape = KimiLinearStateShape.create(
         tp_world_size=1,
         num_heads=4,
-        head_dim=8,
+        head_dim=16,
         num_k_heads=4,
-        head_k_dim=8,
+        head_k_dim=16,
         gate_lower_bound=-5.0,
     )
     cache_params = KimiLinearCacheParams(
@@ -89,7 +89,7 @@ def test_predecay_fresh_slot_resets_independent_cursor_fields():
     )
 
     pool.alloc([req])
-    slot = req.mamba_pool_idx
+    slot = req.kv.mamba_pool_idx
     assert pool.mamba_pool.replayssm_write_pos[slot].item() == 0
     assert pool.mamba_pool.replayssm_cache_base[slot].item() == 0
     pool.mamba_pool.replayssm_write_pos[slot] = 2
@@ -97,6 +97,80 @@ def test_predecay_fresh_slot_resets_independent_cursor_fields():
     pool.mamba_pool.clear_slots(torch.tensor([slot], device="cuda"))
     assert pool.mamba_pool.replayssm_write_pos[slot].item() == 0
     assert pool.mamba_pool.replayssm_cache_base[slot].item() == 0
+
+    slot_indices = torch.tensor([slot], device="cuda")
+    state = pool.mamba_pool.mamba_cache
+    state.replayssm_d[:, slot_indices].zero_()
+    state.replayssm_k[:, slot_indices].zero_()
+    state.replayssm_g[:, slot_indices].zero_()
+    state.replayssm_d[:, slot_indices, :, 1].fill_(0.01)
+    state.replayssm_d[:, slot_indices, :, 2].fill_(0.02)
+    state.replayssm_k[:, slot_indices, :, 1].fill_(0.03)
+    state.replayssm_k[:, slot_indices, :, 2].fill_(0.04)
+    state.replayssm_g[:, slot_indices, :, 1].fill_(-0.1)
+    state.replayssm_g[:, slot_indices, :, 2].fill_(-0.2)
+    pool.mamba_pool.replayssm_write_pos[slot] = 2
+    pool.mamba_pool.replayssm_cache_base[slot] = 1
+    cpu_copy = pool.mamba_pool.get_cpu_copy(slot_indices)
+    assert len(cpu_copy) == 4
+
+    slot_int = int(slot.item())
+    dst_slot = 2 if slot_int == 1 else 1
+    dst_indices = torch.tensor([dst_slot], device="cuda")
+    state.replayssm_d[:, dst_indices].fill_(9.0)
+    state.replayssm_k[:, dst_indices].fill_(9.0)
+    state.replayssm_g[:, dst_indices].fill_(9.0)
+    pool.mamba_pool.reset_replayssm_cursors(dst_indices)
+    pool.mamba_pool.load_cpu_copy(cpu_copy, dst_indices)
+
+    assert torch.equal(
+        state.replayssm_d[:, dst_indices], state.replayssm_d[:, slot_indices]
+    )
+    assert torch.equal(
+        state.replayssm_k[:, dst_indices], state.replayssm_k[:, slot_indices]
+    )
+    assert torch.equal(
+        state.replayssm_g[:, dst_indices], state.replayssm_g[:, slot_indices]
+    )
+    assert pool.mamba_pool.replayssm_write_pos[dst_slot].item() == 2
+    assert pool.mamba_pool.replayssm_cache_base[dst_slot].item() == 1
+
+    def replay_view(idx):
+        index = slice(idx, idx + 1)
+        return {
+            "state": state.temporal[0, index],
+            "d": state.replayssm_d[0, index],
+            "k": state.replayssm_k[0, index],
+            "g": state.replayssm_g[0, index],
+            "base": pool.mamba_pool.replayssm_cache_base[index],
+        }
+
+    mixed, a, b = _inputs(1, 4, 16, torch.bfloat16, 42)
+    write_pos = torch.tensor([2], device="cuda", dtype=torch.int32)
+    force_flush = torch.zeros_like(write_pos)
+    a_log = torch.zeros(4, device="cuda")
+    dt_bias = torch.zeros(4, 16, device="cuda")
+    source_out = _decode(
+        replay_view(slot_int),
+        mixed,
+        a,
+        b,
+        a_log,
+        dt_bias,
+        write_pos,
+        force_flush,
+    )
+    restored_out = _decode(
+        replay_view(dst_slot),
+        mixed,
+        a,
+        b,
+        a_log,
+        dt_bias,
+        write_pos,
+        force_flush,
+    )
+    torch.testing.assert_close(restored_out, source_out, atol=0, rtol=0)
 
 
 def test_predecay_accepts_page_major_slot_stride():

--- a/test/registered/unit/mem_cache/test_replayssm_ring_accounting.py
+++ b/test/registered/unit/mem_cache/test_replayssm_ring_accounting.py
@@ -35,9 +35,14 @@ RL = 8
 LAYERS = [0, 1]
 
 
-def _kda_params():
+def _kda_params(gate_lower_bound=None):
     shape = KimiLinearStateShape.create(
-        tp_world_size=1, num_heads=4, head_dim=8, num_k_heads=4, head_k_dim=8
+        tp_world_size=1,
+        num_heads=4,
+        head_dim=8,
+        num_k_heads=4,
+        head_k_dim=8,
+        gate_lower_bound=gate_lower_bound,
     )
     return KimiLinearCacheParams(shape=shape, dtype=DTYPE, layers=LAYERS)
 
@@ -97,6 +102,27 @@ class TestReplaySSMRingAccounting(CustomTestCase):
             _pp_local_per_request_bytes(4096, [0, 1, 3, 4], 5, 8),
             0,
         )
+
+    def test_ordinary_decode_ring(self):
+        # d 1024 + k 1024 in fp32, plus per-K g 1024 = 3072 bytes/layer,
+        # plus one int32 write cursor per slot.
+        self.assertEqual(
+            _kda_params().replayssm_decode_ring_bytes_per_req(record_len=RL),
+            3072 * len(LAYERS) + 4,
+        )
+        # Safe-gate pre-decay keeps d/k in BF16: 512 + 512 + 1024 = 2048,
+        # plus int32 write_pos and cache_base.
+        self.assertEqual(
+            _kda_params(-5.0).replayssm_decode_ring_bytes_per_req(
+                record_len=RL, predecay_kda=True
+            ),
+            2048 * len(LAYERS) + 8,
+        )
+
+    def test_predecay_capability(self):
+        self.assertTrue(_kda_params(-5.0).supports_kda_replayssm_predecay(16))
+        self.assertFalse(_kda_params().supports_kda_replayssm_predecay(16))
+        self.assertFalse(_kda_params(-5.0).supports_kda_replayssm_predecay(32))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Motivation

ReplaySSM reduces recurrent-state traffic by keeping a checkpoint and a short ring of recent updates. On non-flush decode steps, the output is reconstructed from the checkpoint and the ring without writing the full recurrent state back to HBM.

The existing KDA ReplaySSM path pays an extra KDA-specific cost: the gate is a vector over the key dimension, so every replay rebuilds an `L x K` suffix-decay matrix and applies it to all cached keys. On bounded safe-gate KDA models this gate work can make raw Replay slower than packed decode.

This PR moves the suffix-gate transform to the ring append, stores pre-decayed keys, and adds a natural circular checkpoint lifecycle. On [`inclusionAI/Ling-3.0-flash`](https://huggingface.co/inclusionAI/Ling-3.0-flash), the optimized kernel delivers a `2.003×` speedup over bounded raw Replay at the exact TP8 local shape and improves 8xH200 serving throughput by `2.516%` over ReplaySSM-off packed decode.

This extends the buffered output-only decode work in [#28451](https://github.com/sgl-project/sglang/pull/28451) and addresses the KDA decode follow-up in the ReplaySSM RFC [#28511](https://github.com/sgl-project/sglang/issues/28511).

## What changed

- Add a pre-decayed-key representation for bounded safe-gate KDA ReplaySSM.
- Replace the replay-time `L x K` prefix/suffix gate scan with one `K`-wide total decay; the tensor-core low-rank reconstruction is unchanged.
- Add natural circular checkpointing: fold completed history once and retain the current token as row 0 of the next window.
- Carry `(write_pos, cache_base)` through eager and CUDA Graph decode, with one cursor transition per logical decode step shared by all KDA layers.
- Propagate the safe-gate lower bound from Ling/KDA model configuration and dispatch the optimized path only when its numerical conditions hold.
- Include D/K/G rings and both cursors in Mamba cache-capacity accounting.
- Preserve pending ring records and cursors across CPU retraction restore, and reset them on slot allocation/reuse.
- Add focused coverage for repeated wraps, non-power-of-two windows, forced flushes, BF16/FP32 rings, CUDA Graph replay, strided state slots, retraction, and memory accounting.

## Algorithm

### KDA recurrence

For one value head, let $S_{t-1} \in \mathbb{R}^{V \times K}$ and let the KDA gate be $\mathbf{g}_t \in \mathbb{R}^{K}$. Define $\boldsymbol{\alpha}_t = \exp(\mathbf{g}_t)$. The packed recurrence is

```math
\begin{aligned}
\widetilde{S}_t
  &= S_{t-1}\,\mathrm{Diag}\!\left(\boldsymbol{\alpha}_t\right), \\
d_t
  &= \beta_t\left(v_t-\widetilde{S}_t k_t\right), \\
o_t
  &= \widetilde{S}_t q_t
     + d_t\left(k_t^{\mathsf{T}}q_t\right), \\
S_t
  &= \widetilde{S}_t+d_t k_t^{\mathsf{T}}.
\end{aligned}
```

ReplaySSM keeps a checkpoint $S_0$ and `m` committed ring entries. With

$$
\mathbf{P}_j=\sum_{i=1}^{j}\mathbf{g}_i,
\qquad
\mathbf{G}=\mathbf{P}_m,
$$

the live state before the current token is

```math
S_{\mathrm{live}}
=
S_0\,\mathrm{Diag}\!\left(e^{\mathbf{G}}\right)
+
\sum_{j=1}^{m}
d_j
\left(
k_j\odot e^{\mathbf{G}-\mathbf{P}_j}
\right)^{\mathsf{T}}.
```

### Pre-decayed K

The optimized ring stores the cumulative log-gate and an inverse-prefix-scaled key:

$$
\mathbf{P}_j=\mathbf{P}_{j-1}+\mathbf{g}_j,
\qquad
k'_j=k_j\odot e^{-\mathbf{P}_j}.
$$

At replay time,

$$
k_j\odot e^{\mathbf{G}-\mathbf{P}_j}
=k'_j\odot e^{\mathbf{G}},
$$

so the state reconstruction becomes

```math
\boxed{
S_{\mathrm{live}}
=
\left(
S_0+
\sum_{j=1}^{m}
d_j {k'_j}^{\mathsf{T}}
\right)
  \mathrm{Diag}\!\left(e^{\mathbf{G}}\right)
}
```

This changes the suffix-gate exponentials from $O(LK)$ to $O(K)$ . The $D_{[V,L]}K'_{[L,K]}$ reconstruction remains $O(LVK)$ and continues to run on tensor cores.

For a bounded gate $\mathbf{g}_i \in [\ell,0]^K$, $\ell<0$, each channel of the inverse-prefix scale satisfies

$$
0\le -P_{j,c}\le j|\ell|
\le (L-1)|\ell|\le 80
\qquad \forall c,
$$

which is the dispatch guard used by the implementation.

<img width="1600" height="780" alt="kda_predecayed_key_replay" src="https://github.com/user-attachments/assets/98d7d186-1d25-4a5b-9aa8-fa47869001dd" />

### Natural circular checkpointing

<img width="3200" height="1047" alt="Circular_Ring_三类状态转移_高清" src="https://github.com/user-attachments/assets/2cdcb534-2220-44aa-83b6-a2411ed170f6" />

At a natural full-ring boundary, the output path has already reconstructed the state through token $t-1$. Instead of rebuilding the state a second time to include token $t$, the kernel publishes that history checkpoint and retains the current token in compact form as the first row of the next window:

$$
\begin{aligned}
S_0' &= S_{t-1}, \\
\mathrm{base}' &= (\mathrm{base}+L-1)\bmod L, \\
\mathrm{write\_pos}' &= 1.
\end{aligned}
$$

| Event | Checkpoint update | Ring/cursor transition |
| --- | --- | --- |
| Normal append | None | Append `(d, k', P)`; increment `write_pos` |
| Natural flush | Materialize completed history through $t-1$ | Rotate `cache_base`; keep token $t$ as logical row 0; set `write_pos=1` |
| Forced flush | Materialize history and current token | Clear the logical ring; set `cache_base=write_pos=0` |

<img width="1600" height="850" alt="kda_replayssm_circular_checkpoint" src="https://github.com/user-attachments/assets/cf877c1f-ca4e-4ab5-9c92-7677773a32e0" />



### Runtime integration

`write_pos` and `cache_base` are persistent per physical Mamba slot. For CUDA Graph replay, the metadata builder snapshots both into graph-stable buffers and advances the persistent cursor exactly once per decode step; every KDA layer in that step reads the same snapshot.

The pending D/K/G ring and both cursors are part of CPU retraction backup and restore. This preserves the exact logical state even when a request is restored into a different physical slot. Ring storage is also charged to the Mamba cache solver so slot capacity reflects the real allocation.

## Dispatch conditions

The pre-decayed path is selected for the following configuration:

| Item | Requirement |
| --- | --- |
| Device/backend | CUDA + Triton KDA decode |
| Gate | Finite negative safe-gate lower bound |
| Heads | Equal local key/value head counts (`H == HV`) |
| Checkpoint | FP32 recurrent state |
| Window | `2 <= L <= 16` and `(L - 1) * abs(lower_bound) <= 80` |
| Prefix cache | Radix cache disabled |

Other configurations keep the existing ReplaySSM behavior or packed KDA decode.

## Usage

```bash
python -m sglang.launch_server \
  --model-path inclusionAI/Ling-3.0-flash \
  --linear-attn-decode-backend triton \
  --enable-linear-replayssm \
  --linear-replayssm-cache-len 16 \
  --disable-radix-cache
```

## Validation

### Focused Test Coverage

| Suite | Result | Coverage |
| --- | ---: | --- |
| KDA pre-decay accounting, ring lifecycle, and retraction | 24 passed | Repeated wraps, `L=2/3/4/8/16`, BF16/FP32 rings, forced flush, strided slots, CUDA Graph, CPU restore |
| GDN and CPU-offload regression | 8 passed, 8 deselected | Existing GDN path and CPU-offload integration |
| Spec/shared regression | 34 passed | Shared ReplaySSM/spec infrastructure |
| MTP registered shard | 1 skipped | No runnable item in the test environment |
| Static checks | passed | `ruff check` and `git diff --check` |

The retraction test backs up a pending D/K/G ring and `(write_pos, cache_base)`, restores it into another physical slot, and verifies that the next-token output is bitwise equal to the non-retracted reference.

### GSM8K Accuracy

`inclusionAI/Ling-3.0-flash`, temperature 0, with identical prompts and templates for both runs:

| Mode | Scored | Correct | Accuracy |
| --- | ---: | ---: | ---: |
| ReplaySSM off | 1,314 | 1,233 | 93.8356% |
| Pre-decay + natural circular | 1,314 | 1,232 | 93.7595% |
| Difference | — | -1 | -0.0761 percentage points |

The runner uses the first five test rows as demonstrations and scores the remaining 1,314 items from the 1,319-question set.

## Performance

### Setup

- 8x NVIDIA H200; TP8 / EP8 / DP1 / attention TP8.
- Public model: [`inclusionAI/Ling-3.0-flash`](https://huggingface.co/inclusionAI/Ling-3.0-flash).
- 42 layers: 35 KDA + 7 MLA; global `H=HV=32`, `K=V=128`; TP8 local  `H=HV=4`; safe-gate lower bound `-5`.
- Radix cache off; MTP/speculative decoding off; CUDA Graph on; Triton KDA decode; FlashInfer full attention.
- FP32 recurrent checkpoint; BF16 D/K ring; FP32 cumulative-gate ring; `L=16`.
- 128 max running requests and 128 Mamba slots.
- Serving workload: 640 requests, fixed `ISL=128`, fixed `OSL=1024`, concurrency 128, unlimited request rate, fixed random token IDs.
- Every round completed 81,920 input tokens and 655,360 output tokens.

### End-to-end serving

Both modes used three full-workload warmups. ReplaySSM-off was measured for two rounds and pre-decay for eight rounds.

| Mode | Runs | Duration (s) | Output tok/s | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| ReplaySSM off | 2 | 90.5393 | 7,238.482 | 17.1403 | 17.1556 | 17.7587 |
| Pre-decay + natural circular | 8 | **88.3185** | **7,420.568** | **16.9646** | **16.8851** | **17.5502** |
| Relative change | — | **-2.453%** | **+2.516%** | **-1.025%** | **-1.577%** | **-1.174%** |

The candidate output-throughput CV was `0.482%` over all eight measured rounds and `0.125%` over the first seven.

### Packed decode, raw Replay, and pre-decay

A separate three-way run compared packed decode with the existing bounded raw Replay kernel and the optimized path. Each mode used one full-workload warmup and two measured rounds.

| Mode | Duration (s) | Output tok/s | Mean TPOT (ms) | TPS vs packed | TPOT vs packed |
| --- | ---: | ---: | ---: | ---: | ---: |
| Packed decode | 91.7305 | 7,144.411 | 17.3434 | — | — |
| Bounded raw Replay | 94.5463 | 6,931.844 | 17.9025 | -2.975% | +3.224% |
| Pre-decay + natural circular | 92.2640 | 7,103.295 | 17.4369 | -0.576% | +0.539% |

Compared directly with bounded raw Replay, pre-decay improves output throughput
by `2.473%`, mean TPOT by `2.600%`, and duration by `2.414%`.

### Kernel microbenchmark

H200, `K=V=128`, `L=16`, lower bound `-5`, CUDA Graph, 240 launches per graph, 9 samples, 5 graph replays per sample. Each implementation runs its complete cursor lifecycle.

| Local shape | Packed | Bounded raw Replay | Pre-decay + natural | Raw / pre-decay | Packed / pre-decay |
| --- | ---: | ---: | ---: | ---: | ---: |
| `B=128, H=HV=4` (Ling TP8) | 15.600 µs | 28.332 µs | **14.146 µs** | **2.003×** | **1.103×** |
| `B=128, H=HV=8` | 38.512 µs | 55.737 µs | **33.693 µs** | **1.654×** | **1.143×** |

### Natural circular checkpointing ablation

This direct-kernel ablation keeps dtype, pre-decay, and launch configuration fixed and changes only full flush versus natural retain:

| L | B | Full flush | Natural circular | Speedup | Latency reduction |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 16 | 19.124 µs | 15.502 µs | 1.234× | 18.94% |
| 8 | 64 | 77.032 µs | 65.789 µs | 1.171× | 14.60% |
| 8 | 256 | 277.641 µs | 234.843 µs | 1.182× | 15.42% |
| 16 | 16 | 18.895 µs | 15.300 µs | 1.235× | 19.03% |
| 16 | 64 | 74.105 µs | 61.980 µs | 1.196× | 16.36% |
| 16 | 256 | 266.608 µs | 218.451 µs | 1.220× | 18.06% |

## References

- ReplaySSM RFC: [#28511](https://github.com/sgl-project/sglang/issues/28511)
- Buffered output-only linear-attention decode: [#28451](https://github.com/sgl-project/sglang/pull/28451)
- ReplaySSM: [Dao AI Lab](https://dao-lab.ai/blog/2026/replayssm/)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34081276713](https://github.com/sgl-project/sglang/actions/runs/34081276713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34081276604](https://github.com/sgl-project/sglang/actions/runs/34081276604)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34081276663](https://github.com/sgl-project/sglang/actions/runs/34081276663)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->