### PR TITLE
fix: keep FlashInfer MLA graph kv_indptr current

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -511,6 +511,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         self.fast_decode_kwargs = {
             "qo_indptr_cpu": self.cuda_graph_qo_indptr_cpu,
             "kv_indptr_cpu": self.cuda_graph_kv_indptr_cpu,
+            "kv_indptr_gpu": self.cuda_graph_kv_indptr,
             "kv_indices": self.cuda_graph_kv_indices,
         }
 
@@ -886,6 +887,11 @@ class FlashInferMLAIndicesUpdaterDecode:
         kv_lens = paged_kernel_lens.to(torch.int32)
         sm_scale = self.scaling
         if spec_info is None:
+            if init_metadata_replay:
+                # Keep the capture-stable buffer bound to the wrapper current.
+                # This mirrors kv_indices below and matters to implementations
+                # that read kv_indptr directly during graph replay.
+                kv_indptr = fast_decode_kwargs["kv_indptr_gpu"]
             kv_indptr[1 : bs + 1] = torch.cumsum(paged_kernel_lens, dim=0)
             kv_indptr = kv_indptr[: bs + 1]
             # On replay `kv_indices` IS the capture-stable buffer the captured

--- a/test/registered/attention/unittests/mla/test_flashinfer.py
+++ b/test/registered/attention/unittests/mla/test_flashinfer.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -178,6 +180,62 @@ class TestFlashInferMLAAttentionBackendCorrectness(CustomTestCase):
         for case in self.CUDA_GRAPH_CASES:
             with self.subTest(case=case.name, backend=case.backend):
                 run_mla_cuda_graph_decode_case(self, case, **MLA_SHAPE_KWARGS)
+
+    def test_cuda_graph_replay_updates_wrapper_kv_indptr_buffer(self):
+        from sglang.srt.layers.attention import flashinfer_mla_backend
+
+        class PassthroughTranslator:
+            needs_read_translate = False
+
+            def fill_packed_read_stream(self, **kwargs):
+                return True
+
+        updater = flashinfer_mla_backend.FlashInferMLAIndicesUpdaterDecode.__new__(
+            flashinfer_mla_backend.FlashInferMLAIndicesUpdaterDecode
+        )
+        updater.scaling = 1.0
+        updater.data_type = torch.float16
+        updater.num_local_heads = 4
+        updater.kv_lora_rank = 512
+        updater.qk_rope_head_dim = 64
+        updater.attn_backend = SimpleNamespace(
+            kv_index_translator=PassthroughTranslator()
+        )
+
+        paged_kernel_lens = torch.tensor([2, 3], dtype=torch.int32, device="cuda")
+        eager_kv_indptr = torch.full((3,), -1, dtype=torch.int32, device="cuda")
+        graph_kv_indptr = torch.tensor([0, -1, -1], dtype=torch.int32, device="cuda")
+        wrapper = SimpleNamespace(plan=MagicMock())
+
+        with patch.object(
+            flashinfer_mla_backend,
+            "get_parallel",
+            return_value=SimpleNamespace(dcp_enabled=False),
+        ):
+            updater.call_begin_forward(
+                wrapper,
+                paged_kernel_lens,
+                paged_kernel_lens_sum=5,
+                q_indptr=torch.tensor([0, 1, 2], dtype=torch.int32, device="cuda"),
+                kv_indptr=eager_kv_indptr,
+                init_metadata_replay=True,
+                spec_info=None,
+                req_pool_indices=torch.tensor([0, 1], device="cuda"),
+                qo_indptr_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+                kv_indptr_cpu=torch.tensor([0, 2, 5], dtype=torch.int32),
+                kv_indptr_gpu=graph_kv_indptr,
+                kv_len_arr_cpu=torch.tensor([2, 3], dtype=torch.int32),
+                kv_indices=torch.empty(5, dtype=torch.int32, device="cuda"),
+            )
+
+        expected_graph_kv_indptr = torch.tensor(
+            [0, 2, 5], dtype=torch.int32, device="cuda"
+        )
+        torch.testing.assert_close(graph_kv_indptr, expected_graph_kv_indptr)
+        torch.testing.assert_close(
+            eager_kv_indptr, torch.full_like(eager_kv_indptr, -1)
+        )
+        wrapper.plan.assert_called_once()
 
     def test_runner_mode_split_op_extend_cases(self):
         for case, static_num_tokens in self.SPLIT_OP_CASES:


### PR DESCRIPTION
## Motivation

SGLang constructs FlashInfer’s MLA CUDA-graph wrapper with capture-stable metadata buffers, including `cuda_graph_kv_indptr`.

During graph replay, however, the decode metadata updater rebuilt `kv_indptr` in the ordinary eager buffer rather than the buffer bound to the captured wrapper. Native FlashInfer decode does not directly consume the GPU `kv_indptr`, so the mismatch remained hidden. Trace Apply candidates that do consume it observed stale capture-time sequence boundaries and could produce incorrect output.

## Modifications

- Preserve `cuda_graph_kv_indptr` in the fast decode metadata.
- During CUDA-graph replay, rebuild `kv_indptr` directly in that capture-stable buffer.
- Add a regression test verifying that the graph-bound buffer is updated and   the unrelated eager buffer is not.

This mirrors the existing treatment of the capture-stable `kv_indices` buffer.

## Accuracy Tests

Added:

`TestFlashInferMLAAttentionBackendCorrectness::test_cuda_graph_replay_updates_wrapper_kv_indptr_buffer`

The test:

- Fails on unmodified SGLang `main` because the graph-bound buffer remains   stale.
- Passes with this patch.
- Verifies the expected `kv_indptr` contents after replay metadata preparation.

The existing FlashInfer MLA CUDA-graph decode correctness test also passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33854795387](https://github.com/sgl-project/sglang/actions/runs/33854795387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33854795251](https://github.com/sgl-project/sglang/actions/runs/33854795251)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33854795556](https://github.com/sgl-project/sglang/actions/runs/33854795556)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->