### PR TITLE
[Docs] Fix cuda-graph-max-bs alias and collect-tokens-histogram deprecation

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -940,7 +940,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--collect-tokens-histogram`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Collect prompt/generation tokens histogram.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>Deprecated.</strong> Token histograms are now automatically collected when <code>--enable-metrics</code> is set.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>False</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
@@ -2583,7 +2583,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--cuda-graph-max-bs-decode`</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--cuda-graph-max-bs`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>Deprecated alias</strong> for <code>--cuda-graph-max-bs-decode</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>


### PR DESCRIPTION
## Summary

Two high-confidence CLI/docs drifts in `docs/docs/advanced_features/server_arguments.mdx`:

1. **Self-alias**: the deprecated-alias table listed `` `--cuda-graph-max-bs-decode` `` as a deprecated alias for itself. Live CLI registers bare `` `--cuda-graph-max-bs` `` as the deprecated alias of `` `--cuda-graph-max-bs-decode` ``.
2. **`--collect-tokens-histogram`**: docs presented it as a live bool flag. Live CLI registers it as `DeprecatedAction` — token histograms are collected automatically when `` `--enable-metrics` `` is set.

## Repro

Against `main` @ `5e81d462c3626e1f0082eaf5a120257d4ebdfd43`:

```bash
# 1) Docs self-alias row
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/docs/advanced_features/server_arguments.mdx \
  | rg -n 'Deprecated alias.*cuda-graph-max-bs-decode' -A0 -B1 | head -20

# 2) Live alias registration
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/server_args.py \
  | rg -n '"--cuda-graph-max-bs"|new_flag=.*cuda-graph-max-bs-decode' -A3 | head -30

# 3) Docs still describe collect-tokens-histogram as live
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/docs/advanced_features/server_arguments.mdx \
  | rg -n 'collect-tokens-histogram' -A1 | head -10

# 4) Live DeprecatedAction help
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/server_args.py \
  | rg -n 'collect-tokens-histogram' -A4 | head -20
```

Expected before this PR:
- Docs: `` `--cuda-graph-max-bs-decode` `` → Deprecated alias for `` `--cuda-graph-max-bs-decode` ``
- Code: `` `--cuda-graph-max-bs` `` → Deprecated alias for `` `--cuda-graph-max-bs-decode` ``
- Docs: “Collect prompt/generation tokens histogram.”
- Code: `DeprecatedAction` / “automatically collected when --enable-metrics is set.”

## Changes

- Only `docs/docs/advanced_features/server_arguments.mdx`
- Rename the broken deprecated-alias flag cell to `` `--cuda-graph-max-bs` ``
- Mark `` `--collect-tokens-histogram` `` deprecated with the live help text

## Test plan

- [ ] Confirm primary (non-deprecated) `` `--cuda-graph-max-bs-decode` `` row is unchanged
- [ ] Confirm deprecated-alias row now names `` `--cuda-graph-max-bs` ``
- [ ] Confirm `` `--collect-tokens-histogram` `` description matches `DeprecatedAction` help
- [ ] Docs build / preview of server arguments page

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33826304894](https://github.com/sgl-project/sglang/actions/runs/33826304894)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33826304685](https://github.com/sgl-project/sglang/actions/runs/33826304685)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->