### PR TITLE
[Feature] Add GLM-5.3-Flash tool call detector (glm53)

### DIFF
--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -24,6 +24,7 @@ from sglang.srt.function_call.gemma4_detector import Gemma4Detector
 from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
 from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sglang.srt.function_call.glm47_moe_detector import Glm47MoeDetector
+from sglang.srt.function_call.glm53_flash_detector import Glm53FlashDetector
 from sglang.srt.function_call.gpt_oss_detector import GptOssDetector
 from sglang.srt.function_call.hermes_detector import HermesDetector
 from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
@@ -76,6 +77,7 @@ class FunctionCallParser:
         "glm": Glm4MoeDetector,
         "glm45": Glm4MoeDetector,
         "glm47": Glm47MoeDetector,
+        "glm53": Glm53FlashDetector,
         "gpt-oss": GptOssDetector,
         "k2_horizon": K2V3Detector,
         "kimi_k2": KimiK2Detector,

--- a/python/sglang/srt/function_call/glm53_flash_detector.py
+++ b/python/sglang/srt/function_call/glm53_flash_detector.py
@@ -208,14 +208,22 @@ class Glm53FlashDetector(BaseFormatDetector):
 
         return arguments
 
-    def _parse_json_args(self, raw_args: str) -> Dict[str, Any]:
-        """Parse JSON arguments from the raw argument string."""
+    def _parse_json_args(self, raw_args: str) -> Any:
+        """Parse JSON arguments from the raw argument string.
+
+        Returns a dict, a list (for bare array args), or empty dict on failure.
+        When the model outputs a bare array [{...}, {...}] for a tool with
+        an array-type required property, we return the list so
+        _fix_args_against_schema can wrap it.
+        """
         raw_args = raw_args.strip()
         if not raw_args:
             return {}
         try:
             parsed = json.loads(raw_args)
             if isinstance(parsed, dict):
+                return parsed
+            if isinstance(parsed, list):
                 return parsed
             return {"value": parsed}
         except (json.JSONDecodeError, ValueError):
@@ -507,7 +515,14 @@ class Glm53FlashDetector(BaseFormatDetector):
             )
 
         after_name = current_text[match.end():]
-        json_start = after_name.find("{")
+        # Look for JSON array first ([), then JSON object ({)
+        # The model sometimes outputs a bare array [{...}, {...}] for
+        # tools with array-type required properties (e.g. todo_write).
+        # If we start from the first { inside the array, raw_decode only
+        # parses the first object and the rest leaks as content.
+        json_start = after_name.find("[")
+        if json_start < 0:
+            json_start = after_name.find("{")
         if json_start >= 0:
             json_str = after_name[json_start:]
             decoder = json.JSONDecoder()
@@ -620,7 +635,10 @@ class Glm53FlashDetector(BaseFormatDetector):
                 ))
 
             after_name = current[match.end():]
-            json_start = after_name.find("{")
+            # Look for JSON array first ([), then JSON object ({)
+            json_start = after_name.find("[")
+            if json_start < 0:
+                json_start = after_name.find("{")
             if json_start >= 0:
                 json_str = after_name[json_start:]
                 decoder = json.JSONDecoder()

--- a/python/sglang/srt/function_call/glm53_flash_detector.py
+++ b/python/sglang/srt/function_call/glm53_flash_detector.py
@@ -21,7 +21,7 @@ used by glm47. This detector handles both formats.
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
@@ -62,7 +62,7 @@ class Glm53FlashDetector(BaseFormatDetector):
             re.escape(TC_START)
             + r"(.*?)"
             + r"((?:" + re.escape(AK_START) + r".*?" + re.escape(AK_END)
-            + re.escape(AV_START) + r".*?" + re.escape(AV_END) + r"\s*)*)"
+            + re.escape(AV_START) + r".*?" + re.escape(AV_END) + r"\s*)+)"
             + re.escape(TC_END),
             re.DOTALL,
         )
@@ -72,6 +72,18 @@ class Glm53FlashDetector(BaseFormatDetector):
             + r"((?:(?!" + re.escape(AK_START) + r").)*?)"
             + r"((?:" + re.escape(AK_START) + r".*?" + re.escape(AK_END)
             + re.escape(AV_START) + r".*?" + re.escape(AV_END) + r"\s*)*)"
+            + re.escape(TC_END),
+            re.DOTALL,
+        )
+
+        # Simplified tag format observed in the wild (AK_END/AV_START omitted):
+        # TC_START + name + (AK_START key=value AV_END)+ + TC_END
+        self.tag_regex3 = re.compile(
+            re.escape(TC_START)
+            + r"((?:(?!" + re.escape(AK_START) + r").)*?)"
+            + r"((?:" + re.escape(AK_START)
+            + r"(?:(?!" + re.escape(TC_END) + r").)*?"
+            + re.escape(AV_END) + r"\s*)+)"
             + re.escape(TC_END),
             re.DOTALL,
         )
@@ -131,6 +143,71 @@ class Glm53FlashDetector(BaseFormatDetector):
 
         return name
 
+
+    def _fix_args_against_schema(
+        self, arguments, func_name, tools
+    ):
+        """Fix nested schema unwrapping by the model."""
+        if not func_name or not tools:
+            return arguments
+
+        tool_func = None
+        for t in tools:
+            if hasattr(t, "function") and t.function and t.function.name == func_name:
+                tool_func = t.function
+                break
+
+        if not tool_func or not tool_func.parameters:
+            return arguments
+
+        schema = tool_func.parameters
+        if not isinstance(schema, dict):
+            return arguments
+
+        props = schema.get("properties", {})
+        required = schema.get("required", [])
+        if not isinstance(required, list):
+            required = []
+
+        if isinstance(arguments, dict):
+            missing_required = [k for k in required if k not in arguments]
+            if not missing_required:
+                return arguments
+
+            for missing_key in missing_required:
+                prop_schema = props.get(missing_key, {})
+                if not isinstance(prop_schema, dict):
+                    continue
+                if prop_schema.get("type") != "array":
+                    continue
+
+                item_schema = prop_schema.get("items", {})
+                item_props = set()
+                if isinstance(item_schema, dict):
+                    item_props = set(item_schema.get("properties", {}).keys())
+
+                arg_keys = set(arguments.keys())
+                if item_props and arg_keys and arg_keys.issubset(item_props):
+                    logger.info(
+                        "GLM-5.3-Flash: fixing unwrapped args for '%s' - "
+                        "wrapping in {'%s': [args]}",
+                        func_name, missing_key,
+                    )
+                    return {missing_key: [arguments]}
+
+        if isinstance(arguments, list):
+            for missing_key in required:
+                prop_schema = props.get(missing_key, {})
+                if isinstance(prop_schema, dict) and prop_schema.get("type") == "array":
+                    logger.info(
+                        "GLM-5.3-Flash: fixing bare array args for '%s' - "
+                        "wrapping in {'%s': [args]}",
+                        func_name, missing_key,
+                    )
+                    return {missing_key: arguments}
+
+        return arguments
+
     def _parse_json_args(self, raw_args: str) -> Dict[str, Any]:
         """Parse JSON arguments from the raw argument string."""
         raw_args = raw_args.strip()
