### PR TITLE
[PD] Batch all KV cache layers into a single transfer for intra-node NVLink

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -642,6 +642,12 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             mooncake_session_id, list(src_addrs), list(dst_addrs), list(lengths)
         )
 
+    def _is_intra_node_nvlink_enabled(self) -> bool:
+        return (
+            self.enable_custom_mem_pool
+            and self.custom_mem_pool_type == "INTRA_NODE_NVLINK"
+        )
+
     def _send_kvcache_generic(
         self,
         mooncake_session_id: str,
@@ -781,7 +787,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
             return self._transfer_data(mooncake_session_id, transfer_blocks)
 
-        if self.enable_custom_mem_pool:
+        if self.enable_custom_mem_pool and not self._is_intra_node_nvlink_enabled():
             futures = [
                 executor.submit(
                     process_layer,
@@ -793,8 +799,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             ]
             return self._await_transfer_futures(futures)
         else:
-            # Combining all layers' params in one batch transfer is more efficient
-            # compared to using multiple threads
+            # The default transport and INTRA_NODE_NVLINK both benefit from
+            # combining all layers into one batch transfer. Other custom memory
+            # pools retain their per-layer thread-pool submission behavior.
             return process_layers(layers_params)
 
     def _validate_envelope_kv_layout(
@@ -997,7 +1004,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 set_transfer_blocks(src_ptr, dst_ptr, token_item_len),
             )
 
-        if self.enable_custom_mem_pool:
+        if self.enable_custom_mem_pool and not self._is_intra_node_nvlink_enabled():
             futures = [
                 executor.submit(process_layer, src_ptr, dst_ptr, token_item_len)
                 for src_ptr, dst_ptr, token_item_len in layers_params
@@ -1129,7 +1136,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             tokens_per_page * bytes_per_token_on_decode + dst_head_slice_offset
         )
 
-        def process_layer_tp_aware(src_layer_ptr, dst_layer_ptr):
+        def set_transfer_blocks_tp_aware(
+            src_layer_ptr: int, dst_layer_ptr: int
+        ) -> List[Tuple[int, int, int]]:
             src_page_base_addrs = src_layer_ptr + prefill_page_indices * src_kv_item_len
             dst_page_base_addrs = dst_layer_ptr + decode_page_indices * dst_kv_item_len
             src_slice_addrs = src_page_base_addrs + src_token_slot_offsets
@@ -1138,13 +1147,25 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             src_addr_list = src_slice_addrs.reshape(-1).tolist()
             if not src_addr_list:
                 # Nothing to transfer for this layer.
-                return 0
+                return []
             dst_addr_list = dst_slice_addrs.reshape(-1).tolist()
             total_slices = len(src_addr_list)
             length_list = [heads_bytes_per_token_to_send] * total_slices
-            return self.engine.batch_transfer_sync(
-                mooncake_session_id, src_addr_list, dst_addr_list, length_list
+            return list(zip(src_addr_list, dst_addr_list, length_list))
+
+        def process_layer_tp_aware(src_layer_ptr: int, dst_layer_ptr: int) -> int:
+            return self._transfer_data(
+                mooncake_session_id,
+                set_transfer_blocks_tp_aware(src_layer_ptr, dst_layer_ptr),
             )
+
+        if self._is_intra_node_nvlink_enabled():
+            transfer_blocks = []
+            for src_layer_ptr, dst_layer_ptr in layer_ptr_pairs:
+                transfer_blocks.extend(
+                    set_transfer_blocks_tp_aware(src_layer_ptr, dst_layer_ptr)
+                )
+            return self._transfer_data(mooncake_session_id, transfer_blocks)
 
         futures = [
             executor.submit(process_layer_tp_aware, src_layer_ptr, dst_layer_ptr)


### PR DESCRIPTION
## Motivation

When `SGLANG_MOONCAKE_CUSTOM_MEM_POOL=INTRA_NODE_NVLINK` is enabled, Mooncake currently submits one transfer task per KV-cache layer through the thread pool.

This behavior was inherited from the custom-memory-pool path, which historically avoided large batch transfers for MNNVL/NVLink due to correctness concerns. The underlying transfer path now supports `batch_transfer_sync`, but `INTRA_NODE_NVLINK` still follows the per-layer submission path.

Submitting transfers per layer introduces additional overhead from:

- Thread-pool task creation and scheduling
- Multiple Python-to-Mooncake calls
- Repeated transfer submission and synchronization
- CPU contention when many layers are transferred concurrently

## Changes

This PR enables all-layer batching when the custom memory pool type is `INTRA_NODE_NVLINK`.

For each KV chunk and target decode rank, the transfer path now:

1. Builds transfer blocks for all local KV-cache layers.
2. Combines them into one transfer-block list.
3. Submits the list through a single `batch_transfer_sync` call.

The change covers:

- Generic MHA/MLA KV-cache transfer
- DCP KV-cache relayout transfer
- Heterogeneous-TP head-sliced KV-cache transfer

The existing behavior is preserved for `NVLINK` and `BAREX`, which continue to submit transfers per layer through the thread pool. The default non-custom-memory-pool path is unchanged.

The staging-buffer path already batches all layers and therefore requires no changes.

## Expected Benefit

This reduces transfer submission overhead and thread-pool contention for intra-node NVLink transfers, especially for models with many KV-cache layers.

The batching scope is one KV chunk per target decode rank. Auxiliary states and different chunks are still transferred independently.

## Perf testing


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33737602474](https://github.com/sgl-project/sglang/actions/runs/33737602474)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33737602193](https://github.com/sgl-project/sglang/actions/runs/33737602193)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33737602302](https://github.com/sgl-project/sglang/actions/runs/33737602302)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->