### PR TITLE
[moe] Deal simulated round-robin experts rank-first so no EP rank idles

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -374,12 +374,29 @@ class PackedTopKOutput(NamedTuple):
         return TopKOutputFormat.PACKED
 
 
+def _balanced_routing_num_ranks(num_experts: int) -> int:
+    """EP ranks to deal the balanced assignment across, or 1 when dealing cannot help.
+
+    Rank-first dealing needs equal contiguous blocks. When the EP size does not
+    divide ``num_experts`` the ranks own unequal blocks, no exact per-rank balance
+    exists, and dealing would leave the tail experts unreachable. The override is
+    also driven from standalone benchmark scripts with no distributed launch,
+    where the EP group does not exist and ``get_parallel()`` would assert.
+    """
+    if not torch.distributed.is_initialized():
+        return 1
+    num_ranks = get_parallel().moe_ep_size
+    return num_ranks if num_ranks > 0 and num_experts % num_ranks == 0 else 1
+
+
 @triton.jit
 def _simulate_balanced_routing_kernel(
     topk_ids_ptr,
     topk_weights_ptr,
     num_experts,
     step,
+    num_ranks,
+    experts_per_rank,
     inv_k,
     seed,
     layer_offset,
@@ -404,11 +421,13 @@ def _simulate_balanced_routing_kernel(
     - ``topk_weights_ptr``: ``[num_tokens, K]`` (row-major; strides passed in),
       overwritten in place
 
-    ``RANDOM=False`` is the deterministic round-robin base ``token + layer_offset``;
-    ``RANDOM=True`` is a random per-token base (uniform, balanced in expectation;
-    ``seed`` is a kernel arg, so it is baked at CUDA-graph capture and replays stay
-    balanced). Both spread the k experts by ``step`` and emit global expert ids
-    (any EP logical->physical remap happens later in ``_post_process_topk_ids``).
+    ``RANDOM=False`` numbers the (token, slot) assignments and deals ordinal ``a``
+    to rank ``a % num_ranks``, so every EP rank draws the same token count even
+    when the assignments do not cover all experts; ``RANDOM=True`` is a random
+    per-token base spread by ``step`` (uniform, balanced in expectation; ``seed``
+    is a kernel arg, so it is baked at CUDA-graph capture and replays stay
+    balanced). Both emit global expert ids (any EP logical->physical remap happens
+    later in ``_post_process_topk_ids``).
     ``token_shard_rank`` and ``num_token_shards`` ensure scattered DP ranks generate
     different expert assignments for their local tokens when DP > 1."""
     t = tl.program_id(0)
@@ -417,9 +436,12 @@ def _simulate_balanced_routing_kernel(
     mask = j < K
     if RANDOM:
         base = (tl.rand(seed, global_t) * num_experts).to(tl.int32)
+        gid = (base + j * step) % num_experts
     else:
-        base = global_t + layer_offset
-    gid = (base + j * step) % num_experts
+        deal = global_t * K + j + layer_offset
+        gid = (deal % num_ranks) * experts_per_rank + (
+            deal // num_ranks
+        ) % experts_per_rank
     tl.store(topk_ids_ptr + t * stride_im + j * stride_ik, gid, mask=mask)
     tl.store(
         topk_weights_ptr + t * stride_wm + j * stride_wk,
@@ -461,6 +483,7 @@ def _simulate_balanced_routing(
     if num_tokens == 0 or k == 0:
         return
     assert 0 <= token_shard_rank < num_token_shards
+    num_ranks = _balanced_routing_num_ranks(num_experts)
     if random and seed is None:
         seed = _simulate_uniform_seed
         _simulate_uniform_seed += 1
@@ -471,6 +494,8 @@ def _simulate_balanced_routing(
         topk_weights,
         num_experts,
         max(num_experts // k, 1),
+        num_ranks,
+        max(num_experts // num_ranks, 1),
         1.0 / k,
         seed,
         0 if layer_id is None else layer_id,

--- a/test/registered/moe/test_simulate_balanced_routing.py
+++ b/test/registered/moe/test_simulate_balanced_routing.py
@@ -1,0 +1,96 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.topk import _simulate_balanced_routing
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
+
+NUM_EXPERTS = 256
+TOPK = 8
+
+
+class TestSimulateBalancedRouting(CustomTestCase):
+    """SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS must not leave EP ranks idle.
+
+    Spacing each token's slots by num_experts // topk balances ranks only while
+    num_tokens * topk >= num_experts. Below that, a rank whose expert block is
+    narrower than the spacing is never selected -- at num_experts=256, topk=8,
+    EP16 every odd rank drew zero tokens for any batch under 32.
+    """
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/HIP not available")
+
+    def _route(self, num_tokens, num_ranks, *, random=False, topk=TOPK):
+        ids = torch.zeros(num_tokens, topk, dtype=torch.int32, device="cuda")
+        weights = torch.zeros(num_tokens, topk, dtype=torch.float32, device="cuda")
+        with patch(
+            "sglang.srt.layers.moe.topk._balanced_routing_num_ranks",
+            return_value=num_ranks,
+        ):
+            _simulate_balanced_routing(ids, weights, NUM_EXPERTS, random=random, seed=0)
+        return ids, weights
+
+    def _per_rank_counts(self, ids, num_ranks):
+        block = NUM_EXPERTS // num_ranks
+        return torch.bincount(
+            ids.flatten().to(torch.int64) // block, minlength=num_ranks
+        ).tolist()
+
+    def test_every_rank_draws_the_same_token_count(self):
+        for num_ranks in (1, 2, 4, 8, 16):
+            for num_tokens in (1, 2, 4, 8, 16, 32, 300):
+                with self.subTest(num_ranks=num_ranks, num_tokens=num_tokens):
+                    ids, _ = self._route(num_tokens, num_ranks)
+                    counts = self._per_rank_counts(ids, num_ranks)
+                    assignments = num_tokens * TOPK
+                    self.assertEqual(sum(counts), assignments)
+                    # Off by at most one only when the assignments cannot divide
+                    # across the ranks; exactly equal otherwise.
+                    self.assertLessEqual(max(counts) - min(counts), 1)
+                    if assignments % num_ranks == 0:
+                        self.assertEqual(min(counts), assignments // num_ranks)
+
+    def test_activated_expert_count_and_weights(self):
+        for num_tokens in (1, 4, 32, 300):
+            with self.subTest(num_tokens=num_tokens):
+                ids, weights = self._route(num_tokens, 16)
+                self.assertEqual(
+                    ids.unique().numel(), min(num_tokens * TOPK, NUM_EXPERTS)
+                )
+                torch.testing.assert_close(
+                    weights, torch.full_like(weights, 1.0 / TOPK)
+                )
+
+    def test_each_token_gets_distinct_experts(self):
+        for num_ranks in (1, 4, 16):
+            with self.subTest(num_ranks=num_ranks):
+                ids, _ = self._route(64, num_ranks)
+                for row in ids:
+                    self.assertEqual(row.unique().numel(), TOPK)
+
+    def test_ids_stay_in_range(self):
+        for num_ranks in (1, 4, 16):
+            with self.subTest(num_ranks=num_ranks):
+                ids, _ = self._route(300, num_ranks)
+                self.assertGreaterEqual(int(ids.min()), 0)
+                self.assertLess(int(ids.max()), NUM_EXPERTS)
+
+    def test_uniform_is_flat_across_ranks_in_expectation(self):
+        # The random path keeps its own spacing; assert only that it does not
+        # systematically starve a rank.
+        ids, weights = self._route(4096, 8, random=True)
+        counts = self._per_rank_counts(ids, 8)
+        ideal = 4096 * TOPK // 8
+        self.assertLess(max(counts) - min(counts), ideal // 8)
+        torch.testing.assert_close(weights, torch.full_like(weights, 1.0 / TOPK))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS` exists to remove expert-load imbalance as a
variable when benchmarking MoE. Under expert parallelism it currently does the
opposite for a whole class of shapes: it can leave half the EP ranks with **zero
tokens**, so the measured MoE time is set by the ranks that received everything.

`_simulate_balanced_routing_kernel` spaces each token's `topk` slots by
`num_experts // topk`. A rank owns a contiguous block of
`num_experts / ep_size`. When that block is at least as wide as the spacing,
every rank picks up `topk / ep_size` slots per token and the override behaves as
intended. When the block is *narrower* than the spacing, every slot of a token
lands in the same subset of ranks and the rest get nothing.

With `num_experts=256, topk=8` (spacing 32), EP16 gives blocks of 16, and every
odd rank draws zero tokens for any batch under 32 tokens per call:

```
tokens=8, EP16    before  [8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0, 8, 0]
                  after   [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
```

EP4 and EP8 are unaffected at this shape, which is why it went unnoticed.

## Modifications

Number the `(token, slot)` assignments and deal ordinal `a` to rank
`a % num_ranks`, so consecutive slots land on consecutive EP ranks:

```
a      = global_t * K + j + layer_offset
rank   = a % num_ranks
slot   = (a // num_ranks) % experts_per_rank
expert = rank * experts_per_rank + slot
```

`num_ranks` comes from `_balanced_routing_num_ranks()`, which returns the MoE EP
world size, or `1` in two cases where dealing cannot help:

- **`num_experts % ep_size != 0`.** The ranks own unequal blocks, no exact
  per-rank balance exists, and dealing would leave the tail experts unreachable.
- **No distributed launch.** This override is driven from standalone benchmark
  scripts where the EP group was never created and `get_parallel()` would assert.

Deliberately unchanged:

- **The uniform (`RANDOM=True`) path** keeps its existing `step` spacing. It is
  already flat across ranks in expectation, so there is nothing to fix, and
  leaving it alone keeps the diff to the one broken case.
- **Shared experts.** `fused_append_shared_experts` runs in
  `_post_process_topk_ids`, after this override, so `topk_ids` here holds routed
  experts only and the ordinal stride needs no adjustment.
- **`token_shard_rank` / `num_token_shards`.** The ordinal is built from
  `global_t`, so scattered DP ranks keep generating distinct assignments.

## Accuracy Tests

Not applicable. This is a benchmark-only override behind an env var that defaults
to `False` and is documented "Do NOT use in production" — it discards the
router's output entirely and is never on a serving path.

## Speed Tests and Profiling

No change is expected on any shape where the old formula already balanced, and
the invariants that drive MoE cost are preserved:

- **Per-expert token counts** stay as flat as possible (floor/ceil of
  `num_tokens * topk / num_experts`), so grouped-GEMM group sizes do not change.
  Both orders are permutations of the same numbering.
- **Activated expert count** is unchanged at exactly
  `min(num_tokens * topk, num_experts)` — asserted in the new test.
- **Per-rank counts at EP1 / EP2 / EP4 / EP8** are identical before and after,
  verified for `num_tokens` in `{1, 2, 4, 8, 16, 32, 300}`.

The shapes that do change are exactly the ones that were unbalanced, where the
old numbers reflected idle ranks rather than the balanced scenario being
simulated.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

`test/registered/moe/test_simulate_balanced_routing.py` (CUDA + AMD, ~30s) drives
the real Triton kernel and covers per-rank balance across `num_ranks` in
`{1, 2, 4, 8, 16}` × `num_tokens` in `{1, 2, 4, 8, 16, 32, 300}`, the
activated-expert count, `1/k` weights, per-token distinctness, id range, and the
uniform path's flatness. 5 tests / 45 subtests, all passing on a GB300.

Reverting only the formula (keeping the helper, so the test's mock target still
resolves) fails 5 subtests, all at EP16 — `num_tokens` 2, 4, 8, 16, 300 — which
matches the per-rank analysis above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33728217199](https://github.com/sgl-project/sglang/actions/runs/33728217199)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33728217121](https://github.com/sgl-project/sglang/actions/runs/33728217121)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33728217127](https://github.com/sgl-project/sglang/actions/runs/33728217127)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->