### PR TITLE
[Kernel] Make KDA backend dispatch hardware- and shape-aware

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
@@ -623,15 +623,13 @@ def fused_recurrent_kda_packed_decode(
             f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
         )
 
-    # Batched-decode CUDA fast path:
-    # row-streaming state update reaches the in-place R+W bandwidth of the
-    # part (~9.6 TB/s) where this triton kernel tops out at ~5 TB/s holding a
-    # [BV, K] register tile per warp. ULP-level output differences only
-    # (reduction order); small batches keep triton (launch-bound anyway).
+    # Batched-decode CUDA fast path.  Support and performance selection are
+    # separate: only architectures with a validated row-streaming win opt in;
+    # all other supported inputs stay on the mature Triton V-tiled kernel.
     if use_qk_l2norm_in_kernel:
         from sglang.kernels.ops.attention import kda_packed_decode as kda_decode_cuda
 
-        if kda_decode_cuda.covered(
+        if kda_decode_cuda.supported(
             mixed_qkv,
             a,
             b,
@@ -641,7 +639,7 @@ def fused_recurrent_kda_packed_decode(
             out,
             ssm_state_indices,
             H,
-        ):
+        ) and kda_decode_cuda.prefer_native(mixed_qkv):
             kda_decode_cuda.kda_packed_decode(
                 mixed_qkv,
                 a,

--- a/python/sglang/kernels/ops/attention/kda_packed_decode.py
+++ b/python/sglang/kernels/ops/attention/kda_packed_decode.py
@@ -1,11 +1,10 @@
 """CUDA KDA packed-decode kernel (batched decode fast path).
 
-Row-streaming port of the triton fused_recurrent_kda_packed_decode_kernel:
-the triton kernel keeps a [BV, K] fp32 state tile in one warp's registers and
-tops out at ~5 TB/s; this kernel streams the state one 512B row at a time and
-reaches the in-place read+write bandwidth of the part (~9.6 TB/s probe).
-Outputs match the triton kernel to ULPs (warp-shuffle reduction order), not
-bits. Unsupported inputs fall back to triton through a covered() check.
+Row-streaming port of the Triton fused-recurrent KDA decode kernel.  Semantic
+support and the measured device performance preference are intentionally kept
+separate: unsupported inputs and unvalidated devices use the Triton path.
+Outputs match the Triton kernel to ULPs (warp-shuffle reduction order), not
+bits.
 """
 
 from __future__ import annotations
@@ -25,9 +24,11 @@ if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 _WARPS: int = 8
-# The row-streaming layout needs enough (batch x head) CTAs to fill the GPU;
-# below this the triton kernel's launch cost is already the floor.
+# The row-streaming kernel arrived with the SM10x Kimi-K3 kernel port.  Keep
+# that performance domain explicit: on SM90 the Triton V-tiled implementation
+# is faster (and has a better tail) across the measured decode buckets.
 _MIN_BATCH: int = 8
+_PREFERRED_CC_MAJORS = frozenset({10})
 
 
 @cache_once
@@ -42,7 +43,7 @@ def _jit_kda_packed_decode_module() -> Module:
     )
 
 
-def covered(
+def supported(
     mixed_qkv: torch.Tensor,
     a: torch.Tensor,
     b: torch.Tensor,
@@ -53,12 +54,11 @@ def covered(
     ssm_state_indices: torch.Tensor,
     num_q_heads: int,
 ) -> bool:
-    B = mixed_qkv.shape[0]
     HV, V, K = initial_state.shape[-3:]
     return (
-        B >= _MIN_BATCH
-        and K == 128
+        K == 128
         and V == 128
+        and num_q_heads > 0
         and HV % max(num_q_heads, 1) == 0
         # Per-K gate layout. A per-head scalar gate ([B, HV] / [HV], the GDN
         # shape) is a different kernel, not a slower input for this one.
@@ -84,6 +84,51 @@ def covered(
     )
 
 
+def _prefer_native_for_capability(
+    batch_size: int, compute_capability: tuple[int, int]
+) -> bool:
+    """Return the measured performance policy independently of support.
+
+    Unknown architectures deliberately keep the robust Triton path.  New
+    native fast-path entries should only be added after a same-device,
+    same-boundary benchmark shows a win across the intended batch buckets.
+    """
+    return batch_size >= _MIN_BATCH and compute_capability[0] in _PREFERRED_CC_MAJORS
+
+
+def prefer_native(mixed_qkv: torch.Tensor) -> bool:
+    if mixed_qkv.device.type != "cuda":
+        return False
+    return _prefer_native_for_capability(
+        mixed_qkv.shape[0], torch.cuda.get_device_capability(mixed_qkv.device)
+    )
+
+
+def covered(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_q_heads: int,
+) -> bool:
+    """Compatibility wrapper for callers that need support and preference."""
+    return supported(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        initial_state,
+        out,
+        ssm_state_indices,
+        num_q_heads,
+    ) and prefer_native(mixed_qkv)
+
+
 def kda_packed_decode(
     mixed_qkv: torch.Tensor,
     a: torch.Tensor,
@@ -99,8 +144,8 @@ def kda_packed_decode(
 ) -> None:
     """In-place KDA decode step: updates `initial_state` rows selected by
     `ssm_state_indices` and writes attention output into `out` ([B, 1, HV, V]).
-    Caller must have checked covered(); q/k l2-norm is always applied
-    (matches the production dispatch)."""
+    Caller must have checked ``supported()`` and ``prefer_native()``; q/k
+    l2-norm is always applied (matches the production dispatch)."""
     B = mixed_qkv.shape[0]
     HV, V, _ = initial_state.shape[-3:]
     state = initial_state.view(-1, *initial_state.shape[-3:])

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -331,7 +331,7 @@ class KDAKernelDispatcher:
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         kernel = self.extend_kernel
         if kwargs.get("lower_bound") is not None and not getattr(
             kernel, "supports_safe_gate", True

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
@@ -9,9 +9,133 @@ from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
 # FlashKDA chunk size. Sequences shorter than this fall back to Triton.
 _FLASHKDA_CHUNK_SIZE = 64
 
-# FlashKDA's max sequence length, Batches whose longest sequence exceeds this
-# fall back to Triton for the whole batch.
+# Legacy/default policy ceiling.  Validated device/shape profiles below may
+# use a different crossover; this is not a hard limit of the FlashKDA kernel.
 _FLASHKDA_MAX_SEQ_LEN = 2048
+
+# H200 serving measurements show that FlashKDA's head-parallel K2 is a win for
+# wide local-head shards, while Triton's time-parallel kernel is substantially
+# faster at Q=2048 for narrow TP shards.  The wider shard also keeps enough K2
+# CTAs resident to extend the useful FlashKDA window through the largest GLM
+# chunk-prefill bucket we validate.
+#
+# Do not use the reported device name for this profile: some environments
+# report H200 hardware under a different name.  The tight memory window, exact
+# Hopper capability, and SM count distinguish the measured ~140 GiB H200 from
+# H100 variants while avoiding extrapolation to other devices.
+_GIB = 1 << 30
+_FLASHKDA_H200_COMPUTE_CAPABILITY = (9, 0)
+_FLASHKDA_H200_SM_COUNT = 132
+_FLASHKDA_H200_MIN_TOTAL_MEMORY = 135 * _GIB
+_FLASHKDA_H200_MAX_TOTAL_MEMORY = 145 * _GIB
+_FLASHKDA_H200_LONG_HEADS = 64
+_FLASHKDA_H200_TRITON_HEADS = frozenset({8, 12, 16, 32})
+_FLASHKDA_H200_LONG_MAX_SEQ_LEN = 8192
+
+
+def _is_h200_profile(
+    *,
+    compute_capability: tuple[int, int],
+    multi_processor_count: int,
+    total_memory: int,
+) -> bool:
+    return (
+        compute_capability == _FLASHKDA_H200_COMPUTE_CAPABILITY
+        and multi_processor_count == _FLASHKDA_H200_SM_COUNT
+        and _FLASHKDA_H200_MIN_TOTAL_MEMORY
+        <= total_memory
+        <= _FLASHKDA_H200_MAX_TOTAL_MEMORY
+    )
+
+
+def _prefer_flashkda_for_shape(
+    *,
+    compute_capability: tuple[int, int],
+    multi_processor_count: int,
+    total_memory: int,
+    state_dtype: torch.dtype,
+    num_heads: int,
+    num_sequences: int,
+    min_seq_len: int,
+    max_seq_len: int,
+) -> bool:
+    """Pure performance policy; semantic eligibility is checked separately."""
+    if min_seq_len < _FLASHKDA_CHUNK_SIZE:
+        return False
+    if (
+        _is_h200_profile(
+            compute_capability=compute_capability,
+            multi_processor_count=multi_processor_count,
+            total_memory=total_memory,
+        )
+        and num_sequences == 1
+        and state_dtype == torch.float32
+    ):
+        if num_heads == _FLASHKDA_H200_LONG_HEADS:
+            return max_seq_len <= _FLASHKDA_H200_LONG_MAX_SEQ_LEN
+        if num_heads in _FLASHKDA_H200_TRITON_HEADS:
+            # Preserve existing behavior below the measured Q=2048 bucket,
+            # but do not select the under-filled K2 at or above that crossover.
+            return max_seq_len < _FLASHKDA_MAX_SEQ_LEN
+        # Do not extrapolate the profile to unmeasured head counts.
+        return max_seq_len <= _FLASHKDA_MAX_SEQ_LEN
+    return max_seq_len <= _FLASHKDA_MAX_SEQ_LEN
+
+
+def _flashkda_supported(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    ssm_states: torch.Tensor,
+    cache_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    A_log: Optional[torch.Tensor],
+    dt_bias: Optional[torch.Tensor],
+) -> bool:
+    """Check the external kernel's static tensor contract."""
+    if A_log is None or dt_bias is None:
+        return False
+    if not (q.ndim == k.ndim == v.ndim == g.ndim == 4 and beta.ndim == 3):
+        return False
+    batch, tokens, heads, key_dim = q.shape
+    tensors = (
+        k,
+        v,
+        g,
+        beta,
+        ssm_states,
+        cache_indices,
+        query_start_loc,
+        A_log,
+        dt_bias,
+    )
+    return (
+        batch == 1
+        and key_dim == 128
+        and k.shape == q.shape
+        and v.shape == (batch, tokens, heads, 128)
+        and g.shape == q.shape
+        and beta.shape == (batch, tokens, heads)
+        and q.dtype == torch.bfloat16
+        and k.dtype == torch.bfloat16
+        and v.dtype == torch.bfloat16
+        and g.dtype == torch.bfloat16
+        and beta.dtype in (torch.bfloat16, torch.float32)
+        and ssm_states.ndim == 4
+        and ssm_states.shape[1:] == (heads, 128, 128)
+        and ssm_states.dtype in (torch.bfloat16, torch.float32)
+        and cache_indices.ndim == 1
+        and cache_indices.dtype in (torch.int32, torch.int64)
+        and cache_indices.numel() > 0
+        and cache_indices.numel() == query_start_loc.numel() - 1
+        and query_start_loc.ndim == 1
+        and query_start_loc.dtype in (torch.int32, torch.int64)
+        and A_log.numel() == heads
+        and dt_bias.numel() == heads * key_dim
+        and all(tensor.device == q.device for tensor in tensors)
+    )
 
 
 def _load_flash_kda():
@@ -79,7 +203,8 @@ class FlashKDAKernel(LinearAttnKernelBase):
     kernel, so we pass RAW tensors plus ``A_log``/``dt_bias``/``lower_bound``.
     It is prefill-only, bf16, K == V == 128, HV == H (no GVA), and requires the
     safe (bounded) gate (``lower_bound`` set). The non-safe path and sequences
-    outside [chunk_size, max_seq_len] fall back to Triton ``chunk_kda``.
+    outside the selected device/shape performance window fall back to Triton
+    ``chunk_kda``.
     Requires an SM90+ GPU with the ``flash_kda`` package.
     """
 
@@ -119,13 +244,46 @@ class FlashKDAKernel(LinearAttnKernelBase):
         beta_is_raw: bool = False,
         return_intermediate_states: bool = False,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
+        if q.device.type == "cuda":
+            device_properties = torch.cuda.get_device_properties(q.device)
+            device_profile = (
+                (device_properties.major, device_properties.minor),
+                device_properties.multi_processor_count,
+                device_properties.total_memory,
+            )
+        else:
+            # CPU wrapper tests replace the external CUDA kernel with a stub.
+            device_profile = ((-1, -1), 0, 0)
         # The fused kernel cannot expose per-chunk states (h), which the mamba
         # radix extra_buffer track path needs; route tracked batches through
         # the Triton chunk_kda fallback instead of silently skipping the
         # snapshot (that would corrupt prefix-cache restores).
-        if return_intermediate_states or self._should_fall_back(
-            lower_bound, is_spec_decode, query_start_loc, extend_seq_lens_cpu
+        if (
+            return_intermediate_states
+            or not _flashkda_supported(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                ssm_states,
+                cache_indices,
+                query_start_loc,
+                A_log,
+                dt_bias,
+            )
+            or self._should_fall_back(
+                lower_bound,
+                is_spec_decode,
+                query_start_loc,
+                extend_seq_lens_cpu,
+                num_heads=q.shape[2],
+                state_dtype=ssm_states.dtype,
+                compute_capability=device_profile[0],
+                multi_processor_count=device_profile[1],
+                total_memory=device_profile[2],
+            )
         ):
             return _triton_fallback(
                 q,
@@ -143,22 +301,19 @@ class FlashKDAKernel(LinearAttnKernelBase):
                 return_intermediate_states=return_intermediate_states,
             )
 
-        return (
-            self._flashkda_extend(
-                q,
-                k,
-                v,
-                g,
-                beta,
-                ssm_states=ssm_states,
-                cache_indices=cache_indices,
-                query_start_loc=query_start_loc,
-                A_log=A_log,
-                dt_bias=dt_bias,
-                lower_bound=lower_bound,
-                beta_is_raw=beta_is_raw,
-            ),
-            None,
+        return self._flashkda_extend(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            beta_is_raw=beta_is_raw,
         )
 
     @staticmethod
@@ -167,6 +322,12 @@ class FlashKDAKernel(LinearAttnKernelBase):
         is_spec_decode: bool,
         query_start_loc: torch.Tensor,
         extend_seq_lens_cpu: Optional[list],
+        *,
+        num_heads: int,
+        state_dtype: torch.dtype,
+        compute_capability: tuple[int, int],
+        multi_processor_count: int,
+        total_memory: int,
     ) -> bool:
         """Whether to use the Triton chunk_kda path instead of the fused kernel."""
         # Safe-gate only: the fused kernel does not support the unbounded gate
@@ -191,11 +352,22 @@ class FlashKDAKernel(LinearAttnKernelBase):
             else:
                 lo = min(extend_seq_lens_cpu)
                 hi = max(extend_seq_lens_cpu)
+            num_sequences = len(extend_seq_lens_cpu)
         else:
             seq_lens = query_start_loc[1:] - query_start_loc[:-1]
             lo_t, hi_t = torch.aminmax(seq_lens)
             lo, hi = int(lo_t), int(hi_t)
-        return lo < _FLASHKDA_CHUNK_SIZE or hi > _FLASHKDA_MAX_SEQ_LEN
+            num_sequences = query_start_loc.numel() - 1
+        return not _prefer_flashkda_for_shape(
+            compute_capability=compute_capability,
+            multi_processor_count=multi_processor_count,
+            total_memory=total_memory,
+            state_dtype=state_dtype,
+            num_heads=num_heads,
+            num_sequences=num_sequences,
+            min_seq_len=lo,
+            max_seq_len=hi,
+        )
 
     def _flashkda_extend(
         self,

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -232,7 +232,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
         beta_is_raw: bool = False,
         return_intermediate_states: bool = False,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         return chunk_kda(
             q=q,
             k=k,

--- a/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
@@ -43,7 +43,7 @@ class LinearAttnKernelBase(ABC):
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         **kwargs,
-    ) -> tuple: ...
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]: ...
 
     def target_verify(
         self,

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -401,8 +401,11 @@ class TestKDAPackedDecode(unittest.TestCase):
         b = (torch.randn(B, HV, dtype=dtype, device=device) * 0.5).contiguous()
         A_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.2
         dt_bias = torch.randn(HV * K, dtype=torch.float32, device=device) * 0.1
+        # Production KDA stores the recurrent matrix in FP32.  Keeping this
+        # realistic also ensures SM10 CI actually exercises the native packed
+        # path instead of silently falling back to Triton on dtype support.
         ssm_states = (
-            torch.randn(pool_size, HV, V, K, dtype=dtype, device=device) * 0.01
+            torch.randn(pool_size, HV, V, K, dtype=torch.float32, device=device) * 0.01
         ).contiguous()
         cache_indices = torch.arange(B, device=device, dtype=torch.int32)
         return mixed_qkv, a, b, A_log, dt_bias, ssm_states, cache_indices

--- a/test/registered/attention/test_kda_prefill_flashkda.py
+++ b/test/registered/attention/test_kda_prefill_flashkda.py
@@ -80,7 +80,7 @@ def _chunk_kda_ref(d, lower_bound):
     """Triton chunk_kda reference. chunk_kda mutates g/v and the state in place,
     so feed clones; returns (output, updated_state_slots)."""
     st = d["pool"].clone()
-    out, _ = chunk_kda(
+    out = chunk_kda(
         q=d["q"].clone(),
         k=d["k"].clone(),
         v=d["v"].clone(),
@@ -105,7 +105,7 @@ def test_flashkda_matches_triton_safe_gate(seq_lens):
     ref_out, ref_state = _chunk_kda_ref(d, LOWER_BOUND)
 
     st_fk = d["pool"].clone()
-    out, h = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),
@@ -121,7 +121,6 @@ def test_flashkda_matches_triton_safe_gate(seq_lens):
     )
     torch.cuda.synchronize()
 
-    assert h is None
     assert torch.isfinite(out).all(), "FlashKDA output has non-finite values"
     assert torch.isfinite(st_fk).all(), "FlashKDA final state has non-finite values"
     # bf16 cross-implementation noise (chunk=16 CUTLASS vs chunk=64 Triton);
@@ -141,7 +140,7 @@ def test_flashkda_falls_back_without_lower_bound():
     ref_out, _ = _chunk_kda_ref(d, None)
 
     st_fk = d["pool"].clone()
-    out, _ = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),
@@ -171,7 +170,7 @@ def test_flashkda_spec_verify_falls_back():
     ref_out, _ = _chunk_kda_ref(d, LOWER_BOUND)
 
     st_fk = d["pool"].clone()
-    out, _ = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),

--- a/test/registered/unit/layers/attention/test_kda_flashkda_dispatch.py
+++ b/test/registered/unit/layers/attention/test_kda_flashkda_dispatch.py
@@ -1,0 +1,174 @@
+"""CPU-checkable shape policy tests for the FlashKDA prefill backend."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.kda_flashkda import (
+    _FLASHKDA_H200_MAX_TOTAL_MEMORY,
+    _FLASHKDA_H200_MIN_TOTAL_MEMORY,
+    _flashkda_supported,
+    _is_h200_profile,
+    _prefer_flashkda_for_shape,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _prefer(
+    heads: int,
+    seq_len: int,
+    *,
+    capability: tuple[int, int] = (9, 0),
+    sm_count: int = 132,
+    total_memory: int = 140 * (1 << 30),
+    sequences: int = 1,
+    min_seq_len: int | None = None,
+    state_dtype: torch.dtype = torch.float32,
+) -> bool:
+    return _prefer_flashkda_for_shape(
+        compute_capability=capability,
+        multi_processor_count=sm_count,
+        total_memory=total_memory,
+        state_dtype=state_dtype,
+        num_heads=heads,
+        num_sequences=sequences,
+        min_seq_len=seq_len if min_seq_len is None else min_seq_len,
+        max_seq_len=seq_len,
+    )
+
+
+class TestFlashKdaDispatch(CustomTestCase):
+    def test_h200_narrow_shards_fall_back_at_q2048(self):
+        for heads in (8, 12, 16, 32):
+            with self.subTest(heads=heads):
+                self.assertFalse(_prefer(heads, 2048))
+
+    def test_h200_wide_shard_extends_the_long_window(self):
+        for seq_len in (2048, 4096, 8192):
+            with self.subTest(seq_len=seq_len):
+                self.assertTrue(_prefer(64, seq_len))
+        self.assertFalse(_prefer(64, 8193))
+
+    def test_short_request_forces_whole_batch_fallback(self):
+        self.assertFalse(_prefer(64, 8192, min_seq_len=32))
+
+    def test_unmeasured_multi_request_shapes_keep_existing_policy(self):
+        self.assertTrue(_prefer(8, 2048, sequences=2))
+        self.assertFalse(_prefer(64, 4096, sequences=2))
+
+    def test_unmeasured_state_dtype_keeps_existing_policy(self):
+        self.assertTrue(_prefer(16, 2048, state_dtype=torch.bfloat16))
+        self.assertFalse(_prefer(64, 4096, state_dtype=torch.bfloat16))
+
+    def test_h100_profiles_keep_existing_policy(self):
+        profiles = (
+            ((9, 0), 132, 80 * (1 << 30)),  # H100 SXM 80 GB
+            ((9, 0), 114, 80 * (1 << 30)),  # H100 PCIe 80 GB
+            ((9, 0), 132, 94 * (1 << 30)),  # H100 NVL 94 GB
+        )
+        for capability, sm_count, total_memory in profiles:
+            with self.subTest(
+                capability=capability,
+                sm_count=sm_count,
+                total_memory=total_memory,
+            ):
+                self.assertTrue(
+                    _prefer(
+                        16,
+                        2048,
+                        capability=capability,
+                        sm_count=sm_count,
+                        total_memory=total_memory,
+                    )
+                )
+                self.assertFalse(
+                    _prefer(
+                        64,
+                        4096,
+                        capability=capability,
+                        sm_count=sm_count,
+                        total_memory=total_memory,
+                    )
+                )
+
+    def test_unmeasured_architecture_and_sm_count_keep_existing_policy(self):
+        profiles = (((8, 0), 132), ((10, 0), 132), ((9, 0), 120))
+        for capability, sm_count in profiles:
+            with self.subTest(capability=capability, sm_count=sm_count):
+                self.assertTrue(
+                    _prefer(16, 2048, capability=capability, sm_count=sm_count)
+                )
+                self.assertFalse(
+                    _prefer(64, 4096, capability=capability, sm_count=sm_count)
+                )
+
+    def test_h200_memory_profile_boundaries_are_inclusive(self):
+        for total_memory in (
+            _FLASHKDA_H200_MIN_TOTAL_MEMORY,
+            140 * (1 << 30),
+            _FLASHKDA_H200_MAX_TOTAL_MEMORY,
+        ):
+            with self.subTest(total_memory=total_memory):
+                self.assertTrue(
+                    _is_h200_profile(
+                        compute_capability=(9, 0),
+                        multi_processor_count=132,
+                        total_memory=total_memory,
+                    )
+                )
+
+    def test_memory_outside_h200_profile_keeps_existing_policy(self):
+        for total_memory in (
+            _FLASHKDA_H200_MIN_TOTAL_MEMORY - 1,
+            _FLASHKDA_H200_MAX_TOTAL_MEMORY + 1,
+        ):
+            with self.subTest(total_memory=total_memory):
+                self.assertFalse(
+                    _is_h200_profile(
+                        compute_capability=(9, 0),
+                        multi_processor_count=132,
+                        total_memory=total_memory,
+                    )
+                )
+                self.assertTrue(_prefer(16, 2048, total_memory=total_memory))
+                self.assertFalse(_prefer(64, 4096, total_memory=total_memory))
+
+    def test_unmeasured_head_count_is_not_extrapolated(self):
+        self.assertTrue(_prefer(96, 2048))
+        self.assertFalse(_prefer(96, 4096))
+
+    def test_static_flashkda_contract(self):
+        heads, tokens, slots = 2, 64, 3
+        q = torch.empty(1, tokens, heads, 128, dtype=torch.bfloat16)
+        tensors = dict(
+            q=q,
+            k=torch.empty_like(q),
+            v=torch.empty_like(q),
+            g=torch.empty_like(q),
+            beta=torch.empty(1, tokens, heads, dtype=torch.bfloat16),
+            ssm_states=torch.empty(slots, heads, 128, 128, dtype=torch.float32),
+            cache_indices=torch.tensor([1], dtype=torch.int64),
+            query_start_loc=torch.tensor([0, tokens], dtype=torch.int32),
+            A_log=torch.empty(1, 1, heads, 1),
+            dt_bias=torch.empty(heads * 128),
+        )
+        self.assertTrue(_flashkda_supported(**tensors))
+
+        invalid = (
+            {"v": torch.empty(1, tokens, heads, 64, dtype=torch.bfloat16)},
+            {"v": torch.empty(1, tokens, heads + 1, 128, dtype=torch.bfloat16)},
+            {"q": q.float()},
+            {"A_log": None},
+            {"dt_bias": None},
+        )
+        for override in invalid:
+            with self.subTest(override=tuple(override)):
+                args = tensors | override
+                self.assertFalse(_flashkda_supported(**args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_kda_packed_decode_dispatch.py
+++ b/test/registered/unit/layers/attention/test_kda_packed_decode_dispatch.py
@@ -1,0 +1,34 @@
+"""CPU-checkable policy tests for the KDA packed-decode CUDA fast path."""
+
+import unittest
+
+from sglang.kernels.ops.attention.kda_packed_decode import (
+    _prefer_native_for_capability,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestKdaPackedDecodeDispatch(CustomTestCase):
+    def test_hopper_keeps_triton_for_all_batch_buckets(self):
+        for batch_size in (1, 4, 8, 16, 32, 64, 128, 256, 512, 1024):
+            with self.subTest(batch_size=batch_size):
+                self.assertFalse(_prefer_native_for_capability(batch_size, (9, 0)))
+
+    def test_sm10_keeps_existing_batch_crossover(self):
+        for capability in ((10, 0), (10, 3)):
+            with self.subTest(capability=capability):
+                self.assertFalse(_prefer_native_for_capability(7, capability))
+                self.assertTrue(_prefer_native_for_capability(8, capability))
+
+    def test_unknown_architecture_defaults_to_triton(self):
+        self.assertFalse(_prefer_native_for_capability(1024, (8, 0)))
+        self.assertFalse(_prefer_native_for_capability(1024, (11, 0)))
+        self.assertFalse(_prefer_native_for_capability(1024, (12, 0)))
+        self.assertFalse(_prefer_native_for_capability(1024, (13, 0)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_flashkda_strided_state_access.py
+++ b/test/registered/unit/mem_cache/test_flashkda_strided_state_access.py
@@ -23,10 +23,6 @@ pattern (the code under test) executes.
     python -m pytest test/registered/unit/mem_cache/test_flashkda_strided_state_access.py -v
 """
 
-from sglang.test.ci.ci_register import register_cpu_ci
-
-register_cpu_ci(est_time=6, suite="base-a-test-cpu")
-
 import sys
 import types
 import unittest
@@ -38,6 +34,10 @@ from sglang.srt.mem_cache.layout.page_major import (
     build_page_major_mamba_views,
     mamba_entry_bytes,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 _DEV = "cpu"
 
@@ -45,8 +45,8 @@ _DEV = "cpu"
 _LAYERS = 3
 _LAYER_UNDER_TEST = 1
 _H = 2
-_K = 4
-_V = 4
+_K = 128
+_V = 128
 _SLOTS = 8
 _CONV_SHAPES = (
     (3, 8),
@@ -114,7 +114,7 @@ class _FakeFlashKDA:
         out_buf.fill_(0.25)
 
 
-class TestFlashKDAStridedStateAccess(unittest.TestCase):
+class TestFlashKDAStridedStateAccess(CustomTestCase):
     def setUp(self):
         self._saved_module = sys.modules.get("flash_kda")
         self.fake = _FakeFlashKDA()
@@ -149,7 +149,7 @@ class TestFlashKDAStridedStateAccess(unittest.TestCase):
             query_start_loc=query_start_loc,
             A_log=torch.randn(1, 1, _H, 1),
             dt_bias=torch.randn(_H * _K),
-            lower_bound=-10.0,  # safe gate => fused path (no triton fallback)
+            lower_bound=-5.0,  # GLM safe gate => fused path (no Triton fallback)
             extend_seq_lens_cpu=[_SEQ_LEN] * num_seqs,
         )
 
@@ -178,12 +178,11 @@ class TestFlashKDAStridedStateAccess(unittest.TestCase):
         conv_before = [cv.clone() for cv in conv_views]
 
         cache_indices = torch.tensor([5, 2], dtype=torch.int32)
-        out, intermediate_states = self._run_extend(ssm_states, cache_indices)
+        out = self._run_extend(ssm_states, cache_indices)
 
         # Routing: the fused path ran exactly once (a silent re-route to the
         # triton fallback would make every assertion below vacuous).
         self.assertEqual(self.fake.calls, 1)
-        self.assertIsNone(intermediate_states)
         self.assertEqual(tuple(out.shape), (1, 2 * _SEQ_LEN, _H, _V))
 
         # Gather: the external kernel must receive a CONTIGUOUS copy whose rows


### PR DESCRIPTION
## Motivation

KDA dispatch currently mixes two different decisions:

1. whether a kernel supports a tensor contract;
2. whether that kernel is faster for the current hardware and shape.

This causes two opposite regressions on NVIDIA L20X:

- decode (`Q=1`): the standalone native row-streaming kernel is selected at `batch >= 8`, although Triton's V-tiled kernel is faster across every measured L20X bucket;
- chunk prefill: one global FlashKDA window `[64, 2048]` ignores local-head parallelism. Narrow TP shards underfill FlashKDA K2 at Q=2048, while a 64-head shard remains faster through Q=8192.

## Modifications

This PR contains two independently reviewable commits.

### Packed decode

- Split `supported(...)` (shape/dtype/layout semantics) from `prefer_native(...)` (performance policy).
- Retain the existing native `batch >= 8` crossover on SM10x.
- Use Triton on Hopper and unvalidated architectures.
- Keep `covered(...)` as a compatibility wrapper.
- Exercise production FP32 recurrent state in the existing GPU test.
- Add CPU-checkable architecture-policy tests.

The higher-priority K3 fused `conv -> KDA -> gated RMSNorm` path is unchanged and is still attempted before this standalone recurrence path.

### FlashKDA chunk prefill

For the exact validated profile `("NVIDIA L20X", SM90, 132 SMs)`, one packed request, and FP32 recurrent state:

- `local_heads=64`: use FlashKDA through Q=8192;
- `local_heads in {8,12,16,32}`: use Triton at Q=2048 and above;
- unmeasured head counts retain the previous Q<=2048 policy.

Unmeasured GPUs, multi-request batches, and BF16 recurrent state retain the previous policy.

The wrapper now separates static FlashKDA eligibility from performance selection, checks the external-kernel tensor contract before dispatch, preserves semantic fallbacks, and returns a `Tensor` on the normal fused path. The external stock FlashKDA kernel is not modified.

## Accuracy Tests

### Decode

The strict harness compared forced native, forced Triton, and automatic dispatch with an independent token-by-token FP32 recurrence:

- GLM-5.3-Flash KDA decode, `Q=1`, BF16 inputs, FP32 state, `K=V=128`;
- `local_heads={8,16,32,64}`, batch through 1024;
- random unique int32 slots in a non-dense state pool;
- three distinct consecutive decode steps;
- guard slots and slot-pitch padding checked for unintended writes.

| Check | Result |
|---|---:|
| Backend-step checks | 270 |
| Output mismatches | 0 |
| State mismatches | 0 |
| Maximum output absolute error | `3.05e-5` |
| Maximum state absolute error | `7.45e-8` |

### Prefill

The GLM-5.3-Flash benchmark used BF16 `q/k/v/g`, post-sigmoid BF16 beta, non-zero FP32 state, `K=V=128`, and `lower_bound=-5`. It checked output and final state against an independent token-by-token FP32 recurrence, a carried-state continuation dispatch, and CUDA Graph poison/replay.

| Check | Worst measured result |
|---|---:|
| Output relative RMSE | `0.00570` |
| Output cosine similarity | `>=0.9999838` |
| Final-state relative RMSE | `0.00464` |
| Final-state cosine similarity | `>=0.9999893` |
| Single + continuation checks | 6 / 6 passed |

The public `FlashKDAKernel.extend` route was also run with fallback replaced by fail-fast: 1,206 actual FlashKDA calls and zero fallbacks.

Targeted tests on current `main`:

- decode policy: 3 passed, 12 subtests passed;
- packed decode GPU tests: 8 passed;
- prefill policy/contract/state-pool: 9 passed, 16 subtests passed;
- FlashKDA GPU correctness/fallback tests: 5 passed;
- `ruff format`, `ruff check`, and `git diff --check`: passed.

## Speed Tests and Profiling

Hardware/software: NVIDIA L20X (SM90, 132 SMs, 60 MiB L2), PyTorch 2.11 + CUDA 12.8, Triton 3.6. FlashKDA is stock MoonshotAI commit `7afb9f454f160a6c4bbc0999beca0a8c40a38934`.

### Decode (`Q=1`)

Each backend used a captured production-boundary CUDA Graph, 100 warmups, 500 samples per repeat, 5 repeats, identical inputs/pointers, per-sample state reset, a 120 MiB L2 scrub outside timing, and all six backend-order permutations.

| Local heads | Batch | Native p50 / p95 (us) | Triton p50 / p95 (us) | p50 speedup |
|---:|---:|---:|---:|---:|
| 8 | 16 | 20.000 / 21.216 | 12.544 / 13.376 | 1.594x |
| 8 | 64 | 28.288 / 29.792 | 27.072 / 28.544 | 1.045x |
| 16 | 64 | 49.440 / 50.752 | 43.648 / 45.312 | 1.133x |
| 32 | 256 | 312.416 / 313.408 | 285.024 / 286.112 | 1.096x |
| 64 | 64 | 165.856 / 166.688 | 147.584 / 149.184 | 1.124x |
| 64 | 1024 | 2384.512 / 2385.664 | 2237.248 / 2239.552 | 1.066x |

Across all 22 affected `batch >= 8` buckets, Triton won p50 and p95 in 22/22 cases and all 110/110 repeat-level medians. The p50 improvement range was 1.045x-1.594x. Smaller batches already selected Triton and are unchanged.

### Chunk prefill: Q=2048 head crossover

The production wrapper, including beta adaptation and state gather/scatter, was measured with 100 warmups and 500 CUDA Graph replays.

| Local heads | Triton p50 / p95 (us) | FlashKDA p50 / p95 (us) | Preferred | Improvement |
|---:|---:|---:|---|---:|
| 8 | 153.824 / 154.560 | 327.920 / 329.216 | Triton | 2.132x |
| 12 | 178.624 / 180.000 | 273.440 / 275.040 | Triton | 1.531x |
| 16 | 217.056 / 219.491 | 351.904 / 353.282 | Triton | 1.621x |
| 32 | 344.704 / 347.426 | 398.496 / 401.027 | Triton | 1.156x |
| 64 | 478.592 / 481.056 | 377.040 / 379.266 | FlashKDA | 1.269x |

### Chunk prefill: local_heads=64 long-Q window

| Q | Triton p50 / p95 (us) | FlashKDA p50 / p95 (us) | Speedup p50 / p95 |
|---:|---:|---:|---:|
| 2048 | 478.592 / 481.056 | 377.040 / 379.266 | 1.269x / 1.268x |
| 4096 | 905.376 / 908.768 | 680.992 / 684.419 | 1.329x / 1.328x |
| 8192 | 1767.200 / 1772.066 | 1291.872 / 1296.707 | 1.368x / 1.367x |

Normal public eager routing independently confirmed H=64 improvements of 1.233x/1.323x/1.364x at Q=2048/4096/8192, with zero silent fallback.

## Scope

- These are isolated KDA operator measurements, not full-model tokens/s.
- The decode policy is a conservative native allowlist: SM10x keeps its existing fast path; unvalidated architectures use Triton.
- Prefill routing changes only when `--linear-attn-prefill-backend flashkda` is selected; SGLang's default backend and dependency set are unchanged.
- The extended Q=8192 path requires the exact measured L20X profile, one sequence, 64 local heads, FP32 state, and FlashKDA's existing safe-gate contract.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit tests.
- [x] Documentation is not required; no user-facing option is added.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33985476078](https://github.com/sgl-project/sglang/actions/runs/33985476078)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33985475886](https://github.com/sgl-project/sglang/actions/runs/33985475886)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33985476129](https://github.com/sgl-project/sglang/actions/runs/33985476129)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->