### PR TITLE
Allow the GDN out_proj LoRA target in the CLI

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -4350,6 +4350,7 @@ SUPPORTED_LORA_TARGET_MODULES = [
     # GDN (GatedDeltaNet) projections
     "in_proj_qkvz",
     "in_proj_ba",
+    "out_proj",
 ]
 
 LORA_TARGET_ALL_MODULES = "all"

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -20,7 +20,6 @@ from sglang.srt.entrypoints.sidecar import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
-from sglang.srt.lora.utils import _KNOWN_LORA_TARGET_MODULES
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
@@ -29,7 +28,6 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
-from sglang.srt.utils.common import SUPPORTED_LORA_TARGET_MODULES
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -2242,27 +2240,6 @@ class TestDcpKvEventContract(CustomTestCase):
         # paged, at dcp_size.
         args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
         self.assertEqual(args.kv_event_block_size, 8)
-
-
-class TestGdnLoraTargetModules(CustomTestCase):
-    GDN_TARGET_MODULES = ("in_proj_qkvz", "in_proj_ba", "out_proj")
-
-    def setUp(self):
-        self.parser = server_args_module.argparse.ArgumentParser()
-        ServerArgs.add_cli_args(self.parser)
-
-    def test_cli_accepts_every_gdn_lora_target_module(self):
-        args = self.parser.parse_args(
-            ["--model-path", "dummy", "--lora-target-modules", *self.GDN_TARGET_MODULES]
-        )
-
-        self.assertEqual(list(args.lora_target_modules), list(self.GDN_TARGET_MODULES))
-
-    def test_cli_offers_every_gdn_module_the_lora_runtime_supports(self):
-        for module in self.GDN_TARGET_MODULES:
-            with self.subTest(module=module):
-                self.assertIn(module, _KNOWN_LORA_TARGET_MODULES)
-                self.assertIn(module, SUPPORTED_LORA_TARGET_MODULES)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -20,6 +20,7 @@ from sglang.srt.entrypoints.sidecar import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
+from sglang.srt.lora.utils import _KNOWN_LORA_TARGET_MODULES
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
@@ -28,6 +29,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.srt.utils.common import SUPPORTED_LORA_TARGET_MODULES
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -2240,6 +2242,27 @@ class TestDcpKvEventContract(CustomTestCase):
         # paged, at dcp_size.
         args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
         self.assertEqual(args.kv_event_block_size, 8)
+
+
+class TestGdnLoraTargetModules(CustomTestCase):
+    GDN_TARGET_MODULES = ("in_proj_qkvz", "in_proj_ba", "out_proj")
+
+    def setUp(self):
+        self.parser = server_args_module.argparse.ArgumentParser()
+        ServerArgs.add_cli_args(self.parser)
+
+    def test_cli_accepts_every_gdn_lora_target_module(self):
+        args = self.parser.parse_args(
+            ["--model-path", "dummy", "--lora-target-modules", *self.GDN_TARGET_MODULES]
+        )
+
+        self.assertEqual(list(args.lora_target_modules), list(self.GDN_TARGET_MODULES))
+
+    def test_cli_offers_every_gdn_module_the_lora_runtime_supports(self):
+        for module in self.GDN_TARGET_MODULES:
+            with self.subTest(module=module):
+                self.assertIn(module, _KNOWN_LORA_TARGET_MODULES)
+                self.assertIn(module, SUPPORTED_LORA_TARGET_MODULES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The LoRA runtime already supports `out_proj` end to end. It is in the module normalization map, in `ROW_PARALLELISM_LINEAR_LORA_NAMES`, and in `_KNOWN_LORA_TARGET_MODULES`, whose comment states these are the names `get_hidden_dim`, `init_buffers` and `init_lora_modules` can handle.

Only the CLI allowlist disagrees. #37466 restored the GDN choices lost in a rebase but brought back just `in_proj_qkvz` and `in_proj_ba`, so a server launched with the third GDN name dies in argparse before it starts:

```
default_worker.py: error: argument --lora-target-modules: invalid choice: 'out_proj'
  (choose from 'q_proj', ..., 'in_proj_qkvz', 'in_proj_ba', 'all')
```

This is not hypothetical. A downstream 8-GPU LoRA E2E passes `...self_attention.out_proj` as a LoRA target and cannot start on this branch at all; the process is rejected by argparse and then hangs until its 1800s timeout.

The fix adds the one missing entry. The regression covers all three GDN names two ways: it parses them through the real CLI parser, and it asserts the CLI allowlist stays in sync with the modules the runtime declares supported, so restoring a subset again gets caught.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33832865536](https://github.com/sgl-project/sglang/actions/runs/33832865536)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33832865159](https://github.com/sgl-project/sglang/actions/runs/33832865159)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33832865247](https://github.com/sgl-project/sglang/actions/runs/33832865247)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->