### PR TITLE
[GLM-5.3] Add experimental opt-in for DSA CP prefix caching

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import random
 from collections import deque
 from contextlib import nullcontext
@@ -48,6 +49,7 @@ if is_npu():
 #########################
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 _IS_HIP = is_hip()
+logger = logging.getLogger(__name__)
 
 
 def poll_and_all_reduce_pp(
@@ -173,13 +175,21 @@ def unified_memory_disagg_move_gate(scheduler):
 
 
 def should_bypass_dsa_cp_prefix_cache() -> bool:
-    """Bypass prefix cache under DSA Prefill CP until CP-aware radix resharding
-    exists; without it, cache hits let attention read non-local page rows."""
-    return (
+    """Default to bypassing DSA Prefill CP prefix cache without radix resharding."""
+    needs_resharding = (
         get_disagg().disaggregation_mode == DisaggregationMode.PREFILL.value
         and get_parallel().attn_cp_size > 1
         and get_parallel().enable_dsa_prefill_context_parallel
     )
+    if needs_resharding and envs.SGLANG_ENABLE_EXPERIMENTAL_DSA_CP_RADIX_CACHE.get():
+        logger.warning(
+            "Experimental DSA CP prefix caching: the automatic PD Prefill cache "
+            "bypass is disabled. CP-aware radix resharding is not implemented; "
+            "cache hits may read non-local KV rows and produce incorrect outputs. "
+            "Explicit --disable-radix-cache still takes precedence."
+        )
+        return False
+    return needs_resharding
 
 
 #########################

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -663,6 +663,9 @@ class Envs:
     SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX = EnvBool(True)
     SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(16384)
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
+    # Experimental: skip the DSA PD Prefill CP prefix-cache guard. CP-aware
+    # radix resharding is not implemented; cache hits may read non-local rows.
+    SGLANG_ENABLE_EXPERIMENTAL_DSA_CP_RADIX_CACHE = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)


### PR DESCRIPTION
## Motivation

The GLM-5.3 development branch automatically bypasses prefix caching for native PD Prefill with DSA context parallelism (`attn_cp_size > 1`). This prevents controlled cache-hit experiments even when an operator explicitly accepts the unresolved correctness risk.

This is an experimental opt-in, **not a CP-aware radix resharding fix**. It targets `xinyuan/glm-5.3-flash-support`, where the guard exists, rather than adding GLM development changes to `main`.

## Modifications

- Add `SGLANG_ENABLE_EXPERIMENTAL_DSA_CP_RADIX_CACHE=1` to bypass only this automatic prefix-cache guard.
- Preserve the safe default (`False`) and the precedence of explicit `--disable-radix-cache` and other cache-disable conditions.
- Emit a warning when the experimental override applies. No effect on Decode, non-DSA CP, or CP size 1.

Example: set the environment variable on **P workers only**, alongside the existing DSA Prefill CP flags, without `--disable-radix-cache`.

**Known correctness gap:** CP-aware radix resharding is not implemented. A cache hit can expose KV rows owned by another CP rank, potentially causing incorrect outputs or invalid accesses. This flag permits experimentation; it does not establish correct cache reuse, safe HiCache composition, or production readiness. Keep this PR draft pending cache-hit correctness validation.

## Accuracy Tests

CPU-only checks of the exact candidate guard passed a 36-combination matrix covering role, CP size, DSA CP enablement, and opt-in state. The environment descriptor defaults to false; the unchanged cache-builder expression also preserves explicit cache disabling. Local validation scripts are not included in this minimal patch.

No GPU cache-hit/miss output-equivalence or accuracy result is available for this override. Those checks remain necessary before this can be described as supported.

## Speed Tests and Profiling

Not yet benchmarked. No speedup is claimed. Prior cold-Prefill CP results do not validate this cache-hit path.

## Checklist

- [x] Run repository pre-commit checks on the changed files.
- [x] Use the registered `EnvBool` convention and default the override off.
- [x] Check the guard matrix and explicit-disable precedence locally.
- [x] Document activation, scope, and unresolved correctness risks above.

No unit-test files or documentation files are added. This is a draft experiment, not a completed correctness fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33781948904](https://github.com/sgl-project/sglang/actions/runs/33781948904)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33781948480](https://github.com/sgl-project/sglang/actions/runs/33781948480)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33781948762](https://github.com/sgl-project/sglang/actions/runs/33781948762)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->