### PR TITLE
[Bug] [Rust gateway] reasoning_effort: clamp outer tiers on Harmony + forward effort in Responses→Chat

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -80,6 +80,9 @@ validator = { version = "0.20.0", features = ["derive"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 anyhow = "1.0"
 reasoning-parser = "=1.0.0"
+# TODO: bump once smg releases openai-protocol with smg-project/smg#2410
+# (ReasoningEffort None/Xhigh/Max + as_str/parse). Pin is exact (=) so this
+# fails loudly rather than silently picking up an incompatible version.
 openai-protocol = { version = "=1.0.0", features = ["axum"] }
 tool-parser = "=1.0.0"
 llm-tokenizer = "=1.3.2"

--- a/sgl-model-gateway/src/routers/grpc/harmony/builder.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/builder.rs
@@ -271,15 +271,17 @@ impl HarmonyBuilder {
     }
 
     fn build_system_message_from_chat(&self, request: &ChatCompletionRequest) -> HarmonyMessage {
+        // Harmony knows only low/medium/high; outer OpenAI tiers clamp inward
+        // (mirrors smg #2410 harmony_reasoning_effort_from_str). Chat carries
+        // the tier as a free-form string, so this works without enum variants.
         let reasoning_effort = request
             .reasoning_effort
             .as_deref()
             .map(|effort| match effort {
-                "high" => ReasoningEffort::High,
+                "high" | "xhigh" | "max" => ReasoningEffort::High,
                 "medium" => ReasoningEffort::Medium,
-                "low" => ReasoningEffort::Low,
-                // Harmony does not support minimal reasoning effort
-                "minimal" => ReasoningEffort::Low,
+                "low" | "minimal" | "none" => ReasoningEffort::Low,
+                // Unknown values keep the medium default.
                 _ => ReasoningEffort::Medium,
             });
 
@@ -306,6 +308,9 @@ impl HarmonyBuilder {
                 ResponsesReasoningEffort::Medium => ReasoningEffort::Medium,
                 ResponsesReasoningEffort::Low => ReasoningEffort::Low,
                 ResponsesReasoningEffort::Minimal => ReasoningEffort::Low,
+                // TODO: clamp None→Low and Xhigh/Max→High like the Chat path once
+                // openai-protocol with smg#2410 (7-tier enum) is released. Until
+                // then none/xhigh/max are rejected at deserialization upstream.
             });
 
         self.build_system_message(reasoning_effort, with_custom_tools)

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -15,9 +15,10 @@ use crate::{
             UsageInfo,
         },
         responses::{
-            ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-            ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
-            ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
+            ReasoningEffort, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+            ResponseOutputItem, ResponseReasoningContent::ReasoningText, ResponseStatus,
+            ResponsesRequest, ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig,
+            TextFormat,
         },
         UNKNOWN_MODEL_ID,
     },
@@ -193,6 +194,19 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         tools,
         tool_choice: req.tool_choice.clone(),
         response_format: map_text_to_response_format(&req.text),
+        // Forward reasoning.effort so the chat pipeline sees the tier (previously
+        // dropped, so even supported tiers were lost on the Responses→Chat path).
+        // TODO: switch to `as_str()` once openai-protocol with smg#2410 is released
+        // (adds None/Xhigh/Max + as_str/parse). Local enum currently has 4 variants.
+        reasoning_effort: req.reasoning.as_ref().and_then(|r| r.effort).map(|effort| {
+            match effort {
+                ReasoningEffort::Minimal => "minimal",
+                ReasoningEffort::Low => "low",
+                ReasoningEffort::Medium => "medium",
+                ReasoningEffort::High => "high",
+            }
+            .to_string()
+        }),
         ..Default::default()
     })
 }
@@ -367,6 +381,7 @@ pub(crate) fn chat_to_responses(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::responses::ResponseReasoningParam;
 
     #[test]
     fn test_text_input_conversion() {
@@ -412,6 +427,21 @@ mod tests {
 
         let chat_req = responses_to_chat(&req).unwrap();
         assert_eq!(chat_req.messages.len(), 2); // user + assistant
+    }
+
+    #[test]
+    fn test_reasoning_effort_forwarding() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("Hello".to_string()),
+            reasoning: Some(ResponseReasoningParam {
+                effort: Some(ReasoningEffort::High),
+                summary: None,
+            }),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        assert_eq!(chat_req.reasoning_effort.as_deref(), Some("high"));
     }
 
     #[test]


### PR DESCRIPTION
Implements part of the OpenAI 7-tier `reasoning_effort` support (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`) for the Rust model gateway. See #37912 for the full picture (smg upstream fixed in smg-project/smg#2410, but the fix is **not yet published to crates.io**).

**Draft**: the Responses-path changes and the version bump are blocked on an `openai-protocol` release containing smg-project/smg#2410 (`ReasoningEffort::None`/`Xhigh`/`Max` + `as_str()`/`parse()`). The Chat-path changes below are self-contained and functional already.

## Changes

1. **`harmony/builder.rs::build_system_message_from_chat`** — clamp the free-form string tier to Harmony's Low/Medium/High, mirroring smg#2410's `harmony_reasoning_effort_from_str`:
   - `high`/`xhigh`/`max` → `High`
   - `medium` → `Medium`
   - `low`/`minimal`/`none` → `Low`
   - unknown → `Medium` (default)
   
   Before: `none` fell into `_ => Medium` (kept reasoning **on** when the client asked to turn it off) and `xhigh`/`max` silently degraded to `Medium`.

2. **`regular/responses/conversions.rs::responses_to_chat`** — forward `reasoning.effort` into `ChatCompletionRequest.reasoning_effort`. Previously the field was dropped entirely, so even the 4 supported tiers were lost when a Responses request was converted to the Chat pipeline.

3. **`Cargo.toml`** — TODO comment: bump `openai-protocol` once smg releases the version with #2410.

4. **`harmony/builder.rs::build_system_message_from_responses`** — TODO comment: needs the 7-variant enum from the smg release (`None`→`Low`, `Xhigh`/`Max`→`High`).

## Blocked items (after the smg release)

- Switch `responses_to_chat` to `effort.as_str()`.
- Add `None`/`Xhigh`/`Max` arms to the Responses harmony builder.
- Bump `openai-protocol` pin, then the `/v1/responses` endpoint accepts all 7 tiers (currently `none`/`xhigh`/`max` are rejected with 422 at deserialization because the pinned enum has only 4 variants).

## Test

- New `test_reasoning_effort_forwarding` in `conversions.rs` asserts `reasoning.effort=high` reaches the chat request as `"high"`.
- Harmony clamp behavior matches smg#2410's own unit tests (`harmony_effort_clamps_outer_openai_tiers_inward`).

Not yet CI-runnable locally (no cargo toolchain in this environment); will run `cargo test` once available.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33833270998](https://github.com/sgl-project/sglang/actions/runs/33833270998)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33833270918](https://github.com/sgl-project/sglang/actions/runs/33833270918)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->