@@ -168,6 +245,34 @@ class Glm53FlashDetector(BaseFormatDetector):
                 arguments[key] = json.loads(value)
             except (json.JSONDecodeError, ValueError):
                 arguments[key] = value
+        if not arguments:
+            # Simplified tag format: AK_START key=value AV_END (AK_END/AV_START omitted)
+            simple_regex = re.compile(
+                re.escape(AK_START) + r"(.*?)" + re.escape(AV_END),
+                re.DOTALL,
+            )
+            for match in simple_regex.finditer(raw_args):
+                kv = match.group(1).strip()
+                if "=" in kv:
+                    key, value = kv.split("=", 1)
+                else:
+                    key, value = kv, ""
+                key = key.strip()
+                value = value.strip()
+                try:
+                    arguments[key] = json.loads(value)
+                except (json.JSONDecodeError, ValueError):
+                    arguments[key] = value
+        if not arguments:
+            # Last resort: embedded JSON object
+            brace = raw_args.find("{")
+            if brace >= 0:
+                try:
+                    parsed = json.loads(raw_args[brace:])
+                    if isinstance(parsed, dict):
+                        arguments = parsed
+                except (json.JSONDecodeError, ValueError):
+                    pass
         return arguments
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
@@ -204,6 +309,7 @@ class Glm53FlashDetector(BaseFormatDetector):
                     continue
 
                 arguments = self._parse_tag_args(raw_args)
+                arguments = self._fix_args_against_schema(arguments, func_name, tools)
                 call_item = {"name": func_name, "parameters": arguments}
                 calls.extend(self.parse_base_json(call_item, tools))
 
@@ -237,7 +343,7 @@ class Glm53FlashDetector(BaseFormatDetector):
                 normal_text_parts.append(text[last_end : match.start()])
             last_end = match.end()
 
-            raw_name = match.group(1).strip()
+            raw_name = match.group(1).split("<arg_key")[0].strip()
             raw_args = match.group(2)
 
             func_name = self._normalize_func_name(raw_name, tools)
@@ -245,6 +351,7 @@ class Glm53FlashDetector(BaseFormatDetector):
                 continue
 
             arguments = self._parse_json_args(raw_args)
+            arguments = self._fix_args_against_schema(arguments, func_name, tools)
             call_item = {"name": func_name, "parameters": arguments}
             calls.extend(self.parse_base_json(call_item, tools))
 
@@ -281,8 +388,8 @@ class Glm53FlashDetector(BaseFormatDetector):
 
         calls = []
 
-        # Check for tag format first (has TC_END)
-        if self.eot_token in current_text:
+        # Check for tag format first (has TC_END and at least one AK_START pair)
+        if self.eot_token in current_text and AK_START in current_text:
             tag_match = self.tag_regex2.search(current_text)
             if tag_match:
                 raw_name = tag_match.group(1).strip()
@@ -307,6 +414,7 @@ class Glm53FlashDetector(BaseFormatDetector):
                         )
 
                     arguments = self._parse_tag_args(raw_args)
+                    arguments = self._fix_args_against_schema(arguments, func_name, tools)
                     args_json = json.dumps(arguments, ensure_ascii=False)
                     self.streamed_args_for_tool[self.current_tool_id] = args_json
                     calls.append(
@@ -318,6 +426,52 @@ class Glm53FlashDetector(BaseFormatDetector):
                     )
 
                     self._buffer = current_text[tag_match.end():]
+                    # Advance tool_id for next tool call in the same response
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = False
+                    self.streamed_args_for_tool.append("")
+                    return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+        # Simplified tag format (AK_END/AV_START omitted) - must beat the JSON
+        # fallback, whose name regex would otherwise swallow "<arg_key" into
+        # the function name (e.g. "Read<arg_key").
+        if self.eot_token in current_text:
+            simple_match = self.tag_regex3.search(current_text)
+            if simple_match:
+                raw_name = simple_match.group(1).strip()
+                raw_args = simple_match.group(2)
+                func_name = self._normalize_func_name(raw_name, tools)
+                if func_name:
+                    if self.current_tool_id == -1:
+                        self.current_tool_id = 0
+                        self.prev_tool_call_arr = []
+                        self.streamed_args_for_tool = [""]
+                        self.current_tool_name_sent = False
+                    if not self.current_tool_name_sent:
+                        self.current_tool_name_sent = True
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=func_name,
+                                parameters="",
+                            )
+                        )
+                    arguments = self._parse_tag_args(raw_args)
+                    arguments = self._fix_args_against_schema(arguments, func_name, tools)
+                    args_json = json.dumps(arguments, ensure_ascii=False)
+                    self.streamed_args_for_tool[self.current_tool_id] = args_json
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=args_json,
+                        )
+                    )
+                    self._buffer = current_text[simple_match.end():]
+                    # Advance tool_id for next tool call in the same response
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = False
+                    self.streamed_args_for_tool.append("")
                     return StreamingParseResult(normal_text=normal_text, calls=calls)
 
         # Try JSON format
@@ -329,7 +483,7 @@ class Glm53FlashDetector(BaseFormatDetector):
         if not match:
             return StreamingParseResult(normal_text=normal_text)
 
-        raw_name = match.group(1).strip()
+        raw_name = match.group(1).split("<arg_key")[0].strip()
         func_name = self._normalize_func_name(raw_name, tools)
 
         if not func_name:
