### PR TITLE
[CPU][Spec] Support DFlash target-verify for hybrid GDN models

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
@@ -440,6 +440,115 @@ void causal_conv1d_update_kernel_impl(
   });
 }
 
+template <typename scalar_t>
+void causal_conv1d_verify_kernel_impl(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ conv_states,
+    scalar_t* __restrict__ window,
+    const scalar_t* __restrict__ weight,
+    const scalar_t* __restrict__ bias,
+    const int32_t* __restrict__ conv_indices,
+    const int32_t* __restrict__ window_indices,
+    bool silu_activation,
+    int64_t batch,
+    int64_t dim,
+    int64_t seqlen,
+    int64_t width,
+    int64_t window_strideW,
+    int64_t window_strideT,
+    int64_t window_strideD,
+    int64_t window_strideK) {
+  constexpr int64_t BLOCK_N = block_size_n() * 2;
+  const int64_t NB = div_up(dim, BLOCK_N);
+
+  const bool has_conv_states = conv_states != nullptr;
+  const bool has_conv_indices = conv_indices != nullptr;
+
+  // The whole draft block goes through the rolling-window kernel in one pass:
+  // it already carries the window forward in registers across the M loop, so
+  // only the first token needs to reach back into the incoming state.
+  AT_DISPATCH_BOOL2(bias != nullptr, has_bias, silu_activation, has_silu, [&] {
+    at::parallel_for(0, batch * NB, 0, [&](int64_t begin, int64_t end) {
+      int64_t bs{0}, nb{0};
+      data_index_init(begin, bs, batch, nb, NB);
+
+      for (int64_t i = begin; i < end; ++i) {
+        int64_t mb_start = 0;
+        int64_t mb_size = seqlen;
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(dim - nb_start, BLOCK_N);
+
+        const bool has_initial_states_value = true;
+        int32_t conv_state_index = has_conv_indices ? conv_indices[bs] : bs;
+
+        switch (width << 4 | nb_size >> 4) {
+          case 0x42:
+            LAUNCH_TINYGEMM_KERNEL(4, 32);
+            break;
+          case 0x44:
+            LAUNCH_TINYGEMM_KERNEL(4, 64);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected block size, ", width, " x ", nb_size);
+        }
+
+        data_index_step(bs, batch, nb, NB);
+      }
+    });
+  });
+
+  // The state after token t is the width-1 inputs ending at t, which run off
+  // the front of the block into the incoming state for the first width-2
+  // tokens. `window` may be an overlapping view, so this splits the work by
+  // channel: neighbouring t share elements, neighbouring d never do.
+  constexpr int64_t GRAIN_D = 512;
+  const int64_t ND = div_up(dim, GRAIN_D);
+  at::parallel_for(0, batch * ND, 0, [&](int64_t begin, int64_t end) {
+    int64_t bs{0}, nd{0};
+    data_index_init(begin, bs, batch, nd, ND);
+
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t d_begin = nd * GRAIN_D;
+      const int64_t d_end = std::min(dim, d_begin + GRAIN_D);
+      const int64_t cs_index = has_conv_indices ? conv_indices[bs] : bs;
+      scalar_t* __restrict__ slot = window + int64_t(window_indices[bs]) * window_strideW;
+
+      for (int64_t t = 0; t < seqlen; ++t) {
+        for (int64_t k = 0; k < width - 1; ++k) {
+          const int64_t s = t - (width - 2) + k;
+          const scalar_t* __restrict__ src = (s < 0)
+                                                 ? conv_states + cs_index * (width - 1) * dim + (s + width - 1) * dim
+                                                 : input + bs * seqlen * dim + s * dim;
+          scalar_t* __restrict__ dst = slot + t * window_strideT + k * window_strideK;
+          for (int64_t d = d_begin; d < d_end; ++d) {
+            dst[d * window_strideD] = src[d];
+          }
+        }
+      }
+
+      data_index_step(bs, batch, nd, ND);
+    }
+  });
+
+  // Committing the last snapshot rather than recomputing it keeps this pass
+  // from reading the incoming state the pass above is still consuming.
+  at::parallel_for(0, batch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t bs = begin; bs < end; ++bs) {
+      const int64_t cs_index = has_conv_indices ? conv_indices[bs] : bs;
+      const scalar_t* __restrict__ last =
+          window + int64_t(window_indices[bs]) * window_strideW + (seqlen - 1) * window_strideT;
+      scalar_t* __restrict__ state = conv_states + cs_index * (width - 1) * dim;
+
+      for (int64_t k = 0; k < width - 1; ++k) {
+        for (int64_t d = 0; d < dim; ++d) {
+          state[k * dim + d] = last[k * window_strideK + d * window_strideD];
+        }
+      }
+    }
+  });
+}
+
 }  // anonymous namespace
 
 // from [dim, width] or [N, K]
@@ -698,6 +807,98 @@ at::Tensor causal_conv1d_update_cpu(
         dim,
         seqlen,
         width);
+  });
+  return out;
+}
+
+// Target verify for a linear draft chain.
+//   x: (batch, dim, steps), transposed so that `dim` is the contiguous axis
+//   conv_states: (num_cache_lines, dim, width - 1)
+//   intermediate_conv_window: (num_slots, max_steps, dim, width - 1)
+//   out: (batch, dim, steps), same layout as x
+//
+at::Tensor causal_conv1d_verify_cpu(
+    const at::Tensor& x,
+    at::Tensor& conv_states,
+    const at::Tensor& conv_state_indices,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    bool silu_activation,
+    at::Tensor& intermediate_conv_window,
+    const at::Tensor& intermediate_state_indices,
+    bool is_vnni) {
+  CHECK_CONTIGUOUS(weight);
+  auto packed_w = is_vnni ? weight : causal_conv1d_weight_pack(weight);
+
+  TORCH_CHECK(x.dim() == 3, "causal_conv1d_verify_cpu: expect x to be 3D tensor.");
+
+  int64_t batch = x.size(0);
+  int64_t dim = x.size(1);
+  int64_t seqlen = x.size(2);
+  int64_t width = weight.size(-1);
+  TORCH_CHECK(seqlen > 0, "causal_conv1d_verify_cpu: expect a non-empty draft block.");
+  // A one-token block never steps along the token axis, so its stride carries no information.
+  TORCH_CHECK(
+      x.stride(-2) == 1 && (seqlen == 1 || x.stride(-1) == dim),
+      "causal_conv1d_verify_cpu: expect x to be transposed.");
+  TORCH_CHECK(x.stride(0) == seqlen * dim, "causal_conv1d_verify_cpu: expect x sequences to be packed back to back.");
+
+  const auto scalar_type = x.scalar_type();
+  CHECK_EQ(weight.scalar_type(), scalar_type);
+  CHECK_OPTIONAL_SHAPE_DTYPE(bias, dim, scalar_type);
+
+  auto cache_indices = conv_state_indices.contiguous();
+  auto window_indices = intermediate_state_indices.contiguous();
+  CHECK_EQ(cache_indices.scalar_type(), at::kInt);
+  CHECK_EQ(window_indices.scalar_type(), at::kInt);
+  TORCH_CHECK(cache_indices.numel() >= batch, "causal_conv1d_verify_cpu: conv_state_indices is shorter than batch.");
+  TORCH_CHECK(
+      window_indices.numel() >= batch, "causal_conv1d_verify_cpu: intermediate_state_indices is shorter than batch.");
+
+  CHECK_EQ(conv_states.scalar_type(), scalar_type);
+  CHECK_EQ(conv_states.size(1), dim);
+  CHECK_EQ(conv_states.size(2), width - 1);
+
+  // adjust `conv_states` to be contiguous on `dim`
+  if (conv_states.stride(-2) != 1) {
+    int64_t num_cache_lines = conv_states.size(0);
+    auto conv_states_copy = conv_states.clone();
+    conv_states.as_strided_({num_cache_lines, dim, width - 1}, {(width - 1) * dim, 1, dim});
+    conv_states.copy_(conv_states_copy);
+  }
+
+  CHECK_EQ(intermediate_conv_window.scalar_type(), scalar_type);
+  TORCH_CHECK(
+      intermediate_conv_window.dim() == 4, "causal_conv1d_verify_cpu: expect intermediate_conv_window to be 4D.");
+  TORCH_CHECK(
+      intermediate_conv_window.size(1) >= seqlen,
+      "causal_conv1d_verify_cpu: intermediate_conv_window holds ",
+      intermediate_conv_window.size(1),
+      " steps, need ",
+      seqlen);
+  CHECK_EQ(intermediate_conv_window.size(2), dim);
+  CHECK_EQ(intermediate_conv_window.size(3), width - 1);
+
+  at::Tensor out = at::empty_like(x);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(scalar_type, "causal_conv1d_verify_kernel_impl", [&] {
+    causal_conv1d_verify_kernel_impl<scalar_t>(
+        out.data_ptr<scalar_t>(),
+        x.data_ptr<scalar_t>(),
+        conv_states.data_ptr<scalar_t>(),
+        intermediate_conv_window.data_ptr<scalar_t>(),
+        packed_w.data_ptr<scalar_t>(),
+        conditional_data_ptr<scalar_t>(bias),
+        cache_indices.data_ptr<int32_t>(),
+        window_indices.data_ptr<int32_t>(),
+        silu_activation,
+        batch,
+        dim,
+        seqlen,
+        width,
+        intermediate_conv_window.stride(0),
+        intermediate_conv_window.stride(1),
+        intermediate_conv_window.stride(2),
+        intermediate_conv_window.stride(3));
   });
   return out;
 }

