### PR TITLE
[Qwen4-Exp] Load nvidia/Qwen3.8-Flash-Next-NVFP4 (ModelOpt MIXED_PRECISION: NVFP4 experts, fp8 PLE, fp8 MTP)

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
@@ -16,6 +16,18 @@ from sglang.srt.utils.common import get_quantization_config
 logger = logging.getLogger(__name__)
 
 
+def _mixed_precision_moe_quant_algos(hf_config: Any) -> set:
+    """quant_algo values ModelOpt MIXED_PRECISION assigns to `*.experts` layers."""
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if not isinstance(quantization_config, dict):
+        return set()
+    return {
+        str(info.get("quant_algo", "")).upper()
+        for name, info in quantization_config.get("quantized_layers", {}).items()
+        if ".experts" in name and isinstance(info, dict)
+    }
+
+
 @_register_for(
     "Qwen3MoeForCausalLM",
     "Qwen3VLMoeForConditionalGeneration",
@@ -38,7 +50,23 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["quantization"] = quant_method
             quantization = quant_method
-        if (
+        has_w4a16_moe_layers = (
+            quantization == "modelopt_mixed"
+            and "W4A16_NVFP4" in _mixed_precision_moe_quant_algos(hf_config)
+        )
+        if has_w4a16_moe_layers:
+            # trtllm-gen only has the W4A4 NVFP4 MoE path.
+            if cfg.moe_runner_backend not in ("auto", "marlin"):
+                raise ValueError(
+                    "W4A16_NVFP4 MoE layers require --moe-runner-backend=marlin."
+                )
+            if cfg.moe_runner_backend == "auto":
+                overrides["moe_runner_backend"] = "marlin"
+                logger.info(
+                    "Use marlin as MoE runner backend for "
+                    f"{hf_config.architectures[0]} with W4A16_NVFP4 MoE layers"
+                )
+        elif (
             (
                 quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")
                 or quantization is None

--- a/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
@@ -39,7 +39,10 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["quantization"] = quant_method
             quantization = quant_method
         if (
-            (quantization in ("fp8", "modelopt_fp4") or quantization is None)
+            (
+                quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")
+                or quantization is None
+            )
             and cfg.moe_a2a_backend == "none"
             and cfg.moe_runner_backend == "auto"
         ):

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -871,6 +871,9 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             exclude_modules = quantization_section.get("exclude_modules")
             quantized_layers = quantization_section.get("quantized_layers", {})
 
+        # ModelOpt emits `ignore: []` or omits it; is_layer_skipped iterates it.
+        exclude_modules = list(exclude_modules or [])
+
         if quant_algo != "MIXED_PRECISION":
             raise ValueError(
                 "ModelOptMixedPrecisionConfig only supports MIXED_PRECISION checkpoints."
@@ -993,8 +996,16 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             candidates.append(
                 "language_model.model." + prefix[len("model.language_model.") :]
             )
+            candidates.append("model." + prefix[len("model.language_model.") :])
+        elif prefix.startswith("model."):
+            # VL models such as Qwen4-Exp name the text stack `model.layers.*`
+            # while ModelOpt keys it `model.language_model.layers.*`.
+            candidates.append("model.language_model." + prefix[len("model.") :])
 
         return tuple(dict.fromkeys(candidates))
+
+    def resolve_quant_algo(self, prefix: str) -> Optional[str]:
+        return self._resolve_quant_algo(prefix)
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
@@ -1015,7 +1026,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
-            if quant_algo == "FP8_PB_WO":
+            if quant_algo in ("FP8_PB_WO", "FP8_BLOCK_SCALES"):
                 return Fp8LinearMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
@@ -1046,6 +1057,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return ModelOptFp8MoEMethod(self.fp8_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)
+            # ModelOpt spells 128x128 block fp8 experts (weight_scale_inv)
+            # FP8_BLOCK_SCALES, e.g. the MTP head of Qwen3.8-Flash-Next-NVFP4.
+            if quant_algo == "FP8_BLOCK_SCALES":
+                return Fp8MoEMethod(self.fp8_pb_wo_config)
             if quant_algo == "NVFP4":
                 return ModelOptNvFp4FusedMoEMethod(self.nvfp4_config)
             if quant_algo == "W4A16_NVFP4":

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -57,12 +57,15 @@ def _mtp_quant_config(quant_config):
     # Serialized Qwen3.5 ModelOpt checkpoints keep embedded MTP weights in
     # BF16. Disable quantization for those checkpoints; non-serialized
     # modelopt_fp4 still converts MoE expert weights on load.
+    if quant_config and quant_config.get_name() == "modelopt_mixed":
+        # MIXED_PRECISION lists MTP layers only when they are quantized
+        # (Qwen3.8-Flash-Next-NVFP4 ships FP8_BLOCK_SCALES MTP experts).
+        if any(name.startswith("mtp.") for name in quant_config.quantized_layers):
+            return quant_config
+        return None
     if quant_config and (
-        quant_config.get_name() == "modelopt_mixed"
-        or (
-            quant_config.get_name() == "modelopt_fp4"
-            and quant_config.is_checkpoint_nvfp4_serialized
-        )
+        quant_config.get_name() == "modelopt_fp4"
+        and quant_config.is_checkpoint_nvfp4_serialized
     ):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -43,6 +43,9 @@ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptMixedPrecisionConfig,
+)
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
@@ -66,6 +69,24 @@ from sglang.srt.utils import logger
 # Decode/verify-sized batches only: at prefill sizes both chains are compute
 # bound and serializing them on one stream is faster than contending.
 _QSA_INDEXER_OVERLAP_TOKEN_THRESHOLD = 1024
+
+
+def _ple_table_is_fp8(
+    config: Qwen4ExpTextConfig,
+    quant_config: Optional[QuantizationConfig],
+    prefix: str,
+) -> bool:
+    """fp8 PLE shards: declared by config, an fp8 checkpoint, or a ModelOpt
+    MIXED_PRECISION entry for the ngram table (nvidia/*-Flash-Next-NVFP4)."""
+    if config.ple_embedding_dtype == "float8_e4m3fn":
+        return True
+    if quant_config is None:
+        return False
+    if quant_config.get_name() == "fp8":
+        return True
+    if isinstance(quant_config, ModelOptMixedPrecisionConfig):
+        return quant_config.resolve_quant_algo(prefix) == "FP8"
+    return False
 
 
 def _get_ple_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -423,6 +444,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         embedding_dim: int,
         ple_layer_index: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.config = config
@@ -479,13 +501,13 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
+        ngram_prefix = f"{prefix}.ngram_embedding" if prefix else "ngram_embedding"
         self.ngram_embedding = VocabParallelEmbedding(
             padded_vocab_size,
             self.head_dim_per_ngram,
             params_dtype=(
                 torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                if _ple_table_is_fp8(config, quant_config, ngram_prefix)
                 else torch.bfloat16
             ),
             output_dtype=torch.bfloat16,
@@ -881,6 +903,7 @@ class Qwen4ExpPLELayer(nn.Module):
             self.ple_embed_dim,
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
+            prefix=f"{prefix}.ple_embedding" if prefix else "ple_embedding",
         )
         if config.ple_offload_embedding:
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -1065,17 +1065,6 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         )
 
         self.assertEqual(quant_config.exclude_modules, [])
-        moe = FusedMoE.__new__(FusedMoE)
-        self.assertIsInstance(
-            quant_config.get_quant_method(moe, "mtp.layers.0.mlp.experts"),
-            Fp8MoEMethod,
-        )
-        self.assertEqual(
-            quant_config.get_quant_method(
-                moe, "mtp.layers.0.mlp.experts"
-            ).quant_config.weight_block_size,
-            [128, 128],
-        )
         self.assertEqual(
             quant_config.resolve_quant_algo("model.layers.3.mlp.experts"), "NVFP4"
         )
@@ -1085,12 +1074,11 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
             ),
             "FP8",
         )
-        self.assertIsNone(
-            quant_config.resolve_quant_algo("model.layers.1.ple.key_proj")
+        mtp_method = quant_config.get_quant_method(
+            FusedMoE.__new__(FusedMoE), "mtp.layers.0.mlp.experts"
         )
-        self.assertIsNone(
-            quant_config.resolve_quant_algo("model.layers.3.mlp.shared_expert")
-        )
+        self.assertIsInstance(mtp_method, Fp8MoEMethod)
+        self.assertEqual(mtp_method.quant_config.weight_block_size, [128, 128])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -21,7 +21,12 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.quantization.fp8 import (
+    Fp8Config,
+    Fp8LinearMethod,
+    Fp8MoEMethod,
+)
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -1035,6 +1040,56 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(
             quant_config._resolve_quant_algo("model.layers.2.mixer.qkv_proj"),
             "FP8",
+        )
+
+    def test_mixed_precision_resolves_vl_language_model_keys(self):
+        # nvidia/Qwen3.8-Flash-Next-NVFP4 keys the text stack as
+        # `model.language_model.*` while Qwen4-Exp modules are `model.*`.
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.language_model.layers.3.mlp.experts": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    },
+                    "model.language_model.layers.1.ple.ple_embedding.ngram_embedding": {
+                        "quant_algo": "FP8"
+                    },
+                    "mtp.layers.0.mlp.experts": {
+                        "quant_algo": "FP8_BLOCK_SCALES",
+                        "group_size": 128,
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(quant_config.exclude_modules, [])
+        moe = FusedMoE.__new__(FusedMoE)
+        self.assertIsInstance(
+            quant_config.get_quant_method(moe, "mtp.layers.0.mlp.experts"),
+            Fp8MoEMethod,
+        )
+        self.assertEqual(
+            quant_config.get_quant_method(
+                moe, "mtp.layers.0.mlp.experts"
+            ).quant_config.weight_block_size,
+            [128, 128],
+        )
+        self.assertEqual(
+            quant_config.resolve_quant_algo("model.layers.3.mlp.experts"), "NVFP4"
+        )
+        self.assertEqual(
+            quant_config.resolve_quant_algo(
+                "model.layers.1.ple.ple_embedding.ngram_embedding"
+            ),
+            "FP8",
+        )
+        self.assertIsNone(
+            quant_config.resolve_quant_algo("model.layers.1.ple.key_proj")
+        )
+        self.assertIsNone(
+            quant_config.resolve_quant_algo("model.layers.3.mlp.shared_expert")
         )
 
 

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -607,7 +607,20 @@ class TestWrapperEntryClassGates(_FusionGateCase):
         )
 
         # The normalization the constructor applies, shared with the gate.
-        self.assertIsNone(_mtp_quant_config(_quant("modelopt_mixed")))
+        mixed_bf16_mtp = SimpleNamespace(
+            get_name=lambda: "modelopt_mixed",
+            quantized_layers={"model.layers.0.mlp.experts": {"quant_algo": "NVFP4"}},
+        )
+        self.assertIsNone(_mtp_quant_config(mixed_bf16_mtp))
+        # MIXED_PRECISION checkpoints that quantize the MTP head keep it.
+        mixed_fp8_mtp = SimpleNamespace(
+            get_name=lambda: "modelopt_mixed",
+            quantized_layers={
+                "model.layers.0.mlp.experts": {"quant_algo": "NVFP4"},
+                "mtp.layers.0.mlp.experts": {"quant_algo": "FP8_BLOCK_SCALES"},
+            },
+        )
+        self.assertIs(_mtp_quant_config(mixed_fp8_mtp), mixed_fp8_mtp)
         serialized = SimpleNamespace(
             get_name=lambda: "modelopt_fp4", is_checkpoint_nvfp4_serialized=True
         )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2975,6 +2975,42 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         with override_platform(is_sm100=False):
             self.assertEqual(_qwen3_moe_family_overrides(None, None), {})
 
+    def test_qwen3_moe_family_mixed_precision_moe_runner(self):
+        from sglang.srt.arg_groups.model_overrides.qwen3_moe import (
+            _qwen3_moe_family_overrides,
+        )
+
+        def _mixed(expert_algo):
+            return SimpleNamespace(
+                architectures=["Qwen4ExpForConditionalGeneration"],
+                quantization_config={
+                    "quant_method": "modelopt_mixed",
+                    "quantized_layers": {
+                        "model.language_model.layers.0.mlp.experts": {
+                            "quant_algo": expert_algo
+                        }
+                    },
+                },
+            )
+
+        args = SimpleNamespace(
+            quantization="modelopt_mixed",
+            _quantization_explicitly_unset=False,
+            moe_a2a_backend="none",
+            moe_runner_backend="auto",
+        )
+        with override_platform(is_sm100=True):
+            # W4A4 experts take trtllm-gen like modelopt_fp4; W4A16 has no
+            # trtllm-gen kernel and goes to marlin.
+            self.assertEqual(
+                _qwen3_moe_family_overrides(args, _mixed("NVFP4")),
+                {"moe_runner_backend": "flashinfer_trtllm"},
+            )
+            self.assertEqual(
+                _qwen3_moe_family_overrides(args, _mixed("W4A16_NVFP4")),
+                {"moe_runner_backend": "marlin"},
+            )
+
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides
 


### PR DESCRIPTION
## Motivation

Stacked on #37500. `nvidia/Qwen3.8-Flash-Next-NVFP4` (ModelOpt export) does not load on the `qwen4-main-squashed-rebased` branch. Unlike `RadixArk/Qwen3.8-Flash-Next-NVFP4`, the NVIDIA checkpoint is a ModelOpt **MIXED_PRECISION** export:

| part | quant | checkpoint metadata |
|---|---|---|
| routed experts (48 layers) | NVFP4 g16 | `quantized_layers["model.language_model.layers.N.mlp.experts"]` |
| PLE n-gram table | FP8 per-tensor | `quantized_layers["model.language_model.layers.1.ple.ple_embedding.ngram_embedding"]`, 128 fp8 `shard_N.weight` + `weight_scale` |
| MTP experts | FP8_BLOCK_SCALES g128 | `quantized_layers["mtp.layers.0.mlp.experts"]`, `weight_scale_inv` |
| everything else | bf16 | 292-entry glob `ignore` list |

`config.json` carries the `quantization_config` (`quant_method: modelopt`) and has no `text_config.ple_embedding_dtype`.

On the base branch the server dies while loading weights:

```
ValueError: fp8 PLE auto-switch is unsupported with ple_offload_embedding; set text_config.ple_embedding_dtype="float8_e4m3fn" instead
```

and with `--no-ple-offload-embedding` it dies at CUDA-graph capture:

```
NotImplementedError: Unsupported moe_runner_backend for NVFP4 MoE: MoeRunnerBackend.FLASHINFER_TRTLLM. Use --moe-runner-backend flashinfer_cutlass instead.
```

## Modifications

- `ModelOptMixedPrecisionConfig`: resolve `model.language_model.*` keys against the `model.*` prefixes Qwen4-Exp modules use; default `exclude_modules` to `[]` (ModelOpt may omit `ignore`, and `is_layer_skipped` iterates it); map `FP8_BLOCK_SCALES` to the 128x128 block `Fp8LinearMethod` / `Fp8MoEMethod`.
- `Qwen4ExpNGramEmbedding`: pick fp8 table storage when the mixed config marks the ngram table FP8 (previously only an fp8 checkpoint or explicit `ple_embedding_dtype`), so the pinned-host offload path sees fp8 storage up front instead of hitting the auto-switch error.
- `model_overrides/qwen3_moe.py`: apply the sm100 `flashinfer_trtllm` MoE runner override to `modelopt_mixed` as well. With the runner left on `auto`, `ModelOptNvFp4FusedMoEMethod.create_moe_runner` resolves TRTLLM at run time while `enable_flashinfer_trtllm_moe` was computed as False at init, which is what raised the `NotImplementedError` above.
- `_mtp_quant_config`: keep the mixed config for the MTP head when it lists `mtp.*` layers (the NVIDIA checkpoint quantizes the MTP experts); previously it was dropped, so the fp8 expert weights would have been loaded into bf16 params.
- Unit test for the key resolution and the FP8_BLOCK_SCALES MoE mapping in `test_modelopt_loader.py`.

## Accuracy Tests

All runs: GB300 (sm103), TP1, `--linear-attn-{prefill,decode}-backend flashinfer --mamba-ssm-dtype bfloat16`, container `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729` with this branch overlaid. GSM8K = sgl-eval, 200 examples, thinking on, `max_tokens=16384` (same as `test_qwen4_exp_models.py`, threshold 0.94). MTP = NEXTN 3/1/4.

| checkpoint | source | PLE offload | MTP | startup | GSM8K (200) | accept len |
|---|---|---|---|---|---|---|
| nvidia/Qwen3.8-Flash-Next-NVFP4 | base branch (#37500 head 593134d) | on | off | **fails to load** (`fp8 PLE auto-switch is unsupported with ple_offload_embedding`) | - | - |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | base branch | on | on | **fails to load** (same error) | - | - |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | this PR | on | off | 904 s | 0.965 | - |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | this PR | off | off | 904 s | 0.975 | - |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | this PR | on | on | 1024 s | 0.970 | 3.04 |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | this PR | off | on | 1024 s | 0.965 | 3.02 |
| RadixArk/Qwen3.8-Flash-Next-NVFP4 (regression check) | this PR | on | off | 624 s | 0.970 | - |
| RadixArk/Qwen3.8-Flash-Next-NVFP4 (regression check) | base branch | on | on | 664 s | (5-shot smoke only) | - |

All runs finished with `stop_rate` 1.0 (0.995 on one run) and `error_rate` 0.0; the same code path was also exercised on a synthetic copy of the RadixArk checkpoint rewritten to the NVIDIA MIXED_PRECISION metadata (0.965-0.975, MTP accept 3.03).

Unit tests: `pytest test/registered/unit/model_loader/test_modelopt_loader.py -k MixedPrecision` -> 14 passed.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#accuracy-results).
- [ ] **For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.**
- [ ] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33821513388](https://github.com/sgl-project/sglang/actions/runs/33821513388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33821513119](https://github.com/sgl-project/sglang/actions/runs/33821513119)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33821513209](https://github.com/sgl-project/sglang/actions/runs/33821513209)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->