### PR TITLE
fix(glm5): preserve NEXTN acceptance with AR auto

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1006,12 +1006,24 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
 
 @register_post_process
 def _enforce_disable_allreduce_fusion(view: Any) -> dict:
-    """Slot pass right after the auto-enable: the user's enforce-disable
-    switch wins over every model-specific adjustment."""
+    """Apply terminal safety overrides after all-reduce auto selection."""
     if view.enforce_disable_flashinfer_allreduce_fusion:
         logger.info(
             "FlashInfer allreduce fusion is forcibly disabled "
             "via --enforce-disable-flashinfer-allreduce-fusion."
+        )
+        return {"flashinfer_allreduce_fusion_backend": None}
+    if (
+        view.flashinfer_allreduce_fusion_backend == "auto"
+        and view.nnodes == 1
+        and view.speculative_algorithm in ("EAGLE", "NEXTN")
+        and model_config_of(view).hf_config.architectures[0]
+        == "Glm5NextForConditionalGeneration"
+    ):
+        logger.warning(
+            "Disabling FlashInfer all-reduce auto selection for single-node "
+            "GLM-5 NEXTN to preserve speculative acceptance. Set an explicit "
+            "FlashInfer backend to override."
         )
         return {"flashinfer_allreduce_fusion_backend": None}
     return {}


### PR DESCRIPTION
## Motivation

On single-node B300, FlashInfer AllReduce `auto` resolves to MNNVL for GLM-5.3-Flash. Its valid but different BF16 reduction order changes the NEXTN speculative trajectory, reducing mean accepted tokens from `5.88` to `3.79`.

Fixes #37745.

## Modifications

- disable FlashInfer AllReduce `auto` selection for single-node GLM-5 NEXTN/EAGLE
- keep explicit `mnnvl`/`trtllm` and multi-node configurations unchanged

## Accuracy Tests

Direct 8-GPU eager and CUDA Graph comparisons against NCCL stayed within normal BF16 reduction-order error. Six graph replays were stable, with no evidence of random corruption or graph-state accumulation.

Focused configuration checks covered NEXTN/EAGLE, explicit backends, multi-node, non-speculative, and non-GLM models. Python 3.12 syntax validation passed.

## Speed Tests and Profiling

Matched 8x B300 TP8/EP8 decode workload (`50000` cached input tokens, `700` output tokens, batch size `320`, NEXTN `5/1/6`):

| AllReduce path | Output tok/s | Mean accepted tokens |
|---|---:|---:|
| `auto` -> MNNVL | 17,189.51 | 3.79 |
| explicit `trtllm` | 28,786.99 | 5.72 |
| this change -> custom AllReduce | 32,929.86 | 5.88 |

## Checklist

- [x] Format code with pre-commit.
- [x] Unit tests: N/A for this configuration-only safety guard; no test file is submitted, and the behavior was validated with focused configuration checks and matched hardware runs.
- [x] Documentation is not required for this scoped backend-selection safety guard.
- [x] Accuracy and speed benchmark results are provided above.
- [x] The change follows the SGLang code style guidance.
