### PR TITLE
fix(quantization): per-stream Marlin workspaces to prevent cross-stream CTA deadlock under PD-Multiplexing

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -15,6 +15,9 @@ from sglang.srt.layers.parameter import (
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsLinearScheme,
 )
+from sglang.srt.layers.quantization.marlin_utils import (
+    get_marlin_workspace_for_forward,
+)
 from sglang.srt.layers.quantization.marlin_utils_fp8 import (
     apply_fp8_marlin_linear,
     prepare_fp8_layer_for_marlin,
@@ -129,7 +132,7 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsLinearScheme):
             input=x,
             weight=layer.weight,
             weight_scale=layer.weight_scale,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace_for_forward(layer),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -26,6 +26,8 @@ from sglang.srt.layers.quantization.marlin_utils import (
     MarlinLinearLayerConfig,
     apply_gptq_marlin_linear,
     check_marlin_supports_shape,
+    get_marlin_workspace_for_forward,
+    marlin_init_stream_workspaces,
     marlin_is_k_full,
     marlin_make_empty_g_idx,
     marlin_make_workspace,
@@ -230,6 +232,7 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
 
         # Allocate marlin workspace.
         self.workspace = marlin_make_workspace(device)
+        marlin_init_stream_workspaces(self)
 
         def _transform_param(
             layer: torch.nn.Module, name: Optional[str], fn: Callable
@@ -331,7 +334,7 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
             weight_zp=w_zp,  # type: ignore
             g_idx=w_gidx,  # type: ignore
             g_idx_sort_indices=layer.g_idx_sort_indices,
-            workspace=self.workspace,
+            workspace=get_marlin_workspace_for_forward(self),
             wtype=c.weight_type,
             input_size_per_partition=c.partition_weight_shape[0],
             output_size_per_partition=c.partition_weight_shape[1],

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -21,6 +21,8 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsMoEScheme,
 )
 from sglang.srt.layers.quantization.marlin_utils import (
+    get_marlin_workspace_for_forward,
+    marlin_init_stream_workspaces,
     marlin_make_workspace,
     marlin_moe_permute_scales,
     moe_awq_to_marlin_zero_points,
@@ -401,6 +403,7 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             replace_tensor("w2_weight_zero_point", marlin_w2_zp)
 
         layer.workspace = marlin_make_workspace(layer.w13_weight_packed.device, 4)
+        marlin_init_stream_workspaces(layer, max_blocks_per_sm=4)
         layer.is_marlin_converted = True
 
     def restore_weights_before_loading(self, layer: torch.nn.Module):
@@ -491,7 +494,7 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             is_k_full=self.is_k_full,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
             clamp_limit=self.moe_runner_config.swiglu_limit,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace_for_forward(layer),
         )
         return StandardCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -67,6 +67,9 @@ from sglang.srt.layers.quantization.fp8_utils import (
     resolve_mxfp8_dense_gemm_backend,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
+from sglang.srt.layers.quantization.marlin_utils import (
+    get_marlin_workspace_for_forward,
+)
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
 from sglang.srt.layers.quantization.unquant import (
     UnquantizedFusedMoEMethod,
@@ -974,7 +977,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 input=x,
                 weight=layer.weight,
                 weight_scale=layer.weight_scale,
-                workspace=layer.workspace,
+                workspace=get_marlin_workspace_for_forward(layer),
                 size_n=layer.output_size_per_partition,
                 size_k=layer.input_size_per_partition,
                 bias=bias,

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -276,6 +276,52 @@ def marlin_make_workspace(
     )
 
 
+def marlin_stream_workspaces_enabled() -> bool:
+    """True when PDMux stream groups exist and workspaces must be split."""
+    try:
+        from sglang.srt.multiplex.pdmux_context import get_stream_groups
+
+        return len(get_stream_groups()) > 0
+    except Exception:  # noqa: BLE001 - feature probe must never break forward
+        return False
+
+
+def marlin_init_stream_workspaces(layer: torch.nn.Module, **make_kwargs) -> None:
+    """Opt a layer into per-executing-stream workspaces under PDMux.
+
+    No-op without PDMux: every launch stays serialized on one stream and the
+    original per-layer workspace remains correct.
+    """
+    if marlin_stream_workspaces_enabled():
+        layer.marlin_stream_workspaces = {}
+        if make_kwargs:
+            layer.marlin_workspace_make_kwargs = make_kwargs
+
+
+def get_marlin_workspace_for_forward(layer: torch.nn.Module) -> torch.Tensor:
+    """Return a Marlin workspace private to the executing CUDA stream.
+
+    Marlin kernels use the workspace for cross-CTA synchronization and assume
+    every launch touching one workspace is serialized on a single stream.
+    Under PD-Multiplexing the decode forward and the split-prefill slice of
+    the same layer run concurrently on two green-context streams, so sharing
+    one per-layer workspace lets both launches consume the same barrier
+    slots and a CTA can spin forever. Without PDMux this returns the
+    original per-layer workspace and nothing changes.
+    """
+    workspaces = getattr(layer, "marlin_stream_workspaces", None)
+    if workspaces is None:
+        return layer.workspace
+    stream = torch.cuda.current_stream()
+    key = (stream.device.index, stream.cuda_stream)
+    workspace = workspaces.get(key)
+    if workspace is None:
+        make_kwargs = getattr(layer, "marlin_workspace_make_kwargs", None) or {}
+        workspace = marlin_make_workspace(stream.device, **make_kwargs)
+        workspaces[key] = workspace
+    return workspace
+
+
 def marlin_is_k_full(act_order: bool, is_row_parallel: bool) -> bool:
     return (not act_order) or (act_order and not is_row_parallel)
 

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
@@ -7,6 +7,7 @@ import torch
 
 from sglang.srt.layers.quantization.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
+    marlin_init_stream_workspaces,
     marlin_make_workspace,
     marlin_permute_bias,
     marlin_permute_scales,
@@ -178,6 +179,7 @@ def prepare_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
 
     device = layer.weight.device
     layer.workspace = marlin_make_workspace(device)
+    marlin_init_stream_workspaces(layer)
 
     perm = torch.empty(0, dtype=torch.int, device=device)
     qweight = layer.weight.view(torch.int32).T.contiguous()
@@ -380,6 +382,7 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
 
     device = w13.device
     layer.workspace = marlin_make_workspace(device, 4)
+    marlin_init_stream_workspaces(layer, max_blocks_per_sm=4)
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     def _pad_w13(x: torch.Tensor) -> torch.Tensor:
@@ -490,6 +493,7 @@ def prepare_moe_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
 
     device = w13.device
     layer.workspace = marlin_make_workspace(device, 4)
+    marlin_init_stream_workspaces(layer, max_blocks_per_sm=4)
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     if not layer.moe_runner_config.is_gated:

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
@@ -7,6 +7,7 @@ import torch
 
 from sglang.srt.layers.quantization.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
+    marlin_init_stream_workspaces,
     marlin_make_workspace,
     marlin_permute_scales,
     should_use_atomic_add_reduce,
@@ -122,6 +123,7 @@ def prepare_fp8_layer_for_marlin(
 
     # WORKSPACE
     layer.workspace = marlin_make_workspace(device)
+    marlin_init_stream_workspaces(layer)
 
     # WEIGHT
     # Repack weights to marlin format

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -44,6 +44,9 @@ from sglang.srt.layers.quantization.fp8_utils import (
     flashinfer_per_tensor_fp8_supported,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
+from sglang.srt.layers.quantization.marlin_utils import (
+    get_marlin_workspace_for_forward,
+)
 from sglang.srt.layers.quantization.marlin_utils_fp4 import (
     apply_fp4_marlin_linear,
     prepare_moe_nvfp4_layer_for_marlin,
@@ -641,7 +644,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
                 input=x,
                 weight=layer.weight,
                 weight_scale=layer.weight_scale,
-                workspace=layer.workspace,
+                workspace=get_marlin_workspace_for_forward(layer),
                 size_n=layer.output_size_per_partition,
                 size_k=layer.input_size_per_partition,
                 bias=bias,
@@ -2004,7 +2007,7 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
                 weight=layer.weight,
                 weight_scale=layer.weight_scale,
                 weight_global_scale=layer.weight_global_scale,
-                workspace=layer.workspace,
+                workspace=get_marlin_workspace_for_forward(layer),
                 size_n=layer.output_size_per_partition,
                 size_k=layer.input_size_per_partition,
                 bias=bias,
@@ -2220,7 +2223,7 @@ class ModelOptNvFp4A16LinearMethod(LinearMethodBase):
             weight=layer.weight,
             weight_scale=layer.weight_scale,
             weight_global_scale=layer.weight_global_scale,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace_for_forward(layer),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,

--- a/python/sglang/srt/multiplex/multiplexing_mixin.py
+++ b/python/sglang/srt/multiplex/multiplexing_mixin.py
@@ -37,7 +37,7 @@ class SchedulerMultiplexMixin:
 
         # for pd_multiplexing, Init stream_groups, exclude normal stream for prefill only and decode only
         self.pdmux_config = load_pdmux_config(get_disagg().pdmux_config_path)
-        initialize_stream_groups(self.gpu_id, self.pdmux_config)
+        initialize_stream_groups(self.ps.gpu_id, self.pdmux_config)
         self.stream_groups = get_stream_groups()
         self.sm_counts = get_sm_counts()
         self.real_sm_group_num = len(self.stream_groups)
@@ -214,7 +214,7 @@ class SchedulerMultiplexMixin:
                     )
 
                     self.tp_cpu_group.allreduce(flags, dist.ReduceOp.SUM).wait()
-                    if flags.item() == self.tp_size:
+                    if flags.item() == self.ps.tp_size:
                         self.process_batch_result(
                             self.split_prefill_batch, prefill_result
                         )

--- a/test/manual/quant/test_pdmux_mixed_deadlock_repro.py
+++ b/test/manual/quant/test_pdmux_mixed_deadlock_repro.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Minimal reproducer: SGLang PDMux mixed-batch deadlock on hybrid GDN models.
+
+Symptom
+-------
+On a single A100/H100 with `--enable-pdmux` and a Qwen3.5/Qwen3.8 hybrid
+(GDN + full-attention) model, once the server has completed one >=4K-token
+prompt through the split-prefill path, the NEXT request pattern that runs a
+decode batch and a split-prefill batch concurrently deadlocks the scheduler
+event loop forever. py-spy shows the loop blocked at:
+
+    synchronize (torch/cuda/streams.py)
+    event_loop_pdmux (sglang/srt/multiplex/multiplexing_mixin.py:205)
+
+i.e. `decode_stream.synchronize()` waiting for decode-forward kernels that
+never complete. The watchdog does not fire. No client abort is required.
+
+Reproduction matrix (single A100-SXM4-40GB, SGLang <commit>, budget 256)
+------------------------------------------------------------------------
+prior request                      | following mixed batch
+-----------------------------------+---------------------
+1K-prompt request(s), any decode   | 6/6 pass
+4K-prompt request (512 decode)     | 2/2 deadlock
+4K-prompt request, aborted at 5 s  | 2/2 deadlock
+4K prompt via /flush_cache path    | deadlock independent of flush
+
+Requirements: one A100/H100 (>=40 GB), the Qwen3.8-27B-FP8 checkpoint
+(or any hybrid qwen3_5-family checkpoint that fits), py-spy for the stack
+dump. Runtime is ~8 min plus checkpoint download.
+
+Usage
+-----
+    python test/manual/quant/test_pdmux_mixed_deadlock_repro.py --model Qwen/Qwen3.8-27B-FP8
+
+The script launches its own server, so run it on an idle GPU. With the
+stale-field fix in this PR applied, PDMux starts on current main; without
+the workspace fix the mixed batch deadlocks; with both it runs clean.
+Manual (not CI): needs a >=40GB GPU and downloads the checkpoint.
+See sgl-project/sglang#37904 for the full evidence trail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+PORT = 30000
+BASE_URL = f"http://127.0.0.1:{PORT}"
+STARTUP_TIMEOUT_SECONDS = 1800
+MIXED_TIMEOUT_SECONDS = 300
+PROMPT_1K = "test " * 1023
+PROMPT_4K = "test " * 4095
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3.8-27B-FP8")
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--port", type=int, default=PORT)
+    parser.add_argument("--split-budget", type=int, default=256)
+    parser.add_argument("--mixed-timeout", type=float, default=MIXED_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=3,
+        help="sensitize+trigger rounds; b1 hits ~30-70%/try pre-fix, b2 6/6",
+    )
+    parser.add_argument("--workdir", default=".")
+    return parser.parse_args()
+
+
+ARGS: argparse.Namespace
+
+
+def wait_ready(process: subprocess.Popen[str]) -> None:
+    url = f"http://127.0.0.1:{ARGS.port}"
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"server exited during startup: {process.returncode}")
+        try:
+            with urllib.request.urlopen(url + "/health", timeout=5) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError, ConnectionError):
+            pass
+        time.sleep(2)
+    raise TimeoutError("server readiness timeout")
+
+
+def stop_process_group(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    for sig, timeout in (
+        (signal.SIGINT, 30),
+        (signal.SIGTERM, 15),
+        (signal.SIGKILL, 10),
+    ):
+        try:
+            os.killpg(process.pid, sig)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=timeout)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def generate(prompt: str, max_new_tokens: int, timeout: float) -> dict[str, object]:
+    request = urllib.request.Request(
+        BASE_URL + "/generate",
+        data=json.dumps(
+            {
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            }
+        ).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read())
+
+
+def hash_of(result: dict[str, object]) -> str:
+    return hashlib.sha256(str(result["text"]).encode("utf-8")).hexdigest()
+
+
+def mixed_case(batch_size: int) -> None:
+    """One decode batch plus `batch_size` concurrent split-prefill batches.
+
+    b1 (one prefill) reproduced the deadlock on roughly a third to two
+    thirds of single attempts pre-fix; b2 (two prefills) was 6/6 across
+    the pre-fix baseline campaign. The main loop therefore tries both,
+    several times, re-priming the >=4K sensitizing request each round.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=batch_size + 1) as executor:
+        background = executor.submit(
+            generate, "Count upward: 1, 2, 3,", 256, ARGS.mixed_timeout
+        )
+        time.sleep(0.25)
+        prefills = [
+            executor.submit(generate, PROMPT_1K, 32, ARGS.mixed_timeout)
+            for _ in range(batch_size)
+        ]
+        for future in prefills:
+            future.result(timeout=ARGS.mixed_timeout + 30)
+        background.result(timeout=ARGS.mixed_timeout + 30)
+
+
+def dump_stacks() -> None:
+    py_spy = shutil.which("py-spy")
+    if py_spy is None:
+        print("[repro] py-spy not found; skipping stack dump (pip install py-spy)")
+        return
+    pids = subprocess.run(
+        ["pgrep", "-f", "sglang::scheduler"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.split()
+    for pid in pids:
+        dump = subprocess.run(
+            [py_spy, "dump", "--pid", pid], capture_output=True, text=True, check=False
+        )
+        print(f"[repro] stack of scheduler pid {pid}:\n{dump.stdout}")
+
+
+def main() -> None:
+    global ARGS
+    ARGS = parse_args()
+    workdir = pathlib.Path(ARGS.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    config = (workdir / "pdmux-repro.yaml").resolve()
+    config.write_text(
+        "sm_group_num: 3\n"
+        "manual_divisions:\n"
+        "  - [72, 36, 1]\n"
+        f"split_forward_token_budget: {ARGS.split_budget}\n"
+        "decode_bs_divisor: 36\n",
+        encoding="utf-8",
+    )
+    argv = [
+        "python",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        ARGS.model,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(ARGS.port),
+        "--attention-backend",
+        "triton",
+        "--sampling-backend",
+        "pytorch",
+        "--mem-fraction-static",
+        "0.90",
+        "--max-running-requests",
+        "12",
+        "--max-total-tokens",
+        "24576",
+        "--max-mamba-cache-size",
+        "12",
+        "--mamba-ssm-dtype",
+        "bfloat16",
+        "--kv-cache-dtype",
+        "bfloat16",
+        "--chunked-prefill-size",
+        "-1",
+        "--disable-radix-cache",
+        "--disable-cuda-graph",
+        "--disable-overlap-schedule",
+        "--random-seed",
+        "7",
+        "--watchdog-timeout",
+        "1800",
+        "--skip-server-warmup",
+        "--enable-pdmux",
+        "--sm-group-num",
+        "3",
+        "--pdmux-config-path",
+        str(config),
+    ]
+    if ARGS.revision:
+        argv.extend(["--revision", ARGS.revision])
+
+    log_path = workdir / "pdmux-repro-server.log"
+    print(f"[repro] starting server, log: {log_path}")
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            argv,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            wait_ready(process)
+            print("[repro] step 1: 1K-prompt reference (expected to pass)")
+            generate(PROMPT_1K, 32, ARGS.mixed_timeout)
+            for attempt in range(1, ARGS.attempts + 1):
+                print(
+                    f"[repro] attempt {attempt}/{ARGS.attempts}: 4K-prompt request, 512 decode tokens"
+                )
+                victim = generate(PROMPT_4K, 512, 600)
+                print(
+                    f"[repro]   victim finished, tokens={victim['meta_info']['completion_tokens']}"
+                )
+                for label, batch_size in (("b1", 1), ("b2", 2)):
+                    print(
+                        f"[repro] attempt {attempt} mixed {label}: decode + {batch_size}x 1K prefill"
+                    )
+                    try:
+                        mixed_case(batch_size)
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"[repro] mixed {label} timed out: {type(exc).__name__}")
+                        time.sleep(2)
+                        dump_stacks()
+                        print(
+                            "[repro] DEADLOCK REPRODUCED: the scheduler event loop is blocked\n"
+                            "        in decode_stream.synchronize(); attach nsys or the event\n"
+                            "        tracer from the issue for the device-side wait chain."
+                        )
+                        raise SystemExit(2)
+            print(
+                "[repro] all attempts completed - deadlock did NOT reproduce.\n"
+                "        The race is timing sensitive; please re-run and share\n"
+                "        GPU model + driver + torch version."
+            )
+        finally:
+            stop_process_group(process)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/layers/quantization/test_marlin_workspace_pdmux.py
+++ b/test/registered/unit/layers/quantization/test_marlin_workspace_pdmux.py
@@ -1,0 +1,209 @@
+"""Regression tests for Marlin per-stream workspaces under PD-Multiplexing.
+
+The Marlin kernels use `workspace` as a cross-CTA lock array and assume every
+launch touching one workspace is serialized on a single CUDA stream. Under
+PD-Multiplexing the decode forward and the split-prefill slice of the same
+layer run concurrently on two green-context streams; a shared per-layer
+workspace then lets both launches consume the same barrier slots and a CTA
+spins forever (`barrier_acquire` waits for exact counter equality).
+
+Two properties are pinned here:
+
+1. Host-side: workspace selection is keyed by the executing stream, falls
+   back to the per-layer workspace when the layer is not opted in, opt-in
+   happens only under PDMux, and the per-call `max_blocks_per_sm` sizing is
+   preserved.
+2. Device-side: the same layer driven concurrently on two streams with deep
+   queues (24 launches per stream before any synchronization — shallow
+   one-out/one-in submission never overlaps two launches on the device and
+   cannot reproduce the race) completes and matches the solo reference.
+
+The device-side case runs in a child process with a hard timeout so a
+regression manifests as a clean failure instead of a hung CI runner.
+"""
+
+import hashlib
+import json
+import multiprocessing as mp
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.marlin_utils import (
+    get_marlin_workspace_for_forward,
+    marlin_init_stream_workspaces,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+
+DEEP_QUEUE_DEPTH = 24
+CHILD_TIMEOUT_S = 180
+
+
+def _make_fp8_marlin_layer(k: int, n: int, dev: torch.device):
+    from sglang.srt.layers.quantization.marlin_utils import marlin_make_workspace
+    from sglang.srt.layers.quantization.marlin_utils_fp8 import (
+        prepare_fp8_layer_for_marlin,
+    )
+
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(
+        (torch.randn(k, n, device=dev, dtype=torch.float32) / 10).to(
+            torch.float8_e4m3fn
+        ),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.rand(1, n, device=dev, dtype=torch.float32) * 0.05 + 0.01,
+        requires_grad=False,
+    )
+    layer.orig_dtype = torch.bfloat16
+    layer.output_size_per_partition = n
+    layer.input_size_per_partition = k
+    layer.weight_block_size = None
+    prepare_fp8_layer_for_marlin(layer, size_k_first=True)
+    layer.workspace = marlin_make_workspace(dev)
+    return layer
+
+
+def _run_gemm(layer, x):
+    from sglang.srt.layers.quantization.marlin_utils_fp8 import (
+        apply_fp8_marlin_linear,
+    )
+
+    return apply_fp8_marlin_linear(
+        input=x,
+        weight=layer.weight,
+        weight_scale=layer.weight_scale,
+        workspace=get_marlin_workspace_for_forward(layer),
+        size_n=layer.output_size_per_partition,
+        size_k=layer.input_size_per_partition,
+        bias=None,
+    )
+
+
+def _hash_out(t: torch.Tensor) -> str:
+    return hashlib.sha256(t.float().cpu().contiguous().numpy().tobytes()).hexdigest()
+
+
+def _child_deep_queue(result_path: str) -> None:
+    """Interleave two streams on one layer with deep queues, then verify."""
+    dev = torch.device("cuda:0")
+    torch.cuda.set_device(dev)
+    torch.manual_seed(0)
+
+    layer = _make_fp8_marlin_layer(512, 128, dev)
+    x = torch.randn(8, 512, device=dev, dtype=torch.bfloat16)
+
+    ref = _run_gemm(layer, x)
+    torch.cuda.synchronize()
+    ref_sha = _hash_out(ref)
+
+    # Opt in exactly the state prepare_fp8_layer_for_marlin creates on a
+    # PDMux server (marlin_init_stream_workspaces under enabled stream
+    # groups). The test machine may not run PDMux, so set the state
+    # directly: this is the contract get_marlin_workspace_for_forward
+    # must honor.
+    layer.marlin_stream_workspaces = {}
+
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+    for _ in range(4):
+        outs = []
+        for _ in range(DEEP_QUEUE_DEPTH):
+            with torch.cuda.stream(stream_a):
+                outs.append(_run_gemm(layer, x))
+        for _ in range(DEEP_QUEUE_DEPTH):
+            with torch.cuda.stream(stream_b):
+                outs.append(_run_gemm(layer, x))
+        stream_a.synchronize()
+        stream_b.synchronize()
+        for idx, out in enumerate(outs):
+            if _hash_out(out) != ref_sha:
+                raise AssertionError(
+                    f"wrong result at launch {idx}: {_hash_out(out)} != {ref_sha}"
+                )
+
+    # Both streams must have received private workspaces.
+    assert len(layer.marlin_stream_workspaces) == 2, (
+        f"expected per-stream workspaces, got {len(layer.marlin_stream_workspaces)}"
+    )
+    with open(result_path, "w") as f:
+        json.dump({"ok": True}, f)
+
+
+class TestMarlinWorkspaceSelection(CustomTestCase):
+    def test_falls_back_to_layer_workspace_without_opt_in(self):
+        layer = torch.nn.Module()
+        layer.workspace = torch.zeros(1, dtype=torch.int32)
+        self.assertIs(get_marlin_workspace_for_forward(layer), layer.workspace)
+
+    @patch(
+        "sglang.srt.layers.quantization.marlin_utils.marlin_stream_workspaces_enabled",
+        return_value=False,
+    )
+    def test_init_is_noop_without_pdmux(self, _mock_enabled):
+        layer = torch.nn.Module()
+        marlin_init_stream_workspaces(layer, max_blocks_per_sm=4)
+        self.assertFalse(hasattr(layer, "marlin_stream_workspaces"))
+
+    @patch(
+        "sglang.srt.layers.quantization.marlin_utils.marlin_stream_workspaces_enabled",
+        return_value=True,
+    )
+    def test_init_opts_in_and_records_make_kwargs(self, _mock_enabled):
+        layer = torch.nn.Module()
+        marlin_init_stream_workspaces(layer, max_blocks_per_sm=4)
+        self.assertEqual(layer.marlin_stream_workspaces, {})
+        self.assertEqual(layer.marlin_workspace_make_kwargs, {"max_blocks_per_sm": 4})
+
+    def test_stream_keyed_selection_and_sizing(self):
+        if not torch.cuda.is_available():
+            self.skipTest("requires CUDA")
+        dev = torch.device("cuda:0")
+        torch.cuda.set_device(dev)
+        sms = torch.cuda.get_device_properties(dev).multi_processor_count
+
+        layer = _make_fp8_marlin_layer(512, 128, dev)
+        layer.marlin_stream_workspaces = {}
+        layer.marlin_workspace_make_kwargs = {"max_blocks_per_sm": 4}
+
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        with torch.cuda.stream(stream_a):
+            ws_a = get_marlin_workspace_for_forward(layer)
+        with torch.cuda.stream(stream_b):
+            ws_b = get_marlin_workspace_for_forward(layer)
+        self.assertIsNot(ws_a, ws_b)
+        self.assertEqual(ws_a.numel(), sms * 4)
+        self.assertEqual(ws_b.numel(), sms * 4)
+        with torch.cuda.stream(stream_a):
+            self.assertIs(get_marlin_workspace_for_forward(layer), ws_a)
+
+
+class TestMarlinDeepQueueConcurrency(CustomTestCase):
+    def test_two_streams_deep_queue_complete_and_match(self):
+        if not torch.cuda.is_available():
+            self.skipTest("requires CUDA")
+        ctx = mp.get_context("spawn")
+        result_path = "/tmp/marlin_ws_deep_queue_result.json"
+        child = ctx.Process(target=_child_deep_queue, args=(result_path,))
+        child.start()
+        child.join(timeout=CHILD_TIMEOUT_S)
+        if child.is_alive():
+            child.terminate()
+            child.join(timeout=10)
+            self.fail(
+                "deep-queue marlin concurrency did not complete within "
+                f"{CHILD_TIMEOUT_S}s: workspace serialization regression?"
+            )
+        self.assertEqual(child.exitcode, 0)
+        with open(result_path) as f:
+            self.assertTrue(json.load(f)["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #37904

## Part 1 — prerequisite: repair stale Scheduler fields (PDMux cannot start on current main)

`multiplexing_mixin.py` still reads `self.gpu_id` / `self.tp_size`, fields that no longer exist on `Scheduler` (they moved to `ParallelState`). PDMux raises in `initialize_stream_groups` before the model loads. Replaced with `self.ps.gpu_id` / `self.ps.tp_size`, matching the pattern used elsewhere in `scheduler.py`.

## Part 2 — the deadlock fix

Under `--enable-pdmux`, the decode forward and the split-prefill slice of the **same layer** run concurrently on two green-context streams. Marlin kernels use `workspace` as a cross-CTA lock array (`barrier_acquire` waits for exact counter equality) and assume every launch touching one workspace is serialized on a single stream. Sharing one per-layer workspace lets both launches corrupt the barrier counters and a CTA spins forever — the scheduler hangs in `decode_stream.synchronize()` at 99% SM, and the watchdog never fires. Repro and device-side evidence (cuda-gdb naming the spinning Marlin kernel, py-spy stacks, measured before/after): #37904.

Three helpers in `marlin_utils`, wired through **every** remaining consumer of a shared per-layer workspace (FP8-Marlin dense prepare, NVFP4/MXFP4 prepares, modelopt FP8/FP4 branches, compressed-tensors w8a16_fp8 / wNa16 dense + MoE; the classic MarlinConfig method and `prepare_moe_fp8_layer_for_marlin` were removed from main after this fix was prepared, and `moe_runner/marlin.py` already allocates per-call workspaces — both intentionally untouched):

- `marlin_stream_workspaces_enabled()` — PDMux stream-group probe, exception-safe (always False without PDMux)
- `marlin_init_stream_workspaces(layer, **make_kwargs)` — opt-in at `process_weights_after_loading`; strict no-op without PDMux; preserves the MoE `max_blocks_per_sm=4` sizing
- `get_marlin_workspace_for_forward(layer)` — workspace keyed by `(device.index, stream.cuda_stream)`, lazily created; falls back to `layer.workspace` when not opted in

## Tests — scope stated honestly

- `test/registered/unit/layers/quantization/test_marlin_workspace_pdmux.py` (CI-runnable) pins the **mechanism**: stream-key isolation, non-opt-in fallback, kwargs sizing, PDMux-absent no-op, and a two-stream 24-deep-queue concurrency check (shallow submission never co-resides two launches and cannot reproduce the race) in a subprocess with a hard timeout. It is not an end-to-end `--enable-pdmux` service regression.
- `test/manual/quant/test_pdmux_mixed_deadlock_repro.py` (manual, ≥40GB GPU) is the **service-level** reproducer: with only Part 1 the mixed batch after a ≥4K prefill deadlocks (exit 2, embedded py-spy dump); with both parts it runs clean. Verified in both directions on A100-SXM4-40GB / Qwen3.8-27B-FP8.

## Validation

A100-SXM4-40GB / Qwen3.8-27B-FP8 / FP8-Marlin, at the environment documented in #37904 (which includes the Part 1 prerequisite): pre-fix mixed-batch deadlock 4/4–6/6 across six server iterations; post-fix fast gate 2/2 and the full 8-stage correctness campaign pass (hash-equal overlap matrix, prefix gate, CUDA-Graph+PDMux gate); A/B wall-time within ~10%.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33852419865](https://github.com/sgl-project/sglang/actions/runs/33852419865)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33852419546](https://github.com/sgl-project/sglang/actions/runs/33852419546)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33852419916](https://github.com/sgl-project/sglang/actions/runs/33852419916)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->