### PR TITLE
[Docs] Use --enable-prefill-cp and --cp-strategy in DeepSeek-V3.2 cookbook

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -432,25 +432,25 @@ For production deployments (RBG / LWS-based, DeepEP EP parallelism), see [multi_
 
 #### 4.2.5 DSA Long-Sequence Context Parallel and PP/CP
 
-SGLang provides two context parallel (CP) modes for long-sequence workloads, controlled with `--dsa-prefill-cp-mode`.
+SGLang provides two context parallel (CP) modes for long-sequence workloads. Enable with `--enable-prefill-cp` and select the layout with `--cp-strategy`.
 
-**In-sequence splitting** (`--dsa-prefill-cp-mode in-seq-split`): Each CP rank handles a uniform shard of the sequence; KV cache is gathered via all-gather. Batch size is restricted to 1 during prefill. See [PR #12065](https://github.com/sgl-project/sglang/pull/12065).
+**Zigzag / in-sequence splitting** (`--cp-strategy zigzag`; formerly `--dsa-prefill-cp-mode in-seq-split`): Each CP rank handles a uniform shard of the sequence; KV cache is gathered via all-gather. Batch size is restricted to 1 during prefill. See [PR #12065](https://github.com/sgl-project/sglang/pull/12065).
 
 ```bash Command
 # In-seq splitting mode — EP + DP, batch size 1
 python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp \
   --tp 8 --ep 8 --dp 2 --enable-dp-attention \
-  --enable-dsa-prefill-context-parallel --attn-cp-size 4 \
-  --dsa-prefill-cp-mode in-seq-split --max-running-requests 32
+  --enable-prefill-cp --attn-cp-size 4 \
+  --cp-strategy zigzag --max-running-requests 32
 ```
 
-**Round-robin splitting** (`--dsa-prefill-cp-mode round-robin-split`, default): Distributes tokens by `token_idx % cp_size`. Supports fused MoE, FP8 KV cache, and multi-batch prefill. Cannot be combined with DP attention. See [PR #13959](https://github.com/sgl-project/sglang/pull/13959).
+**Interleave / round-robin splitting** (`--cp-strategy interleave`; formerly `--dsa-prefill-cp-mode round-robin-split`): Distributes tokens by `token_idx % cp_size`. Supports fused MoE, FP8 KV cache, and multi-batch prefill. Cannot be combined with DP attention. See [PR #13959](https://github.com/sgl-project/sglang/pull/13959).
 
 ```bash Command
 # Round-robin splitting — FusedMoE + CP8
 python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp \
-  --tp 8 --enable-dsa-prefill-context-parallel --attn-cp-size 8 \
-  --dsa-prefill-cp-mode round-robin-split --max-running-requests 32
+  --tp 8 --enable-prefill-cp --attn-cp-size 8 \
+  --cp-strategy interleave --max-running-requests 32
 ```
 
 **PP + CP (multi-node):** Combines Pipeline Parallelism and Context Parallelism for cross-node scaling. The production-optimized configurations below have been verified on Hopper:
@@ -499,8 +499,8 @@ sglang_args=$(echo serve \
   --attention-backend dsa \
   --dsa-prefill-backend flashmla_sparse \
   --dsa-decode-backend flashmla_sparse \
-  --enable-dsa-prefill-context-parallel \
-  --dsa-prefill-cp-mode round-robin-split \
+  --enable-prefill-cp \
+  --cp-strategy interleave \
   --cuda-graph-max-bs-decode 128 \
   --max-running-requests 128 \
   --trust-remote-code --host "0.0.0.0" --port 30000 \
@@ -529,20 +529,20 @@ dp_config=" \
 "
 
 cp_config=" \
-  --enable-dsa-prefill-context-parallel \
+  --enable-prefill-cp \
 "
 
 if [ "$dp" -eq 1 ]; then
 
 cp_config=" \
   $cp_config \
-  --dsa-prefill-cp-mode round-robin-split \
+  --cp-strategy interleave \
 "
 
 else
 cp_config=" \
   $cp_config \
-  --dsa-prefill-cp-mode in-seq-split \
+  --cp-strategy zigzag \
 "
 fi
 


### PR DESCRIPTION
## Summary
- DeepSeek-V3.2 cookbook still documents deprecated `--enable-dsa-prefill-context-parallel` and `--dsa-prefill-cp-mode {in-seq-split,round-robin-split}`.
- Live CLI: `--enable-prefill-cp` + `--cp-strategy {zigzag,interleave}` (`python/sglang/srt/server_args.py`; old names are DeprecatedStoreTrueAction / DeprecatedAliasStoreAction).
- Update narrative and command snippets in `docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx` only. Mapping: `in-seq-split`→`zigzag`, `round-robin-split`→`interleave`.

## Repro (default branch)
```bash
# Docs (stale):
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx | rg 'enable-dsa-prefill-context-parallel|dsa-prefill-cp-mode'
# Code (live primary + deprecated aliases):
# enable_prefill_cp / cp_strategy choices zigzag|interleave
# --enable-dsa-prefill-context-parallel → DeprecatedStoreTrueAction → --enable-prefill-cp
# --dsa-prefill-cp-mode → DeprecatedAliasStoreAction → --cp-strategy
```

## Test plan
- [ ] Confirm snippets use `--enable-prefill-cp` and `--cp-strategy zigzag|interleave`
- [ ] Confirm formerly notes still mention the old flag names for readers of older docs/PRs

Signed-off-by: ADou <ikun3.1415927@gmail.com>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33831439526](https://github.com/sgl-project/sglang/actions/runs/33831439526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33831439331](https://github.com/sgl-project/sglang/actions/runs/33831439331)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->