### PR TITLE
[CI] Fix handle_platform_cp_compatibility reading legacy CP flags off the record

### DIFF
--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -566,8 +566,8 @@ def handle_platform_cp_compatibility(server_args: Any):
     is_protected_platform = platform.is_hip or platform.is_npu
     if not is_protected_platform:
         if (
-            server_args.enable_prefill_context_parallel
-            or server_args.enable_dsa_prefill_context_parallel
+            cfg.enable_prefill_context_parallel
+            or cfg.enable_dsa_prefill_context_parallel
         ):
             raise ValueError(
                 "Legacy prefill context-parallel options are supported only "


### PR DESCRIPTION
## Summary

Fixes the `test_resolution_reads_the_declarations` failure from #36223

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33838689292](https://github.com/sgl-project/sglang/actions/runs/33838689292)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33838689041](https://github.com/sgl-project/sglang/actions/runs/33838689041)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33838689275](https://github.com/sgl-project/sglang/actions/runs/33838689275)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->