--- a/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
@@ -1242,6 +1242,186 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
   });
 }
 
+// Speculative-verify variant of the recurrence above.
+//
+// Tokens are packed as tok = bi * steps + t, so the whole draft block for every
+// sequence arrives in a single dispatch. The per-(sequence, v_head) work item
+// walks t sequentially, which is what the recurrence requires, and writes the
+// state after token t straight into intermediate_states_buffer[widx, t]. The
+// committed pool is only read, so a rejected block needs no rollback: the caller
+// just picks the snapshot of the last accepted token.
+template <typename scalar_t, typename param_t>
+void fused_sigmoid_gating_delta_rule_update_spec_kernel_impl(
+    const scalar_t* __restrict__ q_ptr,
+    const scalar_t* __restrict__ k_ptr,
+    const scalar_t* __restrict__ v_ptr,
+    const param_t* __restrict__ A_log_ptr,
+    const scalar_t* __restrict__ a_ptr,
+    const scalar_t* __restrict__ dt_bias_ptr,
+    const scalar_t* __restrict__ b_ptr,
+    const int32_t* __restrict__ state_indices_ptr,
+    const int32_t* __restrict__ window_indices_ptr,
+    float* __restrict__ state_ptr,
+    float* __restrict__ window_ptr,
+    scalar_t* __restrict__ o_ptr,
+    float* __restrict__ qk_scale_buf,
+    int64_t steps,
+    int64_t batch_size,
+    int64_t num_heads,
+    int64_t head_dim,
+    int64_t v_num_heads,
+    int64_t v_head_dim,
+    int64_t q_strideT,
+    int64_t q_strideH,
+    int64_t k_strideT,
+    int64_t k_strideH,
+    int64_t v_strideT,
+    int64_t v_strideH,
+    int64_t window_strideW,
+    int64_t window_strideT,
+    bool use_qk_l2norm_in_kernel,
+    bool disable_state_update,
+    double softplus_threshold) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  constexpr int64_t VecSize = bVec::size();
+  constexpr int64_t fVecSize = fVec::size();
+  const int64_t group_size = v_num_heads / num_heads;
+  const int64_t total_tokens = batch_size * steps;
+  const int64_t head_state_size = head_dim * v_head_dim;
+  const double scale = 1 / std::sqrt(head_dim);
+  const fVec scale_vec = fVec(scale);
+
+  if (use_qk_l2norm_in_kernel) {
+    const float eps = 1e-5;
+    at::parallel_for(0, total_tokens * num_heads, 0, [&](int64_t begin, int64_t end) {
+      int64_t ti{0}, ni{0};
+      data_index_init(begin, ti, total_tokens, ni, num_heads);
+      for (int64_t i = begin; i < end; ++i) {
+        float sum_q = float(0);
+        float sum_k = float(0);
+        fVec sum_q_fvec = fVec(float(0));
+        fVec sum_k_fvec = fVec(float(0));
+        int64_t q_offset = ti * q_strideT + ni * q_strideH;
+        int64_t k_offset = ti * k_strideT + ni * k_strideH;
+        int64_t d;
+#pragma GCC unroll 4
+        for (d = 0; d <= head_dim - VecSize; d += VecSize) {
+          auto [q_fvec0, q_fvec1] = load_float_vec2(q_ptr + q_offset + d);
+          sum_q_fvec += q_fvec0 * q_fvec0;
+          sum_q_fvec += q_fvec1 * q_fvec1;
+          auto [k_fvec0, k_fvec1] = load_float_vec2(k_ptr + k_offset + d);
+          sum_k_fvec += k_fvec0 * k_fvec0;
+          sum_k_fvec += k_fvec1 * k_fvec1;
+        }
+#pragma GCC unroll 4
+        for (; d < head_dim; ++d) {
+          float q_val = static_cast<float>(q_ptr[q_offset + d]);
+          sum_q += q_val * q_val;
+          float k_val = static_cast<float>(k_ptr[k_offset + d]);
+          sum_k += k_val * k_val;
+        }
+
+        sum_q += vec_reduce_sum(sum_q_fvec);
+        sum_k += vec_reduce_sum(sum_k_fvec);
+        qk_scale_buf[ti * num_heads + ni] = float(1) / std::sqrt(sum_q + eps);
+        qk_scale_buf[total_tokens * num_heads + ti * num_heads + ni] = float(1) / std::sqrt(sum_k + eps);
+
+        data_index_step(ti, total_tokens, ni, num_heads);
+      }
+    });
+  }
+
+  at::parallel_for(0, batch_size * v_num_heads, 0, [&](int64_t begin, int64_t end) {
+    int64_t bi{0}, ni{0};
+    data_index_init(begin, bi, batch_size, ni, v_num_heads);
+    for (int64_t i = begin; i < end; ++i) {
+      float* const pool_state = state_ptr + (int64_t(state_indices_ptr[bi]) * v_num_heads + ni) * head_state_size;
+      float* const window_base = window_ptr + int64_t(window_indices_ptr[bi]) * window_strideW + ni * head_state_size;
+      const float A_log_exp = std::exp(float(A_log_ptr[ni]));
+      const float dt_bias_val = float(dt_bias_ptr[ni]);
+
+      for (int64_t t = 0; t < steps; ++t) {
+        const int64_t tok = bi * steps + t;
+        const float* __restrict__ src = (t == 0) ? pool_state : (window_base + (t - 1) * window_strideT);
+        float* __restrict__ dst = window_base + t * window_strideT;
+
+        float g_val_exp =
+            std::exp(-A_log_exp * softplus(float(a_ptr[tok * v_num_heads + ni]) + dt_bias_val, softplus_threshold));
+        fVec g_val_exp_vec = fVec(g_val_exp);
+        float beta_val = 1 / (1 + std::exp(-float(b_ptr[tok * v_num_heads + ni])));
+        fVec beta_vec = fVec(beta_val);
+
+        int64_t q_offset = tok * q_strideT + (ni / group_size) * q_strideH;
+        int64_t k_offset = tok * k_strideT + (ni / group_size) * k_strideH;
+        int64_t v_offset = tok * v_strideT + ni * v_strideH;
+        int64_t o_offset = (tok * v_num_heads + ni) * v_head_dim;
+        int64_t scale_offset = tok * num_heads + (ni / group_size);
+        float q_scale = use_qk_l2norm_in_kernel ? qk_scale_buf[scale_offset] : 1.0f;
+        float k_scale = use_qk_l2norm_in_kernel ? qk_scale_buf[total_tokens * num_heads + scale_offset] : 1.0f;
+
+        int64_t dvi = 0;
+        for (; dvi <= v_head_dim - VecSize; dvi += VecSize) {
+          fVec kv_mem_vec0 = fVec(float(0));
+          fVec kv_mem_vec1 = fVec(float(0));
+          for (int di = 0; di < head_dim; ++di) {
+            fVec k_val_vec = fVec(float(k_ptr[k_offset + di]) * k_scale);
+            auto [state_vec0, state_vec1] = load_float_vec2(src + di * v_head_dim + dvi);
+            kv_mem_vec0 = kv_mem_vec0 + state_vec0 * g_val_exp_vec * k_val_vec;
+            kv_mem_vec1 = kv_mem_vec1 + state_vec1 * g_val_exp_vec * k_val_vec;
+          }
+          auto [v_vec0, v_vec1] = load_float_vec2(v_ptr + v_offset + dvi);
+          fVec dt_vec0 = (v_vec0 - kv_mem_vec0) * beta_vec;
+          fVec dt_vec1 = (v_vec1 - kv_mem_vec1) * beta_vec;
+          fVec o_vec0 = fVec(float(0));
+          fVec o_vec1 = fVec(float(0));
+          for (int di = 0; di < head_dim; ++di) {
+            fVec q_vec = fVec(float(q_ptr[q_offset + di]) * q_scale);
+            fVec k_vec = fVec(float(k_ptr[k_offset + di]) * k_scale);
+            auto [state_vec0, state_vec1] = load_float_vec2(src + di * v_head_dim + dvi);
+            state_vec0 = state_vec0 * g_val_exp_vec + k_vec * dt_vec0;
+            state_vec1 = state_vec1 * g_val_exp_vec + k_vec * dt_vec1;
+            o_vec0 = o_vec0 + state_vec0 * q_vec * scale_vec;
+            o_vec1 = o_vec1 + state_vec1 * q_vec * scale_vec;
+            state_vec0.store(dst + di * v_head_dim + dvi);
+            state_vec1.store(dst + di * v_head_dim + dvi + fVecSize);
+          }
+          bVec o_vec = at::vec::convert_from_float<scalar_t>(o_vec0, o_vec1);
+          o_vec.store(o_ptr + o_offset + dvi);
+        }
+        for (; dvi < v_head_dim; ++dvi) {
+          float kv_mem_val = 0;
+          for (int di = 0; di < head_dim; ++di) {
+            float k_val = float(k_ptr[k_offset + di]) * k_scale;
+            kv_mem_val += src[di * v_head_dim + dvi] * g_val_exp * k_val;
+          }
+          float v_val = float(v_ptr[v_offset + dvi]);
+          float dt_val = (v_val - kv_mem_val) * beta_val;
+          float o_val = 0;
+          for (int di = 0; di < head_dim; ++di) {
+            float q_val = float(q_ptr[q_offset + di]) * q_scale;
+            float k_val = float(k_ptr[k_offset + di]) * k_scale;
+            float state_val = src[di * v_head_dim + dvi] * g_val_exp + k_val * dt_val;
+            dst[di * v_head_dim + dvi] = state_val;
+            o_val += state_val * q_val * scale;
+          }
+          o_ptr[o_offset + dvi] = o_val;
+        }
+      }
+
+      if (!disable_state_update) {
+        const float* last = window_base + (steps - 1) * window_strideT;
+        for (int64_t j = 0; j < head_state_size; ++j) {
+          pool_state[j] = last[j];
+        }
+      }
+
+      data_index_step(bi, batch_size, ni, v_num_heads);
+    }
+  });
+}
+
 template <typename scalar_t>
 void fused_gdn_gating_kernel_impl(
     float* __restrict__ A_log,
@@ -1690,6 +1870,119 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
             v_strideS,
             v_strideH,
             use_qk_l2norm_in_kernel,
+            softplus_threshold);
+      });
+  return core_attn_out;
+}
+
+// q/k/v: [1, batch * steps, num_heads, head_dim], token tok = bi * steps + t
+// a/b: [batch * steps, num_v_heads]
+// initial_state_source: [pool, num_v_heads, head_dim, v_head_dim], read-only
+//   unless disable_state_update is false
+// intermediate_states_buffer: [window_pool, steps, num_v_heads, head_dim,
+//   v_head_dim], receives the state after each draft token
+at::Tensor fused_sigmoid_gating_delta_rule_update_spec_cpu(
+    const at::Tensor& A_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    at::Tensor& initial_state_source,
+    const at::Tensor& initial_state_indices,
+    at::Tensor& intermediate_states_buffer,
+    const at::Tensor& intermediate_state_indices,
+    int64_t steps,
+    bool use_qk_l2norm_in_kernel,
+    bool disable_state_update,
+    double softplus_beta = 1.0,
+    double softplus_threshold = 20.0) {
+  CHECK_DIM(4, q);
+  CHECK_DIM(4, v);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
+  CHECK_EQ(q.size(0), 1);
+  CHECK(steps > 0);
+  int64_t total_tokens = q.size(1);
+  int64_t num_heads = q.size(2);
+  int64_t head_dim = q.size(3);
+  int64_t v_num_heads = v.size(2);
+  int64_t v_head_dim = v.size(3);
+  int64_t batch_size = initial_state_indices.size(0);
+  CHECK_EQ(total_tokens, batch_size * steps);
+  CHECK_INPUT_SHAPE_DTYPE<true>(k, {1, total_tokens, num_heads, head_dim}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(v, {1, total_tokens, v_num_heads, v_head_dim}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(a, {total_tokens, v_num_heads}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(b, {total_tokens, v_num_heads}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(dt_bias, {v_num_heads}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(initial_state_indices, {batch_size}, at::kInt);
+  CHECK_INPUT_SHAPE_DTYPE<true>(
+      initial_state_source, {initial_state_source.size(0), v_num_heads, head_dim, v_head_dim}, at::kFloat);
+  CHECK_DIM(5, intermediate_states_buffer);
+  CHECK_EQ(intermediate_states_buffer.scalar_type(), at::kFloat);
+  CHECK(intermediate_states_buffer.size(1) >= steps);
+  CHECK_EQ(intermediate_states_buffer.size(2), v_num_heads);
+  CHECK_EQ(intermediate_states_buffer.size(3), head_dim);
+  CHECK_EQ(intermediate_states_buffer.size(4), v_head_dim);
+  // Only the trailing [num_v_heads, head_dim, v_head_dim] block has to be
+  // packed; the pool and step axes are addressed through their own strides.
+  CHECK_EQ(intermediate_states_buffer.stride(4), 1);
+  CHECK_EQ(intermediate_states_buffer.stride(3), v_head_dim);
+  CHECK_EQ(intermediate_states_buffer.stride(2), head_dim * v_head_dim);
+  CHECK_EQ(intermediate_state_indices.scalar_type(), at::kInt);
+  CHECK_CONTIGUOUS(intermediate_state_indices);
+  // The caller may hand over the whole pool-sized slot table; only the first
+  // batch_size entries belong to this batch.
+  CHECK(intermediate_state_indices.size(0) >= batch_size);
+  CHECK_EQ(v_num_heads % num_heads, 0);
+  TORCH_CHECK(
+      A_log.sizes() == at::IntArrayRef({v_num_heads}),
+      "Input tensor shape mismatch: expected ",
+      at::IntArrayRef({v_num_heads}),
+      ", got ",
+      A_log.sizes());
+
+  int64_t q_strideT = q.stride(1);
+  int64_t q_strideH = q.stride(2);
+  int64_t k_strideT = k.stride(1);
+  int64_t k_strideH = k.stride(2);
+  int64_t v_strideT = v.stride(1);
+  int64_t v_strideH = v.stride(2);
+  at::Tensor core_attn_out = at::empty({1, total_tokens, v_num_heads, v_head_dim}, q.options());
+  at::Tensor qk_scale_buf = at::empty({2, total_tokens, num_heads}, at::kFloat);
+
+  CPU_DISPATCH_REDUCED_FLOATING_TYPES_EXT(
+      q.scalar_type(), A_log.scalar_type(), "fused_sigmoid_gating_delta_rule_update_spec_kernel_impl", [&] {
+        fused_sigmoid_gating_delta_rule_update_spec_kernel_impl<scalar_t, param_t>(
+            q.data_ptr<scalar_t>(),
+            k.data_ptr<scalar_t>(),
+            v.data_ptr<scalar_t>(),
+            A_log.data_ptr<param_t>(),
+            a.data_ptr<scalar_t>(),
+            dt_bias.data_ptr<scalar_t>(),
+            b.data_ptr<scalar_t>(),
+            initial_state_indices.data_ptr<int32_t>(),
+            intermediate_state_indices.data_ptr<int32_t>(),
+            initial_state_source.data_ptr<float>(),
+            intermediate_states_buffer.data_ptr<float>(),
+            core_attn_out.data_ptr<scalar_t>(),
+            qk_scale_buf.data_ptr<float>(),
+            steps,
+            batch_size,
+            num_heads,
+            head_dim,
+            v_num_heads,
+            v_head_dim,
+            q_strideT,
+            q_strideH,
+            k_strideT,
+            k_strideH,
+            v_strideT,
+            v_strideH,
+            intermediate_states_buffer.stride(0),
+            intermediate_states_buffer.stride(1),
+            use_qk_l2norm_in_kernel,
+            disable_state_update,
             softplus_threshold);
       });
   return core_attn_out;

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -451,6 +451,17 @@ at::Tensor causal_conv1d_update_cpu(
     const std::optional<at::Tensor>& conv_state_indices,
     int64_t pad_slot_id,
     bool is_vnni);
+
+at::Tensor causal_conv1d_verify_cpu(
+    const at::Tensor& x,
+    at::Tensor& conv_states,
+    const at::Tensor& conv_state_indices,
+    const at::Tensor& weight,
+    const std::optional<at::Tensor>& bias,
+    bool silu_activation,
+    at::Tensor& intermediate_conv_window,
+    const at::Tensor& intermediate_state_indices,
+    bool is_vnni);
 #endif
 
 // conv3d fast path for patch embedding
@@ -865,6 +876,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "causal_conv1d_update_cpu(Tensor x, Tensor(a!) conv_states, Tensor weight, Tensor? bias, bool silu_activation,"
       "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, bool is_vnni) -> Tensor");
   m.impl("causal_conv1d_update_cpu", torch::kCPU, &causal_conv1d_update_cpu);
+  // causal_conv1d_verify
+  m.def(
+      "causal_conv1d_verify_cpu(Tensor x, Tensor(a!) conv_states, Tensor conv_state_indices, Tensor weight, "
+      "Tensor? bias, bool silu_activation, Tensor(b!) intermediate_conv_window, Tensor intermediate_state_indices, "
+      "bool is_vnni) -> Tensor");
+  m.impl("causal_conv1d_verify_cpu", torch::kCPU, &causal_conv1d_verify_cpu);
 #endif
 
   // conv3d fast path for patch embedding

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -516,6 +516,24 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     bool use_qk_l2norm_in_kernel,
     double softplus_beta = 1.0,
     double softplus_threshold = 20.0);
+// fused_sigmoid_gating_delta_rule_update_spec
+at::Tensor fused_sigmoid_gating_delta_rule_update_spec_cpu(
+    const at::Tensor& A_log,
+    const at::Tensor& dt_bias,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    at::Tensor& initial_state_source,
+    const at::Tensor& initial_state_indices,
+    at::Tensor& intermediate_states_buffer,
+    const at::Tensor& intermediate_state_indices,
+    int64_t steps,
+    bool use_qk_l2norm_in_kernel,
+    bool disable_state_update,
+    double softplus_beta = 1.0,
+    double softplus_threshold = 20.0);
 // fused_gdn_gating
 std::tuple<at::Tensor, at::Tensor>
 fused_gdn_gating_cpu(const at::Tensor& A_log, const at::Tensor& a, const at::Tensor& b, const at::Tensor& dt_bias);
@@ -893,6 +911,15 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "a, Tensor b, Tensor(a!) initial_state_source, Tensor initial_state_indices, Tensor cu_seqlens, bool "
       "use_qk_l2norm_in_kernel, float softplus_beta=1.0, float softplus_threshold=20.0) -> Tensor");
   m.impl("fused_sigmoid_gating_delta_rule_update_cpu", torch::kCPU, &fused_sigmoid_gating_delta_rule_update_cpu);
+  // fused_sigmoid_gating_delta_rule_update_spec
+  m.def(
+      "fused_sigmoid_gating_delta_rule_update_spec_cpu(Tensor A_log, Tensor dt_bias, Tensor q, Tensor k, Tensor v, "
+      "Tensor a, Tensor b, Tensor(a!) initial_state_source, Tensor initial_state_indices, "
+      "Tensor(b!) intermediate_states_buffer, Tensor intermediate_state_indices, int steps, bool "
+      "use_qk_l2norm_in_kernel, bool disable_state_update, float softplus_beta=1.0, float softplus_threshold=20.0) "
+      "-> Tensor");
+  m.impl(
+      "fused_sigmoid_gating_delta_rule_update_spec_cpu", torch::kCPU, &fused_sigmoid_gating_delta_rule_update_spec_cpu);
   // fused_gdn_gating
   m.def("fused_gdn_gating_cpu(Tensor A_log, Tensor a, Tensor b, Tensor dt_bias) -> (Tensor, Tensor)");
   m.impl("fused_gdn_gating_cpu", torch::kCPU, &fused_gdn_gating_cpu);

--- a/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
@@ -75,9 +75,96 @@ def causal_conv1d_fn_cpu(
     )
 
 
-def causal_conv1d_update_cpu(
-    mixed_qkv, conv_states, conv_weights, bias, activation, conv_state_indices
+def _causal_conv1d_update_cpu_verify(
+    mixed_qkv,
+    conv_states,
+    conv_weights,
+    bias,
+    activation,
+    conv_state_indices,
+    intermediate_conv_window,
+    intermediate_state_indices,
+    retrieve_parent_token,
 ):
+    """Target-verify conv over a linear draft chain.
+
+    With DFlash's chain metadata (``retrieve_next_token[t] == t + 1``, no
+    siblings) the Triton kernel's parent walk degenerates to a rolling window,
+    so the block is just the decode kernel replayed token by token. The C++
+    kernel takes a VNNI-prepacked weight whose layout torch cannot convolve
+    with directly, so it has to do the arithmetic.
+    """
+    seq_len = mixed_qkv.size(-1)
+    cache_idx = conv_state_indices.to(torch.int64)
+    window_idx = intermediate_state_indices.to(torch.int64)
+
+    # Roll a scratch copy so the real pool only sees the final state.
+    scratch = conv_states[cache_idx].contiguous()
+    step_state_indices = torch.arange(
+        cache_idx.numel(), dtype=torch.int32, device=mixed_qkv.device
+    )
+
+    result = torch.empty_like(mixed_qkv)
+    for t in range(seq_len):
+        result[:, :, t] = torch.ops.sgl_kernel.causal_conv1d_update_cpu(
+            mixed_qkv[:, :, t].contiguous(),
+            scratch,
+            conv_weights,
+            bias,
+            activation in ("silu", "swish"),
+            None,
+            step_state_indices,
+            -1,
+            True,
+        )
+        intermediate_conv_window[window_idx, t] = scratch
+
+    conv_states[cache_idx] = scratch
+
+    if retrieve_parent_token is not None:
+        # The Triton kernel fuses this; downstream GDN verify reads it.
+        retrieve_parent_token[:, 0] = 0
+        retrieve_parent_token[:, 1:seq_len] = torch.arange(
+            seq_len - 1,
+            device=retrieve_parent_token.device,
+            dtype=retrieve_parent_token.dtype,
+        )
+
+    return result
+
+
+def causal_conv1d_update_cpu(
+    mixed_qkv,
+    conv_states,
+    conv_weights,
+    bias,
+    activation,
+    conv_state_indices,
+    intermediate_conv_window=None,
+    intermediate_state_indices=None,
+    retrieve_next_token=None,
+    retrieve_next_sibling=None,
+    retrieve_parent_token=None,
+):
+    if intermediate_conv_window is not None:
+        if retrieve_next_sibling is not None and bool(
+            (retrieve_next_sibling != -1).any()
+        ):
+            raise NotImplementedError(
+                "causal_conv1d_update_cpu target-verify supports a linear draft "
+                "chain only (topk <= 1); EAGLE tree verify has siblings."
+            )
+        return _causal_conv1d_update_cpu_verify(
+            mixed_qkv,
+            conv_states,
+            conv_weights,
+            bias,
+            activation,
+            conv_state_indices,
+            intermediate_conv_window,
+            intermediate_state_indices,
+            retrieve_parent_token,
+        )
     return torch.ops.sgl_kernel.causal_conv1d_update_cpu(
         mixed_qkv,
         conv_states,
@@ -89,6 +176,109 @@ def causal_conv1d_update_cpu(
         -1,
         True,
     )
+
+
+def _assert_linear_chain(retrieve_parent_token, steps):
+    if retrieve_parent_token is None:
+        return
+    expected = torch.arange(
+        -1,
+        steps - 1,
+        device=retrieve_parent_token.device,
+        dtype=retrieve_parent_token.dtype,
+    )
+    expected[0] = 0
+    if not torch.equal(
+        retrieve_parent_token, expected.expand_as(retrieve_parent_token)
+    ):
+        raise NotImplementedError(
+            "fused_sigmoid_gating_delta_rule_update_cpu target-verify supports a "
+            "linear draft chain only (topk <= 1); got a branching EAGLE tree."
+        )
+
+
+def fused_sigmoid_gating_delta_rule_update_cpu(
+    *,
+    A_log,
+    dt_bias,
+    q,
+    k,
+    v,
+    a,
+    b,
+    initial_state_source,
+    initial_state_indices,
+    cu_seqlens,
+    use_qk_l2norm_in_kernel,
+    softplus_beta=1.0,
+    softplus_threshold=20.0,
+    is_kda=False,
+    disable_state_update=False,
+    intermediate_states_buffer=None,
+    intermediate_state_indices=None,
+    cache_steps=None,
+    retrieve_parent_token=None,
+):
+    if intermediate_states_buffer is None:
+        return torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+            A_log,
+            dt_bias,
+            q,
+            k,
+            v,
+            a,
+            b,
+            initial_state_source,
+            initial_state_indices,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            softplus_beta,
+            softplus_threshold,
+        )
+
+    # Target verify. The C++ op consumes one token per sequence and rolls the
+    # state in place, so replaying the draft chain step by step against a
+    # scratch copy reproduces the fused kernel's snapshots while leaving the
+    # real ssm_states untouched (disable_state_update).
+    assert not is_kda, "KDA target_verify is not supported on CPU"
+    assert a.dim() == 2, f"expected per-token gating [tokens, heads], got {a.shape}"
+
+    batch = cu_seqlens.numel() - 1
+    steps = q.shape[1] // batch
+    _assert_linear_chain(retrieve_parent_token, steps)
+
+    state_idx = initial_state_indices.to(torch.int64)
+    scratch = initial_state_source[state_idx].contiguous()
+    step_state_indices = torch.arange(batch, dtype=torch.int32, device=q.device)
+    step_cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device)
+    # The caller hands over the whole pool-sized table; the kernel reads it
+    # positionally per request, so only the first `batch` rows are ours.
+    window_idx = intermediate_state_indices[:batch].to(torch.int64)
+
+    core_attn_out = q.new_empty((1, q.shape[1], v.shape[2], v.shape[3]))
+    for t in range(steps):
+        # Token `t` of sequence `n` sits at n * steps + t in the packed axis.
+        out_t = torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+            A_log,
+            dt_bias,
+            q[:, t::steps].contiguous(),
+            k[:, t::steps].contiguous(),
+            v[:, t::steps].contiguous(),
+            a[t::steps].contiguous(),
+            b[t::steps].contiguous(),
+            scratch,
+            step_state_indices,
+            step_cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            softplus_beta,
+            softplus_threshold,
+        )
+        core_attn_out[:, t::steps] = out_t[:, 0]
+        intermediate_states_buffer[window_idx, t] = scratch
+
+    if not disable_state_update:
+        initial_state_source[state_idx] = scratch
+    return core_attn_out
 
 
 def chunk_gated_delta_rule_cpu(

--- a/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
@@ -95,8 +95,18 @@ def _causal_conv1d_update_cpu_verify(
     with directly, so it has to do the arithmetic.
     """
     seq_len = mixed_qkv.size(-1)
+    width = conv_weights.size(-1)
     cache_idx = conv_state_indices.to(torch.int64)
     window_idx = intermediate_state_indices.to(torch.int64)
+
+    # The decode kernel appends the raw input to the state, so the state after
+    # token t is just the width-1 window of [initial_state, block] ending at t.
+    # Batching them avoids one index_put_ per token, which costs ~12us
+    # regardless of how few bytes it moves.
+    extended = torch.cat([conv_states[cache_idx], mixed_qkv], dim=-1)
+    intermediate_conv_window[window_idx, :seq_len] = extended.unfold(-1, width - 1, 1)[
+        :, :, 1:
+    ].permute(0, 2, 1, 3)
 
     # Roll a scratch copy so the real pool only sees the final state.
     scratch = conv_states[cache_idx].contiguous()
@@ -117,7 +127,6 @@ def _causal_conv1d_update_cpu_verify(
             -1,
             True,
         )
-        intermediate_conv_window[window_idx, t] = scratch
 
     conv_states[cache_idx] = scratch
 
@@ -236,10 +245,11 @@ def fused_sigmoid_gating_delta_rule_update_cpu(
             softplus_threshold,
         )
 
-    # Target verify. The C++ op consumes one token per sequence and rolls the
-    # state in place, so replaying the draft chain step by step against a
-    # scratch copy reproduces the fused kernel's snapshots while leaving the
-    # real ssm_states untouched (disable_state_update).
+    # Target verify. Tokens arrive packed as n * steps + t, which is exactly the
+    # layout the spec op expects, so the whole draft block goes out in a single
+    # dispatch: the kernel walks t sequentially per (sequence, v_head) and writes
+    # the state after each token straight into intermediate_states_buffer. The
+    # committed ssm_states are only read unless disable_state_update is False.
     assert not is_kda, "KDA target_verify is not supported on CPU"
     assert a.dim() == 2, f"expected per-token gating [tokens, heads], got {a.shape}"
 
@@ -247,38 +257,24 @@ def fused_sigmoid_gating_delta_rule_update_cpu(
     steps = q.shape[1] // batch
     _assert_linear_chain(retrieve_parent_token, steps)
 
-    state_idx = initial_state_indices.to(torch.int64)
-    scratch = initial_state_source[state_idx].contiguous()
-    step_state_indices = torch.arange(batch, dtype=torch.int32, device=q.device)
-    step_cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device)
-    # The caller hands over the whole pool-sized table; the kernel reads it
-    # positionally per request, so only the first `batch` rows are ours.
-    window_idx = intermediate_state_indices[:batch].to(torch.int64)
-
-    core_attn_out = q.new_empty((1, q.shape[1], v.shape[2], v.shape[3]))
-    for t in range(steps):
-        # Token `t` of sequence `n` sits at n * steps + t in the packed axis.
-        out_t = torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
-            A_log,
-            dt_bias,
-            q[:, t::steps].contiguous(),
-            k[:, t::steps].contiguous(),
-            v[:, t::steps].contiguous(),
-            a[t::steps].contiguous(),
-            b[t::steps].contiguous(),
-            scratch,
-            step_state_indices,
-            step_cu_seqlens,
-            use_qk_l2norm_in_kernel,
-            softplus_beta,
-            softplus_threshold,
-        )
-        core_attn_out[:, t::steps] = out_t[:, 0]
-        intermediate_states_buffer[window_idx, t] = scratch
-
-    if not disable_state_update:
-        initial_state_source[state_idx] = scratch
-    return core_attn_out
+    return torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_spec_cpu(
+        A_log,
+        dt_bias,
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        a.contiguous(),
+        b.contiguous(),
+        initial_state_source,
+        initial_state_indices,
+        intermediate_states_buffer,
+        intermediate_state_indices.contiguous(),
+        steps,
+        use_qk_l2norm_in_kernel,
+        disable_state_update,
+        softplus_beta,
+        softplus_threshold,
+    )
 
 
 def chunk_gated_delta_rule_cpu(

--- a/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
@@ -95,40 +95,31 @@ def _causal_conv1d_update_cpu_verify(
     with directly, so it has to do the arithmetic.
     """
     seq_len = mixed_qkv.size(-1)
-    width = conv_weights.size(-1)
-    cache_idx = conv_state_indices.to(torch.int64)
-    window_idx = intermediate_state_indices.to(torch.int64)
 
-    # The decode kernel appends the raw input to the state, so the state after
-    # token t is just the width-1 window of [initial_state, block] ending at t.
-    # Batching them avoids one index_put_ per token, which costs ~12us
-    # regardless of how few bytes it moves.
-    extended = torch.cat([conv_states[cache_idx], mixed_qkv], dim=-1)
-    intermediate_conv_window[window_idx, :seq_len] = extended.unfold(-1, width - 1, 1)[
-        :, :, 1:
-    ].permute(0, 2, 1, 3)
+    # gdn_backend hands over mixed_qkv.view(batch, steps, -1).transpose(1, 2),
+    # and the kernel strides over tokens that way. Anything else has to be
+    # rebuilt in that layout first. A one-token block has no token stride to
+    # match, and transposing it would not change one either.
+    if mixed_qkv.stride(-2) != 1 or (
+        seq_len > 1 and mixed_qkv.stride(-1) != mixed_qkv.size(-2)
+    ):
+        mixed_qkv = mixed_qkv.transpose(-1, -2).contiguous().transpose(-1, -2)
 
-    # Roll a scratch copy so the real pool only sees the final state.
-    scratch = conv_states[cache_idx].contiguous()
-    step_state_indices = torch.arange(
-        cache_idx.numel(), dtype=torch.int32, device=mixed_qkv.device
+    # The rolling window the decode kernel keeps in registers already spans the
+    # whole block, so one dispatch replays it: only the first token reaches back
+    # into the incoming state. The kernel also writes the per-token snapshots
+    # and commits the final state.
+    result = torch.ops.sgl_kernel.causal_conv1d_verify_cpu(
+        mixed_qkv,
+        conv_states,
+        conv_state_indices,
+        conv_weights,
+        bias,
+        activation in ("silu", "swish"),
+        intermediate_conv_window,
+        intermediate_state_indices,
+        True,
     )
-
-    result = torch.empty_like(mixed_qkv)
-    for t in range(seq_len):
-        result[:, :, t] = torch.ops.sgl_kernel.causal_conv1d_update_cpu(
-            mixed_qkv[:, :, t].contiguous(),
-            scratch,
-            conv_weights,
-            bias,
-            activation in ("silu", "swish"),
-            None,
-            step_state_indices,
-            -1,
-            True,
-        )
-
-    conv_states[cache_idx] = scratch
 
     if retrieve_parent_token is not None:
         # The Triton kernel fuses this; downstream GDN verify reads it.

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -673,6 +673,59 @@ def fused_conv_window_scatter_multi(
     )
 
 
+def _scatter_with_mask_cpu(dst, src, dst_indices_raw, step_indices_raw) -> None:
+    """Torch equivalent of the fused scatter kernels, including their silent
+    out-of-range skips: ``dst[:, dst_idx] = src[:, request, step]``."""
+    steps = step_indices_raw.to(torch.int64)
+    dst_idx = dst_indices_raw.to(torch.int64)
+    req = torch.arange(steps.shape[0], device=steps.device)
+    valid = (
+        (steps >= 0)
+        & (steps < src.shape[2])
+        & (dst_idx >= 0)
+        & (dst_idx < dst.shape[1])
+        & (req < src.shape[1])
+    )
+    if not bool(valid.any()):
+        return
+    dst[:, dst_idx[valid]] = src[:, req[valid], steps[valid]]
+
+
+def _scatter_mamba_states_after_mtp_verify_cpu(
+    mamba_caches,
+    state_indices_tensor: torch.Tensor,
+    last_correct_step_indices: torch.Tensor,
+    mamba_track_indices: torch.Tensor | None,
+    mamba_steps_to_track: torch.Tensor | None,
+) -> None:
+    ssm_states = mamba_caches.temporal
+    if ssm_states.numel() > 0:
+        _scatter_with_mask_cpu(
+            ssm_states,
+            mamba_caches.intermediate_ssm,
+            state_indices_tensor,
+            last_correct_step_indices,
+        )
+        if mamba_track_indices is not None:
+            _scatter_with_mask_cpu(
+                ssm_states,
+                mamba_caches.intermediate_ssm,
+                mamba_track_indices,
+                mamba_steps_to_track,
+            )
+
+    for conv_states, window in zip(
+        mamba_caches.conv, mamba_caches.intermediate_conv_window
+    ):
+        _scatter_with_mask_cpu(
+            conv_states, window, state_indices_tensor, last_correct_step_indices
+        )
+        if mamba_track_indices is not None:
+            _scatter_with_mask_cpu(
+                conv_states, window, mamba_track_indices, mamba_steps_to_track
+            )
+
+
 def scatter_mamba_states_after_mtp_verify(
     mamba_caches,
     state_indices_tensor: torch.Tensor,
@@ -684,6 +737,18 @@ def scatter_mamba_states_after_mtp_verify(
     persistent caches, plus the interval-crossing track slots."""
     ssm_states = mamba_caches.temporal
     intermediate_state_cache = mamba_caches.intermediate_ssm
+
+    if ssm_states.device.type == "cpu":
+        if mamba_track_indices is not None:
+            assert mamba_steps_to_track is not None
+        _scatter_mamba_states_after_mtp_verify_cpu(
+            mamba_caches,
+            state_indices_tensor,
+            last_correct_step_indices,
+            mamba_track_indices,
+            mamba_steps_to_track,
+        )
+        return
 
     if ssm_states.numel() > 0:
         fused_mamba_state_scatter_with_mask(

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
@@ -26,12 +26,13 @@ if is_npu():
     chunk_gated_delta_rule = chunk_gated_delta_rule_npu
     fused_sigmoid_gating_delta_rule_update = fused_sigmoid_gating_delta_rule_update_npu
 elif is_cpu():
-    from sgl_kernel.mamba import chunk_gated_delta_rule_cpu
+    from sgl_kernel.mamba import (
+        chunk_gated_delta_rule_cpu,
+        fused_sigmoid_gating_delta_rule_update_cpu,
+    )
 
     chunk_gated_delta_rule = chunk_gated_delta_rule_cpu
-    fused_sigmoid_gating_delta_rule_update = (
-        torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu
-    )
+    fused_sigmoid_gating_delta_rule_update = fused_sigmoid_gating_delta_rule_update_cpu
 elif is_xpu():
     from sglang.srt.hardware_backend.xpu.kernels.fla.fused_sigmoid_gating_recurrent import (
         fused_sigmoid_gating_delta_rule_update,

--- a/test/registered/cpu/test_causal_conv1d.py
+++ b/test/registered/cpu/test_causal_conv1d.py
@@ -326,5 +326,261 @@ class TestCausalConv1d(CustomTestCase):
         )
 
 
+def chain_verify_window_ref(x, history, width):
+    """Per-token ancestor walk, transcribed from the Triton
+    ``_causal_conv1d_update_kernel`` tree branch.
+
+    The kernel stores the j-th ancestor of each step into window slot
+    ``W - j - 2``; once the walk runs off the front of the draft block it reads
+    the prior conv-state columns. Spelled out with Python loops so the CPU
+    path's window layout is checked against a different formulation. The
+    arithmetic itself is not modelled here -- the C++ kernel consumes a
+    VNNI-prepacked weight, so a plain-weight reference cannot reproduce it;
+    ``test_verify_matches_cpp_decode_kernel`` covers that instead.
+    """
+    batch, dim, seqlen = x.shape
+    window = torch.zeros((batch, seqlen, dim, width - 1), dtype=x.dtype)
+    for b in range(batch):
+        for t in range(seqlen):
+            for j in range(width):
+                idx = t - j
+                # idx < 0 walks off the block into the conv-state history.
+                val = x[b, :, idx] if idx >= 0 else history[b, :, idx + width - 1]
+                if width - j - 2 >= 0:
+                    window[b, t, :, width - j - 2] = val
+    final_state = torch.cat([history, x], dim=-1)[:, :, seqlen:]
+    return window, final_state
+
+
+class TestCausalConv1dChainVerify(CustomTestCase):
+    """Covers the DFlash target-verify path of ``causal_conv1d_update_cpu``.
+
+    DFlash drafts a linear chain, so the kernel's parent walk collapses into a
+    rolling window and the block becomes the decode kernel replayed token by
+    token. These cases pin the index math (window layout, state roll, parent
+    ids, cache-slot targeting) and the arithmetic against that kernel.
+    """
+
+    @parametrize(
+        batch=[1, 3],
+        dim=[96],
+        draft_token_num=[4, 16],
+        width=[4],
+        has_bias=[True, False],
+    )
+    def test_chain_verify_matches_ancestor_walk(
+        self, batch, dim, draft_token_num, width, has_bias
+    ):
+        from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+        dtype = torch.bfloat16
+        state_len = width - 1
+        num_lines = batch + 5
+
+        x = torch.randn(batch, dim, draft_token_num, dtype=dtype)
+        weight = torch.randn(dim, width, dtype=dtype)
+        bias = torch.randn(dim, dtype=dtype) if has_bias else None
+
+        conv_states = torch.randn(num_lines, dim, state_len, dtype=dtype)
+        # Non-contiguous, non-identity slots to catch index-vs-position bugs.
+        conv_state_indices = torch.arange(batch, dtype=torch.int32) + 2
+        history = conv_states[conv_state_indices.long()].clone()
+
+        window_buf = torch.zeros(
+            num_lines, draft_token_num, dim, width - 1, dtype=dtype
+        )
+        intermediate_state_indices = torch.arange(batch, dtype=torch.int32) + 1
+        retrieve_next_token = (
+            torch.arange(1, draft_token_num + 1).unsqueeze(0).repeat(batch, 1)
+        )
+        retrieve_next_token[:, -1] = -1
+        retrieve_next_sibling = torch.full((batch, draft_token_num), -1)
+        retrieve_parent_token = torch.empty_like(retrieve_next_token)
+
+        causal_conv1d_update_cpu(
+            x,
+            conv_states,
+            weight,
+            bias,
+            "silu",
+            conv_state_indices,
+            intermediate_conv_window=window_buf,
+            intermediate_state_indices=intermediate_state_indices,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            retrieve_parent_token=retrieve_parent_token,
+        )
+
+        window_ref, state_ref = chain_verify_window_ref(x, history, width)
+
+        torch.testing.assert_close(
+            window_buf[intermediate_state_indices.long()], window_ref
+        )
+        torch.testing.assert_close(conv_states[conv_state_indices.long()], state_ref)
+
+        expected_parent = (
+            torch.arange(-1, draft_token_num - 1).unsqueeze(0).repeat(batch, 1)
+        )
+        expected_parent[:, 0] = 0
+        torch.testing.assert_close(retrieve_parent_token, expected_parent)
+
+    def test_untouched_slots_are_not_written(self):
+        """The write must land only on the indexed cache lines; a bug that
+        ignores the index tensors would still pass an out-value-only check."""
+        from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+        dtype = torch.bfloat16
+        batch, dim, draft_token_num, width = 2, 96, 8, 4
+
+        conv_states = torch.randn(6, dim, width - 1, dtype=dtype)
+        window_buf = torch.randn(6, draft_token_num, dim, width - 1, dtype=dtype)
+        before_states = conv_states.clone()
+        before_window = window_buf.clone()
+
+        conv_state_indices = torch.tensor([4, 1], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([3, 0], dtype=torch.int32)
+
+        causal_conv1d_update_cpu(
+            torch.randn(batch, dim, draft_token_num, dtype=dtype),
+            conv_states,
+            torch.randn(dim, width, dtype=dtype),
+            None,
+            "silu",
+            conv_state_indices,
+            intermediate_conv_window=window_buf,
+            intermediate_state_indices=intermediate_state_indices,
+            retrieve_next_token=None,
+            retrieve_next_sibling=None,
+            retrieve_parent_token=None,
+        )
+
+        untouched_states = [i for i in range(6) if i not in (4, 1)]
+        untouched_window = [i for i in range(6) if i not in (3, 0)]
+        torch.testing.assert_close(
+            conv_states[untouched_states], before_states[untouched_states]
+        )
+        torch.testing.assert_close(
+            window_buf[untouched_window], before_window[untouched_window]
+        )
+
+    def test_output_layout_allows_caller_transpose_view(self):
+        """The GDN backend does ``out.transpose(1, 2).view(seq_len, -1)``, which
+        only works if the output keeps the caller's transposed strides (the
+        Triton kernel returns ``torch.empty_like(x)``). A plain [B, D, T]
+        contiguous result raises "view size is not compatible"."""
+        from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+        dtype = torch.bfloat16
+        batch, dim, draft_token_num, width = 2, 96, 8, 4
+        seq_len = batch * draft_token_num
+
+        # Exactly how gdn_backend builds the input.
+        packed = torch.randn(seq_len, dim, dtype=dtype)
+        mixed_qkv = packed.view(batch, draft_token_num, -1).transpose(1, 2)
+
+        out = causal_conv1d_update_cpu(
+            mixed_qkv,
+            torch.randn(4, dim, width - 1, dtype=dtype),
+            torch.randn(dim, width, dtype=dtype),
+            None,
+            "silu",
+            torch.zeros(batch, dtype=torch.int32),
+            intermediate_conv_window=torch.zeros(
+                4, draft_token_num, dim, width - 1, dtype=dtype
+            ),
+            intermediate_state_indices=torch.arange(batch, dtype=torch.int32),
+            retrieve_next_token=None,
+            retrieve_next_sibling=None,
+            retrieve_parent_token=None,
+        )
+
+        self.assertEqual(out.transpose(1, 2).view(seq_len, -1).shape, (seq_len, dim))
+
+    def test_verify_matches_cpp_decode_kernel(self):
+        """Replaying the C++ decode kernel token by token is the only oracle for
+        the verify rewrite that shares no code with it."""
+        from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+        torch.manual_seed(0)
+        dtype = torch.bfloat16
+        batch, dim, width, lines = 2, 128, 4, 6
+        cache_idx = torch.tensor([0, 3], dtype=torch.int32)
+
+        for draft_token_num in (1, 4):
+            with self.subTest(draft_token_num=draft_token_num):
+                x = torch.randn(batch, dim, draft_token_num, dtype=dtype)
+                base_state = torch.randn(lines, dim, width - 1, dtype=dtype)
+                weight = torch.randn(dim, width, dtype=dtype) * 0.5
+                bias = torch.randn(dim, dtype=dtype)
+
+                verify_state = base_state.clone()
+                window = torch.zeros(
+                    lines, draft_token_num, dim, width - 1, dtype=dtype
+                )
+                out = causal_conv1d_update_cpu(
+                    x,
+                    verify_state,
+                    weight,
+                    bias,
+                    "silu",
+                    cache_idx,
+                    intermediate_conv_window=window,
+                    intermediate_state_indices=torch.arange(batch, dtype=torch.int32),
+                    retrieve_next_token=None,
+                    retrieve_next_sibling=None,
+                    retrieve_parent_token=None,
+                )
+
+                decode_state = base_state.clone()
+                for t in range(draft_token_num):
+                    ref = causal_conv1d_update_cpu(
+                        x[:, :, t].contiguous(),
+                        decode_state,
+                        weight,
+                        bias,
+                        "silu",
+                        cache_idx,
+                    )
+                    torch.testing.assert_close(out[:, :, t], ref, rtol=5e-2, atol=5e-2)
+                    for req in range(batch):
+                        torch.testing.assert_close(
+                            window[req, t],
+                            decode_state[cache_idx[req]],
+                            rtol=5e-2,
+                            atol=5e-2,
+                        )
+                torch.testing.assert_close(
+                    verify_state, decode_state, rtol=5e-2, atol=5e-2
+                )
+
+    def test_tree_draft_is_rejected(self):
+        """The chain collapse is only valid without siblings; a real EAGLE tree
+        must not silently get chain semantics."""
+        from sgl_kernel.mamba import causal_conv1d_update_cpu
+
+        dtype = torch.bfloat16
+        batch, dim, draft_token_num, width = 1, 96, 8, 4
+
+        sibling = torch.full((batch, draft_token_num), -1)
+        sibling[0, 2] = 3
+
+        with self.assertRaises(NotImplementedError):
+            causal_conv1d_update_cpu(
+                torch.randn(batch, dim, draft_token_num, dtype=dtype),
+                torch.randn(4, dim, width - 1, dtype=dtype),
+                torch.randn(dim, width, dtype=dtype),
+                None,
+                "silu",
+                torch.zeros(batch, dtype=torch.int32),
+                intermediate_conv_window=torch.zeros(
+                    4, draft_token_num, dim, width - 1, dtype=dtype
+                ),
+                intermediate_state_indices=torch.zeros(batch, dtype=torch.int32),
+                retrieve_next_token=torch.zeros(batch, draft_token_num),
+                retrieve_next_sibling=sibling,
+                retrieve_parent_token=None,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/cpu/test_mamba.py
+++ b/test/registered/cpu/test_mamba.py
@@ -446,5 +446,134 @@ def test_fused_sigmoid_gating_delta_rule_update(
         )
 
 
+@pytest.mark.parametrize("batch", [1, 3])
+@pytest.mark.parametrize("steps", [1, 4])
+def test_chain_verify_matches_chunk_kernel(batch, steps):
+    """DFlash target-verify replay vs the chunked prefill kernel.
+
+    ``chunk_gated_delta_rule_cpu`` solves the same recurrence in matrix form
+    instead of step by step, and takes each draft block as one variable-length
+    sequence -- so it also pins the ``n * steps + t`` token packing that the
+    replay's ``[:, t::steps]`` slicing assumes.
+    """
+    from sgl_kernel.mamba import fused_sigmoid_gating_delta_rule_update_cpu
+
+    HK, HV, K, V, POOL = 2, 4, 128, 128, 9
+    total = batch * steps
+
+    q = torch.randn(1, total, HK, K, dtype=torch.bfloat16)
+    k = torch.randn(1, total, HK, K, dtype=torch.bfloat16)
+    v = torch.randn(1, total, HV, V, dtype=torch.bfloat16)
+    a = torch.rand(total, HV, dtype=torch.bfloat16)
+    b = torch.rand(total, HV, dtype=torch.bfloat16)
+    A_log = torch.rand(HV, dtype=torch.float32)
+    dt_bias = torch.rand(HV, dtype=torch.bfloat16)
+
+    pool = torch.randn(POOL, HV, K, V, dtype=torch.float32) * 0.1
+    state_indices = torch.tensor([5, 2, 8, 1], dtype=torch.int32)[:batch]
+    cu_seqlens = torch.arange(0, (batch + 1) * steps, steps, dtype=torch.int32)
+    # Pool-sized and rolled: the kernel reads this table positionally per
+    # request, and its slots must not be confused with the state slots.
+    window_indices = torch.roll(torch.arange(POOL, dtype=torch.int32), 3)
+    window = torch.zeros(POOL, steps, HV, K, V, dtype=torch.float32)
+
+    src = pool.clone()
+    out = fused_sigmoid_gating_delta_rule_update_cpu(
+        A_log=A_log,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        initial_state_source=src,
+        initial_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+        disable_state_update=True,
+        intermediate_states_buffer=window,
+        intermediate_state_indices=window_indices,
+    )
+
+    g, beta = torch.ops.sgl_kernel.fused_gdn_gating_cpu(A_log, a, b, dt_bias)
+    ref_pool = pool.clone()
+    out_ref, _ = torch.ops.sgl_kernel.chunk_gated_delta_rule_cpu(
+        query=q.clone(),
+        key=k.clone(),
+        value=v.clone(),
+        g=g,
+        beta=beta,
+        initial_state=ref_pool,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens.clone(),
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+        initial_state_indices=state_indices.clone(),
+    )
+
+    atol = rtol = precision[out.dtype]
+    torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+    # The snapshot after the last draft token is the end-of-sequence state.
+    torch.testing.assert_close(
+        window[window_indices[:batch].long(), steps - 1],
+        ref_pool[state_indices.long()],
+        atol=atol,
+        rtol=rtol,
+    )
+    # disable_state_update leaves the committed pool alone.
+    torch.testing.assert_close(src, pool)
+
+
+def test_mamba_state_scatter_cpu_matches_per_request_loop():
+    """CPU scatter fallback vs the contract spelled out one request at a time.
+
+    Out-of-range rows are silently skipped by the fused kernels, which is how
+    requests with nothing to commit are excluded, so the -1 rows are part of
+    the contract rather than bad input.
+    """
+    from types import SimpleNamespace
+
+    from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+        scatter_mamba_states_after_mtp_verify,
+    )
+
+    layers, cache_size, spec_size, steps = 2, 7, 4, 3
+    ssm = torch.randn(layers, cache_size, 3, 8, dtype=torch.float32)
+    intermediate_ssm = torch.randn(layers, spec_size, steps, 3, 8)
+    conv = torch.randn(layers, cache_size, 5, 3, dtype=torch.bfloat16)
+    window = torch.randn(layers, spec_size, steps, 5, 3, dtype=torch.bfloat16)
+
+    state_indices = torch.tensor([4, -1, 0, 6], dtype=torch.int32)
+    step_indices = torch.tensor([2, 1, -1, 0], dtype=torch.int32)
+    track_indices = torch.tensor([1, 5, -1, -1], dtype=torch.int32)
+    steps_to_track = torch.tensor([0, 2, 1, -1], dtype=torch.int32)
+
+    caches = SimpleNamespace(
+        temporal=ssm.clone(),
+        intermediate_ssm=intermediate_ssm,
+        conv=[conv.clone()],
+        intermediate_conv_window=[window],
+    )
+    scatter_mamba_states_after_mtp_verify(
+        caches, state_indices, step_indices, track_indices, steps_to_track
+    )
+
+    def scatter_ref(dst, src, dst_indices, step_indices):
+        out = dst.clone()
+        for req in range(dst_indices.numel()):
+            slot, step = int(dst_indices[req]), int(step_indices[req])
+            if 0 <= slot < dst.shape[1] and 0 <= step < src.shape[2]:
+                out[:, slot] = src[:, req, step]
+        return out
+
+    ssm_ref = scatter_ref(ssm, intermediate_ssm, state_indices, step_indices)
+    ssm_ref = scatter_ref(ssm_ref, intermediate_ssm, track_indices, steps_to_track)
+    conv_ref = scatter_ref(conv, window, state_indices, step_indices)
+    conv_ref = scatter_ref(conv_ref, window, track_indices, steps_to_track)
+
+    torch.testing.assert_close(caches.temporal, ssm_ref)
+    torch.testing.assert_close(caches.conv[0], conv_ref)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

This PR enables DFlash speculative decoding for hybrid GDN models such as Qwen3.5-9B on CPU. The CPU AOT mamba ops are decode-only:

- `causal_conv1d_update_cpu` has no target-verify variant (no `intermediate_conv_window` / chain metadata).
- `fused_sigmoid_gating_delta_rule_update_cpu` has no target-verify variant (no `intermediate_states_buffer`).
- `scatter_mamba_states_after_mtp_verify` raises `ValueError: ... only supports CUDA tensors.`

This PR adds those three CPU paths so the DFlash verify step runs end to end on CPU.

Builds on #36782, which enables the `DFLASH` algorithm on CPU.

## Modifications

## Modifications

DFlash drafts a **linear** chain (`retrieve_next_token[t] == t + 1`, no siblings), so the Triton kernels' ancestor walk degenerates to a rolling window and the draft block is a plain sequential walk over the draft tokens.

- **`csrc/cpu/mamba/fla.cpp`** — `fused_sigmoid_gating_delta_rule_update_spec_cpu`, a target-verify variant of the decode kernel. Verify tokens already arrive packed as `n * steps + t`, so one work item per `(sequence, v_head)` carries the recurrence forward across `t` and writes each per-step snapshot straight into `intermediate_states_buffer`. The committed `ssm_states` pool is only written at the end, and only when `disable_state_update` is false.
- **`csrc/cpu/mamba/conv.cpp`** — `causal_conv1d_verify_cpu`, the same idea for the conv. The decode kernel's `tinygemm_kernel` already keeps its rolling window in registers across the whole block it is handed, and only reads `conv_states` for the first token, so one call over the full block is arithmetically identical to replaying it per token. A second pass writes the per-token state snapshots and a third commits the final state from the last snapshot. The snapshot pass partitions over the channel axis, not the token axis, because the deduplicated conv window is an overlapping `as_strided` view in which neighboring tokens share bytes.
- **`sgl_kernel/mamba.py`** — target-verify replay for the conv and SSM ops. Each dispatches the block once through the kernel above, after normalising the input to the token-major layout the kernels stride over. Both validate the chain metadata and raise `NotImplementedError` on a branching tree rather than silently computing the wrong thing.
- **`mamba_state_scatter_triton.py`** — torch fallback for `scatter_mamba_states_after_mtp_verify`, reproducing the fused kernels' contract including their silent out-of-range skips (which is how requests with nothing to commit are excluded).
- **`gdn_triton.py`** — bind the CPU implementations on the `is_cpu()` branch.

Two details worth calling out:

1. **The conv replay must call the C++ kernel, not `F.conv1d`.** The CPU decode path passes `is_vnni=true`, so `layer.conv_weights` is already VNNI-prepacked by `causal_conv1d_weight_pack` and is *not* usable as a plain `[dim, width]` convolution kernel. Feeding it to `F.conv1d` produces garbage with a 0.0 acceptance rate.
2. **`intermediate_state_indices` arrives pool-sized.** `build_verify_intermediate_state_indices` returns an `arange(pool_size)` padded table that the kernels read positionally per request, so the SSM path slices the first `batch` rows. This is benign at batch 1 and crashes at batch 3.

## Accuracy Tests

`test/registered/cpu/test_causal_conv1d.py` and `test/registered/cpu/test_mamba.py` (registered CPU CI).

Each replay is checked against an **independent** implementation rather than a transcription of the code under test:

- **conv** vs. the C++ decode kernel driven one step at a time (`test_verify_matches_cpp_decode_kernel`).
- **SSM** vs. `chunk_gated_delta_rule_cpu` (`test_chain_verify_matches_chunk_kernel`), which solves the same recurrence in matrix form and consumes the draft block as one variable-length sequence — so it also pins the `n * steps + t` token packing that the replay's slicing assumes.
- **scatter** vs. the contract spelled out one request at a time, including the out-of-range rows.

Plus window layout, state-roll, untouched-slot, output-stride and tree-rejection cases.

Both files in full, on this branch, on a Xeon host:

```
$ python -m pytest test/registered/cpu/test_causal_conv1d.py test/registered/cpu/test_mamba.py -q
22 passed, 17 warnings, 47 subtests passed in 9.37s
```

End to end, Qwen3.5-9B greedy on CPU produces text **identical** to the non-speculative baseline.

## Speed Tests and Profiling

Qwen3.5-9B, Xeon 6 (128 physical cores), TP4, `--attention-backend intel_amx`, 20 prompts, greedy, concurrency 1, `--speculative-dflash-block-size 16`. Custom dataset consists of the first 20 rows of the HumanEval test split.
```
python -m sglang.benchmark.serving --backend sglang --model Qwen/Qwen3.5-9B \
  --dataset-name custom --dataset-path /tmp/humaneval20.jsonl \
  --sharegpt-output-len 128 --num-prompts 20 --max-concurrency 1 \
  --request-rate inf --warmup-requests 3 --temperature 0 --seed 42 \
  --host 127.0.0.1 --port 30000

============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 1
Successful requests:                     20
Benchmark duration (s):                  27.11
Total input tokens:                      2041
Total input text tokens:                 2041
Total generated tokens:                  2560
Total generated tokens (retokenized):    2548
Request throughput (req/s):              0.74
Input token throughput (tok/s):          75.29
Output token throughput (tok/s):         94.44
Peak output token throughput (tok/s):    145.00
Peak concurrent requests:                2
Total token throughput (tok/s):          169.73
Concurrency:                             1.00
Accept length:                           6.11
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1354.37
Median E2E Latency (ms):                 1229.74
P90 E2E Latency (ms):                    2082.96
P95 E2E Latency (ms):                    2143.17
P99 E2E Latency (ms):                    2172.93
---------------Time to First Token----------------
Mean TTFT (ms):                          88.47
Median TTFT (ms):                        87.99
P90 TTFT (ms):                           99.70
P95 TTFT (ms):                           102.60
P99 TTFT (ms):                           106.68
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.97
Median TPOT (ms):                        8.89
P90 TPOT (ms):                           15.78
P95 TPOT (ms):                           16.19
P99 TPOT (ms):                           16.35
---------------Inter-Token Latency----------------
Mean ITL (ms):                           9.97
Median ITL (ms):                         5.88
P90 ITL (ms):                            19.69
P95 ITL (ms):                            29.47
P99 ITL (ms):                            58.85
Max ITL (ms):                            63.85
==================================================
```
| | baseline | DFlash | |
|---|---|---|---|
| Output throughput (tok/s) | 29.24 | **94.44** | **3.23x** |
| Mean TPOT (ms) | 33.83 | **9.97** | |
| Accept length | — | 6.11 | |

The two fused kernels are what make that number. Replaying the block token by token cost 768 SSM and 768 conv dispatches per rank per step on a 24-layer model at block size 16; folding the SSM replay into one dispatch took the same configuration from 65.44 to 81.53 tok/s, and folding the conv replay took it from 84.15 to 94.44. Accept length is unchanged across all of them, which is the expected signature of replaying the same arithmetic in fewer calls.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @mingfeima @yizhang2077 @ch-wan


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33905040429](https://github.com/sgl-project/sglang/actions/runs/33905040429)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33905040261](https://github.com/sgl-project/sglang/actions/runs/33905040261)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33905040567](https://github.com/sgl-project/sglang/actions/runs/33905040567)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->