### PR TITLE
Coop indexer topk sm100

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -578,11 +578,7 @@ struct TopKKernel {
       // Below kClusterFloorSmall a batch-1 row can reach topk_main_kernel, which
       // carries no handoff guard, and both kernels would write the same row.
       RuntimeCheck(
-          coop_floor >= kClusterFloorSmall,
-          "coop top-k floor must be >= ",
-          kClusterFloorSmall,
-          ", got ",
-          coop_floor);
+          coop_floor >= kClusterFloorSmall, "coop top-k floor must be >= ", kClusterFloorSmall, ", got ", coop_floor);
       RuntimeCheck(coop_workspace.has_value(), "coop top-k requires a workspace tensor");
       auto W = SymbolicSize{"coop_workspace"};
       TensorMatcher({W})  // coop_workspace: opaque persistent cross-block state

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -14,6 +14,7 @@
 
 #include <sgl_kernel/utils.cuh>
 
+#include <sgl_kernel/deepseek_v4/topk_coop.cuh>
 #include <sgl_kernel/deepseek_v4/topk_impl.cuh>
 
 #include <dlpack/dlpack.h>
@@ -59,6 +60,10 @@ constexpr uint32_t kClusterFloor = 65536;
 constexpr uint32_t kClusterMaxBatch = 512;
 constexpr uint32_t kNumPersistentClusters = 15 * kOccupancy;
 
