### PR TITLE
[Spec][Ngram]: Add global Trie/SAM proposal allocation

### DIFF
--- a/python/sglang/kernels/aot/tests/speculative/test_ngram_utils.py
+++ b/python/sglang/kernels/aot/tests/speculative/test_ngram_utils.py
@@ -33,12 +33,12 @@ def test_reconstruct_indices_from_tree_mask():
             0,
             0,
             1,
-            0,
+            1,
             1,
             0,
             1,
             0,
-            1,
+            0,
             1,
         ],
         device="cuda",
@@ -60,16 +60,16 @@ def test_reconstruct_indices_from_tree_mask():
         [0, 1, 2, 3],
     ], f"{retrive_index=}"
     assert retrive_next_token.tolist() == [
-        [1, -1, 3, -1],
+        [1, 2, -1, -1],
     ], f"{retrive_next_token=}"
     assert retrive_next_sibling.tolist() == [
-        [-1, 2, -1, -1],
+        [-1, 3, -1, -1],
     ], f"{retrive_next_sibling=}"
     assert positions.tolist() == [
         12,
         13,
-        13,
         14,
+        13,
     ], f"{positions=}"
 
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.cpp
@@ -1,0 +1,184 @@
+#include "global_tree.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sglang {
+
+namespace ngram {
+
+GlobalTree::GlobalTree(
+    size_t proposal_budget,
+    size_t max_breadth,
+    size_t max_match_length,
+    GlobalTreeMode score_mode,
+    std::optional<TrieAnchor> trie_anchor,
+    std::vector<SamAnchor> sam_anchors)
+    : proposal_budget_(proposal_budget),
+      max_breadth_(max_breadth),
+      max_match_length_(max_match_length),
+      score_mode_(score_mode),
+      trie_anchor_(std::move(trie_anchor)),
+      sam_anchors_(std::move(sam_anchors)) {
+  const size_t source_count = static_cast<size_t>(trie_anchor_.has_value()) + sam_anchors_.size();
+  const size_t candidates_per_expansion = source_count * max_breadth_;
+  const size_t max_generated_candidates = proposal_budget_ * candidates_per_expansion;
+  nodes_.reserve(proposal_budget_ + 1);
+  cursor_arena_.reserve(source_count + max_generated_candidates);
+  frontier_.reserve(max_generated_candidates);
+  candidate_buffer_.reserve(candidates_per_expansion);
+  trie_transitions_.reserve(max_breadth_);
+  sam_transitions_.reserve(max_breadth_);
+  nodes_.emplace_back();
+}
+
+void GlobalTree::generate() {
+  seedFrontier();
+  for (size_t proposal_index = 0; proposal_index < proposal_budget_ && !frontier_.empty(); ++proposal_index) {
+    selectNextNode();
+  }
+}
+
+double GlobalTree::initialContribution(int32_t matched_length) const {
+  switch (score_mode_) {
+    case GlobalTreeMode::PATH_PROBABILITY:
+      return 1.0;
+    case GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY:
+      return static_cast<double>(matched_length) / static_cast<double>(max_match_length_);
+    case GlobalTreeMode::DISABLED:
+      throw std::runtime_error("GlobalTree cannot use the disabled score mode");
+  }
+  throw std::runtime_error("GlobalTree received an unknown score mode");
+}
+
+void GlobalTree::seedFrontier() {
+  const auto cursor_begin = static_cast<uint32_t>(cursor_arena_.size());
+  if (trie_anchor_) {
+    cursor_arena_.push_back(TrieCursor{trie_anchor_->state, initialContribution(trie_anchor_->matched_length)});
+  }
+  for (size_t sam_index = 0; sam_index < sam_anchors_.size(); ++sam_index) {
+    const auto& anchor = sam_anchors_[sam_index];
+    cursor_arena_.push_back(
+        SamCursor{static_cast<uint32_t>(sam_index), anchor.state, initialContribution(anchor.matched_length)});
+  }
+  expandSelectCursors(0, cursor_begin, static_cast<uint32_t>(cursor_arena_.size() - cursor_begin));
+}
+
+template <typename TypedCursor>
+void GlobalTree::appendCandidate(
+    const TypedCursor& cursor,
+    int32_t token,
+    TypedCursor successor,
+    uint64_t mass,
+    uint64_t total_mass) {
+  if (mass == 0) {
+    return;
+  }
+
+  const double conditional_probability = static_cast<double>(mass) / static_cast<double>(total_mass);
+  const double contribution_score = cursor.contribution_score * conditional_probability;
+  successor.contribution_score = contribution_score;
+  candidate_buffer_.push_back(ScratchCandidate{
+      .successor = std::move(successor),
+      .contribution_score = contribution_score,
+      .token = token,
+      .insertion_sequence = next_insertion_sequence_++,
+  });
+}
+
+void GlobalTree::appendCursorTransitionsCandidates(const Cursor& cursor) {
+  if (const auto* trie_cursor = std::get_if<TrieCursor>(&cursor)) {
+    const auto total_mass =
+        trie_anchor_->trie->frequencyTransitions(trie_cursor->state, max_breadth_, trie_transitions_);
+    for (const auto& transition : trie_transitions_) {
+      appendCandidate(*trie_cursor, transition.token, TrieCursor{transition.state}, transition.mass, total_mass);
+    }
+  } else {
+    const auto& sam_cursor = std::get<SamCursor>(cursor);
+    const auto& anchor = sam_anchors_[sam_cursor.sam_index];
+    const auto total_mass = anchor.sam->frequencyTransitions(sam_cursor.state, max_breadth_, sam_transitions_);
+    for (const auto& transition : sam_transitions_) {
+      appendCandidate(
+          sam_cursor,
+          transition.token,
+          SamCursor{sam_cursor.sam_index, transition.state},
+          transition.mass,
+          total_mass);
+    }
+  }
+}
+
+void GlobalTree::expandSelectCursors(uint32_t global_parent_id, uint32_t cursor_begin, uint32_t cursor_count) {
+  candidate_buffer_.clear();
+  for (uint32_t offset = 0; offset < cursor_count; ++offset) {
+    appendCursorTransitionsCandidates(cursor_arena_[cursor_begin + offset]);
+  }
+  if (candidate_buffer_.empty()) {
+    return;
+  }
+
+  std::sort(candidate_buffer_.begin(), candidate_buffer_.end(), [](const auto& lhs, const auto& rhs) {
+    if (lhs.token != rhs.token) {
+      return lhs.token < rhs.token;
+    }
+    return rhs < lhs;
+  });
+
+  for (size_t group_begin = 0; group_begin < candidate_buffer_.size();) {
+    size_t group_end = group_begin + 1;
+    while (group_end < candidate_buffer_.size() &&
+           candidate_buffer_[group_end].token == candidate_buffer_[group_begin].token) {
+      ++group_end;
+    }
+
+    const auto& best = candidate_buffer_[group_begin];
+    const auto cursor_begin = static_cast<uint32_t>(cursor_arena_.size());
+    for (size_t candidate_index = group_begin; candidate_index < group_end; ++candidate_index) {
+      cursor_arena_.push_back(candidate_buffer_[candidate_index].successor);
+    }
+    frontier_.push_back(FrontierEdge{
+        .contribution_score = best.contribution_score,
+        .parent_id = global_parent_id,
+        .cursor_begin = cursor_begin,
+        .cursor_count = static_cast<uint32_t>(group_end - group_begin),
+        .token = best.token,
+        .insertion_sequence = best.insertion_sequence,
+    });
+    group_begin = group_end;
+  }
+}
+
+void GlobalTree::selectNextNode() {
+  const auto best = std::max_element(frontier_.begin(), frontier_.end());
+  const auto edge = *best;
+  *best = frontier_.back();
+  frontier_.pop_back();
+
+  const auto node_id = static_cast<uint32_t>(nodes_.size());
+  nodes_.push_back(GlobalNode{edge.parent_id, edge.token});
+  if (nodes_.size() - 1 < proposal_budget_) {
+    expandSelectCursors(node_id, edge.cursor_begin, edge.cursor_count);
+  }
+}
+
+Result GlobalTree::materialize(int32_t last_token) const {
+  std::vector<int32_t> proposal_tokens;
+  std::vector<int32_t> proposal_parents;
+  proposal_tokens.reserve(nodes_.size() - 1);
+  proposal_parents.reserve(nodes_.size() - 1);
+
+  for (size_t node_id = 1; node_id < nodes_.size(); ++node_id) {
+    proposal_tokens.push_back(nodes_[node_id].token);
+    proposal_parents.push_back(static_cast<int32_t>(nodes_[node_id].parent_id));
+  }
+
+  return fillResultWithParentArray(
+      last_token, proposal_budget_ + 1, proposal_tokens, proposal_parents);
+}
+
+}  // namespace ngram
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.cpp
@@ -69,11 +69,7 @@ void GlobalTree::seedFrontier() {
 
 template <typename TypedCursor>
 void GlobalTree::appendCandidate(
-    const TypedCursor& cursor,
-    int32_t token,
-    TypedCursor successor,
-    uint64_t mass,
-    uint64_t total_mass) {
+    const TypedCursor& cursor, int32_t token, TypedCursor successor, uint64_t mass, uint64_t total_mass) {
   if (mass == 0) {
     return;
   }
@@ -81,12 +77,13 @@ void GlobalTree::appendCandidate(
   const double conditional_probability = static_cast<double>(mass) / static_cast<double>(total_mass);
   const double contribution_score = cursor.contribution_score * conditional_probability;
   successor.contribution_score = contribution_score;
-  candidate_buffer_.push_back(ScratchCandidate{
-      .successor = std::move(successor),
-      .contribution_score = contribution_score,
-      .token = token,
-      .insertion_sequence = next_insertion_sequence_++,
-  });
+  candidate_buffer_.push_back(
+      ScratchCandidate{
+          .successor = std::move(successor),
+          .contribution_score = contribution_score,
+          .token = token,
+          .insertion_sequence = next_insertion_sequence_++,
+      });
 }
 
 void GlobalTree::appendCursorTransitionsCandidates(const Cursor& cursor) {
@@ -102,11 +99,7 @@ void GlobalTree::appendCursorTransitionsCandidates(const Cursor& cursor) {
     const auto total_mass = anchor.sam->frequencyTransitions(sam_cursor.state, max_breadth_, sam_transitions_);
     for (const auto& transition : sam_transitions_) {
       appendCandidate(
-          sam_cursor,
-          transition.token,
-          SamCursor{sam_cursor.sam_index, transition.state},
-          transition.mass,
-          total_mass);
+          sam_cursor, transition.token, SamCursor{sam_cursor.sam_index, transition.state}, transition.mass, total_mass);
     }
   }
 }
@@ -139,14 +132,15 @@ void GlobalTree::expandSelectCursors(uint32_t global_parent_id, uint32_t cursor_
     for (size_t candidate_index = group_begin; candidate_index < group_end; ++candidate_index) {
       cursor_arena_.push_back(candidate_buffer_[candidate_index].successor);
     }
-    frontier_.push_back(FrontierEdge{
-        .contribution_score = best.contribution_score,
-        .parent_id = global_parent_id,
-        .cursor_begin = cursor_begin,
-        .cursor_count = static_cast<uint32_t>(group_end - group_begin),
-        .token = best.token,
-        .insertion_sequence = best.insertion_sequence,
-    });
+    frontier_.push_back(
+        FrontierEdge{
+            .contribution_score = best.contribution_score,
+            .parent_id = global_parent_id,
+            .cursor_begin = cursor_begin,
+            .cursor_count = static_cast<uint32_t>(group_end - group_begin),
+            .token = best.token,
+            .insertion_sequence = best.insertion_sequence,
+        });
     group_begin = group_end;
   }
 }
