### PR TITLE
[Test] Allow top-k cutoff ties in `test_sampling_mask_matches_topk_logprobs`

### DIFF
--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -321,9 +321,9 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
         ``p = exp(logprob)`` are the exact probabilities. For each token, we check:
 
         1. the sampled token is in the returned mask,
-        2. every mask token is present in the returned top logprobs and sits
-           at or above the top-k cutoff (ties at the cutoff survive, so the
-           mask may hold more than ``top_k`` tokens),
+        2. every mask token is in the returned top logprobs and at or above
+           the top-k cutoff (ties at the cutoff survive, so the mask may
+           exceed ``top_k``),
         3. sampling_logprob == log(p[sampled] / sum(p[t] for t in mask)).
         """
         top_k, top_p = _TOP_K, _TOP_P
@@ -362,10 +362,9 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
 
             self.assertIn(output_id, mask_set)
             self.assertTrue(mask_set.issubset(probs))
-            # top-k keeps every token tied with the k-th largest prob, so the
-            # mask may exceed top_k on ties but never reaches below the cutoff.
             top_k_cutoff = sorted(probs.values(), reverse=True)[top_k - 1]
             for token_id in mask_set:
+                # 1e-3 slack: the kernel cuts on its own probs, not these logprobs.
                 self.assertGreaterEqual(probs[token_id], top_k_cutoff * (1 - 1e-3))
 
             support_mass = sum(probs[token_id] for token_id in mask_set)

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -320,8 +320,10 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
         ``temperature=1.0`` these are the sampler's distribution, so
         ``p = exp(logprob)`` are the exact probabilities. For each token, we check:
 
-        1. the sampled token is in the returned top-k-bounded mask,
-        2. every mask token is present in the returned top logprobs,
+        1. the sampled token is in the returned mask,
+        2. every mask token is present in the returned top logprobs and sits
+           at or above the top-k cutoff (ties at the cutoff survive, so the
+           mask may hold more than ``top_k`` tokens),
         3. sampling_logprob == log(p[sampled] / sum(p[t] for t in mask)).
         """
         top_k, top_p = _TOP_K, _TOP_P
@@ -359,8 +361,12 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             mask_set = set(mask)
 
             self.assertIn(output_id, mask_set)
-            self.assertLessEqual(len(mask_set), top_k)
             self.assertTrue(mask_set.issubset(probs))
+            # top-k keeps every token tied with the k-th largest prob, so the
+            # mask may exceed top_k on ties but never reaches below the cutoff.
+            top_k_cutoff = sorted(probs.values(), reverse=True)[top_k - 1]
+            for token_id in mask_set:
+                self.assertGreaterEqual(probs[token_id], top_k_cutoff * (1 - 1e-3))
 
             support_mass = sum(probs[token_id] for token_id in mask_set)
             expected_logprob = math.log(probs[output_id] / support_mass)


### PR DESCRIPTION
The mask is captured from the sampler support, which keeps every token tied with the k-th largest probability (see `test_flashinfer_joint_cutoff_ties_match_capture` in the same file), so `len(mask) <= top_k` is not an invariant and the case has been flaky on main since #36630 (`11 not less than or equal to 10`). Check the cutoff instead: every mask token sits at or above the k-th largest reported probability.

## Flakiness check
10 manual `Rerun Test` dispatches of `test_sampling_mask.py` at `4ab6d0a10c`, 10/10 passed:
- https://github.com/sgl-project/sglang/actions/runs/33802918557
- https://github.com/sgl-project/sglang/actions/runs/33802925768
- https://github.com/sgl-project/sglang/actions/runs/33802932391
- https://github.com/sgl-project/sglang/actions/runs/33802939209
- https://github.com/sgl-project/sglang/actions/runs/33802946056
- https://github.com/sgl-project/sglang/actions/runs/33802952841
- https://github.com/sgl-project/sglang/actions/runs/33802960240
- https://github.com/sgl-project/sglang/actions/runs/33802966955
- https://github.com/sgl-project/sglang/actions/runs/33802972901
- https://github.com/sgl-project/sglang/actions/runs/33802979415

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33806476386](https://github.com/sgl-project/sglang/actions/runs/33806476386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33806476254](https://github.com/sgl-project/sglang/actions/runs/33806476254)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33806476176](https://github.com/sgl-project/sglang/actions/runs/33806476176)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

