### PR TITLE
[Diffusion] Add API key authentication to HTTP server

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -42,6 +42,10 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import (
     globally_suppress_loggers,
     init_logger,
 )
+from sglang.srt.utils.auth import (
+    add_api_key_middleware,
+    app_has_admin_force_endpoints,
+)
 from sglang.srt.utils.json_response import orjson_response
 from sglang.version import __version__
 
@@ -430,6 +434,17 @@ def create_app(server_args: ServerArgs):
     app.include_router(mesh_api.router)
     app.include_router(weights_api.router)
     app.include_router(rollout_api.router)
+
+    if (
+        server_args.api_key
+        or server_args.admin_api_key
+        or app_has_admin_force_endpoints(app)
+    ):
+        add_api_key_middleware(
+            app,
+            api_key=server_args.api_key,
+            admin_api_key=server_args.admin_api_key,
+        )
 
     app.state.server_args = server_args
     return app

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
@@ -16,6 +16,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBa
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils.auth import AuthLevel, auth_level
 from sglang.srt.utils.json_response import orjson_response
 
 router = APIRouter(prefix="/v1")
@@ -83,6 +84,7 @@ async def _handle_lora_request(req: Any, success_msg: str, failure_msg: str):
 
 
 @router.post("/set_lora")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def set_lora(
     lora_nickname: Union[str, List[str]] = Body(..., embed=True),
     lora_path: Optional[Union[str, List[Optional[str]]]] = Body(None, embed=True),
@@ -131,6 +133,7 @@ async def set_lora(
 
 
 @router.post("/merge_lora_weights")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def merge_lora_weights(
     target: str = Body("all", embed=True),
     strength: float = Body(1.0, embed=True),
@@ -153,6 +156,7 @@ async def merge_lora_weights(
 
 
 @router.post("/unmerge_lora_weights")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def unmerge_lora_weights(
     target: str = Body("all", embed=True),
 ):

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/weights_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/weights_api.py
@@ -11,12 +11,14 @@ from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
     UpdateWeightFromTensorReqInput,
 )
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
+from sglang.srt.utils.auth import AuthLevel, auth_level
 from sglang.srt.utils.json_response import orjson_response
 
 router = APIRouter()
 
 
 @router.post("/update_weights_from_disk")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def update_weights_from_disk(request: Request):
     """Update model weights from disk inplace without restarting the server."""
     body = await request.json()
@@ -58,6 +60,7 @@ async def update_weights_from_disk(request: Request):
 
 
 @router.post("/update_weights_from_tensor")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def update_weights_from_tensor(request: Request):
     """Update model weights from serialized tensor payloads."""
     body = await request.json()
@@ -94,6 +97,7 @@ async def update_weights_from_tensor(request: Request):
 
 
 @router.post("/update_weights_from_tensor_checker")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def update_weights_from_tensor_checker(request: Request):
     """Verify live module weights against expected SHA-256 values."""
     body = await request.json()
@@ -140,6 +144,7 @@ async def update_weights_from_tensor_checker(request: Request):
 
 
 @router.post("/get_weights_checksum")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def get_weights_checksum(request: Request):
     """Return SHA-256 checksum of each requested module's weights."""
     body = await request.json()
@@ -156,6 +161,7 @@ async def get_weights_checksum(request: Request):
 
 
 @router.post("/release_memory_occupation")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def release_memory_occupation():
     """Release GPU memory occupation (sleep the engine)."""
     try:
@@ -180,6 +186,7 @@ async def release_memory_occupation():
 
 
 @router.post("/resume_memory_occupation")
+@auth_level(AuthLevel.ADMIN_FORCE)
 async def resume_memory_occupation():
     """Resume GPU memory occupation (wake the engine)."""
     try:

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -467,6 +467,10 @@ class ServerArgs(DisaggServerArgsMixin):
     host: str | None = "127.0.0.1"
     port: int | None = 30000
 
+    # API key authentication
+    api_key: str | None = field(default=None, repr=False)
+    admin_api_key: str | None = field(default=None, repr=False)
+
     # TODO: webui and their endpoint, check if webui_port is available.
     webui: bool = False
     webui_port: int | None = 12312
@@ -2651,6 +2655,21 @@ class ServerArgs(DisaggServerArgsMixin):
             action=StoreBoolean,
             default=ServerArgs.strict_ports,
             help="If enabled, fail when requested ports are unavailable instead of auto-selecting.",
+        )
+        parser.add_argument(
+            "--api-key",
+            type=str,
+            default=ServerArgs.api_key,
+            help="Set API key of the server. It is also used in the OpenAI API compatible server.",
+        )
+        parser.add_argument(
+            "--admin-api-key",
+            type=str,
+            default=ServerArgs.admin_api_key,
+            help=(
+                "Set admin API key for sensitive management endpoints. When set, "
+                "admin endpoints require this key and do NOT accept --api-key."
+            ),
         )
         parser.add_argument(
             "--webui",

--- a/python/sglang/multimodal_gen/test/unit/test_http_auth.py
+++ b/python/sglang/multimodal_gen/test/unit/test_http_auth.py
@@ -1,0 +1,126 @@
+from dataclasses import fields
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from sglang.multimodal_gen.runtime.entrypoints.http_server import create_app
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.utils import FlexibleArgumentParser
+from sglang.srt.utils.auth import AuthLevel
+
+
+def _server_args(api_key=None, admin_api_key=None):
+    pipeline_config = SimpleNamespace(
+        supports_action_endpoint=lambda: False,
+        supports_openpi_endpoint=lambda: False,
+    )
+    return SimpleNamespace(
+        api_key=api_key,
+        admin_api_key=admin_api_key,
+        pipeline_config=pipeline_config,
+    )
+
+
+def _route_auth_level(app, path):
+    route = next(route for route in app.routes if route.path == path)
+    return getattr(route.endpoint, "_auth_level", AuthLevel.NORMAL)
+
+
+def test_cli_parser_accepts_api_keys_without_exposing_them_in_repr():
+    parser = FlexibleArgumentParser()
+    ServerArgs.add_cli_args(parser)
+
+    args, remaining = parser.parse_known_args(
+        [
+            "--model-path",
+            "/fake",
+            "--api-key",
+            "user-secret",
+            "--admin-api-key",
+            "admin-secret",
+        ]
+    )
+
+    assert remaining == []
+    assert args.api_key == "user-secret"
+    assert args.admin_api_key == "admin-secret"
+
+    server_arg_fields = {field.name: field for field in fields(ServerArgs)}
+    assert not server_arg_fields["api_key"].repr
+    assert not server_arg_fields["admin_api_key"].repr
+
+
+def test_normal_routes_remain_open_when_no_key_is_configured():
+    client = TestClient(create_app(_server_args()))
+
+    assert client.get("/openapi.json").status_code == 200
+    assert client.post("/v1/set_lora").status_code == 403
+
+
+def test_api_key_protects_normal_routes_and_keeps_probes_public():
+    client = TestClient(create_app(_server_args(api_key="user-secret")))
+
+    assert client.get("/openapi.json").status_code == 401
+    assert (
+        client.get(
+            "/openapi.json", headers={"Authorization": "Bearer wrong-secret"}
+        ).status_code
+        == 401
+    )
+    assert (
+        client.get(
+            "/openapi.json", headers={"Authorization": "Bearer user-secret"}
+        ).status_code
+        == 200
+    )
+    assert client.get("/liveness").status_code == 200
+    assert client.get("/liveness-admin").status_code == 401
+
+
+def test_cors_preflight_does_not_require_authentication():
+    client = TestClient(create_app(_server_args(api_key="user-secret")))
+
+    response = client.options(
+        "/openapi.json",
+        headers={
+            "Origin": "https://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_sensitive_management_routes_require_admin_auth():
+    app = create_app(_server_args(api_key="user-secret", admin_api_key="admin-secret"))
+    client = TestClient(app)
+
+    assert (
+        client.post(
+            "/v1/set_lora", headers={"Authorization": "Bearer user-secret"}
+        ).status_code
+        == 401
+    )
+    assert (
+        client.post(
+            "/v1/set_lora", headers={"Authorization": "Bearer admin-secret"}
+        ).status_code
+        == 422
+    )
+
+    for path in (
+        "/v1/set_lora",
+        "/v1/merge_lora_weights",
+        "/v1/unmerge_lora_weights",
+        "/update_weights_from_disk",
+        "/update_weights_from_tensor",
+        "/release_memory_occupation",
+        "/resume_memory_occupation",
+    ):
+        assert _route_auth_level(app, path) == AuthLevel.ADMIN_FORCE
+
+    for path in (
+        "/update_weights_from_tensor_checker",
+        "/get_weights_checksum",
+    ):
+        assert _route_auth_level(app, path) == AuthLevel.ADMIN_OPTIONAL

--- a/python/sglang/multimodal_gen/test/unit/test_http_auth.py
+++ b/python/sglang/multimodal_gen/test/unit/test_http_auth.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from sglang.multimodal_gen.runtime.entrypoints.http_server import create_app
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.utils import FlexibleArgumentParser
-from sglang.srt.utils.auth import AuthLevel
+from sglang.srt.utils.auth import AuthLevel, _iter_effective_routes
 
 
 def _server_args(api_key=None, admin_api_key=None):
@@ -22,7 +22,11 @@ def _server_args(api_key=None, admin_api_key=None):
 
 
 def _route_auth_level(app, path):
-    route = next(route for route in app.routes if route.path == path)
+    route = next(
+        route
+        for route in _iter_effective_routes(app)
+        if getattr(route, "path", None) == path
+    )
     return getattr(route.endpoint, "_auth_level", AuthLevel.NORMAL)
 
 

--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -25,14 +25,6 @@ class AuthLevel(str, Enum):
     ADMIN_FORCE = "admin_force"
 
 
-def _normalize_auth_level(level: Any) -> AuthLevel:
-    """Normalize route metadata that may come from a reloaded auth module."""
-    try:
-        return AuthLevel(level)
-    except (TypeError, ValueError):
-        return AuthLevel.NORMAL
-
-
 def auth_level(level: AuthLevel):
     """Mark endpoint with auth level (stored in endpoint metadata)."""
 
@@ -43,18 +35,25 @@ def auth_level(level: AuthLevel):
     return decorator
 
 
+def _iter_effective_routes(app: Any):
+    """Iterate path operation routes across supported FastAPI versions."""
+    routes = getattr(getattr(app, "router", None), "routes", None) or getattr(
+        app, "routes", []
+    )
+    try:
+        from fastapi.routing import iter_route_contexts
+    except ImportError:
+        return iter(routes)
+    return iter_route_contexts(routes)
+
+
 def _get_auth_level_from_app_and_scope(app: Any, scope: dict) -> AuthLevel:
     """Best-effort resolve auth level by matching the request to a route."""
     # Import lazily to keep this module unit-test friendly (FastAPI/Starlette are not
     # required unless you actually use the middleware / route matching).
     from starlette.routing import Match
 
-    # Prefer app.router.routes when available; fall back to app.routes.
-    routes = getattr(getattr(app, "router", None), "routes", None) or getattr(
-        app, "routes", []
-    )
-
-    for route in routes:
+    for route in _iter_effective_routes(app):
         try:
             match, child_scope = route.matches(scope)
         except Exception:
@@ -62,22 +61,16 @@ def _get_auth_level_from_app_and_scope(app: Any, scope: dict) -> AuthLevel:
         if match == Match.FULL:
             endpoint = child_scope.get("endpoint") or getattr(route, "endpoint", None)
             level = getattr(endpoint, "_auth_level", None)
-            return _normalize_auth_level(level)
+            return level if isinstance(level, AuthLevel) else AuthLevel.NORMAL
 
     return AuthLevel.NORMAL
 
 
 def app_has_admin_force_endpoints(app: Any) -> bool:
     """Return True if any route endpoint is marked as ADMIN_FORCE."""
-    routes = getattr(getattr(app, "router", None), "routes", None) or getattr(
-        app, "routes", []
-    )
-    for route in routes:
+    for route in _iter_effective_routes(app):
         endpoint = getattr(route, "endpoint", None)
-        if (
-            _normalize_auth_level(getattr(endpoint, "_auth_level", None))
-            == AuthLevel.ADMIN_FORCE
-        ):
+        if getattr(endpoint, "_auth_level", None) == AuthLevel.ADMIN_FORCE:
             return True
     return False
 

--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -25,6 +25,14 @@ class AuthLevel(str, Enum):
     ADMIN_FORCE = "admin_force"
 
 
+def _normalize_auth_level(level: Any) -> AuthLevel:
+    """Normalize route metadata that may come from a reloaded auth module."""
+    try:
+        return AuthLevel(level)
+    except (TypeError, ValueError):
+        return AuthLevel.NORMAL
+
+
 def auth_level(level: AuthLevel):
     """Mark endpoint with auth level (stored in endpoint metadata)."""
 
@@ -54,7 +62,7 @@ def _get_auth_level_from_app_and_scope(app: Any, scope: dict) -> AuthLevel:
         if match == Match.FULL:
             endpoint = child_scope.get("endpoint") or getattr(route, "endpoint", None)
             level = getattr(endpoint, "_auth_level", None)
-            return level if isinstance(level, AuthLevel) else AuthLevel.NORMAL
+            return _normalize_auth_level(level)
 
     return AuthLevel.NORMAL
 
@@ -66,7 +74,10 @@ def app_has_admin_force_endpoints(app: Any) -> bool:
     )
     for route in routes:
         endpoint = getattr(route, "endpoint", None)
-        if getattr(endpoint, "_auth_level", None) == AuthLevel.ADMIN_FORCE:
+        if (
+            _normalize_auth_level(getattr(endpoint, "_auth_level", None))
+            == AuthLevel.ADMIN_FORCE
+        ):
             return True
     return False
 

--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -90,14 +90,16 @@ def decide_request_auth(
       it must be rejected (403) even if api_key is provided.
 
     NOTE :
-    - Health/metrics endpoints are always allowed (even when api_key/admin_api_key is set),
-      to support k8s/liveness/readiness and Prometheus scraping without embedding secrets.
-    - We match them by prefix to cover common variants like /health_generate.
+    - Health/liveness/metrics endpoints are always allowed (even when
+      api_key/admin_api_key is set), to support k8s probes and Prometheus scraping
+      without embedding secrets.
+    - Health and metrics are matched by prefix to cover variants like
+      /health_generate. Liveness is matched exactly.
     """
     if method == "OPTIONS":
         return AuthDecision(allowed=True)
 
-    if path.startswith("/health") or path.startswith("/metrics"):
+    if path == "/liveness" or path.startswith("/health") or path.startswith("/metrics"):
         return AuthDecision(allowed=True)
 
     def _check_bearer_token(

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -1,12 +1,10 @@
 """Unit tests for srt/utils/auth.py — no server, no model loading."""
 
 import unittest
-from enum import Enum
 
 from sglang.srt.utils.auth import (
     AuthDecision,
     AuthLevel,
-    _normalize_auth_level,
     auth_level,
     decide_request_auth,
 )
@@ -33,15 +31,6 @@ class TestAuthLevel(CustomTestCase):
         self.assertIsInstance(AuthLevel.NORMAL, str)
         # str mixin allows direct comparison with string values
         self.assertEqual(AuthLevel.NORMAL, "normal")
-
-    def test_normalizes_equivalent_enum_from_reloaded_module(self):
-        class ReloadedAuthLevel(str, Enum):
-            ADMIN_FORCE = "admin_force"
-
-        self.assertEqual(
-            _normalize_auth_level(ReloadedAuthLevel.ADMIN_FORCE),
-            AuthLevel.ADMIN_FORCE,
-        )
 
 
 class TestAuthLevelDecorator(CustomTestCase):

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -1,10 +1,12 @@
 """Unit tests for srt/utils/auth.py — no server, no model loading."""
 
 import unittest
+from enum import Enum
 
 from sglang.srt.utils.auth import (
     AuthDecision,
     AuthLevel,
+    _normalize_auth_level,
     auth_level,
     decide_request_auth,
 )
@@ -31,6 +33,15 @@ class TestAuthLevel(CustomTestCase):
         self.assertIsInstance(AuthLevel.NORMAL, str)
         # str mixin allows direct comparison with string values
         self.assertEqual(AuthLevel.NORMAL, "normal")
+
+    def test_normalizes_equivalent_enum_from_reloaded_module(self):
+        class ReloadedAuthLevel(str, Enum):
+            ADMIN_FORCE = "admin_force"
+
+        self.assertEqual(
+            _normalize_auth_level(ReloadedAuthLevel.ADMIN_FORCE),
+            AuthLevel.ADMIN_FORCE,
+        )
 
 
 class TestAuthLevelDecorator(CustomTestCase):


### PR DESCRIPTION
## Summary

Add API key authentication to the Diffusion HTTP server by reusing the existing `sglang.srt.utils.auth` implementation.

This supersedes #23244, which was automatically closed due to inactivity, and updates the implementation for the current Diffusion server layout and FastAPI router behavior.

## Changes

- Add `--api-key` and `--admin-api-key` to Diffusion `ServerArgs`.
- Install the shared API key middleware in the Diffusion HTTP server.
- Require the normal API key for inference endpoints.
- Require the admin API key for sensitive management endpoints:
  - LoRA set, merge, and unmerge
  - Weight updates
  - Memory release and resume
- Keep `/liveness`, `/health*`, `/metrics*`, and CORS `OPTIONS` requests public.
- Support preserved/nested routers used by FastAPI 0.137+ when resolving endpoint authentication metadata.
- Add CPU-only parser and HTTP middleware tests.

## Validation

```bash
python3 -m pytest \
  python/sglang/multimodal_gen/test/unit/test_http_auth.py \
  test/registered/unit/utils/test_auth.py \
  -q \
  -p no:cacheprovider
```
Result: 
31 passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34801389889](https://github.com/sgl-project/sglang/actions/runs/34801389889)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34801389774](https://github.com/sgl-project/sglang/actions/runs/34801389774)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34801389846](https://github.com/sgl-project/sglang/actions/runs/34801389846)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->