### PR TITLE
[Cache] Forward fast prefix matching capability

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -369,6 +369,10 @@ class UnifiedTreeCoreInterface(ABC):
         """Match a key against the tree; returns device indices + boundary NodeIds."""
         ...
 
+    def supports_fast_match_prefix(self) -> bool:
+        """Whether matching every waiting request is cheap enough for scheduling."""
+        return False
+
     @property
     @abstractmethod
     def empty_match_result(self) -> MatchResult:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -538,6 +538,9 @@ class UnifiedRadixCache(BasePrefixCache):
             result = self.linker.match(params.key, params.req, result)
         return result
 
+    def supports_fast_match_prefix(self) -> bool:
+        return self.tree_core.supports_fast_match_prefix()
+
     def is_chunk_cache(self) -> bool:
         return self.disable
 

--- a/test/registered/unit/managers/test_load_inquirer.py
+++ b/test/registered/unit/managers/test_load_inquirer.py
@@ -31,10 +31,13 @@ class TestSchedulePolicyWaitingQueueMatching(unittest.TestCase):
         policy.tree_cache = SimpleNamespace(supports_fast_match_prefix=lambda: True)
         self.assertTrue(policy.waiting_queue_prefix_matched([]))
 
-    def test_lpm_queue_limit_can_disable_matching(self):
+    def test_lpm_queue_limit_respects_fast_matching_capability(self):
         policy = self.make_policy(CacheAwarePolicy.LPM, False)
         self.assertTrue(policy.waiting_queue_prefix_matched([None] * 128))
         self.assertFalse(policy.waiting_queue_prefix_matched([None] * 129))
+
+        policy.tree_cache = SimpleNamespace(supports_fast_match_prefix=lambda: True)
+        self.assertTrue(policy.waiting_queue_prefix_matched([None] * 129))
 
 
 class TestSchedulerLoadInquirer(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Scheduling can match every waiting request only when the active cache implementation advertises that prefix matching is cheap. `UnifiedRadixCache` currently inherits the conservative default even when its tree core can provide this capability.

## Modifications

- Add a conservative `supports_fast_match_prefix()` default to the unified tree-core interface.
- Forward the capability through `UnifiedRadixCache`.
- Cover LPM queues above the fallback limit when fast matching is supported.

## Accuracy Tests

No model output or numerical behavior changes.

## Speed Tests and Profiling

No benchmarks were run. This change only exposes an existing capability to scheduling.

## Original commits

- `50c1de1494a`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for this internal cache capability.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). No numerical or kernel behavior changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33785071507](https://github.com/sgl-project/sglang/actions/runs/33785071507)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33785071251](https://github.com/sgl-project/sglang/actions/runs/33785071251)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33785071328](https://github.com/sgl-project/sglang/actions/runs/33785071328)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->