### PR TITLE
feat(cache): expose hybrid cache observability

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -170,15 +170,23 @@ class CachedTokensDetails(BaseModel):
     # L3 storage fields are only present when storage backend is enabled
     storage: Optional[int] = None  # Tokens from L3 storage backend
     storage_backend: Optional[str] = None  # Type of storage backend used
+    # Hybrid Full-attention + recurrent-state accounting. These fields are
+    # omitted for non-hybrid models.
+    full_attention_cached_tokens: Optional[int] = None
+    recurrent_state_cached_tokens: Optional[int] = None
+    usable_cached_tokens: Optional[int] = None
+    trimmed_full_attention_tokens: Optional[int] = None
+    full_attention_recomputed_tokens: Optional[int] = None
+    recurrent_recomputed_tokens: Optional[int] = None
+    recurrent_replayed_tokens: Optional[int] = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        # Remove None fields so they don't appear in response when L3 is disabled
-        if self.storage is None:
-            data.pop("storage", None)
-        if self.storage_backend is None:
-            data.pop("storage_backend", None)
+        # Remove optional fields when the corresponding cache feature is absent.
+        for key, value in tuple(data.items()):
+            if value is None:
+                data.pop(key, None)
         return data
 
 

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -123,18 +123,10 @@ def cached_tokens_details_from_dict(
     details: Dict[str, Any],
 ) -> CachedTokensDetails:
     """Convert a raw cached_tokens_details dict to a CachedTokensDetails object."""
-    if "storage" in details:
-        return CachedTokensDetails(
-            device=details.get("device", 0),
-            host=details.get("host", 0),
-            storage=details.get("storage", 0),
-            storage_backend=details.get("storage_backend"),
-        )
-    else:
-        return CachedTokensDetails(
-            device=details.get("device", 0),
-            host=details.get("host", 0),
-        )
+    fields = CachedTokensDetails.model_fields
+    return CachedTokensDetails(
+        **{key: value for key, value in details.items() if key in fields}
+    )
 
 
 def process_cached_tokens_details_from_ret(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1194,6 +1194,14 @@ class Req(ReqDllmMixin):
         self.cached_tokens = 0
         self.already_computed = 0
 
+        # Hybrid-cache prefix-match accounting. These are populated only for
+        # caches with a recurrent-state component. ``full_attention`` is the
+        # raw Full-KV endpoint (A); ``recurrent_state`` is the latest checkpoint
+        # accepted by the component validators (C). The effective cached prefix
+        # reported by ``cached_tokens`` is U.
+        self.hybrid_cache_full_attention_cached_tokens: Optional[int] = None
+        self.hybrid_cache_recurrent_state_cached_tokens: Optional[int] = None
+
         # Detailed breakdown of cached tokens by source (for HiCache)
         self.cached_tokens_device = 0  # Tokens from device cache (GPU)
         self.cached_tokens_host = 0  # Tokens from host cache (CPU memory)
@@ -1482,6 +1490,13 @@ class Req(ReqDllmMixin):
                 match_result.mamba_host_hit_length,
                 match_result.mamba_branching_seqlen,
             )
+            if tree_cache.supports_mamba():
+                self.hybrid_cache_full_attention_cached_tokens = (
+                    match_result.full_kv_hit_length
+                )
+                self.hybrid_cache_recurrent_state_cached_tokens = (
+                    len(match_result.device_indices) + match_result.host_hit_length
+                )
             if match_result.cache_protected_len is not None:
                 self.kv.cache_protected_len = match_result.cache_protected_len
             else:

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -47,6 +47,33 @@ logger = logging.getLogger(__name__)
 DEFAULT_FORCE_STREAM_INTERVAL = envs.SGLANG_FORCE_STREAM_INTERVAL.get()
 
 
