### PR TITLE
Support --language-model-only for Qwen3.5 VL checkpoints

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -248,6 +248,16 @@ class MRotaryEmbedding(RotaryEmbedding):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         assert positions.ndim == 1 or positions.ndim == 2
         self._match_cos_sin_cache_dtype(query)
+        if (
+            positions.ndim == 1
+            and self.mrope_section
+            and fused_set_kv_buffer_arg is None
+        ):
+            # Text-only callers hand over plain 1-D positions (for instance a
+            # VLM served with --language-model-only). The mrope axes are then
+            # all equal, so replicate them and take the fused Triton kernel
+            # instead of the much slower native fallback.
+            positions = positions.unsqueeze(0).expand(3, -1)
         if positions.ndim == 2 and self.mrope_section:
             return self.forward_triton(positions, query, key)
         return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2174,6 +2174,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            if self.visual is None and "visual" in name:
+                # --language-model-only: no vision tower was built.
+                continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3775,7 +3775,12 @@ class ServerArgs:
 
     # ===== END TO BE REFACTORED ====
 
-    LANGUAGE_MODEL_ONLY_ARCHITECTURES = ("MuseGlimmerForConditionalGeneration",)
+    LANGUAGE_MODEL_ONLY_ARCHITECTURES = (
+        "MuseGlimmerForConditionalGeneration",
+        # Qwen3VLForConditionalGeneration already builds without its vision
+        # tower when config.language_model_only is set.
+        "Qwen3_5ForConditionalGeneration",
+    )
 
     # The attention-backend allow-list is enforced via
     # --enable-page-major-kv-layout (implied by the unified pool in


### PR DESCRIPTION
# Support `--language-model-only` for Qwen3.5 VL checkpoints

## Motivation

`--language-model-only` skips the multimodal encoder entirely and frees its memory for the KV cache, but `server_args` only allows it for `MuseGlimmerForConditionalGeneration` (allowlist introduced in #34262). `Qwen3VLForConditionalGeneration` already builds without its vision tower when `config.language_model_only` is set (#22867), so Qwen3.5 VL checkpoints served for text only can use the flag too. On Qwen3.8-27B the vision tower is 0.88 GiB.

Builds on #34262 (allowlist) and #22867 (config-driven support in `qwen3_5.py` / `qwen3_vl.py`). Related to #28194 (umbrella issue: skip multimodal weights to free GPU memory), #27212 (text-only Qwen3.5 checkpoints, closed by the stale bot), #28497 (earlier generic attempt, open), #32425 (same opt-in pattern for Gemma4), and #35345 / #35744 (adjacent fused-kernel dispatch fix in `MRotaryEmbedding`). Note: #31081 and #34479 touch the same files through the `--language-only` encoder-disaggregation path; this PR extends the standalone `--language-model-only` allowlist and does not change that path, but a textual conflict is possible if they merge first.

## Modifications

- `server_args.py`: add `Qwen3_5ForConditionalGeneration` to `LANGUAGE_MODEL_ONLY_ARCHITECTURES`.
- `models/qwen3_5.py`: skip `visual.*` checkpoint tensors in `load_weights` when no vision tower was built, instead of warning about every one of them.
- `layers/rotary_embedding/mrope.py`: `MRotaryEmbedding.forward_cuda` now takes the fused Triton kernel for 1-D positions too (the mrope axes are identical for text), instead of the native fallback. Qwen3.5's attention uses its own fused QK-norm/RoPE kernel, so this only matters for VL models whose layers call `rotary_emb` directly in text-only mode.

Multimodal requests are rejected with HTTP 400 as before (tokenizer manager).

## Accuracy Tests

Qwen3.8-27B NVFP4 + DFlash2 (RTX 5090), greedy text outputs byte-identical with and without the flag (three launches). An image request returns HTTP 400.

## Speed Tests and Profiling

Request latency at equal work (temperature 0, six repetitions): 18-token prompt -> 1 token: 71.5 ms vs 72.5 ms without the flag; 1857-token cached prompt -> 64 tokens: 396 ms vs 449 ms. No measurable difference.

Memory: weights on device 14.73 GB -> 13.85 GB (with `--offload-embedding-to-host`, PR #37826), KV pool 174,553 -> 192,145 tokens.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33770061468](https://github.com/sgl-project/sglang/actions/runs/33770061468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33770061342](https://github.com/sgl-project/sglang/actions/runs/33770061342)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33770061370](https://github.com/sgl-project/sglang/actions/runs/33770061370)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->