### PR TITLE
[Model Loader] Auto-enable checkpoint prefetch on network filesystems (NFS/Lustre)

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -122,6 +122,7 @@ from sglang.srt.model_loader.weight_utils import (
     pt_weights_iterator,
     safetensors_weights_iterator,
     set_runai_streamer_env,
+    should_auto_prefetch_checkpoints,
 )
 from sglang.srt.platforms import current_platform
 from sglang.srt.utils import (
@@ -585,6 +586,10 @@ class DefaultModelLoader(BaseModelLoader):
         elif use_safetensors:
             weight_loader_disable_mmap = get_model().weight_loader_disable_mmap
             configured_prefetch = get_model().weight_loader_prefetch_checkpoints
+            if configured_prefetch is None:
+                # Unset: prefetch only helps when faults cross a network, and
+                # only if the checkpoint can stay in the page cache.
+                configured_prefetch = should_auto_prefetch_checkpoints(hf_weights_files)
             start_iterator_prefetch = (
                 configured_prefetch and not startup_prefetch_started
             )

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -869,6 +869,104 @@ def np_cache_weights_iterator(
         yield name, torch.from_numpy(param)
 
 
+_NETWORK_FS_TYPES = ("nfs", "nfs4", "lustre")
+_PREFETCH_RAM_THRESHOLD_PCT = 90
+
+
+def _get_fs_type(files: List[str]) -> str:
+    """Return the filesystem type backing *files* (Linux only, "" if unknown)."""
+    if not files:
+        return ""
+    try:
+        # All checkpoint shards live in the same directory, so probing the first
+        # file is enough.
+        resolved = os.path.realpath(files[0])
+        best_mount = ""
+        best_fstype = ""
+        # /proc/mounts can contain nested mount points (e.g. "/" -> ext4,
+        # "/data" -> lustre, "/data/local" -> ext4). Pick the longest matching
+        # mount point, which is the rule the kernel uses to resolve a path.
+        with open("/proc/mounts") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                mount_point, fstype = parts[1], parts[2]
+                if (
+                    resolved == mount_point
+                    or resolved.startswith(os.path.join(mount_point, ""))
+                ) and len(mount_point) > len(best_mount):
+                    best_mount = mount_point
+                    best_fstype = fstype
+        return best_fstype
+    except Exception:
+        # /proc/mounts is Linux-specific; treat anything unreadable as unknown.
+        return ""
+
+
+def should_auto_prefetch_checkpoints(files: List[str]) -> bool:
+    """Decide whether to prefetch checkpoints when the user left it unset.
+
+    Prefetching turns the loader's random mmap page faults into sequential reads,
+    which matters on network filesystems where a fault costs a network round
+    trip. It only pays off if the checkpoint can actually stay resident in the
+    page cache, so a checkpoint larger than most of RAM is skipped: prefetching
+    it would just evict its own earlier pages.
+    """
+    if not files:
+        return False
+
+    fs_type = _get_fs_type(files)
+    is_net_fs = fs_type in _NETWORK_FS_TYPES
+
+    try:
+        import psutil
+
+        total_bytes = sum(os.path.getsize(f) for f in files)
+        avail_bytes = psutil.virtual_memory().available
+    except Exception:
+        logger.debug("Could not size checkpoints or RAM; skipping auto-prefetch.")
+        return False
+
+    fits_in_ram = total_bytes <= (_PREFETCH_RAM_THRESHOLD_PCT / 100.0) * avail_bytes
+    fs_name = fs_type.upper() if fs_type else "unknown"
+
+    logger.info(
+        "Filesystem type for checkpoints: %s. Checkpoint size: %.2f GiB. "
+        "Available RAM: %.2f GiB.",
+        fs_name,
+        total_bytes / 1024**3,
+        avail_bytes / 1024**3,
+    )
+
+    if not is_net_fs:
+        logger.info(
+            "Auto-prefetch disabled: %s is not a recognized network filesystem "
+            "(%s). Pass --weight-loader-prefetch-checkpoints to force it.",
+            fs_name,
+            "/".join(_NETWORK_FS_TYPES),
+        )
+        return False
+
+    if not fits_in_ram:
+        logger.warning(
+            "Network filesystem (%s) detected, but the checkpoint (%.2f GiB) "
+            "exceeds %d%% of available RAM (%.2f GiB); skipping auto-prefetch.",
+            fs_name,
+            total_bytes / 1024**3,
+            _PREFETCH_RAM_THRESHOLD_PCT,
+            avail_bytes / 1024**3,
+        )
+        return False
+
+    logger.info(
+        "Network filesystem (%s) detected; enabling checkpoint prefetch. "
+        "Pass --weight-loader-prefetch-checkpoints=False to disable.",
+        fs_name,
+    )
+    return True
+
+
 def _prefetch_checkpoint_file(
     file_path: str,
     cancel_event: Optional[threading.Event] = None,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3325,10 +3325,10 @@ class ServerArgs:
         bool, "Disable mmap while loading weight using safetensors.", NS("model")
     ] = False
     weight_loader_prefetch_checkpoints: A[
-        bool,
-        "Prefetch checkpoint files into OS page cache before loading. Each rank prefetches a fraction of the shards, reducing total network I/O on shared filesystems (NFS/Lustre) from N*checkpoint to 1*checkpoint. Recommended for models on network storage. When enabled, multi-threaded safetensors loading is disabled by default to avoid I/O oversubscription with the prefetch threads; set enable_multithread_load=true in --model-loader-extra-config to keep multi-threaded loading (e.g. on local NVMe where prefetch is a no-op).",
+        Optional[bool],
+        "Prefetch checkpoint files into OS page cache before loading. Each rank prefetches a fraction of the shards, reducing total network I/O on shared filesystems (NFS/Lustre) from N*checkpoint to 1*checkpoint. Left unset (the default), this is enabled automatically when the checkpoint sits on a network filesystem (NFS/Lustre) and fits in available RAM; pass True or False to override the detection. When enabled, multi-threaded safetensors loading is disabled by default to avoid I/O oversubscription with the prefetch threads; set enable_multithread_load=true in --model-loader-extra-config to keep multi-threaded loading (e.g. on local NVMe where prefetch is a no-op).",
         NS("model"),
-    ] = False
+    ] = None
     weight_loader_prefetch_num_threads: A[
         int,
         "Number of threads per rank for checkpoint prefetching (default: 4).",

--- a/test/registered/unit/model_loader/test_prefetch_checkpoints.py
+++ b/test/registered/unit/model_loader/test_prefetch_checkpoints.py
@@ -11,7 +11,7 @@ import threading
 import unittest
 from concurrent.futures import Future
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import safetensors.torch
 import torch
@@ -20,10 +20,12 @@ from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.model_loader.loader import DefaultModelLoader
 from sglang.srt.model_loader.weight_utils import (
     CheckpointFilePrefetchHandle,
+    _get_fs_type,
     _prefetch_all_checkpoints,
     buffered_multi_thread_safetensors_weights_iterator,
     fastsafetensors_weights_iterator,
     safetensors_weights_iterator,
+    should_auto_prefetch_checkpoints,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -689,6 +691,132 @@ class TestPrefetchDispatch(CustomTestCase):
             self._make_loader(
                 {"enable_gds": "false"}, load_format=LoadFormat.FASTSAFETENSORS
             )
+
+
+class TestAutoPrefetchDetection(CustomTestCase):
+    """Verify the filesystem detection behind the ``auto`` prefetch default.
+
+    Prefetch turns the loader's scattered mmap faults into sequential reads,
+    which only pays off when a fault costs a network round trip and the
+    checkpoint can stay resident in the page cache.
+    """
+
+    _MOUNTS = (
+        "rootfs / ext4 rw 0 0\n"
+        "10.0.0.1:/vol /data lustre rw 0 0\n"
+        "/dev/nvme0n1 /data/local ext4 rw 0 0\n"
+    )
+
+    def _patch_mounts(self, contents=None):
+        return patch("builtins.open", mock_open(read_data=contents or self._MOUNTS))
+
+    def test_fs_type_picks_longest_matching_mount(self):
+        """Nested mounts must resolve like the kernel does: longest prefix
+        wins, so /data/local is ext4 even though /data is lustre."""
+        with self._patch_mounts():
+            self.assertEqual(_get_fs_type(["/data/model/f.safetensors"]), "lustre")
+        with self._patch_mounts():
+            self.assertEqual(_get_fs_type(["/data/local/model/f.safetensors"]), "ext4")
+        with self._patch_mounts():
+            self.assertEqual(_get_fs_type(["/opt/model/f.safetensors"]), "ext4")
+
+    def test_fs_type_does_not_match_sibling_prefix(self):
+        """/database must not match the /data mount by string prefix alone."""
+        with self._patch_mounts():
+            self.assertEqual(_get_fs_type(["/database/f.safetensors"]), "ext4")
+
+    def test_fs_type_returns_empty_without_proc_mounts(self):
+        """/proc/mounts is Linux-only; an unreadable file means "unknown"."""
+        with patch("builtins.open", side_effect=OSError):
+            self.assertEqual(_get_fs_type(["/data/f.safetensors"]), "")
+        self.assertEqual(_get_fs_type([]), "")
+
+    def _patch_sizing(self, total_bytes, avail_bytes):
+        return (
+            patch("os.path.getsize", return_value=total_bytes),
+            patch(
+                "psutil.virtual_memory",
+                return_value=SimpleNamespace(available=avail_bytes),
+            ),
+        )
+
+    def test_auto_enables_on_network_fs_that_fits_in_ram(self):
+        p_size, p_mem = self._patch_sizing(10 * 1024**3, 100 * 1024**3)
+        with self._patch_mounts(), p_size, p_mem:
+            self.assertTrue(
+                should_auto_prefetch_checkpoints(["/data/model/f.safetensors"])
+            )
+
+    def test_auto_stays_off_on_local_fs(self):
+        """Local storage has no round-trip cost to amortize."""
+        p_size, p_mem = self._patch_sizing(10 * 1024**3, 100 * 1024**3)
+        with self._patch_mounts(), p_size, p_mem:
+            self.assertFalse(
+                should_auto_prefetch_checkpoints(["/data/local/model/f.safetensors"])
+            )
+
+    def test_auto_stays_off_when_checkpoint_exceeds_ram(self):
+        """Prefetching a checkpoint larger than RAM would evict its own
+        earlier pages, so the read is paid for twice."""
+        p_size, p_mem = self._patch_sizing(95 * 1024**3, 100 * 1024**3)
+        with self._patch_mounts(), p_size, p_mem:
+            self.assertFalse(
+                should_auto_prefetch_checkpoints(["/data/model/f.safetensors"])
+            )
+
+    def test_auto_stays_off_when_sizing_fails(self):
+        with self._patch_mounts(), patch("os.path.getsize", side_effect=OSError):
+            self.assertFalse(
+                should_auto_prefetch_checkpoints(["/data/model/f.safetensors"])
+            )
+
+    def test_auto_requires_files(self):
+        self.assertFalse(should_auto_prefetch_checkpoints([]))
+
+
+class TestAutoPrefetchDispatch(TestPrefetchDispatch):
+    """The ``auto`` default must consult detection only when left unset."""
+
+    def test_unset_prefetch_consults_auto_detection(self):
+        loader = self._make_loader({})
+        p_prep, p_model, p_buffered, p_single, p_warn = self._patch_dispatch(
+            prefetch=None
+        )
+        with (
+            p_prep,
+            p_model,
+            p_buffered as mock_buffered,
+            p_single as mock_single,
+            p_warn,
+            patch(
+                "sglang.srt.model_loader.loader.should_auto_prefetch_checkpoints",
+                return_value=True,
+            ) as mock_auto,
+        ):
+            self._run(loader)
+        mock_auto.assert_called_once_with(["f.safetensors"])
+        mock_single.assert_called_once()
+        mock_buffered.assert_not_called()
+
+    def test_explicit_prefetch_skips_auto_detection(self):
+        """An explicit True/False from the user is authoritative."""
+        for explicit in (True, False):
+            loader = self._make_loader({})
+            p_prep, p_model, p_buffered, p_single, p_warn = self._patch_dispatch(
+                prefetch=explicit
+            )
+            with (
+                p_prep,
+                p_model,
+                p_buffered,
+                p_single,
+                p_warn,
+                patch(
+                    "sglang.srt.model_loader.loader.should_auto_prefetch_checkpoints",
+                ) as mock_auto,
+            ):
+                self._run(loader)
+            mock_auto.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Loading a large MoE checkpoint from network storage is pathologically slow with the default loader settings. On 8×H20 (TP=8) loading GLM-5.2-FP8 (141 shards, 704 GiB) from Lustre, weight loading **did not finish within 20 minutes**.

The default path is not I/O-bandwidth limited — it is limited by *access pattern*:

| metric (20 s sample, `sglang::scheduler_TP0`) | default | with prefetch |
|---|---|---|
| major page faults | **369,655** | **38** |
| `stime` (kernel, fault handling) | **3,336 ticks** | — |
| effective read bandwidth | **28 MiB/s** | 704 GiB in 42.6 s |

97 % of the time is spent in kernel mode servicing page faults at ~18 k faults/s. Sequential reads of the same files reach multiple GB/s, so the storage is not the bottleneck.

### Root cause

`should_async_load()` (`model_loader/utils.py`) returns `True` for every CPU tensor, justified by "using a threadpool can overlap H2D copies" — which holds only when the data is already resident in RAM. A tensor from `safe_open(...).get_tensor(...)` is a *lazy mmap view*, so the premise does not hold on the default loading path. `do_load_weights()` therefore dispatches essentially every `weight_loader(...)` call into a `ThreadPoolExecutor()` constructed without `max_workers` (up to `min(32, cpu_count + 4)`). The result: up to 32 threads fault pages at unrelated offsets across the shards in the iterator's sliding window. Per-VMA readahead never sees a sequential stream, so Lustre degrades to page-sized synchronous RPCs, each paying a network round trip.

SGLang **already ships the fix**: `_prefetch_all_checkpoints()` / `_prefetch_checkpoint_file()` read in 16 MiB blocks and split shards across ranks — by `world_group.local_rank`, which is the right unit because the page cache is node-local. The only thing missing is the decision to turn it on: `weight_loader_prefetch_checkpoints` defaults to `False` and there is no filesystem detection, so users on NFS/Lustre silently get the slow path.

## Modifications

Scope is deliberately limited to **adding the missing auto-detection**. The prefetch implementation, the single-threaded fallback, `weight_loader_prefetch_num_threads` (stays 4), `should_async_load()`, and the executor width in `do_load_weights()` are all left exactly as they are.

| file | change |
|---|---|
| `srt/server_args.py` | `weight_loader_prefetch_checkpoints`: `bool = False` → `Optional[bool] = None` (tri-state, already the established pattern here, e.g. `enable_multimodal`) |
| `srt/model_loader/weight_utils.py` | new `_get_fs_type()` + `should_auto_prefetch_checkpoints()` |
| `srt/model_loader/loader.py` | resolve `None` via the auto check at the existing `configured_prefetch = ...` site |
| `test/registered/unit/model_loader/test_prefetch_checkpoints.py` | unit tests (see below) |

When the flag is left unset, prefetch is enabled if the checkpoint sits on `nfs`/`nfs4`/`lustre` **and** fits within 90 % of available RAM (prefetching a checkpoint larger than RAM would evict its own earlier pages). An explicit `True`/`False` from the user always wins. Filesystem detection parses `/proc/mounts` with **longest-prefix matching** so nested mounts resolve the way the kernel does, and returns "unknown" (prefetch off) wherever `/proc/mounts` is unavailable.

`weight_loader_prefetch_num_threads` keeps its default of 4 — the 4-vs-8 sweep below shows 4 is already enough to saturate the mount and is in fact *faster*, so there is no reason to touch it.

No change to `weight_loader` implementations, TP sharding, expert-shard mapping, or `post_load_weights()` ordering. The patch only affects *when the pages are read*.

## Accuracy Tests

This does not change what is loaded, only when the pages are faulted in, so model outputs are unaffected. The existing `test_weights_match_with_and_without_prefetch` in `test_prefetch_checkpoints.py` already asserts weights are bit-identical with and without prefetch. Verified the server reaches `health=200` and serves completions in the prefetch configuration.

## Speed Tests and Profiling

GLM-5.2-FP8, TP=8, 141 shards / 704 GiB on Lustre, 8×H20-3e, page cache dropped between runs. `Load weight end` is per rank; the slowest rank gates startup.

| configuration | prefetch threads | weight load (slowest rank) |
|---|---|---|
| current default (8-thread mmap iterator, no prefetch) | — | **did not complete in 20 min** |
| **this PR's auto path (shipped default)** | **4** | **151.18 s** |
| prefetch, `num_threads=8` | 8 | 168.81 s |
| prefetch, `num_threads=8`, multi-threaded iterator forced on | 8 | 198.43 s |

Per-rank detail (4 threads, shipped default): prefetch finished in 38.65–39.66 s; `Load weight end` 70.89 / 151.17 / 151.17 / 151.18 s.

Two ablations:

* **Prefetch threads, 4 vs 8**: the shipped default of 4 is not just sufficient, it is ~10 % *faster* (151.18 s vs 168.81 s). Four sequential readers already saturate the mount; four more only add contention.
* **Iterator concurrency**: forcing `enable_multithread_load=true` alongside prefetch regresses the slowest rank from 168.81 s to 198.43 s (~18 % worse), because the shard readers and prefetch threads contend for the same Lustre reads. This confirms the existing single-threaded fallback should stay.

Also confirmed the page-fault collapse (369,655 → 38 faults per 20 s on `scheduler_TP0`) via `/proc/<pid>/stat`, and prefetch activation from the logs (`Rank N: prefetching 17/141 checkpoint shards into page cache ...`).

## Tests added

Extended the existing `test_prefetch_checkpoints.py` rather than adding a new file:

* `TestAutoPrefetchDetection` — `/proc/mounts` longest-prefix parsing, including the nested-mount case (`/` ext4, `/data` lustre, `/data/local` ext4) and a sibling-prefix case (`/database` must not match the `/data` mount); unreadable `/proc/mounts` → "unknown"; auto on for network FS that fits in RAM; auto off for local FS, for a checkpoint exceeding the RAM threshold, and when sizing fails.
* `TestAutoPrefetchDispatch` — the auto check is consulted only when the flag is unset; an explicit `True`/`False` bypasses detection entirely.

## Not yet verified

Being upfront about the gaps rather than implying full coverage:

* **No local-NVMe control run yet.** The logic returns `False` for any non-`nfs`/`nfs4`/`lustre` mount and is covered by `test_auto_stays_off_on_local_fs`, but I have not measured a real local-NVMe load to confirm there is no regression in practice.
* **No run with a checkpoint larger than RAM.** The `fits_in_ram` guard is unit-tested, not measured end to end.
* The measurements above come from one cluster (Lustre + 8×H20-3e). Numbers on other network filesystems may differ.

Happy to run any of these if reviewers want them before merging, or to gate the auto behaviour more conservatively.

## Questions for reviewers

* Should `auto` also cover other shared filesystems (`gpfs`, `ceph`, `beegfs`)? This PR only recognizes NFS and Lustre.
* `weight_loader_drop_cache_after_load` combined with the async mmap path looks hazardous: `posix_fadvise(DONTNEED)` can evict pages while queued worker threads still hold un-copied mmap views of that shard, forcing them to fault again. The code comment in `buffered_multi_thread_safetensors_weights_iterator` already acknowledges this. Out of scope here, but worth a follow-up.
* A deeper fix, independent of prefetch, would be to make `should_async_load()` return `False` for lazy mmap views (mirroring the existing `_sglang_runai_streamer_tensor` opt-out) and/or bound the executor in `do_load_weights()`. That addresses the root cause rather than masking it with readahead, and would also help local-storage users. Happy to follow up if maintainers prefer that direction.

## Duplicate check

Searched open PRs and issues for prefetch / weight-loading / NFS / Lustre. The closest are #33930 (logging cleanup under the same flag) and #35259 (startup weight-load overlap hardening); neither adds filesystem detection or changes the flag's default, so this does not overlap. Please point me at anything I missed.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — ruff, ruff-format, isort, codespell all clean
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests)
- [ ] Update documentation — no user-facing doc change beyond the flag's help text; happy to add a note if there is a preferred place
- [x] Provide accuracy and speed benchmark results (see above; gaps listed under "Not yet verified")
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)

---

*Note: AI assistance was used while preparing this change (investigation, patch, tests, and description). All measurements come from real runs on the cluster described above, and I have reviewed every changed line.*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #35317934871](https://github.com/sgl-project/sglang/actions/runs/35317934871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #35317934597](https://github.com/sgl-project/sglang/actions/runs/35317934597)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:warning: [Run #35317934803](https://github.com/sgl-project/sglang/actions/runs/35317934803)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->