### PR TITLE
fix(dspark): isolate draft MoE from target expert recorder

### DIFF
--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -18,6 +18,9 @@ from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
 )
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_distribution import (
+    get_global_expert_distribution_recorder,
+)
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
@@ -637,9 +640,12 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
     def _run_ffn(self, x: torch.Tensor, forward_batch: ForwardBatch) -> torch.Tensor:
         shape = x.shape
         x = x.reshape(-1, self.dim)
-        y = self._run_moe_ffn_dp_sync(
-            x, forward_batch, input_ids=None, input_ids_global=None
-        )
+        # DSpark stages have separate weights and layer IDs from the target
+        # model, whose expert distribution recorder is shared with the draft.
+        with get_global_expert_distribution_recorder().disable_this_region():
+            y = self._run_moe_ffn_dp_sync(
+                x, forward_batch, input_ids=None, input_ids_global=None
+            )
         return y.view(shape)
 
 

--- a/test/registered/unit/spec/test_dspark_expert_distribution.py
+++ b/test/registered/unit/spec/test_dspark_expert_distribution.py
@@ -1,0 +1,100 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.eplb.expert_distribution import (
+    _ExpertDistributionRecorderReal,
+    _SelectExpertsSinglePassGatherer,
+)
+from sglang.srt.models import deepseek_v4_dspark
+from sglang.srt.utils import Withable
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSparkExpertDistribution(CustomTestCase):
+    def setUp(self):
+        # The recorder belongs to the target; DSpark stages use their own
+        # zero-based layer IDs and must not update these target-layer counts.
+        self.gatherer = _SelectExpertsSinglePassGatherer.__new__(
+            _SelectExpertsSinglePassGatherer
+        )
+        self.gatherer._data = torch.zeros((2, 4), dtype=torch.int)
+        self.recorder = _ExpertDistributionRecorderReal.__new__(
+            _ExpertDistributionRecorderReal
+        )
+        self.recorder._disable_all = False
+        self.recorder._recording = True
+        self.recorder._current_layer_idx = Withable()
+        self.recorder._current_debug_name = Withable()
+        self.recorder._accumulator = SimpleNamespace(
+            get_single_pass_gatherer_key=lambda _: "default"
+        )
+        self.recorder._single_pass_gatherers = {"default": self.gatherer}
+        self.topk_ids = torch.tensor([[0, 2], [2, -1]])
+        self.stage = SimpleNamespace(dim=3, _run_moe_ffn_dp_sync=self.moe_forward)
+        self.inputs = torch.arange(12, dtype=torch.float32).reshape(2, 2, 3)
+
+    def moe_forward(self, x, forward_batch, *, input_ids, input_ids_global):
+        self.assertIsNone(input_ids)
+        self.assertIsNone(input_ids_global)
+        self.recorder.on_select_experts(self.topk_ids)
+        return x + 1
+
+    def run_draft(self):
+        with mock.patch.object(
+            deepseek_v4_dspark,
+            "get_global_expert_distribution_recorder",
+            return_value=self.recorder,
+        ):
+            return deepseek_v4_dspark.DSparkV4Stage._run_ffn(
+                self.stage, self.inputs, None
+            )
+
+    def test_draft_preserves_target_counts_and_output(self):
+        for capturing in (False, True):
+            with (
+                self.subTest(capturing=capturing),
+                mock.patch(
+                    "torch.get_device_module",
+                    return_value=SimpleNamespace(
+                        is_current_stream_capturing=lambda: capturing
+                    ),
+                ),
+            ):
+                self.recorder._recording = not capturing
+                self.gatherer._data.zero_()
+                # Exercise the real stat gatherer before and after draft work.
+                with self.recorder.with_current_layer(1):
+                    self.recorder.on_select_experts(self.topk_ids)
+                result = self.run_draft()
+                self.assertTrue(torch.equal(result, self.inputs + 1))
+                self.assertFalse(self.recorder._disable_all)
+                with self.recorder.with_current_layer(1):
+                    self.recorder.on_select_experts(self.topk_ids)
+                self.assertTrue(
+                    torch.equal(
+                        self.gatherer._data,
+                        torch.tensor([[0, 0, 0, 0], [2, 0, 4, 0]]),
+                    )
+                )
+
+    def test_draft_restores_recorder_after_exception(self):
+        self.stage._run_moe_ffn_dp_sync = mock.Mock(side_effect=ValueError("moe"))
+        with self.assertRaisesRegex(ValueError, "moe"):
+            self.run_draft()
+        self.assertFalse(self.recorder._disable_all)
+
+    def test_draft_preserves_enclosing_disabled_region(self):
+        with self.recorder.disable_this_region():
+            self.run_draft()
+            self.assertTrue(self.recorder._disable_all)
+        self.assertFalse(self.recorder._disable_all)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #34974. With EPLB enabled, DSpark's draft MoE calls the target model's shared expert recorder without a target layer context. The stat gatherer indexes with `layer_idx=None`, and `scatter_add_` fails during draft CUDA graph capture.

DSpark stages have independent NextN weights and zero-based stage IDs. Assigning those IDs to the target recorder would mix draft traffic into unrelated target layers.

## Modifications

- Wrap only the draft MoE call in `DSparkV4Stage._run_ffn` with the existing recorder's `disable_this_region()` context, matching other MTP paths.
- Add registered CPU tests for target-count/output preservation, eager/capture-active hook paths, exception restoration, and nested disabled regions.

The target recorder, expert mapping and MoE arithmetic are otherwise unchanged. The separate draft expert-dispatch mapping work in #34846 is not included.

## Accuracy Tests

On upstream base `06b874980`, the regression invokes the real DSpark FFN method, recorder hook and stat gatherer, substituting only expensive MoE computation. Before the patch, eager and capture-active cases both produce the reported `scatter_add_` dimension error. After the patch:

```bash
python test/registered/unit/spec/test_dspark_expert_distribution.py -v
# 3 tests passed

python test/registered/unit/spec/test_dspark_target_hidden_projection.py -v
# 2 tests passed
```

A manual A100 CUDA graph capture/replay check at the same recorder seam also passed: target counts remained exactly `[[0,0,0,0],[2,0,4,0]]`, the draft output was preserved, and recorder state was restored. It used substituted MoE arithmetic, not the full model. Environment: NVIDIA A100 80GB PCIe, PyTorch `2.13.0+cu130`.

Full 8xH20 DeepSeek-V4-Flash server startup, end-to-end accuracy, speculative acceptance and live expert migration were not tested. Those need matching full-model CI; the seam tests do not establish complete EPLB/DSPARK compatibility.

## Speed Tests and Profiling

No speedup is claimed and no serving benchmark or profile was run. This is a recorder-ownership fix for a startup/capture failure.

## Checklist

- [x] Format code with the pinned pre-commit hooks. `pre-commit run --all-files` passed, including Rust formatting/clippy and registered-test checks; working tree remained clean.
- [x] Add registered tests using `CustomTestCase` and the existing CPU suite.
- [x] Update documentation where applicable. No new public option; an inline comment explains draft/target recorder ownership.
- [x] Provide feature-specific correctness results above. No speedup claim; full-model validation is explicitly pending.
- [x] Follow SGLang code style. Changed-file pinned hooks and registered-test validation passed.

## Review and Merge Process

Maintainer/Codeowner review and authorized platform CI remain required before merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33845538487](https://github.com/sgl-project/sglang/actions/runs/33845538487)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33845538215](https://github.com/sgl-project/sglang/actions/runs/33845538215)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33845538396](https://github.com/sgl-project/sglang/actions/runs/33845538396)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->