### PR TITLE
feat(moe_wna16): 2-bit experts, expert streaming, N-contiguous GEMV

### DIFF
--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -88,8 +88,9 @@ def write_zeros_to_output(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
+# [ncontig] word-load int2 branch
 @triton.jit
-def fused_moe_kernel_gptq_awq(
+def fused_moe_kernel_gptq_awq_word(
     # Pointers to matrices
     a_ptr,
     b_ptr,
@@ -134,6 +135,7 @@ def fused_moe_kernel_gptq_awq(
     has_zp: tl.constexpr,
     use_int4_w4a16: tl.constexpr,
     use_int8_w8a16: tl.constexpr,
+    use_int2_w2a16: tl.constexpr,
     even_Ks: tl.constexpr,
     filter_expert: tl.constexpr,
 ):
@@ -213,7 +215,22 @@ def fused_moe_kernel_gptq_awq(
         offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
     )
 
-    if use_int4_w4a16:
+    if use_int2_w2a16:
+        # STAGE-1.5: b_ptr is the int32 view of the uint8 tensor ([E, N, K//16] words,
+        # strides in words). One word = 16 consecutive K values, value k at bits 2*(k%16).
+        tl.static_assert(even_Ks, "int2 word path needs K % BLOCK_SIZE_K == 0")
+        tl.static_assert(
+            BLOCK_SIZE_K % 16 == 0, "BLOCK_SIZE_K must be a multiple of 16"
+        )
+        offs_kw = tl.arange(0, BLOCK_SIZE_K // 16)
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + offs_kw[:, None] * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (tl.arange(0, 16) * 2)[None, :, None]
+    elif use_int4_w4a16:
         b_ptrs = (
             b_ptr
             + off_experts * stride_be
@@ -229,10 +246,14 @@ def fused_moe_kernel_gptq_awq(
             + offs_bn[None, :] * stride_bn
         )
 
+    if not has_zp and use_int2_w2a16:
+        b_zp_num = 2
     if not has_zp and use_int4_w4a16:
         b_zp_num = 8
     if not has_zp and use_int8_w8a16:
         b_zp_num = 128
+    elif has_zp and use_int2_w2a16:
+        b_zp_shifter = (offs_bn[None, :] % 4) * 2
     elif has_zp and use_int4_w4a16:
         b_zp_shifter = (offs_bn[None, :] % 2) * 4
 
@@ -259,19 +280,67 @@ def fused_moe_kernel_gptq_awq(
             other=0.0,
         )
         b = tl.load(b_ptrs)
-        if use_int4_w4a16:
+        if use_int2_w2a16:
+            # [BK//16, BN] int32 -> [BK//16, 16, BN] -> [BK, BN]; row index 16*word + i == k
+            b = (b[:, None, :] >> b_shifter) & 0x3
+            b = tl.reshape(b, [BLOCK_SIZE_K, BLOCK_SIZE_N])
+        elif use_int4_w4a16:
             b = (b >> b_shifter) & 0xF
 
-        b_scale_ptrs = (
-            b_scale_ptr
-            + off_experts * stride_bse
-            + offs_bn[None, :] * stride_bsn
-            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
-        )
-        b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
-        b_scale = b_scale.to(tl.float32)
+        if use_int2_w2a16:
+            if BLOCK_SIZE_K <= group_size:
+                tl.static_assert(
+                    group_size % BLOCK_SIZE_K == 0,
+                    "group_size must be a multiple of BLOCK_SIZE_K",
+                )
+                # one scale per column for the whole K tile
+                b_scale = tl.load(
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn * stride_bsn
+                    + ((BLOCK_SIZE_K * k) // group_size) * stride_bsk
+                ).to(tl.float32)[None, :]
+            else:
+                tl.static_assert(
+                    BLOCK_SIZE_K % group_size == 0,
+                    "BLOCK_SIZE_K must be a multiple of group_size",
+                )
+                offs_g = tl.arange(0, BLOCK_SIZE_K // group_size)
+                b_scale = tl.load(
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn[None, :] * stride_bsn
+                    + ((BLOCK_SIZE_K * k) // group_size + offs_g[:, None]) * stride_bsk
+                ).to(tl.float32)
+                b_scale = tl.reshape(
+                    tl.broadcast_to(
+                        b_scale[:, None, :],
+                        [BLOCK_SIZE_K // group_size, group_size, BLOCK_SIZE_N],
+                    ),
+                    [BLOCK_SIZE_K, BLOCK_SIZE_N],
+                )
+        else:
+            b_scale_ptrs = (
+                b_scale_ptr
+                + off_experts * stride_bse
+                + offs_bn[None, :] * stride_bsn
+                + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
+            )
+            b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
+            b_scale = b_scale.to(tl.float32)
 
-        if has_zp and use_int4_w4a16:
+        if has_zp and use_int2_w2a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 4) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0x3
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int4_w4a16:
             offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
             b_zp_ptrs = (
                 b_zp_ptr
@@ -302,7 +371,273 @@ def fused_moe_kernel_gptq_awq(
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak
-        if use_int4_w4a16:
+        if use_int2_w2a16:
+            b_ptrs += (BLOCK_SIZE_K // 16) * stride_bk
+        elif use_int4_w4a16:
+            b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+        else:
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+@triton.jit
+def fused_moe_kernel_gptq_awq(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    b_scale_ptr,
+    b_zp_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N: tl.constexpr,
+    K: tl.constexpr,
+    EM,
+    num_valid_tokens,
+    # The stride variables represent how much to increase the ptr by when
+    # moving by 1 element in a particular dimension. E.g. `stride_am` is
+    # how much to increase `a_ptr` by to get the element one row down
+    # (A has M rows).
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_bse,
+    stride_bsk,
+    stride_bsn,
+    stride_bze,
+    stride_bzk,
+    stride_bzn,
+    group_size: tl.constexpr,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+    has_zp: tl.constexpr,
+    use_int4_w4a16: tl.constexpr,
+    use_int8_w8a16: tl.constexpr,
+    use_int2_w2a16: tl.constexpr,
+    even_Ks: tl.constexpr,
+    filter_expert: tl.constexpr,
+):
+    """
+    Implements the fused computation for a Mixture of Experts (MOE) using
+    token and expert matrices.
+    Key Parameters:
+    - A: The input tensor representing tokens with shape (*, K), where '*' can
+        be any shape representing batches and K is the feature dimension of
+        each token.
+    - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+        the number of experts, K is the input feature dimension, and N is
+        the output feature dimension.
+    - C: The output cache tensor with shape (M, topk, N), where M is the
+        total number of tokens post padding, topk is the number of times
+        each token is repeated, and N is the output feature dimension.
+    - sorted_token_ids: A tensor containing the sorted indices of tokens,
+        repeated topk times and arranged by the expert index they are
+        assigned to.
+    - expert_ids: A tensor containing the indices of the expert for each
+        block. It determines which expert matrix from B should be used for
+        each block in A.
+    This kernel performs the multiplication of a token by its corresponding
+    expert matrix as determined by `expert_ids`. The sorting of
+    `sorted_token_ids` by expert index and padding ensures divisibility by
+    BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
+    multiplication across different blocks processed by the same expert.
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    token_mask = offs_token < num_valid_tokens
+
+    off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    if filter_expert and off_experts == -1:
+        # -----------------------------------------------------------
+        # Write back zeros to the output when the expert is not
+        # in the current expert parallel rank.
+        write_zeros_to_output(
+            c_ptr,
+            stride_cm,
+            stride_cn,
+            pid_n,
+            N,
+            offs_token,
+            token_mask,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            compute_type,
+        )
+        return
+
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (
+        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+    )
+
+    if use_int2_w2a16:
+        # 2-bit: 16 values per int32, so after .T.contiguous().view(uint8)
+        # that is 4 values per byte. Byte index = offs_k // 4, shift =
+        # (offs_k % 4) * 2. Verified against real AutoRound tensors: values
+        # 0..3, mean 1.95 (symmetric zero point 2 = 2^(bits-1)).
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] // 4) * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (offs_k[:, None] % 4) * 2
+    elif use_int4_w4a16:
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] // 2) * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (offs_k[:, None] % 2) * 4
+    elif use_int8_w8a16:
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + offs_k[:, None] * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+
+    if not has_zp and use_int2_w2a16:
+        b_zp_num = 2
+    if not has_zp and use_int4_w4a16:
+        b_zp_num = 8
+    if not has_zp and use_int8_w8a16:
+        b_zp_num = 128
+    elif has_zp and use_int2_w2a16:
+        b_zp_shifter = (offs_bn[None, :] % 4) * 2
+    elif has_zp and use_int4_w4a16:
+        b_zp_shifter = (offs_bn[None, :] % 2) * 4
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the
+        # K dimension.
+
+        if not even_Ks:
+            k_mask = offs_k[:, None] < K - k * BLOCK_SIZE_K
+            k_other = 0.0
+        else:
+            k_mask = None
+            k_other = None
+
+        a = tl.load(
+            a_ptrs,
+            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(b_ptrs)
+        if use_int2_w2a16:
+            b = (b >> b_shifter) & 0x3
+        elif use_int4_w4a16:
+            b = (b >> b_shifter) & 0xF
+
+        b_scale_ptrs = (
+            b_scale_ptr
+            + off_experts * stride_bse
+            + offs_bn[None, :] * stride_bsn
+            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
+        )
+        b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
+        b_scale = b_scale.to(tl.float32)
+
+        if has_zp and use_int2_w2a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 4) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0x3
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int4_w4a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 2) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0xF
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int8_w8a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + offs_bn[None, :] * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = b_zp.to(tl.float32)
+
+        # We accumulate along the K dimension.
+        if has_zp:
+            b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
+        else:
+            b = ((b.to(tl.float32) - b_zp_num) * b_scale).to(compute_type)
+        accumulator = tl.dot(a, b, acc=accumulator)
+
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        if use_int2_w2a16:
+            b_ptrs += (BLOCK_SIZE_K // 4) * stride_bk
+        elif use_int4_w4a16:
             b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
         else:
             b_ptrs += BLOCK_SIZE_K * stride_bk
@@ -789,6 +1124,7 @@ def invoke_fused_moe_kernel(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
@@ -812,7 +1148,13 @@ def invoke_fused_moe_kernel(
         # plain half-width output; every other output flavor is out of scope.
         # In particular the LoRA output paths (fuse_add_to_output / mask_output)
         # address C at full width N and would corrupt the half-width buffer.
-        assert not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+        assert not (
+            use_fp8_w8a8
+            or use_int8_w8a8
+            or use_int8_w8a16
+            or use_int4_w4a16
+            or use_int2_w2a16
+        )
         assert bias is None
         assert not mul_routed_weight
         assert not (fuse_add_to_output or mask_output or fuse_sum_all_reduce)
@@ -870,19 +1212,23 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
-    elif use_int8_w8a16 or use_int4_w4a16:
+    elif use_int8_w8a16 or use_int4_w4a16 or use_int2_w2a16:
         assert B_scale is not None
         assert block_shape is None or block_shape[0] == 0
     else:
         assert A_scale is None
         assert B_scale is None
 
+    # int2 in the N-contiguous int32-word layout ([E, K/16, N]): N is dim 2 and the
+    # K used for the even_Ks check is the activation width, not the packed dim
+    _ncontig = use_int2_w2a16 and B.dtype == torch.int32
+    _n_dim = B.shape[2] if _ncontig else B.shape[1]
     grid = lambda META: (
         triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
+        * triton.cdiv(_n_dim, META["BLOCK_SIZE_N"]),
     )
 
-    K = B.shape[2] - padded_size
+    K = A.shape[1] if _ncontig else (B.shape[2] - padded_size)
     if K % config["BLOCK_SIZE_K"] == 0:
         even_Ks = True
     else:
@@ -911,7 +1257,7 @@ def invoke_fused_moe_kernel(
     # ===== END TO BE REFACTORED ====
 
     if (
-        (use_int8_w8a16 or use_int4_w4a16)
+        (use_int8_w8a16 or use_int4_w4a16 or use_int2_w2a16)
         and block_shape is not None
         and block_shape[1] > 0
     ):
@@ -921,7 +1267,9 @@ def invoke_fused_moe_kernel(
         assert B_scale is not None and B_scale.ndim == 3
         assert B_zp is None or B_zp.ndim == 3
         assert bias is None
-        fused_moe_kernel_gptq_awq[grid](
+        (fused_moe_kernel_gptq_awq_word if _ncontig else fused_moe_kernel_gptq_awq)[
+            grid
+        ](
             A,
             B,
             C,
@@ -931,20 +1279,20 @@ def invoke_fused_moe_kernel(
             sorted_token_ids,
             expert_ids,
             num_tokens_post_padded,
-            B.shape[1],
+            B.shape[2] if _ncontig else B.shape[1],
             A.shape[1],
             sorted_token_ids.shape[0],
             topk_ids.numel(),
             A.stride(0),
             A.stride(1),
             B.stride(0),
-            B.stride(2),
-            B.stride(1),
+            B.stride(1) if _ncontig else B.stride(2),
+            B.stride(2) if _ncontig else B.stride(1),
             C.stride(-2),
             C.stride(-1),
             B_scale.stride(0),
-            B_scale.stride(2),
-            B_scale.stride(1),
+            B_scale.stride(1) if _ncontig else B_scale.stride(2),
+            B_scale.stride(2) if _ncontig else B_scale.stride(1),
             B_zp.stride(0) if B_zp is not None else 0,
             B_zp.stride(2) if B_zp is not None else 0,
             B_zp.stride(1) if B_zp is not None else 0,
@@ -955,6 +1303,7 @@ def invoke_fused_moe_kernel(
             has_zp=B_zp is not None,
             use_int4_w4a16=use_int4_w4a16,
             use_int8_w8a16=use_int8_w8a16,
+            use_int2_w2a16=use_int2_w2a16,
             even_Ks=even_Ks,
             filter_expert=filter_expert,
             **config,

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -23,6 +23,25 @@ from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.model_executor.runner import get_is_capture_mode
 
+
+def _qsa_ensure_rope(rotary_emb, positions):
+    """Grow the cos/sin cache without a device sync on the hot path.
+
+    positions.max().item() synchronizes the device once per QSA layer. The
+    cache only ever needs to reach the server context length, so size it to
+    that once (a Python-side comparison afterwards) and fall back to the
+    synchronizing path only if a position somehow exceeds it.
+    """
+    from sglang.srt.server_args import get_global_server_args
+
+    ctx = int(getattr(get_global_server_args(), "context_length", 0) or 0)
+    if ctx > 0:
+        if int(rotary_emb.cos_sin_cache.shape[0]) <= ctx:
+            rotary_emb._ensure_cos_sin_cache_length(ctx)
+        return
+    rotary_emb._ensure_cos_sin_cache_length(int(positions.max().item()))
+
+
 # Bound the dominant FP32 [query_rows, compressed_keys] prefill workspace.
 # Top-k is row-independent, so large scheduler chunks can be scored in smaller
 # row tiles without changing the selected blocks.
@@ -181,9 +200,7 @@ class QSAIndexer(MultiPlatformOp):
             if not get_is_capture_mode() and hasattr(
                 self.rotary_emb, "_ensure_cos_sin_cache_length"
             ):
-                self.rotary_emb._ensure_cos_sin_cache_length(
-                    int(positions.max().item())
-                )
+                _qsa_ensure_rope(self.rotary_emb, positions)
             key_state_buffer = pool.get_qsa_key_state_buffer(self.layer_id)
             q = qsa_index_q_norm_rope_store(
                 qk,
@@ -415,7 +432,7 @@ class QSAIndexer(MultiPlatformOp):
         if not get_is_capture_mode() and hasattr(
             self.rotary_emb, "_ensure_cos_sin_cache_length"
         ):
-            self.rotary_emb._ensure_cos_sin_cache_length(int(positions.max().item()))
+            _qsa_ensure_rope(self.rotary_emb, positions)
 
         # Let the exact Qwen4-Exp RoPE instance compose regular or three-axis
         # multimodal positions.  Its public cache view repeats cos/sin to the

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1021,8 +1021,26 @@ class GemmaRMSNorm(BaseFusedOp):
     def _weight_loader(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
         assert param.size() == loaded_weight.size()
         param.data.copy_(loaded_weight)
+        # gemma_weight is a non-persistent buffer, so it is NOT moved along
+        # when --cpu-offload-gb places the parameter on the CPU. Without this
+        # check, weight loading fails with
+        #   RuntimeError: Expected all tensors to be on the same device,
+        #   but found at least two devices, cuda:0 and cpu!
+        if self.gemma_weight.device != param.data.device:
+            self.gemma_weight = torch.empty_like(param.data)
         # Keep storage stable for CUDA graphs or fused paths that capture this buffer.
         torch.add(param.data, 1.0, out=self.gemma_weight)
+
+    def _gemma_weight_for(self, ref: torch.Tensor) -> torch.Tensor:
+        """gemma_weight on the device of ``ref``.
+
+        The offloader brings the parameter back to the GPU for the forward
+        pass but not the buffer. Without offload this is a plain comparison
+        with no copy.
+        """
+        if self.gemma_weight.device != ref.device:
+            self.gemma_weight = self.weight.data.to(ref.device) + 1.0
+        return self.gemma_weight
 
     def _forward_impl(
         self,
@@ -1097,7 +1115,7 @@ class GemmaRMSNorm(BaseFusedOp):
             # keep Gemma RMSNorm on native torch math for correctness.
             return self.forward_native(x, residual, post_residual_addition)
         else:
-            w = self.gemma_weight
+            w = self._gemma_weight_for(x)
             # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
             #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
             if not x.is_contiguous():
@@ -1146,7 +1164,7 @@ class GemmaRMSNorm(BaseFusedOp):
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
             if x.shape[-1] > _NPU_GEMMA_RMS_NORM_TRITON_MAX_HIDDEN_SIZE:
-                gamma = self.gemma_weight.to(x.dtype)
+                gamma = self._gemma_weight_for(x).to(x.dtype)
                 norm_out, _, residual = torch_npu.npu_add_rms_norm(
                     residual, x, gamma, self.variance_epsilon
                 )
@@ -1190,7 +1208,7 @@ class GemmaRMSNorm(BaseFusedOp):
             x,
             residual,
             post_residual_addition,
-            self.gemma_weight,
+            self._gemma_weight_for(x),
             use_attn_tp_group=True,
         )
 
@@ -1207,7 +1225,7 @@ class GemmaRMSNorm(BaseFusedOp):
             self,
             x,
             residual,
-            self.gemma_weight,
+            self._gemma_weight_for(x),
             group_size,
             use_attn_tp_group,
             keep_bf16,

--- a/python/sglang/srt/layers/moe/expert_gemv.py
+++ b/python/sglang/srt/layers/moe/expert_gemv.py
@@ -1,0 +1,170 @@
+"""Batch-1 int2 MoE GEMV on the N-contiguous int32-word layout, through a pointer table.
+
+Layout per expert (shared with the tiled prefill kernel's word-load int2 branch):
+    qweight  int32 [K/16, N]    word kw holds values 16kw..16kw+15 at bits 2*(k%16), N contiguous
+    scales   f16|bf16 [K/128, N]  symmetric, zero point 2  ->  w = (q - 2) * s
+
+Lanes run along N, so every warp-load is one contiguous 128-B line of int32 words. That is the
+property measured at 320 GB/s from device memory and 51 GB/s (PCIe line rate) from pinned host
+memory (micro-benchmark on real layer-5 tensors); the byte-row variant of the same idea
+reached only 157 / 14 GB/s and was rejected.
+
+Pointer tables: int64 [E] of per-expert base addresses for qweight and scales, on the device.
+An entry may point into device memory or into pinned host memory; the kernel does not care.
+The kernel indexes with the ORIGINAL expert ids. No gather, no staging, no renumbering.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _moe_gemv_int2_tab(
+    a_ptr,
+    stride_am,  # activations bf16 [M, K]; row r uses a[r // TOP_K]
+    wtab_ptr,
+    stab_ptr,  # int64 [E]: base address of qweight / scales per expert
+    topk_ids_ptr,
+    topk_w_ptr,  # [R] original ids, [R] routed weights (fp32)
+    c_ptr,
+    stride_cm,  # out bf16 [R, N]
+    N,
+    K,
+    stride_ww,
+    stride_sg,  # row strides: qweight words per K/16 row, scales per group row
+    TOP_K: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    SCALE_BF16: tl.constexpr,
+):
+    tl.static_assert(BLOCK_K % GROUP == 0)
+    tl.static_assert(BLOCK_K % 16 == 0)
+    pid_n = tl.program_id(0)
+    r = tl.program_id(1)
+    e = tl.load(topk_ids_ptr + r).to(tl.int64)
+    wbase = tl.load(wtab_ptr + e).to(tl.pointer_type(tl.int32))
+    if SCALE_BF16:
+        sbase = tl.load(stab_ptr + e).to(tl.pointer_type(tl.bfloat16))
+    else:
+        sbase = tl.load(stab_ptr + e).to(tl.pointer_type(tl.float16))
+
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    n_mask = offs_n < N
+    NW: tl.constexpr = BLOCK_K // 16
+    NG: tl.constexpr = BLOCK_K // GROUP
+    offs_w = tl.arange(0, NW)
+    a_base = a_ptr + (r // TOP_K) * stride_am
+
+    acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+    for k0 in range(0, K, BLOCK_K):
+        w = tl.load(
+            wbase + (k0 // 16 + offs_w[:, None]) * stride_ww + offs_n[None, :],
+            mask=n_mask[None, :],
+            other=0,
+        )  # [NW, BN] int32
+        part = tl.zeros([NW, BLOCK_N], dtype=tl.float32)
+        for i in tl.static_range(16):
+            x_i = tl.load(a_base + k0 + offs_w * 16 + i).to(
+                tl.float32
+            )  # [NW], warp-uniform
+            part += ((w >> (2 * i)) & 3).to(tl.float32) * x_i[:, None]
+        xs = tl.sum(
+            tl.load(a_base + k0 + tl.arange(0, BLOCK_K))
+            .to(tl.float32)
+            .reshape([NG, GROUP]),
+            axis=1,
+        )  # [NG] zero-point term
+        part_g = tl.sum(
+            tl.reshape(part, [NG, GROUP // 16, BLOCK_N]), axis=1
+        )  # [NG, BN]
+        s = tl.load(
+            sbase
+            + (k0 // GROUP + tl.arange(0, NG)[:, None]) * stride_sg
+            + offs_n[None, :],
+            mask=n_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.sum((part_g - 2.0 * xs[:, None]) * s, axis=0)
+    if MUL_ROUTED_WEIGHT:
+        acc = acc * tl.load(topk_w_ptr + r)
+    tl.store(c_ptr + r * stride_cm + offs_n, acc.to(tl.bfloat16), mask=n_mask)
+
+
+def moe_gemv_int2_tab(
+    a,
+    wtab,
+    stab,
+    topk_ids,
+    topk_w,
+    N,
+    K,
+    stride_ww,
+    stride_sg,
+    top_k,
+    mul_routed_weight,
+    block_n=64,
+    block_k=128,
+    num_warps=4,
+    scale_bf16=True,
+):
+    """a [M, K] bf16; topk_ids/topk_w flat [R]; returns bf16 [R, N].
+    scale_bf16: True on the server (params_dtype), False for raw checkpoint f16 scales.
+    """
+    assert K % block_k == 0 and block_k % 128 == 0, (K, block_k)  # BK=256 breaks K=640
+    R = topk_ids.numel()
+    c = torch.empty((R, N), dtype=torch.bfloat16, device=a.device)
+    _moe_gemv_int2_tab[(triton.cdiv(N, block_n), R)](
+        a,
+        a.stride(0),
+        wtab,
+        stab,
+        topk_ids,
+        topk_w,
+        c,
+        c.stride(0),
+        N,
+        K,
+        stride_ww,
+        stride_sg,
+        TOP_K=top_k,
+        GROUP=128,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        SCALE_BF16=scale_bf16,
+        num_warps=num_warps,
+    )
+    return c
+
+
+def make_tables(qweight, scales):
+    """qweight int32 [E, K/16, N], scales f16/bf16 [E, K/128, N] (device or pinned host, contiguous)
+    -> int64 [E] address tables on the CUDA device, plus the row strides in elements."""
+    assert qweight.dtype == torch.int32 and scales.dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), (qweight.dtype, scales.dtype)
+    assert qweight.is_contiguous() and scales.is_contiguous()
+    E = qweight.shape[0]
+    wt = (
+        torch.arange(E, dtype=torch.int64) * (qweight.stride(0) * 4)
+        + qweight.data_ptr()
+    )
+    st = torch.arange(E, dtype=torch.int64) * (scales.stride(0) * 2) + scales.data_ptr()
+    return wt.cuda(), st.cuda(), qweight.stride(1), scales.stride(1)
+
+
+def to_word_ncontig(qweight_u8_nk):
+    """Loader layout uint8 [E, N, K/4] (what MoeWNA16 holds today) -> int32 [E, K/16, N].
+
+    Byte kb = k//4 of row n becomes byte (kb % 4) of word kb // 4 at column n, little-endian:
+    value k lands at bits 8*((k//4)%4) + 2*(k%4) = 2*(k%16). Bit-exact re-arrangement.
+    """
+    E, N, KB = qweight_u8_nk.shape
+    t = qweight_u8_nk.transpose(1, 2)  # [E, K/4, N]
+    t = t.reshape(E, KB // 4, 4, N).permute(0, 1, 3, 2)  # [E, K/16, N, 4]
+    # view(int32) folds the trailing 4 bytes into one word: [E, K/16, N, 1] -> drop the 1
+    return t.contiguous().view(torch.int32).view(E, KB // 4, N)

--- a/python/sglang/srt/layers/moe/expert_stream.py
+++ b/python/sglang/srt/layers/moe/expert_stream.py
@@ -1,0 +1,220 @@
+"""MoE-aware weight offloading for expert layers.
+
+Why this exists
+---------------
+SGLang's ``--cpu-offload-gb`` copies a module's entire ``state_dict`` to the
+device on every forward pass. That is correct for a dense model; for an MoE
+with 512 experts and top-10 routing it is roughly 40x more traffic than needed.
+
+Measured on Qwen3.8-Flash-Next, RTX PRO 4000, PCIe Gen5 x16:
+    rxpci 55-61 GB/s sustained, ~26 GB per token, 2.3 tok/s.
+    What is actually needed: 10 x 48 x 1.31 MB = 0.63 GB per token.
+
+How it works
+------------
+Nothing is moved or copied. After loading, both device and host memory are
+full, so any additional allocation would trip the OOM killer. Instead the
+expert tensors are excluded from the bulk transfer in ``offloader.py`` and stay
+where the offloader already placed them (pinned host memory, or the GPU). This
+streamer gathers exactly the selected experts into one shared staging buffer
+per forward pass and renumbers the top-k ids onto it. The Triton kernel is
+unchanged - it still sees one contiguous tensor.
+
+Enabled via ``SGLANG_MOE_EXPERT_STREAM=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.utils import logger
+
+
+@triton.jit
+def _gather_rows_kernel(src_ptr, idx_ptr, out_ptr, row_bytes, BLOCK: tl.constexpr):
+    """Copy selected rows bytewise; the source may live in host memory.
+
+    The point is that expert ids stay on the GPU. The naive route
+    (``uniq.to("cpu")`` followed by one copy per row) forces a device
+    synchronization per layer - with 48 layers per token that is the single
+    largest cost, and the GPU only waits. Pinned host memory is directly
+    addressable from a kernel under unified addressing; SGLang does the same
+    for the PLE table.
+    """
+    row = tl.load(idx_ptr + tl.program_id(0)).to(tl.int64)
+    offs = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < row_bytes
+    vals = tl.load(src_ptr + row * row_bytes + offs, mask=mask, other=0)
+    tl.store(
+        out_ptr + tl.program_id(0).to(tl.int64) * row_bytes + offs, vals, mask=mask
+    )
+
+
+_STAGING: Dict[Tuple, torch.Tensor] = {}
+
+
+@triton.jit
+def _gather_rows_tab_kernel(tab_ptr, idx_ptr, out_ptr, row_bytes, BLOCK: tl.constexpr):
+    """Row gather through an address table: expert id -> int64 row address (GPU or pinned host)."""
+    e = tl.load(idx_ptr + tl.program_id(0)).to(tl.int64)
+    base = tl.load(tab_ptr + e)
+    src = base.to(tl.pointer_type(tl.uint8))
+    offs = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < row_bytes
+    vals = tl.load(src + offs, mask=mask, other=0)
+    tl.store(
+        out_ptr + tl.program_id(0).to(tl.int64) * row_bytes + offs, vals, mask=mask
+    )
+
+
+_TENSOR_NAMES = (
+    "w13_qweight",
+    "w2_qweight",
+    "w13_scales",
+    "w2_scales",
+    "w13_qzeros",
+    "w2_qzeros",
+)
+_LOGGED = False
+# Work without deduplication up to this many ids (avoids the device sync).
+_NO_DEDUP_LIMIT = 64
+_ARANGE_CACHE: Dict[Tuple, torch.Tensor] = {}
+
+
+def _cached_arange(n: int, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    key = (n, str(device), dtype)
+    t = _ARANGE_CACHE.get(key)
+    if t is None:
+        t = torch.arange(n, device=device, dtype=dtype)
+        _ARANGE_CACHE[key] = t
+    return t
+
+
+def enabled() -> bool:
+    return os.environ.get("SGLANG_MOE_EXPERT_STREAM") == "1"
+
+
+def _staging(
+    name: str,
+    k: int,
+    max_k: int,
+    rest: Tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """One buffer per tensor kind, at full size, sliced to the first k rows.
+
+    Important: do NOT allocate one buffer per distinct k. The number of
+    selected experts varies from call to call (10 during decode, up to 512
+    during prefill); a buffer per size fills the VRAM within a few requests.
+    """
+    key = (name, dtype, str(device), tuple(rest))
+    buf = _STAGING.get(key)
+    if buf is None:
+        buf = torch.empty((max_k,) + rest, dtype=dtype, device=device)
+        _STAGING[key] = buf
+        logger.info(
+            "MoE staging buffer %s: %s, %.0f MB",
+            name,
+            tuple(buf.shape),
+            buf.numel() * buf.element_size() / 1e6,
+        )
+    return buf[:k]
+
+
+class ExpertStreamer:
+    """Gathers only the selected experts on each forward pass."""
+
+    def __init__(self, layer: torch.nn.Module):
+        self.layer = layer
+        self.names: List[str] = []
+        self.device = torch.device("cuda")
+        for name in _TENSOR_NAMES:
+            t = getattr(layer, name, None)
+            if t is None:
+                continue
+            t = t.data if isinstance(t, torch.nn.Parameter) else t
+            if t.numel() == 0 or t.shape[0] == 0:
+                continue  # qzeros are empty tensors when sym=True
+            self.names.append(name)
+
+        global _LOGGED
+        if not _LOGGED and self.names:
+            _LOGGED = True
+            t = getattr(layer, self.names[0])
+            t = t.data if isinstance(t, torch.nn.Parameter) else t
+            logger.info(
+                "MoE expert streaming active: %d experts, source on %s, " "tensors %s",
+                t.shape[0],
+                t.device,
+                ",".join(self.names),
+            )
+
+    def gather(
+        self, topk_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        flat = topk_ids.reshape(-1)
+        n = flat.numel()
+        if n <= _NO_DEDUP_LIMIT:
+            # During decode this is 10 ids. torch.unique would have to
+            # synchronize here because its output size is data-dependent, and
+            # that per-layer sync is the most expensive item. Copying a
+            # duplicated expert is cheaper than the sync: the renumbering is
+            # then a plain arange.
+            uniq = flat
+            k = n
+            inverse = _cached_arange(n, flat.device, topk_ids.dtype)
+        else:
+            uniq, inverse = torch.unique(flat, return_inverse=True)
+            k = int(uniq.numel())
+
+        out: Dict[str, torch.Tensor] = {}
+        placed = getattr(self.layer, "_placed", None)
+        for name in self.names:
+            if placed is not None:
+                proto = placed["proto"][name]  # a hot GPU tensor: shape[1:], dtype
+                buf = _staging(
+                    name,
+                    k,
+                    placed["E"],
+                    tuple(proto.shape[1:]),
+                    proto.dtype,
+                    self.device,
+                )
+                row_bytes = proto[0].numel() * proto.element_size()
+                BLOCK = 1024
+                _gather_rows_tab_kernel[(k, triton.cdiv(row_bytes, BLOCK))](
+                    placed["addr"][name],
+                    uniq,
+                    buf.view(torch.uint8),
+                    row_bytes,
+                    BLOCK=BLOCK,
+                )
+                out[name] = buf
+                continue
+            src = getattr(self.layer, name)
+            src = src.data if isinstance(src, torch.nn.Parameter) else src
+            buf = _staging(
+                name, k, src.shape[0], tuple(src.shape[1:]), src.dtype, self.device
+            )
+            if src.is_cuda:
+                torch.index_select(src, 0, uniq, out=buf)
+            else:
+                src_u8 = src.view(torch.uint8)
+                buf_u8 = buf.view(torch.uint8)
+                row_bytes = src_u8.numel() // src_u8.shape[0]
+                BLOCK = 1024
+                _gather_rows_kernel[(k, triton.cdiv(row_bytes, BLOCK))](
+                    src_u8,
+                    uniq,
+                    buf_u8,
+                    row_bytes,
+                    BLOCK=BLOCK,
+                )
+            out[name] = buf
+        return inverse.reshape(topk_ids.shape).to(topk_ids.dtype), out

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -61,6 +61,7 @@ class TritonMoeQuantInfo(MoeQuantInfo):
     use_int8_w8a8: bool = False
     use_int8_w8a16: bool = False
     use_int4_w4a16: bool = False
+    use_int2_w2a16: bool = False
     per_channel_quant: bool = False
     w13_scale: Optional[torch.Tensor] = None
     w2_scale: Optional[torch.Tensor] = None
@@ -148,6 +149,7 @@ class TritonRunnerCore(MoeRunnerCore):
             use_int8_w8a8=quant_info.use_int8_w8a8,
             use_int8_w8a16=quant_info.use_int8_w8a16,
             use_int4_w4a16=quant_info.use_int4_w4a16,
+            use_int2_w2a16=quant_info.use_int2_w2a16,
             per_channel_quant=quant_info.per_channel_quant,
             w1_scale=quant_info.w13_scale,
             w2_scale=quant_info.w2_scale,
@@ -243,6 +245,7 @@ def fused_experts_none_to_triton(
             use_int8_w8a8=quant_info.use_int8_w8a8,
             use_int8_w8a16=quant_info.use_int8_w8a16,
             use_int4_w4a16=quant_info.use_int4_w4a16,
+            use_int2_w2a16=quant_info.use_int2_w2a16,
             per_channel_quant=quant_info.per_channel_quant,
             w1_scale=quant_info.w13_scale,
             w2_scale=quant_info.w2_scale,
@@ -299,6 +302,7 @@ def pre_permute_standard_to_triton(
         use_int8_w8a8=quant_info.use_int8_w8a8,
         use_int8_w8a16=quant_info.use_int8_w8a16,
         use_int4_w4a16=quant_info.use_int4_w4a16,
+        use_int2_w2a16=quant_info.use_int2_w2a16,
         per_channel_quant=quant_info.per_channel_quant,
         block_shape=quant_info.block_shape,
     )

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -117,6 +117,7 @@ def inplace_fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -150,6 +151,7 @@ def inplace_fused_experts(
         use_int8_w8a8,
         use_int8_w8a16,
         use_int4_w4a16,
+        use_int2_w2a16,
         per_channel_quant,
         w1_scale,
         w2_scale,
@@ -186,6 +188,7 @@ def outplace_fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -220,6 +223,7 @@ def outplace_fused_experts(
         use_int8_w8a8,
         use_int8_w8a16,
         use_int4_w4a16,
+        use_int2_w2a16,
         per_channel_quant,
         w1_scale,
         w2_scale,
@@ -252,6 +256,7 @@ def fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -285,6 +290,7 @@ def fused_experts(
             use_int8_w8a8,
             use_int8_w8a16,
             use_int4_w4a16,
+            use_int2_w2a16,
             per_channel_quant,
             w1_scale,
             w2_scale,
@@ -319,6 +325,7 @@ def fused_experts(
             use_int8_w8a8,
             use_int8_w8a16,
             use_int4_w4a16,
+            use_int2_w2a16,
             per_channel_quant,
             w1_scale,
             w2_scale,
@@ -387,6 +394,7 @@ def _prepare_fused_moe_run(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     block_shape: Optional[List[int]],
 ):
@@ -406,12 +414,23 @@ def _prepare_fused_moe_run(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         dtype=hidden_states.dtype,
     )
 
+    # Config lookup keys on (E, N, K/pack). In the N-contiguous int32-word layout
+    # ([E, K/16, N], see moe_wna16.process_weights_after_loading) present the shapes
+    # as (E, N, K/4) so the tuned JSON names stay the same as for the byte layout.
+    _ncontig = use_int2_w2a16 and w1.dtype == torch.int32
+    if _ncontig:
+        _w1s = (w1.shape[0], w1.shape[2], w1.shape[1] * 4)
+        _w2s = (w2.shape[0], w2.shape[2], w2.shape[1] * 4 - padded_size)
+    else:
+        _w1s = w1.shape
+        _w2s = (w2.shape[0], w2.shape[1], w2.shape[2] - padded_size)
     config, (down_config, _) = try_get_optimal_moe_config(
-        w1.shape,
-        (w2.shape[0], w2.shape[1], w2.shape[2] - padded_size),
+        _w1s,
+        _w2s,
         topk_ids.shape[1],
         config_dtype,
         num_tokens,
@@ -475,6 +494,7 @@ def _fused_moe_kernel_sequence(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     w1_scale: Optional[torch.Tensor],
     w2_scale: Optional[torch.Tensor],
@@ -511,7 +531,10 @@ def _fused_moe_kernel_sequence(
     still used for output dtype/shape and the inplace combine.
     """
     num_tokens = hidden_states.shape[0]
-    E, N, _ = w1.shape
+    _ncontig = use_int2_w2a16 and w1.dtype == torch.int32
+    E = w1.shape[0]
+    N = w1.shape[2] if _ncontig else w1.shape[1]
+    _w2_hidden = w2.shape[2] if _ncontig else w2.shape[1]
     topk = topk_ids.shape[1]
     compute_type = tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16
 
@@ -542,7 +565,7 @@ def _fused_moe_kernel_sequence(
     if no_combine:
         assert not inplace
         out_hidden_states = torch.empty(
-            (num_tokens, topk, w2.shape[1]),
+            (num_tokens, topk, _w2_hidden),
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
@@ -564,6 +587,7 @@ def _fused_moe_kernel_sequence(
         and (topk > 2)
         and (not use_int8_w8a16)
         and (not use_int4_w4a16)
+        and (not use_int2_w2a16)
     )
 
     if fuse_swiglu_interleaved:
@@ -578,7 +602,13 @@ def _fused_moe_kernel_sequence(
             and gemm1_limit is None
             and swiglu_limit is None
             and b1 is None
-            and not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+            and not (
+                use_fp8_w8a8
+                or use_int8_w8a8
+                or use_int8_w8a16
+                or use_int4_w4a16
+                or use_int2_w2a16
+            )
             and not apply_router_weight_on_input
             # LoRA injects its gate_up delta into the full-width pre-activation
             # buffer that this path eliminates.
@@ -622,6 +652,7 @@ def _fused_moe_kernel_sequence(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         c_sorted=down_moe_use_tma,
@@ -797,7 +828,7 @@ def _fused_moe_kernel_sequence(
     del intermediate_cache1
 
     intermediate_cache3 = torch.empty(
-        (num_tokens, topk, w2.shape[1]),
+        (num_tokens, topk, _w2_hidden),
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
@@ -840,6 +871,7 @@ def _fused_moe_kernel_sequence(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         a_use_tma=down_moe_use_tma,
@@ -952,6 +984,7 @@ def fused_experts_impl(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -975,7 +1008,14 @@ def fused_experts_impl(
         padded_size = 0
 
     # Check constraints.
-    if use_int4_w4a16:
+    if use_int2_w2a16:
+        # 2-bit: 4 values per byte, hence k/4 columns in the packed tensor; in the
+        # N-contiguous int32-word layout K/16 words sit in dim 1 instead
+        if w1.dtype == torch.int32:
+            assert hidden_states.shape[1] == w1.shape[1] * 16, "Hidden size mismatch"
+        else:
+            assert hidden_states.shape[1] // 4 == w1.shape[2], "Hidden size mismatch"
+    elif use_int4_w4a16:
         assert hidden_states.shape[1] // 2 == w1.shape[2], "Hidden size mismatch"
     else:
         assert (
@@ -1004,6 +1044,7 @@ def fused_experts_impl(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
     )
@@ -1027,6 +1068,7 @@ def fused_experts_impl(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         w1_scale=w1_scale,
         w2_scale=w2_scale,
@@ -1064,6 +1106,7 @@ def fused_moe(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -1146,6 +1189,7 @@ def fused_moe(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         w1_scale=w1_scale,
         w2_scale=w2_scale,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -344,6 +344,7 @@ def get_config_dtype_str(
     dtype: torch.dtype,
     use_int8_w8a16: Optional[bool] = False,
     use_int4_w4a16: Optional[bool] = False,
+    use_int2_w2a16: Optional[bool] = False,
     use_fp8_w8a8: Optional[bool] = False,
     use_int8_w8a8: Optional[bool] = False,
 ):
@@ -351,6 +352,11 @@ def get_config_dtype_str(
         return "fp8_w8a8"
     elif use_int8_w8a8:
         return "int8_w8a8"
+    elif use_int2_w2a16:
+        # Distinct name so a tuned int4 config is never picked up by
+        # accident. No int2 config files exist; the caller then falls back to
+        # defaults, which is the correct behaviour.
+        return "int2_w2a16"
     elif use_int4_w4a16:
         return "int4_w4a16"
     elif use_int8_w8a16:

--- a/python/sglang/srt/layers/quantization/moe_wna16.py
+++ b/python/sglang/srt/layers/quantization/moe_wna16.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import numpy as np
@@ -66,7 +67,7 @@ def get_weight_perm(num_bits: int):
 
 
 class MoeWNA16Config(QuantizationConfig):
-    """Config class for MOE WNA16 (W8A16/W4A16) quantization."""
+    """Config class for MOE WNA16 (W8A16/W4A16/W2A16) quantization."""
 
     def __init__(
         self,
@@ -182,7 +183,12 @@ class MoeWNA16Config(QuantizationConfig):
         # Avoid circular import
         awq_min_capability = AWQConfig.get_min_capability()
 
-        gptq_compatible = quant_method == "gptq" and not desc_act and num_bits in [4, 8]
+        # 2-bit added: the Triton kernel now also unpacks 4 values per byte
+        # (use_int2_w2a16). Needed because a 176B MoE only fits on 24 GB VRAM
+        # + 30 GB RAM at ~2 bpw - 4-bit would be 62 GiB.
+        gptq_compatible = (
+            quant_method == "gptq" and not desc_act and num_bits in [2, 4, 8]
+        )
         awq_compatible = (
             quant_method == "awq"
             and num_bits == 4
@@ -229,7 +235,7 @@ def is_layer_skipped_quant(prefix: str, modules_to_not_convert: List[str]):
 
 
 class MoeWNA16Method(FusedMoEMethodBase):
-    """Linear method for MOE WNA16 (W8A16/W4A16) quantization.
+    """Linear method for MOE WNA16 (W8A16/W4A16/W2A16) quantization.
 
     Args:
         quant_config: The MOE WNA16 (W8A16/W4A16) quantization config.
@@ -366,6 +372,10 @@ class MoeWNA16Method(FusedMoEMethodBase):
         self.moe_runner_config = moe_runner_config
         self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
 
+    def _process_weights_after_loading_disabled(self, layer) -> None:
+        """Set up expert streaming right after this layer finished loading."""
+        self._maybe_expert_streamer(layer)
+
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         weight_bits = self.quant_config.weight_bits
         has_zp = self.quant_config.has_zp
@@ -374,12 +384,276 @@ class MoeWNA16Method(FusedMoEMethodBase):
             w2_weight=layer.w2_qweight,
             use_int4_w4a16=weight_bits == 4,
             use_int8_w8a16=weight_bits == 8,
+            use_int2_w2a16=weight_bits == 2,
             w13_scale=layer.w13_scales,
             w2_scale=layer.w2_scales,
             w13_zp=layer.w13_qzeros if has_zp else None,
             w2_zp=layer.w2_qzeros if has_zp else None,
             block_shape=[0, layer.group_size],
         )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """2-bit: re-lay each expert tensor as N-contiguous int32 words / [E, K/128, N] scales.
+
+        Same bytes, re-arranged once. The tiled kernel's B loads become coalesced 128-B
+        lines and the decode GEMV can read experts in place. Offloaded tensors live in
+        pinned host memory at this point; re-pin after the copy.
+        """
+        if self.quant_config.weight_bits != 2:
+            return
+        if os.environ.get("SGLANG_MOE_NCONTIG", "1") != "1":
+            return
+        from sglang.srt.layers.moe.expert_gemv import to_word_ncontig
+
+        for name in ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales"):
+            p = getattr(layer, name, None)
+            if p is None or p.data.dim() != 3:
+                continue
+            t = p.data
+            was_pinned = (not t.is_cuda) and t.is_pinned()
+            if name.endswith("qweight"):
+                t2 = to_word_ncontig(t)  # [E, K/16, N] int32
+            else:
+                t2 = t.transpose(1, 2).contiguous()  # [E, K/128, N]
+            if was_pinned:
+                t2 = t2.pin_memory()
+            p.data = t2
+            del t
+        layer._b_n_contig = True
+        self._collect_for_placement(layer)
+
+    _PLACE_LAYERS = []  # layers seen so far (loader order)
+    _PLACE_FREQ = None
+
+    def _collect_for_placement(self, layer):
+        path = os.environ.get("SGLANG_MOE_PLACEMENT")
+        if not path:
+            return
+        cls = type(self)
+        if cls._PLACE_FREQ is None:
+            cls._PLACE_FREQ = torch.load(path)["mass"]
+        n_layers = int(cls._PLACE_FREQ.shape[0])
+        lid = int(getattr(layer, "layer_id", -1))
+        if 0 <= lid < n_layers:
+            cls._PLACE_LAYERS.append(layer)
+        if len(cls._PLACE_LAYERS) == n_layers:
+            if os.environ.get("SGLANG_MOE_ELASTIC") == "1":
+                from sglang.srt.layers.moe.expert_elastic import ExpertElastic
+
+                inst = ExpertElastic(
+                    cls._PLACE_FREQ,
+                    int(os.environ.get("SGLANG_MOE_PLACEMENT_S", "184")),
+                )
+                inst.place_all(cls._PLACE_LAYERS)
+                cls._ELASTIC = inst
+            else:
+                self._run_placement()
+            cls._PLACE_LAYERS = []
+
+    def _run_placement(self):
+        """Interleaved, memory-neutral hot/cold split over all layers."""
+        cls = type(self)
+        freq = cls._PLACE_FREQ
+        S_ = int(os.environ.get("SGLANG_MOE_PLACEMENT_S", "184"))
+        names = ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales")
+        layers = cls._PLACE_LAYERS
+        host = [l for l in layers if not l.w13_qweight.data.is_cuda]
+        gpu = [l for l in layers if l.w13_qweight.data.is_cuda]
+        logger.info(
+            "expert placement: %d host layers, %d GPU layers, S=%d",
+            len(host),
+            len(gpu),
+            S_,
+        )
+        pools = {n: [] for n in names}  # free host slots: (tensor, row)
+        extra_keep = []
+
+        def split_ids(l):
+            order = torch.argsort(freq[int(l.layer_id)], descending=True)
+            return order[:S_].sort().values, order[S_:].sort().values
+
+        def place_host(l):
+            hot_ids, cold_ids = split_ids(l)
+            E = int(l.w13_qweight.data.shape[0])
+            addr, proto, keep = {}, {}, []
+            for name in names:
+                p = getattr(l, name, None)
+                if p is None:
+                    continue
+                t = p.data
+                rb = t[0].numel() * t.element_size()
+                tab = torch.empty(E, dtype=torch.int64)
+                if t.is_cuda:  # split layer: this kind is on the GPU
+                    tab, h, kp = place_gpu_kind(t, hot_ids, cold_ids, name, rb, E)
+                    keep += kp
+                else:
+                    h = t.index_select(0, hot_ids).to("cuda").contiguous()
+                    tab[hot_ids] = h.data_ptr() + torch.arange(S_) * rb
+                    tab[cold_ids] = t.data_ptr() + cold_ids * rb
+                    pools[name].extend((t, int(r)) for r in hot_ids.tolist())
+                    keep.append(t)
+                p.data = h
+                addr[name] = tab.cuda()
+                proto[name] = h
+                del t
+            l._placed = {"addr": addr, "proto": proto, "E": E, "S": S_, "keep": keep}
+            l._gemv_tabs = None
+
+        def place_gpu_kind(t, hot_ids, cold_ids, name, rb, E):
+            tab = torch.empty(E, dtype=torch.int64)
+            keep = []
+            need = int(cold_ids.numel())
+            pool = pools[name]
+            if len(pool) < need:
+                extra = torch.empty(
+                    (need - len(pool),) + tuple(t.shape[1:]), dtype=t.dtype
+                ).pin_memory()
+                pool.extend((extra, i) for i in range(need - len(pool)))
+                extra_keep.append(extra)
+                keep.append(extra)
+            slots = [pool.pop() for _ in range(need)]
+            cold_cpu = t.index_select(0, cold_ids.to(t.device)).to("cpu")
+            for i, (dst, r) in enumerate(slots):
+                dst[r].copy_(cold_cpu[i])
+                tab[int(cold_ids[i])] = dst.data_ptr() + r * rb
+                keep.append(dst)
+            del cold_cpu
+            h = t.index_select(0, hot_ids.to(t.device)).contiguous()
+            tab[hot_ids] = h.data_ptr() + torch.arange(S_) * rb
+            return tab, h, keep
+
+        def place_gpu(l):
+            hot_ids, cold_ids = split_ids(l)
+            E = int(l.w13_qweight.data.shape[0])
+            addr, proto, keep = {}, {}, []
+            for name in names:
+                p = getattr(l, name, None)
+                if p is None:
+                    continue
+                t = p.data
+                rb = t[0].numel() * t.element_size()
+                tab, h, kp = place_gpu_kind(t, hot_ids, cold_ids, name, rb, E)
+                keep += kp
+                p.data = h
+                addr[name] = tab.cuda()
+                proto[name] = h
+                del t
+            torch.cuda.empty_cache()
+            l._placed = {"addr": addr, "proto": proto, "E": E, "S": S_, "keep": keep}
+            l._gemv_tabs = None
+
+        # interleave so donated slots exist before they are consumed: ~1.8 host layers per GPU layer
+        hi = gi = 0
+        ratio = max(1.0, (E_cold := (512 - S_)) / max(S_, 1))
+        credit = 0.0
+        while hi < len(host) or gi < len(gpu):
+            if hi < len(host) and (credit < ratio or gi >= len(gpu)):
+                place_host(host[hi])
+                hi += 1
+                credit += 1.0
+            else:
+                place_gpu(gpu[gi])
+                gi += 1
+                credit -= ratio
+        free_left = {n: len(v) for n, v in pools.items()}
+        logger.info(
+            "expert placement done: free host slots left %s, pinned fallbacks %d",
+            free_left,
+            len(extra_keep),
+        )
+        cls._PLACE_EXTRA = extra_keep
+
+    def _gemv_tables(self, layer):
+        tabs = getattr(layer, "_gemv_tabs", None)
+        if tabs is None:
+            from sglang.srt.layers.moe.expert_gemv import make_tables
+
+            placed = getattr(layer, "_placed", None)
+            if placed is None:
+                w13, s13 = layer.w13_qweight.data, layer.w13_scales.data
+                w2, s2 = layer.w2_qweight.data, layer.w2_scales.data
+                tabs = (
+                    make_tables(w13, s13),
+                    make_tables(w2, s2),
+                    w13.shape[2],
+                    w13.shape[1] * 16,
+                    w2.shape[2],
+                    w2.shape[1] * 16,
+                    s13.dtype == torch.bfloat16,
+                )
+            else:
+                a, pr = placed["addr"], placed["proto"]
+                h13, h2 = pr["w13_qweight"], pr["w2_qweight"]
+                tabs = (
+                    (
+                        a["w13_qweight"],
+                        a["w13_scales"],
+                        h13.stride(1),
+                        pr["w13_scales"].stride(1),
+                    ),
+                    (
+                        a["w2_qweight"],
+                        a["w2_scales"],
+                        h2.stride(1),
+                        pr["w2_scales"].stride(1),
+                    ),
+                    h13.shape[2],
+                    h13.shape[1] * 16,
+                    h2.shape[2],
+                    h2.shape[1] * 16,
+                    pr["w13_scales"].dtype == torch.bfloat16,
+                )
+            layer._gemv_tabs = tabs
+        return tabs
+
+    def _apply_gemv(self, layer, dispatch_output):
+        """Batch-1 path: T independent 2-bit GEMVs reading experts in place."""
+        from sglang.srt.layers.moe.expert_gemv import moe_gemv_int2_tab
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+        x = dispatch_output.hidden_states
+        topk = dispatch_output.topk_output
+        ids = topk.topk_ids.reshape(-1)
+        w = topk.topk_weights.reshape(-1).to(torch.float32)
+        M_, top_k = topk.topk_ids.shape
+        (wt13, st13, sw13, ss13), (wt2, st2, sw2, ss2), N13, K13, N2, K2, sbf = (
+            self._gemv_tables(layer)
+        )
+        inter = N13 // 2
+        c13 = moe_gemv_int2_tab(
+            x,
+            wt13,
+            st13,
+            ids,
+            w,
+            N13,
+            K13,
+            sw13,
+            ss13,
+            top_k=top_k,
+            mul_routed_weight=False,
+            scale_bf16=sbf,
+        )
+        h = torch.nn.functional.silu(c13[:, :inter]) * c13[:, inter:]
+        c2 = moe_gemv_int2_tab(
+            h,
+            wt2,
+            st2,
+            ids,
+            w,
+            N2,
+            K2,
+            sw2,
+            ss2,
+            top_k=1,
+            mul_routed_weight=True,
+            scale_bf16=sbf,
+        )
+        out = c2.view(M_, top_k, N2).sum(dim=1)
+        rsf = self.moe_runner_config.routed_scaling_factor
+        if rsf is not None and rsf != 1.0:
+            out = out * rsf
+        return StandardCombineInput(hidden_states=out.to(x.dtype))
 
     def apply(
         self,
@@ -389,9 +663,75 @@ class MoeWNA16Method(FusedMoEMethodBase):
         assert (
             self.moe_runner_config.activation == "silu"
         ), "Only SiLU activation is supported."
+        _el = getattr(type(self), "_ELASTIC", None)
+        if _el is not None:
+            _el.poll(
+                int(dispatch_output.hidden_states.shape[0]),
+                int(getattr(layer, "layer_id", 0)),
+            )
 
-        quant_info = self.get_triton_quant_info(layer)
+        if (
+            getattr(layer, "_b_n_contig", False)
+            and self.quant_config.weight_bits == 2
+            and dispatch_output.hidden_states.shape[0] <= 16
+            and os.environ.get("SGLANG_MOE_GEMV", "1") == "1"
+        ):
+            return self._apply_gemv(layer, dispatch_output)
+
+        streamer = self._maybe_expert_streamer(layer)
+        if streamer is None:
+            quant_info = self.get_triton_quant_info(layer)
+            return self.runner.run(dispatch_output, quant_info)
+
+        # MoE-aware offloading: gather only the selected experts into a
+        # compact buffer and renumber the ids onto it. The Triton kernel
+        # stays unchanged.
+        topk = dispatch_output.topk_output
+        new_ids, tensors = streamer.gather(topk.topk_ids)
+        dispatch_output = dispatch_output._replace(
+            topk_output=topk._replace(topk_ids=new_ids)
+        )
+        weight_bits = self.quant_config.weight_bits
+        has_zp = self.quant_config.has_zp
+        quant_info = TritonMoeQuantInfo(
+            w13_weight=tensors["w13_qweight"],
+            w2_weight=tensors["w2_qweight"],
+            use_int4_w4a16=weight_bits == 4,
+            use_int8_w8a16=weight_bits == 8,
+            use_int2_w2a16=weight_bits == 2,
+            w13_scale=tensors["w13_scales"],
+            w2_scale=tensors["w2_scales"],
+            w13_zp=tensors.get("w13_qzeros") if has_zp else None,
+            w2_zp=tensors.get("w2_qzeros") if has_zp else None,
+            block_shape=[0, layer.group_size],
+        )
         return self.runner.run(dispatch_output, quant_info)
+
+    def _maybe_expert_streamer(self, layer):
+        """Create the streamer once, on demand."""
+        st = getattr(layer, "_expert_streamer", "unset")
+        if st != "unset":
+            return st
+        from sglang.srt.layers.moe.expert_stream import ExpertStreamer, enabled
+
+        if not enabled() or not hasattr(layer, "w13_qweight"):
+            layer._expert_streamer = None
+            return None
+        # All four expert tensors resident on the device: the plain path is
+        # byte-for-byte what the streamer would produce, minus the copy. The
+        # gate is per LAYER, never per tensor - one moe_align result numbers
+        # both GEMMs, so a split layer must keep the streamer.
+        _names = ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales")
+        _ts = [getattr(layer, n).data for n in _names if hasattr(layer, n)]
+        if (
+            _ts
+            and all(t.is_cuda for t in _ts)
+            and getattr(layer, "_placed", None) is None
+        ):
+            layer._expert_streamer = None
+            return None
+        layer._expert_streamer = ExpertStreamer(layer)
+        return layer._expert_streamer
 
     @staticmethod
     def get_weight_loader(layer, weight_loader):
@@ -469,10 +809,19 @@ class MoeWNA16Method(FusedMoEMethodBase):
                 else:
                     loaded_weight = loaded_weight.T
             elif layer.quant_config.linear_quant_method == "gptq":
-                assert layer.quant_config.weight_bits in [4, 8]
+                assert layer.quant_config.weight_bits in [2, 4, 8]
                 if "weight" in weight_name:
+                    # Identical for 2/4/8 bits: viewing the int32 storage as
+                    # uint8 lays the values out along K (16/8/4 per int32), and
+                    # the kernel derives byte and shift from the bit width.
+                    # Verified against real AutoRound 2-bit tensors.
                     loaded_weight = loaded_weight.T.contiguous().view(torch.uint8)
                 elif "zeros" in weight_name:
+                    if layer.quant_config.weight_bits == 2:
+                        raise NotImplementedError(
+                            "asymmetric 2-bit GPTQ (qzeros) is not implemented "
+                            "here; only sym=True is supported"
+                        )
                     # add 1 to gptq qzeros to align with awq
                     loaded_weight = loaded_weight.view(torch.uint8)
                     if layer.quant_config.weight_bits == 4:

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -68,13 +68,29 @@ class RadixLinearAttention(nn.Module):
         self.k_dim = num_k_heads * head_k_dim
         self.v_dim = num_v_heads * head_v_dim
 
-        self.conv_weights = conv_weights
+        self._conv_source = conv_weights
         self.bias = bias
         self.activation = activation
 
         self.A_log = A_log
         self.dt_bias = dt_bias
         self.lower_bound = None
+
+    @property
+    def conv_weights(self):
+        """Convolution weights, derived fresh on every access.
+
+        When an nn.Module (nn.Conv1d) is passed, the 2D view is built from the
+        CURRENT parameter. This is required because --cpu-offload-gb replaces
+        param.data; a view stored once then points at stale memory. Tensors
+        and tuples pass through unchanged so other models (KDA, ShortConv,
+        Lightning) are unaffected.
+        """
+        src = self._conv_source
+        if isinstance(src, nn.Module):
+            w = src.weight
+            return w.view(w.size(0), w.size(2))
+        return src
 
     def forward(
         self,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2473,10 +2473,19 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if k_scale is not None and not (
+                isinstance(k_scale, (int, float)) and k_scale == 1
+            ):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if v_scale is not None and not (
+                isinstance(v_scale, (int, float)) and v_scale == 1
+            ):
                 cache_v.div_(v_scale)
+            if (
+                self.dtype == torch.float8_e4m3fn
+            ):  # fp32/bf16 -> e4m3fn returns NaN beyond +-448
+                cache_k = cache_k.clamp(-448.0, 448.0)
+                cache_v = cache_v.clamp(-448.0, 448.0)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
 
@@ -2846,10 +2855,19 @@ class MHATokenToKVPool(KVCache):
             )
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if k_scale is not None and not (
+                isinstance(k_scale, (int, float)) and k_scale == 1
+            ):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if v_scale is not None and not (
+                isinstance(v_scale, (int, float)) and v_scale == 1
+            ):
                 cache_v.div_(v_scale)
+            if (
+                self.dtype == torch.float8_e4m3fn
+            ):  # fp32/bf16 -> e4m3fn returns NaN beyond +-448
+                cache_k = cache_k.clamp(-448.0, 448.0)
+                cache_v = cache_v.clamp(-448.0, 448.0)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
 

--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -142,6 +142,15 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         # CUDA graphs retain tensor addresses, not Python tensor lifetimes.
         self._capture_inputs[shape_key] = capture_inputs
 
+    @staticmethod
+    def _lpo_fields(output):
+        """(name, tensor) pairs of the tensor-valued fields of a LogitsProcessorOutput."""
+        return [(k, v) for k, v in vars(output).items() if torch.is_tensor(v)]
+
+    @staticmethod
+    def _is_lpo(output) -> bool:
+        return type(output).__name__ == "LogitsProcessorOutput"
+
     def _output_rows(self, output: Any, cap: int) -> int:
         """Leading-dim row count actually produced by the body, clamped to ``cap``.
 
@@ -155,6 +164,9 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return min([cap, *rows])
         if isinstance(output, (list, tuple)) and output:
             return min(self._output_rows(o, cap) for o in output if o is not None)
+        if self._is_lpo(output):
+            rows = [t.shape[0] for _, t in self._lpo_fields(output)]
+            return min([cap, *rows]) if rows else cap
         return cap
 
     def _alloc_full_buffer(self, output: Any, size: int) -> Any:
@@ -174,6 +186,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._alloc_full_buffer(o, size) for o in output)
         if isinstance(output, list):
             return [self._alloc_full_buffer(o, size) for o in output]
+        if self._is_lpo(output):
+            import copy as _copy
+
+            buf = _copy.copy(output)
+            for k, t in self._lpo_fields(output):
+                setattr(buf, k, t.new_empty((size, *t.shape[1:])))
+            return buf
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _slice_output(self, output: Any, num_tokens: int) -> Any:
@@ -187,6 +206,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._slice_output(item, num_tokens) for item in output)
         if isinstance(output, list):
             return [self._slice_output(item, num_tokens) for item in output]
+        if self._is_lpo(output):
+            import copy as _copy
+
+            out = _copy.copy(output)
+            for k, t in self._lpo_fields(output):
+                setattr(out, k, t[:num_tokens])
+            return out
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _copy_output_to_buffer(
@@ -201,6 +227,17 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             )
         if torch.is_tensor(output) and torch.is_tensor(output_buffer):
             output_buffer[:num_tokens].copy_(output[:num_tokens])
+            return
+        if self._is_lpo(output) and self._is_lpo(output_buffer):
+            for k, t in self._lpo_fields(output):
+                b = getattr(output_buffer, k, None)
+                if torch.is_tensor(b):
+                    b[:num_tokens].copy_(t[:num_tokens])
+                else:
+                    setattr(output_buffer, k, t)
+            for k, v in vars(output).items():
+                if not torch.is_tensor(v):
+                    setattr(output_buffer, k, v)
             return
         if isinstance(output, PPProxyTensors) and isinstance(
             output_buffer, PPProxyTensors

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -345,9 +345,13 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         set_weight_attrs(self.A_log, {"weight_loader": sharded_weight_loader(0)})
         set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
 
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        # Pass the module, NOT a view: --cpu-offload-gb replaces param.data
+        # on every on/offload, so a .view() taken at construction time ends up
+        # pointing at old, uninitialized memory. Symptom: conv_weights with
+        # magnitudes around 1e-38, GDN output exactly zero, NaN logits. This
+        # never shows on datacenter GPUs, where nobody needs offload.
+        # RadixLinearAttention now derives the view fresh on each access.
+        conv_weights = self.conv1d
         self.attn = RadixLinearAttention(
             layer_id=layer_id,
             num_q_heads=self.num_k_heads // self.attn_tp_size,

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1,6 +1,8 @@
 """Inference-only Qwen4-Exp (text + VL) on the Qwen3.5 backbone."""
 
+import json
 import math
+import os
 from contextlib import nullcontext
 from typing import Any, Iterable, Optional, Set, Tuple
 
@@ -488,18 +490,25 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
-        self.ngram_embedding = VocabParallelEmbedding(
-            padded_vocab_size,
-            self.head_dim_per_ngram,
-            params_dtype=(
-                torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
-                else torch.bfloat16
-            ),
-            output_dtype=torch.bfloat16,
-            use_attn_tp_group=self.use_attn_tp_ngram,
-        )
+        # In mmap mode, create the table on "meta": it then costs no memory
+        # and is replaced by Qwen4ExpMmapEmbedding immediately afterwards.
+        # Without this, 51.2 GB (fp8) or 97.7 GB (bf16) would be allocated
+        # here before any offload can take effect.
+        _ple_mmap_dir = os.environ.get("SGLANG_QWEN4_PLE_MMAP")
+        _alloc_ctx = torch.device("meta") if _ple_mmap_dir else nullcontext()
+        with _alloc_ctx:
+            self.ngram_embedding = VocabParallelEmbedding(
+                padded_vocab_size,
+                self.head_dim_per_ngram,
+                params_dtype=(
+                    torch.float8_e4m3fn
+                    if (quant_config is not None and quant_config.get_name() == "fp8")
+                    or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                    else torch.bfloat16
+                ),
+                output_dtype=torch.bfloat16,
+                use_attn_tp_group=self.use_attn_tp_ngram,
+            )
         self.ngram_embedding.register_buffer(
             "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
         )
@@ -747,6 +756,163 @@ def _gather_ple_embedding_from_pinned_kernel(
     )
 
 
+class Qwen4ExpMmapEmbedding(nn.Module):
+    """PLE table read from NVMe via mmap, without pinned host memory.
+
+    Why this exists: Qwen4ExpPinnedHostEmbedding places the full table in
+    page-locked host memory. For Qwen3.8-Flash-Next that is 51.2 GB (fp8) or
+    97.7 GB (bf16) - impossible on a 30 GiB machine, and the table has already
+    been allocated once by VocabParallelEmbedding before that.
+
+    This variant allocates nothing. It reads the required rows from a mapped
+    file on each access; the kernel page cache handles reloads from SSD.
+    Measured: 16 rows per token, 2560 bytes - negligible for an NVMe.
+
+    Enabled via SGLANG_QWEN4_PLE_MMAP, pointing at the directory holding
+    ple.f8_e4m3.bin and ple.json. weight_scale lives in ple.json because it no
+    longer survives into the quantized checkpoint.
+    """
+
+    _COPIED = (
+        "quant_config",
+        "enable_tp",
+        "use_attn_tp_group",
+        "tp_size",
+        "num_embeddings",
+        "org_vocab_size",
+        "padding_size",
+        "num_added_embeddings",
+        "use_presharded_weights",
+        "org_vocab_size_padded",
+        "num_embeddings_padded",
+        "shard_indices",
+        "embedding_dim",
+        "num_embeddings_per_partition",
+        "num_org_embeddings_per_partition",
+        "num_added_embeddings_per_partition",
+    )
+
+    _DTYPES = {
+        "F8_E4M3": torch.float8_e4m3fn,
+        "BF16": torch.bfloat16,
+    }
+
+    def __init__(self, embedding: VocabParallelEmbedding, directory: str) -> None:
+        nn.Module.__init__(self)
+        import numpy as np
+
+        for name in self._COPIED:
+            setattr(self, name, getattr(embedding, name))
+        self.quant_method = None
+
+        meta = json.load(open(os.path.join(directory, "ple.json")))
+        path = os.path.join(directory, meta["file"])
+        self._rows = int(meta["rows"])
+        self._dim = int(meta["dim"])
+        self._dtype = self._DTYPES[meta["dtype"]]
+        itemsize = torch.empty(0, dtype=self._dtype).element_size()
+        expected = self._rows * self._dim * itemsize
+        actual = os.path.getsize(path)
+        if actual != expected:
+            raise ValueError(
+                f"{path}: {actual} bytes, expected {expected} "
+                f"({self._rows} x {self._dim} x {itemsize})"
+            )
+        if self._dim != self.embedding_dim:
+            raise ValueError(
+                f"ple.json dim={self._dim} does not match embedding_dim="
+                f"{self.embedding_dim}"
+            )
+        # uint8 view: numpy has no fp8; torch reinterprets it later.
+        self._mm = np.memmap(
+            path, dtype=np.uint8, mode="r", shape=(self._rows, self._dim * itemsize)
+        )
+        try:  # rows are 160 B at random offsets: no read-around
+            import mmap as _mmap
+
+            self._mm._mmap.madvise(_mmap.MADV_RANDOM)
+        except Exception as _ex:  # pragma: no cover
+            logger.warning("Qwen4 PLE: madvise(MADV_RANDOM) failed: %s", _ex)
+        self._itemsize = itemsize
+        # Parallel pread path for decode: one 160-byte read per row, GIL released.
+        self._fd = os.open(path, os.O_RDONLY)
+        try:
+            os.posix_fadvise(self._fd, 0, 0, os.POSIX_FADV_RANDOM)
+        except Exception as _ex:  # pragma: no cover
+            logger.warning("Qwen4 PLE: posix_fadvise(RANDOM) failed: %s", _ex)
+        from concurrent.futures import ThreadPoolExecutor
+
+        self._pool = ThreadPoolExecutor(max_workers=16)
+        self._row_bytes = self._dim * itemsize
+
+        scale = torch.tensor([float(meta["weight_scale"])], dtype=torch.bfloat16)
+        self.register_buffer("weight_scale", scale, persistent=True)
+        if hasattr(embedding, "weight"):
+            del embedding.weight
+        logger.info(
+            "Qwen4 PLE: mmap from %s (%d rows x %d, %s, %.2f GB) - "
+            "no pinned host memory",
+            path,
+            self._rows,
+            self._dim,
+            meta["dtype"],
+            actual / 1e9,
+        )
+
+    def allocate_output(self, shape, device: torch.device) -> torch.Tensor:
+        with torch.inference_mode(False):
+            return torch.empty(shape, dtype=torch.bfloat16, device=device)
+
+    def gather(
+        self, input_ids: torch.Tensor, out: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        expected_shape = (*input_ids.shape, self.embedding_dim)
+        output = (
+            self.allocate_output(expected_shape, input_ids.device)
+            if out is None
+            else out
+        )
+        flat = input_ids.reshape(-1)
+        if not flat.numel():
+            return output
+        start = self.shard_indices.org_vocab_start_index
+        end = self.shard_indices.org_vocab_end_index
+        ids = flat.to("cpu", torch.int64)
+        inside = (ids >= start) & (ids < end)
+        local = torch.where(inside, ids - start, torch.zeros_like(ids))
+        if local.numel() <= 64:
+            rb = self._row_bytes
+
+            def _rd(r):
+                return os.pread(self._fd, rb, int(r) * rb)
+
+            buf = b"".join(self._pool.map(_rd, local.tolist()))
+            rows = torch.frombuffer(bytearray(buf), dtype=torch.uint8).view(-1, rb)
+        else:
+            rows = torch.from_numpy(self._mm[local.numpy()])  # uint8, (N, dim*b)
+            if local.numel() >= 512:
+                try:
+                    os.posix_fadvise(self._fd, 0, 0, os.POSIX_FADV_DONTNEED)
+                except Exception:  # pragma: no cover
+                    pass
+        vals = rows.view(self._dtype).to(torch.bfloat16)  # (N, dim)
+        vals = torch.where(
+            inside.unsqueeze(1), vals, torch.zeros((), dtype=torch.bfloat16)
+        )
+        output.copy_(vals.reshape(expected_shape).to(output.device, non_blocking=True))
+        return output
+
+    def reduce(self, output: torch.Tensor) -> torch.Tensor:
+        if self.tp_size > 1 and not get_attn_tp_context().input_scattered:
+            if self.use_attn_tp_group:
+                return attn_tp_all_reduce(output)
+            return tensor_model_parallel_all_reduce(output)
+        return output
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.reduce(self.gather(input_ids))
+
+
 class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
     """PLE table read directly from pinned host memory.
 
@@ -891,7 +1057,12 @@ class Qwen4ExpPLELayer(nn.Module):
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
         )
-        if config.ple_offload_embedding:
+        _ple_mmap_dir = os.environ.get("SGLANG_QWEN4_PLE_MMAP")
+        if _ple_mmap_dir:
+            self.ple_embedding.ngram_embedding = Qwen4ExpMmapEmbedding(
+                self.ple_embedding.ngram_embedding, _ple_mmap_dir
+            )
+        elif config.ple_offload_embedding:
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(
                 self.ple_embedding.ngram_embedding
             )
@@ -1576,6 +1747,13 @@ class Qwen4ExpAttentionDecoderLayer(
 ALL_DECODER_LAYER_TYPES = {
     "attention": Qwen4ExpAttentionDecoderLayer,
     "full_attention": Qwen4ExpAttentionDecoderLayer,
+    # transformers renames "full_attention" to "qwen_sparse_attention" on
+    # load, because those layers actually use an indexer
+    # (configuration_qwen4_exp.py). Every checkpoint saved through
+    # transformers - after quantization, for instance - therefore carries this
+    # name. Without the entry, loading fails with
+    # KeyError: 'qwen_sparse_attention'.
+    "qwen_sparse_attention": Qwen4ExpAttentionDecoderLayer,
     "linear_attention": Qwen4ExpLinearDecoderLayer,
 }
 
@@ -1724,6 +1902,17 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         prefix: str = "",
         language_model_cls=Qwen4ExpVLModel,
     ) -> None:
+        # Without this line AutoRoundConfig.packed_modules_mapping stays
+        # empty and get_layer_config() cannot map fused names back to their
+        # parts. Concretely: in_proj_ba = in_proj_b (48) + in_proj_a (48).
+        # Both are bf16 in the checkpoint, but the fused name only matches the
+        # general regex and lands at 8 bits ->
+        #   gptq_marlin_repack.cuh: size_n = 96 is not divisible by tile_n_size = 64
+        # deepseek_v2.py does the same (there for Quark).
+        if quant_config is not None and hasattr(
+            quant_config, "update_packed_modules_mapping"
+        ):
+            quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
         super().__init__(config, quant_config, prefix, language_model_cls)
         rope_config = getattr(self.config, "rope_parameters", None) or getattr(
             self.config, "rope_scaling", {}
@@ -2130,3 +2319,14 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
 
 EntryClass = [Qwen4ExpForConditionalGeneration]
+
+
+# --- Breakable CUDA Graph: the mmap PLE lookup is the one eager break on the decode path.
+try:
+    from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+        eager_on_graph as _eog,
+    )
+
+    Qwen4ExpMmapEmbedding.forward = _eog(True)(Qwen4ExpMmapEmbedding.forward)
+except Exception as _e:  # pragma: no cover
+    logger.warning("BCG wrap of Qwen4ExpMmapEmbedding.forward failed: %s", _e)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7665,7 +7665,15 @@ class ServerArgs:
         except Exception:
             return False
 
-    LANGUAGE_MODEL_ONLY_ARCHITECTURES = ("MuseGlimmerForConditionalGeneration",)
+    LANGUAGE_MODEL_ONLY_ARCHITECTURES = (
+        "MuseGlimmerForConditionalGeneration",
+        # Qwen4ExpForConditionalGeneration inherits from
+        # Qwen3VLForConditionalGeneration, where language_model_only is already
+        # implemented (qwen3_vl.py:1243/1309/1441). Only the entry here was
+        # missing. For text-only use this saves the vision tower (0.84 GiB of
+        # weights) plus the multimodal reservation inside the KV budget.
+        "Qwen4ExpForConditionalGeneration",
+    )
 
     def _handle_language_model_only(self):
         if not self.language_model_only:

--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -111,11 +111,34 @@ class OffloaderV1(BaseOffloader):
         # offload parameters to CPU
         # use pin_memory if possible, which helps cudagraph capture speed
         offloaded_parameters = False
-        for p in module.parameters():
+        # With MoE expert streaming, offload expert weights only. Everything
+        # else (attention, GDN, norms, hyper-connections) is needed on EVERY
+        # token and belongs on the GPU; experts are needed 10 out of 512 per
+        # token and are fetched selectively. Without this selection the
+        # offloader moves whole layers and keeps transferring their
+        # non-expert part - measured at 4.8 GB per token, which eats the
+        # speedup again.
+        if os.environ.get("SGLANG_MOE_EXPERT_STREAM") == "1":
+            _params = [
+                q for n, q in module.named_parameters() if _is_streamed_expert_param(n)
+            ]
+        else:
+            _params = list(module.parameters())
+        _n_offloaded = 0
+        _n_streamed = 0
+        for p in _params:
             if self._cpu_offload_bytes >= self._cpu_offload_max_bytes:
                 # we use per-parameter offloading
                 # one module might have some parameters offloaded and some not
                 break
+            _n_offloaded += 1
+            _n_streamed += int(
+                any(
+                    p is q
+                    for n, q in module.named_parameters()
+                    if _is_streamed_expert_param(n)
+                )
+            )
 
             # `torch.empty_like` does not support `pin_memory` argument
             cpu_data = torch.empty_strided(
@@ -131,6 +154,12 @@ class OffloaderV1(BaseOffloader):
             self._cpu_offload_bytes += p.data.numel() * p.data.element_size()
             offloaded_parameters = True
 
+        # When every offloaded parameter is a streamed expert param, the hook
+        # below would build device_state from a state_dict() that EXCLUDES all
+        # of them and reparametrize the module with tensors that are already
+        # on the device. That is pure overhead on every forward - skip it.
+        if offloaded_parameters and _n_offloaded == _n_streamed and _n_streamed > 0:
+            offloaded_parameters = False
         if offloaded_parameters:
             original_forward = module.forward
 
@@ -141,14 +170,47 @@ class OffloaderV1(BaseOffloader):
                     # if the parameter is already on the device, it will be a no-op
                     k: v.to(device, non_blocking=True)
                     for k, v in module.state_dict().items()
+                    if not _is_streamed_expert_param(k)
                 }
-                output = functional_call(module, device_state, args=args, kwargs=kwargs)
+                # tie_weights=False: the state_dict contains tied tensors
+                # under several names (for Qwen4-Exp e.g. linear_attn.A_log and
+                # linear_attn.attn.A_log). With the default True,
+                # functional_call fails with "got multiple values for keys ...
+                # which are tied".
+                output = functional_call(
+                    module, device_state, args=args, kwargs=kwargs, tie_weights=False
+                )
                 module.forward = forward
                 return output
 
             module.forward = forward
 
         return module
+
+
+_STREAMED_EXPERT_SUFFIXES = (
+    "w13_qweight",
+    "w2_qweight",
+    "w13_scales",
+    "w2_scales",
+    "w13_qzeros",
+    "w2_qzeros",
+)
+
+
+def _is_streamed_expert_param(key: str) -> bool:
+    """Does this state_dict key belong to the streamed MoE experts?
+
+    These tensors must NOT be copied to the GPU wholesale: they are by far the
+    largest item (32 GB), yet only 10 of 512 experts are needed per token. MoE
+    expert streaming fetches them selectively. Without this exclusion ~26 GB
+    move over PCIe per token and the GPU only waits.
+    """
+    if os.environ.get("SGLANG_MOE_EXPERT_STREAM") != "1":
+        return False
+    return ("experts." in key or key.startswith("experts")) and key.rsplit(".", 1)[
+        -1
+    ] in _STREAMED_EXPERT_SUFFIXES
 
 
 class OffloaderV2(BaseOffloader):
@@ -262,8 +324,13 @@ def _hook_module_forward_raw(module, on_forward_end, get_parameter_and_buffer_di
 
     def forward(*args, **kwargs):
         module.forward = original_forward
+        # see comment above: tied tensors under several names
         output = functional_call(
-            module, get_parameter_and_buffer_dicts(), args=args, kwargs=kwargs
+            module,
+            get_parameter_and_buffer_dicts(),
+            args=args,
+            kwargs=kwargs,
+            tie_weights=False,
         )
         on_forward_end()
         module.forward = forward
@@ -376,6 +443,11 @@ class _CpuParamOffloader(_BaseParamOffloader):
     def __init__(self, module, param_name):
         super().__init__(module, param_name)
         _move_param_to_cpu(self._param, pin_memory=True)
+        # Hard reference to the pinned host storage. Without it the tensor
+        # is only reachable through the module attribute, which functional_call
+        # replaces with the GPU copy. MoE expert streaming needs the original
+        # storage to fetch individual experts.
+        self.cpu_data = self._param.data
 
     def create_device_tensor(self):
         return self._param.to("cuda", non_blocking=True)

--- a/test/manual/test_triton_moe_wna16.py
+++ b/test/manual/test_triton_moe_wna16.py
@@ -20,7 +20,7 @@ def quantize_weights(
     zero_points: bool = False,
     ref_zero_points_after_scales: bool = False,
 ):
-    assert quant_type in ["w4a16", "w4a16b8", "w8a16", "w8a16b128"]
+    assert quant_type in ["w2a16", "w2a16b2", "w4a16", "w4a16b8", "w8a16", "w8a16b128"]
     assert not zero_points or group_size is not None, (
         "to have group zero points, group_size must be provided "
         "(-1 group_size is channelwise)"
@@ -45,7 +45,14 @@ def quantize_weights(
     max_val = torch.max(w, 0, keepdim=True).values
     min_val = torch.min(w, 0, keepdim=True).values
 
-    if quant_type == "w4a16":
+    if quant_type == "w2a16":
+        max_q_val = 3
+        min_q_val = 0
+    elif quant_type == "w2a16b2":
+        # symmetric: q + 2 is stored, the kernel subtracts b_zp_num = 2
+        max_q_val = 1
+        min_q_val = -2
+    elif quant_type == "w4a16":
         max_q_val = 15
         min_q_val = 0
     elif quant_type == "w4a16b8":
@@ -87,7 +94,9 @@ def quantize_weights(
     else:
         w_ref = (w_q - (maybe_w_zp if zero_points else 0)).to(orig_type) * w_s
 
-    if quant_type == "w4a16b8":
+    if quant_type == "w2a16b2":
+        w_q += 2
+    elif quant_type == "w4a16b8":
         w_q += 8
     elif quant_type == "w8a16b128":
         w_q += 128
@@ -145,7 +154,7 @@ def torch_moe(a, w1, w2, score, topk):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("group_size", [64, 128])
 @pytest.mark.parametrize("has_zp", [True, False])
-@pytest.mark.parametrize("weight_bits", [8])  # [4, 8])
+@pytest.mark.parametrize("weight_bits", [2, 8])  # [2, 4, 8])
 def test_fused_moe_wn16(
     m: int,
     n: int,
@@ -164,7 +173,10 @@ def test_fused_moe_wn16(
     w2 = torch.randn((e, k, n), device=get_device(), dtype=dtype) / 10
     score = torch.randn((m, e), device=get_device(), dtype=dtype)
 
-    if weight_bits == 4:
+    if weight_bits == 2:
+        pack_factor = 4
+        quant_type = "w2a16" if has_zp else "w2a16b2"
+    elif weight_bits == 4:
         pack_factor = 2
         quant_type = "w4a16" if has_zp else "w4a16b8"
     elif weight_bits == 8:
@@ -218,7 +230,22 @@ def test_fused_moe_wn16(
         scales = scales.T
         if has_zp:
             qzeros = qzeros.T.contiguous().to(torch.uint8)
-        if weight_bits == 4:
+        if weight_bits == 2:
+            # 4 values per byte, ascending along K from the low bits
+            qweight = (
+                qweight[:, 3::4] * 64
+                + qweight[:, 2::4] * 16
+                + qweight[:, 1::4] * 4
+                + qweight[:, ::4]
+            )
+            if has_zp:
+                qzeros = (
+                    qzeros[3::4, :] * 64
+                    + qzeros[2::4, :] * 16
+                    + qzeros[1::4, :] * 4
+                    + qzeros[::4, :]
+                )
+        elif weight_bits == 4:
             qweight = qweight[:, 1::2] * 16 + qweight[:, ::2]
             if has_zp:
                 qzeros = qzeros[1::2, :] * 16 + qzeros[::2, :]
@@ -242,6 +269,7 @@ def test_fused_moe_wn16(
         topk_output,
         use_int4_w4a16=weight_bits == 4,
         use_int8_w8a16=weight_bits == 8,
+        use_int2_w2a16=weight_bits == 2,
         w1_scale=w1_scales,
         w2_scale=w2_scales,
         w1_zp=w1_qzeros if has_zp else None,

--- a/test/registered/unit/layers/quantization/test_moe_wna16_int2.py
+++ b/test/registered/unit/layers/quantization/test_moe_wna16_int2.py
@@ -1,0 +1,380 @@
+"""Unit tests for the 2-bit (int2) ``moe_wna16`` path on synthetic data: no
+checkpoint, no server (small GPU tests).
+
+  1. the exact 2-bit unpack expressions of ``fused_moe_kernel_gptq_awq`` (byte
+     index ``offs_k // 4``, shift ``(offs_k % 4) * 2``, mask ``0x3``, zero point
+     2) dequantize a synthetic 2-bit matrix bit-identically to a torch
+     reference, including the real expert dims 2560 x 640 g128;
+  2. ``to_word_ncontig`` re-arranges the loader's ``[E, N, K/4]`` uint8 layout
+     into ``[E, K/16, N]`` int32 words with value k at bits ``2*(k % 16)`` of
+     word ``k // 16`` (bit-exact, and invertible); CPU only;
+  3. ``fused_moe(use_int2_w2a16=True)`` on the byte layout, symmetric (zero
+     point 2) and with per-group ``qzeros``, against a torch MoE reference on
+     the dequantized weights;
+  4. the same weights in the N-contiguous word layout (int32 ``[E, K/16, N]``,
+     scales ``[E, K/g, N]``) through ``fused_moe`` agree with the byte layout;
+  5. ``moe_gemv_int2_tab`` (batch-1 GEMV through int64 address tables) against
+     an fp32 reference: one shared activation with TOP_K > 1 (the w13 form) and
+     per-row activations with TOP_K = 1 and routed weights (the w2 form), fp16
+     and bf16 scales, N not a multiple of the block; ``make_tables`` addresses.
+
+Tests that need real expert tensors (pinned-host tables, bandwidth) are not
+ported here.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.expert_gemv import (
+    make_tables,
+    moe_gemv_int2_tab,
+    to_word_ncontig,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
+from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+
+# bf16 outputs from fp32 accumulation in a different order: ~4e-3 relative
+TOL = dict(atol=1e-3, rtol=2e-2)
+
+
+# ---------------------------------------------------------------------- synthetic 2-bit data
+def pack_2bit_along_last(q):
+    """int [.., K] with values in 0..3 -> uint8 [.., K // 4]; value k at bits 2 * (k % 4)
+    of byte k // 4 (the moe_wna16 byte layout)."""
+    return (
+        q[..., 0::4] | (q[..., 1::4] << 2) | (q[..., 2::4] << 4) | (q[..., 3::4] << 6)
+    ).to(torch.uint8)
+
+
+def pack_words_along_k(q):
+    """int [.., K] in 0..3 -> int32 [.., K // 16] words; value k at bits 2 * (k % 16)."""
+    w = torch.zeros(*q.shape[:-1], q.shape[-1] // 16, dtype=torch.int32)
+    for j in range(16):
+        w |= (q[..., j::16].to(torch.int32) & 0x3) << (2 * j)
+    return w
+
+
+def make_int2_experts(e, n, k, group, has_zp, dtype, gen):
+    """Synthetic experts in the moe_wna16 loader layout.
+
+    Returns w_ref [e, n, k] (dequantized), qweight uint8 [e, n, k // 4],
+    scales [e, n, k // group], qzeros uint8 [e, n // 4, k // group] or None.
+    """
+    q = torch.randint(0, 4, (e, n, k), generator=gen)
+    scales = (torch.rand(e, n, k // group, generator=gen) * 0.1 + 0.01).to(dtype)
+    if has_zp:
+        zp = torch.randint(0, 4, (e, n, k // group), generator=gen)
+        qzeros = pack_2bit_along_last(zp.transpose(1, 2)).transpose(1, 2).contiguous()
+        zp_full = zp.repeat_interleave(group, dim=2)
+    else:
+        qzeros = None
+        zp_full = torch.full_like(q, 2)
+    w_ref = ((q - zp_full).float() * scales.float().repeat_interleave(group, dim=2)).to(
+        dtype
+    )
+    return w_ref, pack_2bit_along_last(q), scales, qzeros
+
+
+def torch_moe(a, w1, w2, score, topk):
+    b, d = a.shape
+    a = a.view(b, -1, d).repeat(1, topk, 1).reshape(-1, d)
+    out = torch.zeros(b * topk, w2.shape[1], dtype=a.dtype, device=a.device)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_weight = topk_weight.view(-1)
+    topk_ids = topk_ids.view(-1)
+    for i in range(w1.shape[0]):
+        mask = topk_ids == i
+        if mask.sum():
+            h = a[mask] @ w1[i].transpose(0, 1)
+            n = h.shape[1] // 2
+            out[mask] = (F.silu(h[:, :n]) * h[:, n:]) @ w2[i].transpose(0, 1)
+    return (
+        out.view(b, -1, w2.shape[1]) * topk_weight.view(b, -1, 1).to(out.dtype)
+    ).sum(dim=1)
+
+
+def gemv_reference(w32, s, x, group=128):
+    """w32 [T, K/16, N] int32 words, s [T, K/g, N], x [K] or [T, K] -> [T, N] fp32."""
+    t, kw, n = w32.shape
+    k = kw * 16
+    q = torch.empty((t, k, n), dtype=torch.int32)
+    for j in range(16):
+        q[:, j::16, :] = (w32 >> (2 * j)) & 0x3
+    w = (q.float() - 2.0) * s.float().repeat_interleave(group, dim=1)
+    if x.dim() == 1:
+        return torch.einsum("tkn,k->tn", w, x.float())
+    return torch.einsum("tkn,tk->tn", w, x.float())
+
+
+class TestWordLayoutCPU(CustomTestCase):
+    def test_to_word_ncontig_bit_exact_and_invertible(self):
+        gen = torch.Generator().manual_seed(7)
+        for e, n, k in ((3, 64, 256), (2, 640, 2560), (1, 16, 64)):
+            with self.subTest(shape=(e, n, k)):
+                q = torch.randint(0, 4, (e, n, k), generator=gen)
+                byte_layout = pack_2bit_along_last(q)  # [E, N, K/4]
+                self.assertEqual(byte_layout.shape, (e, n, k // 4))
+                word = to_word_ncontig(byte_layout)  # [E, K/16, N]
+                self.assertEqual(word.dtype, torch.int32)
+                self.assertEqual(word.shape, (e, k // 16, n))
+                self.assertTrue(word.is_contiguous())
+                expected = pack_words_along_k(q).transpose(1, 2).contiguous()
+                self.assertTrue(torch.equal(word, expected))
+                # every value lands at bits 2 * (k % 16) of word k // 16, column n
+                for kk in (0, 1, 15, 16, 17, k - 1):
+                    got = (word[:, kk // 16, :] >> (2 * (kk % 16))) & 0x3
+                    self.assertTrue(torch.equal(got, q[:, :, kk].to(torch.int32)))
+                # invertible: the little-endian byte view restores the byte layout
+                back = word.view(torch.uint8).view(e, k // 16, n, 4)
+                back = back.permute(0, 2, 1, 3).reshape(e, n, k // 4)
+                self.assertTrue(torch.equal(back, byte_layout))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton MoE kernels require CUDA")
+class TestInt2Unpack(CustomTestCase):
+    def test_unpack_expressions_bit_exact(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def deq_w2(
+            b_ptr,
+            s_ptr,
+            out_ptr,
+            K,
+            N,
+            group_size,
+            stride_bk,
+            stride_bn,
+            stride_sk,
+            stride_sn,
+            BLOCK_K: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            # the exact expressions of fused_moe_kernel_gptq_awq's int2 branch
+            pid_k = tl.program_id(0)
+            pid_n = tl.program_id(1)
+            offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+            offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            b_ptrs = (
+                b_ptr + (offs_k[:, None] // 4) * stride_bk + offs_n[None, :] * stride_bn
+            )
+            b_shifter = (offs_k[:, None] % 4) * 2
+            m = (offs_k[:, None] < K) & (offs_n[None, :] < N)
+            b = tl.load(b_ptrs, mask=m, other=0)
+            b = (b >> b_shifter) & 0x3
+            s_ptrs = (
+                s_ptr
+                + (offs_k[:, None] // group_size) * stride_sk
+                + offs_n[None, :] * stride_sn
+            )
+            s = tl.load(s_ptrs, mask=m, other=0.0).to(tl.float32)
+            val = (b.to(tl.float32) - 2) * s  # b_zp_num = 2 (symmetric)
+            tl.store(out_ptr + offs_k[:, None] * N + offs_n[None, :], val, mask=m)
+
+        gen = torch.Generator().manual_seed(7)
+        for k, n, gs in ((2560, 640, 128), (640, 2560, 128), (256, 64, 64)):
+            with self.subTest(K=k, N=n, group=gs):
+                vals = torch.randint(0, 4, (k, n), dtype=torch.int32, generator=gen)
+                sc = (torch.rand(k // gs, n, generator=gen) * 0.02 + 0.001).float()
+                ref = (vals.float() - 2) * sc.repeat_interleave(gs, dim=0)
+                # as MoeWNA16 loads it: [N, K/4] uint8, K packed along the last dim
+                std = pack_2bit_along_last(vals.T.contiguous()).cuda()
+                scg = sc.cuda()
+                out = torch.empty((k, n), dtype=torch.float32, device="cuda")
+                bk = bn = 64
+                deq_w2[(triton.cdiv(k, bk), triton.cdiv(n, bn))](
+                    std,
+                    scg,
+                    out,
+                    k,
+                    n,
+                    gs,
+                    std.stride(1),
+                    std.stride(0),
+                    scg.stride(0),
+                    scg.stride(1),
+                    BLOCK_K=bk,
+                    BLOCK_N=bn,
+                )
+                torch.cuda.synchronize()
+                self.assertTrue(torch.equal(out.cpu(), ref))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton MoE kernels require CUDA")
+class TestFusedMoeInt2(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def _case(self, m, n, k, e, topk, group, has_zp, dtype, ncontig):
+        gen = torch.Generator().manual_seed(m * 1000 + n + k + group + int(has_zp))
+        dev = "cuda"
+        a = (torch.randn((m, k), generator=gen) / 10).to(dtype).to(dev)
+        score = torch.randn((m, e), generator=gen).to(dtype).to(dev)
+        w1_ref, w1_q, w1_s, w1_zp = make_int2_experts(
+            e, 2 * n, k, group, has_zp, dtype, gen
+        )
+        w2_ref, w2_q, w2_s, w2_zp = make_int2_experts(
+            e, k, n, group, has_zp, dtype, gen
+        )
+        if ncontig:  # what process_weights_after_loading does for 2-bit experts
+            w1_q, w2_q = to_word_ncontig(w1_q), to_word_ncontig(w2_q)
+            w1_s = w1_s.transpose(1, 2).contiguous()
+            w2_s = w2_s.transpose(1, 2).contiguous()
+        to = lambda t: None if t is None else t.to(dev)
+        # softmax weights without top-k renormalization, as torch_moe applies them
+        topk_output = select_experts(
+            hidden_states=a,
+            router_logits=score,
+            topk_config=TopKConfig(top_k=topk, renormalize=False),
+        )
+        ref = torch_moe(a, w1_ref.to(dev), w2_ref.to(dev), score, topk)
+        out = fused_moe(
+            a.clone(),  # fused_experts writes its output over the input rows
+            to(w1_q),
+            to(w2_q),
+            topk_output,
+            use_int2_w2a16=True,
+            w1_scale=to(w1_s),
+            w2_scale=to(w2_s),
+            w1_zp=to(w1_zp),
+            w2_zp=to(w2_zp),
+            block_shape=[0, group],
+        )
+        return out, ref
+
+    def test_byte_layout_vs_torch_reference(self):
+        for m in (1, 32):
+            for k in (128, 256):
+                for group in (64, 128):
+                    for has_zp in (False, True):
+                        with self.subTest(m=m, k=k, group=group, has_zp=has_zp):
+                            out, ref = self._case(
+                                m, 128, k, 8, 2, group, has_zp, torch.bfloat16, False
+                            )
+                            torch.testing.assert_close(out, ref, **TOL)
+
+    def test_word_layout_matches_byte_layout(self):
+        for m in (1, 32):
+            for k in (128, 256):
+                for group in (64, 128):
+                    with self.subTest(m=m, k=k, group=group):
+                        out_w, ref = self._case(
+                            m, 128, k, 8, 2, group, False, torch.bfloat16, True
+                        )
+                        out_b, _ = self._case(
+                            m, 128, k, 8, 2, group, False, torch.bfloat16, False
+                        )
+                        torch.testing.assert_close(out_w, ref, **TOL)
+                        torch.testing.assert_close(out_w, out_b, **TOL)
+
+    def test_real_expert_dims(self):
+        # e=8 of the model's 512 experts, n=640, k=2560, g128, symmetric, both layouts
+        for ncontig in (False, True):
+            with self.subTest(ncontig=ncontig):
+                out, ref = self._case(
+                    4, 640, 2560, 8, 2, 128, False, torch.bfloat16, ncontig
+                )
+                torch.testing.assert_close(out, ref, **TOL)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton GEMV requires CUDA")
+class TestInt2Gemv(CustomTestCase):
+    def test_gemv_tab_vs_reference(self):
+        gen = torch.Generator().manual_seed(0)
+        e, k13, n13, k2, n2, topk = 8, 256, 200, 128, 256, 3
+        for sdtype in (torch.float16, torch.bfloat16):
+            with self.subTest(scale_dtype=sdtype):
+                q13 = torch.randint(0, 4, (e, k13, n13), generator=gen)
+                q2 = torch.randint(0, 4, (e, k2, n2), generator=gen)
+                w13 = (
+                    pack_words_along_k(q13.transpose(1, 2)).transpose(1, 2).contiguous()
+                )
+                w2 = pack_words_along_k(q2.transpose(1, 2)).transpose(1, 2).contiguous()
+                s13 = (torch.rand(e, k13 // 128, n13, generator=gen) * 0.1 + 0.01).to(
+                    sdtype
+                )
+                s2 = (torch.rand(e, k2 // 128, n2, generator=gen) * 0.1 + 0.01).to(
+                    sdtype
+                )
+                self.assertEqual(w13.shape, (e, k13 // 16, n13))
+                ids = torch.randperm(e, generator=gen)[:topk].to(torch.int32)
+                x13 = torch.randn(k13, generator=gen).to(torch.bfloat16)
+                x2 = torch.randn(topk, k2, generator=gen).to(torch.bfloat16)
+                rw = torch.rand(topk, generator=gen) + 0.5
+                ref13 = gemv_reference(w13[ids.long()], s13[ids.long()], x13)
+                ref2 = gemv_reference(w2[ids.long()], s2[ids.long()], x2) * rw[:, None]
+                w13d, s13d, w2d, s2d = (t.cuda() for t in (w13, s13, w2, s2))
+                wt13, st13, sw13, ss13 = make_tables(w13d, s13d)
+                wt2, st2, sw2, ss2 = make_tables(w2d, s2d)
+                self.assertEqual((sw13, ss13), (w13d.stride(1), s13d.stride(1)))
+                self.assertTrue(wt13.is_cuda and wt13.dtype == torch.int64)
+                self.assertEqual(int(wt13[3]), w13d.data_ptr() + 3 * w13d.stride(0) * 4)
+                self.assertEqual(int(st13[5]), s13d.data_ptr() + 5 * s13d.stride(0) * 2)
+                ids_d, rw_d = ids.cuda(), rw.float().cuda()
+                # w13 form: one shared [1, K] activation, TOP_K = topk maps row r -> a[0]
+                o13 = moe_gemv_int2_tab(
+                    x13[None].cuda(),
+                    wt13,
+                    st13,
+                    ids_d,
+                    rw_d,
+                    n13,
+                    k13,
+                    sw13,
+                    ss13,
+                    top_k=topk,
+                    mul_routed_weight=False,
+                    scale_bf16=sdtype == torch.bfloat16,
+                )
+                # w2 form: per-row activations, TOP_K = 1, routed weights applied
+                o2 = moe_gemv_int2_tab(
+                    x2.cuda(),
+                    wt2,
+                    st2,
+                    ids_d,
+                    rw_d,
+                    n2,
+                    k2,
+                    sw2,
+                    ss2,
+                    top_k=1,
+                    mul_routed_weight=True,
+                    scale_bf16=sdtype == torch.bfloat16,
+                )
+                torch.cuda.synchronize()
+                self.assertEqual(o13.shape, (topk, n13))
+                self.assertEqual(o13.dtype, torch.bfloat16)
+                self.assertEqual(o2.shape, (topk, n2))
+                for got, ref in ((o13.float().cpu(), ref13), (o2.float().cpu(), ref2)):
+                    rel = ((got - ref).norm() / ref.norm()).item()
+                    self.assertLess(rel, 1e-2, rel)  # bf16 output rounding ~4e-3
+
+    def test_gemv_rejects_bad_block(self):
+        with self.assertRaises(AssertionError):
+            moe_gemv_int2_tab(
+                torch.zeros(1, 64, dtype=torch.bfloat16, device="cuda"),
+                None,
+                None,
+                torch.zeros(1, dtype=torch.int32, device="cuda"),
+                None,
+                8,
+                64,
+                8,
+                8,
+                top_k=1,
+                mul_routed_weight=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft: stacked on https://github.com/sgl-project/sglang/pull/37793 (part 1); parts  precede it in the series.

Part 2/5 of the Qwen3.8-Flash-Next 24 GB serving series (RFC issue: https://github.com/sgl-project/sglang/issues/37792). Patch:
`upstream/series-q4head/0002-feat-moe_wna16-2-bit-experts-expert-streaming-N-cont.patch`
in the companion repository (9 files, +1,583 / -33). Nothing in this part is Qwen4-specific.

## Motivation

`moe_wna16` accepts 4 and 8 bits only, so a symmetric 2-bit AutoRound / GPTQ MoE checkpoint
cannot be loaded at all. For Qwen3.8-Flash-Next (512 experts, top-10, `moe_intermediate_size`
640) the 2-bit experts are what makes the model fit next to a 24 GB card: the served checkpoint
is 2.572 bpw (model card, "Quantization"). Two more things are needed once the experts are
offloaded: `--cpu-offload-gb` copies a whole module's `state_dict` to the device on every forward
(measured ~26 GB per token at 2.3 tok/s, while 10 x 48 x 1.31 MB = 0.63 GB of expert rows are
actually needed; `docs/WRITEUP.md` section 5), and the byte-row `[E, N, K/4]` layout reads
128-byte chunks at 640-byte stride, which limits an in-place decode GEMV to 73 GB/s from device
memory and 5 GB/s from pinned host memory (CAMPAIGN 2026-09-02 08:29-08:31).

Sources: dated entries of `docs/CAMPAIGN.md` and `docs/WRITEUP.md` in
https://github.com/HaberstrohSystems/qwen3.8-flash-next-24gb-sglang and the model card
https://huggingface.co/HaberstrohSystems/Qwen3.8-Flash-Next-int2-mixed-AutoRound-24GB-SGLang.
Reference machine: one RTX PRO 4000 Blackwell (24 GB, sm_120) with 32 GB host RAM.

## Modifications

- `kernels/ops/moe/fused_moe_triton_kernels.py`: 2-bit unpack in `fused_moe_kernel_gptq_awq` as
  the generalization of the 4-bit branch (`offs_k // 4`, shift `(offs_k % 4) * 2`, mask `0x3`,
  zero point 2). New `fused_moe_kernel_gptq_awq_word`: the same kernel reading the N-contiguous
  int32-word layout (one coalesced 128-byte line per warp load instead of 32 distinct lines). The
  layout is derived from the tensor dtype (int2 + `int32` = word layout, int2 + `uint8` = byte
  layout), so nothing crosses the custom-op schema. Reviewer's choice: keep the second Triton
  function or fold it into a `constexpr` branch of the existing kernel.
- `moe_runner/triton.py`, `triton_utils/fused_moe.py`, `triton_utils/fused_moe_triton_config.py`:
  `use_int2_w2a16` plumbing, shape handling for the word layout, config dtype name `int2_w2a16`
  so a tuned int4 config is never picked up by accident. No int2 config files ship; the tuned
  configs used below (for `E={10,512}, N=160` on the RTX PRO 4000 Blackwell) live in the
  companion repository under `assets/moe_configs` and are selected through `SGLANG_MOE_CONFIG_DIR`.
- `layers/quantization/moe_wna16.py`: 2-bit loader; asymmetric `qzeros` raise
  `NotImplementedError` by design. `process_weights_after_loading` re-lays every 2-bit expert
  tensor once from `[E, N, K/4]` uint8 to `[E, K/16, N]` int32 and scales to `[E, K/128, N]`
  (same bytes; `SGLANG_MOE_NCONTIG=0` keeps the byte layout); pinned host tensors are re-pinned
  after the copy, which transiently doubles one layer's host footprint. Deferred placement pass
  at the last layer (`SGLANG_MOE_PLACEMENT=<expert_freq.pt>` with `{"mass": [L, E]}`,
  `SGLANG_MOE_PLACEMENT_S`, default 184): the hottest S experts of every layer are resident on
  the GPU, cold rows of GPU layers take the pinned slots that host layers' hot rows vacate,
  memory-neutral on both sides. With `SGLANG_MOE_ELASTIC=1` the pass hands the layers to
  `ExpertElastic` (part 3).
- `layers/moe/expert_gemv.py` (new): batch-1 int2 GEMV (`moe_gemv_int2_tab`, used for M <= 16
  in `apply()`, `SGLANG_MOE_GEMV=0` disables) that reads experts in place through int64 address
  tables; an entry may point into device or pinned host memory, the kernel indexes with the
  original expert ids. `to_word_ncontig`, `make_tables`.
- `layers/moe/expert_stream.py` (new, `SGLANG_MOE_EXPERT_STREAM=1`): gathers exactly the routed
  experts of a forward into one shared, shape-keyed staging buffer and renumbers the top-k ids
  onto it; fully GPU-resident layers skip the gather; `arange`/cast tensors are memoized.
- `test/registered/unit/layers/quantization/test_moe_wna16_int2.py` (new, `register_cuda_ci`,
  `est_time=60`, stage `base-b`, runner `1-gpu-small`; synthetic data, no checkpoint): the exact
  2-bit unpack expressions against a torch reference (bit-exact, including the real expert dims
  2560 x 640 g128); `to_word_ncontig` byte -> word round trip (bit-exact and invertible, CPU);
  `fused_moe(use_int2_w2a16=True)` on the byte layout (symmetric and with per-group `qzeros`)
  and on the word layout against a torch MoE reference on dequantized weights;
  `moe_gemv_int2_tab` through `make_tables` addresses against an fp32 reference (w13 and w2
  forms, fp16 and bf16 scales, N not a multiple of the block; a bad block is rejected).
- `test/manual/test_triton_moe_wna16.py`: `w2a16` / `w2a16b2` cases and the 2-bit packing. This
  stays a manual test: its 8-bit path fails the tolerance check with the unmodified upstream
  kernel on the reference machine (129 of 144 cases in the 8-bit / group-128 subset, identical on
  the unpatched tree), so it is not a usable gate.

## Accuracy Tests

- `test_moe_wna16_int2.py`: 7 tests, 34 subtests, pass (packing order, unpack expressions and
  the word-layout round trip bit-exact; `fused_moe` on both layouts and the GEMV within
  atol 1e-3 / rtol 2e-2 of the dequantized references, measured ~4e-3 relative). Also passes on
  the finished 5-commit branch.
- Original A/B of the same kernel path on real shapes (dequantized bf16 vs packed 2-bit through
  the same MoE machinery): bit-identical on small shapes, 1e-5 relative on large ones including
  e=64, n=640, k=2560, g128 (`docs/WRITEUP.md` section 8).
- Word layout and GEMV: A/B through the patched `invoke_fused_moe_kernel` at 64/64/32,
  16/16/128, 16/32/128 identical (2e-5) (CAMPAIGN 2026-09-02 11:04); per-layer dump A/B with
  identical inputs 5.1e-5 (M=6) / 1.7e-4 (M=1) relative, i.e. bf16 output rounding from a
  different fp32 accumulation order (CAMPAIGN 2026-09-02 11:25). End-to-end oracle on the 10k
  prompt max 0.275 / mean 0.0125, inside the kernel-class band (CAMPAIGN 2026-09-02 11:30).
- Placement is exact by construction (rows move, values do not): oracle max 0.057 / mean 0.0013
  (CAMPAIGN 2026-09-02 12:10). Tuned int2 configs: max 0.086 / mean 0.0018 (2026-09-02 09:13).

Reproduction (needs `ninja` on `PATH` (otherwise `FileNotFoundError: ninja`) and an nvcc that
supports the GPU architecture at `CUDA_HOME` (compute_120a on the reference machine; a system
nvcc 12.0 does not, the virtualenv's 13.3 does)):

```
git clone https://github.com/sgl-project/sglang.git && cd sglang
git fetch origin qwen4-main-squashed && git checkout 78c5024e9d9f589dcb4deb7f4ba4fb23f7e85385
git am /path/to/upstream/series-q4head/0001-*.patch /path/to/upstream/series-q4head/0002-*.patch
pip install -e python
export CUDA_HOME=<toolkit whose nvcc supports the GPU architecture>; export PATH="$CUDA_HOME/bin:$PATH"
python -m pytest -v test/registered/unit/layers/quantization/test_moe_wna16_int2.py
```

## Speed Tests and Profiling

Streaming bench, single request, ~10k context (`tools/bench_speed.py`; card, "Performance"),
measured on `73a255206f` with the flat patch:

- PCIe traffic per decoded token 26 GB -> 0.31 GB with expert-only offload and the streamer
  (`docs/WRITEUP.md` section 5; first working path 2.24 -> 15.5 tok/s, sections 4 and 5).
- Tuned int2 configs: decode 13.4 -> 15.2 tok/s (CAMPAIGN 2026-09-02 09:13).
- N-contiguous GEMV micro-benchmark on real layer-5 tensors: 320 GB/s from device memory,
  51 GB/s (PCIe line rate) from pinned host memory, 2.1 ms/token all-device; the byte-shuffled
  table variant reached 157 / 14 GB/s and was rejected (CAMPAIGN 2026-09-02 08:29-08:31, 09:45).
- N-contiguous layout + GEMV end to end: decode 19.4 -> 21.8 tok/s, prefill 1,443 -> 2,249 tok/s
  (CAMPAIGN 2026-09-02 11:30).
- Routing-mass placement: the top 171 of 512 experts per layer cover 82 % of routing mass on a
  2,496-token, 3-domain probe (CAMPAIGN 2026-09-02 09:48-09:53); decode 40.0 -> 48.4 tok/s,
  prefill 2,249 -> 2,334 tok/s (CAMPAIGN 2026-09-02 12:10).

Not re-measured on `78c5024e9d` (see the RFC, open question 3). The placement profile
(`assets/expert_freq.pt`, built by `tools/expert_freq.py` from a routing dump) and the tuned
configs are per model and per GPU.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black 26.1.0, isort 7.0.0, ruff 0.15.1 `F401,F821,UP037`, codespell and `py_compile` clean on the commit.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test/registered/unit/layers/quantization/test_moe_wna16_int2.py`, 7 tests / 34 subtests, `register_cuda_ci`.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Missing: the layout-by-dtype convention on `fused_experts`, the placement-profile format, the environment variables.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Kernel A/Bs, the logprob oracle, GEMV micro-benchmark and the streaming bench above; no standard benchmark score.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (Known deviation: switches are environment variables, not server arguments.)

## Suggested reviewers

- `python/sglang/kernels` (Triton MoE kernels): @BBuf (Kernel).
- `python/sglang/srt/layers/moe`, `layers/quantization/moe_wna16.py`: no Merge Oncall area is
  listed for these paths; CODEOWNERS will be requested automatically. @JustinTong0323 as author
  of #36497.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33750768338](https://github.com/sgl-project/sglang/actions/runs/33750768338)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33750768055](https://github.com/sgl-project/sglang/actions/runs/33750768055)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33750768353](https://github.com/sgl-project/sglang/actions/runs/33750768353)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->