### PR TITLE
fix(inkling): prevent server crash from grouped GEMM on SM120

### DIFF
--- a/python/sglang/kernels/ops/moe/inkling_moe.py
+++ b/python/sglang/kernels/ops/moe/inkling_moe.py
@@ -3,7 +3,7 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.jit.utils import is_arch_support_pdl
-from sglang.srt.utils.common import is_sm121
+from sglang.srt.utils.common import is_sm120_supported
 
 DEFAULT_BLOCK_SIZE = 4096
 BLOCK_SIZE_M = 128
@@ -553,6 +553,12 @@ FUSED_PREPROCESS_MAX_TOKENS = 2048
 FUSED_PREPROCESS_WIN_TOKENS = 1024
 
 
+def _small_m_grouped_gemm_num_stages() -> int:
+    # SM120 and SM121 cap per-block shared memory at 99 KiB. Four stages need
+    # 108 KiB for this tile, while three stages fit on both architectures.
+    return 3 if is_sm120_supported() else 4
+
+
 @triton.jit
 def _fused_moe_preprocess_kernel(
     topk_ids_ptr,  # [n] int32, unsorted
@@ -969,10 +975,7 @@ def grouped_gemm_triton(
             "BLOCK_SIZE_K": 128,
             "GROUP_SIZE_M": 8,
             "num_warps": 4,
-            # sm_121 (GB10 / DGX Spark) caps shared memory at 99 KB per block and
-            # num_stages=4 needs 108 KB. The BLOCK_SIZE_M=128 branch below fits at
-            # its default 3 (96 KB) and needs no gate.
-            "num_stages": 3 if is_sm121() else 4,
+            "num_stages": _small_m_grouped_gemm_num_stages(),
         }
     else:
         assert block_size_m == BLOCK_SIZE_M, f"{block_size_m=}"

--- a/test/registered/kernels/ops/moe/test_moe_preprocess.py
+++ b/test/registered/kernels/ops/moe/test_moe_preprocess.py
@@ -6,6 +6,7 @@ configs (the block schedule and kernel config are chosen together).
 import pytest
 import torch
 
+from sglang.kernels.ops.moe import inkling_moe
 from sglang.kernels.ops.moe.inkling_moe import (
     SMALL_M_BLOCK_SIZE_M,
     compute_grouped_gemm_metadata,
@@ -21,6 +22,12 @@ requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA o
 
 E = 256
 TOPK = 6
+
+
+@pytest.mark.parametrize("is_sm12x, expected", [(True, 3), (False, 4)])
+def test_small_grouped_gemm_stage_policy(monkeypatch, is_sm12x: bool, expected: int):
+    monkeypatch.setattr(inkling_moe, "is_sm120_supported", lambda: is_sm12x)
+    assert inkling_moe._small_m_grouped_gemm_num_stages() == expected
 
 
 def _reference(topk_ids_flat: torch.Tensor):


### PR DESCRIPTION
## Motivation

Inkling can crash when its sparse-decode MoE path launches the small-M Triton grouped GEMM on SM120 GPUs such as the RTX 5090.

The small-M launch policy currently reduces the pipeline from four stages to three only on SM121:

```python
"num_stages": 3 if is_sm121() else 4
```

An SM120 GPU does not satisfy `is_sm121()`, so it selects four stages for the same tile configuration. That kernel requires 110,592 bytes of shared memory, exceeding the RTX 5090's 101,376-byte per-block limit, and fails before execution with:

```text
triton.runtime.errors.OutOfResources: out of resource: shared memory,
Required: 110592, Hardware limit: 101376
```

This is an architecture-level kernel launch bug. Any supported SM120 deployment that reaches this Inkling small-M grouped GEMM path can hit the same failure.

## Modifications

- Apply the existing three-stage low-shared-memory policy to supported SM120 and SM121 GPUs:

```python
def _small_m_grouped_gemm_num_stages() -> int:
    return 3 if is_sm120_supported() else 4
```

- Keep the four-stage policy unchanged on architectures where the existing configuration fits.
- Keep the standard `BLOCK_SIZE_M=128` path unchanged; it already uses three stages.
- Isolate the small-M stage decision in a focused helper and add regression coverage for both the SM12x and non-SM12x branches.

The change does not hard-code an RTX 5090 model name, VRAM size, driver version, or workload-specific threshold.

## Accuracy Tests

N/A: this change does not alter model math, tile sizes, accumulation type, or output handling. As functional validation on an NVIDIA GeForce RTX 5090 (SM120), the grouped GEMM tests passed and verified the small-M output against the standard configuration:

```bash
PYTHONPATH=python python3 test/registered/kernels/ops/moe/test_moe_preprocess.py
# 19 passed
```

Additionally, all four registered Inkling E2E cases passed on the latest `upstream/main` base. They used the lightweight `thinkingmachines/Inkling` checkpoint at revision `test` and exercised the same Inkling small-M MoE grouped GEMM launch path; the production checkpoint was not tested directly.

Changed-file pre-commit and `git diff --check` passed. All Python/common hooks in `pre-commit run --all-files` passed; Rust-only hooks were unavailable because the local environment does not have `cargo`/`rustup`, and this PR does not modify Rust files.


## Speed Tests and Profiling

N/A: the affected SM120 baseline cannot launch the kernel.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no user-facing API, configuration, or documented behavior changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Model math is unchanged; the affected baseline cannot launch, and focused kernel and E2E results are provided above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33754286147](https://github.com/sgl-project/sglang/actions/runs/33754286147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33754285783](https://github.com/sgl-project/sglang/actions/runs/33754285783)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33754286568](https://github.com/sgl-project/sglang/actions/runs/33754286568)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->