### PR TITLE
docs(cookbook): compute MiniMax-H3's --sp-degree from ulysses x ring, not the world size

### DIFF
--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -691,7 +691,11 @@ return {
       const world = Number(s.nodes) * Number(s.gpus_per_node);
       const flags = ["--model-path {{MODEL_NAME}}"];
       if (world > 1) flags.push(`--num-gpus ${world}`);
-      if (topology.ring_degree > 1) flags.push(`--sp-degree ${world}`);
+      // The server requires sp_degree === ulysses * ring; validateTopology holds
+      // world === tp * ulysses * ring, so `world` is only correct at tp 1.
+      if (topology.ring_degree > 1) {
+        flags.push(`--sp-degree ${topology.ulysses_degree * topology.ring_degree}`);
+      }
       if (topology.tp_size > 1) flags.push(`--tp-size ${topology.tp_size}`);
       if (topology.ulysses_degree > 1) flags.push(`--ulysses-degree ${topology.ulysses_degree}`);
       if (topology.ring_degree > 1) flags.push(`--ring-degree ${topology.ring_degree}`);


### PR DESCRIPTION
The H3 panel's `resolveDeployment` emits `--sp-degree` as the world size whenever ring
parallelism is on. Its own `validateTopology` holds `world === tp * ulysses * ring`, and
the server requires `sp_degree === ring * ulysses`, so the world size is right only at
`tp 1`. With tensor and ring parallelism both selected, the command the panel renders
stops while resolving arguments:

```
ValueError: sp_degree (8) must equal ring_degree * ulysses_degree (2 * 2 = 4)
  python/sglang/multimodal_gen/runtime/server_args/server_args.py:3607
```

Nothing flags it in the UI: `validateTopology` accepts the topology, so the panel reports
"unverified", not "invalid". The four hand-written commands in `MiniMax-H3.mdx` already set
`--sp-degree` to ulysses × ring.

## Effect on the panel's commands

Enumerating every command the H3 panel renders for a topology it accepts, before and
after, gives 228,144 commands on each side. 63,504 change, all of them with `tp > 1` and
`ring > 1`, and each differs only in the `--sp-degree` value — no flag is added, removed
or reordered.

| | before | after |
|---|---|---|
| rejected at `server_args.py:3607` | 60,912 | 0 |
| resolves | 127,840 | 168,448 |

Of the 60,912, 40,608 now resolve. The other 20,304 all pick SageAttention and reach a
separate check, `MiniMax-H3 ring parallelism requires the FlashAttention backend`
(`configs/pipeline_configs/minimax_h3.py:257`), which already blocks the same pick on
other topologies — this change neither causes nor hides it. No command outside the
`sp_degree` group changes verdict, and the 127,008 `tp 1` commands are byte-identical
before and after, as they should be.

## What this is not verified against

Argument resolution only, on CPU. I have no H3 weights and no multi-GPU machine, so I have
not started a server on any of these recipes; I am not claiming that TP together with ring
parallelism works on H3, only that the flags the panel currently renders for it are
arithmetically inconsistent with the server. Reaching the affected commands also takes
opening "Advanced topology" and raising the tensor-parallel size above 1: no automatic
topology combines a tensor-parallel size above 1 with ring parallelism, so the automatic
recipes are unaffected.

Two other fixes would do as well or better, and I have no attachment to this one. Dropping
the flag entirely also works — `_adjust_parallelism` derives `sp_degree` as
`num_gpus / (dp * tp * cfg)`, which is the same value — and is arguably the better shape
if the panel should not be restating something the server computes. And since
`MiniMax-H3.mdx` lists no verified TP + ring recipe, if the intent is that the panel should
not offer that combination at all, disabling it is better than either. Happy to close in
favour of whichever you prefer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33766343802](https://github.com/sgl-project/sglang/actions/runs/33766343802)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33766343511](https://github.com/sgl-project/sglang/actions/runs/33766343511)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->