### PR TITLE
[Fix] Make test port derivation robust to any CUDA_VISIBLE_DEVICES value

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -235,15 +235,65 @@ def _use_cached_default_models(model_repo: str):
     return ""
 
 
+# DEFAULT_URL_FOR_TEST sits this many ports above the runner port, so a derived
+# base port must leave room for the offset and still be a valid TCP port.
+_TEST_PORT_URL_OFFSET = 1000
+_MAX_TCP_PORT = 65535
+
+
+def _device_index_from_visible_devices(raw: Optional[str]) -> int:
+    """Derive a small non-negative index from a CUDA_VISIBLE_DEVICES value.
+
+    The index only selects a port range so that concurrent per-device test
+    runners do not fight over the same TCP port; it never selects a device.
+    Concurrent runners cannot share a GPU, so their device lists are disjoint
+    and the first entry already discriminates between them.
+
+    CUDA_VISIBLE_DEVICES is user supplied and may legitimately hold values that
+    cannot be mapped to an index -- GPU UUIDs, or the empty string that hides
+    every device. Picking a test port is a convenience, not a correctness
+    requirement, so unparsable values fall back to 0 rather than raising and
+    breaking every import of this module.
+    """
+    if not raw:
+        return 0
+    first = raw.split(",")[0].strip()
+    try:
+        index = int(first)
+    except ValueError:
+        return 0
+    return index if index > 0 else 0
+
+
+def _port_for_device_index(base: int, stride: int, index: int) -> int:
+    """Map a device index onto a base port.
+
+    Indices are no longer truncated, so they can be arbitrarily large; the
+    index is wrapped into the slots that keep the result -- plus
+    _TEST_PORT_URL_OFFSET -- inside the valid TCP port range. Beyond the wrap
+    point ports repeat, which trades uniqueness for validity: a reused port
+    surfaces as "address already in use", an out-of-range one cannot bind at
+    all. The wrap point (45 slots non-CI, 28 in CI) is far above any realistic
+    single-host device count.
+    """
+    slots = (_MAX_TCP_PORT - _TEST_PORT_URL_OFFSET - base) // stride + 1
+    return base + (index % slots) * stride
+
+
+_TEST_DEVICE_INDEX = _device_index_from_visible_devices(
+    os.environ.get("CUDA_VISIBLE_DEVICES")
+)
 if is_in_ci():
-    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 2000
+    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = _port_for_device_index(
+        10000, 2000, _TEST_DEVICE_INDEX
     )
 else:
-    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        20000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 1000
+    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = _port_for_device_index(
+        20000, 1000, _TEST_DEVICE_INDEX
     )
-DEFAULT_URL_FOR_TEST = f"http://127.0.0.1:{DEFAULT_PORT_FOR_SRT_TEST_RUNNER + 1000}"
+DEFAULT_URL_FOR_TEST = (
+    f"http://127.0.0.1:{DEFAULT_PORT_FOR_SRT_TEST_RUNNER + _TEST_PORT_URL_OFFSET}"
+)
 
 if is_in_amd_ci():
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 3600  # Match H200 timeout for large models

