### PR TITLE
[DCP] Drop symm-mem under DCP on NCCL older than 2.30.7

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1407,6 +1407,25 @@ def _data_parallelism_defaults(view: Any) -> dict:
 
 
 @register_post_process
+def _dcp_symm_mem_nccl_guard(view: Any) -> dict:
+    if not (view.enable_symm_mem and view.dcp_size > 1 and not view.disable_cuda_graph):
+        return {}
+
+    from sglang.srt.distributed.device_communicators.pynccl_wrapper import (
+        nccl_has_symmetric_pdl_fix,
+    )
+
+    if nccl_has_symmetric_pdl_fix():
+        return {}
+
+    logger.warning(
+        "Disabling --enable-symm-mem: NCCL before 2.30.7 corrupts small decode "
+        "CUDA-graph batches under DCP. Upgrade NCCL to keep symmetric memory."
+    )
+    return {"enable_symm_mem": False}
+
+
+@register_post_process
 def _tp_lm_head_all_to_all_default(view: Any) -> dict:
     """Enable the TP LM-head all-to-all path only for pure-DP decode nodes.
 

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from sglang.srt.arg_groups.overrides import (
     _data_parallelism_defaults,
+    _dcp_symm_mem_nccl_guard,
     _dp_lm_head_validation,
     _tp_lm_head_all_to_all_default,
     declare_resolution,
@@ -148,6 +149,8 @@ def handle_dcp_validation(server_args: Any):
             "authoritative fabric probe runs at model-runner init; use 'a2a' "
             "or 'ag_rs' on clusters without MNNVL."
         )
+    run_post_process_pass(server_args, _dcp_symm_mem_nccl_guard)
+
     if cfg.dcp_replicate_q_proj:
         if cfg.dcp_size <= 1:
             raise ValueError("--dcp-replicate-q-proj requires --dcp-size > 1.")

--- a/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
@@ -667,3 +667,12 @@ __all__ = [
     "cudaStream_t",
     "buffer_type",
 ]
+
+NCCL_SYMMETRIC_PDL_FIX_VERSION = 23007
+
+
+def nccl_has_symmetric_pdl_fix() -> bool:
+    try:
+        return NCCLLibrary().ncclGetRawVersion() >= NCCL_SYMMETRIC_PDL_FIX_VERSION
+    except Exception:
+        return False

--- a/test/registered/unit/server_args/test_dcp_symm_mem_nccl_guard.py
+++ b/test/registered/unit/server_args/test_dcp_symm_mem_nccl_guard.py
@@ -1,0 +1,90 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""`--enable-symm-mem` must be dropped under DCP with CUDA graphs when the loaded
+NCCL predates 2.30.7, and kept in every other combination.
+
+    python -m pytest test/registered/unit/server_args/test_dcp_symm_mem_nccl_guard.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.overrides import _dcp_symm_mem_nccl_guard
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _run_guard(*, enable_symm_mem, dcp_size, disable_cuda_graph, has_fix):
+    view = SimpleNamespace(
+        enable_symm_mem=enable_symm_mem,
+        dcp_size=dcp_size,
+        disable_cuda_graph=disable_cuda_graph,
+    )
+    with patch(
+        "sglang.srt.distributed.device_communicators.pynccl_wrapper.nccl_has_symmetric_pdl_fix",
+        return_value=has_fix,
+    ):
+        return _dcp_symm_mem_nccl_guard(view)
+
+
+class TestDcpSymmMemNcclGuard(unittest.TestCase):
+    def test_drops_symm_mem_on_old_nccl(self):
+        self.assertEqual(
+            _run_guard(
+                enable_symm_mem=True,
+                dcp_size=4,
+                disable_cuda_graph=False,
+                has_fix=False,
+            ),
+            {"enable_symm_mem": False},
+        )
+
+    def test_keeps_symm_mem_on_fixed_nccl(self):
+        self.assertEqual(
+            _run_guard(
+                enable_symm_mem=True,
+                dcp_size=4,
+                disable_cuda_graph=False,
+                has_fix=True,
+            ),
+            {},
+        )
+
+    def test_keeps_symm_mem_without_dcp(self):
+        self.assertEqual(
+            _run_guard(
+                enable_symm_mem=True,
+                dcp_size=1,
+                disable_cuda_graph=False,
+                has_fix=False,
+            ),
+            {},
+        )
+
+    def test_keeps_symm_mem_without_cuda_graph(self):
+        self.assertEqual(
+            _run_guard(
+                enable_symm_mem=True,
+                dcp_size=4,
+                disable_cuda_graph=True,
+                has_fix=False,
+            ),
+            {},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--enable-symm-mem`, decode context parallelism (`--dcp-size > 1`) and CUDA graphs, decode is silently wrong for small batches. Measured on 8×B200 (DeepSeek-V2-Lite-Chat, tp4 = dcp4, v0.5.18, NCCL 2.29.7), GSM8K on one server:

| `--parallel` | 1 | 2 | 4 | 8 | 16 | 32 |
|---|---|---|---|---|---|---|
| accuracy | **0.100** | **0.450** | 0.625 | 0.575 | 0.575 | 0.650 |

Non-DCP tp4 with symm-mem scores 0.575 at `--parallel 1`, and DCP with `--disable-cuda-graph` scores 0.575, so the corruption needs symmetric memory **and** DCP **and** graph capture. A batched evaluation never forms a small decode batch and cannot see it — the 0.650 above comes from the same broken server.

Cause: NCCL's symmetric collectives lost the consumer-side `cudaGridDependencySynchronize()` barrier when they moved to the device API in 2.28, restored in **2.30.7** (NCCL commit `2948185`, release note: *"ensuring that newly launched kernels cannot access memory modified by prior kernels before it reaches point of coherency"*). Symmetric collectives are armed with programmatic dependent launch, so without that barrier a collective can read its input before the producing kernel reaches coherency.

The corruption is a race and is armed per server launch: within one broken launch it is stable (GSM8K `--parallel 1` = 0.175 / 0.050 / 0.125 on three consecutive runs), but some launches of the same command come up clean. A single clean run therefore does not clear a configuration.

Confirmed on the same server:

| arm | GSM8K `--parallel 1` | `--parallel 2` |
|---|---|---|
| unchanged (NCCL 2.29.7) | 0.100 | 0.450 |
| `NCCL_WIN_ENABLE=0` (no symmetric kernels) | 0.600 | 0.600 |
| NCCL **2.30.7** preloaded | 0.600 | 0.625 |
| `--enable-symm-mem` off | 0.650 | 0.650 |

## Modifications

Read the **loaded** NCCL version through `ncclGetVersion` (not the version torch was built against, which does not track an LD_PRELOAD'd or upgraded runtime) and turn `--enable-symm-mem` off with a warning when DCP and CUDA graphs are on and NCCL predates 2.30.7. On 2.30.7 and newer nothing changes.

Auto-disabling rather than raising is deliberate: `--enable-symm-mem` appears in cookbook launch commands and the failure it causes is silent, so the safe default is to keep the server correct and say so in the log.

Related: #29946 addresses the same NCCL defect from the all-reduce side.

## Accuracy Tests

8×B200, DeepSeek-V2-Lite-Chat tp4 = dcp4, `--enable-symm-mem`, CUDA graphs on, GSM8K 40 questions:

| runtime NCCL | `enable_symm_mem` after resolution | p=1 | p=2 |
|---|---|---|---|
| 2.29.7 | `False` (guard fires, warning logged) | 0.650 | 0.650 |
| 2.30.7 | `True` | 0.600 | 0.625 |

Reproduced under Slurm/pyxis on a second B200 cluster: guard fires, `--parallel 1` goes from 0.025 to 0.650.

New CPU unit test `test/registered/unit/server_args/test_dcp_symm_mem_nccl_guard.py`: drops symm-mem on old NCCL; keeps it on 2.30.7, without DCP, and without CUDA graphs.

## Speed Tests and Profiling

Not benchmarked. On NCCL < 2.30.7 with DCP the change gives up the symmetric-memory fast path, which is the cost of correct output; upgrading NCCL to 2.30.7 keeps it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34093867136](https://github.com/sgl-project/sglang/actions/runs/34093867136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34093866962](https://github.com/sgl-project/sglang/actions/runs/34093866962)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34093867195](https://github.com/sgl-project/sglang/actions/runs/34093867195)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
