### PR TITLE
[GLM-5.3] Fix qkvbfg fusion being disabled by the global quant config

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 from copy import deepcopy
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import numpy
 import torch
@@ -123,6 +123,39 @@ def is_layer_skipped(
 
     assert is_skipped is not None
     return is_skipped
+
+
+def are_linear_prefixes_unquantized(
+    quant_config: Optional[QuantizationConfig],
+    prefixes: Iterable[str],
+) -> bool:
+    """Whether every linear layer in ``prefixes`` would be built unquantized.
+
+    A model-level ``quant_config`` only says the checkpoint carries *some*
+    quantized weights, not that any given layer is one of them -- FP8
+    checkpoints routinely quantize the experts and leave attention in BF16.
+    Callers that swap in a hand-fused module the quant methods cannot feed must
+    therefore ask per layer instead of testing ``quant_config is None``, so
+    resolve each prefix the way the real layer would and accept only
+    ``None`` / ``UnquantizedLinearMethod``.
+    """
+    if quant_config is None:
+        return True
+
+    from sglang.srt.layers.linear import LinearBase
+    from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+
+    # Weightless stand-in: LinearBase.__init__ allocates nothing (create_weights
+    # lives in the subclasses), and quant_config=None keeps constructing the
+    # probe from recursing back into get_quant_method.
+    probe = LinearBase(input_size=1, output_size=1, quant_config=None)
+    for prefix in prefixes:
+        quant_method = quant_config.get_quant_method(probe, prefix=prefix)
+        if quant_method is not None and not isinstance(
+            quant_method, UnquantizedLinearMethod
+        ):
+            return False
+    return True
 
 
 def per_tensor_dequantize(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.utils import are_linear_prefixes_unquantized
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils.common import PPMissingLayer
@@ -336,7 +337,26 @@ class Glm5NextLinearAttention(nn.Module):
         projection_size = self.head_dim * self.num_heads
         self.conv_size = config.linear_attn_config["short_conv_kernel_size"]
 
-        self.do_fuse_qkvbfg = quant_config is None and head_shard_size == self.tp_size
+        # A global quant_config does not mean these six projections are
+        # quantized: GLM-5.3-Flash ships FP8 experts with BF16 attention. Ask
+        # per prefix, since the fused modules can only eat unquantized weights.
+        self.do_fuse_qkvbfg = (
+            head_shard_size == self.tp_size
+            and are_linear_prefixes_unquantized(
+                quant_config,
+                [
+                    f"{prefix}.{name}"
+                    for name in (
+                        "qkv_proj",
+                        "f_a_proj",
+                        "f_b_proj",
+                        "b_proj",
+                        "g_a_proj",
+                        "g_b_proj",
+                    )
+                ],
+            )
+        )
         if self.do_fuse_qkvbfg:
             self.qkvb_sizes = [
                 projection_size,
@@ -350,7 +370,12 @@ class Glm5NextLinearAttention(nn.Module):
                 self.hidden_size,
                 self.qkvb_sizes,
                 self.fg_sizes,
-                quant_config=quant_config,
+                # The gate above already proved the source weights are
+                # unquantized. This name exists in no checkpoint, so an ignore
+                # list written in terms of the real ones is not guaranteed to
+                # cover it -- handing it the global config risks quantizing a
+                # layer whose source weights are BF16.
+                quant_config=None,
                 prefix=f"{prefix}.fused_qkvbfg_a_proj",
             )
             self.split_sizes = [


### PR DESCRIPTION
## Motivation

Stacked on #36507 — this targets that PR's branch (`xinyuan/glm-5.3-flash-support`), not `main`.

`Glm5NextLinearAttention` gates its qkvbfg fusion on:

```python
self.do_fuse_qkvbfg = quant_config is None and head_shard_size == self.tp_size
```

`quant_config is None` asks whether the *model* carries any quantized weights. The question that actually matters here is whether *these six projections* are quantized.

The official GLM-5.3-Flash checkpoint is FP8, but only the routed experts are quantized — attention stays BF16. Dumping the modules the non-fused branch builds, in `forward`, at TP8 on the official FP8 weights:

```
qkv_proj  (3072, 4096) torch.bfloat16
f_a_proj  (128,  4096) torch.bfloat16
f_b_proj  (1024, 128)  torch.bfloat16
b_proj    (8,    4096) torch.bfloat16
g_a_proj  (128,  4096) torch.bfloat16
g_b_proj  (1024, 128)  torch.bfloat16
```

All six resolve to `UnquantizedLinearMethod` with plain BF16 weights. The fusion path can consume them exactly as-is — it is turned off purely because a global FP8 config object exists.

The gate arrived with #17801, which added this fusion for Kimi Linear. That model is pure BF16, so `quant_config` was always `None` there and the check never had to be right. `glm5_next` is the first model to reuse the fusion with a quantization config present.

Cost of the wrong answer: 6 GEMM launches per linear-attention layer per step instead of 2, one of them with `N=8`. #17801 reported 38.8us -> 11.7us on the decode kernel and 5–10% TPOT for the same fusion on Kimi Linear; I have not re-measured those numbers on GLM-5.3-Flash.

## Modifications

**`python/sglang/srt/layers/quantization/utils.py`** — new `are_linear_prefixes_unquantized(quant_config, prefixes)` alongside `is_layer_skipped`:

- `quant_config is None` returns `True` immediately, so unquantized models behave exactly as they do today.
- Otherwise it builds one `LinearBase(1, 1, quant_config=None)` probe and resolves each prefix through `quant_config.get_quant_method(probe, prefix=...)`, accepting only `None` / `UnquantizedLinearMethod`.

Going through `get_quant_method` rather than calling `is_layer_skipped` directly is deliberate: each config wraps the skip check differently (`ignored_layers` in `Fp8Config`, `exclude_modules` + `is_layer_excluded` in ModelOpt, `get_dynamic_override` regexes in GPTQ), and only `get_quant_method` covers them all uniformly.

The probe is safe on the two counts that matter: `LinearBase.__init__` allocates no weights (`create_weights` lives in the subclasses), and passing `quant_config=None` stops it from recursing back into `get_quant_method`. Every `get_quant_method` in `layers/quantization/` `isinstance`-checks the layer in its `LinearBase` branch and reads no attributes off it, so an attribute-less probe is sufficient.

**`python/sglang/srt/models/glm5_next.py`** — the gate becomes per-prefix:

```python
self.do_fuse_qkvbfg = (
    head_shard_size == self.tp_size
    and are_linear_prefixes_unquantized(quant_config, [...six prefixes...])
)
```

The cheap TP condition stays first, so unquantized models never build a probe.

`fused_qkvbfg_a_proj` is now constructed with `quant_config=None`. That name exists in no checkpoint, so an ignore list written in terms of the real projection names is not guaranteed to cover it, and handing it the global config would risk quantizing a layer whose source weights are BF16. Under the old gate `quant_config` was provably `None` at this call site, so this is a no-op for existing behavior. `fused_fg_b_proj` takes no `quant_config` at all.

`load_weights` needs no matching change: it decides per stacked-mapping entry via `candidate not in params_dict`, so it already consumes the module tree `__init__` actually built and cannot disagree with the gate.

No change to `MergedColumnParallelRepeatedLinear` / `ColumnParallelBatchedLinear`, and no other model is touched — Kimi Linear keeps today's behavior, since `quant_config is None` short-circuits to `True`.

## Accuracy Tests

Not yet run — will post GSM8K on GLM-5.3-Flash FP8 at TP8, fused vs. unfused, before this is merged.

Logic verified so far by resolving the six prefixes through `is_layer_skipped` for several ignore-list shapes:

| `ignored_layers` shape                      | fuses?         |
| ------------------------------------------- | -------------- |
| parent path (`linear_attn`) — GLM-5.3-Flash | yes            |
| leaf names (`q_proj`, `k_proj`, …)          | yes            |
| attention fully quantized                   | no, falls back |
| partial (only `b_proj` left in BF16)        | no, falls back |

`qkv_proj` expands through the packed-shard mapping in every case.

Check the two paths' accuracy with a simple POST request.

## Speed Tests and Profiling

Not yet run — will post decode kernel time and TPOT on GLM-5.3-Flash FP8 at TP8, to confirm the #17801 gains carry over.

## Checklist

- [x] Format your code according to the [[Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit)](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [[Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests)](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [[Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations)](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [[Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [[Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [[guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @JustinTong0323

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)

https://claude.ai/code/session_011bZceDMfnfmqUyDGMw7nHP

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33728768058](https://github.com/sgl-project/sglang/actions/runs/33728768058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33728767847](https://github.com/sgl-project/sglang/actions/runs/33728767847)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33728768018](https://github.com/sgl-project/sglang/actions/runs/33728768018)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->