### PR TITLE
fix(topk): preserve candidates across radix buffer overflow

### DIFF
--- a/python/sglang/kernels/aot/csrc/elementwise/topk.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/topk.cu
@@ -33,8 +33,9 @@ constexpr size_t kSmem = 48 * 1024;  // bytes
 #endif
 #else
 // Reduced from 128KB to 32KB to improve occupancy.
-// Each radix pass needs at most ~TopK candidates in the threshold bin,
-// so 4K entries per round (2 rounds = 8K entries = 32KB) is sufficient.
+// Keep two 4K shared-memory candidate buffers for the common fast path.
+// Larger threshold buckets are recovered from the original input by the
+// overflow slow path below.
 constexpr size_t kSmem = 8 * 1024 * sizeof(uint32_t);  // 32KB (bytes)
 #endif
 
@@ -105,6 +106,8 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
   extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
 
   const int tx = threadIdx.x;
+  // First uncached candidate in this thread's tx + n * BLOCK_SIZE lane.
+  int resume_idx = length;
 
   // stage 1: 8bit coarse histogram
   if (tx < RADIX + 1) s_histogram[tx] = 0;
@@ -141,13 +144,13 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
   }
   __syncthreads();
 
-  const auto threshold_bin = s_threshold_bin_id;
-  topk -= s_histogram[threshold_bin + 1];
+  const auto coarse_threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[coarse_threshold_bin + 1];
 
   if (topk == 0) {
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto bin = static_cast<int>(convert_to_uint8(input[idx + row_start]));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
       }
@@ -164,16 +167,22 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto raw_input = input[idx + row_start];
       const auto bin = static_cast<int>(convert_to_uint8(raw_input));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
-      } else if (bin == threshold_bin) {
+      } else if (bin == coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_num_input[0], 1);
-        /// NOTE: (dark) fuse the histogram computation here
         if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
           s_input_idx[0][pos] = idx;
-          const auto bin = convert_to_uint32(raw_input);
-          const auto sub_bin = (bin >> 24) & 0xFF;
+          const auto key = convert_to_uint32(raw_input);
+          const auto sub_bin = (key >> 24) & 0xFF;
+          ::atomicAdd(&s_histogram[sub_bin], 1);
+        } else {
+          if (resume_idx == length) resume_idx = idx;
+          // Overflow candidates remain in the logical set even though they
+          // were not materialized in the shared-memory cache.
+          const auto key = convert_to_uint32(raw_input);
+          const auto sub_bin = (key >> 24) & 0xFF;
           ::atomicAdd(&s_histogram[sub_bin], 1);
         }
       }
@@ -182,39 +191,40 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
   }
 
   // stage 2: refine with 8bit radix passes
+  if (C10_LIKELY(s_num_input[0] <= int(SMEM_INPUT_SIZE))) {
+    // Preserve the original shared-memory-only path for the common case. No
+    // resume prefix is maintained and no raw-input tail is revisited here.
 #pragma unroll 4
-  for (int round = 0; round < 4; ++round) {
-    __shared__ int s_last_remain;
-    const auto r_idx = round % 2;
+    for (int round = 0; round < 4; ++round) {
+      __shared__ int s_last_remain;
+      const auto r_idx = round % 2;
+      const auto num_input = s_num_input[r_idx];
 
-    // clip here to prevent overflow
-    const auto _raw_num_input = s_num_input[r_idx];
-    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE)) ? _raw_num_input : int(SMEM_INPUT_SIZE);
-
-    run_cumsum();
-    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
-      s_threshold_bin_id = tx;
-      s_num_input[r_idx ^ 1] = 0;
-      s_last_remain = topk - s_histogram[tx + 1];
-    }
-    __syncthreads();
-
-    const auto threshold_bin = s_threshold_bin_id;
-    topk -= s_histogram[threshold_bin + 1];
-
-    if (topk == 0) {
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
-        const auto idx = s_input_idx[r_idx][i];
-        const auto offset = 24 - round * 8;
-        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
-        if (bin > threshold_bin) {
-          const auto pos = ::atomicAdd(&s_counter, 1);
-          index[pos] = idx;
-        }
+      run_cumsum();
+      if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+        s_threshold_bin_id = tx;
+        s_num_input[r_idx ^ 1] = 0;
+        s_last_remain = topk - s_histogram[tx + 1];
       }
       __syncthreads();
