### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in PD disaggregation examples

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -563,7 +563,7 @@ python3 -m sglang.launch_server \
         --disaggregation-bootstrap-port 8996 \
         --base-gpu-id 8 \
         --disable-radix-cache \
-        --cuda-graph-bs 1 2 4 8 10 12 14 16 \
+        --cuda-graph-bs-decode 1 2 4 8 10 12 14 16 \
         --speculative-draft-model-quantization unquant \
         --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
         --enable-multi-layer-eagle \
@@ -676,7 +676,7 @@ do
         --port 8001 --trust-remote-code --nnodes 1 --node-rank 0 --tp-size 16 --dp-size 16 \
         --mem-fraction-static 0.8 --max-running-requests 448 --attention-backend ascend --device npu --quantization modelslim \
         --moe-a2a-backend deepep --enable-dp-attention --deepep-mode low_latency --enable-dp-lm-head \
-        --cuda-graph-bs 2 4 6 8 10 12 14 16 18 20 22 24 26 28 --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 8192 \
+        --cuda-graph-bs-decode 2 4 6 8 10 12 14 16 18 20 22 24 26 28 --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 8192 \
         --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4  \
         --prefill-round-robin-balance --disable-shared-experts-fusion --dtype bfloat16 --tokenizer-worker-num 4 \
        	--load-balance-method round_robin


### PR DESCRIPTION
## Summary
Replace deprecated `--cuda-graph-bs` with `--cuda-graph-bs-decode` in PD disaggregation decode-side launch snippets.

In current `server_args.py`, `--cuda-graph-bs` is registered as a **deprecated alias** for `--cuda-graph-bs-decode` (`DeprecatedAliasStoreAction`, `nargs="+"`). The PD disaggregation docs still used the old flag in two decode examples.

## Changes
- `docs/docs/advanced_features/pd_disaggregation.mdx`
  - MiMo-V2-Flash decode snippet: `--cuda-graph-bs …` → `--cuda-graph-bs-decode …`
  - DeepSeek multi-node decode snippet: same replacement

## Local repro / verification
```bash
# 1) Confirm deprecated alias mapping on main
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/server_args.py \
  | rg -n 'cuda-graph-bs"|cuda-graph-bs-decode|Deprecated alias for --cuda-graph-bs-decode' | head

# Expected: --cuda-graph-bs uses action=DeprecatedAliasStoreAction,
#           new_flag="--cuda-graph-bs-decode"

# 2) Confirm docs on main still had the old flag
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/docs/advanced_features/pd_disaggregation.mdx \
  | rg -n -- '--cuda-graph-bs(?![-\w])'
# Expected: 2 hits (decode snippets)

# 3) Confirm this PR diff only renames those two flags
gh pr diff 37934 --repo sgl-project/sglang | rg -n 'cuda-graph-bs'
# Expected: - --cuda-graph-bs / + --cuda-graph-bs-decode (x2)
```

## Notes
- Docs-only; no runtime code changes.
- Does not touch the separate `--prefill-round-robin-balance` cleanup already covered by an open PR on the same file.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33840691049](https://github.com/sgl-project/sglang/actions/runs/33840691049)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33840690925](https://github.com/sgl-project/sglang/actions/runs/33840690925)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->