### PR TITLE
[Kernel] Make FlashKDA prefill routing shape-aware on L20X

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -331,7 +331,7 @@ class KDAKernelDispatcher:
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         kernel = self.extend_kernel
         if kwargs.get("lower_bound") is not None and not getattr(
             kernel, "supports_safe_gate", True

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
@@ -9,9 +9,110 @@ from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
 # FlashKDA chunk size. Sequences shorter than this fall back to Triton.
 _FLASHKDA_CHUNK_SIZE = 64
 
-# FlashKDA's max sequence length, Batches whose longest sequence exceeds this
-# fall back to Triton for the whole batch.
+# Legacy/default policy ceiling.  Validated device/shape profiles below may
+# use a different crossover; this is not a hard limit of the FlashKDA kernel.
 _FLASHKDA_MAX_SEQ_LEN = 2048
+
+# L20X serving measurements show that FlashKDA's head-parallel K2 is a win for
+# wide local-head shards, while Triton's time-parallel kernel is substantially
+# faster at Q=2048 for narrow TP shards.  The wider shard also keeps enough K2
+# CTAs resident to extend the useful FlashKDA window through the largest GLM
+# chunk-prefill bucket we validate.
+_FLASHKDA_L20X_PROFILE = ("NVIDIA L20X", (9, 0), 132)
+_FLASHKDA_L20X_LONG_HEADS = 64
+_FLASHKDA_L20X_TRITON_HEADS = frozenset({8, 12, 16, 32})
+_FLASHKDA_L20X_LONG_MAX_SEQ_LEN = 8192
+
+
+def _prefer_flashkda_for_shape(
+    *,
+    device_name: str,
+    compute_capability: tuple[int, int],
+    multi_processor_count: int,
+    state_dtype: torch.dtype,
+    num_heads: int,
+    num_sequences: int,
+    min_seq_len: int,
+    max_seq_len: int,
+) -> bool:
+    """Pure performance policy; semantic eligibility is checked separately."""
+    if min_seq_len < _FLASHKDA_CHUNK_SIZE:
+        return False
+    if (
+        (
+            device_name,
+            compute_capability,
+            multi_processor_count,
+        )
+        == _FLASHKDA_L20X_PROFILE
+        and num_sequences == 1
+        and state_dtype == torch.float32
+    ):
+        if num_heads == _FLASHKDA_L20X_LONG_HEADS:
+            return max_seq_len <= _FLASHKDA_L20X_LONG_MAX_SEQ_LEN
+        if num_heads in _FLASHKDA_L20X_TRITON_HEADS:
+            # Preserve existing behavior below the measured Q=2048 bucket,
+            # but do not select the under-filled K2 at or above that crossover.
+            return max_seq_len < _FLASHKDA_MAX_SEQ_LEN
+        # Do not extrapolate the profile to unmeasured head counts.
+        return max_seq_len <= _FLASHKDA_MAX_SEQ_LEN
+    return max_seq_len <= _FLASHKDA_MAX_SEQ_LEN
+
+
+def _flashkda_supported(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    ssm_states: torch.Tensor,
+    cache_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    A_log: Optional[torch.Tensor],
+    dt_bias: Optional[torch.Tensor],
+) -> bool:
+    """Check the external kernel's static tensor contract."""
+    if A_log is None or dt_bias is None:
+        return False
+    if not (q.ndim == k.ndim == v.ndim == g.ndim == 4 and beta.ndim == 3):
+        return False
+    batch, tokens, heads, key_dim = q.shape
+    tensors = (
+        k,
+        v,
+        g,
+        beta,
+        ssm_states,
+        cache_indices,
+        query_start_loc,
+        A_log,
+        dt_bias,
+    )
+    return (
+        batch == 1
+        and key_dim == 128
+        and k.shape == q.shape
+        and v.shape == (batch, tokens, heads, 128)
+        and g.shape == q.shape
+        and beta.shape == (batch, tokens, heads)
+        and q.dtype == torch.bfloat16
+        and k.dtype == torch.bfloat16
+        and v.dtype == torch.bfloat16
+        and g.dtype == torch.bfloat16
+        and beta.dtype in (torch.bfloat16, torch.float32)
+        and ssm_states.ndim == 4
+        and ssm_states.shape[1:] == (heads, 128, 128)
+        and ssm_states.dtype in (torch.bfloat16, torch.float32)
+        and cache_indices.ndim == 1
+        and cache_indices.dtype in (torch.int32, torch.int64)
+        and cache_indices.numel() > 0
+        and cache_indices.numel() == query_start_loc.numel() - 1
+        and query_start_loc.ndim == 1
+        and query_start_loc.dtype in (torch.int32, torch.int64)
+        and A_log.numel() == heads
+        and dt_bias.numel() == heads * key_dim
+        and all(tensor.device == q.device for tensor in tensors)
+    )
 
 
 def _load_flash_kda():
@@ -79,7 +180,8 @@ class FlashKDAKernel(LinearAttnKernelBase):
     kernel, so we pass RAW tensors plus ``A_log``/``dt_bias``/``lower_bound``.
     It is prefill-only, bf16, K == V == 128, HV == H (no GVA), and requires the
     safe (bounded) gate (``lower_bound`` set). The non-safe path and sequences
-    outside [chunk_size, max_seq_len] fall back to Triton ``chunk_kda``.
+    outside the selected device/shape performance window fall back to Triton
+    ``chunk_kda``.
     Requires an SM90+ GPU with the ``flash_kda`` package.
     """
 
@@ -119,13 +221,46 @@ class FlashKDAKernel(LinearAttnKernelBase):
         beta_is_raw: bool = False,
         return_intermediate_states: bool = False,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
+        if q.device.type == "cuda":
+            device_properties = torch.cuda.get_device_properties(q.device)
+            device_profile = (
+                device_properties.name,
+                (device_properties.major, device_properties.minor),
+                device_properties.multi_processor_count,
+            )
+        else:
+            # CPU wrapper tests replace the external CUDA kernel with a stub.
+            device_profile = ("CPU test stub", (-1, -1), 0)
         # The fused kernel cannot expose per-chunk states (h), which the mamba
         # radix extra_buffer track path needs; route tracked batches through
         # the Triton chunk_kda fallback instead of silently skipping the
         # snapshot (that would corrupt prefix-cache restores).
-        if return_intermediate_states or self._should_fall_back(
-            lower_bound, is_spec_decode, query_start_loc, extend_seq_lens_cpu
+        if (
+            return_intermediate_states
+            or not _flashkda_supported(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                ssm_states,
+                cache_indices,
+                query_start_loc,
+                A_log,
+                dt_bias,
+            )
+            or self._should_fall_back(
+                lower_bound,
+                is_spec_decode,
+                query_start_loc,
+                extend_seq_lens_cpu,
+                num_heads=q.shape[2],
+                state_dtype=ssm_states.dtype,
+                device_name=device_profile[0],
+                compute_capability=device_profile[1],
+                multi_processor_count=device_profile[2],
+            )
         ):
             return _triton_fallback(
                 q,
@@ -143,22 +278,19 @@ class FlashKDAKernel(LinearAttnKernelBase):
                 return_intermediate_states=return_intermediate_states,
             )
 
-        return (
-            self._flashkda_extend(
-                q,
-                k,
-                v,
-                g,
-                beta,
-                ssm_states=ssm_states,
-                cache_indices=cache_indices,
-                query_start_loc=query_start_loc,
-                A_log=A_log,
-                dt_bias=dt_bias,
-                lower_bound=lower_bound,
-                beta_is_raw=beta_is_raw,
-            ),
-            None,
+        return self._flashkda_extend(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            ssm_states=ssm_states,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+            beta_is_raw=beta_is_raw,
         )
 
     @staticmethod
@@ -167,6 +299,12 @@ class FlashKDAKernel(LinearAttnKernelBase):
         is_spec_decode: bool,
         query_start_loc: torch.Tensor,
         extend_seq_lens_cpu: Optional[list],
+        *,
+        num_heads: int,
+        state_dtype: torch.dtype,
+        device_name: str,
+        compute_capability: tuple[int, int],
+        multi_processor_count: int,
     ) -> bool:
         """Whether to use the Triton chunk_kda path instead of the fused kernel."""
         # Safe-gate only: the fused kernel does not support the unbounded gate
@@ -191,11 +329,22 @@ class FlashKDAKernel(LinearAttnKernelBase):
             else:
                 lo = min(extend_seq_lens_cpu)
                 hi = max(extend_seq_lens_cpu)
+            num_sequences = len(extend_seq_lens_cpu)
         else:
             seq_lens = query_start_loc[1:] - query_start_loc[:-1]
             lo_t, hi_t = torch.aminmax(seq_lens)
             lo, hi = int(lo_t), int(hi_t)
-        return lo < _FLASHKDA_CHUNK_SIZE or hi > _FLASHKDA_MAX_SEQ_LEN
+            num_sequences = query_start_loc.numel() - 1
+        return not _prefer_flashkda_for_shape(
+            device_name=device_name,
+            compute_capability=compute_capability,
+            multi_processor_count=multi_processor_count,
+            state_dtype=state_dtype,
+            num_heads=num_heads,
+            num_sequences=num_sequences,
+            min_seq_len=lo,
+            max_seq_len=hi,
+        )
 
     def _flashkda_extend(
         self,

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -232,7 +232,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
         beta_is_raw: bool = False,
         return_intermediate_states: bool = False,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         return chunk_kda(
             q=q,
             k=k,

--- a/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kernel_backend.py
@@ -43,7 +43,7 @@ class LinearAttnKernelBase(ABC):
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         **kwargs,
-    ) -> tuple: ...
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]: ...
 
     def target_verify(
         self,

--- a/test/registered/attention/test_kda_prefill_flashkda.py
+++ b/test/registered/attention/test_kda_prefill_flashkda.py
@@ -80,7 +80,7 @@ def _chunk_kda_ref(d, lower_bound):
     """Triton chunk_kda reference. chunk_kda mutates g/v and the state in place,
     so feed clones; returns (output, updated_state_slots)."""
     st = d["pool"].clone()
-    out, _ = chunk_kda(
+    out = chunk_kda(
         q=d["q"].clone(),
         k=d["k"].clone(),
         v=d["v"].clone(),
@@ -105,7 +105,7 @@ def test_flashkda_matches_triton_safe_gate(seq_lens):
     ref_out, ref_state = _chunk_kda_ref(d, LOWER_BOUND)
 
     st_fk = d["pool"].clone()
-    out, h = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),
@@ -121,7 +121,6 @@ def test_flashkda_matches_triton_safe_gate(seq_lens):
     )
     torch.cuda.synchronize()
 
-    assert h is None
     assert torch.isfinite(out).all(), "FlashKDA output has non-finite values"
     assert torch.isfinite(st_fk).all(), "FlashKDA final state has non-finite values"
     # bf16 cross-implementation noise (chunk=16 CUTLASS vs chunk=64 Triton);
@@ -141,7 +140,7 @@ def test_flashkda_falls_back_without_lower_bound():
     ref_out, _ = _chunk_kda_ref(d, None)
 
     st_fk = d["pool"].clone()
-    out, _ = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),
@@ -171,7 +170,7 @@ def test_flashkda_spec_verify_falls_back():
     ref_out, _ = _chunk_kda_ref(d, LOWER_BOUND)
 
     st_fk = d["pool"].clone()
-    out, _ = FlashKDAKernel().extend(
+    out = FlashKDAKernel().extend(
         d["q"].clone(),
         d["k"].clone(),
         d["v"].clone(),

--- a/test/registered/unit/layers/attention/test_kda_flashkda_dispatch.py
+++ b/test/registered/unit/layers/attention/test_kda_flashkda_dispatch.py
@@ -1,0 +1,126 @@
+"""CPU-checkable shape policy tests for the FlashKDA prefill backend."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.kda_flashkda import (
+    _flashkda_supported,
+    _prefer_flashkda_for_shape,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _prefer(
+    heads: int,
+    seq_len: int,
+    *,
+    device_name: str = "NVIDIA L20X",
+    capability: tuple[int, int] = (9, 0),
+    sm_count: int = 132,
+    sequences: int = 1,
+    min_seq_len: int | None = None,
+    state_dtype: torch.dtype = torch.float32,
+) -> bool:
+    return _prefer_flashkda_for_shape(
+        device_name=device_name,
+        compute_capability=capability,
+        multi_processor_count=sm_count,
+        state_dtype=state_dtype,
+        num_heads=heads,
+        num_sequences=sequences,
+        min_seq_len=seq_len if min_seq_len is None else min_seq_len,
+        max_seq_len=seq_len,
+    )
+
+
+class TestFlashKdaDispatch(CustomTestCase):
+    def test_l20x_narrow_shards_fall_back_at_q2048(self):
+        for heads in (8, 12, 16, 32):
+            with self.subTest(heads=heads):
+                self.assertFalse(_prefer(heads, 2048))
+
+    def test_l20x_wide_shard_extends_the_long_window(self):
+        for seq_len in (2048, 4096, 8192):
+            with self.subTest(seq_len=seq_len):
+                self.assertTrue(_prefer(64, seq_len))
+        self.assertFalse(_prefer(64, 8193))
+
+    def test_short_request_forces_whole_batch_fallback(self):
+        self.assertFalse(_prefer(64, 8192, min_seq_len=32))
+
+    def test_unmeasured_multi_request_shapes_keep_existing_policy(self):
+        self.assertTrue(_prefer(8, 2048, sequences=2))
+        self.assertFalse(_prefer(64, 4096, sequences=2))
+
+    def test_unmeasured_state_dtype_keeps_existing_policy(self):
+        self.assertTrue(_prefer(16, 2048, state_dtype=torch.bfloat16))
+        self.assertFalse(_prefer(64, 4096, state_dtype=torch.bfloat16))
+
+    def test_unmeasured_hardware_keeps_existing_policy(self):
+        profiles = (
+            ("NVIDIA L20X", (8, 0), 132),
+            ("NVIDIA L20X", (10, 0), 132),
+            ("NVIDIA H200", (9, 0), 132),
+            ("NVIDIA L20X", (9, 0), 120),
+        )
+        for name, capability, sm_count in profiles:
+            with self.subTest(name=name, capability=capability, sm_count=sm_count):
+                self.assertTrue(
+                    _prefer(
+                        16,
+                        2048,
+                        device_name=name,
+                        capability=capability,
+                        sm_count=sm_count,
+                    )
+                )
+                self.assertFalse(
+                    _prefer(
+                        64,
+                        4096,
+                        device_name=name,
+                        capability=capability,
+                        sm_count=sm_count,
+                    )
+                )
+
+    def test_unmeasured_head_count_is_not_extrapolated(self):
+        self.assertTrue(_prefer(96, 2048))
+        self.assertFalse(_prefer(96, 4096))
+
+    def test_static_flashkda_contract(self):
+        heads, tokens, slots = 2, 64, 3
+        q = torch.empty(1, tokens, heads, 128, dtype=torch.bfloat16)
+        tensors = dict(
+            q=q,
+            k=torch.empty_like(q),
+            v=torch.empty_like(q),
+            g=torch.empty_like(q),
+            beta=torch.empty(1, tokens, heads, dtype=torch.bfloat16),
+            ssm_states=torch.empty(slots, heads, 128, 128, dtype=torch.float32),
+            cache_indices=torch.tensor([1], dtype=torch.int64),
+            query_start_loc=torch.tensor([0, tokens], dtype=torch.int32),
+            A_log=torch.empty(1, 1, heads, 1),
+            dt_bias=torch.empty(heads * 128),
+        )
+        self.assertTrue(_flashkda_supported(**tensors))
+
+        invalid = (
+            {"v": torch.empty(1, tokens, heads, 64, dtype=torch.bfloat16)},
+            {"v": torch.empty(1, tokens, heads + 1, 128, dtype=torch.bfloat16)},
+            {"q": q.float()},
+            {"A_log": None},
+            {"dt_bias": None},
+        )
+        for override in invalid:
+            with self.subTest(override=tuple(override)):
+                args = tensors | override
+                self.assertFalse(_flashkda_supported(**args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_flashkda_strided_state_access.py
+++ b/test/registered/unit/mem_cache/test_flashkda_strided_state_access.py
@@ -23,10 +23,6 @@ pattern (the code under test) executes.
     python -m pytest test/registered/unit/mem_cache/test_flashkda_strided_state_access.py -v
 """
 
-from sglang.test.ci.ci_register import register_cpu_ci
-
-register_cpu_ci(est_time=6, suite="base-a-test-cpu")
-
 import sys
 import types
 import unittest
@@ -38,6 +34,10 @@ from sglang.srt.mem_cache.layout.page_major import (
     build_page_major_mamba_views,
     mamba_entry_bytes,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 _DEV = "cpu"
 
@@ -45,8 +45,8 @@ _DEV = "cpu"
 _LAYERS = 3
 _LAYER_UNDER_TEST = 1
 _H = 2
-_K = 4
-_V = 4
+_K = 128
+_V = 128
 _SLOTS = 8
 _CONV_SHAPES = (
     (3, 8),
@@ -114,7 +114,7 @@ class _FakeFlashKDA:
         out_buf.fill_(0.25)
 
 
-class TestFlashKDAStridedStateAccess(unittest.TestCase):
+class TestFlashKDAStridedStateAccess(CustomTestCase):
     def setUp(self):
         self._saved_module = sys.modules.get("flash_kda")
         self.fake = _FakeFlashKDA()
@@ -149,7 +149,7 @@ class TestFlashKDAStridedStateAccess(unittest.TestCase):
             query_start_loc=query_start_loc,
             A_log=torch.randn(1, 1, _H, 1),
             dt_bias=torch.randn(_H * _K),
-            lower_bound=-10.0,  # safe gate => fused path (no triton fallback)
+            lower_bound=-5.0,  # GLM safe gate => fused path (no Triton fallback)
             extend_seq_lens_cpu=[_SEQ_LEN] * num_seqs,
         )
 
@@ -178,12 +178,11 @@ class TestFlashKDAStridedStateAccess(unittest.TestCase):
         conv_before = [cv.clone() for cv in conv_views]
 
         cache_indices = torch.tensor([5, 2], dtype=torch.int32)
-        out, intermediate_states = self._run_extend(ssm_states, cache_indices)
+        out = self._run_extend(ssm_states, cache_indices)
 
         # Routing: the fused path ran exactly once (a silent re-route to the
         # triton fallback would make every assertion below vacuous).
         self.assertEqual(self.fake.calls, 1)
-        self.assertIsNone(intermediate_states)
         self.assertEqual(tuple(out.shape), (1, 2 * _SEQ_LEN, _H, _V))
 
         # Gather: the external kernel must receive a CONTIGUOUS copy whose rows


### PR DESCRIPTION
## Motivation

With `--linear-attn-prefill-backend flashkda`, the wrapper used one global window: FlashKDA for `[64, 2048]`, otherwise Triton `chunk_kda`. This ignored local-head parallelism: narrow shards underfill FlashKDA K2 at Q=2048, while a 64-head shard remains faster through Q=8192.

## Modifications

For the exact validated L20X profile `("NVIDIA L20X", SM90, 132 SMs)`, one packed request, and FP32 recurrent state:

- `local_heads=64`: use FlashKDA through Q=8192;
- `local_heads in {8,12,16,32}`: use Triton at Q=2048 and above;
- unmeasured head counts retain the old Q<=2048 policy.

Unmeasured GPUs, multi-request batches, and BF16 state preserve the old policy.

This PR also separates static eligibility from performance policy, validates the external-kernel tensor contract, preserves semantic fallbacks, fixes the normal fused return to be a `Tensor`, and adds policy/contract/strided-state tests. The external stock FlashKDA kernel is unmodified.

## Accuracy Tests

The strict GLM-5.3-Flash operator benchmark used BF16 `q/k/v/g`, post-sigmoid BF16 beta, non-zero FP32 initial state, `K=V=128`, and `lower_bound=-5`. It checked output/final state against an independent token-by-token FP32 recurrence, a carried-state continuation dispatch, and CUDA Graph poison/replay.

| Check | Worst measured result |
|---|---:|
| Output relative RMSE | `0.00570` |
| Output cosine similarity | `>=0.9999838` |
| Final-state relative RMSE | `0.00464` |
| Final-state cosine similarity | `>=0.9999893` |
| Single-dispatch checks | 3 / 3 passed |
| Two-dispatch continuation checks | 3 / 3 passed |

The public `FlashKDAKernel.extend` route was run with fallback replaced by fail-fast; eager tests recorded 1,206 actual FlashKDA calls and zero fallbacks.

Targeted tests on the rebased branch:

- policy/contract/state-pool tests: 9 passed, 16 subtests passed;
- FlashKDA GPU correctness/fallback tests: 5 passed;
- `ruff format`, `ruff check`, and `git diff --check`: passed.

## Speed Tests and Profiling

Hardware/software: NVIDIA L20X, SM90, 132 SMs; PyTorch 2.11 + CUDA 12.8; Triton 3.6; stock MoonshotAI FlashKDA commit `7afb9f454f160a6c4bbc0999beca0a8c40a38934`.

The benchmark measures the production SGLang wrapper, including beta adaptation and state gather/scatter. Projection and TP collectives are outside this operator boundary. CUDA Graph results use 100 warmups and 500 replays.

### Q=2048 head-count crossover

| Local heads | Triton p50 / p95 (us) | FlashKDA p50 / p95 (us) | Preferred | Improvement |
|---:|---:|---:|---|---:|
| 8 | 153.824 / 154.560 | 327.920 / 329.216 | Triton | 2.132x |
| 12 | 178.624 / 180.000 | 273.440 / 275.040 | Triton | 1.531x |
| 16 | 217.056 / 219.491 | 351.904 / 353.282 | Triton | 1.621x |
| 32 | 344.704 / 347.426 | 398.496 / 401.027 | Triton | 1.156x |
| 64 | 478.592 / 481.056 | 377.040 / 379.266 | FlashKDA | 1.269x |

### Long chunk-prefill buckets, local_heads=64

| Q | Triton p50 / p95 (us) | FlashKDA p50 / p95 (us) | Speedup p50 / p95 |
|---:|---:|---:|---:|
| 2048 | 478.592 / 481.056 | 377.040 / 379.266 | 1.269x / 1.268x |
| 4096 | 905.376 / 908.768 | 680.992 / 684.419 | 1.329x / 1.328x |
| 8192 | 1767.200 / 1772.066 | 1291.872 / 1296.707 | 1.368x / 1.367x |

Normal public eager routing independently confirmed H=64 wins at Q=2048/4096/8192 by 1.233x/1.323x/1.364x, with zero silent fallback.

### Scope

- This changes only explicitly selected `--linear-attn-prefill-backend flashkda`; it does not change the default backend or add a mandatory dependency.
- The extended Q=8192 route requires the exact L20X profile, one packed request, 64 local heads, FP32 state, and the existing safe-gate contract.
- Other devices and unmeasured shapes retain the old policy.
- Results are isolated KDA operator latency, not full-model tokens/s.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit tests.
- [x] Documentation is not required; no user-facing option is added.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33829891855](https://github.com/sgl-project/sglang/actions/runs/33829891855)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33829891771](https://github.com/sgl-project/sglang/actions/runs/33829891771)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33829892061](https://github.com/sgl-project/sglang/actions/runs/33829892061)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->