### PR TITLE
[Docs] Prefer --mamba-radix-cache-strategy in Ascend Qwen best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_5_397b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_5_397b.mdx
@@ -330,7 +330,7 @@ python3 -m sglang.launch_server \
     --max-prefill-tokens 131072 \
     --max-mamba-cache-size 320 \
     --prefill-max-requests 10 \
-    --mamba-scheduler-strategy extra_buffer \
+    --mamba-radix-cache-strategy extra_buffer \
     --trust-remote-code \
     --max-running-requests 64 \
     --mem-fraction-static 0.6 \
@@ -1147,7 +1147,7 @@ python3 -m sglang.launch_server \
     --chunked-prefill-size -1 \
     --max-prefill-tokens 65536 \
     --max-mamba-cache-size 640 \
-    --mamba-scheduler-strategy extra_buffer \
+    --mamba-radix-cache-strategy extra_buffer \
     --trust-remote-code \
     --max-running-requests 128 \
     --mem-fraction-static 0.6 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx
@@ -292,7 +292,7 @@ python3 -m sglang.launch_server \
     --device npu \
     --chunked-prefill-size 32768 \
     --max-prefill-tokens 32768 \
-    --mamba-scheduler-strategy extra_buffer \
+    --mamba-radix-cache-strategy extra_buffer \
     --trust-remote-code \
     --max-running-requests 20 \
     --max-mamba-cache-size 160 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx
@@ -402,7 +402,7 @@ python3 -m sglang.launch_server \
     --max-prefill-tokens 65536 \
     --trust-remote-code \
     --enable-prefill-delayer \
-    --mamba-scheduler-strategy extra_buffer \
+    --mamba-radix-cache-strategy extra_buffer \
     --max-running-requests 103 \
     --max-mamba-cache-size 85 \
     --mem-fraction-static 0.85 \
@@ -800,7 +800,7 @@ python3 -m sglang.launch_server \
     --max-total-tokens 470784 \
     --max-prefill-tokens 65536 \
     --trust-remote-code \
-    --mamba-scheduler-strategy extra_buffer \
+    --mamba-radix-cache-strategy extra_buffer \
     --max-running-requests 40 \
     --max-mamba-cache-size 200 \
     --mem-fraction-static 0.9 \


### PR DESCRIPTION
## Summary
- Prefer canonical `--mamba-radix-cache-strategy` over deprecated alias `--mamba-scheduler-strategy` in Ascend Qwen3.5 / Qwen3.6 best-practice launch snippets.
- Alias is registered as `DeprecatedAliasStoreAction` → `--mamba-radix-cache-strategy` in `server_args.py`; values unchanged (`extra_buffer`).

## Files
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_5_397b.mdx`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx`

## Test plan
- [ ] Confirm snippets now use `--mamba-radix-cache-strategy extra_buffer`
- [ ] Confirm no remaining `--mamba-scheduler-strategy` in these three files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33836065992](https://github.com/sgl-project/sglang/actions/runs/33836065992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33836065834](https://github.com/sgl-project/sglang/actions/runs/33836065834)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->