### PR TITLE
[Spec] Move state capture outputs with the accepted path (EAGLE topk>1, ngram)

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -139,7 +139,8 @@ class SchedulerBatchResultProcessor:
         the full sequence.
 
         Logs a soft warning if the resulting tensor's row count differs from
-        the expected `seqlen - 1 - start_len`, to catch silent regressions.
+        the expected `seqlen - 1 - start_len`, or if the whole tape read back
+        is zero, to catch silent regressions.
         """
         if not req.return_routed_experts:
             return
@@ -171,6 +172,27 @@ class SchedulerBatchResultProcessor:
                 req.seqlen,
                 req.cached_tokens,
                 req.routed_experts_start_len,
+            )
+
+        # The row count above is the length of the slice `get_topk` just took,
+        # so it can only see a truncated `req_to_token` row -- never a tape that
+        # was never written. A forward path that drops the capture handle leaves
+        # the host cache at its zero-initialised contents, and capture only runs
+        # for MoE models, whose router does not pick expert 0 in every layer of
+        # every token. This does NOT catch a tape written into the wrong slots;
+        # that failure is prevented at the source, by the state captures
+        # following the KV through the accepted-path move.
+        if (
+            req.routed_experts is not None
+            and expected_rows > 0
+            and not req.routed_experts.any()
+        ):
+            logger.warning(
+                "routed_experts is entirely zero for req %s (%d rows): the "
+                "capture was never finalized for these KV slots. Check that the "
+                "forward path propagates routed_experts_output.",
+                req.rid,
+                req.routed_experts.shape[0],
             )
 
     def _maybe_collect_indexer_topk(self, req: Req):

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import torch
 
@@ -26,6 +26,7 @@ from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
+    compact_accept_to_front,
     move_accept_tokens_to_target_kvcache,
     record_stream_each,
     record_stream_for_v2_verify,
@@ -53,6 +54,7 @@ if TYPE_CHECKING:
         EAGLEDraftCudaGraphRunner,
     )
     from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+    from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 
 def duplicate_prefix_tail_to_draft_branches(
@@ -413,49 +415,31 @@ def _finalize_accept_tree_path(
     *,
     token_to_kv_pool_allocator: Any,
     num_draft_tokens: int,
+    state_captures: Sequence[Optional[TopkCaptureOutput]],
 ) -> torch.Tensor:
-    """Tree drafting (topk > 1): move the accepted path -- KV slots, predict,
-    hidden_states -- to the contiguous front of each per-req block, which the
-    downstream chain-layout code (draft-extend select_index, committed-KV reads)
-    assumes. Returns compacted predict; mutates logits_output.hidden_states
-    (moved only when present)."""
+    """Tree drafting (topk > 1): move the accepted path -- KV slots, state
+    captures, predict, hidden_states -- to the contiguous front of each per-req
+    block, which the downstream chain-layout code (draft-extend select_index,
+    committed-KV reads) assumes. Returns compacted predict; mutates
+    logits_output.hidden_states (moved only when present)."""
     move_accept_tokens_to_target_kvcache(
-        batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
+        batch,
+        accept_index,
+        accept_lens - 1,
+        token_to_kv_pool_allocator,
+        state_captures=state_captures,
     )
-    predict = _compact_accept_to_front(
+    predict = compact_accept_to_front(
         predict, accept_index, bs, num_draft_tokens=num_draft_tokens
     )
     if logits_output.hidden_states is not None:
-        logits_output.hidden_states = _compact_accept_to_front(
+        logits_output.hidden_states = compact_accept_to_front(
             logits_output.hidden_states,
             accept_index,
             bs,
             num_draft_tokens=num_draft_tokens,
         )
     return predict
-
-
-def _compact_accept_to_front(
-    x: torch.Tensor,
-    accept_index: torch.Tensor,
-    bs: int,
-    *,
-    num_draft_tokens: int,
-) -> torch.Tensor:
-    """Gather the accepted tree path to the front of each per-req block.
-
-    ``x`` is node-indexed over the whole tree (``[bs * num_draft_tokens, ...]``),
-    ``accept_index`` is ``[bs, spec_steps + 1]`` global node indices (-1 padded).
-    Padded entries clamp to node 0 but land past accept_lens (never read);
-    trailing unaccepted slots stay and are freed as overshoot.
-    """
-    nd = num_draft_tokens
-    s1 = accept_index.shape[1]  # spec_steps + 1
-    safe = accept_index.to(torch.int64).clamp(min=0).reshape(-1)
-    gathered = x[safe]
-    out = x.clone()
-    out.view(bs, nd, *x.shape[1:])[:, :s1] = gathered.view(bs, s1, *x.shape[1:])
-    return out
 
 
 def run_eagle_verify(
@@ -645,6 +629,10 @@ def run_eagle_verify(
             bs,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
             num_draft_tokens=num_draft_tokens,
+            state_captures=(
+                forward_batch_output.routed_experts_output,
+                forward_batch_output.indexer_topk_output,
+            ),
         )
 
     next_draft_input = EagleDraftInput(bonus_tokens=bonus_tokens)

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -503,6 +503,10 @@ class NGRAMWorker(BaseSpecWorker):
                 accept_index,
                 num_correct_drafts_per_req,
                 self.token_to_kv_pool_allocator,
+                state_captures=(
+                    batch_result.routed_experts_output,
+                    batch_result.indexer_topk_output,
+                ),
             )
             if batch.return_logprob:
                 compute_spec_logprobs(
@@ -566,4 +570,9 @@ class NGRAMWorker(BaseSpecWorker):
             new_seq_lens=new_seq_lens,
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
+            # Relay the target forward's pending state-capture handles: under
+            # overlap scheduling nothing else finalizes them, so dropping them
+            # leaves the host cache at its zero-initialised contents.
+            routed_experts_output=batch_result.routed_experts_output,
+            indexer_topk_output=batch_result.indexer_topk_output,
         )

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -5,7 +5,16 @@ import logging
 import os
 import time
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import torch
 from huggingface_hub import snapshot_download
@@ -80,6 +89,7 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import TpModelWorker
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+    from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 
 if _is_cuda:
@@ -701,11 +711,68 @@ def spec_stage_span(name: str):
     return profile_range(name)
 
 
+def compact_accept_to_front(
+    x: torch.Tensor,
+    accept_index: torch.Tensor,
+    bs: int,
+    *,
+    num_draft_tokens: int,
+) -> torch.Tensor:
+    """Gather the accepted tree path to the front of each per-req block.
+
+    ``x`` is node-indexed over the whole tree (``[bs * num_draft_tokens, ...]``),
+    ``accept_index`` is ``[bs, spec_steps + 1]`` global node indices (-1 padded).
+    Padded entries clamp to node 0 but land past accept_lens (never read);
+    trailing unaccepted slots stay and are freed as overshoot.
+    """
+    nd = num_draft_tokens
+    s1 = accept_index.shape[1]  # spec_steps + 1
+    safe = accept_index.to(torch.int64).clamp(min=0).reshape(-1)
+    gathered = x[safe]
+    out = x.clone()
+    out.view(bs, nd, *x.shape[1:])[:, :s1] = gathered.view(bs, s1, *x.shape[1:])
+    return out
+
+
+def _compact_state_captures_to_front(
+    state_captures: Sequence[Optional[TopkCaptureOutput]],
+    accept_index: torch.Tensor,
+    bs: int,
+) -> None:
+    """Make the pending per-token state captures follow the KV they describe.
+
+    A capture tape is keyed by KV slot: ``TopkCaptureOutput.finalize`` scatters
+    row ``i`` into ``out_cache_loc[i]``, and a verify batch's
+    ``out_cache_loc[b * num_draft_tokens + k]`` is exactly the slot this move
+    writes request ``b``'s accepted position ``k`` into. Compacting the rows the
+    same way ``predict`` / ``hidden_states`` are compacted therefore lands each
+    accepted token's capture in the slot its KV moved to. Without it the
+    committed slots keep the capture of whichever tree node was originally
+    allocated there -- the front chain, not the accepted path.
+
+    Runs on the forward stream, before ``GenerationBatchResult.copy_to_cpu``
+    maps these tensors to the host, so it also covers the overlap scheduler.
+    """
+    for capture in state_captures:
+        if capture is None:
+            continue
+        capture.topk = compact_accept_to_front(
+            capture.topk,
+            accept_index,
+            bs,
+            # The capture spans the verify batch's [bs, num_draft_tokens] block
+            # layout, the same node indexing accept_index uses.
+            num_draft_tokens=capture.out_cache_loc.shape[0] // bs,
+        )
+
+
 def move_accept_tokens_to_target_kvcache(
     batch: ScheduleBatch,
     accept_index: torch.Tensor,
     num_correct_drafts: torch.Tensor,
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+    *,
+    state_captures: Sequence[Optional[TopkCaptureOutput]],
 ):
     """
     Move accepted tokens (drafts + bonus) to the target KV cache.
