### PR TITLE
[Cookbook] Kimi-K3: add measured B300 1x8 Unified 8k/1k speed numbers

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -81,6 +81,17 @@ import { KimiK3MambaRatioCalculator } from "/src/snippets/_kimi_k3_mamba_ratio_c
 
 <Deployment config={config} benchmarks={benchmarks} />
 
+<Note>
+  B300 1×8 Unified speed numbers are measured on `v0.5.18 @ 71de97b2` with `--random-range-ratio 1.0`,
+  `--warmup-requests 64`, `--flush-cache`, at ISL 8192 / OSL 1024. DSPARK cells pin the acceptance
+  length via the serve env `SGLANG_SIMULATE_ACC_LEN=4.5` — they report what block size 7 delivers at
+  that acceptance, not a measured acceptance rate for this workload. Balanced DSPARK adds
+  `--max-running-requests 256`; without it speculation resets the cap to 48. At concurrency 256 every
+  Balanced cell is admission-bound (101 / 68 / 91 / 60 concurrent requests for MXFP4 NOSPEC / MXFP4
+  DSPARK / NVFP4 NOSPEC / NVFP4 DSPARK), so TTFT there is dominated by queueing and the cells are not
+  comparable to each other at that point.
+</Note>
+
 ### Mamba ratio calculator
 
 <KimiK3MambaRatioCalculator />

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -86,10 +86,9 @@ import { KimiK3MambaRatioCalculator } from "/src/snippets/_kimi_k3_mamba_ratio_c
   `--warmup-requests 64`, `--flush-cache`, at ISL 8192 / OSL 1024. DSPARK cells pin the acceptance
   length via the serve env `SGLANG_SIMULATE_ACC_LEN=4.5` — they report what block size 7 delivers at
   that acceptance, not a measured acceptance rate for this workload. Balanced DSPARK adds
-  `--max-running-requests 256`; without it speculation resets the cap to 48. At concurrency 256 every
-  Balanced cell is admission-bound (101 / 68 / 91 / 60 concurrent requests for MXFP4 NOSPEC / MXFP4
-  DSPARK / NVFP4 NOSPEC / NVFP4 DSPARK), so TTFT there is dominated by queueing and the cells are not
-  comparable to each other at that point.
+  `--max-running-requests 256`; without it speculation resets the cap to 48. The KDA state pool still
+  clamps admission below that (101 / 68 / 91 / 60 concurrent requests for MXFP4 NOSPEC / MXFP4 DSPARK /
+  NVFP4 NOSPEC / NVFP4 DSPARK), which is why no point past concurrency 64 is published for Balanced.
 </Note>
 
 ### Mamba ratio calculator
@@ -135,9 +134,10 @@ are scheduled to release by July 27, 2026**. The recipes on this page were valid
 repository (`moonshotai/Kimi-K3`) and a public `lmsysorg/sglang` image with K3 support will be
 available at launch.
 
-Every cell in the Deploy panel above is currently marked **Final Verification In Progress**: the
-recipe runs, but its serving round on the final weights and current code is still open. Re-measure
-throughput and accuracy before you rely on any of them.
+The B300 1×8 `Unified` Low-Latency and Balanced cells are **Verified** — a speed round on the final
+weights is published below. Every other cell is still marked **Final Verification In Progress**: the
+recipe runs, but its serving round on the final weights and current code is still open. Accuracy has
+not been re-measured on any cell — re-measure before you rely on one.
 </Note>
 
 **Recommended generation:** `temperature=1.0`, `top_p=0.95`, `presence_penalty=0`, `frequency_penalty=0` (fixed by the model; informational — do not hardcode in sample code).
@@ -166,7 +166,7 @@ Speculation: DSPARK holds block size + 1 (= 8) intermediate states per request �
 
 **Context length.** `--context-length` bounds the longest accepted request plus some context-scaled buffers; it does not size the KV pool. For long context the lever that adds capacity is `fp8_e4m3` KV.
 
-**DSPARK.** Adds `--speculative-algorithm DSPARK` plus the draft checkpoint on top of the showing strategy. Leave `--speculative-draft-attention-backend` unset. No serving round on the final draft checkpoint has landed — measure against the same recipe running NOSPEC before adopting.
+**DSPARK.** Adds `--speculative-algorithm DSPARK` plus the draft checkpoint on top of the showing strategy. Leave `--speculative-draft-attention-backend` unset. The published B300 DSPARK numbers pin the acceptance length with `SGLANG_SIMULATE_ACC_LEN`, so no measured acceptance rate exists for a real workload yet — measure against the same recipe running NOSPEC before adopting.
 
 **Per-platform notes:**
 
@@ -190,7 +190,7 @@ Speculation: DSPARK holds block size + 1 (= 8) intermediate states per request �
 - Calculator ratios run well above 1 here (`r > 1` is legal): `bfloat16` state buys admission, `fp8` KV buys context.
 - Don't use EP with an a2a backend: a2a buffers reclaim the KV that DCP buys. Compose only to measure. a2a backend is set when `--moe-a2a-backend` is set.
 