--- a/test/registered/unit/test_test_port_derivation.py
+++ b/test/registered/unit/test_test_port_derivation.py
@@ -1,0 +1,149 @@
+"""Unit tests for how sglang.test.test_utils derives per-device test server ports."""
+
+import os
+import subprocess
+import sys
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import (
+    CustomTestCase,
+    _device_index_from_visible_devices,
+    _port_for_device_index,
+)
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+MAX_TCP_PORT = 65535
+# DEFAULT_URL_FOR_TEST is DEFAULT_PORT_FOR_SRT_TEST_RUNNER + 1000, so a derived
+# base port must leave room for that offset and still be a valid TCP port.
+URL_PORT_OFFSET = 1000
+# (base, stride) for the non-CI and in-CI layouts respectively.
+LAYOUTS = ((20000, 1000), (10000, 2000))
+
+
+class TestDeviceIndexParsing(CustomTestCase):
+    # (CUDA_VISIBLE_DEVICES, expected index, why)
+    CASES = [
+        (None, 0, "unset keeps the historical default"),
+        ("", 0, "empty string hides every GPU; must not raise"),
+        ("0", 0, "single digit"),
+        ("7", 7, "single digit"),
+        ("10", 10, "multi-digit must not be truncated to its first character"),
+        ("2,3", 2, "comma separated list uses the first device"),
+        ("11,12", 11, "multi-digit inside a list"),
+        (" 1 ", 1, "surrounding whitespace is ignored"),
+        ("2, 3", 2, "whitespace after the separator is ignored"),
+        ("GPU-8f2e1c3a-0000-0000-0000-000000000000", 0, "UUID form degrades"),
+        ("-1", 0, "negative is not a usable index"),
+    ]
+
+    def test_parsing_table(self):
+        for raw, expected, why in self.CASES:
+            with self.subTest(cuda_visible_devices=raw, why=why):
+                self.assertEqual(_device_index_from_visible_devices(raw), expected)
+
+    def test_ten_and_one_no_longer_share_a_port(self):
+        # The previous implementation read only the first character, so device
+        # 10 and device 1 derived the same port and raced for it.
+        for base, stride in LAYOUTS:
+            with self.subTest(base=base):
+                self.assertNotEqual(
+                    _port_for_device_index(
+                        base, stride, _device_index_from_visible_devices("10")
+                    ),
+                    _port_for_device_index(
+                        base, stride, _device_index_from_visible_devices("1")
+                    ),
+                )
+
+
+class TestMalformedValuesDegradeGracefully(CustomTestCase):
+    """CUDA_VISIBLE_DEVICES is user supplied. Values this helper cannot map to
+    an index must degrade to the default port rather than raise: choosing a
+    test port is a convenience, not a correctness requirement.
+
+    Note this is a table of awkward inputs, not generative property testing --
+    it exists so the fallback is exercised by values the cases above did not
+    anticipate.
+    """
+
+    MALFORMED = [
+        None,
+        "",
+        "  ",
+        "\n",
+        "abc",
+        "none",
+        "all",
+        "GPU-1,GPU-2",
+        "MIG-GPU-8f2e1c3a",
+        "1.5",
+        "1e3",
+        "0x10",
+        "-0",
+        "--1",
+        ",",
+        ",,,",
+        ",2",
+        "1 2",
+        "x" * 512,
+    ]
+
+    def test_malformed_values_fall_back_to_the_default_index(self):
+        for raw in self.MALFORMED:
+            with self.subTest(cuda_visible_devices=raw):
+                self.assertEqual(_device_index_from_visible_devices(raw), 0)
+
+
+class TestPortDerivation(CustomTestCase):
+    def test_historical_ports_are_unchanged(self):
+        # Indices that occur in practice must keep their existing ports,
+        # otherwise running tests would silently move.
+        self.assertEqual(_port_for_device_index(20000, 1000, 0), 20000)
+        self.assertEqual(_port_for_device_index(20000, 1000, 1), 21000)
+        self.assertEqual(_port_for_device_index(10000, 2000, 0), 10000)
+        self.assertEqual(_port_for_device_index(10000, 2000, 3), 16000)
+
+    def test_ports_are_distinct_across_plausible_device_counts(self):
+        # Uniqueness is guaranteed below the wrap-around point, which is far
+        # above any realistic single-host device count.
+        for base, stride in LAYOUTS:
+            with self.subTest(base=base):
+                ports = [_port_for_device_index(base, stride, i) for i in range(16)]
+                self.assertEqual(len(set(ports)), len(ports), msg=str(ports))
+
+    def test_ports_wrap_instead_of_leaving_the_tcp_range(self):
+        # Indices are no longer truncated, so they can be arbitrarily large.
+        # Wrapping trades uniqueness for validity past the wrap point; a reused
+        # port is recoverable ("address already in use"), an invalid one is not.
+        for base, stride in LAYOUTS:
+            slots = (MAX_TCP_PORT - URL_PORT_OFFSET - base) // stride + 1
+            with self.subTest(base=base, slots=slots):
+                for index in (0, 1, slots - 1, slots, 999, 10**6):
+                    port = _port_for_device_index(base, stride, index)
+                    self.assertGreater(port, 0)
+                    self.assertLessEqual(port + URL_PORT_OFFSET, MAX_TCP_PORT)
+                self.assertEqual(
+                    _port_for_device_index(base, stride, slots),
+                    _port_for_device_index(base, stride, 0),
+                )
+
+
+class TestModuleImportIsRobust(CustomTestCase):
+    """The port is computed at import time, so a rejected value breaks the
+    import itself rather than any single assertion."""
+
+    def test_empty_cuda_visible_devices_does_not_break_import(self):
+        env = dict(os.environ, CUDA_VISIBLE_DEVICES="")
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from sglang.test.test_utils import DEFAULT_PORT_FOR_SRT_TEST_RUNNER as p; print(p)",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr[-2000:])
+        self.assertGreater(int(proc.stdout.strip()), 0)


### PR DESCRIPTION
## Motivation

`DEFAULT_PORT_FOR_SRT_TEST_RUNNER` derives its per-device port offset with:

```python
int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0])
```

Reading a single character has three consequences.

**1. `CUDA_VISIBLE_DEVICES=""` breaks every module that imports `test_utils`.**

The `"0"` default only applies when the variable is *unset*. When it is set but empty, `os.environ.get` returns `""` and `""[0]` raises `IndexError`. Setting it to the empty string is the documented way to hide every GPU, and a natural way to force a CPU-only run on a machine that has one — which is what the CPU unit suites are for.

Because the port is computed at import time, this breaks importing `sglang.test.test_utils` itself, so the failure happens during *collection*:

