### PR TITLE
[Model Loader] Generalize startup weight overlap for RL disk sync

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
+++ b/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
@@ -14,7 +14,6 @@ from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.distributed.parallel_state import monkey_patch_vllm_parallel_state
 from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
 from sglang.srt.model_loader.loader import DefaultModelLoader
-from sglang.srt.model_loader.utils import get_model_architecture
 from sglang.srt.model_loader.weight_utils import (
     CAPTURE_SAFE_WEIGHT_SENTINEL,
     CheckpointFilePrefetchHandle,
@@ -25,7 +24,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_lora,
     get_model,
-    get_parallel,
     get_spec,
 )
 
@@ -33,32 +31,6 @@ if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
 
 logger = logging.getLogger(__name__)
-
-
-_SUPPORTED_ARCHITECTURES = frozenset(
-    {
-        "LlamaForCausalLM",
-        "Qwen2ForCausalLM",
-        "Qwen3ForCausalLM",
-    }
-)
-_SUPPORTED_DTYPES = frozenset({torch.float16, torch.bfloat16})
-
-
-def _get_canonical_model_class(architecture: str):
-    if architecture == "LlamaForCausalLM":
-        from sglang.srt.models.llama import LlamaForCausalLM
-
-        return LlamaForCausalLM
-    if architecture == "Qwen2ForCausalLM":
-        from sglang.srt.models.qwen2 import Qwen2ForCausalLM
-
-        return Qwen2ForCausalLM
-    if architecture == "Qwen3ForCausalLM":
-        from sglang.srt.models.qwen3 import Qwen3ForCausalLM
-
-        return Qwen3ForCausalLM
-    raise ValueError(f"Unsupported startup-overlap architecture: {architecture}")
 
 
 class StartupWeightLoadState(str, enum.Enum):
@@ -78,15 +50,8 @@ class StartupWeightLoadOptions:
     prefill_cuda_graph_backend: Backend
     is_draft_worker: bool
     speculative_algorithm: Optional[str]
-    tp_size: int
-    attn_cp_size: int
-    dcp_size: int
-    pp_size: int
-    dp_size: int
-    ep_size: int
     cpu_offload_gb: int
     offload_group_size: int
-    enable_memory_saver: bool
     enable_weights_cpu_backup: bool
     enable_lora: bool
     has_lora_paths: bool
@@ -119,15 +84,8 @@ class StartupWeightLoadOptions:
             prefill_cuda_graph_backend=cuda_graph_config.prefill.backend,
             is_draft_worker=is_draft_worker,
             speculative_algorithm=get_spec().speculative_algorithm,
-            tp_size=get_parallel().tp_size,
-            attn_cp_size=get_parallel().attn_cp_size,
-            dcp_size=get_parallel().dcp_size,
-            pp_size=get_parallel().pp_size,
-            dp_size=get_parallel().dp_size,
-            ep_size=get_parallel().ep_size,
             cpu_offload_gb=get_exec().offload.cpu_offload_gb,
             offload_group_size=get_exec().offload.offload_group_size,
-            enable_memory_saver=get_exec().features.enable_memory_saver,
             enable_weights_cpu_backup=get_exec().features.enable_weights_cpu_backup,
             enable_lora=get_lora().enable_lora,
             has_lora_paths=bool(get_lora().lora_paths),
@@ -212,15 +170,14 @@ class ModelStorageManifest:
         )
 
     def unchanged_parameter_names(self, value: float) -> Tuple[str, ...]:
-        """Return floating-point parameters still entirely equal to ``value``.
+        """Return floating parameters still entirely equal to ``value``.
 
