### PR TITLE
[HiSparse] Add speculative decoding support with multi-step KV cache swapping

### DIFF
--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -100,6 +100,16 @@ def validate_hisparse(server_args: ServerArgs) -> None:
         cfg.disable_radix_cache
     ), "Hierarchical sparse attention currently requires --disable-radix-cache."
 
+    enable_spec = (
+        cfg.speculative_algorithm is not None
+        and cfg.speculative_algorithm.upper() != "NONE"
+    )
+    if enable_spec and (cfg.speculative_eagle_topk or 1) != 1:
+        raise ValueError(
+            "The minimal HiSparse spec integration supports linear speculation "
+            "only; use --speculative-eagle-topk 1."
+        )
+
     # DSv4 hisparse handles its own dtype/backend pairing elsewhere; the dtype-
     # aware checks below only apply to the DSA hisparse path.
     if is_hip and is_v4_hisparse:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1482,13 +1482,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             device_page_indices = None
             if (
                 self.scheduler.enable_hisparse
-                and isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
+                and (
+                    isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
+                    or self.draft_token_to_kv_pool is not None
+                )
                 and not _is_fake_transfer(decode_req.req)
             ):
                 # alloc_logical_only() already allocated the shared logical pages
-                # used by C4 indexer and C128 KV. These device buffers do not use
-                # the C4 sparse physical-slot mapping; carry their logical page IDs
-                # alongside the independently allocated C4 host page IDs.
+                # used by the indexer and draft KV. These device buffers do not
+                # use target sparse physical slots; carry logical page IDs beside
+                # the independently allocated target host page IDs.
                 full_kv_indices = self.req_to_token_pool.req_to_token[
                     decode_req.req.kv.req_pool_idx,
                     prefix_len:origin_input_len,
@@ -1499,8 +1502,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 ).astype(np.int32)
                 if self.transfer_backend != TransferBackend.MOONCAKE:
                     raise NotImplementedError(
-                        "DSV4 HiSparse direct PD transfer currently requires "
-                        "the Mooncake backend"
+                        "HiSparse device-only PD transfer currently requires the "
+                        "Mooncake backend"
                     )
             metadata_kwargs = {"decode_prefix_len": total_prefix_len}
             if device_page_indices is not None:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -880,14 +880,29 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         dst_device_kv_ptrs = None
         if dst_device_kv_indices is not None:
             compression_ratios = self.kv_args.mla_compression_ratios
-            assert compression_ratios is not None
-            if len(dst_kv_ptrs) == len(self.kv_args.kv_data_ptrs):
+            if compression_ratios is not None:
+                if len(dst_kv_ptrs) == len(self.kv_args.kv_data_ptrs):
+                    start = self.kv_args.prefill_start_layer
+                    end = self.kv_args.prefill_end_layer
+                    assert end is not None
+                    compression_ratios = compression_ratios[start:end]
+                host_backed_kv_count = sum(ratio == 4 for ratio in compression_ratios)
+            else:
+                # Target KV is the host-backed prefix; appended draft KV keeps
+                # the indexer's logical page IDs and uses the device-only suffix.
                 start = self.kv_args.prefill_start_layer
                 end = self.kv_args.prefill_end_layer
