### PR TITLE
feat(qsa): quantized KV pools with dequant-on-gather (fp8/int8/int4)

### DIFF
--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -88,8 +88,9 @@ def write_zeros_to_output(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
+# [ncontig] word-load int2 branch
 @triton.jit
-def fused_moe_kernel_gptq_awq(
+def fused_moe_kernel_gptq_awq_word(
     # Pointers to matrices
     a_ptr,
     b_ptr,
@@ -134,6 +135,7 @@ def fused_moe_kernel_gptq_awq(
     has_zp: tl.constexpr,
     use_int4_w4a16: tl.constexpr,
     use_int8_w8a16: tl.constexpr,
+    use_int2_w2a16: tl.constexpr,
     even_Ks: tl.constexpr,
     filter_expert: tl.constexpr,
 ):
@@ -213,7 +215,22 @@ def fused_moe_kernel_gptq_awq(
         offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
     )
 
-    if use_int4_w4a16:
+    if use_int2_w2a16:
+        # STAGE-1.5: b_ptr is the int32 view of the uint8 tensor ([E, N, K//16] words,
+        # strides in words). One word = 16 consecutive K values, value k at bits 2*(k%16).
+        tl.static_assert(even_Ks, "int2 word path needs K % BLOCK_SIZE_K == 0")
+        tl.static_assert(
+            BLOCK_SIZE_K % 16 == 0, "BLOCK_SIZE_K must be a multiple of 16"
+        )
+        offs_kw = tl.arange(0, BLOCK_SIZE_K // 16)
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + offs_kw[:, None] * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (tl.arange(0, 16) * 2)[None, :, None]
+    elif use_int4_w4a16:
         b_ptrs = (
             b_ptr
             + off_experts * stride_be
@@ -229,10 +246,14 @@ def fused_moe_kernel_gptq_awq(
             + offs_bn[None, :] * stride_bn
         )
 
+    if not has_zp and use_int2_w2a16:
+        b_zp_num = 2
     if not has_zp and use_int4_w4a16:
         b_zp_num = 8
     if not has_zp and use_int8_w8a16:
         b_zp_num = 128
+    elif has_zp and use_int2_w2a16:
+        b_zp_shifter = (offs_bn[None, :] % 4) * 2
     elif has_zp and use_int4_w4a16:
         b_zp_shifter = (offs_bn[None, :] % 2) * 4
 
@@ -259,19 +280,67 @@ def fused_moe_kernel_gptq_awq(
             other=0.0,
         )
         b = tl.load(b_ptrs)
-        if use_int4_w4a16:
+        if use_int2_w2a16:
+            # [BK//16, BN] int32 -> [BK//16, 16, BN] -> [BK, BN]; row index 16*word + i == k
+            b = (b[:, None, :] >> b_shifter) & 0x3
+            b = tl.reshape(b, [BLOCK_SIZE_K, BLOCK_SIZE_N])
+        elif use_int4_w4a16:
             b = (b >> b_shifter) & 0xF
 
-        b_scale_ptrs = (
-            b_scale_ptr
-            + off_experts * stride_bse
-            + offs_bn[None, :] * stride_bsn
-            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
-        )
-        b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
-        b_scale = b_scale.to(tl.float32)
+        if use_int2_w2a16:
+            if BLOCK_SIZE_K <= group_size:
+                tl.static_assert(
+                    group_size % BLOCK_SIZE_K == 0,
+                    "group_size must be a multiple of BLOCK_SIZE_K",
+                )
+                # one scale per column for the whole K tile
+                b_scale = tl.load(
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn * stride_bsn
+                    + ((BLOCK_SIZE_K * k) // group_size) * stride_bsk
+                ).to(tl.float32)[None, :]
+            else:
+                tl.static_assert(
+                    BLOCK_SIZE_K % group_size == 0,
+                    "BLOCK_SIZE_K must be a multiple of group_size",
+                )
+                offs_g = tl.arange(0, BLOCK_SIZE_K // group_size)
+                b_scale = tl.load(
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn[None, :] * stride_bsn
+                    + ((BLOCK_SIZE_K * k) // group_size + offs_g[:, None]) * stride_bsk
+                ).to(tl.float32)
+                b_scale = tl.reshape(
+                    tl.broadcast_to(
+                        b_scale[:, None, :],
+                        [BLOCK_SIZE_K // group_size, group_size, BLOCK_SIZE_N],
+                    ),
+                    [BLOCK_SIZE_K, BLOCK_SIZE_N],
+                )
+        else:
+            b_scale_ptrs = (
+                b_scale_ptr
+                + off_experts * stride_bse
+                + offs_bn[None, :] * stride_bsn
+                + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
+            )
+            b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
+            b_scale = b_scale.to(tl.float32)
 
-        if has_zp and use_int4_w4a16:
+        if has_zp and use_int2_w2a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 4) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0x3
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int4_w4a16:
             offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
             b_zp_ptrs = (
                 b_zp_ptr
@@ -302,7 +371,273 @@ def fused_moe_kernel_gptq_awq(
 
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak
-        if use_int4_w4a16:
+        if use_int2_w2a16:
+            b_ptrs += (BLOCK_SIZE_K // 16) * stride_bk
+        elif use_int4_w4a16:
+            b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+        else:
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+@triton.jit
+def fused_moe_kernel_gptq_awq(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    b_scale_ptr,
+    b_zp_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N: tl.constexpr,
+    K: tl.constexpr,
+    EM,
+    num_valid_tokens,
+    # The stride variables represent how much to increase the ptr by when
+    # moving by 1 element in a particular dimension. E.g. `stride_am` is
+    # how much to increase `a_ptr` by to get the element one row down
+    # (A has M rows).
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_bse,
+    stride_bsk,
+    stride_bsn,
+    stride_bze,
+    stride_bzk,
+    stride_bzn,
+    group_size: tl.constexpr,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+    has_zp: tl.constexpr,
+    use_int4_w4a16: tl.constexpr,
+    use_int8_w8a16: tl.constexpr,
+    use_int2_w2a16: tl.constexpr,
+    even_Ks: tl.constexpr,
+    filter_expert: tl.constexpr,
+):
+    """
+    Implements the fused computation for a Mixture of Experts (MOE) using
+    token and expert matrices.
+    Key Parameters:
+    - A: The input tensor representing tokens with shape (*, K), where '*' can
+        be any shape representing batches and K is the feature dimension of
+        each token.
+    - B: The stacked MOE weight tensor with shape (E, N, K), where E is
+        the number of experts, K is the input feature dimension, and N is
+        the output feature dimension.
+    - C: The output cache tensor with shape (M, topk, N), where M is the
+        total number of tokens post padding, topk is the number of times
+        each token is repeated, and N is the output feature dimension.
+    - sorted_token_ids: A tensor containing the sorted indices of tokens,
+        repeated topk times and arranged by the expert index they are
+        assigned to.
+    - expert_ids: A tensor containing the indices of the expert for each
+        block. It determines which expert matrix from B should be used for
+        each block in A.
+    This kernel performs the multiplication of a token by its corresponding
+    expert matrix as determined by `expert_ids`. The sorting of
+    `sorted_token_ids` by expert index and padding ensures divisibility by
+    BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
+    multiplication across different blocks processed by the same expert.
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    token_mask = offs_token < num_valid_tokens
+
+    off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    if filter_expert and off_experts == -1:
+        # -----------------------------------------------------------
+        # Write back zeros to the output when the expert is not
+        # in the current expert parallel rank.
+        write_zeros_to_output(
+            c_ptr,
+            stride_cm,
+            stride_cn,
+            pid_n,
+            N,
+            offs_token,
+            token_mask,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            compute_type,
+        )
+        return
+
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (
+        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+    )
+
+    if use_int2_w2a16:
+        # 2-bit: 16 values per int32, so after .T.contiguous().view(uint8)
+        # that is 4 values per byte. Byte index = offs_k // 4, shift =
+        # (offs_k % 4) * 2. Verified against real AutoRound tensors: values
+        # 0..3, mean 1.95 (symmetric zero point 2 = 2^(bits-1)).
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] // 4) * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (offs_k[:, None] % 4) * 2
+    elif use_int4_w4a16:
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] // 2) * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+        b_shifter = (offs_k[:, None] % 2) * 4
+    elif use_int8_w8a16:
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + offs_k[:, None] * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
+
+    if not has_zp and use_int2_w2a16:
+        b_zp_num = 2
+    if not has_zp and use_int4_w4a16:
+        b_zp_num = 8
+    if not has_zp and use_int8_w8a16:
+        b_zp_num = 128
+    elif has_zp and use_int2_w2a16:
+        b_zp_shifter = (offs_bn[None, :] % 4) * 2
+    elif has_zp and use_int4_w4a16:
+        b_zp_shifter = (offs_bn[None, :] % 2) * 4
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the
+        # K dimension.
+
+        if not even_Ks:
+            k_mask = offs_k[:, None] < K - k * BLOCK_SIZE_K
+            k_other = 0.0
+        else:
+            k_mask = None
+            k_other = None
+
+        a = tl.load(
+            a_ptrs,
+            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(b_ptrs)
+        if use_int2_w2a16:
+            b = (b >> b_shifter) & 0x3
+        elif use_int4_w4a16:
+            b = (b >> b_shifter) & 0xF
+
+        b_scale_ptrs = (
+            b_scale_ptr
+            + off_experts * stride_bse
+            + offs_bn[None, :] * stride_bsn
+            + ((offs_k[:, None] + BLOCK_SIZE_K * k) // group_size) * stride_bsk
+        )
+        b_scale = tl.load(b_scale_ptrs, mask=k_mask, other=k_other)
+        b_scale = b_scale.to(tl.float32)
+
+        if has_zp and use_int2_w2a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 4) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0x3
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int4_w4a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + (offs_bn[None, :] // 2) * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = (b_zp >> b_zp_shifter) & 0xF
+            b_zp = b_zp.to(tl.float32)
+        elif has_zp and use_int8_w8a16:
+            offs_k_true = (offs_k[:, None] + BLOCK_SIZE_K * k) // group_size
+            b_zp_ptrs = (
+                b_zp_ptr
+                + off_experts * stride_bze
+                + offs_bn[None, :] * stride_bzn
+                + offs_k_true * stride_bzk
+            )
+            b_zp = tl.load(b_zp_ptrs, mask=k_mask, other=k_other)
+            b_zp = b_zp.to(tl.float32)
+
+        # We accumulate along the K dimension.
+        if has_zp:
+            b = ((b.to(tl.float32) - b_zp) * b_scale).to(compute_type)
+        else:
+            b = ((b.to(tl.float32) - b_zp_num) * b_scale).to(compute_type)
+        accumulator = tl.dot(a, b, acc=accumulator)
+
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        if use_int2_w2a16:
+            b_ptrs += (BLOCK_SIZE_K // 4) * stride_bk
+        elif use_int4_w4a16:
             b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
         else:
             b_ptrs += BLOCK_SIZE_K * stride_bk
@@ -789,6 +1124,7 @@ def invoke_fused_moe_kernel(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
@@ -812,7 +1148,13 @@ def invoke_fused_moe_kernel(
         # plain half-width output; every other output flavor is out of scope.
         # In particular the LoRA output paths (fuse_add_to_output / mask_output)
         # address C at full width N and would corrupt the half-width buffer.
-        assert not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+        assert not (
+            use_fp8_w8a8
+            or use_int8_w8a8
+            or use_int8_w8a16
+            or use_int4_w4a16
+            or use_int2_w2a16
+        )
         assert bias is None
         assert not mul_routed_weight
         assert not (fuse_add_to_output or mask_output or fuse_sum_all_reduce)
@@ -870,19 +1212,23 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
-    elif use_int8_w8a16 or use_int4_w4a16:
+    elif use_int8_w8a16 or use_int4_w4a16 or use_int2_w2a16:
         assert B_scale is not None
         assert block_shape is None or block_shape[0] == 0
     else:
         assert A_scale is None
         assert B_scale is None
 
+    # int2 in the N-contiguous int32-word layout ([E, K/16, N]): N is dim 2 and the
+    # K used for the even_Ks check is the activation width, not the packed dim
+    _ncontig = use_int2_w2a16 and B.dtype == torch.int32
+    _n_dim = B.shape[2] if _ncontig else B.shape[1]
     grid = lambda META: (
         triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
+        * triton.cdiv(_n_dim, META["BLOCK_SIZE_N"]),
     )
 
-    K = B.shape[2] - padded_size
+    K = A.shape[1] if _ncontig else (B.shape[2] - padded_size)
     if K % config["BLOCK_SIZE_K"] == 0:
         even_Ks = True
     else:
@@ -911,7 +1257,7 @@ def invoke_fused_moe_kernel(
     # ===== END TO BE REFACTORED ====
 
     if (
-        (use_int8_w8a16 or use_int4_w4a16)
+        (use_int8_w8a16 or use_int4_w4a16 or use_int2_w2a16)
         and block_shape is not None
         and block_shape[1] > 0
     ):
@@ -921,7 +1267,9 @@ def invoke_fused_moe_kernel(
         assert B_scale is not None and B_scale.ndim == 3
         assert B_zp is None or B_zp.ndim == 3
         assert bias is None
-        fused_moe_kernel_gptq_awq[grid](
+        (fused_moe_kernel_gptq_awq_word if _ncontig else fused_moe_kernel_gptq_awq)[
+            grid
+        ](
             A,
             B,
             C,
@@ -931,20 +1279,20 @@ def invoke_fused_moe_kernel(
             sorted_token_ids,
             expert_ids,
             num_tokens_post_padded,
-            B.shape[1],
+            B.shape[2] if _ncontig else B.shape[1],
             A.shape[1],
             sorted_token_ids.shape[0],
             topk_ids.numel(),
             A.stride(0),
             A.stride(1),
             B.stride(0),
-            B.stride(2),
-            B.stride(1),
+            B.stride(1) if _ncontig else B.stride(2),
+            B.stride(2) if _ncontig else B.stride(1),
             C.stride(-2),
             C.stride(-1),
             B_scale.stride(0),
-            B_scale.stride(2),
-            B_scale.stride(1),
+            B_scale.stride(1) if _ncontig else B_scale.stride(2),
+            B_scale.stride(2) if _ncontig else B_scale.stride(1),
             B_zp.stride(0) if B_zp is not None else 0,
             B_zp.stride(2) if B_zp is not None else 0,
             B_zp.stride(1) if B_zp is not None else 0,
@@ -955,6 +1303,7 @@ def invoke_fused_moe_kernel(
             has_zp=B_zp is not None,
             use_int4_w4a16=use_int4_w4a16,
             use_int8_w8a16=use_int8_w8a16,
+            use_int2_w2a16=use_int2_w2a16,
             even_Ks=even_Ks,
             filter_expert=filter_expert,
             **config,

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -23,6 +23,25 @@ from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.model_executor.runner import get_is_capture_mode
 
+
+def _qsa_ensure_rope(rotary_emb, positions):
+    """Grow the cos/sin cache without a device sync on the hot path.
+
+    positions.max().item() synchronizes the device once per QSA layer. The
+    cache only ever needs to reach the server context length, so size it to
+    that once (a Python-side comparison afterwards) and fall back to the
+    synchronizing path only if a position somehow exceeds it.
+    """
+    from sglang.srt.server_args import get_global_server_args
+
+    ctx = int(getattr(get_global_server_args(), "context_length", 0) or 0)
+    if ctx > 0:
+        if int(rotary_emb.cos_sin_cache.shape[0]) <= ctx:
+            rotary_emb._ensure_cos_sin_cache_length(ctx)
+        return
+    rotary_emb._ensure_cos_sin_cache_length(int(positions.max().item()))
+
+
 # Bound the dominant FP32 [query_rows, compressed_keys] prefill workspace.
 # Top-k is row-independent, so large scheduler chunks can be scored in smaller
 # row tiles without changing the selected blocks.
@@ -181,9 +200,7 @@ class QSAIndexer(MultiPlatformOp):
             if not get_is_capture_mode() and hasattr(
                 self.rotary_emb, "_ensure_cos_sin_cache_length"
             ):
-                self.rotary_emb._ensure_cos_sin_cache_length(
-                    int(positions.max().item())
-                )
+                _qsa_ensure_rope(self.rotary_emb, positions)
             key_state_buffer = pool.get_qsa_key_state_buffer(self.layer_id)
             q = qsa_index_q_norm_rope_store(
                 qk,
@@ -415,7 +432,7 @@ class QSAIndexer(MultiPlatformOp):
         if not get_is_capture_mode() and hasattr(
             self.rotary_emb, "_ensure_cos_sin_cache_length"
         ):
-            self.rotary_emb._ensure_cos_sin_cache_length(int(positions.max().item()))
+            _qsa_ensure_rope(self.rotary_emb, positions)
 
         # Let the exact Qwen4-Exp RoPE instance compose regular or three-axis
         # multimodal positions.  Its public cache view repeats cos/sin to the

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -5,6 +5,11 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
+
+KV_INT8_GROUP = (
+    64  # channels per fp16 scale (group 0 = the 64 rotary dims, 1-3 = pass-through)
+)
 
 _H20_CONFIGS = [
     (32, (32, 8, 2)),
@@ -406,6 +411,1157 @@ def _compact_kv(
     tl.store(out_v + dst, tl.load(v + src, mask=mask, other=0.0), mask=mask)
 
 
+@triton.jit
+def _compact_kv_fp8(
+    k,
+    v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    topk: tl.constexpr,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    idx_stride: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """_compact_kv for an fp8_e4m3 pool viewed as uint8: dequantize into the bf16 scratch."""
+    batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    dims = tl.arange(0, BLOCK_D)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    valid_count = tl.load(cu_k + batch + 1) - pack_start
+    positions = tl.load(indices + batch * idx_stride + cols, mask=cols < topk, other=-1)
+    valid = (cols < valid_count) & (positions >= 0) & (positions < length)
+    slots = tl.load(
+        req_to_token + req * req_stride + tl.where(valid, positions, 0),
+        mask=valid,
+        other=0,
+    )
+    src = slots[:, None] * heads * dim + head * dim + dims[None, :]
+    dst = (pack_start + cols)[:, None] * heads * dim + head * dim + dims[None, :]
+    mask = valid[:, None] & (dims[None, :] < dim)
+    kk = (
+        tl.load(k + src, mask=mask, other=0)
+        .to(tl.float8e4nv, bitcast=True)
+        .to(tl.bfloat16)
+    )
+    vv = (
+        tl.load(v + src, mask=mask, other=0)
+        .to(tl.float8e4nv, bitcast=True)
+        .to(tl.bfloat16)
+    )
+    tl.store(out_k + dst, kk, mask=mask)
+    tl.store(out_v + dst, vv, mask=mask)
+
+
+@triton.jit
+def _quant_store_kv_int8(
+    k,
+    v,
+    loc,
+    k_buf,
+    v_buf,
+    k_scale,
+    v_scale,
+    sm_k_inv,
+    sm_v_inv,
+    sk_n,
+    sk_h,
+    sv_n,
+    sv_h,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+):
+    """Program (token, head): quantize one K row and one V row (per-GROUP absmax/127, fp16 scale)
+    and scatter payload + scales into slot loc[token].  Grid (N, H) is static -> capture-safe.
+    """
+    NG: tl.constexpr = D // GROUP
+    t, h = tl.program_id(0), tl.program_id(1)
+    slot = tl.load(loc + t).to(tl.int64)
+    offs = tl.arange(0, D)
+    goffs = tl.arange(0, NG)
+    row = (slot * H + h) * D
+    srow = (slot * H + h) * NG
+
+    x = tl.load(k + t * sk_n + h * sk_h + offs).to(tl.float32)
+    x = x * tl.load(sm_k_inv + h * D + offs).to(tl.float32)
+    xg = tl.reshape(x, [NG, GROUP])
+    a = tl.max(tl.abs(xg), axis=1)
+    s = tl.minimum(tl.where(a > 0, a / 127.0, 1.0), 65504.0).to(
+        tl.float16
+    )  # fp16 max: no inf/NaN on extreme groups            # the stored scale (fp16) is the one used
+    q = libdevice.rint(xg / s.to(tl.float32)[:, None])
+    q = tl.clamp(q, -127.0, 127.0).to(tl.int8)
+    tl.store(k_buf + row + offs, tl.reshape(q, [D]))
+    tl.store(k_scale + srow + goffs, s)
+
+    x = tl.load(v + t * sv_n + h * sv_h + offs).to(tl.float32)
+    x = x * tl.load(sm_v_inv + h * D + offs).to(tl.float32)
+    xg = tl.reshape(x, [NG, GROUP])
+    a = tl.max(tl.abs(xg), axis=1)
+    s = tl.minimum(tl.where(a > 0, a / 127.0, 1.0), 65504.0).to(
+        tl.float16
+    )  # fp16 max: no inf/NaN on extreme groups
+    q = libdevice.rint(xg / s.to(tl.float32)[:, None])
+    q = tl.clamp(q, -127.0, 127.0).to(tl.int8)
+    tl.store(v_buf + row + offs, tl.reshape(q, [D]))
+    tl.store(v_scale + srow + goffs, s)
+
+
+def quant_store_kv_int8(k, v, loc, k_buf, v_buf, k_scale, v_scale, sm_k_inv, sm_v_inv):
+    """k, v: [N, H, D] (any float dtype, unit last stride); loc: [N] int32/int64 slots;
+    k_buf/v_buf: int8 [rows, H, D]; k_scale/v_scale: fp16 [rows, H, D // GROUP]; sm_*_inv: fp16 [H, D].
+    """
+    N, H, D = k.shape
+    assert v.shape == (N, H, D) and k.stride(2) == 1 and v.stride(2) == 1
+    assert k_buf.dtype == torch.int8 and v_buf.dtype == torch.int8
+    assert k_scale.dtype == torch.float16 and v_scale.dtype == torch.float16
+    assert (
+        k_buf.is_contiguous()
+        and v_buf.is_contiguous()
+        and k_scale.is_contiguous()
+        and v_scale.is_contiguous()
+    )
+    assert k_buf.shape[1:] == (H, D) and k_scale.shape[1:] == (H, D // KV_INT8_GROUP)
+    assert sm_k_inv.shape == (H, D) and sm_v_inv.shape == (H, D)
+    assert loc.numel() == N
+    if N == 0:
+        return
+    _quant_store_kv_int8[(N, H)](
+        k,
+        v,
+        loc,
+        k_buf,
+        v_buf,
+        k_scale,
+        v_scale,
+        sm_k_inv,
+        sm_v_inv,
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        H=H,
+        D=D,
+        GROUP=KV_INT8_GROUP,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _compact_kv_int8(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    topk: tl.constexpr,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    idx_stride: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """_compact_kv for an int8 pool: gather + dequantize (q * s * sm, fp32) into the bf16 scratch.
+    Same store mask as _compact_kv / _compact_kv_fp8: only valid (in-region, 0 <= pos < seq_len)
+    columns are written; invalid columns are neither read nor written (on the trtllm strided tables
+    cu_k spans the whole page-aligned stride, so zero-filling them would write every unused column).
+    """
+    NG: tl.constexpr = dim // GROUP
+    batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    dims = tl.arange(0, BLOCK_D)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    valid_count = tl.load(cu_k + batch + 1) - pack_start
+    positions = tl.load(indices + batch * idx_stride + cols, mask=cols < topk, other=-1)
+    valid = (cols < valid_count) & (positions >= 0) & (positions < length)
+    slots = tl.load(
+        req_to_token + req * req_stride + tl.where(valid, positions, 0),
+        mask=valid,
+        other=0,
+    ).to(tl.int64)
+    dmask = dims < dim
+    src = (slots[:, None] * heads + head) * dim + dims[None, :]
+    ssrc = (slots[:, None] * heads + head) * NG + dims[None, :] // GROUP
+    dst = ((pack_start + cols)[:, None] * heads + head) * dim + dims[None, :]
+    mask = valid[:, None] & dmask[None, :]
+    smr_k = tl.load(sm_k + head * dim + dims, mask=dmask, other=0).to(tl.float32)
+    smr_v = tl.load(sm_v + head * dim + dims, mask=dmask, other=0).to(tl.float32)
+    sc = tl.load(k_scale + ssrc, mask=mask, other=0).to(tl.float32)
+    kk = tl.load(k + src, mask=mask, other=0).to(tl.float32) * sc * smr_k[None, :]
+    tl.store(out_k + dst, kk.to(tl.bfloat16), mask=mask)
+    sc = tl.load(v_scale + ssrc, mask=mask, other=0).to(tl.float32)
+    vv = tl.load(v + src, mask=mask, other=0).to(tl.float32) * sc * smr_v[None, :]
+    tl.store(out_v + dst, vv.to(tl.bfloat16), mask=mask)
+
+
+@triton.jit
+def _gather_dequant_rows_int8(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Program (batch, row block, head): rows t < seq_lens[batch] of request req_indices[batch]
+    (slots from req_to_token) -> dequantized bf16 rows cu_k[batch] + t of out_k/out_v.  The row-block
+    count is a grid dimension (runtime max_len), so chunk sizes never recompile the kernel.
+    """
+    NG: tl.constexpr = dim // GROUP
+    batch, block, head = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    t = block * BLOCK_T + tl.arange(0, BLOCK_T)
+    valid = t < length
+    slots = tl.load(req_to_token + req * req_stride + t, mask=valid, other=0).to(
+        tl.int64
+    )
+    dims = tl.arange(0, dim)
+    src = (slots[:, None] * heads + head) * dim + dims[None, :]
+    ssrc = (slots[:, None] * heads + head) * NG + dims[None, :] // GROUP
+    dst = ((pack_start + t)[:, None] * heads + head) * dim + dims[None, :]
+    mask = valid[:, None] & (dims[None, :] < dim)
+    smr_k = tl.load(sm_k + head * dim + dims).to(tl.float32)
+    smr_v = tl.load(sm_v + head * dim + dims).to(tl.float32)
+    sc = tl.load(k_scale + ssrc, mask=mask, other=0).to(tl.float32)
+    kk = tl.load(k + src, mask=mask, other=0).to(tl.float32) * sc * smr_k[None, :]
+    tl.store(out_k + dst, kk.to(tl.bfloat16), mask=mask)
+    sc = tl.load(v_scale + ssrc, mask=mask, other=0).to(tl.float32)
+    vv = tl.load(v + src, mask=mask, other=0).to(tl.float32) * sc * smr_v[None, :]
+    tl.store(out_v + dst, vv.to(tl.bfloat16), mask=mask)
+
+
+def qwen_sparse_prefix_gather_dequant_int8(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    max_len,
+):
+    """Whole-prefix gather-dequant of an int8 pool: rows [0, seq_lens[b]) of every request packed at
+    cu_k[b] into the bf16 out_k/out_v.  Rows at or beyond seq_lens[b] are not written.
+    """
+    _, heads, dim = k.shape
+    assert k.dtype == torch.int8 and v.dtype == torch.int8
+    assert (
+        out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+    ), "int8 KV gather needs a bf16 scratch"
+    assert dim % KV_INT8_GROUP == 0 and dim == triton.next_power_of_2(dim)
+    assert (
+        k_scale.shape[1:] == (heads, dim // KV_INT8_GROUP) and k_scale.is_contiguous()
+    )
+    assert (
+        v_scale.shape[1:] == (heads, dim // KV_INT8_GROUP) and v_scale.is_contiguous()
+    )
+    assert sm_k.shape == (heads, dim) and sm_v.shape == (heads, dim)
+    assert out_k.is_contiguous() and out_v.is_contiguous()
+    block_t = 16
+    if batch == 0 or max_len == 0:
+        return
+    _gather_dequant_rows_int8[(batch, triton.cdiv(int(max_len), block_t), heads)](
+        k,
+        v,
+        k_scale,
+        v_scale,
+        sm_k,
+        sm_v,
+        req_to_token,
+        req_indices,
+        seq_lens,
+        cu_k,
+        out_k,
+        out_v,
+        heads,
+        dim,
+        req_to_token.stride(0),
+        GROUP=KV_INT8_GROUP,
+        BLOCK_T=block_t,
+        num_warps=8,
+    )
+
+
+KV_INT4_GROUP = (
+    32  # channels per fp16 scale for the int4 pool (groups 0-1 = the 64 rotary dims)
+)
+
+
+@triton.jit
+def _quant_store_kv_int4(
+    k,
+    v,
+    loc,
+    k_buf,
+    v_buf,
+    k_scale,
+    v_scale,
+    sm_k_inv,
+    sm_v_inv,
+    sk_n,
+    sk_h,
+    sv_n,
+    sv_h,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+):
+    """Program (token, head): quantize one K row and one V row (per-GROUP absmax/7, fp16 scale,
+    q = rint(x / s) with an IEEE-exact division, clamped to [-7, 7]; s clamped to fp16 max so it is never inf) and pack channel pairs into bytes (low nibble = even channel,
+    high nibble = odd channel, offset-binary q + 8), then scatter D // 2 bytes + D // GROUP scales
+    into slot loc[token].  Grid (N, H) is static -> capture-safe."""
+    DH: tl.constexpr = D // 2
+    NG: tl.constexpr = D // GROUP
+    GH: tl.constexpr = GROUP // 2
+    t, h = tl.program_id(0), tl.program_id(1)
+    slot = tl.load(loc + t).to(tl.int64)
+    pairs = tl.arange(0, DH)
+    even = 2 * pairs
+    odd = even + 1
+    goffs = tl.arange(0, NG)
+    row = (slot * H + h) * DH
+    srow = (slot * H + h) * NG
+
+    base = k + t * sk_n + h * sk_h
+    xe = tl.load(base + even).to(tl.float32) * tl.load(sm_k_inv + h * D + even).to(
+        tl.float32
+    )
+    xo = tl.load(base + odd).to(tl.float32) * tl.load(sm_k_inv + h * D + odd).to(
+        tl.float32
+    )
+    ge = tl.reshape(xe, [NG, GH])  # (g, j) = channel 32 g + 2 j
+    go = tl.reshape(xo, [NG, GH])  # (g, j) = channel 32 g + 2 j + 1
+    a = tl.maximum(tl.max(tl.abs(ge), axis=1), tl.max(tl.abs(go), axis=1))
+    # The stored scale (fp16) is the one used.  Clamp to fp16 max BEFORE the cast: a bf16 group absmax
+    # above 7 * 65504 would otherwise give s = +inf -> nibble 8 -> (8 - 8) * inf = NaN on dequant;
+    # clamped, such channels saturate to +/- 7 * 65504 (finite) instead.
+    s = tl.minimum(tl.where(a > 0, a / 7.0, 1.0), 65504.0).to(tl.float16)
+    # IEEE-exact division: Triton's `/` is the approximate div.full (2 ulp), which breaks exact .5 ties
+    # (x/s = 6.5 -> 6.5000001 -> 7) that int4's coarse grid hits constantly; torch rounds them to even.
+    sf = tl.broadcast_to(s.to(tl.float32)[:, None], [NG, GH])
+    qe = tl.clamp(libdevice.rint(tl.div_rn(ge, sf)), -7.0, 7.0).to(tl.int32) + 8
+    qo = tl.clamp(libdevice.rint(tl.div_rn(go, sf)), -7.0, 7.0).to(tl.int32) + 8
+    packed = (qe | (qo << 4)).to(tl.uint8)
+    tl.store(k_buf + row + pairs, tl.reshape(packed, [DH]))
+    tl.store(k_scale + srow + goffs, s)
+
+    base = v + t * sv_n + h * sv_h
+    xe = tl.load(base + even).to(tl.float32) * tl.load(sm_v_inv + h * D + even).to(
+        tl.float32
+    )
+    xo = tl.load(base + odd).to(tl.float32) * tl.load(sm_v_inv + h * D + odd).to(
+        tl.float32
+    )
+    ge = tl.reshape(xe, [NG, GH])
+    go = tl.reshape(xo, [NG, GH])
+    a = tl.maximum(tl.max(tl.abs(ge), axis=1), tl.max(tl.abs(go), axis=1))
+    s = tl.minimum(tl.where(a > 0, a / 7.0, 1.0), 65504.0).to(
+        tl.float16
+    )  # fp16-max clamp, see K half
+    # IEEE-exact division: Triton's `/` is the approximate div.full (2 ulp), which breaks exact .5 ties
+    # (x/s = 6.5 -> 6.5000001 -> 7) that int4's coarse grid hits constantly; torch rounds them to even.
+    sf = tl.broadcast_to(s.to(tl.float32)[:, None], [NG, GH])
+    qe = tl.clamp(libdevice.rint(tl.div_rn(ge, sf)), -7.0, 7.0).to(tl.int32) + 8
+    qo = tl.clamp(libdevice.rint(tl.div_rn(go, sf)), -7.0, 7.0).to(tl.int32) + 8
+    packed = (qe | (qo << 4)).to(tl.uint8)
+    tl.store(v_buf + row + pairs, tl.reshape(packed, [DH]))
+    tl.store(v_scale + srow + goffs, s)
+
+
+def quant_store_kv_int4(k, v, loc, k_buf, v_buf, k_scale, v_scale, sm_k_inv, sm_v_inv):
+    """k, v: [N, H, D] (any float dtype, unit last stride); loc: [N] int32/int64 slots;
+    k_buf/v_buf: uint8 [rows, H, D // 2]; k_scale/v_scale: fp16 [rows, H, D // GROUP]; sm_*_inv: fp16 [H, D].
+    """
+    N, H, D = k.shape
+    assert v.shape == (N, H, D) and k.stride(2) == 1 and v.stride(2) == 1
+    assert D % KV_INT4_GROUP == 0 and D == triton.next_power_of_2(D)
+    assert k_buf.dtype == torch.uint8 and v_buf.dtype == torch.uint8
+    assert k_scale.dtype == torch.float16 and v_scale.dtype == torch.float16
+    assert (
+        k_buf.is_contiguous()
+        and v_buf.is_contiguous()
+        and k_scale.is_contiguous()
+        and v_scale.is_contiguous()
+    )
+    assert k_buf.shape[1:] == (H, D // 2) and v_buf.shape[1:] == (H, D // 2)
+    assert k_scale.shape[1:] == (H, D // KV_INT4_GROUP) and v_scale.shape[1:] == (
+        H,
+        D // KV_INT4_GROUP,
+    )
+    assert sm_k_inv.shape == (H, D) and sm_v_inv.shape == (H, D)
+    assert loc.numel() == N
+    if N == 0:
+        return
+    _quant_store_kv_int4[(N, H)](
+        k,
+        v,
+        loc,
+        k_buf,
+        v_buf,
+        k_scale,
+        v_scale,
+        sm_k_inv,
+        sm_v_inv,
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        H=H,
+        D=D,
+        GROUP=KV_INT4_GROUP,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _compact_kv_int4(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    topk: tl.constexpr,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    idx_stride: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    """_compact_kv for the int4 pool: gather dim // 2 packed bytes per (slot, head), unpack the two
+    nibbles ((b & 15) - 8 = even channel, (b >> 4) - 8 = odd channel), dequantize (* s * sm, fp32) and
+    interleave into the bf16 scratch.  `dim` is the logical head_dim.  Same store mask as
+    _compact_kv / _compact_kv_int8: only valid (in-region, 0 <= pos < seq_len) columns are written;
+    invalid columns are neither read nor written."""
+    DH: tl.constexpr = dim // 2
+    NG: tl.constexpr = dim // GROUP
+    GH: tl.constexpr = GROUP // 2
+    batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    pairs = tl.arange(0, DH)
+    dims = tl.arange(0, dim)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    valid_count = tl.load(cu_k + batch + 1) - pack_start
+    positions = tl.load(indices + batch * idx_stride + cols, mask=cols < topk, other=-1)
+    valid = (cols < valid_count) & (positions >= 0) & (positions < length)
+    slots = tl.load(
+        req_to_token + req * req_stride + tl.where(valid, positions, 0),
+        mask=valid,
+        other=0,
+    ).to(tl.int64)
+    src = (slots[:, None] * heads + head) * DH + pairs[None, :]
+    ssrc = (slots[:, None] * heads + head) * NG + pairs[None, :] // GH
+    dst = ((pack_start + cols)[:, None] * heads + head) * dim + dims[None, :]
+    pmask = valid[:, None] & (pairs[None, :] < DH)
+    mask = valid[:, None] & (dims[None, :] < dim)
+    sm_e = tl.load(sm_k + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_k + head * dim + 2 * pairs + 1).to(tl.float32)
+    b = tl.load(k + src, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(k_scale + ssrc, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    tl.store(out_k + dst, tl.interleave(lo, hi).to(tl.bfloat16), mask=mask)
+    sm_e = tl.load(sm_v + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_v + head * dim + 2 * pairs + 1).to(tl.float32)
+    b = tl.load(v + src, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(v_scale + ssrc, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    tl.store(out_v + dst, tl.interleave(lo, hi).to(tl.bfloat16), mask=mask)
+
+
+@triton.jit
+def _gather_dequant_rows_int4(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Program (batch, row block, head): rows t < seq_lens[batch] of request req_indices[batch]
+    (slots from req_to_token) -> unpacked + dequantized bf16 rows cu_k[batch] + t of out_k/out_v.
+    The row-block count is a grid dimension (runtime max_len), so chunk sizes never recompile.
+    """
+    DH: tl.constexpr = dim // 2
+    NG: tl.constexpr = dim // GROUP
+    GH: tl.constexpr = GROUP // 2
+    batch, block, head = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    t = block * BLOCK_T + tl.arange(0, BLOCK_T)
+    valid = t < length
+    slots = tl.load(req_to_token + req * req_stride + t, mask=valid, other=0).to(
+        tl.int64
+    )
+    pairs = tl.arange(0, DH)
+    dims = tl.arange(0, dim)
+    src = (slots[:, None] * heads + head) * DH + pairs[None, :]
+    ssrc = (slots[:, None] * heads + head) * NG + pairs[None, :] // GH
+    dst = ((pack_start + t)[:, None] * heads + head) * dim + dims[None, :]
+    pmask = valid[:, None] & (pairs[None, :] < DH)
+    mask = valid[:, None] & (dims[None, :] < dim)
+    sm_e = tl.load(sm_k + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_k + head * dim + 2 * pairs + 1).to(tl.float32)
+    b = tl.load(k + src, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(k_scale + ssrc, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    tl.store(out_k + dst, tl.interleave(lo, hi).to(tl.bfloat16), mask=mask)
+    sm_e = tl.load(sm_v + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_v + head * dim + 2 * pairs + 1).to(tl.float32)
+    b = tl.load(v + src, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(v_scale + ssrc, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    tl.store(out_v + dst, tl.interleave(lo, hi).to(tl.bfloat16), mask=mask)
+
+
+def qwen_sparse_prefix_gather_dequant_int4(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    max_len,
+):
+    """Whole-prefix gather-dequant of the int4 pool (k/v uint8 [rows, H, D // 2]): rows [0, seq_lens[b])
+    of every request packed at cu_k[b] into the bf16 out_k/out_v [.., H, D].  Rows at or beyond
+    seq_lens[b] are not written."""
+    _, heads, dh = k.shape
+    dim = 2 * dh
+    assert k.dtype == torch.uint8 and v.dtype == torch.uint8
+    assert (
+        out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+    ), "int4 KV gather needs a bf16 scratch"
+    assert out_k.shape[1:] == (heads, dim) and out_v.shape[1:] == (heads, dim)
+    assert dim % KV_INT4_GROUP == 0 and dim == triton.next_power_of_2(dim)
+    assert (
+        k_scale.shape[1:] == (heads, dim // KV_INT4_GROUP) and k_scale.is_contiguous()
+    )
+    assert (
+        v_scale.shape[1:] == (heads, dim // KV_INT4_GROUP) and v_scale.is_contiguous()
+    )
+    assert sm_k.shape == (heads, dim) and sm_v.shape == (heads, dim)
+    assert out_k.is_contiguous() and out_v.is_contiguous()
+    block_t = 16
+    if batch == 0 or max_len == 0:
+        return
+    _gather_dequant_rows_int4[(batch, triton.cdiv(int(max_len), block_t), heads)](
+        k,
+        v,
+        k_scale,
+        v_scale,
+        sm_k,
+        sm_v,
+        req_to_token,
+        req_indices,
+        seq_lens,
+        cu_k,
+        out_k,
+        out_v,
+        heads,
+        dim,
+        req_to_token.stride(0),
+        GROUP=KV_INT4_GROUP,
+        BLOCK_T=block_t,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _stamp_ring_owner(loc, owner, N, RING_MASK: tl.constexpr, BLOCK: tl.constexpr):
+    """owner[slot & RING_MASK] = slot for every slot of loc[0:N].  Tokens of one write whose slots share a
+    ring row race on the same int32 word; one of them wins (definite once the launch is complete) and only
+    the winner writes the ring row in the dual-write launch that follows.  Static grid -> capture-safe.
+    """
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    m = offs < N
+    slot = tl.load(loc + offs, mask=m, other=0).to(tl.int64)
+    tl.store(owner + (slot & RING_MASK), slot.to(tl.int32), mask=m)
+
+
+@triton.jit
+def _quant_store_kv_tiered(
+    k,
+    v,
+    loc,
+    k_buf,
+    v_buf,
+    k_scale,
+    v_scale,
+    rk,
+    rv,
+    rks,
+    rvs,
+    owner,
+    sm_k_inv,
+    sm_v_inv,
+    sk_n,
+    sk_h,
+    sv_n,
+    sv_h,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    GROUP4: tl.constexpr,
+    GROUP8: tl.constexpr,
+    RING_MASK: tl.constexpr,
+):
+    """Program (token, head): dual-write of one K row and one V row.  (1) int8-g64 (absmax/127, fp16 scale
+    clamped to fp16 max, q = rint(x / s) clamped to [-127, 127]) into ring row r = slot & RING_MASK of
+    rk/rv/rks/rvs -- the body of _quant_store_kv_int8 plus the clamp -- stored ONLY if owner[r] == slot
+    (stamped by _stamp_ring_owner in the preceding launch: a token that lost a same-write ring-row collision
+    stores nothing into the ring and is cold); (2) int4-g32 nibble-packed into the full-context row `slot`
+    of k_buf/v_buf/k_scale/v_scale for every token -- the body of _quant_store_kv_int4, verbatim.
+    Grid (N, H) is static -> capture-safe."""
+    DH: tl.constexpr = D // 2
+    NG4: tl.constexpr = D // GROUP4
+    GH: tl.constexpr = GROUP4 // 2
+    NG8: tl.constexpr = D // GROUP8
+    t, h = tl.program_id(0), tl.program_id(1)
+    slot = tl.load(loc + t).to(tl.int64)
+    r = slot & RING_MASK
+    hot = (
+        tl.load(owner + r).to(tl.int64) == slot
+    )  # this token owns its ring row (stamp launch done)
+
+    # ---- (1) int8 ring row (owner only) ------------------------------------------------------
+    offs = tl.arange(0, D)
+    hmask = (offs < D) & hot
+    hsmask = (tl.arange(0, NG8) < NG8) & hot
+    goffs8 = tl.arange(0, NG8)
+    row8 = (r * H + h) * D
+    srow8 = (r * H + h) * NG8
+    x = tl.load(k + t * sk_n + h * sk_h + offs).to(tl.float32)
+    x = x * tl.load(sm_k_inv + h * D + offs).to(tl.float32)
+    xg = tl.reshape(x, [NG8, GROUP8])
+    a = tl.max(tl.abs(xg), axis=1)
+    # fp16-max clamp (the int8 kernel lacks it): a bf16 group absmax above 127 * 65504 would give s = inf
+    s = tl.minimum(tl.where(a > 0, a / 127.0, 1.0), 65504.0).to(tl.float16)
+    q = libdevice.rint(xg / s.to(tl.float32)[:, None])
+    q = tl.clamp(q, -127.0, 127.0).to(tl.int8)
+    tl.store(rk + row8 + offs, tl.reshape(q, [D]), mask=hmask)
+    tl.store(rks + srow8 + goffs8, s, mask=hsmask)
+
+    x = tl.load(v + t * sv_n + h * sv_h + offs).to(tl.float32)
+    x = x * tl.load(sm_v_inv + h * D + offs).to(tl.float32)
+    xg = tl.reshape(x, [NG8, GROUP8])
+    a = tl.max(tl.abs(xg), axis=1)
+    s = tl.minimum(tl.where(a > 0, a / 127.0, 1.0), 65504.0).to(
+        tl.float16
+    )  # fp16-max clamp, see K half
+    q = libdevice.rint(xg / s.to(tl.float32)[:, None])
+    q = tl.clamp(q, -127.0, 127.0).to(tl.int8)
+    tl.store(rv + row8 + offs, tl.reshape(q, [D]), mask=hmask)
+    tl.store(rvs + srow8 + goffs8, s, mask=hsmask)
+
+    # ---- (2) int4 full-context row (= _quant_store_kv_int4) ----------------------------------
+    pairs = tl.arange(0, DH)
+    even = 2 * pairs
+    odd = even + 1
+    goffs = tl.arange(0, NG4)
+    row = (slot * H + h) * DH
+    srow = (slot * H + h) * NG4
+
+    base = k + t * sk_n + h * sk_h
+    xe = tl.load(base + even).to(tl.float32) * tl.load(sm_k_inv + h * D + even).to(
+        tl.float32
+    )
+    xo = tl.load(base + odd).to(tl.float32) * tl.load(sm_k_inv + h * D + odd).to(
+        tl.float32
+    )
+    ge = tl.reshape(xe, [NG4, GH])  # (g, j) = channel 32 g + 2 j
+    go = tl.reshape(xo, [NG4, GH])  # (g, j) = channel 32 g + 2 j + 1
+    a = tl.maximum(tl.max(tl.abs(ge), axis=1), tl.max(tl.abs(go), axis=1))
+    s = tl.minimum(tl.where(a > 0, a / 7.0, 1.0), 65504.0).to(tl.float16)
+    sf = tl.broadcast_to(s.to(tl.float32)[:, None], [NG4, GH])
+    qe = tl.clamp(libdevice.rint(tl.div_rn(ge, sf)), -7.0, 7.0).to(tl.int32) + 8
+    qo = tl.clamp(libdevice.rint(tl.div_rn(go, sf)), -7.0, 7.0).to(tl.int32) + 8
+    packed = (qe | (qo << 4)).to(tl.uint8)
+    tl.store(k_buf + row + pairs, tl.reshape(packed, [DH]))
+    tl.store(k_scale + srow + goffs, s)
+
+    base = v + t * sv_n + h * sv_h
+    xe = tl.load(base + even).to(tl.float32) * tl.load(sm_v_inv + h * D + even).to(
+        tl.float32
+    )
+    xo = tl.load(base + odd).to(tl.float32) * tl.load(sm_v_inv + h * D + odd).to(
+        tl.float32
+    )
+    ge = tl.reshape(xe, [NG4, GH])
+    go = tl.reshape(xo, [NG4, GH])
+    a = tl.maximum(tl.max(tl.abs(ge), axis=1), tl.max(tl.abs(go), axis=1))
+    s = tl.minimum(tl.where(a > 0, a / 7.0, 1.0), 65504.0).to(tl.float16)
+    sf = tl.broadcast_to(s.to(tl.float32)[:, None], [NG4, GH])
+    qe = tl.clamp(libdevice.rint(tl.div_rn(ge, sf)), -7.0, 7.0).to(tl.int32) + 8
+    qo = tl.clamp(libdevice.rint(tl.div_rn(go, sf)), -7.0, 7.0).to(tl.int32) + 8
+    packed = (qe | (qo << 4)).to(tl.uint8)
+    tl.store(v_buf + row + pairs, tl.reshape(packed, [DH]))
+    tl.store(v_scale + srow + goffs, s)
+
+
+def quant_store_kv_tiered(
+    k,
+    v,
+    loc,
+    k_buf,
+    v_buf,
+    k_scale,
+    v_scale,
+    rk,
+    rv,
+    rks,
+    rvs,
+    owner,
+    sm_k_inv,
+    sm_v_inv,
+    ring_mask,
+):
+    """k, v: [N, H, D] (any float dtype, unit last stride); loc: [N] int32/int64 slots (N <= R; slots that
+    share a ring row within one write are safe: the stamp launch picks one owner per row, only it writes the
+    ring row, the others are cold); k_buf/v_buf: uint8 [rows, H, D // 2]; k_scale/v_scale:
+    fp16 [rows, H, D // 32]; rk/rv: int8 [R, H, D]; rks/rvs: fp16 [R, H, D // 64]; owner: int32 [R];
+    sm_*_inv: fp16 [H, D]; ring_mask = R - 1 (R a power of two)."""
+    N, H, D = k.shape
+    R = int(ring_mask) + 1
+    assert R > 0 and R & (R - 1) == 0, f"ring_mask + 1 = {R} is not a power of two"
+    assert v.shape == (N, H, D) and k.stride(2) == 1 and v.stride(2) == 1
+    assert (
+        D % KV_INT4_GROUP == 0
+        and D % KV_INT8_GROUP == 0
+        and D == triton.next_power_of_2(D)
+    )
+    assert k_buf.dtype == torch.uint8 and v_buf.dtype == torch.uint8
+    assert k_scale.dtype == torch.float16 and v_scale.dtype == torch.float16
+    assert (
+        k_buf.is_contiguous()
+        and v_buf.is_contiguous()
+        and k_scale.is_contiguous()
+        and v_scale.is_contiguous()
+    )
+    assert k_buf.shape[1:] == (H, D // 2) and v_buf.shape[1:] == (H, D // 2)
+    assert k_scale.shape[1:] == (H, D // KV_INT4_GROUP) and v_scale.shape[1:] == (
+        H,
+        D // KV_INT4_GROUP,
+    )
+    assert (
+        rk.dtype == torch.int8
+        and rv.dtype == torch.int8
+        and rk.shape == (R, H, D)
+        and rv.shape == (R, H, D)
+    )
+    assert rks.dtype == torch.float16 and rvs.dtype == torch.float16
+    assert rks.shape == (R, H, D // KV_INT8_GROUP) and rvs.shape == (
+        R,
+        H,
+        D // KV_INT8_GROUP,
+    )
+    assert (
+        rk.is_contiguous()
+        and rv.is_contiguous()
+        and rks.is_contiguous()
+        and rvs.is_contiguous()
+    )
+    assert owner.dtype == torch.int32 and owner.shape == (R,) and owner.is_contiguous()
+    assert sm_k_inv.shape == (H, D) and sm_v_inv.shape == (H, D)
+    assert loc.numel() == N
+    assert N <= R, f"{N} tokens in one tiered write exceed the ring of {R} slots"
+    if N == 0:
+        return
+    STAMP_BLOCK = 128
+    _stamp_ring_owner[(triton.cdiv(N, STAMP_BLOCK),)](
+        loc, owner, N, RING_MASK=R - 1, BLOCK=STAMP_BLOCK, num_warps=4
+    )
+    _quant_store_kv_tiered[(N, H)](
+        k,
+        v,
+        loc,
+        k_buf,
+        v_buf,
+        k_scale,
+        v_scale,
+        rk,
+        rv,
+        rks,
+        rvs,
+        owner,
+        sm_k_inv,
+        sm_v_inv,
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        H=H,
+        D=D,
+        GROUP4=KV_INT4_GROUP,
+        GROUP8=KV_INT8_GROUP,
+        RING_MASK=R - 1,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _compact_kv_tiered(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    rk,
+    rv,
+    rks,
+    rvs,
+    owner,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    topk: tl.constexpr,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    idx_stride: tl.constexpr,
+    GROUP4: tl.constexpr,
+    GROUP8: tl.constexpr,
+    RING_MASK: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    """_compact_kv for the tiered pool.  Per selected slot the tier is decided on the device:
+    hot = valid & (owner[slot & RING_MASK] == slot) -> int8 ring row (dequant q * s * sm as _compact_kv_int8),
+    cold = valid & ~hot -> int4 full-context row (unpack + dequant as _compact_kv_int4); masked-off lanes of
+    the other tier issue no loads; tl.where selects.  Store mask unchanged: only valid columns are written
+    (trtllm strided tables rely on unused columns never being touched)."""
+    DH: tl.constexpr = dim // 2
+    NG4: tl.constexpr = dim // GROUP4
+    GH: tl.constexpr = GROUP4 // 2
+    NG8: tl.constexpr = dim // GROUP8
+    batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    pairs = tl.arange(0, DH)
+    dims = tl.arange(0, dim)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    valid_count = tl.load(cu_k + batch + 1) - pack_start
+    positions = tl.load(indices + batch * idx_stride + cols, mask=cols < topk, other=-1)
+    valid = (cols < valid_count) & (positions >= 0) & (positions < length)
+    slots = tl.load(
+        req_to_token + req * req_stride + tl.where(valid, positions, 0),
+        mask=valid,
+        other=0,
+    ).to(tl.int64)
+    # device-side tier test
+    r = slots & RING_MASK
+    o = tl.load(owner + r, mask=valid, other=-1).to(tl.int64)
+    hot = valid & (o == slots)
+    cold = valid & (o != slots)
+    dst = ((pack_start + cols)[:, None] * heads + head) * dim + dims[None, :]
+    mask = valid[:, None] & (dims[None, :] < dim)
+    # cold: int4 rows
+    src4 = (slots[:, None] * heads + head) * DH + pairs[None, :]
+    ssrc4 = (slots[:, None] * heads + head) * NG4 + pairs[None, :] // GH
+    pmask = cold[:, None] & (pairs[None, :] < DH)
+    # hot: int8 ring rows
+    src8 = (r[:, None] * heads + head) * dim + dims[None, :]
+    ssrc8 = (r[:, None] * heads + head) * NG8 + dims[None, :] // GROUP8
+    mask8 = hot[:, None] & (dims[None, :] < dim)
+
+    sm_e = tl.load(sm_k + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_k + head * dim + 2 * pairs + 1).to(tl.float32)
+    smr = tl.load(sm_k + head * dim + dims).to(tl.float32)
+    b = tl.load(k + src4, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(k_scale + ssrc4, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    k4 = tl.interleave(lo, hi)
+    sc8 = tl.load(rks + ssrc8, mask=mask8, other=0).to(tl.float32)
+    k8 = tl.load(rk + src8, mask=mask8, other=0).to(tl.float32) * sc8 * smr[None, :]
+    tl.store(out_k + dst, tl.where(hot[:, None], k8, k4).to(tl.bfloat16), mask=mask)
+
+    sm_e = tl.load(sm_v + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_v + head * dim + 2 * pairs + 1).to(tl.float32)
+    smr = tl.load(sm_v + head * dim + dims).to(tl.float32)
+    b = tl.load(v + src4, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(v_scale + ssrc4, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    v4 = tl.interleave(lo, hi)
+    sc8 = tl.load(rvs + ssrc8, mask=mask8, other=0).to(tl.float32)
+    v8 = tl.load(rv + src8, mask=mask8, other=0).to(tl.float32) * sc8 * smr[None, :]
+    tl.store(out_v + dst, tl.where(hot[:, None], v8, v4).to(tl.bfloat16), mask=mask)
+
+
+@triton.jit
+def _gather_dequant_rows_tiered(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    rk,
+    rv,
+    rks,
+    rvs,
+    owner,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    req_stride: tl.constexpr,
+    GROUP4: tl.constexpr,
+    GROUP8: tl.constexpr,
+    RING_MASK: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Program (batch, row block, head): rows t < seq_lens[batch] of request req_indices[batch] (slots from
+    req_to_token) -> bf16 rows cu_k[batch] + t of out_k/out_v, each row from its tier (owner test as in
+    _compact_kv_tiered).  The row-block count is a grid dimension (runtime max_len): no per-chunk recompile.
+    """
+    DH: tl.constexpr = dim // 2
+    NG4: tl.constexpr = dim // GROUP4
+    GH: tl.constexpr = GROUP4 // 2
+    NG8: tl.constexpr = dim // GROUP8
+    batch, block, head = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    length = tl.load(seq_lens + batch)
+    req = tl.load(req_indices + batch)
+    pack_start = tl.load(cu_k + batch)
+    t = block * BLOCK_T + tl.arange(0, BLOCK_T)
+    valid = t < length
+    slots = tl.load(req_to_token + req * req_stride + t, mask=valid, other=0).to(
+        tl.int64
+    )
+    pairs = tl.arange(0, DH)
+    dims = tl.arange(0, dim)
+    r = slots & RING_MASK
+    o = tl.load(owner + r, mask=valid, other=-1).to(tl.int64)
+    hot = valid & (o == slots)
+    cold = valid & (o != slots)
+    dst = ((pack_start + t)[:, None] * heads + head) * dim + dims[None, :]
+    mask = valid[:, None] & (dims[None, :] < dim)
+    src4 = (slots[:, None] * heads + head) * DH + pairs[None, :]
+    ssrc4 = (slots[:, None] * heads + head) * NG4 + pairs[None, :] // GH
+    pmask = cold[:, None] & (pairs[None, :] < DH)
+    src8 = (r[:, None] * heads + head) * dim + dims[None, :]
+    ssrc8 = (r[:, None] * heads + head) * NG8 + dims[None, :] // GROUP8
+    mask8 = hot[:, None] & (dims[None, :] < dim)
+
+    sm_e = tl.load(sm_k + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_k + head * dim + 2 * pairs + 1).to(tl.float32)
+    smr = tl.load(sm_k + head * dim + dims).to(tl.float32)
+    b = tl.load(k + src4, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(k_scale + ssrc4, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    k4 = tl.interleave(lo, hi)
+    sc8 = tl.load(rks + ssrc8, mask=mask8, other=0).to(tl.float32)
+    k8 = tl.load(rk + src8, mask=mask8, other=0).to(tl.float32) * sc8 * smr[None, :]
+    tl.store(out_k + dst, tl.where(hot[:, None], k8, k4).to(tl.bfloat16), mask=mask)
+
+    sm_e = tl.load(sm_v + head * dim + 2 * pairs).to(tl.float32)
+    sm_o = tl.load(sm_v + head * dim + 2 * pairs + 1).to(tl.float32)
+    smr = tl.load(sm_v + head * dim + dims).to(tl.float32)
+    b = tl.load(v + src4, mask=pmask, other=0).to(tl.int32)
+    sc = tl.load(v_scale + ssrc4, mask=pmask, other=0).to(tl.float32)
+    lo = ((b & 15) - 8).to(tl.float32) * sc * sm_e[None, :]
+    hi = ((b >> 4) - 8).to(tl.float32) * sc * sm_o[None, :]
+    v4 = tl.interleave(lo, hi)
+    sc8 = tl.load(rvs + ssrc8, mask=mask8, other=0).to(tl.float32)
+    v8 = tl.load(rv + src8, mask=mask8, other=0).to(tl.float32) * sc8 * smr[None, :]
+    tl.store(out_v + dst, tl.where(hot[:, None], v8, v4).to(tl.bfloat16), mask=mask)
+
+
+def _check_tier_args(
+    heads, dim, k_scale, v_scale, ring_k, ring_v, ring_ks, ring_vs, owner, ring_mask
+):
+    assert (
+        ring_k is not None
+        and ring_v is not None
+        and ring_ks is not None
+        and ring_vs is not None
+    )
+    assert (
+        owner is not None and ring_mask is not None
+    ), "tiered gather needs the owner table and ring_mask"
+    R = int(ring_mask) + 1
+    assert R > 0 and R & (R - 1) == 0, f"ring_mask + 1 = {R} is not a power of two"
+    assert (
+        dim % KV_INT4_GROUP == 0
+        and dim % KV_INT8_GROUP == 0
+        and dim == triton.next_power_of_2(dim)
+    )
+    assert (
+        k_scale.shape[1:] == (heads, dim // KV_INT4_GROUP) and k_scale.is_contiguous()
+    )
+    assert (
+        v_scale.shape[1:] == (heads, dim // KV_INT4_GROUP) and v_scale.is_contiguous()
+    )
+    assert ring_k.dtype == torch.int8 and ring_v.dtype == torch.int8
+    assert ring_k.shape == (R, heads, dim) and ring_v.shape == (R, heads, dim)
+    assert ring_ks.dtype == torch.float16 and ring_vs.dtype == torch.float16
+    assert ring_ks.shape == (R, heads, dim // KV_INT8_GROUP) and ring_vs.shape == (
+        R,
+        heads,
+        dim // KV_INT8_GROUP,
+    )
+    assert (
+        ring_k.is_contiguous()
+        and ring_v.is_contiguous()
+        and ring_ks.is_contiguous()
+        and ring_vs.is_contiguous()
+    )
+    assert owner.dtype == torch.int32 and owner.shape == (R,) and owner.is_contiguous()
+    return R
+
+
+def qwen_sparse_prefix_gather_dequant_tiered(
+    k,
+    v,
+    k_scale,
+    v_scale,
+    sm_k,
+    sm_v,
+    req_to_token,
+    req_indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    max_len,
+    ring_k=None,
+    ring_v=None,
+    ring_ks=None,
+    ring_vs=None,
+    owner=None,
+    ring_mask=None,
+):
+    """Whole-prefix gather-dequant of the tiered pool (int4 rows k/v uint8 [rows, H, D // 2] + int8 ring):
+    rows [0, seq_lens[b]) of every request packed at cu_k[b] into the bf16 out_k/out_v [.., H, D], each row
+    from its tier.  Rows at or beyond seq_lens[b] are not written."""
+    _, heads, dh = k.shape
+    dim = 2 * dh
+    assert k.dtype == torch.uint8 and v.dtype == torch.uint8
+    assert (
+        out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+    ), "tiered KV gather needs a bf16 scratch"
+    assert out_k.shape[1:] == (heads, dim) and out_v.shape[1:] == (heads, dim)
+    assert sm_k.shape == (heads, dim) and sm_v.shape == (heads, dim)
+    assert out_k.is_contiguous() and out_v.is_contiguous()
+    R = _check_tier_args(
+        heads, dim, k_scale, v_scale, ring_k, ring_v, ring_ks, ring_vs, owner, ring_mask
+    )
+    block_t = 16
+    if batch == 0 or max_len == 0:
+        return
+    _gather_dequant_rows_tiered[(batch, triton.cdiv(int(max_len), block_t), heads)](
+        k,
+        v,
+        k_scale,
+        v_scale,
+        ring_k,
+        ring_v,
+        ring_ks,
+        ring_vs,
+        owner,
+        sm_k,
+        sm_v,
+        req_to_token,
+        req_indices,
+        seq_lens,
+        cu_k,
+        out_k,
+        out_v,
+        heads,
+        dim,
+        req_to_token.stride(0),
+        GROUP4=KV_INT4_GROUP,
+        GROUP8=KV_INT8_GROUP,
+        RING_MASK=R - 1,
+        BLOCK_T=block_t,
+        num_warps=8,
+    )
+
+
 def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
     """Valid-count pass alone, for consumers that need per-row lengths but
     not the packed cu_seqlens prefix sum (trtllm paged decode packs rows at
@@ -422,10 +1578,190 @@ def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
 
 
 def qwen_sparse_kv_extraction_compact_triton(
-    k, v, req_to_token, req_indices, indices, seq_lens, cu_k, out_k, out_v, batch, topk
+    k,
+    v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    topk,
+    k_scale=None,
+    v_scale=None,
+    sm_k=None,
+    sm_v=None,
+    kv_bits=None,
+    ring_k=None,
+    ring_v=None,
+    ring_ks=None,
+    ring_vs=None,
+    owner=None,
+    ring_mask=None,
 ):
     _, heads, dim = k.shape
     block_topk = 16
+    if (
+        k.dtype == torch.uint8 and kv_bits == 4 and owner is not None
+    ):  # tiered pool: int8 ring over int4 rows
+        dim = 2 * dim  # k is [rows, H, D // 2] packed; dim = logical D
+        assert (
+            out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+        ), "tiered KV gather needs a bf16 scratch"
+        assert out_k.shape[1:] == (heads, dim) and out_v.shape[1:] == (heads, dim)
+        assert (
+            k_scale is not None
+            and v_scale is not None
+            and sm_k is not None
+            and sm_v is not None
+        )
+        R = _check_tier_args(
+            heads,
+            dim,
+            k_scale,
+            v_scale,
+            ring_k,
+            ring_v,
+            ring_ks,
+            ring_vs,
+            owner,
+            ring_mask,
+        )
+        _compact_kv_tiered[(batch, heads, triton.cdiv(topk, block_topk))](
+            k,
+            v,
+            k_scale,
+            v_scale,
+            ring_k,
+            ring_v,
+            ring_ks,
+            ring_vs,
+            owner,
+            sm_k,
+            sm_v,
+            req_to_token,
+            req_indices,
+            indices,
+            seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            topk,
+            heads,
+            dim,
+            req_to_token.stride(0),
+            indices.stride(0),
+            GROUP4=KV_INT4_GROUP,
+            GROUP8=KV_INT8_GROUP,
+            RING_MASK=R - 1,
+            BLOCK_TOPK=block_topk,
+            num_warps=8,
+        )
+        return
+    if (
+        k.dtype == torch.uint8 and kv_bits == 4
+    ):  # int4_g32 pool (keyed on the pool: fp8 is uint8 too)
+        dim = 2 * dim  # k is [rows, H, D // 2] packed; dim = logical D
+        assert (
+            out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+        ), "int4 KV gather needs a bf16 scratch"
+        assert out_k.shape[1:] == (heads, dim) and out_v.shape[1:] == (heads, dim)
+        assert (
+            k_scale is not None
+            and v_scale is not None
+            and sm_k is not None
+            and sm_v is not None
+        )
+        assert dim % KV_INT4_GROUP == 0 and dim == triton.next_power_of_2(dim)
+        assert k_scale.is_contiguous() and v_scale.is_contiguous()
+        _compact_kv_int4[(batch, heads, triton.cdiv(topk, block_topk))](
+            k,
+            v,
+            k_scale,
+            v_scale,
+            sm_k,
+            sm_v,
+            req_to_token,
+            req_indices,
+            indices,
+            seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            topk,
+            heads,
+            dim,
+            req_to_token.stride(0),
+            indices.stride(0),
+            GROUP=KV_INT4_GROUP,
+            BLOCK_TOPK=block_topk,
+            num_warps=8,
+        )
+        return
+    if k.dtype == torch.int8:  # int8_g64 pool: dequantize into the bf16 scratch
+        assert (
+            out_k.dtype == torch.bfloat16 and out_v.dtype == torch.bfloat16
+        ), "int8 KV gather needs a bf16 scratch"
+        assert (
+            k_scale is not None
+            and v_scale is not None
+            and sm_k is not None
+            and sm_v is not None
+        )
+        assert (
+            dim % KV_INT8_GROUP == 0
+            and k_scale.is_contiguous()
+            and v_scale.is_contiguous()
+        )
+        _compact_kv_int8[(batch, heads, triton.cdiv(topk, block_topk))](
+            k,
+            v,
+            k_scale,
+            v_scale,
+            sm_k,
+            sm_v,
+            req_to_token,
+            req_indices,
+            indices,
+            seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            topk,
+            heads,
+            dim,
+            req_to_token.stride(0),
+            indices.stride(0),
+            GROUP=KV_INT8_GROUP,
+            BLOCK_TOPK=block_topk,
+            BLOCK_D=triton.next_power_of_2(dim),
+            num_warps=8,
+        )
+        return
+    if k.dtype == torch.float8_e4m3fn:  # fp8 pool: dequantize into the bf16 scratch
+        assert out_k.dtype == torch.bfloat16, "fp8 KV gather needs a bf16 scratch"
+        _compact_kv_fp8[(batch, heads, triton.cdiv(topk, block_topk))](
+            k.view(torch.uint8),
+            v.view(torch.uint8),
+            req_to_token,
+            req_indices,
+            indices,
+            seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            topk,
+            heads,
+            dim,
+            req_to_token.stride(0),
+            indices.stride(0),
+            BLOCK_TOPK=block_topk,
+            BLOCK_D=triton.next_power_of_2(dim),
+            num_warps=8,
+        )
+        return
     _compact_kv[(batch, heads, triton.cdiv(topk, block_topk))](
         k,
         v,

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -33,6 +33,9 @@ from sglang.srt.layers.attention.qsa.metadata import (
 from sglang.srt.layers.attention.qsa.sparse_attn import (
     qwen_sparse_fa2_cu_seqlens_triton,
     qwen_sparse_kv_extraction_compact_triton,
+    qwen_sparse_prefix_gather_dequant_int4,
+    qwen_sparse_prefix_gather_dequant_int8,
+    qwen_sparse_prefix_gather_dequant_tiered,
     qwen_sparse_valid_counts_triton,
     sparse_gqa_fwd_interface_triton,
     sparse_gqa_fwd_interface_triton_ck,
@@ -1414,6 +1417,13 @@ class QwenSparseAttnBackend(AttentionBackend):
             metadata = self._resolve_metadata(forward_batch)
             slots = self._logical_to_physical(topk_indices, metadata)
             pool = self.token_to_kv_pool
+            if (
+                pool.get_key_buffer(layer.layer_id).dtype == torch.int8
+                or self._kv_bits() == 4
+            ):
+                raise NotImplementedError(
+                    "int8_g64 / int4_g32 KV cache has no CPU attention fallback"
+                )
             output = qsa_sparse_attention(
                 q,
                 pool.get_key_buffer(layer.layer_id),
@@ -1451,27 +1461,85 @@ class QwenSparseAttnBackend(AttentionBackend):
         k_buffer = pool.get_key_buffer(layer.layer_id)
         v_buffer = pool.get_value_buffer(layer.layer_id)
         req_to_token = self.req_to_token_pool.req_to_token
-        req_indices = forward_batch.req_pool_indices.tolist()
-        k_parts = [
-            k_buffer.index_select(
-                0, req_to_token[req_indices[i], : sequence_lens[i]].long()
-            )
-            for i in range(len(sequence_lens))
-        ]
-        v_parts = [
-            v_buffer.index_select(
-                0, req_to_token[req_indices[i], : sequence_lens[i]].long()
-            )
-            for i in range(len(sequence_lens))
-        ]
         sequence_lens_tensor = torch.tensor(
             sequence_lens, dtype=torch.int32, device=q.device
         )
         cu_seqlens_k = F.pad(sequence_lens_tensor.cumsum(0), (1, 0)).contiguous()
+        kv_bits = self._kv_bits()
+        if (
+            k_buffer.dtype == torch.int8 or kv_bits == 4
+        ):  # int8_g64 / int4_g32 pool: row gather + dequant kernel
+            assert (
+                q.dtype == torch.bfloat16
+            ), "quantized KV prefix gather needs bf16 queries"
+            k_sf, v_sf = pool.get_kv_scale_buffer(layer.layer_id)
+            sm_k, sm_v = pool.get_kv_smooth_buffer(layer.layer_id)
+            # Per-call temporaries (this path is never graph-captured): freed after the layer like the
+            # cat temporaries below, so no prefill-sized buffer outlives the request (2 KB/token bf16).
+            packed_shape = (
+                sum(sequence_lens),
+                k_buffer.shape[1],
+                self._kv_head_dim(k_buffer),
+            )
+            packed_k = torch.empty(
+                packed_shape, dtype=torch.bfloat16, device=k_buffer.device
+            )
+            packed_v = torch.empty(
+                packed_shape, dtype=torch.bfloat16, device=k_buffer.device
+            )
+            tier_kwargs = self._kv_tier_kwargs(layer)
+            gather_dequant = (
+                qwen_sparse_prefix_gather_dequant_tiered
+                if tier_kwargs
+                else (
+                    qwen_sparse_prefix_gather_dequant_int4
+                    if kv_bits == 4
+                    else qwen_sparse_prefix_gather_dequant_int8
+                )
+            )
+            gather_dequant(
+                k_buffer,
+                v_buffer,
+                k_sf,
+                v_sf,
+                sm_k,
+                sm_v,
+                req_to_token,
+                forward_batch.req_pool_indices,
+                sequence_lens_tensor,
+                cu_seqlens_k,
+                packed_k,
+                packed_v,
+                len(sequence_lens),
+                max(sequence_lens),
+                **tier_kwargs,
+            )
+        else:
+            req_indices = forward_batch.req_pool_indices.tolist()
+            _fp8 = k_buffer.dtype == torch.float8_e4m3fn
+            k_src = k_buffer.view(torch.uint8) if _fp8 else k_buffer
+            v_src = v_buffer.view(torch.uint8) if _fp8 else v_buffer
+            k_parts = [
+                k_src.index_select(
+                    0, req_to_token[req_indices[i], : sequence_lens[i]].long()
+                )
+                for i in range(len(sequence_lens))
+            ]
+            v_parts = [
+                v_src.index_select(
+                    0, req_to_token[req_indices[i], : sequence_lens[i]].long()
+                )
+                for i in range(len(sequence_lens))
+            ]
+            if _fp8:  # fp8 pool: dequantize the gathered prefix
+                k_parts = [p.view(torch.float8_e4m3fn).to(q.dtype) for p in k_parts]
+                v_parts = [p.view(torch.float8_e4m3fn).to(q.dtype) for p in v_parts]
+            packed_k = torch.cat(k_parts)
+            packed_v = torch.cat(v_parts)
         output = sparse_gqa_fwd_interface_triton_ck(
             q.contiguous(),
-            torch.cat(k_parts),
-            torch.cat(v_parts),
+            packed_k,
+            packed_v,
             topk_indices,
             cu_seqlens_q,
             cu_seqlens_k,
@@ -1512,6 +1580,59 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
+
+    def _kv_bits(self):
+        """Quantized-pool bit width from the pool (8 = int8_g64, 4 = int4_g32, None otherwise).  The
+        fp8 pool stores uint8 too (viewed as float8), so dispatch is keyed on the pool, not the dtype.
+        """
+        pool = self.token_to_kv_pool
+        return getattr(getattr(pool, "full_kv_pool", pool), "kv_bits", None)
+
+    def _kv_head_dim(self, k_buffer: torch.Tensor) -> int:
+        """Logical head_dim of the KV rows (the int4 pool packs two channels per byte)."""
+        return k_buffer.shape[2] * 2 if self._kv_bits() == 4 else k_buffer.shape[2]
+
+    def _kv_scratch_dtype(self, k_buffer: torch.Tensor) -> torch.dtype:
+        """FA2 / trtllm scratch dtype: bf16 for every quantized pool (fp8, int8_g64, int4_g32)."""
+        if k_buffer.dtype in (torch.float8_e4m3fn, torch.int8) or self._kv_bits() == 4:
+            return torch.bfloat16
+        return k_buffer.dtype
+
+    def _int8_gather_kwargs(self, k_buffer: torch.Tensor, layer) -> dict:
+        """Scale + smoothing tensors (+ kv_bits) for the int8_g64 / int4_g32 gather-dequant kernels
+        ({} for other dtypes)."""
+        kv_bits = self._kv_bits()
+        if k_buffer.dtype != torch.int8 and kv_bits != 4:
+            return {}
+        pool = self.token_to_kv_pool
+        k_sf, v_sf = pool.get_kv_scale_buffer(layer.layer_id)
+        sm_k, sm_v = pool.get_kv_smooth_buffer(layer.layer_id)
+        return dict(
+            k_scale=k_sf,
+            v_scale=v_sf,
+            sm_k=sm_k,
+            sm_v=sm_v,
+            kv_bits=kv_bits,
+            **self._kv_tier_kwargs(layer),
+        )
+
+    def _kv_tier_kwargs(self, layer) -> dict:
+        """Ring buffers + owner table + mask of the tiered pool (int8 ring over int4 rows; {} otherwise).
+        The tensors are fixed for the pool's lifetime (allocated before capture): capture-safe.
+        """
+        pool = self.token_to_kv_pool
+        full_pool = getattr(pool, "full_kv_pool", pool)
+        if not getattr(full_pool, "kv_tiered", False):
+            return {}
+        ring_k, ring_v, ring_ks, ring_vs = pool.get_kv_ring_buffer(layer.layer_id)
+        return dict(
+            ring_k=ring_k,
+            ring_v=ring_v,
+            ring_ks=ring_ks,
+            ring_vs=ring_vs,
+            owner=pool.get_kv_ring_owner(),
+            ring_mask=full_pool.ring_mask,
+        )
 
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)
@@ -1565,8 +1686,8 @@ class QwenSparseAttnBackend(AttentionBackend):
         packed_k, packed_v = self._get_fa2_scratch(
             max(capacity_rows, batch) * stride,
             k_buffer.shape[1],
-            k_buffer.shape[2],
-            k_buffer.dtype,
+            self._kv_head_dim(k_buffer),
+            self._kv_scratch_dtype(k_buffer),
             k_buffer.device,
         )
         qwen_sparse_kv_extraction_compact_triton(
@@ -1585,9 +1706,10 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
+            **self._int8_gather_kwargs(k_buffer, layer),
         )
         num_kv_heads = k_buffer.shape[1]
-        head_dim = k_buffer.shape[2]
+        head_dim = self._kv_head_dim(k_buffer)
         kc = (
             packed_k[: batch * stride]
             .view(-1, page, num_kv_heads, head_dim)
@@ -1647,6 +1769,10 @@ class QwenSparseAttnBackend(AttentionBackend):
         if not q.is_cuda:
             metadata = self._resolve_metadata(forward_batch)
             slots = self._logical_to_physical(topk_indices, metadata)
+            if k_buffer.dtype == torch.int8 or self._kv_bits() == 4:
+                raise NotImplementedError(
+                    "int8_g64 / int4_g32 KV cache has no CPU attention fallback"
+                )
             output = qsa_sparse_attention(q, k_buffer, v_buffer, slots, layer.scaling)
             return output.reshape(q.shape[0], -1)
 
@@ -1694,8 +1820,8 @@ class QwenSparseAttnBackend(AttentionBackend):
         packed_k, packed_v = self._get_fa2_scratch(
             scratch_capacity,
             k_buffer.shape[1],
-            k_buffer.shape[2],
-            k_buffer.dtype,
+            self._kv_head_dim(k_buffer),
+            self._kv_scratch_dtype(k_buffer),
             k_buffer.device,
         )
         qwen_sparse_kv_extraction_compact_triton(
@@ -1714,6 +1840,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
+            **self._int8_gather_kwargs(k_buffer, layer),
         )
         output = flash_attn_varlen_func(
             q=q,

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1021,8 +1021,26 @@ class GemmaRMSNorm(BaseFusedOp):
     def _weight_loader(self, param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
         assert param.size() == loaded_weight.size()
         param.data.copy_(loaded_weight)
+        # gemma_weight is a non-persistent buffer, so it is NOT moved along
+        # when --cpu-offload-gb places the parameter on the CPU. Without this
+        # check, weight loading fails with
+        #   RuntimeError: Expected all tensors to be on the same device,
+        #   but found at least two devices, cuda:0 and cpu!
+        if self.gemma_weight.device != param.data.device:
+            self.gemma_weight = torch.empty_like(param.data)
         # Keep storage stable for CUDA graphs or fused paths that capture this buffer.
         torch.add(param.data, 1.0, out=self.gemma_weight)
+
+    def _gemma_weight_for(self, ref: torch.Tensor) -> torch.Tensor:
+        """gemma_weight on the device of ``ref``.
+
+        The offloader brings the parameter back to the GPU for the forward
+        pass but not the buffer. Without offload this is a plain comparison
+        with no copy.
+        """
+        if self.gemma_weight.device != ref.device:
+            self.gemma_weight = self.weight.data.to(ref.device) + 1.0
+        return self.gemma_weight
 
     def _forward_impl(
         self,
@@ -1097,7 +1115,7 @@ class GemmaRMSNorm(BaseFusedOp):
             # keep Gemma RMSNorm on native torch math for correctness.
             return self.forward_native(x, residual, post_residual_addition)
         else:
-            w = self.gemma_weight
+            w = self._gemma_weight_for(x)
             # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
             #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
             if not x.is_contiguous():
@@ -1146,7 +1164,7 @@ class GemmaRMSNorm(BaseFusedOp):
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
             if x.shape[-1] > _NPU_GEMMA_RMS_NORM_TRITON_MAX_HIDDEN_SIZE:
-                gamma = self.gemma_weight.to(x.dtype)
+                gamma = self._gemma_weight_for(x).to(x.dtype)
                 norm_out, _, residual = torch_npu.npu_add_rms_norm(
                     residual, x, gamma, self.variance_epsilon
                 )
@@ -1190,7 +1208,7 @@ class GemmaRMSNorm(BaseFusedOp):
             x,
             residual,
             post_residual_addition,
-            self.gemma_weight,
+            self._gemma_weight_for(x),
             use_attn_tp_group=True,
         )
 
@@ -1207,7 +1225,7 @@ class GemmaRMSNorm(BaseFusedOp):
             self,
             x,
             residual,
-            self.gemma_weight,
+            self._gemma_weight_for(x),
             group_size,
             use_attn_tp_group,
             keep_bf16,

--- a/python/sglang/srt/layers/moe/expert_elastic.py
+++ b/python/sglang/srt/layers/moe/expert_elastic.py
@@ -1,0 +1,489 @@
+"""Elastic expert residency: a resizable, rank-ordered GPU cache of MoE expert rows.
+
+Every (layer, tensor kind) keeps its expert rows in a RowArena on the GPU, in routing-mass
+order (rank 0 = hottest). The int64 address table addr[e] points either into the arena
+(rank(e) < S) or at the row's home slot in pinned host memory. Growing S gathers the next
+ranks from their host slots straight into the arena (table-driven gather kernel, no staging),
+rewrites their table entries and returns the host slots to a pool. Shrinking S copies the
+tail ranks back into pool slots, rewrites the table, then unmaps the arena tail so the VRAM
+really returns to the driver. Values never change, only where they live; the decode GEMV and
+the prefill gather read through the tables and never notice. CUDA graphs captured against
+the tables stay valid because arena addresses are fixed for the process lifetime.
+
+Host memory is conserved: rows off the GPU always own a host slot. Slots come from the
+offloaded layers' pinned tensors (a host layer's hot rows vacate their slots). With 31 host
+layers of 512 rows and 48 layers, the pool is empty at S = 181, so S_floor is 184 unless a
+pinned fallback budget is granted (SGLANG_MOE_ELASTIC_PIN_MB).
+
+Control (poll() is called from the MoE apply path, prefill/eager only):
+    SGLANG_MOE_ELASTIC_CTL=/path/ctl      one command per write:
+        S <n>            set every layer to S = n (clamped to [S_floor, 512])
+        fill <MB>        grow all layers, keeping <MB> of VRAM free
+        free <MB>        shrink all layers until at least <MB> of VRAM is free
+        status           write the status file only
+    <ctl>.status is rewritten after every command (per-layer S, arena bytes, free VRAM).
+"""
+
+import logging
+import os
+import time
+
+import torch
+
+from sglang.srt.layers.moe.row_arena import ArenaOOM, RowArena
+
+logger = logging.getLogger(__name__)
+NAMES = ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales")
+
+
+def _gather(tab, ids, out_rows_u8, row_bytes):
+    """out_rows_u8[i] <- row at tab[ids[i]] (GPU or pinned host address)."""
+    import triton
+
+    from sglang.srt.layers.moe.expert_stream import _gather_rows_tab_kernel
+
+    BLOCK = 1024
+    _gather_rows_tab_kernel[(int(ids.numel()), triton.cdiv(row_bytes, BLOCK))](
+        tab, ids, out_rows_u8, row_bytes, BLOCK=BLOCK
+    )
+
+
+class _Kind:
+    __slots__ = ("name", "arena", "tab", "home", "tail", "dtype", "rb", "keep")
+
+    def __init__(self, name, arena, tab, home, tail, dtype, rb, keep):
+        self.name, self.arena, self.tab, self.home = name, arena, tab, home
+        self.tail, self.dtype, self.rb, self.keep = tail, dtype, rb, keep
+
+
+class _Layer:
+    __slots__ = ("layer", "lid", "E", "S", "kinds")
+
+    def __init__(self, layer, lid, E, S):
+        self.layer, self.lid, self.E, self.S, self.kinds = layer, lid, E, S, {}
+
+
+class ExpertElastic:
+    inst = None
+
+    def __init__(self, mass: torch.Tensor, S0: int, device="cuda"):
+        self.mass = mass.float()  # [L, E] routing mass
+        self.L, self.E = mass.shape
+        self.order = torch.argsort(
+            self.mass, dim=1, descending=True
+        )  # [L, E] rank -> expert
+        self.rank = torch.empty_like(self.order)
+        self.rank.scatter_(1, self.order, torch.arange(self.E).expand(self.L, -1))
+        self.S0 = int(S0)
+        self.device = device
+        self.layers = {}  # lid -> _Layer
+        self.pool = {n: [] for n in NAMES}  # free host slots (tensor, row)
+        self.pin_budget = int(os.environ.get("SGLANG_MOE_ELASTIC_PIN_MB", "0")) << 20
+        self.pin_used = 0
+        self._pinned_keep = []
+        self._serving = False  # flips after placement
+        self.reserve_rows = int(os.environ.get("SGLANG_MOE_ELASTIC_RESERVE_ROWS", "0"))
+        self.ctl = os.environ.get("SGLANG_MOE_ELASTIC_CTL")
+        self._ctl_mtime = (
+            os.stat(self.ctl).st_mtime if self.ctl and os.path.exists(self.ctl) else 0.0
+        )  # ignore stale commands
+        _af = os.environ.get(
+            "SGLANG_MOE_ELASTIC_FILL_MB"
+        )  # reserve to keep free; unset = no autofill
+        self._autofill = int(_af) if _af else None
+        self.regrow_reserve = (
+            int(_af) if _af else 768
+        )  # after a forced shrink, grow back to this
+        self.pending_regrow = False
+        self._calls = 0
+        ExpertElastic.inst = self
+
+    # ------------------------------------------------------------------ slots
+    def _pin_rows(self, name, need, tail, dtype, why):
+        """Allocate pinned host slots. STARTUP ONLY: on a box with ~26 GB pinned and ~2 GB free a
+        runtime cudaHostAlloc stalls the kernel for tens of seconds (reclaim + compaction).
+        """
+        nbytes = (
+            need
+            * int(torch.empty(0, dtype=dtype).element_size())
+            * int(torch.Size(tail).numel())
+        )
+        if self.pin_used + nbytes > self.pin_budget:
+            raise RuntimeError(
+                f"elastic: pinned budget exhausted for {name} ({why}); "
+                f"SGLANG_MOE_ELASTIC_PIN_MB={self.pin_budget >> 20}, used {self.pin_used >> 20} MB"
+            )
+        extra = torch.empty((need,) + tuple(tail), dtype=dtype, pin_memory=True)
+        self.pin_used += nbytes
+        self.pool[name].extend((extra, i) for i in range(need))
+        self._pinned_keep.append(extra)
+        logger.info(
+            "elastic: pinned %d rows of %s (%.0f MB) [%s]",
+            need,
+            name,
+            nbytes / 1e6,
+            why,
+        )
+
+    def _take_slots(self, name, n, tail, dtype):
+        pool = self.pool[name]
+        if len(pool) < n:
+            if self._serving:
+                raise RuntimeError(
+                    f"elastic: host slot pool for {name} exhausted ({len(pool)} < {n}) "
+                    f"and runtime pinning is disabled (raise SGLANG_MOE_ELASTIC_RESERVE_ROWS)"
+                )
+            self._pin_rows(name, n - len(pool), tail, dtype, "startup shortfall")
+        return [pool.pop() for _ in range(n)]
+
+    @staticmethod
+    def _slot_addr(slot, rb):
+        t, r = slot
+        return t.data_ptr() + r * rb
+
+    # ------------------------------------------------------------------ init
+    def add_layer(self, layer):
+        """Move one FusedMoE layer into arenas + tables. Host layers donate slots, GPU layers
+        consume them: call in an interleaved order (see place_all)."""
+        lid = int(layer.layer_id)
+        E = int(layer.w13_qweight.data.shape[0])
+        S = min(self.S0, E)
+        st = _Layer(layer, lid, E, S)
+        order = self.order[lid]
+        hot = order[:S]
+        cold = order[S:]
+        addr, proto = {}, {}
+        for name in NAMES:
+            p = getattr(layer, name, None)
+            if p is None:
+                continue
+            t = p.data
+            tail, dtype = tuple(t.shape[1:]), t.dtype
+            rb = t[0].numel() * t.element_size()
+            arena = RowArena(
+                rb, E, torch.device(self.device).index or 0, name=f"L{lid}.{name}"
+            )
+            arena.ensure_rows(S)
+            view = arena.view(S, tail, dtype)
+            tab = torch.empty(E, dtype=torch.int64)
+            home = [None] * E
+            keep = []
+            if t.is_cuda:
+                view.copy_(t.index_select(0, hot.to(t.device)))
+                slots = self._take_slots(name, int(cold.numel()), tail, dtype)
+                cold_cpu = t.index_select(0, cold.to(t.device)).cpu()
+                for i, e in enumerate(cold.tolist()):
+                    dst, r = slots[i]
+                    dst[r].copy_(cold_cpu[i])
+                    home[e] = slots[i]
+                    tab[e] = self._slot_addr(slots[i], rb)
+                    keep.append(dst)
+                del cold_cpu
+            else:
+                src_tab = (t.data_ptr() + torch.arange(E, dtype=torch.int64) * rb).to(
+                    self.device
+                )
+                _gather(
+                    src_tab, hot.to(self.device), view.view(torch.uint8).view(S, -1), rb
+                )
+                for e in cold.tolist():
+                    home[e] = (t, e)
+                    tab[e] = t.data_ptr() + e * rb
+                self.pool[name].extend((t, e) for e in hot.tolist())
+                keep.append(t)
+            tab[hot] = arena.base + self.rank[lid][hot] * rb
+            tab = tab.to(self.device)
+            st.kinds[name] = _Kind(name, arena, tab, home, tail, dtype, rb, keep)
+            p.data = view
+            addr[name] = tab
+            proto[name] = view
+            del t
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        layer._placed = {"addr": addr, "proto": proto, "E": E, "S": S, "keep": []}
+        layer._gemv_tabs = None
+        self.layers[lid] = st
+
+    def place_all(self, layers):
+        """Deferred pass over all layers. Host kinds donate slots, GPU kinds consume 512-S each;
+        a layer is placed once every pool it will draw from can serve it (the offloader may
+        split a layer: some kinds on the host, some on the GPU)."""
+
+        def need(l):
+            return {
+                n: (self.E - self.S0 if getattr(l, n).data.is_cuda else 0)
+                for n in NAMES
+                if getattr(l, n, None) is not None
+            }
+
+        donors = [l for l in layers if not any(need(l).values())]
+        takers = [l for l in layers if any(need(l).values())]
+        placed = 0
+        while donors or takers:
+            ready = next(
+                (
+                    l
+                    for l in takers
+                    if all(len(self.pool[n]) >= k for n, k in need(l).items())
+                ),
+                None,
+            )
+            if ready is not None:
+                takers.remove(ready)
+                self.add_layer(ready)
+            elif donors:
+                self.add_layer(donors.pop(0))
+            else:  # pool short: pinned fallback (or a clear error)
+                self.add_layer(takers.pop(0))
+            placed += 1
+        if (
+            self.reserve_rows
+        ):  # one-time reserve so shrinking below S0 never pins at runtime
+            for name in NAMES:
+                k = next(
+                    (
+                        k
+                        for st in self.layers.values()
+                        for k in st.kinds.values()
+                        if k.name == name
+                    ),
+                    None,
+                )
+                if k is not None:
+                    self._pin_rows(
+                        name, self.reserve_rows, k.tail, k.dtype, "startup reserve"
+                    )
+        self._serving = True
+        logger.info(
+            "elastic placement: %d layers at S=%d, free slots %s, VRAM free %.2f GB",
+            placed,
+            self.S0,
+            {n: len(v) for n, v in self.pool.items()},
+            torch.cuda.mem_get_info()[0] / 2**30,
+        )
+        self.write_status()
+
+    # ------------------------------------------------------------------ resize
+    def resize_layer(self, lid, S_new):
+        st = self.layers[lid]
+        S = st.S
+        S_new = max(0, min(int(S_new), st.E))
+        if S_new == S:
+            return
+        order = self.order[lid]
+        torch.cuda.synchronize()
+        if S_new > S:
+            ids = order[S:S_new]
+            for k in st.kinds.values():
+                try:
+                    k.arena.ensure_rows(S_new)
+                except ArenaOOM:
+                    for k2 in st.kinds.values():
+                        k2.arena.shrink_rows(S)
+                    raise
+            for k in st.kinds.values():
+                view = k.arena.view(S_new, k.tail, k.dtype)
+                dst = view.view(torch.uint8).view(S_new, -1)[S:S_new]
+                _gather(k.tab, ids.to(self.device), dst, k.rb)
+            torch.cuda.synchronize()
+            for k in st.kinds.values():
+                k.tab[ids.to(self.device)] = (
+                    k.arena.base + torch.arange(S, S_new, dtype=torch.int64) * k.rb
+                ).to(self.device)
+                for e in ids.tolist():
+                    self.pool[k.name].append(k.home[e])
+                    k.home[e] = None
+        else:
+            ids = order[S_new:S]
+            n = int(ids.numel())
+            taken = {}
+            try:  # acquire-then-commit: nothing is touched until every kind has its slots
+                for k in st.kinds.values():
+                    taken[k.name] = self._take_slots(k.name, n, k.tail, k.dtype)
+            except Exception:
+                for name, slots in taken.items():
+                    self.pool[name].extend(slots)
+                raise
+            for k in st.kinds.values():
+                view = k.arena.view(S, k.tail, k.dtype)
+                slots = taken[k.name]
+                addrs = torch.empty(n, dtype=torch.int64)
+                for i, e in enumerate(ids.tolist()):
+                    dst, r = slots[i]
+                    dst[r].copy_(view[S_new + i], non_blocking=True)
+                    k.home[e] = slots[i]
+                    addrs[i] = self._slot_addr(slots[i], k.rb)
+                torch.cuda.synchronize()
+                k.tab[ids.to(self.device)] = addrs.to(self.device)
+            torch.cuda.synchronize()
+            for k in st.kinds.values():
+                k.arena.shrink_rows(S_new)
+        for k in st.kinds.values():
+            view = k.arena.view(S_new, k.tail, k.dtype)
+            getattr(st.layer, k.name).data = view
+            st.layer._placed["proto"][k.name] = view
+        st.layer._placed["S"] = S_new
+        st.S = S_new
+        torch.cuda.synchronize()
+
+    def s_floor(self):
+        """Smallest uniform S the host side can absorb: pool slots first, then the pinned
+        fallback budget (shared across kinds)."""
+        if not self.layers:
+            return 0
+        L = len(self.layers)
+        cur = sum(st.S for st in self.layers.values())
+        avail = 0 if self._serving else self.pin_budget - self.pin_used
+        rb = {
+            n: next(
+                k.rb
+                for st in self.layers.values()
+                for k in st.kinds.values()
+                if k.name == n
+            )
+            for n in NAMES
+            if any(n in st.kinds for st in self.layers.values())
+        }
+        best = -(-cur // L)  # ceil(mean S): always feasible
+        for S_ in range(best, -1, -1):
+            D = cur - L * S_  # rows per kind that must move to the host
+            cost = sum(max(0, D - len(self.pool[n])) * rb[n] for n in rb)
+            if cost > avail:
+                break
+            best = S_
+        return best
+
+    def set_S(self, S):
+        S = max(self.s_floor(), min(int(S), self.E))
+        t0 = time.time()
+        torch.cuda.empty_cache()  # cuMemCreate needs driver-free memory, not torch-cached
+        for lid in sorted(self.layers):
+            self.resize_layer(lid, S)
+        logger.info(
+            "elastic: S=%d for all layers in %.2fs, VRAM free %.2f GB",
+            S,
+            time.time() - t0,
+            torch.cuda.mem_get_info()[0] / 2**30,
+        )
+
+    def fill(self, reserve_mb, step=8):
+        """Grow all layers uniformly while more than reserve_mb stays free."""
+        reserve = int(reserve_mb) << 20
+        torch.cuda.empty_cache()
+        while True:
+            cur = min(st.S for st in self.layers.values())
+            if cur >= self.E:
+                break
+            need = sum(
+                k.arena.bytes_to_reach(min(self.E, st.S + step))
+                for st in self.layers.values()
+                for k in st.kinds.values()
+            )
+            if torch.cuda.mem_get_info()[0] - need < reserve:
+                break
+            try:
+                for lid in sorted(self.layers):
+                    self.resize_layer(lid, min(self.E, self.layers[lid].S + step))
+            except ArenaOOM:
+                break
+        logger.info(
+            "elastic fill: S=%s, VRAM free %.2f GB",
+            sorted({st.S for st in self.layers.values()}),
+            torch.cuda.mem_get_info()[0] / 2**30,
+        )
+
+    def free(self, want_mb, step=8):
+        """Shrink all layers uniformly until at least want_mb of VRAM is free."""
+        want = int(want_mb) << 20
+        while torch.cuda.mem_get_info()[0] < want:
+            cur = max(st.S for st in self.layers.values())
+            target = max(self.s_floor(), cur - step)
+            if target >= cur:
+                break
+            try:
+                for lid in sorted(self.layers):
+                    if self.layers[lid].S > target:
+                        self.resize_layer(lid, target)
+            except (
+                ArenaOOM,
+                RuntimeError,
+            ) as ex:  # partial shrink is still a shrink; report and stop
+                logger.warning("elastic free stopped: %s", ex)
+                break
+        self.pending_regrow = True
+        logger.info(
+            "elastic free: S=%s, VRAM free %.2f GB",
+            sorted({st.S for st in self.layers.values()}),
+            torch.cuda.mem_get_info()[0] / 2**30,
+        )
+
+    def regrow(self):
+        """Grow back into free VRAM after a forced shrink (called at a safe point: KV pool idle)."""
+        self.pending_regrow = False
+        self.fill(self.regrow_reserve)
+        self.write_status()
+
+    # ------------------------------------------------------------------ control
+    def write_status(self):
+        if not self.ctl:
+            return
+        free, total = torch.cuda.mem_get_info()
+        arena = sum(
+            k.arena.backed_bytes
+            for st in self.layers.values()
+            for k in st.kinds.values()
+        )
+        S = [self.layers[l].S for l in sorted(self.layers)]
+        covered = sum(
+            float(self.mass[l][self.order[l][: self.layers[l].S]].sum())
+            for l in self.layers
+        ) / float(self.mass.sum())
+        with open(self.ctl + ".status", "w") as f:
+            f.write(
+                f"time {time.strftime('%H:%M:%S')}\nS_min {min(S)} S_max {max(S)} floor {self.s_floor()}\n"
+                f"arena_GB {arena / 2**30:.3f}\nvram_free_GB {free / 2**30:.3f}\nmass_covered {covered:.4f}\n"
+                f"pool {[len(self.pool[n]) for n in NAMES]} pin_used_MB {self.pin_used >> 20}\nS {S}\n"
+            )
+
+    def poll(self, m: int = 0, lid: int = 0):
+        """Called from the MoE apply path. Acts only at layer 0 of a small eager forward (m <= 16
+        rows, i.e. a 1-token prefill or eager decode): a resize inside a real prefill would strip
+        that forward's working memory."""
+        self._calls += 1
+        if torch.cuda.is_current_stream_capturing() or lid != 0 or m > 16:
+            return
+        if (
+            self._autofill is not None and self._calls > 48 * 4
+        ):  # after warmup: grow into free VRAM
+            reserve, self._autofill = self._autofill, None
+            try:
+                self.fill(reserve)
+            except Exception as ex:
+                logger.exception("elastic autofill failed: %s", ex)
+            self.write_status()
+        if not self.ctl:
+            return
+        try:
+            m = os.stat(self.ctl).st_mtime
+        except FileNotFoundError:
+            return
+        if m <= self._ctl_mtime:
+            return
+        self._ctl_mtime = m
+        try:
+            cmd = open(self.ctl).read().split()
+            if not cmd:
+                return
+            t0 = time.time()
+            if cmd[0] == "S":
+                self.set_S(int(cmd[1]))
+            elif cmd[0] == "fill":
+                self.fill(int(cmd[1]) if len(cmd) > 1 else 512)
+            elif cmd[0] == "free":
+                self.free(int(cmd[1]))
+            logger.info(
+                "elastic ctl '%s' done in %.2fs", " ".join(cmd), time.time() - t0
+            )
+        except Exception as ex:  # never take the server down over a control command
+            logger.exception("elastic ctl failed: %s", ex)
+        self.write_status()

--- a/python/sglang/srt/layers/moe/expert_gemv.py
+++ b/python/sglang/srt/layers/moe/expert_gemv.py
@@ -1,0 +1,170 @@
+"""Batch-1 int2 MoE GEMV on the N-contiguous int32-word layout, through a pointer table.
+
+Layout per expert (shared with the tiled prefill kernel's word-load int2 branch):
+    qweight  int32 [K/16, N]    word kw holds values 16kw..16kw+15 at bits 2*(k%16), N contiguous
+    scales   f16|bf16 [K/128, N]  symmetric, zero point 2  ->  w = (q - 2) * s
+
+Lanes run along N, so every warp-load is one contiguous 128-B line of int32 words. That is the
+property measured at 320 GB/s from device memory and 51 GB/s (PCIe line rate) from pinned host
+memory (micro-benchmark on real layer-5 tensors); the byte-row variant of the same idea
+reached only 157 / 14 GB/s and was rejected.
+
+Pointer tables: int64 [E] of per-expert base addresses for qweight and scales, on the device.
+An entry may point into device memory or into pinned host memory; the kernel does not care.
+The kernel indexes with the ORIGINAL expert ids. No gather, no staging, no renumbering.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _moe_gemv_int2_tab(
+    a_ptr,
+    stride_am,  # activations bf16 [M, K]; row r uses a[r // TOP_K]
+    wtab_ptr,
+    stab_ptr,  # int64 [E]: base address of qweight / scales per expert
+    topk_ids_ptr,
+    topk_w_ptr,  # [R] original ids, [R] routed weights (fp32)
+    c_ptr,
+    stride_cm,  # out bf16 [R, N]
+    N,
+    K,
+    stride_ww,
+    stride_sg,  # row strides: qweight words per K/16 row, scales per group row
+    TOP_K: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    SCALE_BF16: tl.constexpr,
+):
+    tl.static_assert(BLOCK_K % GROUP == 0)
+    tl.static_assert(BLOCK_K % 16 == 0)
+    pid_n = tl.program_id(0)
+    r = tl.program_id(1)
+    e = tl.load(topk_ids_ptr + r).to(tl.int64)
+    wbase = tl.load(wtab_ptr + e).to(tl.pointer_type(tl.int32))
+    if SCALE_BF16:
+        sbase = tl.load(stab_ptr + e).to(tl.pointer_type(tl.bfloat16))
+    else:
+        sbase = tl.load(stab_ptr + e).to(tl.pointer_type(tl.float16))
+
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    n_mask = offs_n < N
+    NW: tl.constexpr = BLOCK_K // 16
+    NG: tl.constexpr = BLOCK_K // GROUP
+    offs_w = tl.arange(0, NW)
+    a_base = a_ptr + (r // TOP_K) * stride_am
+
+    acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+    for k0 in range(0, K, BLOCK_K):
+        w = tl.load(
+            wbase + (k0 // 16 + offs_w[:, None]) * stride_ww + offs_n[None, :],
+            mask=n_mask[None, :],
+            other=0,
+        )  # [NW, BN] int32
+        part = tl.zeros([NW, BLOCK_N], dtype=tl.float32)
+        for i in tl.static_range(16):
+            x_i = tl.load(a_base + k0 + offs_w * 16 + i).to(
+                tl.float32
+            )  # [NW], warp-uniform
+            part += ((w >> (2 * i)) & 3).to(tl.float32) * x_i[:, None]
+        xs = tl.sum(
+            tl.load(a_base + k0 + tl.arange(0, BLOCK_K))
+            .to(tl.float32)
+            .reshape([NG, GROUP]),
+            axis=1,
+        )  # [NG] zero-point term
+        part_g = tl.sum(
+            tl.reshape(part, [NG, GROUP // 16, BLOCK_N]), axis=1
+        )  # [NG, BN]
+        s = tl.load(
+            sbase
+            + (k0 // GROUP + tl.arange(0, NG)[:, None]) * stride_sg
+            + offs_n[None, :],
+            mask=n_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.sum((part_g - 2.0 * xs[:, None]) * s, axis=0)
+    if MUL_ROUTED_WEIGHT:
+        acc = acc * tl.load(topk_w_ptr + r)
+    tl.store(c_ptr + r * stride_cm + offs_n, acc.to(tl.bfloat16), mask=n_mask)
+
+
+def moe_gemv_int2_tab(
+    a,
+    wtab,
+    stab,
+    topk_ids,
+    topk_w,
+    N,
+    K,
+    stride_ww,
+    stride_sg,
+    top_k,
+    mul_routed_weight,
+    block_n=64,
+    block_k=128,
+    num_warps=4,
+    scale_bf16=True,
+):
+    """a [M, K] bf16; topk_ids/topk_w flat [R]; returns bf16 [R, N].
+    scale_bf16: True on the server (params_dtype), False for raw checkpoint f16 scales.
+    """
+    assert K % block_k == 0 and block_k % 128 == 0, (K, block_k)  # BK=256 breaks K=640
+    R = topk_ids.numel()
+    c = torch.empty((R, N), dtype=torch.bfloat16, device=a.device)
+    _moe_gemv_int2_tab[(triton.cdiv(N, block_n), R)](
+        a,
+        a.stride(0),
+        wtab,
+        stab,
+        topk_ids,
+        topk_w,
+        c,
+        c.stride(0),
+        N,
+        K,
+        stride_ww,
+        stride_sg,
+        TOP_K=top_k,
+        GROUP=128,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        SCALE_BF16=scale_bf16,
+        num_warps=num_warps,
+    )
+    return c
+
+
+def make_tables(qweight, scales):
+    """qweight int32 [E, K/16, N], scales f16/bf16 [E, K/128, N] (device or pinned host, contiguous)
+    -> int64 [E] address tables on the CUDA device, plus the row strides in elements."""
+    assert qweight.dtype == torch.int32 and scales.dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), (qweight.dtype, scales.dtype)
+    assert qweight.is_contiguous() and scales.is_contiguous()
+    E = qweight.shape[0]
+    wt = (
+        torch.arange(E, dtype=torch.int64) * (qweight.stride(0) * 4)
+        + qweight.data_ptr()
+    )
+    st = torch.arange(E, dtype=torch.int64) * (scales.stride(0) * 2) + scales.data_ptr()
+    return wt.cuda(), st.cuda(), qweight.stride(1), scales.stride(1)
+
+
+def to_word_ncontig(qweight_u8_nk):
+    """Loader layout uint8 [E, N, K/4] (what MoeWNA16 holds today) -> int32 [E, K/16, N].
+
+    Byte kb = k//4 of row n becomes byte (kb % 4) of word kb // 4 at column n, little-endian:
+    value k lands at bits 8*((k//4)%4) + 2*(k%4) = 2*(k%16). Bit-exact re-arrangement.
+    """
+    E, N, KB = qweight_u8_nk.shape
+    t = qweight_u8_nk.transpose(1, 2)  # [E, K/4, N]
+    t = t.reshape(E, KB // 4, 4, N).permute(0, 1, 3, 2)  # [E, K/16, N, 4]
+    # view(int32) folds the trailing 4 bytes into one word: [E, K/16, N, 1] -> drop the 1
+    return t.contiguous().view(torch.int32).view(E, KB // 4, N)

--- a/python/sglang/srt/layers/moe/expert_stream.py
+++ b/python/sglang/srt/layers/moe/expert_stream.py
@@ -1,0 +1,220 @@
+"""MoE-aware weight offloading for expert layers.
+
+Why this exists
+---------------
+SGLang's ``--cpu-offload-gb`` copies a module's entire ``state_dict`` to the
+device on every forward pass. That is correct for a dense model; for an MoE
+with 512 experts and top-10 routing it is roughly 40x more traffic than needed.
+
+Measured on Qwen3.8-Flash-Next, RTX PRO 4000, PCIe Gen5 x16:
+    rxpci 55-61 GB/s sustained, ~26 GB per token, 2.3 tok/s.
+    What is actually needed: 10 x 48 x 1.31 MB = 0.63 GB per token.
+
+How it works
+------------
+Nothing is moved or copied. After loading, both device and host memory are
+full, so any additional allocation would trip the OOM killer. Instead the
+expert tensors are excluded from the bulk transfer in ``offloader.py`` and stay
+where the offloader already placed them (pinned host memory, or the GPU). This
+streamer gathers exactly the selected experts into one shared staging buffer
+per forward pass and renumbers the top-k ids onto it. The Triton kernel is
+unchanged - it still sees one contiguous tensor.
+
+Enabled via ``SGLANG_MOE_EXPERT_STREAM=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.utils import logger
+
+
+@triton.jit
+def _gather_rows_kernel(src_ptr, idx_ptr, out_ptr, row_bytes, BLOCK: tl.constexpr):
+    """Copy selected rows bytewise; the source may live in host memory.
+
+    The point is that expert ids stay on the GPU. The naive route
+    (``uniq.to("cpu")`` followed by one copy per row) forces a device
+    synchronization per layer - with 48 layers per token that is the single
+    largest cost, and the GPU only waits. Pinned host memory is directly
+    addressable from a kernel under unified addressing; SGLang does the same
+    for the PLE table.
+    """
+    row = tl.load(idx_ptr + tl.program_id(0)).to(tl.int64)
+    offs = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < row_bytes
+    vals = tl.load(src_ptr + row * row_bytes + offs, mask=mask, other=0)
+    tl.store(
+        out_ptr + tl.program_id(0).to(tl.int64) * row_bytes + offs, vals, mask=mask
+    )
+
+
+_STAGING: Dict[Tuple, torch.Tensor] = {}
+
+
+@triton.jit
+def _gather_rows_tab_kernel(tab_ptr, idx_ptr, out_ptr, row_bytes, BLOCK: tl.constexpr):
+    """Row gather through an address table: expert id -> int64 row address (GPU or pinned host)."""
+    e = tl.load(idx_ptr + tl.program_id(0)).to(tl.int64)
+    base = tl.load(tab_ptr + e)
+    src = base.to(tl.pointer_type(tl.uint8))
+    offs = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < row_bytes
+    vals = tl.load(src + offs, mask=mask, other=0)
+    tl.store(
+        out_ptr + tl.program_id(0).to(tl.int64) * row_bytes + offs, vals, mask=mask
+    )
+
+
+_TENSOR_NAMES = (
+    "w13_qweight",
+    "w2_qweight",
+    "w13_scales",
+    "w2_scales",
+    "w13_qzeros",
+    "w2_qzeros",
+)
+_LOGGED = False
+# Work without deduplication up to this many ids (avoids the device sync).
+_NO_DEDUP_LIMIT = 64
+_ARANGE_CACHE: Dict[Tuple, torch.Tensor] = {}
+
+
+def _cached_arange(n: int, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    key = (n, str(device), dtype)
+    t = _ARANGE_CACHE.get(key)
+    if t is None:
+        t = torch.arange(n, device=device, dtype=dtype)
+        _ARANGE_CACHE[key] = t
+    return t
+
+
+def enabled() -> bool:
+    return os.environ.get("SGLANG_MOE_EXPERT_STREAM") == "1"
+
+
+def _staging(
+    name: str,
+    k: int,
+    max_k: int,
+    rest: Tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """One buffer per tensor kind, at full size, sliced to the first k rows.
+
+    Important: do NOT allocate one buffer per distinct k. The number of
+    selected experts varies from call to call (10 during decode, up to 512
+    during prefill); a buffer per size fills the VRAM within a few requests.
+    """
+    key = (name, dtype, str(device), tuple(rest))
+    buf = _STAGING.get(key)
+    if buf is None:
+        buf = torch.empty((max_k,) + rest, dtype=dtype, device=device)
+        _STAGING[key] = buf
+        logger.info(
+            "MoE staging buffer %s: %s, %.0f MB",
+            name,
+            tuple(buf.shape),
+            buf.numel() * buf.element_size() / 1e6,
+        )
+    return buf[:k]
+
+
+class ExpertStreamer:
+    """Gathers only the selected experts on each forward pass."""
+
+    def __init__(self, layer: torch.nn.Module):
+        self.layer = layer
+        self.names: List[str] = []
+        self.device = torch.device("cuda")
+        for name in _TENSOR_NAMES:
+            t = getattr(layer, name, None)
+            if t is None:
+                continue
+            t = t.data if isinstance(t, torch.nn.Parameter) else t
+            if t.numel() == 0 or t.shape[0] == 0:
+                continue  # qzeros are empty tensors when sym=True
+            self.names.append(name)
+
+        global _LOGGED
+        if not _LOGGED and self.names:
+            _LOGGED = True
+            t = getattr(layer, self.names[0])
+            t = t.data if isinstance(t, torch.nn.Parameter) else t
+            logger.info(
+                "MoE expert streaming active: %d experts, source on %s, " "tensors %s",
+                t.shape[0],
+                t.device,
+                ",".join(self.names),
+            )
+
+    def gather(
+        self, topk_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        flat = topk_ids.reshape(-1)
+        n = flat.numel()
+        if n <= _NO_DEDUP_LIMIT:
+            # During decode this is 10 ids. torch.unique would have to
+            # synchronize here because its output size is data-dependent, and
+            # that per-layer sync is the most expensive item. Copying a
+            # duplicated expert is cheaper than the sync: the renumbering is
+            # then a plain arange.
+            uniq = flat
+            k = n
+            inverse = _cached_arange(n, flat.device, topk_ids.dtype)
+        else:
+            uniq, inverse = torch.unique(flat, return_inverse=True)
+            k = int(uniq.numel())
+
+        out: Dict[str, torch.Tensor] = {}
+        placed = getattr(self.layer, "_placed", None)
+        for name in self.names:
+            if placed is not None:
+                proto = placed["proto"][name]  # a hot GPU tensor: shape[1:], dtype
+                buf = _staging(
+                    name,
+                    k,
+                    placed["E"],
+                    tuple(proto.shape[1:]),
+                    proto.dtype,
+                    self.device,
+                )
+                row_bytes = proto[0].numel() * proto.element_size()
+                BLOCK = 1024
+                _gather_rows_tab_kernel[(k, triton.cdiv(row_bytes, BLOCK))](
+                    placed["addr"][name],
+                    uniq,
+                    buf.view(torch.uint8),
+                    row_bytes,
+                    BLOCK=BLOCK,
+                )
+                out[name] = buf
+                continue
+            src = getattr(self.layer, name)
+            src = src.data if isinstance(src, torch.nn.Parameter) else src
+            buf = _staging(
+                name, k, src.shape[0], tuple(src.shape[1:]), src.dtype, self.device
+            )
+            if src.is_cuda:
+                torch.index_select(src, 0, uniq, out=buf)
+            else:
+                src_u8 = src.view(torch.uint8)
+                buf_u8 = buf.view(torch.uint8)
+                row_bytes = src_u8.numel() // src_u8.shape[0]
+                BLOCK = 1024
+                _gather_rows_kernel[(k, triton.cdiv(row_bytes, BLOCK))](
+                    src_u8,
+                    uniq,
+                    buf_u8,
+                    row_bytes,
+                    BLOCK=BLOCK,
+                )
+            out[name] = buf
+        return inverse.reshape(topk_ids.shape).to(topk_ids.dtype), out

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -61,6 +61,7 @@ class TritonMoeQuantInfo(MoeQuantInfo):
     use_int8_w8a8: bool = False
     use_int8_w8a16: bool = False
     use_int4_w4a16: bool = False
+    use_int2_w2a16: bool = False
     per_channel_quant: bool = False
     w13_scale: Optional[torch.Tensor] = None
     w2_scale: Optional[torch.Tensor] = None
@@ -148,6 +149,7 @@ class TritonRunnerCore(MoeRunnerCore):
             use_int8_w8a8=quant_info.use_int8_w8a8,
             use_int8_w8a16=quant_info.use_int8_w8a16,
             use_int4_w4a16=quant_info.use_int4_w4a16,
+            use_int2_w2a16=quant_info.use_int2_w2a16,
             per_channel_quant=quant_info.per_channel_quant,
             w1_scale=quant_info.w13_scale,
             w2_scale=quant_info.w2_scale,
@@ -243,6 +245,7 @@ def fused_experts_none_to_triton(
             use_int8_w8a8=quant_info.use_int8_w8a8,
             use_int8_w8a16=quant_info.use_int8_w8a16,
             use_int4_w4a16=quant_info.use_int4_w4a16,
+            use_int2_w2a16=quant_info.use_int2_w2a16,
             per_channel_quant=quant_info.per_channel_quant,
             w1_scale=quant_info.w13_scale,
             w2_scale=quant_info.w2_scale,
@@ -299,6 +302,7 @@ def pre_permute_standard_to_triton(
         use_int8_w8a8=quant_info.use_int8_w8a8,
         use_int8_w8a16=quant_info.use_int8_w8a16,
         use_int4_w4a16=quant_info.use_int4_w4a16,
+        use_int2_w2a16=quant_info.use_int2_w2a16,
         per_channel_quant=quant_info.per_channel_quant,
         block_shape=quant_info.block_shape,
     )

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -117,6 +117,7 @@ def inplace_fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -150,6 +151,7 @@ def inplace_fused_experts(
         use_int8_w8a8,
         use_int8_w8a16,
         use_int4_w4a16,
+        use_int2_w2a16,
         per_channel_quant,
         w1_scale,
         w2_scale,
@@ -186,6 +188,7 @@ def outplace_fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -220,6 +223,7 @@ def outplace_fused_experts(
         use_int8_w8a8,
         use_int8_w8a16,
         use_int4_w4a16,
+        use_int2_w2a16,
         per_channel_quant,
         w1_scale,
         w2_scale,
@@ -252,6 +256,7 @@ def fused_experts(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -285,6 +290,7 @@ def fused_experts(
             use_int8_w8a8,
             use_int8_w8a16,
             use_int4_w4a16,
+            use_int2_w2a16,
             per_channel_quant,
             w1_scale,
             w2_scale,
@@ -319,6 +325,7 @@ def fused_experts(
             use_int8_w8a8,
             use_int8_w8a16,
             use_int4_w4a16,
+            use_int2_w2a16,
             per_channel_quant,
             w1_scale,
             w2_scale,
@@ -387,6 +394,7 @@ def _prepare_fused_moe_run(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     block_shape: Optional[List[int]],
 ):
@@ -406,12 +414,23 @@ def _prepare_fused_moe_run(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         dtype=hidden_states.dtype,
     )
 
+    # Config lookup keys on (E, N, K/pack). In the N-contiguous int32-word layout
+    # ([E, K/16, N], see moe_wna16.process_weights_after_loading) present the shapes
+    # as (E, N, K/4) so the tuned JSON names stay the same as for the byte layout.
+    _ncontig = use_int2_w2a16 and w1.dtype == torch.int32
+    if _ncontig:
+        _w1s = (w1.shape[0], w1.shape[2], w1.shape[1] * 4)
+        _w2s = (w2.shape[0], w2.shape[2], w2.shape[1] * 4 - padded_size)
+    else:
+        _w1s = w1.shape
+        _w2s = (w2.shape[0], w2.shape[1], w2.shape[2] - padded_size)
     config, (down_config, _) = try_get_optimal_moe_config(
-        w1.shape,
-        (w2.shape[0], w2.shape[1], w2.shape[2] - padded_size),
+        _w1s,
+        _w2s,
         topk_ids.shape[1],
         config_dtype,
         num_tokens,
@@ -475,6 +494,7 @@ def _fused_moe_kernel_sequence(
     use_int8_w8a8: bool,
     use_int8_w8a16: bool,
     use_int4_w4a16: bool,
+    use_int2_w2a16: bool,
     per_channel_quant: bool,
     w1_scale: Optional[torch.Tensor],
     w2_scale: Optional[torch.Tensor],
@@ -511,7 +531,10 @@ def _fused_moe_kernel_sequence(
     still used for output dtype/shape and the inplace combine.
     """
     num_tokens = hidden_states.shape[0]
-    E, N, _ = w1.shape
+    _ncontig = use_int2_w2a16 and w1.dtype == torch.int32
+    E = w1.shape[0]
+    N = w1.shape[2] if _ncontig else w1.shape[1]
+    _w2_hidden = w2.shape[2] if _ncontig else w2.shape[1]
     topk = topk_ids.shape[1]
     compute_type = tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16
 
@@ -542,7 +565,7 @@ def _fused_moe_kernel_sequence(
     if no_combine:
         assert not inplace
         out_hidden_states = torch.empty(
-            (num_tokens, topk, w2.shape[1]),
+            (num_tokens, topk, _w2_hidden),
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
@@ -564,6 +587,7 @@ def _fused_moe_kernel_sequence(
         and (topk > 2)
         and (not use_int8_w8a16)
         and (not use_int4_w4a16)
+        and (not use_int2_w2a16)
     )
 
     if fuse_swiglu_interleaved:
@@ -578,7 +602,13 @@ def _fused_moe_kernel_sequence(
             and gemm1_limit is None
             and swiglu_limit is None
             and b1 is None
-            and not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+            and not (
+                use_fp8_w8a8
+                or use_int8_w8a8
+                or use_int8_w8a16
+                or use_int4_w4a16
+                or use_int2_w2a16
+            )
             and not apply_router_weight_on_input
             # LoRA injects its gate_up delta into the full-width pre-activation
             # buffer that this path eliminates.
@@ -622,6 +652,7 @@ def _fused_moe_kernel_sequence(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         c_sorted=down_moe_use_tma,
@@ -797,7 +828,7 @@ def _fused_moe_kernel_sequence(
     del intermediate_cache1
 
     intermediate_cache3 = torch.empty(
-        (num_tokens, topk, w2.shape[1]),
+        (num_tokens, topk, _w2_hidden),
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
@@ -840,6 +871,7 @@ def _fused_moe_kernel_sequence(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
         a_use_tma=down_moe_use_tma,
@@ -952,6 +984,7 @@ def fused_experts_impl(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -975,7 +1008,14 @@ def fused_experts_impl(
         padded_size = 0
 
     # Check constraints.
-    if use_int4_w4a16:
+    if use_int2_w2a16:
+        # 2-bit: 4 values per byte, hence k/4 columns in the packed tensor; in the
+        # N-contiguous int32-word layout K/16 words sit in dim 1 instead
+        if w1.dtype == torch.int32:
+            assert hidden_states.shape[1] == w1.shape[1] * 16, "Hidden size mismatch"
+        else:
+            assert hidden_states.shape[1] // 4 == w1.shape[2], "Hidden size mismatch"
+    elif use_int4_w4a16:
         assert hidden_states.shape[1] // 2 == w1.shape[2], "Hidden size mismatch"
     else:
         assert (
@@ -1004,6 +1044,7 @@ def fused_experts_impl(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         block_shape=block_shape,
     )
@@ -1027,6 +1068,7 @@ def fused_experts_impl(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         w1_scale=w1_scale,
         w2_scale=w2_scale,
@@ -1064,6 +1106,7 @@ def fused_moe(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
+    use_int2_w2a16: bool = False,
     per_channel_quant: bool = False,
     w1_scale: Optional[torch.Tensor] = None,
     w2_scale: Optional[torch.Tensor] = None,
@@ -1146,6 +1189,7 @@ def fused_moe(
         use_int8_w8a8=use_int8_w8a8,
         use_int8_w8a16=use_int8_w8a16,
         use_int4_w4a16=use_int4_w4a16,
+        use_int2_w2a16=use_int2_w2a16,
         per_channel_quant=per_channel_quant,
         w1_scale=w1_scale,
         w2_scale=w2_scale,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -344,6 +344,7 @@ def get_config_dtype_str(
     dtype: torch.dtype,
     use_int8_w8a16: Optional[bool] = False,
     use_int4_w4a16: Optional[bool] = False,
+    use_int2_w2a16: Optional[bool] = False,
     use_fp8_w8a8: Optional[bool] = False,
     use_int8_w8a8: Optional[bool] = False,
 ):
@@ -351,6 +352,11 @@ def get_config_dtype_str(
         return "fp8_w8a8"
     elif use_int8_w8a8:
         return "int8_w8a8"
+    elif use_int2_w2a16:
+        # Distinct name so a tuned int4 config is never picked up by
+        # accident. No int2 config files exist; the caller then falls back to
+        # defaults, which is the correct behaviour.
+        return "int2_w2a16"
     elif use_int4_w4a16:
         return "int4_w4a16"
     elif use_int8_w8a16:

--- a/python/sglang/srt/layers/moe/row_arena.py
+++ b/python/sglang/srt/layers/moe/row_arena.py
@@ -1,0 +1,173 @@
+"""RowArena: a GPU cache of fixed-size rows whose physical memory can be handed back.
+
+The arena reserves virtual address space for ``max_rows`` rows once (cuMemAddressReserve) and
+backs a PREFIX of it with physical chunks on demand (cuMemCreate + cuMemMap). Rows are kept in
+rank order (hottest first), so shrinking the cache is a tail unmap: the memory really returns to
+the driver, in chunks, while every row address stays constant for the arena's lifetime. Kernels
+that read rows through an address table, and CUDA graphs that captured such kernels, never need
+to know.
+
+    a = RowArena(row_bytes, max_rows, device_id)
+    a.ensure_rows(n)      rows [0, n) are physically backed (may raise ArenaOOM)
+    a.shrink_rows(n)      release every chunk that lies entirely beyond row n
+    a.row_addr(i)         base + i * row_bytes (valid as an address even when unbacked)
+    a.view(n, tail, dtype) non-owning torch tensor [n, *tail] over the backed prefix
+    a.backed_rows         rows guaranteed backed right now
+
+Chunk size is a multiple of the device granularity (2 MiB on current GPUs); with 4 MiB chunks
+the cache is resizable in ~20-row steps for a 205 KB expert row.
+
+Unit test: test/registered/unit/layers/moe/test_row_arena.py.
+"""
+
+import torch
+
+from sglang.srt.cuda_vmm_utils import (  # the driver plumbing SGLang already ships
+    _get_cuda_driver,
+    align_up,
+    check_drv,
+    get_device_granularity,
+    make_device_allocation_prop,
+    make_rw_access_desc,
+    tensor_from_pointer,
+)
+
+
+class ArenaOOM(RuntimeError):
+    """cuMemCreate failed: the device has no free physical memory for another chunk."""
+
+
+class RowArena:
+    def __init__(
+        self,
+        row_bytes: int,
+        max_rows: int,
+        device_id: int = 0,
+        chunk_bytes: int = 4 << 20,
+        name: str = "",
+    ):
+        drv = _get_cuda_driver()
+        self.row_bytes, self.max_rows, self.device_id, self.name = (
+            int(row_bytes),
+            int(max_rows),
+            int(device_id),
+            name,
+        )
+        self.gran = get_device_granularity(self.device_id)
+        self.chunk = align_up(chunk_bytes, self.gran)
+        self.prop = make_device_allocation_prop(self.device_id, handle_types=None)
+        self.access = [make_rw_access_desc(self.device_id)]
+        self.va_bytes = align_up(self.row_bytes * self.max_rows, self.chunk)
+        self.base = int(
+            check_drv(
+                drv.cuMemAddressReserve(self.va_bytes, 0, 0, 0), "cuMemAddressReserve"
+            )
+        )
+        self._handles = []  # chunk i backs [i*chunk, (i+1)*chunk)
+        self._closed = False
+
+    # ---------------------------------------------------------------- geometry
+    @property
+    def backed_bytes(self) -> int:
+        return len(self._handles) * self.chunk
+
+    @property
+    def backed_rows(self) -> int:
+        return min(self.max_rows, self.backed_bytes // self.row_bytes)
+
+    def row_addr(self, i: int) -> int:
+        return self.base + i * self.row_bytes
+
+    def chunks_for_rows(self, n: int) -> int:
+        return (
+            -(-(min(int(n), self.max_rows) * self.row_bytes) // self.chunk)
+            if n > 0
+            else 0
+        )
+
+    def bytes_to_reach(self, n: int) -> int:
+        """Bytes cuMemCreate would need to make rows [0, n) backed (chunk-granular)."""
+        return max(0, self.chunks_for_rows(n) - len(self._handles)) * self.chunk
+
+    def rows_for_bytes(self, nbytes: int) -> int:
+        return min(self.max_rows, int(nbytes) // self.row_bytes)
+
+    # ---------------------------------------------------------------- resize
+    def ensure_rows(self, n: int) -> int:
+        """Back rows [0, n). Returns the number of bytes newly mapped."""
+        n = max(0, min(int(n), self.max_rows))
+        want_chunks = -(-(n * self.row_bytes) // self.chunk) if n else 0
+        drv = _get_cuda_driver()
+        added = 0
+        with torch.cuda.device(self.device_id):
+            while len(self._handles) < want_chunks:
+                off = len(self._handles) * self.chunk
+                err, handle = drv.cuMemCreate(self.chunk, self.prop, 0)
+                if err != drv.CUresult.CUDA_SUCCESS:
+                    raise ArenaOOM(
+                        f"{self.name}: cuMemCreate({self.chunk >> 20} MiB) -> {err}"
+                    )
+                try:
+                    check_drv(
+                        drv.cuMemMap(self.base + off, self.chunk, 0, handle, 0),
+                        "cuMemMap",
+                    )
+                    check_drv(
+                        drv.cuMemSetAccess(self.base + off, self.chunk, self.access, 1),
+                        "cuMemSetAccess",
+                    )
+                except BaseException:
+                    drv.cuMemRelease(handle)
+                    raise
+                self._handles.append(handle)
+                added += self.chunk
+        return added
+
+    def shrink_rows(self, n: int) -> int:
+        """Keep rows [0, n) backed, release every chunk entirely beyond. Returns bytes freed.
+        The caller must make sure no kernel still reads the released rows (sync first).
+        """
+        n = max(0, min(int(n), self.max_rows))
+        keep_chunks = -(-(n * self.row_bytes) // self.chunk) if n else 0
+        drv = _get_cuda_driver()
+        freed = 0
+        while len(self._handles) > keep_chunks:
+            off = (len(self._handles) - 1) * self.chunk
+            handle = self._handles.pop()
+            check_drv(drv.cuMemUnmap(self.base + off, self.chunk), "cuMemUnmap")
+            check_drv(drv.cuMemRelease(handle), "cuMemRelease")
+            freed += self.chunk
+        return freed
+
+    # ---------------------------------------------------------------- views
+    def view(
+        self, n_rows: int, tail=(), dtype: torch.dtype = torch.uint8
+    ) -> torch.Tensor:
+        """Non-owning tensor [n_rows, *tail] over the backed prefix. Re-create after a shrink."""
+        assert (
+            n_rows <= self.backed_rows
+        ), f"{self.name}: view of {n_rows} rows, only {self.backed_rows} backed"
+        return tensor_from_pointer(
+            self.base,
+            n_rows * self.row_bytes,
+            shape=(n_rows,) + tuple(tail),
+            dtype=dtype,
+            device_id=self.device_id,
+        )
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        torch.cuda.synchronize()
+        self.shrink_rows(0)
+        check_drv(
+            _get_cuda_driver().cuMemAddressFree(self.base, self.va_bytes),
+            "cuMemAddressFree",
+        )
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/python/sglang/srt/layers/quantization/moe_wna16.py
+++ b/python/sglang/srt/layers/quantization/moe_wna16.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import numpy as np
@@ -66,7 +67,7 @@ def get_weight_perm(num_bits: int):
 
 
 class MoeWNA16Config(QuantizationConfig):
-    """Config class for MOE WNA16 (W8A16/W4A16) quantization."""
+    """Config class for MOE WNA16 (W8A16/W4A16/W2A16) quantization."""
 
     def __init__(
         self,
@@ -182,7 +183,12 @@ class MoeWNA16Config(QuantizationConfig):
         # Avoid circular import
         awq_min_capability = AWQConfig.get_min_capability()
 
-        gptq_compatible = quant_method == "gptq" and not desc_act and num_bits in [4, 8]
+        # 2-bit added: the Triton kernel now also unpacks 4 values per byte
+        # (use_int2_w2a16). Needed because a 176B MoE only fits on 24 GB VRAM
+        # + 30 GB RAM at ~2 bpw - 4-bit would be 62 GiB.
+        gptq_compatible = (
+            quant_method == "gptq" and not desc_act and num_bits in [2, 4, 8]
+        )
         awq_compatible = (
             quant_method == "awq"
             and num_bits == 4
@@ -229,7 +235,7 @@ def is_layer_skipped_quant(prefix: str, modules_to_not_convert: List[str]):
 
 
 class MoeWNA16Method(FusedMoEMethodBase):
-    """Linear method for MOE WNA16 (W8A16/W4A16) quantization.
+    """Linear method for MOE WNA16 (W8A16/W4A16/W2A16) quantization.
 
     Args:
         quant_config: The MOE WNA16 (W8A16/W4A16) quantization config.
@@ -366,6 +372,10 @@ class MoeWNA16Method(FusedMoEMethodBase):
         self.moe_runner_config = moe_runner_config
         self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
 
+    def _process_weights_after_loading_disabled(self, layer) -> None:
+        """Set up expert streaming right after this layer finished loading."""
+        self._maybe_expert_streamer(layer)
+
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         weight_bits = self.quant_config.weight_bits
         has_zp = self.quant_config.has_zp
@@ -374,12 +384,276 @@ class MoeWNA16Method(FusedMoEMethodBase):
             w2_weight=layer.w2_qweight,
             use_int4_w4a16=weight_bits == 4,
             use_int8_w8a16=weight_bits == 8,
+            use_int2_w2a16=weight_bits == 2,
             w13_scale=layer.w13_scales,
             w2_scale=layer.w2_scales,
             w13_zp=layer.w13_qzeros if has_zp else None,
             w2_zp=layer.w2_qzeros if has_zp else None,
             block_shape=[0, layer.group_size],
         )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """2-bit: re-lay each expert tensor as N-contiguous int32 words / [E, K/128, N] scales.
+
+        Same bytes, re-arranged once. The tiled kernel's B loads become coalesced 128-B
+        lines and the decode GEMV can read experts in place. Offloaded tensors live in
+        pinned host memory at this point; re-pin after the copy.
+        """
+        if self.quant_config.weight_bits != 2:
+            return
+        if os.environ.get("SGLANG_MOE_NCONTIG", "1") != "1":
+            return
+        from sglang.srt.layers.moe.expert_gemv import to_word_ncontig
+
+        for name in ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales"):
+            p = getattr(layer, name, None)
+            if p is None or p.data.dim() != 3:
+                continue
+            t = p.data
+            was_pinned = (not t.is_cuda) and t.is_pinned()
+            if name.endswith("qweight"):
+                t2 = to_word_ncontig(t)  # [E, K/16, N] int32
+            else:
+                t2 = t.transpose(1, 2).contiguous()  # [E, K/128, N]
+            if was_pinned:
+                t2 = t2.pin_memory()
+            p.data = t2
+            del t
+        layer._b_n_contig = True
+        self._collect_for_placement(layer)
+
+    _PLACE_LAYERS = []  # layers seen so far (loader order)
+    _PLACE_FREQ = None
+
+    def _collect_for_placement(self, layer):
+        path = os.environ.get("SGLANG_MOE_PLACEMENT")
+        if not path:
+            return
+        cls = type(self)
+        if cls._PLACE_FREQ is None:
+            cls._PLACE_FREQ = torch.load(path)["mass"]
+        n_layers = int(cls._PLACE_FREQ.shape[0])
+        lid = int(getattr(layer, "layer_id", -1))
+        if 0 <= lid < n_layers:
+            cls._PLACE_LAYERS.append(layer)
+        if len(cls._PLACE_LAYERS) == n_layers:
+            if os.environ.get("SGLANG_MOE_ELASTIC") == "1":
+                from sglang.srt.layers.moe.expert_elastic import ExpertElastic
+
+                inst = ExpertElastic(
+                    cls._PLACE_FREQ,
+                    int(os.environ.get("SGLANG_MOE_PLACEMENT_S", "184")),
+                )
+                inst.place_all(cls._PLACE_LAYERS)
+                cls._ELASTIC = inst
+            else:
+                self._run_placement()
+            cls._PLACE_LAYERS = []
+
+    def _run_placement(self):
+        """Interleaved, memory-neutral hot/cold split over all layers."""
+        cls = type(self)
+        freq = cls._PLACE_FREQ
+        S_ = int(os.environ.get("SGLANG_MOE_PLACEMENT_S", "184"))
+        names = ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales")
+        layers = cls._PLACE_LAYERS
+        host = [l for l in layers if not l.w13_qweight.data.is_cuda]
+        gpu = [l for l in layers if l.w13_qweight.data.is_cuda]
+        logger.info(
+            "expert placement: %d host layers, %d GPU layers, S=%d",
+            len(host),
+            len(gpu),
+            S_,
+        )
+        pools = {n: [] for n in names}  # free host slots: (tensor, row)
+        extra_keep = []
+
+        def split_ids(l):
+            order = torch.argsort(freq[int(l.layer_id)], descending=True)
+            return order[:S_].sort().values, order[S_:].sort().values
+
+        def place_host(l):
+            hot_ids, cold_ids = split_ids(l)
+            E = int(l.w13_qweight.data.shape[0])
+            addr, proto, keep = {}, {}, []
+            for name in names:
+                p = getattr(l, name, None)
+                if p is None:
+                    continue
+                t = p.data
+                rb = t[0].numel() * t.element_size()
+                tab = torch.empty(E, dtype=torch.int64)
+                if t.is_cuda:  # split layer: this kind is on the GPU
+                    tab, h, kp = place_gpu_kind(t, hot_ids, cold_ids, name, rb, E)
+                    keep += kp
+                else:
+                    h = t.index_select(0, hot_ids).to("cuda").contiguous()
+                    tab[hot_ids] = h.data_ptr() + torch.arange(S_) * rb
+                    tab[cold_ids] = t.data_ptr() + cold_ids * rb
+                    pools[name].extend((t, int(r)) for r in hot_ids.tolist())
+                    keep.append(t)
+                p.data = h
+                addr[name] = tab.cuda()
+                proto[name] = h
+                del t
+            l._placed = {"addr": addr, "proto": proto, "E": E, "S": S_, "keep": keep}
+            l._gemv_tabs = None
+
+        def place_gpu_kind(t, hot_ids, cold_ids, name, rb, E):
+            tab = torch.empty(E, dtype=torch.int64)
+            keep = []
+            need = int(cold_ids.numel())
+            pool = pools[name]
+            if len(pool) < need:
+                extra = torch.empty(
+                    (need - len(pool),) + tuple(t.shape[1:]), dtype=t.dtype
+                ).pin_memory()
+                pool.extend((extra, i) for i in range(need - len(pool)))
+                extra_keep.append(extra)
+                keep.append(extra)
+            slots = [pool.pop() for _ in range(need)]
+            cold_cpu = t.index_select(0, cold_ids.to(t.device)).to("cpu")
+            for i, (dst, r) in enumerate(slots):
+                dst[r].copy_(cold_cpu[i])
+                tab[int(cold_ids[i])] = dst.data_ptr() + r * rb
+                keep.append(dst)
+            del cold_cpu
+            h = t.index_select(0, hot_ids.to(t.device)).contiguous()
+            tab[hot_ids] = h.data_ptr() + torch.arange(S_) * rb
+            return tab, h, keep
+
+        def place_gpu(l):
+            hot_ids, cold_ids = split_ids(l)
+            E = int(l.w13_qweight.data.shape[0])
+            addr, proto, keep = {}, {}, []
+            for name in names:
+                p = getattr(l, name, None)
+                if p is None:
+                    continue
+                t = p.data
+                rb = t[0].numel() * t.element_size()
+                tab, h, kp = place_gpu_kind(t, hot_ids, cold_ids, name, rb, E)
+                keep += kp
+                p.data = h
+                addr[name] = tab.cuda()
+                proto[name] = h
+                del t
+            torch.cuda.empty_cache()
+            l._placed = {"addr": addr, "proto": proto, "E": E, "S": S_, "keep": keep}
+            l._gemv_tabs = None
+
+        # interleave so donated slots exist before they are consumed: ~1.8 host layers per GPU layer
+        hi = gi = 0
+        ratio = max(1.0, (E_cold := (512 - S_)) / max(S_, 1))
+        credit = 0.0
+        while hi < len(host) or gi < len(gpu):
+            if hi < len(host) and (credit < ratio or gi >= len(gpu)):
+                place_host(host[hi])
+                hi += 1
+                credit += 1.0
+            else:
+                place_gpu(gpu[gi])
+                gi += 1
+                credit -= ratio
+        free_left = {n: len(v) for n, v in pools.items()}
+        logger.info(
+            "expert placement done: free host slots left %s, pinned fallbacks %d",
+            free_left,
+            len(extra_keep),
+        )
+        cls._PLACE_EXTRA = extra_keep
+
+    def _gemv_tables(self, layer):
+        tabs = getattr(layer, "_gemv_tabs", None)
+        if tabs is None:
+            from sglang.srt.layers.moe.expert_gemv import make_tables
+
+            placed = getattr(layer, "_placed", None)
+            if placed is None:
+                w13, s13 = layer.w13_qweight.data, layer.w13_scales.data
+                w2, s2 = layer.w2_qweight.data, layer.w2_scales.data
+                tabs = (
+                    make_tables(w13, s13),
+                    make_tables(w2, s2),
+                    w13.shape[2],
+                    w13.shape[1] * 16,
+                    w2.shape[2],
+                    w2.shape[1] * 16,
+                    s13.dtype == torch.bfloat16,
+                )
+            else:
+                a, pr = placed["addr"], placed["proto"]
+                h13, h2 = pr["w13_qweight"], pr["w2_qweight"]
+                tabs = (
+                    (
+                        a["w13_qweight"],
+                        a["w13_scales"],
+                        h13.stride(1),
+                        pr["w13_scales"].stride(1),
+                    ),
+                    (
+                        a["w2_qweight"],
+                        a["w2_scales"],
+                        h2.stride(1),
+                        pr["w2_scales"].stride(1),
+                    ),
+                    h13.shape[2],
+                    h13.shape[1] * 16,
+                    h2.shape[2],
+                    h2.shape[1] * 16,
+                    pr["w13_scales"].dtype == torch.bfloat16,
+                )
+            layer._gemv_tabs = tabs
+        return tabs
+
+    def _apply_gemv(self, layer, dispatch_output):
+        """Batch-1 path: T independent 2-bit GEMVs reading experts in place."""
+        from sglang.srt.layers.moe.expert_gemv import moe_gemv_int2_tab
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+        x = dispatch_output.hidden_states
+        topk = dispatch_output.topk_output
+        ids = topk.topk_ids.reshape(-1)
+        w = topk.topk_weights.reshape(-1).to(torch.float32)
+        M_, top_k = topk.topk_ids.shape
+        (wt13, st13, sw13, ss13), (wt2, st2, sw2, ss2), N13, K13, N2, K2, sbf = (
+            self._gemv_tables(layer)
+        )
+        inter = N13 // 2
+        c13 = moe_gemv_int2_tab(
+            x,
+            wt13,
+            st13,
+            ids,
+            w,
+            N13,
+            K13,
+            sw13,
+            ss13,
+            top_k=top_k,
+            mul_routed_weight=False,
+            scale_bf16=sbf,
+        )
+        h = torch.nn.functional.silu(c13[:, :inter]) * c13[:, inter:]
+        c2 = moe_gemv_int2_tab(
+            h,
+            wt2,
+            st2,
+            ids,
+            w,
+            N2,
+            K2,
+            sw2,
+            ss2,
+            top_k=1,
+            mul_routed_weight=True,
+            scale_bf16=sbf,
+        )
+        out = c2.view(M_, top_k, N2).sum(dim=1)
+        rsf = self.moe_runner_config.routed_scaling_factor
+        if rsf is not None and rsf != 1.0:
+            out = out * rsf
+        return StandardCombineInput(hidden_states=out.to(x.dtype))
 
     def apply(
         self,
@@ -389,9 +663,75 @@ class MoeWNA16Method(FusedMoEMethodBase):
         assert (
             self.moe_runner_config.activation == "silu"
         ), "Only SiLU activation is supported."
+        _el = getattr(type(self), "_ELASTIC", None)
+        if _el is not None:
+            _el.poll(
+                int(dispatch_output.hidden_states.shape[0]),
+                int(getattr(layer, "layer_id", 0)),
+            )
 
-        quant_info = self.get_triton_quant_info(layer)
+        if (
+            getattr(layer, "_b_n_contig", False)
+            and self.quant_config.weight_bits == 2
+            and dispatch_output.hidden_states.shape[0] <= 16
+            and os.environ.get("SGLANG_MOE_GEMV", "1") == "1"
+        ):
+            return self._apply_gemv(layer, dispatch_output)
+
+        streamer = self._maybe_expert_streamer(layer)
+        if streamer is None:
+            quant_info = self.get_triton_quant_info(layer)
+            return self.runner.run(dispatch_output, quant_info)
+
+        # MoE-aware offloading: gather only the selected experts into a
+        # compact buffer and renumber the ids onto it. The Triton kernel
+        # stays unchanged.
+        topk = dispatch_output.topk_output
+        new_ids, tensors = streamer.gather(topk.topk_ids)
+        dispatch_output = dispatch_output._replace(
+            topk_output=topk._replace(topk_ids=new_ids)
+        )
+        weight_bits = self.quant_config.weight_bits
+        has_zp = self.quant_config.has_zp
+        quant_info = TritonMoeQuantInfo(
+            w13_weight=tensors["w13_qweight"],
+            w2_weight=tensors["w2_qweight"],
+            use_int4_w4a16=weight_bits == 4,
+            use_int8_w8a16=weight_bits == 8,
+            use_int2_w2a16=weight_bits == 2,
+            w13_scale=tensors["w13_scales"],
+            w2_scale=tensors["w2_scales"],
+            w13_zp=tensors.get("w13_qzeros") if has_zp else None,
+            w2_zp=tensors.get("w2_qzeros") if has_zp else None,
+            block_shape=[0, layer.group_size],
+        )
         return self.runner.run(dispatch_output, quant_info)
+
+    def _maybe_expert_streamer(self, layer):
+        """Create the streamer once, on demand."""
+        st = getattr(layer, "_expert_streamer", "unset")
+        if st != "unset":
+            return st
+        from sglang.srt.layers.moe.expert_stream import ExpertStreamer, enabled
+
+        if not enabled() or not hasattr(layer, "w13_qweight"):
+            layer._expert_streamer = None
+            return None
+        # All four expert tensors resident on the device: the plain path is
+        # byte-for-byte what the streamer would produce, minus the copy. The
+        # gate is per LAYER, never per tensor - one moe_align result numbers
+        # both GEMMs, so a split layer must keep the streamer.
+        _names = ("w13_qweight", "w2_qweight", "w13_scales", "w2_scales")
+        _ts = [getattr(layer, n).data for n in _names if hasattr(layer, n)]
+        if (
+            _ts
+            and all(t.is_cuda for t in _ts)
+            and getattr(layer, "_placed", None) is None
+        ):
+            layer._expert_streamer = None
+            return None
+        layer._expert_streamer = ExpertStreamer(layer)
+        return layer._expert_streamer
 
     @staticmethod
     def get_weight_loader(layer, weight_loader):
@@ -469,10 +809,19 @@ class MoeWNA16Method(FusedMoEMethodBase):
                 else:
                     loaded_weight = loaded_weight.T
             elif layer.quant_config.linear_quant_method == "gptq":
-                assert layer.quant_config.weight_bits in [4, 8]
+                assert layer.quant_config.weight_bits in [2, 4, 8]
                 if "weight" in weight_name:
+                    # Identical for 2/4/8 bits: viewing the int32 storage as
+                    # uint8 lays the values out along K (16/8/4 per int32), and
+                    # the kernel derives byte and shift from the bit width.
+                    # Verified against real AutoRound 2-bit tensors.
                     loaded_weight = loaded_weight.T.contiguous().view(torch.uint8)
                 elif "zeros" in weight_name:
+                    if layer.quant_config.weight_bits == 2:
+                        raise NotImplementedError(
+                            "asymmetric 2-bit GPTQ (qzeros) is not implemented "
+                            "here; only sym=True is supported"
+                        )
                     # add 1 to gptq qzeros to align with awq
                     loaded_weight = loaded_weight.view(torch.uint8)
                     if layer.quant_config.weight_bits == 4:

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -68,13 +68,29 @@ class RadixLinearAttention(nn.Module):
         self.k_dim = num_k_heads * head_k_dim
         self.v_dim = num_v_heads * head_v_dim
 
-        self.conv_weights = conv_weights
+        self._conv_source = conv_weights
         self.bias = bias
         self.activation = activation
 
         self.A_log = A_log
         self.dt_bias = dt_bias
         self.lower_bound = None
+
+    @property
+    def conv_weights(self):
+        """Convolution weights, derived fresh on every access.
+
+        When an nn.Module (nn.Conv1d) is passed, the 2D view is built from the
+        CURRENT parameter. This is required because --cpu-offload-gb replaces
+        param.data; a view stored once then points at stale memory. Tensors
+        and tuples pass through unchanged so other models (KDA, ShortConv,
+        Lightning) are unaffected.
+        """
+        src = self._conv_source
+        if isinstance(src, nn.Module):
+            w = src.weight
+            return w.view(w.size(0), w.size(2))
+        return src
 
     def forward(
         self,

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -146,6 +146,31 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 pass
         self.clear()
 
+    def _lazy_hook(self, pages: torch.Tensor) -> bool:
+        """Back the KV rows of the pages about to be handed out. False = no physical memory."""
+        kv = getattr(self._kvcache, "full_kv_pool", self._kvcache)
+        ensure = getattr(kv, "lazy_ensure", None)
+        if ensure is None or pages.numel() == 0:
+            return True
+        try:
+            ensure((int(pages.max().item()) + 1) * self.page_size)
+            return True
+        except Exception as ex:
+            __import__("logging").getLogger(__name__).warning(
+                "KV lazy backing: commit failed, allocation refused (%s)", ex
+            )
+            return False
+
+    def _lazy_idle_check(self) -> None:
+        if (
+            len(self.free_pages) + len(self.release_pages) >= self.num_pages
+        ):  # pool idle: slot order + give memory back
+            kv = getattr(self._kvcache, "full_kv_pool", self._kvcache)
+            release = getattr(kv, "lazy_release", None)
+            if release is not None:
+                self.clear()
+                release()
+
     def alloc(self, need_size: int):
         # page-aligned allocation, returning contiguous indices of pages
         if self.debug_mode:
@@ -160,6 +185,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return None
 
         out_pages = self.free_pages[:num_pages]
+        if not self._lazy_hook(out_pages):
+            return None
         self.free_pages = self.free_pages[num_pages:]
 
         out_indices = (
@@ -215,6 +242,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             )
         if num_new_pages > len(self.free_pages):
             return None
+        if not self._lazy_hook(self.free_pages[:num_new_pages]):
+            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
@@ -253,6 +282,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             decode=True,
         )
         if num_new_pages > len(self.free_pages):
+            return None
+        if not self._lazy_hook(self.free_pages[:num_new_pages]):
             return None
 
         self.free_pages = self.free_pages[num_new_pages:]
@@ -312,6 +343,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.release_pages = torch.cat((*page_ids, self.release_pages))
         else:
             self.free_pages = torch.cat((*page_ids, self.free_pages))
+        self._lazy_idle_check()
 
     def free_group_begin(self):
         super().free_group_begin()

--- a/python/sglang/srt/mem_cache/allocator/token.py
+++ b/python/sglang/srt/mem_cache/allocator/token.py
@@ -61,6 +61,19 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         select_index = self.free_pages[:need_size]
         self.free_pages = self.free_pages[need_size:]
+        kv = getattr(self._kvcache, "full_kv_pool", self._kvcache)
+        ensure = getattr(kv, "lazy_ensure", None)
+        if ensure is not None:
+            try:
+                ensure(int(select_index.max().item()) + 1)
+            except (
+                Exception
+            ) as ex:  # no physical memory: hand the slots back, report "full"
+                self.free_pages = torch.cat((select_index, self.free_pages))
+                __import__("logging").getLogger(__name__).warning(
+                    "KV lazy backing: commit failed, allocation refused (%s)", ex
+                )
+                return None
         return select_index
 
     def free(self, free_index: torch.Tensor):
@@ -72,6 +85,14 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 self.release_pages = torch.cat((self.release_pages, free_index))
             else:
                 self.free_pages = torch.cat((self.free_pages, free_index))
+            if (
+                self.available_size() >= self.size
+            ):  # pool idle: slot order + give memory back
+                kv = getattr(self._kvcache, "full_kv_pool", self._kvcache)
+                release = getattr(kv, "lazy_release", None)
+                if release is not None:
+                    self.clear()
+                    release()
         else:
             self.free_group.append(self._copy_for_free_group(free_index))
 

--- a/python/sglang/srt/mem_cache/int4_kv_pool.py
+++ b/python/sglang/srt/mem_cache/int4_kv_pool.py
@@ -1,0 +1,209 @@
+"""INT4-G32 KV pool for the Qwen sparse attention layers.
+
+Layout per local layer l (rows = size + page_size, NHD):
+  k_buffer[l], v_buffer[l]             uint8 [rows, H, D // 2]     two 4-bit channels per byte
+                                       (low nibble = even channel, high = odd, stored q + 8, q in [-7, 7])
+  k_scale_buffer[l], v_scale_buffer[l] fp16 [rows, H, D // GROUP]  absmax/7 per (token, head, group)
+The scale buffers are extra KvBufferDescs (int8 [rows, H * D // GROUP * 2]) on the lazy VMM owner and
+viewed as fp16; on the eager path they are plain zero tensors.  `kv_bits = 4` is the QSA backend's
+dispatch key (the int8 pool carries 8; the fp8 pool also stores uint8, so dtype alone is ambiguous).
+Smoothing constants (sm_k / sm_v and their inverses, fp16 [L, H, D]) are identity, as in the int8 pool.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    KV_INT4_GROUP,
+    quant_store_kv_int4,
+)
+from sglang.srt.mem_cache.memory_pool import (
+    KvBufferDesc,
+    MHATokenToKVPool,
+    unwrap_write_loc,
+)
+from sglang.srt.utils.async_probe import maybe_detect_oob
+
+
+def _is_unit_scale(s) -> bool:
+    return s is None or (isinstance(s, (int, float)) and s == 1)
+
+
+class MHATokenToKVPoolInt4(MHATokenToKVPool):
+    """MHA KV pool storing nibble-packed int4 K/V with fp16 per-(token, head, GROUP-channel) scales."""
+
+    GROUP = KV_INT4_GROUP
+    kv_bits = 4  # QSA backend dispatch key (the int8_g64 pool carries 8)
+
+    def __init__(self, *args, **kwargs):
+        self.k_scale_buffer = None
+        self.v_scale_buffer = None
+        super().__init__(*args, **kwargs)
+        if self.dtype != torch.uint8 or self.store_dtype != torch.uint8:
+            raise ValueError(
+                f"MHATokenToKVPoolInt4 needs dtype uint8, got {self.dtype}/{self.store_dtype}"
+            )
+        if self.use_hnd or self.kv_cache_layout != "nhd":
+            raise ValueError("MHATokenToKVPoolInt4 supports the NHD layout only")
+        # Static per-channel smoothing constants; identity.
+        L, H = self.layer_num, self.head_num
+        self.sm_k = torch.ones(
+            (L, H, self.head_dim), dtype=torch.float16, device=self.device
+        )
+        self.sm_v = torch.ones(
+            (L, H, self.v_head_dim), dtype=torch.float16, device=self.device
+        )
+        self.sm_k_inv = torch.ones_like(self.sm_k)
+        self.sm_v_inv = torch.ones_like(self.sm_v)
+
+    # -- layout ---------------------------------------------------------------------------------
+
+    @property
+    def k_groups(self) -> int:
+        if self.head_dim % self.GROUP:
+            raise ValueError(
+                f"head_dim {self.head_dim} not a multiple of GROUP {self.GROUP}"
+            )
+        return self.head_dim // self.GROUP
+
+    @property
+    def v_groups(self) -> int:
+        if self.v_head_dim % self.GROUP:
+            raise ValueError(
+                f"v_head_dim {self.v_head_dim} not a multiple of GROUP {self.GROUP}"
+            )
+        return self.v_head_dim // self.GROUP
+
+    def _kv_buffer_shapes(self):
+        """Payload rows hold D // 2 bytes per head (two channels per byte)."""
+        if self.use_hnd:
+            raise ValueError("MHATokenToKVPoolInt4 supports the NHD layout only")
+        if self.head_dim % 2 or self.v_head_dim % 2:
+            raise ValueError("MHATokenToKVPoolInt4 needs even head dims")
+        rows = self.size + self.page_size
+        return (
+            (rows, self.head_num, self.head_dim // 2),
+            (rows, self.head_num, self.v_head_dim // 2),
+        )
+
+    def _scale_shapes(self):
+        rows = self.size + self.page_size
+        return (rows, self.head_num, self.k_groups), (
+            rows,
+            self.head_num,
+            self.v_groups,
+        )
+
+    def _create_buffers_normal(self):
+        super()._create_buffers_normal()
+        ks_shape, vs_shape = self._scale_shapes()
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.k_scale_buffer = [
+                torch.zeros(ks_shape, dtype=torch.float16, device=self.device)
+                for _ in range(self.layer_num)
+            ]
+            self.v_scale_buffer = [
+                torch.zeros(vs_shape, dtype=torch.float16, device=self.device)
+                for _ in range(self.layer_num)
+            ]
+
+    def _build_kv_buffer_descs(self):
+        descs = super()._build_kv_buffer_descs()
+        if any(d.tokens_per_row != 1 for d in descs):
+            raise ValueError(
+                "MHATokenToKVPoolInt4 scale descs assume one token per row (NHD)"
+            )
+        ks_shape, vs_shape = self._scale_shapes()
+        for prefix, shape in (("ks", ks_shape), ("vs", vs_shape)):
+            row_bytes = shape[1] * shape[2] * 2  # fp16 scales as int8 bytes
+            for layer in range(self.layer_num):
+                descs.append(
+                    KvBufferDesc(
+                        f"{prefix}{layer}",
+                        (shape[0], row_bytes),
+                        row_bytes=row_bytes,
+                        tokens_per_row=1,
+                    )
+                )
+        return descs
+
+    def _assign_post_capture_tensors(self, tensors):
+        L = self.layer_num
+        ks_shape, vs_shape = self._scale_shapes()
+        self.k_buffer = tensors[:L]
+        self.v_buffer = tensors[L : 2 * L]
+        self.k_scale_buffer = [
+            t.view(torch.float16).view(ks_shape) for t in tensors[2 * L : 3 * L]
+        ]
+        self.v_scale_buffer = [
+            t.view(torch.float16).view(vs_shape) for t in tensors[3 * L : 4 * L]
+        ]
+        # The owner backs exactly one page at construction; zero only those rows (never touch
+        # unbacked VA).  Every other slot is written before it is read.
+        for t in self.k_scale_buffer + self.v_scale_buffer:
+            t[: self.page_size].zero_()
+
+    def _pd_registerable_tensors(self):
+        return self.k_buffer + self.v_buffer + self.k_scale_buffer + self.v_scale_buffer
+
+    # -- accessors ------------------------------------------------------------------------------
+
+    def get_kv_scale_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        idx = layer_id - self.start_layer
+        return self.k_scale_buffer[idx], self.v_scale_buffer[idx]
+
+    def get_kv_smooth_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        idx = layer_id - self.start_layer
+        return self.sm_k[idx], self.sm_v[idx]
+
+    # -- write path -----------------------------------------------------------------------------
+
+    def set_kv_buffer(
+        self,
+        layer,
+        loc_info,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale=None,
+        v_scale=None,
+        layer_id_override: Optional[int] = None,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+    ):
+        if dcp_kv_mask is not None:
+            raise NotImplementedError("int4_g32 KV cache does not support DCP KV masks")
+        if not (_is_unit_scale(k_scale) and _is_unit_scale(v_scale)):
+            raise ValueError(
+                "int4_g32 KV cache computes its own scales; got k_scale/v_scale"
+            )
+        loc, _, _ = unwrap_write_loc(loc_info)
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA-INT4)")
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+        idx = layer_id - self.start_layer
+        cache_k = cache_k.view(-1, self.head_num, self.head_dim)
+        cache_v = cache_v.view(-1, self.head_num, self.v_head_dim)
+        quant_store_kv_int4(
+            cache_k,
+            cache_v,
+            loc,
+            self.k_buffer[idx],
+            self.v_buffer[idx],
+            self.k_scale_buffer[idx],
+            self.v_scale_buffer[idx],
+            self.sm_k_inv[idx],
+            self.sm_v_inv[idx],
+        )
+
+    def set_kv_buffer_prefix_valid(self, *args, **kwargs):
+        raise NotImplementedError(
+            "int4_g32 KV cache: prefix-valid commit is not supported"
+        )
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        raise NotImplementedError("int4_g32 KV cache: CPU offload is not supported")
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        raise NotImplementedError("int4_g32 KV cache: CPU offload is not supported")

--- a/python/sglang/srt/mem_cache/int8_kv_pool.py
+++ b/python/sglang/srt/mem_cache/int8_kv_pool.py
@@ -1,0 +1,197 @@
+"""INT8-G64 KV pool for the Qwen sparse attention layers.
+
+Layout per local layer l (rows = size + page_size, NHD):
+  k_buffer[l], v_buffer[l]             int8 [rows, H, D]
+  k_scale_buffer[l], v_scale_buffer[l] fp16 [rows, H, D // GROUP]   absmax/127 per (token, head, group)
+The scale buffers are extra KvBufferDescs (int8 [rows, H * D // GROUP * 2]) on the lazy VMM owner and
+viewed as fp16; on the eager path they are plain zero tensors.  Per-channel smoothing constants
+(sm_k / sm_v and their inverses, fp16 [L, H, D]) are plumbed but identity; a static smoothing
+A/B was not adopted.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    KV_INT8_GROUP,
+    quant_store_kv_int8,
+)
+from sglang.srt.mem_cache.memory_pool import (
+    KvBufferDesc,
+    MHATokenToKVPool,
+    unwrap_write_loc,
+)
+from sglang.srt.utils.async_probe import maybe_detect_oob
+
+
+def _is_unit_scale(s) -> bool:
+    return s is None or (isinstance(s, (int, float)) and s == 1)
+
+
+class MHATokenToKVPoolInt8(MHATokenToKVPool):
+    """MHA KV pool storing int8 K/V with fp16 per-(token, head, GROUP-channel) absmax scales."""
+
+    GROUP = KV_INT8_GROUP
+    kv_bits = 8  # QSA backend dispatch key (the int4_g32 pool carries 4)
+
+    def __init__(self, *args, **kwargs):
+        self.k_scale_buffer = None
+        self.v_scale_buffer = None
+        super().__init__(*args, **kwargs)
+        if self.dtype != torch.int8 or self.store_dtype != torch.int8:
+            raise ValueError(
+                f"MHATokenToKVPoolInt8 needs dtype int8, got {self.dtype}/{self.store_dtype}"
+            )
+        if self.use_hnd or self.kv_cache_layout != "nhd":
+            raise ValueError("MHATokenToKVPoolInt8 supports the NHD layout only")
+        # Per-channel smoothing constants: plumbed but identity (a static
+        # smoothing A/B was not adopted).
+        L, H = self.layer_num, self.head_num
+        self.sm_k = torch.ones(
+            (L, H, self.head_dim), dtype=torch.float16, device=self.device
+        )
+        self.sm_v = torch.ones(
+            (L, H, self.v_head_dim), dtype=torch.float16, device=self.device
+        )
+        self.sm_k_inv = torch.ones_like(self.sm_k)
+        self.sm_v_inv = torch.ones_like(self.sm_v)
+
+    # -- layout ---------------------------------------------------------------------------------
+
+    @property
+    def k_groups(self) -> int:
+        if self.head_dim % self.GROUP:
+            raise ValueError(
+                f"head_dim {self.head_dim} not a multiple of GROUP {self.GROUP}"
+            )
+        return self.head_dim // self.GROUP
+
+    @property
+    def v_groups(self) -> int:
+        if self.v_head_dim % self.GROUP:
+            raise ValueError(
+                f"v_head_dim {self.v_head_dim} not a multiple of GROUP {self.GROUP}"
+            )
+        return self.v_head_dim // self.GROUP
+
+    def _scale_shapes(self):
+        rows = self.size + self.page_size
+        return (rows, self.head_num, self.k_groups), (
+            rows,
+            self.head_num,
+            self.v_groups,
+        )
+
+    def _create_buffers_normal(self):
+        super()._create_buffers_normal()
+        ks_shape, vs_shape = self._scale_shapes()
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.k_scale_buffer = [
+                torch.zeros(ks_shape, dtype=torch.float16, device=self.device)
+                for _ in range(self.layer_num)
+            ]
+            self.v_scale_buffer = [
+                torch.zeros(vs_shape, dtype=torch.float16, device=self.device)
+                for _ in range(self.layer_num)
+            ]
+
+    def _build_kv_buffer_descs(self):
+        descs = super()._build_kv_buffer_descs()
+        if any(d.tokens_per_row != 1 for d in descs):
+            raise ValueError(
+                "MHATokenToKVPoolInt8 scale descs assume one token per row (NHD)"
+            )
+        ks_shape, vs_shape = self._scale_shapes()
+        for prefix, shape in (("ks", ks_shape), ("vs", vs_shape)):
+            row_bytes = shape[1] * shape[2] * 2  # fp16 scales as int8 bytes
+            for layer in range(self.layer_num):
+                descs.append(
+                    KvBufferDesc(
+                        f"{prefix}{layer}",
+                        (shape[0], row_bytes),
+                        row_bytes=row_bytes,
+                        tokens_per_row=1,
+                    )
+                )
+        return descs
+
+    def _assign_post_capture_tensors(self, tensors):
+        L = self.layer_num
+        ks_shape, vs_shape = self._scale_shapes()
+        self.k_buffer = tensors[:L]
+        self.v_buffer = tensors[L : 2 * L]
+        self.k_scale_buffer = [
+            t.view(torch.float16).view(ks_shape) for t in tensors[2 * L : 3 * L]
+        ]
+        self.v_scale_buffer = [
+            t.view(torch.float16).view(vs_shape) for t in tensors[3 * L : 4 * L]
+        ]
+        # The owner backs exactly one page at construction; zero only those rows (never touch
+        # unbacked VA).  Every other slot is written before it is read.
+        for t in self.k_scale_buffer + self.v_scale_buffer:
+            t[: self.page_size].zero_()
+
+    def _pd_registerable_tensors(self):
+        return self.k_buffer + self.v_buffer + self.k_scale_buffer + self.v_scale_buffer
+
+    # -- accessors ------------------------------------------------------------------------------
+
+    def get_kv_scale_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        idx = layer_id - self.start_layer
+        return self.k_scale_buffer[idx], self.v_scale_buffer[idx]
+
+    def get_kv_smooth_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        idx = layer_id - self.start_layer
+        return self.sm_k[idx], self.sm_v[idx]
+
+    # -- write path -----------------------------------------------------------------------------
+
+    def set_kv_buffer(
+        self,
+        layer,
+        loc_info,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale=None,
+        v_scale=None,
+        layer_id_override: Optional[int] = None,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+    ):
+        if dcp_kv_mask is not None:
+            raise NotImplementedError("int8_g64 KV cache does not support DCP KV masks")
+        if not (_is_unit_scale(k_scale) and _is_unit_scale(v_scale)):
+            raise ValueError(
+                "int8_g64 KV cache computes its own scales; got k_scale/v_scale"
+            )
+        loc, _, _ = unwrap_write_loc(loc_info)
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA-INT8)")
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+        idx = layer_id - self.start_layer
+        cache_k = cache_k.view(-1, self.head_num, self.head_dim)
+        cache_v = cache_v.view(-1, self.head_num, self.v_head_dim)
+        quant_store_kv_int8(
+            cache_k,
+            cache_v,
+            loc,
+            self.k_buffer[idx],
+            self.v_buffer[idx],
+            self.k_scale_buffer[idx],
+            self.v_scale_buffer[idx],
+            self.sm_k_inv[idx],
+            self.sm_v_inv[idx],
+        )
+
+    def set_kv_buffer_prefix_valid(self, *args, **kwargs):
+        raise NotImplementedError(
+            "int8_g64 KV cache: prefix-valid commit is not supported"
+        )
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        raise NotImplementedError("int8_g64 KV cache: CPU offload is not supported")
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        raise NotImplementedError("int8_g64 KV cache: CPU offload is not supported")

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -47,6 +47,8 @@ from sglang.srt.mem_cache.allocator.swa import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
+from sglang.srt.mem_cache.int4_kv_pool import MHATokenToKVPoolInt4
+from sglang.srt.mem_cache.int8_kv_pool import MHATokenToKVPoolInt8
 from sglang.srt.mem_cache.memory_pool import (
     DSATokenToKVPool,
     HybridLinearKVPool,
@@ -63,6 +65,7 @@ from sglang.srt.mem_cache.memory_pool import (
     ReqToTokenPool,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.mem_cache.tiered_kv_pool import MHATokenToKVPoolTiered
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     configured_pp_size,
@@ -1543,9 +1546,22 @@ class KVCacheConfigurator:
         # MXFP8 KV cache needs the block-scaled pool (data + UE8M0 scale
         # buffers) for the full-attention layers, same as the SWA branch.
         full_pool_class = (
-            MHATokenToKVPoolMXFP8
-            if self.kv_cache_dtype_str == "mxfp8" and not self.use_mla_backend
-            else mha_pool_class
+            MHATokenToKVPoolTiered
+            if self.kv_cache_dtype_str == "int8ring_int4"
+            else (
+                MHATokenToKVPoolInt4
+                if self.kv_cache_dtype_str == "int4_g32"
+                else (
+                    MHATokenToKVPoolInt8
+                    if self.kv_cache_dtype_str == "int8_g64"
+                    else (
+                        MHATokenToKVPoolMXFP8
+                        if self.kv_cache_dtype_str == "mxfp8"
+                        and not self.use_mla_backend
+                        else mha_pool_class
+                    )
+                )
+            )
         )
         from sglang.srt.layers.attention.qsa.config import (
             QSA_VARIANT_TOKENWISE,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1900,6 +1900,24 @@ class KVCacheConfigurator:
         If constraints change the value, the configurator re-runs and re-aligns.
         """
         user_limit = get_schedule().max_total_tokens
+        _env = __import__("os").environ
+        _lazy_tokens = (
+            int(_env.get("SGLANG_KV_LAZY_TOKENS", "0"))
+            if _env.get("SGLANG_KV_LAZY") == "1"
+            else 0
+        )
+        if _lazy_tokens > 0:
+            # The profiled capacity is what the free VRAM at startup could back physically; with the
+            # headroom rule (1.5 GB kept free for prefill working memory) the practical limit measured
+            # 0.85 x profiled (84k of 106k tokens at bf16). Longer prompts are rejected at admission
+            # instead of crashing the scheduler mid-prefill.
+            _safety = float(_env.get("SGLANG_KV_LAZY_SAFETY", "0.85"))
+            _new = min(_lazy_tokens, int(token_capacity * _safety))
+            logging.warning(
+                f"KV lazy backing: token capacity {token_capacity} (profiled) -> {_new} "
+                f"(requested {_lazy_tokens}, safety {_safety})"
+            )
+            token_capacity = _new
 
         # Apply user-specified upper bound
         if user_limit is not None:

--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -16,6 +16,8 @@ TORCH_DTYPE_TO_KV_CACHE_STR = {
     torch.float8_e4m3fnuz: "fp8_e4m3",
     torch.float8_e5m2: "fp8_e5m2",
     torch.bfloat16: "bf16",
+    torch.int8: "int8_g64",
+    torch.uint8: "int4_g32",
 }
 
 
@@ -57,6 +59,14 @@ def configure_kv_cache_dtype(
             kv_cache_dtype = torch.float8_e4m3fn
     elif server_args_kv_cache_dtype == "mxfp8":
         kv_cache_dtype = torch.float8_e4m3fn
+    elif server_args_kv_cache_dtype == "int8_g64":
+        kv_cache_dtype = torch.int8
+    elif server_args_kv_cache_dtype == "int4_g32":
+        kv_cache_dtype = torch.uint8
+    elif (
+        server_args_kv_cache_dtype == "int8ring_int4"
+    ):  # int4_g32 rows + int8_g64 ring (tiered pool)
+        kv_cache_dtype = torch.uint8
     elif server_args_kv_cache_dtype in ("bf16", "bfloat16"):
         kv_cache_dtype = torch.bfloat16
     elif server_args_kv_cache_dtype == "fp4_e2m1":

--- a/python/sglang/srt/mem_cache/kv_vmm_backing.py
+++ b/python/sglang/srt/mem_cache/kv_vmm_backing.py
@@ -187,6 +187,38 @@ class KvVmmArena:
         """Total physically-backed bytes (sum of scattered per-buffer ranges)."""
         return self._range_backed
 
+    def uncommit_beyond(self, offset: int, keep_bytes: int) -> int:
+        """Release every mapping of the buffer at ``offset`` that starts at or beyond
+        ``keep_bytes`` (mappings straddling the boundary stay). Returns bytes freed."""
+        if self._closed:
+            return 0
+        from sglang.srt.cuda_vmm_utils import _get_cuda_driver, check_drv
+
+        drv = _get_cuda_driver()
+        start = self.base + offset
+        limit = start + self._committed_by_offset.get(offset, 0)
+        cut = start + self._align(int(keep_bytes))
+        maps = self._allocation._mappings
+        victims = sorted(
+            [m for m in maps if start <= m[0] < limit and m[0] >= cut],
+            key=lambda m: -m[0],
+        )
+        freed = 0
+        with torch.cuda.device(self.device_id):
+            for m in victims:
+                address, size, handle = m
+                check_drv(drv.cuMemUnmap(address, size), "cuMemUnmap(uncommit)")
+                if handle is not None:
+                    check_drv(drv.cuMemRelease(handle), "cuMemRelease(uncommit)")
+                maps.remove(m)
+                freed += size
+        if freed:
+            self._committed_by_offset[offset] = (
+                self._committed_by_offset.get(offset, 0) - freed
+            )
+            self._range_backed -= freed
+        return freed
+
     @property
     def cursor_bytes(self) -> int:
         return int(self._fn_cursor())
@@ -336,6 +368,28 @@ class KvVmmBufferOwner:
         self._back_spans(
             [s.desc.prefix_span_bytes(num_tokens, self.page_size) for s in self._specs]
         )
+        self.backed_tokens = max(getattr(self, "backed_tokens", 0), int(num_tokens))
+
+    def release_beyond(self, num_tokens: int) -> int:
+        """Unmap the backing beyond the first ``num_tokens`` slots of every buffer."""
+        if self._arena is None:
+            return 0
+        torch.cuda.synchronize()
+        freed = 0
+        for s in self._specs:
+            keep = align_up(
+                s.desc.prefix_span_bytes(num_tokens, self.page_size),
+                self._arena.granularity,
+            )
+            freed += self._arena.uncommit_beyond(s.offset, keep)
+            s.backed_to = min(
+                s.backed_to, self._arena._committed_by_offset.get(s.offset, 0)
+            )
+        self.backed_tokens = min(getattr(self, "backed_tokens", 0), int(num_tokens))
+        return freed
+
+    def bytes_per_token(self) -> int:
+        return sum(-(-s.desc.row_bytes // s.desc.tokens_per_row) for s in self._specs)
 
     def finalize(self, final_num_tokens: int) -> None:
         """Back each buffer's final advertised span; set the final serving capacity."""

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2473,10 +2473,19 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if k_scale is not None and not (
+                isinstance(k_scale, (int, float)) and k_scale == 1
+            ):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if v_scale is not None and not (
+                isinstance(v_scale, (int, float)) and v_scale == 1
+            ):
                 cache_v.div_(v_scale)
+            if (
+                self.dtype == torch.float8_e4m3fn
+            ):  # fp32/bf16 -> e4m3fn returns NaN beyond +-448
+                cache_k = cache_k.clamp(-448.0, 448.0)
+                cache_v = cache_v.clamp(-448.0, 448.0)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
 
@@ -2846,10 +2855,19 @@ class MHATokenToKVPool(KVCache):
             )
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if k_scale is not None and not (
+                isinstance(k_scale, (int, float)) and k_scale == 1
+            ):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if v_scale is not None and not (
+                isinstance(v_scale, (int, float)) and v_scale == 1
+            ):
                 cache_v.div_(v_scale)
+            if (
+                self.dtype == torch.float8_e4m3fn
+            ):  # fp32/bf16 -> e4m3fn returns NaN beyond +-448
+                cache_k = cache_k.clamp(-448.0, 448.0)
+                cache_v = cache_v.clamp(-448.0, 448.0)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2056,6 +2056,20 @@ class MHATokenToKVPool(KVCache):
             self.dq_v_buffer = None
             if self.post_capture_active:
                 self._alloc_post_capture_buffers()
+            elif os.environ.get("SGLANG_KV_LAZY") == "1":
+                self._alloc_post_capture_buffers()
+                self._lazy_floor = min(
+                    self.size, int(os.environ.get("SGLANG_KV_LAZY_FLOOR", "4096"))
+                )
+                self._lazy_margin = int(os.environ.get("SGLANG_KV_LAZY_MARGIN", "2048"))
+                self._post_capture_owner.ensure_prefix(self._lazy_floor)
+                logger.info(
+                    "KV lazy backing: %d tokens reserved as VA, %d backed (floor), margin %d, %.1f KB/token",
+                    self.size,
+                    self._lazy_floor,
+                    self._lazy_margin,
+                    self._post_capture_owner.bytes_per_token() / 1024,
+                )
             else:
                 self._create_buffers_normal()
         self._kv_buffer_descs = self._build_kv_buffer_descs()
@@ -2261,6 +2275,97 @@ class MHATokenToKVPool(KVCache):
         """Map owner tensors (in ``_build_kv_buffer_descs`` order) to k/v_buffer."""
         self.k_buffer = tensors[: self.layer_num]
         self.v_buffer = tensors[self.layer_num :]
+
+    def lazy_ensure(self, num_tokens: int) -> None:
+        """Back KV slots [0, num_tokens + margin). A failed commit first shrinks the elastic
+        expert cache, then retries once."""
+        o = getattr(self, "_post_capture_owner", None)
+        if o is None or not hasattr(self, "_lazy_floor"):
+            return
+        m = self._lazy_margin  # commit in margin-sized steps
+        want = min(
+            self.size + self.page_size, -(-(int(num_tokens) + m) // m) * m
+        )  # slot index == size exists
+        if want <= o.backed_tokens:
+            return
+        # watermark: after the commit at least SGLANG_KV_LAZY_HEADROOM_MB must stay driver-free for
+        # the prefill's working memory; otherwise the elastic expert cache gives way first.
+        headroom = int(os.environ.get("SGLANG_KV_LAZY_HEADROOM_MB", "1536")) << 20
+        delta = (want - o.backed_tokens) * o.bytes_per_token()
+        if torch.cuda.mem_get_info()[0] - delta < headroom:
+            from sglang.srt.layers.moe.expert_elastic import ExpertElastic
+
+            el = ExpertElastic.inst
+            # Below the watermark for the whole tail of a long prefill, empty_cache() on every 2048-token
+            # commit forces torch to cudaMalloc its working set again each time (periodic ~1 s spikes).
+            # Only do the expensive part when the expert cache still has rows to give back, else rate-limit.
+            can_shrink = el is not None and any(
+                st.S > el.s_floor() for st in el.layers.values()
+            )
+            now = __import__("time").time()
+            last = getattr(self, "_lazy_last_empty", 0.0)
+            if can_shrink or now - last > 30.0:
+                torch.cuda.empty_cache()
+                self._lazy_last_empty = now
+                if can_shrink and torch.cuda.mem_get_info()[0] - delta < headroom:
+                    el.free(((headroom + delta) >> 20) + 64)
+                if torch.cuda.mem_get_info()[0] - delta < headroom // 2:
+                    raise RuntimeError(
+                        f"KV lazy backing: no headroom for {want} tokens "
+                        f"(free {torch.cuda.mem_get_info()[0] >> 20} MB, need {(delta + headroom) >> 20} MB)"
+                    )
+        try:
+            try:
+                o.ensure_prefix(want)
+            except Exception:
+                torch.cuda.empty_cache()  # torch-cached blocks are not driver-free
+                o.ensure_prefix(want)
+            _free = torch.cuda.mem_get_info()[0]
+            logger.info(
+                "KV lazy commit: tokens %d -> %d (owner backed %.0f MB, torch reserved %.2f GB, driver free %.2f GB, capturing=%s)",
+                num_tokens,
+                want,
+                o.backed_bytes / 2**20,
+                torch.cuda.memory_reserved() / 2**30,
+                _free / 2**30,
+                torch.cuda.is_current_stream_capturing(),
+            )
+        except Exception as ex:
+            from sglang.srt.layers.moe.expert_elastic import ExpertElastic
+
+            el = ExpertElastic.inst
+            if el is None:
+                raise
+            need_mb = (
+                (want - o.backed_tokens) * o.bytes_per_token() >> 20
+            ) + 1024  # + prefill working memory
+            logger.warning(
+                "KV lazy commit failed (%s); shrinking expert cache to free %d MB",
+                ex,
+                need_mb,
+            )
+            el.free(need_mb)
+            o.ensure_prefix(want)
+
+    def lazy_release(self) -> None:
+        o = getattr(self, "_post_capture_owner", None)
+        if o is None or not hasattr(self, "_lazy_floor"):
+            return
+        freed = o.release_beyond(self._lazy_floor)
+        if freed:
+            logger.info(
+                "KV lazy backing: released %.0f MB beyond the %d-token floor",
+                freed / 2**20,
+                self._lazy_floor,
+            )
+        try:  # pool idle = no forward in flight: safe point to regrow experts
+            from sglang.srt.layers.moe.expert_elastic import ExpertElastic
+
+            el = ExpertElastic.inst
+            if el is not None and el.pending_regrow:
+                el.regrow()
+        except Exception as ex:
+            logger.warning("elastic regrow after KV release failed: %s", ex)
 
     def _alloc_post_capture_buffers(self):
         dev = torch.device(self.device)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4047,11 +4047,28 @@ class HybridLinearKVPool(KVCache):
             layer, *args, layer_id_override=local_layer_id, **kwargs
         )
 
+    def get_kv_smooth_buffer(self, layer_id: int):
+        # int8_g64 full_kv_pool exposes per-channel smoothing constants (plumbed
+        # but identity; a static smoothing A/B was not adopted).
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_kv_smooth_buffer(layer_id)
+
     def get_kv_scale_buffer(self, layer_id: int):
         # MXFP8 full_kv_pool exposes per-32 UE8M0 K/V scale buffers.
         self._wait_for_layer(layer_id)
         layer_id = self._transfer_full_attention_id(layer_id)
         return self.full_kv_pool.get_kv_scale_buffer(layer_id)
+
+    def get_kv_ring_buffer(self, layer_id: int):
+        # int8ring_int4 full_kv_pool exposes the per-layer int8 ring (K, V, K scales, V scales).
+        self._wait_for_layer(layer_id)
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return self.full_kv_pool.get_kv_ring_buffer(layer_id)
+
+    def get_kv_ring_owner(self):
+        # int8ring_int4 full_kv_pool: ring-row owner table (shared by all layers).
+        return self.full_kv_pool.get_kv_ring_owner()
 
     @contextmanager
     def _transfer_id_context(self, layer: RadixAttention):

--- a/python/sglang/srt/mem_cache/tiered_kv_pool.py
+++ b/python/sglang/srt/mem_cache/tiered_kv_pool.py
@@ -1,0 +1,210 @@
+"""Tiered KV pool: int8-g64 ring over the int4-g32 full-context pool.
+
+Layout per local layer l: the int4 pool's k/v_buffer + k/v_scale_buffer (rows = size + page_size, on the lazy
+VMM owner, untouched) PLUS a fixed ring of R = SGLANG_KV_TIERS_W slots outside the owner:
+  ring_k[l], ring_v[l]     int8 [R, H, D]                  ring row r = slot & (R - 1)
+  ring_ks[l], ring_vs[l]   fp16 [R, H, D // 64]            absmax/127 per (row, head, 64-channel group)
+  ring_owner               int32 [R]                       slot that owns ring row r (-1 = nobody)
+set_kv_buffer stamps the owner (one launch) and then writes both tiers (dual-write launch; the ring row
+only by the stamped owner, so same-write ring-row collisions degrade to cold instead of mixing bytes);
+readers test owner[slot & mask] == slot on the device and take the int8 ring row (hot) or the int4 row (cold).
+The ring is allocated once at construction (before graph capture; its pointers are baked into the decode
+graph) and never reallocated; it is NOT a KvBufferDesc, so bytes_per_token()/lazy_ensure/kv_lazy.py stay
+exact and PD registration (desc-aligned) is unchanged.  `kv_tiered = True` is the backend's dispatch key
+(kv_bits stays 4: scratch shape, prefix pack shape and the int4 cell size are inherited).
+"""
+
+import logging
+import os
+from typing import Tuple
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    KV_INT8_GROUP,
+    quant_store_kv_tiered,
+)
+from sglang.srt.mem_cache.int4_kv_pool import MHATokenToKVPoolInt4, _is_unit_scale
+from sglang.srt.mem_cache.memory_pool import unwrap_write_loc
+from sglang.srt.utils.async_probe import maybe_detect_oob
+
+logger = logging.getLogger(__name__)
+
+
+def ring_slots_from_env() -> int:
+    """SGLANG_KV_TIERS_W: ring slots R (default 8192); must be a positive power of two (ring index = slot & (R - 1))."""
+    raw = os.environ.get("SGLANG_KV_TIERS_W", "8192")
+    try:
+        r = int(raw)
+    except ValueError:
+        raise ValueError(f"SGLANG_KV_TIERS_W={raw!r} is not an integer") from None
+    if r <= 0 or (r & (r - 1)):
+        raise ValueError(f"SGLANG_KV_TIERS_W must be a positive power of two, got {r}")
+    return r
+
+
+class MHATokenToKVPoolTiered(MHATokenToKVPoolInt4):
+    """int4-g32 full-context rows (inherited) + an int8-g64 ring of the last R written slots + owner table."""
+
+    RING_GROUP = KV_INT8_GROUP
+    kv_tiered = True  # QSA backend dispatch key (kv_bits == 4 is inherited)
+
+    def __init__(self, *args, **kwargs):
+        self.ring_k = None
+        self.ring_v = None
+        self.ring_ks = None
+        self.ring_vs = None
+        self.ring_owner = None
+        super().__init__(*args, **kwargs)
+        R = ring_slots_from_env()
+        if R > self.size:
+            raise ValueError(
+                f"SGLANG_KV_TIERS_W={R} exceeds the KV pool size {self.size}"
+            )
+        if self.head_dim % self.RING_GROUP or self.v_head_dim % self.RING_GROUP:
+            raise ValueError(
+                f"head dims {self.head_dim}/{self.v_head_dim} not multiples of RING_GROUP {self.RING_GROUP}"
+            )
+        self.ring_slots = R
+        L, H = self.layer_num, self.head_num
+        ks_shape = (R, H, self.head_dim // self.RING_GROUP)
+        vs_shape = (R, H, self.v_head_dim // self.RING_GROUP)
+        # Plain torch tensors (torch allocator, no 2 MiB granule rounding), allocated once before capture.
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.ring_k = [
+                torch.zeros((R, H, self.head_dim), dtype=torch.int8, device=self.device)
+                for _ in range(L)
+            ]
+            self.ring_v = [
+                torch.zeros(
+                    (R, H, self.v_head_dim), dtype=torch.int8, device=self.device
+                )
+                for _ in range(L)
+            ]
+            self.ring_ks = [
+                torch.zeros(ks_shape, dtype=torch.float16, device=self.device)
+                for _ in range(L)
+            ]
+            self.ring_vs = [
+                torch.zeros(vs_shape, dtype=torch.float16, device=self.device)
+                for _ in range(L)
+            ]
+            self.ring_owner = torch.full(
+                (R,), -1, dtype=torch.int32, device=self.device
+            )
+        ring_bytes = sum(
+            t.numel() * t.element_size()
+            for t in self.ring_k + self.ring_v + self.ring_ks + self.ring_vs
+        )
+        logger.info(
+            "KV tiers: ring R=%d slots (int8_g%d over int4_g%d), %.0f MB, owner %d KB",
+            R,
+            self.RING_GROUP,
+            self.GROUP,
+            ring_bytes / 2**20,
+            self.ring_owner.numel() * 4 // 1024,
+        )
+
+    # -- layout ---------------------------------------------------------------------------------
+
+    @property
+    def ring_mask(self) -> int:
+        return self.ring_slots - 1
+
+    def _ring_bytes(self) -> Tuple[int, int]:
+        kb = sum(t.numel() * t.element_size() for t in self.ring_k + self.ring_ks)
+        vb = sum(t.numel() * t.element_size() for t in self.ring_v + self.ring_vs)
+        return kb + self.ring_owner.numel() * self.ring_owner.element_size(), vb
+
+    def get_kv_size_bytes(self):
+        k_size_bytes, v_size_bytes = super().get_kv_size_bytes()
+        if self.ring_k is not None:
+            rk, rv = self._ring_bytes()
+            k_size_bytes += rk
+            v_size_bytes += rv
+        return k_size_bytes, v_size_bytes
+
+    # _pd_registerable_tensors is inherited on purpose: get_contiguous_buf_infos zips it with
+    # _kv_buffer_descs, and the ring has no desc (it is not on the owner).  PD transfer of a tiered pool
+    # would move the int4 tier only; PD is unsupported here anyway (CPU offload raises in the int4 pool).
+
+    def _clear_buffers(self):
+        super()._clear_buffers()
+        self.ring_k = self.ring_v = self.ring_ks = self.ring_vs = self.ring_owner = None
+
+    # -- accessors ------------------------------------------------------------------------------
+
+    def get_kv_ring_buffer(
+        self, layer_id: int
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        idx = layer_id - self.start_layer
+        return self.ring_k[idx], self.ring_v[idx], self.ring_ks[idx], self.ring_vs[idx]
+
+    def get_kv_ring_owner(self) -> torch.Tensor:
+        return self.ring_owner
+
+    # -- write path -----------------------------------------------------------------------------
+
+    def set_kv_buffer(
+        self,
+        layer,
+        loc_info,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale=None,
+        v_scale=None,
+        layer_id_override=None,
+        dcp_kv_mask=None,
+    ):
+        if dcp_kv_mask is not None:
+            raise NotImplementedError(
+                "int8ring_int4 KV cache does not support DCP KV masks"
+            )
+        if not (_is_unit_scale(k_scale) and _is_unit_scale(v_scale)):
+            raise ValueError(
+                "int8ring_int4 KV cache computes its own scales; got k_scale/v_scale"
+            )
+        loc, _, _ = unwrap_write_loc(loc_info)
+        maybe_detect_oob(
+            loc, 0, self.size + self.page_size, "set_kv_buffer (MHA-TIERED)"
+        )
+        if loc.numel() > self.ring_slots:
+            # more tokens than ring rows would make every write collide (chunked prefill 1024 <= R); a
+            # collision is safe (the stamp launch picks one owner per ring row, the others are cold) but
+            # this can only be a misconfiguration
+            raise ValueError(
+                f"int8ring_int4: {loc.numel()} tokens in one write exceed the ring of {self.ring_slots} slots"
+            )
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+        idx = layer_id - self.start_layer
+        cache_k = cache_k.view(-1, self.head_num, self.head_dim)
+        cache_v = cache_v.view(-1, self.head_num, self.v_head_dim)
+        quant_store_kv_tiered(
+            cache_k,
+            cache_v,
+            loc,
+            self.k_buffer[idx],
+            self.v_buffer[idx],
+            self.k_scale_buffer[idx],
+            self.v_scale_buffer[idx],
+            self.ring_k[idx],
+            self.ring_v[idx],
+            self.ring_ks[idx],
+            self.ring_vs[idx],
+            self.ring_owner,
+            self.sm_k_inv[idx],
+            self.sm_v_inv[idx],
+            self.ring_mask,
+        )
+
+    # -- lazy VMM hooks -------------------------------------------------------------------------
+
+    def lazy_release(self) -> None:
+        super().lazy_release()
+        # Hygiene only: every slot is re-stamped by its own write before any read, so correctness never
+        # depends on this; it just keeps a stale owner from pointing a reader at an old ring row.
+        if self.ring_owner is not None:
+            self.ring_owner.fill_(-1)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -342,6 +342,26 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 )
                 # FP4 prefill uses one shared FP8 dequant workspace across layers.
                 cell_size += n * k * 2 * kv_size
+            elif self.kv_cache_dtype_str in (
+                "int4_g32",
+                "int8ring_int4",
+            ):  # tiered: int4 rows + a fixed-size int8 ring
+                # two 4-bit channels per byte (the uint8 itemsize above counts one byte per channel)
+                # plus one fp16 absmax scale per (token, kv-head, 32-channel group) for K and V
+                cell_size = cell_size // 2 + (
+                    n
+                    * ((model_config.head_dim + model_config.v_head_dim) // 32)
+                    * 2
+                    * num_layers
+                )
+            elif self.kv_cache_dtype_str == "int8_g64":
+                # fp16 absmax scale per (token, kv-head, 64-channel group) for K and V
+                cell_size += (
+                    n
+                    * ((model_config.head_dim + model_config.v_head_dim) // 64)
+                    * 2
+                    * num_layers
+                )
             elif self.kv_cache_dtype_str == "mxfp8":
                 scale_block_size = 32
                 cell_size += (

--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -142,6 +142,15 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         # CUDA graphs retain tensor addresses, not Python tensor lifetimes.
         self._capture_inputs[shape_key] = capture_inputs
 
+    @staticmethod
+    def _lpo_fields(output):
+        """(name, tensor) pairs of the tensor-valued fields of a LogitsProcessorOutput."""
+        return [(k, v) for k, v in vars(output).items() if torch.is_tensor(v)]
+
+    @staticmethod
+    def _is_lpo(output) -> bool:
+        return type(output).__name__ == "LogitsProcessorOutput"
+
     def _output_rows(self, output: Any, cap: int) -> int:
         """Leading-dim row count actually produced by the body, clamped to ``cap``.
 
@@ -155,6 +164,9 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return min([cap, *rows])
         if isinstance(output, (list, tuple)) and output:
             return min(self._output_rows(o, cap) for o in output if o is not None)
+        if self._is_lpo(output):
+            rows = [t.shape[0] for _, t in self._lpo_fields(output)]
+            return min([cap, *rows]) if rows else cap
         return cap
 
     def _alloc_full_buffer(self, output: Any, size: int) -> Any:
@@ -174,6 +186,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._alloc_full_buffer(o, size) for o in output)
         if isinstance(output, list):
             return [self._alloc_full_buffer(o, size) for o in output]
+        if self._is_lpo(output):
+            import copy as _copy
+
+            buf = _copy.copy(output)
+            for k, t in self._lpo_fields(output):
+                setattr(buf, k, t.new_empty((size, *t.shape[1:])))
+            return buf
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _slice_output(self, output: Any, num_tokens: int) -> Any:
@@ -187,6 +206,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._slice_output(item, num_tokens) for item in output)
         if isinstance(output, list):
             return [self._slice_output(item, num_tokens) for item in output]
+        if self._is_lpo(output):
+            import copy as _copy
+
+            out = _copy.copy(output)
+            for k, t in self._lpo_fields(output):
+                setattr(out, k, t[:num_tokens])
+            return out
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _copy_output_to_buffer(
@@ -201,6 +227,17 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             )
         if torch.is_tensor(output) and torch.is_tensor(output_buffer):
             output_buffer[:num_tokens].copy_(output[:num_tokens])
+            return
+        if self._is_lpo(output) and self._is_lpo(output_buffer):
+            for k, t in self._lpo_fields(output):
+                b = getattr(output_buffer, k, None)
+                if torch.is_tensor(b):
+                    b[:num_tokens].copy_(t[:num_tokens])
+                else:
+                    setattr(output_buffer, k, t)
+            for k, v in vars(output).items():
+                if not torch.is_tensor(v):
+                    setattr(output_buffer, k, v)
             return
         if isinstance(output, PPProxyTensors) and isinstance(
             output_buffer, PPProxyTensors

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -345,9 +345,13 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         set_weight_attrs(self.A_log, {"weight_loader": sharded_weight_loader(0)})
         set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
 
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        # Pass the module, NOT a view: --cpu-offload-gb replaces param.data
+        # on every on/offload, so a .view() taken at construction time ends up
+        # pointing at old, uninitialized memory. Symptom: conv_weights with
+        # magnitudes around 1e-38, GDN output exactly zero, NaN logits. This
+        # never shows on datacenter GPUs, where nobody needs offload.
+        # RadixLinearAttention now derives the view fresh on each access.
+        conv_weights = self.conv1d
         self.attn = RadixLinearAttention(
             layer_id=layer_id,
             num_q_heads=self.num_k_heads // self.attn_tp_size,

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1,6 +1,8 @@
 """Inference-only Qwen4-Exp (text + VL) on the Qwen3.5 backbone."""
 
+import json
 import math
+import os
 from contextlib import nullcontext
 from typing import Any, Iterable, Optional, Set, Tuple
 
@@ -488,18 +490,25 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
-        self.ngram_embedding = VocabParallelEmbedding(
-            padded_vocab_size,
-            self.head_dim_per_ngram,
-            params_dtype=(
-                torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
-                else torch.bfloat16
-            ),
-            output_dtype=torch.bfloat16,
-            use_attn_tp_group=self.use_attn_tp_ngram,
-        )
+        # In mmap mode, create the table on "meta": it then costs no memory
+        # and is replaced by Qwen4ExpMmapEmbedding immediately afterwards.
+        # Without this, 51.2 GB (fp8) or 97.7 GB (bf16) would be allocated
+        # here before any offload can take effect.
+        _ple_mmap_dir = os.environ.get("SGLANG_QWEN4_PLE_MMAP")
+        _alloc_ctx = torch.device("meta") if _ple_mmap_dir else nullcontext()
+        with _alloc_ctx:
+            self.ngram_embedding = VocabParallelEmbedding(
+                padded_vocab_size,
+                self.head_dim_per_ngram,
+                params_dtype=(
+                    torch.float8_e4m3fn
+                    if (quant_config is not None and quant_config.get_name() == "fp8")
+                    or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                    else torch.bfloat16
+                ),
+                output_dtype=torch.bfloat16,
+                use_attn_tp_group=self.use_attn_tp_ngram,
+            )
         self.ngram_embedding.register_buffer(
             "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
         )
@@ -747,6 +756,163 @@ def _gather_ple_embedding_from_pinned_kernel(
     )
 
 
+class Qwen4ExpMmapEmbedding(nn.Module):
+    """PLE table read from NVMe via mmap, without pinned host memory.
+
+    Why this exists: Qwen4ExpPinnedHostEmbedding places the full table in
+    page-locked host memory. For Qwen3.8-Flash-Next that is 51.2 GB (fp8) or
+    97.7 GB (bf16) - impossible on a 30 GiB machine, and the table has already
+    been allocated once by VocabParallelEmbedding before that.
+
+    This variant allocates nothing. It reads the required rows from a mapped
+    file on each access; the kernel page cache handles reloads from SSD.
+    Measured: 16 rows per token, 2560 bytes - negligible for an NVMe.
+
+    Enabled via SGLANG_QWEN4_PLE_MMAP, pointing at the directory holding
+    ple.f8_e4m3.bin and ple.json. weight_scale lives in ple.json because it no
+    longer survives into the quantized checkpoint.
+    """
+
+    _COPIED = (
+        "quant_config",
+        "enable_tp",
+        "use_attn_tp_group",
+        "tp_size",
+        "num_embeddings",
+        "org_vocab_size",
+        "padding_size",
+        "num_added_embeddings",
+        "use_presharded_weights",
+        "org_vocab_size_padded",
+        "num_embeddings_padded",
+        "shard_indices",
+        "embedding_dim",
+        "num_embeddings_per_partition",
+        "num_org_embeddings_per_partition",
+        "num_added_embeddings_per_partition",
+    )
+
+    _DTYPES = {
+        "F8_E4M3": torch.float8_e4m3fn,
+        "BF16": torch.bfloat16,
+    }
+
+    def __init__(self, embedding: VocabParallelEmbedding, directory: str) -> None:
+        nn.Module.__init__(self)
+        import numpy as np
+
+        for name in self._COPIED:
+            setattr(self, name, getattr(embedding, name))
+        self.quant_method = None
+
+        meta = json.load(open(os.path.join(directory, "ple.json")))
+        path = os.path.join(directory, meta["file"])
+        self._rows = int(meta["rows"])
+        self._dim = int(meta["dim"])
+        self._dtype = self._DTYPES[meta["dtype"]]
+        itemsize = torch.empty(0, dtype=self._dtype).element_size()
+        expected = self._rows * self._dim * itemsize
+        actual = os.path.getsize(path)
+        if actual != expected:
+            raise ValueError(
+                f"{path}: {actual} bytes, expected {expected} "
+                f"({self._rows} x {self._dim} x {itemsize})"
+            )
+        if self._dim != self.embedding_dim:
+            raise ValueError(
+                f"ple.json dim={self._dim} does not match embedding_dim="
+                f"{self.embedding_dim}"
+            )
+        # uint8 view: numpy has no fp8; torch reinterprets it later.
+        self._mm = np.memmap(
+            path, dtype=np.uint8, mode="r", shape=(self._rows, self._dim * itemsize)
+        )
+        try:  # rows are 160 B at random offsets: no read-around
+            import mmap as _mmap
+
+            self._mm._mmap.madvise(_mmap.MADV_RANDOM)
+        except Exception as _ex:  # pragma: no cover
+            logger.warning("Qwen4 PLE: madvise(MADV_RANDOM) failed: %s", _ex)
+        self._itemsize = itemsize
+        # Parallel pread path for decode: one 160-byte read per row, GIL released.
+        self._fd = os.open(path, os.O_RDONLY)
+        try:
+            os.posix_fadvise(self._fd, 0, 0, os.POSIX_FADV_RANDOM)
+        except Exception as _ex:  # pragma: no cover
+            logger.warning("Qwen4 PLE: posix_fadvise(RANDOM) failed: %s", _ex)
+        from concurrent.futures import ThreadPoolExecutor
+
+        self._pool = ThreadPoolExecutor(max_workers=16)
+        self._row_bytes = self._dim * itemsize
+
+        scale = torch.tensor([float(meta["weight_scale"])], dtype=torch.bfloat16)
+        self.register_buffer("weight_scale", scale, persistent=True)
+        if hasattr(embedding, "weight"):
+            del embedding.weight
+        logger.info(
+            "Qwen4 PLE: mmap from %s (%d rows x %d, %s, %.2f GB) - "
+            "no pinned host memory",
+            path,
+            self._rows,
+            self._dim,
+            meta["dtype"],
+            actual / 1e9,
+        )
+
+    def allocate_output(self, shape, device: torch.device) -> torch.Tensor:
+        with torch.inference_mode(False):
+            return torch.empty(shape, dtype=torch.bfloat16, device=device)
+
+    def gather(
+        self, input_ids: torch.Tensor, out: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        expected_shape = (*input_ids.shape, self.embedding_dim)
+        output = (
+            self.allocate_output(expected_shape, input_ids.device)
+            if out is None
+            else out
+        )
+        flat = input_ids.reshape(-1)
+        if not flat.numel():
+            return output
+        start = self.shard_indices.org_vocab_start_index
+        end = self.shard_indices.org_vocab_end_index
+        ids = flat.to("cpu", torch.int64)
+        inside = (ids >= start) & (ids < end)
+        local = torch.where(inside, ids - start, torch.zeros_like(ids))
+        if local.numel() <= 64:
+            rb = self._row_bytes
+
+            def _rd(r):
+                return os.pread(self._fd, rb, int(r) * rb)
+
+            buf = b"".join(self._pool.map(_rd, local.tolist()))
+            rows = torch.frombuffer(bytearray(buf), dtype=torch.uint8).view(-1, rb)
+        else:
+            rows = torch.from_numpy(self._mm[local.numpy()])  # uint8, (N, dim*b)
+            if local.numel() >= 512:
+                try:
+                    os.posix_fadvise(self._fd, 0, 0, os.POSIX_FADV_DONTNEED)
+                except Exception:  # pragma: no cover
+                    pass
+        vals = rows.view(self._dtype).to(torch.bfloat16)  # (N, dim)
+        vals = torch.where(
+            inside.unsqueeze(1), vals, torch.zeros((), dtype=torch.bfloat16)
+        )
+        output.copy_(vals.reshape(expected_shape).to(output.device, non_blocking=True))
+        return output
+
+    def reduce(self, output: torch.Tensor) -> torch.Tensor:
+        if self.tp_size > 1 and not get_attn_tp_context().input_scattered:
+            if self.use_attn_tp_group:
+                return attn_tp_all_reduce(output)
+            return tensor_model_parallel_all_reduce(output)
+        return output
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.reduce(self.gather(input_ids))
+
+
 class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
     """PLE table read directly from pinned host memory.
 
@@ -891,7 +1057,12 @@ class Qwen4ExpPLELayer(nn.Module):
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
         )
-        if config.ple_offload_embedding:
+        _ple_mmap_dir = os.environ.get("SGLANG_QWEN4_PLE_MMAP")
+        if _ple_mmap_dir:
+            self.ple_embedding.ngram_embedding = Qwen4ExpMmapEmbedding(
+                self.ple_embedding.ngram_embedding, _ple_mmap_dir
+            )
+        elif config.ple_offload_embedding:
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(
                 self.ple_embedding.ngram_embedding
             )
@@ -1576,6 +1747,13 @@ class Qwen4ExpAttentionDecoderLayer(
 ALL_DECODER_LAYER_TYPES = {
     "attention": Qwen4ExpAttentionDecoderLayer,
     "full_attention": Qwen4ExpAttentionDecoderLayer,
+    # transformers renames "full_attention" to "qwen_sparse_attention" on
+    # load, because those layers actually use an indexer
+    # (configuration_qwen4_exp.py). Every checkpoint saved through
+    # transformers - after quantization, for instance - therefore carries this
+    # name. Without the entry, loading fails with
+    # KeyError: 'qwen_sparse_attention'.
+    "qwen_sparse_attention": Qwen4ExpAttentionDecoderLayer,
     "linear_attention": Qwen4ExpLinearDecoderLayer,
 }
 
@@ -1724,6 +1902,17 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         prefix: str = "",
         language_model_cls=Qwen4ExpVLModel,
     ) -> None:
+        # Without this line AutoRoundConfig.packed_modules_mapping stays
+        # empty and get_layer_config() cannot map fused names back to their
+        # parts. Concretely: in_proj_ba = in_proj_b (48) + in_proj_a (48).
+        # Both are bf16 in the checkpoint, but the fused name only matches the
+        # general regex and lands at 8 bits ->
+        #   gptq_marlin_repack.cuh: size_n = 96 is not divisible by tile_n_size = 64
+        # deepseek_v2.py does the same (there for Quark).
+        if quant_config is not None and hasattr(
+            quant_config, "update_packed_modules_mapping"
+        ):
+            quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
         super().__init__(config, quant_config, prefix, language_model_cls)
         rope_config = getattr(self.config, "rope_parameters", None) or getattr(
             self.config, "rope_scaling", {}
@@ -2130,3 +2319,14 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
 
 EntryClass = [Qwen4ExpForConditionalGeneration]
+
+
+# --- Breakable CUDA Graph: the mmap PLE lookup is the one eager break on the decode path.
+try:
+    from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+        eager_on_graph as _eog,
+    )
+
+    Qwen4ExpMmapEmbedding.forward = _eog(True)(Qwen4ExpMmapEmbedding.forward)
+except Exception as _e:  # pragma: no cover
+    logger.warning("BCG wrap of Qwen4ExpMmapEmbedding.forward failed: %s", _e)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -688,15 +688,26 @@ class ServerArgs:
                 'by the FA4 backend. "nvfp4" selects '
                 'the NVFP4 FP4 E2M1 KV cache recipe; "fp4_mx_block16" '
                 "selects the MX-style block-size-16 FP4 E2M1 KV cache "
-                "recipe. Both require CUDA 12.8+ and PyTorch 2.8.0+"
+                "recipe. Both require CUDA 12.8+ and PyTorch 2.8.0+. "
+                '"int8_g64" and "int4_g32" are group-quantized KV caches (one '
+                "fp16 absmax scale per token, kv-head and 64- or 32-channel "
+                "group) that the Qwen sparse attention backend dequantizes on "
+                'gather; "int8ring_int4" keeps an INT8-G64 ring of the most '
+                "recent SGLANG_KV_TIERS_W (default 8192) tokens over an "
+                "INT4-G32 full-context pool. The three are read by the Qwen "
+                "sparse attention backend only and are validated with "
+                "--page-size 1."
             ),
             choices=[
                 "auto",
                 "fp8_e5m2",
                 "fp8_e4m3",
                 "mxfp8",
+                "int8_g64",
+                "int4_g32",
                 "bf16",
                 "bfloat16",
+                "int8ring_int4",
                 "nvfp4",
                 "fp4_mx_block16",
                 "fp4_e2m1",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7665,7 +7665,15 @@ class ServerArgs:
         except Exception:
             return False
 
-    LANGUAGE_MODEL_ONLY_ARCHITECTURES = ("MuseGlimmerForConditionalGeneration",)
+    LANGUAGE_MODEL_ONLY_ARCHITECTURES = (
+        "MuseGlimmerForConditionalGeneration",
+        # Qwen4ExpForConditionalGeneration inherits from
+        # Qwen3VLForConditionalGeneration, where language_model_only is already
+        # implemented (qwen3_vl.py:1243/1309/1441). Only the entry here was
+        # missing. For text-only use this saves the vision tower (0.84 GiB of
+        # weights) plus the multimodal reservation inside the KV budget.
+        "Qwen4ExpForConditionalGeneration",
+    )
 
     def _handle_language_model_only(self):
         if not self.language_model_only:

--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -111,11 +111,34 @@ class OffloaderV1(BaseOffloader):
         # offload parameters to CPU
         # use pin_memory if possible, which helps cudagraph capture speed
         offloaded_parameters = False
-        for p in module.parameters():
+        # With MoE expert streaming, offload expert weights only. Everything
+        # else (attention, GDN, norms, hyper-connections) is needed on EVERY
+        # token and belongs on the GPU; experts are needed 10 out of 512 per
+        # token and are fetched selectively. Without this selection the
+        # offloader moves whole layers and keeps transferring their
+        # non-expert part - measured at 4.8 GB per token, which eats the
+        # speedup again.
+        if os.environ.get("SGLANG_MOE_EXPERT_STREAM") == "1":
+            _params = [
+                q for n, q in module.named_parameters() if _is_streamed_expert_param(n)
+            ]
+        else:
+            _params = list(module.parameters())
+        _n_offloaded = 0
+        _n_streamed = 0
+        for p in _params:
             if self._cpu_offload_bytes >= self._cpu_offload_max_bytes:
                 # we use per-parameter offloading
                 # one module might have some parameters offloaded and some not
                 break
+            _n_offloaded += 1
+            _n_streamed += int(
+                any(
+                    p is q
+                    for n, q in module.named_parameters()
+                    if _is_streamed_expert_param(n)
+                )
+            )
 
             # `torch.empty_like` does not support `pin_memory` argument
             cpu_data = torch.empty_strided(
@@ -131,6 +154,12 @@ class OffloaderV1(BaseOffloader):
             self._cpu_offload_bytes += p.data.numel() * p.data.element_size()
             offloaded_parameters = True
 
+        # When every offloaded parameter is a streamed expert param, the hook
+        # below would build device_state from a state_dict() that EXCLUDES all
+        # of them and reparametrize the module with tensors that are already
+        # on the device. That is pure overhead on every forward - skip it.
+        if offloaded_parameters and _n_offloaded == _n_streamed and _n_streamed > 0:
+            offloaded_parameters = False
         if offloaded_parameters:
             original_forward = module.forward
 
@@ -141,14 +170,47 @@ class OffloaderV1(BaseOffloader):
                     # if the parameter is already on the device, it will be a no-op
                     k: v.to(device, non_blocking=True)
                     for k, v in module.state_dict().items()
+                    if not _is_streamed_expert_param(k)
                 }
-                output = functional_call(module, device_state, args=args, kwargs=kwargs)
+                # tie_weights=False: the state_dict contains tied tensors
+                # under several names (for Qwen4-Exp e.g. linear_attn.A_log and
+                # linear_attn.attn.A_log). With the default True,
+                # functional_call fails with "got multiple values for keys ...
+                # which are tied".
+                output = functional_call(
+                    module, device_state, args=args, kwargs=kwargs, tie_weights=False
+                )
                 module.forward = forward
                 return output
 
             module.forward = forward
 
         return module
+
+
+_STREAMED_EXPERT_SUFFIXES = (
+    "w13_qweight",
+    "w2_qweight",
+    "w13_scales",
+    "w2_scales",
+    "w13_qzeros",
+    "w2_qzeros",
+)
+
+
+def _is_streamed_expert_param(key: str) -> bool:
+    """Does this state_dict key belong to the streamed MoE experts?
+
+    These tensors must NOT be copied to the GPU wholesale: they are by far the
+    largest item (32 GB), yet only 10 of 512 experts are needed per token. MoE
+    expert streaming fetches them selectively. Without this exclusion ~26 GB
+    move over PCIe per token and the GPU only waits.
+    """
+    if os.environ.get("SGLANG_MOE_EXPERT_STREAM") != "1":
+        return False
+    return ("experts." in key or key.startswith("experts")) and key.rsplit(".", 1)[
+        -1
+    ] in _STREAMED_EXPERT_SUFFIXES
 
 
 class OffloaderV2(BaseOffloader):
@@ -262,8 +324,13 @@ def _hook_module_forward_raw(module, on_forward_end, get_parameter_and_buffer_di
 
     def forward(*args, **kwargs):
         module.forward = original_forward
+        # see comment above: tied tensors under several names
         output = functional_call(
-            module, get_parameter_and_buffer_dicts(), args=args, kwargs=kwargs
+            module,
+            get_parameter_and_buffer_dicts(),
+            args=args,
+            kwargs=kwargs,
+            tie_weights=False,
         )
         on_forward_end()
         module.forward = forward
@@ -376,6 +443,11 @@ class _CpuParamOffloader(_BaseParamOffloader):
     def __init__(self, module, param_name):
         super().__init__(module, param_name)
         _move_param_to_cpu(self._param, pin_memory=True)
+        # Hard reference to the pinned host storage. Without it the tensor
+        # is only reachable through the module attribute, which functional_call
+        # replaces with the GPU copy. MoE expert streaming needs the original
+        # storage to fetch individual experts.
+        self.cpu_data = self._param.data
 
     def create_device_tensor(self):
         return self._param.to("cuda", non_blocking=True)

--- a/test/manual/test_triton_moe_wna16.py
+++ b/test/manual/test_triton_moe_wna16.py
@@ -20,7 +20,7 @@ def quantize_weights(
     zero_points: bool = False,
     ref_zero_points_after_scales: bool = False,
 ):
-    assert quant_type in ["w4a16", "w4a16b8", "w8a16", "w8a16b128"]
+    assert quant_type in ["w2a16", "w2a16b2", "w4a16", "w4a16b8", "w8a16", "w8a16b128"]
     assert not zero_points or group_size is not None, (
         "to have group zero points, group_size must be provided "
         "(-1 group_size is channelwise)"
@@ -45,7 +45,14 @@ def quantize_weights(
     max_val = torch.max(w, 0, keepdim=True).values
     min_val = torch.min(w, 0, keepdim=True).values
 
-    if quant_type == "w4a16":
+    if quant_type == "w2a16":
+        max_q_val = 3
+        min_q_val = 0
+    elif quant_type == "w2a16b2":
+        # symmetric: q + 2 is stored, the kernel subtracts b_zp_num = 2
+        max_q_val = 1
+        min_q_val = -2
+    elif quant_type == "w4a16":
         max_q_val = 15
         min_q_val = 0
     elif quant_type == "w4a16b8":
@@ -87,7 +94,9 @@ def quantize_weights(
     else:
         w_ref = (w_q - (maybe_w_zp if zero_points else 0)).to(orig_type) * w_s
 
-    if quant_type == "w4a16b8":
+    if quant_type == "w2a16b2":
+        w_q += 2
+    elif quant_type == "w4a16b8":
         w_q += 8
     elif quant_type == "w8a16b128":
         w_q += 128
@@ -145,7 +154,7 @@ def torch_moe(a, w1, w2, score, topk):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("group_size", [64, 128])
 @pytest.mark.parametrize("has_zp", [True, False])
-@pytest.mark.parametrize("weight_bits", [8])  # [4, 8])
+@pytest.mark.parametrize("weight_bits", [2, 8])  # [2, 4, 8])
 def test_fused_moe_wn16(
     m: int,
     n: int,
@@ -164,7 +173,10 @@ def test_fused_moe_wn16(
     w2 = torch.randn((e, k, n), device=get_device(), dtype=dtype) / 10
     score = torch.randn((m, e), device=get_device(), dtype=dtype)
 
-    if weight_bits == 4:
+    if weight_bits == 2:
+        pack_factor = 4
+        quant_type = "w2a16" if has_zp else "w2a16b2"
+    elif weight_bits == 4:
         pack_factor = 2
         quant_type = "w4a16" if has_zp else "w4a16b8"
     elif weight_bits == 8:
@@ -218,7 +230,22 @@ def test_fused_moe_wn16(
         scales = scales.T
         if has_zp:
             qzeros = qzeros.T.contiguous().to(torch.uint8)
-        if weight_bits == 4:
+        if weight_bits == 2:
+            # 4 values per byte, ascending along K from the low bits
+            qweight = (
+                qweight[:, 3::4] * 64
+                + qweight[:, 2::4] * 16
+                + qweight[:, 1::4] * 4
+                + qweight[:, ::4]
+            )
+            if has_zp:
+                qzeros = (
+                    qzeros[3::4, :] * 64
+                    + qzeros[2::4, :] * 16
+                    + qzeros[1::4, :] * 4
+                    + qzeros[::4, :]
+                )
+        elif weight_bits == 4:
             qweight = qweight[:, 1::2] * 16 + qweight[:, ::2]
             if has_zp:
                 qzeros = qzeros[1::2, :] * 16 + qzeros[::2, :]
@@ -242,6 +269,7 @@ def test_fused_moe_wn16(
         topk_output,
         use_int4_w4a16=weight_bits == 4,
         use_int8_w8a16=weight_bits == 8,
+        use_int2_w2a16=weight_bits == 2,
         w1_scale=w1_scales,
         w2_scale=w2_scales,
         w1_zp=w1_qzeros if has_zp else None,

--- a/test/registered/unit/layers/attention/qsa/test_sparse_attn_fp8_gather.py
+++ b/test/registered/unit/layers/attention/qsa/test_sparse_attn_fp8_gather.py
@@ -1,0 +1,95 @@
+"""Unit tests for the fp8 QSA gather-dequant path in ``qsa/sparse_attn.py``.
+
+Against a bf16 reference pool (~50 MB VRAM):
+  1. the compact gather from an fp8_e4m3 pool equals the gather from
+     ``pool_bf16.to(fp8).to(bf16)`` bit for bit (the kernel bitcasts the uint8
+     view back to fp8 and widens to bf16);
+  2. the dequantization error of e4m3 on N(0, 3) K/V stays in the expected band
+     (relative RMS, well below the 8 % of an int4-g32 pool).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    qwen_sparse_fa2_cu_seqlens_triton,
+    qwen_sparse_kv_extraction_compact_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+SLOTS, HEADS, DIM, BATCH, TOPK = 4096, 2, 256, 3, 64
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton gather kernels require CUDA")
+class TestFp8GatherDequant(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        dev = cls.dev = "cuda"
+        cls.k16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.v16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.k8 = cls.k16.to(torch.float8_e4m3fn)
+        cls.v8 = cls.v16.to(torch.float8_e4m3fn)
+        cls.seq_lens = torch.tensor([300, 1200, 4000], dtype=torch.int32, device=dev)
+        cls.req_to_token = torch.arange(SLOTS, dtype=torch.int32, device=dev).repeat(
+            BATCH, 1
+        )
+        cls.req_indices = torch.arange(BATCH, dtype=torch.int32, device=dev)
+        cls.indices = torch.stack(
+            [
+                torch.randperm(int(n), device=dev)[:TOPK].sort().values
+                for n in cls.seq_lens
+            ]
+        ).to(torch.int32)
+        cls.cu_k = torch.empty(BATCH + 1, dtype=torch.int32, device=dev)
+        counts = torch.empty(BATCH, dtype=torch.int32, device=dev)
+        qwen_sparse_fa2_cu_seqlens_triton(
+            cls.seq_lens, cls.indices, counts, cls.cu_k, BATCH, TOPK
+        )
+        cls.n = int(cls.cu_k[-1])
+
+    def _gather(self, k, v):
+        out_k = torch.empty(self.n, HEADS, DIM, device=self.dev, dtype=torch.bfloat16)
+        out_v = torch.empty_like(out_k)
+        qwen_sparse_kv_extraction_compact_triton(
+            k,
+            v,
+            self.req_to_token,
+            self.req_indices,
+            self.indices,
+            self.seq_lens,
+            self.cu_k,
+            out_k,
+            out_v,
+            BATCH,
+            TOPK,
+        )
+        torch.cuda.synchronize()
+        return out_k, out_v
+
+    def test_fp8_gather_matches_torch_cast_bit_exact(self):
+        self.assertEqual(self.n, BATCH * TOPK)
+        out_k, out_v = self._gather(self.k8, self.v8)
+        exp_k, exp_v = self._gather(
+            self.k8.to(torch.bfloat16), self.v8.to(torch.bfloat16)
+        )
+        self.assertTrue(torch.equal(out_k, exp_k), "fp8 K gather != torch fp8->bf16")
+        self.assertTrue(torch.equal(out_v, exp_v), "fp8 V gather != torch fp8->bf16")
+
+    def test_e4m3_relative_rms_error(self):
+        ref_k, _ = self._gather(self.k16, self.v16)
+        out_k, _ = self._gather(self.k8, self.v8)
+        err = (
+            (out_k.float() - ref_k.float()).pow(2).mean() / ref_k.float().pow(2).mean()
+        ).sqrt()
+        # e4m3 on N(0, 3): ~2.7 % relative RMS (3 mantissa bits)
+        self.assertGreater(float(err), 0.01)
+        self.assertLess(float(err), 0.04)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_row_arena.py
+++ b/test/registered/unit/layers/moe/test_row_arena.py
@@ -1,0 +1,178 @@
+"""Unit tests for ``RowArena`` (``layers/moe/row_arena.py``): a VMM-backed cache
+of fixed-size rows whose physical memory can be handed back to the driver while
+every row address stays constant.
+
+Needs a CUDA device with ~150 MB free: a 100 MiB virtual reservation of which
+36 MiB are backed, one pinned host row (200 KB) that stands in for the "cold"
+rows, and a Triton gather kernel that reads rows through an address table.
+  1. geometry: chunk / VA alignment, ``chunks_for_rows`` / ``bytes_to_reach`` /
+     ``rows_for_bytes`` before and after backing;
+  2. ``ensure_rows`` backs a prefix (driver-free memory drops by exactly the
+     mapped bytes); a table gather through GPU and host addresses reads every
+     row; a CUDA graph captured against the arena addresses replays after a
+     ``shrink_rows`` (memory returns, evicted rows repointed to the host row)
+     and after growing back (survivor rows intact); ``close`` returns the
+     memory;
+  3. ``ArenaOOM`` is raised when a chunk cannot be created (chunk larger than
+     the device).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.moe.row_arena import ArenaOOM, RowArena
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+ROW_BYTES, E, S = 204800, 512, 184  # a w13 int2 expert row; 184 resident of 512
+SLACK = 8 << 20  # allocator noise allowed on the driver-free deltas
+
+
+def _gather_kernel():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _gather(tab_ptr, idx_ptr, out_ptr, row_bytes, BLOCK: tl.constexpr):
+        r = tl.program_id(0)
+        e = tl.load(idx_ptr + r)
+        src = tl.load(tab_ptr + e).to(tl.pointer_type(tl.uint8))
+        for off in range(0, row_bytes, BLOCK):
+            o = off + tl.arange(0, BLOCK)
+            m = o < row_bytes
+            tl.store(
+                out_ptr + r * row_bytes + o, tl.load(src + o, mask=m, other=0), mask=m
+            )
+
+    return _gather
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "RowArena needs the CUDA driver API")
+class TestRowArena(CustomTestCase):
+    def test_geometry(self):
+        a = RowArena(ROW_BYTES, E, 0, name="geom")
+        try:
+            self.assertEqual(a.chunk % a.gran, 0)
+            self.assertGreaterEqual(a.chunk, 4 << 20)
+            self.assertEqual(a.va_bytes % a.chunk, 0)
+            self.assertGreaterEqual(a.va_bytes, ROW_BYTES * E)
+            self.assertEqual(a.backed_rows, 0)
+            self.assertEqual(a.chunks_for_rows(0), 0)
+            self.assertEqual(a.chunks_for_rows(1), 1)
+            self.assertEqual(a.chunks_for_rows(E), -(-(E * ROW_BYTES) // a.chunk))
+            self.assertEqual(a.chunks_for_rows(E + 100), a.chunks_for_rows(E))
+            self.assertEqual(a.bytes_to_reach(S), a.chunks_for_rows(S) * a.chunk)
+            self.assertEqual(a.rows_for_bytes(a.chunk), min(E, a.chunk // ROW_BYTES))
+            self.assertEqual(a.row_addr(7), a.base + 7 * ROW_BYTES)
+            added = a.ensure_rows(S)
+            self.assertEqual(added, a.chunks_for_rows(S) * a.chunk)
+            self.assertGreaterEqual(a.backed_rows, S)
+            self.assertEqual(a.bytes_to_reach(S), 0)
+            self.assertEqual(a.ensure_rows(S), 0)  # idempotent
+            self.assertEqual(
+                a.bytes_to_reach(E),
+                (a.chunks_for_rows(E) - a.chunks_for_rows(S)) * a.chunk,
+            )
+            with self.assertRaises(AssertionError):
+                a.view(a.backed_rows + 1, (ROW_BYTES,))
+        finally:
+            a.close()
+
+    def test_ensure_shrink_grow_with_graph_replay(self):
+        gather = _gather_kernel()
+        free0 = torch.cuda.mem_get_info()[0]
+        a = RowArena(ROW_BYTES, E, 0, name="w13")
+        try:
+            added = a.ensure_rows(S)
+            free1 = torch.cuda.mem_get_info()[0]
+            self.assertGreaterEqual(a.backed_rows, S)
+            self.assertLess(abs((free0 - free1) - added), SLACK)
+
+            v = a.view(S, (ROW_BYTES,))
+            for i in range(S):
+                v[i].fill_(i % 251)
+            # one "cold" row on the host stands in for every evicted expert
+            host = torch.full((1, ROW_BYTES), 7, dtype=torch.uint8).pin_memory()
+            tab = torch.empty(E, dtype=torch.int64)
+            for e in range(E):
+                tab[e] = a.row_addr(e) if e < S else host.data_ptr()
+            tab = tab.cuda()
+            idx = torch.tensor([0, 5, 183, 184, 511, 63, 64], dtype=torch.int64).cuda()
+            out = torch.empty(len(idx), ROW_BYTES, dtype=torch.uint8, device="cuda")
+
+            def run():
+                gather[(len(idx),)](tab, idx, out, ROW_BYTES, BLOCK=4096)
+
+            run()
+            torch.cuda.synchronize()
+            exp = [i % 251 if i < S else 7 for i in idx.tolist()]
+            self.assertEqual(out[:, 0].tolist(), exp)
+            self.assertEqual(out[:, -1].tolist(), exp)
+
+            # CUDA graph captured against the arena addresses
+            g = torch.cuda.CUDAGraph()
+            s = torch.cuda.Stream()
+            with torch.cuda.stream(s):
+                run()
+            torch.cuda.synchronize()
+            with torch.cuda.graph(g, stream=s):
+                run()
+            torch.cuda.synchronize()
+
+            # shrink to 64 rows: memory returns, addresses stay
+            free_a = torch.cuda.mem_get_info()[0]
+            freed = a.shrink_rows(64)
+            free_b = torch.cuda.mem_get_info()[0]
+            self.assertGreater(freed, 0)
+            self.assertGreaterEqual(a.backed_rows, 64)
+            self.assertLess(a.backed_rows, S)
+            self.assertLess(abs((free_b - free_a) - freed), SLACK)
+            # repoint evicted rows to the host, replay the graph
+            tab_cpu = tab.cpu()
+            for e in range(64, S):
+                tab_cpu[e] = host.data_ptr()
+            tab.copy_(tab_cpu)
+            g.replay()
+            torch.cuda.synchronize()
+            exp2 = [i % 251 if i < 64 else 7 for i in idx.tolist()]
+            self.assertEqual(out[:, 0].tolist(), exp2)
+
+            # grow back, refill, replay: survivors intact
+            a.ensure_rows(S)
+            v = a.view(S, (ROW_BYTES,))
+            for i in range(64, S):
+                v[i].fill_(i % 251)
+            for e in range(64, S):
+                tab_cpu[e] = a.row_addr(e)
+            tab.copy_(tab_cpu)
+            g.replay()
+            torch.cuda.synchronize()
+            self.assertEqual(out[:, 0].tolist(), exp)
+            self.assertEqual(v[:64, 0].tolist(), [i % 251 for i in range(64)])
+            del g
+            # close returns every backed chunk to the driver
+            torch.cuda.synchronize()
+            backed = a.backed_bytes
+            free_c = torch.cuda.mem_get_info()[0]
+        finally:
+            a.close()
+        self.assertEqual(a.backed_rows, 0)
+        self.assertLess(abs((torch.cuda.mem_get_info()[0] - free_c) - backed), SLACK)
+
+    def test_oom_raises_arena_oom(self):
+        total = torch.cuda.mem_get_info()[1]
+        # a single chunk larger than the whole device: cuMemCreate must fail
+        big = RowArena(1 << 20, 4, 0, chunk_bytes=total + (1 << 30), name="oom-probe")
+        try:
+            with self.assertRaises(ArenaOOM):
+                big.ensure_rows(1)
+            self.assertEqual(big.backed_rows, 0)
+        finally:
+            big.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_moe_wna16_int2.py
+++ b/test/registered/unit/layers/quantization/test_moe_wna16_int2.py
@@ -1,0 +1,380 @@
+"""Unit tests for the 2-bit (int2) ``moe_wna16`` path on synthetic data: no
+checkpoint, no server (small GPU tests).
+
+  1. the exact 2-bit unpack expressions of ``fused_moe_kernel_gptq_awq`` (byte
+     index ``offs_k // 4``, shift ``(offs_k % 4) * 2``, mask ``0x3``, zero point
+     2) dequantize a synthetic 2-bit matrix bit-identically to a torch
+     reference, including the real expert dims 2560 x 640 g128;
+  2. ``to_word_ncontig`` re-arranges the loader's ``[E, N, K/4]`` uint8 layout
+     into ``[E, K/16, N]`` int32 words with value k at bits ``2*(k % 16)`` of
+     word ``k // 16`` (bit-exact, and invertible); CPU only;
+  3. ``fused_moe(use_int2_w2a16=True)`` on the byte layout, symmetric (zero
+     point 2) and with per-group ``qzeros``, against a torch MoE reference on
+     the dequantized weights;
+  4. the same weights in the N-contiguous word layout (int32 ``[E, K/16, N]``,
+     scales ``[E, K/g, N]``) through ``fused_moe`` agree with the byte layout;
+  5. ``moe_gemv_int2_tab`` (batch-1 GEMV through int64 address tables) against
+     an fp32 reference: one shared activation with TOP_K > 1 (the w13 form) and
+     per-row activations with TOP_K = 1 and routed weights (the w2 form), fp16
+     and bf16 scales, N not a multiple of the block; ``make_tables`` addresses.
+
+Tests that need real expert tensors (pinned-host tables, bandwidth) are not
+ported here.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.expert_gemv import (
+    make_tables,
+    moe_gemv_int2_tab,
+    to_word_ncontig,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
+from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+
+# bf16 outputs from fp32 accumulation in a different order: ~4e-3 relative
+TOL = dict(atol=1e-3, rtol=2e-2)
+
+
+# ---------------------------------------------------------------------- synthetic 2-bit data
+def pack_2bit_along_last(q):
+    """int [.., K] with values in 0..3 -> uint8 [.., K // 4]; value k at bits 2 * (k % 4)
+    of byte k // 4 (the moe_wna16 byte layout)."""
+    return (
+        q[..., 0::4] | (q[..., 1::4] << 2) | (q[..., 2::4] << 4) | (q[..., 3::4] << 6)
+    ).to(torch.uint8)
+
+
+def pack_words_along_k(q):
+    """int [.., K] in 0..3 -> int32 [.., K // 16] words; value k at bits 2 * (k % 16)."""
+    w = torch.zeros(*q.shape[:-1], q.shape[-1] // 16, dtype=torch.int32)
+    for j in range(16):
+        w |= (q[..., j::16].to(torch.int32) & 0x3) << (2 * j)
+    return w
+
+
+def make_int2_experts(e, n, k, group, has_zp, dtype, gen):
+    """Synthetic experts in the moe_wna16 loader layout.
+
+    Returns w_ref [e, n, k] (dequantized), qweight uint8 [e, n, k // 4],
+    scales [e, n, k // group], qzeros uint8 [e, n // 4, k // group] or None.
+    """
+    q = torch.randint(0, 4, (e, n, k), generator=gen)
+    scales = (torch.rand(e, n, k // group, generator=gen) * 0.1 + 0.01).to(dtype)
+    if has_zp:
+        zp = torch.randint(0, 4, (e, n, k // group), generator=gen)
+        qzeros = pack_2bit_along_last(zp.transpose(1, 2)).transpose(1, 2).contiguous()
+        zp_full = zp.repeat_interleave(group, dim=2)
+    else:
+        qzeros = None
+        zp_full = torch.full_like(q, 2)
+    w_ref = ((q - zp_full).float() * scales.float().repeat_interleave(group, dim=2)).to(
+        dtype
+    )
+    return w_ref, pack_2bit_along_last(q), scales, qzeros
+
+
+def torch_moe(a, w1, w2, score, topk):
+    b, d = a.shape
+    a = a.view(b, -1, d).repeat(1, topk, 1).reshape(-1, d)
+    out = torch.zeros(b * topk, w2.shape[1], dtype=a.dtype, device=a.device)
+    score = torch.softmax(score, dim=-1, dtype=torch.float32)
+    topk_weight, topk_ids = torch.topk(score, topk)
+    topk_weight = topk_weight.view(-1)
+    topk_ids = topk_ids.view(-1)
+    for i in range(w1.shape[0]):
+        mask = topk_ids == i
+        if mask.sum():
+            h = a[mask] @ w1[i].transpose(0, 1)
+            n = h.shape[1] // 2
+            out[mask] = (F.silu(h[:, :n]) * h[:, n:]) @ w2[i].transpose(0, 1)
+    return (
+        out.view(b, -1, w2.shape[1]) * topk_weight.view(b, -1, 1).to(out.dtype)
+    ).sum(dim=1)
+
+
+def gemv_reference(w32, s, x, group=128):
+    """w32 [T, K/16, N] int32 words, s [T, K/g, N], x [K] or [T, K] -> [T, N] fp32."""
+    t, kw, n = w32.shape
+    k = kw * 16
+    q = torch.empty((t, k, n), dtype=torch.int32)
+    for j in range(16):
+        q[:, j::16, :] = (w32 >> (2 * j)) & 0x3
+    w = (q.float() - 2.0) * s.float().repeat_interleave(group, dim=1)
+    if x.dim() == 1:
+        return torch.einsum("tkn,k->tn", w, x.float())
+    return torch.einsum("tkn,tk->tn", w, x.float())
+
+
+class TestWordLayoutCPU(CustomTestCase):
+    def test_to_word_ncontig_bit_exact_and_invertible(self):
+        gen = torch.Generator().manual_seed(7)
+        for e, n, k in ((3, 64, 256), (2, 640, 2560), (1, 16, 64)):
+            with self.subTest(shape=(e, n, k)):
+                q = torch.randint(0, 4, (e, n, k), generator=gen)
+                byte_layout = pack_2bit_along_last(q)  # [E, N, K/4]
+                self.assertEqual(byte_layout.shape, (e, n, k // 4))
+                word = to_word_ncontig(byte_layout)  # [E, K/16, N]
+                self.assertEqual(word.dtype, torch.int32)
+                self.assertEqual(word.shape, (e, k // 16, n))
+                self.assertTrue(word.is_contiguous())
+                expected = pack_words_along_k(q).transpose(1, 2).contiguous()
+                self.assertTrue(torch.equal(word, expected))
+                # every value lands at bits 2 * (k % 16) of word k // 16, column n
+                for kk in (0, 1, 15, 16, 17, k - 1):
+                    got = (word[:, kk // 16, :] >> (2 * (kk % 16))) & 0x3
+                    self.assertTrue(torch.equal(got, q[:, :, kk].to(torch.int32)))
+                # invertible: the little-endian byte view restores the byte layout
+                back = word.view(torch.uint8).view(e, k // 16, n, 4)
+                back = back.permute(0, 2, 1, 3).reshape(e, n, k // 4)
+                self.assertTrue(torch.equal(back, byte_layout))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton MoE kernels require CUDA")
+class TestInt2Unpack(CustomTestCase):
+    def test_unpack_expressions_bit_exact(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def deq_w2(
+            b_ptr,
+            s_ptr,
+            out_ptr,
+            K,
+            N,
+            group_size,
+            stride_bk,
+            stride_bn,
+            stride_sk,
+            stride_sn,
+            BLOCK_K: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            # the exact expressions of fused_moe_kernel_gptq_awq's int2 branch
+            pid_k = tl.program_id(0)
+            pid_n = tl.program_id(1)
+            offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+            offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+            b_ptrs = (
+                b_ptr + (offs_k[:, None] // 4) * stride_bk + offs_n[None, :] * stride_bn
+            )
+            b_shifter = (offs_k[:, None] % 4) * 2
+            m = (offs_k[:, None] < K) & (offs_n[None, :] < N)
+            b = tl.load(b_ptrs, mask=m, other=0)
+            b = (b >> b_shifter) & 0x3
+            s_ptrs = (
+                s_ptr
+                + (offs_k[:, None] // group_size) * stride_sk
+                + offs_n[None, :] * stride_sn
+            )
+            s = tl.load(s_ptrs, mask=m, other=0.0).to(tl.float32)
+            val = (b.to(tl.float32) - 2) * s  # b_zp_num = 2 (symmetric)
+            tl.store(out_ptr + offs_k[:, None] * N + offs_n[None, :], val, mask=m)
+
+        gen = torch.Generator().manual_seed(7)
+        for k, n, gs in ((2560, 640, 128), (640, 2560, 128), (256, 64, 64)):
+            with self.subTest(K=k, N=n, group=gs):
+                vals = torch.randint(0, 4, (k, n), dtype=torch.int32, generator=gen)
+                sc = (torch.rand(k // gs, n, generator=gen) * 0.02 + 0.001).float()
+                ref = (vals.float() - 2) * sc.repeat_interleave(gs, dim=0)
+                # as MoeWNA16 loads it: [N, K/4] uint8, K packed along the last dim
+                std = pack_2bit_along_last(vals.T.contiguous()).cuda()
+                scg = sc.cuda()
+                out = torch.empty((k, n), dtype=torch.float32, device="cuda")
+                bk = bn = 64
+                deq_w2[(triton.cdiv(k, bk), triton.cdiv(n, bn))](
+                    std,
+                    scg,
+                    out,
+                    k,
+                    n,
+                    gs,
+                    std.stride(1),
+                    std.stride(0),
+                    scg.stride(0),
+                    scg.stride(1),
+                    BLOCK_K=bk,
+                    BLOCK_N=bn,
+                )
+                torch.cuda.synchronize()
+                self.assertTrue(torch.equal(out.cpu(), ref))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton MoE kernels require CUDA")
+class TestFusedMoeInt2(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def _case(self, m, n, k, e, topk, group, has_zp, dtype, ncontig):
+        gen = torch.Generator().manual_seed(m * 1000 + n + k + group + int(has_zp))
+        dev = "cuda"
+        a = (torch.randn((m, k), generator=gen) / 10).to(dtype).to(dev)
+        score = torch.randn((m, e), generator=gen).to(dtype).to(dev)
+        w1_ref, w1_q, w1_s, w1_zp = make_int2_experts(
+            e, 2 * n, k, group, has_zp, dtype, gen
+        )
+        w2_ref, w2_q, w2_s, w2_zp = make_int2_experts(
+            e, k, n, group, has_zp, dtype, gen
+        )
+        if ncontig:  # what process_weights_after_loading does for 2-bit experts
+            w1_q, w2_q = to_word_ncontig(w1_q), to_word_ncontig(w2_q)
+            w1_s = w1_s.transpose(1, 2).contiguous()
+            w2_s = w2_s.transpose(1, 2).contiguous()
+        to = lambda t: None if t is None else t.to(dev)
+        # softmax weights without top-k renormalization, as torch_moe applies them
+        topk_output = select_experts(
+            hidden_states=a,
+            router_logits=score,
+            topk_config=TopKConfig(top_k=topk, renormalize=False),
+        )
+        ref = torch_moe(a, w1_ref.to(dev), w2_ref.to(dev), score, topk)
+        out = fused_moe(
+            a.clone(),  # fused_experts writes its output over the input rows
+            to(w1_q),
+            to(w2_q),
+            topk_output,
+            use_int2_w2a16=True,
+            w1_scale=to(w1_s),
+            w2_scale=to(w2_s),
+            w1_zp=to(w1_zp),
+            w2_zp=to(w2_zp),
+            block_shape=[0, group],
+        )
+        return out, ref
+
+    def test_byte_layout_vs_torch_reference(self):
+        for m in (1, 32):
+            for k in (128, 256):
+                for group in (64, 128):
+                    for has_zp in (False, True):
+                        with self.subTest(m=m, k=k, group=group, has_zp=has_zp):
+                            out, ref = self._case(
+                                m, 128, k, 8, 2, group, has_zp, torch.bfloat16, False
+                            )
+                            torch.testing.assert_close(out, ref, **TOL)
+
+    def test_word_layout_matches_byte_layout(self):
+        for m in (1, 32):
+            for k in (128, 256):
+                for group in (64, 128):
+                    with self.subTest(m=m, k=k, group=group):
+                        out_w, ref = self._case(
+                            m, 128, k, 8, 2, group, False, torch.bfloat16, True
+                        )
+                        out_b, _ = self._case(
+                            m, 128, k, 8, 2, group, False, torch.bfloat16, False
+                        )
+                        torch.testing.assert_close(out_w, ref, **TOL)
+                        torch.testing.assert_close(out_w, out_b, **TOL)
+
+    def test_real_expert_dims(self):
+        # e=8 of the model's 512 experts, n=640, k=2560, g128, symmetric, both layouts
+        for ncontig in (False, True):
+            with self.subTest(ncontig=ncontig):
+                out, ref = self._case(
+                    4, 640, 2560, 8, 2, 128, False, torch.bfloat16, ncontig
+                )
+                torch.testing.assert_close(out, ref, **TOL)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton GEMV requires CUDA")
+class TestInt2Gemv(CustomTestCase):
+    def test_gemv_tab_vs_reference(self):
+        gen = torch.Generator().manual_seed(0)
+        e, k13, n13, k2, n2, topk = 8, 256, 200, 128, 256, 3
+        for sdtype in (torch.float16, torch.bfloat16):
+            with self.subTest(scale_dtype=sdtype):
+                q13 = torch.randint(0, 4, (e, k13, n13), generator=gen)
+                q2 = torch.randint(0, 4, (e, k2, n2), generator=gen)
+                w13 = (
+                    pack_words_along_k(q13.transpose(1, 2)).transpose(1, 2).contiguous()
+                )
+                w2 = pack_words_along_k(q2.transpose(1, 2)).transpose(1, 2).contiguous()
+                s13 = (torch.rand(e, k13 // 128, n13, generator=gen) * 0.1 + 0.01).to(
+                    sdtype
+                )
+                s2 = (torch.rand(e, k2 // 128, n2, generator=gen) * 0.1 + 0.01).to(
+                    sdtype
+                )
+                self.assertEqual(w13.shape, (e, k13 // 16, n13))
+                ids = torch.randperm(e, generator=gen)[:topk].to(torch.int32)
+                x13 = torch.randn(k13, generator=gen).to(torch.bfloat16)
+                x2 = torch.randn(topk, k2, generator=gen).to(torch.bfloat16)
+                rw = torch.rand(topk, generator=gen) + 0.5
+                ref13 = gemv_reference(w13[ids.long()], s13[ids.long()], x13)
+                ref2 = gemv_reference(w2[ids.long()], s2[ids.long()], x2) * rw[:, None]
+                w13d, s13d, w2d, s2d = (t.cuda() for t in (w13, s13, w2, s2))
+                wt13, st13, sw13, ss13 = make_tables(w13d, s13d)
+                wt2, st2, sw2, ss2 = make_tables(w2d, s2d)
+                self.assertEqual((sw13, ss13), (w13d.stride(1), s13d.stride(1)))
+                self.assertTrue(wt13.is_cuda and wt13.dtype == torch.int64)
+                self.assertEqual(int(wt13[3]), w13d.data_ptr() + 3 * w13d.stride(0) * 4)
+                self.assertEqual(int(st13[5]), s13d.data_ptr() + 5 * s13d.stride(0) * 2)
+                ids_d, rw_d = ids.cuda(), rw.float().cuda()
+                # w13 form: one shared [1, K] activation, TOP_K = topk maps row r -> a[0]
+                o13 = moe_gemv_int2_tab(
+                    x13[None].cuda(),
+                    wt13,
+                    st13,
+                    ids_d,
+                    rw_d,
+                    n13,
+                    k13,
+                    sw13,
+                    ss13,
+                    top_k=topk,
+                    mul_routed_weight=False,
+                    scale_bf16=sdtype == torch.bfloat16,
+                )
+                # w2 form: per-row activations, TOP_K = 1, routed weights applied
+                o2 = moe_gemv_int2_tab(
+                    x2.cuda(),
+                    wt2,
+                    st2,
+                    ids_d,
+                    rw_d,
+                    n2,
+                    k2,
+                    sw2,
+                    ss2,
+                    top_k=1,
+                    mul_routed_weight=True,
+                    scale_bf16=sdtype == torch.bfloat16,
+                )
+                torch.cuda.synchronize()
+                self.assertEqual(o13.shape, (topk, n13))
+                self.assertEqual(o13.dtype, torch.bfloat16)
+                self.assertEqual(o2.shape, (topk, n2))
+                for got, ref in ((o13.float().cpu(), ref13), (o2.float().cpu(), ref2)):
+                    rel = ((got - ref).norm() / ref.norm()).item()
+                    self.assertLess(rel, 1e-2, rel)  # bf16 output rounding ~4e-3
+
+    def test_gemv_rejects_bad_block(self):
+        with self.assertRaises(AssertionError):
+            moe_gemv_int2_tab(
+                torch.zeros(1, 64, dtype=torch.bfloat16, device="cuda"),
+                None,
+                None,
+                torch.zeros(1, dtype=torch.int32, device="cuda"),
+                None,
+                8,
+                64,
+                8,
+                8,
+                top_k=1,
+                mul_routed_weight=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_int4_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_int4_kv_pool.py
@@ -1,0 +1,673 @@
+"""Unit tests for the int4-g32 QSA KV path: the ``qsa/sparse_attn.py`` kernels
+and ``MHATokenToKVPoolInt4`` (~30 MB VRAM, no server, no model).
+
+Torch reference: per-token-per-head-per-32-group absmax/7, fp16 scale clamped
+to fp16 max, q = rint(x / s) clamped to [-7, 7], nibble packing low = even
+channel / high = odd channel with offset +8, dequant (nibble - 8) * s in fp32
+-> bf16.
+  0. pack / unpack round trip: every q in [-7, 7] survives pack -> unpack;
+  1. ``quant_store_kv_int4``: quantize + scatter into random slots (int32 and
+     int64 loc); payload and scales bit-exact vs the reference; a row that hits
+     every value -7..7 (s = 1); untouched slots keep their sentinel; zero rows
+     and a zero group get s = 1 and nibble 8;
+  2. scale index arithmetic for GROUP=32 with 2 heads: flat index
+     (slot*2 + h)*8 + g; nibble order;
+  3. compact gather (decode / verify path): 3 requests (300 / 1200 / 4000
+     tokens, permuted req_to_token), bit-exact dequant vs torch, rows beyond the
+     packed range untouched, an invalid position inside the packed region is
+     neither read nor written; the trtllm strided layout (cu_k = arange * stride
+     with stride = 64 > topk = 40, topk not a multiple of BLOCK_TOPK, -1 padded
+     indices, a position >= seq_len): valid rows bit-exact, every padding /
+     invalid row of the strided scratch untouched; a bf16 scratch of the packed
+     width is rejected;
+  4. prefix row gather (chunk-prefill path): 3 requests with different lengths
+     (partial last row block, non-identity req_indices) packed with a 32-row
+     gap after EACH request, bit-exact, every gap row and the tail untouched;
+  5. end-to-end relative RMS error of gather-dequant(quant(x)) for x ~ N(0, 3):
+     8-11.5 % (g32);
+  6. fp16-max scale clamp: groups with absmax > 7 * 65504 (1e6, bf16 max) store
+     s = 65504 (never inf), bit-exact vs the reference, and both gather kernels
+     dequantize them to finite +/- 7 * 65504;
+  7. ``MHATokenToKVPoolInt4``: eager and lazy-VMM (SGLANG_KV_LAZY=1) paths,
+     ``set_kv_buffer`` through the pool, payload / scale descs (row_bytes
+     256 / 32), bytes per token 1152 for 2 layers, first-page scale rows zeroed,
+     kv_bits = 4 (and 8 on the int8 pool).
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.attention.qsa.sparse_attn import KV_INT4_GROUP as G
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    quant_store_kv_int4,
+    qwen_sparse_fa2_cu_seqlens_triton,
+    qwen_sparse_kv_extraction_compact_triton,
+    qwen_sparse_prefix_gather_dequant_int4,
+)
+from sglang.srt.mem_cache.int4_kv_pool import MHATokenToKVPoolInt4
+from sglang.srt.mem_cache.int8_kv_pool import MHATokenToKVPoolInt8
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+SLOTS, HEADS, DIM, BATCH, TOPK = 4096, 2, 256, 3, 64
+NG, DH = DIM // G, DIM // 2
+
+
+def ref_pack(q):
+    """q int [.., D] in [-7, 7] -> uint8 [.., D // 2]: low nibble = even channel,
+    high = odd, offset +8."""
+    return ((q[..., 0::2] + 8) | ((q[..., 1::2] + 8) << 4)).to(torch.uint8)
+
+
+def ref_unpack(p):
+    """uint8 [.., D // 2] -> int32 [.., D]."""
+    b = p.to(torch.int32)
+    return torch.stack([(b & 15) - 8, (b >> 4) - 8], dim=-1).reshape(*p.shape[:-1], -1)
+
+
+def ref_quant(x):
+    """x [N, H, D] -> (packed uint8 [N, H, D // 2], s fp16 [N, H, NG], q int32 [N, H, D])."""
+    xf = x.float().reshape(*x.shape[:-1], NG, G)
+    a = xf.abs().amax(-1)
+    # never inf (the kernel clamps too)
+    s = torch.where(a > 0, a / 7.0, torch.ones_like(a)).clamp(max=65504.0).half()
+    q = (
+        torch.clamp(torch.round(xf / s.float()[..., None]), -7, 7)
+        .to(torch.int32)
+        .reshape(x.shape)
+    )
+    return ref_pack(q), s, q
+
+
+def ref_dequant(p, s):
+    return (ref_unpack(p).float() * s.float().repeat_interleave(G, dim=-1)).to(
+        torch.bfloat16
+    )
+
+
+def relerr(a, b):
+    return float(
+        ((a.float() - b.float()).pow(2).mean() / b.float().pow(2).mean()).sqrt()
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton KV kernels require CUDA")
+class TestInt4KVKernels(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        dev = cls.dev = "cuda"
+        cls.ones = torch.ones(HEADS, DIM, dtype=torch.float16, device=dev)
+        cls.qa = torch.arange(-7, 8, device=dev, dtype=torch.int32)  # 15 values
+        # scatter inputs
+        cls.N = 1000
+        cls.xk = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xv = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xk[5] = 0  # zero row -> s = 1, nibble 8
+        cls.xv[7, 1, 64:96] = 0  # one zero group (g = 2) in one head
+        full = torch.tensor(
+            [-7, 7, -6, 6, -5, 5, -4, 4, -3, 3, -2, 2, -1, 1, 0, 7] * 16,
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        cls.xk[3, 0] = full  # absmax 7 -> s = 1 -> q hits every value in [-7, 7]
+        cls.xv[3, 1] = -full
+        cls.pk_ref, cls.sk_ref, cls.qk_ref = ref_quant(cls.xk)
+        cls.pv_ref, cls.sv_ref, cls.qv_ref = ref_quant(cls.xv)
+        # full pool for the gather tests
+        cls.k16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.v16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.k4 = torch.empty(SLOTS, HEADS, DH, dtype=torch.uint8, device=dev)
+        cls.v4 = torch.empty_like(cls.k4)
+        cls.ks4 = torch.empty(SLOTS, HEADS, NG, dtype=torch.float16, device=dev)
+        cls.vs4 = torch.empty_like(cls.ks4)
+        quant_store_kv_int4(
+            cls.k16,
+            cls.v16,
+            torch.arange(SLOTS, device=dev, dtype=torch.int32),
+            cls.k4,
+            cls.v4,
+            cls.ks4,
+            cls.vs4,
+            cls.ones,
+            cls.ones,
+        )
+        torch.cuda.synchronize()
+        pk, sk, _ = ref_quant(cls.k16)
+        pv, sv, _ = ref_quant(cls.v16)
+        cls.full_ref = (pk, sk, pv, sv)
+        cls.dk_all = ref_dequant(pk, sk)  # reference dequant of every slot
+        cls.dv_all = ref_dequant(pv, sv)
+        cls.seq_lens = torch.tensor([300, 1200, 4000], dtype=torch.int32, device=dev)
+        cls.req_to_token = torch.stack(
+            [torch.randperm(SLOTS, device=dev) for _ in range(BATCH)]
+        ).to(torch.int32)
+        cls.req_indices = torch.arange(BATCH, dtype=torch.int32, device=dev)
+        cls.indices = torch.stack(
+            [
+                torch.randperm(int(n), device=dev)[:TOPK].sort().values
+                for n in cls.seq_lens
+            ]
+        ).to(torch.int32)
+
+    # ------------------------------------------------------------ helpers
+    def _scatter(self, loc_dtype):
+        dev = self.dev
+        loc = torch.randperm(SLOTS, device=dev)[: self.N].to(loc_dtype)
+        k_buf = torch.full((SLOTS, HEADS, DH), 0x77, dtype=torch.uint8, device=dev)
+        v_buf = torch.full((SLOTS, HEADS, DH), 0x99, dtype=torch.uint8, device=dev)
+        ks = torch.full((SLOTS, HEADS, NG), 3.0, dtype=torch.float16, device=dev)
+        vs = torch.full((SLOTS, HEADS, NG), 5.0, dtype=torch.float16, device=dev)
+        quant_store_kv_int4(
+            self.xk, self.xv, loc, k_buf, v_buf, ks, vs, self.ones, self.ones
+        )
+        torch.cuda.synchronize()
+        return loc, k_buf, v_buf, ks, vs
+
+    def _run_compact(self, idx, k4=None, v4=None, ks4=None, vs4=None):
+        dev = self.dev
+        cu_k = torch.empty(BATCH + 1, dtype=torch.int32, device=dev)
+        counts = torch.empty(BATCH, dtype=torch.int32, device=dev)
+        qwen_sparse_fa2_cu_seqlens_triton(self.seq_lens, idx, counts, cu_k, BATCH, TOPK)
+        n = int(cu_k[-1])
+        out_k = torch.full(
+            (BATCH * TOPK + 16, HEADS, DIM),
+            float("nan"),
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        out_v = torch.full_like(out_k, float("nan"))
+        qwen_sparse_kv_extraction_compact_triton(
+            self.k4 if k4 is None else k4,
+            self.v4 if v4 is None else v4,
+            self.req_to_token,
+            self.req_indices,
+            idx,
+            self.seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            BATCH,
+            TOPK,
+            k_scale=self.ks4 if ks4 is None else ks4,
+            v_scale=self.vs4 if vs4 is None else vs4,
+            sm_k=self.ones,
+            sm_v=self.ones,
+            kv_bits=4,
+        )
+        torch.cuda.synchronize()
+        return cu_k, n, out_k, out_v
+
+    def _prefix_gather(self):
+        dev = self.dev
+        lens = torch.tensor([300, 1203, 4001], dtype=torch.int32, device=dev)
+        req_idx = torch.tensor([2, 0, 1], dtype=torch.int64, device=dev)
+        gap = 32  # > BLOCK_T (16): a stray row block lands in the gap
+        cu = F.pad((lens + gap).cumsum(0), (1, 0)).to(torch.int32).contiguous()
+        total = int(cu[-1])
+        pk = torch.full(
+            (total + 100, HEADS, DIM), float("nan"), device=dev, dtype=torch.bfloat16
+        )
+        pv = torch.full_like(pk, float("nan"))
+        qwen_sparse_prefix_gather_dequant_int4(
+            self.k4,
+            self.v4,
+            self.ks4,
+            self.vs4,
+            self.ones,
+            self.ones,
+            self.req_to_token,
+            req_idx,
+            lens,
+            cu,
+            pk,
+            pv,
+            BATCH,
+            int(lens.max()),
+        )
+        torch.cuda.synchronize()
+        return lens, req_idx, gap, cu, pk, pv
+
+    # ------------------------------------------------------------ tests
+    def test_pack_unpack_round_trip(self):
+        dev = self.dev
+        qq = torch.cartesian_prod(self.qa, self.qa).reshape(
+            -1
+        )  # every (even, odd) pair
+        pad = torch.zeros(DIM - qq.numel() % DIM, device=dev, dtype=torch.int32)
+        qq = torch.cat([qq, pad]).reshape(-1, DIM)
+        pp = ref_pack(qq)
+        self.assertEqual(pp.dtype, torch.uint8)
+        self.assertGreaterEqual(int(pp.min()), 0x11)
+        self.assertLessEqual(int(pp.max()), 0xFF)
+        self.assertTrue(torch.equal(ref_unpack(pp), qq))
+        self.assertEqual(
+            int(ref_pack(torch.tensor([[-7, 7]], device=dev, dtype=torch.int32))[0, 0]),
+            0x01 | (0x0F << 4),
+        )
+        self.assertEqual(
+            int(ref_pack(torch.tensor([[0, 0]], device=dev, dtype=torch.int32))[0, 0]),
+            0x88,
+        )
+
+    def test_quant_store_scatter_bit_exact(self):
+        self.assertTrue(torch.equal(self.qk_ref[3, 0].unique(), self.qa))
+        self.assertTrue(torch.equal(self.qv_ref[3, 1].unique(), self.qa))
+        for loc_dtype in (torch.int32, torch.int64):
+            with self.subTest(loc_dtype=loc_dtype):
+                loc, k_buf, v_buf, ks, vs = self._scatter(loc_dtype)
+                ll = loc.long()
+                self.assertTrue(torch.equal(k_buf[ll], self.pk_ref), "K payload")
+                self.assertTrue(torch.equal(v_buf[ll], self.pv_ref), "V payload")
+                self.assertTrue(torch.equal(ks[ll], self.sk_ref), "K scales")
+                self.assertTrue(torch.equal(vs[ll], self.sv_ref), "V scales")
+                untouched = torch.ones(SLOTS, dtype=torch.bool, device=self.dev)
+                untouched[ll] = False
+                self.assertTrue((k_buf[untouched] == 0x77).all())
+                self.assertTrue((v_buf[untouched] == 0x99).all())
+                self.assertTrue((ks[untouched] == 3.0).all())
+                self.assertTrue((vs[untouched] == 5.0).all())
+                # zero row -> s = 1, nibbles 8; zero group -> s = 1, nibbles 8
+                self.assertTrue((ks[ll[5]] == 1.0).all())
+                self.assertTrue((k_buf[ll[5]] == 0x88).all())
+                self.assertEqual(float(vs[ll[7], 1, 2]), 1.0)
+                self.assertTrue((v_buf[ll[7], 1, 32:48] == 0x88).all())
+                # full-range rows
+                self.assertTrue((ks[ll[3], 0] == 1.0).all())
+                self.assertTrue(
+                    torch.equal(ref_unpack(k_buf[ll[3], 0]).unique(), self.qa)
+                )
+                self.assertTrue((vs[ll[3], 1] == 1.0).all())
+                self.assertTrue(
+                    torch.equal(ref_unpack(v_buf[ll[3], 1]).unique(), self.qa)
+                )
+                self.assertEqual(int(ref_unpack(k_buf[ll]).abs().max()), 7)
+
+    def test_scale_index_and_nibble_order(self):
+        loc, k_buf, _, ks, _ = self._scatter(torch.int64)
+        flat = ks.view(-1)
+        for _ in range(64):
+            t = int(torch.randint(self.N, (1,)))
+            h = int(torch.randint(HEADS, (1,)))
+            g = int(torch.randint(NG, (1,)))
+            slot = int(loc[t])
+            self.assertEqual(
+                float(flat[(slot * HEADS + h) * NG + g]), float(self.sk_ref[t, h, g])
+            )
+            c = int(torch.randint(DH, (1,)))
+            b = int(k_buf[slot, h, c])
+            self.assertEqual((b & 15) - 8, int(self.qk_ref[t, h, 2 * c]))
+            self.assertEqual((b >> 4) - 8, int(self.qk_ref[t, h, 2 * c + 1]))
+        self.assertFalse(torch.equal(self.sk_ref[:, 0], self.sk_ref[:, 1]))
+
+    def test_full_pool_quant_bit_exact(self):
+        pk, sk, pv, sv = self.full_ref
+        self.assertTrue(torch.equal(self.k4, pk))
+        self.assertTrue(torch.equal(self.ks4, sk))
+        self.assertTrue(torch.equal(self.v4, pv))
+        self.assertTrue(torch.equal(self.vs4, sv))
+
+    def test_compact_gather_bit_exact(self):
+        cu_k, n, out_k, out_v = self._run_compact(self.indices)
+        self.assertEqual(n, BATCH * TOPK)
+        for b in range(BATCH):
+            rows = self.req_to_token[b, self.indices[b].long()].long()
+            a, e = int(cu_k[b]), int(cu_k[b + 1])
+            self.assertTrue(torch.equal(out_k[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(out_v[a:e], self.dv_all[rows]), f"req {b} V")
+        self.assertTrue(torch.isnan(out_k[n:]).all(), "rows beyond the packed range")
+        self.assertTrue(torch.isnan(out_v[n:]).all(), "rows beyond the packed range")
+
+    def test_compact_gather_invalid_position_untouched(self):
+        cu_k, n, out_k, _ = self._run_compact(self.indices)
+        bad = self.indices.clone()
+        bad[1, 0] = int(self.seq_lens[1]) + 5  # invalid position inside request 1
+        cu_b, n_b, ok_b, ov_b = self._run_compact(bad)
+        self.assertEqual(n_b, BATCH * TOPK - 1)
+        a = int(cu_b[1])
+        self.assertTrue(torch.isnan(ok_b[a]).all() and torch.isnan(ov_b[a]).all())
+        rows = self.req_to_token[1, bad[1, 1 : TOPK - 1].long()].long()
+        self.assertTrue(torch.equal(ok_b[a + 1 : a + TOPK - 1], self.dk_all[rows]))
+        self.assertTrue(torch.equal(ov_b[a + 1 : a + TOPK - 1], self.dv_all[rows]))
+        self.assertTrue(torch.equal(ok_b[:a], out_k[:a]))
+        self.assertTrue(torch.equal(ok_b[int(cu_b[2]) : n_b], out_k[int(cu_k[2]) : n]))
+        self.assertTrue(torch.isnan(ok_b[n_b:]).all())
+
+    def test_compact_gather_trtllm_strided_layout(self):
+        # cu_k = arange(batch + 1) * stride with stride = ceil(topk / page) * page > topk,
+        # so valid_count (= stride) never masks anything and the `cols < topk` load
+        # mask (other = -1) keeps the page-padding columns [topk, stride) untouched.
+        dev = self.dev
+        page_s, topk_s = 64, 40
+        stride_s = -(-topk_s // page_s) * page_s
+        self.assertGreater(stride_s, topk_s)
+        self.assertNotEqual(topk_s % 16, 0)
+        cu_s = torch.arange(BATCH + 1, dtype=torch.int32, device=dev) * stride_s
+        nsel = [topk_s, 25, 33]  # valid selections per request; rest -1
+        idx_s = torch.full((BATCH, topk_s), -1, dtype=torch.int32, device=dev)
+        for b in range(BATCH):
+            idx_s[b, : nsel[b]] = (
+                torch.randperm(int(self.seq_lens[b]), device=dev)[: nsel[b]]
+                .sort()
+                .values.to(torch.int32)
+            )
+        idx_s[2, 5] = int(self.seq_lens[2]) + 3  # >= seq_len inside request 2
+        ok_s = torch.full(
+            (BATCH * stride_s, HEADS, DIM),
+            float("nan"),
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        ov_s = torch.full_like(ok_s, float("nan"))
+        qwen_sparse_kv_extraction_compact_triton(
+            self.k4,
+            self.v4,
+            self.req_to_token,
+            self.req_indices,
+            idx_s,
+            self.seq_lens,
+            cu_s,
+            ok_s,
+            ov_s,
+            BATCH,
+            topk_s,
+            k_scale=self.ks4,
+            v_scale=self.vs4,
+            sm_k=self.ones,
+            sm_v=self.ones,
+            kv_bits=4,
+        )
+        torch.cuda.synchronize()
+        written = torch.zeros(BATCH * stride_s, dtype=torch.bool, device=dev)
+        for b in range(BATCH):
+            for c in range(topk_s):
+                pos = int(idx_s[b, c])
+                if 0 <= pos < int(self.seq_lens[b]):
+                    r = b * stride_s + c
+                    slot = int(self.req_to_token[b, pos])
+                    self.assertTrue(torch.equal(ok_s[r], self.dk_all[slot]), (b, c))
+                    self.assertTrue(torch.equal(ov_s[r], self.dv_all[slot]), (b, c))
+                    written[r] = True
+        self.assertEqual(int(written.sum()), sum(nsel) - 1)
+        self.assertTrue(torch.isnan(ok_s[~written]).all())
+        self.assertTrue(torch.isnan(ov_s[~written]).all())
+        self.assertFalse(written.view(BATCH, stride_s)[:, topk_s:].any())
+
+    def test_packed_width_scratch_rejected(self):
+        # the backend derives the logical head_dim from the pool
+        cu_k, n, _, _ = self._run_compact(self.indices)
+        narrow = torch.empty(n, HEADS, DH, device=self.dev, dtype=torch.bfloat16)
+        with self.assertRaises(AssertionError):
+            qwen_sparse_kv_extraction_compact_triton(
+                self.k4,
+                self.v4,
+                self.req_to_token,
+                self.req_indices,
+                self.indices,
+                self.seq_lens,
+                cu_k,
+                narrow,
+                narrow.clone(),
+                BATCH,
+                TOPK,
+                k_scale=self.ks4,
+                v_scale=self.vs4,
+                sm_k=self.ones,
+                sm_v=self.ones,
+                kv_bits=4,
+            )
+
+    def test_prefix_gather_bit_exact_gaps_untouched(self):
+        lens, req_idx, gap, cu, pk, pv = self._prefix_gather()
+        written = torch.zeros(pk.shape[0], dtype=torch.bool, device=self.dev)
+        for b in range(BATCH):
+            rows = self.req_to_token[int(req_idx[b]), : int(lens[b])].long()
+            a, e = int(cu[b]), int(cu[b]) + int(lens[b])
+            self.assertTrue(torch.equal(pk[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(pv[a:e], self.dv_all[rows]), f"req {b} V")
+            written[a:e] = True
+            self.assertTrue(torch.isnan(pk[e : e + gap]).all(), f"gap after req {b}")
+            self.assertTrue(torch.isnan(pv[e : e + gap]).all(), f"gap after req {b}")
+        self.assertTrue(
+            torch.isnan(pk[~written]).all() and torch.isnan(pv[~written]).all()
+        )
+        self.assertEqual(int(written.sum()), int(lens.sum()))
+
+    def test_end_to_end_relative_error(self):
+        lens, req_idx, _, cu, pk, pv = self._prefix_gather()
+        written = torch.zeros(pk.shape[0], dtype=torch.bool, device=self.dev)
+        for b in range(BATCH):
+            written[int(cu[b]) : int(cu[b]) + int(lens[b])] = True
+        gathered_k = torch.cat(
+            [
+                self.k16[self.req_to_token[int(req_idx[b]), : int(lens[b])].long()]
+                for b in range(BATCH)
+            ]
+        )
+        gathered_v = torch.cat(
+            [
+                self.v16[self.req_to_token[int(req_idx[b]), : int(lens[b])].long()]
+                for b in range(BATCH)
+            ]
+        )
+        ek, ev = relerr(pk[written], gathered_k), relerr(pv[written], gathered_v)
+        # g32 on N(0, 3): ~9-10 % (int8_g64 ~0.9 %, e4m3 ~2.7 %)
+        self.assertTrue(0.08 < ek < 0.115, ek)
+        self.assertTrue(0.08 < ev < 0.115, ev)
+
+    def test_fp16_max_scale_clamp(self):
+        dev = self.dev
+        k4, v4, ks4, vs4 = (t.clone() for t in (self.k4, self.v4, self.ks4, self.vs4))
+        big = torch.zeros(1, HEADS, DIM, device=dev, dtype=torch.bfloat16)
+        big[0, 0, :32] = torch.tensor(
+            [1e6, -1e6, 5e5, -5e5, 4.6e5, -4.6e5, 1e5, -1e5] * 4, device=dev
+        ).to(torch.bfloat16)
+        big[0, 1, 64:96] = torch.finfo(torch.bfloat16).max  # every channel of group 2
+        bigv = -big
+        pos7 = 17
+        slot7 = int(self.req_to_token[0, pos7])
+        quant_store_kv_int4(
+            big,
+            bigv,
+            torch.tensor([slot7], dtype=torch.int32, device=dev),
+            k4,
+            v4,
+            ks4,
+            vs4,
+            self.ones,
+            self.ones,
+        )
+        torch.cuda.synchronize()
+        pk_b, sk_b, q_b = ref_quant(big)
+        pv_b, sv_b, _ = ref_quant(bigv)
+        self.assertTrue(torch.isfinite(sk_b).all())
+        self.assertEqual(float(sk_b[0, 0, 0]), 65504.0)
+        self.assertEqual(float(sk_b[0, 1, 2]), 65504.0)
+        self.assertTrue(torch.isfinite(ks4[slot7]).all(), "kernel stored an inf scale")
+        self.assertTrue(torch.isfinite(vs4[slot7]).all(), "kernel stored an inf scale")
+        self.assertTrue(torch.equal(k4[slot7], pk_b[0]))
+        self.assertTrue(torch.equal(ks4[slot7], sk_b[0]))
+        self.assertTrue(torch.equal(v4[slot7], pv_b[0]))
+        self.assertTrue(torch.equal(vs4[slot7], sv_b[0]))
+        sat = torch.tensor(7 * 65504.0, device=dev).to(torch.bfloat16)
+        d_b, dv_b = ref_dequant(pk_b, sk_b)[0], ref_dequant(pv_b, sv_b)[0]
+        self.assertTrue(torch.isfinite(d_b).all())
+        self.assertEqual(float(d_b[0, 0]), float(sat))
+        self.assertEqual(float(d_b[0, 1]), -float(sat))
+        self.assertTrue((d_b[1, 64:96] == sat).all() and (dv_b[1, 64:96] == -sat).all())
+        self.assertEqual(int(q_b[0, 0, :32].abs().max()), 7)
+        self.assertLess(int(q_b[0, 0, 6].abs()), 7)  # 1e5 / 65504 -> 2
+        # compact gather of the clamped row
+        idx7 = self.indices.clone()
+        idx7[0, 0] = pos7
+        cu7, n7, ok7, ov7 = self._run_compact(idx7, k4, v4, ks4, vs4)
+        r7 = int(cu7[0])
+        self.assertTrue(
+            torch.isfinite(ok7[:n7]).all() and torch.isfinite(ov7[:n7]).all()
+        )
+        self.assertTrue(torch.equal(ok7[r7], d_b) and torch.equal(ov7[r7], dv_b))
+        # prefix gather of the clamped row
+        pk7 = torch.full(
+            (pos7 + 8, HEADS, DIM), float("nan"), device=dev, dtype=torch.bfloat16
+        )
+        pv7 = torch.full_like(pk7, float("nan"))
+        qwen_sparse_prefix_gather_dequant_int4(
+            k4,
+            v4,
+            ks4,
+            vs4,
+            self.ones,
+            self.ones,
+            self.req_to_token,
+            torch.tensor([0], dtype=torch.int64, device=dev),
+            torch.tensor([pos7 + 8], dtype=torch.int32, device=dev),
+            torch.tensor([0, pos7 + 8], dtype=torch.int32, device=dev),
+            pk7,
+            pv7,
+            1,
+            pos7 + 8,
+        )
+        torch.cuda.synchronize()
+        self.assertTrue(torch.isfinite(pk7).all() and torch.isfinite(pv7).all())
+        self.assertTrue(torch.equal(pk7[pos7], d_b) and torch.equal(pv7[pos7], dv_b))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KV pools require CUDA")
+class TestInt4KVPool(CustomTestCase):
+    size, page = 1024, 64
+
+    def _make_pool(self, lazy):
+        env = dict(os.environ)
+        env.pop("SGLANG_KV_LAZY", None)
+        if lazy:
+            env["SGLANG_KV_LAZY"] = "1"
+            env["SGLANG_KV_LAZY_FLOOR"] = "512"
+        with patch.dict(os.environ, env, clear=True):
+            return MHATokenToKVPoolInt4(
+                size=self.size,
+                page_size=self.page,
+                dtype=torch.uint8,
+                head_num=HEADS,
+                head_dim=DIM,
+                layer_num=2,
+                device="cuda",
+                enable_memory_saver=False,
+                start_layer=0,
+            )
+
+    def _check_pool(self, pool, lazy):
+        dev = "cuda"
+        rows = self.size + self.page
+        self.assertEqual(pool.kv_bits, 4)
+        self.assertEqual(pool.dtype, torch.uint8)
+        self.assertEqual(pool.store_dtype, torch.uint8)
+        self.assertEqual(pool.head_dim, DIM)
+        for buf in (
+            pool.k_buffer,
+            pool.v_buffer,
+            pool.k_scale_buffer,
+            pool.v_scale_buffer,
+        ):
+            self.assertEqual(len(buf), 2)
+        self.assertEqual(pool.k_buffer[0].shape, (rows, HEADS, DH))
+        self.assertEqual(pool.k_buffer[0].dtype, torch.uint8)
+        self.assertEqual(pool.v_buffer[1].shape, (rows, HEADS, DH))
+        self.assertEqual(pool.v_buffer[1].dtype, torch.uint8)
+        self.assertEqual(pool.k_scale_buffer[0].shape, (rows, HEADS, NG))
+        self.assertEqual(pool.k_scale_buffer[0].dtype, torch.float16)
+        self.assertEqual(pool.get_key_buffer(1).dtype, torch.uint8)
+        self.assertEqual(pool.get_key_buffer(1).data_ptr(), pool.k_buffer[1].data_ptr())
+        descs = pool._kv_buffer_descs
+        self.assertEqual(
+            [d.name for d in descs],
+            ["k0", "k1", "v0", "v1", "ks0", "ks1", "vs0", "vs1"],
+        )
+        self.assertTrue(
+            all(
+                d.row_bytes == HEADS * DH
+                and d.shape == (rows, HEADS, DH)
+                and d.tokens_per_row == 1
+                for d in descs[:4]
+            )
+        )
+        self.assertTrue(
+            all(d.row_bytes == 32 and d.shape == (rows, 32) for d in descs[4:])
+        )
+        kb, vb = pool.get_kv_size_bytes()
+        self.assertEqual(kb, 2 * rows * (HEADS * DH + HEADS * NG * 2))
+        self.assertEqual(vb, kb)
+        if lazy:
+            o = pool._post_capture_owner
+            self.assertIsNotNone(o)
+            self.assertEqual(len(o.tensors), 8)
+            self.assertEqual(o.bytes_per_token(), 2 * (256 + 256 + 32 + 32))
+            self.assertEqual(pool.k_scale_buffer[0].data_ptr(), o.tensors[4].data_ptr())
+            self.assertTrue((pool.k_scale_buffer[1][: self.page] == 0).all())
+            self.assertTrue((pool.v_scale_buffer[0][: self.page] == 0).all())
+        else:
+            self.assertTrue((pool.k_scale_buffer[0] == 0).all())
+            self.assertTrue((pool.k_buffer[0] == 0).all())
+        n = 200
+        loc = torch.randperm(512, device=dev)[:n].to(
+            torch.int64
+        )  # inside the backed floor
+        xk = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        xv = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        # HybridLinearKVPool style (unit scales) and the [N, H*D] form
+        pool.set_kv_buffer(None, loc, xk, xv, 1.0, 1.0, layer_id_override=1)
+        pool.set_kv_buffer(
+            None, loc, xk.reshape(n, -1), xv.reshape(n, -1), layer_id_override=0
+        )
+        torch.cuda.synchronize()
+        pk_r, sk_r, _ = ref_quant(xk)
+        pv_r, sv_r, _ = ref_quant(xv)
+        for layer in (0, 1):
+            ksb, vsb = pool.get_kv_scale_buffer(layer)
+            self.assertTrue(torch.equal(pool.k_buffer[layer][loc], pk_r))
+            self.assertTrue(torch.equal(ksb[loc], sk_r))
+            self.assertTrue(torch.equal(pool.v_buffer[layer][loc], pv_r))
+            self.assertTrue(torch.equal(vsb[loc], sv_r))
+        smk, smv = pool.get_kv_smooth_buffer(1)
+        self.assertEqual(smk.shape, (HEADS, DIM))
+        self.assertTrue(bool((smk == 1).all()) and bool((smv == 1).all()))
+        for bad_kw in (
+            dict(k_scale=0.5),
+            dict(v_scale=torch.ones(1, device=dev)),
+            dict(dcp_kv_mask=torch.ones(n, device=dev)),
+        ):
+            with self.assertRaises((ValueError, NotImplementedError)):
+                pool.set_kv_buffer(None, loc, xk, xv, layer_id_override=0, **bad_kw)
+        with self.assertRaises(NotImplementedError):
+            pool.get_cpu_copy(loc)
+        with self.assertRaises(NotImplementedError):
+            pool.load_cpu_copy(None, loc)
+        with self.assertRaises(NotImplementedError):
+            pool.set_kv_buffer_prefix_valid()
+
+    def test_kv_bits_dispatch_keys(self):
+        self.assertEqual(MHATokenToKVPoolInt4.kv_bits, 4)
+        self.assertEqual(MHATokenToKVPoolInt8.kv_bits, 8)
+
+    def test_pool_eager(self):
+        pool = self._make_pool(lazy=False)
+        try:
+            self._check_pool(pool, lazy=False)
+        finally:
+            pool._clear_buffers()
+
+    def test_pool_lazy_vmm(self):
+        pool = self._make_pool(lazy=True)
+        try:
+            self._check_pool(pool, lazy=True)
+        finally:
+            pool._clear_buffers()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_int8_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_int8_kv_pool.py
@@ -1,0 +1,427 @@
+"""Unit tests for the int8-g64 QSA KV path: the ``qsa/sparse_attn.py`` kernels
+and ``MHATokenToKVPoolInt8`` (~50 MB VRAM, no server, no model).
+
+Torch reference: per-token-per-head-per-64-group absmax/127, fp16 scale,
+q = rint(x / s) clamped to [-127, 127], dequant q * s in fp32 -> bf16.
+  1. ``quant_store_kv_int8``: quantize + scatter into random slots (int32 and
+     int64 loc); payload and scales bit-exact vs the reference; untouched slots
+     keep their sentinel; zero rows get s = 1;
+  2. scale index arithmetic for GROUP=64 with 2 heads: flat index
+     (slot*2 + h)*4 + g;
+  3. compact gather (decode / verify path): 3 requests (300 / 1200 / 4000
+     tokens, permuted req_to_token), bit-exact dequant vs torch, rows beyond the
+     packed range untouched, an invalid position inside the packed region is
+     neither read nor written (same store mask as ``_compact_kv`` /
+     ``_compact_kv_fp8``: on the trtllm strided tables cu_k spans the page
+     stride, so zero-filling would write every unused column);
+  4. prefix row gather (chunk-prefill path): 3 requests with different lengths
+     (partial last row block, non-identity req_indices) packed with a 32-row
+     gap after EACH request, bit-exact, every gap row and the tail untouched;
+  5. end-to-end relative RMS error of gather-dequant(quant(x)) for x ~ N(0, 3)
+     below 1.2 %;
+  6. ``MHATokenToKVPoolInt8``: eager path and lazy-VMM path (SGLANG_KV_LAZY=1),
+     ``set_kv_buffer`` through the pool, scale descs / bytes per token,
+     first-page scale rows zeroed, guards.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.attention.qsa.sparse_attn import KV_INT8_GROUP as G
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    quant_store_kv_int8,
+    qwen_sparse_fa2_cu_seqlens_triton,
+    qwen_sparse_kv_extraction_compact_triton,
+    qwen_sparse_prefix_gather_dequant_int8,
+)
+from sglang.srt.mem_cache.int8_kv_pool import MHATokenToKVPoolInt8
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+SLOTS, HEADS, DIM, BATCH, TOPK = 4096, 2, 256, 3, 64
+NG = DIM // G
+
+
+def ref_quant(x):
+    """x [N, H, D] -> (q int8 [N, H, D], s fp16 [N, H, NG])."""
+    xf = x.float().reshape(*x.shape[:-1], NG, G)
+    a = xf.abs().amax(-1)
+    s = torch.where(a > 0, a / 127.0, torch.ones_like(a)).half()
+    q = (
+        torch.clamp(torch.round(xf / s.float()[..., None]), -127, 127)
+        .to(torch.int8)
+        .reshape(x.shape)
+    )
+    return q, s
+
+
+def ref_dequant(q, s):
+    return (q.float() * s.float().repeat_interleave(G, dim=-1)).to(torch.bfloat16)
+
+
+def relerr(a, b):
+    return float(
+        ((a.float() - b.float()).pow(2).mean() / b.float().pow(2).mean()).sqrt()
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton KV kernels require CUDA")
+class TestInt8KVKernels(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        dev = cls.dev = "cuda"
+        cls.ones = torch.ones(HEADS, DIM, dtype=torch.float16, device=dev)
+        # scatter inputs
+        cls.N = 1000
+        cls.xk = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xv = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xk[5] = 0  # zero row -> s = 1, q = 0
+        cls.xv[7, 1, 64:128] = 0  # one zero group in one head
+        cls.qk_ref, cls.sk_ref = ref_quant(cls.xk)
+        cls.qv_ref, cls.sv_ref = ref_quant(cls.xv)
+        # full pool for the gather tests
+        cls.k16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.v16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.k8 = torch.empty(SLOTS, HEADS, DIM, dtype=torch.int8, device=dev)
+        cls.v8 = torch.empty_like(cls.k8)
+        cls.ks8 = torch.empty(SLOTS, HEADS, NG, dtype=torch.float16, device=dev)
+        cls.vs8 = torch.empty_like(cls.ks8)
+        quant_store_kv_int8(
+            cls.k16,
+            cls.v16,
+            torch.arange(SLOTS, device=dev, dtype=torch.int32),
+            cls.k8,
+            cls.v8,
+            cls.ks8,
+            cls.vs8,
+            cls.ones,
+            cls.ones,
+        )
+        torch.cuda.synchronize()
+        qk, sk = ref_quant(cls.k16)
+        qv, sv = ref_quant(cls.v16)
+        cls.full_ref = (qk, sk, qv, sv)
+        cls.dk_all = ref_dequant(qk, sk)  # reference dequant of every slot
+        cls.dv_all = ref_dequant(qv, sv)
+        cls.seq_lens = torch.tensor([300, 1200, 4000], dtype=torch.int32, device=dev)
+        cls.req_to_token = torch.stack(
+            [torch.randperm(SLOTS, device=dev) for _ in range(BATCH)]
+        ).to(torch.int32)
+        cls.req_indices = torch.arange(BATCH, dtype=torch.int32, device=dev)
+        cls.indices = torch.stack(
+            [
+                torch.randperm(int(n), device=dev)[:TOPK].sort().values
+                for n in cls.seq_lens
+            ]
+        ).to(torch.int32)
+
+    # ------------------------------------------------------------ helpers
+    def _scatter(self, loc_dtype):
+        dev = self.dev
+        loc = torch.randperm(SLOTS, device=dev)[: self.N].to(loc_dtype)
+        k_buf = torch.full((SLOTS, HEADS, DIM), 7, dtype=torch.int8, device=dev)
+        v_buf = torch.full((SLOTS, HEADS, DIM), -7, dtype=torch.int8, device=dev)
+        ks = torch.full((SLOTS, HEADS, NG), 3.0, dtype=torch.float16, device=dev)
+        vs = torch.full((SLOTS, HEADS, NG), 5.0, dtype=torch.float16, device=dev)
+        quant_store_kv_int8(
+            self.xk, self.xv, loc, k_buf, v_buf, ks, vs, self.ones, self.ones
+        )
+        torch.cuda.synchronize()
+        return loc, k_buf, v_buf, ks, vs
+
+    def _run_compact(self, idx):
+        dev = self.dev
+        cu_k = torch.empty(BATCH + 1, dtype=torch.int32, device=dev)
+        counts = torch.empty(BATCH, dtype=torch.int32, device=dev)
+        qwen_sparse_fa2_cu_seqlens_triton(self.seq_lens, idx, counts, cu_k, BATCH, TOPK)
+        n = int(cu_k[-1])
+        out_k = torch.full(
+            (BATCH * TOPK + 16, HEADS, DIM),
+            float("nan"),
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        out_v = torch.full_like(out_k, float("nan"))
+        qwen_sparse_kv_extraction_compact_triton(
+            self.k8,
+            self.v8,
+            self.req_to_token,
+            self.req_indices,
+            idx,
+            self.seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            BATCH,
+            TOPK,
+            k_scale=self.ks8,
+            v_scale=self.vs8,
+            sm_k=self.ones,
+            sm_v=self.ones,
+        )
+        torch.cuda.synchronize()
+        return cu_k, n, out_k, out_v
+
+    def _prefix_gather(self):
+        dev = self.dev
+        lens = torch.tensor([300, 1203, 4001], dtype=torch.int32, device=dev)
+        req_idx = torch.tensor([2, 0, 1], dtype=torch.int64, device=dev)
+        gap = 32  # > BLOCK_T (16): a stray row block lands in the gap
+        cu = F.pad((lens + gap).cumsum(0), (1, 0)).to(torch.int32).contiguous()
+        total = int(cu[-1])
+        pk = torch.full(
+            (total + 100, HEADS, DIM), float("nan"), device=dev, dtype=torch.bfloat16
+        )
+        pv = torch.full_like(pk, float("nan"))
+        qwen_sparse_prefix_gather_dequant_int8(
+            self.k8,
+            self.v8,
+            self.ks8,
+            self.vs8,
+            self.ones,
+            self.ones,
+            self.req_to_token,
+            req_idx,
+            lens,
+            cu,
+            pk,
+            pv,
+            BATCH,
+            int(lens.max()),
+        )
+        torch.cuda.synchronize()
+        return lens, req_idx, gap, cu, pk, pv
+
+    # ------------------------------------------------------------ tests
+    def test_quant_store_scatter_bit_exact(self):
+        for loc_dtype in (torch.int32, torch.int64):
+            with self.subTest(loc_dtype=loc_dtype):
+                loc, k_buf, v_buf, ks, vs = self._scatter(loc_dtype)
+                ll = loc.long()
+                self.assertTrue(torch.equal(k_buf[ll], self.qk_ref), "K payload")
+                self.assertTrue(torch.equal(v_buf[ll], self.qv_ref), "V payload")
+                self.assertTrue(torch.equal(ks[ll], self.sk_ref), "K scales")
+                self.assertTrue(torch.equal(vs[ll], self.sv_ref), "V scales")
+                untouched = torch.ones(SLOTS, dtype=torch.bool, device=self.dev)
+                untouched[ll] = False
+                self.assertTrue((k_buf[untouched] == 7).all())
+                self.assertTrue((v_buf[untouched] == -7).all())
+                self.assertTrue((ks[untouched] == 3.0).all())
+                self.assertTrue((vs[untouched] == 5.0).all())
+                # zero row must give s = 1, q = 0; zero group s = 1
+                self.assertTrue((ks[ll[5]] == 1.0).all())
+                self.assertTrue((k_buf[ll[5]] == 0).all())
+                self.assertEqual(float(vs[ll[7], 1, 1]), 1.0)
+                self.assertEqual(int(self.qk_ref.abs().max()), 127)
+                self.assertEqual(int(k_buf[ll].abs().max()), 127)
+
+    def test_scale_index_arithmetic(self):
+        loc, _, _, ks, _ = self._scatter(torch.int64)
+        flat = ks.view(-1)
+        for _ in range(64):
+            t = int(torch.randint(self.N, (1,)))
+            h = int(torch.randint(HEADS, (1,)))
+            g = int(torch.randint(NG, (1,)))
+            slot = int(loc[t])
+            self.assertEqual(
+                float(flat[(slot * HEADS + h) * NG + g]), float(self.sk_ref[t, h, g])
+            )
+        # heads must carry distinct scales for the probe to be meaningful
+        self.assertFalse(torch.equal(self.sk_ref[:, 0], self.sk_ref[:, 1]))
+
+    def test_full_pool_quant_bit_exact(self):
+        qk, sk, qv, sv = self.full_ref
+        self.assertTrue(torch.equal(self.k8, qk))
+        self.assertTrue(torch.equal(self.ks8, sk))
+        self.assertTrue(torch.equal(self.v8, qv))
+        self.assertTrue(torch.equal(self.vs8, sv))
+
+    def test_compact_gather_bit_exact(self):
+        cu_k, n, out_k, out_v = self._run_compact(self.indices)
+        self.assertEqual(n, BATCH * TOPK)
+        for b in range(BATCH):
+            rows = self.req_to_token[b, self.indices[b].long()].long()
+            a, e = int(cu_k[b]), int(cu_k[b + 1])
+            self.assertTrue(torch.equal(out_k[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(out_v[a:e], self.dv_all[rows]), f"req {b} V")
+        self.assertTrue(torch.isnan(out_k[n:]).all(), "rows beyond the packed range")
+        self.assertTrue(torch.isnan(out_v[n:]).all(), "rows beyond the packed range")
+
+    def test_compact_gather_invalid_position_untouched(self):
+        cu_k, n, out_k, _ = self._run_compact(self.indices)
+        bad = self.indices.clone()
+        bad[1, 0] = int(self.seq_lens[1]) + 5  # invalid position inside request 1
+        cu_b, n_b, ok_b, ov_b = self._run_compact(bad)
+        self.assertEqual(n_b, BATCH * TOPK - 1)
+        a = int(cu_b[1])
+        self.assertTrue(torch.isnan(ok_b[a]).all() and torch.isnan(ov_b[a]).all())
+        rows = self.req_to_token[1, bad[1, 1 : TOPK - 1].long()].long()
+        self.assertTrue(torch.equal(ok_b[a + 1 : a + TOPK - 1], self.dk_all[rows]))
+        self.assertTrue(torch.equal(ov_b[a + 1 : a + TOPK - 1], self.dv_all[rows]))
+        self.assertTrue(torch.equal(ok_b[:a], out_k[:a]))
+        self.assertTrue(torch.equal(ok_b[int(cu_b[2]) : n_b], out_k[int(cu_k[2]) : n]))
+        self.assertTrue(torch.isnan(ok_b[n_b:]).all())
+
+    def test_prefix_gather_bit_exact_gaps_untouched(self):
+        lens, req_idx, gap, cu, pk, pv = self._prefix_gather()
+        written = torch.zeros(pk.shape[0], dtype=torch.bool, device=self.dev)
+        for b in range(BATCH):
+            rows = self.req_to_token[int(req_idx[b]), : int(lens[b])].long()
+            a, e = int(cu[b]), int(cu[b]) + int(lens[b])
+            self.assertTrue(torch.equal(pk[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(pv[a:e], self.dv_all[rows]), f"req {b} V")
+            written[a:e] = True
+            self.assertTrue(torch.isnan(pk[e : e + gap]).all(), f"gap after req {b}")
+            self.assertTrue(torch.isnan(pv[e : e + gap]).all(), f"gap after req {b}")
+        self.assertTrue(
+            torch.isnan(pk[~written]).all() and torch.isnan(pv[~written]).all()
+        )
+        self.assertEqual(int(written.sum()), int(lens.sum()))
+
+    def test_end_to_end_relative_error(self):
+        lens, req_idx, _, cu, pk, pv = self._prefix_gather()
+        written = torch.zeros(pk.shape[0], dtype=torch.bool, device=self.dev)
+        for b in range(BATCH):
+            written[int(cu[b]) : int(cu[b]) + int(lens[b])] = True
+        gathered_k = torch.cat(
+            [
+                self.k16[self.req_to_token[int(req_idx[b]), : int(lens[b])].long()]
+                for b in range(BATCH)
+            ]
+        )
+        gathered_v = torch.cat(
+            [
+                self.v16[self.req_to_token[int(req_idx[b]), : int(lens[b])].long()]
+                for b in range(BATCH)
+            ]
+        )
+        self.assertLess(relerr(pk[written], gathered_k), 0.012)
+        self.assertLess(relerr(pv[written], gathered_v), 0.012)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KV pools require CUDA")
+class TestInt8KVPool(CustomTestCase):
+    size, page = 1024, 64
+
+    def _make_pool(self, lazy):
+        env = dict(os.environ)
+        env.pop("SGLANG_KV_LAZY", None)
+        if lazy:
+            env["SGLANG_KV_LAZY"] = "1"
+            env["SGLANG_KV_LAZY_FLOOR"] = "512"
+        with patch.dict(os.environ, env, clear=True):
+            return MHATokenToKVPoolInt8(
+                size=self.size,
+                page_size=self.page,
+                dtype=torch.int8,
+                head_num=HEADS,
+                head_dim=DIM,
+                layer_num=2,
+                device="cuda",
+                enable_memory_saver=False,
+                start_layer=0,
+            )
+
+    def _check_pool(self, pool, lazy):
+        dev = "cuda"
+        rows = self.size + self.page
+        self.assertEqual(pool.dtype, torch.int8)
+        self.assertEqual(pool.store_dtype, torch.int8)
+        for buf in (
+            pool.k_buffer,
+            pool.v_buffer,
+            pool.k_scale_buffer,
+            pool.v_scale_buffer,
+        ):
+            self.assertEqual(len(buf), 2)
+        self.assertEqual(pool.k_buffer[0].shape, (rows, HEADS, DIM))
+        self.assertEqual(pool.k_buffer[0].dtype, torch.int8)
+        self.assertEqual(pool.k_scale_buffer[0].shape, (rows, HEADS, NG))
+        self.assertEqual(pool.k_scale_buffer[0].dtype, torch.float16)
+        self.assertEqual(pool.get_key_buffer(1).dtype, torch.int8)
+        self.assertEqual(pool.get_key_buffer(1).data_ptr(), pool.k_buffer[1].data_ptr())
+        descs = pool._kv_buffer_descs
+        self.assertEqual(
+            [d.name for d in descs],
+            ["k0", "k1", "v0", "v1", "ks0", "ks1", "vs0", "vs1"],
+        )
+        self.assertTrue(
+            all(d.row_bytes == 16 and d.shape == (rows, 16) for d in descs[4:])
+        )
+        kb, vb = pool.get_kv_size_bytes()
+        self.assertEqual(kb, 2 * rows * (HEADS * DIM + HEADS * NG * 2))
+        self.assertEqual(vb, kb)
+        if lazy:
+            o = pool._post_capture_owner
+            self.assertIsNotNone(o)
+            self.assertEqual(len(o.tensors), 8)
+            self.assertEqual(o.bytes_per_token(), 2 * (512 + 512 + 16 + 16))
+            self.assertEqual(pool.k_scale_buffer[0].data_ptr(), o.tensors[4].data_ptr())
+            self.assertTrue((pool.k_scale_buffer[1][: self.page] == 0).all())
+            self.assertTrue((pool.v_scale_buffer[0][: self.page] == 0).all())
+        else:
+            self.assertTrue((pool.k_scale_buffer[0] == 0).all())
+        n = 200
+        loc = torch.randperm(512, device=dev)[:n].to(
+            torch.int64
+        )  # inside the backed floor
+        xk = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        xv = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        # HybridLinearKVPool style (unit scales) and the [N, H*D] form
+        pool.set_kv_buffer(None, loc, xk, xv, 1.0, 1.0, layer_id_override=1)
+        pool.set_kv_buffer(
+            None, loc, xk.reshape(n, -1), xv.reshape(n, -1), layer_id_override=0
+        )
+        torch.cuda.synchronize()
+        qk_r, sk_r = ref_quant(xk)
+        qv_r, sv_r = ref_quant(xv)
+        for layer in (0, 1):
+            ksb, vsb = pool.get_kv_scale_buffer(layer)
+            self.assertTrue(torch.equal(pool.k_buffer[layer][loc], qk_r))
+            self.assertTrue(torch.equal(ksb[loc], sk_r))
+            self.assertTrue(torch.equal(pool.v_buffer[layer][loc], qv_r))
+            self.assertTrue(torch.equal(vsb[loc], sv_r))
+        smk, smv = pool.get_kv_smooth_buffer(1)
+        self.assertEqual(smk.shape, (HEADS, DIM))
+        self.assertTrue(bool((smk == 1).all()) and bool((smv == 1).all()))
+        for bad_kw in (
+            dict(k_scale=0.5),
+            dict(v_scale=torch.ones(1, device=dev)),
+            dict(dcp_kv_mask=torch.ones(n, device=dev)),
+        ):
+            with self.assertRaises((ValueError, NotImplementedError)):
+                pool.set_kv_buffer(None, loc, xk, xv, layer_id_override=0, **bad_kw)
+        with self.assertRaises(NotImplementedError):
+            pool.get_cpu_copy(loc)
+        with self.assertRaises(NotImplementedError):
+            pool.load_cpu_copy(None, loc)
+        with self.assertRaises(NotImplementedError):
+            pool.set_kv_buffer_prefix_valid()
+
+    def test_kv_bits_dispatch_key(self):
+        self.assertEqual(MHATokenToKVPoolInt8.kv_bits, 8)
+
+    def test_pool_eager(self):
+        pool = self._make_pool(lazy=False)
+        try:
+            self._check_pool(pool, lazy=False)
+        finally:
+            pool._clear_buffers()
+
+    def test_pool_lazy_vmm(self):
+        pool = self._make_pool(lazy=True)
+        try:
+            self._check_pool(pool, lazy=True)
+        finally:
+            pool._clear_buffers()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_tiered_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_tiered_kv_pool.py
@@ -1,0 +1,1051 @@
+"""Unit tests for the tiered (int8-g64 ring over int4-g32) QSA KV path: the
+``qsa/sparse_attn.py`` kernels and ``MHATokenToKVPoolTiered`` (~40 MB VRAM,
+no server, no model).
+
+A small ring R = 64 over a 4096-slot pool, so ring rows are overwritten by
+later slots (s + R). Torch references: int4-g32 for cold rows, int8-g64
+dequant (q8 * s8, fp32 -> bf16) of the ring row for hot rows; ring rows are
+compared bit-exact with the int8 kernel (``quant_store_kv_int8``) itself.
+  1. ``quant_store_kv_tiered``: N = 1000 tokens into random ascending slots
+     (incl. slot 0) written in alias-free chunks (span < R, as chunked prefill
+     with chunk <= R); int32 and int64 loc; int4 rows / scales of EVERY slot
+     bit-exact vs the reference (never overwritten); owner[r] == the last slot
+     of class r; ring rows of every hot slot bit-exact vs
+     ``quant_store_kv_int8``; cold slots' ring rows hold the owning slot;
+  2. hot / cold boundary: write s then s + R -> owner flips to s + R (s cold,
+     s + R hot, int4 row of s intact); write s + R then s -> owner == s; N > R
+     in one launch raises;
+  3. same-launch ring-row collisions (slots congruent mod R in ONE write, as
+     with several requests in a batch): exactly one owner per contested ring
+     row, its ring row bit-exact, the losers cold, every int4 row exact,
+     uncontested rows hot; 20 random collision patterns;
+  4. compact gather: 3 requests (300 / 1200 / 4000 tokens, permuted
+     req_to_token), random owner pattern (per ring row: -1 or a random member
+     of its slot class, with the ring row re-quantized from that slot),
+     poisoned ring rows for the unowned classes -> rows bit-exact vs the
+     per-tier torch reference; rows beyond the packed range untouched; an
+     invalid position inside the packed region untouched; the trtllm strided
+     layout (cu_k = arange * 64, topk 40, -1 padding, pos >= seq_len); a stale
+     owner (owner = slot +/- R) -> int4 path; a call without ring / owner takes
+     the plain int4 path;
+  5. prefix row gather: 3 lengths, 32-row gaps after each request, mixed tiers,
+     bit-exact, gaps untouched, missing ring args rejected;
+  6. fp16-max scale clamp on the ring: absmax 1e6 / bf16-max groups -> s8 =
+     65504 (never inf), ring row bit-exact vs the clamped torch reference, int4
+     half bit-exact, both gathers finite + bit-exact, after eviction the int4
+     row is served;
+  7. an all-cold gather (owner = -1) equals ``_compact_kv_int4`` and an all-hot
+     gather (a 4096-row ring with owner = arange) equals ``_compact_kv_int8``;
+  8. ``MHATokenToKVPoolTiered`` (SGLANG_KV_TIERS_W=64): eager and lazy-VMM
+     paths; ring shapes / dtypes, owner -1, kv_tiered / kv_bits / ring_mask,
+     descs identical to the int4 pool (the ring is not on the owner),
+     ``get_kv_size_bytes`` includes the ring, ``set_kv_buffer`` bit-exact (both
+     tiers + owner), N > R raises, ``lazy_release`` resets the owner, guards;
+     bad SGLANG_KV_TIERS_W rejected.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.attention.qsa.sparse_attn import KV_INT4_GROUP as G4
+from sglang.srt.layers.attention.qsa.sparse_attn import KV_INT8_GROUP as G8
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    quant_store_kv_int8,
+    quant_store_kv_tiered,
+    qwen_sparse_fa2_cu_seqlens_triton,
+    qwen_sparse_kv_extraction_compact_triton,
+    qwen_sparse_prefix_gather_dequant_tiered,
+)
+from sglang.srt.mem_cache.int4_kv_pool import MHATokenToKVPoolInt4
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.srt.mem_cache.tiered_kv_pool import (
+    MHATokenToKVPoolTiered,
+    ring_slots_from_env,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=40, stage="base-b", runner_config="1-gpu-small")
+
+SLOTS, HEADS, DIM, BATCH, TOPK = 4096, 2, 256, 3, 64
+R = 64
+MASK = R - 1
+NG4, DH, NG8 = DIM // G4, DIM // 2, DIM // G8
+
+
+# ---------------------------------------------------------------------- torch references
+def ref_pack(q):
+    return ((q[..., 0::2] + 8) | ((q[..., 1::2] + 8) << 4)).to(torch.uint8)
+
+
+def ref_unpack(p):
+    b = p.to(torch.int32)
+    return torch.stack([(b & 15) - 8, (b >> 4) - 8], dim=-1).reshape(*p.shape[:-1], -1)
+
+
+def ref_quant4(x):
+    xf = x.float().reshape(*x.shape[:-1], NG4, G4)
+    a = xf.abs().amax(-1)
+    s = torch.where(a > 0, a / 7.0, torch.ones_like(a)).clamp(max=65504.0).half()
+    q = (
+        torch.clamp(torch.round(xf / s.float()[..., None]), -7, 7)
+        .to(torch.int32)
+        .reshape(x.shape)
+    )
+    return ref_pack(q), s
+
+
+def ref_dequant4(p, s):
+    return (ref_unpack(p).float() * s.float().repeat_interleave(G4, dim=-1)).to(
+        torch.bfloat16
+    )
+
+
+def ref_quant8(x):
+    """int8-g64 with the fp16-max clamp (what the tiered writer stores in the ring)."""
+    xf = x.float().reshape(*x.shape[:-1], NG8, G8)
+    a = xf.abs().amax(-1)
+    s = torch.where(a > 0, a / 127.0, torch.ones_like(a)).clamp(max=65504.0).half()
+    q = (
+        torch.clamp(torch.round(xf / s.float()[..., None]), -127, 127)
+        .to(torch.int8)
+        .reshape(x.shape)
+    )
+    return q, s
+
+
+def ref_dequant8(q, s):
+    return (q.float() * s.float().repeat_interleave(G8, dim=-1)).to(torch.bfloat16)
+
+
+def chunks_alias_free(sl):
+    """Split an ascending slot list into consecutive chunks whose span is < R."""
+    out, start = [], 0
+    for i in range(1, len(sl) + 1):
+        if i == len(sl) or int(sl[i]) - int(sl[start]) >= R:
+            out.append((start, i))
+            start = i
+    return out
+
+
+def new_bufs(dev):
+    k4 = torch.full((SLOTS, HEADS, DH), 0x77, dtype=torch.uint8, device=dev)
+    v4 = torch.full((SLOTS, HEADS, DH), 0x99, dtype=torch.uint8, device=dev)
+    ks4 = torch.full((SLOTS, HEADS, NG4), 3.0, dtype=torch.float16, device=dev)
+    vs4 = torch.full((SLOTS, HEADS, NG4), 5.0, dtype=torch.float16, device=dev)
+    rk = torch.full((R, HEADS, DIM), 0x33, dtype=torch.int8, device=dev)
+    rv = torch.full((R, HEADS, DIM), 0x44, dtype=torch.int8, device=dev)
+    rks = torch.full((R, HEADS, NG8), 7.0, dtype=torch.float16, device=dev)
+    rvs = torch.full((R, HEADS, NG8), 9.0, dtype=torch.float16, device=dev)
+    owner = torch.full((R,), -1, dtype=torch.int32, device=dev)
+    return [k4, v4, ks4, vs4, rk, rv, rks, rvs, owner]
+
+
+def tiered_write(xk, xv, loc, bufs, ones):
+    k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+    quant_store_kv_tiered(
+        xk, xv, loc, k4, v4, ks4, vs4, rk, rv, rks, rvs, owner, ones, ones, MASK
+    )
+
+
+def one(i, dev):
+    return torch.tensor([i], dtype=torch.int32, device=dev)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Triton KV kernels require CUDA")
+class TestTieredKVKernels(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        dev = cls.dev = "cuda"
+        cls.ones = torch.ones(HEADS, DIM, dtype=torch.float16, device=dev)
+        # ---- inputs of the write tests
+        cls.N = 1000
+        cls.xk = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xv = torch.randn(cls.N, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.xk[5] = 0  # zero row -> s = 1 in both tiers
+        sl = torch.randperm(SLOTS, device=dev)[: cls.N].sort().values
+        sl[0] = 0  # slot 0 (the dummy-write slot) is part of the set
+        cls.sl = sl
+        cls.pk_ref, cls.sk_ref = ref_quant4(cls.xk)
+        cls.pv_ref, cls.sv_ref = ref_quant4(cls.xv)
+        # int8 reference straight from the int8 kernel (identical arithmetic)
+        cls.k8_ref = torch.empty(SLOTS, HEADS, DIM, dtype=torch.int8, device=dev)
+        cls.v8_ref = torch.empty_like(cls.k8_ref)
+        cls.ks8_ref = torch.empty(SLOTS, HEADS, NG8, dtype=torch.float16, device=dev)
+        cls.vs8_ref = torch.empty_like(cls.ks8_ref)
+        quant_store_kv_int8(
+            cls.xk,
+            cls.xv,
+            sl.to(torch.int32),
+            cls.k8_ref,
+            cls.v8_ref,
+            cls.ks8_ref,
+            cls.vs8_ref,
+            cls.ones,
+            cls.ones,
+        )
+        torch.cuda.synchronize()
+        cls.q8k, cls.s8k = ref_quant8(cls.xk)
+        cls.q8v, cls.s8v = ref_quant8(cls.xv)
+        # ---- full pool with a random owner pattern for the gather tests
+        cls.k16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        cls.v16 = torch.randn(SLOTS, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        bufs = cls.bufs = new_bufs(dev)
+        for a in range(0, SLOTS, R):  # ascending chunks of exactly R slots
+            tiered_write(
+                cls.k16[a : a + R],
+                cls.v16[a : a + R],
+                torch.arange(a, a + R, device=dev, dtype=torch.int32),
+                bufs,
+                cls.ones,
+            )
+        torch.cuda.synchronize()
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        cls.pk, cls.sk = ref_quant4(cls.k16)
+        cls.pv, cls.sv = ref_quant4(cls.v16)
+        cls.owner_after_fill = owner.clone()
+        # random owner pattern: per ring row r either -1 (nobody) or a random member
+        # s' of the class {r, r + R, ...}; the ring row is then re-quantized from s'
+        n_cls = cls.n_cls = SLOTS // R
+        pick = torch.randint(0, n_cls, (R,), device=dev)
+        pick = torch.where(
+            torch.rand(R, device=dev) < 0.35, torch.full_like(pick, -1), pick
+        )
+        own = torch.where(
+            pick < 0, torch.full_like(pick, -1), pick * R + torch.arange(R, device=dev)
+        )
+        own[0] = 0  # ring row 0 owned by slot 0 (dummy-write slot)
+        own[1] = -1
+        own[2] = 2 + R * (n_cls - 1)  # the last slot of its class
+        owner.copy_(own.to(torch.int32))
+        cls.hot_rows = torch.nonzero(own >= 0).flatten()
+        quant_store_kv_int8(
+            cls.k16[own[cls.hot_rows]],
+            cls.v16[own[cls.hot_rows]],
+            cls.hot_rows.to(torch.int32),
+            rk,
+            rv,
+            rks,
+            rvs,
+            cls.ones,
+            cls.ones,
+        )
+        # poison every unowned ring row: garbage payload and NaN scales must never
+        # reach the output
+        cls.dead = torch.nonzero(own < 0).flatten()
+        rk[cls.dead] = -128
+        rv[cls.dead] = 127
+        rks[cls.dead] = float("nan")
+        rvs[cls.dead] = float("inf")
+        torch.cuda.synchronize()
+        cls.k8_all = torch.empty(SLOTS, HEADS, DIM, dtype=torch.int8, device=dev)
+        cls.v8_all = torch.empty_like(cls.k8_all)
+        cls.ks8_all = torch.empty(SLOTS, HEADS, NG8, dtype=torch.float16, device=dev)
+        cls.vs8_all = torch.empty_like(cls.ks8_all)
+        quant_store_kv_int8(
+            cls.k16,
+            cls.v16,
+            torch.arange(SLOTS, device=dev, dtype=torch.int32),
+            cls.k8_all,
+            cls.v8_all,
+            cls.ks8_all,
+            cls.vs8_all,
+            cls.ones,
+            cls.ones,
+        )
+        torch.cuda.synchronize()
+        ar = torch.arange(SLOTS, device=dev)
+        cls.is_hot = owner.long()[ar & MASK] == ar  # [SLOTS] bool
+        cls.d4k, cls.d4v = ref_dequant4(cls.pk, cls.sk), ref_dequant4(cls.pv, cls.sv)
+        cls.d8k = ref_dequant8(cls.k8_all, cls.ks8_all)
+        cls.d8v = ref_dequant8(cls.v8_all, cls.vs8_all)
+        cls.dk_all = torch.where(cls.is_hot[:, None, None], cls.d8k, cls.d4k)
+        cls.dv_all = torch.where(cls.is_hot[:, None, None], cls.d8v, cls.d4v)
+        # ---- requests
+        cls.seq_lens = torch.tensor([300, 1200, 4000], dtype=torch.int32, device=dev)
+        cls.req_to_token = torch.stack(
+            [torch.randperm(SLOTS, device=dev) for _ in range(BATCH)]
+        ).to(torch.int32)
+        cls.req_indices = torch.arange(BATCH, dtype=torch.int32, device=dev)
+        indices = torch.stack(
+            [
+                torch.randperm(int(n), device=dev)[:TOPK].sort().values
+                for n in cls.seq_lens
+            ]
+        ).to(torch.int32)
+        # the random owner pattern leaves only ~2/3 R hot slots in 4096: make sure
+        # every request selects up to 8 of them
+        for b in range(BATCH):
+            hot_pos = torch.nonzero(
+                cls.is_hot[cls.req_to_token[b, : int(cls.seq_lens[b])].long()]
+            ).flatten()
+            if hot_pos.numel():
+                take = hot_pos[torch.randperm(hot_pos.numel(), device=dev)[:8]]
+                taken = set(take.tolist())
+                rest = torch.tensor(
+                    [p for p in indices[b].tolist() if p not in taken],
+                    device=dev,
+                    dtype=torch.int64,
+                )
+                indices[b] = (
+                    torch.cat([rest[: TOPK - take.numel()], take])
+                    .sort()
+                    .values.to(torch.int32)
+                )
+        cls.indices = indices
+
+    # ------------------------------------------------------------ helpers
+    def tier_kwargs(self, bufs=None, owner=None):
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, own = bufs or self.bufs
+        return dict(
+            k_scale=ks4,
+            v_scale=vs4,
+            sm_k=self.ones,
+            sm_v=self.ones,
+            kv_bits=4,
+            ring_k=rk,
+            ring_v=rv,
+            ring_ks=rks,
+            ring_vs=rvs,
+            owner=own if owner is None else owner,
+            ring_mask=MASK,
+        )
+
+    def int4_kwargs(self, bufs=None):
+        k4, v4, ks4, vs4 = (bufs or self.bufs)[:4]
+        return dict(k_scale=ks4, v_scale=vs4, sm_k=self.ones, sm_v=self.ones, kv_bits=4)
+
+    def run_compact(self, idx, kw=None, bufs=None):
+        dev = self.dev
+        k4, v4 = (bufs or self.bufs)[:2]
+        cu_k = torch.empty(BATCH + 1, dtype=torch.int32, device=dev)
+        counts = torch.empty(BATCH, dtype=torch.int32, device=dev)
+        qwen_sparse_fa2_cu_seqlens_triton(self.seq_lens, idx, counts, cu_k, BATCH, TOPK)
+        n = int(cu_k[-1])
+        out_k = torch.full(
+            (BATCH * TOPK + 16, HEADS, DIM),
+            float("nan"),
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        out_v = torch.full_like(out_k, float("nan"))
+        qwen_sparse_kv_extraction_compact_triton(
+            k4,
+            v4,
+            self.req_to_token,
+            self.req_indices,
+            idx,
+            self.seq_lens,
+            cu_k,
+            out_k,
+            out_v,
+            BATCH,
+            TOPK,
+            **(kw or self.tier_kwargs(bufs)),
+        )
+        torch.cuda.synchronize()
+        return cu_k, n, out_k, out_v
+
+    # ------------------------------------------------------------ 1. dual write
+    def test_dual_write_ascending_slots_ring_wrap(self):
+        dev, sl = self.dev, self.sl
+        self.assertEqual(int(sl.unique().numel()), self.N)
+        self.assertTrue(torch.equal(self.k8_ref[sl], self.q8k))
+        self.assertTrue(torch.equal(self.ks8_ref[sl], self.s8k))
+        ch = chunks_alias_free(sl)
+        self.assertGreater(len(ch), 20)
+        self.assertLessEqual(max(e - a for a, e in ch), R)
+        exp_owner = torch.full((R,), -1, dtype=torch.int64, device=dev)
+        for s in sl.tolist():
+            exp_owner[s & MASK] = s  # ascending -> the last writer of each class
+        n_wrapped = int(((sl & MASK).bincount(minlength=R) > 1).sum())
+        self.assertGreater(n_wrapped, 40, "the slot set must make most ring rows wrap")
+        for loc_dtype in (torch.int32, torch.int64):
+            with self.subTest(loc_dtype=loc_dtype):
+                bufs = new_bufs(dev)
+                k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+                for a, e in ch:
+                    tiered_write(
+                        self.xk[a:e],
+                        self.xv[a:e],
+                        sl[a:e].to(loc_dtype),
+                        bufs,
+                        self.ones,
+                    )
+                torch.cuda.synchronize()
+                ll = sl.long()
+                self.assertTrue(torch.equal(k4[ll], self.pk_ref))
+                self.assertTrue(torch.equal(ks4[ll], self.sk_ref))
+                self.assertTrue(torch.equal(v4[ll], self.pv_ref))
+                self.assertTrue(torch.equal(vs4[ll], self.sv_ref))
+                untouched = torch.ones(SLOTS, dtype=torch.bool, device=dev)
+                untouched[ll] = False
+                self.assertTrue((k4[untouched] == 0x77).all())
+                self.assertTrue((ks4[untouched] == 3.0).all())
+                self.assertTrue(torch.equal(owner.long(), exp_owner))
+                self.assertGreaterEqual(int(exp_owner[0]), 0)
+                hot = ll[
+                    owner.long()[ll & MASK] == ll
+                ]  # slots that still own their row
+                cold = ll[owner.long()[ll & MASK] != ll]
+                self.assertEqual(hot.numel(), int((exp_owner >= 0).sum()))
+                self.assertEqual(cold.numel(), self.N - hot.numel())
+                self.assertGreater(cold.numel(), 900)
+                self.assertTrue(torch.equal(rk[hot & MASK], self.k8_ref[hot]))
+                self.assertTrue(torch.equal(rks[hot & MASK], self.ks8_ref[hot]))
+                self.assertTrue(torch.equal(rv[hot & MASK], self.v8_ref[hot]))
+                self.assertTrue(torch.equal(rvs[hot & MASK], self.vs8_ref[hot]))
+                own_of_cold = owner.long()[cold & MASK]
+                self.assertTrue(torch.equal(rk[cold & MASK], self.k8_ref[own_of_cold]))
+                # zero row: s = 1, nibbles 8 (and s8 = 1, q8 = 0 while hot)
+                self.assertTrue((ks4[ll[5]] == 1.0).all() and (k4[ll[5]] == 0x88).all())
+                if int(owner[ll[5] & MASK]) == int(ll[5]):
+                    self.assertTrue((rks[ll[5] & MASK] == 1.0).all())
+                    self.assertTrue((rk[ll[5] & MASK] == 0).all())
+
+    # ------------------------------------------------------------ 2. hot/cold boundary
+    def test_hot_cold_boundary(self):
+        dev, s0 = self.dev, 100
+        xk, xv = self.xk, self.xv
+        bufs = new_bufs(dev)
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        tiered_write(xk[:1], xv[:1], one(s0, dev), bufs, self.ones)
+        torch.cuda.synchronize()
+        self.assertEqual(int(owner[s0 & MASK]), s0)
+        self.assertTrue(torch.equal(rk[s0 & MASK], self.q8k[0]))
+        self.assertTrue(torch.equal(k4[s0], self.pk_ref[0]))
+        tiered_write(xk[1:2], xv[1:2], one(s0 + R, dev), bufs, self.ones)  # evicts s0
+        torch.cuda.synchronize()
+        self.assertEqual(int(owner[s0 & MASK]), s0 + R, "owner must flip to s + R")
+        self.assertTrue(torch.equal(rk[s0 & MASK], self.q8k[1]))
+        self.assertTrue(torch.equal(rks[s0 & MASK], self.s8k[1]))
+        self.assertTrue(torch.equal(k4[s0], self.pk_ref[0]), "int4 row of s intact")
+        self.assertTrue(torch.equal(ks4[s0], self.sk_ref[0]))
+        self.assertTrue(torch.equal(k4[s0 + R], self.pk_ref[1]))
+        self.assertTrue(torch.equal(v4[s0 + R], self.pv_ref[1]))
+        self.assertEqual(int((owner == -1).sum()), R - 1)
+        bufs = new_bufs(dev)
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        tiered_write(xk[1:2], xv[1:2], one(s0 + R, dev), bufs, self.ones)
+        tiered_write(xk[:1], xv[:1], one(s0, dev), bufs, self.ones)  # s after s + R
+        torch.cuda.synchronize()
+        self.assertEqual(int(owner[s0 & MASK]), s0)
+        self.assertTrue(torch.equal(rk[s0 & MASK], self.q8k[0]))
+        self.assertTrue(torch.equal(k4[s0 + R], self.pk_ref[1]))
+        with self.assertRaises(AssertionError):  # N > R in one launch
+            tiered_write(
+                xk[: R + 1],
+                xv[: R + 1],
+                torch.arange(R + 1, device=dev, dtype=torch.int32),
+                bufs,
+                self.ones,
+            )
+
+    # ------------------------------------------------------------ 3. collisions
+    def test_same_launch_ring_row_collisions(self):
+        # slots congruent mod R in the same write: the stamp launch picks one owner
+        # per ring row, only the owner's programs write the ring row, the losers
+        # are cold; no row may mix two tokens' bytes.
+        dev = self.dev
+        n_contested_total = 0
+        for _ in range(20):
+            bufs = new_bufs(dev)
+            k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+            n_c = R  # N = R tokens, heavy aliasing
+            classes = torch.randint(0, 8, (n_c,), device=dev)  # ring rows 0..7 only
+            members = torch.randperm(SLOTS // R, device=dev)[:n_c]  # distinct slots
+            loc_c = (members * R + classes).to(torch.int32)
+            self.assertEqual(int(loc_c.unique().numel()), n_c)
+            perm = torch.randperm(self.N, device=dev)[:n_c]
+            tiered_write(self.xk[perm], self.xv[perm], loc_c, bufs, self.ones)
+            torch.cuda.synchronize()
+            ll = loc_c.long()
+            self.assertTrue(torch.equal(k4[ll], self.pk_ref[perm]))
+            self.assertTrue(torch.equal(ks4[ll], self.sk_ref[perm]))
+            self.assertTrue(torch.equal(v4[ll], self.pv_ref[perm]))
+            self.assertTrue(torch.equal(vs4[ll], self.sv_ref[perm]))
+            for r_ in range(R):
+                cand = ll[(ll & MASK) == r_]
+                if cand.numel() == 0:
+                    self.assertEqual(int(owner[r_]), -1)
+                    self.assertTrue((rk[r_] == 0x33).all() and (rks[r_] == 7.0).all())
+                    continue
+                w = int(owner[r_])
+                self.assertIn(w, set(cand.tolist()), f"owner of row {r_}")
+                # the token (row of xk) written to slot w
+                i_w = int(perm[int(torch.nonzero(loc_c == w).item())])
+                self.assertTrue(torch.equal(rk[r_], self.q8k[i_w]), f"ring row {r_}")
+                self.assertTrue(torch.equal(rks[r_], self.s8k[i_w]), f"ring row {r_}")
+                self.assertTrue(torch.equal(rv[r_], self.q8v[i_w]), f"ring row {r_}")
+                self.assertTrue(torch.equal(rvs[r_], self.s8v[i_w]), f"ring row {r_}")
+                n_contested_total += int(cand.numel() > 1)
+            hot_c = ll[owner.long()[ll & MASK] == ll]
+            self.assertEqual(hot_c.numel(), int((owner >= 0).sum()))
+            self.assertLessEqual(hot_c.numel(), 8)
+        self.assertGreater(n_contested_total, 100)
+        # an uncontested token in the same launch as a contested row stays hot
+        bufs = new_bufs(dev)
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        loc_m = torch.tensor([5, 5 + R, 5 + 2 * R, 7], dtype=torch.int32, device=dev)
+        tiered_write(self.xk[:4], self.xv[:4], loc_m, bufs, self.ones)
+        torch.cuda.synchronize()
+        w5 = int(owner[5])
+        self.assertIn(w5, (5, 5 + R, 5 + 2 * R))
+        self.assertEqual(int(owner[7]), 7)
+        i5 = {5: 0, 5 + R: 1, 5 + 2 * R: 2}[w5]
+        self.assertTrue(
+            torch.equal(rk[5], self.q8k[i5]) and torch.equal(rks[5], self.s8k[i5])
+        )
+        self.assertTrue(
+            torch.equal(rv[5], self.q8v[i5]) and torch.equal(rvs[5], self.s8v[i5])
+        )
+        self.assertTrue(
+            torch.equal(rk[7], self.q8k[3]) and torch.equal(rv[7], self.q8v[3])
+        )
+        self.assertTrue(torch.equal(k4[loc_m.long()], self.pk_ref[:4]))
+        self.assertEqual(int((owner >= 0).sum()), 2)
+
+    # ------------------------------------------------------------ 4. compact gather
+    def test_full_pool_and_owner_pattern_premises(self):
+        k4, v4, ks4, vs4 = self.bufs[:4]
+        self.assertTrue(torch.equal(k4, self.pk) and torch.equal(ks4, self.sk))
+        self.assertTrue(torch.equal(v4, self.pv) and torch.equal(vs4, self.sv))
+        self.assertTrue(
+            torch.equal(
+                self.owner_after_fill.long(),
+                torch.arange(SLOTS - R, SLOTS, device=self.dev),
+            )
+        )
+        self.assertTrue(10 < self.hot_rows.numel() < R - 5)
+        self.assertEqual(int(self.is_hot.sum()), self.hot_rows.numel())
+        self.assertTrue(bool(self.is_hot[0]) and not bool(self.is_hot[1]))
+        self.assertTrue(bool(self.is_hot[2 + R * (self.n_cls - 1)]))
+        # the tiers must differ for the gather tests to discriminate
+        self.assertFalse(torch.equal(self.d8k[self.is_hot], self.d4k[self.is_hot]))
+
+    def test_compact_gather_per_tier_bit_exact(self):
+        cu_k, n, out_k, out_v = self.run_compact(self.indices)
+        self.assertEqual(n, BATCH * TOPK)
+        n_hot_sel = 0
+        for b in range(BATCH):
+            rows = self.req_to_token[b, self.indices[b].long()].long()
+            a, e = int(cu_k[b]), int(cu_k[b + 1])
+            self.assertTrue(torch.equal(out_k[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(out_v[a:e], self.dv_all[rows]), f"req {b} V")
+            n_hot_sel += int(self.is_hot[rows].sum())
+        self.assertTrue(
+            10 < n_hot_sel < n, f"needs a hot/cold mix, got {n_hot_sel}/{n}"
+        )
+        self.assertTrue(torch.isnan(out_k[n:]).all() and torch.isnan(out_v[n:]).all())
+        self.assertTrue(torch.isfinite(out_k[:n]).all(), "a poisoned ring row leaked")
+        # the same call with the int4 kwargs only (no owner) takes the plain int4 path
+        _, _, ok4, ov4 = self.run_compact(self.indices, self.int4_kwargs())
+        for b in range(BATCH):
+            rows = self.req_to_token[b, self.indices[b].long()].long()
+            a, e = int(cu_k[b]), int(cu_k[b + 1])
+            self.assertTrue(torch.equal(ok4[a:e], self.d4k[rows]))
+            self.assertTrue(torch.equal(ov4[a:e], self.d4v[rows]))
+
+    def test_compact_gather_invalid_position_untouched(self):
+        cu_k, n, out_k, _ = self.run_compact(self.indices)
+        bad = self.indices.clone()
+        bad[1, 0] = int(self.seq_lens[1]) + 5
+        cu_b, n_b, ok_b, ov_b = self.run_compact(bad)
+        self.assertEqual(n_b, BATCH * TOPK - 1)
+        a = int(cu_b[1])
+        self.assertTrue(torch.isnan(ok_b[a]).all() and torch.isnan(ov_b[a]).all())
+        rows = self.req_to_token[1, bad[1, 1 : TOPK - 1].long()].long()
+        self.assertTrue(torch.equal(ok_b[a + 1 : a + TOPK - 1], self.dk_all[rows]))
+        self.assertTrue(torch.equal(ov_b[a + 1 : a + TOPK - 1], self.dv_all[rows]))
+        self.assertTrue(torch.equal(ok_b[:a], out_k[:a]))
+        self.assertTrue(torch.equal(ok_b[int(cu_b[2]) : n_b], out_k[int(cu_k[2]) : n]))
+        self.assertTrue(torch.isnan(ok_b[n_b:]).all())
+
+    def test_compact_gather_trtllm_strided_layout(self):
+        # cu_k = arange * stride (stride 64 > topk 40), -1 padding, a position >= seq_len
+        dev = self.dev
+        page_s, topk_s = 64, 40
+        stride_s = -(-topk_s // page_s) * page_s
+        cu_s = torch.arange(BATCH + 1, dtype=torch.int32, device=dev) * stride_s
+        nsel = [topk_s, 25, 33]
+        idx_s = torch.full((BATCH, topk_s), -1, dtype=torch.int32, device=dev)
+        for b in range(BATCH):
+            idx_s[b, : nsel[b]] = (
+                torch.randperm(int(self.seq_lens[b]), device=dev)[: nsel[b]]
+                .sort()
+                .values.to(torch.int32)
+            )
+        idx_s[2, 5] = int(self.seq_lens[2]) + 3
+        ok_s = torch.full(
+            (BATCH * stride_s, HEADS, DIM),
+            float("nan"),
+            device=dev,
+            dtype=torch.bfloat16,
+        )
+        ov_s = torch.full_like(ok_s, float("nan"))
+        k4, v4 = self.bufs[:2]
+        qwen_sparse_kv_extraction_compact_triton(
+            k4,
+            v4,
+            self.req_to_token,
+            self.req_indices,
+            idx_s,
+            self.seq_lens,
+            cu_s,
+            ok_s,
+            ov_s,
+            BATCH,
+            topk_s,
+            **self.tier_kwargs(),
+        )
+        torch.cuda.synchronize()
+        written = torch.zeros(BATCH * stride_s, dtype=torch.bool, device=dev)
+        for b in range(BATCH):
+            for c in range(topk_s):
+                pos = int(idx_s[b, c])
+                if 0 <= pos < int(self.seq_lens[b]):
+                    r_ = b * stride_s + c
+                    slot = int(self.req_to_token[b, pos])
+                    self.assertTrue(torch.equal(ok_s[r_], self.dk_all[slot]), (b, c))
+                    self.assertTrue(torch.equal(ov_s[r_], self.dv_all[slot]), (b, c))
+                    written[r_] = True
+        self.assertEqual(int(written.sum()), sum(nsel) - 1)
+        self.assertTrue(torch.isnan(ok_s[~written]).all())
+        self.assertTrue(torch.isnan(ov_s[~written]).all())
+
+    def test_stale_owner_falls_back_to_int4(self):
+        # a hot slot's ring row is re-owned by slot +/- R (as after an eviction)
+        owner = self.bufs[8].clone()
+        sel_slot = int(self.req_to_token[0, self.indices[0, 3].long()])
+        owner[sel_slot & MASK] = sel_slot + R if sel_slot + R < SLOTS else sel_slot - R
+        cu_t, _, ok_t, ov_t = self.run_compact(
+            self.indices, self.tier_kwargs(owner=owner)
+        )
+        r0 = int(cu_t[0]) + 3
+        self.assertTrue(torch.equal(ok_t[r0], self.d4k[sel_slot]))
+        self.assertTrue(torch.equal(ov_t[r0], self.d4v[sel_slot]))
+
+    # ------------------------------------------------------------ 5. prefix gather
+    def _prefix_gather(self, bufs, lens, req_idx, cu, pk, pv, batch, max_len):
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        qwen_sparse_prefix_gather_dequant_tiered(
+            k4,
+            v4,
+            ks4,
+            vs4,
+            self.ones,
+            self.ones,
+            self.req_to_token,
+            req_idx,
+            lens,
+            cu,
+            pk,
+            pv,
+            batch,
+            max_len,
+            ring_k=rk,
+            ring_v=rv,
+            ring_ks=rks,
+            ring_vs=rvs,
+            owner=owner,
+            ring_mask=MASK,
+        )
+        torch.cuda.synchronize()
+
+    def test_prefix_gather_mixed_tiers_gaps_untouched(self):
+        dev = self.dev
+        lens = torch.tensor([300, 1203, 4001], dtype=torch.int32, device=dev)
+        req_idx = torch.tensor([2, 0, 1], dtype=torch.int64, device=dev)
+        gap = 32
+        cu = F.pad((lens + gap).cumsum(0), (1, 0)).to(torch.int32).contiguous()
+        total = int(cu[-1])
+        pkk = torch.full(
+            (total + 100, HEADS, DIM), float("nan"), device=dev, dtype=torch.bfloat16
+        )
+        pvv = torch.full_like(pkk, float("nan"))
+        self._prefix_gather(
+            self.bufs, lens, req_idx, cu, pkk, pvv, BATCH, int(lens.max())
+        )
+        written = torch.zeros(pkk.shape[0], dtype=torch.bool, device=dev)
+        n_hot_pre = 0
+        for b in range(BATCH):
+            rows = self.req_to_token[int(req_idx[b]), : int(lens[b])].long()
+            a, e = int(cu[b]), int(cu[b]) + int(lens[b])
+            self.assertTrue(torch.equal(pkk[a:e], self.dk_all[rows]), f"req {b} K")
+            self.assertTrue(torch.equal(pvv[a:e], self.dv_all[rows]), f"req {b} V")
+            written[a:e] = True
+            n_hot_pre += int(self.is_hot[rows].sum())
+            self.assertTrue(torch.isnan(pkk[e : e + gap]).all(), f"gap after req {b}")
+            self.assertTrue(torch.isnan(pvv[e : e + gap]).all(), f"gap after req {b}")
+        self.assertTrue(
+            torch.isnan(pkk[~written]).all() and torch.isnan(pvv[~written]).all()
+        )
+        self.assertEqual(int(written.sum()), int(lens.sum()))
+        self.assertTrue(0 < n_hot_pre < int(lens.sum()))
+        k4, v4, ks4, vs4 = self.bufs[:4]
+        with self.assertRaises(AssertionError):  # ring / owner missing
+            qwen_sparse_prefix_gather_dequant_tiered(
+                k4,
+                v4,
+                ks4,
+                vs4,
+                self.ones,
+                self.ones,
+                self.req_to_token,
+                req_idx,
+                lens,
+                cu,
+                pkk,
+                pvv,
+                BATCH,
+                int(lens.max()),
+            )
+
+    # ------------------------------------------------------------ 6. fp16-max clamp
+    def test_fp16_max_scale_clamp_on_ring(self):
+        dev = self.dev
+        bufs = [t.clone() for t in self.bufs]
+        k4, v4, ks4, vs4, rk, rv, rks, rvs, owner = bufs
+        big = torch.zeros(1, HEADS, DIM, device=dev, dtype=torch.bfloat16)
+        big[0, 0, :32] = torch.tensor(
+            [1e6, -1e6, 5e5, -5e5, 4.6e5, -4.6e5, 1e5, -1e5] * 4, device=dev
+        ).to(torch.bfloat16)
+        big[0, 1, 64:96] = torch.finfo(torch.bfloat16).max
+        bigv = -big
+        pos7 = 17
+        slot7 = int(self.req_to_token[0, pos7])
+        tiered_write(big, bigv, one(slot7, dev), bufs, self.ones)
+        torch.cuda.synchronize()
+        q8b, s8b = ref_quant8(big)
+        q8bv, s8bv = ref_quant8(bigv)
+        p4b, s4b = ref_quant4(big)
+        p4bv, s4bv = ref_quant4(bigv)
+        self.assertEqual(float(s8b[0, 1, 1]), 65504.0)
+        self.assertEqual(float(s4b[0, 1, 2]), 65504.0)
+        self.assertTrue(torch.isfinite(s8b).all())
+        self.assertEqual(int(owner[slot7 & MASK]), slot7)
+        self.assertTrue(torch.isfinite(rks[slot7 & MASK]).all(), "ring scale inf")
+        self.assertTrue(torch.isfinite(rvs[slot7 & MASK]).all(), "ring scale inf")
+        self.assertTrue(torch.equal(rk[slot7 & MASK], q8b[0]))
+        self.assertTrue(torch.equal(rks[slot7 & MASK], s8b[0]))
+        self.assertTrue(torch.equal(rv[slot7 & MASK], q8bv[0]))
+        self.assertTrue(torch.equal(rvs[slot7 & MASK], s8bv[0]))
+        self.assertTrue(
+            torch.equal(k4[slot7], p4b[0]) and torch.equal(ks4[slot7], s4b[0])
+        )
+        self.assertTrue(
+            torch.equal(v4[slot7], p4bv[0]) and torch.equal(vs4[slot7], s4bv[0])
+        )
+        d8b, d8bv = ref_dequant8(q8b, s8b)[0], ref_dequant8(q8bv, s8bv)[0]
+        self.assertTrue(torch.isfinite(d8b).all())
+        self.assertEqual(
+            float(d8b[1, 64]), float(torch.tensor(127 * 65504.0).to(torch.bfloat16))
+        )
+        idx7 = self.indices.clone()
+        idx7[0, 0] = pos7
+        cu7, n7, ok7, ov7 = self.run_compact(idx7, bufs=bufs)
+        r7 = int(cu7[0])
+        self.assertTrue(
+            torch.isfinite(ok7[:n7]).all() and torch.isfinite(ov7[:n7]).all()
+        )
+        self.assertTrue(torch.equal(ok7[r7], d8b) and torch.equal(ov7[r7], d8bv))
+        pk7 = torch.full(
+            (pos7 + 8, HEADS, DIM), float("nan"), device=dev, dtype=torch.bfloat16
+        )
+        pv7 = torch.full_like(pk7, float("nan"))
+        self._prefix_gather(
+            bufs,
+            torch.tensor([pos7 + 8], dtype=torch.int32, device=dev),
+            torch.tensor([0], dtype=torch.int64, device=dev),
+            torch.tensor([0, pos7 + 8], dtype=torch.int32, device=dev),
+            pk7,
+            pv7,
+            1,
+            pos7 + 8,
+        )
+        self.assertTrue(torch.isfinite(pk7).all() and torch.isfinite(pv7).all())
+        self.assertTrue(torch.equal(pk7[pos7], d8b) and torch.equal(pv7[pos7], d8bv))
+        # evict it (write slot7 +/- R) and read again: the (clamped) int4 row is served
+        owner[slot7 & MASK] = slot7 + R if slot7 + R < SLOTS else slot7 - R
+        cu7c, n7c, ok7c, _ = self.run_compact(idx7, bufs=bufs)
+        self.assertTrue(torch.equal(ok7c[int(cu7c[0])], ref_dequant4(p4b, s4b)[0]))
+        self.assertTrue(torch.isfinite(ok7c[:n7c]).all())
+
+    # ------------------------------------------------------------ 7. single-tier equivalence
+    def test_all_cold_and_all_hot_match_single_tier_kernels(self):
+        dev = self.dev
+        tk_ = 2048
+        seq_b = torch.tensor([4000], dtype=torch.int32, device=dev)
+        idx_b = (
+            torch.randperm(4000, device=dev)[:tk_].sort().values.to(torch.int32)[None]
+        )
+        cu_b = torch.tensor([0, tk_], dtype=torch.int32, device=dev)
+        k4, v4, ks4, vs4 = self.bufs[:4]
+        rows_b = self.req_to_token[0, idx_b[0].long()].long()
+
+        def gather(k, v, kw):
+            ob_k = torch.empty(tk_, HEADS, DIM, device=dev, dtype=torch.bfloat16)
+            ob_v = torch.empty_like(ob_k)
+            qwen_sparse_kv_extraction_compact_triton(
+                k, v, self.req_to_token, self.req_indices, idx_b, seq_b, cu_b,
+                ob_k, ob_v, 1, tk_, **kw,
+            )  # fmt: skip
+            torch.cuda.synchronize()
+            return ob_k, ob_v
+
+        # all-cold: owner = -1 everywhere -> equals the int4 kernel
+        owner_all_cold = torch.full((R,), -1, dtype=torch.int32, device=dev)
+        cold_k, cold_v = gather(k4, v4, self.tier_kwargs(owner=owner_all_cold))
+        i4_k, i4_v = gather(k4, v4, self.int4_kwargs())
+        self.assertTrue(torch.equal(cold_k, i4_k) and torch.equal(cold_v, i4_v))
+        self.assertTrue(torch.equal(cold_k, self.d4k[rows_b]))
+        # all-hot: a ring as large as the pool (slot & mask == slot) whose rows ARE
+        # the int8 pool and whose owner table is arange -> every selected slot is hot
+        owner_all_hot = torch.arange(SLOTS, device=dev, dtype=torch.int32)
+        n_hot_b = int((owner_all_hot.long()[rows_b & (SLOTS - 1)] == rows_b).sum())
+        self.assertEqual(n_hot_b, tk_)
+        kw_hot = dict(
+            k_scale=ks4,
+            v_scale=vs4,
+            sm_k=self.ones,
+            sm_v=self.ones,
+            kv_bits=4,
+            ring_k=self.k8_all,
+            ring_v=self.v8_all,
+            ring_ks=self.ks8_all,
+            ring_vs=self.vs8_all,
+            owner=owner_all_hot,
+            ring_mask=SLOTS - 1,
+        )
+        hot_k, hot_v = gather(k4, v4, kw_hot)
+        kw_i8 = dict(
+            k_scale=self.ks8_all,
+            v_scale=self.vs8_all,
+            sm_k=self.ones,
+            sm_v=self.ones,
+            kv_bits=8,
+        )
+        i8_k, i8_v = gather(self.k8_all, self.v8_all, kw_i8)
+        self.assertTrue(torch.equal(hot_k, i8_k) and torch.equal(hot_v, i8_v))
+        self.assertTrue(torch.equal(hot_k, self.d8k[rows_b]))
+        self.assertTrue(torch.equal(hot_v, self.d8v[rows_b]))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KV pools require CUDA")
+class TestTieredKVPool(CustomTestCase):
+    size, page = 1024, 64
+
+    def test_class_keys_and_hybrid_pool_hooks(self):
+        self.assertEqual(MHATokenToKVPoolTiered.kv_bits, 4)
+        self.assertIs(MHATokenToKVPoolTiered.kv_tiered, True)
+        self.assertFalse(getattr(MHATokenToKVPoolInt4, "kv_tiered", False))
+        self.assertTrue(
+            callable(getattr(HybridLinearKVPool, "get_kv_ring_buffer", None))
+        )
+        self.assertTrue(
+            callable(getattr(HybridLinearKVPool, "get_kv_ring_owner", None))
+        )
+
+    def test_ring_slots_from_env(self):
+        for bad_w in ("0", "-8", "100", "abc"):
+            with patch.dict(os.environ, {"SGLANG_KV_TIERS_W": bad_w}):
+                with self.assertRaises(ValueError):
+                    ring_slots_from_env()
+        env = dict(os.environ)
+        env.pop("SGLANG_KV_TIERS_W", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(ring_slots_from_env(), 8192)
+        with patch.dict(os.environ, {"SGLANG_KV_TIERS_W": str(R)}):
+            self.assertEqual(ring_slots_from_env(), R)
+
+    def _pool_env(self, lazy):
+        env = dict(os.environ)
+        env.pop("SGLANG_KV_LAZY", None)
+        env["SGLANG_KV_TIERS_W"] = str(R)
+        if lazy:
+            env["SGLANG_KV_LAZY"] = "1"
+            env["SGLANG_KV_LAZY_FLOOR"] = "512"
+        return env
+
+    def _make_pools(self, lazy):
+        mk = dict(
+            size=self.size,
+            page_size=self.page,
+            dtype=torch.uint8,
+            head_num=HEADS,
+            head_dim=DIM,
+            layer_num=2,
+            device="cuda",
+            enable_memory_saver=False,
+            start_layer=0,
+        )
+        # the reference int4 pool is always eager: its descs and byte counts do not
+        # depend on the backing mode, and one VMM arena per process keeps the
+        # teardown simple
+        with patch.dict(os.environ, self._pool_env(lazy=False), clear=True):
+            ref_pool = MHATokenToKVPoolInt4(**mk)
+            ref_descs = [
+                (d.name, d.shape, d.row_bytes, d.tokens_per_row)
+                for d in ref_pool._kv_buffer_descs
+            ]
+            ref_kb, ref_vb = ref_pool.get_kv_size_bytes()
+            ref_pool._clear_buffers()
+        with patch.dict(os.environ, self._pool_env(lazy), clear=True):
+            pool = MHATokenToKVPoolTiered(**mk)
+        return pool, ref_descs, ref_kb, ref_vb
+
+    def _check_pool(self, pool, ref_descs, ref_kb, ref_vb, lazy):
+        dev = "cuda"
+        ones = torch.ones(HEADS, DIM, dtype=torch.float16, device=dev)
+        rows = self.size + self.page
+        self.assertTrue(pool.kv_tiered)
+        self.assertEqual(pool.kv_bits, 4)
+        self.assertEqual(pool.ring_slots, R)
+        self.assertEqual(pool.ring_mask, MASK)
+        self.assertEqual(pool.dtype, torch.uint8)
+        self.assertEqual(pool.store_dtype, torch.uint8)
+        self.assertEqual(pool.head_dim, DIM)
+        for ring in (pool.ring_k, pool.ring_v, pool.ring_ks, pool.ring_vs):
+            self.assertEqual(len(ring), 2)
+        self.assertEqual(pool.ring_k[0].shape, (R, HEADS, DIM))
+        self.assertEqual(pool.ring_k[0].dtype, torch.int8)
+        self.assertEqual(pool.ring_v[1].shape, (R, HEADS, DIM))
+        self.assertEqual(pool.ring_v[1].dtype, torch.int8)
+        self.assertEqual(pool.ring_ks[0].shape, (R, HEADS, NG8))
+        self.assertEqual(pool.ring_ks[0].dtype, torch.float16)
+        self.assertEqual(pool.ring_vs[1].shape, (R, HEADS, NG8))
+        self.assertEqual(pool.ring_vs[1].dtype, torch.float16)
+        self.assertEqual(pool.ring_owner.shape, (R,))
+        self.assertEqual(pool.ring_owner.dtype, torch.int32)
+        self.assertTrue((pool.ring_owner == -1).all())
+        self.assertEqual(
+            pool.get_kv_ring_owner().data_ptr(), pool.ring_owner.data_ptr()
+        )
+        rb = pool.get_kv_ring_buffer(1)
+        self.assertEqual(
+            [t.data_ptr() for t in rb],
+            [
+                pool.ring_k[1].data_ptr(),
+                pool.ring_v[1].data_ptr(),
+                pool.ring_ks[1].data_ptr(),
+                pool.ring_vs[1].data_ptr(),
+            ],
+        )
+        self.assertEqual(pool.k_buffer[0].shape, (rows, HEADS, DH))
+        self.assertEqual(pool.k_scale_buffer[0].shape, (rows, HEADS, NG4))
+        descs = [
+            (d.name, d.shape, d.row_bytes, d.tokens_per_row)
+            for d in pool._kv_buffer_descs
+        ]
+        self.assertEqual(
+            descs, ref_descs, "descs must equal the int4 pool (ring not a desc)"
+        )
+        kb, vb = pool.get_kv_size_bytes()
+        ring_k_bytes = 2 * R * HEADS * (DIM + NG8 * 2)
+        self.assertEqual(kb, ref_kb + ring_k_bytes + R * 4, "ring (+ owner) in K bytes")
+        self.assertEqual(vb, ref_vb + ring_k_bytes, "ring in V bytes")
+        if lazy:
+            o = pool._post_capture_owner
+            self.assertIsNotNone(o)
+            self.assertEqual(len(o.tensors), 8)
+            self.assertEqual(o.bytes_per_token(), 2 * (256 + 256 + 32 + 32))
+            lo = min(t.data_ptr() for t in o.tensors)
+            hi = max(t.data_ptr() + t.numel() * t.element_size() for t in o.tensors)
+            for t in (
+                pool.ring_k
+                + pool.ring_v
+                + pool.ring_ks
+                + pool.ring_vs
+                + [pool.ring_owner]
+            ):
+                self.assertFalse(
+                    lo <= t.data_ptr() < hi, "ring must live outside the owner"
+                )
+            self.assertTrue((pool.k_scale_buffer[1][: self.page] == 0).all())
+        else:
+            self.assertTrue((pool.k_scale_buffer[0] == 0).all())
+            self.assertTrue((pool.k_buffer[0] == 0).all())
+        # alias-free loc mod R inside the backed floor (the pool only enforces N <= R)
+        loc = (torch.randperm(400, device=dev)[:50] + 64).sort().values
+        seen, keep = set(), []
+        for s in loc.tolist():
+            if (s & MASK) not in seen:
+                seen.add(s & MASK)
+                keep.append(s)
+        loc = torch.tensor(keep, dtype=torch.int64, device=dev)
+        n = loc.numel()
+        self.assertGreaterEqual(n, 30)
+        xk_p = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        xv_p = torch.randn(n, HEADS, DIM, device=dev, dtype=torch.bfloat16) * 3
+        pool.set_kv_buffer(None, loc, xk_p, xv_p, 1.0, 1.0, layer_id_override=1)
+        pool.set_kv_buffer(
+            None, loc, xk_p.reshape(n, -1), xv_p.reshape(n, -1), layer_id_override=0
+        )
+        torch.cuda.synchronize()
+        pk_p, sk_p = ref_quant4(xk_p)
+        pv_p, sv_p = ref_quant4(xv_p)
+        q8_p, s8_p = ref_quant8(xk_p)
+        q8v_p, s8v_p = ref_quant8(xv_p)
+        for layer in (0, 1):
+            ksb, vsb = pool.get_kv_scale_buffer(layer)
+            self.assertTrue(torch.equal(pool.k_buffer[layer][loc], pk_p))
+            self.assertTrue(torch.equal(ksb[loc], sk_p))
+            self.assertTrue(torch.equal(pool.v_buffer[layer][loc], pv_p))
+            self.assertTrue(torch.equal(vsb[loc], sv_p))
+            rk_p, rv_p, rks_p, rvs_p = pool.get_kv_ring_buffer(layer)
+            self.assertTrue(torch.equal(rk_p[loc & MASK], q8_p))
+            self.assertTrue(torch.equal(rks_p[loc & MASK], s8_p))
+            self.assertTrue(torch.equal(rv_p[loc & MASK], q8v_p))
+            self.assertTrue(torch.equal(rvs_p[loc & MASK], s8v_p))
+        self.assertTrue(torch.equal(pool.ring_owner.long()[loc & MASK], loc))
+        self.assertEqual(int((pool.ring_owner == -1).sum()), R - n)
+        zeros = torch.zeros(R + 1, HEADS, DIM, device=dev, dtype=torch.bfloat16)
+        with self.assertRaises(ValueError):  # N > R
+            pool.set_kv_buffer(
+                None,
+                torch.arange(R + 1, device=dev, dtype=torch.int64),
+                zeros,
+                zeros,
+                layer_id_override=0,
+            )
+        for bad_kw in (
+            dict(k_scale=0.5),
+            dict(v_scale=torch.ones(1, device=dev)),
+            dict(dcp_kv_mask=torch.ones(n, device=dev)),
+        ):
+            with self.assertRaises((ValueError, NotImplementedError)):
+                pool.set_kv_buffer(None, loc, xk_p, xv_p, layer_id_override=0, **bad_kw)
+        pool.lazy_release()
+        self.assertTrue((pool.ring_owner == -1).all(), "lazy_release resets the owner")
+        smk, _ = pool.get_kv_smooth_buffer(1)
+        self.assertEqual(smk.shape, (HEADS, DIM))
+        self.assertTrue(bool((smk == 1).all()))
+        self.assertTrue(torch.equal(smk, ones))
+
+    def _run_pool_case(self, lazy):
+        pool, ref_descs, ref_kb, ref_vb = self._make_pools(lazy)
+        cleared = False
+        try:
+            self._check_pool(pool, ref_descs, ref_kb, ref_vb, lazy)
+            pool._clear_buffers()
+            cleared = True
+            self.assertIsNone(pool.ring_k)
+            self.assertIsNone(pool.ring_owner)
+        finally:
+            if not cleared:
+                pool._clear_buffers()
+
+    def test_pool_eager(self):
+        self._run_pool_case(lazy=False)
+
+    def test_pool_lazy_vmm(self):
+        self._run_pool_case(lazy=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft: stacked on https://github.com/sgl-project/sglang/pull/37793 (part 1); parts 2, 3 precede it in the series.

Part 4/5 of the Qwen3.8-Flash-Next 24 GB serving series (RFC issue: https://github.com/sgl-project/sglang/issues/37792). Patch:
`upstream/series-q4head/0004-feat-qsa-quantized-KV-pools-with-dequant-on-gather-f.patch`
in the companion repository (14 files, +4,424 / -25). The pool classes are general; the read
path is specific to the Qwen sparse attention backend.

## Motivation

The Qwen sparse attention (QSA) kernels read bf16/fp16 K/V only, so the stock `fp8_e4m3` KV
option cannot be consumed by Qwen4-Exp, and a bf16 KV cache (24 KB per token over the 12 QSA
layers) stops a 24 GB card at about 80k tokens once the expert cache is at its floor (CAMPAIGN
2026-09-02 13:55). QSA has exactly two places where every K/V row is gathered anyway (the
decode/verify compaction into the attention scratch and the prefix-chunk row gather), so
dequantization is free there and the attention kernels stay untouched. The formats were chosen
from measured K/V statistics of this model (~19k tokens): simulated relative RMS error e4m3
2.66 %, int8 per-token 1.3 %, int8 with 64-channel groups 0.9 % (CAMPAIGN 2026-09-02 15:50;
`docs/ELASTIC_MEMORY.md`, "The three mechanisms", 3).

Sources: dated entries of `docs/CAMPAIGN.md`, `docs/ELASTIC_MEMORY.md` and
`docs/logs/tiers-validate.log` in https://github.com/HaberstrohSystems/qwen3.8-flash-next-24gb-sglang
and the model card
https://huggingface.co/HaberstrohSystems/Qwen3.8-Flash-Next-int2-mixed-AutoRound-24GB-SGLang.
Reference machine: one RTX PRO 4000 Blackwell (24 GB, sm_120) with 32 GB host RAM.

## Modifications

New `--kv-cache-dtype` values `int8_g64`, `int4_g32`, `int8ring_int4` (`server_args.py` with
help text, `mem_cache/kv_cache_dtype.py`, `mem_cache/kv_cache_configurator.py` pool-class
selection, `model_executor/pool_configurator.py` cell sizes). Pool classes are subclasses of
`MHATokenToKVPool`; the payload and the fp16 group scales are extra `KvBufferDesc`s on the same
(lazy, part 3) VMM owner, and writing is one fused quantize + scatter Triton launch.

- `mem_cache/int8_kv_pool.py` (new): int8 K/V `[rows, H, D]` plus one fp16 absmax/127 scale per
  (token, kv-head, 64-channel group), the first group being the rotary dimensions; 12.4 KB per
  token over the 12 QSA layers. `kv_bits = 8` is the backend's dispatch key.
- `mem_cache/int4_kv_pool.py` (new): nibble-packed K/V `[rows, H, D/2]` (low nibble = even
  channel, offset-binary q + 8, q in [-7, 7]) plus fp16 absmax/7 scales per 32-channel group;
  6.75 KB per token. `kv_bits = 4`.
- `mem_cache/tiered_kv_pool.py` (new, `int8ring_int4`): every token is written twice, int8-g64
  into a ring of `SGLANG_KV_TIERS_W` (8192) slots with an int32 owner table, and int4-g32 into
  the full-context pool. Readers test `owner[slot & (R-1)] == slot` on the device and read the
  int8 ring row (hot) or the int4 row (cold) with `tl.where`: CUDA-graph safe, no compactor, no
  unmapping mid-request. 7,308 B per token at 256k (6,912 int4 + 12,672 x 8192/262,144), ring
  103.8 MB + 32 KB owner table.
- `layers/attention/qsa/sparse_attn.py`: `_compact_kv_fp8` (uint8 -> fp8 bitcast -> bf16 into
  the attention scratch), `_quant_store_kv_int8` / `_compact_kv_int8` /
  `_gather_dequant_rows_int8` (the last replaces `index_select + cat` for prefix chunks), the
  int4 siblings, `_stamp_ring_owner`, `_quant_store_kv_tiered`, `_compact_kv_tiered`,
  `_gather_dequant_rows_tiered` and their wrappers; fp16 scale clamp to 65504 in every write
  kernel. On-disk layouts (nibble order, scale index arithmetic, owner-table semantics) are in
  the module docstrings.
- `layers/attention/qwen_sparse_attn_backend.py`: dispatch on `pool.kv_bits` / `pool.kv_tiered`
  (`_kv_bits`, `_kv_head_dim`, `_kv_scratch_dtype`, `_int8_gather_kwargs`, `_kv_tier_kwargs`),
  bf16 scratch keyed by the query dtype, prefix-chunk gather on the uint8 view for fp8; the CPU
  fallback raises `NotImplementedError` for int8/int4 pools.
- `mem_cache/memory_pool.py`: `HybridLinearKVPool.get_kv_smooth_buffer`, `get_kv_ring_buffer`,
  `get_kv_ring_owner` forwarders. Per-channel smoothing constants are plumbed but identity: a
  static smoothing A/B on the fake-quantized int4-g32 pool was mixed and was not adopted
  (CAMPAIGN 2026-09-03 00:40).
- Registered unit tests (`register_cuda_ci`, stage `base-b`, runner `1-gpu-small`, 30-50 MB of
  VRAM each, torch references, no server):
  `test/registered/unit/layers/attention/qsa/test_sparse_attn_fp8_gather.py` (`est_time=10`),
  `test/registered/unit/mem_cache/test_int8_kv_pool.py` (20), `test_int4_kv_pool.py` (20),
  `test_tiered_kv_pool.py` (40); contents under Accuracy Tests.

Decode routing on `qwen4-main-squashed` (#36806, #36845): `_forward_paged_attention` first tries
`_resolve_trtllm_sparse_decode()`, which returns FlashInfer's `trtllm_batch_decode_with_kv_cache`
on exact SM120 as well as SM100, and otherwise uses `_resolve_flash_attn_varlen_func()` (the KDA
kernel on SM121, else FA2, else FA4). Both routes gather the selected rows through
`qwen_sparse_kv_extraction_compact_triton`, which this PR extends with the scale / smoothing /
ring arguments, so a quantized pool is dequantized into the bf16 scratch before either attention
kernel runs, and the prefix-chunk gather in `forward_extend` is not routed by device at all; no
device-specific guard is added. What does change on SM120 relative to the base the numbers below
were measured on (`73a255206f`, FlashInfer route gated on SM100 only): the attention over the
gathered scratch runs FlashInfer's XQA kernel (JIT-compiled at the first sparse decode; it needs
an nvcc >= 12.9 at `CUDA_HOME`, FlashInfer's bound in `flashinfer/compilation_context.py`
(`_normalize_cuda_arch`: SM 12.x requires CUDA >= 12.9); otherwise FlashInfer raises
`RuntimeError: No supported CUDA architectures found`) instead of FA2 `flash_attn_varlen_func`.
A standalone call of that kernel with the backend's arguments (24 query heads, 2 KV heads,
head_dim 256, page 64, topk 2,051 = `indexer_budget` 2048 + `indexer_compress_ratio` 4 - 1, the
index-row width `token_topk + compress_ratio - 1` of `qsa_indexer.py`; batch 1 and 4, plus topk
130 at batch 3; bf16) on the RTX PRO 4000 with flashinfer 0.6.17 and nvcc 13.3 matches a torch
softmax reference within bf16 precision (max relative error 3.9e-3, 2.5e-3, 2.5e-3; no NaN):
`tools/probe_trtllm_sm120.py` and its output `docs/logs/probe_trtllm_sm120.log` in the companion
repository. See the RFC, open question 3.

Scope and known limits, disclosed: the read path exists for `qwen_sparse_attn_backend` only; any
other GPU backend that meets one of these pools today would read raw bytes, so a generic guard or
a `kv_bits`-aware materialisation is the follow-up (RFC, open question 2).
`TORCH_DTYPE_TO_KV_CACHE_STR` maps `torch.uint8` to `int4_g32`, which the tiered mode shares.
`fp8_e4m3` mode still crashes on 1-token prompts (CAMPAIGN 2026-09-02 15:26). Prefix-chunk
prefill materialises the prefix as bf16 per layer and chunk; a paged prefix kernel reading the
pools directly was built, verified within 2 row-ulps and rejected as 4-5x slower
(`docs/ELASTIC_MEMORY.md`, "Where the long-context prefill time goes"). `SGLANG_KV_TIERS_W`
should become a server argument.

## Accuracy Tests

Protocol (card, "Serving fidelity"; `docs/ELASTIC_MEMORY.md`, "Quality protocol"): prompts
shorter than one prefill chunk never read the KV cache, so the decisive test scores every
position from the second chunk on (8,561 positions of a 9.6k-token text, bf16 pool as reference,
run-to-run noise NLL +0.0002 / mean |dlogprob| 0.059), plus the 512-window test (noise 0.099 /
+-0.008 NLL), the 10k logprob oracle, and needle retrieval with `ignore_eos`.

- Registered tests, all pass (41 tests, 6 subtests; also on the finished 5-commit branch):
  - `test_sparse_attn_fp8_gather.py` (2): the fp8 compaction gather equals `pool.to(fp8).to(bf16)`
    bit for bit; e4m3 relative RMS error in (0.01, 0.04) on N(0, 3).
  - `test_int8_kv_pool.py` (10 + 2 subtests): int8-g64 quantize + scatter (int32 and int64
    loc), scale index arithmetic, compaction gather-dequant (3 requests, permuted `req_to_token`,
    invalid positions untouched), prefix row gather-dequant with interior gaps, all bit-exact;
    relative RMS error < 1.2 %; `MHATokenToKVPoolInt8` eager and lazy-VMM paths.
  - `test_int4_kv_pool.py` (14 + 2): nibble packing and unpack round trip, quantize + scatter
    with `rint` tie rounding, scale index and nibble order, compaction gather including the
    trtllm strided layout (a packed-width scratch is rejected), prefix gather with gaps,
    fp16-max scale clamp, all bit-exact; relative RMS error 8-11.5 %; `MHATokenToKVPoolInt4`
    eager and lazy-VMM paths; `kv_bits` keys.
  - `test_tiered_kv_pool.py` (15 + 2): ring owner stamping (R = 64 over 4,096 slots, ring wrap),
    hot/cold boundary and same-launch ring-row collisions (x20), hot/cold selection in the
    compaction and prefix gathers (stale owner and no owner -> int4 path), fp16-max clamp on the
    ring, all-cold == int4 and all-hot == int8 kernels; `MHATokenToKVPoolTiered` eager and
    lazy-VMM paths, ring reset on `lazy_release`, a bad `SGLANG_KV_TIERS_W` rejected.
- Fake-quant ladder on the bf16 pool, 512 window, mean |dlogprob|: noise 0.099, int8_g64 0.099,
  int8 per-token 0.100, int8_g32 0.106, e4m3 0.110 (CAMPAIGN 2026-09-02 16:17).
- INT8-G64 server: short NLL -0.001, 512-window 0.094 vs noise 0.099, NLL +0.010 (noise
  +-0.008), oracle 0.0019; all-position +0.001 / 0.059; needle 41k 5/5 (CAMPAIGN 2026-09-02
  16:45 and 21:05).
- INT4-G32 server: all-position NLL +0.0088 / 0.138 (fake-quant int4_g32 +0.0078 / 0.139),
  oracle 0.0015; needle 5/5 at 247,629 tokens (CAMPAIGN 2026-09-02 19:40 and 20:00).
- Tiered default: short NLL -0.0002, 512-window 0.118, all-position NLL -0.0001 / 0.074,
  oracle 0.0019; needles 5/5 at 41,370 and 5/5 at 247,629 tokens (CAMPAIGN 2026-09-02 21:05).
- Controls: fake int2_g16 +0.30 / 0.62 (the cliff), K/V := 0 +3.70 / 3.92. The ladder was
  re-measured after the write-path fake-quant hook was found to be bypassed by the int8 pool
  subclass; the K/V := 0 control caught it (CAMPAIGN 2026-09-02 19:40).

Reproduction (needs `ninja` on `PATH` (otherwise `FileNotFoundError: ninja`) and an nvcc that
supports the GPU architecture at `CUDA_HOME` (compute_120a on the reference machine; a system
nvcc 12.0 does not, the virtualenv's 13.3 does); the lazy-VMM cases build a `load_inline` stub):

```
git clone https://github.com/sgl-project/sglang.git && cd sglang
git fetch origin qwen4-main-squashed && git checkout 78c5024e9d9f589dcb4deb7f4ba4fb23f7e85385
git am /path/to/upstream/series-q4head/000{1,2,3,4}-*.patch
pip install -e python
export CUDA_HOME=<toolkit whose nvcc supports the GPU architecture>; export PATH="$CUDA_HOME/bin:$PATH"
python -m pytest -v test/registered/unit/layers/attention/qsa/test_sparse_attn_fp8_gather.py \
    test/registered/unit/mem_cache/test_int8_kv_pool.py \
    test/registered/unit/mem_cache/test_int4_kv_pool.py \
    test/registered/unit/mem_cache/test_tiered_kv_pool.py
# server level (companion repository): tools/nll_long.py with NLL_LONG_ALL=1, tools/logprob_diff.py,
# tools/needle_test.py against a server started with --kv-cache-dtype int8ring_int4
```

## Speed Tests and Profiling

Streaming bench, single request, ~10k context (`tools/bench_speed.py`; card, "Performance"),
measured on `73a255206f` with the flat patch and the FA2 decode route:

- fp8 read path: decode 55.9-57.2 / prefill 2,303-2,339 tok/s, parity with bf16 (CAMPAIGN
  2026-09-02 15:12).
- INT8-G64: decode 56.1-57.4 / prefill 2,301-2,316; 115,560-token prompt prefill 71.8 s
  (1,610 tok/s), decode 50.8 (16:45); the longest prompt admitted on the reference machine
  162,215 tokens at prefill 95.8 s (1,694 tok/s), decode 51.2, VRAM free bottomed at 1.18 GB, a
  ~179k prompt refused at admission (17:00).
- INT4-G32: decode 55-57, prefill 1,493 at 10k (int8 2,316: the unpack gather); 257,905-token
  prompt prefill 182.2 s (1,415 tok/s), decode 51.9 (19:40 and 19:34); needle haystack of
  247,629 random-word tokens prefill 269 s (920 tok/s, PLE rows from NVMe), decode 51.4 (20:00).
- Tiered default: decode 54-57 (56.2 / 54.3 / 56.8 / 55.7 / 54.5 at context 101 / 421 / 1,701 /
  6,821 / 10,001), prefill 2,271 at 10k; 257,905-token prompt prefill 171 s (1,508 tok/s), decode
  51.8; lazy backing 366,976 tokens profiled -> 262,144 admitted (21:05; `tiers-validate.log`);
  with the rate-limited `empty_cache` of part 3: 165.3 s (1,560 tok/s), decode 52.3 (2026-09-03
  00:55). Per-chunk prefill time at 258k fits 615 ms + 0.49 us x prefix tokens; the O(prefix)
  term is the QSA indexer, not the KV gather (`docs/ELASTIC_MEMORY.md`, "Where the long-context
  prefill time goes").

Not re-measured on `78c5024e9d`, where SM120 decode runs FlashInfer XQA after the gather (see
Modifications).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black 26.1.0, isort 7.0.0, ruff 0.15.1 `F401,F821,UP037`, codespell and `py_compile` clean on the commit.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (The four registered tests above, 41 tests / 6 subtests, `register_cuda_ci`. Missing: an end-to-end test with a model, which needs a checkpoint.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Missing: the three new `--kv-cache-dtype` values in the server-arguments documentation, `SGLANG_KV_TIERS_W`, the on-disk layouts outside the docstrings.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Long-text NLL ladder against a bf16 KV cache with controls, logprob oracle, needle retrieval, streaming bench and long-prompt runs above; no standard benchmark score.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (Known deviations: `kv_bits` / `kv_tiered` as `getattr` class attributes, `SGLANG_KV_TIERS_W` as an environment variable.)

## Suggested reviewers

- `python/sglang/srt/layers/attention` (QSA kernels and backend): @Fridge003, @ishandhanani,
  @Qiaolin-Yu (NV and model-specific optimizations); @JustinTong0323 as author of #36497 and of
  the SM120 routing changes (#36806, #36845).
- `python/sglang/srt/mem_cache` (pools, dtype, configurator): @ispobock, @xiezhq-hermann
  (KV Cache).
- `python/sglang/srt/model_executor` (`pool_configurator.py`): @merrymercy, @hnyls2002, @cctry
  (Scheduler).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33750783183](https://github.com/sgl-project/sglang/actions/runs/33750783183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33750782869](https://github.com/sgl-project/sglang/actions/runs/33750782869)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33750782984](https://github.com/sgl-project/sglang/actions/runs/33750782984)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->