### PR TITLE
fix(glm4v): disambiguate mixed image video offsets

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1471,6 +1471,22 @@ class BaseMultimodalProcessor(ABC):
 
         return list(zip(indices_start.tolist(), indices_end.tolist()))
 
+    def get_mm_item_offsets(
+        self,
+        input_ids: torch.Tensor,
+        mm_tokens: MultimodalSpecialTokens,
+        modality: Modality,
+    ) -> List[Tuple[int, int]]:
+        """Return placeholder offsets belonging to one modality.
+
+        Processors that reuse one token ID for multiple modalities can override
+        this method and use surrounding boundary tokens to disambiguate spans.
+        """
+        mm_token_id = mm_tokens.get_token_id_by_modality(modality)
+        if mm_token_id is None:
+            raise ValueError(f"No token id found for modality: {modality}")
+        return self.get_mm_items_offset(input_ids, mm_token_id)
+
     def collect_mm_items_from_processor_output(
         self, data_dict: dict, modality: Modality = None
     ) -> List[MultimodalDataItem]:
@@ -1834,12 +1850,10 @@ class BaseMultimodalProcessor(ABC):
         for mm_item in all_collected_items:
             if mm_item.offsets is not None:
                 continue
-            mm_token_id = mm_tokens.get_token_id_by_modality(mm_item.modality)
-            if mm_token_id is None:
-                raise ValueError(f"No token id found for modality: {mm_item.modality}")
-            mm_item.offsets = self.get_mm_items_offset(
+            mm_item.offsets = self.get_mm_item_offsets(
                 input_ids=input_ids,
-                mm_token_id=mm_token_id,
+                mm_tokens=mm_tokens,
+                modality=mm_item.modality,
             )
 
         # Split bundled items into per-image/video items for better cache granularity

--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -1,12 +1,12 @@
 import asyncio
 import math
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import torch
 
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
-from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
+from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutput
 from sglang.srt.models.glm4v import Glm4vForConditionalGeneration
 from sglang.srt.models.glm4v_moe import Glm4vMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
@@ -295,6 +295,37 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
             # Note: For GLM4v videos, it uses the video token before tokenization but uses image token after tokenization
             video_token_id=self.IM_TOKEN_ID,
         ).build(_processor)
+
+    def get_mm_item_offsets(
+        self,
+        input_ids: torch.Tensor,
+        mm_tokens: MultimodalSpecialTokens,
+        modality: Modality,
+    ) -> List[Tuple[int, int]]:
+        """Disambiguate image and video spans sharing ``IM_TOKEN_ID``."""
+        if (
+            modality not in (Modality.IMAGE, Modality.VIDEO)
+            or mm_tokens.image_token_id != mm_tokens.video_token_id
+        ):
+            return super().get_mm_item_offsets(input_ids, mm_tokens, modality)
+
+        all_offsets = self.get_mm_items_offset(input_ids, self.IM_TOKEN_ID)
+        video_ranges = self.get_mm_items_offset_by_pair(
+            input_ids,
+            self.VIDEO_START_TOKEN_ID,
+            self.VIDEO_END_TOKEN_ID,
+        )
+
+        def is_video_offset(offset: Tuple[int, int]) -> bool:
+            start, end = offset
+            return any(
+                video_start <= start and end <= video_end
+                for video_start, video_end in video_ranges
+            )
+
+        if modality == Modality.VIDEO:
+            return [offset for offset in all_offsets if is_video_offset(offset)]
+        return [offset for offset in all_offsets if not is_video_offset(offset)]
 
     def compute_mrope_positions(self, input_ids, mm_items):
         image_grid_thw = None

--- a/test/registered/unit/multimodal/test_glm4v_mixed_offsets.py
+++ b/test/registered/unit/multimodal/test_glm4v_mixed_offsets.py
@@ -1,0 +1,96 @@
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.glm4v import Glm4vImageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _processor():
+    processor = Glm4vImageProcessor.__new__(Glm4vImageProcessor)
+    processor.IM_TOKEN_ID = 99
+    processor.VIDEO_START_TOKEN_ID = 101
+    processor.VIDEO_END_TOKEN_ID = 102
+    return processor
+
+
+def test_glm4v_partitions_shared_image_and_video_token_offsets():
+    processor = _processor()
+    mm_tokens = MultimodalSpecialTokens(image_token_id=99, video_token_id=99)
+    input_ids = torch.tensor(
+        [
+            1,
+            99,
+            99,  # image 1
+            2,
+            99,
+            99,
+            99,  # image 2
+            3,
+            101,  # begin video
+            4,
+            99,
+            99,  # frame 1
+            5,
+            99,
+            99,
+            99,  # frame 2
+            6,
+            102,  # end video
+            7,
+        ]
+    )
+
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.IMAGE) == [
+        (1, 2),
+        (4, 6),
+    ]
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.VIDEO) == [
+        (10, 11),
+        (13, 15),
+    ]
+
+
+def test_glm4v_keeps_interleaved_media_offsets_in_their_modalities():
+    processor = _processor()
+    mm_tokens = MultimodalSpecialTokens(image_token_id=99, video_token_id=99)
+    input_ids = torch.tensor(
+        [
+            101,
+            99,
+            99,
+            102,  # video 1
+            8,
+            99,  # image
+            9,
+            101,
+            99,
+            10,
+            99,
+            102,  # video 2
+        ]
+    )
+
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.IMAGE) == [
+        (5, 5)
+    ]
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.VIDEO) == [
+        (1, 2),
+        (8, 8),
+        (10, 10),
+    ]
+
+
+def test_glm4v_uses_default_offsets_when_token_ids_are_distinct():
+    processor = _processor()
+    mm_tokens = MultimodalSpecialTokens(image_token_id=99, video_token_id=100)
+    input_ids = torch.tensor([99, 99, 1, 100, 100])
+
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.IMAGE) == [
+        (0, 1)
+    ]
+    assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.VIDEO) == [
+        (3, 4)
+    ]

