### PR TITLE
[CPU] Implement fused QK Norm and RoPE kernels

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/norm.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/norm.cpp
@@ -1120,6 +1120,151 @@ void fused_qk_norm_kernel_impl(
   });
 }
 
+template <typename scalar_t>
+inline float
+fused_qk_norm_rope_freq(float base, int64_t rotary_dim, int64_t half_dim, float factor, float low, float high) {
+  float freq = std::pow(base, -2.0f * static_cast<float>(half_dim) / static_cast<float>(rotary_dim));
+  if (std::abs(factor - 1.0f) > 1e-6f) {
+    const float inv_freq_extrapolation = freq;
+    const float inv_freq_interpolation = freq / factor;
+    const float high_adj = std::abs(low - high) <= 1e-6f ? high + 0.001f : high;
+    const float linear_func = (static_cast<float>(half_dim) - low) / (high_adj - low);
+    const float ramp_func = std::min(std::max(linear_func, 0.0f), 1.0f);
+    const float inv_freq_extrapolation_factor = 1.0f - ramp_func;
+    freq = inv_freq_interpolation * (1.0f - inv_freq_extrapolation_factor) +
+           inv_freq_extrapolation * inv_freq_extrapolation_factor;
+  }
+  return freq;
+}
+
+template <typename scalar_t>
+void fused_qk_norm_rope_per_head(
+    scalar_t* __restrict__ data,
+    const scalar_t* __restrict__ weight,
+    int64_t head_dim,
+    int64_t rotary_dim,
+    int64_t position,
+    float eps,
+    float base,
+    bool is_neox,
+    float factor,
+    float low,
+    float high,
+    float attention_factor) {
+  float sum_sq = 0.0f;
+  for (int64_t d = 0; d < head_dim; ++d) {
+    const float x = static_cast<float>(data[d]);
+    sum_sq += x * x;
+  }
+  const float scale = 1.0f / std::sqrt(sum_sq / static_cast<float>(head_dim) + eps);
+  for (int64_t d = 0; d < head_dim; ++d) {
+    data[d] = static_cast<scalar_t>(static_cast<float>(data[d]) * scale * static_cast<float>(weight[d]));
+  }
+
+  if (rotary_dim <= 0 || rotary_dim > head_dim) {
+    return;
+  }
+  if (rotary_dim % 2 != 0) {
+    TORCH_CHECK(false, "rotary_dim must be even, got ", rotary_dim);
+  }
+
+  std::vector<float> rotated(rotary_dim);
+  if (is_neox) {
+    const int64_t half_rotary = rotary_dim / 2;
+    for (int64_t d = 0; d < half_rotary; ++d) {
+      const float x = static_cast<float>(data[d]);
+      const float y = static_cast<float>(data[d + half_rotary]);
+      const int64_t dim_idx = (d * 2) % rotary_dim;
+      const int64_t half_dim = dim_idx / 2;
+      const float freq = fused_qk_norm_rope_freq<scalar_t>(base, rotary_dim, half_dim, factor, low, high);
+      const float theta = static_cast<float>(position) * freq;
+      const float s = std::sin(theta);
+      const float c = std::cos(theta);
+      rotated[d] = x * c - y * s;
+      rotated[d + half_rotary] = y * c + x * s;
+    }
+    for (int64_t d = 0; d < rotary_dim; ++d) {
+      data[d] = static_cast<scalar_t>(rotated[d] * attention_factor);
+    }
+  } else {
+    for (int64_t d = 0; d < rotary_dim; d += 2) {
+      const float x = static_cast<float>(data[d]);
+      const float y = static_cast<float>(data[d + 1]);
+      const int64_t half_dim = (d / 2);
+      const float freq = fused_qk_norm_rope_freq<scalar_t>(base, rotary_dim, half_dim, factor, low, high);
+      const float theta = static_cast<float>(position) * freq;
+      const float s = std::sin(theta);
+      const float c = std::cos(theta);
+      rotated[d] = x * c - y * s;
+      rotated[d + 1] = y * c + x * s;
+    }
+    for (int64_t d = 0; d < rotary_dim; ++d) {
+      data[d] = static_cast<scalar_t>(rotated[d] * attention_factor);
+    }
+  }
+}
+
+template <typename scalar_t>
+void fused_qk_norm_rope_kernel_impl(
+    scalar_t* __restrict__ q,
+    scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ q_weight,
+    const scalar_t* __restrict__ k_weight,
+    int64_t num_tokens,
+    int64_t num_q_heads,
+    int64_t num_kv_heads,
+    int64_t head_dim,
+    int64_t q_stride,
+    int64_t k_stride,
+    float eps,
+    float base,
+    bool is_neox,
+    const int64_t* position_ids,
+    float factor,
+    float low,
+    float high,
+    float attention_factor,
+    int64_t rotary_dim) {
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t token = begin; token < end; ++token) {
+      const int64_t pos = position_ids[token];
+      scalar_t* q_ptr = q + token * q_stride;
+      scalar_t* k_ptr = k + token * k_stride;
+
+      for (int64_t h = 0; h < num_q_heads; ++h) {
+        fused_qk_norm_rope_per_head<scalar_t>(
+            q_ptr + h * head_dim,
+            q_weight,
+            head_dim,
+            rotary_dim,
+            pos,
+            eps,
+            base,
+            is_neox,
+            factor,
+            low,
+            high,
+            attention_factor);
+      }
+      for (int64_t h = 0; h < num_kv_heads; ++h) {
+        fused_qk_norm_rope_per_head<scalar_t>(
+            k_ptr + h * head_dim,
+            k_weight,
+            head_dim,
+            rotary_dim,
+            pos,
+            eps,
+            base,
+            is_neox,
+            factor,
+            low,
+            high,
+            attention_factor);
+      }
+    }
+  });
+}
+
 }  // anonymous namespace
 
 void fused_qk_norm_cpu(
@@ -1153,5 +1298,76 @@ void fused_qk_norm_cpu(
         q.stride(0),
         k.stride(0),
         static_cast<float>(eps));
+  });
+}
+
+void fused_qk_norm_rope_cpu(
+    at::Tensor& q,
+    at::Tensor& k,
+    const at::Tensor& q_weight,
+    const at::Tensor& k_weight,
+    double eps,
+    double base,
+    bool is_neox,
+    const at::Tensor& position_ids,
+    double factor,
+    double low,
+    double high,
+    double attention_factor,
+    int64_t rotary_dim) {
+  const auto st = q.scalar_type();
+  CHECK_INPUT_ND<2>(q);
+  CHECK_INPUT_ND<2>(k);
+  CHECK_EQ(k.size(0), q.size(0));
+  CHECK_EQ(k.scalar_type(), st);
+  CHECK_EQ(position_ids.dim(), 1);
+  CHECK_EQ(position_ids.size(0), q.size(0));
+  TORCH_CHECK(
+      position_ids.scalar_type() == at::kLong || position_ids.scalar_type() == at::kInt,
+      "position_ids must be int32 or int64, got ",
+      position_ids.scalar_type());
+
+  const int64_t head_dim = q_weight.numel();
+  CHECK_GT(head_dim, 0);
+  CHECK_INPUT_SHAPE_DTYPE<false>(q_weight, {head_dim}, st);
+  CHECK_INPUT_SHAPE_DTYPE<false>(k_weight, {head_dim}, st);
+  CHECK_EQ(q.size(1) % head_dim, 0);
+  CHECK_EQ(k.size(1) % head_dim, 0);
+  TORCH_CHECK(rotary_dim > 0 && rotary_dim <= head_dim, "rotary_dim must be in (0, head_dim]");
+
+  const int64_t num_tokens = q.size(0);
+  if (num_tokens == 0) return;
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "fused_qk_norm_rope_kernel", [&] {
+    std::vector<int64_t> position_ids_i64;
+    const int64_t* pos_ptr;
+    if (position_ids.scalar_type() == at::kInt) {
+      position_ids_i64.resize(num_tokens);
+      const int* position_ids_i32 = position_ids.data_ptr<int>();
+      std::copy(position_ids_i32, position_ids_i32 + num_tokens, position_ids_i64.begin());
+      pos_ptr = position_ids_i64.data();
+    } else {
+      pos_ptr = position_ids.data_ptr<int64_t>();
+    }
+    fused_qk_norm_rope_kernel_impl<scalar_t>(
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        q_weight.data_ptr<scalar_t>(),
+        k_weight.data_ptr<scalar_t>(),
+        num_tokens,
+        q.size(1) / head_dim,
+        k.size(1) / head_dim,
+        head_dim,
+        q.stride(0),
+        k.stride(0),
+        static_cast<float>(eps),
+        static_cast<float>(base),
+        is_neox,
+        pos_ptr,
+        static_cast<float>(factor),
+        static_cast<float>(low),
+        static_cast<float>(high),
+        static_cast<float>(attention_factor),
+        rotary_dim);
   });
 }

