### PR TITLE
[Runtime] Let out-of-tree platforms provide full graph backends

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/utils.py
+++ b/python/sglang/srt/model_executor/runner_backend/utils.py
@@ -37,9 +37,8 @@ from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
 from sglang.srt.model_executor.runner_backend.tc_piecewise_cuda_graph_backend import (
     TcPiecewiseCudaGraphBackend,
 )
-from sglang.srt.runtime_context import (
-    get_exec,
-)
+from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import get_exec
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
@@ -99,8 +98,17 @@ def resolve_decode_backend(
                 "falling back to 'full'."
             )
             _TC_PIECEWISE_DECODE_FALLBACK_LOGGED = True
-    return FullCudaGraphBackend(
-        cuda_graph_runner, enable_memory_saver=enable_memory_saver
+
+    full_backend_cls = None
+    if current_platform.is_out_of_tree():
+        full_backend_cls = current_platform.get_full_graph_backend_cls()
+
+    if full_backend_cls is None:
+        full_backend_cls = FullCudaGraphBackend
+
+    return full_backend_cls(
+        cuda_graph_runner,
+        enable_memory_saver=enable_memory_saver,
     )
 
 

--- a/python/sglang/srt/platforms/interface.py
+++ b/python/sglang/srt/platforms/interface.py
@@ -12,7 +12,7 @@ Out-of-tree platforms register via setuptools entry_points under the
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Any, Optional, Type
 
 from sglang.srt.platforms.device_mixin import DeviceMixin, PlatformEnum
 
@@ -59,6 +59,10 @@ class SRTPlatform(DeviceMixin):
     def get_graph_runner_cls(self) -> type:
         """Return the graph runner class for this platform."""
         raise NotImplementedError
+
+    def get_full_graph_backend_cls(self) -> type[Any]:
+        """Return the full device-graph backend class for this platform."""
+        return None
 
     def get_mha_kv_pool_cls(self) -> type:
         """Return the MHA KV pool class for this platform."""

--- a/test/registered/unit/model_executor/runner_backend/test_backend_resolution.py
+++ b/test/registered/unit/model_executor/runner_backend/test_backend_resolution.py
@@ -1,0 +1,189 @@
+"""CPU-only tests for decode graph backend resolution."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.runner_backend import utils as backend_utils
+from sglang.srt.platforms.device_mixin import PlatformEnum
+from sglang.srt.platforms.interface import SRTPlatform
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_graph_runner(*, device="custom"):
+    return SimpleNamespace(model_runner=SimpleNamespace(device=device))
+
+
+def _make_exec_config(
+    *,
+    backend=Backend.FULL,
+    enable_memory_saver=False,
+    debug_cuda_graph=False,
+):
+    return SimpleNamespace(
+        graph=SimpleNamespace(
+            cuda_graph_config=SimpleNamespace(decode=SimpleNamespace(backend=backend)),
+            debug_cuda_graph=debug_cuda_graph,
+        ),
+        features=SimpleNamespace(
+            enable_memory_saver=enable_memory_saver,
+        ),
+    )
+
+
+def _make_platform(*, is_out_of_tree, full_backend_cls=None):
+    return SimpleNamespace(
+        is_out_of_tree=mock.Mock(return_value=is_out_of_tree),
+        get_full_graph_backend_cls=mock.Mock(return_value=full_backend_cls),
+    )
+
+
+class _OutOfTreePlatformWithoutFullGraphBackend(SRTPlatform):
+    _enum = PlatformEnum.OOT
+
+
+class TestResolveDecodeBackend(CustomTestCase):
+    def test_out_of_tree_platform_provides_full_backend(self):
+        runner = _make_graph_runner()
+        exec_config = _make_exec_config(enable_memory_saver=True)
+        expected_backend = object()
+        backend_cls = mock.Mock(return_value=expected_backend)
+        platform = _make_platform(
+            is_out_of_tree=True,
+            full_backend_cls=backend_cls,
+        )
+
+        with (
+            mock.patch.object(
+                backend_utils,
+                "get_exec",
+                return_value=exec_config,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "current_platform",
+                platform,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "FullCudaGraphBackend",
+            ) as default_backend_cls,
+        ):
+            actual_backend = backend_utils.resolve_decode_backend(runner)
+
+        self.assertIs(actual_backend, expected_backend)
+        platform.get_full_graph_backend_cls.assert_called_once_with()
+        backend_cls.assert_called_once_with(
+            runner,
+            enable_memory_saver=True,
+        )
+        default_backend_cls.assert_not_called()
+
+    def test_out_of_tree_platform_without_full_backend_uses_default(self):
+        runner = _make_graph_runner()
+        exec_config = _make_exec_config()
+        expected_backend = object()
+        platform = _OutOfTreePlatformWithoutFullGraphBackend()
+
+        with (
+            mock.patch.object(
+                backend_utils,
+                "get_exec",
+                return_value=exec_config,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "current_platform",
+                platform,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "FullCudaGraphBackend",
+                return_value=expected_backend,
+            ) as default_backend_cls,
+        ):
+            actual_backend = backend_utils.resolve_decode_backend(runner)
+
+        self.assertIs(actual_backend, expected_backend)
+        default_backend_cls.assert_called_once_with(
+            runner,
+            enable_memory_saver=False,
+        )
+
+    def test_in_tree_platform_uses_default_full_backend(self):
+        runner = _make_graph_runner(device="cuda")
+        exec_config = _make_exec_config()
+        expected_backend = object()
+        platform = _make_platform(is_out_of_tree=False)
+
+        with (
+            mock.patch.object(
+                backend_utils,
+                "get_exec",
+                return_value=exec_config,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "current_platform",
+                platform,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "FullCudaGraphBackend",
+                return_value=expected_backend,
+            ) as default_backend_cls,
+        ):
+            actual_backend = backend_utils.resolve_decode_backend(runner)
+
+        self.assertIs(actual_backend, expected_backend)
+        platform.get_full_graph_backend_cls.assert_not_called()
+        default_backend_cls.assert_called_once_with(
+            runner,
+            enable_memory_saver=False,
+        )
+
+    def test_breakable_backend_does_not_consult_full_backend_factory(self):
+        runner = _make_graph_runner()
+        exec_config = _make_exec_config(
+            backend=Backend.BREAKABLE,
+            enable_memory_saver=True,
+            debug_cuda_graph=True,
+        )
+        expected_backend = object()
+        platform = _make_platform(is_out_of_tree=True)
+
+        with (
+            mock.patch.object(
+                backend_utils,
+                "get_exec",
+                return_value=exec_config,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "current_platform",
+                platform,
+            ),
+            mock.patch.object(
+                backend_utils,
+                "BreakableCudaGraphBackend",
+                return_value=expected_backend,
+            ) as breakable_backend_cls,
+        ):
+            actual_backend = backend_utils.resolve_decode_backend(runner)
+
+        self.assertIs(actual_backend, expected_backend)
+        platform.is_out_of_tree.assert_not_called()
+        platform.get_full_graph_backend_cls.assert_not_called()
+        breakable_backend_cls.assert_called_once_with(
+            runner,
+            enable_memory_saver=True,
+            debug_eager=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Out-of-tree platforms can provide a custom graph runner, but full decode
backend resolution always constructs FullCudaGraphBackend. This prevents an
out-of-tree platform from supplying its own device-graph implementation
without replacing core runner logic.

## Modifications

- Add an optional full graph backend class hook to `SRTPlatform`.
- Consult that hook when resolving the full decode backend for an
  out-of-tree platform.
- Preserve the existing backend for built-in platforms and for plugins that
  do not implement the hook.
- Add CPU-only tests for backend selection and fallback behavior.

## Accuracy Tests

Not applicable. This changes backend selection only and does not modify model
computation.

## Speed Tests and Profiling

Not applicable. This introduces no kernels or execution-path changes for
existing platforms.

# Test Plan

- python3 test/registered/unit/model_executor/runner_backend/test_backend_resolution.py
- python3 test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
- python3 test/run_suite.py --hw cpu --suite base-a-test-cpu
- pre-commit run --all-files

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35312873998](https://github.com/sgl-project/sglang/actions/runs/35312873998)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #35312876596](https://github.com/sgl-project/sglang/actions/runs/35312876596)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35312874016](https://github.com/sgl-project/sglang/actions/runs/35312874016)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->