### PR TITLE
[jit_kernel] port murmur_hash32 to CUDA JIT with tests and benchmark

### DIFF
--- a/python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh
+++ b/python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
@@ -112,11 +114,13 @@ struct MurmurHashKernel {
 
     const auto n = N.unwrap();
     const auto m = M.unwrap();
-    RuntimeCheck(n * m == Total.unwrap(), "out numel must equal n * m");
+    CHECK_HOST(n * m == Total.unwrap()) << "out numel must equal n * m";
     if (n == 0 || m == 0) return;
 
+    // grid.x carries one block per row; grid.y one block per kBlockSize columns.
+    CHECK_HOST(n <= 2147483647LL) << "num_rows " << n << " exceeds CUDA grid.x limit (2^31-1)";
     const auto col_blocks = div_ceil(static_cast<uint32_t>(m), kBlockSize);
-    RuntimeCheck(col_blocks <= 65535u, "num_cols too large for CUDA grid.y (65535 blocks)");
+    CHECK_HOST(col_blocks <= 65535u) << "num_cols too large for CUDA grid.y (" << col_blocks << " > 65535 blocks)";
 
     const auto params = MurmurHashParams{
         .seed = static_cast<const uint64_t*>(seed.data_ptr()),

--- a/python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh
+++ b/python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh
@@ -1,0 +1,133 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+
+namespace sglang {
+
+/// \brief Rotate a 32-bit value left by `r` bits.
+SGL_DEVICE uint32_t murmur3_rotl32(uint32_t x, uint32_t r) {
+  return (x << r) | (x >> (32u - r));
+}
+
+/// \brief Mix one 32-bit key into the MurmurHash3 accumulator.
+///
+/// Mirrors the reference MurmurHash3 x86_32 body: the accumulator and key
+/// both go through the k*^= rotations and the len-4 mixing step.
+SGL_DEVICE uint32_t murmur3_mix32(uint32_t h, uint32_t k) {
+  k *= 0xCC9E2D51u;
+  k = murmur3_rotl32(k, 15u);
+  k *= 0x1B873593u;
+  h ^= k;
+  h = murmur3_rotl32(h, 13u);
+  h = h * 5u + 0xE6546B64u;
+  return h;
+}
+
+/// \brief Final avalanche pass of MurmurHash3 x86_32.
+SGL_DEVICE uint32_t murmur3_fmix32(uint32_t h) {
+  h ^= h >> 16u;
+  h *= 0x85EBCA6Bu;
+  h ^= h >> 13u;
+  h *= 0xC2B2AE35u;
+  h ^= h >> 16u;
+  return h;
+}
+
+/// \brief Shared launch parameters for the MurmurHash32 kernel.
+///
+/// `positions` and `col_indices` are stored as `void*` and read through the
+/// templated element type so every 32-bit integer dtype (signed or unsigned,
+/// 32- or 64-bit) truncates to `uint32_t` exactly the way the reference
+/// Triton kernel's `.to(tl.uint32)` does.
+struct MurmurHashParams {
+  const uint64_t* __restrict__ seed;     // [n] row seeds
+  const void* __restrict__ positions;    // [n] per-row positions, truncated to u32
+  const void* __restrict__ col_indices;  // [m] per-column indices, truncated to u32
+  uint32_t* __restrict__ out;            // [n * m]
+  uint32_t m;                            // number of columns
+};
+
+/// \brief MurmurHash3 x86_32 over seed, position, and column index.
+///
+/// Treats the 64-bit seed, 32-bit position, and 32-bit column index as four
+/// 4-byte blocks, bit-blends them through `murmur3_mix32`, then finalizes
+/// with length 16. Bit-identical to `sglang.kernels.ops.sampling.murmur_hash`
+/// Triton reference.
+///
+/// \tparam TPos Element type of `positions` (int32/int64/uint32/uint64)
+/// \tparam TCol Element type of `col_indices` (int32/int64/uint32/uint64)
+template <typename TPos, typename TCol>
+__global__ void murmur_hash32_kernel(const __grid_constant__ MurmurHashParams params) {
+  // Rows on grid.x (batch can be large; grid.x spans 2^31-1), column blocks on
+  // grid.y. Threads in a warp keep consecutive `col`, so `out[row * m + col]`
+  // stays coalesced.
+  const uint32_t row = blockIdx.x;
+  const uint32_t col = blockIdx.y * blockDim.x + threadIdx.x;
+  if (col >= params.m) return;
+
+  const uint64_t seed = params.seed[row];
+  const uint32_t pos = static_cast<uint32_t>(static_cast<const TPos*>(params.positions)[row]);
+  const uint32_t col_val = static_cast<uint32_t>(static_cast<const TCol*>(params.col_indices)[col]);
+
+  uint32_t h = murmur3_mix32(0u, static_cast<uint32_t>(seed & 0xFFFFFFFFull));
+  h = murmur3_mix32(h, static_cast<uint32_t>(seed >> 32u));
+  h = murmur3_mix32(h, pos);
+  h = murmur3_mix32(h, col_val);
+  h ^= 16u;
+  h = murmur3_fmix32(h);
+
+  params.out[static_cast<uint64_t>(row) * params.m + col] = h;
+}
+
+/// \brief Host launcher for `murmur_hash32_kernel`.
+///
+/// \tparam TPos Element type of `positions` (int32/int64/uint32/uint64)
+/// \tparam TCol Element type of `col_indices` (int32/int64/uint32/uint64)
+template <typename TPos, typename TCol>
+struct MurmurHashKernel {
+  static constexpr uint32_t kBlockSize = 256u;
+
+  static void launch(
+      const tvm::ffi::TensorView seed,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView col_indices,
+      const tvm::ffi::TensorView out) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_rows"};
+    auto M = SymbolicSize{"num_cols"};
+    auto Total = SymbolicSize{"numel"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N}).with_dtype<uint64_t>().with_device(device_).verify(seed);
+    TensorMatcher({N}).with_dtype<TPos>().with_device(device_).verify(positions);
+    TensorMatcher({M}).with_dtype<TCol>().with_device(device_).verify(col_indices);
+    TensorMatcher({Total}).with_dtype<uint32_t>().with_device(device_).verify(out);
+
+    const auto n = N.unwrap();
+    const auto m = M.unwrap();
+    RuntimeCheck(n * m == Total.unwrap(), "out numel must equal n * m");
+    if (n == 0 || m == 0) return;
+
+    const auto col_blocks = div_ceil(static_cast<uint32_t>(m), kBlockSize);
+    RuntimeCheck(col_blocks <= 65535u, "num_cols too large for CUDA grid.y (65535 blocks)");
+
+    const auto params = MurmurHashParams{
+        .seed = static_cast<const uint64_t*>(seed.data_ptr()),
+        .positions = positions.data_ptr(),
+        .col_indices = col_indices.data_ptr(),
+        .out = static_cast<uint32_t*>(out.data_ptr()),
+        .m = static_cast<uint32_t>(m),
+    };
+    const auto grid = dim3(static_cast<uint32_t>(n), col_blocks);
+    LaunchKernel(grid, kBlockSize, device_.unwrap())(murmur_hash32_kernel<TPos, TCol>, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/ops/sampling/__init__.py
+++ b/python/sglang/kernels/ops/sampling/__init__.py
@@ -62,10 +62,10 @@ __all__ = ["top_k_renorm_probs", "top_p_renorm_probs"]
 
 # Migrated from srt/layers/utils/hash.py (RFC #29630, Phase 2.5).
 # One backend per device: JIT on CUDA, Triton on ROCm. The ``capabilities``
-# make exactly one spec eligible per platform, and each target is the concrete
-# implementation so ``get_kernel(..., backend=...)`` can force either one. The
-# ``murmur_hash32`` entry point in murmur_hash.py does the same dispatch for
-# callers that import it directly.
+# make exactly one spec eligible per platform (so ``backend=`` only selects
+# among the specs eligible on the current device). The ``murmur_hash32`` entry
+# point in murmur_hash.py does the same device dispatch for callers that import
+# it directly.
 register_kernel(
     KernelSpec(
         op="sampling.murmur_hash32",

--- a/python/sglang/kernels/ops/sampling/__init__.py
+++ b/python/sglang/kernels/ops/sampling/__init__.py
@@ -6,7 +6,15 @@ from typing import TYPE_CHECKING, Union
 
 from sglang.kernels.registry import register_kernel
 from sglang.kernels.selector import get_kernel
-from sglang.kernels.spec import FormatSignature, KernelBackend, KernelSpec
+from sglang.kernels.spec import (
+    CapabilityRequirement,
+    FormatSignature,
+    KernelBackend,
+    KernelSpec,
+)
+
+_CUDA = frozenset({CapabilityRequirement.CUDA})
+_HIP = frozenset({CapabilityRequirement.HIP})
 
 if TYPE_CHECKING:
     import torch
@@ -53,10 +61,26 @@ __all__ = ["top_k_renorm_probs", "top_p_renorm_probs"]
 
 
 # Migrated from srt/layers/utils/hash.py (RFC #29630, Phase 2.5).
+# One backend per device: JIT on CUDA, Triton on ROCm. The ``capabilities``
+# make exactly one spec eligible per platform, and each target is the concrete
+# implementation so ``get_kernel(..., backend=...)`` can force either one. The
+# ``murmur_hash32`` entry point in murmur_hash.py does the same dispatch for
+# callers that import it directly.
+register_kernel(
+    KernelSpec(
+        op="sampling.murmur_hash32",
+        backend=KernelBackend.JIT,
+        target="sglang.kernels.ops.sampling.murmur_hash:_murmur_hash32_jit",
+        capabilities=_CUDA,
+        description="MurmurHash3 x86_32 (CUDA JIT kernel).",
+    )
+)
 register_kernel(
     KernelSpec(
         op="sampling.murmur_hash32",
         backend=KernelBackend.TRITON,
-        target="sglang.kernels.ops.sampling.murmur_hash:murmur_hash32",
+        target="sglang.kernels.ops.sampling.murmur_hash:_murmur_hash32_triton",
+        capabilities=_HIP,
+        description="MurmurHash3 x86_32 (Triton reference, ROCm).",
     )
 )

--- a/python/sglang/kernels/ops/sampling/murmur_hash.py
+++ b/python/sglang/kernels/ops/sampling/murmur_hash.py
@@ -1,6 +1,33 @@
+"""MurmurHash3 x86_32 for deterministic sampling coins.
+
+Two backends behind one ``murmur_hash32(seed, positions, col_indices)`` entry:
+
+- ``_murmur_hash32_jit``: CUDA JIT kernel (``python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh``).
+- ``_murmur_hash32_triton``: Triton reference, kept as the ROCm fallback.
+
+Both are bit-identical: the JIT kernel reuses the same four-block blend and
+finalization. The Triton kernel stays importable so callers and tests can
+cross-check the two implementations against each other.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import torch
 import triton
 import triton.language as tl
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+_is_hip = torch.version.hip is not None
+
+#: Dtypes accepted for ``positions`` / ``col_indices``; all truncate to uint32
+#: in-kernel exactly like the Triton reference's ``.to(tl.uint32)``.
+_SUPPORTED_INDEX_DTYPES = (torch.int32, torch.int64, torch.uint32, torch.uint64)
 
 
 @triton.jit
@@ -101,17 +128,49 @@ def murmur_hash32_kernel(
     tl.store(output_ptr + row_idx * num_cols + col_offsets, h, mask=mask)
 
 
-def murmur_hash32(seed, positions, col_indices):
-    assert seed.shape == positions.shape, (
-        "Seed and positions must have the same shape (n,)"
+@cache_once
+def _jit_murmur_hash_module(pos_dtype: torch.dtype, col_dtype: torch.dtype) -> Module:
+    """Compile and cache the JIT MurmurHash32 module for the given dtypes."""
+    if (
+        pos_dtype not in _SUPPORTED_INDEX_DTYPES
+        or col_dtype not in _SUPPORTED_INDEX_DTYPES
+    ):
+        raise RuntimeError(
+            f"murmur_hash32: unsupported index dtypes {pos_dtype=} {col_dtype=}; "
+            f"expected one of {_SUPPORTED_INDEX_DTYPES}"
+        )
+    args = make_cpp_args(pos_dtype, col_dtype)
+    return load_jit(
+        "murmur_hash32",
+        *args,
+        cuda_files=["sampling/murmur_hash.cuh"],
+        cuda_wrappers=[("murmur_hash32", f"MurmurHashKernel<{args}>::launch")],
     )
-    assert len(seed.shape) == 1 and len(col_indices.shape) == 1, (
-        f"Inputs must be 1D tensors {seed.shape=} {col_indices.shape=}"
-    )
+
+
+def _murmur_hash32_jit(
+    seed: torch.Tensor, positions: torch.Tensor, col_indices: torch.Tensor
+) -> torch.Tensor:
+    """CUDA JIT path. Bit-identical to ``_murmur_hash32_triton``."""
     n = seed.shape[0]
     m = col_indices.shape[0]
-    device = seed.device
-    hashed = torch.empty((n, m), dtype=torch.uint32, device=device)
+    out = torch.empty((n, m), dtype=torch.uint32, device=seed.device)
+    if n == 0 or m == 0:
+        return out
+    module = _jit_murmur_hash_module(positions.dtype, col_indices.dtype)
+    module.murmur_hash32(seed, positions, col_indices, out.view(-1))
+    return out
+
+
+def _murmur_hash32_triton(
+    seed: torch.Tensor, positions: torch.Tensor, col_indices: torch.Tensor
+) -> torch.Tensor:
+    """Triton reference implementation (kept as ROCm fallback)."""
+    n = seed.shape[0]
+    m = col_indices.shape[0]
+    hashed = torch.empty((n, m), dtype=torch.uint32, device=seed.device)
+    if n == 0 or m == 0:
+        return hashed
 
     BLOCK_SIZE = 1024
     grid = (n, triton.cdiv(m, BLOCK_SIZE))
@@ -119,3 +178,18 @@ def murmur_hash32(seed, positions, col_indices):
         seed, positions, col_indices, hashed, n, m, BLOCK_SIZE=BLOCK_SIZE
     )
     return hashed
+
+
+def murmur_hash32(
+    seed: torch.Tensor, positions: torch.Tensor, col_indices: torch.Tensor
+) -> torch.Tensor:
+    """Bit-identical MurmurHash3 x86_32 of ``seed``, ``positions``, ``col_indices``.
+
+    ``seed`` is ``uint64`` (per row), ``positions`` is a per-row 32-bit index,
+    and ``col_indices`` a per-column 32-bit index; the hash of the four 4-byte
+    blocks lands in an ``(n, m)`` ``uint32`` tensor. CUDA uses the JIT kernel;
+    ROCm falls back to the Triton reference.
+    """
+    if _is_hip:
+        return _murmur_hash32_triton(seed, positions, col_indices)
+    return _murmur_hash32_jit(seed, positions, col_indices)

--- a/python/sglang/kernels/ops/sampling/murmur_hash.py
+++ b/python/sglang/kernels/ops/sampling/murmur_hash.py
@@ -165,7 +165,17 @@ def _murmur_hash32_jit(
 def _murmur_hash32_triton(
     seed: torch.Tensor, positions: torch.Tensor, col_indices: torch.Tensor
 ) -> torch.Tensor:
-    """Triton reference implementation (kept as ROCm fallback)."""
+    """Triton reference implementation (kept as ROCm fallback).
+
+    The JIT path validates shapes in its C++ launcher; this path has no such
+    guard, so the checks the kernel relies on live here.
+    """
+    assert seed.ndim == 1 and positions.ndim == 1 and col_indices.ndim == 1, (
+        f"inputs must be 1D {seed.shape=} {positions.shape=} {col_indices.shape=}"
+    )
+    assert seed.shape == positions.shape, (
+        f"seed and positions must have the same shape {seed.shape=} {positions.shape=}"
+    )
     n = seed.shape[0]
     m = col_indices.shape[0]
     hashed = torch.empty((n, m), dtype=torch.uint32, device=seed.device)

--- a/test/registered/kernels/benchmark/sampling/bench_murmur_hash.py
+++ b/test/registered/kernels/benchmark/sampling/bench_murmur_hash.py
@@ -22,7 +22,9 @@ FN_MAP = {
 @marker.parametrize("m", [2**14, 2**16, 2**17], [2**14])
 @marker.benchmark("impl", ["jit", "triton"])
 def benchmark(n: int, m: int, impl: str):
-    seed = torch.randint(0, torch.iinfo(torch.int64).max, (n,), dtype=torch.uint64, device="cuda")
+    seed = torch.randint(
+        0, torch.iinfo(torch.int64).max, (n,), dtype=torch.uint64, device="cuda"
+    )
     positions = torch.arange(n, dtype=torch.int64, device="cuda")
     col_indices = torch.arange(m, dtype=torch.int64, device="cuda")
     return marker.do_bench(

--- a/test/registered/kernels/benchmark/sampling/bench_murmur_hash.py
+++ b/test/registered/kernels/benchmark/sampling/bench_murmur_hash.py
@@ -1,0 +1,40 @@
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.sampling.murmur_hash import (
+    _murmur_hash32_jit,
+    _murmur_hash32_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=10, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+FN_MAP = {
+    "jit": _murmur_hash32_jit,
+    "triton": _murmur_hash32_triton,
+}
+
+
+# `m` spans typical vocab sizes, `n` typical sampling batch sizes.
+@marker.parametrize("n", [1, 4, 16, 64, 256], [16])
+@marker.parametrize("m", [2**14, 2**16, 2**17], [2**14])
+@marker.benchmark("impl", ["jit", "triton"])
+def benchmark(n: int, m: int, impl: str):
+    seed = torch.randint(0, torch.iinfo(torch.int64).max, (n,), dtype=torch.uint64, device="cuda")
+    positions = torch.arange(n, dtype=torch.int64, device="cuda")
+    col_indices = torch.arange(m, dtype=torch.int64, device="cuda")
+    return marker.do_bench(
+        FN_MAP[impl],
+        input_args=(seed, positions, col_indices),
+        # All three tensors are read every call; clone them per iteration so
+        # L2 reuse does not skew the timings.
+        graph_clone_args=(0, 1, 2),
+        # Defaults already report bandwidth: memory_args="all" counts the three
+        # inputs, memory_output="out" counts the returned (n, m) uint32 tensor.
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/sampling/test_murmur_hash.py
+++ b/test/registered/kernels/ops/sampling/test_murmur_hash.py
@@ -1,0 +1,147 @@
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from sglang.kernels.ops.sampling.murmur_hash import (
+    _murmur_hash32_jit,
+    _murmur_hash32_triton,
+    murmur_hash32,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+# (positions_dtype, col_indices_dtype) used by production call sites plus a
+# few extra integer dtypes the kernels accept.
+INDEX_DTYPE_COMBOS = [
+    (torch.int64, torch.int64),  # sampler path
+    (torch.uint64, torch.int64),  # eagle verify-side path
+    (torch.int32, torch.int32),
+    (torch.uint32, torch.uint32),
+    (torch.int64, torch.uint32),
+]
+
+SIZES = [1, 2, 33, 100, 1023, 1024, 1025, 4096]
+
+
+def _seed_positions(n, pos_dtype, device):
+    seed = torch.randint(
+        0, torch.iinfo(torch.int64).max, (n,), dtype=torch.uint64, device=device
+    )
+    positions = torch.randint(0, 1 << 30, (n,), device=device).to(pos_dtype)
+    return seed, positions
+
+
+def _murmur_hash32_reference(seed, positions, col_indices):
+    """Bit-exact PyTorch CPU reference implementation for a CPU oracle."""
+
+    seed_np = seed.cpu().numpy().astype(np.uint64).reshape(-1, 1)
+    positions_np = positions.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(-1, 1)
+    col_indices_np = col_indices.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(1, -1)
+
+    M32 = np.uint64(0xFFFFFFFF)
+    C1 = np.uint64(0xCC9E2D51)
+    C2 = np.uint64(0x1B873593)
+    N5 = np.uint64(5)
+    NN = np.uint64(0xE6546B64)
+
+    def mix(h, k):
+        k = (k * C1) & M32
+        k = ((k << np.uint64(15)) | (k >> np.uint64(17))) & M32
+        k = (k * C2) & M32
+        h = (h ^ k) & M32
+        h = ((h << np.uint64(13)) | (h >> np.uint64(19))) & M32
+        h = (h * N5 + NN) & M32
+        return h
+
+    def fmix(h):
+        h = (h ^ (h >> np.uint64(16))) & M32
+        h = (h * np.uint64(0x85EBCA6B)) & M32
+        h = (h ^ (h >> np.uint64(13))) & M32
+        h = (h * np.uint64(0xC2B2AE35)) & M32
+        h = (h ^ (h >> np.uint64(16))) & M32
+        return h
+
+    h = mix(np.zeros_like(seed_np), seed_np & M32)
+    h = mix(h, (seed_np >> np.uint64(32)) & M32)
+    h = mix(h, positions_np)
+    h = mix(h, col_indices_np)
+    h = h ^ np.uint64(16)
+    res_np = fmix(h).astype(np.uint32).reshape(-1)
+    return torch.from_numpy(res_np)
+
+
+@pytest.mark.parametrize("n", [1, 2, 33])
+@pytest.mark.parametrize("m", [1, 2, 100, 1023, 1024, 1025])
+@pytest.mark.parametrize("pos_dtype, col_dtype", INDEX_DTYPE_COMBOS)
+def test_murmur_hash_jit_matches_reference(n, m, pos_dtype, col_dtype):
+    seed, positions = _seed_positions(n, pos_dtype, "cuda")
+    col_indices = torch.arange(m, device="cuda", dtype=torch.int64).to(col_dtype)
+    out = _murmur_hash32_jit(seed, positions, col_indices)
+    expected = _murmur_hash32_reference(seed, positions, col_indices)
+    assert torch.equal(out.reshape(-1), expected.to("cuda"))
+
+
+@pytest.mark.parametrize("n", [1, 2, 33])
+@pytest.mark.parametrize("m", [1, 2, 100, 1023, 1024, 1025, 4096])
+@pytest.mark.parametrize("pos_dtype, col_dtype", INDEX_DTYPE_COMBOS)
+def test_murmur_hash_jit_matches_triton(n, m, pos_dtype, col_dtype):
+    seed, positions = _seed_positions(n, pos_dtype, "cuda")
+    col_indices = torch.arange(m, device="cuda", dtype=torch.int64).to(col_dtype)
+    jit_out = _murmur_hash32_jit(seed, positions, col_indices)
+    triton_out = _murmur_hash32_triton(seed, positions, col_indices)
+    assert torch.equal(jit_out, triton_out)
+
+
+def test_murmur_hash_large_grid():
+    # m spans multiple 256-thread blocks; n larger than one grid.y row.
+    n, m = 500, 10000
+    seed, positions = _seed_positions(n, torch.int64, "cuda")
+    col_indices = torch.arange(m, device="cuda", dtype=torch.int64)
+    out = _murmur_hash32_jit(seed, positions, col_indices)
+    assert out.shape == (n, m)
+    assert torch.equal(
+        out.reshape(-1),
+        _murmur_hash32_reference(seed, positions, col_indices).to("cuda"),
+    )
+
+
+def test_murmur_hash_empty_batch():
+    seed = torch.empty(0, dtype=torch.uint64, device="cuda")
+    positions = torch.empty(0, dtype=torch.int64, device="cuda")
+    col_indices = torch.arange(16, device="cuda", dtype=torch.int64)
+    out = _murmur_hash32_jit(seed, positions, col_indices)
+    assert out.shape == (0, 16)
+
+
+def test_murmur_hash_entry_point_matches_jit():
+    n, m = 4, 1024
+    seed, positions = _seed_positions(n, torch.int64, "cuda")
+    col_indices = torch.arange(m, device="cuda", dtype=torch.int64)
+    assert torch.equal(
+        murmur_hash32(seed, positions, col_indices),
+        _murmur_hash32_jit(seed, positions, col_indices),
+    )
+
+
+def test_murmur_hash_production_shapes():
+    # Sampler: batch x vocab. Eagle: batch x (draft_token_num + 1).
+    seed = torch.randint(0, torch.iinfo(torch.int64).max, (8,), dtype=torch.uint64, device="cuda")
+    positions = torch.arange(8, dtype=torch.int64, device="cuda")
+    col_indices = torch.arange(32768, device="cuda", dtype=torch.int64)
+    out = murmur_hash32(seed, positions, col_indices)
+    assert out.shape == (8, 32768)
+    assert torch.equal(
+        out.reshape(-1),
+        _murmur_hash32_reference(seed, positions, col_indices).to("cuda"),
+    )
+
+    cols = torch.arange(5, device="cuda", dtype=torch.int64)
+    eagle = murmur_hash32(seed, positions.to(torch.uint64), cols)
+    assert eagle.shape == (8, 5)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/kernels/ops/sampling/test_murmur_hash.py
+++ b/test/registered/kernels/ops/sampling/test_murmur_hash.py
@@ -38,8 +38,12 @@ def _murmur_hash32_reference(seed, positions, col_indices):
     """Bit-exact PyTorch CPU reference implementation for a CPU oracle."""
 
     seed_np = seed.cpu().numpy().astype(np.uint64).reshape(-1, 1)
-    positions_np = positions.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(-1, 1)
-    col_indices_np = col_indices.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(1, -1)
+    positions_np = (
+        positions.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(-1, 1)
+    )
+    col_indices_np = (
+        col_indices.cpu().numpy().astype(np.uint32).astype(np.uint64).reshape(1, -1)
+    )
 
     M32 = np.uint64(0xFFFFFFFF)
     C1 = np.uint64(0xCC9E2D51)
@@ -128,7 +132,9 @@ def test_murmur_hash_entry_point_matches_jit():
 
 def test_murmur_hash_production_shapes():
     # Sampler: batch x vocab. Eagle: batch x (draft_token_num + 1).
-    seed = torch.randint(0, torch.iinfo(torch.int64).max, (8,), dtype=torch.uint64, device="cuda")
+    seed = torch.randint(
+        0, torch.iinfo(torch.int64).max, (8,), dtype=torch.uint64, device="cuda"
+    )
     positions = torch.arange(8, dtype=torch.int64, device="cuda")
     col_indices = torch.arange(32768, device="cuda", dtype=torch.int64)
     out = murmur_hash32(seed, positions, col_indices)


### PR DESCRIPTION
## Motivation

`sampling.murmur_hash32` (the deterministic sampling-coin hash migrated from
`srt/layers/utils/hash.py` in RFC #29630) currently only has a Triton
implementation. This ports it to a CUDA JIT kernel so the CUDA path no longer
pays Triton launch/compile overhead, while keeping the Triton kernel as the
ROCm fallback.

## Modifications

- **`python/sglang/kernels/jit/csrc/sampling/murmur_hash.cuh`** (new): CUDA JIT
  kernel `murmur_hash32_kernel` + host launcher `MurmurHashKernel<TPos, TCol>::launch`.
  Templated on the `positions` / `col_indices` element type so every 32-/64-bit
  integer dtype truncates to `uint32` exactly like the Triton reference's
  `.to(tl.uint32)`. Same four-block MurmurHash3 x86_32 blend + finalization
  (len 16) as the Triton kernel, so the two are bit-identical.
- **`python/sglang/kernels/ops/sampling/murmur_hash.py`**: split into
  `_murmur_hash32_jit` (CUDA, JIT-compiled and cached per dtype pair) and
  `_murmur_hash32_triton` (unchanged reference). `murmur_hash32(...)` now
  dispatches: JIT on CUDA, Triton on ROCm (`torch.version.hip`). Both paths
  short-circuit empty `n`/`m`.
- **`python/sglang/kernels/ops/sampling/__init__.py`**: register a
  `KernelBackend.JIT` `KernelSpec` for `sampling.murmur_hash32` ahead of the
  existing Triton spec.
- **`test/registered/kernels/ops/sampling/test_murmur_hash.py`** (new): a
  bit-exact NumPy CPU oracle; JIT-vs-oracle and JIT-vs-Triton parametrized over
  index-dtype combos (int32/int64/uint32/uint64) and sizes spanning block
  boundaries; large-grid, empty-batch, entry-point, and production-shape
  (sampler `batch x vocab`, eagle `batch x (draft_token_num + 1)`) cases.
  `register_cuda_ci(stage="base-b-kernel-unit")`.
- **`test/registered/kernels/benchmark/sampling/bench_murmur_hash.py`** (new):
  JIT vs Triton across typical sampling batch sizes and vocab sizes.
  `register_cuda_ci(stage="base-b-kernel-benchmark")`.

## Accuracy Tests

`test/registered/kernels/ops/sampling/test_murmur_hash.py` checks the JIT
kernel is bit-identical (`torch.equal` on `uint32`) to both the independent
NumPy oracle and the existing Triton kernel, across the dtype combos and sizes
above. Requires a CUDA GPU (`register_cuda_ci`, `1-gpu-large`); please trigger
CI to run it.

## Speed Tests and Profiling

`bench_murmur_hash.py` reports bandwidth for JIT vs Triton over
`n in {1,4,16,64,256}` x `m in {2**14, 2**16, 2**17}`. Runs on the
`base-b-kernel-benchmark` CI stage; local GPU numbers to be added.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33834025461](https://github.com/sgl-project/sglang/actions/runs/33834025461)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33834025313](https://github.com/sgl-project/sglang/actions/runs/33834025313)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33834025396](https://github.com/sgl-project/sglang/actions/runs/33834025396)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->