### PR TITLE
[Docs] Prefer --mamba-radix-cache-strategy in NIXL HiCache README

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/README.md
+++ b/python/sglang/srt/mem_cache/storage/nixl/README.md
@@ -206,7 +206,7 @@ Important details from this validation:
 
 - Use a real `.toml` file path with `--hicache-storage-backend-extra-config`.
 - For this validated path, the storage directory was provided through `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`.
-- Use `--mamba-scheduler-strategy extra_buffer` to support page sizes larger than 1.
+- Use `--mamba-radix-cache-strategy extra_buffer` to support page sizes larger than 1.
 
 Example TOML file:
 
@@ -237,7 +237,7 @@ export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/tmp/sglang_nixl_e2e_storage
   --disable-cuda-graph \
   --hicache-storage-backend nixl \
   --hicache-storage-backend-extra-config @/tmp/nixl.config.toml \
-  --mamba-scheduler-strategy extra_buffer
+  --mamba-radix-cache-strategy extra_buffer
 ```
 
 Expected behavior for this validated setup:


### PR DESCRIPTION
## Summary
Prefer the canonical `--mamba-radix-cache-strategy` flag in the NIXL HiCache hybrid-model README. The serve tip and example still used the deprecated alias `--mamba-scheduler-strategy` (`DeprecatedAliasStoreAction` → `--mamba-radix-cache-strategy`). Value `extra_buffer` is unchanged.

Distinct from other open mamba docs PRs that only touch Ling-3.0-flash config or Ascend Qwen best-practice cookbooks.

## Files
- `python/sglang/srt/mem_cache/storage/nixl/README.md` (tip + example command)

## Repro
```bash
# Deprecated alias registration
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/01e66a62db889b6ed921eaf08360119ea4e2ba75/python/sglang/srt/server_args.py \
  | sed -n '3938,3946p'
# Live field choices include extra_buffer
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/01e66a62db889b6ed921eaf08360119ea4e2ba75/python/sglang/srt/server_args.py \
  | sed -n '2623,2631p'
# Docs still teach the alias (×2)
curl -sL https://raw.githubusercontent.com/sgl-project/sglang/01e66a62db889b6ed921eaf08360119ea4e2ba75/python/sglang/srt/mem_cache/storage/nixl/README.md \
  | rg -n 'mamba-scheduler-strategy|mamba-radix-cache-strategy'
```

## Test plan
- [ ] Confirm README tip + example use `--mamba-radix-cache-strategy extra_buffer`
- [ ] Confirm no remaining `--mamba-scheduler-strategy` in this file
- [ ] Docs-only change; no runtime CI required beyond lint/docs gates

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33850326436](https://github.com/sgl-project/sglang/actions/runs/33850326436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33850326276](https://github.com/sgl-project/sglang/actions/runs/33850326276)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33850326507](https://github.com/sgl-project/sglang/actions/runs/33850326507)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->