### PR TITLE
fix(mm): stop passing frame_count_limit positionally into load_video

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -334,7 +334,12 @@ class EncoderPreprocessor:
                     }
                 return img
             elif modality == Modality.VIDEO:
-                return load_video(data, frame_count_limit)
+                # NOTE: frame_count_limit is only computed for IMAGE items; it
+                # must not be forwarded here. load_video's second parameter is
+                # use_gpu, so passing frame_count_limit positionally would
+                # silently route video decoding to CUDA whenever it is a
+                # positive int.
+                return load_video(data, use_gpu=False)
             elif modality == Modality.AUDIO:
                 return load_audio(data, self.model_audio_sr)
 

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -909,7 +909,12 @@ class BaseMultimodalProcessor(ABC):
                         return img.convert("RGB")
                 return img
             elif modality == Modality.VIDEO:
-                return load_video(data, frame_count_limit)
+                # NOTE: frame_count_limit is only computed for IMAGE items
+                # (see the caller); it must not be forwarded here. load_video's
+                # second parameter is use_gpu, so passing frame_count_limit
+                # positionally would silently route video decoding to CUDA
+                # whenever it is a positive int.
+                return load_video(data, use_gpu=False)
             elif modality == Modality.AUDIO:
                 return load_audio(data, audio_sample_rate)
 

--- a/test/registered/unit/multimodal/test_base_processor_video_decode.py
+++ b/test/registered/unit/multimodal/test_base_processor_video_decode.py
@@ -1,0 +1,61 @@
+"""Unit tests for video decoding in ``BaseMultimodalProcessor._load_single_item``.
+
+Regression test for the positional-argument bug where the video branch called
+``load_video(data, frame_count_limit)`` even though ``load_video``'s second
+parameter is ``use_gpu: bool = True`` (a leftover from #5888, which renamed
+``encode_video(video_path, frame_count_limit)`` without updating call sites).
+
+It was harmless only because ``frame_count_limit`` is computed exclusively for
+IMAGE items and is always ``None`` on the video path (falsy -> CPU decode). Had
+it ever become a positive int for a video item, video decoding would silently
+move to CUDA in the tokenizer process, creating an unexpected CUDA context.
+
+No server, no model loading, no codec backend — pure CPU with the decoder
+patched out.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.test.test_utils import CustomTestCase
+
+
+class _StubProcessor(BaseMultimodalProcessor):
+    # gpu_image_decode=False is irrelevant for video but keeps construction
+    # consistent with the sibling image-decode tests. The abstract methods are
+    # never called: only the _load_single_item classmethod is exercised.
+    gpu_image_decode = False
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class TestLoadSingleItemVideoDecode(CustomTestCase):
+    def _load_video_with_limit(self, frame_count_limit):
+        with patch("sglang.srt.utils.common.VideoDecoderWrapper") as mock_decoder:
+            _StubProcessor._load_single_item(
+                b"payload", Modality.VIDEO, frame_count_limit=frame_count_limit
+            )
+        mock_decoder.assert_called_once()
+        # Positional args of VideoDecoderWrapper(source, device=...): device is
+        # passed as a keyword by load_video.
+        return mock_decoder.call_args.kwargs["device"]
+
+    def test_video_decode_stays_on_cpu(self):
+        # The normal video path: frame_count_limit is None.
+        self.assertEqual(self._load_video_with_limit(None), "cpu")
+
+    def test_frame_count_limit_does_not_leak_into_use_gpu(self):
+        # The landmine: a positive frame_count_limit must NOT be interpreted as
+        # use_gpu=True. Before the fix this returned "cuda".
+        self.assertEqual(self._load_video_with_limit(30), "cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`_load_single_item` in both the base multimodal processor and the EPD encoder preprocessor calls:

```python
return load_video(data, frame_count_limit)
```

But `load_video`'s signature is `load_video(video_file, use_gpu: bool = True)` (`python/sglang/srt/utils/common.py`) — it has **never** accepted a `frame_count_limit` argument. This is a leftover from #5888, which renamed `encode_video(video_path, frame_count_limit)` to `load_video(...)` without updating the call sites; `fba785c459` later copied the same call into the EPD path.

**Why it hasn't blown up:** `frame_count_limit` is only computed for `Modality.IMAGE` items (the image-estimated-frames path in `base_processor.py`); on the video path it is always `None`, and `None` is falsy → `use_gpu=None` → CPU decode. Current behavior is accidentally correct.

**The landmine:** if `frame_count_limit` ever becomes a positive int for a video item (e.g. someone wires the image-estimated-frames logic up to video, which the naming suggests was the original intent), video decoding would **silently move to CUDA** in the tokenizer / encoder-preprocessor process — an unexpected CUDA context and GPU memory usage in a process meant to stay on CPU.

## Modifications

- `python/sglang/srt/multimodal/processors/base_processor.py`: video branch of `_load_single_item` now calls `load_video(data, use_gpu=False)` explicitly, with a comment explaining why `frame_count_limit` must not be forwarded. **No behavior change** (video path always had `frame_count_limit=None` → CPU decode before; still CPU decode now).
- `python/sglang/srt/disaggregation/encoder/preprocessor.py`: same fix in the EPD encoder preprocessor.
- `test/registered/unit/multimodal/test_base_processor_video_decode.py` (new, CPU-only, registered in `base-a-test-cpu`): regression tests asserting that `VideoDecoderWrapper` is always constructed with `device="cpu"` from the video branch — including with `frame_count_limit=30`, which returned `"cuda"` before the fix.

Restoring actual pre-decode frame limiting (which `encode_video` had before #5888 via `uniform_sample`) is a separate feature — it belongs in `VideoDecoderWrapper` (torchcodec `get_frames_at` can decode only sampled indices) and is out of scope here.

## Accuracy Tests

No model forward / kernel / output-path change — media loading behavior is byte-identical (CPU decode before and after), so model accuracy is unaffected by construction. Covered instead by targeted regression tests:

- `test_video_decode_stays_on_cpu`: video branch of `_load_single_item` constructs `VideoDecoderWrapper` with `device="cpu"`
- `test_frame_count_limit_does_not_leak_into_use_gpu`: with `frame_count_limit=30`, pre-fix code constructs it with `device="cuda"` (fails pre-fix, passes post-fix)

```
pytest test/registered/unit/multimodal/test_base_processor_video_decode.py
2 passed
```

## Speed Tests and Profiling

No performance-sensitive path affected: the change is a keyword argument at two call sites (`load_video(data, use_gpu=False)`); the executed decode path (torchcodec CPU decoder) is identical before and after.

## Verification

- [x] New regression tests pass: `pytest test/registered/unit/multimodal/test_base_processor_video_decode.py` → 2 passed
- [x] Tests **fail on the pre-fix code** as intended (`test_frame_count_limit_does_not_leak_into_use_gpu` gets `device="cuda"`)
- [x] Neighboring suites pass: `test_base_processor_image_decode.py` + `test_base_processor_bad_input.py` → 22 passed (the `test_audio_container_decode.py` failures are pre-existing local-env issues: missing `torchaudio` / network retry, unrelated to this change)
- [x] `pre-commit run` on all changed files: all hooks pass

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — internal fix, no user-facing behavior change)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — see sections above)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33754012682](https://github.com/sgl-project/sglang/actions/runs/33754012682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33754012243](https://github.com/sgl-project/sglang/actions/runs/33754012243)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33754012332](https://github.com/sgl-project/sglang/actions/runs/33754012332)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->