### PR TITLE
fix(spec): commit PLE state after ReplaySSM verify, NGRAM on Qwen4-Exp

### DIFF
--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -116,9 +116,8 @@ def _prepare_ple_batch(
 
     if forward_batch.tbo_parent_token_range is not None:
         raise NotImplementedError("Qwen4 PLE is not compatible with two-batch overlap")
-    spec_algorithm = forward_batch.spec_algorithm
-    if spec_algorithm is not None and spec_algorithm.is_ngram():
-        raise NotImplementedError("Qwen4 PLE does not support NGRAM speculation")
+    # NGRAM speculation runs on a forced linear draft chain (see
+    # ngram_worker._linearize_chain); the top-k guard below therefore holds for it.
     if (
         forward_batch.spec_info is not None
         and getattr(forward_batch.spec_info, "topk", 1) != 1
@@ -129,6 +128,31 @@ def _prepare_ple_batch(
     get_req_to_token_pool().ple_window_cache = None
     if mode.is_idle():
         return None
+    if mode.is_target_verify():
+        # Both PLE intermediates are allocated only when speculative_num_draft_tokens reaches
+        # HybridReqToTokenPool; if either is None the post-verify commit scatters nothing and
+        # the PLE history silently freezes.
+        _pool = get_req_to_token_pool()
+        _ngram_pool = getattr(_pool, "ngram_pool", None)
+        _conv_pool = getattr(_pool, "short_conv_pool", None)
+        if ngram_size is not None and (
+            _ngram_pool is None
+            or not _ngram_pool.enabled
+            or _ngram_pool.intermediate_context is None
+        ):
+            raise RuntimeError(
+                "Qwen4 PLE target verify: ngram_pool.intermediate_context is not allocated "
+                "(speculative_num_draft_tokens did not reach HybridReqToTokenPool)"
+            )
+        if (
+            _conv_pool is not None
+            and _conv_pool.enabled
+            and _conv_pool.intermediate_conv_state is None
+        ):
+            raise RuntimeError(
+                "Qwen4 PLE target verify: short_conv_pool.intermediate_conv_state is not allocated "
+                "(speculative_num_draft_tokens did not reach HybridReqToTokenPool)"
+            )
     use_decode_fast_path = (
         envs.SGLANG_ENABLE_QWEN4_PLE_FUSION.get() and mode.is_decode()
     )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -68,6 +68,46 @@ def _derive_tree_links(
     return torch.from_numpy(next_token), torch.from_numpy(next_sibling)
 
 
+def _linearize_chain(req_drafts, mask, bs, D):
+    """Collapse each request's draft tree into one root chain.
+
+    Even at bfs-breadth 1 the corpus fans out at the root (one chain per
+    anchor, trie.cpp:236-260) and zero-padding nodes are root children
+    (result.cpp:34-38).  GDN replayssm fold, QSA (no tree mask, pending ring
+    keyed by position % 4) and the int8 KV move all assume a chain: row j-1 is
+    row j's parent.  Keep the longest root chain (ties -> lowest node index,
+    i.e. BFS order), pad with token 0 chained after it; mask := tril.
+    Padding token 0 chained after the real drafts is lossless: greedy verify
+    accepts a node only if it equals the target argmax at its parent row.
+    Inputs/outputs are the flat int arrays of NgramCorpus.batch_get:
+    tokens (bs*D,), mask (bs*D*D,) with mask[b, i, j] = j is an ancestor of i.
+    """
+    toks = np.asarray(req_drafts).reshape(bs, D).copy()
+    tree = np.asarray(mask).reshape(bs, D, D)
+    order = np.arange(D)
+    below = order[None, :] < order[:, None]  # [i, j]: j < i
+    for b in range(bs):
+        ancestor = (tree[b] != 0) & below
+        parents = np.where(ancestor.any(-1), (ancestor * order).argmax(-1), -1)
+        parents[0] = -1
+        children = [np.flatnonzero(parents == i) for i in range(D)]
+
+        def longest(i):
+            best = [i]
+            for k in children[i]:  # ascending index: first wins ties
+                cand = [i] + longest(int(k))
+                if len(cand) > len(best):
+                    best = cand
+            return best
+
+        best = longest(0)
+        new = np.zeros(D, dtype=toks.dtype)
+        new[: len(best)] = toks[b, best]
+        toks[b] = new
+    tri = np.tril(np.ones((D, D), dtype=tree.dtype))
+    return toks.reshape(-1), np.broadcast_to(tri, (bs, D, D)).reshape(-1).copy()
+
+
 class NGRAMWorker(BaseSpecWorker):
     def alloc_memory_pool(self, **kwargs):
         # The target memory pool does not exist yet when __init__ runs.
@@ -94,6 +134,11 @@ class NGRAMWorker(BaseSpecWorker):
         self.tp_rank = ps.tp_rank
         self.page_size = get_schedule().page_size
         self.draft_token_num: int = server_args.speculative_num_draft_tokens
+        assert server_args.speculative_ngram_max_bfs_breadth == 1, (
+            "Qwen4-Exp (GDN replayssm fold + QSA + PLE) needs a chain draft: "
+            "--speculative-ngram-max-bfs-breadth 1 (it sets speculative_eagle_topk, "
+            f"the hybrid backend's chain switch); got {server_args.speculative_ngram_max_bfs_breadth}"
+        )
         self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.topk = server_args.speculative_eagle_topk
@@ -285,6 +330,7 @@ class NGRAMWorker(BaseSpecWorker):
         req_drafts, mask = self.ngram_corpus.batch_get(
             req_ids, batch_tokens, total_lens
         )
+        req_drafts, mask = _linearize_chain(req_drafts, mask, bs, self.draft_token_num)
         total_draft_token_num = len(req_drafts)
 
         # Check if speculative decoding is needed; here we always enforce it

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -907,6 +907,26 @@ def commit_mamba_states_after_verify(
             mamba_steps_to_track=mamba_steps_to_track,
             null_block_id=-1,
         )
+        # PLE n-gram history + PLE short-conv state live outside the GDN fold;
+        # roll them to the last accepted node like the generic path does
+        # (hybrid_linear_attn_backend.py _update_ple_state_after_mtp_verify).
+        # The generic path scatters with PHYSICAL slot ids
+        # (forward_metadata.mamba_cache_indices, translated track indices);
+        # get_mamba_indices returns VIRTUAL ids, so translate (identity for the
+        # static HybridReqToTokenPool, a lookup for the unified pool).  Without
+        # this call the early return above skips the PLE roll and the n-gram
+        # history freezes after the first verify step.
+        attn_backend = model_runner.attn_backend
+        if hasattr(attn_backend, "_update_ple_state_after_mtp_verify"):
+            _ple_track = batch.mamba_track_indices
+            if _ple_track is not None:
+                _ple_track = req_pool.translate_mamba_indices(_ple_track)
+            attn_backend._update_ple_state_after_mtp_verify(
+                req_pool.translate_mamba_indices(state_batch_indices),
+                last_correct_step_indices,
+                _ple_track,
+                mamba_steps_to_track,
+            )
         return
 
     if (
@@ -957,6 +977,19 @@ def commit_mamba_states_after_verify(
         # snapshot; not wired for Part B (server_args forbids extra_buffer with
         # --enable-linear-replayssm-spec), so the per-track scatters are intentionally
         # skipped here.
+        # PLE side states: the ring branch returns early as well, so the PLE
+        # roll of the generic path has to happen here too.  The track scatter is
+        # skipped like the conv one above (extra_buffer is forbidden with replayssm),
+        # so no track indices / steps are passed.  Physical slot ids (see the fold
+        # branch): translate the virtual get_mamba_indices() result.
+        attn_backend = model_runner.attn_backend
+        if hasattr(attn_backend, "_update_ple_state_after_mtp_verify"):
+            attn_backend._update_ple_state_after_mtp_verify(
+                req_pool.translate_mamba_indices(state_batch_indices),
+                last_correct_step_indices,
+                None,
+                None,
+            )
         return
 
     # KDA ReplaySSM (fold-every-commit): KDA keeps its own recurrent verify kernel

--- a/test/registered/unit/spec/test_ngram_linearize_chain.py
+++ b/test/registered/unit/spec/test_ngram_linearize_chain.py
@@ -1,0 +1,436 @@
+"""Unit tests for ``ngram_worker._linearize_chain`` (CPU, no server, no model).
+
+Inputs are built in the layout ``NgramCorpus.batch_get`` returns: flat int64
+tokens ``(bs*D,)`` and a flat int64 ancestor mask ``(bs*D*D,)``, produced by a
+Python replica of ``trie.cpp`` ``buildRecency`` (bfs breadth 1: every anchor
+re-enters from the root and inserts one chain, shared prefixes merge, node
+budget D-1) followed by ``result.cpp`` ``fillResult`` (BFS order, zero-padding
+nodes as ROOT children, mask row i = copy of the parent row + the diagonal).
+
+One thing the replica cannot pin down: ``Node.next`` is a
+``std::unordered_map`` (``result.h``), so the BFS order AMONG SIBLINGS -- and
+therefore which chain is "first" on a length tie -- is hash order in the real
+corpus. The replica takes a ``child_order`` hook and every star / partial case
+is run under several sibling orders; the assertions only require the result to
+be ONE of the depth-maximal root chains, never a specific sibling.
+
+Checks
+  1. a single chain is preserved (tokens and tril mask unchanged);
+  2. a star (several anchors -> several depth-1 root children) collapses to ONE
+     depth-1 child, padded, under every sibling order; the unlinearized star has
+     duplicate positions;
+  3. a partial match (one 2-chain + one 1-chain) keeps the longest chain under
+     every sibling order;
+  4. padding nodes (root children with token 0) never displace a real chain;
+     no-match -> [root, 0, 0, 0];
+  5. branching below the root (D=6) keeps the longest path, not the first child;
+  6. batched (bs=3) inputs: per-request results, output dtypes / shapes match
+     ``batch_get``, inputs untouched;
+  7. what the verify code derives from the mask: a replica of
+     ``reconstruct_indices_from_tree_mask`` (``ngram_utils.cu``) gives positions
+     seq_len..seq_len+D-1, retrieve_next_token [1..D-1, -1], retrieve_next_sibling
+     all -1, parent(row j) == row j-1; the host-side ``_derive_tree_links`` agrees;
+  8. a replica of ``verify_tree_greedy`` (``kernels/aot/csrc/cpu/spec.cpp``) on
+     the chain: accept_index is always a row prefix b*D + arange(n), -1 after;
+     accept_lens in [1, D]; a padding-0 node is accepted only when the target
+     argmax at its parent row is 0;
+  9. the real JIT ``NgramCorpus`` at breadth 1 / D=4 fed with a history that
+     provably creates a multi-anchor star (the raw mask of request 0 is asserted
+     to be non-tril); its ``batch_get`` output is linearized and re-checked
+     (skipped when the corpus extension cannot be built on the host).
+"""
+
+import unittest
+from collections import deque
+
+import numpy as np
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+from sglang.srt.speculative.ngram_worker import (  # noqa: E402
+    _derive_tree_links,
+    _linearize_chain,
+)
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+D = 4
+ROOT = 1234
+
+
+# ---------------------------------------------------------------------- corpus replicas
+def fill_result(last_token, d, tree, child_order=None):
+    """``result.cpp`` ``fillResult``: ``tree[node] = {token: child_node}``; BFS from
+    root 0; the root row holds ``last_token``; zero padding to ``d`` with
+    ``prevs = 0`` (root children); ``mask[i] = mask[parent][:parent+1]`` then the
+    diagonal. ``child_order(items) -> items`` models the ``std::unordered_map``
+    iteration order of ``Node.next``: insertion order by default here."""
+    child_order = child_order or (lambda items: items)
+    tokens, prevs = [last_token], [-1]
+    queue = deque((tok, nxt, 0) for tok, nxt in child_order(list(tree[0].items())))
+    while queue:
+        tok, nxt, prev = queue.popleft()
+        tokens.append(tok)
+        prevs.append(prev)
+        for t, n in child_order(list(tree[nxt].items())):
+            queue.append((t, n, len(tokens) - 1))
+    while len(tokens) < d:
+        tokens.append(0)
+        prevs.append(0)
+    n = len(tokens)
+    mask = np.zeros((n, n), dtype=np.int64)
+    mask[0, 0] = 1
+    for i in range(n):
+        if prevs[i] != -1:
+            mask[i, : prevs[i] + 1] = mask[prevs[i], : prevs[i] + 1]
+        mask[i, i] = 1
+    return np.array(tokens, dtype=np.int64), mask
+
+
+# sibling orders a std::unordered_map could produce
+SIBLING_ORDERS = [
+    lambda items: items,
+    lambda items: list(reversed(items)),
+    lambda items: items[1:] + items[:1],  # rotate: the middle child first
+    lambda items: sorted(items, key=lambda kv: kv[0]),
+    lambda items: sorted(items, key=lambda kv: (kv[0] * 2654435761) % 97),
+]
+
+
+def build_recency(last_token, d, anchor_paths, child_order=None):
+    """``trie.cpp`` ``buildRecency`` at bfs breadth 1: each anchor (deepest first)
+    re-enters from the root and inserts its chain (an existing token at the
+    parent is reused); node ids 1..d-1."""
+    n_real = d - 1
+    tree = [dict() for _ in range(d)]
+    cursor = 1
+    for path in anchor_paths:
+        parent = 0
+        for tok in path:
+            if cursor > n_real:
+                break
+            if tok in tree[parent]:
+                parent = tree[parent][tok]
+            else:
+                tree[parent][tok] = cursor
+                parent = cursor
+                cursor += 1
+    return fill_result(last_token, d, tree, child_order)
+
+
+def maximal_root_chains(toks, mask, d):
+    """All root->leaf token paths of maximal depth in one request's tree
+    (padding nodes included: they are root children with token 0)."""
+    toks = np.asarray(toks).reshape(d)
+    m = np.asarray(mask).reshape(d, d)
+    parents = [-1] + [max(j for j in range(i) if m[i, j]) for i in range(1, d)]
+    children = [[i for i in range(d) if parents[i] == p] for p in range(d)]
+
+    def paths(i):
+        if not children[i]:
+            return [[]]
+        return [[c] + rest for c in children[i] for rest in paths(c)]
+
+    all_paths = paths(0)
+    depth = max(len(p) for p in all_paths)
+    return depth, {tuple(int(toks[k]) for k in p) for p in all_paths if len(p) == depth}
+
+
+def batch_get_like(results):
+    """Flatten per-request (tokens, mask) exactly like ``NgramCorpus.batch_get``."""
+    toks = np.concatenate([t for t, _ in results]).astype(np.int64)
+    mask = np.concatenate([m.reshape(-1) for _, m in results]).astype(np.int64)
+    return toks, mask
+
+
+def tril(d):
+    return np.tril(np.ones((d, d), dtype=np.int64))
+
+
+# ---------------------------------------------------------------------- verify-side replicas
+def reconstruct_ref(mask, seq_lens, bs, d):
+    """Replica of sgl_kernel ``reconstructIndicesFromTreeMask`` (``ngram_utils.cu``)."""
+    tree = mask.reshape(bs, d, d).astype(bool)
+    positions = np.empty(bs * d, dtype=np.int64)
+    ri = np.empty((bs, d), dtype=np.int64)
+    nt = np.full((bs, d), -1, dtype=np.int64)
+    ns = np.full((bs, d), -1, dtype=np.int64)
+    parents = np.full((bs, d), -1, dtype=np.int64)
+    for b in range(bs):
+        for t in range(d):
+            depth, parent = 0, -1
+            for i in range(t - 1, -1, -1):
+                if tree[b, t, i]:
+                    depth += 1
+                    if parent == -1:
+                        parent = i
+            ri[b, t] = b * d + t
+            positions[b * d + t] = depth + seq_lens[b]
+            parents[b, t] = parent
+            for i in range(t + 1, d):
+                if tree[b, i, t]:
+                    nt[b, t] = i
+                    break
+            if parent != -1:
+                for i in range(t + 1, d):
+                    if tree[b, i, parent] and not tree[b, i, parent + 1 : i].any():
+                        ns[b, t] = i
+                        break
+    return positions, ri, nt, ns, parents
+
+
+def verify_greedy_ref(candidates, ri, nt, ns, target_predict, bs, d):
+    """Replica of ``verify_tree_greedy_kernel_impl`` (``kernels/aot/csrc/cpu/spec.cpp``);
+    accept_index has ``num_spec_step = d`` columns."""
+    predicts = np.zeros(bs * d, dtype=np.int64)
+    accept_index = np.full((bs, d), -1, dtype=np.int64)
+    accept_token_num = np.zeros(bs, dtype=np.int64)
+    cand, rif, ntf, nsf, tp = (
+        x.reshape(-1) for x in (candidates, ri, nt, ns, target_predict)
+    )
+    for bx in range(bs):
+        off = bx * d
+        last = rif[off]
+        accept_index[bx, 0] = last
+        n_correct, cur = 0, 0
+        for _ in range(1, d):
+            cur = ntf[off + cur]
+            while cur != -1:
+                draft_idx, draft_tok = rif[off + cur], cand[off + cur]
+                if draft_tok == tp[last]:
+                    predicts[last] = tp[last]
+                    n_correct += 1
+                    accept_index[bx, n_correct] = draft_idx
+                    last = draft_idx
+                    break
+                cur = nsf[off + cur]
+            if cur == -1:
+                break
+        accept_token_num[bx] = n_correct
+        predicts[last] = tp[last]
+    return predicts, accept_index, accept_token_num + 1  # accept_lens incl. bonus
+
+
+class TestLinearizeChain(CustomTestCase):
+    def assert_linearized(self, toks, mask, d, expect_depth=None):
+        """One request: result is a depth-maximal root chain + zero padding, mask tril."""
+        depth, chains = maximal_root_chains(toks, mask, d)
+        if expect_depth is not None:
+            self.assertEqual(depth, expect_depth, chains)
+        t, m = _linearize_chain(*batch_get_like([(toks, mask)]), 1, d)
+        self.assertTrue((m.reshape(d, d) == tril(d)).all(), m)
+        self.assertEqual(t[0], toks[0])
+        self.assertIn(tuple(t[1 : 1 + depth].tolist()), chains, t.tolist())
+        self.assertTrue((t[1 + depth :] == 0).all(), t)
+        return t, m, chains
+
+    def check_chain_derivations(self, toks, mask, bs, d, seq_lens=None):
+        """Checks 7 and 8 on a linearized (toks, mask) pair."""
+        if seq_lens is None:
+            seq_lens = np.array([100 + 7 * b for b in range(bs)], dtype=np.int64)
+        m = mask.reshape(bs, d, d)
+        self.assertTrue((m == tril(d)[None]).all(), f"mask is not tril:\n{m}")
+        positions, ri, nt, ns, parents = reconstruct_ref(mask, seq_lens, bs, d)
+        exp_pos = (seq_lens[:, None] + np.arange(d)[None, :]).reshape(-1)
+        self.assertTrue((positions == exp_pos).all(), (positions, exp_pos))
+        self.assertTrue(
+            (ri == (np.arange(bs)[:, None] * d + np.arange(d)[None, :])).all()
+        )
+        exp_nt = np.tile(np.append(np.arange(1, d), -1), (bs, 1))
+        self.assertTrue((nt == exp_nt).all(), (nt, exp_nt))
+        self.assertTrue((ns == -1).all(), ns)
+        exp_par = np.tile(np.arange(-1, d - 1), (bs, 1))
+        self.assertTrue((parents == exp_par).all(), parents)
+        h_nt, h_ns = _derive_tree_links(mask, bs, d)
+        self.assertTrue(torch.equal(h_nt, torch.from_numpy(exp_nt)), h_nt)
+        self.assertTrue(torch.equal(h_ns, torch.from_numpy(ns)), h_ns)
+        # greedy verify: accept 0..d-1 drafts by crafting target_predict per request
+        cand = toks.reshape(bs, d)
+        for n_acc in range(d):
+            tp = np.full((bs, d), -7, dtype=np.int64)  # -7: never equal to a draft
+            for b in range(bs):
+                tp[b, :n_acc] = cand[b, 1 : n_acc + 1]  # row j predicts draft row j+1
+                tp[b, n_acc:] = 999_999 + b  # bonus token(s)
+            predicts, ai, al = verify_greedy_ref(cand, ri, nt, ns, tp, bs, d)
+            for b in range(bs):
+                n = int(al[b])
+                self.assertEqual(n, n_acc + 1)
+                self.assertTrue((ai[b, :n] == b * d + np.arange(n)).all(), ai[b])
+                self.assertTrue((ai[b, n:] == -1).all(), ai[b])
+                acc = predicts[ai[b, :n]]
+                self.assertTrue((acc[:-1] == cand[b, 1:n]).all(), acc)
+                self.assertEqual(acc[-1], 999_999 + b)
+        return positions, ri, nt, ns
+
+    def test_single_chain_preserved(self):
+        toks, mask = build_recency(ROOT, D, [[11, 12, 13]])
+        self.assertEqual(toks.tolist(), [ROOT, 11, 12, 13])
+        self.assertTrue((mask == tril(D)).all())
+        t, m = _linearize_chain(*batch_get_like([(toks, mask)]), 1, D)
+        self.assertEqual(t.tolist(), [ROOT, 11, 12, 13])
+        self.assertTrue((m.reshape(D, D) == tril(D)).all())
+
+    def test_star_collapses_to_one_chain(self):
+        # three anchors, each one depth-1 child -> ONE depth-1 child kept, padded with 0.
+        toks, mask = build_recency(ROOT, D, [[21], [22], [23]])
+        self.assertEqual(toks.tolist(), [ROOT, 21, 22, 23])
+        self.assertEqual(
+            mask.tolist(),
+            [[1, 0, 0, 0], [1, 1, 0, 0], [1, 0, 1, 0], [1, 0, 0, 1]],
+        )
+        pos_star = reconstruct_ref(mask.reshape(-1), np.array([50]), 1, D)[0]
+        self.assertEqual(pos_star.tolist(), [50, 51, 51, 51])  # the collision
+        seen = []
+        for order in SIBLING_ORDERS:
+            toks_o, mask_o = build_recency(ROOT, D, [[21], [22], [23]], order)
+            self.assertTrue((mask_o == mask).all())
+            self.assertEqual(sorted(toks_o.tolist()), sorted(toks.tolist()))
+            t, _, chains = self.assert_linearized(toks_o, mask_o, D, expect_depth=1)
+            self.assertEqual(chains, {(21,), (22,), (23,)})
+            # lowest node index wins the tie
+            self.assertEqual(t.tolist(), [ROOT, int(toks_o[1]), 0, 0])
+            seen.append(int(t[1]))
+        self.assertEqual(set(seen), {21, 22, 23})  # the orders really differed
+
+    def test_partial_star_keeps_longest_chain(self):
+        # root->a->b and root->c (deepest anchor first, as getExpandableAnchors_ orders them)
+        toks, mask = build_recency(ROOT, D, [[31, 32], [33]])
+        self.assertEqual(toks.tolist(), [ROOT, 31, 33, 32])  # BFS: depth-1 nodes first
+        self.assertEqual(
+            mask.tolist(),
+            [[1, 0, 0, 0], [1, 1, 0, 0], [1, 0, 1, 0], [1, 1, 0, 1]],
+        )
+        t, _, chains = self.assert_linearized(toks, mask, D, expect_depth=2)
+        self.assertEqual(chains, {(31, 32)})
+        self.assertEqual(t.tolist(), [ROOT, 31, 32, 0])
+        for order in SIBLING_ORDERS:
+            for anchors in ([[31, 32], [33]], [[33], [31, 32]]):
+                toks_o, mask_o = build_recency(ROOT, D, anchors, order)
+                t, _, _ = self.assert_linearized(toks_o, mask_o, D, expect_depth=2)
+                self.assertEqual(t.tolist(), [ROOT, 31, 32, 0], (toks_o, mask_o))
+
+    def test_padding_and_no_match(self):
+        toks, mask = build_recency(ROOT, D, [[41]])
+        self.assertEqual(toks.tolist(), [ROOT, 41, 0, 0])
+        self.assertEqual(  # pads are root children
+            mask.tolist(),
+            [[1, 0, 0, 0], [1, 1, 0, 0], [1, 0, 1, 0], [1, 0, 0, 1]],
+        )
+        t, m = _linearize_chain(*batch_get_like([(toks, mask)]), 1, D)
+        self.assertEqual(t.tolist(), [ROOT, 41, 0, 0])
+        self.assertTrue((m.reshape(D, D) == tril(D)).all())
+        toks, mask = build_recency(ROOT, D, [])
+        self.assertEqual(toks.tolist(), [ROOT, 0, 0, 0])
+        t, m = _linearize_chain(*batch_get_like([(toks, mask)]), 1, D)
+        self.assertEqual(t.tolist(), [ROOT, 0, 0, 0])
+        self.assertTrue((m.reshape(D, D) == tril(D)).all())
+        # a real 2-chain listed AFTER a padding-like real child keeps the 2-chain
+        toks, mask = build_recency(ROOT, D, [[0], [42, 43]])
+        t, _ = _linearize_chain(*batch_get_like([(toks, mask)]), 1, D)
+        self.assertEqual(t.tolist(), [ROOT, 42, 43, 0])
+
+    def test_branch_below_root_keeps_longest_path(self):
+        d6 = 6
+        toks, mask = build_recency(ROOT, d6, [[51, 52], [51, 53, 54]])
+        self.assertEqual(toks.tolist(), [ROOT, 51, 52, 53, 54, 0])
+        t, m = _linearize_chain(*batch_get_like([(toks, mask)]), 1, d6)
+        self.assertEqual(t.tolist(), [ROOT, 51, 53, 54, 0, 0])
+        self.assertTrue((m.reshape(d6, d6) == tril(d6)).all())
+        self.check_chain_derivations(t, m, 1, d6)
+        for order in SIBLING_ORDERS:
+            toks_o, mask_o = build_recency(ROOT, d6, [[51, 52], [51, 53, 54]], order)
+            t, _, _ = self.assert_linearized(toks_o, mask_o, d6, expect_depth=3)
+            self.assertEqual(t.tolist(), [ROOT, 51, 53, 54, 0, 0], toks_o)
+
+    def _batched(self):
+        rs = [
+            build_recency(1, D, [[11, 12, 13]]),
+            build_recency(2, D, [[21], [22], [23]]),
+            build_recency(3, D, []),
+        ]
+        return batch_get_like(rs)
+
+    def test_batched_shapes_dtypes_inputs_untouched(self):
+        toks, mask = self._batched()
+        toks0, mask0 = toks.copy(), mask.copy()
+        self.assertEqual((toks.dtype, mask.dtype), (np.int64, np.int64))
+        self.assertEqual((toks.shape, mask.shape), ((3 * D,), (3 * D * D,)))
+        t, m = _linearize_chain(toks, mask, 3, D)
+        self.assertEqual((t.dtype, m.dtype), (np.int64, np.int64))
+        self.assertEqual((t.shape, m.shape), ((3 * D,), (3 * D * D,)))
+        self.assertTrue(t.flags.c_contiguous and m.flags.c_contiguous)
+        self.assertTrue(t.flags.writeable and m.flags.writeable)
+        self.assertEqual(
+            t.reshape(3, D).tolist(),
+            [[1, 11, 12, 13], [2, 21, 0, 0], [3, 0, 0, 0]],
+        )
+        self.assertTrue((toks == toks0).all() and (mask == mask0).all())
+
+    def test_verify_side_derivations(self):
+        toks, mask = self._batched()
+        t, m = _linearize_chain(toks, mask, 3, D)
+        _, ri, nt, ns = self.check_chain_derivations(t, m, 3, D)
+        # padding-0 semantics: accepted only when the parent row's argmax is 0
+        cand = t.reshape(3, D)
+        tp = np.array([[11, 12, 13, 5], [21, 0, 0, 5], [0, 0, 7, 5]])
+        predicts, ai, al = verify_greedy_ref(cand, ri, nt, ns, tp, 3, D)
+        self.assertEqual(al.tolist(), [4, 4, 3])
+        self.assertEqual(ai.tolist(), [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, -1]])
+        self.assertEqual(predicts[ai[2, :3]].tolist(), [0, 0, 7])
+        tp = np.array([[11, 12, 13, 5], [21, 9, 0, 5], [9, 0, 7, 5]])
+        _, ai, al = verify_greedy_ref(cand, ri, nt, ns, tp, 3, D)
+        self.assertEqual(al.tolist(), [4, 2, 1])
+        self.assertEqual(ai.tolist(), [[0, 1, 2, 3], [4, 5, -1, -1], [8, -1, -1, -1]])
+
+    def test_real_corpus_star(self):
+        try:
+            from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
+
+            # max_trie_depth=4: the deepest anchor (7,8) of query [7,8] yields the
+            # chain 20->5 and the depth-1 anchor (8) inserts its most recent child
+            # 30 as a SECOND root child -> a star, raw mask not tril.
+            corpus = NgramCorpus(
+                max_trie_depth=4,
+                min_bfs_breadth=1,
+                max_bfs_breadth=1,
+                draft_token_num=D,
+            )
+        except Exception as e:  # the JIT extension cannot be built on this host
+            self.skipTest(f"NgramCorpus unavailable: {type(e).__name__}: {e}")
+        corpus.batch_put([[7, 8, 20, 5, 8, 30]])
+        corpus.synchronize()
+        q = [[7, 8], [5, 8], [99, 98]]
+        raw_t, raw_m = corpus.batch_get(
+            [f"r{i}" for i in range(3)], q, [len(x) for x in q]
+        )
+        self.assertEqual((raw_t.dtype, raw_m.dtype), (np.int64, np.int64))
+        self.assertEqual(raw_t.shape, (3 * D,))
+        raw_m3 = raw_m.reshape(3, D, D)
+        self.assertFalse((raw_m3[0] == tril(D)).all(), raw_m3[0])
+        star_pos = reconstruct_ref(raw_m3[0].reshape(-1), np.array([50]), 1, D)[0]
+        self.assertLess(len(set(star_pos.tolist())), D)  # duplicate positions
+        self.assertEqual(sorted(raw_t.reshape(3, D)[0, 1:].tolist()), [5, 20, 30])
+        depth0, chains0 = maximal_root_chains(raw_t.reshape(3, D)[0], raw_m3[0], D)
+        self.assertEqual((depth0, chains0), (2, {(20, 5)}))
+        lt, lm = _linearize_chain(raw_t, raw_m, 3, D)
+        self.assertEqual(lt.reshape(3, D)[0].tolist(), [8, 20, 5, 0])
+        self.check_chain_derivations(lt, lm, 3, D)
+        for b in range(3):
+            self.assert_linearized(raw_t.reshape(3, D)[b], raw_m3[b], D)
+            chain = [x for x in lt.reshape(3, D)[b, 1:].tolist() if x != 0]
+            leaf_paths = corpus.leaf_paths_from_mask(
+                raw_t.reshape(3, D)[b].tolist(), raw_m3[b].tolist()
+            )
+            leaf_paths = [p[1:] for p in leaf_paths]  # drop the root token
+            self.assertTrue(
+                any(p[: len(chain)] == chain for p in leaf_paths) or not chain,
+                (chain, leaf_paths),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part 5/5 of the Qwen3.8-Flash-Next 24 GB serving series (RFC issue: https://github.com/sgl-project/sglang/issues/37792). Patch:
`upstream/series-q4head/0005-fix-spec-commit-PLE-state-after-ReplaySSM-verify-NGR.patch`
in the companion repository (4 files, +542 / -3). The `spec_utils.py` change is a bug fix that
stands on its own; the rest is an opt-in. Patch 0005 applies on `qwen4-main-squashed`
(`78c5024e9d`) alone (verified with `git apply --check` against that tree), so this part can be
opened and merged first; it is listed as stacked on part 1 only because both touch
`models/qwen4_exp.py`, and parts 2-4 are not needed for it.

## Motivation

Two things stop speculative decoding on Qwen4-Exp. First, a bug: `commit_mamba_states_after_verify`
returns early in both ReplaySSM branches (fold and ring), before the generic path that rolls the
PLE n-gram history and the PLE short-conv state to the last accepted node
(`hybrid_linear_attn_backend._update_ple_state_after_mtp_verify`). After a verify step the PLE
history therefore silently freezes. This affects MTP with top-k 1 under
`--enable-linear-replayssm-spec` as well, not only NGRAM (CAMPAIGN 2026-09-02 17:08). Second,
`_prepare_ple_batch` refuses NGRAM outright, and even at `--speculative-ngram-max-bfs-breadth 1`
the n-gram corpus returns a star (one chain per anchor, zero-padding nodes as root children),
while the GDN ReplaySSM fold, the QSA pending ring (keyed by position % 4) and the KV move of the
accepted tokens all assume a chain in which row j-1 is row j's parent.

On the reference machine (RTX PRO 4000 Blackwell 24 GB, 32 GB host RAM) MTP is not an option:
the checkpoint's MTP experts are bf16, 4.7 GiB plus a 2.5 GB transient (CAMPAIGN 2026-09-02
17:08; `docs/ELASTIC_MEMORY.md`, "Speculative decoding"), so NGRAM is the only speculation
available there.

Sources: dated entries of `docs/CAMPAIGN.md` and `docs/ELASTIC_MEMORY.md` in
https://github.com/HaberstrohSystems/qwen3.8-flash-next-24gb-sglang and the model card
https://huggingface.co/HaberstrohSystems/Qwen3.8-Flash-Next-int2-mixed-AutoRound-24GB-SGLang.

## Modifications

- `speculative/spec_utils.py`: in both ReplaySSM branches of `commit_mamba_states_after_verify`,
  call `attn_backend._update_ple_state_after_mtp_verify(...)` when the backend has it. The
  generic path scatters with physical slot ids, while `get_mamba_indices` returns virtual ids,
  so the state batch indices (and the track indices in the fold branch) go through
  `req_pool.translate_mamba_indices` (identity for the static `HybridReqToTokenPool`, a lookup
  for the unified pool). In the ring branch no track indices are passed, mirroring the conv
  scatter that is skipped there.
- `speculative/ngram_worker.py`: `_linearize_chain` collapses each request's draft tree into its
  longest root chain (ties -> lowest node index, i.e. BFS order), pads with token 0 chained after
  it and sets the mask to `tril`. Padding token 0 after the real drafts is lossless: greedy verify
  accepts a node only if it equals the target argmax at its parent row. The constructor asserts
  `speculative_ngram_max_bfs_breadth == 1`. The function is general for any hybrid backend that
  assumes a chain.
- `models/qwen4_exp.py`: drop the "Qwen4 PLE does not support NGRAM speculation" guard (the
  top-k guard stays). On the first target-verify forward, check that
  `ngram_pool.intermediate_context` and `short_conv_pool.intermediate_conv_state` are allocated
  and raise a `RuntimeError` naming the cause otherwise; without both, the post-verify commit
  scatters nothing and the history freezes silently.
- `test/registered/unit/spec/test_ngram_linearize_chain.py` (new, `register_cpu_ci`,
  `est_time=30`, suite `base-a-test-cpu`): `_linearize_chain` against the trie/result semantics,
  with the corpus output rebuilt by a Python replica of `trie.cpp` / `result.cpp` at breadth 1
  and run under several sibling orders: a single chain is preserved, a star collapses to one
  chain, a partial match keeps the longest chain, padding nodes never displace a real chain,
  branching below the root keeps the longest path, batched inputs stay untouched with
  `batch_get` shapes and dtypes, the verify-side derivations (`reconstruct_indices_from_tree_mask`,
  `verify_tree_greedy` replicas) see a chain with parent(row j) == row j-1 and a prefix
  `accept_index`, and the real JIT `NgramCorpus` fed with a star-producing history is linearized
  and re-checked (skipped when the extension cannot be built, e.g. without `ninja`).

Opt-in; nothing changes unless `--speculative-algorithm NGRAM` is passed. Validated launch:
`--speculative-algorithm NGRAM --speculative-num-draft-tokens 4
--speculative-ngram-min-bfs-breadth 1 --speculative-ngram-max-bfs-breadth 1
--enable-linear-replayssm-spec` with eager decode (`--disable-cuda-graph`); 12 draft tokens did
not fit the mamba intermediate-state reserve on the reference machine (CAMPAIGN 2026-09-02
12:44). Not covered yet: a test that the PLE context advances after a verify step.

## Accuracy Tests

Lossless gate (`docs/ELASTIC_MEMORY.md`, "Speculative decoding"; card, "Serving fidelity"):
speculative-path logprobs versus teacher forcing with a top-1 / near-tie top-2 rule, plus the
prefill oracle.

- `test_ngram_linearize_chain.py`: 8 tests pass on the CPU with the JIT `NgramCorpus` built;
  without `ninja` on `PATH` the real-corpus test skips cleanly (7 pass + 1 skip). Also passes on
  the finished 5-commit branch.
- Prefill oracle mean 0.0015; 0 mismatches in 600 tokens (7 near-ties); spec-path vs
  teacher-forced mean |dlogprob| 0.009-0.019, max 0.25 (CAMPAIGN 2026-09-02 18:25).
- The non-speculative server on the same gate gives mean |dlogprob| 0.019 / 0.009 / 0.011
  (speculative 0.019 / 0.011 / 0.010), max 0.16-0.27 (speculative 0.18-0.25), 0 mismatches,
  4 near-ties: the speculative path is lossless within the decode-vs-prefill floor of about 0.01
  (CAMPAIGN 2026-09-02 18:50).

Reproduction:

```
git clone https://github.com/sgl-project/sglang.git && cd sglang
git fetch origin qwen4-main-squashed && git checkout 78c5024e9d9f589dcb4deb7f4ba4fb23f7e85385
git am /path/to/upstream/series-q4head/0005-*.patch      # applies without parts 1-4
pip install -e python
python -m pytest -v test/registered/unit/spec/test_ngram_linearize_chain.py     # CPU; ninja on PATH for the real-corpus case
# server level (companion repository): tools/spec_lossless.py against a server started with the NGRAM flags above
```

## Speed Tests and Profiling

No speed-up on this model: mean accept length 1.11-1.27 (accept rate 7-9 %) on prose, reasoning
and code prompts, QSA caps drafts at 4, and with eager verify decode is 22-25 tok/s against
56 tok/s for the non-speculative graph path (CAMPAIGN 2026-09-02 18:25 and 18:50;
`docs/ELASTIC_MEMORY.md`, "Speculative decoding"). It is therefore an opt-in for repetitive or
structured workloads; the `spec_utils.py` change is a bug fix regardless of that outcome.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black 26.1.0, isort 7.0.0, ruff 0.15.1 `F401,F821,UP037`, codespell and `py_compile` clean on the commit.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test/registered/unit/spec/test_ngram_linearize_chain.py`, 8 tests, `register_cpu_ci`. Missing: a test that the PLE context advances after a verify step.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Missing: a note in the speculative-decoding documentation that NGRAM on Qwen4-Exp requires breadth 1 and `--enable-linear-replayssm-spec`.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Lossless gate and the accept-length / throughput measurement above, which shows no speed-up.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Suggested reviewers

- `python/sglang/srt/speculative`: @hnyls2002, @Qiaolin-Yu (Speculative decoding).
- `python/sglang/srt/models` (`qwen4_exp.py`): @Fridge003, @ishandhanani, @Qiaolin-Yu;
  @JustinTong0323 as author of #36497.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #34829433012](https://github.com/sgl-project/sglang/actions/runs/34829433012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #34829432612](https://github.com/sgl-project/sglang/actions/runs/34829432612)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #34829432928](https://github.com/sgl-project/sglang/actions/runs/34829432928)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->