### PR TITLE
[Fix] function_call: stream "{}" for zero-argument tool calls in the base detector

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -273,7 +273,11 @@ class BaseFormatDetector(ABC):
             # Case 2: Handle streaming arguments
             # This happens when we've already sent the tool name and now need to stream arguments incrementally
             else:
+                # A zero-parameter call omits the key entirely; the completed
+                # call still owes the client "{}" and the bookkeeping below.
                 cur_arguments = current_tool_call.get("arguments")
+                if cur_arguments is None and is_current_complete:
+                    cur_arguments = {}
                 res = StreamingParseResult()
 
                 if cur_arguments is not None:

--- a/test/registered/unit/function_call/test_zero_argument_tool_call.py
+++ b/test/registered/unit/function_call/test_zero_argument_tool_call.py
@@ -1,0 +1,85 @@
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.json_array_parser import JsonArrayParser
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+def _tool(name: str, properties: dict) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=name,
+            parameters={"type": "object", "properties": properties},
+        ),
+    )
+
+
+class TestZeroArgumentToolCallStreaming(unittest.TestCase):
+    """A tool call that carries no ``arguments`` key must still stream ``{}``.
+
+    A zero-parameter tool call leaves ``arguments`` absent. Streaming used to
+    skip its whole bookkeeping block, so the call streamed an empty argument
+    string (``json.loads("")`` raises client-side), the buffer was never
+    drained, and ``current_tool_id`` never advanced -- which silently dropped
+    every later tool call in the same response.
+    """
+
+    def setUp(self):
+        self.tools = [
+            _tool("get_time", {}),
+            _tool("get_weather", {"city": {"type": "string"}}),
+        ]
+
+    def _stream(self, detector, text):
+        events = []
+        for ch in text:
+            result = detector.parse_streaming_increment(ch, self.tools)
+            for call in result.calls or []:
+                events.append((call.tool_index, call.name, call.parameters))
+        return events
+
+    def test_zero_argument_call_streams_empty_object(self):
+        events = self._stream(
+            Qwen25Detector(), '<tool_call>\n{"name": "get_time"}\n</tool_call>'
+        )
+        names = [name for _, name, _ in events if name]
+        self.assertEqual(names, ["get_time"])
+        streamed_args = "".join(args for _, _, args in events if args)
+        self.assertEqual(streamed_args, "{}")
+
+    def test_zero_argument_call_does_not_drop_the_next_call(self):
+        events = self._stream(
+            Qwen25Detector(),
+            '<tool_call>\n{"name": "get_time"}\n</tool_call>\n'
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n'
+            "</tool_call>",
+        )
+        names = [name for _, name, _ in events if name]
+        self.assertEqual(names, ["get_time", "get_weather"])
+        per_tool = {}
+        for index, _, args in events:
+            if args:
+                per_tool[index] = per_tool.get(index, "") + args
+        self.assertEqual(per_tool.get(0), "{}")
+        self.assertEqual(per_tool.get(1), '{"city": "Paris"}')
+
+    def test_zero_argument_call_drains_the_buffer(self):
+        detector = Qwen25Detector()
+        self._stream(detector, '<tool_call>\n{"name": "get_time"}\n</tool_call>')
+        self.assertNotIn("get_time", detector._buffer)
+
+    def test_json_array_parser_streams_empty_object(self):
+        # tool_choice="required" constrains output to a JSON array and is
+        # model-independent, so it reaches this path for every model.
+        events = self._stream(JsonArrayParser(), '[{"name": "get_time"}]')
+        streamed_args = "".join(args for _, _, args in events if args)
+        self.assertEqual(streamed_args, "{}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `stream=true` and tools, a tool call that arrives without an `arguments` key — the normal shape for a zero-parameter tool, e.g. `<tool_call>{"name": "get_time"}</tool_call>` — makes `BaseFormatDetector.parse_streaming_increment` skip its whole argument-handling block. The client receives `arguments=""` (so `json.loads` fails) and never `{}`; the buffer is never drained; `current_tool_id` never advances; and every later tool call in the same response is silently dropped. The non-streaming path already treats a missing key as `{}`, so streaming and non-streaming disagree on the same text.

Related: #35564 (covers the explicit `"arguments": {}` shape; this PR is the missing-key sibling).

## Modifications

Once the call's JSON is complete, treat a missing `arguments` as `{}` so the existing block emits the `{}` delta and performs its bookkeeping (drain buffer, fill `prev_tool_call_arr`, advance `current_tool_id`). +4 lines in `base_format_detector.py`.

Affects every detector that delegates to the base implementation — qwen25, hermes, llama32, mistral, trinity — and `JsonArrayParser` (`tool_choice="required"`, model-independent).

Explicit `"arguments": null` now also streams `{}` (non-streaming returns `null`); previously it wedged the parser the same way. Scope is intentionally the Case 2 branch only — the "entire call lands in the final delta" gap is the general problem tracked by #32167 and is left untouched here.

## Accuracy Tests

New `test/registered/unit/function_call/test_zero_argument_tool_call.py` (4 cases, real detector classes, char-by-char streaming): streams `{}`; does not drop the next call; drains the buffer; `JsonArrayParser` path. All 4 fail before the fix (`'' != '{}'`, `['get_time'] != ['get_time', 'get_weather']`) and pass after. Full `test/registered/unit/function_call` suite: 490 passed.

## Speed Tests and Profiling

N/A — parser-only change on the tool-call streaming path; no kernel or model forward code touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (not applicable)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (not applicable — see above)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33835048864](https://github.com/sgl-project/sglang/actions/runs/33835048864)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33835048749](https://github.com/sgl-project/sglang/actions/runs/33835048749)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33835048835](https://github.com/sgl-project/sglang/actions/runs/33835048835)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->