### PR TITLE
[Fix] FA3: size k/v descale from cu_seqlens_q

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -123,6 +123,26 @@ class FlashAttentionMetadata:
     swa_spec_metadata: Optional[FlashAttentionMetadata] = None
 
 
+def fa_descale_batch_size(
+    cu_seqlens_q: Optional[torch.Tensor], fallback_batch_size: int
+) -> int:
+    """Batch size that FA validates ``k_descale`` / ``v_descale`` against.
+
+    FA requires ``k_descale.shape == (batch_size, num_heads_k)`` where
+    ``batch_size`` is the one implied by the ``cu_seqlens_q`` handed to that same
+    call, i.e. ``cu_seqlens_q.numel() - 1``. That is not always the logical
+    ``forward_batch.batch_size``: several paths build ``cu_seqlens_q`` from a
+    per-request segment list rather than from the batch row count, and some grow
+    ``batch_size`` after the metadata was built.
+
+    ``cu_seqlens_q`` is ``None`` on the non-varlen paths, where the logical batch
+    size is the right answer.
+    """
+    if cu_seqlens_q is None:
+        return fallback_batch_size
+    return cu_seqlens_q.numel() - 1
+
+
 class FlashAttentionBackend(AttentionBackend):
     """FlashAttention backend implementation.
 
@@ -1418,6 +1438,21 @@ class FlashAttentionBackend(AttentionBackend):
             cache_seqlens = metadata.cache_seqlens_int32
             max_seqlen_q = metadata.max_seq_len_q
             cu_seqlens_k = metadata.cu_seqlens_k
+
+        if fa_k_descale is not None:
+            # prepare_paged_mha_query() sized the descale from
+            # forward_batch.batch_size before it was known which cu_seqlens_q this
+            # call would use. Re-derive it from the tensor that is actually passed
+            # to FA below, otherwise the kernel rejects the descale with
+            # "k_descale must have shape (batch_size, num_heads_k)".
+            descale_shape = (
+                fa_descale_batch_size(cu_seqlens_q, forward_batch.batch_size),
+                layer.tp_k_head_num,
+            )
+            fa_k_descale = layer.k_scale.expand(descale_shape)
+            fa_v_descale = layer.v_scale.expand(descale_shape)
+            kwargs["k_descale"] = fa_k_descale
+            kwargs["v_descale"] = fa_v_descale
 
         # Use Flash Attention for prefill
         if not self.use_mla:

--- a/test/registered/attention/test_fa3_descale_batch_size.py
+++ b/test/registered/attention/test_fa3_descale_batch_size.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for the FA k/v_descale batch dimension.
+
+FA validates ``k_descale.shape == (batch_size, num_heads_k)`` where ``batch_size``
+is the one implied by the ``cu_seqlens_q`` handed to that same call, i.e.
+``cu_seqlens_q.numel() - 1``. Sizing the descale from the logical
+``forward_batch.batch_size`` instead is wrong whenever the two differ, and the
+kernel then rejects the call with
+
+    RuntimeError: k_descale must have shape (batch_size, num_heads_k)
+
+taking the whole batch (and the scheduler process) down with it.
+
+The two are not the same tensor-shape source: some paths build ``cu_seqlens_q``
+from a per-request segment list (``pad(cumsum(extend_seq_lens))``) while
+``batch_size`` counts batch rows, and some paths grow ``batch_size`` after the
+attention metadata was already built.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.flashattention_backend import fa_descale_batch_size
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-large-amd")
+
+
+def _cu_seqlens_q_from_segments(segments, device="cpu"):
+    """Build cu_seqlens_q the way the varlen extend paths do."""
+    lens = torch.tensor(segments, dtype=torch.int32, device=device)
+    return torch.nn.functional.pad(torch.cumsum(lens, dim=0, dtype=torch.int32), (1, 0))
+
+
+class TestFaDescaleBatchSize(unittest.TestCase):
+    def test_batch_size_comes_from_cu_seqlens_not_forward_batch(self):
+        """cu_seqlens_q wins whenever it disagrees with forward_batch.batch_size."""
+        # (segments, forward_batch.batch_size) pairs where the two disagree.
+        # The batch_size values are larger here, which is the direction produced
+        # when the batch is padded after the metadata was built.
+        for segments, logical_batch_size in [
+            ([4], 2),
+            ([4, 4], 3),
+            ([4, 4, 4], 4),
+            ([1, 3, 2], 5),
+        ]:
+            with self.subTest(segments=segments, batch_size=logical_batch_size):
+                cu_seqlens_q = _cu_seqlens_q_from_segments(segments)
+                self.assertNotEqual(cu_seqlens_q.numel() - 1, logical_batch_size)
+                self.assertEqual(
+                    fa_descale_batch_size(cu_seqlens_q, logical_batch_size),
+                    len(segments),
+                )
+
+    def test_descale_first_dim_matches_cu_seqlens_q(self):
+        """The expanded descale is what FA will accept for that cu_seqlens_q."""
+        num_kv_heads = 8
+        # A scalar scale, which is what RadixAttention holds when the KV cache
+        # quantization method created it.
+        k_scale = torch.tensor(0.5, dtype=torch.float32)
+        v_scale = torch.tensor(0.25, dtype=torch.float32)
+
+        segments = [4, 4, 4]
+        cu_seqlens_q = _cu_seqlens_q_from_segments(segments)
+        logical_batch_size = 5  # padded, disagrees with cu_seqlens_q on purpose
+
+        descale_shape = (
+            fa_descale_batch_size(cu_seqlens_q, logical_batch_size),
+            num_kv_heads,
+        )
+        k_descale = k_scale.expand(descale_shape)
+        v_descale = v_scale.expand(descale_shape)
+
+        expected_batch = cu_seqlens_q.numel() - 1
+        self.assertEqual(k_descale.shape, (expected_batch, num_kv_heads))
+        self.assertEqual(v_descale.shape, (expected_batch, num_kv_heads))
+        self.assertNotEqual(k_descale.shape[0], logical_batch_size)
+
+    def test_falls_back_when_cu_seqlens_q_is_absent(self):
+        """Non-varlen paths keep the logical batch size."""
+        self.assertEqual(fa_descale_batch_size(None, 7), 7)
+
+    def test_agrees_when_segments_match_batch_rows(self):
+        """The uniform case is unchanged: one segment per batch row."""
+        for batch_size in (1, 2, 8, 40):
+            with self.subTest(batch_size=batch_size):
+                cu_seqlens_q = _cu_seqlens_q_from_segments([1] * batch_size)
+                self.assertEqual(
+                    fa_descale_batch_size(cu_seqlens_q, batch_size), batch_size
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

FlashAttention validates the first dimension of k_descale and v_descale against the batch implied by cu_seqlens_q. In DRAFT_EXTEND_V2 with FP8 KV cache and DP attention, forward_batch.batch_size can grow after attention metadata is built, so the two values diverge and FA rejects the call with a descale shape error.

## Modifications

- Derive the descale batch dimension from the cu_seqlens_q selected by the local-attention, sliding-window, or default extend branch.
- Preserve forward_batch.batch_size as the fallback when cu_seqlens_q is absent.
- Keep forward_decode unchanged because the reproduced divergence is limited to forward_extend.
- Add regression coverage for mismatched logical batch and segment counts, the fallback path, and unchanged matching sizes.

Context-parallel chunks and the cascade second stage use per-call cu_seqlens_q tensors and are intentionally outside this narrowly scoped fix.

## Accuracy Tests

No model output semantics are changed. The patch only corrects descale tensor shape metadata.

## Speed Tests and Profiling

Not run. The change only re-expands scalar scale tensors to the FA-required shape.

## Checklist

- [x] Run repository pre-commit formatting.
- [x] Add unit tests.
- [x] Documentation is not required for this internal correctness fix.
- [x] Accuracy and speed benchmarks are not applicable to the shape-only change.
- [x] Python syntax compilation and diff whitespace checks pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #34576990138](https://github.com/sgl-project/sglang/actions/runs/34576990138)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #34576989917](https://github.com/sgl-project/sglang/actions/runs/34576989917)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #34576989944](https://github.com/sgl-project/sglang/actions/runs/34576989944)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->