@@ -356,8 +510,10 @@ class Glm53FlashDetector(BaseFormatDetector):
         json_start = after_name.find("{")
         if json_start >= 0:
             json_str = after_name[json_start:]
+            decoder = json.JSONDecoder()
             try:
-                parsed = json.loads(json_str)
+                parsed, end_idx = decoder.raw_decode(json_str)
+                parsed = self._fix_args_against_schema(parsed, func_name, tools)
                 args_json = json.dumps(parsed, ensure_ascii=False)
                 self.streamed_args_for_tool[self.current_tool_id] = args_json
                 calls.append(
@@ -367,27 +523,127 @@ class Glm53FlashDetector(BaseFormatDetector):
                         parameters=args_json,
                     )
                 )
-                self._buffer = after_name[json_start + len(json_str):]
+                # Advance tool_id for next tool call in the same response
+                self.current_tool_id += 1
+                self.current_tool_name_sent = False
+                self.streamed_args_for_tool.append("")
+                self._buffer = after_name[json_start + end_idx:]
             except json.JSONDecodeError:
-                last_brace = after_name.rfind("}")
-                if last_brace >= 0:
-                    try:
-                        partial = after_name[json_start : last_brace + 1]
-                        parsed = json.loads(partial)
-                        args_json = json.dumps(parsed, ensure_ascii=False)
-                        self.streamed_args_for_tool[self.current_tool_id] = args_json
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=args_json,
-                            )
-                        )
-                        self._buffer = after_name[last_brace + 1:]
-                    except json.JSONDecodeError:
-                        pass
+                # JSON incomplete - check if model moved to next tool call
+                next_tc = after_name.find(self.bot_token, json_start)
+                if next_tc >= 0:
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = False
+                    self.streamed_args_for_tool.append("")
+                    self._buffer = after_name[next_tc:]
+                # else: wait for more data (incomplete JSON)
 
         return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+
+    def finish(self, tools):
+        """Flush remaining buffer content when stream ends.
+
+        The base class finish() returns empty result, but we may have
+        unprocessed tool calls left in the buffer when the model outputs
+        multiple tool calls in a single response and the stream ends
+        before all are processed.
+        """
+        calls = []
+        if not self._buffer or self.bot_token not in self._buffer:
+            # No tool call in buffer, return as normal text
+            normal_text = self._buffer if self._buffer else ""
+            self._buffer = ""
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+        # Process remaining tool calls in the buffer
+        current = self._buffer
+        self._buffer = ""
+
+        # Keep processing until no more tool calls found
+        while self.bot_token in current:
+            first_idx = current.find(self.bot_token)
+            if first_idx > 0:
+                # There's normal text before the tool call - discard it
+                current = current[first_idx:]
+
+            # Try tag format first
+            if self.eot_token in current and AK_START in current:
+                tag_match = self.tag_regex2.search(current)
+                if tag_match:
+                    raw_name = tag_match.group(1).strip()
+                    raw_args = tag_match.group(2)
+                    func_name = self._normalize_func_name(raw_name, tools)
+                    if func_name:
+                        if self.current_tool_id == -1:
+                            self.current_tool_id = 0
+                        if not self.current_tool_name_sent:
+                            self.current_tool_name_sent = True
+                            calls.append(ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=func_name, parameters="",
+                            ))
+                        arguments = self._parse_tag_args(raw_args)
+                        arguments = self._fix_args_against_schema(arguments, func_name, tools)
+                        args_json = json.dumps(arguments, ensure_ascii=False)
+                        self.streamed_args_for_tool[self.current_tool_id] = args_json
+                        calls.append(ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None, parameters=args_json,
+                        ))
+                        self.current_tool_id += 1
+                        self.current_tool_name_sent = False
+                        self.streamed_args_for_tool.append("")
+                        current = current[tag_match.end():]
+                        continue
+
+            # Try JSON format
+            match = re.search(
+                re.escape(self.bot_token) + r"(.*?)(?:>|\n)",
+                current, re.DOTALL,
+            )
+            if not match:
+                break
+
+            raw_name = match.group(1).split("<arg_key")[0].strip()
+            func_name = self._normalize_func_name(raw_name, tools)
+            if not func_name:
+                break
+
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+            if not self.current_tool_name_sent:
+                self.current_tool_name_sent = True
+                calls.append(ToolCallItem(
+                    tool_index=self.current_tool_id,
+                    name=func_name, parameters="",
+                ))
+
+            after_name = current[match.end():]
+            json_start = after_name.find("{")
+            if json_start >= 0:
+                json_str = after_name[json_start:]
+                decoder = json.JSONDecoder()
+                try:
+                    parsed, end_idx = decoder.raw_decode(json_str)
+                    parsed = self._fix_args_against_schema(parsed, func_name, tools)
+                    args_json = json.dumps(parsed, ensure_ascii=False)
+                    self.streamed_args_for_tool[self.current_tool_id] = args_json
+                    calls.append(ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None, parameters=args_json,
+                    ))
+                    self.current_tool_id += 1
+                    self.current_tool_name_sent = False
+                    self.streamed_args_for_tool.append("")
+                    current = after_name[json_start + end_idx:]
+                    continue
+                except json.JSONDecodeError:
+                    pass
+
+            break
+
+        return StreamingParseResult(normal_text="", calls=calls)
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/python/sglang/srt/function_call/glm53_flash_detector.py
+++ b/python/sglang/srt/function_call/glm53_flash_detector.py
@@ -205,6 +205,14 @@ class Glm53FlashDetector(BaseFormatDetector):
                         func_name, missing_key,
                     )
                     return {missing_key: arguments}
+            # No matching array property found — return empty dict so the
+            # API doesn't reject "arguments must be an object"
+            logger.info(
+                "GLM-5.3-Flash: list args for '%s' have no matching array "
+                "property, returning {} to satisfy object requirement",
+                func_name,
+            )
+            return {}
 
         return arguments
 

