### PR TITLE
[Docs] Refresh TPU model list and link cookbooks

### DIFF
--- a/docs/docs/hardware-platforms/tpu.mdx
+++ b/docs/docs/hardware-platforms/tpu.mdx
@@ -188,8 +188,20 @@ SGLang-JAX supports the following model families. Use the linked TPU cookbooks f
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md">Qwen3 MoE</a></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen/Qwen2.5-VL-32B-Instruct">Qwen2.5-VL</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen2.5-VL.md">Qwen2.5-VL</a></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/meta-llama">Llama/LLaMA</a></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.1.md">Llama 3.1</a> / <a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md">Llama 3.3 70B</a></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/deepseek-ai/DeepSeek-V3">DeepSeek V3</a> / <a href="https://huggingface.co/deepseek-ai/DeepSeek-R1">R1</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.md">DeepSeek V3</a> / <a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/DeepSeek/DeepSeek-R1.md">DeepSeek R1</a></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct">Kimi-Linear</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Moonshotai/Kimi-Linear.md">Kimi-Linear</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/xai-org">Grok-2</a></td>

--- a/docs/docs/hardware-platforms/tpu.mdx
+++ b/docs/docs/hardware-platforms/tpu.mdx
@@ -212,6 +212,14 @@ The following models have been tested and optimized for TPU deployment:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash">MiMo-V2-Flash</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU v6e and v7x (<a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md">SGLang-JAX deployment guide</a>)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro">MiMo-V2.5-Pro</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU v6e and v7x (<a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md">SGLang-JAX deployment guide</a>)</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Bailing MoE</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
     </tr>

--- a/docs/docs/hardware-platforms/tpu.mdx
+++ b/docs/docs/hardware-platforms/tpu.mdx
@@ -188,18 +188,6 @@ SGLang-JAX supports the following model families. Use the linked TPU cookbooks f
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md">Qwen3 MoE</a></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 2</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 2 MoE</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 1.5</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
-    </tr>
-    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/meta-llama">Llama/LLaMA</a></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.1.md">Llama 3.1</a> / <a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md">Llama 3.3 70B</a></td>
     </tr>
@@ -220,8 +208,8 @@ SGLang-JAX supports the following model families. Use the linked TPU cookbooks f
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md">MiMo-V2.5-Pro</a></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Bailing MoE</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/inclusionAI/Ling-2.6-1T">Ling-2.6</a></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/InclusionAI/Ling-2.6.md">Ling-2.6</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/docs/hardware-platforms/tpu.mdx
+++ b/docs/docs/hardware-platforms/tpu.mdx
@@ -165,7 +165,7 @@ SGLang-JAX provides comprehensive TPU-optimized features for production LLM serv
 
 ## Optimized Model List
 
-The following models have been tested and optimized for TPU deployment:
+SGLang-JAX supports the following model families. Use the linked TPU cookbooks for deployment instructions.
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
   <colgroup>
@@ -175,53 +175,53 @@ The following models have been tested and optimized for TPU deployment:
   <thead>
     <tr style={{borderBottom: "2px solid #d55816"}}>
       <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Model Family</th>
-      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Performance Status</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Cookbook</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 3</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>⭐ Recommended for production</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen3.md">Qwen3</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 3 MoE</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>⭐ Best performance</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen3-MoE.md">Qwen3 MoE</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 2</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 2 MoE</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/Qwen">Qwen 1.5</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/meta-llama">Llama/LLaMA</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.1.md">Llama 3.1</a> / <a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Llama/Llama3.3-70B.md">Llama 3.3 70B</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/xai-org">Grok-2</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Grok/Grok2.md">Grok-2</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/google">Gemma 2</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Google/Gemma2.md">Gemma 2</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash">MiMo-V2-Flash</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU v6e and v7x (<a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md">SGLang-JAX deployment guide</a>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.md">MiMo-V2-Flash</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><a href="https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro">MiMo-V2.5-Pro</a></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verified on TPU v6e and v7x (<a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md">SGLang-JAX deployment guide</a>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><a href="https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Xiaomi/MiMo-V2.5-Pro.md">MiMo-V2.5-Pro</a></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Bailing MoE</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Needs improvement</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No dedicated cookbook yet</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Motivation

The TPU model table omits MiMo-V2-Flash, MiMo-V2.5-Pro, DeepSeek V3 / R1, Qwen2.5-VL, and Kimi-Linear. It also lists older entries without dedicated cookbooks and shows performance labels without directing readers to deployment instructions.

## Modifications

- Add MiMo-V2-Flash, MiMo-V2.5-Pro, DeepSeek V3 / R1, Qwen2.5-VL, and Kimi-Linear to the model list, with model cards and dedicated TPU cookbooks.
- Replace the Performance Status column with Cookbook links to the corresponding SGLang-JAX TPU deployment recipes. Group DeepSeek V3 and R1 in one row with separate recipe links.
- Replace the generic Bailing MoE entry with Ling-2.6 and link its model card and TPU cookbook.
- Remove Qwen 2, Qwen 2 MoE, and Qwen 1.5 from this table.

## Validation

- `git diff --check`: passed.
- `mint broken-links --check-anchors --check-redirects` (4.2.559, matching CI): passed.
- `mint validate` (4.2.559): passed.
- Verified all 13 cookbook paths against the current SGLang-JAX source tree.

## Accuracy Tests

Not applicable: documentation-only change. The linked recipes contain historical TPU validation results; no new inference run was performed for this PR.

## Speed Tests and Profiling

Not applicable: no runtime changes.

## Checklist

- [x] Follow the existing documentation format and SGLang code style.
- [x] Update documentation.
- [x] Verify model support and cookbook links against upstream sources.
- Unit tests and new accuracy/speed benchmarks are not applicable to this documentation-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33732959274](https://github.com/sgl-project/sglang/actions/runs/33732959274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33732958527](https://github.com/sgl-project/sglang/actions/runs/33732958527)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->


