### PR TITLE
[DSpark] Make SPS M-bin width configurable

### DIFF
--- a/python/sglang/benchmark/dspark_sps_profiler.py
+++ b/python/sglang/benchmark/dspark_sps_profiler.py
@@ -293,6 +293,7 @@ def fit_profile(
     *,
     out: str,
     max_batch_tokens: Optional[int],
+    mbin_w: int = 64,
     self_check: bool,
     plot: bool,
 ) -> None:
@@ -309,7 +310,10 @@ def fit_profile(
     offdiag = any(summary.get("frac") is not None for summary in summaries)
 
     table = build_table_from_summaries(
-        summaries=summaries, max_batch_tokens=max_batch_tokens, offdiag=offdiag
+        summaries=summaries,
+        max_batch_tokens=max_batch_tokens,
+        offdiag=offdiag,
+        mbin_w=mbin_w,
     )
     paths["table"].write_text(table.to_json(), encoding="utf-8")
     if offdiag:
@@ -344,6 +348,7 @@ def profile_all(
     settings: RoundSettings,
     out: str,
     max_batch_tokens: Optional[int],
+    mbin_w: int = 64,
     repeats: int,
     self_check: bool,
     local_tokenizer_path: Optional[str],
@@ -362,6 +367,7 @@ def profile_all(
     fit_profile(
         out=out,
         max_batch_tokens=max_batch_tokens,
+        mbin_w=mbin_w,
         self_check=self_check,
         plot=plot,
     )
@@ -388,11 +394,15 @@ def summaries_to_cells(*, summaries: list[dict]) -> list[dict]:
 
 
 def build_table_from_summaries(
-    *, summaries: list[dict], max_batch_tokens: Optional[int], offdiag: bool
+    *,
+    summaries: list[dict],
+    max_batch_tokens: Optional[int],
+    offdiag: bool,
+    mbin_w: int = 64,
 ):
     if offdiag:
         return build_additive_table_from_cells(
-            cells=summaries_to_cells(summaries=summaries)
+            cells=summaries_to_cells(summaries=summaries), mbin_w=mbin_w
         )
 
     by_batch_tokens: dict[int, list[float]] = {}
@@ -1142,12 +1152,16 @@ def plot_fit(*, cells: list[dict], table, plot_path: Path) -> None:
     logger.info("Wrote fit plot to %s", plot_path)
 
 
-def build_additive_table_from_cells(*, cells: list[dict]) -> SpsAdditiveCostTable:
+def build_additive_table_from_cells(
+    *, cells: list[dict], mbin_w: int = 64
+) -> SpsAdditiveCostTable:
     if len(cells) < 4:
         raise RuntimeError(
             f"Off-diagonal fit needs at least 4 cells, got {len(cells)}."
         )
-    bias, alpha, theta, _rel, _stats = ols_resid_backfit(cells)
+    if mbin_w <= 0:
+        raise ValueError(f"mbin_w must be positive, got {mbin_w}.")
+    bias, alpha, theta, _rel, _stats = ols_resid_backfit(cells, mbin_w=mbin_w)
     bs_probes = sorted(alpha)
     m_probes = sorted(theta)
     return SpsAdditiveCostTable(
@@ -1470,6 +1484,13 @@ def add_run_args(parser: argparse.ArgumentParser) -> None:
 
 def add_fit_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
+        "--mbin-w",
+        type=int,
+        default=64,
+        help="M-bin width for the off-diagonal additive SPS fit. Defaults to "
+        "64 to preserve the existing fit behavior.",
+    )
+    parser.add_argument(
         "--max-batch-tokens",
         type=int,
         default=None,
@@ -1554,6 +1575,7 @@ def cli_main() -> None:
         fit_profile(
             out=args.out,
             max_batch_tokens=args.max_batch_tokens,
+            mbin_w=args.mbin_w,
             self_check=args.self_check,
             plot=args.plot,
         )
@@ -1564,6 +1586,7 @@ def cli_main() -> None:
             settings=run_settings(args=args),
             out=args.out,
             max_batch_tokens=args.max_batch_tokens,
+            mbin_w=args.mbin_w,
             repeats=args.repeats,
             self_check=args.self_check,
             local_tokenizer_path=args.local_tokenizer_path,

--- a/test/registered/spec/dspark/test_dspark_sps_profiler.py
+++ b/test/registered/spec/dspark/test_dspark_sps_profiler.py
@@ -1,9 +1,11 @@
+import argparse
 import unittest
 
 from sglang.benchmark.dspark_sps_profiler import (
     LoadInfo,
     ServerContext,
     SpsRow,
+    add_fit_args,
     build_request_count_sweep,
     build_table_from_summaries,
     count_aligned_steps,
@@ -199,6 +201,13 @@ class TestPostprocessRoundCrossRank(CustomTestCase):
 
 
 class TestTableAssembly(CustomTestCase):
+    def test_mbin_width_cli_default_and_override(self):
+        parser = argparse.ArgumentParser()
+        add_fit_args(parser)
+
+        self.assertEqual(parser.parse_args([]).mbin_w, 64)
+        self.assertEqual(parser.parse_args(["--mbin-w", "6"]).mbin_w, 6)
+
     def test_repeats_take_the_median_per_batch_tokens(self):
         rounds = [
             postprocess_round(
@@ -221,6 +230,53 @@ class TestTableAssembly(CustomTestCase):
         )
         self.assertEqual(table.sample_batch_tokens, [32])
         self.assertAlmostEqual(table.sample_steps_per_sec[0], 50.0)
+
+    def test_offdiag_mbin_width_controls_m_probes(self):
+        summaries = [
+            {
+                "batch_size_per_rank": bs,
+                "batch_tokens": m,
+                "steps_per_sec": 1.0 / (0.1 + 0.01 * bs + 0.001 * m),
+                "frac": 0.5,
+            }
+            for bs in (1, 2)
+            for m in (0, 6, 12)
+        ]
+
+        coarse = build_table_from_summaries(
+            summaries=summaries,
+            max_batch_tokens=None,
+            offdiag=True,
+        )
+        fine = build_table_from_summaries(
+            summaries=summaries,
+            max_batch_tokens=None,
+            offdiag=True,
+            mbin_w=6,
+        )
+
+        self.assertEqual(coarse.m_probes, [0])
+        self.assertEqual(fine.m_probes, [0, 6, 12])
+
+    def test_offdiag_mbin_width_must_be_positive(self):
+        summaries = [
+            {
+                "batch_size_per_rank": bs,
+                "batch_tokens": m,
+                "steps_per_sec": 10.0,
+                "frac": 0.5,
+            }
+            for bs in (1, 2)
+            for m in (0, 6)
+        ]
+
+        with self.assertRaisesRegex(ValueError, "mbin_w must be positive"):
+            build_table_from_summaries(
+                summaries=summaries,
+                max_batch_tokens=None,
+                offdiag=True,
+                mbin_w=0,
+            )
 
 
 class TestSweepHelpers(CustomTestCase):


### PR DESCRIPTION
## Motivation

The off-diagonal DSpark SPS fitter currently uses a fixed M-bin width of 64. For profiles whose verify workload range is smaller than or comparable to 64 tokens, distinct measurements collapse into only a few M probes, preventing the fitted `theta(M)` term from representing the measured verify-cost structure.

In a DeepSeek-V4-Flash DSpark profile spanning M=2–48, the fixed width produced only two M probes. Making the width configurable allows the same raw profiling data to be fitted at a resolution appropriate for the workload.

## Modifications

- Add `--mbin-w` to the `fit` and `all` SPS profiler subcommands.
- Thread the configured width through the off-diagonal additive-table fitting path.
- Reject non-positive M-bin widths.
- Keep the default width at 64, preserving existing CLI and Python-call behavior.
- Add unit coverage for the CLI default/override, probe granularity, and invalid widths.

## Accuracy Tests

The same 40 `(batch size, verify workload M)` cells were collected twice. The first current-environment run was used for fitting and the second as an independent validation set.

Collection repeatability:

- Median absolute step-time difference: 0.1337 ms
- Maximum absolute step-time difference: 0.3175 ms
- Mean step-time difference: -0.0205 ms

Held-out SPS prediction accuracy:

| M-bin width | M probes | MAE | RMSE | Maximum error | Mean bias |
|---:|---:|---:|---:|---:|---:|
| 64 | 2 | 1.7228 ms | 2.1976 ms | 5.3721 ms | 0.8031 ms |
| 6 | 9 | 0.4514 ms | 0.5788 ms | 1.1860 ms | 0.0128 ms |
| 1 | 25 | 0.1223 ms | 0.1527 ms | 0.3394 ms | 0.0205 ms |

Compared with the existing width of 64, width 6 reduced held-out MAE by 73.8%, and width 1 reduced it by 92.9%. The default remains unchanged.

This change only affects SPS table fitting when the new option is explicitly supplied; it does not modify model execution or numerical outputs.

## Speed Tests and Profiling

No serving-path code is changed, so no runtime throughput impact is expected.

Validation used real DSpark SPS profiles with:

- 40 training cells and 40 independently repeated validation cells
- Per-rank batch sizes 1–8
- Verify workload M=2–48
- Identical manifests and server configuration between the two current-environment collections

Local syntax compilation and `git diff --check` passed. The added unit test could not be collected on the local macOS system Python 3.9 because current SGLang requires Python 3.10+; CI is expected to run it in the supported environment.

## Checklist

- [ ] Format the code with pre-commit.
- [x] Add unit tests according to the contribution guide.
- [x] Update documentation as needed (no user-facing documentation change required).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33760251964](https://github.com/sgl-project/sglang/actions/runs/33760251964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33760251788](https://github.com/sgl-project/sglang/actions/runs/33760251788)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33760251973](https://github.com/sgl-project/sglang/actions/runs/33760251973)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->