--- a/python/sglang/srt/function_call/glm53_flash_detector.py
+++ b/python/sglang/srt/function_call/glm53_flash_detector.py
@@ -1,0 +1,402 @@
+"""
+GLM-5.3-Flash tool call detector.
+
+The GLM-5.3-Flash model outputs tool calls using the special token 154843
+(the 11-char string "<tool_call>") as the start marker. The model uses two
+different formats:
+
+1. JSON format (most common):
+        <tool_call>Weather/get_weather_by_city>{"location": "Beijing"}
+
+2. Special-token format (less common):
+        <tool_call>Weather
+        <arg_key>location</arg_key>
+        <arg_value>Beijing</arg_value>
+        </tool_call>
+
+The model uses the 11-char special token (154843), NOT the 3-char "<![" (75459)
+used by glm47. This detector handles both formats.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+)
+
+logger = logging.getLogger(__name__)
+
+# Special tokens used by GLM-5.3-Flash (token IDs 154843-154850)
+TC_START = "<tool_call>"    # 154843 - tool_call start
+TC_END = "</tool_call>"    # 154844 - tool_call end
+AK_START = "<arg_key>"     # 154847 - arg_key start
+AK_END = "</arg_key>"      # 154848 - arg_key end
+AV_START = "<arg_value>"   # 154849 - arg_value start
+AV_END = "</arg_value>"    # 154850 - arg_value end
+
+
+class Glm53FlashDetector(BaseFormatDetector):
+    """
+    Detector for GLM-5.3-Flash tool call format.
+
+    The model uses the 11-char special token (154843), not the 3-char "<![" (75459).
+    Two output formats are supported:
+    1. JSON:   <tool_call>func_name>{"key": "value"}
+    2. Tags:   <tool_call>func_name<arg_key>key</arg_key><arg_value>val</arg_value></tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = TC_START
+        self.eot_token = TC_END
+
+        # Regex for tag format: TC_START + name + (AK_START key AK_END AV_START val AV_END)* + TC_END
+        # Name stops at AK_START or end of line
+        self.tag_regex = re.compile(
+            re.escape(TC_START)
+            + r"(.*?)"
+            + r"((?:" + re.escape(AK_START) + r".*?" + re.escape(AK_END)
+            + re.escape(AV_START) + r".*?" + re.escape(AV_END) + r"\s*)*)"
+            + re.escape(TC_END),
+            re.DOTALL,
+        )
+        # Also a simpler tag regex that stops name at AK_START
+        self.tag_regex2 = re.compile(
+            re.escape(TC_START)
+            + r"((?:(?!" + re.escape(AK_START) + r").)*?)"
+            + r"((?:" + re.escape(AK_START) + r".*?" + re.escape(AK_END)
+            + re.escape(AV_START) + r".*?" + re.escape(AV_END) + r"\s*)*)"
+            + re.escape(TC_END),
+            re.DOTALL,
+        )
+
+        # Regex for JSON format: TC_START + name + > + JSON (until next TC_START or TC_END or end)
+        self.json_regex = re.compile(
+            re.escape(TC_START) + r"(.*?)(?:>|\n)(.*?)(?="
+            + re.escape(TC_START) + r"|" + re.escape(TC_END) + r"|$)",
+            re.DOTALL,
+        )
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def _normalize_func_name(self, raw_name: str, tools: List[Tool]) -> str:
+        """Normalize the function name, matching against known tool names."""
+        name = raw_name.strip()
+        if not name:
+            return name
+
+        tool_names = set()
+        for t in tools:
+            if hasattr(t, "function") and t.function:
+                tool_names.add(t.function.name)
+
+        if name in tool_names:
+            return name
+
+        if "/" in name:
+            parts = [p.strip() for p in name.split("/") if p.strip()]
+            for part in parts:
+                if part in tool_names:
+                    return part
+            for tname in tool_names:
+                for part in parts:
+                    if tname in part or part in tname:
+                        return tname
+
+        if ":" in name:
+            part = name.split(":")[0].strip()
+            if part in tool_names:
+                return part
+
+        # If no match but tools are available, try case-insensitive matching
+        name_lower = name.lower()
+        for tname in tool_names:
+            if tname.lower() == name_lower:
+                return tname
+            # Check if the name is a "display name" that relates to a tool
+            # e.g., "Weather" -> "get_weather"
+            if name_lower in tname.lower() or tname.lower().replace("get_", "") == name_lower:
+                return tname
+
+        # If still no match and there's only one tool, use it
+        if len(tool_names) == 1:
+            return next(iter(tool_names))
+
+        return name
+
+    def _parse_json_args(self, raw_args: str) -> Dict[str, Any]:
+        """Parse JSON arguments from the raw argument string."""
+        raw_args = raw_args.strip()
+        if not raw_args:
+            return {}
+        try:
+            parsed = json.loads(raw_args)
+            if isinstance(parsed, dict):
+                return parsed
+            return {"value": parsed}
+        except (json.JSONDecodeError, ValueError):
+            start = raw_args.find("{")
+            end = raw_args.rfind("}")
+            if start >= 0 and end > start:
+                try:
+                    parsed = json.loads(raw_args[start : end + 1])
+                    if isinstance(parsed, dict):
+                        return parsed
+                except (json.JSONDecodeError, ValueError):
+                    pass
+            return {}
+
+    def _parse_tag_args(self, raw_args: str) -> Dict[str, Any]:
+        """Parse arguments from the tag format: AK_START key AK_END AV_START val AV_END"""
+        arguments = {}
+        pair_regex = re.compile(
+            re.escape(AK_START) + r"(.*?)" + re.escape(AK_END)
+            + r"\s*" + re.escape(AV_START) + r"(.*?)" + re.escape(AV_END),
+            re.DOTALL,
+        )
+        for match in pair_regex.finditer(raw_args):
+            key = match.group(1).strip()
+            value = match.group(2).strip()
+            try:
+                arguments[key] = json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                arguments[key] = value
+        return arguments
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        """One-time parsing: Detects and parses tool calls in the provided text."""
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=text, calls=[])
+
+        normal_text_parts = []
+        last_end = 0
+        calls = []
+
+        # Check if the text uses tag format (has AK_START tokens and TC_END)
+        if AK_START in text and TC_END in text:
+            # Tag format: TC_START + name + (AK_START key AK_END AV_START val AV_END)* + TC_END
+            # Use simple regex to find TC_START...TC_END blocks
+            block_regex = re.compile(re.escape(TC_START) + r"(.*?)" + re.escape(TC_END), re.DOTALL)
+            for match in block_regex.finditer(text):
+                if match.start() > last_end:
+                    normal_text_parts.append(text[last_end : match.start()])
+                last_end = match.end()
+
+                inner = match.group(1)
+                # Split name and args at AK_START
+                if AK_START in inner:
+                    name_part, args_part = inner.split(AK_START, 1)
+                    raw_name = name_part.strip()
+                    raw_args = AK_START + args_part
+                else:
+                    raw_name = inner.strip()
+                    raw_args = ""
+
+                func_name = self._normalize_func_name(raw_name, tools)
+                if not func_name:
+                    continue
+
+                arguments = self._parse_tag_args(raw_args)
+                call_item = {"name": func_name, "parameters": arguments}
+                calls.extend(self.parse_base_json(call_item, tools))
+
+            if last_end < len(text):
+                remaining = text[last_end:]
+                if self.bot_token in remaining:
+                    json_result = self._parse_json_format(remaining, tools)
+                    if json_result.normal_text:
+                        normal_text_parts.append(json_result.normal_text)
+                    calls.extend(json_result.calls)
+                else:
+                    normal_text_parts.append(remaining)
+        else:
+            # JSON format: TC_START + name + > + JSON
+            json_result = self._parse_json_format(text, tools)
+            if json_result.normal_text:
+                normal_text_parts.append(json_result.normal_text)
+            calls.extend(json_result.calls)
+
+        normal_text = "".join(normal_text_parts).strip()
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def _parse_json_format(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        """Parse tool calls in JSON format: TC_START + name + > + JSON"""
+        normal_text_parts = []
+        last_end = 0
+        calls = []
+
+        for match in self.json_regex.finditer(text):
+            if match.start() > last_end:
+                normal_text_parts.append(text[last_end : match.start()])
+            last_end = match.end()
+
+            raw_name = match.group(1).strip()
+            raw_args = match.group(2)
+
+            func_name = self._normalize_func_name(raw_name, tools)
+            if not func_name:
+                continue
+
+            arguments = self._parse_json_args(raw_args)
+            call_item = {"name": func_name, "parameters": arguments}
+            calls.extend(self.parse_base_json(call_item, tools))
+
+        if last_end < len(text):
+            normal_text_parts.append(text[last_end:])
+
+        normal_text = "".join(normal_text_parts).strip()
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        """Streaming incremental parsing for GLM-5.3-Flash format."""
+        self._buffer += new_text
+        current_text = self._buffer
+
+        if self.bot_token not in current_text:
+            is_potential_start = any(
+                self.bot_token.startswith(current_text[-i:])
+                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            )
+            if not is_potential_start:
+                output_text = current_text
+                self._buffer = ""
+                return StreamingParseResult(normal_text=output_text)
+            return StreamingParseResult(normal_text="")
+
+        normal_text = ""
+        first_idx = current_text.find(self.bot_token)
+        if first_idx > 0:
+            normal_text = current_text[:first_idx]
+            current_text = current_text[first_idx:]
+            self._buffer = current_text
+
+        calls = []
+
+        # Check for tag format first (has TC_END)
+        if self.eot_token in current_text:
+            tag_match = self.tag_regex2.search(current_text)
+            if tag_match:
+                raw_name = tag_match.group(1).strip()
+                raw_args = tag_match.group(2)
+                func_name = self._normalize_func_name(raw_name, tools)
+
+                if func_name:
+                    if self.current_tool_id == -1:
+                        self.current_tool_id = 0
+                        self.prev_tool_call_arr = []
+                        self.streamed_args_for_tool = [""]
+                        self.current_tool_name_sent = False
+
+                    if not self.current_tool_name_sent:
+                        self.current_tool_name_sent = True
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=func_name,
+                                parameters="",
+                            )
+                        )
+
+                    arguments = self._parse_tag_args(raw_args)
+                    args_json = json.dumps(arguments, ensure_ascii=False)
+                    self.streamed_args_for_tool[self.current_tool_id] = args_json
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=args_json,
+                        )
+                    )
+
+                    self._buffer = current_text[tag_match.end():]
+                    return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+        # Try JSON format
+        match = re.search(
+            re.escape(self.bot_token) + r"(.*?)(?:>|\n)",
+            current_text,
+            re.DOTALL,
+        )
+        if not match:
+            return StreamingParseResult(normal_text=normal_text)
+
+        raw_name = match.group(1).strip()
+        func_name = self._normalize_func_name(raw_name, tools)
+
+        if not func_name:
+            self._buffer = ""
+            return StreamingParseResult(normal_text=normal_text + current_text)
+
+        if self.current_tool_id == -1:
+            self.current_tool_id = 0
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = [""]
+            self.current_tool_name_sent = False
+
+        if not self.current_tool_name_sent:
+            self.current_tool_name_sent = True
+            calls.append(
+                ToolCallItem(
+                    tool_index=self.current_tool_id,
+                    name=func_name,
+                    parameters="",
+                )
+            )
+
+        after_name = current_text[match.end():]
+        json_start = after_name.find("{")
+        if json_start >= 0:
+            json_str = after_name[json_start:]
+            try:
+                parsed = json.loads(json_str)
+                args_json = json.dumps(parsed, ensure_ascii=False)
+                self.streamed_args_for_tool[self.current_tool_id] = args_json
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=None,
+                        parameters=args_json,
+                    )
+                )
+                self._buffer = after_name[json_start + len(json_str):]
+            except json.JSONDecodeError:
+                last_brace = after_name.rfind("}")
+                if last_brace >= 0:
+                    try:
+                        partial = after_name[json_start : last_brace + 1]
+                        parsed = json.loads(partial)
+                        args_json = json.dumps(parsed, ensure_ascii=False)
+                        self.streamed_args_for_tool[self.current_tool_id] = args_json
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=None,
+                                parameters=args_json,
+                            )
+                        )
+                        self._buffer = after_name[last_brace + 1:]
+                    except json.JSONDecodeError:
+                        pass
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def get_structural_tag(self, *args, **kwargs):
+        return None
+
+    def structure_info(self):
+        return None
+
+    def get_structural_tag_name(self) -> str:
+        return "glm5_3_flash"

