### PR TITLE
fix(attention): auto-split SM120 FA4 target verification

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -59,6 +59,20 @@ def _should_disable_scheduler_metadata_precompute() -> bool:
     return bool(get_parallel().enable_prefill_cp or get_parallel().enable_dp_attention)
 
 
+def _forward_splitkv_policy(
+    *,
+    forward_mode: ForwardMode,
+    prefill_num_splits: int,
+    decode_num_splits: int,
+    target_verify_uses_decode_policy: bool,
+    max_seqlen_k: int,
+) -> tuple[int, Optional[int]]:
+    """Select the runtime-owned split policy and its planning KV length."""
+    if forward_mode.is_target_verify() and target_verify_uses_decode_policy:
+        return decode_num_splits, max_seqlen_k
+    return prefill_num_splits, None
+
+
 @dataclass
 class FlashAttentionMetadata:
     """Metadata to be init once in the model forward pass,
@@ -271,6 +285,7 @@ class FlashAttentionBackend(AttentionBackend):
         # Select version
         self.fa_impl_ver = fa_impl_ver
         device_capability = get_device_capability()
+        self.device_capability = device_capability
         if self.fa_impl_ver == 3:
             from sgl_kernel.flash_attn import (
                 flash_attn_varlen_func,
@@ -1417,6 +1432,33 @@ class FlashAttentionBackend(AttentionBackend):
                 cu_seqlens_k = metadata.encoder_cu_seqlens_k
                 window_size = (-1, -1)
 
+            target_verify_uses_decode_policy = (
+                self.fa_impl_ver == 4
+                and self.device_capability[0] == 12
+                and forward_batch.forward_mode.is_target_verify()
+                and not cp_active
+                and q.dtype == torch.bfloat16
+                and key_cache.dtype == torch.bfloat16
+                and value_cache.dtype == torch.bfloat16
+                and causal
+                and not use_cascade_attn
+                and not use_local_attn
+                and not is_swa_layer
+                and not self.fa_skip_kv_cache
+                and not layer.is_cross_attention
+                and score_mod is None
+                and sinks is None
+                and rel_bias is None
+                and layer.logit_cap in (None, 0.0)
+            )
+            forward_num_splits, forward_max_seqlen_k = _forward_splitkv_policy(
+                forward_mode=forward_batch.forward_mode,
+                prefill_num_splits=self.num_splits,
+                decode_num_splits=self.decode_num_splits,
+                target_verify_uses_decode_policy=target_verify_uses_decode_policy,
+                max_seqlen_k=metadata.max_seq_len_k,
+            )
+
             if cp_active:
 
                 def _fa_cp_attn(
@@ -1516,12 +1558,13 @@ class FlashAttentionBackend(AttentionBackend):
                     cu_seqlens_q=cu_seqlens_q,
                     cu_seqlens_k_new=cu_seqlens_k if not use_local_attn else None,
                     max_seqlen_q=max_seqlen_q,
+                    max_seqlen_k=forward_max_seqlen_k,
                     softmax_scale=layer.scaling,
                     causal=False if use_cascade_attn else causal,
                     window_size=window_size,
                     softcap=layer.logit_cap,
                     return_softmax_lse=use_cascade_attn,
-                    num_splits=self.num_splits,
+                    num_splits=forward_num_splits,
                     out=_fa_out,
                     ver=self.fa_impl_ver,
                     **kwargs,

--- a/test/registered/kernels/ops/attention/test_flash_attention_4_sm120.py
+++ b/test/registered/kernels/ops/attention/test_flash_attention_4_sm120.py
@@ -60,6 +60,80 @@ def test_sm120_runtime_policy_delegates_decode_shapes():
     assert not future_policy.decode_uses_static_max_seqlen_k
 
 
+@pytest.mark.parametrize(("q_len", "q_heads"), [(2, 6), (8, 16)])
+def test_sm120_short_query_auto_split_matches_unsplit_graph(
+    monkeypatch, q_len, q_heads
+):
+    sm120_forward_host.clear_launch_plans()
+    resolved_plans = []
+    original_resolve_plan = Sm120ForwardHost.resolve_plan
+
+    def recording_resolve_plan(**kwargs):
+        plan = original_resolve_plan(**kwargs)
+        resolved_plans.append((kwargs["requested_num_splits"], plan))
+        return plan
+
+    monkeypatch.setattr(
+        Sm120ForwardHost,
+        "resolve_plan",
+        staticmethod(recording_resolve_plan),
+    )
+    torch.manual_seed(20260904 + q_len)
+    kv_len, page_size, head_dim = 1024, 64, 128
+    q = torch.randn(q_len, q_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(
+        kv_len // page_size,
+        page_size,
+        1,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn_like(k)
+    page_table = torch.arange(kv_len // page_size, device="cuda", dtype=torch.int32)[
+        None
+    ]
+    cache_seqlens = torch.tensor([kv_len], device="cuda", dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, q_len], device="cuda", dtype=torch.int32)
+
+    def run(num_splits, out):
+        return flash_attn_with_kvcache(
+            q,
+            k,
+            v,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=q_len,
+            max_seqlen_k=kv_len,
+            causal=True,
+            num_splits=num_splits,
+            pack_gqa=True,
+            out=out,
+        )
+
+    unsplit_out = torch.empty_like(q)
+    eager_auto_out = torch.empty_like(q)
+    graph_auto_out = torch.empty_like(q)
+    run(1, unsplit_out)
+    run(0, eager_auto_out)
+    torch.cuda.synchronize()
+
+    auto_plans = [plan for requested, plan in resolved_plans if requested == 0]
+    assert auto_plans
+    assert all(plan.num_splits > 1 for plan in auto_plans)
+    torch.testing.assert_close(eager_auto_out, unsplit_out, atol=2e-3, rtol=0.0)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run(0, graph_auto_out)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured.data_ptr() == graph_auto_out.data_ptr()
+    torch.testing.assert_close(graph_auto_out, unsplit_out, atol=2e-3, rtol=0.0)
+
+
 def test_sm120_preallocated_output_contract_is_validated_before_launch():
     q = torch.empty((1, 1, 1, 32), device="cuda", dtype=torch.bfloat16)
     k = torch.empty((1, 1, 1, 32), device="cuda", dtype=torch.bfloat16)

--- a/test/registered/unit/layers/test_flashattention_paged_mha.py
+++ b/test/registered/unit/layers/test_flashattention_paged_mha.py
@@ -20,7 +20,9 @@ with patch.dict(
 ):
     from sglang.srt.layers.attention.flashattention_backend import (
         FlashAttentionBackend,
+        _forward_splitkv_policy,
     )
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
@@ -37,6 +39,49 @@ def _backend():
 
 
 class TestFlashAttentionPagedMHA(unittest.TestCase):
+    def test_target_verify_uses_decode_splitkv_policy_only_when_eligible(self):
+        common = {
+            "prefill_num_splits": 4,
+            "decode_num_splits": 0,
+        }
+        self.assertEqual(
+            _forward_splitkv_policy(
+                forward_mode=ForwardMode.EXTEND,
+                target_verify_uses_decode_policy=True,
+                max_seqlen_k=1024,
+                **common,
+            ),
+            (4, None),
+        )
+        self.assertEqual(
+            _forward_splitkv_policy(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                target_verify_uses_decode_policy=True,
+                max_seqlen_k=1024,
+                **common,
+            ),
+            (0, 1024),
+        )
+        self.assertEqual(
+            _forward_splitkv_policy(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                target_verify_uses_decode_policy=False,
+                max_seqlen_k=1024,
+                **common,
+            ),
+            (4, None),
+        )
+        self.assertEqual(
+            _forward_splitkv_policy(
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                prefill_num_splits=4,
+                decode_num_splits=1,
+                target_verify_uses_decode_policy=True,
+                max_seqlen_k=1024,
+            ),
+            (1, 1024),
+        )
+
     def test_get_paged_mha_kv_cache_supports_head_groups(self):
         backend = _backend()
         backend.token_to_kv_pool = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Route eligible SM120 FA4 BF16 target-verification calls through the existing
  architecture-owned decode SplitKV policy instead of the ordinary prefill
  policy.
- Forward the live maximum KV length when target verification delegates
  automatic split selection.
- Preserve ordinary prefill, deterministic inference, explicit split requests,
  non-SM120 backends, and unsupported attention variants.

## Motivation

SGLang represents target verification through `forward_extend`, so it currently
inherits the SM120 FA4 prefill policy (`num_splits=1`).  Target verification is
instead a short-query workload and can use the existing decode-side automatic
SplitKV heuristic without changing the public FlashAttention API.

## Scope

The new default applies only to SM120 FA4 with BF16 Q/K/V, causal global paged
attention, and no cascade, context parallelism, local/sliding attention, sinks,
score modification, relative bias, cross attention, softcap, or KV-cache bypass.
All other calls retain their previous policy.

This change does not add a calibration model, tuning cache, per-shape
refinement, FP8 KV support, startup hook, or configuration variable.

## Performance

Measured on three otherwise idle NVIDIA RTX PRO 6000 Blackwell Server Edition
GPUs with paired CUDA Graph replay timing.  Each p50 contains seven alternating
batches of 256 replays.

The matrix covers BF16, head dimension 128, page size 64, one KV head, GQA
groups 6/8/16, target-verification lengths 2 through 8, and KV lengths
128/256/512/768/1024 (105 shapes total).

- 105/105 correctness comparisons passed against explicit unsplit execution.
- 61 shapes selected the exact unsplit launch plan.
- 44 shapes selected SplitKV; every one was faster than unsplit.
- Worst SplitKV/unsplit p50 ratio: 0.6662 (at least 1.50x faster).
- Selected split counts: 6, 8, 12, and 16.

By KV length, the heuristic selected SplitKV for 0/21, 0/21, 2/21, 21/21,
and 21/21 shapes respectively.

## Test plan

- `test_flashattention_paged_mha.py`: 3 passed.
- `test_flash_attention_4_sm120.py`: 55 passed.
- Registered-test metadata checker passed.
- `git diff --check` passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34332168736](https://github.com/sgl-project/sglang/actions/runs/34332168736)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34332168480](https://github.com/sgl-project/sglang/actions/runs/34332168480)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34332168592](https://github.com/sgl-project/sglang/actions/runs/34332168592)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->