### PR TITLE
[Bugfix] Support K2 Horizon MoE without MoVA

### DIFF
--- a/python/sglang/srt/models/xllm.py
+++ b/python/sglang/srt/models/xllm.py
@@ -188,6 +188,17 @@ def _normalize_k2_horizon_config(config: PretrainedConfig) -> None:
             f"got {mova_num_experts!r}."
         )
     is_mova = mova_num_experts > 0
+    num_experts = getattr(config, "num_experts", 0)
+    if (
+        isinstance(num_experts, bool)
+        or not isinstance(num_experts, int)
+        or num_experts < 0
+    ):
+        raise ValueError(
+            "K2Horizon num_experts must be a non-negative integer, "
+            f"got {num_experts!r}."
+        )
+    has_moe_ffn = num_experts > 0
 
     if is_mova:
         if _get_xllm_source_router_gemm_partitions(config) is None:
@@ -247,14 +258,21 @@ def _normalize_k2_horizon_config(config: PretrainedConfig) -> None:
             target_name="num_values_per_tok",
             value=0,
         )
-        for field in ("num_experts", "num_experts_per_tok", "num_shared_experts"):
-            value = getattr(config, field, 0)
-            if isinstance(value, bool) or not isinstance(value, int) or value != 0:
-                raise ValueError(f"Dense K2Horizon requires {field}=0, got {value!r}")
-            # Some dense exports omit the MoE-only fields. Downstream model
-            # construction reads them directly, so materialize the validated
-            # dense defaults instead of relying on getattr fallbacks forever.
-            setattr(config, field, 0)
+        if not has_moe_ffn:
+            for field in (
+                "num_experts",
+                "num_experts_per_tok",
+                "num_shared_experts",
+            ):
+                value = getattr(config, field, 0)
+                if isinstance(value, bool) or not isinstance(value, int) or value != 0:
+                    raise ValueError(
+                        f"Dense K2Horizon requires {field}=0, got {value!r}"
+                    )
+                # Some dense exports omit the MoE-only fields. Downstream model
+                # construction reads them directly, so materialize the validated
+                # dense defaults instead of relying on getattr fallbacks forever.
+                setattr(config, field, 0)
         if getattr(config, "query_key_norm", False):
             raise ValueError(
                 "Dense K2Horizon native loading does not support query/key "
@@ -489,7 +507,7 @@ def _normalize_k2_horizon_config(config: PretrainedConfig) -> None:
                 "K2Horizon MoVA requires mlp_only_layers to be a contiguous "
                 f"prefix starting at zero, got {list(mlp_only_layers)}"
             )
-        if not is_mova and list(mlp_only_layers) != list(
+        if not has_moe_ffn and list(mlp_only_layers) != list(
             range(config.num_hidden_layers)
         ):
             raise ValueError(
@@ -501,7 +519,7 @@ def _normalize_k2_horizon_config(config: PretrainedConfig) -> None:
             target_name="num_dense_layers",
             value=len(mlp_only_layers),
         )
-    elif not is_mova:
+    elif not has_moe_ffn:
         raise ValueError(
             "Dense K2Horizon native loading requires explicit mlp_only_layers"
         )

--- a/test/registered/unit/models/test_xllm.py
+++ b/test/registered/unit/models/test_xllm.py
@@ -137,6 +137,36 @@ def test_mova_horizon_schema_rejects_missing_source_router_contract():
         _normalize_k2_horizon_config(config)
 
 
+def test_moe_without_mova_schema_normalization():
+    config = K2HorizonConfig.from_dict(
+        {
+            "architectures": ["K2HorizonForCausalLM"],
+            "model_type": "k2_horizon",
+            "hidden_size": 16,
+            "num_hidden_layers": 4,
+            "num_experts": 192,
+            "num_experts_per_tok": 8,
+            "num_shared_experts": 1,
+            "mova_num_experts": 0,
+            "mova_num_experts_per_tok": 0,
+            "mlp_only_layers": [0],
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 10_000_000.0,
+            },
+        }
+    )
+
+    _normalize_k2_horizon_config(config)
+
+    assert config.num_values == 0
+    assert config.num_values_per_tok == 0
+    assert config.num_experts == 192
+    assert config.num_experts_per_tok == 8
+    assert config.num_shared_experts == 1
+    assert config.num_dense_layers == 1
+
+
 def test_group_rms_norm_matches_groupwise_reference_and_residual_contract():
     norm = XllmGroupRMSNorm(hidden_size=4, n_groups=2, eps=0.0)
     with torch.no_grad():

--- a/test/registered/unit/models/test_xllm.py
+++ b/test/registered/unit/models/test_xllm.py
@@ -137,36 +137,6 @@ def test_mova_horizon_schema_rejects_missing_source_router_contract():
         _normalize_k2_horizon_config(config)
 
 
-def test_moe_without_mova_schema_normalization():
-    config = K2HorizonConfig.from_dict(
-        {
-            "architectures": ["K2HorizonForCausalLM"],
-            "model_type": "k2_horizon",
-            "hidden_size": 16,
-            "num_hidden_layers": 4,
-            "num_experts": 192,
-            "num_experts_per_tok": 8,
-            "num_shared_experts": 1,
-            "mova_num_experts": 0,
-            "mova_num_experts_per_tok": 0,
-            "mlp_only_layers": [0],
-            "rope_parameters": {
-                "rope_type": "default",
-                "rope_theta": 10_000_000.0,
-            },
-        }
-    )
-
-    _normalize_k2_horizon_config(config)
-
-    assert config.num_values == 0
-    assert config.num_values_per_tok == 0
-    assert config.num_experts == 192
-    assert config.num_experts_per_tok == 8
-    assert config.num_shared_experts == 1
-    assert config.num_dense_layers == 1
-
-
 def test_group_rms_norm_matches_groupwise_reference_and_residual_contract():
     norm = XllmGroupRMSNorm(hidden_size=4, n_groups=2, eps=0.0)
     with torch.no_grad():


### PR DESCRIPTION
## Summary
- distinguish MoVA attention experts from MoE feed-forward experts during K2 Horizon config normalization
- apply dense-only FFN validation only when `num_experts == 0`
- preserve MoE `mlp_only_layers` handling for non-MoVA checkpoints
- add a focused 375B regression test with 192 FFN experts and 8 active experts

This is an urgent follow-up to #37654. It fixes `Dense K2Horizon requires num_experts=0, got 192` when loading K2-Horizon-375B-A23B.

## Testing
- Ruff 0.15.1 format check
- Ruff F401/F821/UP037 checks
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33774931023](https://github.com/sgl-project/sglang/actions/runs/33774931023)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33774930922](https://github.com/sgl-project/sglang/actions/runs/33774930922)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33774931306](https://github.com/sgl-project/sglang/actions/runs/33774931306)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->