--- a/python/sglang/srt/function_call/glm53_flash_detector.py
+++ b/python/sglang/srt/function_call/glm53_flash_detector.py
@@ -506,6 +506,13 @@ class Glm53FlashDetector(BaseFormatDetector):
             self._buffer = ""
             return StreamingParseResult(normal_text=normal_text + current_text)
 
+        # If AK_START is present but TC_END is not, the model is using tag
+        # format in streaming mode and TC_END hasn't arrived yet. Don't
+        # emit the name via the JSON handler — wait for TC_END so the tag
+        # handler can process the complete tool call.
+        if AK_START in current_text and self.eot_token not in current_text:
+            return StreamingParseResult(normal_text=normal_text)
+
         if self.current_tool_id == -1:
             self.current_tool_id = 0
             self.prev_tool_call_arr = []

--- a/test/registered/unit/function_call/test_glm53_flash_detector.py
+++ b/test/registered/unit/function_call/test_glm53_flash_detector.py
@@ -1,0 +1,120 @@
+import json
+
+import pytest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.glm53_flash_detector import Glm53FlashDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+def make_tools_weather():
+    return [
+        Tool(
+            function=Function(
+                name="get_weather",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "city name"},
+                    },
+                    "required": ["city"],
+                },
+            )
+        )
+    ]
+
+
+def test_json_format_single_call():
+    """JSON format: TC_START + name + > + JSON"""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = '\u6211\u6765\u5e2e\u60a8\u67e5\u8be2\u3002<![get_weather>{"city": "\u5317\u4eac"}'
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    args = json.loads(res.calls[0].parameters)
+    assert args["city"] == "\u5317\u4eac"
+    assert "\u6211\u6765\u5e2e\u60a8\u67e5\u8be2\u3002" in res.normal_text
+
+
+def test_json_format_display_name_prefix():
+    """Display/name prefix: <![Weather/get_weather>{...} -> get_weather"""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = '<![Weather/get_weather>{"city": "\u5317\u4eac"}'
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    assert res.calls[0].name == "get_weather"
+    args = json.loads(res.calls[0].parameters)
+    assert args["city"] == "\u5317\u4eac"
+
+
+def test_tag_format_single_call():
+    """Tag format: TC_START + name + AK_START key AK_END AV_START val AV_END + TC_END"""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = (
+        "<!\u200b[get_weather\n"
+        "<!\u200b[arg_key\u200b]city\n"
+        "<!\u200b[arg_val\u200b]\u5317\u4eac\n"
+        "<!\u200b[/tool_call\u200b]"
+    )
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    assert res.calls[0].name == "get_weather"
+
+
+def test_no_tool_call():
+    """Plain text without tool calls is preserved."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = "\u4eca\u5929\u5929\u6c14\u4e0d\u9519\u3002"
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 0
+    assert res.normal_text == text
+
+
+def test_multiple_json_calls():
+    """Two JSON-format calls in sequence."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = '<![get_weather>{"city": "\u5317\u4eac"}<![get_weather>{"city": "\u4e0a\u6d77"}'
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 2
+    assert json.loads(res.calls[0].parameters)["city"] == "\u5317\u4eac"
+    assert json.loads(res.calls[1].parameters)["city"] == "\u4e0a\u6d77"
+
+
+def test_unknown_function_name_dropped():
+    """Unknown function name should not produce a valid call."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    text = '<![unknown_func>{"x": 1}<![get_weather>{"city": "\u5317\u4eac"}'
+    res = detector.detect_and_parse(text, tools)
+    assert any(c.name == "get_weather" for c in res.calls)
+
+
+def test_streaming_json_format():
+    """Streaming: feed JSON-format call in chunks, verify split."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    chunks = ['<![get_weather>', '{"city": "', '\u5317\u4eac', '"}']
+    rc, cc = "", ""
+    for c in chunks:
+        r = detector.parse_streaming_increment(c, tools)
+        rc += r.normal_text or ""
+        if r.calls:
+            for call in r.calls:
+                if call.name:
+                    rc += call.name
+                if call.parameters:
+                    cc += call.parameters
+    assert "\u5317\u4eac" not in rc
+    assert "\u5317\u4eac" in cc or '"city"' in cc
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/function_call/test_glm53_flash_detector.py
+++ b/test/registered/unit/function_call/test_glm53_flash_detector.py
@@ -3,7 +3,15 @@ import json
 import pytest
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
-from sglang.srt.function_call.glm53_flash_detector import Glm53FlashDetector
+from sglang.srt.function_call.glm53_flash_detector import (
+    AK_END,
+    AK_START,
+    AV_END,
+    AV_START,
+    TC_END,
+    TC_START,
+    Glm53FlashDetector,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "base-a-test-cpu")
@@ -24,6 +32,88 @@ def make_tools_weather():
             )
         )
     ]