@@ -715,6 +782,11 @@ def move_accept_tokens_to_target_kvcache(
         accept_index: The index of the accepted tokens (incl. bonus).
         num_correct_drafts: Per-req count of correct drafts (excludes bonus);
             seq_lens is advanced by ``num_correct_drafts + 1`` to cover the bonus slot.
+        state_captures: Pending per-token state captures (routed experts,
+            indexer topk) whose rows are keyed by the KV slots this move
+            rewrites. Keyword-only and required: a caller with none passes
+            ``()``, so a new verify path has to decide rather than silently
+            leave the tape behind.
     """
     bs = len(batch.seq_lens)
     device = batch.seq_lens.device
@@ -764,6 +836,7 @@ def move_accept_tokens_to_target_kvcache(
     token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
         tgt_cache_loc, accept_out_cache_loc
     )
+    _compact_state_captures_to_front(state_captures, accept_index, bs)
 
 
 def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:

--- a/test/registered/spec/test_spec_routed_experts.py
+++ b/test/registered/spec/test_spec_routed_experts.py
@@ -1,0 +1,225 @@
+"""Routed-expert capture (R3) under speculative decoding.
+
+The capture tape is keyed by KV slot, so a verify step that relocates accepted
+KV has to relocate the capture with it, and a verify worker that drops the
+capture handle leaves the tape at its zero-initialised contents.
+
+Both arms check one request against itself on one server: its DECODE rows must
+agree with the PREFILL rows for the same token sequence. Prefill never runs the
+verify path, so it is the no-speculation ground truth, and a fresh cache salt
+forces the reference request through a cold extend rather than the tape the
+decode steps just wrote.
+
+The NGRAM arm needs no draft model and drafts an irregular tree, so it covers
+both the capture-handle and the accepted-path failures. The EAGLE arm runs
+`--speculative-eagle-topk 4`, and topk > 1 is the only setting where the
+accepted path is not already the front of each per-request block.
+"""
+
+import unittest
+
+import numpy as np
+import requests
+from transformers import AutoConfig
+
+from sglang.srt.state_capturer.routed_experts import (
+    extract_routed_experts_from_meta_info,
+)
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_ENABLE_ROUTED_EXPERTS_MODEL_NAME_FOR_TEST,
+    DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+    DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=1200, stage="extra-a", runner_config="2-gpu-large")
+
+# Repetitive on purpose: NGRAM drafts from the corpus it has already seen, so a
+# prompt that invites repetition keeps the verify path busy.
+PROMPT = (
+    "Repeat the following list back exactly, then continue it in the same "
+    "format: item one, item two, item three, item four, item five, item six, "
+    "item seven, item eight, item nine, item ten, item eleven, item twelve,"
+)
+MAX_NEW_TOKENS = 96
+
+# Prefill and decode take different kernels and batch shapes, so a small number
+# of near-tied router scores flip between them. Same budget the DeepEP
+# routed-experts parity test uses for the same reason.
+MAX_MISMATCH_FRACTION = 0.10
+
+
+def _count_expert_mismatches(lhs: np.ndarray, rhs: np.ndarray) -> int:
+    """Expert ids present on one side but not the other, per (token, layer).
+
+    Compared as sets: the captured top-k order is score order, which can differ
+    between two kernels that select the same experts.
+    """
+    mismatches = 0
+    for lhs_token, rhs_token in zip(lhs, rhs):
+        for lhs_layer, rhs_layer in zip(lhs_token, rhs_token):
+            mismatches += len(set(lhs_layer.tolist()) - set(rhs_layer.tolist()))
+    return mismatches
+
+
+class _SpecRoutedExpertsMixin:
+    """Subclasses set `model`, `server_args` and (if needed) `hf_config_kwargs`."""
+
+    model: str
+    server_args: list
+    hf_config_kwargs: dict = {}
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_layers = AutoConfig.from_pretrained(
+            cls.model, **cls.hf_config_kwargs
+        ).num_hidden_layers
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.server_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _generate(self, payload: dict) -> dict:
+        resp = requests.post(f"{self.base_url}/generate", json=payload, timeout=600)
+        self.assertEqual(resp.status_code, 200, resp.text)
+        return resp.json()
+
+    def _routing_rows(self, body: dict) -> np.ndarray:
+        """`[seqlen - 1, num_layers, topk]`: one row per input position."""
+        meta = body["meta_info"]
+        rows = meta["prompt_tokens"] + meta["completion_tokens"] - 1
+        flat = extract_routed_experts_from_meta_info(body)
+        self.assertEqual(flat.size % (rows * self.num_layers), 0, "unexpected shape")
+        return flat.reshape(rows, self.num_layers, -1)
+
+    def _assert_drafts_were_accepted(self):
+        """Without acceptance the verify path under test never runs and the
+        comparison below would pass on any implementation."""
+        internal = requests.get(f"{self.base_url}/server_info").json()
+        accept_length = internal["internal_states"][0].get("avg_spec_accept_length")
+        self.assertIsNotNone(accept_length, "server reported no accept length")
+        self.assertGreater(
+            accept_length,
+            1.0,
+            "no draft token was accepted, so this test proves nothing",
+        )
+
+    def test_decode_routing_matches_prefill_routing(self):
+        spec = self._generate(
+            {
+                "text": PROMPT,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": MAX_NEW_TOKENS,
+                    "ignore_eos": True,
+                },
+                "return_routed_experts": True,
+                "return_logprob": True,
+                "logprob_start_len": 0,
+                "extra_key": "spec-decode",
+            }
+        )
+        meta = spec["meta_info"]
+        prompt_len = meta["prompt_tokens"]
+        token_ids = [tok for _, tok, _ in meta["input_token_logprobs"]] + [
+            tok for _, tok, _ in meta["output_token_logprobs"]
+        ]
+        self.assertEqual(len(token_ids), prompt_len + meta["completion_tokens"])
+        self._assert_drafts_were_accepted()
+
+        spec_rows = self._routing_rows(spec)
+        self.assertTrue(
+            spec_rows.any(),
+            "routed_experts came back entirely zero: the verify path dropped the "
+            "capture handle, so the host cache was never written",
+        )
+
+        reference = self._generate(
+            {
+                "input_ids": token_ids,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 1,
+                    "ignore_eos": True,
+                },
+                "return_routed_experts": True,
+                "extra_key": "prefill-reference",
+            }
+        )
+        self.assertEqual(
+            reference["meta_info"].get("cached_tokens", 0),
+            0,
+            "reference request hit the radix cache, so its rows are the decode "
+            "rows under test rather than a fresh prefill",
+        )
+        reference_rows = self._routing_rows(reference)
+
+        # Row i is the routing for the token at position i, so decode rows start
+        # at prompt_len; the reference covers the same positions from prefill.
+        decode = spec_rows[prompt_len:]
+        self.assertGreater(decode.shape[0], 0, "no decode rows to compare")
+        mismatches = _count_expert_mismatches(
+            decode, reference_rows[prompt_len : spec_rows.shape[0]]
+        )
+        fraction = mismatches / decode.size
+        self.assertLess(
+            fraction,
+            MAX_MISMATCH_FRACTION,
+            f"{mismatches} of {decode.size} captured expert ids differ from the "
+            f"prefill capture of the same tokens ({fraction:.2%}); the decode "
+            "rows are describing different tokens",
+        )
+
+
+class TestNgramRoutedExperts(_SpecRoutedExpertsMixin, CustomTestCase):
+    model = DEFAULT_ENABLE_ROUTED_EXPERTS_MODEL_NAME_FOR_TEST
+    server_args = [
+        "--tp",
+        "2",
+        "--enable-return-routed-experts",
+        "--speculative-algorithm",
+        "NGRAM",
+        "--speculative-num-draft-tokens",
+        "16",
+    ]
+
+
+class TestEagleTopkRoutedExperts(_SpecRoutedExpertsMixin, CustomTestCase):
+    model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+    hf_config_kwargs = {"trust_remote_code": True}
+    server_args = [
+        "--trust-remote-code",
+        "--tp",
+        "2",
+        "--enable-return-routed-experts",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-draft-model-path",
+        DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN,
+        # Same tree as the topk > 1 arm of test/manual/attention/test_fa3.py,
+        # which holds an accept length above 2.95 on this model pair. topk > 1
+        # is the point: at topk == 1 the accepted path already is the front of
+        # each block and the compaction under test is an identity.
+        "--speculative-num-steps",
+        "5",
+        "--speculative-eagle-topk",
+        "4",
+        "--speculative-num-draft-tokens",
+        "8",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_accepted_path_state_capture.py
+++ b/test/registered/unit/spec/test_accepted_path_state_capture.py
@@ -1,0 +1,126 @@
+"""Per-token state captures must follow the KV through the accepted-path move.
+
+A capture tape (routed experts, indexer topk) is keyed by KV slot:
+``TopkCaptureOutput.finalize`` scatters row ``i`` into ``out_cache_loc[i]``, and
+readback goes through ``req_to_token``. ``move_accept_tokens_to_target_kvcache``
+moves each accepted tree node's KV to the front of its per-request block, so the
+capture rows have to be compacted the same way or the committed slots keep the
+routing of whichever tree node was originally allocated there.
+
+These tests drive ``_compact_state_captures_to_front`` against the slot layout
+``eagle_prepare_for_verify`` / ``NGRAMWorker`` build, so they need no GPU, no
+model and no KV pool.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.speculative.spec_utils import _compact_state_captures_to_front
+from sglang.srt.state_capturer.base import TopkCaptureOutput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+BS = 2
+NUM_DRAFT_TOKENS = 8
+NUM_LAYERS = 3
+TOPK_SIZE = 4
+NUM_SLOTS = 64
+# The verify block starts partway into the pool so slot != row index.
+SLOT_BASE = 16
+SEQ_LEN = 5
+
+
+def _node_capture(node: int) -> torch.Tensor:
+    """A per-node capture row, distinct from the zero-initialised host cache."""
+    return torch.full((NUM_LAYERS, TOPK_SIZE), node + 1, dtype=torch.int32)
+
+
+class TestAcceptedPathStateCapture(CustomTestCase):
+    def _verify_layout(self):
+        """out_cache_loc and req_to_token as the verify prologue builds them.
+
+        ``out_cache_loc`` is ``[bs * num_draft_tokens]`` with block ``b`` equal to
+        ``req_to_token[b][seq_len : seq_len + num_draft_tokens]``, so committed
+        position ``seq_len + k`` and block position ``k`` name the same slot.
+        """
+        out_cache_loc = torch.arange(
+            SLOT_BASE, SLOT_BASE + BS * NUM_DRAFT_TOKENS, dtype=torch.int64
+        )
+        req_to_token = torch.zeros((BS, SEQ_LEN + NUM_DRAFT_TOKENS), dtype=torch.int64)
+        req_to_token[:, SEQ_LEN:] = out_cache_loc.view(BS, NUM_DRAFT_TOKENS)
+        return out_cache_loc, req_to_token
+
+    def _finalized_tape(self, accept_index, *, compact: bool):
+        out_cache_loc, req_to_token = self._verify_layout()
+        capture = TopkCaptureOutput(
+            out_cache_loc=out_cache_loc,
+            topk=torch.stack(
+                [_node_capture(node) for node in range(BS * NUM_DRAFT_TOKENS)]
+            ),
+            host_cache=SimpleNamespace(
+                buffer=torch.zeros(
+                    (NUM_SLOTS, NUM_LAYERS, TOPK_SIZE), dtype=torch.int32
+                )
+            ),
+        )
+        if compact:
+            _compact_state_captures_to_front((capture, None), accept_index, BS)
+        capture.finalize()
+        return capture.host_cache.buffer, req_to_token
+
+    def _committed_rows(self, tape, req_to_token, req, accept_len):
+        """Read back exactly what ``BaseTopkCapturer.get_topk`` would read."""
+        return tape[req_to_token[req][SEQ_LEN : SEQ_LEN + accept_len]]
+
+    def test_committed_slots_hold_the_accepted_path(self):
+        # Neither request accepts the front chain: req 0 takes nodes 0/3/5,
+        # req 1 takes 0/1/6/7 (-1 pads an unaccepted tail).
+        accept_index = torch.tensor([[0, 3, 5, -1], [8, 9, 14, 15]], dtype=torch.int32)
+        accept_lens = [3, 4]
+        tape, req_to_token = self._finalized_tape(accept_index, compact=True)
+
+        for req, accept_len in enumerate(accept_lens):
+            got = self._committed_rows(tape, req_to_token, req, accept_len)
+            want = torch.stack(
+                [_node_capture(int(node)) for node in accept_index[req, :accept_len]]
+            )
+            self.assertTrue(
+                torch.equal(got, want),
+                f"req {req}: committed slots hold {got[:, 0, 0].tolist()}, "
+                f"expected the accepted path {want[:, 0, 0].tolist()}",
+            )
+
+    def test_without_compaction_committed_slots_hold_the_front_chain(self):
+        """Pins the failure the compaction removes, so the test above cannot
+        pass vacuously: the slots the KV move targets are the front of each
+        block, whose capture rows belong to nodes 0..accept_len-1."""
+        accept_index = torch.tensor([[0, 3, 5, -1], [8, 9, 14, 15]], dtype=torch.int32)
+        accept_lens = [3, 4]
+        tape, req_to_token = self._finalized_tape(accept_index, compact=False)
+
+        for req, accept_len in enumerate(accept_lens):
+            got = self._committed_rows(tape, req_to_token, req, accept_len)
+            front_chain = torch.stack(
+                [_node_capture(req * NUM_DRAFT_TOKENS + k) for k in range(accept_len)]
+            )
+            self.assertTrue(torch.equal(got, front_chain))
+            accepted = torch.stack(
+                [_node_capture(int(node)) for node in accept_index[req, :accept_len]]
+            )
+            self.assertFalse(torch.equal(got, accepted))
+
+    def test_front_chain_acceptance_is_an_identity(self):
+        """topk == 1 never runs the KV move because the accepted path already is
+        the front chain; the compaction must agree and change nothing."""
+        accept_index = torch.tensor([[0, 1, 2, 3], [8, 9, 10, 11]], dtype=torch.int32)
+        compacted, _ = self._finalized_tape(accept_index, compact=True)
+        untouched, _ = self._finalized_tape(accept_index, compact=False)
+        self.assertTrue(torch.equal(compacted, untouched))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Per-token state capture (`--enable-return-routed-experts` / `return_routed_experts`, and the indexer-topk capture) returns wrong data under speculative decoding, in two distinct ways. Both are silent: the response carries a full-size, plausible-looking tape.

The tape is keyed by **KV slot**. `TopkCaptureOutput.finalize` scatters row `i` into `out_cache_loc[i]`, and `BaseTopkCapturer.get_topk` reads back through `req_to_token[req_pool_idx][start_len : seqlen - 1]`. A capture row is correct only if it sits in the slot whose KV it describes.

**1. EAGLE-family with `--speculative-eagle-topk > 1` returns rows from the wrong slots.** `move_accept_tokens_to_target_kvcache` relocates each accepted tree node's KV to the front of its per-request block, and `_finalize_accept_tree_path` does the same for `predict` and `hidden_states` — but the capture tape is left in tree order. The committed slots therefore keep the capture of whichever tree node was originally allocated there: the front chain, not the accepted path. At `topk == 1` the accepted path already *is* the front chain, which is why this only appears for tree drafting.

**2. NGRAM returns an all-zeros tape.** `NGRAMWorker.forward_batch_generation` builds its `GenerationBatchResult` without `routed_experts_output` / `indexer_topk_output`, so under overlap scheduling nothing finalizes the target forward's captures and the host cache is read back at its zero-initialised contents. Same class as #34026 ("[Spec] Propagate state capture outputs in DFlash"), whose description records the symptom exactly: *"before: every decode routing row in a cold request remained zero."* The EAGLE worker already relays both handles; ngram is the remaining path.

Neither combination is covered today — no test exercises `enable_return_routed_experts` together with `speculative_algorithm` (`test/registered/rl/test_return_routed_experts.py` covers the non-speculative path). The R3 roadmap issue #16379 was closed with `- [ ] Compatible with mtp` still unchecked, so this is a known gap rather than a regression.

This data feeds MoE routing replay in RL trainers, where routing that looks right but describes different tokens is worse than an error.

## Modifications

**The fix: whoever moves the KV moves the capture.**

`move_accept_tokens_to_target_kvcache` gains a **required keyword-only** `state_captures` argument and, right after `move_kv_cache`, compacts each pending capture with the same transform already applied to `predict` and `hidden_states`.

This is correct because of the verify batch's slot layout. `eagle_prepare_for_verify` sets `out_cache_loc = assign_extend_cache_locs_uniform_func(...)`, so

```
out_cache_loc[b * num_draft_tokens + k] == req_to_token[req_b][seq_len + k]
```

which is exactly the slot this move writes request `b`'s accepted position `k` into. Compacting row `b*nd+k` to hold accepted position `k` therefore lands each accepted token's capture in the slot its KV moved to — no change to `out_cache_loc` itself, no GPU→CPU sync. It runs on the forward stream, before `GenerationBatchResult.copy_to_cpu` maps these tensors to the host, so the overlap scheduler is covered too.

- `spec_utils.py` — `_compact_accept_to_front` moves here from `eagle_worker_common.py` as `compact_accept_to_front` (the import dependency runs `eagle_worker_common -> spec_utils`, so it cannot go the other way); adds `_compact_state_captures_to_front`; adds the required kwarg. `num_draft_tokens` is derived from the capture's own `out_cache_loc`, so the common no-capture path does no work.
- `eagle_worker_common.py` — `_finalize_accept_tree_path` threads the captures through to the mover.
- `ngram_worker.py` — passes the captures to the mover **and** relays both handles onto the returned `GenerationBatchResult`.
- `batch_result_processor.py` — adds an entirely-zero warning (below).

**Tradeoff, flagged for review.** Making `state_captures` required touches every caller of a shared helper — both of them today — and a new verify path will not run until it decides what to pass. That is the intent: this bug class is "a path forgot to carry the capture", and #34026 was the same forgetting. If you would rather keep the helper's signature stable, the alternative is an optional kwarg plus an assertion in each worker; say so and I will switch it rather than spend a round trip.

**The guard.** The existing row-count check in `_maybe_collect_routed_experts` compares the returned row count against `seqlen - 1 - start_len` — but the returned tensor *is* that slice, so it can only fire on a truncated `req_to_token` row, never on a tape that was never written. Added: warn when the whole tape reads back zero, which is exactly what failure (2) produces (capture only runs for MoE models, whose router does not pick expert 0 in every layer of every token). The code comment states what it does **not** catch: it cannot see a wrong-slot tape. That failure is prevented at the source by the compaction; the guard is a net for the propagation class only. Undocumented guards get read as coverage, which is how the tautological one survived.

## Accuracy Tests

**I have no GPU on this machine.** Splitting what is proved how, so nothing here is taken on trust:

**Proved by reading the source at `d122ca99b`:** the slot identity above (`eagle_prepare_for_verify` → `assign_extend_cache_locs_uniform_func`); that `tgt_cache_loc` inside the mover names those same slots; that `finalize` / `get_topk` key on KV slot; that `GenerationBatchResult.copy_to_cpu` reads `holder.topk` at map time, so mutating it in the verify path is safe under overlap scheduling; and that `NGRAMWorker` constructs its result without the two handles while the EAGLE worker relays them.

**Proved by an executed test:** `test/registered/unit/spec/test_accepted_path_state_capture.py` (CPU, no model, no KV pool) drives the real `_compact_state_captures_to_front` and the real `TopkCaptureOutput` against the verify slot layout, and reads back the way `get_topk` does. It passes on this branch and **fails on unpatched code** — with the compaction stubbed out it reports `req 0: committed slots hold [1, 2, 3], expected the accepted path [1, 4, 6]`. A second test pins that unpatched behaviour explicitly so the first cannot pass vacuously, and a third asserts the `topk == 1` case is an identity.

Also run: `pre-commit run --files` over all six changed files — green, no reformats.

**Written but NOT executed:** `test/registered/spec/test_spec_routed_experts.py`. I could not run it; it needs a 2-GPU H100/H200-class box — the `extra-a-test-2-gpu-large` runner it is registered for. It compares one request's decode routing rows against a cold-prefill reference of the same token sequence on the same server (a distinct `extra_key` forces the cold prefill, asserted via `cached_tokens == 0`), asserts the tape is not all zeros, and asserts a non-vacuous accept length from `/server_info`. Two arms: NGRAM on `Qwen/Qwen3-30B-A3B`, and EAGLE `--speculative-eagle-topk 4` on `lmsys/sglang-ci-dsv3-test` + NextN, reusing the tree config from the `topk > 1` arm of `test/manual/attention/test_fa3.py`. Please run it before merging — I would rather have its model choices and mismatch threshold corrected than trusted.

There is no model-output or accuracy impact: the change reorders rows in a capture buffer that only exists when routed-experts / indexer capture is enabled, and is a no-op when it is off.

## Speed Tests and Profiling

Not applicable. When capture is disabled both handles are `None` and the added loop does nothing. When it is enabled the compaction is one gather over `[bs * num_draft_tokens, num_layers, topk]` `int32`, on the forward stream, alongside the gathers already done for `predict` and `hidden_states`.

## Follow-ups (not in this PR)

1. **A token-id witness alongside the tape.** Capturing the token id each row describes would make a wrong-slot capture self-evident to the consumer instead of requiring a reference run. Happy to open it separately if maintainers want it.
2. **`get_dp_local_slice_cpu` stride.** It computes `local_start_pos = dp_rank * cuda_graph_batch`, where `cuda_graph_batch` is a padded *request* count while the stride into the gathered buffer is *tokens*. Separate concern; I will file it once this lands.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing behaviour change to document; the flag's contract is unchanged, it just holds now.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — see Accuracy Tests above; no GPU available to me, and the change is not on any speed-relevant path.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33846820639](https://github.com/sgl-project/sglang/actions/runs/33846820639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33846820388](https://github.com/sgl-project/sglang/actions/runs/33846820388)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33846820475](https://github.com/sgl-project/sglang/actions/runs/33846820475)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->