### PR TITLE
fix: report DeepSeek-V4 KV cache memory usage

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -20,7 +20,7 @@ from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
-from sglang.srt.mem_cache.memory_pool import KVCache
+from sglang.srt.mem_cache.memory_pool import KVCache, get_tensor_size_bytes
 from sglang.srt.runtime_context import get_exec, get_spec
 from sglang.srt.utils import ceil_div, is_hip
 
@@ -109,6 +109,11 @@ class DeepSeekV4SingleKVPool(KVCache):
                     )
                     for _ in range(self.layer_num)
                 ]
+
+        self._finalize_allocation_log(self.size)
+
+    def get_kv_size_bytes(self) -> int:
+        return get_tensor_size_bytes(self.kv_buffer)
 
     def get_bytes_per_token(self) -> int:
         dim_per_token = (
@@ -327,17 +332,34 @@ class DeepSeekV4IndexerPool(KVCache):
                         for _ in range(self.layer_num)
                     ]
                     self.index_k_with_scale_buffer = None
-                    return
+                else:
+                    self.index_k_with_scale_buffer = [
+                        torch.zeros(
+                            num_pages,
+                            page_bytes,
+                            dtype=self.index_k_with_scale_buffer_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
 
-                self.index_k_with_scale_buffer = [
-                    torch.zeros(
-                        num_pages,
-                        page_bytes,
-                        dtype=self.index_k_with_scale_buffer_dtype,
-                        device=self.device,
-                    )
-                    for _ in range(self.layer_num)
-                ]
+        self._finalize_allocation_log(self.size)
+
+    def get_kv_size_bytes(self) -> int:
+        buffers = []
+        for name in (
+            "index_k_with_scale_buffer",
+            "index_k_payload_buffer",
+            "index_k_scale_buffer",
+            # NPU adds dedicated buffers alongside the packed compatibility
+            # buffer allocated by the base indexer pool.
+            "index_k_buffer",
+            "index_scale_buffer",
+        ):
+            buffer = getattr(self, name, None)
+            if buffer is not None:
+                buffers.append(buffer)
+        return sum(get_tensor_size_bytes(buffer) for buffer in buffers)
 
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError()
@@ -499,6 +521,9 @@ class DeepSeekV4UnifiedKVPool:
 
     def get_unified_kv(self, local_layer_id: int) -> torch.Tensor:
         return self.kv_buffer[local_layer_id]
+
+    def get_kv_size_bytes(self) -> int:
+        return get_tensor_size_bytes(self.kv_buffer)
 
     def get_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs = [b.data_ptr() for b in self.kv_buffer]
@@ -700,6 +725,26 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self._init_compressed_layer_mapping()
 
         self._init_paged_compress_states(enable_memory_saver)
+        self._finalize_allocation_log(swa_size)
+
+    def get_kv_size_bytes(self) -> int:
+        if self._unified_kv:
+            kv_size_bytes = self.unified_kv_pool.get_kv_size_bytes()
+        else:
+            kv_size_bytes = sum(
+                pool.get_kv_size_bytes()
+                for pool in (self.swa_kv_pool, self.c4_kv_pool, self.c128_kv_pool)
+                if pool is not None
+            )
+
+        kv_size_bytes += self.c4_indexer_kv_pool.get_kv_size_bytes()
+        kv_size_bytes += sum(
+            get_tensor_size_bytes(pool.kv_score_buffer.kv_score)
+            for pools in (self.compress_state_pools, self.indexer_compress_state_pools)
+            for pool in pools
+            if pool is not None
+        )
+        return kv_size_bytes
 
     def get_unified_kv(self, layer_id: int) -> torch.Tensor:
         # Under HiCache the compressed region is loaded H->D per layer; wait for this

--- a/test/registered/unit/mem_cache/test_dsv4_memory_usage.py
+++ b/test/registered/unit/mem_cache/test_dsv4_memory_usage.py
@@ -1,0 +1,117 @@
+import types
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    DeepSeekV4IndexerPool,
+    DeepSeekV4SingleKVPool,
+    DeepSeekV4TokenToKVPool,
+    DeepSeekV4UnifiedKVPool,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _single_pool(*shapes):
+    pool = object.__new__(DeepSeekV4SingleKVPool)
+    pool.kv_buffer = [torch.empty(shape, dtype=torch.uint8) for shape in shapes]
+    return pool
+
+
+def _indexer_pool(*named_buffers):
+    pool = object.__new__(DeepSeekV4IndexerPool)
+    for name, buffers in named_buffers:
+        setattr(
+            pool,
+            name,
+            [torch.empty(shape, dtype=torch.uint8) for shape in buffers],
+        )
+    return pool
+
+
+def _state_pool(shape):
+    return types.SimpleNamespace(
+        kv_score_buffer=types.SimpleNamespace(
+            kv_score=torch.empty(shape, dtype=torch.float32)
+        )
+    )
+
+
+class TestDeepSeekV4MemoryUsage(CustomTestCase):
+    def test_single_pool_reports_allocated_bytes(self):
+        pool = _single_pool((2, 3), (4, 5))
+
+        self.assertEqual(pool.get_kv_size_bytes(), 2 * 3 + 4 * 5)
+
+    def test_indexer_reports_each_active_layout_buffer(self):
+        layouts = (
+            ((("index_k_with_scale_buffer", [(2, 3)]),), 2 * 3),
+            (
+                (
+                    ("index_k_payload_buffer", [(4, 5)]),
+                    ("index_k_scale_buffer", [(6, 7)]),
+                ),
+                4 * 5 + 6 * 7,
+            ),
+            (
+                (
+                    ("index_k_with_scale_buffer", [(8, 9)]),
+                    ("index_k_buffer", [(10, 11)]),
+                    ("index_scale_buffer", [(12, 13)]),
+                ),
+                8 * 9 + 10 * 11 + 12 * 13,
+            ),
+        )
+        for buffers, expected in layouts:
+            with self.subTest(buffers=buffers):
+                pool = _indexer_pool(*buffers)
+                self.assertEqual(pool.get_kv_size_bytes(), expected)
+
+    def test_top_level_pool_aggregates_separate_layout_and_state_storage(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = False
+        pool.swa_kv_pool = _single_pool((2, 3))
+        pool.c4_kv_pool = _single_pool((4, 5))
+        pool.c128_kv_pool = _single_pool((6, 7))
+        pool.c4_indexer_kv_pool = _indexer_pool(("index_k_with_scale_buffer", [(8, 9)]))
+        pool.compress_state_pools = [_state_pool((10, 11)), None]
+        pool.indexer_compress_state_pools = [None, _state_pool((12, 13))]
+
+        expected = 2 * 3 + 4 * 5 + 6 * 7 + 8 * 9
+        expected += 10 * 11 * 4 + 12 * 13 * 4
+        self.assertEqual(pool.get_kv_size_bytes(), expected)
+
+    def test_top_level_pool_aggregates_unified_storage(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = True
+        pool.unified_kv_pool = object.__new__(DeepSeekV4UnifiedKVPool)
+        pool.unified_kv_pool.kv_buffer = [
+            torch.empty((2, 3), dtype=torch.bfloat16),
+            torch.empty((4, 5), dtype=torch.bfloat16),
+        ]
+        pool.c4_indexer_kv_pool = _indexer_pool(("index_k_with_scale_buffer", [(6, 7)]))
+        pool.compress_state_pools = [_state_pool((8, 9))]
+        pool.indexer_compress_state_pools = []
+        expected = (2 * 3 + 4 * 5) * 2 + 6 * 7 + 8 * 9 * 4
+        self.assertEqual(pool.get_kv_size_bytes(), expected)
+
+    def test_top_level_allocation_log_exposes_gib(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = True
+        pool.unified_kv_pool = object.__new__(DeepSeekV4UnifiedKVPool)
+        pool.unified_kv_pool.kv_buffer = [torch.empty((1024,), dtype=torch.uint8)]
+        pool.c4_indexer_kv_pool = _indexer_pool()
+        pool.compress_state_pools = []
+        pool.indexer_compress_state_pools = []
+        pool.allocation_label = None
+
+        pool._finalize_allocation_log(1)
+
+        self.assertAlmostEqual(pool.mem_usage, 1024 / (1024**3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #37852.

DeepSeek-V4 allocates KV storage through several layout-specific pools, but none of the pools populated the inherited `mem_usage` field. As a result, `sglang:kv_cache_memory_usage_gb` and the scheduler internal state reported `0` for a running DeepSeek-V4 server.

## Modifications

- Add tensor-backed byte accounting to the single KV, indexer, and unified KV pools.
- Count the active SWA/C4/C128, indexer, and compression-state storage at the top-level DeepSeek-V4 pool.
- Initialize the per-pool and top-level `mem_usage` values from the actual allocated tensors, including backend-specific indexer buffers.

## Tests

- `ruff check --select=F401,F821,UP037` on changed files
- `ruff format --check` on changed files
- `python -m compileall` on changed files
- `git diff --check`
- Targeted tensor-accounting regression checks loaded from the changed source with CPU Torch

The repository pytest module cannot be collected on this Windows environment because the import path requires Linux-only `resource` and Triton dependencies. The targeted test is registered for the repository CPU unit-test suite so it can run in CI.

## AI assistance

This change was prepared with AI assistance. I reviewed the implementation, repository contribution rules, and the affected storage layouts, and I can explain and defend every changed line.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33841109762](https://github.com/sgl-project/sglang/actions/runs/33841109762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33841109720](https://github.com/sgl-project/sglang/actions/runs/33841109720)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33841109736](https://github.com/sgl-project/sglang/actions/runs/33841109736)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->