### PR TITLE
[Bugfix] Fix Gloo collective mismatch in disagg prefill bootstrap when TP/CP > 1

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -469,6 +469,7 @@ class PrefillBootstrapQueue:
                     tp_group,
                 )
             else:
+
                 def _empty():
                     return [] if not return_failed_reqs else ([], [])
 
@@ -497,7 +498,9 @@ class PrefillBootstrapQueue:
                     return _empty()
 
                 rid_to_req = {req.rid: req for req in self.queue}
-                aligned_reqs = [rid_to_req[rid] for rid in common_rids if rid in rid_to_req]
+                aligned_reqs = [
+                    rid_to_req[rid] for rid in common_rids if rid in rid_to_req
+                ]
                 if not aligned_reqs:
                     return _empty()
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 import torch
+import torch.distributed as dist
 
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.base.conn import StateType
@@ -425,13 +426,13 @@ class PrefillBootstrapQueue:
         failed_reqs = []
         indices_to_remove = set()
 
-        if len(self.queue) == 0:
-            if return_failed_reqs is False:
-                return []
-            else:
-                return [], []
-
         if self.pp_size > 1:
+            if len(self.queue) == 0:
+                if return_failed_reqs is False:
+                    return []
+                else:
+                    return [], []
+
             polls = poll_and_all_reduce_pp(
                 (req.rid for req in self.queue),
                 KVPoll.WaitingForInput,
@@ -449,11 +450,67 @@ class PrefillBootstrapQueue:
                     if local_poll == KVPoll.Failed:
                         polls[i] = KVPoll.Failed
         else:
-            polls = poll_and_all_reduce_attn_cp_tp_group(
-                [req.disagg_kv_sender for req in self.queue],
-                self.scheduler.attn_cp_cpu_group,
-                self.scheduler.attn_tp_cpu_group,
-            )
+            tp_group = self.scheduler.attn_tp_cpu_group
+            cp_group = self.scheduler.attn_cp_cpu_group
+
+            need_rid_align = (
+                tp_group is not None and dist.get_world_size(tp_group) > 1
+            ) or (cp_group is not None and dist.get_world_size(cp_group) > 1)
+
+            if not need_rid_align:
+                if len(self.queue) == 0:
+                    if return_failed_reqs is False:
+                        return []
+                    else:
+                        return [], []
+                polls = poll_and_all_reduce_attn_cp_tp_group(
+                    [req.disagg_kv_sender for req in self.queue],
+                    cp_group,
+                    tp_group,
+                )
+            else:
+                def _empty():
+                    return [] if not return_failed_reqs else ([], [])
+
+                has_req = torch.tensor(
+                    [1 if self.queue else 0], dtype=torch.uint8, device="cpu"
+                )
+
+                for group in (tp_group, cp_group):
+                    if group is not None and dist.get_world_size(group) > 1:
+                        dist.all_reduce(has_req, op=dist.ReduceOp.MAX, group=group)
+                if int(has_req.item()) == 0:
+                    return _empty()
+
+                common_rids = [req.rid for req in self.queue]
+                for group in (tp_group, cp_group):
+                    if group is None or dist.get_world_size(group) <= 1:
+                        common_rids = sorted(set(common_rids))
+                        continue
+                    gathered = [None] * dist.get_world_size(group)
+                    dist.all_gather_object(gathered, common_rids, group=group)
+                    common_rids = sorted(
+                        set.intersection(*(set(rids or []) for rids in gathered))
+                    )
+
+                if not common_rids:
+                    return _empty()
+
+                rid_to_req = {req.rid: req for req in self.queue}
+                aligned_reqs = [rid_to_req[rid] for rid in common_rids if rid in rid_to_req]
+                if not aligned_reqs:
+                    return _empty()
+
+                aligned_polls = poll_and_all_reduce_attn_cp_tp_group(
+                    [req.disagg_kv_sender for req in aligned_reqs],
+                    cp_group,
+                    tp_group,
+                )
+
+                rid_to_poll = {
+                    req.rid: poll for req, poll in zip(aligned_reqs, aligned_polls)
+                }
+                polls = [rid_to_poll.get(req.rid) for req in self.queue]
 
         for i, (req, poll) in enumerate(zip(self.queue, polls)):
             if poll is None:

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py
@@ -92,9 +92,7 @@ class TestPrefillBootstrapRidAlign(CustomTestCase):
                 "sglang.srt.disaggregation.prefill.dist.all_reduce",
                 side_effect=all_reduce,
             ) as reduce,
