### PR TITLE
Map OpenAI/Anthropic reasoning_effort names onto template-declared levels

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -94,6 +94,7 @@ from sglang.srt.parser.jinja_template_utils import (
     process_content_for_template_format,
 )
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.parser.template_detection import normalize_reasoning_effort
 from sglang.srt.sampling.sampling_params import (
     set_request_reasoning_end_token_ids,
 )
@@ -1451,12 +1452,30 @@ class OpenAIServingChat(OpenAIServingBase):
             )
 
             extra_template_kwargs = {}
+            effort_config = self.template_manager.reasoning_config
             if request.reasoning_effort is not None:
-                extra_template_kwargs["reasoning_effort"] = request.reasoning_effort
+                effort = request.reasoning_effort
+                if (
+                    effort_config is not None
+                    and effort_config.effort_levels
+                    and effort not in effort_config.effort_levels
+                ):
+                    mapped = normalize_reasoning_effort(effort, effort_config)
+                    logger.warning(
+                        "Model '%s' supports reasoning_effort %s; requested %r, %s",
+                        self.tokenizer_manager.served_model_name,
+                        effort_config.effort_levels,
+                        effort,
+                        f"mapped to {mapped!r}"
+                        if mapped != effort
+                        else "falling back to the chat template default",
+                    )
+                    effort = mapped
+                extra_template_kwargs["reasoning_effort"] = effort
             if request.chat_template_kwargs:
                 extra_template_kwargs.update(request.chat_template_kwargs)
 
-            rc = self.template_manager.reasoning_config
+            rc = self.template_manager.reasoning_toggle_config
             if rc is not None and rc.effort_kwarg is not None:
                 if request.reasoning_effort == "low":
                     extra_template_kwargs.setdefault(rc.effort_kwarg, True)
@@ -2440,7 +2459,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
     def _get_reasoning_toggle_param(self) -> Optional[str]:
         """Resolve the chat-template kwarg that toggles reasoning, if any."""
-        config = self.template_manager.reasoning_config
+        config = self.template_manager.reasoning_toggle_config
         if config is not None:
             return config.toggle_param
 
@@ -2479,7 +2498,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 request.reasoning_effort = "none"
                 return
 
-        config = self.template_manager.reasoning_config
+        config = self.template_manager.reasoning_toggle_config
         is_mistral = (config is not None and config.special_case == "mistral") or (
             config is None and self._reasoning_default_mode() == "mistral"
         )
@@ -2507,7 +2526,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # name itself is resolvable, so writing the kwarg would set up the
         # template to emit reasoning tokens while the parser ignores them
         # (literal ``<think>`` markers leak into the assistant text).
-        config = self.template_manager.reasoning_config
+        config = self.template_manager.reasoning_toggle_config
         read_side_supported = toggle_param is not None and (
             config is None or config.default_enabled is not None
         )
@@ -2544,7 +2563,7 @@ class OpenAIServingChat(OpenAIServingBase):
             # output into reasoning_content.
             return request.reasoning_effort not in (None, "none", "no_think")
 
-        config = self.template_manager.reasoning_config
+        config = self.template_manager.reasoning_toggle_config
         if config is None:
             # Fallback to parser-level defaults when template toggle config
             # cannot be inferred (e.g., parser-only <think> templates).

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -789,7 +789,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             return effort not in (None, "none", "no_think")
         if self.template_manager.force_reasoning:
             return True
-        config = self.template_manager.reasoning_config
+        config = self.template_manager.reasoning_toggle_config
         if config is None:
             # Parser-only models (DeepSeek-R1, …) carry the thinking default in
             # the detector itself.

--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -68,10 +68,26 @@ class ReasoningToggleConfig:
     default_enabled: Optional[bool] = None
     special_case: Optional[str] = None
     effort_kwarg: Optional[str] = None
+    effort_levels: Optional[Tuple[str, ...]] = None
+    effort_aliases: Optional[Tuple[Tuple[str, str], ...]] = None
 
     @property
     def always_on(self) -> bool:
         return self.special_case == "always"
+
+    @property
+    def has_toggle(self) -> bool:
+        return self.special_case is not None or self.toggle_param is not None
+
+
+def normalize_reasoning_effort(
+    effort: str, config: Optional[ReasoningToggleConfig]
+) -> str:
+    """Map an OpenAI/Anthropic-style effort name onto the levels the chat
+    template declares; returns the input unchanged when nothing applies."""
+    if config is None or not config.effort_levels or effort in config.effort_levels:
+        return effort
+    return dict(config.effort_aliases or ()).get(effort, effort)
 
 
 class _GenerationTagExtension(jinja2.ext.Extension):
