### PR TITLE
[ROCm] Admit any head count up to the MFMA tile to the gfx950 Triton sparse-MLA prefill path

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -2,9 +2,16 @@
 
 A per-query flash-attention kernel over the indexer-selected topk KV. On
 gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
-prefill regime (n_groups=1): the attention tile is tiny (M=16 heads = one
-16x16 MFMA), so a small-warp per-program kernel avoids the intra-block
-coordination overhead of the 256-thread TileLang block.
+prefill regime (n_groups=1): the attention tile is tiny (up to 16 heads,
+padded to one 16x16 MFMA), so a small-warp per-program kernel avoids the
+intra-block coordination overhead of the 256-thread TileLang block.
+
+The head padding is here because tl.dot needs a 16-row tile on this path. A
+Gluon kernel can run BLOCK_M below 16 natively instead -- see ROCm/aiter#4919,
+which adds a gfx950 sparse-MLA covering the same GLM-5 prefill shapes -- so if
+this path ever dispatches there, the padding becomes redundant rather than
+wrong. It is not urgent: measured at H=4/8/12 the padded rows add no KV traffic
+and cost nothing, because the kernel is selected-KV bandwidth bound.
 """
 
 import torch
@@ -51,6 +58,7 @@ def _sparse_mla_fwd_kernel(
     fp8_max,
     topk,
     H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
     DIM: tl.constexpr,
     D_V: tl.constexpr,
     D_TAIL: tl.constexpr,
@@ -58,22 +66,27 @@ def _sparse_mla_fwd_kernel(
 ):
     s_i = tl.program_id(0)
 
-    h = tl.arange(0, H)
+    h = tl.arange(0, BLOCK_H)
+    hmask = h < H
     dv = tl.arange(0, D_V)
     dt = tl.arange(0, D_TAIL)
     # q is read as two separate tensors (q_nope width D_V, q_rope width D_TAIL):
     # the upstream concat into a single [.., DIM] tensor is skipped since this
     # kernel splits q into main/tail anyway.
-    q_main = tl.load(q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :]).to(
-        q_nope_ptr.dtype.element_ty
-    )  # [H, D_V]
+    q_main = tl.load(
+        q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
+        mask=hmask[:, None],
+        other=0.0,
+    ).to(q_nope_ptr.dtype.element_ty)  # [BLOCK_H, D_V]
     q_tail = tl.load(
-        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :]
-    ).to(q_nope_ptr.dtype.element_ty)  # [H, D_TAIL]
+        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :],
+        mask=hmask[:, None],
+        other=0.0,
+    ).to(q_nope_ptr.dtype.element_ty)  # [BLOCK_H, D_TAIL]
 
-    m_i = tl.full([H], -float("inf"), tl.float32)
-    l_i = tl.zeros([H], tl.float32)
-    acc = tl.zeros([H, D_V], tl.float32)
+    m_i = tl.full([BLOCK_H], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_H], tl.float32)
+    acc = tl.zeros([BLOCK_H, D_V], tl.float32)
 
     n = tl.arange(0, BLOCK_N)
     for k0 in range(0, topk, BLOCK_N):
@@ -92,7 +105,7 @@ def _sparse_mla_fwd_kernel(
         qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
         qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
         qk = qk * sm_scale
-        qk = tl.where(valid[None, :], qk, -float("inf"))
+        qk = tl.where(hmask[:, None] & valid[None, :], qk, -float("inf"))
 
         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
         # Guard an all-masked row (m_new == -inf): shift by 0 instead so that
@@ -113,6 +126,7 @@ def _sparse_mla_fwd_kernel(
     tl.store(
         o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
         acc.to(o_ptr.dtype.element_ty),
+        mask=hmask[:, None],
     )
 
 
@@ -149,6 +163,7 @@ def triton_sparse_mla_fwd(
         _FP8_MAX,
         topk,
         H=H,
+        BLOCK_H=max(16, triton.next_power_of_2(H)),
         DIM=dim,
         D_V=d_v,
         D_TAIL=d_tail,

--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -40,6 +40,15 @@ _AUTOTUNE_CONFIGS = [
     for w in (1, 2, 4)
     for ns in (1, 2)
 ]
+if torch.version.hip is not None:
+    # waves_per_eu is a ROCm launch attribute, so only offer it on HIP builds;
+    # a CUDA compile must never see an unknown Config key. Autotune picks it on
+    # merit at the gfx950 sparse-MLA prefill shapes rather than it being pinned
+    # to one head count.
+    _AUTOTUNE_CONFIGS.insert(
+        0,
+        triton.Config({"BLOCK_N": 32, "waves_per_eu": 2}, num_warps=2, num_stages=2),
+    )
 
 
 @triton.autotune(

--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -39,16 +39,11 @@ _AUTOTUNE_CONFIGS = [
     for bn in (32, 64, 128)
     for w in (1, 2, 4)
     for ns in (1, 2)
+    # The torch 2.11 HIP Triton/LLVM stack aborts on this candidate for gfx950's
+    # padded-head path. Autotune cannot recover from a compiler process abort,
+    # so omit it only from the HIP grid; other backends retain the full grid.
+    if torch.version.hip is None or not (bn == 128 and w == 1 and ns == 2)
 ]
-if torch.version.hip is not None:
-    # waves_per_eu is a ROCm launch attribute, so only offer it on HIP builds;
-    # a CUDA compile must never see an unknown Config key. Autotune picks it on
-    # merit at the gfx950 sparse-MLA prefill shapes rather than it being pinned
-    # to one head count.
-    _AUTOTUNE_CONFIGS.insert(
-        0,
-        triton.Config({"BLOCK_N": 32, "waves_per_eu": 2}, num_warps=2, num_stages=2),
-    )
 
 
 @triton.autotune(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2014,13 +2014,14 @@ class DeepseekSparseAttnBackend(
             if q_rope is not None:
                 # Triton prefill kernel reads q_nope/q_rope directly, skipping
                 # the concat (it splits q into main/tail internally anyway).
-                # Gated to gfx950 + the validated shape (16 heads, d_v=512,
-                # tail=64, topk=2048); everything else uses TileLang.
+                # Gated to gfx950 + the validated shape family (any head
+                # count up to the 16-row MFMA tile, d_v=512, tail=64,
+                # topk=2048); everything else uses TileLang.
                 if (
                     _DSA_TRITON_PREFILL
                     and _IS_GFX95
                     and kv_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
-                    and layer.tp_q_head_num == 16
+                    and layer.tp_q_head_num <= 16
                     and layer.v_head_dim == 512
                     and (layer.head_dim - layer.v_head_dim) == 64
                     and page_table_1.shape[-1] == 2048

--- a/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
+++ b/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
@@ -31,31 +31,44 @@ def _require_gfx950() -> None:
         pytest.skip(f"the sparse-MLA Triton prefill path requires gfx950, got {arch}")
 
 
-def _make_indices(pattern: str) -> torch.Tensor:
+def _make_indices(
+    pattern: str,
+    *,
+    seq: int = SEQ,
+    pool_size: int = POOL_SIZE,
+    topk: int = TOPK,
+) -> torch.Tensor:
     if pattern == "trailing":
-        base = torch.arange(POOL_SIZE - TOPK, POOL_SIZE)
+        base = torch.arange(pool_size - topk, pool_size)
     elif pattern == "strided":
-        base = torch.arange(0, POOL_SIZE, 2)
+        base = torch.arange(0, pool_size, pool_size // topk)
     elif pattern == "head_tail":
         base = torch.cat(
             [
-                torch.arange(0, TOPK // 2),
-                torch.arange(POOL_SIZE - TOPK // 2, POOL_SIZE),
+                torch.arange(0, topk // 2),
+                torch.arange(pool_size - topk // 2, pool_size),
             ]
         )
     else:
         raise ValueError(f"unknown index pattern: {pattern}")
 
-    rows = [torch.roll(base, shifts=row) for row in range(SEQ)]
+    rows = [torch.roll(base, shifts=row) for row in range(seq)]
     return torch.stack(rows).to(device="cuda", dtype=torch.int32).unsqueeze(1)
 
 
-def _make_inputs(num_heads: int, pattern: str):
+def _make_inputs(
+    num_heads: int,
+    pattern: str,
+    *,
+    seq: int = SEQ,
+    pool_size: int = POOL_SIZE,
+    topk: int = TOPK,
+):
     generator = torch.Generator(device="cuda")
     generator.manual_seed(20260901 + num_heads)
     q_nope = (
         torch.randn(
-            SEQ,
+            seq,
             num_heads,
             VALUE_DIM,
             device="cuda",
@@ -65,7 +78,7 @@ def _make_inputs(num_heads: int, pattern: str):
     ).to(torch.float8_e4m3fn)
     q_rope = (
         torch.randn(
-            SEQ,
+            seq,
             num_heads,
             ROPE_DIM,
             device="cuda",
@@ -75,7 +88,7 @@ def _make_inputs(num_heads: int, pattern: str):
     ).to(torch.float8_e4m3fn)
     kv = (
         torch.randn(
-            POOL_SIZE,
+            pool_size,
             1,
             HEAD_DIM,
             device="cuda",
@@ -83,7 +96,12 @@ def _make_inputs(num_heads: int, pattern: str):
         )
         * 0.25
     ).to(torch.float8_e4m3fn)
-    return q_nope, q_rope, kv, _make_indices(pattern)
+    return (
+        q_nope,
+        q_rope,
+        kv,
+        _make_indices(pattern, seq=seq, pool_size=pool_size, topk=topk),
+    )
 
 
 def _reference(
@@ -116,6 +134,28 @@ def test_triton_sparse_mla_raw_fp8(num_heads: int, pattern: str) -> None:
     """
     _require_gfx950()
     q_nope, q_rope, kv, indices = _make_inputs(num_heads, pattern)
