### PR TITLE
[Memory] Retire graph borrow pool before updating static runs

### DIFF
--- a/python/sglang/srt/model_executor/runner_utils/pool.py
+++ b/python/sglang/srt/model_executor/runner_utils/pool.py
@@ -58,9 +58,11 @@ def set_graph_pool_borrow_runs(runs: list[tuple[int, int]]) -> None:
     borrowing.
     """
     global _borrow_static_runs
-    _borrow_static_runs = sorted(runs, key=lambda run: run[1], reverse=True)[
+    static_runs = sorted(runs, key=lambda run: run[1], reverse=True)[
         : BumpArenaStub.MAX_EXTENTS
     ]
+    _teardown_borrow_pool()
+    _borrow_static_runs = static_runs
     logger.info(
         "Graph pool borrow runs pinned: runs=%d free=%d",
         len(_borrow_static_runs),

--- a/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
+++ b/test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py
@@ -122,6 +122,20 @@ class TestGraphPoolBorrow(CustomTestCase):
             pool.disable_graph_pool_borrow("graph storage is externally managed")
             self.assertFalse(pool.graph_pool_borrow_enabled())
 
+    def test_setting_static_runs_retires_previous_borrow_pool(self):
+        runs = [(0x1000, 4096), (0x2000, 8192)]
+
+        def reset_static_runs():
+            pool._borrow_static_runs = None
+
+        with patch.object(
+            pool, "_teardown_borrow_pool", side_effect=reset_static_runs
+        ) as teardown:
+            pool.set_graph_pool_borrow_runs(runs)
+
+        teardown.assert_called_once_with()
+        self.assertEqual(pool._borrow_static_runs, [(0x2000, 8192), (0x1000, 4096)])
+
     def test_eagle_non_greedy_probabilities_do_not_borrow_graph_pool(self):
         def fake_sampling(**kwargs):
             kwargs["predicts"].fill_(3)


### PR DESCRIPTION
## Motivation

Replacing fixed graph-storage extents while a borrow memory pool remains live leaves allocator state tied to the previous address set.

## Modifications

- Sort and retain the replacement extents before teardown.
- Retire the existing borrow pool before publishing the new extents.
- Add a regression test that verifies teardown ordering and the final sorted extent list.

## Testing

- `TMPDIR=<isolated> LD_PRELOAD=/usr/lib64/libnuma.so.1 uv run --locked --no-sync pytest -q test/registered/unit/model_executor/runner_utils/test_graph_pool_borrow.py` — 12 passed.
- Scoped pre-commit hooks — passed.

## Original commits

- `ed5631a004984b45ed13a76934d19fc70d2ffbd0`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33852585663](https://github.com/sgl-project/sglang/actions/runs/33852585663)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33852585484](https://github.com/sgl-project/sglang/actions/runs/33852585484)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33852585675](https://github.com/sgl-project/sglang/actions/runs/33852585675)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->