### PR TITLE
[PD] Use one logical-range contract for DSA state indices

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -54,6 +54,7 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     build_kv_layer_ids,
     build_staging_slot_metadata,
+    get_dsa_state_page_indices,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_dsv4_c128_online_enabled,
@@ -1407,6 +1408,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 device_page_size = self.token_to_kv_pool.page_size
                 return kv_to_page_indices(kv_indices_full, device_page_size)
 
+            def _dsa_payload():
+                return get_dsa_state_page_indices(
+                    self.req_to_token_pool.req_to_token[decode_req.req.kv.req_pool_idx],
+                    origin_input_len,
+                    self.token_to_kv_pool.page_size,
+                )
+
             def _swa_ring_payload():
                 # Mirror of prefill _swa_ring_payload using this side's req_pool_idx.
                 # Same window positions and order -> positional match with prefill.
@@ -1438,7 +1446,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             payloads = {
                 StateType.MAMBA: _mamba_payload,
                 StateType.SWA: _swa_payload,
-                StateType.DSA: _full_kv_pages_payload,
+                StateType.DSA: _dsa_payload,
                 StateType.MINIMAX_INDEX_K: _full_kv_pages_payload,
                 StateType.SWA_RING: _swa_ring_payload,
                 StateType.C128_STATE: _c128_state_payload,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -45,6 +45,7 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     build_kv_layer_ids,
     build_staging_slot_metadata,
+    get_dsa_state_page_indices,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_aborted,
@@ -1242,6 +1243,13 @@ class SchedulerDisaggregationPrefillMixin:
                 ]
                 return kv_to_page_indices(kv_indices_full, page_size)
 
+            def _dsa_payload():
+                return get_dsa_state_page_indices(
+                    self.req_to_token_pool.req_to_token[req.kv.req_pool_idx],
+                    transfer_input_len,
+                    self.token_to_kv_pool_allocator.get_kvcache().page_size,
+                )
+
             def _swa_ring_payload():
                 # Unified_kv SWA ring rows (req_pool_idx*ring_stride + pos%ring_stride)
                 # for the last `window` positions, in ascending position order so
