### PR TITLE
[Docs] Use --context-length in GLM AMD BF16 deployment snippets

### DIFF
--- a/docs/src/snippets/autoregressive/glm-45-deployment.jsx
+++ b/docs/src/snippets/autoregressive/glm-45-deployment.jsx
@@ -116,7 +116,7 @@ export const GLM45Deployment = () => {
 
     // MI300X/MI325X BF16 requires extra flags
     if ((hardware === 'mi300x' || hardware === 'mi325x') && quantization === 'bf16') {
-      cmd += ` \\\n  --max-context-length 8192 \\\n  --mem-fraction-static 0.9`;
+      cmd += ` \\\n  --context-length 8192 \\\n  --mem-fraction-static 0.9`;
     }
 
     // Strategy-specific parameters

--- a/docs/src/snippets/autoregressive/glm-46-deployment.jsx
+++ b/docs/src/snippets/autoregressive/glm-46-deployment.jsx
@@ -127,7 +127,7 @@ export const GLM46Deployment = () => {
 
     // MI300X/MI325X BF16 requires extra flags
     if ((hardware === 'mi300x' || hardware === 'mi325x') && quantization === 'bf16') {
-      cmd += ` \\\n  --max-context-length 8192 \\\n  --mem-fraction-static 0.9`;
+      cmd += ` \\\n  --context-length 8192 \\\n  --mem-fraction-static 0.9`;
     }
 
     // Strategy-specific parameters

--- a/docs/src/snippets/autoregressive/glm-47-deployment.jsx
+++ b/docs/src/snippets/autoregressive/glm-47-deployment.jsx
@@ -173,7 +173,7 @@ export const GLM47Deployment = () => {
 
       // MI300X/MI325X BF16 requires extra flags
       if ((hardware === 'mi300x' || hardware === 'mi325x') && quantization === 'bf16') {
-        cmd += ` \\\n  --max-context-length 8192 \\\n  --mem-fraction-static 0.9`;
+        cmd += ` \\\n  --context-length 8192 \\\n  --mem-fraction-static 0.9`;
       }
       if (strategyArray.includes('dp')) {
         cmd += ` \\\n  --dp 8 \\\n  --enable-dp-attention`;


### PR DESCRIPTION
## Motivation

The GLM cookbook deployment snippets emit `--max-context-length 8192` on the MI300X / MI325X BF16 branch:

```js
// docs/src/snippets/autoregressive/glm-47-deployment.jsx
if ((hardware === 'mi300x' || hardware === 'mi325x') && quantization === 'bf16') {
  cmd += ` \\\n  --max-context-length 8192 \\\n  --mem-fraction-static 0.9`;
}
```

`sglang.launch_server` has no `--max-context-length` option. `ServerArgs` declares the field `context_length` (`python/sglang/srt/server_args.py`), which `add_cli_args_from_dataclass` exposes as `--context-length` via `_field_to_cli_name`, and no `aliases=[...]` entry maps `--max-context-length` to it. A tree-wide search for `max-context-length` matches only these three snippet files, so nothing else defines it.

Because `--max-context-length` is not a prefix of any registered option either, argparse cannot fall back to abbreviation matching, and the copy-pasted command aborts before the server starts:

```
sglang.launch_server: error: unrecognized arguments: --max-context-length 8192
```

The three affected snippets are `glm-45-deployment.jsx`, `glm-46-deployment.jsx`, and `glm-47-deployment.jsx`.

## Modifications

Rename the flag to `--context-length` in the AMD BF16 branch of the three GLM deployment snippets. Values and surrounding flags are unchanged.

This matches the sibling snippets that already express the same AMD memory-headroom recipe correctly, e.g. `docs/src/snippets/autoregressive/qwen3-coder-deployment.jsx` and `qwen3-coder-480b-a35b-deployment.jsx` both emit `--context-length 8192`, and `docs/cookbook/autoregressive/Qwen/Qwen3-Coder.mdx` documents `--context-length 8192` for MI300X/MI325X/MI355X.

Docs-only change; no runtime code is touched.

## Accuracy Tests

Not applicable — documentation snippets only.

## Speed Tests and Profiling

Not applicable — documentation snippets only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33772562309](https://github.com/sgl-project/sglang/actions/runs/33772562309)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33772562187](https://github.com/sgl-project/sglang/actions/runs/33772562187)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->