### PR TITLE
[ROCm][DSA] Add AITER top-k backend

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1466,7 +1466,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsa-topk-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend for the target model. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`sgl-kernel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code>, <code>aiter</code> (ROCm only)</td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-deepseek-v4-fp4-indexer`</td>
@@ -1618,7 +1618,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-dsa-topk-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend for speculative draft workers. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`sgl-kernel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code>, <code>aiter</code> (ROCm only)</td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-moe-runner-backend`</td>

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -204,7 +204,7 @@ To enable EAGLE speculative decoding the following parameters are relevant:
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dsa-topk-backend</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Select the DSA indexer top-k backend for speculative draft workers independently of <code>--dsa-topk-backend</code>. Options are <code>sgl-kernel</code>, <code>torch</code>, and <code>flashinfer</code>; <code>torch</code> requires <code>SGLANG_DSA_FUSE_TOPK=false</code>.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Select the DSA indexer top-k backend for speculative draft workers independently of <code>--dsa-topk-backend</code>. Options are <code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code>, and <code>aiter</code> (ROCm only); <code>torch</code> requires <code>SGLANG_DSA_FUSE_TOPK=false</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>sgl-kernel</code></td>
     </tr>
     <tr>
@@ -837,7 +837,7 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dsa-topk-backend</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>sgl-kernel</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSA indexer top-k backend for speculative draft workers, independent of <code>--dsa-topk-backend</code> (<code>sgl-kernel</code>, <code>torch</code>, or <code>flashinfer</code>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSA indexer top-k backend for speculative draft workers, independent of <code>--dsa-topk-backend</code> (<code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code>, or <code>aiter</code> on ROCm)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-moe-runner-backend</code></td>

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -23,6 +23,7 @@ from sglang.kernels.ops.attention.dsv4.metadata_kernel import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     CompressorBackendMixin,
     FusedCompressMetadata,
@@ -449,6 +450,7 @@ class DeepseekV4HipRadixBackend(
         speculative_num_steps=0,
     ):
         super().__init__()
+        self.dsa_topk_backend = DSATopKBackend.resolve(model_runner)
         self.device = torch.device(model_runner.device)
         head_dim = model_runner.model_config.head_dim
         assert head_dim == 512, (

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -7,6 +7,7 @@ import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_exec, get_spec
+from sglang.srt.utils import is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
@@ -28,6 +29,7 @@ class DSATopKBackend(Enum):
     SGL_KERNEL = "sgl-kernel"
     TORCH = "torch"
     FLASHINFER = "flashinfer"
+    AITER = "aiter"
 
     @classmethod
     def resolve(cls, model_runner: ModelRunner) -> DSATopKBackend:
@@ -36,9 +38,15 @@ class DSATopKBackend(Enum):
         ``--dsa-topk-backend`` selects the target backend, while
         ``--speculative-dsa-topk-backend`` independently selects the draft.
         """
-        if model_runner.is_draft_worker:
-            return cls(get_spec().speculative_dsa_topk_backend)
-        return cls(get_exec().kernel.dsa_topk_backend)
+        value = (
+            get_spec().speculative_dsa_topk_backend
+            if model_runner.is_draft_worker
+            else get_exec().kernel.dsa_topk_backend
+        )
+        backend = cls(value)
+        if backend.is_aiter() and not is_hip():
+            raise ValueError("dsa_topk_backend='aiter' requires ROCm.")
+        return backend
 
     def is_sgl_kernel(self) -> bool:
         return self == DSATopKBackend.SGL_KERNEL
@@ -48,6 +56,9 @@ class DSATopKBackend(Enum):
 
     def is_flashinfer(self) -> bool:
         return self == DSATopKBackend.FLASHINFER
+
+    def is_aiter(self) -> bool:
+        return self == DSATopKBackend.AITER
 
     def should_use_topk_v2(self) -> bool:
         return self.is_sgl_kernel() and envs.SGLANG_OPT_USE_TOPK_V2.get()
@@ -88,6 +99,8 @@ class DSATopKBackend(Enum):
                     "dsa_graph_safe": True,
                 },
             )
+        if self.is_aiter():
+            return _aiter_topk(score, lengths, topk, row_starts=row_starts)
         raise RuntimeError(f"Unsupported {self = }.")
 
     def topk_transform(
@@ -146,6 +159,19 @@ class DSATopKBackend(Enum):
         ):
             return _topk_transform_v2_ragged(
                 logits, lengths, topk, topk_indices_offset, row_starts
+            )
+
+        if self.is_aiter():
+            return _aiter_topk_transform(
+                logits=logits,
+                lengths=lengths,
+                topk=topk,
+                topk_transform_method=topk_transform_method,
+                attn_metadata=attn_metadata,
+                cu_seqlens_q_topk=cu_seqlens_q_topk,
+                topk_indices_offset=topk_indices_offset,
+                row_starts=row_starts,
+                batch_idx_list=batch_idx_list,
             )
 
         # The legacy transforms below read attn_metadata.page_table_1 (page_size=1),
@@ -231,6 +257,257 @@ class DSATopKBackend(Enum):
             raise RuntimeError(f"Unsupported {topk_transform_method = }.")
 
         raise RuntimeError(f"Unsupported {self = } for SGLANG_DSA_FUSE_TOPK.")
+
+
+def _aiter_row_bounds(
+    lengths: torch.Tensor,
+    row_starts: Optional[torch.Tensor],
+    device: torch.device,
+) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor]:
+    lengths = lengths.to(dtype=torch.int32, device=device).contiguous()
+    if row_starts is None:
+        starts = torch.zeros_like(lengths)
+        return None, starts, lengths
+    starts = row_starts.to(dtype=torch.int32, device=device).contiguous()
+    return starts, starts, starts + lengths
+
+
+def _aiter_topk(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if not is_hip():
+        raise ValueError("The AITER DSA top-k backend requires ROCm.")
+    if score.dtype != torch.float32 or score.dim() != 2:
+        raise ValueError("AITER DSA top-k expects a 2D float32 score tensor.")
+    if score.stride(1) != 1:
+        score = score.contiguous()
+
+    num_rows, width = score.shape
+    if out is None:
+        out = score.new_full((num_rows, topk), -1, dtype=torch.int32)
+    if num_rows == 0 or topk == 0 or width == 0:
+        out.fill_(-1)
+        return out
+
+    lengths = lengths.to(dtype=torch.int32, device=score.device).contiguous()
+    if width <= topk:
+        positions = torch.arange(topk, dtype=torch.int32, device=score.device)
+        out.copy_(
+            torch.where(
+                positions.unsqueeze(0) < lengths.unsqueeze(1),
+                positions.unsqueeze(0),
+                -1,
+            )
+        )
+        return out
+
+    import aiter
+
+    op_name = "top_k_per_row_decode" if row_starts is None else "top_k_per_row_prefill"
+    topk_op = getattr(aiter, op_name, None)
+    if not callable(topk_op):
+        raise RuntimeError(f"The AITER DSA top-k backend requires {op_name}.")
+    if row_starts is None:
+        topk_op(
+            score,
+            1,
+            lengths,
+            out,
+            num_rows,
+            score.stride(0),
+            score.stride(1),
+            k=topk,
+        )
+        return out
+
+    _, starts, ends = _aiter_row_bounds(lengths, row_starts, score.device)
+    topk_op(
+        score,
+        starts,
+        ends,
+        out,
+        None,
+        num_rows,
+        score.stride(0),
+        score.stride(1),
+        k=topk,
+        stable=True,
+    )
+    valid = out >= 0
+    out.sub_(starts.unsqueeze(1))
+    out.masked_fill_(~valid, -1)
+    return out
+
+
+def _map_topk_to_pages(
+    raw_indices: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    row_to_batch: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if page_size <= 0 or page_size & (page_size - 1):
+        raise ValueError("page_size must be a positive power of two.")
+    if row_to_batch is None and page_table.shape[0] != raw_indices.shape[0]:
+        raise ValueError("AITER top-k rows must match page-table rows.")
+    if page_table.shape[1] == 0:
+        mapped = torch.full_like(raw_indices, -1)
+        if out is not None:
+            out.copy_(mapped)
+            return out
+        return mapped
+
+    page_bits = page_size.bit_length() - 1
+    page_mask = page_size - 1
+    valid = raw_indices >= 0
+    safe_indices = raw_indices.clamp_min(0)
+    logical_pages = (safe_indices >> page_bits).to(torch.long)
+    if row_to_batch is None:
+        physical_pages = torch.gather(page_table, 1, logical_pages)
+    else:
+        physical_pages = page_table[
+            row_to_batch.to(torch.long).unsqueeze(1), logical_pages
+        ]
+    mapped = (physical_pages << page_bits) | (safe_indices & page_mask)
+    mapped.masked_fill_(~valid, -1)
+    if out is not None:
+        out.copy_(mapped)
+        return out
+    return mapped
+
+
+def _build_aiter_row_to_batch(
+    batch_idx_list: Optional[List[int]],
+    cu_seqlens_q_topk: Optional[torch.Tensor],
+    device: torch.device,
+    num_rows: int,
+    require_mapping: bool = False,
+) -> Optional[torch.Tensor]:
+    row_to_batch = (
+        torch.as_tensor(batch_idx_list, dtype=torch.int32, device=device)
+        if batch_idx_list is not None
+        else None
+    )
+    if row_to_batch is not None and cu_seqlens_q_topk is not None:
+        if row_to_batch.shape[0] != num_rows:
+            q_lens = (cu_seqlens_q_topk[1:] - cu_seqlens_q_topk[:-1]).to(
+                dtype=torch.int32, device=device
+            )
+            row_to_batch = torch.repeat_interleave(
+                row_to_batch, q_lens, output_size=num_rows
+            )
+        return row_to_batch
+
+    if row_to_batch is None and cu_seqlens_q_topk is not None:
+        num_batches = cu_seqlens_q_topk.shape[0] - 1
+        if require_mapping or num_rows != num_batches:
+            q_lens = (cu_seqlens_q_topk[1:] - cu_seqlens_q_topk[:-1]).to(
+                dtype=torch.int32, device=device
+            )
+            row_to_batch = torch.repeat_interleave(
+                torch.arange(q_lens.shape[0], dtype=torch.int32, device=device),
+                q_lens,
+                output_size=num_rows,
+            )
+    return row_to_batch
+
+
+def aiter_topk_transform_paged(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+    row_to_batch: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if out is None:
+        out = logits.new_empty((logits.shape[0], topk), dtype=torch.int32)
+    if logits.shape[0] == 0 or topk == 0 or logits.shape[1] == 0:
+        out.fill_(-1)
+        if out_raw_indices is not None:
+            out_raw_indices.fill_(-1)
+        return out
+
+    import aiter
+
+    fused_op = getattr(aiter, "dsa_topk_transform", None)
+    if callable(fused_op) and topk == 2048 and out_raw_indices is None:
+        starts_arg, _, ends = _aiter_row_bounds(lengths, row_starts, logits.device)
+        fused_op(
+            logits,
+            starts_arg,
+            ends,
+            page_table,
+            out,
+            page_size,
+            topk,
+            ptRowMap=row_to_batch,
+        )
+        return out
+
+    raw_indices = (
+        out_raw_indices
+        if out_raw_indices is not None
+        else logits.new_empty((logits.shape[0], topk), dtype=torch.int32)
+    )
+    _aiter_topk(logits, lengths, topk, row_starts=row_starts, out=raw_indices)
+    return _map_topk_to_pages(
+        raw_indices,
+        page_table,
+        page_size,
+        row_to_batch=row_to_batch,
+        out=out,
+    )
+
+
+def _aiter_topk_transform(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    topk_transform_method: TopkTransformMethod,
+    attn_metadata,
+    cu_seqlens_q_topk: Optional[torch.Tensor],
+    topk_indices_offset: Optional[torch.Tensor],
+    row_starts: Optional[torch.Tensor],
+    batch_idx_list: Optional[List[int]],
+) -> torch.Tensor:
+    if topk_transform_method == TopkTransformMethod.PAGED:
+        if attn_metadata.page_table_1 is None:
+            raise RuntimeError("PAGED AITER top-k requires a page table.")
+        row_to_batch = _build_aiter_row_to_batch(
+            batch_idx_list,
+            cu_seqlens_q_topk,
+            logits.device,
+            logits.shape[0],
+            require_mapping=row_starts is not None,
+        )
+        return aiter_topk_transform_paged(
+            logits,
+            lengths,
+            attn_metadata.page_table_1,
+            1,
+            topk,
+            row_starts=row_starts,
+            row_to_batch=row_to_batch,
+        )
+
+    if topk_transform_method == TopkTransformMethod.RAGGED:
+        if topk_indices_offset is None:
+            raise RuntimeError("RAGGED AITER top-k requires topk_indices_offset.")
+        raw_indices = _aiter_topk(logits, lengths, topk, row_starts=row_starts)
+        offsets = topk_indices_offset.to(dtype=torch.int32, device=logits.device)
+        if offsets.dim() == 1:
+            offsets = offsets.unsqueeze(1)
+        return torch.where(raw_indices >= 0, raw_indices + offsets, -1)
+
+    raise RuntimeError(f"Unsupported {topk_transform_method = }.")
 
 
 def _topk_unfused(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -722,6 +722,7 @@ class DeepseekSparseAttnBackend(
         if (
             self.dsa_topk_backend.is_sgl_kernel()
             or self.dsa_topk_backend.is_flashinfer()
+            or self.dsa_topk_backend.is_aiter()
         ):
             return topk_indices
         raise RuntimeError(

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -31,7 +31,10 @@ from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
+    DSATopKBackend,
+    aiter_topk_transform_paged,
+)
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
 from sglang.srt.layers.attention.dsv4.metadata import (
@@ -867,6 +870,16 @@ class C4IndexerBackendMixin:
                     c4_sparse_page_indices[rows],
                     indexer_metadata.c4_page_size,
                     row_raw_indices,
+                )
+            elif self.dsa_topk_backend.is_aiter():
+                aiter_topk_transform_paged(
+                    logits,
+                    c4_seq_lens[rows],
+                    page_table[rows],
+                    indexer_metadata.c4_page_size,
+                    c4_sparse_page_indices.shape[1],
+                    out=c4_sparse_page_indices[rows],
+                    out_raw_indices=row_raw_indices,
                 )
             elif self.dsa_topk_backend.should_use_topk_v2() and raw_indices is None:
                 topk_transform_paged_v2(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1814,8 +1814,8 @@ class ServerArgs:
     dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
-            choices=["sgl-kernel", "torch", "flashinfer"],
+            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer', 'aiter' (ROCm only). The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            choices=["sgl-kernel", "torch", "flashinfer", "aiter"],
         ),
         NS("exec.kernel"),
     ] = "sgl-kernel"
@@ -2184,8 +2184,8 @@ class ServerArgs:
     speculative_dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend for speculative draft workers. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
-            choices=["sgl-kernel", "torch", "flashinfer"],
+            help="DSA indexer top-k backend for speculative draft workers. Options: 'sgl-kernel', 'torch', 'flashinfer', 'aiter' (ROCm only). The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            choices=["sgl-kernel", "torch", "flashinfer", "aiter"],
         ),
         NS("spec"),
     ] = "sgl-kernel"

--- a/test/registered/kernels/ops/attention/test_dsa_topk_aiter.py
+++ b/test/registered/kernels/ops/attention/test_dsa_topk_aiter.py
@@ -1,0 +1,319 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
+    DSATopKBackend,
+    TopkTransformMethod,
+    aiter_topk_transform_paged,
+)
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+pytestmark = pytest.mark.skipif(
+    torch.version.hip is None, reason="AITER DSA top-k requires ROCm"
+)
+
+
+def test_aiter_backend_resolves_for_target_and_draft() -> None:
+    with get_context().override_server_args(
+        dsa_topk_backend="aiter",
+        speculative_dsa_topk_backend="sgl-kernel",
+    ):
+        target = DSATopKBackend.resolve(SimpleNamespace(is_draft_worker=False))
+        draft = DSATopKBackend.resolve(SimpleNamespace(is_draft_worker=True))
+
+    assert target is DSATopKBackend.AITER
+    assert draft is DSATopKBackend.SGL_KERNEL
+
+    with get_context().override_server_args(
+        dsa_topk_backend="sgl-kernel",
+        speculative_dsa_topk_backend="aiter",
+    ):
+        target = DSATopKBackend.resolve(SimpleNamespace(is_draft_worker=False))
+        draft = DSATopKBackend.resolve(SimpleNamespace(is_draft_worker=True))
+
+    assert target is DSATopKBackend.SGL_KERNEL
+    assert draft is DSATopKBackend.AITER
+    assert not DSATopKBackend.AITER.should_use_topk_v2()
+
+    with (
+        get_context().override_server_args(dsa_topk_backend="aiter"),
+        patch(
+            "sglang.srt.layers.attention.dsa.dsa_topk_backend.is_hip",
+            return_value=False,
+        ),
+        pytest.raises(ValueError, match="requires ROCm"),
+    ):
+        DSATopKBackend.resolve(SimpleNamespace(is_draft_worker=False))
+
+
+def _assert_selected_values(
+    scores: torch.Tensor,
+    starts: torch.Tensor,
+    lengths: torch.Tensor,
+    indices: torch.Tensor,
+) -> None:
+    for row in range(scores.shape[0]):
+        length = int(lengths[row])
+        count = min(length, indices.shape[1])
+        selected = indices[row, :count].to(torch.long)
+        assert selected.unique().numel() == count
+        assert bool(((selected >= 0) & (selected < length)).all())
+        expected = (
+            torch.topk(scores[row, starts[row] : starts[row] + length], count)
+            .values.sort()
+            .values
+        )
+        actual = scores[row, starts[row] + selected].sort().values
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        assert bool((indices[row, count:] == -1).all())
+
+
+@torch.inference_mode()
+def test_aiter_topk_returns_row_relative_indices() -> None:
+    torch.manual_seed(20260903)
+    scores = torch.randn(4, 4096, dtype=torch.float32, device="cuda")
+    starts = torch.tensor([0, 17, 64, 101], dtype=torch.int32, device="cuda")
+    lengths = torch.tensor([0, 127, 2048, 3995], dtype=torch.int32, device="cuda")
+
+    indices = DSATopKBackend.AITER.topk_func(scores, lengths, 1024, row_starts=starts)
+    _assert_selected_values(scores, starts, lengths, indices)
+
+
+@torch.inference_mode()
+def test_aiter_topk_compact_page_and_raw_outputs() -> None:
+    torch.manual_seed(20260904)
+    batch, width, topk, page_size = 4, 512, 64, 64
+    scores = torch.randn(batch, width, dtype=torch.float32, device="cuda")
+    lengths = torch.tensor([32, 129, 384, 512], dtype=torch.int32, device="cuda")
+    page_table = torch.stack(
+        [torch.randperm(width // page_size, device="cuda") for _ in range(batch)]
+    ).to(torch.int32)
+    mapped = torch.empty((batch, topk), dtype=torch.int32, device="cuda")
+    raw = torch.empty_like(mapped)
+
+    aiter_topk_transform_paged(
+        scores,
+        lengths,
+        page_table,
+        page_size,
+        topk,
+        out=mapped,
+        out_raw_indices=raw,
+    )
+
+    valid = raw >= 0
+    safe = raw.clamp_min(0)
+    expected = (page_table.gather(1, (safe // page_size).long()) * page_size) + (
+        safe % page_size
+    )
+    expected.masked_fill_(~valid, -1)
+    torch.testing.assert_close(mapped, expected, rtol=0, atol=0)
+    _assert_selected_values(
+        scores,
+        torch.zeros(batch, dtype=torch.int32, device="cuda"),
+        lengths,
+        raw,
+    )
+
+
+@torch.inference_mode()
+def test_aiter_topk_ragged_offsets() -> None:
+    torch.manual_seed(20260905)
+    scores = torch.randn(3, 256, dtype=torch.float32, device="cuda")
+    starts = torch.tensor([3, 19, 47], dtype=torch.int32, device="cuda")
+    lengths = torch.tensor([64, 128, 200], dtype=torch.int32, device="cuda")
+    offsets = torch.tensor([1000, 2000, 3000], dtype=torch.int32, device="cuda")
+
+    raw = DSATopKBackend.AITER.topk_func(scores, lengths, 32, row_starts=starts)
+    metadata = type("Metadata", (), {"page_table_1": None})()
+    ragged = DSATopKBackend.AITER.topk_transform(
+        scores,
+        lengths,
+        32,
+        TopkTransformMethod.RAGGED,
+        metadata,
+        topk_indices_offset=offsets,
+        row_starts=starts,
+    )
+
+    torch.testing.assert_close(
+        ragged.sort(dim=1).values,
+        torch.where(raw >= 0, raw + offsets.unsqueeze(1), -1).sort(dim=1).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
+def test_aiter_topk_expanded_paged_rows() -> None:
+    torch.manual_seed(20260906)
+    num_rows, width, topk = 4, 256, 32
+    scores = torch.randn(num_rows, width, dtype=torch.float32, device="cuda")
+    lengths = torch.full((num_rows,), width, dtype=torch.int32, device="cuda")
+    page_table = torch.stack(
+        [
+            torch.arange(width, dtype=torch.int32, device="cuda"),
+            torch.arange(width, dtype=torch.int32, device="cuda") + 10_000,
+        ]
+    )
+    metadata = type(
+        "Metadata",
+        (),
+        {
+            "page_table_1": page_table,
+            "cu_seqlens_k": torch.tensor(
+                [0, width, 2 * width], dtype=torch.int32, device="cuda"
+            ),
+        },
+    )()
+    cu_seqlens_q = torch.tensor([0, 2, 4], dtype=torch.int32, device="cuda")
+
+    mapped = DSATopKBackend.AITER.topk_transform(
+        scores,
+        lengths,
+        topk,
+        TopkTransformMethod.PAGED,
+        metadata,
+        cu_seqlens_q_topk=cu_seqlens_q,
+    )
+    raw = DSATopKBackend.AITER.topk_func(scores, lengths, topk)
+    row_to_batch = torch.tensor([0, 0, 1, 1], device="cuda")
+    expected = page_table[row_to_batch].gather(1, raw.long())
+    torch.testing.assert_close(
+        mapped.sort(dim=1).values,
+        expected.sort(dim=1).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
+def test_aiter_topk_graph_replay() -> None:
+    torch.manual_seed(20260907)
+    batch, width, topk, page_size = 4, 65536, 64, 64
+    scores = torch.randn(batch, width, dtype=torch.float32, device="cuda")
+    lengths = torch.full((batch,), width, dtype=torch.int32, device="cuda")
+    page_table = torch.stack(
+        [torch.randperm(width // page_size, device="cuda") for _ in range(batch)]
+    ).to(torch.int32)
+    mapped = torch.empty((batch, topk), dtype=torch.int32, device="cuda")
+    raw = torch.empty_like(mapped)
+
+    aiter_topk_transform_paged(
+        scores,
+        lengths,
+        page_table,
+        page_size,
+        topk,
+        out=mapped,
+        out_raw_indices=raw,
+    )
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        aiter_topk_transform_paged(
+            scores,
+            lengths,
+            page_table,
+            page_size,
+            topk,
+            out=mapped,
+            out_raw_indices=raw,
+        )
+
+    scores.copy_(
+        torch.arange(width, 0, -1, dtype=torch.float32, device="cuda")
+        .unsqueeze(0)
+        .expand(batch, -1)
+    )
+    lengths.copy_(torch.tensor([32, 127, 32769, 65536], device="cuda"))
+    page_table.add_(100)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    valid = raw >= 0
+    safe = raw.clamp_min(0)
+    expected = (page_table.gather(1, (safe // page_size).long()) * page_size) + (
+        safe % page_size
+    )
+    expected.masked_fill_(~valid, -1)
+    torch.testing.assert_close(mapped, expected, rtol=0, atol=0)
+    _assert_selected_values(
+        scores,
+        torch.zeros(batch, dtype=torch.int32, device="cuda"),
+        lengths,
+        raw,
+    )
+
+
+@torch.inference_mode()
+def test_aiter_topk_empty_paged_rows() -> None:
+    scores = torch.empty((2, 0), dtype=torch.float32, device="cuda")
+    lengths = torch.zeros(2, dtype=torch.int32, device="cuda")
+    page_table = torch.empty((2, 0), dtype=torch.int32, device="cuda")
+    mapped = torch.empty((2, 16), dtype=torch.int32, device="cuda")
+    raw = torch.empty_like(mapped)
+
+    aiter_topk_transform_paged(
+        scores,
+        lengths,
+        page_table,
+        64,
+        16,
+        out=mapped,
+        out_raw_indices=raw,
+    )
+
+    assert bool((mapped == -1).all())
+    assert bool((raw == -1).all())
+
+
+@torch.inference_mode()
+def test_aiter_topk_shifted_graph_replay() -> None:
+    torch.manual_seed(20260908)
+    batch, width, topk, page_size = 4, 4096, 64, 64
+    scores = torch.randn(batch, width, dtype=torch.float32, device="cuda")
+    starts = torch.tensor([3, 17, 65, 129], dtype=torch.int32, device="cuda")
+    lengths = torch.tensor([512, 1024, 2048, 3967], dtype=torch.int32, device="cuda")
+    page_table = torch.stack(
+        [torch.randperm(width // page_size, device="cuda") for _ in range(batch)]
+    ).to(torch.int32)
+    mapped = torch.empty((batch, topk), dtype=torch.int32, device="cuda")
+    raw = torch.empty_like(mapped)
+
+    aiter_topk_transform_paged(
+        scores,
+        lengths,
+        page_table,
+        page_size,
+        topk,
+        row_starts=starts,
+        out=mapped,
+        out_raw_indices=raw,
+    )
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        aiter_topk_transform_paged(
+            scores,
+            lengths,
+            page_table,
+            page_size,
+            topk,
+            row_starts=starts,
+            out=mapped,
+            out_raw_indices=raw,
+        )
+
+    scores.normal_()
+    lengths.copy_(torch.tensor([256, 777, 1537, 3000], device="cuda"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    _assert_selected_values(scores, starts, lengths, raw)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -179,6 +179,25 @@ class TestPrepareServerArgs(CustomTestCase):
         with self.assertRaises(SystemExit):
             parser.parse_args(base_args + ["--dsv4-prefill-backend", "flashmla_kv"])
 
+    def test_aiter_dsa_topk_backend_cli_choices(self):
+        parser = server_args_module.argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+
+        target = parser.parse_args(
+            ["--model-path", "dummy-model", "--dsa-topk-backend", "aiter"]
+        )
+        self.assertEqual(target.dsa_topk_backend, "aiter")
+
+        draft = parser.parse_args(
+            [
+                "--model-path",
+                "dummy-model",
+                "--speculative-dsa-topk-backend",
+                "aiter",
+            ]
+        )
+        self.assertEqual(draft.speculative_dsa_topk_backend, "aiter")
+
     def test_return_hidden_states_mode_configuration(self):
         def _resolved(**kwargs):
             server_args = ServerArgs(**kwargs)


### PR DESCRIPTION
## Motivation

Expose AITER as a selectable DSA indexer top-k backend on ROCm for target and speculative draft workers.

## Modifications

- Add `aiter` to `--dsa-topk-backend` and `--speculative-dsa-topk-backend`.
- Resolve target and draft backend settings independently in the HIP radix backend.
- Support row-relative raw indices, paged and ragged transforms, compact page tables, expanded speculative rows, and dual raw/mapped output.
- Keep SGL top-k v2 planning limited to the `sgl-kernel` backend.
- Reject explicit AITER selection outside ROCm.
- Document both command-line options.

Existing defaults are unchanged.

## Test

Validated on MI355X with `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260902`:

- AITER backend selection, mapping, short/empty rows, target/draft routing, and HIP graph replay: 8 passed.
- CLI parser coverage: 1 passed.
- Existing DSV4 indexer suite: 9 passed, 16 subtests passed.
- Fused paged transform smoke: passed.
- All applicable pre-commit hooks: passed.

## AI assistance

GitHub Copilot assisted with codebase inspection, implementation, testing, and drafting this description. The submitter reviewed the resulting changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33748432566](https://github.com/sgl-project/sglang/actions/runs/33748432566)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33748432765](https://github.com/sgl-project/sglang/actions/runs/33748432765)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33748432387](https://github.com/sgl-project/sglang/actions/runs/33748432387)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->