### PR TITLE
[AMD] Clamp SwiGLU gate/up on HIP in the Triton MoE runner

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -95,6 +95,12 @@ padding_size = get_moe_padding_size(_use_aiter)
 logger = logging.getLogger(__name__)
 
 
+def _clamp_swiglu_inputs_(x: torch.Tensor, limit: float) -> None:
+    half = x.shape[-1] // 2
+    x[..., :half].clamp_(max=limit)
+    x[..., half:].clamp_(min=-limit, max=limit)
+
+
 def _validate_fused_swiglu_interleaved(
     *,
     activation: str,
@@ -708,6 +714,10 @@ def _fused_moe_kernel_sequence(
 
             if filter_expert:
                 swiglu_limit_for_triton = swiglu_limit
+            elif _is_hip:
+                # The fused clamp kernel is CUDA/XPU-only; apply its gate/up
+                # contract before the regular HIP silu_and_mul kernel.
+                _clamp_swiglu_inputs_(intermediate_cache1, swiglu_limit)
             else:
                 assert _is_cuda or _is_xpu, (
                     "fused silu_and_mul_clamp kernel is CUDA/XPU only; HIP must disable SWIGLU_CLAMP_FUSION"

--- a/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
@@ -1,0 +1,39 @@
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
+    _clamp_swiglu_inputs_,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestFusedMoeSwigluClamp(CustomTestCase):
+    def test_clamps_gate_and_up_with_the_deepseek_contract(self):
+        inputs = torch.tensor([[-20.0, 20.0, -20.0, 20.0], [3.0, 11.0, -4.0, 5.0]])
+
+        _clamp_swiglu_inputs_(inputs, limit=10.0)
+
+        # Gate is bounded above only; up is bounded on both sides.
+        torch.testing.assert_close(
+            inputs,
+            torch.tensor([[-20.0, 10.0, -10.0, 10.0], [3.0, 10.0, -4.0, 5.0]]),
+        )
+
+    def test_clamped_inputs_match_reference_swiglu(self):
+        inputs = torch.tensor([[-12.0, 14.0, -13.0, 15.0]])
+
+        _clamp_swiglu_inputs_(inputs, limit=10.0)
+        output = F.silu(inputs[..., :2]) * inputs[..., 2:]
+
+        expected_gate = torch.tensor([[-12.0, 10.0]])
+        expected_up = torch.tensor([[-10.0, 10.0]])
+        torch.testing.assert_close(output, F.silu(expected_gate) * expected_up)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
@@ -34,6 +34,21 @@ class TestFusedMoeSwigluClamp(CustomTestCase):
         expected_up = torch.tensor([[-10.0, 10.0]])
         torch.testing.assert_close(output, F.silu(expected_gate) * expected_up)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "needs a GPU")
+    def test_matches_cpu_on_device_in_moe_dtype(self):
+        # The MoE runner only ever calls this on a device tensor, and on the
+        # bf16 intermediate cache rather than fp32, so cover that shape too.
+        reference = torch.randn(64, 2 * 96, dtype=torch.bfloat16) * 8.0
+        on_device = reference.clone().cuda()
+
+        _clamp_swiglu_inputs_(reference, limit=10.0)
+        _clamp_swiglu_inputs_(on_device, limit=10.0)
+
+        torch.testing.assert_close(on_device.cpu(), reference)
+        half = reference.shape[-1] // 2
+        self.assertLessEqual(reference[..., :half].max().item(), 10.0)
+        self.assertLessEqual(reference[..., half:].abs().max().item(), 10.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`_fused_moe_kernel_sequence` splits the DeepSeek-V4 `swiglu_limit` path in two. With `filter_expert` the clamp folds into `act_and_mul_triton`, which builds on HIP. Without it the code selects `silu_and_mul_clamp`, a fused kernel that exists only for CUDA and XPU, and the preceding assert converts that into an abort. Any HIP run of the **Triton** MoE runner on a model that sets `swiglu_limit` dies at the first MoE layer, so ROCm has no non-AITER MoE runner to fall back to or to compare against. Applying the fused kernel's own clamp contract in place, then falling through to the regular HIP `silu_and_mul`, reproduces it.

| Path | `filter_expert` | Kernel | HIP before | HIP after |
| --- | --- | --- | --- | --- |
| fused clamp | True | `act_and_mul_triton` | works | unchanged |
| separate clamp | False | `silu_and_mul_clamp` | **assert abort** | **`_clamp_swiglu_inputs_` + `silu_and_mul`** |

## Scope

HIP only, and only on the Triton MoE runner: the abort lives in `moe_runner/triton_utils/fused_moe.py`, which `--moe-runner-backend aiter` never enters. Production ROCm deployments of GLM-5.3-Flash use the AITER runner and are unaffected either way — this restores the Triton runner as a working reference path on ROCm. CUDA and XPU keep selecting `silu_and_mul_clamp`; the `filter_expert` branch keeps folding the clamp into `act_and_mul_triton` on every platform. Nothing is gated on an env var, because the previous behaviour on this branch was an abort rather than a working alternative.

## Test plan

Base image `lmsysorg/sglang:v0.5.18-rocm720-mi35x` (`sha256:6d68cd19`, AITER `d9e5ef7c`), GLM-5.3-Flash BF16 on MI355X TP8, launched with `--moe-runner-backend triton`. The single variable between the two builds is this patch.

| Build | Result |
| --- | --- |
| baseline | `AssertionError: fused silu_and_mul_clamp kernel is CUDA/XPU only; HIP must disable SWIGLU_CLAMP_FUSION`, all 8 ranks, no server |
| this PR | **server reaches "fired up and ready", serves generations** |

`_clamp_swiglu_inputs_` is covered three ways: the contract asserted directly (gate bounded above at the limit, up bounded to the symmetric interval), the clamped tensor through `F.silu(gate) * up` matched against the reference, and a device case that runs the clamp on a `bfloat16` tensor shaped like the real `intermediate_cache1` and compares it against the CPU result. The third is the one that exercises the dtype and device the MoE runner actually uses.

```
test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py  3 passed   (MI355X, gfx950)
```

**Accuracy:** GSM8K on this Triton path is still being measured and will be posted before this leaves draft. On the same base and stack the AITER runner scores 0.9719 TP8 and 0.9697 TP4 (1319 examples, single pass each) — that is the reference this Triton path exists to be compared against, not a number this PR moves.

This re-lands the same fix from #36607, reverted wholesale in c767511ea8.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33741245007](https://github.com/sgl-project/sglang/actions/runs/33741245007)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33741244856](https://github.com/sgl-project/sglang/actions/runs/33741244856)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33741244924](https://github.com/sgl-project/sglang/actions/runs/33741244924)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->