### PR TITLE
[Cherry-pick to release/v0.5.19] [AMD][CI] Correct MI355X Slurm exclude node (#37779)

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -131,6 +131,7 @@ jobs:
       CONFIG_FILE: ${{ matrix.config.config_file }}
       RESULT_FILENAME: mi355x-${{ matrix.config.name }}
       MATRIX_CONFIG_NAME: ${{ matrix.config.name }}
+      SLURM_EXCLUDE: mia1-p01-g20,mia1-p01-g09
       # NOTE: RUNNER_NAME is a built-in default env var on every runner, so the
       # launch + cleanup steps read it directly. Do NOT set it here from
       # ${{ runner.name }} -- the `runner` context is not available in job-level
@@ -255,7 +256,8 @@ jobs:
       - setup
       - nightly-mi355x-2n
     if: |
-      !cancelled() && github.repository == 'sgl-project/sglang'
+      false
+      && !cancelled() && github.repository == 'sgl-project/sglang'
       && needs.setup.result == 'success'
       && needs.setup.outputs.matrix-4n != '{"include":[]}'
     runs-on: linux-sglang-mi35x-di

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -131,7 +131,7 @@ jobs:
       CONFIG_FILE: ${{ matrix.config.config_file }}
       RESULT_FILENAME: mi355x-${{ matrix.config.name }}
       MATRIX_CONFIG_NAME: ${{ matrix.config.name }}
-      SLURM_EXCLUDE: mia1-p01-g20,mia1-p01-g09
+      SLURM_EXCLUDE: mia1-p01-g20,mia1-p02-g09
       # NOTE: RUNNER_NAME is a built-in default env var on every runner, so the
       # launch + cleanup steps read it directly. Do NOT set it here from
       # ${{ runner.name }} -- the `runner` context is not available in job-level


### PR DESCRIPTION
Cherry-pick of commit `f59a4840c508766d13ed982272bdf68a974a462f` to `release/v0.5.19`.

**Source PR:** #37779 (https://github.com/sgl-project/sglang/pull/37779)
**Source commit:** `f59a4840c508766d13ed982272bdf68a974a462f`
**Original title:** [AMD][CI] Correct MI355X Slurm exclude node

> **Stacked on #37866.** This PR corrects the Slurm exclude-node name that #37518 introduces, so it does not apply to `release/v0.5.19` on its own (cherry-picking it directly conflicts in `.github/workflows/nightly-amd-mi355x-disagg.yml`). Its base is therefore the #37518 cherry-pick branch `cherry-pick/0157f1f552-to-v0.5.19-3679ea9a`; **merge #37866 first**, after which GitHub retargets this PR onto `release/v0.5.19` and the diff reduces to the one-line node-name fix. Alternatively, close this and fold the one-line fix into #37866.

---
*Cherry-picked by hand (the `bot-cherry-pick` workflow currently cannot push branches: see run 33794784647).*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33807022400](https://github.com/sgl-project/sglang/actions/runs/33807022400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33807021501](https://github.com/sgl-project/sglang/actions/runs/33807021501)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->