-      break;
-    } else {
+
+      const auto threshold_bin = s_threshold_bin_id;
+      topk -= s_histogram[threshold_bin + 1];
+
+      if (topk == 0) {
+        for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+          const auto idx = s_input_idx[r_idx][i];
+          const auto offset = 24 - round * 8;
+          const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
+          if (bin > threshold_bin) {
+            const auto pos = ::atomicAdd(&s_counter, 1);
+            index[pos] = idx;
+          }
+        }
+        __syncthreads();
+        break;
+      }
+
       __syncthreads();
       if (tx < RADIX + 1) {
         s_histogram[tx] = 0;
@@ -237,15 +247,134 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
           } else {
             const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
             if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
-              /// NOTE: (dark) fuse the histogram computation here
               s_input_idx[r_idx ^ 1][pos] = idx;
-              const auto bin = convert_to_uint32(raw_input);
-              const auto sub_bin = (bin >> (offset - 8)) & 0xFF;
+              const auto key = convert_to_uint32(raw_input);
+              const auto sub_bin = (key >> (offset - 8)) & 0xFF;
               ::atomicAdd(&s_histogram[sub_bin], 1);
             }
           }
         }
       }
+      __syncthreads();
+    }
+    return;
+  }
+
+  // Slow path: the first threshold bucket overflowed the smem cache.
+  uint32_t refine_prefix = 0;
+#pragma unroll 4
+  for (int round = 0; round < 4; ++round) {
+    __shared__ int s_last_remain;
+    const auto r_idx = round % 2;
+
+    // clip here to prevent overflow
+    const auto _raw_num_input = s_num_input[r_idx];
+    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE)) ? _raw_num_input : int(SMEM_INPUT_SIZE);
+
+    run_cumsum();
+    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+      s_threshold_bin_id = tx;
+      s_num_input[r_idx ^ 1] = 0;
+      s_last_remain = topk - s_histogram[tx + 1];
+    }
+    __syncthreads();
+
+    const auto threshold_bin = s_threshold_bin_id;
+    topk -= s_histogram[threshold_bin + 1];
+    const auto offset = 24 - round * 8;
+    const uint32_t prefix_mask = round == 0 ? 0u : 0xFFFFFFFFu << (32 - round * 8);
+
+    if (topk == 0) {
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      for (int idx = resume_idx; idx < length; idx += BLOCK_SIZE) {
+        const auto raw_input = input[idx + row_start];
+        if (static_cast<int>(convert_to_uint8(raw_input)) != coarse_threshold_bin) continue;
+        const auto key = convert_to_uint32(raw_input);
+        if ((key & prefix_mask) != refine_prefix) continue;
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      __syncthreads();
+      break;
+    } else {
+      __syncthreads();
+      if (tx < RADIX + 1) {
+        s_histogram[tx] = 0;
+      }
+      __syncthreads();
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = input[idx + row_start];
+        const auto key = convert_to_uint32(raw_input);
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[TopK - pos] = idx;
+            }
+          } else {
+            const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+            // Materialized candidates run before the tail, so their survivor
+            // count is bounded by num_input and always fits.
+            s_input_idx[r_idx ^ 1][pos] = idx;
+            const auto sub_bin = (key >> (offset - 8)) & 0xFF;
+            ::atomicAdd(&s_histogram[sub_bin], 1);
+          }
+        }
+      }
+      __syncthreads();
+
+      // Process the raw tail only after every materialized survivor has claimed
+      // its next-cache slot. A failed store advances this thread's resume point,
+      // but scanning continues so the next histogram remains complete.
+      int idx = resume_idx;
+      resume_idx = length;
+      bool tail_overflowed = false;
+      for (; idx < length; idx += BLOCK_SIZE) {
+        const auto raw_input = input[idx + row_start];
+        if (static_cast<int>(convert_to_uint8(raw_input)) != coarse_threshold_bin) continue;
+        const auto key = convert_to_uint32(raw_input);
+        if ((key & prefix_mask) != refine_prefix) continue;
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[TopK - pos] = idx;
+            }
+          } else {
+            const auto sub_bin = (key >> (offset - 8)) & 0xFF;
+            ::atomicAdd(&s_histogram[sub_bin], 1);
+            if (!tail_overflowed) {
+              const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+              if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
+                s_input_idx[r_idx ^ 1][pos] = idx;
+              } else {
+                resume_idx = idx;
+                tail_overflowed = true;
+              }
+            }
+          }
+        }
+      }
+      refine_prefix |= static_cast<uint32_t>(threshold_bin) << offset;
       __syncthreads();
     }
   }