@@ -254,6 +270,24 @@ REASONING_MODE_RULES = (
             or ctx.has_pattern(r"thinking\s+is\s+not\s+defined\s+or\s+thinking")
             or ctx.has_pattern(r"namespace\([^)]*thinking\s*=\s*true")
             or _has_toggle_default_assignment(ctx, "thinking", True)
+        ),
+    ),
+    # GLM-5.3 style: thinking is always on and the template only honors an
+    # effort allowlist (`in ['low', 'high'] else 'max'`). Kept last so it only
+    # claims templates no earlier rule recognizes.
+    DetectionRule(
+        name="glm53_reasoning_effort",
+        value=ReasoningToggleConfig(
+            effort_levels=("low", "high", "max"),
+            effort_aliases=(
+                ("none", "low"),
+                ("minimal", "low"),
+                ("medium", "high"),
+                ("xhigh", "max"),
+            ),
+        ),
+        predicate=lambda ctx: (
+            ctx.has_text("reasoning_effort") and ctx.has_text("Reasoning Effort:")
         ),
     ),
 )

--- a/python/sglang/srt/parser/template_manager.py
+++ b/python/sglang/srt/parser/template_manager.py
@@ -104,6 +104,13 @@ class TemplateManager:
         return self._reasoning_config
 
     @property
+    def reasoning_toggle_config(self) -> Optional[ReasoningToggleConfig]:
+        """reasoning_config restricted to configs that actually toggle
+        reasoning; effort-level-only configs (GLM-5.3) read as no toggle."""
+        config = self._reasoning_config
+        return config if config is not None and config.has_toggle else None
+
+    @property
     def suggested_reasoning_parser(self) -> Optional[str]:
         """Get the auto-detected reasoning parser name, or None."""
         return self._suggested_reasoning_parser

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -189,6 +189,11 @@ class _MockTemplateManager:
         self.force_reasoning = False
         self.jinja_template_may_reorder_tool_results = False
 
+    @property
+    def reasoning_toggle_config(self):
+        config = self.reasoning_config
+        return config if config is not None and config.has_toggle else None
+
 
 class ServingChatTestCase(unittest.TestCase):
     # ------------- common fixtures -------------
@@ -3287,6 +3292,44 @@ class ServingChatTestCase(unittest.TestCase):
         kwargs = self._run_jinja_with_effort("high")
         self.assertNotIn("low_effort", kwargs)
 
