### PR TITLE
[Diffusion] MiniMax-H3 VAE decoder: unfused w2 bias on SM12.x (cuBLAS 16x16 kernel mis-dispatch)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_video_vae/base_module.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_video_vae/base_module.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Transformer building blocks for the MiniMax H3 visual VAE ViT decoder.
+import functools
 import math
 from contextlib import nullcontext
 from typing import Optional
@@ -31,6 +32,33 @@ def _vit_norm_input(module, hidden_states):
 def _scaled_residual_add(residual, x, scale):
     fused = try_fused_scaled_residual_add_exact(residual, x, scale)
     return residual + x * scale if fused is None else fused
+
+
+@functools.lru_cache(maxsize=1)
+def _is_sm120() -> bool:
+    return bool(current_platform.is_sm120())
+
+
+def _unfused_bias_linear(
+    linear: nn.Linear, hidden_states: torch.Tensor
+) -> torch.Tensor:
+    """``linear`` as a plain matmul plus a separate bias add on SM12.x.
+
+    For the decoder's w2 shape ([~1800, 8192] x [8192, 2048], fp16/bf16) the
+    fused ``addmm`` epilogue makes cuBLAS on a GB10 pick a 16x16 wmma kernel
+    that runs at 14 TFLOPS; the same product without the fused bias runs at
+    76-91 TFLOPS (measured: 4.0 ms -> 0.8 ms per call, 3780 calls per decode).
+    """
+    if (
+        linear.bias is None
+        or not hidden_states.is_cuda
+        or hidden_states.dtype != linear.weight.dtype
+        or not _is_sm120()
+    ):
+        return linear(hidden_states)
+    out = torch.matmul(hidden_states, linear.weight.t())
+    out += linear.bias
+    return out
 
 
 class FeedForward(nn.Module):
@@ -99,7 +127,7 @@ class FeedForward(nn.Module):
         else:
             hidden_states = self.act_fn(hidden_states)
 
-        hidden_states = self.w2(hidden_states)
+        hidden_states = _unfused_bias_linear(self.w2, hidden_states)
         return hidden_states
 
     def _get_forward_impl(self):


### PR DESCRIPTION
## What

On a DGX Spark (GB10, SM 12.1, CUDA 13.0 cuBLAS) the MiniMax-H3 video VAE decoder spends 40% of its time in one GEMM that cuBLAS mis-dispatches. The feed-forward's `w2` projection, `[~1800, 8192] × [8192, 2048]` in fp16/bf16 **with a fused bias** (`addmm`), lands on a `cutlass_80_wmma_tensorop 16x16` kernel at 14 TFLOPS (4.0 ms per call). The same product without the fused bias epilogue gets the normal tensor-op kernel at 76–91 TFLOPS (0.8 ms). The other three decoder GEMMs (qkv, out, w1) already run at 83–90 TFLOPS.

Tiled decode of an 864×480×124f video runs this GEMM 3780 times (105 tiles × 36 blocks): about 12 s of a 32 s decode.

## Fix

`FeedForward._forward_impl` computes `w2` as `matmul` + a separate in-place bias add on SM12.x only (`_unfused_bias_linear`); every other architecture keeps the fused `addmm`. The gate is a cached capability check, the extra bias pass is a 7 MB elementwise op per call. Numerically the two forms differ only in the order of the fp32-accumulated bias add.

## Measurements (GB10, fp16, M=1797)

| form | TFLOPS | per call |
|---|---|---|
| `F.linear` (fused bias) | 15.0 | 4.02 ms |
| `x @ wᵀ` + separate bias | 76–91 | 0.66–0.79 ms |
| batched tiles (M=3594), fused bias | 82 | 1.47 ms |

`cublasLt`, `allow_fp16_reduced_precision_reduction=False`, an NN layout and bf16 all still pick the 16×16 kernel for the fused form; the bias epilogue is what steers the heuristic. End-to-end on the Spark recipe (MiniMax-H3 fl2va, 864×480×124f, 20 steps, planner-chosen placement), same server code otherwise:

| | before | after |
|---|---|---|
| VAE decode | 32.4 s | 19.2 s |
| warm request | 258 s | 245 s (ComfyUI 302.6 s) |

Text encoding (4.8 s) and denoise (205.5 s) unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33776722820](https://github.com/sgl-project/sglang/actions/runs/33776722820)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33776722544](https://github.com/sgl-project/sglang/actions/runs/33776722544)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33776722732](https://github.com/sgl-project/sglang/actions/runs/33776722732)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->