### PR TITLE
[Fix] Skip the chunk-boundary mamba checkpoint when no slot can be donated

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -509,13 +509,20 @@ class MambaComponent(TreeComponent):
     def _log_skipped_donation(self, req: Req) -> None:
         self._skipped_donations += 1
         if self._skipped_donations == 1 or self._skipped_donations % 1000 == 0:
+            ct = self.component_type
+            allocator = self.cache.req_to_token_pool.mamba_allocator
             logger.warning(
-                "No free mamba slot to donate the chunk-boundary checkpoint of "
-                "request %s; skipping it (%d skipped so far). Every slot is held "
-                "by a running request: raise --max-mamba-cache-size or "
+                "No free mamba slot to donate the checkpoint of request %s at "
+                "seqlen %s; skipping it (%d skipped so far). Pool: available=%d "
+                "evictable=%d protected=%d. Every slot is held by a running "
+                "request: raise --max-mamba-cache-size or "
                 "--mamba-full-memory-ratio to keep prefix reuse.",
                 req.rid,
+                req.kv.mamba_last_track_seqlen,
                 self._skipped_donations,
+                allocator.available_size(),
+                self.tree_core.component_evictable_size_[ct],
+                self.tree_core.component_protected_size_[ct],
             )
 
     @property

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
@@ -54,6 +55,9 @@ if TYPE_CHECKING:
         UnifiedRadixCache,
         UnifiedTreeNode,
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 class MambaComponent(TreeComponent):
@@ -490,14 +494,29 @@ class MambaComponent(TreeComponent):
                 self.tree_core.component_protected_size_[ct] -= vlen
             cd.lock_ref -= 1
 
-    def _alloc_mamba_slot(self) -> torch.Tensor:
-        """Allocate one mamba pool slot, evicting if necessary."""
+    def _try_alloc_mamba_slot(self) -> Optional[torch.Tensor]:
+        """One mamba slot, evicting if needed; None when every slot is pinned."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
             self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
-            assert slot is not None, "Can not alloc mamba cache"
         return slot
+
+    # Skipped donations recur at every chunk boundary while the pool stays
+    # pinned, so log the first one and then every 1000th.
+    _skipped_donations = 0
+
+    def _log_skipped_donation(self, req: Req) -> None:
+        self._skipped_donations += 1
+        if self._skipped_donations == 1 or self._skipped_donations % 1000 == 0:
+            logger.warning(
+                "No free mamba slot to donate the chunk-boundary checkpoint of "
+                "request %s; skipping it (%d skipped so far). Every slot is held "
+                "by a running request: raise --max-mamba-cache-size or "
+                "--mamba-full-memory-ratio to keep prefix reuse.",
+                req.rid,
+                self._skipped_donations,
+            )
 
     @property
     def int8_ckpt_pool(self):
@@ -571,10 +590,20 @@ class MambaComponent(TreeComponent):
         else:
             if cache_len is None:
                 return 0
-            # Donate the mamba index to the radix cache instead of copying.
+            # Donate the mamba index to the radix cache instead of copying. All
+            # strategies but int8 no_buffer need a fresh slot before donating; a
+            # pinned pool skips this boundary's checkpoint and the next one retries.
+            needs_new_slot = (
+                self.cache.enable_mamba_extra_buffer or self.int8_ckpt_pool is None
+            )
+            new_slot = None
+            if needs_new_slot:
+                new_slot = self._try_alloc_mamba_slot()
+                if new_slot is None:
+                    self._log_skipped_donation(req)
+                    return 0
             if self.int8_ckpt_pool is not None:
                 if self.cache.enable_mamba_extra_buffer:
-                    new_slot = self._alloc_mamba_slot()
                     src_active = (
                         self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                             req, new_slot
@@ -587,14 +616,13 @@ class MambaComponent(TreeComponent):
                         req.kv.mamba_pool_idx.view(-1)
                     )
             elif self.cache.enable_mamba_extra_buffer:
-                new_slot = self._alloc_mamba_slot()
                 mamba_value_donated = (
                     self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                         req, new_slot
                     )
                 )
             else:
-                mamba_value_donated = self._alloc_mamba_slot()
+                mamba_value_donated = new_slot
                 # mamba_pool is a pure PHYSICAL store; translate both slot ids
                 # virtual->physical (identity for the non-unified memory pool) first.
                 translate = self.cache.req_to_token_pool.translate_mamba_indices

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -9,6 +9,10 @@ the donated alloc comes back empty and that boundary's checkpoint is skipped;
 ratio 3 (pool = 3N) has headroom. Once decode's
 skip_mamba leaves the matched prefix evictable, even ratio 2 recovers via
 eviction -- which is why the peak, not the decode steady state, sets the floor.
+
+The lazy strategy has a real hole in that budget: under overlap the first
+decode step's pending ping-pong slot and the donate slot coexist for one step,
+so a pool sized exactly at the lazy ratio skips that boundary's checkpoint.
 """
 
 import unittest