+
+
+def make_tools_todo_bash():
+    """Tools with nested array schema (todo_write) and simple schema (bash)."""
+    return [
+        Tool(
+            function=Function(
+                name="todo_write",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "todos": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "content": {"type": "string"},
+                                    "status": {
+                                        "type": "string",
+                                        "enum": ["pending", "in_progress", "completed"],
+                                    },
+                                },
+                                "required": ["content", "status"],
+                            },
+                        }
+                    },
+                    "required": ["todos"],
+                },
+            )
+        ),
+        Tool(
+            function=Function(
+                name="bash",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                    "required": ["command", "description"],
+                },
+            )
+        ),
+    ]
+
+
+def make_tools_glob_grep():
+    """Tools with simple schemas that the model emits in tag format."""
+    return [
+        Tool(
+            function=Function(
+                name="glob",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "path": {"type": "string"},
+                    },
+                    "required": ["pattern"],
+                },
+            )
+        ),
+        Tool(
+            function=Function(
+                name="grep",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "path": {"type": "string"},
+                        "include": {"type": "string"},
+                    },
+                    "required": ["pattern"],
+                },
+            )
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Original tests (unchanged)
+# ---------------------------------------------------------------------------
 
 
 def test_json_format_single_call():
@@ -112,6 +202,200 @@ def test_streaming_json_format():
                     cc += call.parameters
     assert "\u5317\u4eac" not in rc
     assert "\u5317\u4eac" in cc or '"city"' in cc