--- a/python/sglang/kernels/aot/tests/test_topk.py
+++ b/python/sglang/kernels/aot/tests/test_topk.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Optional
+from typing import Optional
 
 import pytest
 import torch
@@ -65,6 +65,7 @@ def _ref_torch_transform_ragged_impl(
 
 
 MAX_SEQ_LEN = 131072
+SMEM_CANDIDATE_CAPACITY = 4096
 
 
 def assert_equal(
@@ -98,6 +99,116 @@ def assert_equal(
                     f"{bs=}, {k=}, {seq_len=}, {i=}, {more=}, {less=} failed, with {more_values=}, {less_values=}"
                 )
         assert wrong_values <= max_permit_error, f"{wrong_values=}, {max_permit_error=}"
+
+
+def _assert_exact_selected_values(
+    score: torch.Tensor, indices: torch.Tensor, topk: int
+) -> None:
+    selected = score.gather(1, indices.long()).sort(dim=1, descending=True).values
+    reference = torch.topk(score, topk, dim=1, sorted=True).values
+    torch.testing.assert_close(selected, reference, rtol=0, atol=0)
+
+
+def _assert_valid_indices(
+    indices: torch.Tensor, lengths: torch.Tensor, topk: int
+) -> None:
+    """Strict structural checks: shape, range, no duplicates, exact K valid."""
+    B = indices.shape[0]
+    assert indices.shape == (B, topk), f"shape mismatch: {indices.shape}"
+    assert (indices >= 0).all(), "negative index found"
+    for i in range(B):
+        L = lengths[i].item()
+        assert (indices[i] < L).all(), f"row {i}: index >= length ({L})"
+        sorted_row = indices[i].sort().values
+        dups = (sorted_row[1:] == sorted_row[:-1]).sum().item()
+        assert dups == 0, f"row {i}: {dups} duplicate indices"
+
+
+def _coarse_threshold_bucket_population(score: torch.Tensor, topk: int) -> torch.Tensor:
+    half_bits = score.to(torch.float16).view(torch.int16).to(torch.int32) & 0xFFFF
+    keys = torch.where(half_bits & 0x8000 != 0, half_bits ^ 0xFFFF, half_bits | 0x8000)
+    bins = (keys >> 8) & 0xFF
+    kth_indices = torch.topk(score, topk, dim=1).indices[:, -1:]
+    kth_bins = bins.gather(1, kth_indices)
+    return (bins == kth_bins).sum(dim=1)
+
+
+@pytest.mark.parametrize("entrypoint", ["plain", "decode", "prefill", "ragged"])
+@torch.inference_mode()
+def test_topk_candidate_cache_overflow(entrypoint: str) -> None:
+    """All AOT callers must recover candidates beyond the 4096-entry cache."""
+    torch.manual_seed(0)
+    batch_size, seq_len, topk = 2, 256 * 1024, 2048
+    score = torch.randn(batch_size, seq_len, dtype=torch.float32, device="cuda")
+    score_input = score
+    lengths = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+    assert bool(
+        (_coarse_threshold_bucket_population(score, topk) > SMEM_CANDIDATE_CAPACITY)
+        .all()
+        .item()
+    )
+
+    if entrypoint == "plain":
+        indices = fast_topk_v2(score, lengths, topk)
+    elif entrypoint in ("decode", "prefill"):
+        page_table = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+        page_table = page_table.unsqueeze(0).expand(batch_size, -1)
+        cu_seqlens_q = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda")
+        # A non-null row_starts selects the prefill kernel. Use nonzero starts
+        # so overflow recovery also exercises per-row input windows; returned
+        # indices remain relative and therefore match the identity page table.
+        row_starts = None
+        if entrypoint == "prefill":
+            row_starts = torch.tensor([17, 31], dtype=torch.int32, device="cuda")
+            score_input = torch.empty(
+                batch_size, seq_len + 64, dtype=torch.float32, device="cuda"
+            )
+            for row, start in enumerate(row_starts.tolist()):
+                score_input[row, start : start + seq_len] = score[row]
+        indices = fast_topk_transform_fused(
+            score_input,
+            lengths,
+            page_table,
+            cu_seqlens_q,
+            topk,
+            row_starts=row_starts,
+        )
+    else:
+        offsets = torch.zeros(batch_size, dtype=torch.int32, device="cuda")
+        indices = fast_topk_transform_ragged_fused(score, lengths, offsets, topk)
+
+    _assert_valid_indices(indices, lengths, topk)
+    _assert_exact_selected_values(score, indices, topk)
+
+
+@torch.inference_mode()
+def test_topk_repeated_candidate_cache_overflow() -> None:
+    """A raw tail remains complete when several consecutive radix bins overflow."""
+    torch.manual_seed(1)
+    batch_size, seq_len, topk = 2, 16 * 1024, 2048
+    values = 1.0 + torch.linspace(0, 1e-4, seq_len, dtype=torch.float32, device="cuda")
+    score = torch.stack(
+        [values[torch.randperm(seq_len, device="cuda")] for _ in range(batch_size)]
+    )
+    lengths = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+
+    # This narrow interval shares both the coarse bin and the first two full-key
+    # bytes, forcing the resume tail to survive more than one overflow round.
+    assert bool(
+        (_coarse_threshold_bucket_population(score, topk) > SMEM_CANDIDATE_CAPACITY)
+        .all()
+        .item()
+    )
+    bits = score.view(torch.int32)
+    full_keys = torch.where(bits < 0, ~bits, bits | torch.iinfo(torch.int32).min)
+    kth_indices = torch.topk(score, topk, dim=1).indices[:, -1:]
+    kth_prefix = (full_keys.gather(1, kth_indices) >> 16) & 0xFFFF
+    prefix_population = (((full_keys >> 16) & 0xFFFF) == kth_prefix).sum(dim=1)
+    assert bool((prefix_population > SMEM_CANDIDATE_CAPACITY).all().item())
+
+    indices = fast_topk_v2(score, lengths, topk)
+    _assert_valid_indices(indices, lengths, topk)
+    _assert_exact_selected_values(score, indices, topk)
 
 
 @pytest.mark.parametrize("bs", [1, 132, 256, 4096])

--- a/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
+++ b/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
@@ -67,6 +67,8 @@ fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index,
   extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
 
   const int tx = threadIdx.x;
+  // First uncached candidate in this thread's tx + n * BLOCK_SIZE lane.
+  int resume_idx = length;
 
   if (tx < RADIX + 1) s_histogram[tx] = 0;
   __syncthreads();
@@ -102,13 +104,13 @@ fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index,
   }
   __syncthreads();
 
-  const auto threshold_bin = s_threshold_bin_id;
-  topk -= s_histogram[threshold_bin + 1];
+  const auto coarse_threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[coarse_threshold_bin + 1];
 
   if (topk == 0) {
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto bin = static_cast<int>(convert_to_uint8(input[idx + row_start]));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
       }
@@ -125,15 +127,22 @@ fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index,
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto raw_input = input[idx + row_start];
       const auto bin = static_cast<int>(convert_to_uint8(raw_input));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
-      } else if (bin == threshold_bin) {
+      } else if (bin == coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_num_input[0], 1);
         if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
           s_input_idx[0][pos] = idx;
