### PR TITLE
fix(qsa): prevent out-of-bounds reads from padded extend plans

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/metadata.py
+++ b/python/sglang/srt/layers/attention/qsa/metadata.py
@@ -72,12 +72,15 @@ class QSAIndexerMetadata(msgspec.Struct, frozen=True):
     # row owning it. For extend forwards, compress_member_rows additionally
     # holds each group's first member as a token-row index into this
     # forward's packed tensors (extend chunks are group-aligned, so every
-    # member is in-chunk); paged forwards leave it None and source members
-    # from the per-request pending ring instead.
+    # member is in-chunk); compress_plan_valid marks the fixed-capacity plan's
+    # real entries so padded entries can use in-bounds dummy reads. Paged
+    # forwards leave compress_member_rows None and source members from the
+    # per-request pending ring instead.
     write_locs: Optional[torch.Tensor] = None
     compress_group_positions: Optional[torch.Tensor] = None
     compress_sequence_ids: Optional[torch.Tensor] = None
     compress_member_rows: Optional[torch.Tensor] = None
+    compress_plan_valid: Optional[torch.Tensor] = None
     is_cuda_graph: bool = False
     graph_write_locs: Optional[torch.Tensor] = None
     graph_compressed_page_table: Optional[torch.Tensor] = None

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -330,6 +330,11 @@ class QSAIndexer(MultiPlatformOp):
             group_locs = member_rows[:, None] + torch.arange(
                 self.compress_ratio, device=member_rows.device, dtype=torch.long
             )
+            plan_valid = metadata.compress_plan_valid
+            if plan_valid is not None:
+                group_locs = torch.where(
+                    plan_valid[:, None], group_locs, member_rows[:, None]
+                )
             source_keys = token_k
             source_rope = metadata.extend_rope_matrix
             if source_rope is None:

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -542,7 +542,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                 row_token_starts[rows] + blocks * compress_ratio - prefix_lens[rows],
                 torch.zeros_like(blocks),
             )
-        return write_locs, group_end_positions, rows, member_rows
+        return write_locs, group_end_positions, rows, member_rows, valid
 
     def _qsa_build_write_plan(
         self,
@@ -554,9 +554,9 @@ class QwenSparseAttnBackend(AttentionBackend):
     ):
         """Plan the compressed writes for this forward, device-side only.
 
-        Returns (write_locs, group_end_positions, sequence_ids). The only
-        per-mode part is the block range each row owns, which is device
-        arithmetic over lengths the batch already carries.
+        Returns (write_locs, group_end_positions, sequence_ids, member_rows,
+        plan_valid). The only per-mode part is the block range each row owns,
+        which is device arithmetic over lengths the batch already carries.
         """
         ratio = self.token_to_kv_pool.qsa_compress_ratio
         lengths = sequence_lengths.long()
@@ -700,6 +700,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         group_positions = None
         group_sequence_ids = None
         group_member_rows = None
+        group_plan_valid = None
         decode_page_table = None
         decode_lengths = None
         decode_logical_positions = None
@@ -710,13 +711,17 @@ class QwenSparseAttnBackend(AttentionBackend):
             self.qsa_profile is None
             or self.qsa_profile.variant == QSA_VARIANT_COMPRESSED
         ):
