### PR TITLE
feat(eplb): add topology-aware expert placement

### DIFF
--- a/docs/docs/advanced_features/expert_parallelism.mdx
+++ b/docs/docs/advanced_features/expert_parallelism.mdx
@@ -245,6 +245,40 @@ To enable EPLB, use the flags `--enable-eplb`. For optimal performance, increase
 
 For more details, refer to the [EPLB Section in the Large-Scale EP Blog](https://lmsys.org/blog/2025-05-05-large-scale-ep/#expert-parallelism-load-balancer) and the [EPLB Repository](https://github.com/deepseek-ai/eplb).
 
+### Topology-aware placement (experimental)
+
+The default EPLB balances expert load without using the physical links between
+EP ranks. `--eplb-algorithm topology_aware` also uses a user-provided cost
+matrix, so the planner can prefer a rank with a cheaper path for the observed
+token traffic. The matrix is relative: smaller values mean cheaper
+communication, and the diagonal must be zero.
+
+Create a JSON file with one row and column per EP rank:
+
+```json
+{
+  "rank_cost_matrix": [
+    [0.0, 1.0],
+    [1.0, 0.0]
+  ]
+}
+```
+
+Then enable the planner on a CUDA deployment:
+
+```bash
+python -m sglang.launch_server \
+  --model-path MODEL_PATH \
+  --tp-size 8 \
+  --enable-eplb \
+  --eplb-algorithm topology_aware \
+  --eplb-topology /path/to/ep_topology.json
+```
+
+The current implementation requires `ep_size == tp_size`,
+`--moe-data-parallel-size 1`, no redundant experts, and the `stat` or
+`stat_approx` expert-distribution recorder. It does not support elastic EP.
+
 
 ## Ascend NPU Guidance
 ### Guidance on SGLang configuration in Ascend NPU

--- a/docs/docs/advanced_features/expert_parallelism.mdx
+++ b/docs/docs/advanced_features/expert_parallelism.mdx
@@ -275,9 +275,15 @@ python -m sglang.launch_server \
   --eplb-topology /path/to/ep_topology.json
 ```
 
-The current implementation requires `ep_size == tp_size`,
+The current implementation requires an A2A backend, `ep_size == tp_size`,
 `--moe-data-parallel-size 1`, no redundant experts, and the `stat` or
-`stat_approx` expert-distribution recorder. It does not support elastic EP.
+`stat_approx` expert-distribution recorder. `stat_approx` is supported only
+with DeepEP normal mode; DeepEP low-latency/auto and Mori do not expose the
+source-rank counts needed by this planner. It does not support elastic EP.
+
+Rows and columns in the matrix use the SGLang MoE-EP group rank order (the
+same rank order used by the CUDA process group and `CUDA_VISIBLE_DEVICES`),
+not an independently sorted PCIe or hostname order.
 
 
 ## Ascend NPU Guidance

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1867,6 +1867,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--eplb-topology`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Path to a JSON rank-to-rank communication cost matrix used by topology-aware EPLB</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
+    </tr>
+        <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--eplb-rebalance-num-iterations`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of iterations to automatically trigger a EPLB re-balance.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`1000`</td>

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -528,6 +528,37 @@ def handle_eplb_and_dispatch(server_args: Any):
             "EPLB is enabled. The expert_distribution_recorder_mode is automatically set."
         )
 
+    if cfg.eplb_algorithm == "topology_aware":
+        if not cfg.enable_eplb:
+            raise ValueError(
+                "--eplb-algorithm topology_aware requires --enable-eplb"
+            )
+        if cfg.eplb_topology is None:
+            raise ValueError(
+                "--eplb-algorithm topology_aware requires --eplb-topology"
+            )
+        if cfg.ep_num_redundant_experts != 0:
+            raise ValueError(
+                "topology-aware EPLB currently requires --ep-num-redundant-experts 0"
+            )
+        if cfg.elastic_ep_backend is not None:
+            raise ValueError(
+                "topology-aware EPLB currently does not support elastic EP"
+            )
+        if cfg.moe_dp_size != 1:
+            raise ValueError(
+                "topology-aware EPLB currently requires --moe-data-parallel-size 1"
+            )
+        if resolved_view(server_args).ep_size != cfg.tp_size:
+            raise ValueError(
+                "topology-aware EPLB currently requires ep_size == tp_size"
+            )
+        if cfg.expert_distribution_recorder_mode not in ("stat", "stat_approx"):
+            raise ValueError(
+                "topology-aware EPLB requires expert distribution recorder mode "
+                "'stat' or 'stat_approx'"
+            )
+
     # Without an a2a backend all EP ranks run the MoE over the same tokens and
     # sum their partial outputs, so the pick has to agree across ranks.
     needs_rank_invariant_dispatch = resolved_view(server_args).moe_a2a_backend == "none"

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -553,6 +553,11 @@ def handle_eplb_and_dispatch(server_args: Any):
             raise ValueError(
                 "topology-aware EPLB currently requires ep_size == tp_size"
             )
+        if getattr(cfg, "ep_dispatch_algorithm", None) not in (None, "static"):
+            raise ValueError(
+                "topology-aware EPLB currently requires "
+                "--ep-dispatch-algorithm static"
+            )
         if cfg.expert_distribution_recorder_mode not in ("stat", "stat_approx"):
             raise ValueError(
                 "topology-aware EPLB requires expert distribution recorder mode "

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -530,13 +530,9 @@ def handle_eplb_and_dispatch(server_args: Any):
 
     if cfg.eplb_algorithm == "topology_aware":
         if not cfg.enable_eplb:
-            raise ValueError(
-                "--eplb-algorithm topology_aware requires --enable-eplb"
-            )
+            raise ValueError("--eplb-algorithm topology_aware requires --enable-eplb")
         if cfg.eplb_topology is None:
-            raise ValueError(
-                "--eplb-algorithm topology_aware requires --eplb-topology"
-            )
+            raise ValueError("--eplb-algorithm topology_aware requires --eplb-topology")
         if cfg.ep_num_redundant_experts != 0:
             raise ValueError(
                 "topology-aware EPLB currently requires --ep-num-redundant-experts 0"
@@ -555,8 +551,7 @@ def handle_eplb_and_dispatch(server_args: Any):
             )
         if getattr(cfg, "ep_dispatch_algorithm", None) not in (None, "static"):
             raise ValueError(
-                "topology-aware EPLB currently requires "
-                "--ep-dispatch-algorithm static"
+                "topology-aware EPLB currently requires --ep-dispatch-algorithm static"
             )
         if cfg.expert_distribution_recorder_mode not in ("stat", "stat_approx"):
             raise ValueError(

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -558,6 +558,25 @@ def handle_eplb_and_dispatch(server_args: Any):
                 "topology-aware EPLB requires expert distribution recorder mode "
                 "'stat' or 'stat_approx'"
             )
+        a2a_backend = resolved_view(server_args).moe_a2a_backend
+        if a2a_backend == "none":
+            raise ValueError(
+                "topology-aware EPLB requires an MoE A2A backend; "
+                "--moe-a2a-backend none has no source-to-destination traffic"
+            )
+        if cfg.expert_distribution_recorder_mode == "stat_approx" and (
+            a2a_backend != "deepep" or cfg.deepep_mode != "normal"
+        ):
+            raise ValueError(
+                "topology-aware EPLB with stat_approx requires DeepEP normal mode"
+            )
+        if (a2a_backend == "deepep" and cfg.deepep_mode != "normal") or (
+            a2a_backend == "mori"
+        ):
+            raise ValueError(
+                "topology-aware EPLB requires a source-aware A2A path; "
+                "DeepEP low-latency/auto and Mori do not expose source counts"
+            )
 
     # Without an a2a backend all EP ranks run the MoE over the same tokens and
     # sum their partial outputs, so the pick has to agree across ranks.

--- a/python/sglang/srt/eplb/eplb_algorithms/__init__.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/__init__.py
@@ -3,7 +3,12 @@ from typing import Optional
 
 import torch
 
-from sglang.srt.eplb.eplb_algorithms import deepseek, deepseek_vec, elasticity_aware
+from sglang.srt.eplb.eplb_algorithms import (
+    deepseek,
+    deepseek_vec,
+    elasticity_aware,
+    topology_aware,
+)
 
 
 class EplbAlgorithm(Enum):
@@ -13,6 +18,7 @@ class EplbAlgorithm(Enum):
     deepseek_vec_hierarchical = auto()
     elasticity_aware = auto()
     elasticity_aware_hierarchical = auto()
+    topology_aware = auto()
     # TODO may have more algorithm later
 
 
@@ -23,7 +29,22 @@ def rebalance_experts(
     num_groups: Optional[int],
     num_nodes: int,
     algorithm: EplbAlgorithm,
+    tokens_per_source_expert: Optional[torch.Tensor] = None,
+    rank_cost_matrix: Optional[torch.Tensor] = None,
 ):
+    if algorithm == EplbAlgorithm.topology_aware:
+        if tokens_per_source_expert is None or rank_cost_matrix is None:
+            raise ValueError(
+                "topology-aware EPLB requires source-rank expert counts and "
+                "a rank cost matrix"
+            )
+        return topology_aware.rebalance_experts_topology_aware(
+            tokens_per_source_expert=tokens_per_source_expert,
+            rank_cost_matrix=rank_cost_matrix,
+            num_physical_experts=num_physical_experts,
+            num_local_physical_experts=num_local_physical_experts,
+        )
+
     if algorithm in [EplbAlgorithm.deepseek, EplbAlgorithm.deepseek_hierarchical]:
         return deepseek.rebalance_experts(
             weight=tokens_per_expert.sum(dim=0),

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -185,7 +185,9 @@ def _improve_topology(
     # full pass over the ranks on the usual 8-way EP setup.
     for _ in range(max(1, num_ranks)):
         feasible_delta = delta.masked_fill(~pair_mask, float("inf"))
-        feasible_delta = feasible_delta.masked_fill(feasible_delta >= -1e-12, float("inf"))
+        feasible_delta = feasible_delta.masked_fill(
+            feasible_delta >= -1e-12, float("inf")
+        )
         best_flat = int(feasible_delta.argmin())
         if not torch.isfinite(feasible_delta.flatten()[best_flat]):
             return assignment

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -20,11 +20,14 @@ many tokens each source rank sent to each expert.  This module deliberately
 keeps that distinction explicit by accepting a ``[layers, source_ranks,
 experts]`` tensor.
 
-This first version handles the no-replication case.  It seeds the placement
-with a load-balanced assignment and then applies communication-improving
-pairwise swaps without increasing the baseline's maximum rank load.  The
-implementation is deliberately small and pure PyTorch so it can run during a
-rebalance without an external optimizer.
+This first version handles the no-replication case.  It starts from the
+default node-uniform placement, applies communication-improving pairwise
+swaps, and then spends a tiny bounded communication budget on reducing the
+busiest destination rank.  The swaps never exceed that placement's
+busiest-rank load; keeping the default compute envelope matters because the
+MoE runner's kernel shape and occupancy depend on which experts share a rank.
+The implementation is deliberately small and pure PyTorch so it can run
+during a rebalance without an external optimizer.
 """
 
 from __future__ import annotations
@@ -34,6 +37,17 @@ from typing import Tuple
 import torch
 
 from sglang.srt.eplb.topology import _validate_rank_cost_matrix
+
+
+# A tiny communication budget lets the planner remove a critical-rank hot
+# spot without allowing the topology objective to drift materially.  The
+# default node-uniform fallback below still protects against a net regression.
+_MAX_COMM_REGRESSION_RATIO = 5e-4
+
+# Keep part of the bounded local-search budget for the serving critical path.
+# Without an explicit reservation, the communication phase can consume every
+# swap and leave a hot destination rank untouched.
+_COMMUNICATION_PHASE_FRACTION = 0.5
 
 
 def _validate_inputs(
@@ -115,53 +129,53 @@ def _assignment_to_maps(
     return physical_to_logical, logical_to_physical, expert_count
 
 
-def _load_balanced_seed(total_load: torch.Tensor, num_ranks: int) -> torch.Tensor:
-    """Build the same kind of load-first, equal-capacity seed as EPLB."""
-    num_experts = total_load.numel()
+def _node_uniform_seed(num_experts: int, num_ranks: int) -> torch.Tensor:
+    """Return the default contiguous expert-to-rank assignment."""
     experts_per_rank = num_experts // num_ranks
-    order = sorted(
-        range(num_experts), key=lambda expert: (-float(total_load[expert]), expert)
-    )
-    assignment = torch.empty(num_experts, dtype=torch.int64)
-    rank_load = [0.0] * num_ranks
-    rank_items = [0] * num_ranks
-    for expert in order:
-        eligible = [
-            rank for rank in range(num_ranks) if rank_items[rank] < experts_per_rank
-        ]
-        destination_rank = min(eligible, key=lambda rank: (rank_load[rank], rank))
-        assignment[expert] = destination_rank
-        rank_items[destination_rank] += 1
-        rank_load[destination_rank] += float(total_load[expert])
-    return assignment
+    return torch.arange(num_experts, dtype=torch.int64) // experts_per_rank
 
 
-def _improve_topology(
+def _rank_loads(
+    assignment: torch.Tensor, total_load: torch.Tensor, num_ranks: int
+) -> torch.Tensor:
+    """Sum logical-expert traffic for each destination rank."""
+    loads = torch.zeros(num_ranks, dtype=torch.float64)
+    loads.scatter_add_(0, assignment, total_load.to(torch.float64))
+    return loads
+
+
+def _build_swap_state(
     assignment: torch.Tensor,
     total_load: torch.Tensor,
     communication_cost: torch.Tensor,
     num_ranks: int,
-) -> torch.Tensor:
-    """Apply deterministic improving swaps within the seed's load envelope."""
-    rank_load = [0.0] * num_ranks
-    for expert, rank in enumerate(assignment.tolist()):
-        rank_load[rank] += float(total_load[expert])
-    rank_load = torch.tensor(rank_load, dtype=torch.float64)
-    max_seed_load = rank_load.max().item()
-
+    rank_load: torch.Tensor,
+    max_seed_load: float,
+    expert_ids: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Build the pairwise swap tensors for the current assignment."""
     num_experts = assignment.numel()
-    expert_ids = torch.arange(num_experts, dtype=torch.int64)
     first_rank = assignment[:, None].expand(num_experts, num_experts)
     second_rank = assignment[None, :].expand(num_experts, num_experts)
     pair_mask = torch.triu(
-        torch.ones((num_experts, num_experts), dtype=torch.bool), diagonal=1
+        torch.ones(
+            (num_experts, num_experts),
+            dtype=torch.bool,
+            device=assignment.device,
+        ),
+        diagonal=1,
     )
     pair_mask &= first_rank != second_rank
 
-    # The rank loads of all non-swapped ranks are already within the seed's
-    # envelope.  Therefore a proposed swap is feasible exactly when its two
-    # changed ranks stay below that envelope; this avoids an O(num_ranks)
-    # max-reduction for every pair.
+    # A swap only changes the loads of the two ranks that own its experts.
+    # Every other rank is already within the seed envelope.
     new_first_load = (
         rank_load[first_rank]
         - total_load[:, None]
@@ -183,55 +197,239 @@ def _improve_topology(
         - communication_cost[first_ids, first_rank]
         - communication_cost[second_ids, second_rank]
     )
+    return (
+        first_rank,
+        second_rank,
+        pair_mask,
+        new_first_load,
+        new_second_load,
+        delta,
+    )
 
-    # Rebalancing runs in the serving process.  A bounded number of swaps keeps
-    # the planner predictable for large expert counts while still allowing a
-    # full pass over the ranks on the usual 8-way EP setup.
-    for _ in range(max(1, num_ranks)):
+
+def _apply_swap(
+    assignment: torch.Tensor,
+    rank_load: torch.Tensor,
+    new_first_load: torch.Tensor,
+    new_second_load: torch.Tensor,
+    first: int,
+    second: int,
+) -> None:
+    """Apply one expert swap and update the two affected rank loads."""
+    first_rank = int(assignment[first])
+    second_rank = int(assignment[second])
+    assignment[first] = second_rank
+    assignment[second] = first_rank
+    rank_load[first_rank] = new_first_load[first, second]
+    rank_load[second_rank] = new_second_load[first, second]
+
+
+def _run_communication_swaps(
+    assignment: torch.Tensor,
+    total_load: torch.Tensor,
+    communication_cost: torch.Tensor,
+    num_ranks: int,
+    rank_load: torch.Tensor,
+    max_seed_load: float,
+    expert_ids: torch.Tensor,
+    max_swaps: int,
+) -> int:
+    """Apply the bounded phase that strictly reduces communication cost."""
+    used_swaps = 0
+    for _ in range(max_swaps):
+        (
+            _first_rank,
+            _second_rank,
+            pair_mask,
+            new_first_load,
+            new_second_load,
+            delta,
+        ) = _build_swap_state(
+            assignment,
+            total_load,
+            communication_cost,
+            num_ranks,
+            rank_load,
+            max_seed_load,
+            expert_ids,
+        )
         feasible_delta = delta.masked_fill(~pair_mask, float("inf"))
         feasible_delta = feasible_delta.masked_fill(
             feasible_delta >= -1e-12, float("inf")
         )
         best_flat = int(feasible_delta.argmin())
         if not torch.isfinite(feasible_delta.flatten()[best_flat]):
-            return assignment
+            break
 
-        first = best_flat // num_experts
-        second = best_flat % num_experts
-        first_rank_id = int(assignment[first])
-        second_rank_id = int(assignment[second])
-        assignment[first] = second_rank_id
-        assignment[second] = first_rank_id
-        rank_load[first_rank_id] = new_first_load[first, second]
-        rank_load[second_rank_id] = new_second_load[first, second]
+        first = best_flat // assignment.numel()
+        second = best_flat % assignment.numel()
+        _apply_swap(
+            assignment,
+            rank_load,
+            new_first_load,
+            new_second_load,
+            first,
+            second,
+        )
+        used_swaps += 1
+    return used_swaps
 
-        # Keep the pair tensors synchronized with the changed assignment for
-        # the next bounded iteration.
-        first_rank = assignment[:, None].expand(num_experts, num_experts)
-        second_rank = assignment[None, :].expand(num_experts, num_experts)
-        new_first_load = (
-            rank_load[first_rank]
-            - total_load[:, None]
-            + total_load[None, :]
+
+def _run_load_swaps(
+    assignment: torch.Tensor,
+    total_load: torch.Tensor,
+    communication_cost: torch.Tensor,
+    num_ranks: int,
+    rank_load: torch.Tensor,
+    max_seed_load: float,
+    expert_ids: torch.Tensor,
+    max_swaps: int,
+    used_swaps: int,
+    max_comm_regression_ratio: float,
+) -> None:
+    """Spend the explicit communication budget on critical-rank balancing."""
+    if max_comm_regression_ratio == 0.0 or used_swaps >= max_swaps:
+        return
+
+    communication_limit = (
+        communication_cost[expert_ids, assignment].sum().item()
+        * (1.0 + max_comm_regression_ratio)
+    )
+    rank_ids = torch.arange(
+        num_ranks, dtype=torch.int64, device=assignment.device
+    )[None, None, :]
+    for _ in range(max_swaps - used_swaps):
+        (
+            first_rank,
+            second_rank,
+            pair_mask,
+            new_first_load,
+            new_second_load,
+            delta_comm,
+        ) = _build_swap_state(
+            assignment,
+            total_load,
+            communication_cost,
+            num_ranks,
+            rank_load,
+            max_seed_load,
+            expert_ids,
         )
-        new_second_load = (
-            rank_load[second_rank]
-            - total_load[None, :]
-            + total_load[:, None]
-        )
-        pair_mask = torch.triu(
-            torch.ones((num_experts, num_experts), dtype=torch.bool), diagonal=1
-        )
-        pair_mask &= first_rank != second_rank
-        pair_mask &= new_first_load <= max_seed_load + 1e-12
-        pair_mask &= new_second_load <= max_seed_load + 1e-12
-        delta = (
-            communication_cost[first_ids, second_rank]
-            + communication_cost[second_ids, first_rank]
-            - communication_cost[first_ids, first_rank]
-            - communication_cost[second_ids, second_rank]
+        pair_mask &= (
+            communication_cost[expert_ids, assignment].sum()
+            + delta_comm
+            <= communication_limit + 1e-12
         )
 
+        changed_rank = (rank_ids == first_rank[:, :, None]) | (
+            rank_ids == second_rank[:, :, None]
+        )
+        other_max = rank_load[None, None, :].masked_fill(
+            changed_rank, float("-inf")
+        ).amax(dim=-1)
+        new_max = torch.maximum(
+            torch.maximum(new_first_load, new_second_load), other_max
+        )
+        old_max = rank_load.max()
+        old_sumsq = rank_load.square().sum()
+        new_sumsq = (
+            old_sumsq
+            - rank_load[first_rank].square()
+            - rank_load[second_rank].square()
+            + new_first_load.square()
+            + new_second_load.square()
+        )
+        max_improving = new_max < old_max - 1e-12
+        max_tied = (new_max - old_max).abs() <= 1e-12
+        pair_mask &= max_improving | (
+            max_tied & (new_sumsq < old_sumsq - 1e-12)
+        )
+
+        feasible_max = new_max.masked_fill(~pair_mask, float("inf"))
+        best_max = feasible_max.min()
+        if not torch.isfinite(best_max):
+            break
+        tied_mask = pair_mask & ((new_max - best_max).abs() <= 1e-12)
+        feasible_sumsq = new_sumsq.masked_fill(~tied_mask, float("inf"))
+        best_flat = int(feasible_sumsq.argmin())
+
+        first = best_flat // assignment.numel()
+        second = best_flat % assignment.numel()
+        _apply_swap(
+            assignment,
+            rank_load,
+            new_first_load,
+            new_second_load,
+            first,
+            second,
+        )
+
+
+def _improve_topology(
+    assignment: torch.Tensor,
+    total_load: torch.Tensor,
+    communication_cost: torch.Tensor,
+    num_ranks: int,
+    max_allowed_load: float | None = None,
+    max_swaps: int | None = None,
+    max_comm_regression_ratio: float = 0.0,
+) -> torch.Tensor:
+    """Apply deterministic swaps within a rank-load envelope.
+
+    The first phase only accepts communication-improving swaps.  An optional
+    small communication budget can then be spent on swaps that lower the
+    busiest destination rank.  The latter models the serving critical path:
+    one overloaded rank can hold up the whole expert-parallel step even when
+    the aggregate communication score is marginally better.
+    """
+    if max_comm_regression_ratio < 0:
+        raise ValueError("max_comm_regression_ratio must be non-negative")
+    rank_load = _rank_loads(assignment, total_load, num_ranks)
+    max_seed_load = (
+        rank_load.max().item()
+        if max_allowed_load is None
+        else float(max_allowed_load)
+    )
+    num_experts = assignment.numel()
+    expert_ids = torch.arange(
+        num_experts, dtype=torch.int64, device=assignment.device
+    )
+    if max_swaps is None:
+        # Five rounds per local expert slot reach the useful local-search basin
+        # on the observed 8-way EP workloads without a long scheduler pause.
+        max_swaps = max(1, 5 * (num_experts // num_ranks))
+
+    communication_swaps = max_swaps
+    if max_comm_regression_ratio > 0.0:
+        # Reserve the remaining rounds for the critical-rank load phase.  A
+        # communication-only search can otherwise consume the entire budget,
+        # leaving no opportunity to fix a straggling destination rank.
+        communication_swaps = max(
+            1, int(max_swaps * _COMMUNICATION_PHASE_FRACTION)
+        )
+
+    used_swaps = _run_communication_swaps(
+        assignment,
+        total_load,
+        communication_cost,
+        num_ranks,
+        rank_load,
+        max_seed_load,
+        expert_ids,
+        communication_swaps,
+    )
+    _run_load_swaps(
+        assignment,
+        total_load,
+        communication_cost,
+        num_ranks,
+        rank_load,
+        max_seed_load,
+        expert_ids,
+        max_swaps,
+        used_swaps,
+        max_comm_regression_ratio,
+    )
     return assignment
 
 
@@ -247,10 +445,12 @@ def rebalance_experts_topology_aware(
     ``tokens_per_source_expert[layer, source, expert]`` is the number of
     routed tokens originating at ``source`` for ``expert``.  Each logical
     expert is assigned to exactly one destination rank, and every rank gets
-    the same number of experts.  A load-balanced seed is improved with
-    communication-reducing swaps that keep the seed's maximum rank load as an
-    upper bound.  Ties are resolved by expert and rank id, making the result
-    deterministic.
+    the same number of experts.  The default node-uniform layout is improved
+    with communication-reducing swaps followed by a tiny, bounded
+    load-balancing phase.  The maximum rank load never exceeds the default
+    layout's busiest rank, and the default layout is used as a
+    communication-cost fallback.  Ties are resolved by expert and rank id,
+    making the result deterministic.
 
     The return value follows ``rebalance_experts``: physical-to-logical map,
     logical-to-physical map, and the per-expert replica count.
@@ -269,13 +469,36 @@ def rebalance_experts_topology_aware(
     assignment = torch.empty(
         (num_layers, num_logical_experts), dtype=torch.int64, device="cpu"
     )
+    node_uniform_assignment = _node_uniform_seed(
+        num_logical_experts, num_ranks
+    )
+    expert_ids = torch.arange(num_logical_experts, dtype=torch.int64)
     for layer in range(num_layers):
         total_load = counts[layer].sum(dim=0)
         communication_cost = counts[layer].transpose(0, 1).matmul(costs)
-        assignment[layer] = _load_balanced_seed(total_load, num_ranks)
-        assignment[layer] = _improve_topology(
-            assignment[layer], total_load, communication_cost, num_ranks
+        node_uniform_load = _rank_loads(
+            node_uniform_assignment, total_load, num_ranks
         )
+        max_allowed_load = node_uniform_load.max().item()
+        assignment[layer] = _improve_topology(
+            node_uniform_assignment.clone(),
+            total_load,
+            communication_cost,
+            num_ranks,
+            max_allowed_load=max_allowed_load,
+            max_comm_regression_ratio=_MAX_COMM_REGRESSION_RATIO,
+        )
+        # A bounded local search can stop before finding a good swap sequence.
+        # The node-uniform layout is always a valid fallback, so never return a
+        # topology placement with a higher communication objective.
+        candidate_cost = communication_cost[
+            expert_ids, assignment[layer]
+        ].sum()
+        node_uniform_cost = communication_cost[
+            expert_ids, node_uniform_assignment
+        ].sum()
+        if candidate_cost > node_uniform_cost:
+            assignment[layer] = node_uniform_assignment
 
     return _assignment_to_maps(assignment, num_ranks)
 

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -20,9 +20,11 @@ many tokens each source rank sent to each expert.  This module deliberately
 keeps that distinction explicit by accepting a ``[layers, source_ranks,
 experts]`` tensor.
 
-This first version handles the no-replication case.  It is a small, pure
-PyTorch planner that is useful for validating the placement contract before
-the runtime recorder and CLI are wired up.
+This first version handles the no-replication case.  It seeds the placement
+with a load-balanced assignment and then applies communication-improving
+pairwise swaps without increasing the baseline's maximum rank load.  The
+implementation is deliberately small and pure PyTorch so it can run during a
+rebalance without an external optimizer.
 """
 
 from __future__ import annotations
@@ -109,6 +111,124 @@ def _assignment_to_maps(
     return physical_to_logical, logical_to_physical, expert_count
 
 
+def _load_balanced_seed(total_load: torch.Tensor, num_ranks: int) -> torch.Tensor:
+    """Build the same kind of load-first, equal-capacity seed as EPLB."""
+    num_experts = total_load.numel()
+    experts_per_rank = num_experts // num_ranks
+    order = sorted(
+        range(num_experts), key=lambda expert: (-float(total_load[expert]), expert)
+    )
+    assignment = torch.empty(num_experts, dtype=torch.int64)
+    rank_load = [0.0] * num_ranks
+    rank_items = [0] * num_ranks
+    for expert in order:
+        eligible = [
+            rank for rank in range(num_ranks) if rank_items[rank] < experts_per_rank
+        ]
+        destination_rank = min(eligible, key=lambda rank: (rank_load[rank], rank))
+        assignment[expert] = destination_rank
+        rank_items[destination_rank] += 1
+        rank_load[destination_rank] += float(total_load[expert])
+    return assignment
+
+
+def _improve_topology(
+    assignment: torch.Tensor,
+    total_load: torch.Tensor,
+    communication_cost: torch.Tensor,
+    num_ranks: int,
+) -> torch.Tensor:
+    """Apply deterministic improving swaps within the seed's load envelope."""
+    rank_load = [0.0] * num_ranks
+    for expert, rank in enumerate(assignment.tolist()):
+        rank_load[rank] += float(total_load[expert])
+    rank_load = torch.tensor(rank_load, dtype=torch.float64)
+    max_seed_load = rank_load.max().item()
+
+    num_experts = assignment.numel()
+    expert_ids = torch.arange(num_experts, dtype=torch.int64)
+    first_rank = assignment[:, None].expand(num_experts, num_experts)
+    second_rank = assignment[None, :].expand(num_experts, num_experts)
+    pair_mask = torch.triu(
+        torch.ones((num_experts, num_experts), dtype=torch.bool), diagonal=1
+    )
+    pair_mask &= first_rank != second_rank
+
+    # The rank loads of all non-swapped ranks are already within the seed's
+    # envelope.  Therefore a proposed swap is feasible exactly when its two
+    # changed ranks stay below that envelope; this avoids an O(num_ranks)
+    # max-reduction for every pair.
+    new_first_load = (
+        rank_load[first_rank]
+        - total_load[:, None]
+        + total_load[None, :]
+    )
+    new_second_load = (
+        rank_load[second_rank]
+        - total_load[None, :]
+        + total_load[:, None]
+    )
+    pair_mask &= new_first_load <= max_seed_load + 1e-12
+    pair_mask &= new_second_load <= max_seed_load + 1e-12
+
+    first_ids = expert_ids[:, None]
+    second_ids = expert_ids[None, :]
+    delta = (
+        communication_cost[first_ids, second_rank]
+        + communication_cost[second_ids, first_rank]
+        - communication_cost[first_ids, first_rank]
+        - communication_cost[second_ids, second_rank]
+    )
+
+    # Rebalancing runs in the serving process.  A bounded number of swaps keeps
+    # the planner predictable for large expert counts while still allowing a
+    # full pass over the ranks on the usual 8-way EP setup.
+    for _ in range(max(1, num_ranks)):
+        feasible_delta = delta.masked_fill(~pair_mask, float("inf"))
+        feasible_delta = feasible_delta.masked_fill(feasible_delta >= -1e-12, float("inf"))
+        best_flat = int(feasible_delta.argmin())
+        if not torch.isfinite(feasible_delta.flatten()[best_flat]):
+            return assignment
+
+        first = best_flat // num_experts
+        second = best_flat % num_experts
+        first_rank_id = int(assignment[first])
+        second_rank_id = int(assignment[second])
+        assignment[first] = second_rank_id
+        assignment[second] = first_rank_id
+        rank_load[first_rank_id] = new_first_load[first, second]
+        rank_load[second_rank_id] = new_second_load[first, second]
+
+        # Keep the pair tensors synchronized with the changed assignment for
+        # the next bounded iteration.
+        first_rank = assignment[:, None].expand(num_experts, num_experts)
+        second_rank = assignment[None, :].expand(num_experts, num_experts)
+        new_first_load = (
+            rank_load[first_rank]
+            - total_load[:, None]
+            + total_load[None, :]
+        )
+        new_second_load = (
+            rank_load[second_rank]
+            - total_load[None, :]
+            + total_load[:, None]
+        )
+        pair_mask = torch.triu(
+            torch.ones((num_experts, num_experts), dtype=torch.bool), diagonal=1
+        )
+        pair_mask &= first_rank != second_rank
+        pair_mask &= new_first_load <= max_seed_load + 1e-12
+        pair_mask &= new_second_load <= max_seed_load + 1e-12
+        delta = (
+            communication_cost[first_ids, second_rank]
+            + communication_cost[second_ids, first_rank]
+            - communication_cost[first_ids, first_rank]
+            - communication_cost[second_ids, second_rank]
+        )
+
+    return assignment
+
+
 def rebalance_experts_topology_aware(
     tokens_per_source_expert: torch.Tensor,
     rank_cost_matrix: torch.Tensor,
@@ -121,9 +241,10 @@ def rebalance_experts_topology_aware(
     ``tokens_per_source_expert[layer, source, expert]`` is the number of
     routed tokens originating at ``source`` for ``expert``.  Each logical
     expert is assigned to exactly one destination rank, and every rank gets
-    the same number of experts.  Experts are considered in descending total
-    load; each one is assigned to the currently cheapest rank with remaining
-    capacity.  Ties are resolved by rank id, making the result deterministic.
+    the same number of experts.  A load-balanced seed is improved with
+    communication-reducing swaps that keep the seed's maximum rank load as an
+    upper bound.  Ties are resolved by expert and rank id, making the result
+    deterministic.
 
     The return value follows ``rebalance_experts``: physical-to-logical map,
     logical-to-physical map, and the per-expert replica count.
@@ -142,24 +263,13 @@ def rebalance_experts_topology_aware(
     assignment = torch.empty(
         (num_layers, num_logical_experts), dtype=torch.int64, device="cpu"
     )
-    experts_per_rank = num_physical_experts // num_ranks
-
     for layer in range(num_layers):
         total_load = counts[layer].sum(dim=0)
         communication_cost = counts[layer].transpose(0, 1).matmul(costs)
-        order = sorted(
-            range(num_logical_experts),
-            key=lambda expert: (-float(total_load[expert]), expert),
+        assignment[layer] = _load_balanced_seed(total_load, num_ranks)
+        assignment[layer] = _improve_topology(
+            assignment[layer], total_load, communication_cost, num_ranks
         )
-        remaining = [experts_per_rank] * num_ranks
-        for expert in order:
-            eligible = [rank for rank in range(num_ranks) if remaining[rank] > 0]
-            destination_rank = min(
-                eligible,
-                key=lambda rank: (float(communication_cost[expert, rank]), rank),
-            )
-            assignment[layer, expert] = destination_rank
-            remaining[destination_rank] -= 1
 
     return _assignment_to_maps(assignment, num_ranks)
 

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -38,7 +38,6 @@ import torch
 
 from sglang.srt.eplb.topology import _validate_rank_cost_matrix
 
-
 # A tiny communication budget lets the planner remove a critical-rank hot
 # spot without allowing the topology objective to drift materially.  The
 # default node-uniform fallback below still protects against a net regression.
@@ -107,9 +106,7 @@ def _assignment_to_maps(
     num_layers, num_experts = assignment.shape
     experts_per_rank = num_experts // num_ranks
     physical_to_logical = torch.empty_like(assignment)
-    logical_to_physical = torch.empty(
-        (num_layers, num_experts, 1), dtype=torch.int64
-    )
+    logical_to_physical = torch.empty((num_layers, num_experts, 1), dtype=torch.int64)
 
     for layer in range(num_layers):
         next_slot = [0] * num_ranks
@@ -176,16 +173,8 @@ def _build_swap_state(
 
     # A swap only changes the loads of the two ranks that own its experts.
     # Every other rank is already within the seed envelope.
-    new_first_load = (
-        rank_load[first_rank]
-        - total_load[:, None]
-        + total_load[None, :]
-    )
-    new_second_load = (
-        rank_load[second_rank]
-        - total_load[None, :]
-        + total_load[:, None]
-    )
+    new_first_load = rank_load[first_rank] - total_load[:, None] + total_load[None, :]
+    new_second_load = rank_load[second_rank] - total_load[None, :] + total_load[:, None]
     pair_mask &= new_first_load <= max_seed_load + 1e-12
     pair_mask &= new_second_load <= max_seed_load + 1e-12
 
@@ -291,13 +280,12 @@ def _run_load_swaps(
     if max_comm_regression_ratio == 0.0 or used_swaps >= max_swaps:
         return
 
-    communication_limit = (
-        communication_cost[expert_ids, assignment].sum().item()
-        * (1.0 + max_comm_regression_ratio)
+    communication_limit = communication_cost[expert_ids, assignment].sum().item() * (
+        1.0 + max_comm_regression_ratio
     )
-    rank_ids = torch.arange(
-        num_ranks, dtype=torch.int64, device=assignment.device
-    )[None, None, :]
+    rank_ids = torch.arange(num_ranks, dtype=torch.int64, device=assignment.device)[
+        None, None, :
+    ]
     for _ in range(max_swaps - used_swaps):
         (
             first_rank,
@@ -316,17 +304,18 @@ def _run_load_swaps(
             expert_ids,
         )
         pair_mask &= (
-            communication_cost[expert_ids, assignment].sum()
-            + delta_comm
+            communication_cost[expert_ids, assignment].sum() + delta_comm
             <= communication_limit + 1e-12
         )
 
         changed_rank = (rank_ids == first_rank[:, :, None]) | (
             rank_ids == second_rank[:, :, None]
         )
-        other_max = rank_load[None, None, :].masked_fill(
-            changed_rank, float("-inf")
-        ).amax(dim=-1)
+        other_max = (
+            rank_load[None, None, :]
+            .masked_fill(changed_rank, float("-inf"))
+            .amax(dim=-1)
+        )
         new_max = torch.maximum(
             torch.maximum(new_first_load, new_second_load), other_max
         )
@@ -341,9 +330,7 @@ def _run_load_swaps(
         )
         max_improving = new_max < old_max - 1e-12
         max_tied = (new_max - old_max).abs() <= 1e-12
-        pair_mask &= max_improving | (
-            max_tied & (new_sumsq < old_sumsq - 1e-12)
-        )
+        pair_mask &= max_improving | (max_tied & (new_sumsq < old_sumsq - 1e-12))
 
         feasible_max = new_max.masked_fill(~pair_mask, float("inf"))
         best_max = feasible_max.min()
@@ -386,14 +373,10 @@ def _improve_topology(
         raise ValueError("max_comm_regression_ratio must be non-negative")
     rank_load = _rank_loads(assignment, total_load, num_ranks)
     max_seed_load = (
-        rank_load.max().item()
-        if max_allowed_load is None
-        else float(max_allowed_load)
+        rank_load.max().item() if max_allowed_load is None else float(max_allowed_load)
     )
     num_experts = assignment.numel()
-    expert_ids = torch.arange(
-        num_experts, dtype=torch.int64, device=assignment.device
-    )
+    expert_ids = torch.arange(num_experts, dtype=torch.int64, device=assignment.device)
     if max_swaps is None:
         # Five rounds per local expert slot reach the useful local-search basin
         # on the observed 8-way EP workloads without a long scheduler pause.
@@ -404,9 +387,7 @@ def _improve_topology(
         # Reserve the remaining rounds for the critical-rank load phase.  A
         # communication-only search can otherwise consume the entire budget,
         # leaving no opportunity to fix a straggling destination rank.
-        communication_swaps = max(
-            1, int(max_swaps * _COMMUNICATION_PHASE_FRACTION)
-        )
+        communication_swaps = max(1, int(max_swaps * _COMMUNICATION_PHASE_FRACTION))
 
     used_swaps = _run_communication_swaps(
         assignment,
@@ -469,16 +450,12 @@ def rebalance_experts_topology_aware(
     assignment = torch.empty(
         (num_layers, num_logical_experts), dtype=torch.int64, device="cpu"
     )
-    node_uniform_assignment = _node_uniform_seed(
-        num_logical_experts, num_ranks
-    )
+    node_uniform_assignment = _node_uniform_seed(num_logical_experts, num_ranks)
     expert_ids = torch.arange(num_logical_experts, dtype=torch.int64)
     for layer in range(num_layers):
         total_load = counts[layer].sum(dim=0)
         communication_cost = counts[layer].transpose(0, 1).matmul(costs)
-        node_uniform_load = _rank_loads(
-            node_uniform_assignment, total_load, num_ranks
-        )
+        node_uniform_load = _rank_loads(node_uniform_assignment, total_load, num_ranks)
         max_allowed_load = node_uniform_load.max().item()
         assignment[layer] = _improve_topology(
             node_uniform_assignment.clone(),
@@ -491,9 +468,7 @@ def rebalance_experts_topology_aware(
         # A bounded local search can stop before finding a good swap sequence.
         # The node-uniform layout is always a valid fallback, so never return a
         # topology placement with a higher communication objective.
-        candidate_cost = communication_cost[
-            expert_ids, assignment[layer]
-        ].sum()
+        candidate_cost = communication_cost[expert_ids, assignment[layer]].sum()
         node_uniform_cost = communication_cost[
             expert_ids, node_uniform_assignment
         ].sum()

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -65,9 +65,13 @@ def _validate_inputs(
         raise TypeError("rank_cost_matrix must use a floating-point dtype")
     _validate_rank_cost_matrix(rank_cost_matrix, expected_num_ranks=num_ranks)
 
-    if num_physical_experts != num_logical_experts:
+    if num_physical_experts > num_logical_experts:
         raise NotImplementedError(
             "topology-aware placement currently requires no redundant experts"
+        )
+    if num_physical_experts != num_logical_experts:
+        raise ValueError(
+            "num_physical_experts must match the source-count expert dimension"
         )
     if num_physical_experts <= 0 or num_physical_experts % num_ranks != 0:
         raise ValueError("num_physical_experts must be positive and divisible by ranks")

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -1,0 +1,173 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+"""Topology-aware expert placement primitives.
+
+The existing EPLB algorithms receive one global count for each logical
+expert.  A topology-aware planner needs one extra piece of information: how
+many tokens each source rank sent to each expert.  This module deliberately
+keeps that distinction explicit by accepting a ``[layers, source_ranks,
+experts]`` tensor.
+
+This first version handles the no-replication case.  It is a small, pure
+PyTorch planner that is useful for validating the placement contract before
+the runtime recorder and CLI are wired up.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+
+def _validate_inputs(
+    tokens_per_source_expert: torch.Tensor,
+    rank_cost_matrix: torch.Tensor,
+    num_physical_experts: int,
+    num_local_physical_experts: int | None,
+) -> tuple[int, int, int]:
+    if tokens_per_source_expert.ndim != 3:
+        raise ValueError(
+            "tokens_per_source_expert must have shape "
+            "[num_layers, num_source_ranks, num_logical_experts]"
+        )
+    num_layers, num_ranks, num_logical_experts = tokens_per_source_expert.shape
+    if num_layers <= 0 or num_ranks <= 0 or num_logical_experts <= 0:
+        raise ValueError("tokens_per_source_expert dimensions must be positive")
+    if not torch.is_floating_point(tokens_per_source_expert) and not (
+        tokens_per_source_expert.dtype == torch.int32
+        or tokens_per_source_expert.dtype == torch.int64
+    ):
+        raise TypeError("tokens_per_source_expert must use an integer or float dtype")
+    if torch.any(tokens_per_source_expert < 0) or (
+        torch.is_floating_point(tokens_per_source_expert)
+        and not torch.isfinite(tokens_per_source_expert).all()
+    ):
+        raise ValueError("tokens_per_source_expert must be finite and non-negative")
+
+    if (
+        rank_cost_matrix.ndim != 2
+        or rank_cost_matrix.shape != (num_ranks, num_ranks)
+    ):
+        raise ValueError("rank_cost_matrix must be square and match source ranks")
+    if not torch.is_floating_point(rank_cost_matrix):
+        raise TypeError("rank_cost_matrix must use a floating-point dtype")
+    if not torch.isfinite(rank_cost_matrix).all() or torch.any(rank_cost_matrix < 0):
+        raise ValueError("rank_cost_matrix must be finite and non-negative")
+    if torch.any(torch.diagonal(rank_cost_matrix) != 0):
+        raise ValueError("rank_cost_matrix diagonal must be zero")
+
+    if num_physical_experts != num_logical_experts:
+        raise NotImplementedError(
+            "topology-aware placement currently requires no redundant experts"
+        )
+    if num_physical_experts <= 0 or num_physical_experts % num_ranks != 0:
+        raise ValueError("num_physical_experts must be positive and divisible by ranks")
+    expected_local = num_physical_experts // num_ranks
+    if num_local_physical_experts is not None and (
+        num_local_physical_experts != expected_local
+    ):
+        raise ValueError(
+            "num_local_physical_experts must equal "
+            "num_physical_experts // num_source_ranks"
+        )
+    return num_layers, num_ranks, num_logical_experts
+
+
+def _assignment_to_maps(
+    assignment: torch.Tensor, num_ranks: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert ``[layers, experts] -> destination rank`` into EPLB maps."""
+    num_layers, num_experts = assignment.shape
+    experts_per_rank = num_experts // num_ranks
+    physical_to_logical = torch.empty_like(assignment)
+    logical_to_physical = torch.empty(
+        (num_layers, num_experts, 1), dtype=torch.int64
+    )
+
+    for layer in range(num_layers):
+        next_slot = [0] * num_ranks
+        for logical_expert in range(num_experts):
+            destination_rank = int(assignment[layer, logical_expert])
+            slot = next_slot[destination_rank]
+            if slot >= experts_per_rank:
+                raise ValueError("assignment exceeds per-rank expert capacity")
+            physical_expert = destination_rank * experts_per_rank + slot
+            physical_to_logical[layer, physical_expert] = logical_expert
+            logical_to_physical[layer, logical_expert, 0] = physical_expert
+            next_slot[destination_rank] += 1
+        if next_slot != [experts_per_rank] * num_ranks:
+            raise ValueError("assignment does not fill every physical expert slot")
+
+    expert_count = torch.ones((num_layers, num_experts), dtype=torch.int64)
+    return physical_to_logical, logical_to_physical, expert_count
+
+
+def rebalance_experts_topology_aware(
+    tokens_per_source_expert: torch.Tensor,
+    rank_cost_matrix: torch.Tensor,
+    *,
+    num_physical_experts: int | None = None,
+    num_local_physical_experts: int | None = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Place experts using source-to-destination communication costs.
+
+    ``tokens_per_source_expert[layer, source, expert]`` is the number of
+    routed tokens originating at ``source`` for ``expert``.  Each logical
+    expert is assigned to exactly one destination rank, and every rank gets
+    the same number of experts.  Experts are considered in descending total
+    load; each one is assigned to the currently cheapest rank with remaining
+    capacity.  Ties are resolved by rank id, making the result deterministic.
+
+    The return value follows ``rebalance_experts``: physical-to-logical map,
+    logical-to-physical map, and the per-expert replica count.
+    """
+    if num_physical_experts is None:
+        num_physical_experts = int(tokens_per_source_expert.shape[-1])
+    num_layers, num_ranks, num_logical_experts = _validate_inputs(
+        tokens_per_source_expert,
+        rank_cost_matrix,
+        num_physical_experts,
+        num_local_physical_experts,
+    )
+
+    counts = tokens_per_source_expert.to(dtype=torch.float64, device="cpu")
+    costs = rank_cost_matrix.to(dtype=torch.float64, device="cpu")
+    assignment = torch.empty(
+        (num_layers, num_logical_experts), dtype=torch.int64, device="cpu"
+    )
+    experts_per_rank = num_physical_experts // num_ranks
+
+    for layer in range(num_layers):
+        total_load = counts[layer].sum(dim=0)
+        communication_cost = counts[layer].transpose(0, 1).matmul(costs)
+        order = sorted(
+            range(num_logical_experts),
+            key=lambda expert: (-float(total_load[expert]), expert),
+        )
+        remaining = [experts_per_rank] * num_ranks
+        for expert in order:
+            eligible = [rank for rank in range(num_ranks) if remaining[rank] > 0]
+            destination_rank = min(
+                eligible,
+                key=lambda rank: (float(communication_cost[expert, rank]), rank),
+            )
+            assignment[layer, expert] = destination_rank
+            remaining[destination_rank] -= 1
+
+    return _assignment_to_maps(assignment, num_ranks)
+
+
+__all__ = ["rebalance_experts_topology_aware"]

--- a/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/topology_aware.py
@@ -31,6 +31,8 @@ from typing import Tuple
 
 import torch
 
+from sglang.srt.eplb.topology import _validate_rank_cost_matrix
+
 
 def _validate_inputs(
     tokens_per_source_expert: torch.Tensor,
@@ -57,17 +59,9 @@ def _validate_inputs(
     ):
         raise ValueError("tokens_per_source_expert must be finite and non-negative")
 
-    if (
-        rank_cost_matrix.ndim != 2
-        or rank_cost_matrix.shape != (num_ranks, num_ranks)
-    ):
-        raise ValueError("rank_cost_matrix must be square and match source ranks")
     if not torch.is_floating_point(rank_cost_matrix):
         raise TypeError("rank_cost_matrix must use a floating-point dtype")
-    if not torch.isfinite(rank_cost_matrix).all() or torch.any(rank_cost_matrix < 0):
-        raise ValueError("rank_cost_matrix must be finite and non-negative")
-    if torch.any(torch.diagonal(rank_cost_matrix) != 0):
-        raise ValueError("rank_cost_matrix diagonal must be zero")
+    _validate_rank_cost_matrix(rank_cost_matrix, expected_num_ranks=num_ranks)
 
     if num_physical_experts != num_logical_experts:
         raise NotImplementedError(

--- a/python/sglang/srt/eplb/eplb_manager.py
+++ b/python/sglang/srt/eplb/eplb_manager.py
@@ -126,6 +126,7 @@ class EPLBManager:
             output_mode="object"
         )
         logical_count = dump_record_output["logical_count"]
+        logical_count_by_rank = dump_record_output.get("logical_count_by_rank")
         average_utilization_rate_over_window = dump_record_output[
             "average_utilization_rate_over_window"
         ]
@@ -136,6 +137,7 @@ class EPLBManager:
 
         expert_location_metadata = self._compute_expert_location_metadata(
             logical_count,
+            logical_count_by_rank=logical_count_by_rank,
             broadcast_over_world=is_post_scale_rebalance,
         )
 
@@ -188,12 +190,13 @@ class EPLBManager:
         logger.info(msg)
 
     def _compute_expert_location_metadata(
-        self, logical_count, *, broadcast_over_world: bool
+        self, logical_count, *, logical_count_by_rank=None, broadcast_over_world: bool
     ) -> ExpertLocationMetadata:
         if not broadcast_over_world:
             return ExpertLocationMetadata.init_by_eplb(
                 self._model_config,
                 logical_count,
+                logical_count_by_rank=logical_count_by_rank,
             )
 
         current_metadata = get_global_expert_location_metadata()
@@ -204,6 +207,7 @@ class EPLBManager:
             computed_metadata = ExpertLocationMetadata.init_by_eplb(
                 self._model_config,
                 logical_count,
+                logical_count_by_rank=logical_count_by_rank,
                 # Arbitrary append topologies may not preserve node divisibility.
                 use_flat_topology=True,
             )

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -915,6 +915,21 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
             physical_to_logical_map=self._expert_location_metadata.physical_to_logical_map,
         )
 
+        logical_count_by_rank = None
+        if get_exec().moe.eplb_algorithm == "topology_aware":
+            # Keep the sender dimension for the topology-aware planner.  The
+            # regular EPLB path still uses the cheaper all-reduce below.
+            local_logical_count = logical_count_of_buffered_step.sum(dim=0)
+            from sglang.srt.distributed import get_moe_ep_group
+
+            ep_group = get_moe_ep_group()
+            gathered = ep_group.all_gather(local_logical_count, dim=0)
+            logical_count_by_rank = gathered.reshape(
+                ep_group.world_size,
+                self._expert_location_metadata.num_layers,
+                self._expert_location_metadata.num_logical_experts,
+            )
+
         if self._first_dump:
             self._first_dump = False
             torch.get_device_module().empty_cache()
@@ -928,6 +943,8 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
             logical_count=logical_count_of_buffered_step,
             average_utilization_rate_over_window=self._get_global_average_utilization_rate(),
         )
+        if logical_count_by_rank is not None:
+            output["logical_count_by_rank"] = logical_count_by_rank
 
         if output_mode == "file":
             if self._rank == 0:

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -557,6 +557,7 @@ class _SelectExpertsSinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
 class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._source_objects_of_layer = {}
         if torch.distributed.get_rank() == 0:
             logger.info(
                 "DeepepNormalSinglePassGatherer gathers approximate statistics. "
@@ -573,6 +574,33 @@ class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):
     ):
         assert isinstance(local_physical_count_of_layer, list)
         self._on_layer_data(layer_idx, local_physical_count_of_layer)
+        if get_exec().moe.eplb_algorithm == "topology_aware":
+            # ``local_physical_count_of_layer`` is the post-A2A receive count.
+            # The topology planner needs the pre-A2A source traffic instead,
+            # which DeepEP exposes as ``num_tokens_per_expert``.
+            if isinstance(num_tokens_per_expert, torch.Tensor):
+                source_count = num_tokens_per_expert.detach().cpu().tolist()
+            else:
+                source_count = list(num_tokens_per_expert)
+            if (
+                len(source_count)
+                != self._expert_location_metadata.num_physical_experts
+            ):
+                raise ValueError(
+                    "DeepEP source expert counts must cover all physical experts "
+                    f"(got {len(source_count)}, expected "
+                    f"{self._expert_location_metadata.num_physical_experts})"
+                )
+            if layer_idx in self._source_objects_of_layer:
+                self._source_objects_of_layer[layer_idx] = _list_sum(
+                    self._source_objects_of_layer[layer_idx], source_count
+                )
+            else:
+                self._source_objects_of_layer[layer_idx] = source_count
+
+    def reset(self):
+        super().reset()
+        self._source_objects_of_layer.clear()
 
     def collect(self) -> Dict:
         local_physical_count = super()._collect_objects(
@@ -581,10 +609,20 @@ class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):
         global_physical_count = _convert_local_to_global_physical_count(
             local_physical_count,
             rank=self._rank,
-            num_local_physical_experts=self._expert_location_metadata.num_local_physical_experts,
+            num_local_physical_experts=(
+                self._expert_location_metadata.num_local_physical_experts
+            ),
             num_physical_experts=self._expert_location_metadata.num_physical_experts,
         )
-        return dict(global_physical_count=global_physical_count)
+        output = dict(global_physical_count=global_physical_count)
+        if get_exec().moe.eplb_algorithm == "topology_aware":
+            source_physical_count = [
+                self._source_objects_of_layer.get(layer_index)
+                or ([0] * self._expert_location_metadata.num_physical_experts)
+                for layer_index in range(self._expert_location_metadata.num_layers)
+            ]
+            output["source_physical_count"] = torch.tensor(source_physical_count)
+        return output
 
 
 class _DeepepLowLatencySinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
@@ -888,6 +926,17 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
             dtype=torch.int32,
             device=get_device_namespace().device,
         )
+        self._logical_count_by_source_of_buffered_step = None
+        if get_exec().moe.eplb_algorithm == "topology_aware":
+            self._logical_count_by_source_of_buffered_step = _Buffer.init_new(
+                item_shape=(
+                    self._expert_location_metadata.num_layers,
+                    self._expert_location_metadata.num_logical_experts,
+                ),
+                buffer_size=get_exec().moe.expert_distribution_recorder_buffer_size,
+                dtype=torch.int32,
+                device=get_device_namespace().device,
+            )
         self._first_dump = True
 
     def append(
@@ -902,10 +951,37 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
         self._global_physical_count_of_buffered_step.append(
             single_pass_data["global_physical_count"]
         )
+        if self._logical_count_by_source_of_buffered_step is not None:
+            source_physical_count = single_pass_data.get(
+                "source_physical_count",
+                single_pass_data["global_physical_count"],
+            ).to(get_device_namespace().device)
+            expected_shape = (
+                self._expert_location_metadata.num_layers,
+                self._expert_location_metadata.num_physical_experts,
+            )
+            if tuple(source_physical_count.shape) != expected_shape:
+                raise ValueError(
+                    "topology-aware EPLB source counts must have shape "
+                    f"{expected_shape}, got {tuple(source_physical_count.shape)}"
+                )
+            source_logical_count = _convert_global_physical_count_to_logical_count(
+                source_physical_count.unsqueeze(0),
+                num_layers=self._expert_location_metadata.num_layers,
+                num_logical_experts=self._expert_location_metadata.num_logical_experts,
+                physical_to_logical_map=(
+                    self._expert_location_metadata.physical_to_logical_map
+                ),
+            )[0]
+            self._logical_count_by_source_of_buffered_step.append(
+                source_logical_count
+            )
 
     def reset(self):
         super().reset()
         self._global_physical_count_of_buffered_step.reset()
+        if self._logical_count_by_source_of_buffered_step is not None:
+            self._logical_count_by_source_of_buffered_step.reset()
 
     def dump(self, output_mode: _OutputMode):
         logical_count_of_buffered_step = _convert_global_physical_count_to_logical_count(
@@ -916,13 +992,22 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
         )
 
         logical_count_by_rank = None
-        if get_exec().moe.eplb_algorithm == "topology_aware":
+        if self._logical_count_by_source_of_buffered_step is not None:
             # Keep the sender dimension for the topology-aware planner.  The
             # regular EPLB path still uses the cheaper all-reduce below.
-            local_logical_count = logical_count_of_buffered_step.sum(dim=0)
+            local_logical_count = (
+                self._logical_count_by_source_of_buffered_step.get_all().sum(dim=0)
+            )
             from sglang.srt.distributed import get_moe_ep_group
 
             ep_group = get_moe_ep_group()
+            if ep_group.world_size != self._expert_location_metadata.ep_size:
+                raise RuntimeError(
+                    "topology-aware EPLB source-count gather group does not "
+                    "match the configured EP size "
+                    f"(group={ep_group.world_size}, "
+                    f"metadata={self._expert_location_metadata.ep_size})"
+                )
             gathered = ep_group.all_gather(local_logical_count, dim=0)
             logical_count_by_rank = gathered.reshape(
                 ep_group.world_size,

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -582,10 +582,7 @@ class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):
                 source_count = num_tokens_per_expert.detach().cpu().tolist()
             else:
                 source_count = list(num_tokens_per_expert)
-            if (
-                len(source_count)
-                != self._expert_location_metadata.num_physical_experts
-            ):
+            if len(source_count) != self._expert_location_metadata.num_physical_experts:
                 raise ValueError(
                     "DeepEP source expert counts must cover all physical experts "
                     f"(got {len(source_count)}, expected "
@@ -973,9 +970,7 @@ class _StatAccumulator(_UtilizationRateAccumulatorMixin):
                     self._expert_location_metadata.physical_to_logical_map
                 ),
             )[0]
-            self._logical_count_by_source_of_buffered_step.append(
-                source_logical_count
-            )
+            self._logical_count_by_source_of_buffered_step.append(source_logical_count)
 
     def reset(self):
         super().reset()

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -229,6 +229,17 @@ class ExpertLocationMetadata:
             # planner works layer-major to match the other EPLB algorithms.
             if not isinstance(logical_count_by_rank, torch.Tensor):
                 logical_count_by_rank = torch.as_tensor(logical_count_by_rank)
+            expected_source_shape = (
+                common["ep_size"],
+                logical_count.shape[-2],
+                model_config_for_expert_location.num_logical_experts,
+            )
+            if tuple(logical_count_by_rank.shape) != expected_source_shape:
+                raise ValueError(
+                    "topology-aware EPLB source counts must have shape "
+                    f"{expected_source_shape}, got "
+                    f"{tuple(logical_count_by_rank.shape)}"
+                )
             tokens_per_source_expert = logical_count_by_rank.movedim(0, 1)
 
         physical_to_logical_map, logical_to_all_physical_map, expert_count = (

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -178,6 +178,7 @@ class ExpertLocationMetadata:
         model_config: ModelConfig,
         logical_count: torch.Tensor,
         *,
+        logical_count_by_rank: Optional[torch.Tensor] = None,
         use_flat_topology: bool = False,
     ):
         if not isinstance(logical_count, torch.Tensor):
@@ -198,6 +199,38 @@ class ExpertLocationMetadata:
 
         from sglang.srt.eplb import eplb_algorithms
 
+        algorithm = eplb_algorithms.compute_algorithm(
+            raw_algorithm=get_exec().moe.eplb_algorithm,
+            num_groups=num_groups,
+            num_nodes=num_nodes,
+        )
+        rank_cost_matrix = None
+        tokens_per_source_expert = None
+        if algorithm == eplb_algorithms.EplbAlgorithm.topology_aware:
+            if use_flat_topology:
+                raise ValueError(
+                    "topology-aware EPLB does not support elastic flat topology"
+                )
+            if logical_count_by_rank is None:
+                raise ValueError(
+                    "topology-aware EPLB requires logical_count_by_rank"
+                )
+            if get_exec().moe.eplb_topology is None:
+                raise ValueError(
+                    "topology-aware EPLB requires --eplb-topology"
+                )
+            from sglang.srt.eplb.topology import load_rank_cost_matrix
+
+            rank_cost_matrix = load_rank_cost_matrix(
+                get_exec().moe.eplb_topology,
+                expected_num_ranks=common["ep_size"],
+            )
+            # The recorder exposes [source-rank, layer, expert], while the
+            # planner works layer-major to match the other EPLB algorithms.
+            if not isinstance(logical_count_by_rank, torch.Tensor):
+                logical_count_by_rank = torch.as_tensor(logical_count_by_rank)
+            tokens_per_source_expert = logical_count_by_rank.movedim(0, 1)
+
         physical_to_logical_map, logical_to_all_physical_map, expert_count = (
             eplb_algorithms.rebalance_experts(
                 tokens_per_expert=logical_count,
@@ -205,11 +238,9 @@ class ExpertLocationMetadata:
                 num_local_physical_experts=num_physical_experts // common["ep_size"],
                 num_groups=num_groups,
                 num_nodes=num_nodes,
-                algorithm=eplb_algorithms.compute_algorithm(
-                    raw_algorithm=get_exec().moe.eplb_algorithm,
-                    num_groups=num_groups,
-                    num_nodes=num_nodes,
-                ),
+                algorithm=algorithm,
+                tokens_per_source_expert=tokens_per_source_expert,
+                rank_cost_matrix=rank_cost_matrix,
             )
         )
 
@@ -793,7 +824,9 @@ def compute_initial_expert_location_metadata(
             "init_expert_location from init_by_eplb using ServerArgs.init_expert_location"
         )
         return ExpertLocationMetadata.init_by_eplb(
-            model_config, logical_count=data_dict["logical_count"]
+            model_config,
+            logical_count=data_dict["logical_count"],
+            logical_count_by_rank=data_dict.get("logical_count_by_rank"),
         )
     else:
         raise NotImplementedError(

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -212,13 +212,9 @@ class ExpertLocationMetadata:
                     "topology-aware EPLB does not support elastic flat topology"
                 )
             if logical_count_by_rank is None:
-                raise ValueError(
-                    "topology-aware EPLB requires logical_count_by_rank"
-                )
+                raise ValueError("topology-aware EPLB requires logical_count_by_rank")
             if get_exec().moe.eplb_topology is None:
-                raise ValueError(
-                    "topology-aware EPLB requires --eplb-topology"
-                )
+                raise ValueError("topology-aware EPLB requires --eplb-topology")
             from sglang.srt.eplb.topology import load_rank_cost_matrix
 
             rank_cost_matrix = load_rank_cost_matrix(

--- a/python/sglang/srt/eplb/topology.py
+++ b/python/sglang/srt/eplb/topology.py
@@ -1,0 +1,92 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+"""Validation and loading helpers for EP rank topology descriptions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+
+
+def _validate_rank_cost_matrix(
+    rank_cost_matrix: torch.Tensor, expected_num_ranks: int | None = None
+) -> torch.Tensor:
+    if (
+        rank_cost_matrix.ndim != 2
+        or rank_cost_matrix.shape[0] != rank_cost_matrix.shape[1]
+    ):
+        raise ValueError("rank_cost_matrix must be square")
+    if rank_cost_matrix.shape[0] <= 0:
+        raise ValueError("rank_cost_matrix must contain at least one rank")
+    if expected_num_ranks is not None and rank_cost_matrix.shape[0] != (
+        expected_num_ranks
+    ):
+        raise ValueError(
+            "rank_cost_matrix size does not match the EP group: "
+            f"matrix={rank_cost_matrix.shape[0]} expected={expected_num_ranks}"
+        )
+
+    rank_cost_matrix = rank_cost_matrix.to(device="cpu", dtype=torch.float64)
+    if not torch.isfinite(rank_cost_matrix).all() or torch.any(rank_cost_matrix < 0):
+        raise ValueError("rank_cost_matrix must be finite and non-negative")
+    if torch.any(torch.diagonal(rank_cost_matrix) != 0):
+        raise ValueError("rank_cost_matrix diagonal must be zero")
+    return rank_cost_matrix.contiguous()
+
+
+def load_rank_cost_matrix(
+    topology: str | Path | Mapping[str, Any],
+    *,
+    expected_num_ranks: int | None = None,
+) -> torch.Tensor:
+    """Load a rank cost matrix from a path or a JSON object.
+
+    The JSON form is intentionally small and hardware-agnostic::
+
+        {"rank_cost_matrix": [[0.0, 1.0], [1.0, 0.0]]}
+
+    Values are relative costs; only their ordering affects placement.  The
+    diagonal must be zero because sending to the local rank does not require
+    inter-rank communication.
+    """
+    if isinstance(topology, (str, Path)):
+        path = Path(topology)
+        try:
+            data = json.loads(path.read_text())
+        except OSError as exc:
+            raise ValueError(f"unable to read EPLB topology file: {path}") from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"EPLB topology file is not valid JSON: {path}") from exc
+    else:
+        data = topology
+
+    if isinstance(data, Mapping):
+        if "rank_cost_matrix" not in data:
+            raise ValueError("topology JSON must contain rank_cost_matrix")
+        data = data["rank_cost_matrix"]
+
+    try:
+        rank_cost_matrix = torch.as_tensor(data, dtype=torch.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "rank_cost_matrix must be a rectangular numeric array"
+        ) from exc
+    return _validate_rank_cost_matrix(rank_cost_matrix, expected_num_ranks)
+
+
+__all__ = ["load_rank_cost_matrix"]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2460,6 +2460,12 @@ class ServerArgs:
     )
     enable_eplb: A[bool, "Enable EPLB algorithm", NS("exec.moe")] = False
     eplb_algorithm: A[str, "Chosen EPLB algorithm", NS("exec.moe")] = "auto"
+    eplb_topology: A[
+        Optional[str],
+        "JSON file containing the EP rank-to-rank communication cost matrix for "
+        "topology-aware EPLB.",
+        NS("exec.moe"),
+    ] = None
     eplb_rebalance_num_iterations: A[
         int,
         "Number of iterations to automatically trigger a EPLB re-balance.",

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -112,6 +112,19 @@ class TestTopologyAwarePlacement(unittest.TestCase):
                 algorithm=EplbAlgorithm.topology_aware,
             )
 
+    def test_topology_swaps_without_worsening_load_balance(self):
+        # The load-balanced seed assigns [0, 1] to rank 0 and [2, 3] to rank
+        # 1. The traffic is reversed, so two swaps should make the placement
+        # local while keeping both ranks at the same total load.
+        counts = torch.zeros((1, 2, 4), dtype=torch.int64)
+        counts[0, 0, 2:] = 10
+        counts[0, 1, :2] = 10
+        costs = torch.tensor([[0.0, 5.0], [5.0, 0.0]])
+
+        physical_to_logical, _, _ = rebalance_experts_topology_aware(counts, costs)
+
+        self.assertEqual(physical_to_logical[0].tolist(), [2, 3, 0, 1])
+
     def test_rejects_replication_until_supported(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)
         costs = torch.zeros((2, 2), dtype=torch.float32)

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -13,6 +13,9 @@ import torch
 from sglang.srt.arg_groups.parallel_hook import handle_eplb_and_dispatch
 from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
+    _improve_topology,
+    _node_uniform_seed,
+    _rank_loads,
     rebalance_experts_topology_aware,
 )
 from sglang.srt.eplb.eplb_algorithms import EplbAlgorithm, rebalance_experts
@@ -135,7 +138,7 @@ class TestTopologyAwarePlacement(CustomTestCase):
         self.assertTrue(torch.all(expert_count == 1))
 
     def test_topology_swaps_without_worsening_load_balance(self):
-        # The load-balanced seed assigns [0, 1] to rank 0 and [2, 3] to rank
+        # The node-uniform seed assigns [0, 1] to rank 0 and [2, 3] to rank
         # 1. The traffic is reversed, so two swaps should make the placement
         # local while keeping both ranks at the same total load.
         counts = torch.zeros((1, 2, 4), dtype=torch.int64)
@@ -146,6 +149,149 @@ class TestTopologyAwarePlacement(CustomTestCase):
         physical_to_logical, _, _ = rebalance_experts_topology_aware(counts, costs)
 
         self.assertEqual(physical_to_logical[0].tolist(), [2, 3, 0, 1])
+
+    def test_topology_does_not_regress_node_uniform_communication(self):
+        # A topology-only swap can move a slightly hotter expert away
+        # from its source rank.  The topology pass may use the node-uniform
+        # layout's load envelope, but must never make its communication cost
+        # worse.
+        counts = torch.zeros((1, 2, 4), dtype=torch.int64)
+        counts[0, 0] = torch.tensor([10, 9, 8, 7])
+        costs = torch.tensor([[0.0, 10.0], [10.0, 0.0]])
+
+        physical_to_logical, _, _ = rebalance_experts_topology_aware(
+            counts, costs
+        )
+        destination = torch.empty(4, dtype=torch.long)
+        for rank in range(2):
+            start = rank * 2
+            destination[physical_to_logical[0, start : start + 2]] = rank
+
+        node_uniform_destination = torch.tensor([0, 0, 1, 1])
+        communication = counts[0].to(torch.float64) * costs[:, destination]
+        node_uniform_communication = (
+            counts[0].to(torch.float64) * costs[:, node_uniform_destination]
+        )
+        self.assertLessEqual(
+            communication.sum().item(), node_uniform_communication.sum().item()
+        )
+
+        total_load = counts[0].sum(dim=0)
+        candidate_load = torch.zeros(2, dtype=torch.int64)
+        candidate_load.scatter_add_(0, destination, total_load)
+        node_uniform_load = torch.tensor(
+            [total_load[:2].sum(), total_load[2:].sum()]
+        )
+        self.assertLessEqual(candidate_load.max(), node_uniform_load.max())
+
+    def test_load_phase_spends_only_explicit_communication_budget(self):
+        # A hot expert pair leaves an opportunity to lower the critical rank
+        # after the communication-only phase.  The private helper is exercised
+        # directly so the test can use a deliberately large budget; the
+        # public planner keeps its much smaller production budget.
+        counts = torch.tensor(
+            [
+                [80, 20, 1, 0],
+                [1, 0, 10, 10],
+            ],
+            dtype=torch.float64,
+        )
+        costs = torch.tensor(
+            [[0.0, 1.0], [1.0, 0.0]],
+            dtype=torch.float64,
+        )
+        total_load = counts.sum(dim=0)
+        communication = counts.transpose(0, 1).matmul(costs)
+        seed = _node_uniform_seed(4, 2)
+        seed_load = _rank_loads(seed, total_load, 2)
+        assignment = _improve_topology(
+            seed.clone(),
+            total_load,
+            communication,
+            2,
+            max_allowed_load=seed_load.max().item(),
+            max_swaps=10,
+            max_comm_regression_ratio=20.0,
+        )
+        candidate_load = _rank_loads(assignment, total_load, 2)
+        self.assertLess(candidate_load.max(), seed_load.max())
+        candidate_cost = communication[
+            torch.arange(4), assignment
+        ].sum().item()
+        seed_cost = communication[torch.arange(4), seed].sum().item()
+        self.assertLessEqual(candidate_cost, seed_cost * 21.0 + 1e-12)
+
+    def test_system_phase_reserves_search_budget_for_critical_rank(self):
+        counts = torch.tensor(
+            [[28, 8, 23, 7], [0, 8, 21, 10]], dtype=torch.float64
+        )
+        costs = torch.tensor(
+            [[0.0, 1.0], [1.0, 0.0]], dtype=torch.float64
+        )
+        total_load = counts.sum(dim=0)
+        communication = counts.transpose(0, 1).matmul(costs)
+        seed = _node_uniform_seed(4, 2)
+        seed_load = _rank_loads(seed, total_load, 2)
+
+        communication_only = _improve_topology(
+            seed.clone(),
+            total_load,
+            communication,
+            2,
+            max_allowed_load=seed_load.max().item(),
+            max_swaps=4,
+        )
+        system_aware = _improve_topology(
+            seed.clone(),
+            total_load,
+            communication,
+            2,
+            max_allowed_load=seed_load.max().item(),
+            max_swaps=4,
+            max_comm_regression_ratio=1.0,
+        )
+        self.assertLess(
+            _rank_loads(system_aware, total_load, 2).max(),
+            _rank_loads(communication_only, total_load, 2).max(),
+        )
+
+    def test_system_phase_breaks_equal_peak_load_ties(self):
+        # With three ranks, a first swap can leave the busiest rank unchanged
+        # while reducing the other ranks' variance.  Accepting that tie-break
+        # gives the next swap a better starting point.
+        total_load = torch.tensor([12, 8, 6, 4, 12, 8], dtype=torch.float64)
+        communication = torch.zeros((6, 3), dtype=torch.float64)
+        seed = _node_uniform_seed(6, 3)
+        seed_load = _rank_loads(seed, total_load, 3)
+        assignment = _improve_topology(
+            seed.clone(),
+            total_load,
+            communication,
+            3,
+            max_allowed_load=seed_load.max().item(),
+            max_swaps=1,
+            max_comm_regression_ratio=1.0,
+        )
+        candidate_load = _rank_loads(assignment, total_load, 3)
+        self.assertLess(
+            candidate_load.square().sum(), seed_load.square().sum()
+        )
+        self.assertEqual(candidate_load.max(), seed_load.max())
+
+    def test_rejects_negative_communication_budget(self):
+        counts = torch.ones((1, 2, 4), dtype=torch.int64)
+        costs = torch.tensor(
+            [[0.0, 1.0], [1.0, 0.0]],
+            dtype=torch.float64,
+        )
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            _improve_topology(
+                _node_uniform_seed(4, 2),
+                counts[0].sum(dim=0),
+                counts[0].to(torch.float64).transpose(0, 1).matmul(costs),
+                2,
+                max_comm_regression_ratio=-1.0,
+            )
 
     def test_server_guard_requires_eplb(self):
         with self.assertRaisesRegex(ValueError, "requires --enable-eplb"):
@@ -180,6 +326,25 @@ class TestTopologyAwarePlacement(CustomTestCase):
                     ep_size=2,
                     tp_size=2,
                     moe_a2a_backend="none",
+                )
+            )
+
+    def test_server_guard_requires_static_dispatch(self):
+        with self.assertRaisesRegex(ValueError, "requires.*ep-dispatch-algorithm static"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(
+                    eplb_algorithm="topology_aware",
+                    enable_eplb=True,
+                    eplb_topology="topology.json",
+                    ep_num_redundant_experts=0,
+                    elastic_ep_backend=None,
+                    moe_dp_size=1,
+                    expert_distribution_recorder_mode="stat",
+                    ep_size=2,
+                    tp_size=2,
+                    ep_dispatch_algorithm="dynamic",
+                    moe_a2a_backend="flashinfer",
+                    deepep_mode="auto",
                 )
             )
 

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -11,14 +11,14 @@ from types import SimpleNamespace
 import torch
 
 from sglang.srt.arg_groups.parallel_hook import handle_eplb_and_dispatch
-from sglang.srt.eplb.topology import load_rank_cost_matrix
+from sglang.srt.eplb.eplb_algorithms import EplbAlgorithm, rebalance_experts
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     _improve_topology,
     _node_uniform_seed,
     _rank_loads,
     rebalance_experts_topology_aware,
 )
-from sglang.srt.eplb.eplb_algorithms import EplbAlgorithm, rebalance_experts
+from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -55,12 +55,10 @@ class TestTopologyAwarePlacement(CustomTestCase):
             ],
             dtype=torch.int64,
         )
-        costs = torch.tensor(
-            [[0.0, 1.0, 3.0], [1.0, 0.0, 2.0], [3.0, 2.0, 0.0]]
-        )
+        costs = torch.tensor([[0.0, 1.0, 3.0], [1.0, 0.0, 2.0], [3.0, 2.0, 0.0]])
 
-        physical_to_logical, logical_to_physical, _ = (
-            rebalance_experts_topology_aware(counts, costs)
+        physical_to_logical, logical_to_physical, _ = rebalance_experts_topology_aware(
+            counts, costs
         )
         for layer in range(counts.shape[0]):
             self.assertEqual(
@@ -159,9 +157,7 @@ class TestTopologyAwarePlacement(CustomTestCase):
         counts[0, 0] = torch.tensor([10, 9, 8, 7])
         costs = torch.tensor([[0.0, 10.0], [10.0, 0.0]])
 
-        physical_to_logical, _, _ = rebalance_experts_topology_aware(
-            counts, costs
-        )
+        physical_to_logical, _, _ = rebalance_experts_topology_aware(counts, costs)
         destination = torch.empty(4, dtype=torch.long)
         for rank in range(2):
             start = rank * 2
@@ -179,9 +175,7 @@ class TestTopologyAwarePlacement(CustomTestCase):
         total_load = counts[0].sum(dim=0)
         candidate_load = torch.zeros(2, dtype=torch.int64)
         candidate_load.scatter_add_(0, destination, total_load)
-        node_uniform_load = torch.tensor(
-            [total_load[:2].sum(), total_load[2:].sum()]
-        )
+        node_uniform_load = torch.tensor([total_load[:2].sum(), total_load[2:].sum()])
         self.assertLessEqual(candidate_load.max(), node_uniform_load.max())
 
     def test_load_phase_spends_only_explicit_communication_budget(self):
@@ -215,19 +209,13 @@ class TestTopologyAwarePlacement(CustomTestCase):
         )
         candidate_load = _rank_loads(assignment, total_load, 2)
         self.assertLess(candidate_load.max(), seed_load.max())
-        candidate_cost = communication[
-            torch.arange(4), assignment
-        ].sum().item()
+        candidate_cost = communication[torch.arange(4), assignment].sum().item()
         seed_cost = communication[torch.arange(4), seed].sum().item()
         self.assertLessEqual(candidate_cost, seed_cost * 21.0 + 1e-12)
 
     def test_system_phase_reserves_search_budget_for_critical_rank(self):
-        counts = torch.tensor(
-            [[28, 8, 23, 7], [0, 8, 21, 10]], dtype=torch.float64
-        )
-        costs = torch.tensor(
-            [[0.0, 1.0], [1.0, 0.0]], dtype=torch.float64
-        )
+        counts = torch.tensor([[28, 8, 23, 7], [0, 8, 21, 10]], dtype=torch.float64)
+        costs = torch.tensor([[0.0, 1.0], [1.0, 0.0]], dtype=torch.float64)
         total_load = counts.sum(dim=0)
         communication = counts.transpose(0, 1).matmul(costs)
         seed = _node_uniform_seed(4, 2)
@@ -273,9 +261,7 @@ class TestTopologyAwarePlacement(CustomTestCase):
             max_comm_regression_ratio=1.0,
         )
         candidate_load = _rank_loads(assignment, total_load, 3)
-        self.assertLess(
-            candidate_load.square().sum(), seed_load.square().sum()
-        )
+        self.assertLess(candidate_load.square().sum(), seed_load.square().sum())
         self.assertEqual(candidate_load.max(), seed_load.max())
 
     def test_rejects_negative_communication_budget(self):
@@ -330,7 +316,9 @@ class TestTopologyAwarePlacement(CustomTestCase):
             )
 
     def test_server_guard_requires_static_dispatch(self):
-        with self.assertRaisesRegex(ValueError, "requires.*ep-dispatch-algorithm static"):
+        with self.assertRaisesRegex(
+            ValueError, "requires.*ep-dispatch-algorithm static"
+        ):
             handle_eplb_and_dispatch(
                 SimpleNamespace(
                     eplb_algorithm="topology_aware",
@@ -389,17 +377,13 @@ class TestTopologyAwarePlacement(CustomTestCase):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)
         costs = torch.zeros((2, 2), dtype=torch.float32)
         with self.assertRaisesRegex(NotImplementedError, "no redundant experts"):
-            rebalance_experts_topology_aware(
-                counts, costs, num_physical_experts=6
-            )
+            rebalance_experts_topology_aware(counts, costs, num_physical_experts=6)
 
     def test_rejects_inconsistent_physical_expert_dimension(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)
         costs = torch.zeros((2, 2), dtype=torch.float32)
         with self.assertRaisesRegex(ValueError, "must match"):
-            rebalance_experts_topology_aware(
-                counts, costs, num_physical_experts=2
-            )
+            rebalance_experts_topology_aware(counts, costs, num_physical_experts=2)
 
     def test_rejects_nonzero_self_cost(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -6,10 +6,12 @@ register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
 from tempfile import NamedTemporaryFile
+from types import SimpleNamespace
 
 import torch
 
 from sglang.srt.eplb.topology import load_rank_cost_matrix
+from sglang.srt.arg_groups.parallel_hook import handle_eplb_and_dispatch
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     rebalance_experts_topology_aware,
 )
@@ -124,6 +126,25 @@ class TestTopologyAwarePlacement(unittest.TestCase):
         physical_to_logical, _, _ = rebalance_experts_topology_aware(counts, costs)
 
         self.assertEqual(physical_to_logical[0].tolist(), [2, 3, 0, 1])
+
+    def test_server_guard_requires_eplb(self):
+        with self.assertRaisesRegex(ValueError, "requires --enable-eplb"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(eplb_algorithm="topology_aware", enable_eplb=False)
+            )
+
+    def test_server_guard_rejects_elastic_ep(self):
+        with self.assertRaisesRegex(ValueError, "does not support elastic EP"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(
+                    eplb_algorithm="topology_aware",
+                    enable_eplb=True,
+                    eplb_topology="topology.json",
+                    ep_num_redundant_experts=0,
+                    elastic_ep_backend="mooncake",
+                    expert_distribution_recorder_mode=None,
+                )
+            )
 
     def test_rejects_replication_until_supported(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -5,9 +5,11 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 import unittest
+from tempfile import NamedTemporaryFile
 
 import torch
 
+from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     rebalance_experts_topology_aware,
 )
@@ -93,6 +95,20 @@ class TestTopologyAwarePlacement(unittest.TestCase):
         costs = torch.ones((2, 2), dtype=torch.float32)
         with self.assertRaisesRegex(ValueError, "diagonal"):
             rebalance_experts_topology_aware(counts, costs)
+
+    def test_loads_and_validates_json_topology(self):
+        topology = {"rank_cost_matrix": [[0, 1], [1, 0]]}
+        matrix = load_rank_cost_matrix(topology, expected_num_ranks=2)
+        self.assertEqual(matrix.dtype, torch.float64)
+        self.assertTrue(
+            torch.equal(matrix, torch.tensor(topology["rank_cost_matrix"]).double())
+        )
+
+        with NamedTemporaryFile(mode="w+", suffix=".json") as file:
+            file.write('{"rank_cost_matrix": [[0, 2], [2, 0]]}')
+            file.flush()
+            loaded = load_rank_cost_matrix(file.name, expected_num_ranks=2)
+        self.assertEqual(loaded.tolist(), [[0.0, 2.0], [2.0, 0.0]])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -16,9 +16,10 @@ from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     rebalance_experts_topology_aware,
 )
 from sglang.srt.eplb.eplb_algorithms import EplbAlgorithm, rebalance_experts
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestTopologyAwarePlacement(unittest.TestCase):
+class TestTopologyAwarePlacement(CustomTestCase):
     def test_prefers_the_cheapest_destination(self):
         # Four experts, two source/destination ranks, two slots per rank.
         # Experts 0 and 1 originate on rank 0; experts 2 and 3 on rank 1.
@@ -113,6 +114,25 @@ class TestTopologyAwarePlacement(unittest.TestCase):
                 num_nodes=1,
                 algorithm=EplbAlgorithm.topology_aware,
             )
+
+    def test_default_algorithm_remains_available_without_topology(self):
+        # The public legacy API receives [DP, layers, experts] and reduces the
+        # DP dimension before invoking the original EPLB implementation.
+        tokens_per_expert = torch.tensor([[[4, 2, 1, 0]]], dtype=torch.int64)
+
+        physical_to_logical, logical_to_physical, expert_count = rebalance_experts(
+            tokens_per_expert=tokens_per_expert,
+            num_physical_experts=4,
+            num_local_physical_experts=2,
+            num_groups=None,
+            num_nodes=1,
+            algorithm=EplbAlgorithm.deepseek,
+        )
+
+        self.assertEqual(physical_to_logical.shape, (1, 4))
+        self.assertEqual(logical_to_physical.shape, (1, 4, 1))
+        self.assertEqual(expert_count.shape, (1, 4))
+        self.assertTrue(torch.all(expert_count == 1))
 
     def test_topology_swaps_without_worsening_load_balance(self):
         # The load-balanced seed assigns [0, 1] to rank 0 and [2, 3] to rank

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -1,0 +1,99 @@
+"""CPU tests for the topology-aware EPLB placement primitive."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.eplb.eplb_algorithms.topology_aware import (
+    rebalance_experts_topology_aware,
+)
+
+
+class TestTopologyAwarePlacement(unittest.TestCase):
+    def test_prefers_the_cheapest_destination(self):
+        # Four experts, two source/destination ranks, two slots per rank.
+        # Experts 0 and 1 originate on rank 0; experts 2 and 3 on rank 1.
+        counts = torch.zeros((1, 2, 4), dtype=torch.int64)
+        counts[0, 0, :2] = 10
+        counts[0, 1, 2:] = 10
+        costs = torch.tensor([[0.0, 5.0], [5.0, 0.0]])
+
+        physical_to_logical, logical_to_physical, expert_count = (
+            rebalance_experts_topology_aware(counts, costs)
+        )
+
+        self.assertEqual(physical_to_logical[0].tolist(), [0, 1, 2, 3])
+        self.assertEqual(logical_to_physical[0, :, 0].tolist(), [0, 1, 2, 3])
+        self.assertEqual(expert_count[0].tolist(), [1, 1, 1, 1])
+
+    def test_maps_are_permutations_with_equal_capacity(self):
+        counts = torch.tensor(
+            [
+                [
+                    [4, 0, 2, 1, 0, 0],
+                    [0, 3, 0, 0, 5, 1],
+                    [2, 1, 0, 0, 1, 4],
+                ],
+                [
+                    [0, 1, 6, 0, 2, 0],
+                    [3, 0, 0, 4, 0, 1],
+                    [1, 0, 0, 2, 5, 0],
+                ],
+            ],
+            dtype=torch.int64,
+        )
+        costs = torch.tensor(
+            [[0.0, 1.0, 3.0], [1.0, 0.0, 2.0], [3.0, 2.0, 0.0]]
+        )
+
+        physical_to_logical, logical_to_physical, _ = (
+            rebalance_experts_topology_aware(counts, costs)
+        )
+        for layer in range(counts.shape[0]):
+            self.assertEqual(
+                sorted(physical_to_logical[layer].tolist()), list(range(6))
+            )
+            self.assertEqual(
+                sorted(logical_to_physical[layer, :, 0].tolist()), list(range(6))
+            )
+            # Two physical experts per rank.
+            for rank in range(3):
+                start = rank * 2
+                end = start + 2
+                self.assertEqual(
+                    sum(
+                        int(logical_to_physical[layer, expert, 0]) in range(start, end)
+                        for expert in range(6)
+                    ),
+                    2,
+                )
+
+    def test_is_deterministic(self):
+        counts = torch.tensor([[[3, 3, 1, 1], [1, 1, 3, 3]]], dtype=torch.int64)
+        costs = torch.tensor([[0.0, 2.0], [2.0, 0.0]])
+        first = rebalance_experts_topology_aware(counts, costs)
+        second = rebalance_experts_topology_aware(counts, costs)
+        for first_value, second_value in zip(first, second):
+            self.assertTrue(torch.equal(first_value, second_value))
+
+    def test_rejects_replication_until_supported(self):
+        counts = torch.ones((1, 2, 4), dtype=torch.int64)
+        costs = torch.zeros((2, 2), dtype=torch.float32)
+        with self.assertRaisesRegex(NotImplementedError, "no redundant experts"):
+            rebalance_experts_topology_aware(
+                counts, costs, num_physical_experts=6
+            )
+
+    def test_rejects_nonzero_self_cost(self):
+        counts = torch.ones((1, 2, 4), dtype=torch.int64)
+        costs = torch.ones((2, 2), dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "diagonal"):
+            rebalance_experts_topology_aware(counts, costs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -343,6 +343,7 @@ class TestTopologyAwarePlacement(CustomTestCase):
                     ep_size=2,
                     tp_size=2,
                     ep_dispatch_algorithm="dynamic",
+                    ep_join_mode=None,
                     moe_a2a_backend="flashinfer",
                     deepep_mode="auto",
                 )

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -13,6 +13,7 @@ from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     rebalance_experts_topology_aware,
 )
+from sglang.srt.eplb.eplb_algorithms import EplbAlgorithm, rebalance_experts
 
 
 class TestTopologyAwarePlacement(unittest.TestCase):
@@ -81,6 +82,35 @@ class TestTopologyAwarePlacement(unittest.TestCase):
         second = rebalance_experts_topology_aware(counts, costs)
         for first_value, second_value in zip(first, second):
             self.assertTrue(torch.equal(first_value, second_value))
+
+    def test_public_algorithm_dispatch(self):
+        counts = torch.tensor([[[2, 0], [0, 2]]], dtype=torch.int64)
+        costs = torch.tensor([[0.0, 3.0], [3.0, 0.0]])
+        direct = rebalance_experts_topology_aware(counts, costs)
+        dispatched = rebalance_experts(
+            tokens_per_expert=counts.sum(dim=1),
+            num_physical_experts=2,
+            num_local_physical_experts=1,
+            num_groups=None,
+            num_nodes=1,
+            algorithm=EplbAlgorithm.topology_aware,
+            tokens_per_source_expert=counts,
+            rank_cost_matrix=costs,
+        )
+        for direct_value, dispatched_value in zip(direct, dispatched):
+            self.assertTrue(torch.equal(direct_value, dispatched_value))
+
+    def test_public_algorithm_requires_topology_inputs(self):
+        counts = torch.ones((1, 2), dtype=torch.int64)
+        with self.assertRaisesRegex(ValueError, "source-rank expert counts"):
+            rebalance_experts(
+                tokens_per_expert=counts,
+                num_physical_experts=2,
+                num_local_physical_experts=1,
+                num_groups=None,
+                num_nodes=1,
+                algorithm=EplbAlgorithm.topology_aware,
+            )
 
     def test_rejects_replication_until_supported(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)

--- a/test/registered/unit/eplb/test_topology_aware.py
+++ b/test/registered/unit/eplb/test_topology_aware.py
@@ -10,8 +10,8 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.srt.arg_groups.parallel_hook import handle_eplb_and_dispatch
+from sglang.srt.eplb.topology import load_rank_cost_matrix
 from sglang.srt.eplb.eplb_algorithms.topology_aware import (
     rebalance_experts_topology_aware,
 )
@@ -166,6 +166,59 @@ class TestTopologyAwarePlacement(CustomTestCase):
                 )
             )
 
+    def test_server_guard_requires_a2a_backend(self):
+        with self.assertRaisesRegex(ValueError, "requires an MoE A2A backend"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(
+                    eplb_algorithm="topology_aware",
+                    enable_eplb=True,
+                    eplb_topology="topology.json",
+                    ep_num_redundant_experts=0,
+                    elastic_ep_backend=None,
+                    moe_dp_size=1,
+                    expert_distribution_recorder_mode="stat",
+                    ep_size=2,
+                    tp_size=2,
+                    moe_a2a_backend="none",
+                )
+            )
+
+    def test_server_guard_rejects_deepep_low_latency(self):
+        with self.assertRaisesRegex(ValueError, "source-aware A2A path"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(
+                    eplb_algorithm="topology_aware",
+                    enable_eplb=True,
+                    eplb_topology="topology.json",
+                    ep_num_redundant_experts=0,
+                    elastic_ep_backend=None,
+                    moe_dp_size=1,
+                    expert_distribution_recorder_mode="stat",
+                    ep_size=2,
+                    tp_size=2,
+                    moe_a2a_backend="deepep",
+                    deepep_mode="low_latency",
+                )
+            )
+
+    def test_server_guard_rejects_approximate_non_deepep_stats(self):
+        with self.assertRaisesRegex(ValueError, "stat_approx requires DeepEP"):
+            handle_eplb_and_dispatch(
+                SimpleNamespace(
+                    eplb_algorithm="topology_aware",
+                    enable_eplb=True,
+                    eplb_topology="topology.json",
+                    ep_num_redundant_experts=0,
+                    elastic_ep_backend=None,
+                    moe_dp_size=1,
+                    expert_distribution_recorder_mode="stat_approx",
+                    ep_size=2,
+                    tp_size=2,
+                    moe_a2a_backend="flashinfer",
+                    deepep_mode="normal",
+                )
+            )
+
     def test_rejects_replication_until_supported(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)
         costs = torch.zeros((2, 2), dtype=torch.float32)
@@ -174,10 +227,24 @@ class TestTopologyAwarePlacement(CustomTestCase):
                 counts, costs, num_physical_experts=6
             )
 
+    def test_rejects_inconsistent_physical_expert_dimension(self):
+        counts = torch.ones((1, 2, 4), dtype=torch.int64)
+        costs = torch.zeros((2, 2), dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "must match"):
+            rebalance_experts_topology_aware(
+                counts, costs, num_physical_experts=2
+            )
+
     def test_rejects_nonzero_self_cost(self):
         counts = torch.ones((1, 2, 4), dtype=torch.int64)
         costs = torch.ones((2, 2), dtype=torch.float32)
         with self.assertRaisesRegex(ValueError, "diagonal"):
+            rebalance_experts_topology_aware(counts, costs)
+
+    def test_rejects_rank_cost_matrix_shape_mismatch(self):
+        counts = torch.ones((1, 2, 4), dtype=torch.int64)
+        costs = torch.zeros((3, 3), dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "does not match"):
             rebalance_experts_topology_aware(counts, costs)
 
     def test_loads_and_validates_json_topology(self):
@@ -193,6 +260,17 @@ class TestTopologyAwarePlacement(CustomTestCase):
             file.flush()
             loaded = load_rank_cost_matrix(file.name, expected_num_ranks=2)
         self.assertEqual(loaded.tolist(), [[0.0, 2.0], [2.0, 0.0]])
+
+    def test_preserves_ep_rank_order_in_asymmetric_matrix(self):
+        topology = {
+            "rank_cost_matrix": [
+                [0, 1, 4],
+                [2, 0, 3],
+                [5, 6, 0],
+            ]
+        }
+        matrix = load_rank_cost_matrix(topology, expected_num_ranks=3)
+        self.assertEqual(matrix.tolist(), topology["rank_cost_matrix"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Expert-parallel placement currently follows a node-uniform layout and does not use the measured communication cost between EP ranks. On machines with asymmetric NVLink/PCIe/NUMA links, this can send a large fraction of routed tokens over slower paths. This PR adds an opt-in `topology_aware` EPLB algorithm that uses source-rank traffic and a user-provided EP rank cost matrix, while preserving the existing EPLB behavior by default.

## Modifications

- Add `--eplb-topology`, with validation for a square, finite, non-negative rank-cost matrix whose diagonal is zero. Matrix rows/columns follow the SGLang MoE-EP rank order.
- Record source-rank expert traffic for the standard expert-selection path and DeepEP normal mode, and pass the `[source, layer, expert]` statistics to EPLB.
- Add a deterministic, bounded topology planner. It starts from the default node-uniform placement, performs communication-reducing swaps, reserves a small budget for the busiest-rank load, and falls back to node-uniform if the communication objective regresses.
- Keep the feature explicitly opt-in and reject unsupported configurations: redundant experts, `ep_size != tp_size`, `moe_dp_size > 1`, elastic EP, dynamic dispatch, missing A2A source traffic, and unsupported recorder modes.
- Document the JSON topology format and current limitations.

## Accuracy Tests

- Registered EPLB CPU suite on a remote Linux test environment, using this branch:

  ```bash
  PYTHONPATH=python:test \
    python -m unittest discover \
    -s test/registered/unit/eplb \
    -p "test_*.py"
  ```

  Result: **59 tests passed**.

- SGLang `run_eval` GSM8K sanity check, 200 examples, Qwen3-30B-A3B-Instruct-2507, BF16, deterministic decoding, same server/model settings:

  | Layout | Score |
  | --- | ---: |
  | Baseline node-uniform | 0.945 |
  | Topology-aware | 0.950 |

  The candidate does not regress this sanity score. Per SGLang guidance, this is an accuracy sanity check, not a serving-speed measurement; the observed 0.5 percentage-point difference is not treated as an accuracy improvement.

## Speed Tests and Profiling

The serving comparison used the companion FlashInfer-A2A/Triton-runner compatibility path from [#37611](https://github.com/sgl-project/sglang/pull/37611), because that A100 backend support is intentionally a separate PR. The topology files and planner are from this PR. Both cases used the same Qwen3-30B-A3B checkpoint, 8 x NVIDIA A100 80GB PCIe GPUs, FlashInfer A2A, Triton MoE runner, `generated-shared-prefix`, 80 prompts, max concurrency 8, 8 warmup requests, seed `20260903`, temperature 0, top-p 1, and the same A100 topology matrix. The candidate used a topology-aware map generated from recorded source-rank-0 traffic; the request routing header was fixed to DP rank 0. This is a targeted topology workload, not a claim of a universal speedup.

`bench_serving` was repeated three times per layout:

| Layout | Repeat 1 output tok/s | Repeat 2 | Repeat 3 | Median | Median delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline node-uniform | 30.5145 | 30.4337 | 30.1635 | 30.4337 | -- |
| Topology-aware | 34.7817 | 34.6623 | 35.0564 | 34.7817 | **+14.29%** |

Median latency changes were also positive: p95 E2E latency 7355.0 ms to 6394.7 ms (-13.06%), median TTFT 908.4 ms to 795.5 ms (-12.43%), and median TPOT 210.1 ms to 178.6 ms (-14.99%).

With `--profile-activities GPU --profile-start-step 8 --profile-steps 12`, the eight-rank aggregate duration of the actual MoE A2A dispatch and combine kernels (`moeA2ADispatchKernel` and `moeA2ACombineKernel`) was 2188.33 ms for the baseline and 2149.53 ms for the candidate (-1.77%). Profiled throughput itself is not used as evidence because profiler collection adds overhead.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). The pinned pre-commit suite passed in GitHub Actions [Lint run #33836937724](https://github.com/sgl-project/sglang/actions/runs/33836937724); focused `py_compile`, registered-test lint, and `git diff --check` also passed.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). The registered EPLB suite passed with 59 tests.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Added the topology JSON format, CLI example, rank-order definition, supported modes, and limitations.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). The GSM8K sanity result, repeated `bench_serving` measurements, and GPU profiler comparison are recorded above; the backend dependency is stated explicitly.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). The pinned pre-commit suite and documentation checks passed in [Lint run #33836937724](https://github.com/sgl-project/sglang/actions/runs/33836937724); focused syntax, registry, and patch-hygiene checks also passed.

## Remaining Validation

- The pinned pre-commit suite and Mintlify broken-link check passed in GitHub Actions [Lint run #33836937724](https://github.com/sgl-project/sglang/actions/runs/33836937724).
- Re-run the serving benchmark after #37611 is merged, or with an upstream-supported A2A backend, before making a broader performance claim.
- The remaining platform `pr-gate` jobs are blocked by SGLang’s `run-ci` label permission gate on this fork; they did not run product tests. Maintainer review and an authorized CI rerun are pending.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with the documented commands or contact an authorized user if needed.
4. After green CI and required approvals, ask Merge Oncalls or a person with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33836938121](https://github.com/sgl-project/sglang/actions/runs/33836938121)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33836937927](https://github.com/sgl-project/sglang/actions/runs/33836937927)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33836938140](https://github.com/sgl-project/sglang/actions/runs/33836938140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->