-          const auto bin = convert_to_uint32(raw_input);
-          const auto sub_bin = (bin >> 24) & 0xFF;
+          const auto key = convert_to_uint32(raw_input);
+          const auto sub_bin = (key >> 24) & 0xFF;
+          ::atomicAdd(&s_histogram[sub_bin], 1);
+        } else {
+          if (resume_idx == length) resume_idx = idx;
+          // Overflow candidates remain in the logical set even though they
+          // were not materialized in the shared-memory cache.
+          const auto key = convert_to_uint32(raw_input);
+          const auto sub_bin = (key >> 24) & 0xFF;
           ::atomicAdd(&s_histogram[sub_bin], 1);
         }
       }
@@ -141,38 +150,40 @@ fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index,
     __syncthreads();
   }
 
+  if (C10_LIKELY(s_num_input[0] <= int(SMEM_INPUT_SIZE))) {
+    // Preserve the original shared-memory-only path for the common case. No
+    // resume prefix is maintained and no raw-input tail is revisited here.
 #pragma unroll 4
-  for (int round = 0; round < 4; ++round) {
-    __shared__ int s_last_remain;
-    const auto r_idx = round % 2;
+    for (int round = 0; round < 4; ++round) {
+      __shared__ int s_last_remain;
+      const auto r_idx = round % 2;
+      const auto num_input = s_num_input[r_idx];
 
-    const auto _raw_num_input = s_num_input[r_idx];
-    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE)) ? _raw_num_input : int(SMEM_INPUT_SIZE);
-
-    run_cumsum();
-    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
-      s_threshold_bin_id = tx;
-      s_num_input[r_idx ^ 1] = 0;
-      s_last_remain = topk - s_histogram[tx + 1];
-    }
-    __syncthreads();
-
-    const auto threshold_bin = s_threshold_bin_id;
-    topk -= s_histogram[threshold_bin + 1];
-
-    if (topk == 0) {
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
-        const auto idx = s_input_idx[r_idx][i];
-        const auto offset = 24 - round * 8;
-        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
-        if (bin > threshold_bin) {
-          const auto pos = ::atomicAdd(&s_counter, 1);
-          index[pos] = idx;
-        }
+      run_cumsum();
+      if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+        s_threshold_bin_id = tx;
+        s_num_input[r_idx ^ 1] = 0;
+        s_last_remain = topk - s_histogram[tx + 1];
       }
       __syncthreads();
