### PR TITLE
[Bugfix] Neutralize literal GLM-V media placeholders

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -197,10 +197,13 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
 KIMI_K3_IMAGE_PLACEHOLDER = "<|kimi_image_placeholder|>"
 KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED = "<| kimi_image_placeholder |>"
 
+# Keep in sync with Glm4vImageProcessor.models (multimodal/processors/glm4v.py):
+# a model family added there but not here silently disables neutralization.
 GLM_V_ARCHITECTURES = frozenset(
     {
         "Glm4vForConditionalGeneration",
         "Glm4vMoeForConditionalGeneration",
+        "Glm5NextForConditionalGeneration",
         "GlmOcrForConditionalGeneration",
     }
 )

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -197,6 +197,18 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
 KIMI_K3_IMAGE_PLACEHOLDER = "<|kimi_image_placeholder|>"
 KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED = "<| kimi_image_placeholder |>"
 
+GLM_V_ARCHITECTURES = frozenset(
+    {
+        "Glm4vForConditionalGeneration",
+        "Glm4vMoeForConditionalGeneration",
+        "GlmOcrForConditionalGeneration",
+    }
+)
+GLM_V_PLACEHOLDER_REPLACEMENTS = {
+    "<|image|>": "<| image |>",
+    "<|video|>": "<| video |>",
+}
+
 
 def neutralize_kimi_k3_image_placeholder(text: str) -> str:
     return text.replace(KIMI_K3_IMAGE_PLACEHOLDER, KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED)
@@ -211,6 +223,24 @@ def neutralize_kimi_k3_image_placeholder_value(value: Any) -> Any:
         return {
             key: neutralize_kimi_k3_image_placeholder_value(item)
             for key, item in value.items()
+        }
+    return value
+
+
+def neutralize_glm_v_placeholders(text: str) -> str:
+    for placeholder, escaped_placeholder in GLM_V_PLACEHOLDER_REPLACEMENTS.items():
+        text = text.replace(placeholder, escaped_placeholder)
+    return text
+
+
+def neutralize_glm_v_placeholder_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return neutralize_glm_v_placeholders(value)
+    if isinstance(value, list):
+        return [neutralize_glm_v_placeholder_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: neutralize_glm_v_placeholder_value(item) for key, item in value.items()
         }
     return value
 
@@ -306,6 +336,10 @@ class OpenAIServingChat(OpenAIServingBase):
             and self.tokenizer_manager.model_config.hf_config.model_type
             in ("gemma4", "gemma4_unified")
         )
+        architectures = getattr(
+            self.tokenizer_manager.model_config.hf_config, "architectures", []
+        )
+        self.is_glm_v = bool(GLM_V_ARCHITECTURES.intersection(architectures or []))
 
         # Which Python-based chat encoder (if any) bypasses apply_chat_template.
         # Values: "dsv32", "dsv4", or custom values set by subclass. None for default.
@@ -500,6 +534,45 @@ class OpenAIServingChat(OpenAIServingBase):
                 messages, request
             )
         return messages, image_count, assistant_prefix
+
+    @staticmethod
+    def _prepare_glm_v_messages(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Keep literal GLM-V media placeholders in message text non-structural.
+
+        Real image/video parts remain structured until the model's chat template
+        renders their wrapped placeholders.
+        """
+        for message in messages:
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = neutralize_glm_v_placeholders(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") in ("text", "input_text") and isinstance(
+                        part.get("text"), str
+                    ):
+                        part["text"] = neutralize_glm_v_placeholders(part["text"])
+
+            if message.get("role") == "assistant":
+                for key in ("reasoning_content", "reasoning"):
+                    if key in message:
+                        message[key] = neutralize_glm_v_placeholder_value(message[key])
+                for tool_call in message.get("tool_calls") or []:
+                    function = (
+                        tool_call.get("function")
+                        if isinstance(tool_call, dict)
+                        else None
+                    )
+                    if isinstance(function, dict) and "arguments" in function:
+                        function["arguments"] = neutralize_glm_v_placeholder_value(
+                            function["arguments"]
+                        )
+
+        return messages
 
     def _encode_messages(
         self,
@@ -1425,7 +1498,13 @@ class OpenAIServingChat(OpenAIServingBase):
         else:
             if self.template_manager.jinja_template_may_reorder_tool_results:
                 messages = self._canonicalize_tool_message_order(messages)
-            for msg_dict in copy.deepcopy(messages):
+            messages_for_template = copy.deepcopy(messages)
+            if self.is_glm_v:
+                messages_for_template = self._prepare_glm_v_messages(
+                    messages_for_template
+                )
+
+            for msg_dict in messages_for_template:
                 if msg_dict.get("content") is None:
                     msg_dict["content"] = ""
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -339,9 +339,7 @@ class OpenAIServingChat(OpenAIServingBase):
             and self.tokenizer_manager.model_config.hf_config.model_type
             in ("gemma4", "gemma4_unified")
         )
-        architectures = getattr(
-            self.tokenizer_manager.model_config.hf_config, "architectures", []
-        )
+        architectures = self.tokenizer_manager.model_config.hf_config.architectures
         self.is_glm_v = bool(GLM_V_ARCHITECTURES.intersection(architectures or []))
 
         # Which Python-based chat encoder (if any) bypasses apply_chat_template.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -6,7 +6,7 @@ or
     python -m unittest discover -s tests -p "test_*unit.py" -v
 """
 
-from sglang.test.test_utils import maybe_stub_sgl_kernel
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
 
@@ -190,7 +190,7 @@ class _MockTemplateManager:
         self.jinja_template_may_reorder_tool_results = False
 
 
-class ServingChatTestCase(unittest.TestCase):
+class ServingChatTestCase(CustomTestCase):
     # ------------- common fixtures -------------
     def setUp(self):
         self.tm = _MockTokenizerManager()
@@ -376,6 +376,130 @@ class ServingChatTestCase(unittest.TestCase):
             [item.url for item in result.image_data], ["image-b", "image-a"]
         )
         self.assertEqual(self.tm.tokenizer.apply_chat_template.call_count, 1)