@@ -1277,7 +1285,7 @@ class SchedulerDisaggregationPrefillMixin:
             payloads = {
                 StateType.MAMBA: _mamba_payload,
                 StateType.SWA: _swa_payload,
-                StateType.DSA: _full_kv_pages_payload,
+                StateType.DSA: _dsa_payload,
                 StateType.MINIMAX_INDEX_K: _full_kv_pages_payload,
                 StateType.SWA_RING: _swa_ring_payload,
                 StateType.C128_STATE: _c128_state_payload,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -98,6 +98,30 @@ def get_dsv4_c128_state_indices(
     return np.array([page], dtype=np.int32)
 
 
+def get_dsa_state_page_indices(
+    kv_indices: torch.Tensor,
+    logical_input_len: int,
+    device_page_size: int,
+) -> np.ndarray:
+    """Build request-scoped DSA state indices from the logical input range."""
+    if logical_input_len < 0:
+        raise ValueError(
+            f"logical_input_len must be non-negative, got {logical_input_len}"
+        )
+    if device_page_size <= 0:
+        raise ValueError(f"device_page_size must be positive, got {device_page_size}")
+
+    logical_kv_indices = kv_indices[:logical_input_len]
+    if logical_kv_indices.numel() != logical_input_len:
+        raise ValueError(
+            "DSA state range exceeds the request-to-token row: "
+            f"logical_input_len={logical_input_len}, "
+            f"available={logical_kv_indices.numel()}"
+        )
+
+    return (logical_kv_indices[::device_page_size] // device_page_size).cpu().numpy()
+
+
 class DisaggregationMode(Enum):
     NULL = "null"
     PREFILL = "prefill"

--- a/test/registered/unit/disaggregation/test_dsa_state_transfer.py
+++ b/test/registered/unit/disaggregation/test_dsa_state_transfer.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import torch
+
+from sglang.srt.disaggregation.base.conn import StateType
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.srt.disaggregation.utils import get_dsa_state_page_indices
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSAStatePageIndices(CustomTestCase):
+    def test_uses_logical_input_range(self):
+        kv_indices = torch.arange(0, 192, dtype=torch.int64)
+
+        indices = get_dsa_state_page_indices(
+            kv_indices, logical_input_len=129, device_page_size=64
+        )
+
+        np.testing.assert_array_equal(indices, np.array([0, 1, 2]))
+
+    def test_rejects_incomplete_or_invalid_layout(self):
+        kv_indices = torch.arange(0, 64, dtype=torch.int64)
+
+        with self.assertRaisesRegex(ValueError, "exceeds the request-to-token row"):
+            get_dsa_state_page_indices(
+                kv_indices, logical_input_len=65, device_page_size=64
+            )
+        with self.assertRaisesRegex(ValueError, "device_page_size must be positive"):
+            get_dsa_state_page_indices(
+                kv_indices, logical_input_len=64, device_page_size=0
+            )
+
+
+class TestPrefillDSAStateContract(CustomTestCase):
+    def test_last_chunk_uses_logical_range_and_device_page_size(self):
+        sender = MagicMock()
+        sender.should_send_kv_chunk.return_value = True
+        req_to_token = torch.arange(0, 192, dtype=torch.int64).reshape(1, -1)
+        device_pool = SimpleNamespace(page_size=64)
+        allocator = SimpleNamespace(
+            page_size=1,
+            get_kvcache=lambda: device_pool,
+            translate_kv_indices_for_transfer=lambda indices: indices,
+        )
+        scheduler = SimpleNamespace(
+            token_to_kv_pool_allocator=allocator,
+            req_to_token_pool=SimpleNamespace(req_to_token=req_to_token),
+            disagg_metadata_buffers=MagicMock(),
+            disagg_prefill_bootstrap_queue=SimpleNamespace(
+                kv_manager=SimpleNamespace(
+                    kv_args=SimpleNamespace(state_types=[StateType.DSA])
+                )
+            ),
+            enable_staging=False,
+            disagg_prefill_pending_chunk_rids=set(),
+        )
+        req = SimpleNamespace(
+            rid="request",
+            start_send_idx=0,
+            origin_input_ids=list(range(129)),
+            extend_range=SimpleNamespace(end=64),
+            kv=SimpleNamespace(req_pool_idx=0),
+            disagg_kv_sender=sender,
+        )
+
+        SchedulerDisaggregationPrefillMixin.send_kv_chunk(
+            scheduler, req, last_chunk=True
+        )
+
+        state_indices = sender.send.call_args.args[1]
+        np.testing.assert_array_equal(state_indices[0], np.array([0, 1, 2]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This is the first implementation slice of #37765 and contributes to the shared-protocol work tracked by #34510 and #33861.

DSA indexer state is request-scoped. Decode already builds its destination indices from the full logical input length and the device KV pool page size. Prefill currently reuses the generic full-KV helper, which is based on:

```python
seq_len = min(req.extend_range.end, len(req.origin_input_ids))
```

and the allocator page size. This couples DSA state shape to the locally materialized Prefill range and to an unqualified page-size domain. A cache-hit or chunked-Prefill transition can therefore produce a source state count different from the destination registered by Decode.

## Changes

- Add `get_dsa_state_page_indices()` as the shared request-scoped DSA index builder.
- Make both Prefill and Decode use the logical input length and device KV pool page size through that helper.
- Reject an invalid page size or a logical range larger than the request-to-token row before transport submission.
- Add a CPU regression test where:
  - logical input length is 129 tokens;
  - Prefill `extend_end` is 64;
  - allocator page size is 1;
  - device DSA page size is 64.

The expected DSA payload contains three device pages. It is independent of the shorter Prefill extend range and the unrelated allocator page size.

## Scope

This PR intentionally does not change the wire format or transport state machine. It also does not implement repacking between different Prefill and Decode device page sizes; that work remains tracked in #37765. The explicit request-role truth table is already covered by #34977 and is not duplicated here.

## Validation

- Linux CPU: the new regression file plus the existing PD wire and NIXL unit tests passed: `75 passed, 12 subtests passed`.
- New regression file alone: `3 passed`.
- Static checks passed for all changed files: ruff format, the repository ruff rule set, isort, registered-test validation, Python compilation, and `git diff --check`.
- An equal-page-size NIXL Prefill/Decode GPU run produced matching DSA counts for both baseline and this candidate, including a full cache hit. It did not enter the range-divergence state, so this is no-regression evidence rather than a current-main reproduction.

## Follow-ups

- Carry named source/destination page-layout metadata in the common transfer plan.
- Add an explicit repack path for heterogeneous device page sizes instead of clipping state-index arrays.
- Propagate plan-validation errors as terminal per-room failures.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33740502212](https://github.com/sgl-project/sglang/actions/runs/33740502212)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33740501887](https://github.com/sgl-project/sglang/actions/runs/33740501887)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33740501912](https://github.com/sgl-project/sglang/actions/runs/33740501912)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->