### PR TITLE
fix(moe): support N64 Marlin tiles for INT4 expert shards

### DIFF
--- a/python/sglang/kernels/jit/csrc/gemm/marlin_moe/moe_wna16_marlin.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/marlin_moe/moe_wna16_marlin.cuh
@@ -142,14 +142,16 @@ thread_config_t small_batch_thread_configs[] = {
 
     // thread_k, thread_n, num_threads
     {128, 128, 256},
-    {64, 128, 128}};
+    {64, 128, 128},
+    {128, 64, 128}};
 
 thread_config_t large_batch_thread_configs[] = {
     // Ordered by priority
 
     // thread_k, thread_n, num_threads
     {64, 256, 256},
-    {64, 128, 128}};
+    {64, 128, 128},
+    {128, 64, 128}};
 
 typedef struct {
   int blocks_per_sm;
@@ -460,6 +462,9 @@ MarlinFuncPtr get_marlin_kernel(
   COMMON_GET_IF(host::kU4B8)
   COMMON_GET_IF(host::kU8B128)
 
+  COMMON_GET_IF_M1(host::kU4B8, 4, 8, 128)
+  COMMON_GET_IF_M234(host::kU4B8, 4, 8, 128)
+
   NVFP4_GET_IF(host::kFE2M1f)
 
   BIGGROUP_GET_IF(host::kFE4M3fn)
@@ -501,6 +506,10 @@ exec_config_t determine_exec_config(
   constexpr int device_max_reg_size = 255 * 1024;
   for (int i = 0; i < thread_configs_size; i++) {
     thread_config_t th_config = thread_configs[i];
+
+    // Keep the existing tuning for N-aligned shapes; use the narrower tile
+    // only for TP shards that cannot use any of the 128-wide candidates.
+    if (th_config.thread_n == 64 && prob_n % 128 == 0) continue;
 
     if (!is_valid_config(
             th_config,

--- a/test/registered/kernels/ops/moe/test_moe_wna16_marlin.py
+++ b/test/registered/kernels/ops/moe/test_moe_wna16_marlin.py
@@ -348,6 +348,74 @@ def test_moe_wna16_marlin_gemm(
     torch.testing.assert_close(c_jit, c_aot, rtol=0, atol=0)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "n,k,block_size_m",
+    [(320, 2560, block) for block in [8, 16, 32, 48, 64]]
+    + [(64, 128, 8), (192, 2560, 8), (384, 2560, 8)],
+)
+def test_moe_wna16_marlin_n64_tiles(dtype, n, k, block_size_m):
+    """TP shards can have N divisible by 64 but not by 128 (issue #37089)."""
+    torch.manual_seed(0)
+    m, e, topk = 64, 4, 2
+    quant_type = scalar_types.uint4b8
+    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+    w_ref, qweight, scales, zeros, g_idx, sort_indices = _setup_moe_weights(
+        e, n, k, quant_type, 128, False, dtype
+    )
+    topk_weights, topk_ids = torch.topk(
+        torch.randn((m, e), device="cuda").softmax(-1), topk
+    )
+    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        topk_ids, block_size_m, e
+    )
+    sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+    workspace = torch.zeros(sms * 4, dtype=torch.int32, device="cuda")
+
+    def run():
+        return _run_single_gemm(
+            moe_wna16_marlin_gemm,
+            a,
+            None,
+            qweight,
+            scales,
+            zeros,
+            g_idx,
+            sort_indices,
+            workspace,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            topk_weights,
+            quant_type,
+            block_size_m,
+            topk,
+            m,
+            n,
+            k,
+            False,
+            True,
+            False,
+        )
+
+    output = run()
+    expected = torch.stack(
+        [
+            a[token].float() @ w_ref[topk_ids[token, route]].float().T
+            for token in range(m)
+            for route in range(topk)
+        ]
+    )
+    torch.testing.assert_close(output.float(), expected, rtol=0.02, atol=0.01)
+
+    # The original failure was reached during decode CUDA graph capture.
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    graph.replay()
+    torch.testing.assert_close(captured.float(), expected, rtol=0.02, atol=0.01)
+
+
 @pytest.mark.skipif(
     not (is_sm80_supported() or is_sm90_supported()),
     reason="Non-gated NVFP4 Marlin fallback test requires CUDA SM8X/SM9X",


### PR DESCRIPTION
## Motivation

Addresses the Marlin MoE failure in #37089. On A100, the INT4 expert GEMM with `M=64, K=2560, N=320` fails with `Invalid thread config`: the available MoE tiles require N divisible by 128 or 256. N=320 needs a 64-wide tile.

This PR fixes that operator path. It does not address the separate QSA/FA-CuTe failure in the issue or claim complete Flash-Next model support.

## Modifications

- Add the existing dense Marlin `(K=128, N=64, threads=128)` tile pattern and its symmetric INT4 MoE specializations.
- Exclude the new tile when N is divisible by 128, preserving the existing configuration search for those shapes.
- Add FP16/BF16 numerical and CUDA graph regression cases for the reported shape, MoE block sizes 8/16/32/48/64, and N=64/192/384 controls.

## Accuracy Tests

Tested on NVIDIA A100 80GB PCIe (SM80), PyTorch `2.13.0+cu130`, from upstream base `06b874980` plus this patch.

- Before the fix: the N=320 case reproduces the reported exception; the equivalent N=384 numerical/capture control passes.
- After the fix: **16 new cases pass**, each comparing output with a dequantized FP32 reference and checking real CUDA graph capture/replay. **One existing fused-MoE regression also passes.**

```bash
python -m pytest test/registered/kernels/ops/moe/test_moe_wna16_marlin.py \
  -k 'n64_tiles and dtype1' -q --tb=short --disable-warnings
# 8 passed, 39 deselected

python -m pytest test/registered/kernels/ops/moe/test_moe_wna16_marlin.py \
  -k '(n64_tiles and dtype0) or test_fused_marlin_moe_non_gated_relu2' \
  -q --tb=short --disable-warnings
# 9 passed, 38 deselected
```

Full-model evaluation and other GPU architectures were not tested. A paired down projection can have additional K/group constraints; fixing this one GEMM does not establish support for the complete model.

## Speed Tests and Profiling

No speedup is claimed. This enables a shape that previously failed before serving; no `bench_serving` or profiler result is presented. The new tile is not considered for N divisible by 128.

## Checklist

- [x] Format code with the pinned pre-commit hooks. `pre-commit run --all-files` passed, including Rust formatting/clippy and registered-test checks; working tree remained clean.
- [x] Add registered regression tests using the existing kernel test suite.
- [x] Update documentation where applicable. No CLI/configuration change; the kernel comment and regression document the shape constraint.
- [x] Provide appropriate accuracy results: numerical and CUDA graph checks above. Serving-speed benchmarking is not applicable to a speedup claim in this compatibility fix.
- [x] Follow SGLang code style. Changed-file pinned hooks, including clang-format and registered-test validation, passed.

## Review and Merge Process

Maintainer/Codeowner review and authorized platform CI remain required before merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33845532526](https://github.com/sgl-project/sglang/actions/runs/33845532526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33845532399](https://github.com/sgl-project/sglang/actions/runs/33845532399)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33845532384](https://github.com/sgl-project/sglang/actions/runs/33845532384)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->