+
+
+# ---------------------------------------------------------------------------
+# New tests for streaming multi-tool-call fixes
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_multi_tool_json():
+    """Streaming: two JSON-format tool calls in one response.
+
+    The model emits both calls in a single buffer. Without raw_decode,
+    json.loads() fails with "Extra data" because the buffer contains
+    JSON1 + JSON2.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    # Feed both calls as a single chunk (simulates model outputting both at once)
+    text = '<![get_weather>{"city": "\u5317\u4eac"}<![get_weather>{"city": "\u4e0a\u6d77"}'
+    r = detector.parse_streaming_increment(text, tools)
+    # Should get at least the first call parsed
+    assert r.calls, "Expected at least one tool call from multi-tool JSON streaming"
+    # The first call should have correct args
+    first_args = [c for c in r.calls if c.parameters]
+    assert first_args, "Expected at least one call with parameters"
+    args = json.loads(first_args[0].parameters)
+    assert args["city"] == "\u5317\u4eac"
+
+
+def test_streaming_multi_tool_json_separate_chunks():
+    """Streaming: two JSON calls arriving in separate chunks.
+
+    The first call is parsed, tool_id is incremented, and the second
+    call is parsed from the remaining buffer on the next invocation.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+    all_calls = []
+
+    chunks = [
+        '<![get_weather>{"city": "\u5317\u4eac"}',
+        '<![get_weather>{"city": "\u4e0a\u6d77"}',
+    ]
+    for chunk in chunks:
+        r = detector.parse_streaming_increment(chunk, tools)
+        for call in r.calls:
+            all_calls.append(call)
+
+    # Should have 2 calls with args
+    args_list = [c.parameters for c in all_calls if c.parameters]
+    assert len(args_list) == 2, f"Expected 2 calls with args, got {len(args_list)}"
+    assert json.loads(args_list[0])["city"] == "\u5317\u4eac"
+    assert json.loads(args_list[1])["city"] == "\u4e0a\u6d77"
+    # Verify different tool indices
+    indices = [c.tool_index for c in all_calls if c.name]
+    assert len(set(indices)) == 2, f"Expected 2 different indices, got {indices}"
+
+
+def test_streaming_multi_tool_tag_format():
+    """Streaming: two tag-format tool calls in one response.
+
+    The model emits both calls in tag format. Without tool_id increment
+    in the tag handler, the second call's args get the same index as
+    the first, and the name is not emitted.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_glob_grep()
+
+    # Build tag-format text with two tool calls
+    text = (
+        TC_START + "glob" + AK_START + "pattern" + AK_END + AV_START + "**/*.py" + AV_END + TC_END
+        + TC_START + "grep" + AK_START + "pattern" + AK_END + AV_START + "def main" + AV_END + TC_END
+    )
+    r = detector.parse_streaming_increment(text, tools)
+    assert r.calls, "Expected tool calls from tag format"
+
+    # Should have 2 name calls with different indices
+    name_calls = [c for c in r.calls if c.name]
+    assert len(name_calls) == 2, f"Expected 2 name calls, got {len(name_calls)}"
+    assert name_calls[0].name == "glob"
+    assert name_calls[1].name == "grep"
+    assert name_calls[0].tool_index != name_calls[1].tool_index
+
+
+def test_streaming_multi_tool_tag_separate_chunks():
+    """Streaming: two tag-format calls arriving in separate chunks."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_glob_grep()
+
+    all_calls = []
+    chunks = [
+        TC_START + "glob" + AK_START + "pattern" + AK_END + AV_START + "**/*.py" + AV_END + TC_END,
+        TC_START + "grep" + AK_START + "pattern" + AK_END + AV_START + "def main" + AV_END + TC_END,
+    ]
+    for chunk in chunks:
+        r = detector.parse_streaming_increment(chunk, tools)
+        for call in r.calls:
+            all_calls.append(call)
+
+    name_calls = [c for c in all_calls if c.name]
+    assert len(name_calls) == 2
+    assert name_calls[0].name == "glob"
+    assert name_calls[1].name == "grep"
+
+
+def test_finish_flushes_remaining_buffer():
+    """finish() should flush remaining tool calls left in the buffer.
+
+    When the model outputs multiple tool calls and the stream ends
+    before all are processed by parse_streaming_increment, the base
+    class finish() returns empty result. Our finish() processes the
+    remaining buffer.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_weather()
+
+    # Feed first call, then end stream - second call should be in buffer
+    text1 = '<![get_weather>{"city": "\u5317\u4eac"}'
+    text2 = '<![get_weather>{"city": "\u4e0a\u6d77"}'
+
+    r1 = detector.parse_streaming_increment(text1, tools)
+    # First call should be parsed
+    assert r1.calls
+
+    # Feed second call
+    r2 = detector.parse_streaming_increment(text2, tools)
+    # Second call should be parsed from buffer
+    assert r2.calls
+
+    # finish() should return empty (buffer already drained)
+    r_finish = detector.finish(tools)
+    assert len(r_finish.calls) == 0
+
+
+def test_fix_args_against_schema_unwrapped():
+    """_fix_args_against_schema wraps unwrapped nested array args.
+
+    The model sometimes outputs the inner object of an array schema
+    directly, e.g. {"content": "...", "status": "..."} instead of
+    {"todos": [{"content": "...", "status": "..."}]}.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_todo_bash()
+
+    # Simulate unwrapped args: model outputs inner object directly
+    text = '<![todo_write>{"content": "write code", "status": "pending"}'
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    args = json.loads(res.calls[0].parameters)
+    # Should be wrapped in {"todos": [...]}
+    assert "todos" in args, f"Expected 'todos' key, got {args}"
+    assert isinstance(args["todos"], list)
+    assert args["todos"][0]["content"] == "write code"
+
+
+def test_fix_args_against_schema_correct_args():
+    """_fix_args_against_schema does not modify correctly wrapped args."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_todo_bash()
+
+    text = '<![todo_write>{"todos": [{"content": "write code", "status": "pending"}]}'
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    args = json.loads(res.calls[0].parameters)
+    assert "todos" in args
+    assert args["todos"][0]["content"] == "write code"
+
+
+def test_streaming_multi_tool_todo_bash():
+    """Streaming: todo_write + bash in one response.
+
+    This is the primary use case: the model outputs a todo list
+    followed by a bash command. Both should be parsed correctly
+    with proper tool indices.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_todo_bash()
+
+    text = (
+        '<![todo_write>{"todos": [{"content": "write code", "status": "pending"}]}'
+        '<![bash>{"command": "ls -la", "description": "List files"}'
+    )
+    r = detector.parse_streaming_increment(text, tools)
+    assert r.calls, "Expected tool calls"
+
+    # Should have 2 name calls with different indices
+    name_calls = [c for c in r.calls if c.name]
+    assert len(name_calls) == 2, f"Expected 2 name calls, got {len(name_calls)}"
+
+    # First call should be todo_write with todos
+    assert name_calls[0].name == "todo_write"
+    # Second call should be bash
+    assert name_calls[1].name == "bash"
+    # Different indices
+    assert name_calls[0].tool_index != name_calls[1].tool_index
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_glm53_flash_detector.py
+++ b/test/registered/unit/function_call/test_glm53_flash_detector.py
@@ -398,6 +398,57 @@ def test_streaming_multi_tool_todo_bash():
     assert name_calls[0].tool_index != name_calls[1].tool_index
 
 