-                assert end is not None
-                compression_ratios = compression_ratios[start:end]
-            c4_layer_num = sum(ratio == 4 for ratio in compression_ratios)
-            dst_device_kv_ptrs = set(dst_kv_ptrs[c4_layer_num:])
+                if end is None:
+                    raise ValueError(
+                        "HiSparse spec PD transfer requires prefill_end_layer"
+                    )
+                host_backed_kv_count = end - start
+                if not 0 <= host_backed_kv_count < len(dst_kv_ptrs):
+                    raise ValueError(
+                        "HiSparse spec PD transfer requires an appended device-only "
+                        "draft KV buffer"
+                    )
+            dst_device_kv_ptrs = set(dst_kv_ptrs[host_backed_kv_count:])
         return self._send_kvcache_generic(
             mooncake_session_id=mooncake_session_id,
             src_data_ptrs=self.kv_args.kv_data_ptrs,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2006,10 +2006,23 @@ class DeepseekSparseAttnBackend(
 
         # todo hisparse: to cover more backends
         if self.hisparse_coordinator is not None:
-            # flash_mla_sparse_fwd / tilelang require int32 page indices.
-            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
-                page_table_1
-            ).to(torch.int32)
+            if forward_batch.forward_mode.is_target_verify():
+                num_reqs = forward_batch.req_pool_indices.shape[0]
+                num_steps = self.speculative_num_draft_tokens
+                assert topk_indices is not None
+                grouped_topk_indices = topk_indices.view(num_reqs, num_steps, -1)
+                assert metadata.dsa_seqlens_expanded is not None
+                page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
+                    forward_batch.req_pool_indices,
+                    metadata.dsa_seqlens_expanded,
+                    grouped_topk_indices,
+                    layer.layer_id,
+                ).view(num_reqs * num_steps, -1)
+            else:
+                # flash_mla_sparse_fwd / tilelang require int32 page indices.
+                page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                ).to(torch.int32)
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
@@ -3389,7 +3402,10 @@ class DeepseekSparseAttnBackend(
     ) -> DSAIndexerMetadata:
         force_unfused = not self.use_fused_topk or (
             self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+            and (
+                forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.forward_mode.is_target_verify()
+            )
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,14 +1,17 @@
 # to be combined with the sparse coordinator class and sparse algorithm family
 
 import logging
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+import weakref
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 
 from sglang.kernels.ops.kvcache.hisparse import (
+    HiSparseSpecState,
     copy_cache_planned_mla,
     load_cache_to_device_buffer_dsv4_mla,
     load_cache_to_device_buffer_mla,
+    load_cache_to_device_buffer_spec_mla,
 )
 from sglang.srt.configs.model_config import dsa_layer_skips_topk, is_deepseek_dsa
 from sglang.srt.environ import envs
@@ -24,6 +27,9 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.memory_pool_host import DeepSeekV4PagedHostPool
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
 from sglang.srt.utils import get_device_module, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
 
 device_module = get_device_module()
 
@@ -49,13 +55,12 @@ def resolve_shared_index_layers(
     *,
     hf_text_config,
     pp_size: int,
-    is_speculative: bool,
 ) -> Optional[List[bool]]:
     """Per-layer "reuses the previous layer's top-k index" pattern, or None.
 
     Mirrors DeepseekV2AttentionMLA's skip_topk derivation (index_topk_pattern /
     index_topk_freq / cli_factor); None when the model has no sharing or the
-    prefetch cannot run (PP, speculative decoding, kill-switch).
+    prefetch cannot run (pipeline parallelism or the kill-switch).
     """
     if not is_deepseek_dsa(hf_text_config):
         return None
@@ -67,11 +72,10 @@ def resolve_shared_index_layers(
         pattern = [dsa_layer_skips_topk(hf_text_config, i) for i in range(num_layers)]
     if not any(pattern):
         return None
-    if pp_size != 1 or is_speculative:
+    if pp_size != 1:
         logger.warning(
             "HiSparse shared-index prefetch is unsupported under pipeline "
-            "parallelism / speculative decoding; falling back to synchronous "
-            "swap-in."
+            "parallelism; falling back to synchronous swap-in."
         )
         return None
     if envs.SGLANG_DISABLE_HISPARSE_PREFETCH.get():
@@ -108,6 +112,465 @@ def _build_prefetch_groups(
     return groups, slot
 
 
+class HiSparseSpecSwapManager:
+    """Own HiSparse speculative-swap state and request lifecycle."""
+
+    HASH_MULTIPLIER = 2654435761
+    MIN_SCRATCH_CAPACITY = 1024
+    NUM_METADATA_VALUES_PER_OCCURRENCE = 5
+    NUM_COUNTERS_PER_REQUEST = 4
+
+    def __init__(
+        self,
+        coordinator: "HiSparseCoordinator",
+        *,
+        num_draft_tokens: int,
+    ) -> None:
+        self._coordinator = weakref.proxy(coordinator)
+        self.enabled = num_draft_tokens > 0
+        self.num_draft_tokens = num_draft_tokens
+        self.scratch_capacity = 0
+        self._scratch_reqs: set[int] = set()
+
+        layer_num = coordinator.mem_pool_device.layer_num
+        max_num_req_slots = coordinator.req_to_token_pool.req_to_token.shape[0]
+        self.req_to_scratch = torch.empty(
+            (layer_num, max_num_req_slots, 0),
+            dtype=torch.int32,
+            device=coordinator.device,
+        )
+        self.states: tuple[HiSparseSpecState, ...] = ()
+        self.top_k_device_locs: Optional[torch.Tensor] = None
+        if not self.enabled:
+            return
+
+        if coordinator.is_dsv4_hisparse:
+            raise ValueError("HiSparse spec swap currently supports DSA caches only.")
+        if not 2 <= num_draft_tokens <= 4 or coordinator.top_k < 1024:
+            raise ValueError(
+                "HiSparse spec swap requires 2-4 draft tokens and top_k >= 1024."
+            )
+        workspace_capacity = num_draft_tokens * coordinator.top_k
+        if workspace_capacity > 8192:
+            raise ValueError("HiSparse spec swap supports at most 8192 occurrences.")
+        if max_num_req_slots > coordinator.device_buffer_size:
+            raise ValueError(
+                "HiSparse spec request capacity must not exceed device_buffer_size."
+            )
+
+        self.scratch_capacity = min(
+            workspace_capacity,
+            max(
+                self.MIN_SCRATCH_CAPACITY,
+                workspace_capacity - coordinator.device_buffer_size,
+            ),
+        )
+        hash_size = 1 << max(1, (2 * coordinator.device_buffer_size - 1).bit_length())
+        self._cache_index = torch.full(
+            (layer_num, max_num_req_slots, 2, hash_size),
+            -1,
+            dtype=torch.int64,
+            device=coordinator.device,
+        )
+        self._cache_policy = torch.zeros(
+            (layer_num, max_num_req_slots + 1, coordinator.device_buffer_size),
+            dtype=torch.int32,
+            device=coordinator.device,
+        )
+        metadata_width = max(
+            self.NUM_COUNTERS_PER_REQUEST * max_num_req_slots,
+            self.NUM_METADATA_VALUES_PER_OCCURRENCE * workspace_capacity,
+        )
+        self._scratch_state = torch.full(
+            (max_num_req_slots + 1, metadata_width),
+            -1,
+            dtype=torch.int32,
+            device=coordinator.device,
+        )
+        self._scratch_state[0].zero_()
+        self.req_to_scratch = torch.zeros(
+            (layer_num, max_num_req_slots, self.scratch_capacity),
+            dtype=torch.int32,
+            device=coordinator.device,
+        )
+        self.states = tuple(
+            HiSparseSpecState(
+                cache_index=self._cache_index[layer_id],
+                cache_policy=self._cache_policy[layer_id],
+                scratch_locs=self.req_to_scratch[layer_id],
+                scratch_state=self._scratch_state,
+            )
+            for layer_id in range(layer_num)
+        )
+
+        tokens = torch.arange(
+            coordinator.device_buffer_size,
+            dtype=torch.int64,
+            device=coordinator.device,
+        )
+        self._hash_slots = ((tokens * self.HASH_MULTIPLIER) & (hash_size - 1)).to(
+            torch.long
+        )
+        self._hash_entries = (tokens << 32) | tokens
+        self.top_k_device_locs = torch.full(
+            (max_num_req_slots, num_draft_tokens, coordinator.top_k),
+            -1,
+            dtype=torch.int32,
+            device=coordinator.device,
+        )
+
+    @property
+    def miss_plan_capacity(self) -> int:
+        return self._coordinator.top_k * max(1, self.num_draft_tokens)
+
+    def invalidate_cache(self, req_pool_idx: int) -> None:
+        if self.enabled:
+            self._cache_index[:, req_pool_idx].fill_(-1)
+
+    def reset(self, req_pool_idx: int) -> None:
+        if not self.enabled:
+            return
+        self._cache_index[:, req_pool_idx].fill_(-1)
+        self._cache_index[:, req_pool_idx, 0, self._hash_slots] = (
+            self._hash_entries.view(1, -1)
+        )
+        self._cache_policy[:, 0, req_pool_idx].zero_()
+        self._cache_policy[:, req_pool_idx + 1].zero_()
+        max_num_req_slots = self.req_to_scratch.shape[1]
+        self._scratch_state[
+            0,
+            req_pool_idx : self.NUM_COUNTERS_PER_REQUEST
+            * max_num_req_slots : max_num_req_slots,
+        ] = 0
+        self._scratch_state[req_pool_idx + 1].fill_(-1)
+
+    def ensure_scratch(self, req_pool_indices_cpu: torch.Tensor) -> None:
+        if not self.enabled:
+            return
+        req_indices = [int(idx) for idx in req_pool_indices_cpu.tolist()]
+        missing = [idx for idx in req_indices if idx not in self._scratch_reqs]
+        if not missing:
+            return
+
+        total_slots = len(missing) * self.scratch_capacity
+        allocator = self._coordinator.token_to_kv_pool_allocator
+        scratch_locs = allocator.hisparse_attn_allocator.alloc(total_slots)
+        if scratch_locs is None:
+            raise RuntimeError(
+                f"HiSparse spec failed to allocate {total_slots} scratch slots."
+            )
+        scratch_locs = scratch_locs.to(torch.int32).view(
+            len(missing), self.scratch_capacity
+        )
+        for row, req_pool_idx in enumerate(missing):
+            # Physical slots are shared by all KV layers, but every full-index
+            # layer rotates those IDs between persistent cache and scratch
+            # independently. Keep per-layer location views so one layer cannot
+            # overwrite the next layer's ownership state.
+            self.req_to_scratch[:, req_pool_idx].copy_(scratch_locs[row])
+            self._scratch_reqs.add(req_pool_idx)
+
+    def free_scratch(self, req_pool_idx: int) -> None:
+        if not self.enabled or req_pool_idx not in self._scratch_reqs:
+            return
+        scratch_locs = torch.unique(self.req_to_scratch[:, req_pool_idx].reshape(-1))
+        self._coordinator.token_to_kv_pool_allocator.free_hisparse_indices(scratch_locs)
+        self.clear_scratch(req_pool_idx)
+
+    def clear_scratch(self, req_pool_idx: int) -> None:
+        if not self.enabled or req_pool_idx not in self._scratch_reqs:
+            return
+        self.req_to_scratch[:, req_pool_idx].zero_()
+        self._scratch_reqs.remove(req_pool_idx)
+
+    def extend_owned_locs(
+        self, req_pool_idx: int, owned_locs: torch.Tensor
+    ) -> torch.Tensor:
+        if not self.enabled or req_pool_idx not in self._scratch_reqs:
+            return owned_locs
+        return torch.cat([owned_locs, self.req_to_scratch[:, req_pool_idx].reshape(-1)])
+
+    def release_decode_reserve(
+        self,
+        batch: "ScheduleBatch",
+        current_kv_lens_cpu: torch.Tensor,
+        next_kv_lens_cpu: torch.Tensor,
+    ) -> None:
+        """Release physical pages hidden behind spec decode's logical reserve."""
+        coordinator = self._coordinator
+        req_pool_indices = batch.req_pool_indices
+        logical_locs = [
+            coordinator.req_to_token_pool.req_to_token[
+                req_pool_idx, current_len:next_len
+            ]
+            for req_pool_idx, current_len, next_len in zip(
+                req_pool_indices,
+                current_kv_lens_cpu.tolist(),
+                next_kv_lens_cpu.tolist(),
+                strict=True,
+            )
+            if current_len < next_len
+        ]
+        if not logical_locs:
+            return
+        logical_locs = torch.cat(logical_locs)
+        allocator = coordinator.token_to_kv_pool_allocator
+        mapping = allocator.full_to_hisparse_device_index_mapping
+        mapped_device_locs = mapping[logical_locs]
+        mapped_device_locs = mapped_device_locs[mapped_device_locs > 0]
+        if mapped_device_locs.numel() > 0:
+            allocator.free_hisparse_indices(mapped_device_locs)
+        mapping[logical_locs] = 0
+
+    def prepare_verify(self, batch: "ScheduleBatch") -> None:
+        """Bind target-verify KV writes to the side buffer's extra page."""
+        coordinator = self._coordinator
+        req_pool_indices = batch.req_pool_indices
+        req_pool_indices_cpu = batch.req_pool_indices_cpu
+        if req_pool_indices_cpu is None:
+            req_pool_indices_cpu = req_pool_indices.cpu()
+        verify_cache_locs = batch.out_cache_loc
+        start_positions = batch.seq_lens
+
+        if not self.enabled:
+            raise RuntimeError("HiSparse spec is not initialized.")
+        if self.num_draft_tokens > coordinator.page_size - 1:
+            raise ValueError(
+                f"HiSparse spec needs {self.num_draft_tokens} verify slots, but the "
+                f"extra page has only {coordinator.page_size - 1} usable slots."
+            )
+        expected_slots = req_pool_indices.numel() * self.num_draft_tokens
+        if verify_cache_locs.numel() != expected_slots:
+            raise ValueError(
+                f"HiSparse verify slot mismatch: expected {expected_slots}, "
+                f"got {verify_cache_locs.numel()}."
+            )
+
+        coordinator._grow_device_buffers_to(
+            req_pool_indices_cpu,
+            torch.full_like(req_pool_indices_cpu, coordinator.padded_buffer_size),
+        )
+        self.ensure_scratch(req_pool_indices_cpu)
+
+        extra_start = coordinator.device_buffer_size + 1
+        total_slots = req_pool_indices.numel() * self.num_draft_tokens
+        row_indices = torch.repeat_interleave(req_pool_indices, self.num_draft_tokens)
+        offsets = (
+            torch.arange(total_slots, dtype=torch.int64, device=req_pool_indices.device)
+            % self.num_draft_tokens
+        )
+        token_positions = (
+            torch.repeat_interleave(
+                start_positions.to(torch.int64), self.num_draft_tokens
+            )
+            + offsets
+        )
+        columns = extra_start + offsets
+        device_locs = coordinator.req_to_device_buffer[row_indices, columns]
+        coordinator.req_device_buffer_tokens[:, row_indices, columns] = (
+            token_positions.to(torch.int32).unsqueeze(0)
+        )
+        coordinator.req_device_buffer_token_locs[:, row_indices, columns] = (
+            device_locs.to(torch.int32).unsqueeze(0)
+        )
+        coordinator.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+            verify_cache_locs
+        ] = device_locs
+
+    def _backup_device_locs_to_host(
+        self,
+        host_locs: torch.Tensor,
+        device_locs: torch.Tensor,
+        *,
+        wait: bool,
+    ) -> None:
+        if host_locs.numel() == 0:
+            return
+        coordinator = self._coordinator
+        coordinator.wait_for_pending_backup()
+        schedule_stream = device_module.current_stream()
+        device_locs = device_locs.contiguous()
+        with device_module.stream(coordinator.decode_backup_stream):
+            coordinator.decode_backup_stream.wait_stream(schedule_stream)
+            if coordinator.decode_producer_stream is not None:
+                coordinator.decode_backup_stream.wait_stream(
+                    coordinator.decode_producer_stream
+                )
+            coordinator.mem_pool_host.backup_from_device_all_layer(
+                coordinator.mem_pool_device,
+                host_locs,
+                device_locs,
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(coordinator.decode_backup_stream)
+            if device_locs.is_cuda:
+                device_locs.record_stream(coordinator.decode_backup_stream)
+            coordinator._backup_done_event.record()
+        coordinator._has_pending_backup = True
+        if wait:
+            coordinator.wait_for_pending_backup()
+
+    def commit_accept_tokens(
+        self, batch: "ScheduleBatch", accept_indices: torch.Tensor
+    ) -> None:
+        """Persist accepted target-verify KV in host and the persistent buffer."""
+        if batch.forward_mode.is_idle():
+            return
+        coordinator = self._coordinator
+        req_pool_indices = batch.req_pool_indices
+        req_pool_indices_cpu = batch.req_pool_indices_cpu
+        if req_pool_indices_cpu is None:
+            req_pool_indices_cpu = req_pool_indices.cpu()
+        seq_lens = batch.seq_lens
+        seq_lens_cpu = batch.seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = seq_lens.cpu()
+        verify_cache_locs = batch.out_cache_loc
+
+        if verify_cache_locs.numel() == 0:
+            return
+        batch_size = req_pool_indices.numel()
+        if batch_size == 0 or verify_cache_locs.numel() % batch_size != 0:
+            raise ValueError("HiSparse verify cache locations are not request-aligned.")
+
+        counts = (accept_indices >= 0).sum(dim=1).to(torch.int64)
+        counts_cpu = counts.cpu()
+        num_accept_tokens = int(counts_cpu.sum().item())
+        mapping = (
+            coordinator.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        if num_accept_tokens == 0:
+            mapping[verify_cache_locs] = 0
+            return
+        accept_offsets = accept_indices[accept_indices >= 0].to(torch.int64)
+        if torch.any(accept_offsets >= verify_cache_locs.numel()):
+            raise ValueError("HiSparse accept_indices point outside verify_cache_locs.")
+
+        accept_source_locs = verify_cache_locs[accept_offsets]
+        source_device_locs = mapping[accept_source_locs].clone()
+        accept_req_indices = torch.repeat_interleave(req_pool_indices, counts)
+        segment_offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=counts.device),
+                counts.cumsum(dim=0),
+            ]
+        )
+        positions_in_req = torch.arange(
+            num_accept_tokens, dtype=torch.int64, device=counts.device
+        ) - torch.repeat_interleave(segment_offsets[:-1], counts)
+        accept_positions = (
+            torch.repeat_interleave(seq_lens.to(torch.int64), counts) + positions_in_req
+        )
+        canonical_locs = coordinator.req_to_token_pool.req_to_token[
+            accept_req_indices, accept_positions
+        ]
+
+        destination_locs = source_device_locs.clone()
+        hot_mask = accept_positions < coordinator.device_buffer_size
+        if torch.any(hot_mask):
+            destination_locs[hot_mask] = coordinator.req_to_device_buffer[
+                accept_req_indices[hot_mask], accept_positions[hot_mask]
+            ]
+        last_offsets = segment_offsets[1:] - 1
+        last_positions = accept_positions[last_offsets]
+        newest_columns = last_positions.clamp(max=coordinator.device_buffer_size)
+        newest_locs = coordinator.req_to_device_buffer[req_pool_indices, newest_columns]
+        destination_locs[last_offsets] = newest_locs
+
+        needs_copy = destination_locs != source_device_locs
+        if torch.any(needs_copy):
+            coordinator.mem_pool_device.transfer_values_on_device(
+                dst_indices=destination_locs[needs_copy],
+                src_indices=source_device_locs[needs_copy],
+            )
+
+        host_locs = []
+        for req_pool_idx, seq_len, count in zip(
+            req_pool_indices_cpu.tolist(),
+            seq_lens_cpu.tolist(),
+            counts_cpu.tolist(),
+            strict=True,
+        ):
+            count = int(count)
+            if count > 0:
+                host_locs.append(
+                    coordinator.mem_pool_host.alloc_paged_token_slots(
+                        coordinator.req_to_host_pool,
+                        coordinator.req_to_host_pool_allocated_len,
+                        int(req_pool_idx),
+                        int(seq_len),
+                        count,
+                    )
+                )
+        self._backup_device_locs_to_host(
+            torch.cat(host_locs), destination_locs, wait=True
+        )
+
+        mapping[verify_cache_locs] = 0
+        if torch.any(hot_mask):
+            mapping[canonical_locs[hot_mask]] = destination_locs[hot_mask]
+            coordinator.req_device_buffer_tokens[
+                :, accept_req_indices[hot_mask], accept_positions[hot_mask]
+            ] = (accept_positions[hot_mask].to(torch.int32).unsqueeze(0))
+            coordinator.req_device_buffer_token_locs[
+                :, accept_req_indices[hot_mask], accept_positions[hot_mask]
+            ] = (destination_locs[hot_mask].to(torch.int32).unsqueeze(0))
+
+        mapping[canonical_locs[last_offsets]] = newest_locs
+        coordinator.req_device_buffer_tokens[:, req_pool_indices, newest_columns] = (
+            last_positions.to(torch.int32).unsqueeze(0)
+        )
+        coordinator.req_device_buffer_token_locs[
+            :, req_pool_indices, newest_columns
+        ] = newest_locs.to(torch.int32).unsqueeze(0)
+        for req_pool_idx in req_pool_indices_cpu.tolist():
+            coordinator._skip_first_backup[int(req_pool_idx)] = True
+
+    def swap_in(
+        self,
+        req_pool_indices: torch.Tensor,
+        compressed_seq_lens: torch.Tensor,
+        top_k_result: torch.Tensor,
+        layer_id: int,
+        **plan,
+    ) -> torch.Tensor:
+        if not self.enabled:
+            raise RuntimeError("HiSparse spec swap is not initialized.")
+        num_reqs = req_pool_indices.size(0)
+        num_steps, num_top_k = top_k_result.shape[1:]
+        if num_steps != self.num_draft_tokens:
+            raise ValueError(
+                f"HiSparse spec step mismatch: expected {self.num_draft_tokens}, "
+                f"got {num_steps}."
+            )
+        assert self.top_k_device_locs is not None
+        top_k_indices = self.top_k_device_locs[:num_reqs, :num_steps, :num_top_k]
+        coordinator = self._coordinator
+        load_cache_to_device_buffer_spec_mla(
+            top_k_tokens=top_k_result,
+            device_buffer_tokens=coordinator.req_device_buffer_tokens[layer_id],
+            host_cache_locs=coordinator.req_to_host_pool,
+            device_buffer_locs=coordinator.req_device_buffer_token_locs[layer_id],
+            host_cache=coordinator.mem_pool_host.kv_buffer[layer_id],
+            device_buffer=coordinator.mem_pool_device.kv_buffer[layer_id],
+            top_k_device_locs=top_k_indices,
+            req_pool_indices=req_pool_indices,
+            seq_lens=compressed_seq_lens,
+            state=self.states[layer_id],
+            num_real_reqs=coordinator.num_real_reqs,
+            **plan,
+        )
+        return top_k_indices
+
+    def output_locs(self, top_k_result: torch.Tensor, num_reqs: int) -> torch.Tensor:
+        if not self.enabled or self.top_k_device_locs is None:
+            raise RuntimeError("HiSparse spec swap is not initialized.")
+        return self.top_k_device_locs[
+            :num_reqs, : top_k_result.shape[1], : top_k_result.shape[2]
+        ]
+
+
 class HiSparseCoordinator:
     def __init__(
         self,
@@ -123,6 +586,7 @@ class HiSparseCoordinator:
         host_to_device_ratio: int = 2,
         swap_in_block_size: int = 960,
         shared_index_layers: Optional[List[bool]] = None,
+        num_draft_tokens: int = 0,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -237,6 +701,10 @@ class HiSparseCoordinator:
             .repeat(layer_num, max_num_req_slots, 1)
             .contiguous()
         )
+        self.spec_swap = HiSparseSpecSwapManager(
+            self,
+            num_draft_tokens=num_draft_tokens,
+        )
         self._device_buffer_arange_i32 = torch.arange(
             self.device_buffer_size, dtype=torch.int32, device=device
         )
@@ -298,11 +766,16 @@ class HiSparseCoordinator:
         # Plan recorded by the current anchor, replayed by its skip layers. One
         # buffer set suffices: the last skip layer's event wait orders the next
         # anchor's writes after this group's copies.
+        miss_plan_capacity = self.spec_swap.miss_plan_capacity
         self._miss_src = torch.zeros(
-            (max_num_req_slots, self.top_k), dtype=torch.int64, device=self.device
+            (max_num_req_slots, miss_plan_capacity),
+            dtype=torch.int64,
+            device=self.device,
         )
         self._miss_dst = torch.zeros(
-            (max_num_req_slots, self.top_k), dtype=torch.int32, device=self.device
+            (max_num_req_slots, miss_plan_capacity),
+            dtype=torch.int32,
+            device=self.device,
         )
         self._miss_count = torch.zeros(
             (max_num_req_slots,), dtype=torch.int32, device=self.device
@@ -413,6 +886,7 @@ class HiSparseCoordinator:
             self.req_device_buffer_tokens[
                 :, req.kv.req_pool_idx, : self.device_buffer_size
             ] = -1
+            self.spec_swap.invalidate_cache(req.kv.req_pool_idx)
 
         req.hisparse_staging = False
         self._skip_first_backup[req.kv.req_pool_idx] = True
@@ -484,6 +958,7 @@ class HiSparseCoordinator:
         self.req_device_buffer_token_locs[:, req.kv.req_pool_idx, :alloc_size] = (
             buffer_indices[:alloc_size]
         )
+        self.spec_swap.reset(req.kv.req_pool_idx)
 
     def _grow_device_buffers(
         self,
@@ -558,6 +1033,34 @@ class HiSparseCoordinator:
         reserved_positions = (seq_lens - 1).clamp(max=self.device_buffer_size)
         return self.req_to_device_buffer[req_pool_indices, reserved_positions]
 
+    def _grow_device_buffers_to(
+        self, req_pool_indices_cpu: torch.Tensor, target_caps: torch.Tensor
+    ) -> None:
+        """Grow selected request buffers to explicit capacities."""
+        grow_reqs = []
+        for req_pool_idx, target_cap in zip(
+            req_pool_indices_cpu.tolist(), target_caps.tolist(), strict=True
+        ):
+            old_cap = int(self.req_device_buffer_size[req_pool_idx])
+            if old_cap < target_cap:
+                grow_reqs.append((int(req_pool_idx), old_cap, int(target_cap)))
+        total_grow = sum(new - old for _, old, new in grow_reqs)
+        if total_grow == 0:
+            return
+
+        new_locs = self.token_to_kv_pool_allocator.hisparse_attn_allocator.alloc(
+            total_grow
+        )
+        if new_locs is None:
+            raise RuntimeError(f"HiSparse failed to allocate {total_grow} KV slots.")
+        offset = 0
+        for req_pool_idx, old_cap, new_cap in grow_reqs:
+            chunk = new_locs[offset : offset + new_cap - old_cap]
+            offset += new_cap - old_cap
+            self.req_to_device_buffer[req_pool_idx, old_cap:new_cap] = chunk
+            self.req_device_buffer_token_locs[:, req_pool_idx, old_cap:new_cap] = chunk
+            self.req_device_buffer_size[req_pool_idx] = new_cap
+
     def has_ongoing_staging(self) -> bool:
         return len(self.ack_staging_queue) > 0
 
@@ -589,6 +1092,24 @@ class HiSparseCoordinator:
             finish_count -= 1
             ready_reqs.append(req)
         return ready_reqs
+
+    def release_spec_decode_reserve(
+        self,
+        batch: "ScheduleBatch",
+        current_kv_lens_cpu: torch.Tensor,
+        next_kv_lens_cpu: torch.Tensor,
+    ) -> None:
+        self.spec_swap.release_decode_reserve(
+            batch, current_kv_lens_cpu, next_kv_lens_cpu
+        )
+
+    def prepare_spec_verify(self, batch: "ScheduleBatch") -> None:
+        self.spec_swap.prepare_verify(batch)
+
+    def commit_spec_accept_tokens(
+        self, batch: "ScheduleBatch", accept_indices: torch.Tensor
+    ) -> None:
+        self.spec_swap.commit_accept_tokens(batch, accept_indices)
 
     def map_last_loc_to_buffer(
         self,
@@ -899,17 +1420,24 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv.kv_allocated_len
+        req_pool_idx = req.kv.req_pool_idx
 
-        # release memory -- only free actually-allocated buffer indices
-        current_cap = int(self.req_device_buffer_size[req.kv.req_pool_idx])
+        # The spec commit kernel rotates physical locations between each
+        # layer's persistent cache and scratch.  Their current union is the
+        # request's allocation ownership; the original side-buffer row is no
+        # longer authoritative after the first rotation.
+        current_cap = int(self.req_device_buffer_size[req_pool_idx])
         if current_cap > 0:
-            side_buf_hi = self.req_to_device_buffer[req.kv.req_pool_idx, :current_cap]
-            all_hi = torch.unique(side_buf_hi[side_buf_hi > 0])
+            owned_locs = self.req_device_buffer_token_locs[
+                :, req_pool_idx, :current_cap
+            ].reshape(-1)
+            owned_locs = self.spec_swap.extend_owned_locs(req_pool_idx, owned_locs)
+            all_hi = torch.unique(owned_locs[owned_locs > 0])
             if all_hi.numel() > 0:
                 self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
 
         allocated_locs = self.req_to_token_pool.req_to_token[
-            req.kv.req_pool_idx, :allocated_len
+            req_pool_idx, :allocated_len
         ]
         compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
             allocated_locs
@@ -918,21 +1446,22 @@ class HiSparseCoordinator:
 
         host_indices = self.mem_pool_host.allocated_host_indices(
             self.req_to_host_pool,
-            req.kv.req_pool_idx,
-            self.req_to_host_pool_allocated_len[req.kv.req_pool_idx],
+            req_pool_idx,
+            self.req_to_host_pool_allocated_len[req_pool_idx],
         )
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
         # clear req info
-        self.req_device_buffer_tokens[:, req.kv.req_pool_idx, :] = -1
-        self.req_device_buffer_token_locs[:, req.kv.req_pool_idx, :] = -1
-        self.req_to_device_buffer[req.kv.req_pool_idx, :] = 0
-        self.req_device_buffer_size[req.kv.req_pool_idx] = 0
-        self.req_to_host_pool[req.kv.req_pool_idx, :] = -1
-        self.req_to_host_pool_allocated_len[req.kv.req_pool_idx] = 0
-        self.lru_slots[:, req.kv.req_pool_idx, :].copy_(self._lru_init)
-        self._skip_first_backup[req.kv.req_pool_idx] = False
+        self.req_device_buffer_tokens[:, req_pool_idx, :] = -1
+        self.req_device_buffer_token_locs[:, req_pool_idx, :] = -1
+        self.req_to_device_buffer[req_pool_idx, :] = 0
+        self.req_device_buffer_size[req_pool_idx] = 0
+        self.req_to_host_pool[req_pool_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req_pool_idx] = 0
+        self.lru_slots[:, req_pool_idx, :].copy_(self._lru_init)
+        self.spec_swap.clear_scratch(req_pool_idx)
+        self._skip_first_backup[req_pool_idx] = False
 
     def _run_swap_in_kernel(
         self,
@@ -948,13 +1477,6 @@ class HiSparseCoordinator:
         miss plan into self._miss_{src,dst,count} for the skip layers to replay.
         """
         num_reqs = req_pool_indices.size(0)
-        top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
-
-        swap_in_fn = (
-            load_cache_to_device_buffer_dsv4_mla
-            if self.is_dsv4_hisparse
-            else load_cache_to_device_buffer_mla
-        )
         plan = (
             dict(
                 miss_src=self._miss_src[:num_reqs],
@@ -963,6 +1485,24 @@ class HiSparseCoordinator:
             )
             if record_plan
             else {}
+        )
+
+        if top_k_result.ndim == 3:
+            return self.spec_swap.swap_in(
+                req_pool_indices,
+                compressed_seq_lens,
+                top_k_result,
+                layer_id,
+                **plan,
+            )
+        if top_k_result.ndim != 2:
+            raise ValueError("HiSparse top-k must be two- or three-dimensional.")
+
+        top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
+        swap_in_fn = (
+            load_cache_to_device_buffer_dsv4_mla
+            if self.is_dsv4_hisparse
+            else load_cache_to_device_buffer_mla
         )
         swap_in_fn(
             top_k_tokens=top_k_result,
@@ -1025,6 +1565,8 @@ class HiSparseCoordinator:
             # applies (shared index + lockstep buffers).
             slot = self._prefetch_slot[layer_id]
             self._prefetch_events[slot].wait(device_module.current_stream())
+            if top_k_result.ndim == 3:
+                return self.spec_swap.output_locs(top_k_result, num_reqs)
             return self.top_k_device_locs_buffer[:num_reqs]
 
         # Anchor: swap in synchronously (recording the plan), then prefetch the

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -394,6 +394,26 @@ class FutureMap:
             device=self.device,
         )
 
+    def make_staged_spec_input(self, future_indices: torch.Tensor):
+        """Build the relay handle for a request leaving HiSparse staging."""
+        if not (self.spec_algo.is_eagle() or self.spec_algo.is_standalone()):
+            raise RuntimeError(
+                "HiSparse staging only supports EAGLE-family speculative inputs."
+            )
+
+        from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+        from sglang.srt.speculative.eagle_info import EagleDraftInput
+
+        return EagleDraftInput(
+            capture_hidden_mode=(
+                CaptureHiddenMode.NULL
+                if self.spec_algo.is_standalone()
+                else CaptureHiddenMode.LAST
+            ),
+            future_indices=future_indices,
+            future_dsa_topk_indices_available=(self.dsa_topk_indices_buf is not None),
+        )
+
     def resolve_confidence_cpu(
         self, batch: ScheduleBatch
     ) -> Optional[ResolvedConfidence]:
@@ -611,12 +631,15 @@ class FutureMap:
             self.output_tokens_buf.dtype
         )
 
-        if self.need_topk:
+        # Staging transitions refresh only the bonus token. Preserve top-k and
+        # hidden state already published by the preceding target forward.
+        if self.need_topk and payload.topk_p is not None:
+            assert payload.topk_index is not None
             self.topk_p_buf[indices] = payload.topk_p.to(self.topk_p_buf.dtype)
             self.topk_index_buf[indices] = payload.topk_index.to(
                 self.topk_index_buf.dtype
             )
-        if self.need_hidden_states:
+        if self.need_hidden_states and payload.hidden_states is not None:
             self.hidden_states_buf[indices] = payload.hidden_states.to(
                 self.hidden_states_buf.dtype
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3321,6 +3321,11 @@ class Scheduler(
         )
         batch.input_ids = None
 
+        if not batch.spec_algorithm.is_none():
+            batch.spec_info = self.future_map.make_staged_spec_input(
+                batch.req_pool_indices
+            )
+
         if batch.return_logprob:
             batch.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
             batch.token_ids_logprobs = [list(r.origin_input_ids) for r in reqs]

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -682,20 +682,44 @@ def alloc_for_spec_decode(
             last_loc = get_last_loc(
                 req_to_token_pool.req_to_token, req_pool_indices, cur_kv_lens
             )
-            device_type = getattr(
-                batch.device, "type", str(batch.device).split(":", 1)[0]
-            )
-            out_cache_loc = ALLOC_EXTEND_FUNCS[device_type](
-                tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-                req_pool_indices=req_pool_indices,
-                batch=batch,
-            )
+            allocator = tree_cache.token_to_kv_pool_allocator
+            if batch is not None and batch.hisparse_coordinator is not None:
+                # Spec decode reserves logical target slots here. Target verify
+                # later binds those slots to HiSparse's extra page; allocating
+                # target physical pages first both wastes memory and breaks the
+                # physical paged allocator's last_loc chain after the reserve is
+                # released. Draft KV has its own logical GPU-page mapping.
+                evict_from_tree_cache(
+                    tree_cache,
+                    num_needed_tokens + len(nxt_kv_lens_cpu) * allocator.page_size,
+                )
+                out_cache_loc = allocator.alloc_logical_only(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
+                if out_cache_loc is None:
+                    raise RuntimeError(
+                        "HiSparse spec decode failed to allocate logical KV slots."
+                    )
+            else:
+                device_type = getattr(
+                    batch.device, "type", str(batch.device).split(":", 1)[0]
+                )
+                out_cache_loc = ALLOC_EXTEND_FUNCS[device_type](
+                    tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    req_pool_indices=req_pool_indices,
+                    batch=batch,
+                )
         # Updating req_to_token is a write to a shared tensor: it must not overlap
         # with the previous batch's forward, which also reads req_to_token.
         assign_req_to_token_pool_func(

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -165,7 +165,10 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return buffer_indices
 
     def free_hisparse_indices(self, buffer_indices: torch.Tensor):
-        self.hisparse_attn_allocator.free(buffer_indices[buffer_indices > 0])
+        # Page zero is the padding sink and is never owned by a request.
+        self.hisparse_attn_allocator.free(
+            buffer_indices[buffer_indices >= self.page_size]
+        )
 
     def get_last_loc_compressed(self, last_locs: torch.Tensor):
         return last_locs
@@ -476,7 +479,9 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return buffer_indices
 
     def free_hisparse_indices(self, buffer_indices: torch.Tensor):
-        self.hisparse_attn_allocator.free(buffer_indices[buffer_indices > 0])
+        self.hisparse_attn_allocator.free(
+            buffer_indices[buffer_indices >= self.hisparse_page_size]
+        )
 
     def get_last_loc_compressed(self, last_locs: torch.Tensor):
         return (last_locs - 3) // self.compress_ratio

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -511,6 +511,18 @@ class KVCacheConfigurator:
                 sizes = msgspec.structs.replace(
                     sizes, max_total_num_tokens=draft_virtual_id_space
                 )
+            elif isinstance(token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator):
+                # HiSparse's target allocator hands out logical IDs from its
+                # host-expanded address space. Draft KV is direct-indexed by
+                # those shared IDs, so its GPU pool must span the same space.
+                draft_virtual_id_space = token_to_kv_pool_allocator.size_full
+                page = max(int(self.pool_page_size or 1), 1)
+                draft_virtual_id_space = (
+                    (draft_virtual_id_space + page - 1) // page * page
+                )
+                sizes = msgspec.structs.replace(
+                    sizes, max_total_num_tokens=draft_virtual_id_space
+                )
 
         # Initialize req_to_token_pool
         if req_to_token_pool is None:
@@ -1494,7 +1506,7 @@ class KVCacheConfigurator:
             dsa_cp_layer_shard_size,
         ) = get_glm_dsa_cp_layer_shard_info(self)
         pool_kwargs = {}
-        if get_memory().enable_hisparse:
+        if get_memory().enable_hisparse and not self.is_draft_worker:
             PoolCls = HiSparseDSATokenToKVPool
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -375,7 +375,9 @@ class ModelRunner:
         self._pending_elastic_scale_update = None
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
-        self.enable_hisparse = get_memory().enable_hisparse
+        # HiSparse owns target KV only. Draft KV keeps its logical GPU page
+        # space and must not construct a second sparse coordinator.
+        self.enable_hisparse = get_memory().enable_hisparse and not is_draft_worker
         self._sampling_observer: Optional[SamplingObserver] = None
 
         self.init_startup_observability()
@@ -945,7 +947,11 @@ class ModelRunner:
             shared_index_layers=resolve_shared_index_layers(
                 hf_text_config=self.model_config.hf_text_config,
                 pp_size=self.ps.pp_size,
-                is_speculative=self.spec_algorithm.is_speculative(),
+            ),
+            num_draft_tokens=(
+                0
+                if self.spec_algorithm.is_none()
+                else get_spec().speculative_num_draft_tokens or 0
             ),
         )
 

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -546,6 +546,8 @@ def eagle_prepare_for_verify(
             draft_token_num=verify_input.draft_token_num,
             device=device,
         )
+        if batch.hisparse_coordinator is not None:
+            batch.hisparse_coordinator.prepare_spec_verify(batch)
 
         batch.out_cache_loc_dsv4 = maybe_build_dsv4_verify_bundle(
             batch, verify_input.draft_token_num

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -586,6 +586,11 @@ def run_eagle_verify(
         accept_index,
     ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
     new_seq_lens = batch.seq_lens + accept_lens
+    if batch.hisparse_coordinator is not None:
+        batch.hisparse_coordinator.commit_spec_accept_tokens(
+            batch=batch,
+            accept_indices=accept_index,
+        )
     clear_unaccepted_c128 = getattr(
         token_to_kv_pool_allocator.get_kvcache(),
         "clear_unaccepted_c128_draft_states",

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -44,7 +44,9 @@ from sglang.srt.runtime_context import get_context
 from sglang.srt.speculative.eagle_disaggregation import (
     build_eagle_disagg_draft_input,
 )
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
@@ -254,6 +256,52 @@ class TestStagingWatermark(unittest.TestCase):
         sock.send_multipart.assert_called_once_with(
             [b"WATERMARK", b"3", b"0", b"session-new"]
         )
+
+
+class TestMooncakeHiSparseSpecIndices(CustomTestCase):
+    def test_draft_buffers_use_logical_device_indices(self):
+        manager = object.__new__(MooncakeKVManager)
+        manager.kv_args = SimpleNamespace(
+            mla_compression_ratios=None,
+            prefill_start_layer=10,
+            prefill_end_layer=12,
+            kv_data_ptrs=[1, 2, 3],
+            kv_item_lens=[4, 4, 4],
+            kv_layer_ids=[],
+        )
+        manager._send_kvcache_generic = Mock(return_value=0)
+        device_indices = np.array([7, 8], dtype=np.int32)
+
+        with patch(
+            "sglang.srt.disaggregation.mooncake.conn.get_memory",
+            return_value=SimpleNamespace(enable_unified_memory=False),
+        ):
+            status = manager.send_kvcache(
+                mooncake_session_id="session",
+                prefill_kv_indices=np.array([1, 2], dtype=np.int32),
+                dst_kv_ptrs=[101, 102, 201],
+                dst_kv_indices=np.array([11, 12], dtype=np.int32),
+                executor=Mock(),
+                dst_device_kv_indices=device_indices,
+            )
+
+        self.assertEqual(status, 0)
+        kwargs = manager._send_kvcache_generic.call_args.kwargs
+        self.assertEqual(kwargs["dst_device_data_ptrs"], {201})
+        np.testing.assert_array_equal(kwargs["dst_device_data_indices"], device_indices)
+
+
+class TestHiSparseStagedSpecRelay(CustomTestCase):
+    def test_builds_lightweight_eagle_relay_handle(self):
+        future_map = object.__new__(FutureMap)
+        future_map.spec_algo = SpeculativeAlgorithm.EAGLE
+        future_map.dsa_topk_indices_buf = None
+        future_indices = torch.tensor([2, 5], device="cpu")
+
+        spec_input = future_map.make_staged_spec_input(future_indices)
+
+        self.assertIs(spec_input.future_indices, future_indices)
+        self.assertFalse(spec_input.future_dsa_topk_indices_available)
 
 
 class TestMooncakePPStaging(unittest.TestCase):

--- a/test/registered/unit/managers/test_hisparse_spec_coordinator.py
+++ b/test/registered/unit/managers/test_hisparse_spec_coordinator.py
@@ -1,0 +1,251 @@
+"""Unit tests for the minimal HiSparse spec coordinator lifecycle."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.managers.hisparse_coordinator import (
+    HiSparseCoordinator,
+    HiSparseSpecSwapManager,
+)
+from sglang.srt.mem_cache import allocation
+from sglang.srt.mem_cache.allocator.hisparse import HiSparseTokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestHiSparseSpecCoordinator(CustomTestCase):
+    def test_spec_decode_reserve_allocates_logical_pages_only(self):
+        logical_locs = torch.tensor([64, 65, 66, 67], dtype=torch.int64)
+        allocator = SimpleNamespace(
+            page_size=64,
+            alloc_logical_only=MagicMock(return_value=logical_locs),
+        )
+        tree_cache = SimpleNamespace(token_to_kv_pool_allocator=allocator)
+        req_to_token = torch.full((1, 16), -1, dtype=torch.int64)
+        req_to_token[0, 1] = 63
+        req_to_token_pool = SimpleNamespace(req_to_token=req_to_token)
+        req = SimpleNamespace(kv=SimpleNamespace(kv_allocated_len=2))
+        batch = SimpleNamespace(
+            device=torch.device("cpu"),
+            hisparse_coordinator=object(),
+        )
+
+        def assign_on_cpu(
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            batch_size,
+        ):
+            del end_offset, batch_size
+            start = int(start_offset[0])
+            req_to_token[
+                int(req_pool_indices[0]), start : start + out_cache_loc.numel()
+            ] = out_cache_loc
+
+        with (
+            patch.object(allocation, "evict_from_tree_cache"),
+            patch.object(allocation, "get_last_loc", return_value=torch.tensor([63])),
+            patch.object(
+                allocation,
+                "assign_req_to_token_pool_func",
+                side_effect=assign_on_cpu,
+            ),
+        ):
+            allocation.alloc_for_spec_decode(
+                tree_cache,
+                req_to_token_pool,
+                reqs=[req],
+                req_pool_indices=torch.tensor([0]),
+                cur_kv_lens=torch.tensor([2]),
+                cur_kv_lens_cpu=torch.tensor([2]),
+                nxt_kv_lens=torch.tensor([6]),
+                nxt_kv_lens_cpu=torch.tensor([6]),
+                num_needed_tokens=4,
+                batch=batch,
+            )
+
+        allocator.alloc_logical_only.assert_called_once()
+        torch.testing.assert_close(req_to_token[0, 2:6], logical_locs)
+
+    def test_physical_free_excludes_reserved_page_zero(self):
+        allocator = object.__new__(HiSparseTokenToKVPoolAllocator)
+        allocator.page_size = 64
+        allocator.hisparse_attn_allocator = MagicMock()
+
+        allocator.free_hisparse_indices(torch.tensor([0, 1, 63, 64, 65]))
+
+        freed = allocator.hisparse_attn_allocator.free.call_args.args[0]
+        torch.testing.assert_close(freed, torch.tensor([64, 65]))
+
+    def test_spec_swap_manager_owns_runtime_state(self):
+        coordinator = MagicMock()
+        coordinator.mem_pool_device.layer_num = 2
+        coordinator.req_to_token_pool.req_to_token = torch.empty((3, 16))
+        coordinator.device = "cpu"
+        coordinator.is_dsv4_hisparse = False
+        coordinator.top_k = 1024
+        coordinator.device_buffer_size = 4096
+
+        spec_swap = HiSparseSpecSwapManager(
+            coordinator,
+            num_draft_tokens=2,
+        )
+
+        self.assertTrue(spec_swap.enabled)
+        self.assertEqual(spec_swap.num_draft_tokens, 2)
+        self.assertEqual(spec_swap.scratch_capacity, 1024)
+        self.assertEqual(len(spec_swap.states), 2)
+        self.assertEqual(spec_swap.req_to_scratch.shape, (2, 3, 1024))
+        self.assertEqual(spec_swap.top_k_device_locs.shape, (3, 2, 1024))
+        self.assertIs(
+            spec_swap.states[0].scratch_state, spec_swap.states[1].scratch_state
+        )
+
+    def test_speculative_reserve_releases_transient_device_pages(self):
+        coordinator = object.__new__(HiSparseCoordinator)
+        mapping = torch.zeros(256, dtype=torch.int64)
+        mapping[130:134] = torch.arange(66, 70)
+        req_to_token = torch.zeros((1, 16), dtype=torch.int64)
+        req_to_token[0, 2:6] = torch.arange(130, 134)
+        coordinator.req_to_token_pool = SimpleNamespace(req_to_token=req_to_token)
+        freed_locs = []
+        coordinator.token_to_kv_pool_allocator = SimpleNamespace(
+            full_to_hisparse_device_index_mapping=mapping,
+            free_hisparse_indices=lambda locs: freed_locs.append(locs.clone()),
+        )
+
+        batch = SimpleNamespace(req_pool_indices=torch.tensor([0]))
+        spec_swap = object.__new__(HiSparseSpecSwapManager)
+        spec_swap._coordinator = coordinator
+        spec_swap.release_decode_reserve(
+            batch=batch,
+            current_kv_lens_cpu=torch.tensor([2]),
+            next_kv_lens_cpu=torch.tensor([6]),
+        )
+
+        torch.testing.assert_close(freed_locs[0], torch.arange(66, 70))
+        self.assertEqual(mapping[130:134].count_nonzero(), 0)
+
+    def test_scratch_allocation_has_per_layer_location_views(self):
+        scratch_allocator = MagicMock()
+        scratch_allocator.alloc.return_value = torch.arange(9, 13)
+        freed_locs = []
+        coordinator = SimpleNamespace(
+            token_to_kv_pool_allocator=SimpleNamespace(
+                hisparse_attn_allocator=scratch_allocator,
+                free_hisparse_indices=lambda locs: freed_locs.append(locs.clone()),
+            )
+        )
+        spec_swap = object.__new__(HiSparseSpecSwapManager)
+        spec_swap._coordinator = coordinator
+        spec_swap.enabled = True
+        spec_swap.scratch_capacity = 4
+        spec_swap._scratch_reqs = set()
+        spec_swap.req_to_scratch = torch.zeros((3, 2, 4), dtype=torch.int32)
+
+        spec_swap.ensure_scratch(torch.tensor([1]))
+
+        expected = torch.arange(9, 13, dtype=torch.int32)
+        for layer_id in range(3):
+            torch.testing.assert_close(spec_swap.req_to_scratch[layer_id, 1], expected)
+        self.assertIn(1, spec_swap._scratch_reqs)
+
+        spec_swap.free_scratch(1)
+
+        torch.testing.assert_close(freed_locs[0], expected)
+        self.assertNotIn(1, spec_swap._scratch_reqs)
+        self.assertEqual(spec_swap.req_to_scratch[:, 1].count_nonzero(), 0)
+
+    def test_accept_commit_keeps_hot_and_newest_device_slots(self):
+        coordinator = object.__new__(HiSparseCoordinator)
+        coordinator.device_buffer_size = 5
+        coordinator.req_to_device_buffer = torch.tensor(
+            [[20, 21, 22, 23, 24, 25, 26]], dtype=torch.int64
+        )
+        coordinator.req_device_buffer_tokens = torch.full(
+            (2, 1, 7), -1, dtype=torch.int32
+        )
+        coordinator.req_device_buffer_token_locs = torch.full(
+            (2, 1, 7), -1, dtype=torch.int32
+        )
+        coordinator._skip_first_backup = [False]
+
+        verify_cache_locs = torch.tensor([50, 51, 52, 53], dtype=torch.int64)
+        req_to_token = torch.zeros((1, 16), dtype=torch.int64)
+        req_to_token[0, 4:8] = verify_cache_locs
+        coordinator.req_to_token_pool = SimpleNamespace(req_to_token=req_to_token)
+
+        full_to_device_mapping = torch.zeros(128, dtype=torch.int64)
+        full_to_device_mapping[verify_cache_locs] = torch.tensor([10, 11, 12, 13])
+        transfer_values = MagicMock()
+        coordinator.mem_pool_device = SimpleNamespace(
+            transfer_values_on_device=transfer_values
+        )
+        coordinator.token_to_kv_pool_allocator = SimpleNamespace(
+            full_to_hisparse_device_index_mapping=full_to_device_mapping
+        )
+
+        alloc_host = MagicMock(
+            side_effect=lambda _pool, _allocated, _req, start, count: torch.arange(
+                1000 + start, 1000 + start + count, dtype=torch.int64
+            )
+        )
+        coordinator.mem_pool_host = SimpleNamespace(alloc_paged_token_slots=alloc_host)
+        coordinator.req_to_host_pool = torch.full((1, 16), -1, dtype=torch.int64)
+        coordinator.req_to_host_pool_allocated_len = torch.zeros(1, dtype=torch.int64)
+
+        spec_swap = object.__new__(HiSparseSpecSwapManager)
+        spec_swap._coordinator = coordinator
+        spec_swap._backup_device_locs_to_host = MagicMock()
+
+        batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(is_idle=lambda: False),
+            req_pool_indices=torch.tensor([0]),
+            req_pool_indices_cpu=torch.tensor([0]),
+            seq_lens=torch.tensor([4]),
+            seq_lens_cpu=torch.tensor([4]),
+            out_cache_loc=verify_cache_locs,
+        )
+        spec_swap.commit_accept_tokens(
+            batch=batch,
+            accept_indices=torch.tensor([[0, 1, 2, -1]], dtype=torch.int32),
+        )
+
+        transfer_call = transfer_values.call_args
+        torch.testing.assert_close(
+            transfer_call.kwargs["src_indices"], torch.tensor([10, 12])
+        )
+        torch.testing.assert_close(
+            transfer_call.kwargs["dst_indices"], torch.tensor([24, 25])
+        )
+        backup_call = spec_swap._backup_device_locs_to_host.call_args
+        torch.testing.assert_close(
+            backup_call.args[0], torch.tensor([1004, 1005, 1006])
+        )
+        torch.testing.assert_close(backup_call.args[1], torch.tensor([24, 11, 25]))
+        self.assertTrue(backup_call.kwargs["wait"])
+
+        self.assertEqual(full_to_device_mapping[50], 24)
+        self.assertEqual(full_to_device_mapping[51], 0)
+        self.assertEqual(full_to_device_mapping[52], 25)
+        self.assertEqual(full_to_device_mapping[53], 0)
+        torch.testing.assert_close(
+            coordinator.req_device_buffer_tokens[:, 0, 4],
+            torch.tensor([4, 4], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            coordinator.req_device_buffer_tokens[:, 0, 5],
+            torch.tensor([6, 6], dtype=torch.int32),
+        )
+        self.assertTrue(coordinator._skip_first_backup[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Prerequisite

- Kernel implementation #32162 provides the multi-step gather/commit swap kernel, including cross-step miss deduplication, extra-page lookup, scratch-space management, cache commit, and device-location resolution. This PR focuses on integrating that kernel into the SGLang serving path.

## Motivation

This PR adds end-to-end HiSparse support for multi-step speculative decoding, currently targeting linear EAGLE/MTP decoding with multiple draft tokens. It integrates the multi-step swap kernel from #32162 into the HiSparse coordinator and speculative-decoding lifecycle, covering logical target-slot reservation, per-layer scratch and cache state, verify preparation, accepted-token commit, host backup, and request cleanup. Draft KV remains in its logical GPU address space instead of reusing the HiSparse target KV physical mapping, while the target KV continues to use HiSparse host/device placement. The PR also preserves speculative state when requests transition through HiSparse staging and, for Mooncake PD serving, carries separate target host/physical page indices and draft logical-device page indices. Together, these changes make HiSparse compatible with multi-step speculative decoding without falling back to sequential per-step LRU swapping.


## Accuracy Tests

- Model: GLM-5.2-W4AFP8
- Serving topology: 1P1D, TP8/DP8 with DP Attention
- KV cache: FP8
- Speculative decoding: EAGLE, 3 steps, top-k 1, 4 draft tokens
- CUDA Graph: enabled
- HiSparse: top-k 2048, 4096-slot device buffer, host/device ratio 4
- The only A/B variable was whether HiSparse was enabled.

| Benchmark | HiSparse ON | HiSparse OFF | Delta |
|---|---:|---:|---:|
| GSM8K 20-shot (200 samples) | 195/200 (97.50%) | 192/200 (96.00%) | +1.50 pp |
| GPQA-Diamond (198 samples) | 180/198 (90.91%) | 182/198 (91.92%) | -1.01 pp |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35713392311](https://github.com/sgl-project/sglang/actions/runs/35713392311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35713392068](https://github.com/sgl-project/sglang/actions/runs/35713392068)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:hourglass_flowing_sand: [Run #35713392543](https://github.com/sgl-project/sglang/actions/runs/35713392543)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->