-      break;
-    } else {
+
+      const auto threshold_bin = s_threshold_bin_id;
+      topk -= s_histogram[threshold_bin + 1];
+
+      if (topk == 0) {
+        for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+          const auto idx = s_input_idx[r_idx][i];
+          const auto offset = 24 - round * 8;
+          const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
+          if (bin > threshold_bin) {
+            const auto pos = ::atomicAdd(&s_counter, 1);
+            index[pos] = idx;
+          }
+        }
+        __syncthreads();
+        break;
+      }
+
       __syncthreads();
       if (tx < RADIX + 1) {
         s_histogram[tx] = 0;
@@ -196,13 +207,132 @@ fast_topk_cuda_tl_impl(const float* __restrict__ input, int* __restrict__ index,
             const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
             if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
               s_input_idx[r_idx ^ 1][pos] = idx;
-              const auto bin = convert_to_uint32(raw_input);
-              const auto sub_bin = (bin >> (offset - 8)) & 0xFF;
+              const auto key = convert_to_uint32(raw_input);
+              const auto sub_bin = (key >> (offset - 8)) & 0xFF;
               ::atomicAdd(&s_histogram[sub_bin], 1);
             }
           }
         }
       }
+      __syncthreads();
+    }
+    return;
+  }
+
+  // Slow path: the first threshold bucket overflowed the smem cache.
+  uint32_t refine_prefix = 0;
+#pragma unroll 4
+  for (int round = 0; round < 4; ++round) {
+    __shared__ int s_last_remain;
+    const auto r_idx = round % 2;
+
+    const auto _raw_num_input = s_num_input[r_idx];
+    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE)) ? _raw_num_input : int(SMEM_INPUT_SIZE);
+
+    run_cumsum();
+    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+      s_threshold_bin_id = tx;
+      s_num_input[r_idx ^ 1] = 0;
+      s_last_remain = topk - s_histogram[tx + 1];
+    }
+    __syncthreads();
+
+    const auto threshold_bin = s_threshold_bin_id;
+    topk -= s_histogram[threshold_bin + 1];
+    const auto offset = 24 - round * 8;
+    const uint32_t prefix_mask = round == 0 ? 0u : 0xFFFFFFFFu << (32 - round * 8);
+
+    if (topk == 0) {
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      for (int idx = resume_idx; idx < length; idx += BLOCK_SIZE) {
+        const auto raw_input = input[idx + row_start];
+        if (static_cast<int>(convert_to_uint8(raw_input)) != coarse_threshold_bin) continue;
+        const auto key = convert_to_uint32(raw_input);
+        if ((key & prefix_mask) != refine_prefix) continue;
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      __syncthreads();
+      break;
+    } else {
+      __syncthreads();
+      if (tx < RADIX + 1) {
+        s_histogram[tx] = 0;
+      }
+      __syncthreads();
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = input[idx + row_start];
+        const auto key = convert_to_uint32(raw_input);
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[K - pos] = idx;
+            }
+          } else {
+            const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+            // Materialized candidates run before the tail, so their survivor
+            // count is bounded by num_input and always fits.
+            s_input_idx[r_idx ^ 1][pos] = idx;
+            const auto sub_bin = (key >> (offset - 8)) & 0xFF;
+            ::atomicAdd(&s_histogram[sub_bin], 1);
+          }
+        }
+      }
+      __syncthreads();
+
+      // Process the raw tail only after every materialized survivor has claimed
+      // its next-cache slot. A failed store advances this thread's resume point,
+      // but scanning continues so the next histogram remains complete.
+      int idx = resume_idx;
+      resume_idx = length;
+      bool tail_overflowed = false;
+      for (; idx < length; idx += BLOCK_SIZE) {
+        const auto raw_input = input[idx + row_start];
+        if (static_cast<int>(convert_to_uint8(raw_input)) != coarse_threshold_bin) continue;
+        const auto key = convert_to_uint32(raw_input);
+        if ((key & prefix_mask) != refine_prefix) continue;
+        const auto bin = (key >> offset) & 0xFF;
+        if (bin > threshold_bin) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[K - pos] = idx;
+            }
+          } else {
+            const auto sub_bin = (key >> (offset - 8)) & 0xFF;
+            ::atomicAdd(&s_histogram[sub_bin], 1);
+            if (!tail_overflowed) {
+              const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+              if (C10_LIKELY(pos < SMEM_INPUT_SIZE)) {
+                s_input_idx[r_idx ^ 1][pos] = idx;
+              } else {
+                resume_idx = idx;
+                tail_overflowed = true;
+              }
+            }
+          }
+        }
+      }
+      refine_prefix |= static_cast<uint32_t>(threshold_bin) << offset;
       __syncthreads();
     }
   }

