### PR TITLE
[NPU] Fix ViT graph key layout handling

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/graph_runner/vit_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/vit_npu_graph_runner.py
@@ -63,7 +63,7 @@ class ViTNpuGraphRunner(ViTCudaGraphRunner):
 
     def _create_graph(
         self,
-        graph_key: int,
+        graph_key: Hashable,
     ):
 
         graph = torch_npu.npu.NPUGraph()
@@ -132,9 +132,16 @@ class ViTNpuGraphRunner(ViTCudaGraphRunner):
         cu_seqlens: torch.Tensor,
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
-    ) -> int:
+        attention_layout_key: Optional[Hashable] = None,
+    ) -> Hashable:
         vit = self.vit
-        graph_key = self._get_graph_key(x_3d)
+        graph_key = self._get_graph_key(
+            x_3d,
+            cu_seqlens,
+            None,
+            attention_layout_key,
+        )
+        seq_len = x_3d.shape[0]
 
         if graph_key in self.block_graphs:
             return graph_key
@@ -155,7 +162,7 @@ class ViTNpuGraphRunner(ViTCudaGraphRunner):
             self.block_output[graph_key] = x_3d
             self.block_input[graph_key] = x_3d
             self.block_ws[graph_key] = torch.empty(
-                graph_key,
+                seq_len,
                 num_heads,
                 attn_head_dim,
                 device=self.device,
@@ -178,7 +185,7 @@ class ViTNpuGraphRunner(ViTCudaGraphRunner):
 
     def replay(
         self,
-        graph_key: int,
+        graph_key: Hashable,
         x_3d: torch.Tensor,
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
@@ -210,16 +217,23 @@ class ViTNpuGraphRunner(ViTCudaGraphRunner):
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
         output_indices: Optional[torch.Tensor] = None,
+        attention_layout_key: Optional[Hashable] = None,
     ) -> torch.Tensor:
         # x: [seq_len, hidden] -> [S, B=1, H]
         x_3d = x.unsqueeze(1)
-        graph_key = self._get_graph_key(x_3d)
+        graph_key = self._get_graph_key(
+            x_3d,
+            cu_seqlens,
+            None,
+            attention_layout_key,
+        )
         if graph_key not in self.block_graphs:
             self.create_graph(
                 x_3d=x_3d,
                 cu_seqlens=cu_seqlens,
                 rotary_pos_emb_cos=rotary_pos_emb_cos,
                 rotary_pos_emb_sin=rotary_pos_emb_sin,
+                attention_layout_key=attention_layout_key,
             )
 
         return self.replay(

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1029,6 +1029,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             rotary_pos_emb_sin,
         ) = self._prepare_graph_inputs(x, grid_thw)
 
+        attention_layout_key = (tuple(cu_seqlens.tolist()), None)
         cu_seqlens = cu_seqlens.to("cpu")
         return self.graph_runners.run(
             x=x,
@@ -1036,6 +1037,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             rotary_pos_emb_sin=rotary_pos_emb_sin,
             cu_seqlens=cu_seqlens,
             output_indices=None,
+            attention_layout_key=attention_layout_key,
         )
 
     def forward_with_cuda_graph(

--- a/test/registered/unit/multimodal/test_vit_npu_graph_runner.py
+++ b/test/registered/unit/multimodal/test_vit_npu_graph_runner.py
@@ -1,0 +1,92 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _Block:
+    attn = SimpleNamespace(
+        qkv_backend_name="ascend_attn",
+        num_attention_heads_per_partition=2,
+        head_size=4,
+    )
+
+    def forward(self, x, output_ws=None):
+        return x
+
+
+class _FakeGraph:
+    def replay(self):
+        pass
+
+
+def _load_npu_graph_runner():
+    torch_npu = SimpleNamespace()
+    allocator = SimpleNamespace(set_graph_pool_id=lambda pool: None)
+    with patch.dict(
+        sys.modules,
+        {
+            "torch_npu": torch_npu,
+            "sglang.srt.distributed.device_communicators.pynccl_allocator": allocator,
+        },
+    ):
+        module = importlib.import_module(
+            "sglang.srt.hardware_backend.npu.graph_runner.vit_npu_graph_runner"
+        )
+    return module.ViTNpuGraphRunner
+
+
+def test_npu_vit_graph_keys_include_attention_boundaries():
+    runner_cls = _load_npu_graph_runner()
+    vit = SimpleNamespace(
+        blocks=[_Block()],
+        merger=lambda x: x,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        deepstack_visual_indexes=[],
+        deepstack_merger_list=None,
+    )
+
+    with patch(
+        "torch.get_device_module",
+        return_value=SimpleNamespace(graph_pool_handle=lambda: object()),
+    ):
+        runner = runner_cls(vit)
+
+    runner_cls._graph_memory_pool = None
+    runner._create_graph = lambda graph_key: runner.block_graphs.__setitem__(
+        graph_key, _FakeGraph()
+    )
+
+    x = torch.zeros(8, 8)
+    rotary = torch.zeros(8, 4)
+    first_layout = torch.tensor([0, 4, 8], dtype=torch.int32)
+    second_layout = torch.tensor([0, 2, 8], dtype=torch.int32)
+
+    runner.run(
+        x,
+        first_layout,
+        rotary_pos_emb_cos=rotary,
+        rotary_pos_emb_sin=rotary,
+    )
+    runner.run(
+        x,
+        second_layout,
+        rotary_pos_emb_cos=rotary,
+        rotary_pos_emb_sin=rotary,
+    )
+
+    assert len(runner.block_graphs) == 2
+    assert {key[1][0] for key in runner.block_graphs} == {
+        (0, 4, 8),
+        (0, 2, 8),
+    }
+    assert all(
+        workspace.shape[0] == x.shape[0] for workspace in runner.block_ws.values()
+    )

--- a/test/registered/unit/multimodal/test_vit_npu_graph_runner.py
+++ b/test/registered/unit/multimodal/test_vit_npu_graph_runner.py
@@ -3,6 +3,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -27,13 +28,13 @@ class _FakeGraph:
 
 
 def _load_npu_graph_runner():
+    # Load shared modules before stubbing torch_npu so platform detection stays on CPU.
+    importlib.import_module("sglang.srt.multimodal.vit_cuda_graph_runner")
     torch_npu = SimpleNamespace()
-    allocator = SimpleNamespace(set_graph_pool_id=lambda pool: None)
     with patch.dict(
         sys.modules,
         {
             "torch_npu": torch_npu,
-            "sglang.srt.distributed.device_communicators.pynccl_allocator": allocator,
         },
     ):
         module = importlib.import_module(
@@ -69,18 +70,22 @@ def test_npu_vit_graph_keys_include_attention_boundaries():
     first_layout = torch.tensor([0, 4, 8], dtype=torch.int32)
     second_layout = torch.tensor([0, 2, 8], dtype=torch.int32)
 
-    runner.run(
-        x,
-        first_layout,
-        rotary_pos_emb_cos=rotary,
-        rotary_pos_emb_sin=rotary,
-    )
-    runner.run(
-        x,
-        second_layout,
-        rotary_pos_emb_cos=rotary,
-        rotary_pos_emb_sin=rotary,
-    )
+    with patch(
+        "sglang.srt.hardware_backend.npu.graph_runner."
+        "vit_npu_graph_runner.set_graph_pool_id"
+    ):
+        runner.run(
+            x,
+            first_layout,
+            rotary_pos_emb_cos=rotary,
+            rotary_pos_emb_sin=rotary,
+        )
+        runner.run(
+            x,
+            second_layout,
+            rotary_pos_emb_cos=rotary,
+            rotary_pos_emb_sin=rotary,
+        )
 
     assert len(runner.block_graphs) == 2
     assert {key[1][0] for key in runner.block_graphs} == {
@@ -90,3 +95,7 @@ def test_npu_vit_graph_keys_include_attention_boundaries():
     assert all(
         workspace.shape[0] == x.shape[0] for workspace in runner.block_ws.values()
     )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

PR #37043 made ViT graph keys layout-aware by changing ViTCudaGraphRunner._get_graph_key to accept cumulative sequence boundaries and return a composite hashable key. ViTNpuGraphRunner still called the old single-argument API, causing Qwen3.6-27B multimodal requests with ViT NPU graph enabled to fail with:

    TypeError: ViTCudaGraphRunner._get_graph_key() missing 2 required positional arguments: 'cu_seqlens' and 'cu_window_seqlens'

The NPU runner also used the old integer graph key as the first dimension of a tensor workspace. That is invalid after graph keys become tuples.

## Modifications

- Pass cu_seqlens and the attention layout key when creating and looking up NPU ViT graphs.
- Preserve the Qwen3-VL attention layout before moving cumulative sequence lengths to CPU.
- Use the actual sequence length for NPU attention workspace allocation.
- Update NPU graph key type annotations from int to Hashable.
- Add a CPU regression test verifying that equal token counts with different cumulative sequence boundaries create distinct cached graphs and retain correctly shaped workspaces.

## Accuracy Tests

There is currently no registered Qwen3.6-27B multimodal accuracy test. The existing Qwen3.6-27B GPQA tests are text-only and do not exercise the ViT graph path.

Functional validation used the registered Qwen3.6-27B multimodal performance case on Ascend NPU with ViT graph and DP encoder enabled. Both benchmark attempts completed 240/240 image requests without the original exception.

## Speed Tests and Profiling

Command target:

    test/registered/npu/performance/qwen3_6_27b/test_npu_qwen3_6_27b_1p_in1024x1024_30_out1024_50ms.py

Configuration: Qwen3.6-27B BF16, TP=2, 240 requests, concurrency=60, one 1024x1024 image per request.

- Attempt 1: TPOT 61.60 ms, output throughput 655.62 tok/s.
- Attempt 2: TPOT 56.84 ms, output throughput 789.25 tok/s.

The functional regression is fixed. The performance test still fails its pre-existing TPOT gate of 51.0 ms; this PR does not target performance.

Unit tests:

    PYTHONPATH=python python3 -m pytest -q       test/registered/unit/multimodal/test_vit_npu_graph_runner.py       test/registered/unit/multimodal/test_vit_cuda_graph_runner.py
    # 7 passed

Formatting and lint:

    python3 -m ruff check       python/sglang/srt/hardware_backend/npu/graph_runner/vit_npu_graph_runner.py       python/sglang/srt/models/qwen3_vl.py       test/registered/unit/multimodal/test_vit_npu_graph_runner.py
    python3 -m ruff format --check       python/sglang/srt/hardware_backend/npu/graph_runner/vit_npu_graph_runner.py       python/sglang/srt/models/qwen3_vl.py       test/registered/unit/multimodal/test_vit_npu_graph_runner.py

## Checklist

- [x] Format the changed code.
- [x] Add a regression unit test.
- [x] Documentation changes are not required for this compatibility fix.
- [x] Provide available functional and performance results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34096353480](https://github.com/sgl-project/sglang/actions/runs/34096353480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34096353158](https://github.com/sgl-project/sglang/actions/runs/34096353158)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34096353429](https://github.com/sgl-project/sglang/actions/runs/34096353429)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->