### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in DeepSeek-V3 cookbook

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.mdx
@@ -392,7 +392,7 @@ python3 -m sglang.launch_server \
 The default configuration is `--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`. Find the best values for your workload with [bench_speculative.py](https://github.com/sgl-project/sglang/blob/main/scripts/playground/bench_speculative.py). The minimum viable config is `--speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2`.
 
 <Note>
-For large batch sizes (>48), increase `--max-running-requests` beyond the default of 48 for MTP. Also set `--cuda-graph-bs` to include your target batch sizes (default captured sizes for speculative decoding: 48).
+For large batch sizes (>48), increase `--max-running-requests` beyond the default of 48 for MTP. Also set `--cuda-graph-bs-decode` to include your target batch sizes (default captured sizes for speculative decoding: 48).
 </Note>
 
 <Tip>


### PR DESCRIPTION
## Summary
In `docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.mdx`, the MTP note still recommends `--cuda-graph-bs`.

In `python/sglang/srt/server_args.py`, `--cuda-graph-bs` is registered as a **deprecated alias** for `--cuda-graph-bs-decode` (`DeprecatedAliasStoreAction`). Prefer the current flag name in the cookbook note.

## Local repro
```bash
# 1) Stale docs flag (upstream main)
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3.mdx \
  | rg -n 'cuda-graph-bs'

# 2) Canonical mapping in server_args.py
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/server_args.py \
  | rg -n -A6 '"--cuda-graph-bs"'
# expect: DeprecatedAliasStoreAction, new_flag="--cuda-graph-bs-decode", dest="cuda_graph_bs_decode"
```

## Test plan
- [x] Confirmed `--cuda-graph-bs` → `--cuda-graph-bs-decode` in `server_args.py`
- [x] Single-line docs update; no other flags changed
- [ ] Docs preview / maintainer glance at DeepSeek-V3 MTP note

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33837688850](https://github.com/sgl-project/sglang/actions/runs/33837688850)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33837688641](https://github.com/sgl-project/sglang/actions/runs/33837688641)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->