```
$ CUDA_VISIBLE_DEVICES="" pytest test/registered/unit/test_legacy_global_ratchet.py
E   IndexError: string index out of range
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

301 of the 464 test modules under `test/registered/unit/` import `test_utils`, so none of them can be collected in that configuration.

**2. Non-numeric values that CUDA accepts raise `ValueError`.** `CUDA_VISIBLE_DEVICES=GPU-<uuid>` is supported by CUDA and is the recommended form when enumeration order is not stable, but `int("G")` raises. A leading space (`" 1"`) fails the same way.

**3. Device indices of 10 or more are truncated to their first digit.** Index `10` and index `1` derive the same port, so two concurrent runners on those devices race for it.

CI does not hit any of these: the CPU runners have no GPU, so the variable is unset and the `"0"` default applies, and the GPU runners use single-digit indices.

**This is inconsistent with how the rest of the repository already reads this variable.** `_visible_gpu_indices` — in this same file, a few hundred lines below — splits on commas, strips each entry, and explicitly degrades on the UUID form:

```python
entries = [entry.strip() for entry in visible.split(",") if entry.strip()]
if not all(entry.isdigit() for entry in entries):
    # UUID-style entries; fall back to checking all GPUs.
    return list(range(num_gpus))
```

`disaggregation_fixture.py` does the same, and additionally guards the empty string:

```python
if not cuda_visible_devices:
    warnings.warn("CUDA_VISIBLE_DEVICES is not set. Using default RDMA devices.")
    return ...
try:
    gpu_indices = [int(idx.strip()) for idx in cuda_visible_devices.split(",") if idx.strip()]
except ValueError:
    warnings.warn(f"Invalid CUDA_VISIBLE_DEVICES format: {cuda_visible_devices}")
    return ...
```

So the repository already treats "split on comma, strip, parse the full integer, degrade on anything else" as the correct reading, and already recognises that the UUID form must not be parsed as a number. This PR applies that same handling to the port derivation, which was left behind.

## Modifications

- Extract parsing into `_device_index_from_visible_devices` and the port layout into `_port_for_device_index`. These constants are computed on first import and cannot be re-derived from inside a test process, so extracting them is what makes the behaviour testable at all.
- Parsing takes the first comma-separated entry, strips surrounding whitespace, and falls back to `0` for anything it cannot map to an index instead of raising. Taking the first entry is sufficient because concurrent runners cannot share a GPU, so their device lists are disjoint and the first entry already discriminates between them. Choosing a test port is a convenience, not a correctness requirement, so it must never break an import.
- Because indices are no longer truncated they can now be arbitrarily large, so the port is wrapped into the slots that keep `DEFAULT_URL_FOR_TEST` (`base + 1000`) a valid TCP port.

Two limits of that fallback, stated rather than implied:

- Values with no numeric index — the `GPU-<uuid>` and `MIG-<...>` forms — **all map to the default port**. This restores importability; it does not give such runners distinct ports. Deriving a stable index from a UUID (hashing, or querying the driver) would be a behaviour change beyond the scope of this fix.
- Ports **repeat past the wrap point** (45 slots non-CI, 28 in CI), so uniqueness holds below it, not for arbitrary indices. That trade is deliberate: a reused port surfaces as `address already in use`, an out-of-range one cannot bind at all. Both bounds are far above any realistic single-host device count.
- Add `test/registered/unit/test_test_port_derivation.py`, registered as CPU-only.

Ports for every value that occurs today are unchanged:

| `CUDA_VISIBLE_DEVICES` | before | after |
|---|---|---|
| unset | 20000 | 20000 |
| `""` | **IndexError** | 20000 |
| `"0"` | 20000 | 20000 |
| `"1"` | 21000 | 21000 |
| `"10"` | **21000** (collides with `"1"`) | 30000 |
| `"2,3"` | 22000 | 22000 |
| `" 1 "` | **ValueError** | 21000 |
| `"GPU-<uuid>"` | **ValueError** | 20000 |

The in-CI layout (`10000 + index * 2000`) is untouched.

### Tests

`test/registered/unit/test_test_port_derivation.py` covers:

- a parsing table for unset, empty, single- and multi-digit, comma-separated, whitespace-padded, UUID and negative values;
- that device `10` and device `1` no longer derive the same port, in both layouts;
- a table of malformed values (`"1.5"`, `"0x10"`, `",,,"`, `"1 2"`, MIG form, ...) asserting they fall back to the default index rather than raising — this is a table of awkward inputs, not generative property testing;
- the historical port values, so this change cannot silently move existing tests to new ports;
- port distinctness across 16 indices (well above any realistic single-host device count) and the wrap-around behaviour asserted **at** its boundary, so the trade-off is pinned rather than assumed;
- an end-to-end guard that imports `test_utils` in a subprocess with `CUDA_VISIBLE_DEVICES=""`.

Verified locally on a single-GPU machine (13 tests, 36 subtests, CPU only); `CUDA_VISIBLE_DEVICES="" pytest test/registered/unit/test_legacy_global_ratchet.py` fails collection before this change and passes after.

### Note, not addressed here

While reading this code I noticed that in the non-CI branch the per-index stride (`1000`) equals the `DEFAULT_URL_FOR_TEST` offset (`1000`), so index `n`'s URL port equals index `n+1`'s base port; the in-CI branch uses a stride of `2000` and does not have that property. I have not established whether both constants are ever bound concurrently, so I have deliberately left it out of this PR. Happy to open a separate issue if that would be useful.

## Accuracy Tests

Not applicable — this changes test infrastructure only; no model, kernel or serving code is touched.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