-        This is the capture-sentinel check, and it is deliberately strict: every
-        floating-point parameter must be rewritten by ``model.load_weights()``.
-        A model that keeps an ``__init__``-computed floating-point parameter with
-        no checkpoint entry will fail startup here rather than silently serve the
-        sentinel, so this doubles as the admission gate for widening
-        ``_SUPPORTED_ARCHITECTURES``. Buffers are excluded because
-        ``initialize_capture_safe_weights`` never overwrites them.
+        The sentinel check detects a parameter that the normal checkpoint path
+        did not replace. Packed integral parameters are deliberately excluded:
+        zero is a valid packed value, and loader invocation alone cannot prove
+        that every shard or expert region was written. Their value correctness
+        remains the responsibility of the unchanged serial loader contract.
+        Buffers and tensors marked ``_skip_weight_check`` are also excluded.
         """
         names = []
         checks = []
@@ -230,6 +187,7 @@ class ModelStorageManifest:
             if (
                 not name.startswith("parameter:")
                 or not torch.is_floating_point(tensor)
+                or getattr(tensor, "_skip_weight_check", False)
                 or id(tensor) in seen_tensor_ids
             ):
                 continue
@@ -246,7 +204,7 @@ class ModelStorageManifest:
 
 
 class StartupWeightLoadManager:
-    """Coordinate native CPU staging with capture and post-capture commit."""
+    """Coordinate CPU staging with capture and post-capture weight commit."""
 
     def __init__(
         self,
@@ -331,12 +289,6 @@ class StartupWeightLoadManager:
         load_config: LoadConfig,
         options: StartupWeightLoadOptions,
     ) -> Optional[str]:
-        architectures = tuple(model_config.hf_config.architectures or ())
-        # NOTE(2026-08): The initial rollout supports only the configurations
-        # admitted below. Expand this matrix only with storage-stability,
-        # capture-sentinel, and startup-correctness coverage for the new case.
-        # Keep these checks here because they depend on resolved loader and model
-        # state; ServerArgs owns only the mode selection.
         basic_rules = (
             (not options.is_cuda_platform or options.device != "cuda", "CUDA only"),
             (not options.cuda_graph_enabled, "CUDA graph capture is disabled"),
@@ -344,7 +296,6 @@ class StartupWeightLoadManager:
                 options.prefill_cuda_graph_backend == Backend.TC_PIECEWISE,
                 "tc_piecewise prefill CUDA graphs are not supported",
             ),
-            (type(loader) is not DefaultModelLoader, "DefaultModelLoader only"),
             (
                 load_config.load_format
                 not in (LoadFormat.AUTO, LoadFormat.SAFETENSORS),
@@ -359,24 +310,11 @@ class StartupWeightLoadManager:
                 options.speculative_algorithm is not None,
                 "speculative decoding is not supported",
             ),
-            (options.tp_size not in (1, 2), "only TP1 and TP2 are supported"),
-            (
-                options.attn_cp_size != 1,
-                "attention context parallelism is not supported",
-            ),
-            (
-                options.dcp_size != 1,
-                "decode context parallelism is not supported",
-            ),
-            (options.pp_size != 1, "pipeline parallelism is not supported"),
-            (options.dp_size != 1, "data parallelism is not supported"),
-            (options.ep_size != 1, "expert parallelism is not supported"),
             (options.cpu_offload_gb > 0, "CPU offload is not supported"),
             (
                 options.offload_group_size > 0,
                 "layer-group offloading is not supported",
             ),
-            (options.enable_memory_saver, "memory saver is not supported"),
             (
                 options.enable_weights_cpu_backup,
                 "CPU weight backup is not supported",
@@ -406,37 +344,9 @@ class StartupWeightLoadManager:
         if unsupported_reason is not None:
             return unsupported_reason
 
-        model_rules = (
-            (model_config.dtype not in _SUPPORTED_DTYPES, "FP16 or BF16 only"),
-            (model_config.quantization is not None, "quantization is not supported"),
-            (
-                bool(getattr(model_config, "modelopt_quant", False)),
-                "ModelOpt is not supported",
-            ),
-            (model_config.is_multimodal, "multimodal models are not supported"),
-            (not model_config.is_generation, "generation models only"),
-            (
-                len(architectures) != 1
-                or architectures[0] not in _SUPPORTED_ARCHITECTURES,
-                "model architecture is not in the startup-overlap allowlist",
-            ),
-        )
-        unsupported_reason = next(
-            (reason for unsupported, reason in model_rules if unsupported),
-            None,
-        )
-        if unsupported_reason is not None:
-            return unsupported_reason
-
-        architecture = architectures[0]
-        resolved_model_class, resolved_architecture = get_model_architecture(
-            model_config
-        )
-        if (
-            resolved_architecture != architecture
-            or resolved_model_class is not _get_canonical_model_class(architecture)
-        ):
-            return "the native SGLang model implementation is required"
+        supports_overlap = getattr(loader, "supports_startup_weight_load_overlap", None)
+        if supports_overlap is None or not supports_overlap(model_config):
+            return f"{type(loader).__name__} does not support split startup loading"
         return None
 
     @property
@@ -508,30 +418,33 @@ class StartupWeightLoadManager:
         startup_prefetch_active = self._prepare_prefetch_for_commit()
         commit_started_at = time.perf_counter()
         monkey_patch_vllm_parallel_state()
-        self._loader.commit_model_weights(
-            model=self._model,
-            model_config=self._model_config,
-            resolved_sources=self._resolved_sources,
-            target_device=torch.device(self._device_config.device),
-            startup_prefetch_active=startup_prefetch_active,
-        )
-        torch.cuda.synchronize()
-        changed_names = manifest.changed_names(self._model)
-        if changed_names:
-            preview = ", ".join(changed_names[:8])
-            raise RuntimeError(
-                f"Startup weight commit changed graph-visible tensor storage: {preview}"
+        try:
+            self._loader.commit_model_weights(
+                model=self._model,
+                model_config=self._model_config,
+                resolved_sources=self._resolved_sources,
+                target_device=torch.device(self._device_config.device),
+                startup_prefetch_active=startup_prefetch_active,
             )
-        unchanged_names = manifest.unchanged_parameter_names(
-            CAPTURE_SAFE_WEIGHT_SENTINEL
-        )
-        if unchanged_names:
-            preview = ", ".join(unchanged_names[:8])
-            raise RuntimeError(
-                "Startup weight commit did not replace capture-safe dummy values: "
-                f"{preview}"
+            torch.cuda.synchronize()
+            changed_names = manifest.changed_names(self._model)
+            if changed_names:
+                preview = ", ".join(changed_names[:8])
+                raise RuntimeError(
+                    "Startup weight commit changed graph-visible tensor storage: "
+                    f"{preview}"
+                )
+            unchanged_names = manifest.unchanged_parameter_names(
+                CAPTURE_SAFE_WEIGHT_SENTINEL
             )
-        monkey_patch_vllm_parallel_state(reverse=True)
+            if unchanged_names:
+                preview = ", ".join(unchanged_names[:8])
+                raise RuntimeError(
+                    "Startup weight commit did not populate capture-safe parameters: "
+                    f"{preview}"
+                )
+        finally:
+            monkey_patch_vllm_parallel_state(reverse=True)
         self._stop_prefetch()
         self._state = StartupWeightLoadState.READY
         logger.info(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -316,6 +316,10 @@ class BaseModelLoader(ABC):
     def __init__(self, load_config: LoadConfig):
         self.load_config = load_config
 
+    def supports_startup_weight_load_overlap(self, model_config: ModelConfig) -> bool:
+        """Whether this loader implements the split prepare/commit contract."""
+        return False
+
     @abstractmethod
     def download_model(self, model_config: ModelConfig) -> None:
         """Download a model so that it can be immediately loaded."""
@@ -361,6 +365,11 @@ class DefaultModelLoader(BaseModelLoader):
     DEFAULT_NUM_THREADS = 8
 
     _MTP_PATTERN = re.compile(r"model\.mtp\.layers\.(\d+)\.")
+
+    def supports_startup_weight_load_overlap(self, model_config: ModelConfig) -> bool:
+        # Subclasses must opt in explicitly because overriding load_model or
+        # post-processing can invalidate the split startup contract.
+        return type(self) is DefaultModelLoader
 
     @dataclasses.dataclass
     class Source:
@@ -792,14 +801,12 @@ class DefaultModelLoader(BaseModelLoader):
         values so ``commit_model_weights`` can prove every one of them was
         replaced.
 
-        Note that this runs ``process_weights_after_loading`` on the sentinel
-        values, and ``commit_model_weights`` runs it again on the real weights,
-        so overlap invokes it once more than the serial path. That is safe for
-        the currently supported matrix, where the CUDA unquantized path is a
-        no-op, and it is not covered by the storage manifest, which proves
-        tensor identity rather than idempotence. Any quantization method that
-        mutates weights in place therefore has to be evaluated here before its
-        configuration is added to the supported set.
+        This runs ``process_weights_after_loading`` on capture-safe values, and
+        ``commit_model_weights`` runs it again on the checkpoint. The startup
+        manager validates after commit that parameters and buffers kept the
+        storage captured by CUDA graphs. Graph-visible derived tensors must be
+        registered as nonpersistent buffers before capture and updated in place.
+        Loaders with a different split/post-processing contract must opt in.
         """
         with set_default_torch_dtype(model_config.dtype):
             initialize_capture_safe_weights(model)
