### PR TITLE
[Docs] Drop ghost --max-seq-len from MiMo-V2.5 deployment playground

### DIFF
--- a/docs/src/snippets/autoregressive/mimo-v25-deployment.jsx
+++ b/docs/src/snippets/autoregressive/mimo-v25-deployment.jsx
@@ -269,7 +269,6 @@ export const MiMoV25Deployment = () => {
         flags.push("  --swa-full-tokens-ratio 0.25");
         flags.push("  --log-level info");
       } else {
-        flags.push("  --max-seq-len 4096");
         flags.push("  --max-prefill-tokens 16384");
         flags.push("  --mem-fraction-static 0.92");
         flags.push("  --swa-full-tokens-ratio 0.15");


### PR DESCRIPTION
## What drifted

In `docs/src/snippets/autoregressive/mimo-v25-deployment.jsx`, the non-v7x (`else`) branch of the MiMo-V2.5 deployment playground still emits:

```js
flags.push("  --max-seq-len 4096");
```

`--max-seq-len` / `max_seq_len` is not a live SGLang server argument: it does not appear in `python/sglang/srt/server_args.py` (fields, aliases, `cli_name`, or deprecated names). The same generated command already sets a real length limit via `--context-length 262144`. The sibling v7x branch correctly omits `--max-seq-len`.

## Fix

Delete that single `flags.push("  --max-seq-len 4096");` line in the non-v7x branch. No other changes.

## Repro

```bash
# Ghost flag still on upstream main (non-v7x branch)
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/src/snippets/autoregressive/mimo-v25-deployment.jsx \
  | grep -n 'max-seq-len'

# No matching CLI in server_args
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/server_args.py \
  | grep -nE 'max_seq_len|max-seq-len' || echo 'no matches'

# Same snippet already documents the real length flag
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/src/snippets/autoregressive/mimo-v25-deployment.jsx \
  | grep -n 'context-length'
```

Expected: grep finds `--max-seq-len` only in the playground snippet; `server_args.py` has zero matches; `--context-length 262144` is already present on the shared flags path (before the v7x/else split).

## Evidence

- `server_args.py` has no `max_seq_len` / `--max-seq-len` field, alias, or deprecated CLI name.
- The playground already pushes `--context-length 262144` for all variants, so the ghost `--max-seq-len 4096` is redundant even if it were valid.
- The v7x branch in the same file already omits `--max-seq-len`, which is the correct pattern for the else branch as well.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33849000864](https://github.com/sgl-project/sglang/actions/runs/33849000864)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33849000404](https://github.com/sgl-project/sglang/actions/runs/33849000404)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->