+// Sentinel for TopKPagedParams::coop_floor: no seq_len can exceed it, so with the
+// handoff off the guard is a single compare that never fires.
+constexpr uint32_t kCoopFloorOff = std::numeric_limits<uint32_t>::max();
+
 /// Metadata tensor rows (each 8 B / 2 int32). Row 0 is the global plan result;
 /// rows 1..N are the (batch_id, seq_len) of items routed to the cluster pool.
 struct alignas(8) GlobalMetadata {
@@ -82,6 +87,8 @@ struct TopKPagedParams {
   uint32_t topk;
   uint32_t page_bits;
   uint32_t cluster_floor;  // seq_len > this routes to the cluster path (batch-aware, host-set)
+  // seq_len > this is owned by coop_topk_kernel instead; kCoopFloorOff disables it.
+  uint32_t coop_floor;
 
   SGL_DEVICE const GlobalMetadata& global() const {
     return *reinterpret_cast<const GlobalMetadata*>(metadata);
@@ -319,6 +326,10 @@ template <bool kPDL, TopKMode kMode>
 CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKPagedParams params) {
   device::enable_smem_spilling();
   auto problem = params.problem(blockIdx.x);
+  // Handoff to coop_topk_kernel, which carries the inverse guard: both read the
+  // same device-side length, so a captured graph routes per replay with no host
+  // branch. Off by default, when coop_floor is kCoopFloorOff.
+  if (problem.seq_len > params.coop_floor) return;
   __shared__ impl::MaxSmem<Streaming::Smem, Cluster::Smem> smem;
   if (problem.seq_len <= problem.topk) return trivial_transform<kPDL, kMode>(problem);
 
@@ -490,7 +501,9 @@ struct TopKKernel {
       const tvm::ffi::Optional<tvm::ffi::TensorView> page_table,
       const tvm::ffi::TensorView page_indices,
       const uint32_t page_size,
-      const tvm::ffi::TensorView metadata) {
+      const tvm::ffi::TensorView metadata,
+      const uint32_t coop_floor,  // 0 disables the cooperative handoff entirely
+      const tvm::ffi::Optional<tvm::ffi::TensorView> coop_workspace) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
     auto Bp1 = SymbolicSize{"batch_size_plus_1"};
@@ -550,6 +563,39 @@ struct TopKKernel {
     // The floor is chosen on the host per launch.
     constexpr uint32_t kClusterFloorSmall = 32768;
     constexpr uint32_t kSmallBatchLowFloor = 15;
+
+    // Hand the row to the grid-wide cooperative kernel only in the shape it was
+    // measured in (one row, longer than the floor). `max_seq_len` is the score
+    // buffer width, so this decision is fixed at capture time while the per-replay
+    // routing stays on the device-side length.
+    auto coop_floor_value = kCoopFloorOff;
+#ifdef USE_ROCM
+    (void)coop_workspace;
+    RuntimeCheck(coop_floor == 0, "coop top-k needs a cooperative launch, which this build does not support");
+#else
+    void* coop_ws = nullptr;
+    if (coop_floor != 0 && batch_size == 1 && max_seq_len > coop_floor) {
+      // Below kClusterFloorSmall a batch-1 row can reach topk_main_kernel, which
+      // carries no handoff guard, and both kernels would write the same row.
+      RuntimeCheck(
+          coop_floor >= kClusterFloorSmall,
+          "coop top-k floor must be >= ",
+          kClusterFloorSmall,
+          ", got ",
+          coop_floor);
+      RuntimeCheck(coop_workspace.has_value(), "coop top-k requires a workspace tensor");
+      auto W = SymbolicSize{"coop_workspace"};
+      TensorMatcher({W})  // coop_workspace: opaque persistent cross-block state
+          .with_dtype<int32_t>()
+          .with_device(device_)
+          .verify(coop_workspace.value());
+      const auto want = coop_workspace_bytes();
+      RuntimeCheck(W.unwrap() * 4 >= want, "coop workspace must be at least ", want, " bytes");
+      coop_ws = coop_workspace.value().data_ptr();
+      coop_floor_value = coop_floor;
+    }
+#endif
+
     const auto params = TopKPagedParams{
         .scores = static_cast<const float*>(scores.data_ptr()),
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
@@ -561,6 +607,7 @@ struct TopKKernel {
         .topk = topk,
         .page_bits = page_bits,
         .cluster_floor = (batch_size <= kSmallBatchLowFloor) ? kClusterFloorSmall : kClusterFloor,
+        .coop_floor = coop_floor_value,
     };
 
 #ifndef USE_ROCM
@@ -609,6 +656,33 @@ struct TopKKernel {
             .launch(topk_main_kernel<kUsePDL, /*kLevel=*/2, kMode>, params);
       }
     });
+
+#ifndef USE_ROCM
+    if (coop_ws != nullptr) {
+      const auto coop_params = coop_topk::CoopParams{
+          .scores = params.scores,
+          .seq_lens = params.seq_lens,
+          .page_table = params.page_table,
+          .out = params.page_indices,
+          .ws = static_cast<coop_topk::CoopWorkspace*>(coop_ws),
+          .topk = topk,
+          .page_bits = page_bits,
+          .floor = coop_floor_value,
+      };
+      dispatch([&]<TopKMode kMode>() {  //
+        coop_topk::launch<kMode == TopKMode::PAGE_TABLE>(coop_params, device);
+      });
+    }
+#endif
+  }
+
+  /// Bytes of workspace `transform_paged` needs for the cooperative handoff.
+  static int64_t coop_workspace_bytes() {
+#ifdef USE_ROCM
+    return 0;
+#else
+    return coop_topk::workspace_bytes();
+#endif
   }
 
   /**

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh
@@ -1,0 +1,335 @@
+/// \file topk_coop.cuh
+/// \brief Grid-wide cooperative top-k for a single very long row.
+///
+/// The kernels in `csrc/deepseek_v4/topk_v2.cuh` spread one row over at most one
+/// 8-block cluster, which leaves most of a B200 idle at batch size 1. This kernel
+/// spreads that row over every SM instead, so it needs a cooperative launch.
+///
+/// It does not replace them: the two run back to back on the same stream and
+/// partition the rows by length. `topk_small_batch_kernel` returns early for rows
+/// above `TopKPagedParams::coop_floor`, this kernel returns early for rows at or
+/// below `CoopParams::floor`, and `TopKKernel::transform_paged` sets both from one
+/// host value, so exactly one of the two writes any row.
+
+#pragma once
+
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/utils.cuh>
+
+#include <sgl_kernel/deepseek_v4/topk_impl.cuh>
+
+#include <cstdint>
+
+#ifndef USE_ROCM
+#include <cooperative_groups.h>
+
+namespace sglang::coop_topk {
+
+namespace impl = device::topk;
+
+constexpr uint32_t kBlockSize = impl::TopKConfig::kBlockSize;
+constexpr uint32_t kMaxNumTie = impl::TopKConfig::kMaxNumTie;
+constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+
+// Level 0 bins the top 12 bits of the key and each refine the next 10, so the
+// three levels (shifts 20/10/0) cover the whole 32-bit key and ties are exact.
+constexpr uint32_t kHist0 = 4096;
+constexpr uint32_t kHistRefine = 1024;
+constexpr uint32_t kNumLevels = 3;
+static_assert(kHist0 % kBlockSize == 0 && kHistRefine % kBlockSize == 0);
+
+// Keys come from impl::extract_exact_bin, so the band search and the
+// handle_tie it feeds agree on ordering. NaN is removed before the map is
+// applied; see drop_nan.
+
+struct Counters {
+  uint32_t win;
+  uint32_t tie;
+};
+constexpr uint32_t kCounterWords = sizeof(Counters) / sizeof(uint32_t);
+
+/**
+ * \brief Cross-block state, owned by the caller and reused across launches.
+ *
+ * Must be zero at first use. Each launch leaves `hist` zero again and zeroes the
+ * counter slot the next launch will read, so the caller never clears it;
+ * `parity` is the one field that carries over, and it alternates.
+ */
+struct CoopWorkspace {
+  uint32_t hist[kNumLevels][kHist0];
+  Counters cnt[2];
+  uint32_t parity;
+  impl::TieValue ties[kMaxNumTie];
+};
+
+struct CoopParams {
+  const float* __restrict__ scores;      // one row, [seq_len], 16B-aligned base
+  const int32_t* __restrict__ seq_lens;  // row length, read on the device
+  const int32_t* __restrict__ page_table;
+  int32_t* __restrict__ out;  // [topk]
+  CoopWorkspace* __restrict__ ws;
+  uint32_t topk;
+  uint32_t page_bits;
+  uint32_t floor;  // rows with seq_len <= floor belong to the official kernel
+};
+
+struct CoopSmem {
+  uint32_t hist[kHist0];
+  uint32_t warp_sum[kNumWarps];
+  uint32_t bin;      // threshold bin of the current level
+  uint32_t above;    // elements above the threshold bin
+  uint32_t incount;  // elements inside the threshold bin
+  uint32_t seq_len;
+  impl::TopKConfig::TieHandleSmem tie_handle;
+  impl::TieValue ties[kMaxNumTie];
+};
+
+// Past 48 KB a block's shared memory has to be dynamic and opted into with
+// cudaFuncAttributeMaxDynamicSharedMemorySize before any occupancy query.
+static_assert(sizeof(CoopSmem) <= 48 * 1024, "static shared memory limit");
+
+/// Map NaN to -inf. Its integer key outranks +inf, so a NaN score would be
+/// selected, and it makes the tie comparator answer false both ways, which
+/// collides ranks and leaves output slots unwritten.
+SGL_DEVICE float drop_nan(float v) {
+  return v != v ? -INFINITY : v;
+}
+
+/// Visit block `g`'s share of the row, interleaved in runs of 16 float4, so one
+/// iteration of a block covers a 256-byte-contiguous stretch. Every value is
+/// passed through `drop_nan`, so all three passes rank the same sanitized row.
+template <typename F>
+SGL_DEVICE void for_each_score(const float* scores, uint32_t seq_len, uint32_t g, uint32_t G, F&& fn) {
+  constexpr uint32_t kRun = 16;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t num_vecs = seq_len / 4;
+  const auto* vecs = reinterpret_cast<const float4*>(scores);
+  for (uint32_t j = tx;; j += kBlockSize) {
+    const uint32_t vi = (j / kRun) * (G * kRun) + g * kRun + (j % kRun);
+    if (vi >= num_vecs) break;
+    const float4 v = vecs[vi];
+    const uint32_t base = vi * 4u;
+    fn(drop_nan(v.x), base);
+    fn(drop_nan(v.y), base + 1);
+    fn(drop_nan(v.z), base + 2);
+    fn(drop_nan(v.w), base + 3);
+  }
+  const uint32_t tail_start = num_vecs * 4;
+  if (g == 0 && tx < seq_len - tail_start) {
+    fn(drop_nan(scores[tail_start + tx]), tail_start + tx);
+  }
+}
+
+/// Suffix-scan the histogram for the bin holding the `need`-th largest key, with
+/// `kBinsPerThread` consecutive bins per thread. Writes `bin` (the threshold bin),
+/// `above` (count strictly above it) and `incount` (its own population).
+template <uint32_t kBinsPerThread>
+SGL_DEVICE void scan_hist(CoopSmem* smem, uint32_t need) {
+  const uint32_t tx = threadIdx.x;
+  uint32_t bins[kBinsPerThread];
+  uint32_t owned = 0;
+#pragma unroll
+  for (uint32_t i = 0; i < kBinsPerThread; ++i) {
+    bins[i] = smem->hist[tx * kBinsPerThread + i];
+    owned += bins[i];
+  }
+  const uint32_t lane = tx % device::kWarpThreads;
+  const uint32_t warp = tx / device::kWarpThreads;
+  uint32_t inclusive = owned;
+#pragma unroll
+  for (uint32_t off = 1; off < device::kWarpThreads; off <<= 1) {
+    const uint32_t peer = __shfl_down_sync(device::kFullMask, inclusive, off);
+    if (lane + off < device::kWarpThreads) inclusive += peer;
+  }
+  if (lane == 0) smem->warp_sum[warp] = inclusive;
+  __syncthreads();
+  uint32_t higher_warps = 0;
+  for (uint32_t w = warp + 1; w < kNumWarps; ++w) higher_warps += smem->warp_sum[w];
+  uint32_t run = inclusive + higher_warps - owned;  // bins owned by threads above tx
+#pragma unroll
+  for (int i = static_cast<int>(kBinsPerThread) - 1; i >= 0; --i) {
+    const uint32_t count = bins[i];
+    if (run < need && run + count >= need) {
+      smem->bin = tx * kBinsPerThread + static_cast<uint32_t>(i);
+      smem->above = run;
+      smem->incount = count;
+    }
+    run += count;
+  }
+  __syncthreads();
+}
+
+/**
+ * \brief Select the top-k of one row across the whole grid.
+ *
+ * \tparam kTransform apply the page-table transform to the selected indices.
+ *
+ * Every block histograms its share of the row into shared memory and merges into
+ * the workspace; after a grid barrier all blocks derive the same threshold band,
+ * and refines narrow it to the full key width. The final pass writes the elements
+ * above the band straight into `out` and collects the band's members as tie
+ * candidates, which block 0 then resolves with the shared `handle_tie`. A band
+ * still holding more than kMaxNumTie candidates at full key width keeps an
+ * arbitrary kMaxNumTie of them; they are bit-identical, so the result is a valid
+ * top-k, but which indices it names is not fixed across launches.
+ */
+template <bool kTransform>
+__global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_constant__ CoopParams p) {
+  device::enable_smem_spilling();
+  __shared__ CoopSmem smem;
+  const auto grid = cooperative_groups::this_grid();
+  const uint32_t g = blockIdx.x;
+  const uint32_t G = gridDim.x;
+  const uint32_t tx = threadIdx.x;
+
+  if (tx == 0) smem.seq_len = static_cast<uint32_t>(p.seq_lens[0]);
+  __syncthreads();
+  const uint32_t seq_len = smem.seq_len;
+  // Inverse of the guard in topk_small_batch_kernel. Every block reads the same
+  // device-side length and returns together before touching the workspace or the
+  // grid barrier, so a captured graph routes per replay with no host branch. A
+  // length of 0 (a padded or capture-time row) exits here as well.
+  if (seq_len <= p.floor) return;
+  // The host holds floor >= kClusterFloorSmall > kMaxTopK, so seq_len <= topk
+  // belongs to the official kernel and needs no trivial path here.
+  const auto problem = impl::TopKProblem{
+      .in = p.scores,
+      .out = p.out,
+      .page_table = p.page_table,
+      .topk = p.topk,
+      .seq_len = seq_len,
+      .page_bits = p.page_bits,
+  };
+
+  // Read before the first barrier; block 0 flips it after the last one.
+  const uint32_t parity = p.ws->parity;
+  Counters* cnt = &p.ws->cnt[parity];
+
+  for (uint32_t b = tx; b < kHist0; b += kBlockSize) smem.hist[b] = 0;
+  __syncthreads();
+  for_each_score(p.scores, seq_len, g, G, [&](float val, uint32_t) {
+    atomicAdd(&smem.hist[impl::extract_exact_bin(val) >> 20], 1);
+  });
+  __syncthreads();
+  for (uint32_t b = tx; b < kHist0; b += kBlockSize) {
+    if (smem.hist[b]) atomicAdd(&p.ws->hist[0][b], smem.hist[b]);
+  }
+  grid.sync();
+
+  uint32_t level = 0, band_shift = 20, band_prefix = 0, need = p.topk;
+  for (;;) {
+    const uint32_t num_bins = level == 0 ? kHist0 : kHistRefine;
+    for (uint32_t b = tx; b < num_bins; b += kBlockSize) smem.hist[b] = p.ws->hist[level][b];
+    __syncthreads();
+    if (level == 0) {
+      scan_hist<kHist0 / kBlockSize>(&smem, need);
+      band_prefix = smem.bin;
+    } else {
+      scan_hist<kHistRefine / kBlockSize>(&smem, need);
+      band_prefix = (band_prefix << 10) | smem.bin;
+    }
+    if (smem.incount <= kMaxNumTie || band_shift == 0) break;
+
+    need -= smem.above;
+    band_shift -= 10;
+    ++level;
+    for (uint32_t b = tx; b < kHistRefine; b += kBlockSize) smem.hist[b] = 0;
+    __syncthreads();
+    for_each_score(p.scores, seq_len, g, G, [&](float val, uint32_t) {
+      const uint32_t key = impl::extract_exact_bin(val);
+      if ((key >> (band_shift + 10)) == band_prefix) {
+        atomicAdd(&smem.hist[(key >> band_shift) & (kHistRefine - 1)], 1);
+      }
+    });
+    __syncthreads();
+    for (uint32_t b = tx; b < kHistRefine; b += kBlockSize) {
+      if (smem.hist[b]) atomicAdd(&p.ws->hist[level][b], smem.hist[b]);
+    }
+    grid.sync();
+  }
+
+  for_each_score(p.scores, seq_len, g, G, [&](float val, uint32_t idx) {
+    const uint32_t key = impl::extract_exact_bin(val);
+    const uint32_t banded = band_shift ? (key >> band_shift) : key;
+    if (banded > band_prefix) {
+      const uint32_t pos = atomicAdd(&cnt->win, 1);
+      if (pos < p.topk) [[likely]] p.out[pos] = static_cast<int32_t>(idx);
+    } else if (banded == band_prefix) {
+      const uint32_t slot = atomicAdd(&cnt->tie, 1);
+      if (slot < kMaxNumTie) [[likely]] p.ws->ties[slot] = {val, idx};
+    }
+  });
+  grid.sync();
+
+  // Slot `parity` is read-only from here on, so block 0 can resolve the ties
+  // while the others transform the winner slots and clear the workspace for the
+  // next launch, including `cnt[1 - parity]` -- the slot the next launch reads,
+  // since block 0 flips `parity` below.
+  const uint32_t above_count = min(cnt->win, p.topk);
+  auto* hist = reinterpret_cast<uint32_t*>(p.ws->hist);
+  if (g != 0) {
+    if constexpr (kTransform) {
+      for (uint32_t t = (g - 1) * kBlockSize + tx; t < above_count; t += (G - 1) * kBlockSize) {
+        problem.transform_output(t, p.out[t]);
+      }
+    }
+    for (uint32_t i = (g - 1) * kBlockSize + tx; i < kNumLevels * kHist0; i += (G - 1) * kBlockSize) {
+      hist[i] = 0;
+    }
+    if (g == 1 && tx < kCounterWords) reinterpret_cast<uint32_t*>(&p.ws->cnt[1u - parity])[tx] = 0;
+    return;
+  }
+
+  const uint32_t tie_count = min(cnt->tie, kMaxNumTie);
+  for (uint32_t t = tx; t < tie_count; t += kBlockSize) smem.ties[t] = p.ws->ties[t];
+  __syncthreads();
+  if (tx == 0) p.ws->parity = 1u - parity;
+  impl::TopKConfig::handle_tie(smem.ties, problem, above_count, tie_count, p.topk - above_count, &smem.tie_handle);
+  __syncthreads();
+  if constexpr (kTransform) {
+    for (uint32_t t = above_count + tx; t < p.topk; t += kBlockSize) {
+      problem.transform_output(t, p.out[t]);
+    }
+  }
+  if (G == 1) {
+    if constexpr (kTransform) {
+      for (uint32_t t = tx; t < above_count; t += kBlockSize) problem.transform_output(t, p.out[t]);
+    }
+    for (uint32_t i = tx; i < kNumLevels * kHist0; i += kBlockSize) hist[i] = 0;
+    if (tx < kCounterWords) {
+      reinterpret_cast<uint32_t*>(&p.ws->cnt[0])[tx] = 0;
+      reinterpret_cast<uint32_t*>(&p.ws->cnt[1])[tx] = 0;
+    }
+  }
+}
+
+/// Bytes of workspace the caller must provide, zero-initialized on allocation.
+constexpr int64_t workspace_bytes() {
+  return static_cast<int64_t>(sizeof(CoopWorkspace));
+}
+
+/**
+ * \brief Enqueue the cooperative top-k on the same stream as the official kernel.
+ *
+ * One block per SM, which on a 148-SM B200 is close to the 144 blocks the speedup
+ * was measured with. The occupancy query is what makes the grid legal: a
+ * cooperative launch needs every block co-resident, so it fails outright if even
+ * one block does not fit.
+ *
+ * No PDL here. The kernel it takes rows from runs first on the same stream, so
+ * stream order already sequences them.
+ */
+template <bool kTransform>
+inline void launch(const CoopParams& params, DLDevice device) {
+  const auto kernel = coop_topk_kernel<kTransform>;
+  // Not cached: get_blocks_per_sm queries whichever device is current, so a
+  // process driving two devices would launch the second with the first's grid.
+  const uint32_t blocks_per_sm = host::runtime::get_blocks_per_sm(kernel, kBlockSize);
+  const uint32_t sm_count = host::runtime::get_sm_count(device.device_id);
+  host::RuntimeCheck(blocks_per_sm >= 1, "cooperative top-k does not fit one block per SM");
+  host::LaunchKernel(sm_count, kBlockSize, device).config({.cooperative = true}).launch(kernel, params);
+}
+
+}  // namespace sglang::coop_topk
+
+#endif  // !USE_ROCM

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh
@@ -144,7 +144,8 @@ SGL_DEVICE void scan_hist(CoopSmem* smem, uint32_t need) {
   if (lane == 0) smem->warp_sum[warp] = inclusive;
   __syncthreads();
   uint32_t higher_warps = 0;
-  for (uint32_t w = warp + 1; w < kNumWarps; ++w) higher_warps += smem->warp_sum[w];
+  for (uint32_t w = warp + 1; w < kNumWarps; ++w)
+    higher_warps += smem->warp_sum[w];
   uint32_t run = inclusive + higher_warps - owned;  // bins owned by threads above tx
 #pragma unroll
   for (int i = static_cast<int>(kBinsPerThread) - 1; i >= 0; --i) {
@@ -205,7 +206,8 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
   const uint32_t parity = p.ws->parity;
   Counters* cnt = &p.ws->cnt[parity];
 
-  for (uint32_t b = tx; b < kHist0; b += kBlockSize) smem.hist[b] = 0;
+  for (uint32_t b = tx; b < kHist0; b += kBlockSize)
+    smem.hist[b] = 0;
   __syncthreads();
   for_each_score(p.scores, seq_len, g, G, [&](float val, uint32_t) {
     atomicAdd(&smem.hist[impl::extract_exact_bin(val) >> 20], 1);
@@ -219,7 +221,8 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
   uint32_t level = 0, band_shift = 20, band_prefix = 0, need = p.topk;
   for (;;) {
     const uint32_t num_bins = level == 0 ? kHist0 : kHistRefine;
-    for (uint32_t b = tx; b < num_bins; b += kBlockSize) smem.hist[b] = p.ws->hist[level][b];
+    for (uint32_t b = tx; b < num_bins; b += kBlockSize)
+      smem.hist[b] = p.ws->hist[level][b];
     __syncthreads();
     if (level == 0) {
       scan_hist<kHist0 / kBlockSize>(&smem, need);
@@ -233,7 +236,8 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
     need -= smem.above;
     band_shift -= 10;
     ++level;
-    for (uint32_t b = tx; b < kHistRefine; b += kBlockSize) smem.hist[b] = 0;
+    for (uint32_t b = tx; b < kHistRefine; b += kBlockSize)
+      smem.hist[b] = 0;
     __syncthreads();
     for_each_score(p.scores, seq_len, g, G, [&](float val, uint32_t) {
       const uint32_t key = impl::extract_exact_bin(val);
@@ -253,10 +257,12 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
     const uint32_t banded = band_shift ? (key >> band_shift) : key;
     if (banded > band_prefix) {
       const uint32_t pos = atomicAdd(&cnt->win, 1);
-      if (pos < p.topk) [[likely]] p.out[pos] = static_cast<int32_t>(idx);
+      if (pos < p.topk) [[likely]]
+        p.out[pos] = static_cast<int32_t>(idx);
     } else if (banded == band_prefix) {
       const uint32_t slot = atomicAdd(&cnt->tie, 1);
-      if (slot < kMaxNumTie) [[likely]] p.ws->ties[slot] = {val, idx};
+      if (slot < kMaxNumTie) [[likely]]
+        p.ws->ties[slot] = {val, idx};
     }
   });
   grid.sync();
@@ -281,7 +287,8 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
   }
 
   const uint32_t tie_count = min(cnt->tie, kMaxNumTie);
-  for (uint32_t t = tx; t < tie_count; t += kBlockSize) smem.ties[t] = p.ws->ties[t];
+  for (uint32_t t = tx; t < tie_count; t += kBlockSize)
+    smem.ties[t] = p.ws->ties[t];
   __syncthreads();
   if (tx == 0) p.ws->parity = 1u - parity;
   impl::TopKConfig::handle_tie(smem.ties, problem, above_count, tie_count, p.topk - above_count, &smem.tie_handle);
@@ -293,9 +300,11 @@ __global__ __launch_bounds__(kBlockSize) void coop_topk_kernel(const __grid_cons
   }
   if (G == 1) {
     if constexpr (kTransform) {
-      for (uint32_t t = tx; t < above_count; t += kBlockSize) problem.transform_output(t, p.out[t]);
+      for (uint32_t t = tx; t < above_count; t += kBlockSize)
+        problem.transform_output(t, p.out[t]);
     }
-    for (uint32_t i = tx; i < kNumLevels * kHist0; i += kBlockSize) hist[i] = 0;
+    for (uint32_t i = tx; i < kNumLevels * kHist0; i += kBlockSize)
+      hist[i] = 0;
     if (tx < kCounterWords) {
       reinterpret_cast<uint32_t*>(&p.ws->cnt[0])[tx] = 0;
       reinterpret_cast<uint32_t*>(&p.ws->cnt[1])[tx] = 0;

--- a/python/sglang/kernels/jit/include/sgl_kernel/utils.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/utils.cuh
@@ -267,6 +267,7 @@ struct LaunchKernel {
   struct KernelConfig {
     bool use_pdl = false;
     std::optional<dim3> cluster_dim = std::nullopt;
+    bool cooperative = false;
   };
 
  public:
@@ -309,6 +310,24 @@ struct LaunchKernel {
     return *this;
   }
 
+  /// \brief Require the whole grid to be co-resident, for `cooperative_groups::this_grid()`.
+  /// \note The caller must size the grid to fit; see `host::runtime::get_blocks_per_sm`.
+  auto enable_cooperative(bool enabled = true) -> LaunchKernel& {
+#ifdef USE_ROCM
+    // Unlike PDL this is a correctness requirement, so silently dropping the
+    // attribute would hang the kernel at its first grid barrier.
+    RuntimeCheck(!enabled, "cooperative launch is not supported on this platform");
+#else
+    if (enabled) {
+      auto& attr = m_attrs[m_config.numAttrs++];
+      attr.id = cudaLaunchAttributeCooperative;
+      attr.val.cooperative = 1;
+      m_config.attrs = m_attrs;
+    }
+#endif
+    return *this;
+  }
+
   auto enable_cluster(dim3 cluster_dim) -> LaunchKernel& {
 #ifdef USE_ROCM
     (void)cluster_dim;
@@ -332,6 +351,7 @@ struct LaunchKernel {
   auto config(const KernelConfig& config) -> LaunchKernel& {
     if (config.use_pdl) this->enable_pdl(true);
     if (config.cluster_dim) this->enable_cluster(*config.cluster_dim);
+    if (config.cooperative) this->enable_cooperative(true);
     return *this;
   }
 
@@ -373,7 +393,8 @@ struct LaunchKernel {
 
   cudaLaunchConfig_t m_config;
   const DebugInfo m_location;
-  cudaLaunchAttribute m_attrs[2];
+  // One slot per attribute the enable_* methods can set at the same time.
+  cudaLaunchAttribute m_attrs[3];
 };
 
 // The empty-true-branch if/else form keeps a trailing `else` in user code

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -11,6 +11,7 @@ from sglang.kernels.jit.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.srt.environ import envs
 from sglang.srt.utils import is_xpu
 
 from .utils import make_name
@@ -43,7 +44,55 @@ def _jit_topk_v2_module():
             ("topk_transform_paged", "TopKKernel::transform_paged"),
             ("topk_transform_ragged", "TopKKernel::transform_ragged"),
             ("topk_plan", "TopKKernel::plan"),
+            ("topk_coop_workspace_bytes", "TopKKernel::coop_workspace_bytes"),
         ],
+    )
+
+
+# kClusterFloorSmall in topk_v2.cuh. The handoff guard the cooperative kernel
+# pairs with lives on the official kernel's cluster path, which a batch-1 row
+# only takes above this length.
+_COOP_TOPK_MIN_FLOOR = 32768
+
+
+def _coop_topk_floor() -> int:
+    # Row length above which paged top-k v2 hands off to the cooperative kernel;
+    # 0 is the wire value for "off". Read per call, like SGLANG_OPT_USE_TOPK_V2
+    # on this path; a captured graph freezes both at capture.
+    if is_hip_runtime() or not envs.SGLANG_OPT_USE_COOP_TOPK.get():
+        return 0
+    floor = envs.SGLANG_OPT_COOP_TOPK_FLOOR.get()
+    # Under the bound, a row the cooperative kernel claims can take the official
+    # kernel's non-cluster path, which carries no handoff guard: two writers into
+    # one output row. The kernel takes the floor as uint32_t, so a value past
+    # 0xffffffff would arrive truncated -- and truncated to 0 means "off".
+    if floor is None or not _COOP_TOPK_MIN_FLOOR <= floor <= 0xFFFFFFFF:
+        raise ValueError(
+            f"SGLANG_OPT_COOP_TOPK_FLOOR must be at least {_COOP_TOPK_MIN_FLOOR} "
+            f"and at most {0xFFFFFFFF} when SGLANG_OPT_USE_COOP_TOPK is set, "
+            f"got {floor}"
+        )
+    return floor
+
+
+@cache_once
+def _coop_topk_workspace(device_index: int) -> torch.Tensor:
+    # Cross-block state for the cooperative kernel: zeroed once here, and every
+    # launch leaves it ready for the next. One buffer per device serves every
+    # launch, so that handoff holds only while launches never overlap -- true
+    # while they are enqueued in order on the caller's stream, and false if a
+    # second stream ever reaches this entry point concurrently.
+    if torch.cuda.is_current_stream_capturing():
+        # Graph-private memory is reused after capture, so a buffer allocated
+        # here would be handed out again while a replay still reads it. Raising
+        # rather than asserting: python -O strips the assert and leaves the
+        # corruption silent.
+        raise RuntimeError(
+            "coop top-k workspace must be allocated before CUDA graph capture"
+        )
+    nbytes = int(_jit_topk_v2_module().topk_coop_workspace_bytes())
+    return torch.zeros(
+        -(-nbytes // 4), dtype=torch.int32, device=torch.device("cuda", device_index)
     )
 
 
@@ -148,6 +197,11 @@ def topk_transform_paged_v2(
     * ``page_tables`` given -- ``out_page_indices`` receives the page-table
       transform of them.
 
+    With ``SGLANG_OPT_USE_COOP_TOPK`` set, rows longer than
+    ``SGLANG_OPT_COOP_TOPK_FLOOR`` are instead selected by a second,
+    grid-cooperative kernel enqueued on the same stream; both output modes and
+    the contract below are unchanged.
+
     IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE, and
     ``metadata`` must come from :func:`plan_topk_v2` over the same ``seq_lens``
     values. The kernel reads lengths as ``uint32_t``: a negative entry
@@ -168,6 +222,7 @@ def topk_transform_paged_v2(
         )
         return
     module = _jit_topk_v2_module()
+    coop_floor = _coop_topk_floor()
     module.topk_transform_paged(
         scores,
         seq_lens,
@@ -175,4 +230,6 @@ def topk_transform_paged_v2(
         out_page_indices,
         page_size,
         metadata,
+        coop_floor,
+        _coop_topk_workspace(scores.device.index) if coop_floor else None,
     )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1158,6 +1158,15 @@ class Envs:
     # and benchmarks at parity, so this is a consolidation escape hatch, not a perf flip.
     SGLANG_OPT_USE_JIT_KERNEL_GROUPED_TOPK = EnvBool(False)
     SGLANG_OPT_USE_TOPK_V2 = EnvBool(True)
+    # Opt-in: hand batch-size-1 top-k v2 rows longer than the floor below to a
+    # grid-wide cooperative kernel, which spreads one row over every SM instead of
+    # one 8-block cluster. Needs SGLANG_OPT_USE_TOPK_V2 and a cooperative launch,
+    # so CUDA only. Measured on B200 at 512K-1M context; untuned elsewhere.
+    SGLANG_OPT_USE_COOP_TOPK = EnvBool(False)
+    # Rows with seq_len > this go to the cooperative kernel, the rest stay on the
+    # official one. Measured crossover on 8xB200 TP8; must be >= 32768, below which
+    # a batch-1 row can reach a top-k v2 kernel that carries no handoff guard.
+    SGLANG_OPT_COOP_TOPK_FLOOR = EnvInt(524288)
 
     # ===================================================================
     # Kernel selection and fused backends

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -20,23 +20,31 @@ and two cluster dispatch shapes: the fused small-batch kernel (batch <= 30) and
 the persistent-pool + main kernel (30 < batch <= 128). Boundary seq lengths
 (8192/8193, 16384/16385, 65535/65536/65537) and batch sizes (30/31, 128/129) are
 included explicitly, across k in {512,1024,2048} and identity/perm page tables.
+
+The opt-in cooperative kernel (``SGLANG_OPT_USE_COOP_TOPK``) is a fifth path that
+takes batch-1 rows away from Cluster; it has its own section further down.
 """
 
 from __future__ import annotations
 
+import contextlib
 import sys
 
 import pytest
 import torch
 
+from sglang.kernels.jit.utils import is_hip_runtime
 from sglang.kernels.ops.attention.dsv4.topk import (
+    _COOP_TOPK_MIN_FLOOR,
+    _coop_topk_floor,
     plan_topk_v2,
     topk_transform_paged_v2,
     topk_transform_ragged_v2,
 )
+from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
-register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=130, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 
 PAGE_SIZE = 64  # c4 page size = 256 // 4
@@ -268,6 +276,253 @@ def test_topk_v2_output_indices(batch: int, seq: int, k: int) -> None:
     our_raw = _run_raw(scores, seq_lens, k)
     ref_raw = _reference(scores, seq_lens, k)
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
+
+
+# --- cooperative handoff (SGLANG_OPT_USE_COOP_TOPK) --------------------------
+# With the handoff on, a grid-wide cooperative kernel runs after the official one
+# and takes the batch-1 rows longer than the floor, which the official kernel
+# returns early for. Both read the length from device memory, so the host cannot
+# tell which side a row lands on and the partition has to hold per row.
+# `_assert_topk_close` already fails on either way of getting it wrong: no writer
+# leaves -1 padding, two writers duplicate output slots.
+COOP_FLOOR = _COOP_TOPK_MIN_FLOOR  # the lowest floor either side accepts
+
+
+@contextlib.contextmanager
+def _coop_enabled(floor: int = COOP_FLOOR):
+    if is_hip_runtime():
+        pytest.skip("the cooperative handoff is CUDA-only")
+    with (
+        envs.SGLANG_OPT_USE_COOP_TOPK.override(True),
+        envs.SGLANG_OPT_COOP_TOPK_FLOOR.override(floor),
+    ):
+        yield
+
+
+@pytest.mark.parametrize("floor", [0, COOP_FLOOR - 1, 1 << 32])
+def test_topk_v2_coop_floor_out_of_range_is_rejected(floor: int) -> None:
+    """Floors the two kernels cannot partition the rows with are refused up front.
+
+    Under kClusterFloorSmall a row just past the floor takes the official
+    kernel's non-cluster path, which has no handoff guard, so both kernels write
+    it; 0 also reaches the kernel as the wire value for "off". Past 0xffffffff
+    the kernel's uint32_t truncates the value, and 1 << 32 truncates to exactly
+    that same "off", so the two ends of the range fail the same way.
+    """
+    with _coop_enabled(floor), pytest.raises(ValueError, match="at least"):
+        _coop_topk_floor()
+
+
+@pytest.mark.parametrize("k", [512, 2048])
+@pytest.mark.parametrize(
+    "seq",
+    [
+        COOP_FLOOR + 1,  # one past the floor: the cooperative kernel owns it
+        131072,  # whole float4 runs, no tail
+        131075,  # partial trailing float4, so the scalar tail is read
+    ],
+)
+@torch.inference_mode()
+def test_topk_v2_coop(seq: int, k: int) -> None:
+    torch.manual_seed(seq * 31 + k)
+    device = "cuda"
+    width = (seq + 3) & ~3
+    scores = torch.randn(1, width, dtype=torch.float32, device=device)[:, :seq]
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    num_pages = (seq + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(1, num_pages, "perm", device)
+
+    with _coop_enabled():
+        our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@pytest.mark.parametrize("k", [512, 2048])
+@pytest.mark.parametrize("seq", [1024, 20000, COOP_FLOOR])
+@torch.inference_mode()
+def test_topk_v2_coop_short_row_in_wide_buffer(seq: int, k: int) -> None:
+    """A row at or below the floor in a buffer wide enough to arm the handoff.
+
+    The host arms the cooperative launch without reading the length, so both
+    kernels run and only the device-side length decides which one writes.
+    ``seq == COOP_FLOOR`` is the boundary: the official kernel keeps it.
+    """
+    torch.manual_seed(seq * 17 + k)
+    device = "cuda"
+    width = 131072
+    scores = torch.randn(1, width, dtype=torch.float32, device=device)
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    page_table, inv_cpu = _make_page_table(1, width // PAGE_SIZE, "perm", device)
+
+    with _coop_enabled():
+        our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@pytest.mark.parametrize("k", [512, 2048])
+@torch.inference_mode()
+def test_topk_v2_coop_output_indices(k: int) -> None:
+    """No page table: the cooperative kernel must not run the page transform.
+
+    The transform is compiled out per mode rather than skipped at runtime, so a
+    mode that keeps it would gather through a null page table.
+    """
+    torch.manual_seed(9001 + k)
+    device = "cuda"
+    seq = 131072
+    scores = torch.randn(1, seq, dtype=torch.float32, device=device)
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+
+    with _coop_enabled():
+        our_raw = _run_raw(scores, seq_lens, k)
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@torch.inference_mode()
+def test_topk_v2_coop_reuses_workspace() -> None:
+    """Consecutive launches share one workspace that no caller ever clears.
+
+    Each launch leaves the histograms zeroed and zeroes the counter slot the next
+    launch will read, alternating between two slots. Launches 1 and 2 still read
+    slots the allocation zeroed, so launch 3 is the first to read one a launch
+    cleared and launch 4 is the first on the other slot: fewer than four trials
+    cannot tell the self-clean apart from the memset.
+    """
+    device = "cuda"
+    seq, k = 65537, 2048
+    width = (seq + 3) & ~3
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    page_table, inv_cpu = _make_page_table(1, seq // PAGE_SIZE + 1, "perm", device)
+
+    with _coop_enabled():
+        for trial in range(4):
+            torch.manual_seed(1234 + trial)
+            scores = torch.randn(1, width, dtype=torch.float32, device=device)[:, :seq]
+            our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+            ref_raw = _reference(scores, seq_lens, k)
+            _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@pytest.mark.parametrize("head", [0, 300])
+@torch.inference_mode()
+def test_topk_v2_coop_quantized_scores_force_refine(head: int) -> None:
+    """Scores coarse enough that the k-th value's level-0 bin overflows kMaxNumTie.
+
+    Over random floats the threshold bin sits in the sparse top tail and holds
+    far fewer than kMaxNumTie elements, so level 0 always breaks immediately and
+    the two refine levels, the extra grid barriers they take, and the
+    band_shift == 0 exit never run at all. Eight distinct values put ~16k
+    elements in one bin instead -- the shape a saturated or quantized indexer
+    score row has. ``head`` seeds a sparse band above the threshold so the
+    refine is also covered with a nonzero above-count.
+    """
+    torch.manual_seed(4242 + head)
+    device = "cuda"
+    seq, k = 131072, 2048
+    scores = torch.randint(0, 8, (1, seq), device=device).to(torch.float32)
+    if head:
+        scores[0, torch.randperm(seq, device=device)[:head]] = 9.0
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    page_table, inv_cpu = _make_page_table(1, seq // PAGE_SIZE, "perm", device)
+
+    with _coop_enabled():
+        our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@pytest.mark.parametrize(
+    "seq,nan_count",
+    [
+        (131072, 1),  # whole float4 runs
+        (131075, 3),  # odd length, so the last NaN is read by the scalar tail
+        (131072, 4096),  # more NaN than kMaxNumTie, so the tie buffer overflows too
+    ],
+)
+@torch.inference_mode()
+def test_topk_v2_coop_drops_nan_keeps_inf(seq: int, nan_count: int) -> None:
+    """NaN must not be selected, and +inf must still be.
+
+    The radix key is the order-preserving integer image of the float bits, under
+    which a positive NaN outranks +inf, so a NaN reaching the histogram is picked
+    as the largest element -- while the official kernel below the floor drops it,
+    which would make the two sides disagree on one row. NaN is also unordered
+    against itself, so the tie comparator answers false both ways: ranks collide,
+    output slots stay unwritten, and the page transform reads them anyway. The
+    +inf positions pin the other direction, that only NaN is dropped rather than
+    every non-finite value.
+    """
+    torch.manual_seed(31337 + seq + nan_count)
+    device = "cuda"
+    k = 2048
+    width = (seq + 3) & ~3
+    scores = torch.randn(1, width, dtype=torch.float32, device=device)[:, :seq]
+    perm = torch.randperm(seq - 1, device=device).tolist()
+    nan_pos = perm[: nan_count - 1] + [seq - 1]
+    inf_pos = perm[nan_count - 1 : nan_count + 7]
+    scores[0, nan_pos] = float("nan")
+    scores[0, inf_pos] = float("inf")
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    num_pages = (seq + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(1, num_pages, "perm", device)
+
+    with _coop_enabled():
+        our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+
+    selected = set(our_raw[0])
+    assert selected.isdisjoint(nan_pos), (
+        f"NaN selected: {sorted(selected & set(nan_pos))[:4]}"
+    )
+    assert set(inf_pos) <= selected, (
+        f"+inf dropped: {sorted(set(inf_pos) - selected)[:4]}"
+    )
+    # Mapping NaN to -inf is what the kernel does, so torch.topk over the mapped
+    # row is the reference; it also keeps the tie compare free of NaN.
+    clean = torch.where(scores.isnan(), torch.full_like(scores, -float("inf")), scores)
+    ref_raw = _reference(clean, seq_lens, k)
+    _assert_topk_close(clean.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+
+
+@torch.inference_mode()
+def test_topk_v2_coop_graph_capture_and_replay() -> None:
+    """The cooperative launch must survive capture, and replays must be correct.
+
+    cudaLaunchAttributeCooperative is set per launch and the grid is only legal
+    while it holds, so a capture that dropped it would turn the kernel's grid
+    barrier into a hang with no diagnostic. Decode runs this kernel inside a
+    captured graph; every other case here launches eagerly.
+    """
+    device = "cuda"
+    seq, k = 65537, 2048
+    width = (seq + 3) & ~3
+    seq_lens = torch.full((1,), seq, dtype=torch.int32, device=device)
+    page_table, inv_cpu = _make_page_table(1, seq // PAGE_SIZE + 1, "perm", device)
+    # The graph replays over this exact buffer, so the row is refilled in place.
+    scores = torch.randn(1, width, dtype=torch.float32, device=device)[:, :seq]
+    out = torch.full((1, k), -1, dtype=torch.int32, device=device)
+
+    with _coop_enabled():
+        # Eager first: the workspace allocation refuses to run under capture, and
+        # the plan synchronizes, so both have to be done before the graph opens.
+        _run(scores, seq_lens, page_table, inv_cpu, k)
+        metadata = _plan(seq_lens)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            topk_transform_paged_v2(
+                scores, seq_lens, page_table, out, PAGE_SIZE, metadata
+            )
+        for trial in range(3):
+            torch.manual_seed(555 + trial)
+            scores.copy_(torch.randn(1, seq, dtype=torch.float32, device=device))
+            out.fill_(-1)  # so a partial write shows up as missing slots
+            graph.replay()
+            torch.cuda.synchronize()
+            our_raw = [_invert(out.cpu().tolist()[0], inv_cpu[0])]
+            ref_raw = _reference(scores, seq_lens, k)
+            _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
 
 
 # --- ragged entry point ------------------------------------------------------

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -37,6 +37,7 @@ from sglang.kernels.jit.utils import is_hip_runtime
 from sglang.kernels.ops.attention.dsv4.topk import (
     _COOP_TOPK_MIN_FLOOR,
     _coop_topk_floor,
+    _coop_topk_workspace,
     plan_topk_v2,
     topk_transform_paged_v2,
     topk_transform_ragged_v2,
@@ -287,6 +288,33 @@ def test_topk_v2_output_indices(batch: int, seq: int, k: int) -> None:
 # leaves -1 padding, two writers duplicate output slots.
 COOP_FLOOR = _COOP_TOPK_MIN_FLOOR  # the lowest floor either side accepts
 
+# CoopWorkspace::parity as an int32 word index -- the witness that the cooperative
+# kernel ran. The result comparisons below are satisfied by the official kernel too,
+# so by themselves they cannot see arming fail; the lone exception is the 4096-NaN
+# case, where the official path selects NaN once the tie buffer overflows.
+# Layout from topk_coop.cuh:59-62: hist[3][4096] = 12288 words,
+# then Counters cnt[2] = 4 words, then parity. Written only at topk_coop.cuh:293,
+# after the last grid.sync(); the below-floor guard (:193) returns before the first,
+# so a row under the floor must leave it untouched.
+_COOP_WS_PARITY_WORD = 3 * 4096 + 2 * 2
+
+# Same layout, total size: 49,172 bytes through parity, padded to 49,176 because
+# TieValue is alignas(8) (topk_impl.cuh:170), then ties[2048] -> 65,560.
+_COOP_WS_BYTES = 65560
+
+
+def _coop_parity(ws: torch.Tensor) -> int:
+    # sizeof(CoopWorkspace) as the compiled module reports it, so reordering or
+    # extending the struct goes red here instead of silently reading another field;
+    # a size-preserving reorder is caught instead by callers comparing
+    # {before, after} == {0, 1} rather than !=, which no wrong offset satisfies.
+    assert ws.numel() * 4 == _COOP_WS_BYTES, (
+        f"workspace is {ws.numel() * 4} bytes, expected {_COOP_WS_BYTES}: the "
+        f"CoopWorkspace layout changed, so parity is not at word "
+        f"{_COOP_WS_PARITY_WORD}"
+    )
+    return int(ws[_COOP_WS_PARITY_WORD].item())
+
 
 @contextlib.contextmanager
 def _coop_enabled(floor: int = COOP_FLOOR):
@@ -356,9 +384,21 @@ def test_topk_v2_coop_short_row_in_wide_buffer(seq: int, k: int) -> None:
     page_table, inv_cpu = _make_page_table(1, width // PAGE_SIZE, "perm", device)
 
     with _coop_enabled():
+        ws = _coop_topk_workspace(torch.cuda.current_device())
+        before = _coop_parity(ws)
         our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
+        after = _coop_parity(ws)
     ref_raw = _reference(scores, seq_lens, k)
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+    # Every seq is at or below the floor while the buffer is wide enough to arm, so
+    # the coop kernel launches and must return at its below-floor guard without
+    # reaching the barrier that writes parity. The comparison above passes whichever
+    # kernel wrote the row, so nothing else here can see an inverted guard.
+    assert after == before and before in (0, 1), (
+        f"parity moved from {before} to {after} on a row at or below the floor: the "
+        f"cooperative kernel did work it must leave to the official kernel, so the "
+        f"two guards are not complementary"
+    )
 
 
 @pytest.mark.parametrize("k", [512, 2048])
@@ -398,12 +438,21 @@ def test_topk_v2_coop_reuses_workspace() -> None:
     page_table, inv_cpu = _make_page_table(1, seq // PAGE_SIZE + 1, "perm", device)
 
     with _coop_enabled():
+        ws = _coop_topk_workspace(torch.cuda.current_device())
         for trial in range(4):
             torch.manual_seed(1234 + trial)
             scores = torch.randn(1, width, dtype=torch.float32, device=device)[:, :seq]
+            before = _coop_parity(ws)
             our_raw = _run(scores, seq_lens, page_table, inv_cpu, k)
             ref_raw = _reference(scores, seq_lens, k)
             _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)
+            # The comparison above is satisfied by either kernel; this says which one
+            # produced it, and so is what puts the alternating-slot protocol on test.
+            assert {before, _coop_parity(ws)} == {0, 1}, (
+                f"trial {trial}: parity did not toggle, so the cooperative kernel "
+                f"never reached its final barrier -- the self-clean handoff this test "
+                f"exists to check was not exercised, and the results cannot show that"
+            )
 
 
 @pytest.mark.parametrize("head", [0, 300])
@@ -508,6 +557,9 @@ def test_topk_v2_coop_graph_capture_and_replay() -> None:
         # Eager first: the workspace allocation refuses to run under capture, and
         # the plan synchronizes, so both have to be done before the graph opens.
         _run(scores, seq_lens, page_table, inv_cpu, k)
+        # Already allocated by the eager run above, so this is a cache hit and cannot
+        # trip the under-capture raise. Read outside the graph, per replay.
+        ws = _coop_topk_workspace(torch.cuda.current_device())
         metadata = _plan(seq_lens)
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph):
@@ -518,8 +570,17 @@ def test_topk_v2_coop_graph_capture_and_replay() -> None:
             torch.manual_seed(555 + trial)
             scores.copy_(torch.randn(1, seq, dtype=torch.float32, device=device))
             out.fill_(-1)  # so a partial write shows up as missing slots
+            before = _coop_parity(ws)
             graph.replay()
             torch.cuda.synchronize()
+            # A graph that dropped the cooperative attribute, or never contained the
+            # launch, still replays and still returns the right answer; without this
+            # the assertions below cannot tell that apart from a captured launch.
+            assert {before, _coop_parity(ws)} == {0, 1}, (
+                f"replay {trial}: parity did not flip, so the captured graph contains "
+                f"no completed cooperative launch -- which is exactly what this test "
+                f"claims to rule out"
+            )
             our_raw = [_invert(out.cpu().tolist()[0], inv_cpu[0])]
             ref_raw = _reference(scores, seq_lens, k)
             _assert_topk_close(scores.cpu(), ref_raw, our_raw, 1, seq_lens.cpu(), k)


### PR DESCRIPTION
<!--
  PR body draft, 2026-09-04: the swap this comment asked for is done. Every results
  table quoted as the submission's own numbers now comes from cells 09-12 -- pristine
  main plus only this patch, the feature toggled by env var on ONE compiled artifact --
  so the quoted numbers come from exactly the code in this diff. The v0.5.17 and
  v0.5.18 cells remain in the document, labelled as reproduction across versions rather
  than as the submitted numbers. All four holds this comment referred to have been
  retired against their stated conditions; the token they used is deliberately absent
  from their settled records, so _pr_submit.sh:52's word-presence check stays meaningful
  for any hold added later.
-->

## Motivation

At batch size 1 the paged indexer top-k v2 kernel assigns one sequence row to at
most one 8-block cluster. On a 148-SM B200 that leaves most of the device idle
while a single row of up to ~1M scores is reduced, and the cost grows linearly
with context length. For long-context decode this is a measurable share of the
step: replacing this one kernel moves end-to-end TPOT by **+2.16% at 1M context on
GLM-5.3**, which is the measurement below on this branch rather than a profile
share. (Earlier drafts of this text quoted ~3% from a different tree and build;
the figure quoted here is the one this diff produces.)

**Scope, stated up front: this is primarily a GLM speedup.** One patch and one
kernel serve both model families — see the routing note below — but the two do not
gain equally, and the tables are laid out so that is visible rather than averaged
away. On GLM-5.3 the gain is real and grows monotonically with context, +1.21% at
512k to +2.16% at 1M. On DeepSeek-V4 it is small enough that this PR does not
claim it: no row on either V4 ladder on this branch reaches +0.6%. V4-Pro's three
publishable rows are +0.28%, +0.46% and +0.47% at 512k, 640k and 768k — those sit
above the harness's own no-op band and are the only V4 rows this PR would defend,
and at that same 768k rung GLM-5.3 measures +1.50%. On V4-Flash every row where
the kernel can fire is either inside that band or carries the aggregator's
within-noise flag, the largest being +0.31%, so that ladder establishes no gain at
all and is not offered as one. The V4 tables are here as a reproduction of the
shape, not as a speedup. Why the same kernel does so much less on V4 is explained
just above those tables.

This adds a second top-k kernel that reduces one row across the whole grid with
a cooperative launch, and routes rows to it by length: below a floor the existing
v2 kernel keeps the row unchanged, above the floor the cooperative kernel takes
it. It is off by default, and with it off the existing path is behaviourally
unchanged — what it gains is one compare against a sentinel floor that never
fires, one field in the `__grid_constant__` parameter struct, and an `#include`.

## Modifications

Six files, +820 −3 — that stat is `git apply --numstat` against `dae126d510`, not a
figure typed by hand, and the diff applies to that commit with no context fuzz.
Five files are inert unless `SGLANG_OPT_USE_COOP_TOPK` is set; the
sixth is the launch-helper change of commit 1, which is unconditional
infrastructure:

| file | change |
| --- | --- |
| `python/sglang/kernels/jit/include/sgl_kernel/utils.cuh` | let `host::LaunchKernel` request a cooperative launch |
| `python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh` | new: grid-wide cooperative top-k |
| `python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh` | handoff guard, workspace accessor |
| `python/sglang/kernels/ops/attention/dsv4/topk.py` | host-side floor resolution and validation |
| `python/sglang/srt/environ.py` | `SGLANG_OPT_USE_COOP_TOPK`, `SGLANG_OPT_COOP_TOPK_FLOOR` |
| `test/registered/kernels/ops/attention/test_topk_v2.py` | tests |

**Why a patch under `deepseek_v4/` is the GLM patch as well.** Every file above sits
in a DeepSeek-named directory, while the largest gains reported below are on GLM.
That reads as a contradiction until the routing is followed, so it is stated here
rather than left to a reviewer to reconstruct. `GlmMoeDsaForCausalLM` is declared as
a subclass of `DeepseekV2ForCausalLM`
(`python/sglang/srt/models/glm4_moe.py:1444`), so the GLM DSA models inherit
DeepSeek's attention path outright; and the DSA top-k backend that both families
reach imports the patched host wrapper directly —
`from sglang.kernels.ops.attention.dsv4.topk import topk_transform_paged_v2`
(`python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py:309` on decode, with
the ragged prefill twin at `:362`). Both line numbers are quoted at `dae126d510`,
the commit this diff applies to. The `dsv4` in the path is a historical name, not a
scope, which is why one patch and one PR cover both model families rather than two.

The measurements are themselves the strongest evidence of that routing:
`SGLANG_OPT_USE_COOP_TOPK` gates nothing but this kernel, and arming it moves
GLM-5.3 on the submission branch by up to **+2.16%**, while every row where the
floor keeps the kernel from firing sits inside the measured zero band. Were GLM
not going through the patched kernel, arming the flag would be a no-op on GLM.

The first commit is separable and useful on its own: `host::LaunchKernel` had no
way to set `cudaLaunchAttributeCooperative`, so any cooperative kernel in this
tree would have had to bypass the launch helper.

Design notes:

- **Selection.** Three-level radix histogram over the monotone integer image of
  the scores (4096 buckets, then 1024, then 1024 again at full key width),
  narrowing to the k-th value. Ties at the k-th value go through the shared
  `handle_tie`, so the selected *values* match the existing kernel exactly. They
  carry the same caveat it does: a band still holding more than the 2048-entry tie
  buffer at full key width keeps an arbitrary 2048 of them, so the result is a
  valid top-k but the index set it names is not fixed across launches. That is
  pre-existing behaviour (`kMaxNumTie` is the same constant in `topk_impl.cuh`),
  not something this patch introduces.
- **Workspace.** 65,560 bytes, allocated once and outside CUDA-graph capture.
  Each launch leaves the workspace in the state the next launch needs, so the
  caller never memsets it; a `parity` field double-buffers the one slot that has
  to survive across launches.
- **Handoff.** The guard added to `topk_v2.cuh` and the early return in
  `topk_coop.cuh` are exact inverses, so every row is handled by exactly one of
  the two kernels.
- **NaN.** The row is read through a single helper that maps NaN to `-inf` before
  anything ranks it, so a NaN is never selected. Neither does the existing kernel
  select one, as a side effect of classifying with `>=` — but "never selected" is
  the whole of what the two share on such a row, and this PR does not claim their
  answers otherwise agree on it (see the classifier note below). This is load-bearing
  rather than cosmetic: the monotone integer key the radix histogram ranks on maps
  a positive NaN *above* `+inf`, so an unsanitized NaN would be selected as the
  largest element and the two sides of the floor would disagree on the same row.
  NaN is also unordered against itself, which makes the shared tie comparator
  answer false in both directions, colliding ranks and leaving output slots
  unwritten. The existing kernel's two classifiers disagree about NaN:
  `extract_coarse_bin` in `topk_impl.cuh` classifies through fp16, where a NaN
  lands in a bin above `+inf`'s, while the collect pass classifies with `>=`,
  which is false in both directions for a NaN. This patch does not touch that
  path. An earlier draft of this bullet summarized the consequence as "a NaN
  shifts that kernel's coarse threshold while still never being selected." That
  is too mild, and I am correcting it rather than leaving it, because it would
  invite a reviewer to wave the case through. Traced end to end in
  `topk_impl.cuh` — every step below read in this tree, not inferred:
  - `extract_coarse_bin` casts through fp16, so a positive NaN becomes ordered
    key `0xFE00` and lands in bin 1016 at `kHistBits = 10`, above `+inf`'s 1008,
    and the histogram counts it like any other element.
  - `coarse_bin_lower_bound` saturates NaN-space keys to `FLT_MAX` on *both*
    edges, and `0.5f * (FLT_MAX + FLT_MAX)` overflows, so a threshold bin in NaN
    space yields `v_lo == v_hi == +inf` rather than a finite boundary.
  - The collect pass classifies `val >= v_hi` / `else if (val >= v_lo)`, and both
    comparisons are false for a NaN, so the NaN enters neither `count_gt` nor
    `count_eq` — while the fp16 histogram already counted it. Phase 4 then drives
    the output layout from the collect counts, which its comment says is
    deliberate ("even if rounding moves a boundary element"); that is right for
    rounding, but for a NaN the element is in *neither* set, so the layout is
    short by the NaN count.
  - `handle_tie` makes up the shortfall in its padding branch, which is
    `problem.emit(base + t, base + t)` — the slot number emitted as the raw index.

  So on a row carrying at least `topk` NaN, the threshold bin *is* the NaN bin,
  nothing finite is collected at all, and every output slot is filled with raw
  indices `0..k-1`: the row's answer becomes "the first k tokens", silently, with
  no out-of-bounds access to give it away. With fewer than `topk` NaN, up to that
  many slots can be fabricated depending on how fat the threshold bin is. This is
  pre-existing behaviour in `main` and **not** introduced here — I verified that
  `topk_impl.cuh` is byte-identical between this PR's base (dae126d510) and the clone
  I read it in — and it needs a row with NaN scores to reach, which in the DSA
  indexer means something upstream is already broken. It is stated because
  `coarse_bin_lower_bound`'s own comment names exactly this failure mode ("rows
  whose scores contain >= topk (+/-)inf or >65504 values come back short — the
  padded slots then illegal-address downstream") and hardened it for `±inf`; the
  NaN saturation on that line was for boundary monotonicity and does not fix the
  classification, so the guarded-against mode is still live for NaN. The
  cooperative kernel's `drop_nan` closes it on the rows it owns. That also means
  the two halves of the same build genuinely disagree on a NaN row — fabricated
  indices below the floor, a correct top-k of the finite values above it — and
  this PR claims the improvement rather than parity.

  Three things about how much this matters, because "needs a NaN to reach it" is
  easy to read as "theoretical", and it is a weaker statement than it looks:

  - **This bug class has already been a production incident, for `inf` rather than
    NaN.** Commit `bda1dc0d95` — *"[DSA] Fix top-k v2 emitting invalid indices under
    tie overflow / inf scores (IMA in FA3 sparse decode)"* (#30645), +168/−87 on this
    exact file, already in `main` at this PR's base — is the same failure walked all
    the way to an illegal memory access in FA3 sparse decode. Its own comment is the
    one quoted above. So the mode is not hypothetical; it has been hit, diagnosed and
    fixed once, and the fix's saturation of NaN-space keys was for boundary
    monotonicity, which is why `+inf` boundaries and therefore the NaN gap remain.
  - **I audited whether a NaN can actually reach these scores, and the answer is
    robustness-only — but the thing standing in the way is an unenforced invariant,
    not a sanitizer.** No NaN generator exists in any in-tree logits producer: the
    indexer scoring is `relu → ×weight → sum → ×k_scale` with no softmax and no
    normalization, so there is no `0×inf`, no `inf−inf` and no divide-by-a-zero-sum;
    every fp8/fp4 quantizer floors the amax before reciprocating (`fmaxf(1e-4f,
    abs_max)`), so no zero or infinite dequant scale; and the Q-side scale is folded
    in as a product, never a quotient. There is no `nan_to_num`, `isnan`, `isfinite`
    or finiteness assert anywhere between any producer and this kernel. What keeps
    the kernel safe is that it provably reads only `[0, seq_len)` — while NaN-capable
    uninitialized bits are *deliberately* present in the same buffer a few columns
    further along, because the DeepGEMM path passes `clean_logits=False` over a
    `torch.empty` buffer and an in-tree test (`test_dsa_skip_logits_clean.py`) asserts
    that the invalid tail really is not all `-inf`. One producer, `sgl-deep-gemm`, is
    an external package I could not read, so it is bounded only indirectly by its
    inputs being fp8-clamped. The gap is narrow rather than comfortable, and
    `drop_nan` is one comparison.
  - **There is no NaN test for the base kernel.** The NaN coverage this PR adds
    (`test_topk_v2_coop_drops_nan_keeps_inf`) runs entirely under `_coop_enabled()`,
    so it exercises the new path only. I have deliberately not added a base-kernel
    NaN test that would fail, since that would make this PR's own CI red for a
    pre-existing bug; a maintainer may reasonably want it added as an `xfail`.
- **Graph capture.** In a standalone probe on sm_100, capture and three replays
  produce correct results, so `cudaLaunchAttributeCooperative` survives capture (a
  dropped attribute would hang on the first grid barrier rather than return a wrong
  answer). The registered test that encodes this is newer than the probe and its
  own status is in Correctness.

## Accuracy Tests

- **Unit tests.** `test/registered/kernels/ops/attention/test_topk_v2.py`
  compares the cooperative kernel against the reference implementation, and
  covers the handoff boundary in both directions, the rejected-configuration
  branch, the no-page-table output mode, the scalar tail of the vectorized read,
  workspace reuse across four consecutive launches, CUDA-graph capture and
  replay, and a row carrying both NaN and `+inf` (the NaN must be dropped and the
  `+inf` kept, in the float4 body and in the scalar tail, and over a row where
  NaN outnumbers the tie buffer's capacity). Note what that last case does *not*
  do, because a comment in the submitted test file claims otherwise: it does not
  overflow the tie buffer. `drop_nan` maps NaN to `-inf`, whose exact-bin key is
  the bottom of the ordering, and the row is `randn` with `k = 2048`, so the
  threshold band sits near +2.2σ and the 4096 `-inf` keys cannot reach it. The
  case is still worth having — it covers the vector and scalar paths over a
  NaN-dominated row — but the inline comment `# more NaN than kMaxNumTie, so the
  tie buffer overflows too` is wrong about why. The test that genuinely overflows
  the tie buffer is the quantized-scores one described just below, and its own
  docstring says so correctly. The comment is left as-is rather than corrected so
  that the tree these numbers were measured on stays byte-identical to the
  submitted diff; it should be fixed in review. Eight new test functions, 24 new parametrized cases; the
  file's CI budget goes from 90 s to 130 s. One test feeds deliberately coarse
  scores so that the k-th value's level-0 bin overflows the tie limit and the
  refine loop actually runs — over `randn` the search always terminates at level
  0, so without it two of the three radix levels never execute, nor the grid
  barrier inside that loop, and no test ever leaves `hist[1]`/`hist[2]` dirty for
  the workspace's self-clean to handle. Every boundary case runs at the minimum
  legal floor, 32768, to keep the rows small; what it exercises is the
  length-against-floor comparison, which does not depend on the floor's magnitude,
  so the shipped default of 524288 is covered by the measurements rather than by a
  unit test.
  <!-- SETTLED 2026-09-04: the log line this block waited for is now quotable from
       all four main-branch cells (FORENSICS_20260904T030445Z.txt, section F6). The
       paragraph below states the result instead of withholding it. -->
  **Status on B200 / sm_100, and how it is known.** Seven of the eight new functions
  have passed on this hardware, including `..._coop_reuses_workspace` and
  `..._coop_graph_capture_and_replay`, which failed on a first attempt and whose
  fixes are in this diff. That is asserted from the harness rather than from a
  screenshot of a test run: every cell whose numbers this PR quotes runs
  `pytest test/registered/kernels/ops/attention/test_topk_v2.py -k "not drops_nan"`
  as its first act, and on failure exits before either server boots — so a cell that
  fails this gate produces no timings at all. The gate is not hypothetical; it fired.
  The four certifying cells were queued once against a tree in which those two
  functions still failed, aborted on exactly this gate, and yielded nothing, which is
  why they were re-queued with the fixes in place. The three cells behind every
  main-branch table below then produced complete context ladders. Timings existing is
  therefore the pass: 21 parametrized cases on the cooperative path, plus the file's
  pre-existing v2 suite, on the tree those cells ran.

  **That tree is not byte-identical to the submitted one, and the difference is dated.**
  Each cell records `GITHEAD=1fb8505` and `PATCHED_FILES=6`, the latter being
  `git status --porcelain | wc -l` — a count, not a content check. No hash of the six
  patched files was recorded and no `pytest` summary line was collected, so nothing
  here pins the copy that ran to a byte-exact revision; what does pin the fixes is the
  abort described above, since a tree in which those two functions failed yielded no
  timings at all. One difference is known outright: the last commit in this diff adds
  61 lines to the test file and nothing else, and it was authored after the last cell
  log was collected. Those 61 lines are the parity witness — `_coop_parity`, two
  `{before, after} == {0, 1}` assertions and one below-floor negative assertion — so
  **no collected log witnesses them run.** An uncollected container run between that
  commit and the halt is not excluded, so what is asserted here is the bound and not the
  absolute; nothing on record covers those 61 lines, and CI on this PR should be treated
  as their first execution. Their single layout constant is checked
  by construction rather than by trial: `hist[3][4096]` followed by
  `Counters{win,tie}[2]` puts `parity` at word 12292, and `TieValue` (`alignas(8)`,
  8 bytes) times 2048 after padding gives 65560. Both match `sizeof(CoopWorkspace)`,
  which is their single source, exported through `coop_workspace_bytes()` and derived
  rather than duplicated on the Python side.

  The eighth function is the three NaN cases, and **their result is deliberately not
  inferable the same way.** They were written last, after the certifying cells were
  queued, and are run as a *second, non-blocking* invocation — `-k "drops_nan"`,
  whose failure branch says `timings still produced, correctness claim withheld`.
  That split was chosen on purpose: a bad test should not cost a night of timings.
  The cost of the choice is exactly here, and it is not to be papered over — for
  these three cases the existence of the numbers below is no evidence whatsoever.
  **That log line can now be quoted, so the withholding is lifted.** All four
  main-branch cells — the only cells whose numbers this PR quotes — print
  `SELFCHECK_NAN_PASS` in their console logs, at line 32 of each: `pr_glm52`,
  `pr_glm53`, `pr_v4flash` and `pr_v4pro`. No cell anywhere prints
  `SELFCHECK_NAN_FAILED`. So the three NaN cases pass on B200 / sm_100 on the tree those
  cells ran, whose only recorded difference from the submitted one is in the test file
  (dated above), and the NaN row of the coverage list above may be read as passed rather than
  merely covered. Two silences are part of the claim rather than footnotes to it.
  **The eight v0.5.17 / v0.5.18 cells print `SELFCHECK_PASS` and no `SELFCHECK_NAN`
  line in either polarity**, because the NaN cases were written after those cells were
  queued — and it is the `SELFCHECK_PASS` line that makes that absence a real absence
  rather than a grep that missed, which is why both polarities and a positive control
  are collected together. **The V4-Pro cell's first boot is silent the same way**, and
  from the other side of the same boundary: it was queued before the NaN cases existed,
  it is not a cell whose numbers this PR quotes, and its silence independently dates the
  two boots.
- **Cooperative launch under graph capture.** The failure mode worth ruling out
  is `cudaLaunchAttributeCooperative` being dropped at capture, which would turn
  the grid barrier into a hang with no diagnostic. Probed directly on sm_100:
  eager launch correct; capture accepted; three graph replays each correct.
- **End-to-end text comparison is *not* offered as evidence.** On these models
  the baseline itself is not reproducible run to run: within a single leg, five
  repeats of the same prompt produce five different continuations. Lengths below
  the floor — where this patch's kernel provably never executes — diverge between
  legs just as much as lengths above it. Any character-level comparison here
  measures baseline nondeterminism, not this change.
- **If one of these tests fails, the reported failure will overstate the damage,
  and the cause is upstream rather than in this diff.** `EnvField.override` in
  `python/sglang/srt/environ.py` is a `@contextmanager` whose restore path sits
  after a bare `yield` with no `try`/`finally`, so an exception raised inside the
  `with` body skips restoration and the variable leaks for the rest of the process.
  The new tests drive both env vars through a `_coop_enabled` fixture built on it, so
  they inherit this. The concrete case: `test_topk_v2_coop_floor_out_of_range_is_rejected`
  wraps `pytest.raises(ValueError)` inside the fixture, so if the floor validator ever
  *stops* rejecting a bad floor — a genuine regression — `pytest.raises` raises, the
  override never unwinds, and every later test in the file runs with the cooperative
  path forced on at a rejected floor and fails with `ValueError`. One real failure
  presents as a suite-wide collapse.

  Left as-is deliberately, for two reasons. `override` is untouched by this diff and
  is pre-existing upstream code with **492 call sites** across the repository, so every
  test that uses it has the same exposure — fixing it here would be an unrelated
  repo-wide change riding on a performance patch. And the numbers below were measured
  from exactly this tree, so amending the diff now would break the property that the
  submitted code is the measured code. Flagging it rather than fixing it: a `try`/`finally`
  around that one `yield` would fix it for all 492 sites at once, and is worth doing
  separately.

## Speed Tests and Profiling

All measurements on **8x B200, TP8, single node, no expert parallelism**.
Metric is `per_req_tpot_ms` at batch size 1 on real long-context text, 192
output tokens, median of 5 repeats per point. The only difference between legs is
this patch's kernel.

**What "baseline" means here, stated precisely, because a speedup is only as good as
what it is measured against:**

* `SGLANG_OPT_USE_TOPK_V2=1` is pinned on both legs — but that is **belt-and-braces,
  not an upgrade**: it is already the default (`EnvBool(True)`, `python/sglang/srt/environ.py:1160`),
  as is `--dsa-topk-backend sgl-kernel`. Pinning it only makes the configuration
  explicit in the launch line. An earlier draft of this section implied the pin was
  what made the baseline fast; it is not.
* The stronger statement is about dispatch. At batch 1 with a score row above
  `kClusterFloorSmall` (32768), `topk_transform_paged` reaches
  `topk_small_batch_kernel` and takes its cluster branch — `TopKCluster<8>`, all eight
  blocks splitting the row. That is the **widest kernel v2 has for this shape**, not a
  fallback: `Register4` caps at 16384 elements and physically cannot hold these rows,
  `Streaming` is a single block and is gated to `seq_len <= cluster_floor` anyway, and
  `topk_persistent_cluster_kernel` runs the *same* `Cluster::forward` but is gated to
  batch > `kNumPersistentClusters` and needs a second `topk_main_kernel` epilogue
  launch, so at batch 1 it would be the same eight blocks plus an extra launch. There
  is also no autotune, no tuned-config cache and no plan tuning on this path — at
  batch 1 `topk_small_batch_kernel` never reads the plan's `cluster_threshold` at all.
  Eight blocks on a 148-SM B200 is exactly the headroom this patch attacks.
* **The baseline is this binary with the handoff disarmed, not upstream `main`
  bit-for-bit.** The disarmed leg still carries one `uint32_t` in the
  `__grid_constant__` params struct and one never-taken `problem.seq_len >
  params.coop_floor` compare against `kCoopFloorOff`, plus one env read per call. Both
  legs are the same binary, so this cancels in the delta — but the honest claim is
  "coop off vs coop on in one build", which is also the stronger one.
* One adjacency worth volunteering: `--dsa-paged-mqa-logits-backend` defaults to
  `auto`, which resolves to DeepGEMM, while its own help text says `cutedsl` "wins at
  low batch size and long context" (`python/sglang/srt/server_args.py:1808`) — literally this regime, and
  SM100 is available here. That is the indexer **scoring** kernel; it never enters the
  top-k dispatch and is identical on both legs, so no delta below is affected. But the
  e2e TPOT denominator does contain a scoring kernel that is arguably not on its
  fastest setting, so read these percentages as "same scoring backend on both legs"
  rather than "the fastest server configuration that exists".

The table below is the **main branch with this patch applied**, which is the tree this PR
submits. An earlier revision of this section carried the v0.5.17 cell instead, marked
provisional, and its figures were higher: +1.79% at 512k rising to +3.19% at 1M. Those
numbers are real and are reported separately, but they were measured on a different tree
and a different build, so they are **not** this patch's result on main and the difference
between the two is not a version effect — nothing here separates tree, build and boot.
The rule this campaign follows is that a comparison is only meaningful within one build,
which is exactly why both legs of every table below come from the same binary.

### GLM-5.3, floor 524288

| context | prompt_tokens | baseline (ms) | with coop (ms) | speedup |
| --- | --- | --- | --- | --- |
| 32k | 31,486 | 16.046 | 16.080 | &mdash; (below floor) |
| 64k | 61,928 | 16.127 | 16.173 | &mdash; (below floor) |
| 128k | 126,350 | 16.231 | 16.275 | &mdash; (below floor) |
| 256k | 272,851 | 16.377 | 16.420 | &mdash; (below floor) |
| 512k | 549,126 | 16.601 | 16.400 | **+1.21%** |
| 640k | 663,402 | 16.707 | 16.502 | **+1.23%** |
| 768k | 784,306 | 16.810 | 16.558 | **+1.50%** |
| 896k | 908,021 | 16.926 | 16.619 | **+1.81%** |
| 1M | 1,040,025 | 17.038 | 16.670 | **+2.16%** |

The gain appears exactly at the floor and grows monotonically with context
length, which is what a per-row reduction whose cost is linear in row length
should do. Note that floor membership follows the real `prompt_tokens`, not the
nominal label: the 256k body tokenizes to 272,851 (below 524288) and the 512k
body to 549,126 (above).

### GLM-5.2, floor 524288

| context | prompt_tokens | baseline (ms) | with coop (ms) | speedup |
| --- | --- | --- | --- | --- |
| 32k | 31,486 | 16.044 | 16.081 | &mdash; (below floor) |
| 64k | 61,928 | 16.134 | 16.169 | &mdash; (below floor) |
| 128k | 126,350 | 16.236 | 16.274 | &mdash; (below floor) |
| 256k | 272,851 | 16.384 | 16.425 | &mdash; (below floor) |
| 512k | 549,126 | 16.622 | 16.402 | **+1.32%** |
| 640k | 663,402 | 16.714 | 16.504 | **+1.26%** |
| 768k | 784,306 | 16.815 | 16.555 | **+1.55%** |
| 896k | 908,021 | 16.928 | 16.622 | **+1.81%** |
| 1M | 1,040,025 | 17.040 | 16.675 | **+2.14%** |


**On the size of the error bar.** Spread within a single leg (max-min over the
median) is 0.03-0.66% across the two V4 tables below (V4-Pro and V4-Flash), once
the excluded 512k rung is set aside — its own legs span 4.27%. But that is jitter inside one boot and is
not the bar that matters, because the two legs are two separate boots. The bar that matters is how
far apart two boots land when the kernel cannot fire, and that is measured
directly rather than assumed: every below-floor row of the thirteen live A/B cells
(two apiece on seven V4 ladders, four apiece on six GLM ladders), plus every
length of two further arms of the same A/B with the floor set beyond the whole
ladder so the cooperative launch is never enqueued (nine rows and five). That is
**52 rows in which the patch provably does nothing**, and they span **-0.658 to +0.015 pp**. So
two boots of a configuration that does nothing can differ by up to about 0.66 pp.
That is **5.5x the median per-rung spread of those same two V4 tables** — 0.120%,
taking the wider of each rung's two legs, over their 15 non-excluded rungs — and it
is larger than 14 of those 15, which is why the within-leg column cannot stand in
for it. The two units are worth keeping straight, because a reader who pairs the
per-LEG range just quoted (0.03-0.66%, 30 legs) with the per-RUNG median here (0.120%, 15
rungs) gets 22x from one and 5.5x from the other; both are right and they answer
different questions.

**Two figures in this section round to 0.66 and they are unrelated.** The bar is
**-0.658 pp**, a *delta* between two boots, measured at v0517/v4flash 64k. The
widest kept spread is **0.66%**, a *spread* within one leg, at main/pr_v4flash 1M
safe. Different cells, different quantities, independently measured — and they
coincide to the precision each is quoted at, so the ratio between them is 1.00x.
Nothing about the bar is derived from that spread; if it were, comparing them would
be circular, and the coincidence is close enough to invite exactly that reading.
<!-- SETTLED 2026-09-04. Nothing in this block is open, and the history is kept
     because the same digits were correct under three different premises. It once said
     main/pr_v4pro was mid-re-run with its rows temporarily absent, so pooling att1 was
     a temporary expedient and 42/41 would move "once the cell has rows again". The cell
     landed; copy_premise_broken() reports 7 of 7 shared rungs DIFFERING, so att1 is a
     genuine second boot and pooling it is permanently right rather than a stopgap.
     Then main/pr_glm52 landed too, exactly as this block predicted, adding a sixth GLM
     ladder and four below-floor rows: 42/41 -> 48/47 -> 52/51, with both band EDGES
     unmoved at every step (the generator re-derives them every run and printed no
     widening warning). Provenance, and quote it with the counts:
       aggregate=AGG_FINAL.tsv md5=b005bde09e21dfdf277e05fc7ff62515
       dedup-policy=PAIRED_RERUNS[empty (pooled: both boots counted)]
     Re-derive, never hand-count: `python3 _audit_dupcounts.py AGG_FINAL.tsv` and
     `_check_peer_claims.py AGG_FINAL.tsv` item 2. NOTE for whoever re-derives next: the
     stale-figure arm hunts the 42-generation, not the 48-generation, so it stayed green
     through this edit -- the 48 sites were located by calling its own scan_docs() with
     the 48/47 pair, and its patterns are blind to three real forms (a word between the
     digit and "rows", markup between them, and the ordered-pair form "48/47"). The
     patterns locate sites; they do not certify that none was missed. -->
The count pools both boots of the V4-Pro cell, and the right answer here changed
twice. Attempt 1 was copied aside under a second name before a requeue; while both
names held the same seven rungs it was one measurement counted twice and was
correctly subtracted, and now that the requeue has landed and all seven shared
rungs differ, subtracting it would count a real boot pair zero times instead of
once. Whether something is a duplicate is a property of the data, not of the name.


That bar is also, empirically, **one-sided**: 51 of the 52 rows are negative, the
single exception is +0.015 pp, and the widest is -0.658. Every one of the fifteen
contributing boots reproduces the sign — fourteen cells, the V4-Pro one contributing
both of its boots — and their below-floor means are -0.04, -0.05, -0.23, -0.26, -0.27,
-0.28, -0.28, -0.31, -0.36, -0.40, -0.41, -0.42, -0.44, -0.56 and -0.62 pp. Each of those
means is over that boot's own below-floor rows, and the row set differs between the
two kinds of boot: a feature cell contributes the two or four rungs beneath its
floor, while the two calibration cells have a floor beyond the ladder and so
contribute every rung they measured, nine and five. That is why the v0.5.17 GLM-5.3
calibration cell reads -0.44 pp in this list but -0.38 pp in the 2x2 contrast
below, where it is cut down to the four rungs its partner cells share: one cell
over two row sets, not two measurements of one. The bar can therefore make a real gain look smaller but cannot
manufacture one, so the speedups below are understated by up to about 0.66 pp
rather than inflated by it, and it is quoted as a magnitude in the conservative
direction rather than as a symmetric interval.

Against that 0.66 pp bar, the main-branch GLM-5.3 cell gives **1.8x** at 512k
(+1.211%) and **3.3x** at 1M (+2.160%). The v0.5.17 cell, on its own separate
tree and build, gives 2.7x and 4.8x; both clear the bar by a wide margin, and it
is the main-branch pair that describes this PR.
Rows whose magnitude falls under twice their own spread are flagged by the
aggregator and are not used to support any claim here.

**Which bar applies to which number.** The 0.66 pp figure bounds a single raw
per-length delta, because it is dominated by a per-boot offset that a raw delta
carries whole. Two of the estimates below cancel that offset by construction — a
step measured within one cell across its own floor, and a same-length contrast
against the floor-beyond-the-ladder arm of the same model, version and leg order —
and for those the residual bar is the drift of the control along the ladder
(0.071 pp over five lengths) plus the parallel-trends residual where neither cell
arms (0.046 pp). Applying the raw bar to those, or their bar to a raw delta,
misstates the DeepSeek-V4 result by roughly 7x in one direction or the other.

<!-- SETTLED 2026-09-04 10:41: the GLM-5.2 main-branch cell landed with all nine
     rungs and is spliced in above (+1.32% at 512k to +2.14% at 1M), alongside the
     GLM-5.3 main-branch cell (+1.21% at 512k to +2.16% at 1M). The two V4 tables below
     are final. Every table in this document came from _splice_tables.py reading the
     aggregator's TSV; re-run that splice, do not hand-edit a cell. -->

### Why the same kernel gains much less on DeepSeek-V4

The kernel replaces one stage: the reduction of a single row of indexer scores.
Its work therefore scales with the length of that row, and that row is not
`seq_len` on V4. The C4 path scores a compressed row — `c4_seq_lens: seq_lens //
4` (`python/sglang/srt/layers/attention/dsv4/metadata.py:49` at `dae126d510`) — so
at any given context length V4 hands this kernel a quarter of the elements GLM
does. The stage being replaced is correspondingly a smaller part of the decode
step, and the achievable end-to-end gain is capped by that share no matter how
much faster the stage itself becomes. This is also why the two floors in the table
above differ by 16x while both are expressed in score-row elements: they are
tuned against row length, not against prompt length.

Earlier B200 profiling on this same v2 implementation is consistent in direction —
the indexer top-k stage measured single-digit percent of TPOT at 1M on GLM-5.2 and
a fraction of a percent on V4-Pro — but those runs used a different tree and
denominators that are close rather than identical, so they are offered as
corroboration of the direction and not as a coefficient. This PR does not attempt
to attribute the residual difference beyond the row-length fact above.

The two DeepSeek-V4 tables on the submission branch itself follow. Read them as
**a reproduction of the shape and not as a gain**: on V4, no row on this branch
clears the systematic bar in either direction, and both ends of the V4-Flash
ladder are named below the table rather than only the favourable one.

<!-- SETTLED 2026-09-04: the re-splice is done and the document is no longer split
     across two boots. The table below and the prose after it are boot 2
     (main/pr_v4pro, +0.28 / +0.46 / +0.47), matching the Scope paragraph at the top,
     which was already boot 2. Residue check from this marker's own instructions,
     `grep -n '0\.33%\|0\.42%\|0\.55%' _pr_body.md index.html`, now returns only
     this comment and an unrelated GLM below-floor mean of -0.42%.

     WHICH BOOT IS WHICH is settled by three independent signals, not by recency:
       (1) status: main/pr_v4pro is status=done, main/pr_v4pro_att1 is status=INCOMPLETE
           (its driver was rewritten underneath it and died before its own done marker).
       (2) flags: boot 1's 640k row carries the aggregator's NOISE flag and boot 2's
           does not, so of boot 1's three armed rows one was machine-flagged. Publishing
           boot 1 would have put a row the aggregator declines to vouch for in bold --
           the splice retired a publication-rule violation, not merely a digit.
       (3) the NaN selfcheck: boot 2's log prints SELFCHECK_NAN_PASS, boot 1's prints
           only SELFCHECK_PASS, because the NaN cases were written between the two
           boots. That dates the boots from a different signal than either of the above.
     Signal (3) also bounds what the pair measures: both boots ran the SAME sglang tree
     (GITHEAD=1fb8505, 6 patched files, per FORENSICS_20260904T030445Z.txt) but not the
     same DRIVER revision, and the known driver difference -- one extra non-blocking
     selfcheck invocation -- completes before either server boots, so it cannot enter a
     timing. Any other difference between the two driver revisions is uncharacterized,
     and the drift floor should be read with that stated rather than as two runs of one
     script.

     The spread paragraph above was re-derived against the landed cell (it supplies 7 of
     the 15 rungs): per-RUNG median 0.170 -> 0.120 and with it 3.9x -> 5.5x, per-rung
     minimum 0.08 -> 0.09, and the per-LEG range 0.03-0.66 over 30 legs UNCHANGED, so
     21.9x did not move -- an earlier wording here, that "3.9x and 21.9x both move with
     it", was wrong about the second. "Larger than 14 of those 15" also survived. That
     paragraph's population is main/pr_v4flash + main/pr_v4pro only, which is why
     main/pr_glm52 landing could not move it. `_agg_change_gate.py AGG_REF_PREREQUEUE.tsv`
     shows exactly what changed. -->
### DeepSeek-V4-Pro, floor 32768

| context | prompt_tokens | baseline (ms) | with coop (ms) | speedup |
| --- | --- | --- | --- | --- |
| 32k | 34,943 | 15.625 | 15.689 | &mdash; (below floor) |
| 64k | 67,970 | 15.739 | 15.799 | &mdash; (below floor) |
| 128k | 138,630 | 16.044 | 16.085 | -0.26% (inside the measured zero band, -0.658..+0.015) |
| 256k | 301,985 | 16.298 | 16.303 | -0.03% (within noise) |
| 512k | 605,209 | 16.755 | 16.708 | **+0.28%** |
| 640k | 730,334 | 16.947 | 16.869 | **+0.46%** |
| 768k | 864,534 | 17.114 | 17.033 | **+0.47%** |

### DeepSeek-V4-Flash, floor 32768

| context | prompt_tokens | baseline (ms) | with coop (ms) | speedup |
| --- | --- | --- | --- | --- |
| 32k | 34,943 | 9.361 | 9.413 | &mdash; (below floor) |
| 64k | 67,970 | 9.442 | 9.495 | &mdash; (below floor) |
| 128k | 138,630 | 9.657 | 9.706 | -0.51% (inside the measured zero band, -0.658..+0.015) |
| 256k | 301,985 | 9.846 | 9.875 | -0.29% (within noise) |
| 512k | 605,209 | 10.165 | 10.179 | excluded &mdash; repeats span 4.3% of the median |
| 640k | 730,334 | 10.234 | 10.235 | -0.01% (within noise) |
| 768k | 864,534 | 10.413 | 10.398 | +0.14% (within noise) |
| 896k | 1,002,144 | 10.532 | 10.499 | +0.31% (within noise) |
| 1M safe (1,020,876 tok) | 1,020,876 | 10.556 | 10.533 | +0.22% (within noise) |

**What the two V4 tables above do and do not establish.** Both reproduce the shape
the GLM cells established — flat-to-negative below the floor, rising with context
above it — and neither establishes a gain on this branch. V4-Pro's largest armed
row is **+0.47% at 768k** — that is boot 2 of that cell, and boot 1 measured **+0.55%**
at the same rung, the pair being the drift measurement quoted above. Boot 2 is the one
published, for two reasons pointing the same way: it is the boot that completed with all
its markers (`status=done`, against `INCOMPLETE` for boot 1), and all three of its armed
rows pass the aggregator's noise test where boot 1's 640k row does not. Publishing the
larger of two boots is also how a drift floor gets quietly spent. V4-Flash's largest
armed row is **+0.31% at 896k**; both are under the
0.658 pp systematic bar, and V4-Flash's own repeats at that rung span 0.15% and
0.35%, so the aggregator calls it noise. The negative end gets named too:
**-0.51% at 128k** is *not* a cost, because the measured band of between-boot
zeros in this campaign runs **-0.658 to +0.015 pp** with 51 of 52 known-zero rows
negative, and -0.51% sits inside it. One rung of the V4-Flash ladder is excluded
rather than dropped: at 512k its repeats span 4.27% and 4.11% of their own
medians, the only rung in the campaign above 1.0% (the next worst, 0.66%, is this
same cell at 1M safe). Its cause is unattributed, and it is left out of the range
rather than quietly averaged in.

GLM-5.2 and the main-branch GLM-5.3 cell are still outstanding; the GLM figures
quoted above come from the v0.5.17 and v0.5.18 cells and are labelled as such.
All models are measured on **one commit and one binary**. The
launcher is not quite as uniform, so the precise claim is "one binary; the
launcher gained the GLM MoE flag partway through the campaign": the two earliest
main-branch cells finished before the harness script acquired
`--moe-runner-backend deep_gemm`, so they ran under an earlier revision of it than
the later cells. The launcher delta is exactly that flag, which is already
described below, and every cell records `GITHEAD` and its patched-file count in
its own console — identical (`GITHEAD=1fb8505`, 6 patched files) across every
main-branch cell that produced data. So this changes the wording and not any
number, but "same harness" was overstating it.

### The table is raw

The floor-beyond-the-ladder arm is used two ways and never a third. It is the
error bar above, and it is the no-fire side of a same-length contrast (below). It
is never subtracted from a real row to produce a corrected column, and no
corrected column appears anywhere in this description. Subtracting it cannot speak to the above-floor rows
even in principle: the one nuisance that could bias those is the cooperative
kernel itself — an extra cooperative launch, a 64 KB workspace, different
occupancy — and that nuisance is absent from the calibration arm by construction.
The offset also has no fixed magnitude to subtract: under an identical harness the
below-floor bands read −0.28, −0.38 and −0.42 pp on GLM-5.3 but −0.04 and −0.05 pp
on GLM-5.2, on both sglang versions. With one boot pair per corner that is equally
consistent with the nuisance tracking the model and with it tracking those
particular boots — and the earlier round measured the same two models and got
−0.09 pp for GLM-5.3 against −0.13 and +0.20 pp for GLM-5.2, which inverts the
pattern. What the 2x2 does establish is narrower: the offset is not the sglang
version and not whether the feature was compiled in.

### DeepSeek-V4-Pro: a gain smaller than the raw bar, established anyway

These rows are from v0.5.17 — a different tree and a different build from the
GLM-5.3 table above, which is the submission branch; what they share is the A/B
harness, the ladder and the leg order, not the binary. V4-Pro's
raw deltas are +0.02% at 256k and +0.57% at 512k — and +0.57 is **0.87x** the
0.66 pp bar, so as a raw number it does not clear it. Two estimates that cancel
the per-boot offset do, and they were computed on different data:

- **Within one cell, across its own floor.** The armed peak minus the same cell's
  own below-floor mean is **+0.854 pp**. One boot pair, one leg order, one binary,
  so no cross-cell offset enters.
- **Same length, fire against no-fire.** Contrasting each row against the identical
  length of the floor-beyond-the-ladder arm of the same model, version and leg
  order gives **+0.841 pp** at 512k. Everything is matched except whether the
  kernel armed, and — unlike a subtraction — this leaves the cooperative launch's
  own cost inside the estimate rather than removing it.

The two agree to **0.013 pp** on different data, against a control whose drift
along the whole ladder is 0.071 pp and a parallel-trends residual of 0.046 pp
where neither cell arms. The gain is real and small: about +0.20, +0.31 and
+0.84 pp at 128k, 256k and 512k. Two limits worth stating: that cell reached only
five of the nine lengths, so +0.84 is the largest measured point and not the peak;
and this is decode-only TPOT at batch size 1.

On that truncation, since a reviewer comparing V4-Pro's rows against V4-Flash's
nine will ask, and since the aggregate does not say so by itself: **the rungs are
absent, not reported as failed.** The reducer drops a length when *either* leg is
missing it, with no flag on the row and no marker in the file, so a row count is
not a rung count. The absent lengths are 640k, 768k, 896k and 1msafe under
v0.5.17, and 896k and 1msafe on main. They are a **property of V4-Pro on this
machine, not of the ladder** — V4-Flash completes all nine rungs of the identical
V4 ladder, and both V4-Pro cells, treatment and control, stop at exactly the same
length, which is what a per-model limit looks like rather than a ladder that stops
short. The cause is diagnosed: the server SIGKILLs its own process tree at the
first rung past a memory boundary (see "Unrelated bug found while measuring").

The per-leg form of that is what actually closes the question, because it is the
one a reviewer can turn into a doubt about the patch: **both legs attempted both
rungs and both legs were killed there.** In the main-branch V4-Pro cell each leg
prints its `CTX` and `GPUSTATE` lines for 896k *and* 1msafe — 18 `CTX` lines, the
same count as the V4-Flash cell that finished 9 of 9, so nothing was skipped — and
each leg then ends in `_pr_ab.sh: line 106: ... Killed`, once with `use_coop=1` and
once with `use_coop=0`. The resource signature is symmetric to the digit as well:
`GPUSTATE`'s second field reads 1965 at 896k and collapses to 120 at 1msafe on
both legs alike. So the rung was reached with the patch **disabled** and lost
there too, which is the direct rebuttal rather than the inferred one; the same
truncation also appears on v0.5.18, where the treatment leg is `handoff` and not
`coop` at all, and it is driven by a different runner script. The discriminator
across the family is footprint, not the patch: V4-Flash at `--chunked-prefill-size
8192` completes all nine rungs where V4-Pro at 16384 does not. One
thing that would *not* be presentable is a hole — an absent length below a present
one — because a top truncation can be a known crash while a hole cannot; there are
none in any cell here, and the generator refuses to emit a table containing one.

DeepSeek-V4-Flash ran the full ladder but has no matched control of its own — its
leg order is reversed relative to the only V4 control — so only its raw deltas are
quoted, and it carries the largest below-floor offset on the campaign (-0.62 pp).
Its three rows that clear both the noise flag and the bar are +0.47% at 640k,
+0.89% at 896k and +1.04% at its longest body; four of its seven armed rows are
flagged as noise and are not used.

## Invariants a reviewer should push on

<!-- split-note -->

GitHub caps a pull request description at 65,536 characters, and the full text of this
description is 101,076. This section is therefore posted **verbatim as the first comment on
this PR**, and `## Reproducing` as the second. Nothing was shortened, reflowed or rewritten
to make the description fit: the description and those two comments are a partition of one
document, so every character below is byte-identical to the text these results were checked
against.

<!-- /split-note -->

## Reproducing

<!-- split-note -->

Posted **verbatim as the second comment on this PR**, for the same reason as the section
above: GitHub caps a pull request description at 65,536 characters. It carries the launch
line, the four extra flags on the main-branch cells with the bound that
makes each a no-op for this kernel, the two floors and why neither is a measured crossover
point, and the flashinfer/DeepGEMM version gap that cost one GLM-5.2 cell its first
measurement.

<!-- /split-note -->

## Unrelated bug found while measuring

Worth a separate issue, noted here because it blocks reproducing the DeepSeek-V4
rows on v0.5.18+. Observed: at TP8 with expert parallelism off, neither V4 model
boots — a decode-sized batch reaches the DSV4 clamped-swiglu path of the
`deep_gemm` MoE runner and trips its
`assert N % 4 == 0 and G % 4 == 0 and D // 8 >= E`, where `D` is the per-rank
intermediate size and `E` the local expert count. For V4-Flash the arithmetic is
readable straight off the shipped config (`moe_intermediate_size = 2048`,
`n_routed_experts = 256`): at TP8 with EP off, `D = 256`, `G = 2`, `D // 8 = 32`,
`E = 256`, so `D // 8 >= E` cannot hold. V4-Pro fails the same assert with
`G=3, D//8=48, E=384` — those numbers are from the boot log, not from a config in
the tree. `SGLANG_DEEPGEMM_STANDARD_LAYOUT=compact` forces the non-masked branch
of the same runner and is what the measurements above use for V4. I have not
traced why `auto` now picks the masked layout for a decode-sized batch where it
previously did not, so treat the mechanism as unconfirmed and the symptom as the
report.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  Run with the pinned tools, and it found something, so the detail is worth stating.
  `codespell` 2.4.3 against the repo's `.codespellrc`: clean on all six files.
  `ruff` 0.15.1 with the hook's `--select=F401,F821,UP037`: all checks passed, and
  `ruff format --diff`: already formatted. `clang-format` 20.1.7 `--style=file
  --dry-run -Werror` against `python/sglang/kernels/jit/.clang-format`: **initially
  failed**, on four lines this PR adds -- a five-argument `RuntimeCheck` split across
  five lines in `topk_v2.cuh`, and nine single-statement `for`/`if` bodies sharing a
  line with their head in `topk_coop.cuh`. The base file at `dae126d510` has zero
  violations and all four line numbers are added lines, so these were introduced here
  and not inherited.

  The fix is the last commit, `[DSA] Apply clang-format to the cooperative top-k
  sources`, and it is deliberately its own commit rather than folded into the commit
  that introduced the lines. The reason is that the commit before it is the exact tree
  the B200 numbers below were measured on. Keeping it intact means a reviewer can
  check it out and get source bit-identical to what produced the measurements, and can
  `git show` the last commit to confirm the remainder is whitespace. That
  bit-identity is **verified by content hash, not assumed**, and the check was worth
  doing because the benchmark host was not running a checkout of that commit at all:
  it sat on the PR base with the patch applied as uncommitted working-tree edits, so
  no commit object for the measured tree ever existed there. Hashing the six patched
  files on the benchmark host with `git hash-object` yields exactly the six blobs that
  commit reads, and the host's `HEAD` is the PR base with those six paths — and only
  those six — differing. So the measured source and that commit's tree are the same
  content by construction. That the reformat
  changes no token is checkable rather than asserted, and here is the check to run,
  because the obvious one does not work. **`git diff -w` does not show this and will
  look like it disproves it:** on the reformat commit it prints `2 files changed, 19
  insertions(+), 14 deletions(-)` — byte for byte the same output as without `-w`, so
  `-w` suppresses nothing at all. That is expected, not a contradiction: `-w` ignores
  whitespace *within* a line, while a reformat *moves line breaks*, which `-w` cannot
  see through. **Reaching for a stronger flag makes it worse, not better:** `-b`,
  `--ignore-blank-lines`, `-w --ignore-blank-lines`, and
  `--ignore-all-space --ignore-blank-lines` all print that identical
  `2 files changed, 19 insertions(+), 14 deletions(-)`. Six invocations, one answer —
  so a reviewer who escalates through git's whitespace options ends up *more*
  confident the whitespace-only claim is false, which is exactly backwards. None of
  these flags can help, for the same structural reason: they all normalize whitespace
  within a line. The gate that does work is a whitespace-stripped stream comparison —
  delete every whitespace character from each version and hash what is left:

  ```
  for f in python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh \
           python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_coop.cuh; do
    git show <reformat>^:$f | tr -d '[:space:]' | shasum
    git show <reformat>:$f  | tr -d '[:space:]' | shasum
  done
  ```

  Both sides agree on both files, first 12 hex digits: `27b7aeb7befd` for
  `topk_v2.cuh` and `2f726c1f2518` for `topk_coop.cuh`. Those two files are the only
  ones the commit touches. Reproduce the reformat itself with `clang-format -i --style=file` on the
  same two paths.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  Eight new test functions, 24 new parametrized cases, in the existing
  `test/registered/kernels/ops/attention/test_topk_v2.py` under its existing
  `register_cuda_ci(stage="base-b-kernel-unit", runner_config="1-gpu-large")`. Which of
  them have actually executed on a GPU, and which have not, is stated explicitly in the
  Accuracy Tests section rather than left for a reviewer to discover.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  Nothing to update, and deliberately so: `docs/docs/references/environment_variables.mdx`
  documents no `SGLANG_OPT_*` toggle at all, so documenting these two would be the
  deviation. Say so rather than tick a box for a file that was not touched.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  Half done, and the missing half is named. End-to-end decode TPOT is measured on 8xB200
  across a nine-point context ladder for four models on two sglang versions, and is
  below. The *kernel* microbenchmark that `.claude/skills/add-jit-kernel/SKILL.md` marks
  `## Step 5: Add a benchmark (required)` is not: no `coop` provider line was added to
  `test/registered/kernels/benchmark/attention/bench_topk.py`, which already imports
  `plan_topk_v2` and is the obvious place for one. It is absent because it has never been
  run -- adding a benchmark whose output nobody has seen is worse than naming the gap --
  and because every number in this PR is required to come from the exact bytes measured.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
  Ticked for the linked guidance -- naming, import order, no dead code, no commented-out
  blocks -- with one deviation against a different rule file stated up front rather than
  buried: seventeen added comment blocks run three to eight lines against the two-line bar
  in `.claude/rules/comment-style.md`. Every one is listed with file and line count in the
  Invariants section, so the deviation can be measured rather than taken on trust; the
  longest is an 8-line block in `test_topk_v2.py` (an earlier draft of this line said
  seven, from before the parity-witness commit added the longer one). I am not claiming they are within the
  rule. The two mitigations offered there are narrow and are worth exactly what they say:
  the `environ.py` pair matches the length of the entry directly above it, and the caller
  one frame up carries a 32-line docstring. Neither generalizes to the other eleven.
  Happy to cut all of them to two lines in one pass -- the only reason they are not
  already cut is that every number in this PR has to come from bytes identical to the
  submitted diff, and that constraint lifts the moment a reviewer asks.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