@@ -45,6 +49,9 @@ class _BoundedMambaAllocator:
 
     def free(self, value: torch.Tensor):
         self.free_ids.extend(int(v) for v in value.tolist())
+
+    def available_size(self) -> int:
+        return len(self.free_ids)
 
 
 class _RatioCache:

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -4,8 +4,9 @@ Pins the sizing invariant behind MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO:
 at the first cache_unfinished_req, a request still holds its admission-locked
 matched-prefix mamba (protected) plus its own COW slot, and then allocates a
 donated slot. With N distinct-prefix requests that peak is N own + N locked +
-1 donated. An effective ratio of 2 (pool = 2N) leaves no evictable victim and
-the donated alloc asserts; ratio 3 (pool = 3N) has headroom. Once decode's
+1 donated. An effective ratio of 2 (pool = 2N) leaves no evictable victim, so
+the donated alloc comes back empty and that boundary's checkpoint is skipped;
+ratio 3 (pool = 3N) has headroom. Once decode's
 skip_mamba leaves the matched prefix evictable, even ratio 2 recovers via
 eviction -- which is why the peak, not the decode steady state, sets the floor.
 """
@@ -18,6 +19,7 @@ import torch
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
     IncLockRefResult,
+    InsertParams,
 )
 from sglang.srt.mem_cache.unified_cache.components.mamba_component import MambaComponent
 from sglang.srt.mem_cache.unified_cache.components.tree_component import ComponentType
@@ -219,8 +221,30 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
     def test_prefill_peak_ratio2_exhausts_pool(self):
         # pool = 2N, all N prefixes admission-locked: no evictable victim.
         component, cache, _ = _build_peak(pool_size=2 * N, lock_prefixes=True)
-        with self.assertRaisesRegex(AssertionError, "Can not alloc mamba cache"):
-            component._alloc_mamba_slot()
+        self.assertIsNone(component._try_alloc_mamba_slot())
+        self.assertEqual(
+            cache.alloc_evict_params, [EvictParams(num_tokens=0, mamba_num=1)]
+        )
+
+    def test_exhausted_pool_skips_chunk_boundary_donation(self):
+        # Pinned pool through the chunked-prefill hook: the checkpoint is skipped
+        # (cache_len 0, nothing inserted) and the request keeps its ping-pong slots.
+        component, cache, owned = _build_peak(pool_size=2 * N, lock_prefixes=True)
+        cache.enable_mamba_extra_buffer = True
+        cache.req_to_token_pool.donate_mamba_ping_pong_slot = lambda *_: self.fail(
+            "donated without a replacement slot"
+        )
+        req = SimpleNamespace(
+            rid="r0",
+            kv=SimpleNamespace(mamba_pool_idx=owned[0], mamba_last_track_seqlen=64),
+        )
+        insert_params = InsertParams(prev_prefix_len=0)
+        cache_len = component.prepare_for_caching_req(
+            req, insert_params, token_ids_len=128, is_finished=False
+        )
+        self.assertEqual(cache_len, 0)
+        self.assertIsNone(insert_params.mamba_value)
+        self.assertEqual(cache.allocator.free_ids, [])
         self.assertEqual(
             cache.alloc_evict_params, [EvictParams(num_tokens=0, mamba_num=1)]
         )
@@ -228,7 +252,7 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
     def test_prefill_peak_ratio3_has_headroom(self):
         # pool = 3N: N free slots remain after own + locked prefix.
         component, cache, _ = _build_peak(pool_size=3 * N, lock_prefixes=True)
-        slot = component._alloc_mamba_slot()
+        slot = component._try_alloc_mamba_slot()
         self.assertIsNotNone(slot)
         self.assertEqual(cache.component_protected_size_[ComponentType.MAMBA], N)
 
@@ -236,7 +260,7 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
         # pool = 2N but the matched prefixes are evictable (skip_mamba on decode):
         # eviction reclaims a victim, so even ratio 2 serves the donated alloc.
         component, cache, _ = _build_peak(pool_size=2 * N, lock_prefixes=False)
-        slot = component._alloc_mamba_slot()
+        slot = component._try_alloc_mamba_slot()
         self.assertIsNotNone(slot)
         self.assertEqual(len(cache.prefix_nodes), N - 1)
         self.assertEqual(


### PR DESCRIPTION
## Motivation

Fixes the `Can not alloc mamba cache` scheduler crash reported in the second half of #37066 (runtime part; #37074 covered the sizing guide).

### Root cause

The `extra_buffer_lazy` slot budget is `base 3 + 1 = 4` per request: active state, one ping-pong slot, the admission-locked matched-prefix checkpoint, and one spare. Under overlap scheduling the spare is spent twice in the same step:

1. A prefix hit COW-allocates the active slot and locks the matched node (2 slots). The prefill crosses a checkpoint grid, so `mamba_last_track_seqlen` is set.
2. `event_loop_overlap` launches the next batch before processing the last one. The prefill batch is merged into the running batch and the first decode step is prepared: `spec_prepare_for_decode` -> `mamba_lazy_spec_prepare` allocates the pending second ping-pong slot when a track crossing is within `2 * draft` tokens, with no evict retry (3 slots). The non-spec path `mamba_lazy_prealloc_at_boundary` has the same window when the first decode seq_len lands on a track boundary.
3. Only then is the prefill result processed: `process_batch_result_prefill` -> `cache_unfinished_req` -> `prepare_for_caching_req(is_finished=False)` -> `_alloc_mamba_slot` needs a fifth slot to replace the donated ping-pong slot. The only tree checkpoint is the request's own locked node, `evict_for_alloc(mamba_num=1)` frees nothing, and the assert kills the scheduler.

With `--max-mamba-cache-size` at exactly `running x 4` this is deterministic once the pending and donate slots coincide (needs a prefix hit, hence lance0's "only under real multi-turn traffic"). Reproduced on main in 12 s with Qwen3.5-4B, `extra_buffer_lazy`, NEXTN, `--max-running-requests 1 --max-mamba-cache-size 4`, one growing conversation; a per-step slot audit at the assert showed `allocated=4 free=0 req_owned=3 tree_locked=1 tree_evictable=0`, no orphaned slot and no lock imbalance, with the pending-slot allocation logged as the line right before it.

The non-lazy `extra_buffer` budget (5 per request) is not affected: steady demand is 4 (active + 2 ping-pong + lock) and the donate transient is the 5th, so `5N >= 4N + 1` always holds. The first report in #37066 (non-lazy, TP8 + dp-attention 8, `mamba usage 1.00` with 4 running) does not reproduce on its own commit `033446bb05`; the ownership walk caps protected slots at `4N + 1 <= 25` of 30 there. That case stays open and the enriched warning below is meant to capture it in the field.

## Modifications

- `_alloc_mamba_slot` becomes `_try_alloc_mamba_slot` and returns `None` instead of asserting when eviction cannot free a slot.
- In the chunk-boundary / prefill-end donate path the fresh slot is allocated once up front. If none is available the component logs a rate-limited warning (first, then every 1000th) carrying the request's checkpoint seqlen and the pool's `available / evictable / protected` counts, and returns `cache_len = 0`: nothing is inserted for this boundary, the request keeps its ping-pong slots, and the next boundary retries. The pending lazy slot is transient, so the retry normally succeeds. Cost is prefix reuse for that one checkpoint.
- The finished-request path is unchanged: it inserts the request's own slot without allocating.
- `mamba_radix_cache.py` has the same pattern but is not instantiated anywhere (the registry builds `UnifiedRadixCache` for every hybrid-SSM model), so it is left alone.

## Tests

`test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py` (CPU only):

- `test_prefill_peak_ratio2_exhausts_pool`: the pinned-pool alloc returns `None` after one `evict_for_alloc(mamba_num=1)`.
- `test_exhausted_pool_skips_chunk_boundary_donation`: driving `prepare_for_caching_req(is_finished=False)` on a pinned pool returns `0`, sets no `mamba_value`, never calls `donate_mamba_ping_pong_slot`, and leaks no slot.
The lazy sequence itself is covered by the pinned-pool case above (the pending slot is just what pins the pool); its arithmetic is documented in the module docstring.

9 passed on an H200 devbox.

E2E on 1x H200, Qwen3.5-4B, the reproducer above (`extra_buffer_lazy`, NEXTN, `--max-running-requests 1 --max-mamba-cache-size 4`, one growing conversation, 60 turns): main asserts at turn 18; this branch completes all turns with exactly 1 skipped donation logged (at the same seqlen 33984 where main asserted) and a 0.94 cache hit ratio.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel if you have any questions.