--- a/python/sglang/kernels/aot/csrc/cpu/norm.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/norm.cpp
@@ -1052,3 +1052,106 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> fused_qk_gemma_rmsnorm_with_gate_
   });
   return std::make_tuple(q_out, k_out, gate_out);
 }
+
+namespace {
+
+template <typename scalar_t>
+inline void
+fused_qk_norm_per_head(scalar_t* __restrict__ data, const scalar_t* __restrict__ weight, int64_t D, float eps) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();
+
+  fVec sum2_fvec{0.f};
+  float sum2_val{0.f};
+
+  int64_t d = 0;
+#pragma GCC unroll 4
+  for (; d <= D - kVecSize; d += kVecSize) {
+    auto [x_fvec0, x_fvec1] = load_float_vec2(data + d);
+    sum2_fvec += x_fvec0 * x_fvec0;
+    sum2_fvec += x_fvec1 * x_fvec1;
+  }
+  for (; d < D; ++d) {
+    const float x_val = static_cast<float>(data[d]);
+    sum2_val += x_val * x_val;
+  }
+
+  const float scale = 1.f / std::sqrt((sum2_val + vec_reduce_sum(sum2_fvec)) / D + eps);
+  const fVec scale_fvec{scale};
+
+  d = 0;
+#pragma GCC unroll 4
+  for (; d <= D - kVecSize; d += kVecSize) {
+    auto [x_fvec0, x_fvec1] = load_float_vec2(data + d);
+    auto [w_fvec0, w_fvec1] = load_float_vec2(weight + d);
+    convert_from_float_ext<scalar_t>(x_fvec0 * scale_fvec * w_fvec0, x_fvec1 * scale_fvec * w_fvec1).store(data + d);
+  }
+  for (; d < D; ++d) {
+    data[d] = static_cast<scalar_t>(static_cast<float>(data[d]) * scale * static_cast<float>(weight[d]));
+  }
+}
+
+template <typename scalar_t>
+void fused_qk_norm_kernel_impl(
+    scalar_t* __restrict__ q,
+    scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ q_weight,
+    const scalar_t* __restrict__ k_weight,
+    int64_t num_tokens,
+    int64_t num_q_heads,
+    int64_t num_kv_heads,
+    int64_t head_dim,
+    int64_t q_stride,
+    int64_t k_stride,
+    float eps) {
+  const int64_t num_qk_heads = num_q_heads + num_kv_heads;
+
+  at::parallel_for(0, num_tokens * num_qk_heads, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t work = begin; work < end; ++work) {
+      const int64_t token = work / num_qk_heads;
+      const int64_t local_head = work % num_qk_heads;
+      const bool is_q = local_head < num_q_heads;
+
+      scalar_t* __restrict__ data = is_q ? q + token * q_stride + local_head * head_dim
+                                         : k + token * k_stride + (local_head - num_q_heads) * head_dim;
+      fused_qk_norm_per_head<scalar_t>(data, is_q ? q_weight : k_weight, head_dim, eps);
+    }
+  });
+}
+
+}  // anonymous namespace
+
+void fused_qk_norm_cpu(
+    at::Tensor& q, at::Tensor& k, const at::Tensor& q_weight, const at::Tensor& k_weight, double eps) {
+  const auto st = q.scalar_type();
+  CHECK_INPUT_ND<2>(q);
+  CHECK_INPUT_ND<2>(k);
+  CHECK_EQ(k.size(0), q.size(0));
+  CHECK_EQ(k.scalar_type(), st);
+
+  const int64_t head_dim = q_weight.numel();
+  CHECK_GT(head_dim, 0);
+  CHECK_INPUT_SHAPE_DTYPE<false>(q_weight, {head_dim}, st);
+  CHECK_INPUT_SHAPE_DTYPE<false>(k_weight, {head_dim}, st);
+  CHECK_EQ(q.size(1) % head_dim, 0);
+  CHECK_EQ(k.size(1) % head_dim, 0);
+
+  const int64_t num_tokens = q.size(0);
+  if (num_tokens == 0) return;
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "fused_qk_norm_kernel", [&] {
+    fused_qk_norm_kernel_impl<scalar_t>(
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        q_weight.data_ptr<scalar_t>(),
+        k_weight.data_ptr<scalar_t>(),
+        num_tokens,
+        q.size(1) / head_dim,
+        k.size(1) / head_dim,
+        head_dim,
+        q.stride(0),
+        k.stride(0),
+        static_cast<float>(eps));
+  });
+}