@@ -175,8 +169,7 @@ Result GlobalTree::materialize(int32_t last_token) const {
     proposal_parents.push_back(static_cast<int32_t>(nodes_[node_id].parent_id));
   }
 
-  return fillResultWithParentArray(
-      last_token, proposal_budget_ + 1, proposal_tokens, proposal_parents);
+  return fillResultWithParentArray(last_token, proposal_budget_ + 1, proposal_tokens, proposal_parents);
 }
 
 }  // namespace ngram

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.h
@@ -79,12 +79,8 @@ class GlobalTree {
   double initialContribution(int32_t matched_length) const;
   void seedFrontier();
   template <typename TypedCursor>
-  void appendCandidate(
-      const TypedCursor& cursor,
-      int32_t token,
-      TypedCursor successor,
-      uint64_t mass,
-      uint64_t total_mass);
+  void
+  appendCandidate(const TypedCursor& cursor, int32_t token, TypedCursor successor, uint64_t mass, uint64_t total_mass);
   void appendCursorTransitionsCandidates(const Cursor& cursor);
   void expandSelectCursors(uint32_t global_parent_id, uint32_t cursor_begin, uint32_t cursor_count);
   void selectNextNode();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/global_tree.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "param.h"
+#include "result.h"
+#include "suffix_automaton.h"
+#include "trie.h"
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace sglang {
+
+namespace ngram {
+
+class GlobalTree {
+ public:
+  GlobalTree(
+      size_t proposal_budget,
+      size_t max_breadth,
+      size_t max_match_length,
+      GlobalTreeMode score_mode,
+      std::optional<TrieAnchor> trie_anchor,
+      std::vector<SamAnchor> sam_anchors);
+
+  void generate();
+  Result materialize(int32_t last_token) const;
+
+ private:
+  struct TrieCursor {
+    const TrieNode* state = nullptr;
+    double contribution_score = 1.0;
+  };
+
+  struct SamCursor {
+    uint32_t sam_index = 0;
+    int state = 0;
+    double contribution_score = 1.0;
+  };
+
+  using Cursor = std::variant<TrieCursor, SamCursor>;
+
+  struct ScratchCandidate {
+    Cursor successor;
+    double contribution_score = 0.0;
+    int32_t token = 0;
+    uint32_t insertion_sequence = 0;
+
+    bool operator<(const ScratchCandidate& other) const noexcept {
+      if (contribution_score != other.contribution_score) {
+        return contribution_score < other.contribution_score;
+      }
+      return insertion_sequence > other.insertion_sequence;
+    }
+  };
+
+  struct FrontierEdge {
+    double contribution_score = 0.0;
+    uint32_t parent_id = 0;
+    uint32_t cursor_begin = 0;
+    uint32_t cursor_count = 0;
+    int32_t token = 0;
+    uint32_t insertion_sequence = 0;
+
+    bool operator<(const FrontierEdge& other) const noexcept {
+      if (contribution_score != other.contribution_score) {
+        return contribution_score < other.contribution_score;
+      }
+      return insertion_sequence > other.insertion_sequence;
+    }
+  };
+
+  struct GlobalNode {
+    uint32_t parent_id = 0;
+    int32_t token = 0;
+  };
+
+  double initialContribution(int32_t matched_length) const;
+  void seedFrontier();
+  template <typename TypedCursor>
+  void appendCandidate(
+      const TypedCursor& cursor,
+      int32_t token,
+      TypedCursor successor,
+      uint64_t mass,
+      uint64_t total_mass);
+  void appendCursorTransitionsCandidates(const Cursor& cursor);
+  void expandSelectCursors(uint32_t global_parent_id, uint32_t cursor_begin, uint32_t cursor_count);
+  void selectNextNode();
+
+  size_t proposal_budget_;
+  size_t max_breadth_;
+  size_t max_match_length_;
+  GlobalTreeMode score_mode_;
+  std::optional<TrieAnchor> trie_anchor_;
+  std::vector<SamAnchor> sam_anchors_;
+  std::vector<GlobalNode> nodes_;
+  std::vector<Cursor> cursor_arena_;
+  std::vector<FrontierEdge> frontier_;
+  std::vector<ScratchCandidate> candidate_buffer_;
+  std::vector<TrieFrequencyTransition> trie_transitions_;
+  std::vector<SamFrequencyTransition> sam_transitions_;
+  uint32_t next_insertion_sequence_ = 0;
+};
+
+}  // namespace ngram
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
@@ -1,6 +1,8 @@
 #include "ngram.h"
 
+#include "global_tree.h"
 #include "trie.h"
+#include <algorithm>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -27,6 +29,14 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.draft_token_num > 0)) {
     throw std::runtime_error(
         "draft_token_num must be greater than 0, current value: " + std::to_string(param_.draft_token_num));
+  }
+  switch (param_.global_tree_mode) {
+    case GlobalTreeMode::DISABLED:
+    case GlobalTreeMode::PATH_PROBABILITY:
+    case GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY:
+      break;
+    default:
+      throw std::runtime_error("Unknown global tree mode");
   }
   for (auto config : param_.batch_draft_token_num) {
     if (config != std::numeric_limits<decltype(config)>::max()) {
@@ -151,6 +161,69 @@ Result Ngram::batchMatch(
 
   std::unique_lock<std::mutex> lock(mutex_);
 
+  switch (param_.global_tree_mode) {
+    case GlobalTreeMode::DISABLED:
+      return batchMatchLegacy_(state_ids, tokens, total_lens);
+    case GlobalTreeMode::PATH_PROBABILITY:
+    case GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY:
+      return batchMatchGlobalTree_(state_ids, tokens, total_lens);
+    default:
+      throw std::runtime_error("Unknown global tree mode");
+  }
+}
+
+Result Ngram::batchMatchGlobalTree_(
+    const std::vector<int64_t>& state_ids,
+    const std::vector<std::vector<int32_t>>& tokens,
+    const std::vector<size_t>& total_lens) {
+  const auto proposal_budget = param_.get_draft_token_num(tokens.size());
+
+  std::vector<std::pair<std::string, const SuffixAutomaton*>> sorted_sams;
+  sorted_sams.reserve(sams_.size());
+  for (const auto& [corpus_id, sam] : sams_) {
+    sorted_sams.emplace_back(corpus_id, sam.get());
+  }
+  std::sort(
+      sorted_sams.begin(), sorted_sams.end(), [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+
+  Result merged;
+  for (size_t i = 0; i < state_ids.size(); ++i) {
+    const auto& suffix = tokens[i];
+    if (suffix.empty()) {
+      throw std::runtime_error("batchMatch received an empty token tail");
+    }
+
+    auto& state = match_state_[state_ids[i]];
+    auto trie_anchor = trie_->longestExpandableMatch(suffix.data(), suffix.size(), state, total_lens[i]);
+
+    std::vector<SamAnchor> sam_anchors;
+    sam_anchors.reserve(sorted_sams.size());
+    for (const auto& sam_entry : sorted_sams) {
+      const auto* sam = sam_entry.second;
+      if (auto sam_match = sam->longestExpandableMatch(suffix.data(), suffix.size(), param_.max_trie_depth)) {
+        sam_anchors.push_back(*sam_match);
+      }
+    }
+
+    GlobalTree tree(
+        proposal_budget,
+        param_.max_bfs_breadth,
+        param_.max_trie_depth,
+        param_.global_tree_mode,
+        std::move(trie_anchor),
+        std::move(sam_anchors));
+    tree.generate();
+    auto result = tree.materialize(suffix.back());
+    merged.token.insert(merged.token.end(), result.token.begin(), result.token.end());
+    merged.mask.insert(merged.mask.end(), result.mask.begin(), result.mask.end());
+  }
+  return merged;
+}
+
+Result Ngram::batchMatchLegacy_(
+    const std::vector<int64_t>& state_ids,
+    const std::vector<std::vector<int32_t>>& tokens,
+    const std::vector<size_t>& total_lens) {
   using TrieResultBuildFn =
       Result (Trie::*)(const int32_t*, size_t, int32_t, size_t, const Param&, MatchState&, size_t) const;
   using SamResultBuildFn = Result (SuffixAutomaton::*)(const int32_t*, size_t, int32_t, size_t, const Param&) const;

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
@@ -30,14 +30,6 @@ Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
     throw std::runtime_error(
         "draft_token_num must be greater than 0, current value: " + std::to_string(param_.draft_token_num));
   }
-  switch (param_.global_tree_mode) {
-    case GlobalTreeMode::DISABLED:
-    case GlobalTreeMode::PATH_PROBABILITY:
-    case GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY:
-      break;
-    default:
-      throw std::runtime_error("Unknown global tree mode");
-  }
   for (auto config : param_.batch_draft_token_num) {
     if (config != std::numeric_limits<decltype(config)>::max()) {
       if (!(config <= param_.draft_token_num)) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
@@ -86,6 +86,14 @@ class Ngram {
   }
 
  private:
+  Result batchMatchGlobalTree_(
+      const std::vector<int64_t>& state_ids,
+      const std::vector<std::vector<int32_t>>& tokens,
+      const std::vector<size_t>& total_lens);
+  Result batchMatchLegacy_(
+      const std::vector<int64_t>& state_ids,
+      const std::vector<std::vector<int32_t>>& tokens,
+      const std::vector<size_t>& total_lens);
   void insertWorker();
 };
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -27,7 +27,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       int64_t draft_token_num,
       int64_t match_type,
       int64_t external_sam_budget,
-      int64_t external_corpus_max_tokens) {
+      int64_t external_corpus_max_tokens,
+      int64_t global_tree_mode) {
     ngram::Param param;
     param.enable = true;
     param.enable_router_mode = false;
@@ -36,6 +37,19 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.max_bfs_breadth = static_cast<size_t>(max_bfs_breadth);
     param.draft_token_num = static_cast<size_t>(draft_token_num);
     param.match_type = (match_type == 0) ? "BFS" : "PROB";
+    switch (global_tree_mode) {
+      case 0:
+        param.global_tree_mode = ngram::GlobalTreeMode::DISABLED;
+        break;
+      case 1:
+        param.global_tree_mode = ngram::GlobalTreeMode::PATH_PROBABILITY;
+        break;
+      case 2:
+        param.global_tree_mode = ngram::GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY;
+        break;
+      default:
+        throw std::runtime_error("Unknown global tree mode: " + std::to_string(global_tree_mode));
+    }
     param.external_sam_budget = static_cast<size_t>(external_sam_budget);
     param.external_corpus_max_tokens = static_cast<size_t>(external_corpus_max_tokens);
     ngram_ = std::make_unique<ngram::Ngram>(static_cast<size_t>(capacity), param);
@@ -155,7 +169,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
 void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
-      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
+      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)
       .def("erase_match_state", &NgramCorpusObj::erase_match_state)

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
@@ -14,6 +15,24 @@ namespace sglang {
 
 namespace ngram {
 
+enum class GlobalTreeMode : int64_t {
+  DISABLED = 0,
+  PATH_PROBABILITY = 1,
+  SPECIFICITY_PATH_PROBABILITY = 2,
+};
+
+inline const char* globalTreeModeName(GlobalTreeMode mode) {
+  switch (mode) {
+    case GlobalTreeMode::DISABLED:
+      return "disabled";
+    case GlobalTreeMode::PATH_PROBABILITY:
+      return "path_probability";
+    case GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY:
+      return "specificity_path_probability";
+  }
+  return "unknown";
+}
+
 struct Param {
   bool enable;
   bool enable_router_mode;
@@ -24,6 +43,7 @@ struct Param {
   size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
   std::string match_type;
+  GlobalTreeMode global_tree_mode = GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY;
 
   std::vector<size_t> batch_draft_token_num;
 
@@ -97,7 +117,8 @@ struct Param {
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
        << ", external_sam_budget = " << external_sam_budget
-       << ", external_corpus_max_tokens = " << external_corpus_max_tokens << ", match_type = " << match_type;
+       << ", external_corpus_max_tokens = " << external_corpus_max_tokens << ", match_type = " << match_type
+       << ", global_tree_mode = " << globalTreeModeName(global_tree_mode);
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {
       ss << i << "|" << batch_draft_token_num[i] << ",";

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
@@ -43,7 +43,7 @@ struct Param {
   size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
   std::string match_type;
-  GlobalTreeMode global_tree_mode = GlobalTreeMode::SPECIFICITY_PATH_PROBABILITY;
+  GlobalTreeMode global_tree_mode = GlobalTreeMode::DISABLED;
 
   std::vector<size_t> batch_draft_token_num;
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstring>
 #include <queue>
+#include <stdexcept>
 #include <tuple>
 
 namespace sglang {
@@ -48,6 +49,55 @@ Result fillResult(int last_token, int draft_token_num, std::vector<Node>& tree, 
   }
 
   return info;
+}
+
+Result fillResultWithParentArray(
+    int32_t last_token,
+    size_t result_length,
+    const std::vector<int32_t>& proposal_tokens,
+    const std::vector<int32_t>& proposal_parents) {
+  if (result_length == 0) {
+    throw std::runtime_error("result_length must be positive");
+  }
+  if (proposal_tokens.size() != proposal_parents.size()) {
+    throw std::runtime_error("proposal tokens and parents must have the same size");
+  }
+  if (proposal_tokens.size() + 1 > result_length) {
+    throw std::runtime_error("proposal tree exceeds the fixed result length");
+  }
+
+  Result result;
+  std::vector<int32_t> parents;
+  result.token.reserve(result_length);
+  parents.reserve(result_length);
+  result.token.push_back(last_token);
+  parents.push_back(-1);
+  for (size_t i = 0; i < proposal_tokens.size(); ++i) {
+    const auto output_index = static_cast<int32_t>(i + 1);
+    if (proposal_parents[i] < 0 || proposal_parents[i] >= output_index) {
+      throw std::runtime_error("proposal parent must precede its child");
+    }
+    result.token.push_back(proposal_tokens[i]);
+    parents.push_back(proposal_parents[i]);
+  }
+
+  while (result.token.size() < result_length) {
+    result.token.push_back(0);
+    parents.push_back(0);
+  }
+
+  result.mask.assign(result_length * result_length, 0);
+  for (size_t i = 0; i < result_length; ++i) {
+    const auto parent = parents[i];
+    if (parent >= 0) {
+      std::memcpy(
+          &result.mask[i * result_length],
+          &result.mask[static_cast<size_t>(parent) * result_length],
+          (static_cast<size_t>(parent) + 1) * sizeof(result.mask[0]));
+    }
+    result.mask[i * result_length + i] = 1;
+  }
+  return result;
 }
 
 std::vector<std::vector<int32_t>> extractLeafPaths_(const Result& result) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
@@ -21,6 +21,11 @@ struct Node {
 };
 
 Result fillResult(int last_token, int draft_token_num, std::vector<Node>& tree, int root);
+Result fillResultWithParentArray(
+    int32_t last_token,
+    size_t result_length,
+    const std::vector<int32_t>& proposal_tokens,
+    const std::vector<int32_t>& proposal_parents);
 std::vector<std::vector<int32_t>> extractLeafPaths_(const Result& result);
 Result buildResultFromLeafPaths_(int last_token, int draft_token_num, const std::vector<std::vector<int32_t>>& paths);
 Result combineRootResults_(int last_token, int draft_token_num, const Result& primary, const Result& secondary);

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -222,9 +222,7 @@ Result SuffixAutomaton::buildRecency(
   for (const auto& anchor : anchors) {
     std::queue<std::tuple<int, double, int>> queue;
     queue.push(
-        {root,
-         (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth,
-         anchor.state});
+        {root, (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
     while (!queue.empty() && cursor <= static_cast<int>(draft_token_num)) {
       auto [parent, cur_breadth, state] = queue.front();
       queue.pop();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -114,6 +114,7 @@ void SuffixAutomaton::propagateOccurrencesAndRecency_() {
   for (auto& state : states_) {
     state.children_by_freq.clear();
     state.children_by_recency.clear();
+    state.outgoing_occurrence_mass = 0;
     state.children_by_freq.reserve(state.next.size());
     state.children_by_recency.reserve(state.next.size());
     for (const auto& [token, child_state] : state.next) {
@@ -122,6 +123,7 @@ void SuffixAutomaton::propagateOccurrencesAndRecency_() {
       }
       state.children_by_freq.emplace_back(token, child_state);
       state.children_by_recency.emplace_back(token, child_state);
+      state.outgoing_occurrence_mass += states_[child_state].occ_count;
     }
 
     std::sort(state.children_by_freq.begin(), state.children_by_freq.end(), [this](const auto& lhs, const auto& rhs) {
@@ -167,7 +169,7 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
   std::vector<SamAnchor> anchors;
   while (state > 0 && matched_len > 0) {
     if (!states_[state].children_by_freq.empty()) {
-      anchors.push_back({state, matched_len});
+      anchors.push_back({this, state, matched_len});
     }
     state = states_[state].link;
     if (state <= 0) {
@@ -176,6 +178,36 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
     matched_len = std::min<int32_t>(matched_len, states_[state].max_len);
   }
   return anchors;
+}
+
+std::optional<SamAnchor>
+SuffixAutomaton::longestExpandableMatch(const int32_t* context, size_t len, size_t max_depth) const {
+  auto anchors = match(context, len, max_depth);
+  if (anchors.empty()) {
+    return std::nullopt;
+  }
+  return anchors.front();
+}
+
+uint64_t SuffixAutomaton::frequencyTransitions(
+    int state, size_t max_breadth, std::vector<SamFrequencyTransition>& ranked) const {
+  ranked.clear();
+  if (state < 0 || state >= static_cast<int>(states_.size()) || max_breadth == 0) {
+    return 0;
+  }
+
+  const auto& sam_state = states_[state];
+  if (sam_state.outgoing_occurrence_mass == 0) {
+    return 0;
+  }
+  ranked.reserve(std::min(max_breadth, sam_state.children_by_freq.size()));
+  for (const auto& [token, child_state] : sam_state.children_by_freq) {
+    ranked.push_back(SamFrequencyTransition{token, child_state, states_[child_state].occ_count});
+    if (ranked.size() >= max_breadth) {
+      break;
+    }
+  }
+  return sam_state.outgoing_occurrence_mass;
 }
 
 Result SuffixAutomaton::buildRecency(
@@ -190,7 +222,9 @@ Result SuffixAutomaton::buildRecency(
   for (const auto& anchor : anchors) {
     std::queue<std::tuple<int, double, int>> queue;
     queue.push(
-        {root, (max_match_depth - anchor.matched_len) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
+        {root,
+         (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth,
+         anchor.state});
     while (!queue.empty() && cursor <= static_cast<int>(draft_token_num)) {
       auto [parent, cur_breadth, state] = queue.front();
       queue.pop();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -12,9 +13,12 @@ namespace sglang {
 
 namespace ngram {
 
+class SuffixAutomaton;
+
 struct SamAnchor {
+  const SuffixAutomaton* sam = nullptr;
   int state = 0;
-  int32_t matched_len = 0;
+  int32_t matched_length = 0;
 };
 
 struct SamState {
@@ -23,8 +27,15 @@ struct SamState {
   std::unordered_map<int32_t, int> next;
   uint64_t occ_count = 0;
   int64_t max_end_pos = -1;
+  uint64_t outgoing_occurrence_mass = 0;
   std::vector<std::pair<int32_t, int>> children_by_freq;
   std::vector<std::pair<int32_t, int>> children_by_recency;
+};
+
+struct SamFrequencyTransition {
+  int32_t token = 0;
+  int state = 0;
+  uint64_t mass = 0;
 };
 
 class SuffixAutomaton {
@@ -50,6 +61,10 @@ class SuffixAutomaton {
 
   Result buildFrequency(
       const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const;
+
+  std::optional<SamAnchor> longestExpandableMatch(const int32_t* context, size_t len, size_t max_depth) const;
+
+  uint64_t frequencyTransitions(int state, size_t max_breadth, std::vector<SamFrequencyTransition>& ranked) const;
 
  private:
   void reset_();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
@@ -47,11 +47,13 @@ void Trie::insert(const int32_t* tokens, size_t len) {
         node->global_lru_pos = --global_lru_.end();
         node->freq = 1;
         cursor->sorted_children.insert(node);
+        ++cursor->outgoing_freq_sum;
       } else {
         auto node = iter->second;
         cursor->sorted_children.erase(node);
         node->freq++;
         cursor->sorted_children.insert(node);
+        ++cursor->outgoing_freq_sum;
         cursor->lru.splice(cursor->lru.begin(), cursor->lru, node->parent_lru_pos);
       }
       cursor = iter->second;
@@ -85,6 +87,7 @@ void Trie::squeeze(size_t count) {
 
     last->parent->lru.erase(last->parent_lru_pos);
     last->parent->sorted_children.erase(last);
+    last->parent->outgoing_freq_sum -= static_cast<uint64_t>(last->freq);
     last->parent->child.erase(last->token);
     retireNode(last);
 
@@ -189,20 +192,20 @@ bool Trie::advanceMatchState_(MatchState& state, const int32_t* tokens, size_t l
   return true;
 }
 
-std::vector<std::pair<const TrieNode*, int32_t>> Trie::getExpandableAnchors_(const MatchState& state) const {
-  std::vector<std::pair<const TrieNode*, int32_t>> result;
+std::vector<TrieAnchor> Trie::getExpandableAnchors_(const MatchState& state) const {
+  std::vector<TrieAnchor> result;
   result.reserve(state.anchors.size());
   for (size_t depth = state.anchors.size(); depth > 0; --depth) {
     const auto node = resolve(state, state.anchors[depth - 1]);
     if (node != nullptr && !node->child.empty()) {
-      result.emplace_back(node, static_cast<int32_t>(depth));
+      result.push_back(TrieAnchor{this, node, static_cast<int32_t>(depth)});
     }
   }
   return result;
 }
 
-std::vector<std::pair<const TrieNode*, int32_t>>
-Trie::match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const {
+std::vector<TrieAnchor> Trie::match(
+    const int32_t* context, size_t len, MatchState& state, size_t total_len) const {
   const bool has_forward_progress = total_len >= state.processed_total_len;
   const auto appended_len = has_forward_progress ? total_len - state.processed_total_len : 0;
   const auto expected_prev_depth = std::min(state.processed_total_len, param_.max_trie_depth);
@@ -215,6 +218,32 @@ Trie::match(const int32_t* context, size_t len, MatchState& state, size_t total_
 
   rebuildMatchState_(context, len, state, total_len);
   return getExpandableAnchors_(state);
+}
+
+std::optional<TrieAnchor>
+Trie::longestExpandableMatch(const int32_t* context, size_t len, MatchState& state, size_t total_len) const {
+  auto anchors = match(context, len, state, total_len);
+  if (anchors.empty()) {
+    return std::nullopt;
+  }
+  return anchors.front();
+}
+
+uint64_t Trie::frequencyTransitions(
+    const TrieNode* state, size_t max_breadth, std::vector<TrieFrequencyTransition>& ranked) const {
+  ranked.clear();
+  if (state == nullptr || max_breadth == 0 || state->outgoing_freq_sum == 0) {
+    return 0;
+  }
+
+  ranked.reserve(std::min(max_breadth, state->sorted_children.size()));
+  for (const auto* child : state->sorted_children) {
+    ranked.push_back(TrieFrequencyTransition{child->token, child, static_cast<uint64_t>(child->freq)});
+    if (ranked.size() >= max_breadth) {
+      break;
+    }
+  }
+  return state->outgoing_freq_sum;
 }
 
 Result Trie::buildRecency(
@@ -233,9 +262,12 @@ Result Trie::buildRecency(
   int root = 0;
   int cursor = 1;
 
-  for (auto [node, depth] : anchors) {
+  for (const auto& anchor : anchors) {
     std::queue<std::tuple<int32_t, double, const TrieNode*>> queue;
-    queue.push({root, (max_match_depth - depth) * bfs_breadth_scale + param.min_bfs_breadth, node});
+    queue.push(
+        {root,
+         (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth,
+         anchor.state});
     while (queue.size() && cursor <= static_cast<int>(draft_token_num)) {
       auto front = queue.front();
       queue.pop();
@@ -308,8 +340,8 @@ Result Trie::buildFrequency(
     }
   };
 
-  for (auto [node, _] : anchors) {
-    addToHeap(root, node, 1.0);
+  for (const auto& anchor : anchors) {
+    addToHeap(root, anchor.state, 1.0);
 
     while (!heap.empty() && cursor <= static_cast<int>(draft_token_num)) {
       auto [parent, trie_node, prob] = heap.top();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/trie.cpp
@@ -204,8 +204,7 @@ std::vector<TrieAnchor> Trie::getExpandableAnchors_(const MatchState& state) con
   return result;
 }
 
-std::vector<TrieAnchor> Trie::match(
-    const int32_t* context, size_t len, MatchState& state, size_t total_len) const {
+std::vector<TrieAnchor> Trie::match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const {
   const bool has_forward_progress = total_len >= state.processed_total_len;
   const auto appended_len = has_forward_progress ? total_len - state.processed_total_len : 0;
   const auto expected_prev_depth = std::min(state.processed_total_len, param_.max_trie_depth);
@@ -265,9 +264,7 @@ Result Trie::buildRecency(
   for (const auto& anchor : anchors) {
     std::queue<std::tuple<int32_t, double, const TrieNode*>> queue;
     queue.push(
-        {root,
-         (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth,
-         anchor.state});
+        {root, (max_match_depth - anchor.matched_length) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
     while (queue.size() && cursor <= static_cast<int>(draft_token_num)) {
       auto front = queue.front();
       queue.pop();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/trie.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/trie.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <list>
 #include <new>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <unordered_map>
@@ -24,6 +25,7 @@ struct TrieNode {
   TrieNode* parent;
   std::list<TrieNode*> lru;
   int32_t freq = 0;
+  uint64_t outgoing_freq_sum = 0;
   // Logical generation of this TrieNode. retireNode() bumps it before the node
   // goes back to the pool so stale NodeRefs fail validation after reuse.
   // Starts at 1 so that a default-constructed NodeRef (version=0) never
@@ -55,6 +57,20 @@ struct MatchState {
   std::vector<NodeRef> anchors;
 };
 
+class Trie;
+
+struct TrieAnchor {
+  const Trie* trie = nullptr;
+  const TrieNode* state = nullptr;
+  int32_t matched_length = 0;
+};
+
+struct TrieFrequencyTransition {
+  int32_t token = 0;
+  const TrieNode* state = nullptr;
+  uint64_t mass = 0;
+};
+
 class Trie {
  public:
   Trie(size_t capacity, const Param& param);
@@ -79,6 +95,12 @@ class Trie {
       MatchState& state,
       size_t total_len) const;
 
+  std::optional<TrieAnchor>
+  longestExpandableMatch(const int32_t* context, size_t len, MatchState& state, size_t total_len) const;
+
+  uint64_t
+  frequencyTransitions(const TrieNode* state, size_t max_breadth, std::vector<TrieFrequencyTransition>& ranked) const;
+
   void squeeze(size_t count);
 
   void reset();
@@ -88,8 +110,7 @@ class Trie {
   // this request, infer the newly appended suffix from (`context`, `total_len`)
   // and advance anchors incrementally; otherwise rebuild the cached anchors from
   // `context`. Returns only the suffix matches that are currently expandable.
-  std::vector<std::pair<const TrieNode*, int32_t>>
-  match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const;
+  std::vector<TrieAnchor> match(const int32_t* context, size_t len, MatchState& state, size_t total_len) const;
   // Recompute all cached anchors from the current tail. After this, for every
   // d in [1, min(len, max_trie_depth)], anchors[d - 1] represents the suffix of
   // length d ending at context[len - 1].
@@ -103,7 +124,7 @@ class Trie {
   // MatchState keeps all live suffix matches, including leaves. This helper
   // filters the cached anchors down to the suffixes that currently have children and
   // therefore can seed BFS / PROB draft construction.
-  std::vector<std::pair<const TrieNode*, int32_t>> getExpandableAnchors_(const MatchState& state) const;
+  std::vector<TrieAnchor> getExpandableAnchors_(const MatchState& state) const;
   // Resolve a cached NodeRef back to a live trie node. nullptr means the
   // cached location went stale and the caller should rebuild from context.
   const TrieNode* resolve(const MatchState& state, const NodeRef& ref) const;

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -10,6 +10,11 @@ import tvm_ffi
 from sglang.kernels.jit.utils import cache_once, load_jit
 
 _MATCH_TYPE_MAP = {"BFS": 0, "PROB": 1}
+_GLOBAL_TREE_MODE_MAP = {
+    "disabled": 0,
+    "path_probability": 1,
+    "specificity_path_probability": 2,
+}
 
 
 def _to_csr(batch_tokens: List[List[int]]) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -31,6 +36,7 @@ def get_ngram_corpus_cls():
             "ngram_corpus/result.cpp",
             "ngram_corpus/trie.cpp",
             "ngram_corpus/suffix_automaton.cpp",
+            "ngram_corpus/global_tree.cpp",
             "ngram_corpus/ngram.cpp",
             "ngram_corpus/ngram_corpus_ffi.cpp",
         ],
@@ -52,11 +58,19 @@ def get_ngram_corpus_cls():
             match_type: str,
             external_sam_budget: int = 0,
             external_corpus_max_tokens: int = 10000000,
+            global_tree_mode: str = "specificity_path_probability",
         ) -> None:
             mt = _MATCH_TYPE_MAP.get(match_type)
             if mt is None:
                 raise ValueError(
                     f"Unknown match_type: '{match_type}'. Must be 'BFS' or 'PROB'."
+                )
+            gtm = _GLOBAL_TREE_MODE_MAP.get(global_tree_mode)
+            if gtm is None:
+                raise ValueError(
+                    f"Unknown global_tree_mode: '{global_tree_mode}'. Must be "
+                    "'disabled', 'path_probability', or "
+                    "'specificity_path_probability'."
                 )
             self.__ffi_init__(
                 capacity,
@@ -67,6 +81,7 @@ def get_ngram_corpus_cls():
                 mt,
                 external_sam_budget,
                 external_corpus_max_tokens,
+                gtm,
             )
             self._draft_token_num = draft_token_num
 

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -58,7 +58,7 @@ def get_ngram_corpus_cls():
             match_type: str,
             external_sam_budget: int = 0,
             external_corpus_max_tokens: int = 10000000,
-            global_tree_mode: str = "specificity_path_probability",
+            global_tree_mode: str = "disabled",
         ) -> None:
             mt = _MATCH_TYPE_MAP.get(match_type)
             if mt is None:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -15,7 +15,6 @@ from sglang.srt.arg_groups.overrides import (
     resolving_view,
     run_post_process_pass,
 )
-from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
 
 if TYPE_CHECKING:
@@ -985,14 +984,6 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
 
 def _handle_ngram(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
-    if (
-        cfg.speculative_ngram_global_tree_mode != "disabled"
-        and not envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.get()
-    ):
-        raise ValueError(
-            "--speculative-ngram-global-tree-mode requires "
-            "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1 when global tree allocation is enabled."
-        )
     if cfg.device not in ("cuda", "cpu"):
         raise ValueError(
             "Ngram speculative decoding only supports CUDA or CPU devices."

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -1029,10 +1029,17 @@ def _handle_ngram(server_args: ServerArgs) -> None:
             // cfg.speculative_eagle_topk,
         )
     if cfg.speculative_ngram_external_corpus_path is not None:
-        if cfg.speculative_ngram_external_sam_budget <= 0:
+        uses_legacy_allocation = (
+            cfg.speculative_ngram_global_tree_mode == "disabled"
+        )
+        if (
+            uses_legacy_allocation
+            and cfg.speculative_ngram_external_sam_budget <= 0
+        ):
             raise ValueError(
                 "--speculative-ngram-external-sam-budget must be positive when "
-                "--speculative-ngram-external-corpus-path is set."
+                "--speculative-ngram-external-corpus-path is set and global tree "
+                "allocation is disabled."
             )
         if cfg.speculative_ngram_external_corpus_max_tokens <= 0:
             raise ValueError(
@@ -1040,7 +1047,8 @@ def _handle_ngram(server_args: ServerArgs) -> None:
                 "--speculative-ngram-external-corpus-path is set."
             )
         if (
-            cfg.speculative_ngram_external_sam_budget
+            uses_legacy_allocation
+            and cfg.speculative_ngram_external_sam_budget
             > cfg.speculative_num_draft_tokens - 1
         ):
             raise ValueError(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -15,6 +15,7 @@ from sglang.srt.arg_groups.overrides import (
     resolving_view,
     run_post_process_pass,
 )
+from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
 
 if TYPE_CHECKING:
@@ -984,6 +985,14 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
 
 def _handle_ngram(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
+    if (
+        cfg.speculative_ngram_global_tree_mode != "disabled"
+        and not envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.get()
+    ):
+        raise ValueError(
+            "--speculative-ngram-global-tree-mode requires "
+            "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1 when global tree allocation is enabled."
+        )
     if cfg.device not in ("cuda", "cpu"):
         raise ValueError(
             "Ngram speculative decoding only supports CUDA or CPU devices."

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -1029,13 +1029,8 @@ def _handle_ngram(server_args: ServerArgs) -> None:
             // cfg.speculative_eagle_topk,
         )
     if cfg.speculative_ngram_external_corpus_path is not None:
-        uses_legacy_allocation = (
-            cfg.speculative_ngram_global_tree_mode == "disabled"
-        )
-        if (
-            uses_legacy_allocation
-            and cfg.speculative_ngram_external_sam_budget <= 0
-        ):
+        uses_legacy_allocation = cfg.speculative_ngram_global_tree_mode == "disabled"
+        if uses_legacy_allocation and cfg.speculative_ngram_external_sam_budget <= 0:
             raise ValueError(
                 "--speculative-ngram-external-sam-budget must be positive when "
                 "--speculative-ngram-external-corpus-path is set and global tree "

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1225,6 +1225,8 @@ class Envs:
     # Experimental; auto-falls back to eager if the backend's prep is not capturable.
     SGLANG_ENABLE_METADATA_GLUE_GRAPH = EnvBool(False)
     SGLANG_OPT_FUSED_KDA_VERIFY = EnvBool(False)
+    # Opt in to global Trie/SAM proposal allocation for NGRAM.
+    SGLANG_ENABLE_NGRAM_GLOBAL_TREE = EnvBool(False)
     # A/B: keep the DFLASH draft greedy head eager (not folded in-graph).
     SGLANG_DFLASH_EAGER_DRAFT_SAMPLER = EnvBool(False)
     SGLANG_RAGGED_VERIFY_MODE = EnvStr("static")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1225,8 +1225,6 @@ class Envs:
     # Experimental; auto-falls back to eager if the backend's prep is not capturable.
     SGLANG_ENABLE_METADATA_GLUE_GRAPH = EnvBool(False)
     SGLANG_OPT_FUSED_KDA_VERIFY = EnvBool(False)
-    # Opt in to global Trie/SAM proposal allocation for NGRAM.
-    SGLANG_ENABLE_NGRAM_GLOBAL_TREE = EnvBool(False)
     # A/B: keep the DFLASH draft greedy head eager (not folded in-graph).
     SGLANG_DFLASH_EAGER_DRAFT_SAMPLER = EnvBool(False)
     SGLANG_RAGGED_VERIFY_MODE = EnvStr("static")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -352,6 +352,14 @@ add_linear_attn_kernel_backend_choices = LINEAR_ATTN_KERNEL_BACKEND_CHOICES.exte
 # --------------------------------------------------------------------------
 
 
+def _default_speculative_ngram_global_tree_mode() -> str:
+    return (
+        "specificity_path_probability"
+        if envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.get()
+        else "disabled"
+    )
+
+
 @dataclasses.dataclass
 class ServerArgs:
     """Server-wide configuration for SGLang.
@@ -2337,11 +2345,12 @@ class ServerArgs:
             "path_probability",
             "specificity_path_probability",
         ],
-        "Global Trie/SAM proposal allocation mode. The default ranks paths by "
-        "source-local occurrence probability weighted by match specificity; "
+        "Global Trie/SAM proposal allocation mode. Requires "
+        "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1. When enabled, the default ranks paths "
+        "by source-local occurrence probability weighted by match specificity; "
         "disabled preserves fixed source budgets and the configured BFS/PROB path.",
         NS("spec"),
-    ] = "specificity_path_probability"
+    ] = dataclasses.field(default_factory=_default_speculative_ngram_global_tree_mode)
     speculative_ngram_max_trie_depth: A[
         int, "The max trie depth for ngram speculative decoding.", NS("spec")
     ] = 18

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -352,14 +352,6 @@ add_linear_attn_kernel_backend_choices = LINEAR_ATTN_KERNEL_BACKEND_CHOICES.exte
 # --------------------------------------------------------------------------
 
 
-def _default_speculative_ngram_global_tree_mode() -> str:
-    return (
-        "specificity_path_probability"
-        if envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.get()
-        else "disabled"
-    )
-
-
 @dataclasses.dataclass
 class ServerArgs:
     """Server-wide configuration for SGLang.
@@ -2345,12 +2337,10 @@ class ServerArgs:
             "path_probability",
             "specificity_path_probability",
         ],
-        "Global Trie/SAM proposal allocation mode. Requires "
-        "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1. When enabled, the default ranks paths "
-        "by source-local occurrence probability weighted by match specificity; "
-        "disabled preserves fixed source budgets and the configured BFS/PROB path.",
+        "Global Trie/SAM proposal allocation mode. Disabled preserves fixed "
+        "source budgets and the configured BFS/PROB path.",
         NS("spec"),
-    ] = dataclasses.field(default_factory=_default_speculative_ngram_global_tree_mode)
+    ] = "disabled"
     speculative_ngram_max_trie_depth: A[
         int, "The max trie depth for ngram speculative decoding.", NS("spec")
     ] = 18

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2331,6 +2331,17 @@ class ServerArgs:
     speculative_ngram_match_type: A[
         Literal["BFS", "PROB"], "The match type for cache tree.", NS("spec")
     ] = "BFS"
+    speculative_ngram_global_tree_mode: A[
+        Literal[
+            "disabled",
+            "path_probability",
+            "specificity_path_probability",
+        ],
+        "Global Trie/SAM proposal allocation mode. The default ranks paths by "
+        "source-local occurrence probability weighted by match specificity; "
+        "disabled preserves fixed source budgets and the configured BFS/PROB path.",
+        NS("spec"),
+    ] = "specificity_path_probability"
     speculative_ngram_max_trie_depth: A[
         int, "The max trie depth for ngram speculative decoding.", NS("spec")
     ] = 18
@@ -2344,7 +2355,8 @@ class ServerArgs:
     ] = None
     speculative_ngram_external_sam_budget: A[
         int,
-        "Number of draft nodes reserved for the external SAM subtree in ngram speculative decoding.",
+        "Number of draft nodes reserved for external SAMs by legacy fixed "
+        "allocation. Experimental global tree modes ignore this value.",
         NS("spec"),
     ] = 0
     speculative_ngram_external_corpus_max_tokens: A[

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -22,6 +22,7 @@ class NgramCorpus:
         capacity=1000000,
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
+        global_tree_mode="specificity_path_probability",
     ) -> None:
         cls = get_ngram_corpus_cls()
         self._obj = cls(
@@ -31,6 +32,7 @@ class NgramCorpus:
             max_bfs_breadth=max_bfs_breadth,
             draft_token_num=draft_token_num,
             match_type=match_type,
+            global_tree_mode=global_tree_mode,
             external_sam_budget=external_sam_budget,
             external_corpus_max_tokens=external_corpus_max_tokens,
         )

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -22,7 +22,7 @@ class NgramCorpus:
         capacity=1000000,
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
-        global_tree_mode="specificity_path_probability",
+        global_tree_mode="disabled",
     ) -> None:
         cls = get_ngram_corpus_cls()
         self._obj = cls(

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -116,6 +116,7 @@ class NGRAMWorker(BaseSpecWorker):
             min_bfs_breadth=get_spec().speculative_ngram_min_bfs_breadth,
             max_bfs_breadth=get_spec().speculative_ngram_max_bfs_breadth,
             match_type=get_spec().speculative_ngram_match_type,
+            global_tree_mode=get_spec().speculative_ngram_global_tree_mode,
             capacity=get_spec().speculative_ngram_capacity,
             max_trie_depth=get_spec().speculative_ngram_max_trie_depth,
             draft_token_num=get_spec().speculative_num_draft_tokens,

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -921,9 +921,7 @@ class TestReconstructIndicesFromTreeMask(CustomTestCase):
         )
 
         self.assertEqual(retrieve_index.tolist(), [[0, 1, 2, 3], [4, 5, 6, 7]])
-        self.assertEqual(
-            retrieve_next_token.tolist(), [[1, 2, -1, -1], [1, 2, 3, -1]]
-        )
+        self.assertEqual(retrieve_next_token.tolist(), [[1, 2, -1, -1], [1, 2, 3, -1]])
         self.assertEqual(
             retrieve_next_sibling.tolist(),
             [[-1, 3, -1, -1], [-1, -1, -1, -1]],

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -862,9 +862,9 @@ class TestReconstructIndicesFromTreeMask(CustomTestCase):
 
         bs, draft_token_num = 2, 4
         seq_lens = torch.tensor([12, 5], dtype=torch.int64)
-        # Request 0: root(0) -> {1, 2}, 2 -> 3 (golden case from
-        # python/sglang/kernels/aot/tests/speculative/test_ngram_utils.py).
-        # Request 1: plain chain 0 -> 1 -> 2 -> 3.
+        # Request 0 uses parent-before-child selection order without requiring
+        # BFS order: root(0) -> 1 -> 2 and root(0) -> 3.
+        # Request 1 is a plain chain: root(0) -> 1 -> 2 -> 3.
         tree_mask = torch.tensor(
             # fmt: off
             [
@@ -877,12 +877,12 @@ class TestReconstructIndicesFromTreeMask(CustomTestCase):
                 0,
                 0,
                 1,
-                0,
+                1,
                 1,
                 0,
                 1,
                 0,
-                1,
+                0,
                 1,
                 1,
                 0,
@@ -921,11 +921,14 @@ class TestReconstructIndicesFromTreeMask(CustomTestCase):
         )
 
         self.assertEqual(retrieve_index.tolist(), [[0, 1, 2, 3], [4, 5, 6, 7]])
-        self.assertEqual(retrieve_next_token.tolist(), [[1, -1, 3, -1], [1, 2, 3, -1]])
         self.assertEqual(
-            retrieve_next_sibling.tolist(), [[-1, 2, -1, -1], [-1, -1, -1, -1]]
+            retrieve_next_token.tolist(), [[1, 2, -1, -1], [1, 2, 3, -1]]
         )
-        self.assertEqual(positions.tolist(), [12, 13, 13, 14, 5, 6, 7, 8])
+        self.assertEqual(
+            retrieve_next_sibling.tolist(),
+            [[-1, 3, -1, -1], [-1, -1, -1, -1]],
+        )
+        self.assertEqual(positions.tolist(), [12, 13, 14, 13, 5, 6, 7, 8])
 
 
 class TestFillKernels(CustomTestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1609,6 +1609,7 @@ class TestNgramExternalSamArgs(CustomTestCase):
         args.speculative_num_draft_tokens = 12
         args.device = "cuda"
         args.page_size = 1
+        args.speculative_ngram_global_tree_mode = "disabled"
         for key, value in overrides.items():
             setattr(args, key, value)
         return args
@@ -1640,25 +1641,43 @@ class TestNgramExternalSamArgs(CustomTestCase):
             speculative_ngram_external_sam_budget=0,
             speculative_ngram_global_tree_mode="path_probability",
         )
-        handle_speculative_decoding(args)
+        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
+            handle_speculative_decoding(args)
         self.assertEqual(args.speculative_ngram_global_tree_mode, "path_probability")
 
-    def test_global_tree_mode_defaults_to_specificity_path_probability(self):
-        args = prepare_server_args(["--model-path", "dummy"])
+    def test_global_tree_mode_defaults_to_disabled(self):
+        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(False):
+            args = prepare_server_args(["--model-path", "dummy"])
+        self.assertEqual(args.speculative_ngram_global_tree_mode, "disabled")
+
+    def test_global_tree_env_enables_specificity_path_probability_by_default(self):
+        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
+            args = prepare_server_args(["--model-path", "dummy"])
         self.assertEqual(
             args.speculative_ngram_global_tree_mode,
             "specificity_path_probability",
         )
 
-    def test_global_tree_mode_cli_round_trip(self):
-        args = prepare_server_args(
-            [
-                "--model-path",
-                "dummy",
-                "--speculative-ngram-global-tree-mode",
-                "specificity_path_probability",
-            ]
+    def test_global_tree_mode_requires_env_gate(self):
+        args = self._make_dummy_ngram_args(
+            speculative_ngram_global_tree_mode="path_probability"
         )
+        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(False):
+            with self.assertRaisesRegex(
+                ValueError, "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1"
+            ):
+                handle_speculative_decoding(args)
+
+    def test_global_tree_mode_cli_round_trip(self):
+        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
+            args = prepare_server_args(
+                [
+                    "--model-path",
+                    "dummy",
+                    "--speculative-ngram-global-tree-mode",
+                    "specificity_path_probability",
+                ]
+            )
         self.assertEqual(
             args.speculative_ngram_global_tree_mode,
             "specificity_path_probability",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1609,7 +1609,6 @@ class TestNgramExternalSamArgs(CustomTestCase):
         args.speculative_num_draft_tokens = 12
         args.device = "cuda"
         args.page_size = 1
-        args.speculative_ngram_global_tree_mode = "disabled"
         for key, value in overrides.items():
             setattr(args, key, value)
         return args
@@ -1641,43 +1640,35 @@ class TestNgramExternalSamArgs(CustomTestCase):
             speculative_ngram_external_sam_budget=0,
             speculative_ngram_global_tree_mode="path_probability",
         )
-        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
-            handle_speculative_decoding(args)
+        handle_speculative_decoding(args)
         self.assertEqual(args.speculative_ngram_global_tree_mode, "path_probability")
 
     def test_global_tree_mode_defaults_to_disabled(self):
-        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(False):
-            args = prepare_server_args(["--model-path", "dummy"])
+        args = self._make_dummy_ngram_args()
+        handle_speculative_decoding(args)
+        self.assertEqual(args.speculative_ngram_global_tree_mode, "disabled")
+        self.assertEqual(
+            resolution_result(args, "speculative_ngram_global_tree_mode"),
+            "disabled",
+        )
+        self.assertEqual(
+            args.resolved_dict()["speculative_ngram_global_tree_mode"],
+            "disabled",
+        )
+
+    def test_global_tree_mode_cli_defaults_to_disabled(self):
+        args = prepare_server_args(["--model-path", "dummy"])
         self.assertEqual(args.speculative_ngram_global_tree_mode, "disabled")
 
-    def test_global_tree_env_enables_specificity_path_probability_by_default(self):
-        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
-            args = prepare_server_args(["--model-path", "dummy"])
-        self.assertEqual(
-            args.speculative_ngram_global_tree_mode,
-            "specificity_path_probability",
-        )
-
-    def test_global_tree_mode_requires_env_gate(self):
-        args = self._make_dummy_ngram_args(
-            speculative_ngram_global_tree_mode="path_probability"
-        )
-        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(False):
-            with self.assertRaisesRegex(
-                ValueError, "SGLANG_ENABLE_NGRAM_GLOBAL_TREE=1"
-            ):
-                handle_speculative_decoding(args)
-
     def test_global_tree_mode_cli_round_trip(self):
-        with envs.SGLANG_ENABLE_NGRAM_GLOBAL_TREE.override(True):
-            args = prepare_server_args(
-                [
-                    "--model-path",
-                    "dummy",
-                    "--speculative-ngram-global-tree-mode",
-                    "specificity_path_probability",
-                ]
-            )
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-ngram-global-tree-mode",
+                "specificity_path_probability",
+            ]
+        )
         self.assertEqual(
             args.speculative_ngram_global_tree_mode,
             "specificity_path_probability",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1608,6 +1608,7 @@ class TestNgramExternalSamArgs(CustomTestCase):
         args.speculative_algorithm = "NGRAM"
         args.speculative_num_draft_tokens = 12
         args.device = "cuda"
+        args.page_size = 1
         for key, value in overrides.items():
             setattr(args, key, value)
         return args
@@ -1617,6 +1618,7 @@ class TestNgramExternalSamArgs(CustomTestCase):
             speculative_num_draft_tokens=4,
             speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
             speculative_ngram_external_sam_budget=4,
+            speculative_ngram_global_tree_mode="disabled",
         )
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
@@ -1631,6 +1633,38 @@ class TestNgramExternalSamArgs(CustomTestCase):
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+    def test_global_tree_mode_does_not_require_legacy_sam_budget(self):
+        args = self._make_dummy_ngram_args(
+            speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
+            speculative_ngram_external_sam_budget=0,
+            speculative_ngram_global_tree_mode="path_probability",
+        )
+        handle_speculative_decoding(args)
+        self.assertEqual(
+            args.speculative_ngram_global_tree_mode, "path_probability"
+        )
+
+    def test_global_tree_mode_defaults_to_specificity_path_probability(self):
+        args = prepare_server_args(["--model-path", "dummy"])
+        self.assertEqual(
+            args.speculative_ngram_global_tree_mode,
+            "specificity_path_probability",
+        )
+
+    def test_global_tree_mode_cli_round_trip(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-ngram-global-tree-mode",
+                "specificity_path_probability",
+            ]
+        )
+        self.assertEqual(
+            args.speculative_ngram_global_tree_mode,
+            "specificity_path_probability",
+        )
 
 
 class TestDecoupledSpecArgs(CustomTestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1641,9 +1641,7 @@ class TestNgramExternalSamArgs(CustomTestCase):
             speculative_ngram_global_tree_mode="path_probability",
         )
         handle_speculative_decoding(args)
-        self.assertEqual(
-            args.speculative_ngram_global_tree_mode, "path_probability"
-        )
+        self.assertEqual(args.speculative_ngram_global_tree_mode, "path_probability")
 
     def test_global_tree_mode_defaults_to_specificity_path_probability(self):
         args = prepare_server_args(["--model-path", "dummy"])

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -26,24 +26,25 @@ def _make_corpus(match_type="BFS", **kwargs):
         capacity=100000,
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
+        global_tree_mode="disabled",
     )
     defaults.update(kwargs)
     defaults["match_type"] = match_type
     corpus = NgramCorpus(**defaults)
     if external_corpus_documents is not None:
-        from sglang.srt.speculative.cpp_ngram.external_corpus import SEPARATOR_TOKEN
-
-        chunks = []
-        has_prev = False
-        for doc in external_corpus_documents:
-            if has_prev:
-                chunks.append([SEPARATOR_TOKEN] + list(doc))
-            else:
-                chunks.append(list(doc))
-            has_prev = True
-        loaded_token_count = corpus.load_external_corpus_named("test_corpus", chunks)
-        corpus.commit_external_corpus_load("test_corpus", loaded_token_count)
+        _load_external_documents(corpus, "test_corpus", external_corpus_documents)
     return corpus
+
+
+def _load_external_documents(corpus, corpus_id, documents):
+    from sglang.srt.speculative.cpp_ngram.external_corpus import SEPARATOR_TOKEN
+
+    chunks = []
+    for index, document in enumerate(documents):
+        prefix = [SEPARATOR_TOKEN] if index else []
+        chunks.append(prefix + list(document))
+    loaded_token_count = corpus.load_external_corpus_named(corpus_id, chunks)
+    corpus.commit_external_corpus_load(corpus_id, loaded_token_count)
 
 
 def _batch_get(
@@ -688,6 +689,248 @@ class TestNgramCorpusExternalSam(CustomTestCase):
 
         ids, _ = _batch_get(corpus, [[1, 2, 3]])
         self.assertEqual(ids.tolist(), [3, 20])
+
+
+class TestNgramCorpusGlobalTree(CustomTestCase):
+    def test_all_child_denominator_lets_sam_beat_top_one_trie(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=2,
+            max_bfs_breadth=1,
+            external_sam_budget=0,
+            external_corpus_documents=[[1, 2, 3, 20]],
+        )
+        corpus.batch_put([[1, 2, 3, 10]] * 6)
+        corpus.batch_put([[1, 2, 3, 11]] * 4)
+        corpus.synchronize()
+
+        ids, _ = _batch_get(corpus, [[1, 2, 3]])
+
+        self.assertEqual(ids.tolist(), [3, 20])
+
+    def test_strong_trie_beats_weak_sam(self):
+        corpus = _make_corpus(
+            "PROB",
+            global_tree_mode="path_probability",
+            draft_token_num=2,
+            max_bfs_breadth=2,
+            external_sam_budget=0,
+            external_corpus_documents=[
+                [1, 2, 3, 20],
+                [1, 2, 3, 20],
+                [1, 2, 3, 20],
+                [1, 2, 3, 21],
+                [1, 2, 3, 21],
+            ],
+        )
+        corpus.batch_put([[1, 2, 3, 10]] * 9)
+        corpus.batch_put([[1, 2, 3, 11]])
+        corpus.synchronize()
+
+        ids, _ = _batch_get(corpus, [[1, 2, 3]])
+        self.assertEqual(ids.tolist(), [3, 10])
+
+    def test_specificity_mode_reverses_short_concentrated_choice(self):
+        def build(mode):
+            corpus = _make_corpus(
+                "BFS",
+                global_tree_mode=mode,
+                max_trie_depth=6,
+                draft_token_num=2,
+                max_bfs_breadth=2,
+                external_sam_budget=0,
+                external_corpus_documents=[
+                    [1, 2, 3, 4, 10],
+                    [1, 2, 3, 4, 11],
+                ],
+            )
+            corpus.batch_put([[90, 3, 4, 20]] * 9)
+            corpus.batch_put([[91, 3, 4, 21]])
+            corpus.synchronize()
+            return corpus
+
+        probability_ids, _ = _batch_get(
+            build("path_probability"), [[1, 2, 3, 4]]
+        )
+        specificity_ids, _ = _batch_get(
+            build("specificity_path_probability"), [[1, 2, 3, 4]]
+        )
+
+        self.assertEqual(probability_ids.tolist(), [4, 20])
+        self.assertEqual(specificity_ids.tolist(), [4, 10])
+
+    def test_path_probability_tie_does_not_use_match_specificity(self):
+        def build(mode):
+            corpus = _make_corpus(
+                "BFS",
+                global_tree_mode=mode,
+                max_trie_depth=6,
+                draft_token_num=2,
+                external_sam_budget=0,
+                external_corpus_documents=[[1, 2, 3, 4, 10]],
+            )
+            corpus.batch_put([[90, 3, 4, 20]])
+            corpus.synchronize()
+            return corpus
+
+        probability_ids, _ = _batch_get(
+            build("path_probability"), [[1, 2, 3, 4]]
+        )
+        specificity_ids, _ = _batch_get(
+            build("specificity_path_probability"), [[1, 2, 3, 4]]
+        )
+
+        self.assertEqual(probability_ids.tolist(), [4, 20])
+        self.assertEqual(specificity_ids.tolist(), [4, 10])
+
+    def test_shared_prefix_retains_divergent_source_cursors(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=4,
+            max_bfs_breadth=2,
+            external_sam_budget=0,
+            external_corpus_documents=[[1, 2, 3, 7, 9]],
+        )
+        corpus.batch_put([[1, 2, 3, 7, 8]])
+        corpus.synchronize()
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+        leaf_paths = corpus.leaf_paths_from_mask(
+            ids.tolist(), masks.reshape(4, 4).tolist()
+        )
+
+        self.assertEqual(ids.tolist(), [3, 7, 8, 9])
+        self.assertEqual(leaf_paths, [[3, 7, 8], [3, 7, 9]])
+
+    def test_best_first_selection_is_materialized_in_selection_order(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=4,
+            max_bfs_breadth=2,
+        )
+        corpus.batch_put([[1, 2, 3, 10, 11]] * 6)
+        corpus.batch_put([[1, 2, 3, 20, 21]] * 4)
+        corpus.synchronize()
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+
+        self.assertEqual(ids.tolist(), [3, 10, 11, 20])
+        self.assertEqual(
+            masks.reshape(4, 4).tolist(),
+            [
+                [1, 0, 0, 0],
+                [1, 1, 0, 0],
+                [1, 1, 1, 0],
+                [1, 0, 0, 1],
+            ],
+        )
+
+    def test_underfilled_tree_has_fixed_shape_and_ancestor_mask(self):
+        corpus = _make_corpus(
+            "PROB",
+            global_tree_mode="path_probability",
+            max_trie_depth=6,
+            draft_token_num=6,
+            max_bfs_breadth=2,
+        )
+        corpus.batch_put([[1, 2, 3, 10, 11]])
+        corpus.synchronize()
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+        mask = masks.reshape(6, 6).tolist()
+
+        self.assertEqual(ids.tolist(), [3, 10, 11, 0, 0, 0])
+        self.assertEqual(mask[2], [1, 1, 1, 0, 0, 0])
+        self.assertEqual(len(mask), 6)
+        self.assertTrue(all(len(row) == 6 for row in mask))
+
+    def test_sam_only_and_proposal_budget_one(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=2,
+            external_sam_budget=0,
+            external_corpus_documents=[[1, 2, 3, 20, 21]],
+        )
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+
+        self.assertEqual(ids.tolist(), [3, 20])
+        self.assertEqual(masks.reshape(2, 2).tolist(), [[1, 0], [1, 1]])
+
+    def test_zero_proposal_budget_returns_root_only(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=1,
+            external_sam_budget=0,
+            external_corpus_documents=[[1, 2, 3, 20]],
+        )
+        corpus.batch_put([[1, 2, 3, 10]])
+        corpus.synchronize()
+
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+
+        self.assertEqual(ids.tolist(), [3])
+        self.assertEqual(masks.reshape(1, 1).tolist(), [[1]])
+
+    def test_no_match_returns_root_and_padding(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            draft_token_num=3,
+            external_sam_budget=0,
+        )
+
+        ids, _ = _batch_get(corpus, [[1, 2, 3]])
+        self.assertEqual(ids.tolist(), [3, 0, 0])
+
+    def test_corpus_load_order_does_not_affect_equal_score_tie(self):
+        def build(corpus_order):
+            corpus = _make_corpus(
+                "BFS",
+                global_tree_mode="path_probability",
+                draft_token_num=2,
+                external_sam_budget=0,
+            )
+            documents = {"alpha": [[1, 2, 3, 20]], "zeta": [[1, 2, 3, 10]]}
+            for corpus_id in corpus_order:
+                _load_external_documents(corpus, corpus_id, documents[corpus_id])
+            return corpus
+
+        forward_ids, forward_masks = _batch_get(
+            build(["alpha", "zeta"]), [[1, 2, 3]]
+        )
+        reverse_ids, reverse_masks = _batch_get(
+            build(["zeta", "alpha"]), [[1, 2, 3]]
+        )
+
+        self.assertEqual(forward_ids.tolist(), [3, 20])
+        np.testing.assert_array_equal(forward_ids, reverse_ids)
+        np.testing.assert_array_equal(forward_masks, reverse_masks)
+
+    def test_incremental_trie_cursor_matches_stateless_global_lookup(self):
+        corpus = _make_corpus(
+            "BFS",
+            global_tree_mode="path_probability",
+            max_trie_depth=4,
+            draft_token_num=4,
+        )
+        corpus.batch_put([[1, 2, 3, 4, 5, 6], [9, 3, 4, 7, 8]])
+        corpus.synchronize()
+
+        req_id = "global-incremental"
+        for full_sequence in ([1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5, 6]):
+            current_tail = full_sequence[-4:]
+            incremental_ids, incremental_masks = _batch_get_with_state(
+                corpus, req_id, current_tail, len(full_sequence)
+            )
+            stateless_ids, stateless_masks = _batch_get(corpus, [current_tail])
+            np.testing.assert_array_equal(incremental_ids, stateless_ids)
+            np.testing.assert_array_equal(incremental_masks, stateless_masks)
 
 
 class TestNgramCorpusMatchBenchmark(CustomTestCase):

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -750,9 +750,7 @@ class TestNgramCorpusGlobalTree(CustomTestCase):
             corpus.synchronize()
             return corpus
 
-        probability_ids, _ = _batch_get(
-            build("path_probability"), [[1, 2, 3, 4]]
-        )
+        probability_ids, _ = _batch_get(build("path_probability"), [[1, 2, 3, 4]])
         specificity_ids, _ = _batch_get(
             build("specificity_path_probability"), [[1, 2, 3, 4]]
         )
@@ -774,9 +772,7 @@ class TestNgramCorpusGlobalTree(CustomTestCase):
             corpus.synchronize()
             return corpus
 
-        probability_ids, _ = _batch_get(
-            build("path_probability"), [[1, 2, 3, 4]]
-        )
+        probability_ids, _ = _batch_get(build("path_probability"), [[1, 2, 3, 4]])
         specificity_ids, _ = _batch_get(
             build("specificity_path_probability"), [[1, 2, 3, 4]]
         )
@@ -901,12 +897,8 @@ class TestNgramCorpusGlobalTree(CustomTestCase):
                 _load_external_documents(corpus, corpus_id, documents[corpus_id])
             return corpus
 
-        forward_ids, forward_masks = _batch_get(
-            build(["alpha", "zeta"]), [[1, 2, 3]]
-        )
-        reverse_ids, reverse_masks = _batch_get(
-            build(["zeta", "alpha"]), [[1, 2, 3]]
-        )
+        forward_ids, forward_masks = _batch_get(build(["alpha", "zeta"]), [[1, 2, 3]])
+        reverse_ids, reverse_masks = _batch_get(build(["zeta", "alpha"]), [[1, 2, 3]])
 
         self.assertEqual(forward_ids.tolist(), [3, 20])
         np.testing.assert_array_equal(forward_ids, reverse_ids)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of the NGRAM series: https://github.com/sgl-project/sglang/issues/21052

This follows the external-corpus and dynamic-allocation work in https://github.com/sgl-project/sglang/pull/22538.

The current NGRAM path reserves separate portions of the draft-token budget for the online Trie and external suffix automata (SAMs). Fixed quotas cannot adapt to the relative quality of their continuations and become increasingly restrictive when multiple external corpora are attached.

This PR replaces that fixed split with one proposal tree built across the online Trie and every matching SAM. The accompanying benchmark is https://github.com/sgl-project/sglang/pull/37877.

## Modifications

- Add a native best-first global-tree builder with typed Trie/SAM anchors and cursors.
- Rank candidate paths by accumulated source-local occurrence probability, optionally weighted by normalized match specificity.
- Merge identical child tokens across sources while retaining their divergent cursors for later expansion.
- Materialize the selected parent-before-child order directly into proposal tokens and ancestor masks.
- Expose frequency-aware Trie and SAM transitions and wire global-tree allocation through the JIT FFI, Python wrapper, server arguments, and NGRAM worker.
- Keep `--speculative-ngram-global-tree-mode disabled` as the legacy fixed-budget mode.
- Make `specificity_path_probability` the default mode because it produced the highest acceptance length in every SAM-backed phase of the current benchmark run.
- Update native reconstruction goldens and add unit coverage for global allocation, shared prefixes, source competition, deterministic ties, mode validation, and server arguments.

## Accuracy Tests

Passed locally:

```bash
python -m pytest \
  test/registered/unit/server_args/test_server_args.py::TestNgramExternalSamArgs \
  test/registered/unit/spec/test_ngram_corpus.py::TestNgramCorpusGlobalTree -q
```

```text
17 passed
```

Python byte-compilation and `git diff --check upstream/main...HEAD` also pass.

See https://github.com/sgl-project/sglang/pull/37877 for the one-GPU end-to-end benchmark.

## Speed Tests and Profiling

See https://github.com/sgl-project/sglang/pull/37877 for the country-card/distractor benchmark across legacy allocation, path probability, and specificity-weighted path probability.

The current run measures `avg_spec_accept_length`, which is a proxy for fewer target verification forwards rather than a direct tokens-per-second measurement. Wall-clock throughput profiling will follow after the speculative-counter readback includes its live tail.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34001389500](https://github.com/sgl-project/sglang/actions/runs/34001389500)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34001389357](https://github.com/sgl-project/sglang/actions/runs/34001389357)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34001389585](https://github.com/sgl-project/sglang/actions/runs/34001389585)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->