### PR TITLE
[Fix] Register triton.runtime.cache.triton_key in the MPS stub so torch.compile keeps working

### DIFF
--- a/python/sglang/_platform_stubs.py
+++ b/python/sglang/_platform_stubs.py
@@ -105,6 +105,10 @@ def _next_power_of_2(n: int) -> int:
     return 1 << (n - 1).bit_length() if n > 0 else 1
 
 
+def _triton_key() -> str:
+    return "triton-stub"
+
+
 class _Config:
     """Minimal stand-in for ``triton.Config`` used in ``@triton.autotune``."""
 
@@ -438,6 +442,10 @@ def install_platform_stubs() -> None:
         jit_mod.KernelInterface = _KernelInterface
         runtime.jit = jit_mod
 
+        cache_mod = _make_mock("triton.runtime.cache")
+        cache_mod.triton_key = _triton_key
+        runtime.cache = cache_mod
+
         # Torch 2.13 imports these as classes while initializing Inductor, even on
         # MPS where no Triton kernel is compiled. Define them explicitly so the
         # catch-all meta-path finder does not materialize class names as modules.
@@ -465,7 +473,7 @@ def install_platform_stubs() -> None:
             pass
 
         compiler_impl.ASTSource = _ASTSource
-        compiler_impl.triton_key = lambda: "triton-stub"
+        compiler_impl.triton_key = _triton_key
         compiler_root.compiler = compiler_impl
         triton.compiler = compiler_root
 

--- a/test/registered/unit/platforms/test_mps_triton_stub.py
+++ b/test/registered/unit/platforms/test_mps_triton_stub.py
@@ -40,6 +40,25 @@ assert _KernelType is not None
             msg=f"stdout={completed.stdout}\nstderr={completed.stderr}",
         )
 