-            write_locs, group_positions, group_sequence_ids, group_member_rows = (
-                self._qsa_build_write_plan(
-                    forward_batch=forward_batch,
-                    speculative_paged=speculative_paged,
-                    token_slot_table=token_slot_table,
-                    sequence_lengths=sequence_lengths,
-                )
+            (
+                write_locs,
+                group_positions,
+                group_sequence_ids,
+                group_member_rows,
+                group_plan_valid,
+            ) = self._qsa_build_write_plan(
+                forward_batch=forward_batch,
+                speculative_paged=speculative_paged,
+                token_slot_table=token_slot_table,
+                sequence_lengths=sequence_lengths,
             )
             decode_like = speculative_paged or forward_batch.forward_mode.is_decode()
             if decode_like:
@@ -780,6 +785,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             compress_group_positions=group_positions,
             compress_sequence_ids=group_sequence_ids,
             compress_member_rows=group_member_rows,
+            compress_plan_valid=group_plan_valid,
             decode_page_table=decode_page_table,
             decode_lengths=decode_lengths,
             decode_logical_positions=decode_logical_positions,

--- a/test/registered/kernels/test_qsa.py
+++ b/test/registered/kernels/test_qsa.py
@@ -47,6 +47,84 @@ BLOCK_TOPK = TOKEN_TOPK // COMPRESS_RATIO
 FINAL_TOPK = TOKEN_TOPK + COMPRESS_RATIO - 1
 
 
+class _RecordingCompressedPool:
+    def __init__(self):
+        self.write_locs = None
+        self.compressed = None
+
+    def set_qsa_compressed_k_buffer(self, layer_id, locs, compressed):
+        self.write_locs = locs.clone()
+        self.compressed = compressed.clone()
+
+
+def _run_extend_compression_plan(token_values, end_blocks, capacity):
+    token_k = torch.tensor(token_values, dtype=torch.float32).reshape(-1, 1, 1)
+    token_slot_table = torch.arange(4, 20, dtype=torch.int32).reshape(1, -1)
+    (
+        write_locs,
+        group_positions,
+        group_sequence_ids,
+        member_rows,
+        plan_valid,
+    ) = QwenSparseAttnBackend._qsa_write_plan(
+        token_slot_table=token_slot_table,
+        start_blocks=torch.zeros(1, dtype=torch.long),
+        end_blocks=torch.tensor([end_blocks], dtype=torch.long),
+        capacity=capacity,
+        compress_ratio=COMPRESS_RATIO,
+        row_token_starts=torch.zeros(1, dtype=torch.long),
+        prefix_lens=torch.zeros(1, dtype=torch.long),
+    )
+    pool = _RecordingCompressedPool()
+    metadata = SimpleNamespace(
+        token_to_kv_pool=pool,
+        compress_member_rows=member_rows,
+        compress_plan_valid=plan_valid,
+        is_cuda_graph=False,
+        write_locs=write_locs,
+        compress_group_positions=group_positions,
+        extend_rope_matrix=torch.zeros(token_k.shape[0], 3, dtype=torch.long),
+    )
+    indexer = SimpleNamespace(
+        layer_id=0,
+        compress_ratio=COMPRESS_RATIO,
+        _use_fused_compress=lambda pool: False,
+        _rope_from_matrix=lambda positions: positions[:, 0],
+        normalize_compressed_keys=lambda keys, positions: keys,
+    )
+    QSAIndexer.update_key_state_and_compress(
+        indexer,
+        token_k,
+        torch.arange(token_k.shape[0]),
+        torch.arange(token_k.shape[0]),
+        metadata,
+        state_stored=True,
+    )
+    return pool, plan_valid, group_sequence_ids
+
+
+@pytest.mark.parametrize("extend_len", [1, 2, 3])
+def test_qsa_short_extend_padding_uses_in_bounds_dummy_reads(extend_len):
+    pool, plan_valid, group_sequence_ids = _run_extend_compression_plan(
+        list(range(1, extend_len + 1)), end_blocks=0, capacity=1
+    )
+
+    assert plan_valid.tolist() == [False]
+    assert group_sequence_ids.tolist() == [0]
+    assert pool.write_locs.tolist() == [0]
+    assert pool.compressed.flatten().tolist() == [1.0]
+
+
+def test_qsa_extend_padding_does_not_change_real_group_compression():
+    pool, plan_valid, _ = _run_extend_compression_plan(
+        [0.0, 1.0, 2.0, 3.0], end_blocks=1, capacity=2
+    )
+
+    assert plan_valid.tolist() == [True, False]
+    assert pool.write_locs.tolist() == [1, 0]
+    assert pool.compressed.flatten().tolist() == [1.5, 0.0]
+
+
 @pytest.mark.parametrize(
     ("capability", "expected"),
     [((12, 0), True), ((12, 1), False), ((10, 0), False)],


### PR DESCRIPTION
## Motivation

The fixed-capacity QSA compressed-write plan pads unused entries with row 0
and a reserved slot-0 write. The write is inert, but the corresponding extend
read is not: `member_rows=0` is expanded to `[0, 1, 2, 3]` for a compression
ratio of 4.

An extend shorter than the compression ratio has no complete group, but its
shape-derived plan still contains one padded entry. A one-token extend
therefore reads rows 1 through 3 from a one-row `token_k` tensor. Depending on
the allocation layout, this can surface as an index error or a CUDA illegal
memory access.

This is a follow-up to the short-extend out-of-bounds report in #36497.

## Modifications

- Carry the write plan's `valid` mask through `QSAIndexerMetadata`.
- Before eager or fused extend compression, fold every padded entry's member
  locations onto its in-bounds dummy row.
- Preserve the fixed-capacity plan, reserved slot-0 write convention, and
  device-only/no-host-sync execution.
- Add regression coverage for 1-, 2-, and 3-token extends and for a real
  compression group followed by a padded entry.

## Accuracy Tests

- The new short-extend regression reproduces an `IndexError` on the unpatched
  source and passes for extend lengths 1, 2, and 3 after the fix.
- A four-token real group still produces the same FP32 average while the
  trailing padded entry writes only to reserved slot 0.
- `black`, `isort`, Python compilation, and `git diff --check` pass for all
  modified files.

Full registered GPU CI is left to the upstream workflow.

## Speed Tests and Profiling

Not separately profiled. The change preserves all plan shapes and adds no host
synchronization; it adds one elementwise selection over the fixed-capacity
extend compression plan before both eager and fused compression.

## Checklist

- [x] Format the modified code with the repository's Black and isort versions.
- [x] Add focused unit regression coverage.
- [x] No documentation update is needed for this correctness fix.
- [ ] Run the upstream registered GPU test suite.
- [x] Follow the existing SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829431806](https://github.com/sgl-project/sglang/actions/runs/34829431806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829431456](https://github.com/sgl-project/sglang/actions/runs/34829431456)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829431756](https://github.com/sgl-project/sglang/actions/runs/34829431756)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->