@@ -3747,6 +3754,11 @@ class ModelOptModelLoader(DefaultModelLoader):
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
         # Any ModelOpt specific initialization if needed
+
+    def supports_startup_weight_load_overlap(self, model_config: ModelConfig) -> bool:
+        # Pre-quantized checkpoints use DefaultModelLoader's load and
+        # post-processing path. Calibration/export workflows do not.
+        return model_config._is_already_quantized()
 
     def _setup_modelopt_quantization(
         self,

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1634,14 +1634,22 @@ def initialize_capture_safe_weights(
     model: torch.nn.Module,
     value: float = CAPTURE_SAFE_WEIGHT_SENTINEL,
 ) -> None:
-    """Fill floating-point parameters with finite values for graph warmup.
+    """Fill parameters with deterministic values safe for graph warmup.
 
-    Persistent buffers are intentionally left intact: unlike parameters, they
-    are not guaranteed to be replaced by ``model.load_weights()``.
+    Persistent buffers and parameters marked ``_skip_weight_check`` are left
+    intact because they are not guaranteed to be replaced by
+    ``model.load_weights()``. Checkpoint-backed floating weights use a
+    detectable finite sentinel. Integral parameters are zeroed only when they
+    explicitly own a checkpoint loader; other integral parameters may contain
+    initialized routing or layout metadata that must survive dummy setup.
     """
     for param in model.parameters():
+        if getattr(param, "_skip_weight_check", False):
+            continue
         if torch.is_floating_point(param):
             param.fill_(value)
+        elif callable(getattr(param, "weight_loader", None)):
+            param.zero_()
 
 
 def initialize_dummy_weights(

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=420, stage="extra-b", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=900, stage="extra-b", runner_config="4-gpu-b200")
 
 import time
 import unittest
@@ -48,7 +48,7 @@ class UpdateWeightsFromDiskBase:
                 "Subclass must set non-empty 'backend_test_suites'"
             )
 
-    def _launch_server(self, backend_test_suite):
+    def _launch_server(self, backend_test_suite, startup_weight_load_mode):
         launch_kwargs = {
             "env": {
                 "SGLANG_MEMORY_SAVER_CUDA_GRAPH": "1",
@@ -58,6 +58,7 @@ class UpdateWeightsFromDiskBase:
         other_args = (
             *backend_test_suite.get("other_args", ()),
             "--enable-memory-saver",
+            f"--startup-weight-load-mode={startup_weight_load_mode}",
             "--cuda-graph-backend-prefill=disabled",
         )
         return popen_launch_server(
@@ -168,12 +169,22 @@ class UpdateWeightsFromDiskBase:
         for backend_test_suite in self.backend_test_suites:
             case_name = backend_test_suite.get("name", "default")
             with self.subTest(model=self.model, case_name=case_name):
-                process = self._launch_server(backend_test_suite)
+                serial_process = self._launch_server(backend_test_suite, "serial")
+                try:
+                    self.assertEqual(self._get_model_info(), self.model)
+                    serial_startup_sig = self._get_decode_logprob_signature()
+                finally:
+                    kill_process_tree(serial_process.pid, wait_timeout=60)
+
+                process = self._launch_server(backend_test_suite, "overlap")
                 try:
                     origin_model_path = self._get_model_info()
                     self.assertEqual(origin_model_path, self.model)
                     self._assert_non_empty_decode()
                     baseline_sig = self._get_decode_logprob_signature()
+                    self._assert_decode_logprob_unchanged(
+                        serial_startup_sig, baseline_sig
+                    )
 
                     for update_test_suite in self.update_test_suites:
                         with self.subTest(case_name=case_name, **update_test_suite):

--- a/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
@@ -17,6 +17,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.cuda_graph_config import Backend, CudaGraphConfig
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -26,7 +27,7 @@ from sglang.srt.model_executor.model_runner_components.startup_weight_load impor
     StartupWeightLoadOptions,
     StartupWeightLoadState,
 )
-from sglang.srt.model_loader.loader import DefaultModelLoader
+from sglang.srt.model_loader.loader import DefaultModelLoader, ModelOptModelLoader
 from sglang.srt.model_loader.weight_utils import initialize_capture_safe_weights
 from sglang.srt.runtime_context import get_context, publish, reset_context
 from sglang.srt.server_args import ServerArgs
@@ -39,14 +40,6 @@ _STARTUP_MODULE = (
 )
 
 
-class _CanonicalModel:
-    pass
-
-
-class _ExternalModel:
-    pass
-
-
 def _make_options(**overrides):
     options = StartupWeightLoadOptions(
         device="cuda",
@@ -55,15 +48,8 @@ def _make_options(**overrides):
         prefill_cuda_graph_backend=Backend.FULL,
         is_draft_worker=False,
         speculative_algorithm=None,
-        tp_size=1,
-        attn_cp_size=1,
-        dcp_size=1,
-        pp_size=1,
-        dp_size=1,
-        ep_size=1,
         cpu_offload_gb=0,
         offload_group_size=-1,
-        enable_memory_saver=False,
         enable_weights_cpu_backup=False,
         enable_lora=False,
         has_lora_paths=False,
@@ -86,6 +72,7 @@ def _make_model_config(**overrides):
         is_generation=True,
         model_impl=ModelImpl.SGLANG,
         _resolved_model_impl=ModelImpl.SGLANG,
+        _is_already_quantized=lambda: False,
     )
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -156,6 +143,33 @@ class _TiedWeightModel(nn.Module):
         self.register_buffer("scale", torch.ones(2))
 
 
+class _RuntimeStateModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(2, 2))
+        self.scratch = {"indices": torch.ones(1)}
+        self.register_buffer("graph_scale", torch.ones(1), persistent=False)
+
+
+class _PackedWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(2, 2))
+        self.optional_scale = nn.Parameter(torch.full((1,), -1.0))
+        self.optional_scale._skip_weight_check = True
+        self.packed_weight = nn.Parameter(
+            torch.full((2, 2), 7, dtype=torch.uint8), requires_grad=False
+        )
+        self.packed_weight.weight_loader = lambda param, loaded: param.copy_(loaded)
+        self.routing_table = nn.Parameter(
+            torch.tensor([[1, 2], [3, 4]], dtype=torch.int32), requires_grad=False
+        )
+
+
+class _UnsupportedDefaultLoaderSubclass(DefaultModelLoader):
+    pass
+
+
 class TestStartupWeightLoadSelector(CustomTestCase):
     def setUp(self):
         self.load_config = LoadConfig(load_format=LoadFormat.SAFETENSORS)
@@ -169,35 +183,48 @@ class TestStartupWeightLoadSelector(CustomTestCase):
         model_config=None,
         load_config=None,
         loader=None,
-        resolved_model_class=None,
     ):
         model_config = _make_model_config() if model_config is None else model_config
-        architecture = model_config.hf_config.architectures[0]
-        with (
-            patch(
-                f"{_STARTUP_MODULE}.get_model_architecture",
-                return_value=(
-                    resolved_model_class or _CanonicalModel,
-                    architecture,
-                ),
-            ),
-            patch(
-                f"{_STARTUP_MODULE}._get_canonical_model_class",
-                return_value=_CanonicalModel,
-            ),
-        ):
-            return StartupWeightLoadManager.create(
-                loader=self.loader if loader is None else loader,
-                model_config=model_config,
-                load_config=self.load_config if load_config is None else load_config,
-                device_config=self.device_config,
-                options=_make_options() if options is None else options,
-            )
+        return StartupWeightLoadManager.create(
+            loader=self.loader if loader is None else loader,
+            model_config=model_config,
+            load_config=self.load_config if load_config is None else load_config,
+            device_config=self.device_config,
+            options=_make_options() if options is None else options,
+        )
 
     def test_supported_overlap_creates_a_manager(self):
+        supported_cases = (
+            dict(model_config=_make_model_config(quantization="mxfp8")),
+            dict(
+                model_config=_make_model_config(
+                    hf_config=SimpleNamespace(architectures=["OtherForCausalLM"])
+                )
+            ),
+            dict(
+                model_config=_make_model_config(
+                    model_impl=ModelImpl.TRANSFORMERS,
+                    _resolved_model_impl=ModelImpl.TRANSFORMERS,
+                )
+            ),
+        )
         self.assertIsInstance(self._create(), StartupWeightLoadManager)
+        for kwargs in supported_cases:
+            with self.subTest(kwargs=kwargs):
+                self.assertIsInstance(
+                    self._create(**kwargs),
+                    StartupWeightLoadManager,
+                )
+
+    def test_prequantized_modelopt_loader_supports_overlap(self):
+        model_config = _make_model_config(
+            quantization="modelopt_fp4",
+            _is_already_quantized=lambda: True,
+        )
+        loader = ModelOptModelLoader(self.load_config)
+
         self.assertIsInstance(
-            self._create(options=_make_options(tp_size=2)),
+            self._create(model_config=model_config, loader=loader),
             StartupWeightLoadManager,
         )
 
@@ -262,24 +289,17 @@ class TestStartupWeightLoadSelector(CustomTestCase):
                 "speculative decoding is not supported",
             ),
             (
-                "tp3",
-                dict(options=_make_options(tp_size=3)),
-                "only TP1 and TP2 are supported",
+                "loader_without_split_contract",
+                dict(loader=_UnsupportedDefaultLoaderSubclass(self.load_config)),
+                "does not support split startup loading",
             ),
             (
-                "attention_context_parallel",
-                dict(options=_make_options(tp_size=2, attn_cp_size=2)),
-                "attention context parallelism is not supported",
-            ),
-            (
-                "decode_context_parallel",
-                dict(options=_make_options(tp_size=2, dcp_size=2)),
-                "decode context parallelism is not supported",
-            ),
-            (
-                "quantized_model",
-                dict(model_config=_make_model_config(quantization="fp8")),
-                "quantization is not supported",
+                "online_modelopt",
+                dict(
+                    loader=ModelOptModelLoader(self.load_config),
+                    model_config=_make_model_config(quantization="modelopt_fp4"),
+                ),
+                "does not support split startup loading",
             ),
             (
                 "layer_group_offload",
@@ -290,31 +310,6 @@ class TestStartupWeightLoadSelector(CustomTestCase):
                 "torch_compile",
                 dict(options=_make_options(enable_torch_compile=True)),
                 "torch.compile is not supported",
-            ),
-            (
-                "transformers_model_impl",
-                dict(
-                    model_config=_make_model_config(
-                        model_impl=ModelImpl.TRANSFORMERS,
-                        _resolved_model_impl=ModelImpl.TRANSFORMERS,
-                    ),
-                    resolved_model_class=_ExternalModel,
-                ),
-                "the native SGLang model implementation is required",
-            ),
-            (
-                "external_model_implementation",
-                dict(resolved_model_class=_ExternalModel),
-                "the native SGLang model implementation is required",
-            ),
-            (
-                "unknown_architecture",
-                dict(
-                    model_config=_make_model_config(
-                        hf_config=SimpleNamespace(architectures=["OtherForCausalLM"])
-                    )
-                ),
-                "model architecture is not in the startup-overlap allowlist",
             ),
         )
         for name, kwargs, reason in cases:
@@ -425,7 +420,7 @@ class TestStartupWeightLoadManager(CustomTestCase):
             patch(f"{_STARTUP_MODULE}.torch.cuda.synchronize"),
             self.assertRaisesRegex(
                 RuntimeError,
-                "did not replace capture-safe dummy values: parameter:tied_weight",
+                "did not populate capture-safe parameters: parameter:tied_weight",
             ),
         ):
             manager.finalize()
@@ -552,15 +547,62 @@ class TestModelStorageManifest(CustomTestCase):
             ("parameter:tied_weight",),
         )
 
+    def test_nonpersistent_buffers_are_manifested_but_plain_state_is_not(self):
+        model = _RuntimeStateModel()
+        manifest = ModelStorageManifest.capture(model)
+
+        model.scratch["indices"] = model.scratch["indices"].clone()
+        with torch.no_grad():
+            model.graph_scale.fill_(2)
+
+        self.assertNotIn("graph_scale", model.state_dict())
+        self.assertEqual(manifest.changed_names(model), ())
+
+        model.graph_scale = model.graph_scale.clone()
+
+        self.assertEqual(manifest.changed_names(model), ("buffer:graph_scale",))
+
+    def test_integral_weights_are_excluded_from_sentinel_check(self):
+        model = _PackedWeightModel()
+        initialize_capture_safe_weights(model)
+        manifest = ModelStorageManifest.capture(model)
+
+        self.assertEqual(
+            manifest.unchanged_parameter_names(1e-3),
+            ("parameter:weight",),
+        )
+
 
 class TestCaptureSafeWeightInitialization(CustomTestCase):
-    def test_only_parameters_are_filled(self):
-        model = _TiedWeightModel()
+    def test_parameters_are_filled_with_dtype_safe_values(self):
+        model = _PackedWeightModel()
+        model.register_buffer("scale", torch.ones(2))
 
         initialize_capture_safe_weights(model, value=0.125)
 
         torch.testing.assert_close(model.weight, torch.full_like(model.weight, 0.125))
+        torch.testing.assert_close(
+            model.packed_weight, torch.zeros_like(model.packed_weight)
+        )
+        torch.testing.assert_close(model.optional_scale, torch.full((1,), -1.0))
+        torch.testing.assert_close(
+            model.routing_table,
+            torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+        )
         torch.testing.assert_close(model.scale, torch.ones_like(model.scale))
+
+    def test_omitted_kv_cache_scales_keep_their_serial_default(self):
+        layer = nn.Module()
+        method = BaseKVCacheMethod(SimpleNamespace())
+        method.create_weights(layer)
+
+        initialize_capture_safe_weights(layer)
+        method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.k_scale.item(), 1.0)
+        self.assertEqual(layer.v_scale.item(), 1.0)
+        self.assertEqual(layer.k_scale_float, 1.0)
+        self.assertEqual(layer.v_scale_float, 1.0)
 
 
 class _LifecycleRunner:


### PR DESCRIPTION
## Motivation

@humansand

- Follow up #32017 by making startup weight-load overlap usable with the
  existing Blackwell RL disk-weight-sync coverage.
- Replace architecture/model/backend/topology profiles with a loader-owned
  split-load capability and generic runtime invariants.
- Keep the feature opt-in: `serial` remains the default.
- This overlaps with #35259, but deliberately uses a loader contract instead of
  enumerating supported model and backend profiles.

## Modifications

- **General admission:** remove architecture, native model class, dtype,
  quantization, memory-saver, and TP/DP/EP admission lists. Retain only
  constraints inherent to the split-loading workflow, such as safetensors,
  CUDA graphs, no custom loader/offload/LoRA/speculative draft, and no
  `torch.compile`.
- **Loader contract:** add `supports_startup_weight_load_overlap()` with a
  fail-closed base default. The exact default loader implements the contract;
  subclasses opt in explicitly. ModelOpt opts in only for already-quantized
  checkpoints, excluding calibration/export workflows.
- **Capture-safe initialization:** preserve parameters marked
  `_skip_weight_check`, use the detectable finite sentinel for floating
  checkpoint weights, zero integral checkpoint parameters that own a loader,
  and preserve integral routing/layout metadata without a loader.
- **Commit validation:** retain storage identity checks for every registered
  parameter and buffer, and exclude optional `_skip_weight_check` parameters
  from the sentinel-completeness check.
- **RL regression:** every existing case in
  `test/registered/rl/test_update_weights_from_disk_blackwell.py` now launches a
  serial control, launches with overlap, compares token IDs/text/per-token
  logprobs, and then runs both existing release/resume + disk-update variants.

## Accuracy Tests

Source under test: `11178bc5123d499deed5faab875767b9ea530a83`

Environment:

- C2 devbox, one node allocated with 8 x NVIDIA B300 SXM6 AC; tests used GPUs
  0-3.
- Image:
  `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729`
- Manifest digest:
  `sha256:eb090e39434085f713d39421cb2e5b6d342424aa95c3d9ecdfe8cadd4289e99b`
- Linux/amd64 digest:
  `sha256:605112675a761001da6fceb21bd811c8bfee02c56993f91ad26d29f86476839d`
- Driver 590.48.01; PyTorch 2.13.0+cu130; CUDA 13.0; FlashInfer 0.6.18.
- Repository source selected with
  `PYTHONPATH=/hai-workspace/sglang-startup-overlap/python`.

Commands:

```bash
PYTHONPATH=/hai-workspace/sglang-startup-overlap/python \
python3 test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py

CUDA_VISIBLE_DEVICES=0,1,2,3 \
PYTHONPATH=/hai-workspace/sglang-startup-overlap/python \
python3 test/registered/rl/test_update_weights_from_disk_blackwell.py
```

Raw focused-unit result:

```text
Ran 26 tests in 0.049s

OK
```

Raw Blackwell result:

```text
Ran 4 tests in 949.567s

OK
```

The complete runner log is 466,073 bytes with SHA-256
`33b9f4f44aeb3784a1810f9dee6d62b2e1eb9c2352eecdccd5d83cbf7f36e7f5`.

The four registered cases cover:

| Checkpoint | Quantization | Runtime layout |
| --- | --- | --- |
| `zianglih/JoyAI-LLM-Flash-MXFP8-last-6-BF16` | MXFP8 | TP4 + DP4 + DP attention + FlashInfer TRT-LLM routed MoE |
| `nvidia/Qwen3-30B-A3B-NVFP4` | NVFP4 | TP4 + FlashInfer TRT-LLM routed MoE |
| `nvidia/Qwen3-30B-A3B-NVFP4` | NVFP4 | TP4 + EP4 + CuTe DSL W4A4 |
| `nvidia/Qwen3-30B-A3B-NVFP4` | NVFP4 | TP4 + DP4 + EP4 + DP attention + CuTe DSL W4A16 |

For each row, the test requires serial-versus-overlap equality of generated
text and token IDs plus per-token logprob absolute difference at most `1e-4`.
It then requires the same signature after each of the two existing
same-checkpoint disk reloads.

Limitations: this is same-checkpoint reload coverage, not a changed-checkpoint
weight propagation test. It does not benchmark startup performance, and it does
not enable overlap by default. The loader contract also requires post-load
processing to keep graph-visible derived tensor storage stable; the manager
validates all registered parameters and buffers after the commit.

## Speed Tests and Profiling

- Not run. This PR changes the support contract and correctness coverage; it
  makes no performance claim.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing default or CLI syntax changed.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy validation is above; no speed claim.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33732913592](https://github.com/sgl-project/sglang/actions/runs/33732913592)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33732913327](https://github.com/sgl-project/sglang/actions/runs/33732913327)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33732913539](https://github.com/sgl-project/sglang/actions/runs/33732913539)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->