-No cell has a serving round in this exact shape — treat them as starting points to verify.
+Outside the two verified B300 1×8 `Unified` cells, no cell has a serving round in this exact shape — treat those as starting points to verify.
 
 <a id="amd-env" />
 

--- a/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
@@ -19,4 +19,84 @@ export const benchmarks = [
   { match: { hw: "gb200", pdMode: "unified", strategy: "low-latency" } },
   { match: { hw: "gb200", pdMode: "unified", strategy: "balanced"    } },
   { match: { hw: "gb200", pdMode: "unified", strategy: "high-throughput"    } },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "low-latency", quant: "mxfp4", spec: "none" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 378, tpot_ms: 8.51, tokens_per_sec_per_gpu: 127 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 3539, tpot_ms: 19.47, tokens_per_sec_per_gpu: 785 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "low-latency", quant: "mxfp4", spec: "dspark" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 389, tpot_ms: 2.84, tokens_per_sec_per_gpu: 351 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 3942, tpot_ms: 9.88, tokens_per_sec_per_gpu: 1319 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "low-latency", quant: "nvfp4", spec: "none" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 369, tpot_ms: 10.12, tokens_per_sec_per_gpu: 107 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 3387, tpot_ms: 20.94, tokens_per_sec_per_gpu: 742 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "low-latency", quant: "nvfp4", spec: "dspark" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 380, tpot_ms: 3.24, tokens_per_sec_per_gpu: 313 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 3765, tpot_ms: 9.77, tokens_per_sec_per_gpu: 1345 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "balanced", quant: "mxfp4", spec: "none" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 11635, tpot_ms: 40.19, tokens_per_sec_per_gpu: 1395 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 104864, tpot_ms: 52.1, tokens_per_sec_per_gpu: 1603 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "balanced", quant: "mxfp4", spec: "dspark" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 12038, tpot_ms: 24.47, tokens_per_sec_per_gpu: 1987 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 121390, tpot_ms: 25.28, tokens_per_sec_per_gpu: 1995 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "balanced", quant: "nvfp4", spec: "none" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 11063, tpot_ms: 41.55, tokens_per_sec_per_gpu: 1373 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 142418, tpot_ms: 50.63, tokens_per_sec_per_gpu: 1518 },
+    ],
+  },
+  {
+    match: { hw: "b300", pdMode: "unified", strategy: "balanced", quant: "nvfp4", spec: "dspark" },
+    sglang_version: "v0.5.18 @ 71de97b2",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 11664, tpot_ms: 22.17, tokens_per_sec_per_gpu: 1946 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
+        ttft_ms: 117159, tpot_ms: 22.61, tokens_per_sec_per_gpu: 1987 },
+    ],
+  },
 ];

--- a/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
@@ -65,8 +65,6 @@ export const benchmarks = [
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
         ttft_ms: 11635, tpot_ms: 40.19, tokens_per_sec_per_gpu: 1395 },
-      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
-        ttft_ms: 104864, tpot_ms: 52.1, tokens_per_sec_per_gpu: 1603 },
     ],
   },
   {
@@ -75,8 +73,6 @@ export const benchmarks = [
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
         ttft_ms: 12038, tpot_ms: 24.47, tokens_per_sec_per_gpu: 1987 },
-      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
-        ttft_ms: 121390, tpot_ms: 25.28, tokens_per_sec_per_gpu: 1995 },
     ],
   },
   {
@@ -85,8 +81,6 @@ export const benchmarks = [
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
         ttft_ms: 11063, tpot_ms: 41.55, tokens_per_sec_per_gpu: 1373 },
-      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
-        ttft_ms: 142418, tpot_ms: 50.63, tokens_per_sec_per_gpu: 1518 },
     ],
   },
   {
@@ -95,8 +89,6 @@ export const benchmarks = [
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
         ttft_ms: 11664, tpot_ms: 22.17, tokens_per_sec_per_gpu: 1946 },
-      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256 },
-        ttft_ms: 117159, tpot_ms: 22.61, tokens_per_sec_per_gpu: 1987 },
     ],
   },
 ];

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -454,7 +454,7 @@ export const config = {
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} --random-range-ratio 1.0 \\
   --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
