### PR TITLE
Treat a null optional config section the same as a missing one

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -229,10 +229,10 @@ class CompressedTensorsConfig(QuantizationConfig):
         # Format: {"activation_scheme": "dynamic", "fmt": "e4m3",
         #          "quant_method": "fp8", "weight_block_size": [128, 128]}
         linear_fp8_config = None
-        if "linear_fp8_config" in config:
+        fp8_cfg = config.get("linear_fp8_config")
+        if fp8_cfg is not None:
             from sglang.srt.layers.quantization.fp8 import Fp8Config
 
-            fp8_cfg = config["linear_fp8_config"]
             # Check if it's fp8 format based on quant_method field
             is_fp8 = fp8_cfg.get("quant_method") == "fp8"
             linear_fp8_config = Fp8Config(

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -364,10 +364,10 @@ def get_hf_text_config(config: PretrainedConfig):
                 _sub.dtype = parent_dtype
 
     # Priority: thinker_config > llm_config > language_config > text_config
-    if hasattr(config, "thinker_config"):
+    if getattr(config, "thinker_config", None) is not None:
         # qwen2.5 omni
         thinker_config = config.thinker_config
-        if hasattr(thinker_config, "text_config"):
+        if getattr(thinker_config, "text_config", None) is not None:
             setattr(
                 thinker_config.text_config,
                 "dtype",
@@ -376,13 +376,13 @@ def get_hf_text_config(config: PretrainedConfig):
             text_config = thinker_config.text_config
         else:
             text_config = thinker_config
-    elif hasattr(config, "llm_config"):
+    elif getattr(config, "llm_config", None) is not None:
         # PointsV1.5 Chat Model
         assert hasattr(config.llm_config, "num_attention_heads")
         text_config = config.llm_config
-    elif hasattr(config, "language_config"):
+    elif getattr(config, "language_config", None) is not None:
         text_config = config.language_config
-    elif hasattr(config, "text_config"):
+    elif getattr(config, "text_config", None) is not None:
         # The code operates under the assumption that text_config should have
         # `num_attention_heads` (among others). Assert here to fail early
         # if transformers config doesn't align with this assumption.


### PR DESCRIPTION
## Motivation

Fixes #37846.

Several optional config sections are gated on the *key* rather than the *value*, so a section explicitly set to `null` passes the check and is then dereferenced as if it were populated. The user gets an unrelated error far from the real cause, and deleting the same key makes the model load fine.

Two places from the issue, both reproducible on `main`:

**1. `get_hf_text_config`** — `python/sglang/srt/utils/hf_transformers/common.py`

```python
    if hasattr(config, "thinker_config"):
    elif hasattr(config, "llm_config"):
    elif hasattr(config, "language_config"):
    elif hasattr(config, "text_config"):
        assert hasattr(config.text_config, "num_attention_heads")   # AssertionError when it is None
```

`MiniMaxVLBaseConfig()` default-constructs with `text_config=None` (`_coerce_sub_config(None, "mixtral")` returns `None` for a non-dict), so this fires on a config class shipped in the repo:

```python
from sglang.srt.configs.minimax_vl import MiniMaxVLBaseConfig
from sglang.srt.utils.hf_transformers.common import get_hf_text_config

cfg = MiniMaxVLBaseConfig()   # text_config is None
get_hf_text_config(cfg)       # AssertionError
delattr(cfg, "text_config")   # same object, section now absent
get_hf_text_config(cfg)       # ok
```

**2. `CompressedTensorsConfig.from_config`** — `.../quantization/compressed_tensors/compressed_tensors.py`

```python
        if "linear_fp8_config" in config:
            fp8_cfg = config["linear_fp8_config"]
            is_fp8 = fp8_cfg.get("quant_method") == "fp8"   # AttributeError when it is None
```

Adding `"linear_fp8_config": null` to an FP8 checkpoint's `quantization_config` takes the scheduler down with `AttributeError: 'NoneType' object has no attribute 'get'`.

## Modifications

Test the value rather than the key, so a `null` section takes the same fallback path as an absent one — which is what the rest of the function already does (`_sub = getattr(config, _attr, None)` … `elif _sub is not None` a few lines above the selection chain):

- `hasattr(config, X)` → `getattr(config, X, None) is not None` for `thinker_config`, `thinker_config.text_config`, `llm_config`, `language_config`, `text_config`;
- `if "linear_fp8_config" in config` → fetch with `config.get(...)` and gate on `is not None`. `linear_fp8_config` then stays `None`, which is exactly what the consumer at `:171` already expects (`if self.linear_fp8_config is not None`).

Scoped to the two sites the issue reproduces; `ModelConfig._derive_model_shapes` is also named there and can be handled separately.

## Verification

No GPU or server needed — both failures are pure config handling. Extracted `get_hf_text_config` and the `linear_fp8_config` block verbatim from the file with `ast`, stubbed only `PretrainedConfig` / `Fp8Config` / the rope helper, and ran the three cases (null / absent / populated) against the unpatched and patched sources:

```
== BEFORE (upstream)
   text_config=None          -> AssertionError
   text_config absent        -> ok, returned config itself
   text_config populated     -> ok, heads = 8
   "linear_fp8_config": null -> AttributeError: 'NoneType' object has no attribute 'get'
   key absent                -> linear_fp8_config = None
   populated                 -> Fp8Config(is_checkpoint_fp8_serialized=True, activation_scheme='dynamic', ...)

== AFTER (patched)
   text_config=None          -> ok, returned config itself
   text_config absent        -> ok, returned config itself
   text_config populated     -> ok, heads = 8
   "linear_fp8_config": null -> linear_fp8_config = None
   key absent                -> linear_fp8_config = None
   populated                 -> Fp8Config(is_checkpoint_fp8_serialized=True, activation_scheme='dynamic', ...)
```

Both crashes are gone and the *absent* and *populated* paths are bit-identical before and after, so nothing that worked before changes.

`ruff-format` and `ruff check --select=F401,F821,UP037` (the `.pre-commit-config.yaml` pin, v0.15.1) pass on the changed lines.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-to-ci) — n/a, no new behaviour; the fix restores the documented fallback path and is covered by the reproductions above.
- [x] Update documentation / docstrings — n/a.
- [x] Provide throughput / latency benchmark results — n/a, config-time only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33837068795](https://github.com/sgl-project/sglang/actions/runs/33837068795)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33837068476](https://github.com/sgl-project/sglang/actions/runs/33837068476)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33837068756](https://github.com/sgl-project/sglang/actions/runs/33837068756)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->