### PR TITLE
[AMD][Diffusion] FlyDSL fused norm kernels on wave32 targets (gfx1250)

### DIFF
--- a/python/sglang/kernels/ops/diffusion/norm/fused_residual_norm_flydsl.py
+++ b/python/sglang/kernels/ops/diffusion/norm/fused_residual_norm_flydsl.py
@@ -1,4 +1,4 @@
-"""FlyDSL fused normalization kernels for AMD ROCm (gfx950).
+"""FlyDSL fused normalization kernels for AMD ROCm (wave64 and wave32).
 
 Provides two fused kernels:
   - flydsl_fused_residual_norm_scale_shift:
@@ -26,9 +26,21 @@ import flydsl.expr as fx
 import torch
 from flydsl.expr import const_expr, range_constexpr
 
-WARP_SIZE = 64
+
+def _detect_warp_size() -> int:
+    try:
+        return torch.cuda.get_device_properties(0).warp_size
+    except Exception:
+        return 64
+
+
+WARP_SIZE = _detect_warp_size()
 _VEC = 8
-_NUM_WAVES = 10
+_BLOCK = 640
+# Deriving the wave count from the fixed block size keeps BLOCK and the public
+# FLYDSL_NORM_MIN_ALIGNED_DIM guard identical on wave32 and wave64, so callers
+# do not have to care which one they are on.
+_NUM_WAVES = _BLOCK // WARP_SIZE
 FLYDSL_NORM_MIN_ALIGNED_DIM = WARP_SIZE * _NUM_WAVES * _VEC  # 5120
 
 # Kernel-side epsilon. The public `eps` argument is intentionally ignored, as it
@@ -39,7 +51,10 @@ _EPS = 1e-6
 _ELEM_BITS = 16
 
 # Reduction order is part of the numerical contract; keep the descending sequence.
-_SHUFFLE_OFFSETS = (32, 16, 8, 4, 2, 1)
+# The ladder has to start at WARP_SIZE // 2. A stride of 32 on a wave32 part
+# crosses the wave boundary and lowers to permlane32_swap, which only exists in
+# the wave64 ISA.
+_SHUFFLE_OFFSETS = tuple(1 << i for i in reversed(range(WARP_SIZE.bit_length() - 1)))
 
 
 def _require_stable_api() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation


Applies on top of #36349 (FlyDSL v0.3.0 stable-API migration).

## Problem

`SGLANG_USE_ROCM_FLYDSL=1` aborts at kernel compile time on gfx1250 (MI450):

```
LLVM ERROR: Cannot select: intrinsic %llvm.amdgcn.permlane32.swap
```

This is not a regression from #36349 -- the pre-migration kernel fails
identically. Both versions carry the same wave64 assumption.

## Root cause

`fused_residual_norm_flydsl.py` hardcodes `WARP_SIZE = 64` and
`_SHUFFLE_OFFSETS = (32, 16, 8, 4, 2, 1)`. gfx1250 is a wave32 part
(`torch.cuda.get_device_properties().warp_size == 32`), so the leading stride-32
XOR shuffle of width 64 crosses the wave boundary. The lowering can only express
that as `permlane32_swap`, which exists only in the wave64 ISA, so instruction
selection fails.

## Fix

Derive the three wave-dependent constants from the device warp size:

- `WARP_SIZE` from `torch.cuda.get_device_properties().warp_size`, falling back
  to 64 when no device is visible.
- `_NUM_WAVES` from a fixed 640-thread block, so `BLOCK` and the public
  `FLYDSL_NORM_MIN_ALIGNED_DIM` (5120) stay identical on both wave sizes and
  callers are unaffected.
- `_SHUFFLE_OFFSETS` starting at `WARP_SIZE // 2`.

No other change is needed: both reduction sites go through `wave_reduce_add`,
which already iterates `len(_SHUFFLE_OFFSETS)`.

On wave64 every derived value is identical to before (`_NUM_WAVES = 10`, offsets
`(32, 16, 8, 4, 2, 1)`), so gfx950 codegen is unchanged.

## Validation

gfx1250 (MI450), ROCm 10, Wan2.2-T2V-A14B, 480x832, 33 frames, 4 steps,
`HIP_FORCE_DEV_KERNARG=0`:

| | FLYDSL=0 | FLYDSL=1 before | FLYDSL=1 after |
| --- | --- | --- | --- |
| result | ok | LLVM ERROR | ok |
| latent neighbour corr (w/h/frame) | .9433 / .9020 / .9488 | -- | .9430 / .9064 / .9494 |
| latent corr vs FLYDSL=0 | -- | -- | 0.9778 |
| denoise | 8.95 s/step | -- | 8.48 s/step |

Structural metrics match the FLYDSL=0 reference to within 0.005 (pure noise
scores ~0.001 on the same metric) and the decoded video is visually
indistinguishable. The residual latent difference is the expected bf16 rounding
drift from a different reduction order, and it grows with step count as it
accumulates -- at 17 frames / 2 steps the same comparison gives 0.9991.

## Note for reviewers

FlyDSL 0.3.1 separately misclassifies gfx1250 as CDNA: `is_rdna_arch()` only
matches the `gfx10` / `gfx11` / `gfx120` prefixes, so gfx1250 falls through and
gets `warp_size = 64` plus a `wave64 = true` compile target. That does not block
this fix -- verified by A/B running with and without a shim that corrects the
classification, both produce correct output -- but the same predicate also
drives buffer descriptor flag selection, so it is worth fixing upstream.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829420545](https://github.com/sgl-project/sglang/actions/runs/34829420545)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829420101](https://github.com/sgl-project/sglang/actions/runs/34829420101)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829420138](https://github.com/sgl-project/sglang/actions/runs/34829420138)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->