### PR TITLE
[Cherry-pick to release/v0.5.19] [AMD] Fix DSv4 draft extend taking the target compression path during prefill (#37713)

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -464,9 +464,9 @@ class DeepseekV4HipRadixBackend(
         self.mtp_enabled = self.topk > 0
         self.speculative_num_steps = speculative_num_steps
         self.speculative_num_draft_tokens: int = get_spec().speculative_num_draft_tokens
+        self.is_draft_worker = getattr(model_runner, "is_draft_worker", False)
         self.is_dspark_draft = (
-            getattr(model_runner, "is_draft_worker", False)
-            and model_runner.spec_algorithm.is_dspark()
+            self.is_draft_worker and model_runner.spec_algorithm.is_dspark()
         )
         self.target_verify_num_draft_tokens = self.speculative_num_draft_tokens
         if self.is_dspark_draft:
@@ -1048,7 +1048,9 @@ class DeepseekV4HipRadixBackend(
                 and extend_seq_lens is not None
                 and extend_seq_lens_cpu is not None
             )
-            is_draft = forward_batch.forward_mode.is_draft_extend_v2()
+            is_draft = (
+                forward_batch.forward_mode.is_draft_extend_v2() or self.is_draft_worker
+            )
             metadata = self.init_forward_metadata_prefill(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,


### PR DESCRIPTION
Cherry-pick of commit `429ac2d82ccc931712a866e6e0991cf0413e82d4` to `release/v0.5.19`.

**Source PR:** #37713 (https://github.com/sgl-project/sglang/pull/37713)
**Source commit:** `429ac2d82ccc931712a866e6e0991cf0413e82d4`
**Original title:** [AMD] Fix DSv4 draft extend taking the target compression path during prefill

---
*Cherry-picked by hand; applied cleanly with no conflicts. (The `bot-cherry-pick` workflow currently cannot push branches -- see run 33794784647.)*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33795320042](https://github.com/sgl-project/sglang/actions/runs/33795320042)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33795319780](https://github.com/sgl-project/sglang/actions/runs/33795319780)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33795319955](https://github.com/sgl-project/sglang/actions/runs/33795319955)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->