--- a/test/registered/kernels/test_kpool_topk_transform.py
+++ b/test/registered/kernels/test_kpool_topk_transform.py
@@ -1,0 +1,61 @@
+"""Correctness tests for the fused k-pool top-k candidate cache."""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Test requires CUDA")
+class TestKpoolTopKTransform(CustomTestCase):
+    def test_repeated_candidate_cache_overflow(self):
+        from sglang.kernels.ops.moe.kpool_topk_transform import (
+            fast_kpool_topk_transform_fused,
+        )
+
+        torch.manual_seed(2)
+        batch_size, seq_len = 1, 16 * 1024
+        pool_size, group_topk = 2, 512
+        values = 1.0 + torch.linspace(
+            0, 1e-4, seq_len, dtype=torch.float32, device="cuda"
+        )
+        score = values[torch.randperm(seq_len, device="cuda")].reshape(
+            batch_size, seq_len
+        )
+        lengths = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+        offsets = torch.zeros(batch_size, dtype=torch.int32, device="cuda")
+
+        output = fast_kpool_topk_transform_fused(
+            score=score,
+            lengths=lengths,
+            pool_size=pool_size,
+            topk=group_topk * pool_size,
+            topk_indices_offset=offsets,
+        )
+        # Each selected group expands to its two consecutive token positions.
+        selected_groups = output[:, ::pool_size] // pool_size
+
+        # Explicit structural checks: shape, range, no duplicates.
+        assert selected_groups.shape == (batch_size, group_topk), (
+            f"shape mismatch: {selected_groups.shape}"
+        )
+        assert (selected_groups >= 0).all(), "negative index found"
+        assert (selected_groups < seq_len).all(), "index >= seq_len"
+        sorted_row = selected_groups[0].sort().values
+        dups = (sorted_row[1:] == sorted_row[:-1]).sum().item()
+        assert dups == 0, f"{dups} duplicate indices"
+
+        selected_values = (
+            score.gather(1, selected_groups.long()).sort(dim=1, descending=True).values
+        )
+        reference_values = torch.topk(score, group_topk, dim=1, sorted=True).values
+        torch.testing.assert_close(selected_values, reference_values, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #36807.

The radix top-k implementation used by `sgl_kernel.fast_topk_v2` can silently
return an incorrect top-k set when the threshold radix bucket contains more
candidates than the fixed shared-memory candidate buffer.

The existing CUDA path uses a 4096-entry shared-memory buffer as both a cache
and, effectively, a correctness bound. Once the threshold bucket exceeds that
capacity, later candidates are not materialized and their contributions to the
next radix histogram are lost. The kernel still returns exactly `k` valid,
duplicate-free indices, so the corruption is silent.

Current main also contains a JIT k-pool top-k implementation that copies the
same radix-selection core and has the same fixed-buffer truncation behavior.

This PR makes the shared-memory buffer a performance cache rather than a
correctness bound.

## Modifications

### AOT `fast_topk_v2`

Update:

`python/sglang/kernels/aot/csrc/elementwise/topk.cu`

On candidate overflow:

- keep the existing shared-memory candidate buffers;
- record a thread-local `resume_idx` for the first candidate that could not be
  materialized by each thread;
- continue counting every surviving candidate in the next-radix histogram,
  regardless of whether it fits in shared memory;
- refine the already-cached candidates first;
- synchronize;
- then resume each thread's original strided input scan from its uncached tail.

The cached and uncached candidate sets therefore remain disjoint and together
represent the full logical candidate population.

For repeated overflow, cached candidates are always materialized before the raw
tail is allowed to consume remaining cache slots. This prevents a previously
cached survivor from becoming unrecoverable.

The existing `<= 4096` shared-memory-only path is preserved.

### JIT k-pool variant

Apply the same overflow-safe refinement scheme to:

`python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh`

This implementation copies the same radix-selection algorithm and otherwise
retains the same silent truncation behavior.

### Regression coverage

Add overflow correctness tests to:

- `python/sglang/kernels/aot/tests/test_topk.py`
- `test/registered/kernels/test_kpool_topk_transform.py`

The new tests use strict value-multiset equality against `torch.topk`
(`rtol=0`, `atol=0`) and additionally require:

- zero invalid indices;
- zero duplicate indices;
- zero wrong rows;
- zero wrong selected values.

Coverage includes:

- non-overflow 64K rows;
- 256K overflow;
- repeated radix overflow;
- concentrated distinct values;
- exact ties;
- all affected AOT entry points.

## Accuracy Tests

### H800 / SM90 kernel validation

| Case | Baseline | Fixed |
|---|---:|---:|
| 64K random | 0 wrong rows | 0 wrong rows |
| 256K random | 64/64 wrong | 0/64 wrong |
| 1M random | 64/64 wrong | 0/64 wrong |
| repeated overflow | 4/4 wrong | 0/4 wrong |
| concentrated distinct | 4/4 wrong | 0/4 wrong |
| exact ties | multiset-correct | multiset-correct |

The repeated-overflow fixture keeps the logical threshold candidate population
above the shared-memory capacity across multiple radix rounds:

```text
coarse: 16384
round 0: 16384
round 1: 16384
round 2: 5000
round 3: 19
```

The fixed kernel returns the exact torch.topk value multiset for this case.

Boundary cases with threshold populations of 4095, 4096, and 4097 also pass.

### AOT integration

Environment:

- GPU: NVIDIA H100 80GB HBM3
- Compute capability: SM90
- Driver: 580.126.20
- CUDA toolkit: 13.0
- PyTorch: 2.13.0+cu130
- Python: 3.12.3
- sglang-kernel: 0.4.6.post1, built from this source tree

A fresh AOT wheel was built and installed successfully.

Existing AOT top-k tests:

117 passed, 6 skipped

Affected AOT entry points:

| Entry point | Result |
|---|---|
| fast_topk_v2 | PASS |
| topk_transform_decode | PASS |
| topk_transform_prefill | PASS |
| topk_transform_prefill_ragged | PASS |

All new regression cases report:

- wrong rows: 0
- wrong values: 0
- duplicate indices: 0
- invalid indices: 0

compute-sanitizer validation on H800:

- memcheck: 0 errors
- racecheck: 0 hazards

## Speed Tests and Profiling

Same-machine H800 A/B measurements using CUDA events,
20 warmup iterations and 100 measured iterations:

| Shape | Baseline median | Fixed median |
|---|---:|---:|
| 64K × 64 | 44.42 us | 44.75 us |
| 256K × 64 | 206.08 us | 222.13 us |
| 1M × 64 | 712.80 us | 998.91 us |

The non-overflow fast path changes by about +0.7% in median latency.

The overflow path performs additional raw-input scanning in order to preserve
the full logical candidate population; the baseline timings in those cases
correspond to an implementation that can return incorrect results.

Compiler resource usage on SM90:

| Kernel | Before | After |
|---|---:|---:|
| plain topk | 30 reg | 32 reg |
| decode | 30 reg | 32 reg |
| prefill | 32 reg | 32 reg |
| ragged | 32 reg | 32 reg |

- local-memory spill: 0
- additional shared-memory allocation: none

A separate H100 integration smoke run measured:

- 64K × 64: median 44.70 us, p95 45.73 us
- 256K × 64: median 199.58 us, p95 201.15 us

These H100 measurements are reported only as integration smoke results, not as
the A/B regression comparison.

## Checklist

- [x] Added focused regression tests
- [x] Built and installed a fresh sglang-kernel wheel
- [x] Existing test_topk.py passes
- [x] Tested all affected AOT entry points
- [x] Added JIT regression coverage for the copied radix core
- [x] compute-sanitizer memcheck/racecheck pass
- [x] git diff --check passes

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33876095416](https://github.com/sgl-project/sglang/actions/runs/33876095416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33876095229](https://github.com/sgl-project/sglang/actions/runs/33876095229)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33876095407](https://github.com/sgl-project/sglang/actions/runs/33876095407)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->