### PR TITLE
[DSA] Pin the ROCm top-k launch bound to the physical wave floor

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -50,7 +50,36 @@ constexpr uint32_t kClusterSize = Cluster::kClusterSize;
 constexpr uint32_t kReg2MaxSeqLen = Register2::kMaxSeqLen;  // 8192
 constexpr uint32_t kReg4MaxSeqLen = Register4::kMaxSeqLen;  // 16384
 
+#ifdef USE_ROCM
+// HIP reads the second __launch_bounds__ argument as MIN_WARPS_PER_EXECUTION_UNIT
+// -- waves per SIMD -- where CUDA reads it as minBlocksPerMultiprocessor. Spell
+// the ROCm side as what the hardware actually needs: one block resident, which
+// for a 1024-thread block is 16 waves spread over 4 SIMDs, i.e. 4 per SIMD.
+//
+// Do NOT translate kOccupancy into this figure. Reading it as "kOccupancy blocks
+// per CU" gives 8 waves/SIMD, which caps the allocator at 512/8 = 64 VGPRs. On
+// current main that binds nothing -- the seven top-k kernels peak at 57 VGPRs --
+// but combined with a change that pushes them past the cap it forces spills:
+// measured at 63 VGPRs and 108 SGPR spills, of which the kLevel=2 INDICES kernel
+// accounts for 92. It buys nothing in return: the grid is batch_size, at most 72
+// blocks against 256 CUs, so a second resident block per CU is never scheduled
+// on any shape this kernel serves.
+//
+// The wave size is a literal rather than a query. __AMDGCN_WAVEFRONT_SIZE__ was
+// deprecated in ROCm 6.3 and the ROCm 7 compiler no longer defines it in either
+// the device or the host pass, and warpSize is not constexpr, so HIP offers no
+// compile-time replacement. Every target this kernel is built for is CDNA, which
+// is wave64. On a wave32 target the figure would come out too low, which only
+// makes the bound non-binding again -- never over-constrains the allocator.
+inline constexpr uint32_t kSimdsPerCu = 4;      // CDNA: 4 SIMDs per compute unit
+inline constexpr uint32_t kWavefrontSize = 64;  // CDNA: wave64
+inline constexpr uint32_t kWavesPerBlock = kBlockSize / kWavefrontSize;
+inline constexpr uint32_t kMinWavesPerSimd = kWavesPerBlock / kSimdsPerCu;
+static_assert(kMinWavesPerSimd > 0, "kBlockSize must cover at least one wave per SIMD");
+#define TOPK_KERNEL __global__ __launch_bounds__(kBlockSize, kMinWavesPerSimd)
+#else
 #define TOPK_KERNEL __global__ __launch_bounds__(kBlockSize, kOccupancy)
+#endif
 #ifndef USE_ROCM
 #define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
 #endif


### PR DESCRIPTION
## Motivation

The second argument of `__launch_bounds__` is `minBlocksPerMultiprocessor` on CUDA but `MIN_WARPS_PER_EXECUTION_UNIT` — waves per SIMD — on HIP. `topk_v2.cuh` passes `kOccupancy` on both sides, so on ROCm it asks for 2 waves/SIMD. That is *below* the physical floor for this kernel: one 1024-thread block is already 16 waves spread over 4 SIMDs, i.e. 4 per SIMD. The ROCm bound currently says less than "one resident block", so it expresses no intent at all.

## Modifications

Spell the ROCm side as the physical floor, derived from `kBlockSize` and the CDNA wave/SIMD geometry, and document why `kOccupancy` must **not** be translated into that figure. The CUDA spelling is unchanged.

The wave size is written as a literal rather than queried. `__AMDGCN_WAVEFRONT_SIZE__` was deprecated in ROCm 6.3 and [removed from clang](https://github.com/llvm/llvm-project/pull/157463); the ROCm 7 compiler defines it in neither the device nor the host pass. Verified locally on 7.2.3, which is the same generation as both CI images (`rocm720` / `rocm724`):

```
$ hipcc --offload-arch=gfx950 -c probe.hip
warning: MACRO IS NOT DEFINED -- fallback branch taken   (compiling for gfx950)
warning: MACRO IS NOT DEFINED -- fallback branch taken   (compiling for host)
```

`warpSize` is not `constexpr` either, so HIP offers no compile-time replacement and guarding on the macro would only ever select a dead fallback. Every target this kernel is built for is CDNA, i.e. wave64. On a hypothetical wave32 target the derived figure would come out too low, which merely makes the bound non-binding again — it never over-constrains the allocator.

## Benchmarking and Profiling

**This is codegen-neutral today and is not a performance change.** Verified on gfx950 by extracting the code object with `roc-obj` and reading `.vgpr_count` / `.sgpr_spill_count` out of the metadata note: with this patch the seven top-k kernels come out at exactly the same VGPR counts and the same zero spills as without it.

| tree | max VGPR | spills |
|---|---|---|
| current main | 57 | 0 |
| current main + this patch | 57 | 0 |

The bound itself does reach codegen: the emitted `amdgpu-waves-per-eu` is `4` (against `2` on main), alongside `amdgpu-flat-work-group-size="1,1024"`.

The reason to make the intent explicit is that the plausible wrong reading is expensive, and it only bites once the kernel needs more registers than main currently does. Reading the argument as "`kOccupancy` blocks per CU" gives 8 waves/SIMD, which caps the allocator at 512/8 = 64 VGPRs. On main that binds nothing (max 57). Combined with a change that pushes the kernel to 77 VGPRs — #37941 is one such change — the same bound gives:

| tree | max VGPR | spills |
|---|---|---|
| main + #37941, bound as today | 77 | 0 |
| main + #37941, bound as "kOccupancy blocks" | 63 | **108 SGPR spills** (the kLevel=2 INDICES kernel spills 92 by itself) |
| main + #37941, bound as the physical floor (this patch) | 77 | 0 |

The demand buys nothing in exchange: the grid is `batch_size`, at most 72 blocks against 256 CUs, so a second resident block per CU is never scheduled on any shape this kernel serves.

## Accuracy Tests

No behavioural change. `test/registered/kernels/ops/attention/test_topk_v2.py` passes unchanged, and a separate 50-case top-k gate scores identically with and without this patch.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34105483974](https://github.com/sgl-project/sglang/actions/runs/34105483974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34105483737](https://github.com/sgl-project/sglang/actions/runs/34105483737)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34105484252](https://github.com/sgl-project/sglang/actions/runs/34105484252)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