+def get_hybrid_cache_details(req: Req) -> Optional[CachedTokensDetails]:
+    """Build component-level accounting for a hybrid-cache request."""
+    full_attention_cached = getattr(
+        req, "hybrid_cache_full_attention_cached_tokens", None
+    )
+    recurrent_state_cached = getattr(
+        req, "hybrid_cache_recurrent_state_cached_tokens", None
+    )
+    if full_attention_cached is None or recurrent_state_cached is None:
+        return None
+
+    usable = req.cached_tokens
+    recomputed = max(0, len(req.origin_input_ids) - usable)
+    return {
+        "full_attention_cached_tokens": full_attention_cached,
+        "recurrent_state_cached_tokens": recurrent_state_cached,
+        "usable_cached_tokens": usable,
+        "trimmed_full_attention_tokens": max(0, full_attention_cached - usable),
+        # SGLang currently re-prefills the whole model from U. There is no
+        # recurrent-only C:A replay path, so both components execute for every
+        # uncached prompt token.
+        "full_attention_recomputed_tokens": recomputed,
+        "recurrent_recomputed_tokens": recomputed,
+        "recurrent_replayed_tokens": 0,
+    }
+
+
 @dataclass(kw_only=True, slots=True)
 class SchedulerOutputStreamer:
     has_additional_customized_info: ClassVar[bool] = False
@@ -90,6 +117,7 @@ class SchedulerOutputStreamer:
             - {"device": X, "host": Y} without storage breakdown
             - {"device": X, "host": Y, "storage": Z} with storage breakdown
         """
+        details = None
         if (
             req.cached_tokens_device > 0
             or req.cached_tokens_host > 0
@@ -105,15 +133,19 @@ class SchedulerOutputStreamer:
                 details["storage"] = req.cached_tokens_storage
             if self.enable_hicache_storage():
                 details["storage_backend"] = self._get_storage_backend_type()
-            return details
-
-        if req.cached_tokens > 0:
-            return {
+        elif req.cached_tokens > 0:
+            details = {
                 "device": req.cached_tokens,
                 "host": 0,
             }
 
-        return None
+        hybrid_details = get_hybrid_cache_details(req)
+        if hybrid_details is not None:
+            if details is None:
+                details = {"device": 0, "host": 0}
+            details.update(hybrid_details)
+
+        return details
 
     def stream_output(
         self,

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -258,7 +258,11 @@ def alloc_req_slots(
             if tree_cache is not None and tree_cache.supports_mamba():
                 mamba_num = max(0, mamba_state_needed - mamba_available_size)
                 tree_cache.evict_for_alloc(
-                    EvictParams(num_tokens=0, mamba_num=mamba_num)
+                    EvictParams(
+                        num_tokens=0,
+                        mamba_num=mamba_num,
+                        reason="recurrent_allocation_pressure",
+                    )
                 )
     req_pool_indices = req_to_token_pool.alloc(reqs)
     if req_pool_indices is None:

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -116,6 +116,8 @@ class EvictParams:
     num_tokens: int = 0
     swa_num_tokens: int = 0
     mamba_num: int = 0
+    # Stable, bounded value for eviction observability; never request-derived.
+    reason: str = "unspecified"
 
 
 @dataclasses.dataclass
@@ -307,6 +309,16 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
                 time.perf_counter() - start_time
             )
             self.metrics_collector.increment_eviction_num_tokens(num_evicted)
+
+    def update_hybrid_eviction_metrics(
+        self, full_attention_tokens: int, recurrent_states: int, reason: str
+    ) -> None:
+        if self.metrics_collector is not None:
+            self.metrics_collector.increment_hybrid_cache_evictions(
+                full_attention_tokens=full_attention_tokens,
+                recurrent_states=recurrent_states,
+                reason=reason,
+            )
 
     def release_host_resources(self) -> None:
         """Release pinned host buffers in userspace on graceful shutdown.

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -183,14 +183,21 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
             full_num_tokens = max(0, num_tokens - full_available_size)
             swa_num_tokens = max(0, num_tokens - swa_available_size)
             tree_cache.evict_for_alloc(
-                EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
+                EvictParams(
+                    num_tokens=full_num_tokens,
+                    swa_num_tokens=swa_num_tokens,
+                    reason="kv_allocation_pressure",
+                )
             )
     else:
         # Standard allocator: evict only the shortfall (mirrors the SWA arm)
         available_size = allocator.available_size()
         if available_size < num_tokens:
             tree_cache.evict_for_alloc(
-                EvictParams(num_tokens=num_tokens - available_size)
+                EvictParams(
+                    num_tokens=num_tokens - available_size,
+                    reason="kv_allocation_pressure",
+                )
             )
 
 

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -204,7 +204,13 @@ class MambaComponent(TreeComponent):
                 # stops at this request's window boundary instead of walking to
                 # root and over-decrementing locks held by other requests.
                 lock_result = self.cache.inc_lock_ref(result.best_match_node)
