### PR TITLE
Fix block-scale swizzling device placement

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -615,7 +615,7 @@ def swizzle_blockscale(scale: torch.Tensor):
     assert cols % 4 == 0
     padded_scale = padded_scale.reshape(batches, rows // 128, 4, 32, cols // 4, 4)
     swizzled_scale = padded_scale.permute((0, 1, 4, 3, 2, 5))
-    swizzled_scale = swizzled_scale.contiguous().cuda()
+    swizzled_scale = swizzled_scale.contiguous().to(scale.device)
     return (
         swizzled_scale.reshape(M_padded, K_padded)
         if scale_ndim == 2


### PR DESCRIPTION
## Motivation

`swizzle_blockscale` unconditionally moved its result to the default CUDA device, which can place the tensor on a different device from its input.

## Modifications

Move the contiguous swizzled tensor to `scale.device` so the helper preserves the input tensor device.

## Accuracy Tests

Not applicable. This changes tensor placement only and does not alter the swizzle operation.

## Speed Tests and Profiling

Not applicable. No computational operations were added.

## Test plan

- `python3 -m py_compile python/sglang/srt/layers/quantization/utils.py` — passed.
- `with-proxy uv run pre-commit run --files python/sglang/srt/layers/quantization/utils.py` — passed.
- GPU runtime tests were not run locally.

## Original commits

- `4f6489ae66`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33786218675](https://github.com/sgl-project/sglang/actions/runs/33786218675)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33786217621](https://github.com/sgl-project/sglang/actions/runs/33786217621)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33786218337](https://github.com/sgl-project/sglang/actions/runs/33786218337)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->