+    def _setup_glm53_effort_levels(self):
+        self.tm.server_args.reasoning_parser = "glm45"
+        self.chat.reasoning_parser = "glm45"
+        self.template_manager.chat_template_name = None
+        self.template_manager.reasoning_config = ReasoningToggleConfig(
+            effort_levels=("low", "high", "max"),
+            effort_aliases=(
+                ("none", "low"),
+                ("minimal", "low"),
+                ("medium", "high"),
+                ("xhigh", "max"),
+            ),
+        )
+        self.chat.chat_encoding_spec = None
+
+    def test_glm53_unsupported_effort_mapped_with_warning(self):
+        self._setup_glm53_effort_levels()
+        with self.assertLogs(
+            "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+        ) as logs:
+            kwargs = self._run_jinja_with_effort("medium")
+        self.assertEqual(kwargs.get("reasoning_effort"), "high")
+        self.assertTrue(any("mapped to 'high'" in m for m in logs.output))
+
+    def test_glm53_supported_effort_passes_through(self):
+        self._setup_glm53_effort_levels()
+        kwargs = self._run_jinja_with_effort("max")
+        self.assertEqual(kwargs.get("reasoning_effort"), "max")
+
+    def test_glm53_unaliased_effort_falls_back_with_warning(self):
+        self._setup_glm53_effort_levels()
+        with self.assertLogs(
+            "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+        ) as logs:
+            kwargs = self._run_jinja_with_effort(0.5)
+        self.assertEqual(kwargs.get("reasoning_effort"), 0.5)
+        self.assertTrue(any("template default" in m for m in logs.output))
+
     def test_non_stream_reasoning_response_preserves_payload_whitespace(self):
         self.chat.reasoning_parser = "qwen3"
         self.template_manager.force_reasoning = False
@@ -3759,7 +3802,9 @@ class InklingReasoningEffortTest(unittest.TestCase):
         "none" (0.0) expresses exactly that."""
         serving = object.__new__(OpenAIServingChat)
         serving.reasoning_parser = "inkling"
-        serving.template_manager = Mock(reasoning_config=None)
+        serving.template_manager = Mock(
+            reasoning_config=None, reasoning_toggle_config=None
+        )
         serving._reasoning_detector = Mock(reasoning_default="always")
         request = ChatCompletionRequest(
             model="test-model", messages=[{"role": "user", "content": "hi"}]

--- a/test/registered/unit/entrypoints/openai/utils.py
+++ b/test/registered/unit/entrypoints/openai/utils.py
@@ -81,6 +81,11 @@ class MockTemplateManager:
         self.force_reasoning = False
         self.jinja_template_may_reorder_tool_results = False
 
+    @property
+    def reasoning_toggle_config(self):
+        config = self.reasoning_config
+        return config if config is not None and config.has_toggle else None
+
 
 def make_serving(*, is_multimodal: bool = False) -> OpenAIServingResponses:
     return OpenAIServingResponses(

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -11,6 +11,7 @@ from sglang.srt.parser.template_detection import (
     detect_reasoning_parser,
     detect_reasoning_pattern,
     detect_tool_call_parser,
+    normalize_reasoning_effort,
     resolve_auto_parsers,
 )
 from sglang.srt.server_args import ServerArgs
@@ -76,6 +77,44 @@ class TestTemplateManagerReasoningDetection(unittest.TestCase):
             ReasoningToggleConfig(toggle_param="enable_thinking", default_enabled=True),
         )
         self.assertEqual(parser, "glm45")
+
+    GLM53_EFFORT_CONFIG = ReasoningToggleConfig(
+        effort_levels=("low", "high", "max"),
+        effort_aliases=(
+            ("none", "low"),
+            ("minimal", "low"),
+            ("medium", "high"),
+            ("xhigh", "max"),
+        ),
+    )
+
+    def test_glm53_effort_levels_detected_without_toggle(self):
+        template = """
+        [gMASK]<sop>
+        {%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+        <|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}
+        """
+        force, config, parser = self._detect(
+            template, ["<tool_call>", "<|endoftext|>", "<|user|>"]
+        )
+
+        self.assertFalse(force)
+        self.assertEqual(config, self.GLM53_EFFORT_CONFIG)
+        self.assertFalse(config.has_toggle)
+        # glm45 parser detection keys on the enable_thinking toggle config;
+        # an effort-level-only config must not trigger it.
+        self.assertIsNone(parser)
+
+    def test_glm53_effort_alias_mapping(self):
+        config = self.GLM53_EFFORT_CONFIG
+        self.assertEqual(normalize_reasoning_effort("none", config), "low")
+        self.assertEqual(normalize_reasoning_effort("minimal", config), "low")
+        self.assertEqual(normalize_reasoning_effort("medium", config), "high")
+        self.assertEqual(normalize_reasoning_effort("xhigh", config), "max")
+        for supported in ("low", "high", "max"):
+            self.assertEqual(normalize_reasoning_effort(supported, config), supported)
+        self.assertEqual(normalize_reasoning_effort("extreme", config), "extreme")
+        self.assertEqual(normalize_reasoning_effort("medium", None), "medium")
 
     def test_interns1_detects_enable_thinking_default_true(self):
         template = """


### PR DESCRIPTION
## Motivation

GLM-5.3-style chat templates only honor an explicit effort allowlist:

```jinja
{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
```

Harnesses that send OpenAI/Anthropic-style levels (`medium`, `xhigh`, `minimal`, `none`) therefore silently get `max` — a client asking for `medium` runs at `max` with no signal, and every session has to be reconfigured by hand (see zai-org/GLM-5.3-Flash discussion [#41](https://huggingface.co/zai-org/GLM-5.3-Flash/discussions/41)). Hosted APIs add an alias-mapping layer for this; open-source serving had none.

## Modifications

- `template_detection.py`: `ReasoningToggleConfig` gains `effort_levels` / `effort_aliases`; a new terminal rule detects GLM-5.3-style templates (`reasoning_effort` + `Reasoning Effort:` markers) and declares levels `("low", "high", "max")` with aliases `none`/`minimal` -> `low`, `medium` -> `high`, `xhigh` -> `max`. `normalize_reasoning_effort()` maps a requested effort onto the declared levels.
- `serving_chat.py`: before Jinja rendering, an unsupported `reasoning_effort` is normalized with a warning instead of being passed through verbatim.
- `template_manager.py`: new `reasoning_toggle_config` view that treats effort-level-only configs as "no toggle". The toggle consumers (`apply_reasoning_enabled`, `_get_reasoning_from_request`, Responses API reasoning gating) use it, so reasoning-mode inference for these models is unchanged, and `force_reasoning` stays `False` (parser auto-detection untouched).

Behavior:

| request | before | after |
|---|---|---|
| `low` / `high` / `max` | unchanged | unchanged |
| `medium` | silently `max` | `high` (+ warning) |
| `xhigh` | silently `max` | `max` (+ warning) |
| `none` / `minimal` | silently `max` | `low` (+ warning) |
| numeric / unaliased | template default | template default (+ warning) |

## Accuracy Tests

Serving-layer only; no model-forward/kernel changes, so no accuracy runs.

- `pytest test/registered/unit/parser/test_template_manager.py test/registered/unit/entrypoints/openai/test_serving_chat.py test/registered/unit/entrypoints/openai/test_serving_responses.py` — 200 passed, 119 subtests passed (includes new detection, alias-mapping, and serving-level mapping tests).
- Rendered the real GLM-5.3-Flash chat template with normalized efforts: `medium` -> `Reasoning Effort: High`, `xhigh` -> `Max`, `none` -> `Low`; GLM-4.6 / GLM-5 template detection results unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33856031012](https://github.com/sgl-project/sglang/actions/runs/33856031012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34094977150](https://github.com/sgl-project/sglang/actions/runs/34094977150)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33856031158](https://github.com/sgl-project/sglang/actions/runs/33856031158)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->