### PR TITLE
[AMD] Fix DeepSeek-R1-MXFP4 accuracy with AITER FP8

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -322,6 +322,7 @@ def _fused_rope_cat_and_cache(
         q_nope_out.dtype
         if attn.kv_cache_dtype == "fp8_e4m3"
         and attn.current_attention_backend == "aiter"
+        and q_nope_out.shape[-2] == 12
         else kv_cache_dtype
     )
     return fused_qk_rope_cat_and_cache_mla(


### PR DESCRIPTION
## Summary

- Keep the BF16 query exception only for the 12-head AITER + FP8 case it was added for.
- Let other head counts use FP8 queries again.

## Why

#34647 added the BF16 exception for Kimi-K3 TP8, which has 12 local MLA heads. The condition also applied to every other AITER + FP8 MLA model, causing DeepSeek-R1-MXFP4 TP2, TP4, and TP4-MTP to select the wrong kernel and lose nearly all GSM8K accuracy.

This change adds only the missing 12-head check.

## Validation
<img width="1801" height="1224" alt="image" src="https://github.com/user-attachments/assets/e0b89f18-a82e-44fe-97ad-623d770220c5" />

https://github.com/sgl-project/sglang/actions/runs/35080647993/job/104743576749

Full 1319-question GSM8K runs on 8x MI355X with ROCm 7.2.4:

- DeepSeek-R1-MXFP4 TP2: 0.948 accuracy, 0.000 invalid
- DeepSeek-R1-MXFP4 TP4: 0.948 accuracy, 0.000 invalid
- DeepSeek-R1-MXFP4 TP4-MTP: 0.948 accuracy, 0.000 invalid
- Kimi-K3 TP8 h12 FP8 Gluon: 0.951 accuracy, 0.001 invalid, with no Gluon failure or fallback

Kimi-K3 uses a separate NoPE path, so its run is a non-regression check for the original h12 Gluon behavior. The DeepSeek-R1 runs directly exercise the changed condition.

Regression example: https://github.com/sgl-project/sglang/actions/runs/33489586349/job/99797792543

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35080202480](https://github.com/sgl-project/sglang/actions/runs/35080202480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35080202269](https://github.com/sgl-project/sglang/actions/runs/35080202269)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35080202462](https://github.com/sgl-project/sglang/actions/runs/35080202462)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->