### PR TITLE
[ROCm][DSV4] Honor configured top-k backend in HIP radix

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -23,6 +23,7 @@ from sglang.kernels.ops.attention.dsv4.metadata_kernel import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     CompressorBackendMixin,
     FusedCompressMetadata,
@@ -449,6 +450,7 @@ class DeepseekV4HipRadixBackend(
         speculative_num_steps=0,
     ):
         super().__init__()
+        self.dsa_topk_backend = DSATopKBackend.resolve(model_runner)
         self.device = torch.device(model_runner.device)
         head_dim = model_runner.model_config.head_dim
         assert head_dim == 512, (


### PR DESCRIPTION
## Motivation

`C4IndexerBackendMixin` defaults to `sgl-kernel`, but `DeepseekV4HipRadixBackend` did not resolve the target or draft runner configuration. As a result, `--dsa-topk-backend` and `--speculative-dsa-topk-backend` were ignored on this backend.

## Modification

Resolve `dsa_topk_backend` with `DSATopKBackend.resolve(model_runner)` after mixin initialization, matching the generic DeepSeek-V4 backend. The default remains `sgl-kernel`; this draft validates independent `sgl-kernel` and `torch` selection for target and draft workers.

## Test

- All applicable pre-commit hooks passed.
- Target/draft/default constructor checks passed in `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260902`.
- Existing DSV4 indexer suite: 9 passed, 16 subtests passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33732813741](https://github.com/sgl-project/sglang/actions/runs/33732813741)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33732813264](https://github.com/sgl-project/sglang/actions/runs/33732813264)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33732813695](https://github.com/sgl-project/sglang/actions/runs/33732813695)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->