-  --flush-cache`,
+  --warmup-requests 64 --flush-cache`,
     // num_prompts = 5 × concurrency (measured floor 16).
     numPromptsByConc: { 1: 16, 16: 80, 64: 320, 256: 1280, 1024: 5120 },
   },

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -1013,8 +1013,7 @@ export const config = {
     {
       match: { hw: "b300", pdMode: "unified", strategy: "low-latency" },
       nnodes: 1,
-      verified: false,
-      verificationStatus: "in-progress",
+      verified: true,
       env: [],
       // No --enable-symm-mem: it makes the fused all-reduce auto-probe skip.
       flags: [
@@ -1031,8 +1030,7 @@ export const config = {
     {
       match: { hw: "b300", pdMode: "unified", strategy: "balanced" },
       nnodes: 1,
-      verified: false,
-      verificationStatus: "in-progress",
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",


### PR DESCRIPTION
## Motivation

The B300 1×8 `Unified` cells on the Kimi-K3 cookbook page rendered as **pending** — no serving round had been published for them. This fills them with a measured ISL 8192 / OSL 1024 sweep and marks the two covered cells verified.

Matrix: **Low-Latency / Balanced** × **MXFP4 / NVFP4** × **NOSPEC / DSPARK** = 8 servers. Concurrency follows the cookbook convention with `num_prompts` from the page's own `numPromptsByConc`.

## Measurements

`v0.5.18 @ 71de97b2`, real weights (`moonshotai/Kimi-K3` @ `a590ce09`, `nvidia/Kimi-K3-NVFP4` @ `b2428a0b`, `RadixArk/Kimi-K3-DSpark` @ `3c5bac30`), one dedicated server per cell.

| strategy | quant | spec | conc | TTFT ms | TPOT ms | tok/s/GPU |
|---|---|---|---|---|---|---|
| Low-Latency | MXFP4 | NOSPEC | 1 / 16 | 378 / 3539 | 8.51 / 19.47 | 127 / 785 |
| Low-Latency | MXFP4 | DSPARK | 1 / 16 | 389 / 3942 | 2.84 / 9.88 | 351 / 1319 |
| Low-Latency | NVFP4 | NOSPEC | 1 / 16 | 369 / 3387 | 10.12 / 20.94 | 107 / 742 |
| Low-Latency | NVFP4 | DSPARK | 1 / 16 | 380 / 3765 | 3.24 / 9.77 | 313 / 1345 |
| Balanced | MXFP4 | NOSPEC | 64 | 11635 | 40.19 | 1395 |
| Balanced | MXFP4 | DSPARK | 64 | 12038 | 24.47 | 1987 |
| Balanced | NVFP4 | NOSPEC | 64 | 11063 | 41.55 | 1373 |
| Balanced | NVFP4 | DSPARK | 64 | 11664 | 22.17 | 1946 |

Concurrency 256 was also swept but is **not published**: the KDA state pool clamps admission to 101 / 68 / 91 / 60 against the 256 requested (peak `#running-req` in the decode logs confirmed 100 / 67 / 90 / 59), so TTFT there measured queueing rather than the recipe, and the four cells were not comparable to each other at that point.

## Caveats recorded on the page

- **DSPARK cells pin `SGLANG_SIMULATE_ACC_LEN=4.5`.** They report what block size 7 delivers *at that acceptance*, not a measured acceptance rate for this workload. Reported accept length came back 4.46–4.52 across all four DSPARK cells, confirming the env took effect.
- **Balanced DSPARK adds `--max-running-requests 256`.** Left unset, `_handle_dspark` resets the cap to 48 (`python/sglang/srt/arg_groups/speculative_hook.py`), which would silently cap concurrency 64.
- **Accuracy is unmeasured** on every cell, including the two now marked verified. The `<Note>` under the model introduction says so.

## Modifications

- `docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx` — eight entries keyed on `hw` + `pdMode` + `strategy` + `quant` + `spec`. The existing bare `b300` stubs stay as the fallback for cells still unmeasured (High-Throughput), which continue to render pending.
- `docs/src/snippets/configs/moonshotai/kimi-k3.jsx` — the two measured cells flip from `verificationStatus: "in-progress"` to `verified: true`; the reproduce command gains `--warmup-requests 64` so it matches the command that produced these numbers.
- `docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx` — measurement note under the Deploy panel (following the GLM-5.2 page's convention), plus the three statements that claimed no cell had a serving round, which the verified flip makes false.

## Reproduce

```bash
python3 -m sglang.bench_serving \
  --backend sglang \
  --host localhost --port 30000 \
  --model moonshotai/Kimi-K3 \
  --dataset-name random \
  --random-input-len 8192 --random-output-len 1024 --random-range-ratio 1.0 \
  --num-prompts 80 --max-concurrency 16 \
  --warmup-requests 64 --flush-cache
```

`num_prompts` per concurrency follows the page's `numPromptsByConc` (1 → 16, 16 → 80, 64 → 320). Serve commands are exactly what the Deploy panel emits for each cell, with `--mamba-full-memory-ratio` from the page calculator at L = 8192 + 1024 = 9216 (1.1 / 1.05 Low-Latency NOSPEC / DSPARK, 8.82 / 6.28 Balanced NOSPEC / DSPARK).

## Checklist

- [x] `node docs/scripts/check_cookbook_configs.mjs` → `cookbook config check: OK`
- [x] All eight combinations resolve to their new entry and render the Verified badge; High-Throughput and every other platform still resolve to a pending stub and keep their in-progress badge
- [x] Docs-only change — no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33813187942](https://github.com/sgl-project/sglang/actions/runs/33813187942)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33813186265](https://github.com/sgl-project/sglang/actions/runs/33813186265)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->