### PR TITLE
[Docs] Prefer --enable-prefill-cp in Ascend GLM/DeepSeek examples

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_1.mdx
@@ -258,8 +258,8 @@ do
         --disable-cuda-graph \
         --dtype bfloat16 \
         --speculative-draft-model-quantization unquant \
-        --enable-nsa-prefill-context-parallel \
-        --nsa-prefill-cp-mode in-seq-split \
+        --enable-prefill-cp \
+        --cp-strategy zigzag \
         --attn-cp-size 4 \
         --disable-radix-cache \
         --enable-dp-lm-head \
@@ -672,8 +672,8 @@ do
         --disable-cuda-graph \
         --dtype bfloat16 \
         --speculative-draft-model-quantization unquant \
-        --enable-nsa-prefill-context-parallel \
-        --nsa-prefill-cp-mode in-seq-split \
+        --enable-prefill-cp \
+        --cp-strategy zigzag \
         --attn-cp-size 4 \
         --disable-radix-cache \
         --enable-dp-lm-head \
@@ -874,8 +874,8 @@ do
         --disable-cuda-graph \
         --dtype bfloat16 \
         --speculative-draft-model-quantization unquant \
-        --enable-nsa-prefill-context-parallel \
-        --nsa-prefill-cp-mode in-seq-split \
+        --enable-prefill-cp \
+        --cp-strategy zigzag \
         --attn-cp-size 4 \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_2.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_2.mdx
@@ -123,8 +123,8 @@ do
         --disable-cuda-graph \
         --dtype bfloat16 \
         --speculative-draft-model-quantization unquant \
-        --enable-nsa-prefill-context-parallel \
-        --nsa-prefill-cp-mode in-seq-split \
+        --enable-prefill-cp \
+        --cp-strategy zigzag \
         --attn-cp-size 4 \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/deepseek_v3_2.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/deepseek_v3_2.mdx
@@ -26,7 +26,7 @@ recommended to use v0.5.16 or a later version.
 | Tensor Parallelism            | `--tp-size 32`                                                                                |
 | Data Parallelism              | `--dp-size 8`                                                                                 |
 | Expert Parallelism            | `--ep-size 32 \`<br/>`--moe-a2a-backend deepep \`<br/>`--deepep-mode low_latency`                             |
-| Context Parallelism           | `--enable-nsa-prefill-context-parallel \`<br/>`--nsa-prefill-cp-mode in-seq-split \`<br/>`--attn-cp-size 32`  |
+| Context Parallelism           | `--enable-prefill-cp \`<br/>`--cp-strategy zigzag \`<br/>`--attn-cp-size 32`  |
 | PD Disaggregation             | `--disaggregation-mode prefill \`<br/>`--disaggregation-transfer-backend ascend`                      |
 | Quantization                  | `--quantization modelslim`                                                                    |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4` |

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/glm_5_1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/glm_5_1.mdx
@@ -27,7 +27,7 @@ v0.5.16 or a later version.
 | Tensor Parallelism            | `--tp-size 16`                                                                    |
 | Data Parallelism              | `--dp-size 16`                                                                    |
 | Expert Parallelism            | `--ep-size 16 \`<br/>`--moe-a2a-backend deepep \`<br/>`--deepep-mode auto`         |
-| Context Parallelism           | `--enable-nsa-prefill-context-parallel \`<br/>`--nsa-prefill-cp-mode in-seq-split \`<br/>`--attn-cp-size 4` |
+| Context Parallelism           | `--enable-prefill-cp \`<br/>`--cp-strategy zigzag \`<br/>`--attn-cp-size 4` |
 | PD Disaggregation             | `--disaggregation-mode prefill \`<br/>`--disaggregation-transfer-backend ascend`  |
 | Quantization                  | `--quantization modelslim`                                                        |
 | Chunked Prefill               | auto based on device memory, or set explicit value;<br/>disable with `--chunked-prefill-size -1`; e.g., `--chunked-prefill-size 16384` |

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/glm_5_2.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/glm_5_2.mdx
@@ -391,8 +391,8 @@ do
         --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2
 
         # cp
-        #--enable-nsa-prefill-context-parallel \
-        #--nsa-prefill-cp-mode in-seq-split \
+        #--enable-prefill-cp \
+        #--cp-strategy zigzag \
         #--attn-cp-size 4 \
         NODE_RANK=$i
         break


### PR DESCRIPTION
## Summary
Ascend NPU GLM/DeepSeek best-practices and tutorials still use deprecated prefill-CP aliases:
- `--enable-nsa-prefill-context-parallel` → `--enable-prefill-cp`
- `--nsa-prefill-cp-mode in-seq-split` → `--cp-strategy zigzag`

These aliases are still remapped on Ascend, but docs should prefer the canonical flags (same mapping documented in `server_args.py` / `parallel_hook.py`).

## Files
- `best-practices/glm_5_1.mdx`, `glm_5_2.mdx`
- `tutorials/deepseek_v3_2.mdx`, `glm_5_1.mdx`, `glm_5_2.mdx`

Distinct from the DeepSeek-V3.2 cookbook CP update.

## Test plan
- [x] Confirmed deprecated aliases in `server_args.py`
- [x] Confirmed `in-seq-split`→`zigzag` in `parallel_hook.py`
- [x] No leftover `--nsa-prefill-*` in touched files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33854304152](https://github.com/sgl-project/sglang/actions/runs/33854304152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33854303900](https://github.com/sgl-project/sglang/actions/runs/33854303900)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->