### PR TITLE
fix(qwen3_5): let the GDN gated norm follow the model's device

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -361,7 +361,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             eps=self.layer_norm_epsilon,
             group_size=None,
             norm_before_gate=True,
-            device=torch.get_device_module().current_device(),
             dtype=torch.get_default_dtype(),
             **(
                 {"activation": self.output_gate_type}


### PR DESCRIPTION
## What

`Qwen3_5GatedDeltaNet` builds its gated norm with an explicit
`device=torch.get_device_module().current_device()`. The loader already builds
the whole model inside `with torch.device(device_config.device)`, and
`RMSNorm.__init__` defaults `device=None` precisely so its parameter inherits
that context — so passing the accelerator explicitly is what overrides it.

Dropping the argument is the whole change; `dtype` is left alone since
`set_default_torch_dtype` makes it equivalent either way.

## Why it matters

The norm's weight lands on CUDA even when the caller asked for a CPU model: 24
of Qwen3.5-4B's 627 parameters, 128 elements each. A few kilobytes, but enough
to break any path that needs a genuine CPU replica. SGLang's own p2p/RDMA weight
transfer stages one and pins it, which fails outright:

```
RuntimeError: cannot pin 'CUDABFloat16Type' only dense CPU tensors can be pinned
```

Every training backend hits this, since the replica is built before any weights
are streamed.

## Evidence

Reproduced with no training backend in the picture, by building the replica the
way the transfer does:

```python
get_model(
    model_config=ModelConfig(path),
    load_config=LoadConfig(load_format="dummy"),
    device_config=DeviceConfig(device="cpu"),
)
```

| model | before | after |
|---|---|---|
| Qwen3.5-4B | 24 of 627 params on CUDA, `pin_memory` raises | **0 of 627, `pin_memory` ok** |
| Qwen3-30B-A3B | 0 of 435 (no GDN layers) | 0 of 435, unchanged |

Also confirmed end to end: with this fix the p2p weight-transfer path completes
on Qwen3.5-4B, where it previously failed during `connect`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33848852054](https://github.com/sgl-project/sglang/actions/runs/33848852054)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33848851527](https://github.com/sgl-project/sglang/actions/runs/33848851527)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33848852004](https://github.com/sgl-project/sglang/actions/runs/33848852004)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->