+
+    def test_prepare_messages_neutralizes_text_but_preserves_media_parts(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "literal <|image|> and <|video|>",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/video.mp4"},
+                    },
+                ],
+            }
+        ]
+
+        prepared = OpenAIServingChat._prepare_glm_v_messages(messages)
+
+        self.assertEqual(
+            prepared[0]["content"][0]["text"],
+            "literal <| image |> and <| video |>",
+        )
+        self.assertEqual(
+            prepared[0]["content"][1],
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        )
+        self.assertEqual(
+            prepared[0]["content"][2],
+            {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/video.mp4"},
+            },
+        )
+
+    def test_prepare_messages_covers_assistant_metadata(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer <|image|>",
+                "reasoning_content": {"text": "reason about <|video|>"},
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "inspect",
+                            "arguments": '{"token":"<|image|>"}',
+                        }
+                    }
+                ],
+            }
+        ]
+
+        prepared = OpenAIServingChat._prepare_glm_v_messages(messages)
+
+        self.assertEqual(prepared[0]["content"], "answer <| image |>")
+        self.assertEqual(
+            prepared[0]["reasoning_content"], {"text": "reason about <| video |>"}
+        )
+        self.assertEqual(
+            prepared[0]["tool_calls"][0]["function"]["arguments"],
+            '{"token":"<| image |>"}',
+        )
+
+    def test_architecture_gate_only_enables_glm_v_family(self):
+        for architecture, expected in (
+            ("Glm4vForConditionalGeneration", True),
+            ("Glm4vMoeForConditionalGeneration", True),
+            ("GlmOcrForConditionalGeneration", True),
+            ("LlamaForCausalLM", False),
+        ):
+            with self.subTest(architecture=architecture):
+                tm = _MockTokenizerManager()
+                tm.model_config.hf_config.architectures = [architecture]
+                serving = OpenAIServingChat(tm, _MockTemplateManager())
+                self.assertEqual(serving.is_glm_v, expected)
+
+    def test_glm_v_jinja_path_neutralizes_only_literal_placeholders(self):
+        self.chat.is_glm_v = True
+        self.template_manager.jinja_template_content_format = "openai"
+        self.tm.tokenizer.apply_chat_template.return_value = "rendered prompt"
+        request = ChatCompletionRequest(
+            model="glm-v",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "explain <|image|>"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.png"},
+                        },
+                    ],
+                }
+            ],
+        )
+
+        result = self.chat._apply_jinja_template(
+            request, tools=None, is_multimodal=True
+        )
+
+        rendered_messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
+        self.assertEqual(
+            rendered_messages[0]["content"],
+            [
+                {"type": "text", "text": "explain <| image |>"},
+                {"type": "image"},
+            ],
+        )
+        self.assertEqual(
+            [image.url for image in result.image_data],
+            ["https://example.com/image.png"],
+        )
+        self.assertEqual(
+            request.messages[0].content[0].text,
+            "explain <|image|>",
+        )
 
     def test_parsers_follow_the_control_plane_overlay(self):
         """Template detection records the parsers through `override`, so they

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -452,6 +452,7 @@ class ServingChatTestCase(CustomTestCase):
             ("Glm4vForConditionalGeneration", True),
             ("Glm4vMoeForConditionalGeneration", True),
             ("GlmOcrForConditionalGeneration", True),
+            ("Glm5NextForConditionalGeneration", True),
             ("LlamaForCausalLM", False),
         ):
             with self.subTest(architecture=architecture):


### PR DESCRIPTION
## Motivation

Literal `<|image|>` and `<|video|>` strings in GLM-V chat messages can be incorrectly treated as multimodal placeholders.

Fixes #37579.

## Changes

- Follow the Kimi K3 approach and neutralize literal media placeholders before rendering the chat template.
- Keep structured image and video parts unchanged.
- Add unit tests for related message fields.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34076920870](https://github.com/sgl-project/sglang/actions/runs/34076920870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34076920632](https://github.com/sgl-project/sglang/actions/runs/34076920632)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34076920847](https://github.com/sgl-project/sglang/actions/runs/34076920847)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->