--- a/python/sglang/kernels/aot/csrc/cpu/norm.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/norm.cpp
@@ -1121,86 +1121,76 @@ void fused_qk_norm_kernel_impl(
 }
 
 template <typename scalar_t>
-inline float
-fused_qk_norm_rope_freq(float base, int64_t rotary_dim, int64_t half_dim, float factor, float low, float high) {
-  float freq = std::pow(base, -2.0f * static_cast<float>(half_dim) / static_cast<float>(rotary_dim));
-  if (std::abs(factor - 1.0f) > 1e-6f) {
-    const float inv_freq_extrapolation = freq;
-    const float inv_freq_interpolation = freq / factor;
-    const float high_adj = std::abs(low - high) <= 1e-6f ? high + 0.001f : high;
-    const float linear_func = (static_cast<float>(half_dim) - low) / (high_adj - low);
-    const float ramp_func = std::min(std::max(linear_func, 0.0f), 1.0f);
-    const float inv_freq_extrapolation_factor = 1.0f - ramp_func;
-    freq = inv_freq_interpolation * (1.0f - inv_freq_extrapolation_factor) +
-           inv_freq_extrapolation * inv_freq_extrapolation_factor;
+inline void fused_qk_norm_rope_apply_interleaved(
+    scalar_t* __restrict__ data, const scalar_t* __restrict__ cache, int64_t rotary_dim) {
+  constexpr int64_t kVecSize = at::vec::Vectorized<scalar_t>::size();
+  const int64_t half_rotary = rotary_dim / 2;
+
+  int64_t d = 0;
+  for (; d <= rotary_dim - kVecSize; d += kVecSize) {
+    auto [xy0, xy1] = load_float_vec2(data + d);
+    auto [x, y] = at::vec::deinterleave2(xy0, xy1);
+    auto cos = load_float_vec(cache + d / 2);
+    auto sin = load_float_vec(cache + half_rotary + d / 2);
+    auto out0 = x * cos - y * sin;
+    auto out1 = y * cos + x * sin;
+    std::tie(xy0, xy1) = at::vec::interleave2(out0, out1);
+    convert_from_float_ext<scalar_t>(xy0, xy1).store(data + d);
   }
-  return freq;
+  for (; d < rotary_dim; d += 2) {
+    const float x = static_cast<float>(data[d]);
+    const float y = static_cast<float>(data[d + 1]);
+    const float c = static_cast<float>(cache[d / 2]);
+    const float s = static_cast<float>(cache[half_rotary + d / 2]);
+    data[d] = static_cast<scalar_t>(x * c - y * s);
+    data[d + 1] = static_cast<scalar_t>(y * c + x * s);
+  }
 }
 
 template <typename scalar_t>
-void fused_qk_norm_rope_per_head(
+inline void
+fused_qk_norm_rope_apply_neox(scalar_t* __restrict__ data, const scalar_t* __restrict__ cache, int64_t rotary_dim) {
+  constexpr int64_t kVecSize = at::vec::Vectorized<scalar_t>::size();
+  const int64_t half_rotary = rotary_dim / 2;
+
+  int64_t d = 0;
+  for (; d <= half_rotary - kVecSize; d += kVecSize) {
+    auto [x0, x1] = load_float_vec2(data + d);
+    auto [y0, y1] = load_float_vec2(data + half_rotary + d);
+    auto [cos0, cos1] = load_float_vec2(cache + d);
+    auto [sin0, sin1] = load_float_vec2(cache + half_rotary + d);
+    auto out0 = x0 * cos0 - y0 * sin0;
+    auto out1 = x1 * cos1 - y1 * sin1;
+    auto out2 = y0 * cos0 + x0 * sin0;
+    auto out3 = y1 * cos1 + x1 * sin1;
+    convert_from_float_ext<scalar_t>(out0, out1).store(data + d);
+    convert_from_float_ext<scalar_t>(out2, out3).store(data + half_rotary + d);
+  }
+  for (; d < half_rotary; ++d) {
+    const float x = static_cast<float>(data[d]);
+    const float y = static_cast<float>(data[d + half_rotary]);
+    const float c = static_cast<float>(cache[d]);
+    const float s = static_cast<float>(cache[half_rotary + d]);
+    data[d] = static_cast<scalar_t>(x * c - y * s);
+    data[d + half_rotary] = static_cast<scalar_t>(y * c + x * s);
+  }
+}
+
+template <typename scalar_t>
+inline void fused_qk_norm_rope_per_head(
     scalar_t* __restrict__ data,
     const scalar_t* __restrict__ weight,
     int64_t head_dim,
     int64_t rotary_dim,
-    int64_t position,
-    float eps,
-    float base,
+    const scalar_t* __restrict__ cache_row,
     bool is_neox,
-    float factor,
-    float low,
-    float high,
-    float attention_factor) {
-  float sum_sq = 0.0f;
-  for (int64_t d = 0; d < head_dim; ++d) {
-    const float x = static_cast<float>(data[d]);
-    sum_sq += x * x;
-  }
-  const float scale = 1.0f / std::sqrt(sum_sq / static_cast<float>(head_dim) + eps);
-  for (int64_t d = 0; d < head_dim; ++d) {
-    data[d] = static_cast<scalar_t>(static_cast<float>(data[d]) * scale * static_cast<float>(weight[d]));
-  }
+    float eps) {
+  fused_qk_norm_per_head<scalar_t>(data, weight, head_dim, eps);
 
-  if (rotary_dim <= 0 || rotary_dim > head_dim) {
-    return;
-  }
-  if (rotary_dim % 2 != 0) {
-    TORCH_CHECK(false, "rotary_dim must be even, got ", rotary_dim);
-  }
-
-  std::vector<float> rotated(rotary_dim);
   if (is_neox) {
-    const int64_t half_rotary = rotary_dim / 2;
-    for (int64_t d = 0; d < half_rotary; ++d) {
-      const float x = static_cast<float>(data[d]);
-      const float y = static_cast<float>(data[d + half_rotary]);
-      const int64_t dim_idx = (d * 2) % rotary_dim;
-      const int64_t half_dim = dim_idx / 2;
-      const float freq = fused_qk_norm_rope_freq<scalar_t>(base, rotary_dim, half_dim, factor, low, high);
-      const float theta = static_cast<float>(position) * freq;
-      const float s = std::sin(theta);
-      const float c = std::cos(theta);
-      rotated[d] = x * c - y * s;
-      rotated[d + half_rotary] = y * c + x * s;
-    }
-    for (int64_t d = 0; d < rotary_dim; ++d) {
-      data[d] = static_cast<scalar_t>(rotated[d] * attention_factor);
-    }
+    fused_qk_norm_rope_apply_neox<scalar_t>(data, cache_row, rotary_dim);
   } else {
-    for (int64_t d = 0; d < rotary_dim; d += 2) {
-      const float x = static_cast<float>(data[d]);
-      const float y = static_cast<float>(data[d + 1]);
-      const int64_t half_dim = (d / 2);
-      const float freq = fused_qk_norm_rope_freq<scalar_t>(base, rotary_dim, half_dim, factor, low, high);
-      const float theta = static_cast<float>(position) * freq;
-      const float s = std::sin(theta);
-      const float c = std::cos(theta);
-      rotated[d] = x * c - y * s;
-      rotated[d + 1] = y * c + x * s;
-    }
-    for (int64_t d = 0; d < rotary_dim; ++d) {
-      data[d] = static_cast<scalar_t>(rotated[d] * attention_factor);
-    }
+    fused_qk_norm_rope_apply_interleaved<scalar_t>(data, cache_row, rotary_dim);
   }
 }
 
@@ -1217,50 +1207,22 @@ void fused_qk_norm_rope_kernel_impl(
     int64_t q_stride,
     int64_t k_stride,
     float eps,
-    float base,
     bool is_neox,
-    const int64_t* position_ids,
-    float factor,
-    float low,
-    float high,
-    float attention_factor,
+    const int64_t* __restrict__ position_ids,
+    const scalar_t* __restrict__ cos_sin_cache,
     int64_t rotary_dim) {
-  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t token = begin; token < end; ++token) {
-      const int64_t pos = position_ids[token];
-      scalar_t* q_ptr = q + token * q_stride;
-      scalar_t* k_ptr = k + token * k_stride;
+  const int64_t num_qk_heads = num_q_heads + num_kv_heads;
+  at::parallel_for(0, num_tokens * num_qk_heads, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t work = begin; work < end; ++work) {
+      const int64_t token = work / num_qk_heads;
+      const int64_t local_head = work % num_qk_heads;
+      const bool is_q = local_head < num_q_heads;
 
-      for (int64_t h = 0; h < num_q_heads; ++h) {
-        fused_qk_norm_rope_per_head<scalar_t>(
-            q_ptr + h * head_dim,
-            q_weight,
-            head_dim,
-            rotary_dim,
-            pos,
-            eps,
-            base,
-            is_neox,
-            factor,
-            low,
-            high,
-            attention_factor);
-      }
-      for (int64_t h = 0; h < num_kv_heads; ++h) {
-        fused_qk_norm_rope_per_head<scalar_t>(
-            k_ptr + h * head_dim,
-            k_weight,
-            head_dim,
-            rotary_dim,
-            pos,
-            eps,
-            base,
-            is_neox,
-            factor,
-            low,
-            high,
-            attention_factor);
-      }
+      scalar_t* __restrict__ data = is_q ? q + token * q_stride + local_head * head_dim
+                                         : k + token * k_stride + (local_head - num_q_heads) * head_dim;
+      const scalar_t* __restrict__ cache_row = cos_sin_cache + position_ids[token] * rotary_dim;
+      fused_qk_norm_rope_per_head<scalar_t>(
+          data, is_q ? q_weight : k_weight, head_dim, rotary_dim, cache_row, is_neox, eps);
     }
   });
 }
@@ -1307,25 +1269,24 @@ void fused_qk_norm_rope_cpu(
     const at::Tensor& q_weight,
     const at::Tensor& k_weight,
     double eps,
-    double base,
     bool is_neox,
     const at::Tensor& position_ids,
-    double factor,
-    double low,
-    double high,
-    double attention_factor,
+    const at::Tensor& cos_sin_cache,
     int64_t rotary_dim) {
   const auto st = q.scalar_type();
   CHECK_INPUT_ND<2>(q);
   CHECK_INPUT_ND<2>(k);
   CHECK_EQ(k.size(0), q.size(0));
   CHECK_EQ(k.scalar_type(), st);
-  CHECK_EQ(position_ids.dim(), 1);
+  CHECK_DIM(1, position_ids);
   CHECK_EQ(position_ids.size(0), q.size(0));
   TORCH_CHECK(
       position_ids.scalar_type() == at::kLong || position_ids.scalar_type() == at::kInt,
       "position_ids must be int32 or int64, got ",
       position_ids.scalar_type());
+  CHECK_INPUT_ND<2>(cos_sin_cache);
+  CHECK_EQ(cos_sin_cache.scalar_type(), st);
+  CHECK_EQ(cos_sin_cache.size(1), rotary_dim);
 
   const int64_t head_dim = q_weight.numel();
   CHECK_GT(head_dim, 0);
@@ -1334,6 +1295,7 @@ void fused_qk_norm_rope_cpu(
   CHECK_EQ(q.size(1) % head_dim, 0);
   CHECK_EQ(k.size(1) % head_dim, 0);
   TORCH_CHECK(rotary_dim > 0 && rotary_dim <= head_dim, "rotary_dim must be in (0, head_dim]");
+  TORCH_CHECK(rotary_dim % 2 == 0, "rotary_dim must be even, got ", rotary_dim);
 
   const int64_t num_tokens = q.size(0);
   if (num_tokens == 0) return;
@@ -1361,13 +1323,9 @@ void fused_qk_norm_rope_cpu(
         q.stride(0),
         k.stride(0),
         static_cast<float>(eps),
-        static_cast<float>(base),
         is_neox,
         pos_ptr,
-        static_cast<float>(factor),
-        static_cast<float>(low),
-        static_cast<float>(high),
-        static_cast<float>(attention_factor),
+        cos_sin_cache.data_ptr<scalar_t>(),
         rotary_dim);
   });
 }

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -58,6 +58,10 @@ at::Tensor fused_add_layernorm_cpu(
     const std::optional<at::Tensor>& bias,
     double eps);
 
