### PR TITLE
Add --offload-embedding-to-host: keep the input embedding table in pinned host memory

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -2337,6 +2337,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`cpu`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
     </tr>
+        <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--offload-embedding-to-host`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Keep the input embedding table in page-locked host memory instead of device memory; rows are gathered directly from the host over PCIe (zero-copy, CUDA-graph safe). Frees device memory equal to the table size for a few microseconds per forward. CUDA only, unquantized embeddings only.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: bool</td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/kernels/ops/embeddings/__init__.py
+++ b/python/sglang/kernels/ops/embeddings/__init__.py
@@ -14,4 +14,14 @@ register_kernel(
     )
 )
 
+register_kernel(
+    KernelSpec(
+        op="embeddings.host_embedding_gather",
+        backend=KernelBackend.TRITON,
+        target=(
+            "sglang.kernels.ops.embeddings.host_embedding_gather:host_embedding_gather"
+        ),
+    )
+)
+
 __all__ = []

--- a/python/sglang/kernels/ops/embeddings/host_embedding_gather.py
+++ b/python/sglang/kernels/ops/embeddings/host_embedding_gather.py
@@ -1,0 +1,91 @@
+"""Zero-copy gather of embedding rows from a page-locked host table.
+
+The embedding table stays in pinned host memory and the GPU reads the requested
+rows directly over PCIe through unified virtual addressing (UVA). Compared with
+a host-side ``index_select`` followed by a device copy, this needs no
+host/device synchronisation and no staging buffer, and the launch is a plain
+kernel launch, so it can be captured in a CUDA graph.
+
+A decode step gathers a handful of rows (a few microseconds); a 1024-token
+prefill chunk moves ~10 MB for a 5120-wide table and runs at PCIe bandwidth
+(~0.4 ms on PCIe 4.0 x16).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+_TORCH_TO_TRITON_DTYPE = {
+    torch.float32: tl.float32,
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+}
+
+
+@triton.jit
+def _host_embedding_gather_kernel(
+    input_ptr,
+    # Raw host address of the pinned table, cast to a typed pointer below. The
+    # launcher receives a plain integer so no device-placement check is applied
+    # to what is, from PyTorch's point of view, a CPU tensor.
+    table_addr,
+    out_ptr,
+    hidden_dim: tl.constexpr,
+    table_stride0: tl.constexpr,
+    DTYPE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    # Widen first: Triton specialises small integer arguments to i32 and
+    # int_to_ptr needs a 64-bit operand.
+    table_ptr = table_addr.to(tl.int64).to(tl.pointer_type(DTYPE))
+    row = tl.program_id(0).to(tl.int64)
+    col_block = tl.program_id(1)
+    cols = col_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    col_mask = cols < hidden_dim
+
+    token = tl.load(input_ptr + row).to(tl.int64)
+    vals = tl.load(table_ptr + token * table_stride0 + cols, mask=col_mask, other=0.0)
+    tl.store(out_ptr + row * hidden_dim + cols, vals, mask=col_mask)
+
+
+def host_embedding_gather(input_: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+    """Return ``table[input_]`` where ``table`` lives in pinned host memory.
+
+    ``input_`` is a CUDA int32/int64 tensor of any shape; the result has shape
+    ``(*input_.shape, hidden_dim)`` on the same device with the table's dtype.
+    Out-of-range ids are not checked here (the caller masks or asserts them):
+    an out-of-range host read is an illegal address for the GPU.
+    """
+    assert input_.is_cuda
+    assert input_.dtype in (torch.int32, torch.int64)
+    assert table.device.type == "cpu"
+    # cudaPointerGetAttributes is not a stream op, but keep it out of capture
+    # anyway: the table's residency is fixed for the process lifetime.
+    if not torch.cuda.is_current_stream_capturing():
+        assert table.is_pinned(), "host embedding table must be in pinned memory"
+    assert table.ndim == 2
+    assert table.stride(1) == 1
+    assert table.dtype in _TORCH_TO_TRITON_DTYPE
+
+    input_ = input_.contiguous()
+    hidden_dim = table.shape[1]
+    output = torch.empty(
+        (*input_.shape, hidden_dim), dtype=table.dtype, device=input_.device
+    )
+    n_tokens = input_.numel()
+    if n_tokens == 0:
+        return output
+
+    block_h = min(1024, triton.next_power_of_2(hidden_dim))
+    grid = (n_tokens, triton.cdiv(hidden_dim, block_h))
+    _host_embedding_gather_kernel[grid](
+        input_,
+        table.data_ptr(),
+        output,
+        hidden_dim,
+        table.stride(0),
+        DTYPE=_TORCH_TO_TRITON_DTYPE[table.dtype],
+        BLOCK_H=block_h,
+        num_warps=4,
+    )
+    return output

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.6.3.post1/vllm/model_executor/layers/vocab_parallel_embedding.py
 
+import contextlib
 import logging
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
@@ -9,6 +10,9 @@ from typing import List, Optional, Sequence, Tuple
 import torch
 from torch.nn.parameter import Parameter, UninitializedParameter
 
+from sglang.kernels.ops.embeddings.host_embedding_gather import (
+    host_embedding_gather,
+)
 from sglang.kernels.ops.embeddings.vocab_parallel_embedding import (
     vocab_parallel_embedding as fused_vocab_parallel_embedding,
 )
@@ -35,7 +39,7 @@ from sglang.srt.layers.quantization.base_config import (
     method_has_implemented_embedding,
 )
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_compiler_backend,
@@ -46,6 +50,36 @@ from sglang.srt.utils import (
 from sglang.srt.utils.async_probe import maybe_detect_oob
 
 DEFAULT_VOCAB_PADDING_SIZE = 64
+
+# Tables below this size stay on the device when host offload is requested:
+# a PCIe read buys nothing for a vision tower's position table.
+HOST_OFFLOAD_MIN_BYTES = 64 << 20
+
+
+def _host_offload_requested() -> bool:
+    """``--offload-embedding-to-host``; False when no config is published
+    (layers built outside a server, e.g. in unit tests)."""
+    try:
+        return bool(get_exec().offload.offload_embedding_to_host)
+    except Exception:
+        return False
+
+
+def _config_ties_word_embeddings() -> bool:
+    """Return True when the model config sets ``tie_word_embeddings``.
+
+    Tied embeddings share their ``nn.Parameter`` with the LM head, so
+    moving the embedding to the host would also move the logits weight and
+    break the sampler's device matmul.
+    """
+    try:
+        from sglang.srt.runtime_context import get_server_args
+
+        hf_config = get_server_args().get_model_config().hf_config
+        return bool(getattr(hf_config, "tie_word_embeddings", False))
+    except Exception:
+        return False
+
 
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
@@ -244,6 +278,7 @@ class VocabParallelEmbedding(torch.nn.Module):
     ):
         super().__init__()
         self.quant_config = quant_config
+        self.prefix = prefix
 
         self.enable_tp = enable_tp
         self.use_attn_tp_group = use_attn_tp_group
@@ -335,15 +370,44 @@ class VocabParallelEmbedding(torch.nn.Module):
             - self.shard_indices.added_vocab_start_index
         )
 
-        self.quant_method.create_weights(
-            self,
-            self.embedding_dim,
-            [self.num_embeddings_per_partition],
-            self.embedding_dim,
-            self.num_embeddings_padded,
-            params_dtype=params_dtype,
-            weight_loader=self.weight_loader,
+        # Input-embedding layers only (an LM head feeds a matmul). When the
+        # table is to live on the host, build it there straight away: a device
+        # tensor created and dropped here would only sit in the allocator cache
+        # (the caching allocator does not hand its pieces to the layers built
+        # afterwards), and the free-memory measurement that sizes the KV pool
+        # would never see it.
+        place_on_host = (
+            is_embedding_layer
+            and _host_offload_requested()
+            and isinstance(quant_method, UnquantizedEmbeddingMethod)
+            and params_dtype in (torch.float32, torch.float16, torch.bfloat16)
+            and self.num_embeddings_per_partition
+            * embedding_dim
+            * torch.empty((), dtype=params_dtype, device="cpu").element_size()
+            >= HOST_OFFLOAD_MIN_BYTES
+            # Meta-device construction is materialised later; the post-load
+            # fallback (offload_weight_to_host) takes over in that case.
+            and torch.empty(()).device.type == "cuda"
+            # Tied embeddings share their Parameter with an LM head; moving
+            # the table to the host would break the logits matmul.  The
+            # model config is not always reachable here, but _host_offload
+            # is only called from VocabParallelEmbedding.__init__ where the
+            # caller has not yet called tie_weights, so the tie is unknown.
+            # We conservatively check the HF config when available.
+            and not _config_ties_word_embeddings()
         )
+        with torch.device("cpu") if place_on_host else contextlib.nullcontext():
+            self.quant_method.create_weights(
+                self,
+                self.embedding_dim,
+                [self.num_embeddings_per_partition],
+                self.embedding_dim,
+                self.num_embeddings_padded,
+                params_dtype=params_dtype,
+                weight_loader=self.weight_loader,
+            )
+        if place_on_host:
+            self._pin_host_weight()
 
     @classmethod
     def _get_indices(
@@ -526,6 +590,102 @@ class VocabParallelEmbedding(torch.nn.Module):
             and self.weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
         )
 
+    def _pin_host_weight(self) -> None:
+        """Replace a pageable host table with a page-locked copy the GPU can
+        read (see ``host_embedding_gather``)."""
+        weight = self.weight
+        assert weight.device.type == "cpu"
+        self.weight.data = weight.data.pin_memory()
+        self._host_weight_verified = True
+        logger.info(
+            "Embedding table %s created in pinned host memory (%.2f GiB)",
+            self.prefix or type(self).__name__,
+            weight.numel() * weight.element_size() / (1 << 30),
+        )
+
+    def offload_weight_to_host(self) -> int:
+        """Move the embedding table to page-locked host memory.
+
+        The lookup then gathers rows straight from the host over PCIe
+        (:func:`host_embedding_gather`), so the table costs no device memory
+        and no host/device synchronisation. Returns the number of device bytes
+        released, 0 if nothing was moved. Only unquantized fp32/fp16/bf16
+        tables living on a CUDA device are eligible.
+        """
+        weight = self.weight
+        if not weight.is_cuda:
+            return 0
+        if weight.numel() * weight.element_size() < HOST_OFFLOAD_MIN_BYTES:
+            return 0
+        if not isinstance(self.quant_method, UnquantizedEmbeddingMethod):
+            logger.warning(
+                "Not offloading %s to host: quantized embedding method %s",
+                type(self).__name__,
+                type(self.quant_method).__name__,
+            )
+            return 0
+        if weight.ndim != 2 or weight.dtype not in (
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+        ):
+            logger.warning(
+                "Not offloading %s to host: unsupported weight %s %s",
+                type(self).__name__,
+                tuple(weight.shape),
+                weight.dtype,
+            )
+            return 0
+        host = torch.empty(
+            weight.shape, dtype=weight.dtype, device="cpu", pin_memory=True
+        )
+        host.copy_(weight)
+        nbytes = weight.numel() * weight.element_size()
+        # Keep the Parameter object (weight_loader and friends hang off it);
+        # only its storage moves. The device copy dies with `weight`.
+        self.weight.data = host
+        self._host_weight_verified = True
+        logger.info(
+            "Embedding table %s moved to pinned host memory (%.2f GiB)",
+            self.prefix or type(self).__name__,
+            nbytes / (1 << 30),
+        )
+        return nbytes
+
+    def _weight_is_host_resident(self, input_: torch.Tensor) -> bool:
+        if self.weight.device.type != "cpu" or not input_.is_cuda:
+            return False
+        if not getattr(self, "_host_weight_verified", False):
+            # The table can also arrive through weight sharing (a draft model
+            # handed the target's embedding); make sure the GPU may read it.
+            if not self.weight.is_pinned():
+                raise RuntimeError(
+                    "VocabParallelEmbedding weight is on the host but not pinned; "
+                    "CUDA inputs cannot be embedded from pageable memory."
+                )
+            self._host_weight_verified = True
+        return True
+
+    def _embed_local_shard_from_host(
+        self, input_: torch.Tensor, symm_alloc
+    ) -> torch.Tensor:
+        """Host-resident table: same contract as ``_embed_local_shard``."""
+        if self.tp_size == 1:
+            with symm_alloc:
+                return host_embedding_gather(input_, self.weight)
+        masked_input, input_mask = get_masked_input_and_mask(
+            input_,
+            self.shard_indices.org_vocab_start_index,
+            self.shard_indices.org_vocab_end_index,
+            self.shard_indices.num_org_vocab_padding,
+            self.shard_indices.added_vocab_start_index,
+            self.shard_indices.added_vocab_end_index,
+        )
+        with symm_alloc:
+            output_parallel = host_embedding_gather(masked_input, self.weight)
+        output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
+        return output_parallel
+
     def _embed_local_shard(self, input_: torch.Tensor) -> torch.Tensor:
         """Embed against the local vocab shard; out-of-shard rows are zero
         (identity when tp_size == 1).
@@ -537,6 +697,8 @@ class VocabParallelEmbedding(torch.nn.Module):
         symm_alloc = use_symmetric_memory(
             get_tp_group(), disabled=not is_allocation_symmetric()
         )
+        if self._weight_is_host_resident(input_):
+            return self._embed_local_shard_from_host(input_, symm_alloc)
         if self.tp_size == 1:
             with symm_alloc:
                 return self.quant_method.embedding(self, input_.long())
@@ -588,6 +750,42 @@ class VocabParallelEmbedding(torch.nn.Module):
         if self.enable_tp:
             s += f", tp_size={self.tp_size}"
         return s
+
+
+def offload_input_embeddings_to_host(
+    model: torch.nn.Module,
+) -> List[Tuple[str, int]]:
+    """Offload any input-embedding table of ``model`` still on the device.
+
+    Tables are normally placed on the host at construction (see
+    ``VocabParallelEmbedding.__init__``); this catches the ones built on a
+    meta device and materialised later. LM heads (``ParallelLMHead``) are
+    left alone: they feed a matmul, not a gather. Embeddings that share
+    their weight tensor with an LM head (``tie_word_embeddings``) are also
+    skipped, because moving the shared tensor would break the logits matmul.
+    Returns ``(module_name, device_bytes_released)`` per table moved.
+    """
+    # Collect data pointers of all LM-head weights so we can detect ties.
+    lm_head_ptrs: set = set()
+    for module in model.modules():
+        if isinstance(module, ParallelLMHead):
+            w = getattr(module, "weight", None)
+            if w is not None:
+                lm_head_ptrs.add(w.data.data_ptr())
+
+    moved = []
+    for name, module in model.named_modules():
+        if not isinstance(module, VocabParallelEmbedding) or isinstance(
+            module, ParallelLMHead
+        ):
+            continue
+        if module.weight.data.data_ptr() in lm_head_ptrs:
+            logger.info("Not offloading %s: weight is tied with an LM head", name)
+            continue
+        nbytes = module.offload_weight_to_host()
+        if nbytes:
+            moved.append((name, nbytes))
+    return moved
 
 
 class ParallelLMHead(VocabParallelEmbedding):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1142,6 +1142,38 @@ class ModelRunner:
     def init_shared_mooncake_transfer_engine(self):
         maybe_init_shared_mooncake_transfer_engine(gpu_id=self.gpu_id)
 
+    def _offload_input_embeddings_to_host(self) -> None:
+        """``--offload-embedding-to-host``: make sure the input embedding
+        table(s) live in pinned host memory. They are normally placed there at
+        construction; this moves any table that still sits on the device (built
+        on a meta device, materialised at load) before the free-memory
+        measurement that sizes the KV pool."""
+        if self.device != "cuda":
+            raise ValueError("--offload-embedding-to-host requires a CUDA device")
+        from sglang.srt.layers.vocab_parallel_embedding import (
+            ParallelLMHead,
+            VocabParallelEmbedding,
+            offload_input_embeddings_to_host,
+        )
+
+        moved = offload_input_embeddings_to_host(self.model)
+        for name, nbytes in moved:
+            logger.info(
+                f"Offloaded input embedding {name} ({nbytes / (1 << 30):.2f} GB) "
+                "to pinned host memory after loading"
+            )
+        on_host = [
+            name
+            for name, module in self.model.named_modules()
+            if isinstance(module, VocabParallelEmbedding)
+            and not isinstance(module, ParallelLMHead)
+            and module.weight.device.type == "cpu"
+        ]
+        if not on_host:
+            logger.warning(
+                "--offload-embedding-to-host: no eligible input embedding table found"
+            )
+
     def load_model(self):
         tic_total = time.perf_counter()
         before_avail_memory = get_available_gpu_memory(self.device, self.gpu_id)
@@ -1202,6 +1234,8 @@ class ModelRunner:
 
         if not self.is_draft_worker:
             get_offloader().post_init()
+            if get_exec().offload.offload_embedding_to_host:
+                self._offload_input_embeddings_to_host()
 
         self.maybe_precompile_model_kernels_after_loading()
 

--- a/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
+++ b/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
@@ -86,6 +86,7 @@ class StartupWeightLoadOptions:
     ep_size: int
     cpu_offload_gb: int
     offload_group_size: int
+    offload_embedding_to_host: bool
     enable_memory_saver: bool
     enable_weights_cpu_backup: bool
     enable_lora: bool
@@ -127,6 +128,7 @@ class StartupWeightLoadOptions:
             ep_size=get_parallel().ep_size,
             cpu_offload_gb=get_exec().offload.cpu_offload_gb,
             offload_group_size=get_exec().offload.offload_group_size,
+            offload_embedding_to_host=get_exec().offload.offload_embedding_to_host,
             enable_memory_saver=get_exec().features.enable_memory_saver,
             enable_weights_cpu_backup=get_exec().features.enable_weights_cpu_backup,
             enable_lora=get_lora().enable_lora,
@@ -375,6 +377,10 @@ class StartupWeightLoadManager:
             (
                 options.offload_group_size > 0,
                 "layer-group offloading is not supported",
+            ),
+            (
+                options.offload_embedding_to_host,
+                "embedding host offload is not supported",
             ),
             (options.enable_memory_saver, "memory saver is not supported"),
             (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3083,6 +3083,15 @@ class ServerArgs:
         int, "Steps to prefetch in offloading.", NS("exec.offload")
     ] = 1
     offload_mode: A[str, "Mode of offloading.", NS("exec.offload")] = "cpu"
+    offload_embedding_to_host: A[
+        bool,
+        "Keep the input embedding table in page-locked host memory instead of "
+        "device memory; rows are gathered directly from the host over PCIe "
+        "(zero-copy, CUDA-graph safe). Frees device memory equal to the table "
+        "size for a few microseconds per forward. CUDA only, unquantized "
+        "embeddings only.",
+        NS("exec.offload"),
+    ] = False
 
     # -------------------------------------------------------------------------
     # LMCache

--- a/test/registered/kernels/ops/embeddings/test_host_embedding_gather.py
+++ b/test/registered/kernels/ops/embeddings/test_host_embedding_gather.py
@@ -1,0 +1,80 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.ops.embeddings.host_embedding_gather import host_embedding_gather
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for this test."
+)
+
+
+def _run_case(input_ids, table):
+    # The gather must be bit-exact with a plain device-side lookup.
+    expected = F.embedding(input_ids.long(), table.cuda())
+    actual = host_embedding_gather(input_ids, table)
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    assert actual.is_contiguous()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("input_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("hidden_dim", [7, 128, 5120])
+def test_host_embedding_gather(dtype, input_dtype, hidden_dim):
+    table = torch.randn((64, hidden_dim), dtype=dtype).pin_memory()
+    input_ids = torch.tensor([0, 63, 5, 5, 17], dtype=input_dtype, device="cuda")
+    _run_case(input_ids, table)
+    # Any input shape is allowed; the hidden dim is appended.
+    _run_case(input_ids.view(5, 1).expand(5, 3).contiguous(), table)
+    # Non-contiguous ids are handled by the wrapper.
+    _run_case(torch.arange(0, 64, device="cuda", dtype=input_dtype)[::4], table)
+
+
+def test_host_embedding_gather_empty_input():
+    table = torch.randn((8, 16), dtype=torch.bfloat16).pin_memory()
+    ids = torch.empty((0,), dtype=torch.int64, device="cuda")
+    out = host_embedding_gather(ids, table)
+    assert out.shape == (0, 16) and out.dtype == torch.bfloat16 and out.is_cuda
+
+
+def test_host_embedding_gather_cuda_graph():
+    # The whole point of reading the host table from the GPU: no host-side
+    # work per lookup, so the launch can live inside a captured graph.
+    table = torch.randn((256, 128), dtype=torch.bfloat16).pin_memory()
+    static_ids = torch.zeros((9,), dtype=torch.int64, device="cuda")
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            host_embedding_gather(static_ids, table)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_out = host_embedding_gather(static_ids, table)
+    for _ in range(3):
+        ids = torch.randint(0, 256, (9,), device="cuda")
+        static_ids.copy_(ids)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            static_out, F.embedding(ids, table.cuda()), rtol=0, atol=0
+        )
+
+
+def test_host_embedding_gather_rejects_pageable_table():
+    # A pageable table would be an illegal address for the GPU; refuse it
+    # before launching anything.
+    table = torch.randn((8, 16), dtype=torch.bfloat16)
+    ids = torch.zeros((2,), dtype=torch.int64, device="cuda")
+    with pytest.raises(AssertionError, match="pinned"):
+        host_embedding_gather(ids, table)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# Add `--offload-embedding-to-host`: keep the input embedding table in pinned host memory

## Motivation

The input embedding of a large-vocabulary model is a sizeable BF16 table that is only ever read a few rows at a time: 248,320 x 5,120 = 2.37 GiB for Qwen3.8-27B. On a single consumer GPU that is KV-cache memory. This PR lets the table live in page-locked host memory and gathers the requested rows straight from the host through UVA with a small Triton kernel, so the device never holds it.

This is the same mechanism as the PLE host offload of #36497 (`Qwen4ExpPinnedHostEmbedding`, restricted to the Qwen4-Exp n-gram table); here it is applied to the regular `embed_tokens` of any model through `VocabParallelEmbedding`, so the two are complementary and touch different files.

Related to #36497 (model-specific PLE table vs. generic `embed_tokens` here), #37068 / #36567 (PLE table backends stacked on #36497), #36514 (asks for a generic `--offload-module`; this PR is host-only and could be folded into that interface), #35626 (prior art: large vocab tables kept on the host in the diffusion runtime, pure Python), #24531 (OffloaderV2 all-weights offload; this PR is a narrower CUDA-graph-safe path for the embedding table only). Prior art elsewhere: llama.cpp keeps the input layer on the CPU by default; vLLM #54371 (UVA PLE offload).

## Modifications

- `python/sglang/kernels/ops/embeddings/host_embedding_gather.py` (new): Triton gather reading a pinned host table through its raw address (UVA). No host-side gather, no staging copy, no host/device synchronisation; the launch is a plain kernel launch and is captured in CUDA graphs. Registered in the kernel registry as `embeddings.host_embedding_gather`.
- `VocabParallelEmbedding`: when `--offload-embedding-to-host` is set, input-embedding layers (not `ParallelLMHead`) create their weight on the CPU and pin it, before any weight is loaded, so the device never allocates it and the free-memory measurement that sizes the KV pool sees the full saving. `_embed_local_shard` routes host-resident tables to the gather (TP > 1 keeps the existing masked path). A post-load fallback (`offload_weight_to_host`) handles tables built on a meta device. Tables under 64 MiB stay on the device (e.g. a vision tower's position table). Quantized embeddings are left alone with a warning.
- `ModelRunner.load_model`: applies the fallback and logs what lives on the host.
- `--offload-embedding-to-host` (server arg, `exec.offload` namespace), excluded from the startup weight prefetch path, documented in `server_arguments.mdx`.
- Unit test: `test/registered/kernels/ops/embeddings/test_host_embedding_gather.py` (bit-exact vs `F.embedding`, int32/int64 ids, 1-D/2-D ids, empty input, CUDA-graph capture, pageable table rejected).

## Accuracy Tests

Qwen3.8-27B NVFP4 + DFlash2 draft (NVFP4), RTX 5090, greedy, thinking disabled: outputs are byte-identical with and without the flag across five server launches (text, 3K/8.5K-token conversations, prefix reuse, and an image request through the multimodal path). The unit test asserts bit-exactness of the gather.

## Speed Tests and Profiling

Micro-benchmark (RTX 5090 on PCIe 4.0 x16, 248,320 x 5,120 bf16 table):

| rows gathered | device table | host table (this kernel) |
|---|---|---|
| 9 (decode/verify step) | 4.3 us | 6.4 us |
| 64 | 4.5 us | 26.8 us |
| 1024 (prefill chunk) | 6.3 us | 394 us (10 MB at PCIe bandwidth) |

End to end (Qwen3.8-27B NVFP4, DFlash2, single request, temperature 0.7 so within sampling noise): 205-246 tok/s baseline vs 209-282 tok/s with the flag; bench.py TTFT unchanged. Request latency at equal work (temperature 0, 18-token and 1857-token prompts, 1 and 64 output tokens): unchanged.

Memory: weights on device 17.10 GB -> 14.73 GB, KV pool 132,016 -> 174,553 tokens (fp8 KV, hybrid GDN model). With `--enable-memory-saver` the gain is smaller (130,378 -> 157,955): the weights region is a MemPool that keeps freed blocks, so only same-region allocations reuse them.

Notes for reviewers:
- Host RAM: the table is pinned; with `--hicache-ratio` the larger KV pool also grows the host pool, so hosts with little RAM may need `--hicache-size`.
- TP > 1 uses the same masked path as the device lookup but was not exercised (single GPU).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with Claude Code

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33769791922](https://github.com/sgl-project/sglang/actions/runs/33769791922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33769792441](https://github.com/sgl-project/sglang/actions/runs/33769792441)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33769792111](https://github.com/sgl-project/sglang/actions/runs/33769792111)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->