-                self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+                self.cache.evict_for_alloc(
+                    EvictParams(
+                        num_tokens=0,
+                        mamba_num=1,
+                        reason="recurrent_allocation_pressure",
+                    )
+                )
                 dst_index = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
                 self.cache.dec_lock_ref(
                     result.best_match_node, lock_result.to_dec_params()
@@ -264,7 +270,7 @@ class MambaComponent(TreeComponent):
         tail: UnifiedTreeNode,
         device_frees: dict[ComponentType, list[torch.Tensor]],
         host_frees: dict[ComponentType, list[torch.Tensor]],
-    ) -> None:
+    ) -> int:
         """Evict shallow eligible device checkpoints beyond the path cap.
 
         Full KV and any existing host backup are retained. The tail, forks,
@@ -274,7 +280,7 @@ class MambaComponent(TreeComponent):
         """
         cap = self.mamba_max_states_per_path
         if cap < 0:
-            return
+            return 0
 
         ct = self.component_type
         holders = []
@@ -286,7 +292,7 @@ class MambaComponent(TreeComponent):
 
         excess = len(holders) - cap
         if excess <= 0:
-            return
+            return 0
 
         tracker = {component: 0 for component in self.cache.tree_components}
         for node in reversed(holders):
@@ -306,6 +312,7 @@ class MambaComponent(TreeComponent):
             )
             self.tree_core._cascade_evict(node, self, tracker, device_frees, host_frees)
             excess -= 1
