### PR TITLE
[Cherry-pick to release/v0.5.19] [AMD] fix aiter cannot get heuristic kernel regression (#37438)

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -466,9 +466,16 @@ class AiterAttnBackend(AttentionBackend):
                 intra_batch_mode = False
             # Zero-pad topology (h12->qh16): prefer Gluon decode over PS kernel.
             if self.head_pad_mode == "zero" and self.kv_cache_dtype == fp8_dtype:
-                _use_mla_ps_kernel = False
-                fast_mode = False
-                intra_batch_mode = False
+                # Disable ps only when gluon kernel is selected to avoid falling
+                # back to incorrect aiter kernel
+                if prefer_mla_gluon_decode(
+                    head_pad_mode=self.head_pad_mode,
+                    num_head=self.num_head,
+                    kv_cache_dtype=self.kv_cache_dtype,
+                ):
+                    _use_mla_ps_kernel = False
+                    fast_mode = False
+                    intra_batch_mode = False
                 log_mla_gluon_capability(logger)
 
             self.max_split_per_batch = 32 if _use_mla_ps_kernel else None


### PR DESCRIPTION
Cherry-pick of commit `44a92e54b9efdd56be68a915ed717f4964f2e6ab` to `release/v0.5.19`.

**Source PR:** #37438 (https://github.com/sgl-project/sglang/pull/37438)
**Source commit:** `44a92e54b9efdd56be68a915ed717f4964f2e6ab`
**Original title:** [AMD] fix aiter cannot get heuristic kernel regression

---
*Cherry-picked by hand; applied cleanly with no conflicts. (The `bot-cherry-pick` workflow currently cannot push branches -- see run 33794784647.)*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33795260871](https://github.com/sgl-project/sglang/actions/runs/33795260871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33795260316](https://github.com/sgl-project/sglang/actions/runs/33795260316)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33795260683](https://github.com/sgl-project/sglang/actions/runs/33795260683)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->