+// fused_qk_norm (per-head, in place)
+void fused_qk_norm_cpu(
+    at::Tensor& q, at::Tensor& k, const at::Tensor& q_weight, const at::Tensor& k_weight, double eps);
+
 // fused_qk_rmsnorm
 std::tuple<at::Tensor, at::Tensor> fused_qk_rmsnorm_cpu(
     const at::Tensor& q, const at::Tensor& k, const at::Tensor& q_weight, const at::Tensor& k_weight, double eps);
@@ -612,6 +616,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "fused_add_layernorm_cpu(Tensor input, Tensor residual, Tensor weight, Tensor? bias, float eps) -> "
       "Tensor");
   m.impl("fused_add_layernorm_cpu", torch::kCPU, &fused_add_layernorm_cpu);
+  m.def("fused_qk_norm_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps) -> ()");
+  m.impl("fused_qk_norm_cpu", torch::kCPU, &fused_qk_norm_cpu);
   m.def(
       "fused_qk_rmsnorm_cpu(Tensor q, Tensor k, Tensor q_weight, Tensor k_weight, float eps) -> "
       "(Tensor, Tensor)");

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -61,6 +61,20 @@ at::Tensor fused_add_layernorm_cpu(
 // fused_qk_norm (per-head, in place)
 void fused_qk_norm_cpu(
     at::Tensor& q, at::Tensor& k, const at::Tensor& q_weight, const at::Tensor& k_weight, double eps);
+void fused_qk_norm_rope_cpu(
+    at::Tensor& q,
+    at::Tensor& k,
+    const at::Tensor& q_weight,
+    const at::Tensor& k_weight,
+    double eps,
+    double base,
+    bool is_neox,
+    const at::Tensor& position_ids,
+    double factor,
+    double low,
+    double high,
+    double attention_factor,
+    int64_t rotary_dim);
 
 // fused_qk_rmsnorm
 std::tuple<at::Tensor, at::Tensor> fused_qk_rmsnorm_cpu(
@@ -618,6 +632,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("fused_add_layernorm_cpu", torch::kCPU, &fused_add_layernorm_cpu);
   m.def("fused_qk_norm_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps) -> ()");
   m.impl("fused_qk_norm_cpu", torch::kCPU, &fused_qk_norm_cpu);
+  m.def(
+      "fused_qk_norm_rope_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps, float base, "
+      "bool is_neox, Tensor position_ids, float factor, float low, float high, float attention_factor, int rotary_dim) "
+      "-> "
+      "()");
+  m.impl("fused_qk_norm_rope_cpu", torch::kCPU, &fused_qk_norm_rope_cpu);
   m.def(
       "fused_qk_rmsnorm_cpu(Tensor q, Tensor k, Tensor q_weight, Tensor k_weight, float eps) -> "
       "(Tensor, Tensor)");

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -67,13 +67,9 @@ void fused_qk_norm_rope_cpu(
     const at::Tensor& q_weight,
     const at::Tensor& k_weight,
     double eps,
-    double base,
     bool is_neox,
     const at::Tensor& position_ids,
-    double factor,
-    double low,
-    double high,
-    double attention_factor,
+    const at::Tensor& cos_sin_cache,
     int64_t rotary_dim);
 
 // fused_qk_rmsnorm
@@ -633,10 +629,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("fused_qk_norm_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps) -> ()");
   m.impl("fused_qk_norm_cpu", torch::kCPU, &fused_qk_norm_cpu);
   m.def(
-      "fused_qk_norm_rope_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps, float base, "
-      "bool is_neox, Tensor position_ids, float factor, float low, float high, float attention_factor, int rotary_dim) "
-      "-> "
-      "()");
+      "fused_qk_norm_rope_cpu(Tensor(a!) q, Tensor(b!) k, Tensor q_weight, Tensor k_weight, float eps, "
+      "bool is_neox, Tensor position_ids, Tensor cos_sin_cache, int rotary_dim) -> ()");
   m.impl("fused_qk_norm_rope_cpu", torch::kCPU, &fused_qk_norm_rope_cpu);
   m.def(
       "fused_qk_rmsnorm_cpu(Tensor q, Tensor k, Tensor q_weight, Tensor k_weight, float eps) -> "

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -19,6 +19,7 @@
 
 import logging
 import math
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import torch
@@ -71,6 +72,7 @@ from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    is_cpu,
     is_cuda,
     is_flashinfer_available,
     is_non_idle_and_non_empty,
@@ -79,12 +81,19 @@ from sglang.srt.utils import (
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_cuda = is_cuda()
+_is_cpu = is_cpu()
 
 if _is_cuda:
     from sglang.kernels.ops.attention.fused_qknorm_rope import (
         can_use_fused_qk_norm_rope,
         fused_qk_norm_rope,
     )
+
+
+@lru_cache(maxsize=1)
+def _has_cpu_fused_qk_norm_rope() -> bool:
+    return hasattr(torch.ops.sgl_kernel, "fused_qk_norm_rope_cpu")
+
 
 TConfig = TypeVar("TConfig", bound=PretrainedConfig)
 
@@ -527,6 +536,12 @@ class Qwen3MoeAttention(nn.Module):
                 _yarn_factor != 1.0,
             )
         )
+        self.use_fused_qk_norm_rope_cpu = (
+            _is_cpu
+            and not isinstance(self.rotary_emb, MRotaryEmbedding)
+            and self.rotary_emb.rotary_dim % 2 == 0
+            and _has_cpu_fused_qk_norm_rope()
+        )
         self._used_fused_qk_norm_rope_last_call = False
 
         self.attn = RadixAttention(
@@ -594,31 +609,53 @@ class Qwen3MoeAttention(nn.Module):
         return None, forward_batch, inner_state
 
     def apply_qk_norm_rope(self, qkv, positions, forward_batch):
-        use_fused = self.use_fused_qk_norm_rope and qkv.dtype == torch.bfloat16
+        use_fused = (self.use_fused_qk_norm_rope and qkv.dtype == torch.bfloat16) or (
+            self.use_fused_qk_norm_rope_cpu
+            and qkv.dtype in (torch.bfloat16, torch.float16)
+        )
         if use_fused:
-            theta = self.rope_theta
-            positions = (
-                positions.view(-1).to(dtype=torch.int32, device=qkv.device).contiguous()
-            )
-            factor, low, high, attention_factor = compute_yarn_parameters(self.config)
-            fused_qk_norm_rope(
-                qkv,
-                self.num_heads,
-                self.num_kv_heads,
-                self.num_kv_heads,
-                self.head_dim,
-                self.q_norm.variance_epsilon,
-                self.q_norm.weight,
-                self.k_norm.weight,
-                theta,
-                self.rotary_emb.is_neox_style,
-                positions,
-                factor,
-                low,
-                high,
-                attention_factor,
-            )
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            if _is_cuda:
+                theta = self.rope_theta
+                positions = (
+                    positions.view(-1)
+                    .to(dtype=torch.int32, device=qkv.device)
+                    .contiguous()
+                )
+                factor, low, high, attention_factor = compute_yarn_parameters(
+                    self.config
+                )
+                fused_qk_norm_rope(
+                    qkv,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                    self.q_norm.variance_epsilon,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    theta,
+                    self.rotary_emb.is_neox_style,
+                    positions,
+                    factor,
+                    low,
+                    high,
+                    attention_factor,
+                )
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            elif _is_cpu:
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+                self.rotary_emb._match_cos_sin_cache_dtype(q)
+                torch.ops.sgl_kernel.fused_qk_norm_rope_cpu(
+                    q,
+                    k,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    self.q_norm.variance_epsilon,
+                    self.rotary_emb.is_neox_style,
+                    positions.view(-1),
+                    self.rotary_emb.cos_sin_cache,
+                    self.rotary_emb.rotary_dim,
+                )
             self._used_fused_qk_norm_rope_last_call = True
         else:
             # Fallback to non-fused QK Norm & RoPE implementation

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -38,7 +38,7 @@ from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.runtime_context import get_exec
-from sglang.srt.utils import get_current_device_stream_fast, is_cuda, is_hip
+from sglang.srt.utils import get_current_device_stream_fast, is_cpu, is_cuda, is_hip
 from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_cpu = is_cpu()
 
 WeightsMapping = Mapping[str, Optional[str]]
 """If a key maps to a value of `None`, the corresponding weight is ignored."""
@@ -449,6 +450,30 @@ def _reshape_for_qk_norm(x: torch.Tensor, head_dim: int) -> torch.Tensor:
     return x.reshape(-1, head_dim)
 
 
+@lru_cache(maxsize=1)
+def _has_cpu_fused_qk_norm() -> bool:
+    return hasattr(torch.ops.sgl_kernel, "fused_qk_norm_cpu")
+
+
+def can_use_fused_qk_norm_cpu(
+    q: torch.Tensor, k: torch.Tensor, head_dim: int, q_eps: float, k_eps: float
+) -> bool:
+    return (
+        _is_cpu
+        and q_eps == k_eps
+        and q.dim() == 2
+        and k.dim() == 2
+        and q.dtype in (torch.bfloat16, torch.float16)
+        and k.dtype == q.dtype
+        # q/k are usually strided views into qkv; only the head rows must be dense
+        and q.stride(-1) == 1
+        and k.stride(-1) == 1
+        and q.size(-1) % head_dim == 0
+        and k.size(-1) % head_dim == 0
+        and _has_cpu_fused_qk_norm()
+    )
+
+
 def apply_qk_norm(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -478,6 +503,12 @@ def apply_qk_norm(
     batch_size = q.size(0)
     q_eps = q_norm.variance_epsilon
     k_eps = k_norm.variance_epsilon
+
+    if allow_inplace and can_use_fused_qk_norm_cpu(q, k, head_dim, q_eps, k_eps):
+        torch.ops.sgl_kernel.fused_qk_norm_cpu(
+            q, k, q_norm.weight, k_norm.weight, q_eps
+        )
+        return q, k
 
     if (
         _is_cuda  # TODO(dark): have not tested on ROCm or other backends

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -471,5 +471,76 @@ class TestFusedQKGemmaRMSNorm:
         )
 
 
+class TestFusedQKNorm:
+    def _norm_per_head_native(
+        self, x: torch.Tensor, weight: torch.Tensor, head_dim: int, eps: float
+    ):
+        out = x.reshape(-1, head_dim).float()
+        out = out * torch.rsqrt(out.pow(2).mean(-1, keepdim=True) + eps)
+        out = out.to(x.dtype) * weight
+        return out.reshape(x.shape)
+
+    @pytest.mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
+    @pytest.mark.parametrize(
+        "batch_size,num_head,num_head_kv,head_dim",
+        [
+            (1, 16, 2, 128),
+            (256, 16, 2, 128),
+            (17, 8, 1, 64),
+            (5, 3, 1, 96),
+        ],
+    )
+    def test_fused_qk_norm(
+        self, batch_size: int, num_head: int, num_head_kv: int, head_dim: int, dtype
+    ):
+        """In-place per-head RMSNorm over strided q/k views of a packed qkv."""
+        q_size = num_head * head_dim
+        kv_size = num_head_kv * head_dim
+        qkv = torch.randn([batch_size, q_size + 2 * kv_size], dtype=dtype)
+        q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+        v_before = v.clone()
+
+        q_weight = torch.randn(head_dim, dtype=dtype)
+        k_weight = torch.randn(head_dim, dtype=dtype)
+
+        ref_q_out = self._norm_per_head_native(q, q_weight, head_dim, eps)
+        ref_k_out = self._norm_per_head_native(k, k_weight, head_dim, eps)
+
+        torch.ops.sgl_kernel.fused_qk_norm_cpu(q, k, q_weight, k_weight, eps)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(q, ref_q_out, atol=atol, rtol=rtol)
+        torch.testing.assert_close(k, ref_k_out, atol=atol, rtol=rtol)
+        # The in-place write must not spill past the q/k head rows into V.
+        torch.testing.assert_close(v, v_before, atol=0, rtol=0)
+
+    @pytest.mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
+    def test_fused_qk_norm_matches_apply_qk_norm(self, dtype):
+        from sglang.srt.layers.layernorm import RMSNorm
+        from sglang.srt.models.utils import apply_qk_norm
+
+        batch_size, num_head, num_head_kv, head_dim = 33, 16, 2, 128
+        q_size = num_head * head_dim
+        kv_size = num_head_kv * head_dim
+
+        qkv = torch.randn([batch_size, q_size + 2 * kv_size], dtype=dtype)
+        q, k, _ = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+        q_norm = RMSNorm(head_dim, eps=eps).to(dtype)
+        k_norm = RMSNorm(head_dim, eps=eps).to(dtype)
+        with torch.no_grad():
+            q_norm.weight.copy_(torch.randn(head_dim, dtype=dtype))
+            k_norm.weight.copy_(torch.randn(head_dim, dtype=dtype))
+
+        ref_q = self._norm_per_head_native(q, q_norm.weight, head_dim, eps)
+        ref_k = self._norm_per_head_native(k, k_norm.weight, head_dim, eps)
+
+        q_out, k_out = apply_qk_norm(q, k, q_norm, k_norm, head_dim)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(q_out, ref_q, atol=atol, rtol=rtol)
+        torch.testing.assert_close(k_out, ref_k, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -485,15 +485,14 @@ class TestFusedQKNorm:
         "batch_size,num_head,num_head_kv,head_dim",
         [
             (1, 16, 2, 128),
+            (9, 8, 1, 64),
             (256, 16, 2, 128),
-            (17, 8, 1, 64),
-            (5, 3, 1, 96),
+            (4109, 3, 1, 96),
         ],
     )
     def test_fused_qk_norm(
         self, batch_size: int, num_head: int, num_head_kv: int, head_dim: int, dtype
     ):
-        """In-place per-head RMSNorm over strided q/k views of a packed qkv."""
         q_size = num_head * head_dim
         kv_size = num_head_kv * head_dim
         qkv = torch.randn([batch_size, q_size + 2 * kv_size], dtype=dtype)
@@ -513,33 +512,6 @@ class TestFusedQKNorm:
         torch.testing.assert_close(k, ref_k_out, atol=atol, rtol=rtol)
         # The in-place write must not spill past the q/k head rows into V.
         torch.testing.assert_close(v, v_before, atol=0, rtol=0)
-
-    @pytest.mark.parametrize("dtype", DTYPES, ids=DTYPE_IDS)
-    def test_fused_qk_norm_matches_apply_qk_norm(self, dtype):
-        from sglang.srt.layers.layernorm import RMSNorm
-        from sglang.srt.models.utils import apply_qk_norm
-
-        batch_size, num_head, num_head_kv, head_dim = 33, 16, 2, 128
-        q_size = num_head * head_dim
-        kv_size = num_head_kv * head_dim
-
-        qkv = torch.randn([batch_size, q_size + 2 * kv_size], dtype=dtype)
-        q, k, _ = qkv.split([q_size, kv_size, kv_size], dim=-1)
-
-        q_norm = RMSNorm(head_dim, eps=eps).to(dtype)
-        k_norm = RMSNorm(head_dim, eps=eps).to(dtype)
-        with torch.no_grad():
-            q_norm.weight.copy_(torch.randn(head_dim, dtype=dtype))
-            k_norm.weight.copy_(torch.randn(head_dim, dtype=dtype))
-
-        ref_q = self._norm_per_head_native(q, q_norm.weight, head_dim, eps)
-        ref_k = self._norm_per_head_native(k, k_norm.weight, head_dim, eps)
-
-        q_out, k_out = apply_qk_norm(q, k, q_norm, k_norm, head_dim)
-
-        atol = rtol = precision[dtype]
-        torch.testing.assert_close(q_out, ref_q, atol=atol, rtol=rtol)
-        torch.testing.assert_close(k_out, ref_k, atol=atol, rtol=rtol)
 
 
 if __name__ == "__main__":

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -513,6 +513,87 @@ class TestFusedQKNorm:
         # The in-place write must not spill past the q/k head rows into V.
         torch.testing.assert_close(v, v_before, atol=0, rtol=0)
 
+    @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bfloat16"])
+    @pytest.mark.parametrize("is_neox", [False, True], ids=["interleaved", "neox"])
+    @pytest.mark.parametrize(
+        "num_head,num_head_kv,head_dim", [(16, 2, 64), (8, 1, 128)]
+    )
+    def test_fused_qk_norm_rope(
+        self,
+        dtype,
+        is_neox: bool,
+        num_head: int,
+        num_head_kv: int,
+        head_dim: int,
+    ):
+        batch_size = 3
+        q_size = num_head * head_dim
+        kv_size = num_head_kv * head_dim
+        q = torch.randn([batch_size, q_size], dtype=dtype)
+        k = torch.randn([batch_size, kv_size], dtype=dtype)
+        q_weight = torch.randn(head_dim, dtype=dtype)
+        k_weight = torch.randn(head_dim, dtype=dtype)
+        position_ids = torch.arange(batch_size, dtype=torch.int32)
+        base = 10000.0
+
+        ref_q = q.clone()
+        ref_k = k.clone()
+        ref_q = self._norm_per_head_native(ref_q, q_weight, head_dim, eps)
+        ref_k = self._norm_per_head_native(ref_k, k_weight, head_dim, eps)
+
+        def apply_rope(x: torch.Tensor, pos: int) -> torch.Tensor:
+            x = x.reshape(x.shape[0], -1, head_dim)
+            rotated = x.clone()
+            for b in range(x.shape[0]):
+                for h in range(x.shape[1]):
+                    row = x[b, h].clone()
+                    if is_neox:
+                        half = head_dim // 2
+                        for d in range(half):
+                            x0 = row[d]
+                            y0 = row[d + half]
+                            freq = base ** (-2.0 * d / head_dim)
+                            theta = pos * freq
+                            s = torch.sin(torch.tensor(theta, dtype=torch.float32))
+                            c = torch.cos(torch.tensor(theta, dtype=torch.float32))
+                            rotated[b, h, d] = x0 * c - y0 * s
+                            rotated[b, h, d + half] = y0 * c + x0 * s
+                    else:
+                        for d in range(0, head_dim, 2):
+                            x0 = row[d]
+                            y0 = row[d + 1]
+                            freq = base ** (-2.0 * (d / 2) / head_dim)
+                            theta = pos * freq
+                            s = torch.sin(torch.tensor(theta, dtype=torch.float32))
+                            c = torch.cos(torch.tensor(theta, dtype=torch.float32))
+                            rotated[b, h, d] = x0 * c - y0 * s
+                            rotated[b, h, d + 1] = y0 * c + x0 * s
+            return rotated.reshape_as(x)
+
+        for pos_idx, pos in enumerate(position_ids.tolist()):
+            ref_q[pos_idx] = apply_rope(ref_q[pos_idx : pos_idx + 1], pos).reshape(-1)
+            ref_k[pos_idx] = apply_rope(ref_k[pos_idx : pos_idx + 1], pos).reshape(-1)
+
+        torch.ops.sgl_kernel.fused_qk_norm_rope_cpu(
+            q,
+            k,
+            q_weight,
+            k_weight,
+            eps,
+            base,
+            is_neox,
+            position_ids,
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            head_dim,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(q, ref_q, atol=atol, rtol=rtol)
+        torch.testing.assert_close(k, ref_k, atol=atol, rtol=rtol)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -574,19 +574,22 @@ class TestFusedQKNorm:
             ref_q[pos_idx] = apply_rope(ref_q[pos_idx : pos_idx + 1], pos).reshape(-1)
             ref_k[pos_idx] = apply_rope(ref_k[pos_idx : pos_idx + 1], pos).reshape(-1)
 
+        half = head_dim // 2
+        freqs = base ** (-2.0 * torch.arange(half, dtype=torch.float32) / head_dim)
+        theta = position_ids.to(torch.float32)[:, None] * freqs[None, :]
+        cos_sin_cache = torch.cat([torch.cos(theta), torch.sin(theta)], dim=-1).to(
+            dtype
+        )
+
         torch.ops.sgl_kernel.fused_qk_norm_rope_cpu(
             q,
             k,
             q_weight,
             k_weight,
             eps,
-            base,
             is_neox,
             position_ids,
-            1.0,
-            0.0,
-            0.0,
-            1.0,
+            cos_sin_cache,
             head_dim,
         )
 


### PR DESCRIPTION
## Motivation

This PR adds a CPU fused QK Norm and RoPE kernels to cut redundant kernel-launch/dispatch overhead for models (e.g. Qwen3-MoE) that apply RMSNorm to Q/K per head before RoPE. CUDA reference: https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/jit/csrc/elementwise/qknorm.cuh, https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/aot/csrc/moe/fused_qknorm_rope_kernel.cu

## Modifications

 - python/sglang/kernels/aot/csrc/cpu/norm.cpp: Added fused_qk_norm_cpu (fused per-head RMSNorm for Q/K) and fused_qk_norm_rope_cpu (fused per-head RMSNorm + RoPE). The RoPE op takes (q, k, q_weight, k_weight, eps, is_neox, position_ids, cos_sin_cache, rotary_dim) — no base/factor/low/high/attention_factor — and indexes into the caller-supplied cos_sin_cache via position_ids[token] * rotary_dim. Both interleaved (GPT-J) and NeoX RoPE styles are vectorized with at::vec (AVX512-capable), avoiding per-element scalar sin/cos calls and a per-call heap allocation from the original implementation.
 - python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp: Registered fused_qk_norm_cpu and fused_qk_norm_rope_cpu op schemas (Tensor(a!) in-place markers on q/k).
 - python/sglang/srt/models/utils.py: Added _has_cpu_fused_qk_norm() / can_use_fused_qk_norm_cpu() and wired fused_qk_norm_cpu into the shared apply_qk_norm() helper (used by many models) as a CPU fast path, gated on dtype (bf16/fp16), contiguity, and op availability.
 - python/sglang/srt/models/qwen3_moe.py: Added _has_cpu_fused_qk_norm_rope() and Qwen3MoeAttention.use_fused_qk_norm_rope_cpu eligibility check (CPU, non-MRotaryEmbedding, even rotary_dim, op available). Restructured apply_qk_norm_rope so CUDA and CPU fused paths share a single use_fused branch (if _is_cuda: ... elif _is_cpu: ...), with the CPU path calling torch.ops.sgl_kernel.fused_qk_norm_rope_cpu using self.rotary_emb.cos_sin_cache / rotary_dim (built once, reused every call) instead of recomputing sin/cos per call; falls back to the original separate apply_qk_norm + rotary_emb() path otherwise.
 - test/registered/cpu/test_norm.py: Added unit tests for fused_qk_norm_cpu and fused_qk_norm_rope_cpu, including building a reference cos_sin_cache and comparing against a separate RMSNorm+RoPE reference implementation for both interleaved and NeoX RoPE styles.

## Accuracy Tests

 - pytest test/registered/cpu/test_norm.py — 12 passed, covering fused_qk_norm_cpu and fused_qk_norm_rope_cpu (bf16/fp16, interleaved/NeoX, various shapes) against a separate-ops reference implementation.

## Speed Tests and Profiling

fused_qk_norm_rope_cpu > fused_qk_norm_cpu > separate QK-Norm+RoPE, consistently across batch sizes and dtypes.

batch_size | num_head | num_head_kv | head_dim | dtype | norm_speedup | norm_rope_speedup
-- | -- | -- | -- | -- | -- | --
1 | 32 | 8 | 128 | bfloat16 | 1.738 | 2.176
1 | 32 | 8 | 128 | float16 | 1.693 | 2.127
1 | 16 | 2 | 128 | bfloat16 | 1.730 | 1.968
1 | 16 | 2 | 128 | float16 | 1.606 | 1.851
128 | 32 | 8 | 128 | bfloat16 | 1.375 | 2.345
128 | 32 | 8 | 128 | float16 | 1.529 | 2.514
128 | 16 | 2 | 128 | bfloat16 | 1.429 | 2.366
128 | 16 | 2 | 128 | float16 | 1.538 | 2.427
1024 | 32 | 8 | 128 | bfloat16 | 1.019 | 2.290
1024 | 32 | 8 | 128 | float16 | 1.267 | 4.330
1024 | 16 | 2 | 128 | bfloat16 | 1.200 | 2.313
1024 | 16 | 2 | 128 | float16 | 1.402 | 3.233

---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34449099991](https://github.com/sgl-project/sglang/actions/runs/34449099991)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34449099787](https://github.com/sgl-project/sglang/actions/runs/34449099787)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34449099907](https://github.com/sgl-project/sglang/actions/runs/34449099907)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34561508953](https://github.com/sgl-project/sglang/actions/runs/34561508953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34561508681](https://github.com/sgl-project/sglang/actions/runs/34561508681)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34561509035](https://github.com/sgl-project/sglang/actions/runs/34561509035)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->