### PR TITLE
fix: release LoRA adapter on request abort

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3256,6 +3256,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         }
         del self.rid_to_state[recv_obj.rid]
 
+        # Release the LoRA adapter so aborted requests don't pin it forever.
+        if self.enable_lora and state.obj.lora_path:
+            asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+
         state.out_list.append(out)
         state.event.set()
 


### PR DESCRIPTION
## Summary

Fixes #34205.

When a request is aborted, `_handle_abort_req` deletes the request state from `rid_to_state` but never releases the LoRA adapter reference acquired earlier by `_resolve_lora_path()` via `lora_registry.acquire()`. The adapter stays pinned in the registry forever, blocking dynamic unload/eviction.

**Root cause:** The normal completion path in `_handle_batch_output` (line 2480) calls `lora_registry.release()`, but the abort path has no matching release.

**Fix:** Mirror the existing release pattern — call `lora_registry.release` via `asyncio.create_task` after removing the state, same as `_handle_batch_output` already does.

## Test plan

- [x] Code inspection: release pattern matches existing `_handle_batch_output` (line 2480)
- [x] Guard conditions (`enable_lora` and `state.obj.lora_path`) match the acquire path
- [ ] Load test with LoRA adapter + request cancellation to verify adapter slot is freed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33787535076](https://github.com/sgl-project/sglang/actions/runs/33787535076)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33787534797](https://github.com/sgl-project/sglang/actions/runs/33787534797)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33787535084](https://github.com/sgl-project/sglang/actions/runs/33787535084)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->