+    actual = triton_sparse_mla_fwd(
+        q_nope,
+        q_rope,
+        kv,
+        indices,
+        sm_scale=1.0 / math.sqrt(HEAD_DIM),
+        d_v=VALUE_DIM,
+    ).squeeze(0)
+    expected = _reference(q_nope, q_rope, kv, indices)
+    torch.testing.assert_close(actual.float(), expected, atol=0.2, rtol=0.2)
+
+
+def test_triton_sparse_mla_gfx950_full_topk() -> None:
+    """Compile every candidate in the gfx950 padded-head dispatch grid."""
+    _require_gfx950()
+    q_nope, q_rope, kv, indices = _make_inputs(
+        8,
+        "trailing",
+        seq=1,
+        pool_size=2048,
+        topk=2048,
+    )
     actual = triton_sparse_mla_fwd(
         q_nope,
         q_rope,

--- a/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
+++ b/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
@@ -1,0 +1,132 @@
+import math
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsa.triton_sparse_mla import (
+    _FP8_MAX,
+    triton_sparse_mla_fwd,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=90, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is None,
+    reason="requires an AMD GPU",
+)
+
+SEQ = 3
+HEAD_DIM = 576
+VALUE_DIM = 512
+ROPE_DIM = HEAD_DIM - VALUE_DIM
+POOL_SIZE = 64
+TOPK = 32
+
+
+def _require_gfx950() -> None:
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    if "gfx950" not in arch:
+        pytest.skip(f"the sparse-MLA Triton prefill path requires gfx950, got {arch}")
+
+
+def _make_indices(pattern: str) -> torch.Tensor:
+    if pattern == "trailing":
+        base = torch.arange(POOL_SIZE - TOPK, POOL_SIZE)
+    elif pattern == "strided":
+        base = torch.arange(0, POOL_SIZE, 2)
+    elif pattern == "head_tail":
+        base = torch.cat(
+            [
+                torch.arange(0, TOPK // 2),
+                torch.arange(POOL_SIZE - TOPK // 2, POOL_SIZE),
+            ]
+        )
+    else:
+        raise ValueError(f"unknown index pattern: {pattern}")
+
+    rows = [torch.roll(base, shifts=row) for row in range(SEQ)]
+    return torch.stack(rows).to(device="cuda", dtype=torch.int32).unsqueeze(1)
+
+
+def _make_inputs(num_heads: int, pattern: str):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260901 + num_heads)
+    q_nope = (
+        torch.randn(
+            SEQ,
+            num_heads,
+            VALUE_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    q_rope = (
+        torch.randn(
+            SEQ,
+            num_heads,
+            ROPE_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    kv = (
+        torch.randn(
+            POOL_SIZE,
+            1,
+            HEAD_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    return q_nope, q_rope, kv, _make_indices(pattern)
+
+
+def _reference(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    q = torch.cat([q_nope, q_rope], dim=-1).float()
+    selected = kv[:, 0].float()[indices[:, 0].long()]
+    scores = torch.einsum("shd,std->sht", q, selected) / math.sqrt(HEAD_DIM)
+    probabilities = torch.softmax(scores, dim=-1)
+    probabilities = (probabilities * _FP8_MAX).to(q_nope.dtype).float() / _FP8_MAX
+    return torch.einsum("sht,std->shd", probabilities, selected[:, :, :VALUE_DIM])
+
+
+@pytest.mark.parametrize("num_heads", [4, 8, 12, 16])
+@pytest.mark.parametrize("pattern", ["trailing", "strided", "head_tail"])
+def test_triton_sparse_mla_raw_fp8(num_heads: int, pattern: str) -> None:
+    """Padded-head correctness for the gfx950 raw-FP8 sparse-MLA prefill path.
+
+    ``num_heads=4``, ``8`` and ``12`` exercise the BLOCK_H padding: fewer
+    real heads than the tile occupy a
+    16-row MFMA tile, so a regression in the query load/store masking or in the
+    softmax row mask lets padded rows contaminate the denominator or write
+    garbage into the output. ``num_heads=16`` is the unpadded control, which
+    isolates a padding regression from a general kernel regression. The three
+    index patterns cover contiguous, strided and split selections, so a masking
+    error that only appears on non-contiguous KV cannot pass unnoticed.
+    """
+    _require_gfx950()
+    q_nope, q_rope, kv, indices = _make_inputs(num_heads, pattern)
+    actual = triton_sparse_mla_fwd(
+        q_nope,
+        q_rope,
+        kv,
+        indices,
+        sm_scale=1.0 / math.sqrt(HEAD_DIM),
+        d_v=VALUE_DIM,
+    ).squeeze(0)
+    expected = _reference(q_nope, q_rope, kv, indices)
+    torch.testing.assert_close(actual.float(), expected, atol=0.2, rtol=0.2)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

The gfx950 Triton sparse-MLA prefill kernel is admitted only when a rank holds
exactly 16 query heads:

```python
and layer.tp_q_head_num == 16
```

Any tensor-parallel width that puts fewer than 16 heads on a rank therefore
falls back to the slower TileLang partial+combine path. The fallback is silent
and correct, so nothing fails — it just costs prefill latency. GLM-5.2 has 64
attention heads, so TP8 gives 8 heads per rank and never reaches the Triton
kernel. Any `heads / TP < 16` configuration is affected.

The kernel could not simply be dispatched at fewer heads: `tl.dot` on gfx950
requires a 16-row MFMA tile.

Note that `dsa_backend.py` already does exactly this padding for the aiter
`mla_decode_fwd` path, citing this same model and TP width:

```python
# Aiter mla_decode_fwd supports num_heads multiples of 16 in range [16, 128].
# For models with fewer heads per GPU (e.g. GLM-5 64 heads / TP8 = 8), need to pad the heads to 16.
self.need_pad_heads = self.num_q_heads < 16
```

This PR applies the same idea to the Triton prefill path, and adds the launch
configuration that measured best at those shapes.

## Modifications

**1. Pad the query-head tile** (`triton_sparse_mla.py`). Pad to
`BLOCK_H = max(16, next_power_of_2(H))`, mask the padded rows on load and on
store, and exclude them from the online softmax. `m_i`/`l_i`/`acc` are sized to
`BLOCK_H`. Real values and indices are unchanged.

**2. Widen the dispatch gate** (`dsa_backend.py`) from `== 16` to `<= 16`, i.e.
any head count that fits the MFMA tile. It stays narrowly guarded on gfx950,
FP8 KV, `v_head_dim == 512`, RoPE tail 64 and topk 2048; every other shape keeps
the existing TileLang fallback.

**3. Drop one autotune candidate on HIP** (`triton_sparse_mla.py`). The torch
2.11 HIP Triton/LLVM stack aborts the compiler process on `BLOCK_N=128,
num_warps=1, num_stages=2` for the padded-head path. Autotune cannot recover
from a process abort, so that single candidate is omitted from the HIP grid;
every other backend keeps the full grid.

**4. Test** (`test_triton_sparse_mla.py`). New test over H=4, 8, 12 and 16 with
trailing, strided and head-plus-tail sparse index patterns, registered to
`stage-b-test-1-gpu-small-amd-mi35x` (the gfx950 runner pool; the
`jit-kernel-unit-test-amd` suite dispatches to mi300/mi325, both gfx942, where
the arch guard would skip every case) and skipped off gfx950.

The padded rows add no memory traffic — the K/V operand is unchanged — and this
kernel is selected-KV bandwidth bound, so the extra MFMA rows occupy issue slots
that were already stalled on HBM. Consistent with that, larger generic KV tiles
and higher warp counts measured neutral-to-slower and are not included.

## Accuracy Tests

Against the TileLang kernel it replaces, at the deployed shape (8148 tokens,
H=8, `Dqk=576`, `Dv=512`, topk 2048, raw E4M3 Q/KV):

- mean absolute error `8.11e-5`, maximum absolute error `0.00586`
- zero elements exceeding SGLang's existing `atol=0.2, rtol=0.2` gate for this op

Against an independently accumulated FP8 reference, Triton and TileLang show
the **identical** `0.000772` mismatch fraction. Since the padded path does not
move that fraction at all relative to the kernel it replaces, the residual sits
in reference/production probability rounding rather than in the head padding —
i.e. the padding is numerically inert.

Executed on an MI355X (`gfx950:sramecc+:xnack-`, ROCm 7.2, torch 2.9.1) against
this branch: **12/12 cases pass** (H=4, 8, 12, 16 across all three index
patterns), no skips. A separate case covers the production top-k of 2048, which
is the shape at which the excluded autotune candidate above was found to abort
the compiler on torch 2.11 — note that the timings below were taken on torch
2.9.1, so they do not cover that newer toolchain.

## Speed Tests and Profiling

MI355X, seq 8148, topk 2048, `Dqk` 576, `Dv` 512, OCP e4m3, 20 warmup + 50
timed iterations. Triton against the TileLang fallback at each head count —
the comparison the dispatch gate actually makes:

| H | TileLang | Triton | speedup | vs fallback |
|---:|---:|---:|---:|---:|
| 4 | 2.2386 ms | 1.3149 ms | **1.702x** | **-41.3%** |
| 8 | 2.2522 ms | 1.3170 ms | **1.710x** | **-41.5%** |
| 12 | 2.3062 ms | 1.3210 ms | **1.746x** | **-42.7%** |
| 16 | 2.3035 ms | 1.3449 ms | **1.713x** | **-41.6%** |

Triton wins at every head count by a near-constant 1.70–1.75x, so H=4 and H=12
behave exactly like the head counts the original `== 16` gate admitted. Both
kernels are near-flat across head count, the expected signature of a
bandwidth-bound operator, and the reason the padded rows are free.

**Regression control.** The dispatch gate is narrow, but the kernel change also
executes on the shipping H=16 path, so that path was benched with the kernel
installed in the image and with this branch's kernel, back to back:
1.3480 ms → 1.3480 ms, **+0.00%**.

**End-to-end serving**, GLM-5.2 MXFP4 on 8x MI355X, TP8/EP1, closed-loop
concurrency 4, 8K input / 1K output, FP8 KV cache, MTP K3 with pinned
acceptance, chunked prefill 8192. Repeated A/B, 4-run control median against
3-run candidate median, for the head-padding change alone:

| Metric | TileLang | Triton | Change |
|---|---:|---:|---:|
| Wall time | 82.784 s | 80.388 s | **-2.9%** |
| Output throughput | 444.591 tok/s | 457.841 tok/s | **+3.0%** |
| Median TTFT | 429.868 ms | 366.780 ms | **-14.7%** |
| Median TPOT | 8.356 ms | 8.176 ms | -2.2% |

Candidate runs spanned 80.076–80.406 s against 82.308–82.941 s for the controls.

## Future work

The head padding exists because `tl.dot` needs a 16-row tile on this path. A
Gluon kernel can run `BLOCK_M` below 16 natively instead — ROCm/aiter#4919 adds
a gfx950 sparse-MLA covering these same GLM-5 prefill shapes and does exactly
that. If SGLang ever dispatches DSA prefill to that kernel, this padding becomes
redundant rather than wrong, and the module docstring records the pointer so a
future reader does not have to rediscover it.

It is not urgent: measured at H=4, 8 and 12 the padded rows add no KV traffic
and cost nothing. Note also that #4919 targets vLLM and consumes those models'
default cache format (fp8 with a per-tensor scale, caller-quantized q), whereas
this ROCm SGLang path stores raw FP8 nope + raw FP8 rope with no scale record —
so it is not a drop-in replacement today. Maintainers who know the intended
direction here, please say so on this PR.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33835245358](https://github.com/sgl-project/sglang/actions/runs/33835245358)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33835245209](https://github.com/sgl-project/sglang/actions/runs/33835245209)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33835245291](https://github.com/sgl-project/sglang/actions/runs/33835245291)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->