-            patch(
-                "sglang.srt.disaggregation.prefill.dist.all_gather_object"
-            ) as gather,
+            patch("sglang.srt.disaggregation.prefill.dist.all_gather_object") as gather,
             patch(
                 "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group"
             ) as poll,

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py
@@ -1,0 +1,368 @@
+"""Unit tests for PrefillBootstrapQueue.pop_bootstrapped TP/CP rid alignment.
+
+When attn TP or CP world size > 1, ranks may have divergent bootstrap queues.
+pop_bootstrapped must intersect rids across the group before polling so
+poll_and_all_reduce_attn_cp_tp_group does not hang / crash on length mismatch.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_req(rid: str):
+    return SimpleNamespace(
+        rid=rid,
+        disagg_kv_sender=MagicMock(name=f"sender-{rid}"),
+        prefill_attempt_count=0,
+        is_retracted=False,
+        time_stats=SimpleNamespace(set_wait_queue_entry_time=MagicMock()),
+    )
+
+
+def _make_queue(rids, *, tp_world_size=1, cp_world_size=1):
+    queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+    queue.pp_size = 1
+    queue.queue = [_make_req(rid) for rid in rids]
+    tp_group = object() if tp_world_size > 1 else None
+    cp_group = object() if cp_world_size > 1 else None
+    queue.scheduler = SimpleNamespace(
+        attn_tp_cpu_group=tp_group,
+        attn_cp_cpu_group=cp_group,
+        handle_bootstrap_failure=MagicMock(),
+    )
+    queue.finalize_bootstrap = MagicMock(return_value=True)
+    queue.ensure_metadata_buffer = MagicMock(return_value=True)
+    queue._tp_world_size = tp_world_size
+    queue._cp_world_size = cp_world_size
+    return queue
+
+
+def _world_size_side_effect(queue):
+    def _get_world_size(group):
+        if group is queue.scheduler.attn_tp_cpu_group:
+            return queue._tp_world_size
+        if group is queue.scheduler.attn_cp_cpu_group:
+            return queue._cp_world_size
+        return 1
+
+    return _get_world_size
+
+
+class TestPrefillBootstrapRidAlign(CustomTestCase):
+    def test_empty_queue_without_rid_align_returns_early(self):
+        queue = _make_queue([], tp_world_size=1, cp_world_size=1)
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group"
+            ) as poll,
+        ):
+            self.assertEqual(queue.pop_bootstrapped(), [])
+            self.assertEqual(queue.pop_bootstrapped(return_failed_reqs=True), ([], []))
+            poll.assert_not_called()
+
+    def test_empty_queue_rid_align_all_ranks_idle(self):
+        queue = _make_queue([], tp_world_size=2)
+
+        def all_reduce(tensor, op=None, group=None):
+            # Peer ranks are also empty → MAX stays 0.
+            return None
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_reduce",
+                side_effect=all_reduce,
+            ) as reduce,
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object"
+            ) as gather,
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group"
+            ) as poll,
+        ):
+            self.assertEqual(queue.pop_bootstrapped(), [])
+            reduce.assert_called()
+            gather.assert_not_called()
+            poll.assert_not_called()
+
+    def test_empty_local_queue_skips_poll_when_peers_have_reqs(self):
+        """Local rank empty but peer has reqs: after intersection, local polls nothing."""
+        queue = _make_queue([], tp_world_size=2)
+
+        def all_reduce(tensor, op=None, group=None):
+            tensor[0] = 1  # peer has requests
+
+        def all_gather_object(gathered, obj, group=None):
+            # Local empty; peer has rid-a. Intersection is empty.
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-a"]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_reduce",
+                side_effect=all_reduce,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group"
+            ) as poll,
+        ):
+            self.assertEqual(queue.pop_bootstrapped(), [])
+            poll.assert_not_called()
+            self.assertEqual(queue.queue, [])
+
+    def test_rid_align_polls_only_common_intersection(self):
+        """Local [a,b], peer [a,c] → only poll a; b stays with poll=None."""
+        queue = _make_queue(["rid-a", "rid-b"], tp_world_size=2)
+        req_a, req_b = queue.queue
+
+        def all_gather_object(gathered, obj, group=None):
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-a", "rid-c"]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.WaitingForInput],
+            ) as poll,
+            patch(
+                "sglang.srt.disaggregation.prefill.should_force_retry",
+                return_value=False,
+            ),
+        ):
+            bootstrapped = queue.pop_bootstrapped()
+
+        poll.assert_called_once()
+        senders = poll.call_args.args[0]
+        self.assertEqual(len(senders), 1)
+        self.assertIs(senders[0], req_a.disagg_kv_sender)
+        self.assertEqual(bootstrapped, [req_a])
+        self.assertEqual(queue.queue, [req_b])
+        queue.finalize_bootstrap.assert_called_once_with(req_a)
+
+    def test_rid_align_cp_group_also_intersects(self):
+        queue = _make_queue(["rid-a", "rid-b"], cp_world_size=2)
+        req_a, req_b = queue.queue
+
+        def all_gather_object(gathered, obj, group=None):
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-b"]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.WaitingForInput],
+            ) as poll,
+            patch(
+                "sglang.srt.disaggregation.prefill.should_force_retry",
+                return_value=False,
+            ),
+        ):
+            bootstrapped = queue.pop_bootstrapped()
+
+        senders = poll.call_args.args[0]
+        self.assertEqual(len(senders), 1)
+        self.assertIs(senders[0], req_b.disagg_kv_sender)
+        self.assertEqual(bootstrapped, [req_b])
+        self.assertEqual(queue.queue, [req_a])
+
+    def test_rid_align_failed_common_req(self):
+        queue = _make_queue(["rid-fail"], tp_world_size=2)
+        req = queue.queue[0]
+
+        def all_gather_object(gathered, obj, group=None):
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-fail"]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Failed],
+            ),
+        ):
+            bootstrapped, failed = queue.pop_bootstrapped(return_failed_reqs=True)
+
+        self.assertEqual(bootstrapped, [])
+        self.assertEqual(failed, [req])
+        self.assertEqual(queue.queue, [])
+        queue.scheduler.handle_bootstrap_failure.assert_called_once_with(req)
+
+    def test_rid_align_maps_polls_by_sorted_common_order(self):
+        """Multiple common rids: local queue order != sorted intersection order.
+
+        In pop_bootstrapped, aligned_reqs is built from the *sorted* intersection,
+        while polls are mapped back onto the local queue via rid->poll dict. This
+        pins the zip between aligned_reqs (sorted) and the poll return so a poll
+        lands on the right request even when the local queue is unsorted.
+        """
+        queue = _make_queue(["rid-c", "rid-a", "rid-b"], tp_world_size=2)
+        req_c, req_a, req_b = queue.queue
+
+        def all_gather_object(gathered, obj, group=None):
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-a", "rid-b"]  # sorted peer view
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Failed, KVPoll.WaitingForInput],
+            ) as poll,
+            patch(
+                "sglang.srt.disaggregation.prefill.should_force_retry",
+                return_value=False,
+            ),
+        ):
+            bootstrapped, failed = queue.pop_bootstrapped(return_failed_reqs=True)
+
+        # aligned_reqs is sorted by rid: [rid-a, rid-b], so poll[0] is rid-a's
+        # (Failed) and poll[1] is rid-b's (WaitingForInput), regardless of the
+        # unsorted local-queue insertion order [rid-c, rid-a, rid-b].
+        senders = poll.call_args.args[0]
+        self.assertIs(senders[0], req_a.disagg_kv_sender)
+        self.assertIs(senders[1], req_b.disagg_kv_sender)
+        self.assertEqual(bootstrapped, [req_b])
+        self.assertEqual(failed, [req_a])
+        self.assertEqual(queue.queue, [req_c])
+        queue.scheduler.handle_bootstrap_failure.assert_called_once_with(req_a)
+
+    def test_rid_align_tp_and_cp_intersect_in_sequence(self):
+        """tp == cp (both sizes equal, here 2): the two all_gathers intersect in order.
+
+        pop_bootstrapped runs all_gather once per active group in deterministic
+        tp-then-cp order, so the mock keys off the call index instead of group
+        identity. The first pass narrows to peers that have rid-a; the second
+        narrows further to rid-a only.
+        """
+        queue = _make_queue(["rid-a", "rid-b"], tp_world_size=2, cp_world_size=2)
+        req_a, req_b = queue.queue
+
+        phase = 0
+
+        def all_gather_object(gathered, obj, group=None):
+            nonlocal phase
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-a", "rid-c"] if phase == 0 else ["rid-a"]
+            phase += 1
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.WaitingForInput],
+            ) as poll,
+            patch(
+                "sglang.srt.disaggregation.prefill.should_force_retry",
+                return_value=False,
+            ),
+        ):
+            bootstrapped = queue.pop_bootstrapped()
+
+        # Both groups gathered (tp pass then cp pass); the sequential intersection
+        # kills rid-b on every rank, so only rid-a is polled.
+        self.assertEqual(phase, 2)
+        senders = poll.call_args.args[0]
+        self.assertEqual(len(senders), 1)
+        self.assertIs(senders[0], req_a.disagg_kv_sender)
+        self.assertEqual(bootstrapped, [req_a])
+        self.assertEqual(queue.queue, [req_b])
+        queue.finalize_bootstrap.assert_called_once_with(req_a)
+
+    def test_no_common_rids_leaves_local_queue_untouched(self):
+        queue = _make_queue(["rid-local-only"], tp_world_size=2)
+
+        def all_gather_object(gathered, obj, group=None):
+            gathered[0] = list(obj)
+            gathered[1] = ["rid-peer-only"]
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.get_world_size",
+                side_effect=_world_size_side_effect(queue),
+            ),
+            patch("sglang.srt.disaggregation.prefill.dist.all_reduce"),
+            patch(
+                "sglang.srt.disaggregation.prefill.dist.all_gather_object",
+                side_effect=all_gather_object,
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group"
+            ) as poll,
+        ):
+            self.assertEqual(queue.pop_bootstrapped(), [])
+
+        poll.assert_not_called()
+        self.assertEqual([r.rid for r in queue.queue], ["rid-local-only"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

**Base version: SGLang v0.5.18**.

Under PD disaggregation with attn TP or CP world size > 1, bootstrap queues can diverge across ranks. `pop_bootstrapped` previously polled the full local queue and then ran `poll_and_all_reduce_attn_cp_tp_group`, which `all_reduce` poll tensors of unequal length and crashes with a Gloo collective mismatch:

```text
terminate called after throwing an instance of 'gloo::EnforceNotMet'
  what():  [enforce fail at .../gloo/transport/tcp/pair.cc:456] op.preamble.length <= op.nbytes. 8 vs 1. Received data size doesn't match expected size. Is there a distributed collective mismatch in your code?
Fatal Python error: Aborted
```

Relevant stack (paths redacted):

```text
File ".../torch/distributed/distributed_c10d.py", line 3075, in all_reduce
File ".../sglang/srt/disaggregation/utils.py", line 199, in poll_and_all_reduce_attn_cp_tp_group
File ".../sglang/srt/disaggregation/prefill.py", in pop_bootstrapped
File ".../sglang/srt/disaggregation/prefill.py", in event_loop_normal_disagg_prefill
File ".../sglang/srt/managers/scheduler.py", in dispatch_event_loop
```

Follow-on symptom after the peer aborts:

```text
RuntimeError: [.../gloo/transport/tcp/pair.cc:...] Connection closed by peer
```

### Reproduction (prefill node)

Observed on PD prefill with `--tp 4` and `--attn-cp-size 4` (attn TP/CP world size > 1). Prefill launch command:

```bash
python3 -m sglang.launch_server \
    --host 0.0.0.0 \
    --port $port \
    --served-model-name deepseek-v4-flash-0731 \
    --page-size 256 \
    --model-path /data/models/DeepSeek-V4-Flash-0731-FP8 \
    --disaggregation-ib-device "mlx5_0,mlx5_1,mlx5_2,mlx5_3" \
    --chunked-prefill-size 65536 \
    --max-prefill-tokens 65536 \
    --tp 4 \
    --dp 1 \
    --ep 4 \
    --attn-cp-size 4 \
    --offload-group-size 2 \
    --offload-num-in-group 1 \
    --offload-prefetch-step 1 \
    --offload-mode cpu \
    --enable-dp-lm-head \
    --speculative-algorithm DSPARK \
    --speculative-dspark-block-size 6 \
    --enable-dsa-prefill-context-parallel \
    --dsa-prefill-cp-mode round-robin-split \
    --disaggregation-mode prefill \
    --swa-full-tokens-ratio 0.4 \
    --mem-fraction-static 0.75 \
    --disable-overlap-schedule \
    --moe-a2a-backend deepep \
    --deepep-mode normal \
    --moe-runner-backend deep_gemm \
    --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
    --watchdog-timeout 1000000 \
    --disaggregation-bootstrap-port 6998 \
    --dist-init-addr $LWS_LEADER_ADDRESS:20102 \
    --nnodes $LWS_GROUP_SIZE \
    --node-rank $LWS_WORKER_INDEX \
    --dist-timeout 7200 \
    --trust-remote-code \
    --moe-dense-tp-size 1 \
    --max-running-requests 8 \
    --enable-cache-report \
    --enable-metrics \
    --collect-tokens-histogram \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4 \
    --disable-piecewise-cuda-graph \
    --enable-request-time-stats-logging \
    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 32}' \
    --kv-cache-dtype fp8_e4m3 \
    --enable-hierarchical-cache \
    --hicache-ratio 1.5 \
    --hicache-io-backend direct \
    --hicache-mem-layout page_first_direct \
    --hicache-write-policy write_through \
    --hicache-storage-prefetch-policy  timeout \
    --hicache-storage-backend mooncake \
    --hicache-storage-backend-extra-config '{"extra_backend_tag":"deepseek-v4-flash-0731","prefetch_threshold": 1024, "prefetch_timeout_base": 1, "prefetch_timeout_per_ki_token": 0.1}'
```

## Modifications

- In the non-PP path of `pop_bootstrapped`, when attn TP/CP world size > 1, align request rids across the group before polling:
  - `all_reduce(MAX)` a `has_req` flag so idle ranks still participate
  - `all_gather_object` local rids and take the intersection
  - poll only the common requests, then map polls back onto the local queue by rid (`poll is None` for local-only rids)
- Keep the original early-return / direct-poll path when rid alignment is not needed (TP=1 and CP=1)
- Add unit tests in `test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py` covering empty-queue exits, rid intersection, sorted-order poll mapping, Failed handling, and sequential TP+CP intersection

## Environment

- SGLang v0.5.18
- CUDA 13.0
- NVIDIA H200 141G

## Test plan

- [x] `pytest test/registered/unit/disaggregation/test_prefill_bootstrap_rid_align.py -v`
- [ ] Reproduce previously failing PD prefill with TP/CP > 1 and divergent bootstrap queues; confirm no Gloo mismatch abort
- [ ] Sanity: PD prefill with TP=1, CP=1 still bootstraps normally

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33834063055](https://github.com/sgl-project/sglang/actions/runs/33834063055)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33834062910](https://github.com/sgl-project/sglang/actions/runs/33834062910)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33834063071](https://github.com/sgl-project/sglang/actions/runs/33834063071)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->