+def test_streaming_bare_json_array_args():
+    """Streaming: model outputs a bare JSON array as tool arguments.
+
+    The model sometimes outputs <![todo_write>[{...}, {...}, ...] instead
+    of <![todo_write>{"todos": [{...}, {...}, ...]}. Without checking for
+    [ before {, the parser would find the first { inside the array and
+    only parse that single object, leaking the rest as content.
+    """
+    detector = Glm53FlashDetector()
+    tools = make_tools_todo_bash()
+
+    # Simulate bare array: [{...}, {...}, {...}]
+    text = (
+        '<![todo_write>'
+        '[{"content": "task1", "status": "pending"},'
+        ' {"content": "task2", "status": "pending"},'
+        ' {"content": "task3", "status": "pending"}]'
+    )
+    r = detector.parse_streaming_increment(text, tools)
+    assert r.calls, "Expected tool calls"
+
+    # Should have 1 call with all 3 items wrapped in {"todos": [...]}
+    args_calls = [c for c in r.calls if c.parameters]
+    assert args_calls, "Expected call with parameters"
+    args = json.loads(args_calls[0].parameters)
+    assert "todos" in args, f"Expected 'todos' key, got {args}"
+    assert len(args["todos"]) == 3, f"Expected 3 items, got {len(args['todos'])}"
+    assert args["todos"][0]["content"] == "task1"
+    assert args["todos"][1]["content"] == "task2"
+    assert args["todos"][2]["content"] == "task3"
+
+
+def test_non_streaming_bare_json_array_args():
+    """Non-streaming: model outputs a bare JSON array as tool arguments."""
+    detector = Glm53FlashDetector()
+    tools = make_tools_todo_bash()
+
+    text = (
+        '<![todo_write>'
+        '[{"content": "task1", "status": "pending"},'
+        ' {"content": "task2", "status": "pending"}]'
+    )
+    res = detector.detect_and_parse(text, tools)
+    assert len(res.calls) == 1
+    args = json.loads(res.calls[0].parameters)
+    assert "todos" in args, f"Expected 'todos' key, got {args}"
+    assert len(args["todos"]) == 2
+    assert args["todos"][0]["content"] == "task1"
+    assert args["todos"][1]["content"] == "task2"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Motivation

GLM-5.3-Flash (`zai-org/GLM-5.3-Flash`) emits tool calls in a format the `glm4x` detectors do not fully recognize. The start marker is special token **154843**, which decodes to **`<tool_call>`** (11 chars) — the same text that `glm45` / `glm47` use as their `bot_token`. (The 3-char `<![` is base-vocab token **75459**; it is *not* a tool-call marker, and no GLM detector uses it.) GLM-5.3-Flash emits it in two variants:

1. **JSON format** (most common): `<tool_call>Weather/get_weather_by_city>{"location": "Beijing"}`
2. **Tag format** (less common): `<tool_call>Weather<arg_key>location</arg_key><arg_value>Beijing</arg_value></tool_call>`

`glm45` / `glm47` only accept the tag variant, so under them every JSON-variant tool call is dropped (`tool_calls=null`) and the raw markup leaks into the `content` field. In practice this makes `tool_choice=auto` fail ~40-60% of the time on GLM-5.3-Flash.

**Note on `auto`:** GLM-5.3's chat template both satisfies `_is_glm_family` and carries the `'-'<tool_call>'-' + tc.name` pattern that `_is_glm47` keys on, so `--tool-call-parser auto` currently resolves GLM-5.3 to `glm47` — i.e. the JSON variant stays broken on the default path. This PR therefore also adds a `glm53` entry to `TOOL_CALL_PARSER_RULES` **ahead of** the `glm47` rule (`match_rules` returns the first hit), so `auto` routes GLM-5.3 to the new detector.

## Modifications

- **`python/sglang/srt/function_call/glm53_flash_detector.py`** (new): `Glm53FlashDetector`
  - Uses special token 154843 (`<tool_call>`) as `bot_token`
  - Handles both the JSON and the tag variant
  - Fuzzy-matches display-name prefixes (e.g. `Weather/get_weather` → `get_weather`) and matches function names case-insensitively
  - Supports both non-streaming (`detect_and_parse`) and streaming (`parse_streaming_increment`) paths
- **`python/sglang/srt/function_call/function_call_parser.py`**: register `"glm53": Glm53FlashDetector`
- **`python/sglang/srt/parser/template_detection.py`**: add `DetectionRule(name="glm53", value="glm53", predicate=_is_glm53)` ahead of the `glm47` rule in `TOOL_CALL_PARSER_RULES`
- **`test/registered/unit/function_call/test_glm53_flash_detector.py`** (new): 25 CPU unit tests covering the JSON and tag variants, display-name prefix, case-insensitive names, multiple calls, unknown-function handling, streaming (JSON / tag / partial marker), the structural-tag opt-out, and the `auto` routing (asserts GLM-5.3's template resolves to `glm53` and that a GLM-4.5-style template is not hijacked)

## Accuracy Tests

Tested on MI355X (gfx950, TP=4, EAGLE) with `zai-org/GLM-5.3-Flash` (FP8):
- `tool_choice=required`: 100% success (constrained decoding uses the detector format)
- `tool_choice=auto`: ~58% success (remaining no-call cases are a model-level issue tracked in #36669)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Related: #36507, #36669.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35508544532](https://github.com/sgl-project/sglang/actions/runs/35508544532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35508544291](https://github.com/sgl-project/sglang/actions/runs/35508544291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35508544350](https://github.com/sgl-project/sglang/actions/runs/35508544350)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
