### PR TITLE
[HiCache] Count hit allocations and in-flight backups in the buffer pipeline idle check

### DIFF
--- a/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
+++ b/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
@@ -275,13 +275,15 @@ class BufferModePipeline:
         self._anchor_lock_cap_skips = 0
 
     def is_idle(self) -> bool:
-        """No queued or in-flight operation holds host staging or can restart I/O."""
+        """No pending or in-flight buffer-mode transfer work."""
         return not (
-            self.pending_write_queue
+            self.pending_hit_allocs
             or self.staged_prefetches
+            or self.ongoing_buffer_load_back
+            or self.pending_write_queue
+            or self.inflight_backup_node_ids
             or self.ongoing_write_through
             or self.ongoing_backup
-            or self.ongoing_buffer_load_back
         )
 
     # ---- backup pipeline (device -> staging -> storage) ----


### PR DESCRIPTION
## Motivation

`BufferModePipeline.is_idle()` tells the cache when buffer-mode transfer work is quiescent, which gates the idle-time memory invariant check. It missed two kinds of in-flight work: storage hits parked in `pending_hit_allocs` waiting for host staging (they still hold prefetch occupancy and restart I/O once space frees), and nodes in `inflight_backup_node_ids` whose backup intent was admitted but whose D2H staging has not launched. Either can make the idle checker run against a pipeline that is about to move memory and report a spurious leak.

## Modifications

- `is_idle()` now also returns False while `pending_hit_allocs` or `inflight_backup_node_ids` are non-empty. The docstring is updated to match.

## Original commits

- `5e155a3447`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

## Testing

- `ruff format --check`, `ruff check --select F401,F821,UP037`, `py_compile` on the changed file.
- Buffer-mode / staged-prefetch / anchor-lock slice of `test_unified_radix_cache_unittest.py` and `test_hicache_staged_write_back_dispatch.py` with `SGLANG_ENABLE_ASYNC_ASSERT=true`: 127 passed, 279 skipped (non-applicable component configs).
- Validated end-to-end on an internal L3-backed buffer-mode CI lane with the strict idle memory check enabled; the spurious idle-leak reports no longer occur. Not re-run from this branch; relying on CI for GPU suites.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33815929441](https://github.com/sgl-project/sglang/actions/runs/33815929441)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33815929214](https://github.com/sgl-project/sglang/actions/runs/33815929214)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33815929395](https://github.com/sgl-project/sglang/actions/runs/33815929395)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->