### PR TITLE
[Fix] Skip the sampler's token-id sync when its group has one rank

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -99,6 +99,7 @@ class Sampler(nn.Module):
         self.tp_sync_group = get_tp_group().device_group
         if is_dp_attention_enabled():
             self.tp_sync_group = get_parallel().attn_tp_group.device_group
+        self.tp_sync_world_size = dist.get_world_size(self.tp_sync_group)
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -647,7 +648,11 @@ class Sampler(nn.Module):
     def _sync_token_ids_across_tp(
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
-        if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+        if (
+            SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars
+        ) and self.tp_sync_world_size > 1:
+            # A one-rank group has nothing to reconcile, and issuing a collective
+            # on it would create the group's NCCL communicator on first use.
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
             # the last all-reduce, the last lm_head matmul, and all sampling kernels.


### PR DESCRIPTION
## Motivation

`Sampler._sync_token_ids_across_tp` issues an `all_reduce(MIN)` over `tp_sync_group` for grammar-constrained batches (and for every batch with `SYNC_TOKEN_IDS_ACROSS_TP`). With DP attention the group is the attention-TP group, which has one rank when `attn_tp_size == 1`, so the reduction is the identity.

torch creates a process group's NCCL communicator on its first collective, and NCCL allocates its buffers (about 512 MiB per rank, measured 518 MiB with NCCL 2.27 on a one-rank group) outside the caching allocator to do so. On a one-rank sync group that first collective is the first grammar request the server sees. If it arrives after the caching allocator has grown to fill device memory, the allocation fails inside `all_reduce`:

```
torch.distributed.DistBackendError: NCCL error ... ncclUnhandledCudaError: Call to CUDA function failed.
Last error: Failed to CUDA calloc 536870912 bytes
```

and the scheduler process dies. We hit this on GLM-5.2-NVFP4 with `--dp 8 --tp 8 --enable-dp-attention --mem-fraction-static 0.8`, hours after start, on the first `json_schema` request.

## Modifications

Record the sync group's world size at construction and skip the collective when it is 1. Nothing needs reconciling on a one-rank group, no communicator is created, and the per-step call goes away. Behaviour on multi-rank groups is unchanged.

## Accuracy Tests

Not applicable: on a one-rank group the removed reduction returned the rank's own token ids.

## Benchmarking and Profiling

Removes one NCCL launch per sampling step on one-rank groups (about 10 µs); no other change.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#accuracy-results).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33850914776](https://github.com/sgl-project/sglang/actions/runs/33850914776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33850914666](https://github.com/sgl-project/sglang/actions/runs/33850914666)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33850914730](https://github.com/sgl-project/sglang/actions/runs/33850914730)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->