+    def test_torch_compile_works_after_sglang_installs_stub(self):
+        script = """
+import sglang
+import torch
+torch.compile(lambda x: x * 2 + 1)(torch.randn(8))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            msg=f"stdout={completed.stdout}\nstderr={completed.stderr}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Symptom

On macOS arm64 with MPS and no real Triton installed, `torch.compile` is broken **process-wide** for any code, not just sglang's own, as soon as `sglang` has been imported:

```bash
# without sglang -> works
python -c "import torch; torch.compile(lambda x: x*2+1)(torch.randn(8))"

# with sglang imported first -> fails
python -c "import sglang, torch; torch.compile(lambda x: x*2+1)(torch.randn(8))"
# torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
# TypeError: 'module' object is not callable
```

## Cause

`python/sglang/_platform_stubs.py::install_platform_stubs()` installs a fake `triton` package plus a `_TritonFinder` meta-path finder so sglang's own `import triton` / `@triton.jit` kernel files can load on a box with no real Triton. This is gated on darwin+arm64, then `torch.backends.mps.is_available()`, then genuine absence of `triton`.

Torch 2.13's inductor FX-graph cache fingerprinting (`torch/_inductor/codecache.py::CacheBase.get_system()` -> `triton_key()`) unconditionally probes for a triton version string, on every `torch.compile`, regardless of the compile target device. It does this via `torch/_inductor/runtime/triton_compat.py`, which tries:

```python
try:
    from triton.runtime.cache import triton_key
except ImportError:
    from triton.compiler.compiler import triton_key
```

The stub already defines a working callable at the fallback location (`triton.compiler.compiler.triton_key = lambda: "triton-stub"`), but never registers `triton.runtime.cache` at all — that path was presumably added for an older torch that only checked the fallback location.

Because `triton.runtime.cache` isn't pre-registered, the import falls through to the catch-all `_TritonFinder.find_spec()`, which returns a `ModuleSpec` with `loader=None`. Python's import machinery treats a loader-less package spec as a **namespace package**: it materializes a brand-new, real, empty `types.ModuleType` and silently overwrites/bypasses our `_MockModule` (with its `__getattr__`/`__call__` behavior) in `sys.modules`. So `from triton.runtime.cache import triton_key` doesn't raise `ImportError` (which would correctly trigger the fallback) — it "succeeds" by binding `triton_key` to an inert, non-callable module object. Torch then calls it and blows up with `TypeError: 'module' object is not callable`.

This exact failure mode — the catch-all finder materializing something that torch expects to be more specific than a generic mock — is the same class of bug the stub already worked around once, for `triton.runtime.autotuner.{OutOfResources,PTXASError}` ("Torch 2.13 imports these as classes while initializing Inductor... Define them explicitly so the catch-all meta-path finder does not materialize class names as modules").

## Fix

Register `triton.runtime.cache.triton_key` explicitly, as a real callable, mirroring the existing `triton.compiler.compiler.triton_key` stub (both now share one `_triton_key()` helper returning a stable `"triton-stub"` string). This makes torch's *primary* lookup path succeed with a genuinely callable stub, directly, without relying on exception-driven fallback through the buggy catch-all finder path.

### Why this shape, and not the alternatives

- **Not a meta-path-finder rewrite.** The root architectural issue (loader-less specs get treated as namespace packages, silently discarding `_MockModule` instances) is real and could in principle also bite other dynamically-materialized `triton.*` submodules accessed via `import`/`from...import` statements. But fixing it generally is a much larger, riskier change with wide blast radius across the whole mock system. Registering the one concrete symbol torch actually needs, the same way the file already does for the autotuner exception classes, is the smaller and more robust fix and matches existing precedent in this file.
- **Not `torch.utils._triton.has_triton()`.** That function isn't on this call path at all — `torch/_inductor/runtime/triton_compat.py` derives triton availability from its own bare `try: import triton except ImportError: triton = None`, independent of `has_triton()`. Making `has_triton()` return `False` would not prevent this crash.
- **`triton.__version__` left untouched.** It advertises `"3.0.0"`, which is arguably dishonest ("the stub's job is to survive `import triton`, not to claim Triton works"), but it isn't part of this crash's causal chain (the crash happens before any version string is consulted). Several sglang kernel files branch on it at *module import time* (`kernels/ops/attention/extend_attention.py`, `kernels/ops/mamba/triton_ops/mamba_ssm.py`, `kernels/ops/attention/fla/utils.py`, `srt/layers/attention/dsa/utils.py`, etc.), so changing it is unrelated risk with no benefit to this bug and was left out of scope.

## Blast radius

Any Python process that imports `sglang` on an Apple-Silicon box without a real Triton installed had `torch.compile` broken for the remainder of the process — including completely unrelated, non-sglang code sharing the interpreter.

## Verification

- `import sglang, torch; torch.compile(lambda x: x*2+1)(torch.randn(8))` now succeeds.
- `import sglang` and `import sglang.srt.mem_cache.allocator.paged` still succeed with no real Triton installed.
- `test/registered/unit/platforms/` and `test/registered/unit/mem_cache/test_asymmetric_mha_pool_host_unit.py` pass (71 passed) with no `torch.compile` shim required.
- A handful of other module-scope `@triton.jit` / `triton.Config` / `triton.__version__`-gated modules (`merge_state`, `rotary_triton`, `extend_attention`, `decode_attention`, `dsa_metadata`, `mla_kv_pack_quantize_fp8`, `mamba_ssm`, `ssd_combined`, `ssd_chunk_scan`, `fla/utils`, `lora_tuning_config`, `dsa/utils`, `aiter_mla_gluon`, `fused_moe_triton_config`) still import cleanly, confirming no regression to the no-Triton import path.
- Added a regression test in `test/registered/unit/platforms/test_mps_triton_stub.py` that actually runs `torch.compile(...)` after `import sglang` (the existing test in that file only checked an import, not a compile).
- `ruff format` / `ruff check --select=F401,F821,UP037` clean on both changed files.

### Limitation of the regression test

The stub installs only on darwin+arm64 with MPS and no real Triton, so on Linux CI the new test passes trivially -- it exercises nothing. The same is true of the test already in that file. It has teeth only when run on Apple Silicon, which is where the bug lives; it is a guard for local development and for anyone running the suite on a Mac, not a CI gate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33842274863](https://github.com/sgl-project/sglang/actions/runs/33842274863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #33842274652](https://github.com/sgl-project/sglang/actions/runs/33842274652)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33842274859](https://github.com/sgl-project/sglang/actions/runs/33842274859)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->