+        return tracker[ct]
 
     def redistribute_on_node_split(
         self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode
@@ -494,7 +501,13 @@ class MambaComponent(TreeComponent):
         """Allocate one mamba pool slot, evicting if necessary."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
-            self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+            self.cache.evict_for_alloc(
+                EvictParams(
+                    num_tokens=0,
+                    mamba_num=1,
+                    reason="recurrent_allocation_pressure",
+                )
+            )
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert slot is not None, "Can not alloc mamba cache"
         return slot
@@ -506,7 +519,13 @@ class MambaComponent(TreeComponent):
     def _alloc_int8_ckpt_slot(self) -> torch.Tensor:
         slot = self.int8_ckpt_pool.alloc(1)
         if slot is None:
-            self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+            self.cache.evict(
+                EvictParams(
+                    num_tokens=0,
+                    mamba_num=1,
+                    reason="recurrent_allocation_pressure",
+                )
+            )
             slot = self.int8_ckpt_pool.alloc(1)
             assert slot is not None, "Can not alloc int8 mamba checkpoint slot"
         return slot
@@ -677,7 +696,13 @@ class MambaComponent(TreeComponent):
             return PrepareLoadBackResult()
         dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if dst is None:
-            self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+            self.cache.evict_for_alloc(
+                EvictParams(
+                    num_tokens=0,
+                    mamba_num=1,
+                    reason="recurrent_allocation_pressure",
+                )
+            )
             dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert dst is not None, "Cannot alloc mamba for load_back"
         req.kv.mamba_pool_idx = dst[0]
@@ -924,8 +949,13 @@ class MambaComponent(TreeComponent):
             # Drain even if the walk raises so tombstoned slots are not leaked;
             # the walk runs behind the tree-core interface (Rust runs it natively).
             try:
-                self.tree_core.evict_excess_path_states(
+                recurrent_states = self.tree_core.evict_excess_path_states(
                     action.tail_node_id, device_frees, host_frees
+                )
+                self.cache.update_hybrid_eviction_metrics(
+                    full_attention_tokens=0,
+                    recurrent_states=recurrent_states,
+                    reason="path_state_cap",
                 )
             finally:
                 self.cache._free_values(device_frees, host_frees)

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1482,8 +1482,8 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         tail_node_id: NodeId,
         device_frees: dict[ComponentType, list[torch.Tensor]],
         host_frees: dict[ComponentType, list[torch.Tensor]],
-    ) -> None:
-        self.components_by_type[ComponentType.MAMBA]._evict_excess_path_states(
+    ) -> int:
+        return self.components_by_type[ComponentType.MAMBA]._evict_excess_path_states(
             self.node_by_id(tail_node_id), device_frees, host_frees
         )
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -635,6 +635,11 @@ class UnifiedRadixCache(BasePrefixCache):
 
         # Report full-layer tokens only
         self.update_eviction_metrics(tracker[BASE_COMPONENT_TYPE], start_time)
+        self.update_hybrid_eviction_metrics(
+            full_attention_tokens=tracker[BASE_COMPONENT_TYPE],
+            recurrent_states=tracker.get(ComponentType.MAMBA, 0),
+            reason=params.reason,
+        )
         return EvictResult(
             num_tokens_evicted=tracker[BASE_COMPONENT_TYPE],
             swa_num_tokens_evicted=tracker.get(ComponentType.SWA, 0),
@@ -1508,7 +1513,9 @@ class UnifiedRadixCache(BasePrefixCache):
         avail = self._component_available_size(ComponentType.FULL)
         if avail < kv_tokens:
             needed = kv_tokens - avail
-            self.evict_for_alloc(EvictParams(num_tokens=needed))
+            self.evict_for_alloc(
+                EvictParams(num_tokens=needed, reason="hicache_load_back_pressure")
+            )
             if self._component_available_size(ComponentType.FULL) < kv_tokens:
                 self.dec_lock_ref(node_id, ancestor_lock_params)
                 self.dec_host_lock_ref(node_id, host_anchor_params)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1601,6 +1601,14 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
             labelnames=list(labels.keys()) + ["cache_source"],
         )
 
+        self.hybrid_cache_request_tokens_total = Counter(
+            name="sglang:hybrid_cache_request_tokens_total",
+            documentation="Per-request hybrid-cache token accounting by kind: "
+            "raw Full-attention hits, recurrent-state hits, usable hits, "
+            "trimmed Full-attention hits, recomputation, and replay.",
+            labelnames=list(labels.keys()) + ["kind"],
+        )
+
         self.num_requests_total = Counter(
             name="sglang:num_requests_total",
             documentation="Number of requests processed.",
@@ -1788,6 +1796,23 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 # Fallback for backward compatibility
                 labels_total = {**labels, "cache_source": "total"}
                 self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
+
+        if cached_tokens_details:
+            hybrid_fields = {
+                "full_attention_hit": "full_attention_cached_tokens",
+                "recurrent_state_hit": "recurrent_state_cached_tokens",
+                "usable_hit": "usable_cached_tokens",
+                "trimmed_full_attention": "trimmed_full_attention_tokens",
+                "full_attention_recomputed": "full_attention_recomputed_tokens",
+                "recurrent_recomputed": "recurrent_recomputed_tokens",
+                "recurrent_replayed": "recurrent_replayed_tokens",
+            }
+            for kind, field in hybrid_fields.items():
+                value = cached_tokens_details.get(field)
+                if value is not None and value > 0:
+                    self.hybrid_cache_request_tokens_total.labels(
+                        **labels, kind=kind
+                    ).inc(value)
 
         self.num_requests_total.labels(**stream_labels).inc(1)
         if has_grammar:
@@ -2099,6 +2124,20 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        self.hybrid_cache_evicted_full_attention_tokens = Counter(
+            name="sglang:hybrid_cache_evicted_full_attention_tokens_total",
+            documentation="Number of Full-attention KV token slots freed by "
+            "UnifiedRadixCache eviction, including cascaded frees.",
+            labelnames=list(labels.keys()) + ["reason"],
+        )
+
+        self.hybrid_cache_evicted_recurrent_states = Counter(
+            name="sglang:hybrid_cache_evicted_recurrent_states_total",
+            documentation="Number of recurrent checkpoint states freed by "
+            "UnifiedRadixCache eviction, including cascaded frees.",
+            labelnames=list(labels.keys()) + ["reason"],
+        )
+
         self.load_back_duration_seconds = Histogram(
             name="sglang:load_back_duration_seconds",
             documentation="Time taken to load KV cache from CPU back to GPU in seconds.",
@@ -2162,6 +2201,18 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
 
     def increment_eviction_num_tokens(self, num_tokens: int) -> None:
         self.eviction_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def increment_hybrid_cache_evictions(
+        self, full_attention_tokens: int, recurrent_states: int, reason: str
+    ) -> None:
+        if full_attention_tokens > 0:
+            self.hybrid_cache_evicted_full_attention_tokens.labels(
+                **self.labels, reason=reason
+            ).inc(full_attention_tokens)
+        if recurrent_states > 0:
+            self.hybrid_cache_evicted_recurrent_states.labels(
+                **self.labels, reason=reason
+            ).inc(recurrent_states)
 
     def increment_load_back_num_tokens(self, num_tokens: int, pool: str) -> None:
         self.load_back_num_tokens.labels(**self.labels, pool=pool).inc(num_tokens)

--- a/test/registered/unit/managers/test_hybrid_cache_observability.py
+++ b/test/registered/unit/managers/test_hybrid_cache_observability.py
@@ -1,0 +1,73 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.openai.utils import cached_tokens_details_from_dict
+from sglang.srt.managers.scheduler_components.output_streamer import (
+    SchedulerOutputStreamer,
+    get_hybrid_cache_details,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHybridCacheObservability(unittest.TestCase):
+    def test_reports_raw_joint_trimmed_and_compute_tokens(self):
+        req = SimpleNamespace(
+            origin_input_ids=list(range(21)),
+            cached_tokens=8,
+            cached_tokens_device=8,
+            cached_tokens_host=0,
+            cached_tokens_storage=0,
+            hybrid_cache_full_attention_cached_tokens=16,
+            hybrid_cache_recurrent_state_cached_tokens=8,
+        )
+
+        details = get_hybrid_cache_details(req)
+
+        self.assertEqual(details["full_attention_cached_tokens"], 16)
+        self.assertEqual(details["recurrent_state_cached_tokens"], 8)
+        self.assertEqual(details["usable_cached_tokens"], 8)
+        self.assertEqual(details["trimmed_full_attention_tokens"], 8)
+        self.assertEqual(details["full_attention_recomputed_tokens"], 13)
+        self.assertEqual(details["recurrent_recomputed_tokens"], 13)
+        self.assertEqual(details["recurrent_replayed_tokens"], 0)
+
+    def test_native_and_openai_details_preserve_hybrid_fields(self):
+        req = SimpleNamespace(
+            origin_input_ids=list(range(9)),
+            cached_tokens=0,
+            cached_tokens_device=0,
+            cached_tokens_host=0,
+            cached_tokens_storage=0,
+            hybrid_cache_full_attention_cached_tokens=0,
+            hybrid_cache_recurrent_state_cached_tokens=0,
+        )
+        streamer = SimpleNamespace(enable_hicache_storage=lambda: False)
+
+        details = SchedulerOutputStreamer.get_cached_tokens_details(streamer, req)
+        wire_details = cached_tokens_details_from_dict(details).model_dump(
+            exclude_none=True
+        )
+
+        self.assertEqual(wire_details, details)
+        self.assertEqual(wire_details["usable_cached_tokens"], 0)
+        self.assertEqual(wire_details["full_attention_recomputed_tokens"], 9)
+
+    def test_non_hybrid_request_keeps_existing_shape(self):
+        req = SimpleNamespace(
+            origin_input_ids=list(range(9)),
+            cached_tokens=4,
+            cached_tokens_device=4,
+            cached_tokens_host=0,
+            cached_tokens_storage=0,
+        )
+        streamer = SimpleNamespace(enable_hicache_storage=lambda: False)
+
+        details = SchedulerOutputStreamer.get_cached_tokens_details(streamer, req)
+
+        self.assertEqual(details, {"device": 4, "host": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_mamba_path_state_cap.py
+++ b/test/registered/unit/mem_cache/test_mamba_path_state_cap.py
@@ -294,6 +294,7 @@ class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
         """The walked target's backup executes before commit hooks, so a mamba
         value re-stamped by the same insert stays out of the host backup."""
         cache, allocator, req_to_token_pool = self._build_hicache_fixture()
+        cache.metrics_collector = mock.Mock()
         mamba_comp = cache.components[ComponentType.MAMBA]
 
         self._insert(cache, allocator, req_to_token_pool, [1, 2])
@@ -304,6 +305,11 @@ class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
         mamba_comp.mamba_max_states_per_path = 1
         self._insert(cache, allocator, req_to_token_pool, [1, 2, 3, 4, 5, 6])
         self.assertIsNone(ancestor.component_data[ComponentType.MAMBA].value)
+        cache.metrics_collector.increment_hybrid_cache_evictions.assert_called_with(
+            full_attention_tokens=0,
+            recurrent_states=2,
+            reason="path_state_cap",
+        )
 
         # Re-inserting [1, 2] crosses the threshold and re-stamps the tombstone
         # in the same insert; the backup must not carry the fresh mamba state.

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1821,6 +1821,7 @@ class UnifiedRadixCacheSuite:
         if not self.cfg.has_mamba:
             self.skipTest("requires Mamba component")
         cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        cache.metrics_collector = mock.Mock()
         seq_short = self._make_seq(1, 2)
         seq_long = seq_short + self._make_seq(500, 2)
         self._insert(cache, allocator, req_to_token_pool, seq_short)
@@ -1829,6 +1830,11 @@ class UnifiedRadixCacheSuite:
 
         result = cache.evict(EvictParams(num_tokens=0, mamba_num=1))
         self.assertGreaterEqual(result.mamba_num_evicted, 1)
+        cache.metrics_collector.increment_hybrid_cache_evictions.assert_called_once_with(
+            full_attention_tokens=0,
+            recurrent_states=result.mamba_num_evicted,
+            reason="unspecified",
+        )
         self.assertGreaterEqual(cache.full_evictable_size(), 0)
         cache.sanity_check()
 


### PR DESCRIPTION
## Motivation

Hybrid models can have different reusable prefix boundaries for Full-attention KV and recurrent state. The existing aggregate cached-token metric exposes only the jointly usable prefix, so it cannot answer whether cache loss came from Full KV, recurrent checkpoint alignment, recomputation, or component eviction.

This PR adds model-independent observability for unified hybrid-cache models. It is complementary to #33799: that PR reports evictable cache referenced by radix-native sessions, while this PR reports component hit boundaries, recomputation, and eviction causes.

## Modifications

- Preserve the raw Full-KV hit and recurrent-compatible hit on each hybrid-cache request.
- Extend native/OpenAI cached-token details with:
  - Full-attention cached tokens
  - recurrent-state cached tokens
  - jointly usable cached tokens
  - trimmed Full-attention tokens
  - Full/recurrent recomputed tokens
  - recurrent replayed tokens
- Export `sglang:hybrid_cache_request_tokens_total{kind=...}` for aggregate request accounting.
- Export separate Full-token and recurrent-state eviction counters with bounded reason labels:
  - `kv_allocation_pressure`
  - `recurrent_allocation_pressure`
  - `hicache_load_back_pressure`
  - `path_state_cap`
  - `unspecified`
- Make path-state-cap eviction return and report its actual recurrent-state count.
- Preserve the existing response shape for non-hybrid requests.

## Accuracy Tests

N/A. This PR does not change model execution, sampling, kernels, or cache matching decisions.

## Speed Tests and Profiling

This is observability-only and makes no inference-speed claim.

The metrics were exercised in three production-trace studies:

- Mooncake C32, three repeats: mean raw Full hit 68.3271%, usable hit 68.2418%.
- AgentX 256K C32: raw Full hit 88.2297%, usable hit 88.0594%.
- AgentX 256K C64: raw Full hit 6.5437%, usable hit 6.4065%; eviction causes identified Full-KV pressure as the dominant loss.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit tests.
- [ ] Update documentation. The new fields and metric names are self-describing in protocol types and collector help; production-metrics documentation can be added during review if desired.
- [x] Provide accuracy and speed-test disposition.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33800658168](https://github.com/sgl-project/sglang/actions/runs/33800658168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33800657785](https://github.com/sgl-project/sglang/actions/runs/33800657785)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33800658074](https://github.com/sgl-project/sglang/actions/runs/33800658074)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->