### PR TITLE
[ROCm] Offer the waves_per_eu=2 launch to autotune for gfx950 sparse-MLA prefill

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -2,9 +2,16 @@
 
 A per-query flash-attention kernel over the indexer-selected topk KV. On
 gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
-prefill regime (n_groups=1): the attention tile is tiny (M=16 heads = one
-16x16 MFMA), so a small-warp per-program kernel avoids the intra-block
-coordination overhead of the 256-thread TileLang block.
+prefill regime (n_groups=1): the attention tile is tiny (up to 16 heads,
+padded to one 16x16 MFMA), so a small-warp per-program kernel avoids the
+intra-block coordination overhead of the 256-thread TileLang block.
+
+The head padding is here because tl.dot needs a 16-row tile on this path. A
+Gluon kernel can run BLOCK_M below 16 natively instead -- see ROCm/aiter#4919,
+which adds a gfx950 sparse-MLA covering the same GLM-5 prefill shapes -- so if
+this path ever dispatches there, the padding becomes redundant rather than
+wrong. It is not urgent: measured at H=4/8/12 the padded rows add no KV traffic
+and cost nothing, because the kernel is selected-KV bandwidth bound.
 """
 
 import torch
@@ -51,6 +58,7 @@ def _sparse_mla_fwd_kernel(
     fp8_max,
     topk,
     H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
     DIM: tl.constexpr,
     D_V: tl.constexpr,
     D_TAIL: tl.constexpr,
@@ -58,22 +66,27 @@ def _sparse_mla_fwd_kernel(
 ):
     s_i = tl.program_id(0)
 
-    h = tl.arange(0, H)
+    h = tl.arange(0, BLOCK_H)
+    hmask = h < H
     dv = tl.arange(0, D_V)
     dt = tl.arange(0, D_TAIL)
     # q is read as two separate tensors (q_nope width D_V, q_rope width D_TAIL):
     # the upstream concat into a single [.., DIM] tensor is skipped since this
     # kernel splits q into main/tail anyway.
-    q_main = tl.load(q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :]).to(
-        q_nope_ptr.dtype.element_ty
-    )  # [H, D_V]
+    q_main = tl.load(
+        q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
+        mask=hmask[:, None],
+        other=0.0,
+    ).to(q_nope_ptr.dtype.element_ty)  # [BLOCK_H, D_V]
     q_tail = tl.load(
-        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :]
-    ).to(q_nope_ptr.dtype.element_ty)  # [H, D_TAIL]
+        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :],
+        mask=hmask[:, None],
+        other=0.0,
+    ).to(q_nope_ptr.dtype.element_ty)  # [BLOCK_H, D_TAIL]
 
-    m_i = tl.full([H], -float("inf"), tl.float32)
-    l_i = tl.zeros([H], tl.float32)
-    acc = tl.zeros([H, D_V], tl.float32)
+    m_i = tl.full([BLOCK_H], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_H], tl.float32)
+    acc = tl.zeros([BLOCK_H, D_V], tl.float32)
 
     n = tl.arange(0, BLOCK_N)
     for k0 in range(0, topk, BLOCK_N):
@@ -92,7 +105,7 @@ def _sparse_mla_fwd_kernel(
         qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
         qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
         qk = qk * sm_scale
-        qk = tl.where(valid[None, :], qk, -float("inf"))
+        qk = tl.where(hmask[:, None] & valid[None, :], qk, -float("inf"))
 
         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
         # Guard an all-masked row (m_new == -inf): shift by 0 instead so that
@@ -113,6 +126,7 @@ def _sparse_mla_fwd_kernel(
     tl.store(
         o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
         acc.to(o_ptr.dtype.element_ty),
+        mask=hmask[:, None],
     )
 
 
@@ -149,6 +163,7 @@ def triton_sparse_mla_fwd(
         _FP8_MAX,
         topk,
         H=H,
+        BLOCK_H=max(16, triton.next_power_of_2(H)),
         DIM=dim,
         D_V=d_v,
         D_TAIL=d_tail,

--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -40,6 +40,15 @@ _AUTOTUNE_CONFIGS = [
     for w in (1, 2, 4)
     for ns in (1, 2)
 ]
+if torch.version.hip is not None:
+    # waves_per_eu is a ROCm launch attribute, so only offer it on HIP builds;
+    # a CUDA compile must never see an unknown Config key. Autotune picks it on
+    # merit at the gfx950 sparse-MLA prefill shapes rather than it being pinned
+    # to one head count.
+    _AUTOTUNE_CONFIGS.insert(
+        0,
+        triton.Config({"BLOCK_N": 32, "waves_per_eu": 2}, num_warps=2, num_stages=2),
+    )
 
 
 @triton.autotune(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2014,13 +2014,14 @@ class DeepseekSparseAttnBackend(
             if q_rope is not None:
                 # Triton prefill kernel reads q_nope/q_rope directly, skipping
                 # the concat (it splits q into main/tail internally anyway).
-                # Gated to gfx950 + the validated shape (16 heads, d_v=512,
-                # tail=64, topk=2048); everything else uses TileLang.
+                # Gated to gfx950 + the validated shape family (any head
+                # count up to the 16-row MFMA tile, d_v=512, tail=64,
+                # topk=2048); everything else uses TileLang.
                 if (
                     _DSA_TRITON_PREFILL
                     and _IS_GFX95
                     and kv_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
-                    and layer.tp_q_head_num == 16
+                    and layer.tp_q_head_num <= 16
                     and layer.v_head_dim == 512
                     and (layer.head_dim - layer.v_head_dim) == 64
                     and page_table_1.shape[-1] == 2048

--- a/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
+++ b/test/registered/kernels/ops/attention/test_triton_sparse_mla.py
@@ -1,0 +1,132 @@
+import math
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsa.triton_sparse_mla import (
+    _FP8_MAX,
+    triton_sparse_mla_fwd,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=90, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is None,
+    reason="requires an AMD GPU",
+)
+
+SEQ = 3
+HEAD_DIM = 576
+VALUE_DIM = 512
+ROPE_DIM = HEAD_DIM - VALUE_DIM
+POOL_SIZE = 64
+TOPK = 32
+
+
+def _require_gfx950() -> None:
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    if "gfx950" not in arch:
+        pytest.skip(f"the sparse-MLA Triton prefill path requires gfx950, got {arch}")
+
+
+def _make_indices(pattern: str) -> torch.Tensor:
+    if pattern == "trailing":
+        base = torch.arange(POOL_SIZE - TOPK, POOL_SIZE)
+    elif pattern == "strided":
+        base = torch.arange(0, POOL_SIZE, 2)
+    elif pattern == "head_tail":
+        base = torch.cat(
+            [
+                torch.arange(0, TOPK // 2),
+                torch.arange(POOL_SIZE - TOPK // 2, POOL_SIZE),
+            ]
+        )
+    else:
+        raise ValueError(f"unknown index pattern: {pattern}")
+
+    rows = [torch.roll(base, shifts=row) for row in range(SEQ)]
+    return torch.stack(rows).to(device="cuda", dtype=torch.int32).unsqueeze(1)
+
+
+def _make_inputs(num_heads: int, pattern: str):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260901 + num_heads)
+    q_nope = (
+        torch.randn(
+            SEQ,
+            num_heads,
+            VALUE_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    q_rope = (
+        torch.randn(
+            SEQ,
+            num_heads,
+            ROPE_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    kv = (
+        torch.randn(
+            POOL_SIZE,
+            1,
+            HEAD_DIM,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    return q_nope, q_rope, kv, _make_indices(pattern)
+
+
+def _reference(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    q = torch.cat([q_nope, q_rope], dim=-1).float()
+    selected = kv[:, 0].float()[indices[:, 0].long()]
+    scores = torch.einsum("shd,std->sht", q, selected) / math.sqrt(HEAD_DIM)
+    probabilities = torch.softmax(scores, dim=-1)
+    probabilities = (probabilities * _FP8_MAX).to(q_nope.dtype).float() / _FP8_MAX
+    return torch.einsum("sht,std->shd", probabilities, selected[:, :, :VALUE_DIM])
+
+
+@pytest.mark.parametrize("num_heads", [4, 8, 12, 16])
+@pytest.mark.parametrize("pattern", ["trailing", "strided", "head_tail"])
+def test_triton_sparse_mla_raw_fp8(num_heads: int, pattern: str) -> None:
+    """Padded-head correctness for the gfx950 raw-FP8 sparse-MLA prefill path.
+
+    ``num_heads=4``, ``8`` and ``12`` exercise the BLOCK_H padding: fewer
+    real heads than the tile occupy a
+    16-row MFMA tile, so a regression in the query load/store masking or in the
+    softmax row mask lets padded rows contaminate the denominator or write
+    garbage into the output. ``num_heads=16`` is the unpadded control, which
+    isolates a padding regression from a general kernel regression. The three
+    index patterns cover contiguous, strided and split selections, so a masking
+    error that only appears on non-contiguous KV cannot pass unnoticed.
+    """
+    _require_gfx950()
+    q_nope, q_rope, kv, indices = _make_inputs(num_heads, pattern)
+    actual = triton_sparse_mla_fwd(
+        q_nope,
+        q_rope,
+        kv,
+        indices,
+        sm_scale=1.0 / math.sqrt(HEAD_DIM),
+        d_v=VALUE_DIM,
+    ).squeeze(0)
+    expected = _reference(q_nope, q_rope, kv, indices)
+    torch.testing.assert_close(actual.float(), expected, atol=0.2, rtol=0.2)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Follow-up to #37847, which admits any head count up to the 16-row MFMA tile to
the gfx950 Triton sparse-MLA prefill path. This adds one launch configuration
that measured substantially faster at those shapes.

> **Stacked on #37847.** This branch contains that PR's commit as its first
> commit, so the diff below includes it. Please review only the second commit;
> I will rebase once #37847 lands.

## Modifications

Add `BLOCK_N=32, num_warps=2, num_stages=2, waves_per_eu=2` to
`_AUTOTUNE_CONFIGS`, on HIP builds only. `waves_per_eu` is a ROCm launch
attribute, so a CUDA compile never sees an unknown `Config` key.

That is the entire change — nine lines, and `_prune_configs` is untouched.

**An earlier revision of this pinned the config to `H == 8` in
`_prune_configs`. That was wrong twice over and both faults were found by
running it:**

- It raised `KeyError: 'H'`. `H` is a `tl.constexpr`, and Triton passes
  constexprs to `early_config_prune` in `kwargs`, not `named_args`. Since
  `early_config_prune` runs on the first launch of every new autotune key, that
  made the kernel unusable rather than merely mis-tuned.
- Once fixed, it turned out to be unnecessary. With the config merely present in
  the set, Triton's autotune selects it **on merit at H=16 as well as H=8**. A
  head-count branch would have added shape-specific logic that changes no
  outcome, which is exactly the kind of thing that should not go into a shared
  kernel.

## Accuracy Tests

Selecting a different autotune configuration does not change the computation.
Covered by `test/registered/kernels/ops/attention/test_triton_sparse_mla.py`
from #37847, which passes 12/12 on an MI355X (H=4, 8, 12, 16 across trailing,
strided and head-plus-tail index patterns).

## Speed Tests and Profiling

MI355X (`gfx950:sramecc+:xnack-`), ROCm 7.2, seq 8148, topk 2048, `Dqk` 576,
`Dv` 512, OCP e4m3, 20 warmup + 50 timed iterations. Baseline is #37847's
branch, i.e. the same kernel with this config absent:

| H | without | with | change |
|---:|---:|---:|---:|
| 8 | 1.3156 ms | **1.1256 ms** | **-14.4%** |
| 16 | 1.3459 ms | **1.1853 ms** | **-11.9%** |

Both head counts report `waves_per_eu: 2` as the selected configuration, H=16
having chosen it against the full 18-entry grid.

Placed against the TileLang fallback that this operator used before #37847, so
the whole chain is visible (TileLang and plain-Triton columns measured in a
separate run on the same node and shape; the two runs agree on Triton to within
0.15%):

| H | TileLang (before #37847) | Triton (#37847) | Triton + this PR | cumulative |
|---:|---:|---:|---:|---:|
| 8 | 2.2522 ms | 1.3170 ms | **1.1256 ms** | **2.00x** |
| 16 | 2.3035 ms | 1.3449 ms | **1.1853 ms** | **1.94x** |

So #37847 recovers 1.71x by reaching the Triton kernel at all, and this PR takes
the total to almost exactly 2x at the deployed TP8 shape. The H=16 column
matters because that path is already shipping — it gains ~12% from a
nine-line change with no head-count logic.

Two honest notes on these numbers. They are larger than the ~4.7% recorded for
this launch in our earlier internal sweep; that sweep compared against a pinned
`BLOCK_N=32/2 warps/2 stages` baseline rather than an autotuned one, and the
discrepancy is not yet explained. And the index distribution here is uniformly
random rather than the trailing/strided/head-plus-tail patterns that sweep used.
Run-to-run spread within this harness is about 0.3%, so the direction and rough
magnitude are solid even though the exact figure should not be over-read.

Small-`topk` shapes were also exercised (`topk` 16 and 32) to confirm the
existing `BLOCK_N <= topk` pruning still falls back cleanly when no config
qualifies: both ran, at 0.0819 ms and 0.0823 ms.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