--- a/test/registered/unit/multimodal/test_glm4v_mixed_offsets.py
+++ b/test/registered/unit/multimodal/test_glm4v_mixed_offsets.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from sglang.srt.managers.schedule_batch import Modality
@@ -94,3 +95,7 @@ def test_glm4v_uses_default_offsets_when_token_ids_are_distinct():
     assert processor.get_mm_item_offsets(input_ids, mm_tokens, Modality.VIDEO) == [
         (3, 4)
     ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

GLM-V models use different placeholders for images and videos before tokenization, but video frames are represented using the image token ID after tokenization:

```python
image_token_id=self.IM_TOKEN_ID
video_token_id=self.IM_TOKEN_ID
```

The generic multimodal offset collection logic currently finds placeholder spans using only the modality token ID. Therefore, when a request contains both images and a video, the image and video items can both receive all image-token spans.

For example, a request containing six images and one video sampled into 31 frames produced an image item with six image grids but 37 offsets:

```text
6 image spans + 31 video-frame spans = 37 offsets
```

During chunked prefill, the incorrect offsets caused the number of expected multimodal tokens to exceed the available image embeddings:

```text
RuntimeError: Insufficient multimodal embedding length:
num_mm_tokens_in_input_ids=16325
vs num_mm_tokens_in_embedding=5391
```

Image-only and video-only requests are unaffected because there is no ambiguity between modalities.

Fixes #37968 

## Modifications

- Added `BaseMultimodalProcessor.get_mm_item_offsets()` as an overridable hook for assigning placeholder offsets to a specific modality.
- Preserved the existing token-ID-based behavior as the default implementation for other multimodal processors.
- Overrode the hook in `Glm4vImageProcessor`.
- Used the distinct `<|begin_of_video|>` and `<|end_of_video|>` boundary tokens to identify which shared image-token spans belong to videos.
- Assigned spans inside video boundaries to `Modality.VIDEO`.
- Assigned the remaining spans to `Modality.IMAGE`.
- Performed the classification before `get_new_expanded_mm_items()` splits bundled multimodal features.
- Added CPU unit tests covering:
  - Multiple images followed by a multi-frame video.
  - Interleaved image and video content.
  - Existing behavior when image and video token IDs are distinct.

The implementation uses video boundaries instead of assigning the first `N` offsets to images, so it also works when images and videos are interleaved.

## Accuracy Tests

This change only corrects multimodal placeholder ownership during request preprocessing. It does not modify model weights, kernels, or forward computation.

Before the fix, the mixed image-video request failed with HTTP 500:

```text
IMAGE item:
  image_grid_thw shape: (6, 3)
  offset count: 37

offset_mm_tokens=16325
embedding_tokens=5391
```

The expected assignment after the fix is:

```text
IMAGE item:
  image grids: 6
  offsets: 6 image spans

VIDEO item:
  video grids: 1
  offsets: 31 video-frame spans
```

A regression test was added:

```bash
pytest -q test/registered/unit/multimodal/test_glm4v_mixed_offsets.py
```

The test is registered in the CPU CI suite:

```python
register_cpu_ci(est_time=2, suite="base-a-test-cpu")
```

Local validation:

```text
Python syntax compilation: passed
git diff --check: passed
pre-commit hooks: passed
```

The complete pytest run was not executed on the local development host because PyTorch is not installed there. The test is registered to run in the SGLang CPU CI environment.

## Speed Tests and Profiling

Not applicable.

The additional classification only runs while constructing multimodal request metadata. It does not affect model execution, CUDA kernels, attention, or decoding.

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [unit testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because this is an internal correctness fix with no user-facing API changes.
- [x] Accuracy and speed benchmarks are not applicable because this change only corrects request preprocessing metadata.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, and `/rerun-failed-ci`.
4. After CI passes and the required approvals are obtained, ask Merge Oncalls or a maintainer with write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33880026410](https://github.com/sgl-project/sglang/actions/runs/33880026410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33880052393](https://github.com/sgl-project/sglang/actions/runs/33880052393)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33880026117](https://github.com/sgl-project/sglang/actions/runs/33880026117)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->