### PR TITLE
fix(bailing): pass qualified prefix to lm_head

### DIFF
--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -30,7 +30,10 @@ from sglang.srt.layers.linear import (
     QKVParallelLinear,
     RowParallelLinear,
 )
-from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessor,
+    should_apply_lm_head_quant_method,
+)
 from sglang.srt.layers.moe import should_skip_post_experts_all_reduce
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
@@ -1372,8 +1375,11 @@ class BailingMoELinearForCausalLM(nn.Module):
             pp_proxy_tensors=pp_proxy_tensors,
         )
         if self.pp_group.is_last_rank:
+            quant_method = getattr(self.lm_head, "quant_method", None)
+            if not should_apply_lm_head_quant_method(self.lm_head, quant_method):
+                hidden_states = hidden_states.float()
             return self.logits_processor(
-                input_ids, hidden_states.float(), self.lm_head, forward_batch
+                input_ids, hidden_states, self.lm_head, forward_batch
             )
         else:
             return hidden_states

--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -1085,6 +1085,7 @@ class BailingMoELinearForCausalLM(nn.Module):
                     config.hidden_size,
                     params_dtype=torch.float32,
                     quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
                     use_attn_tp_group=get_parallel().enable_dp_lm_head,
                 )
             )

--- a/test/registered/unit/models/test_bailing_lm_head_prefix.py
+++ b/test/registered/unit/models/test_bailing_lm_head_prefix.py
@@ -1,0 +1,65 @@
+"""Regression tests for Bailing's qualified lm_head quantization prefix."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import torch
+
+import sglang.srt.layers.vocab_parallel_embedding as embedding
+import sglang.srt.models.bailing_moe_linear as bailing
+from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
+from sglang.test.test_utils import CustomTestCase
+
+
+class _RecordingQuantConfig:
+    def __init__(self):
+        self.prefixes = []
+
+    def get_quant_method(self, _layer, prefix):
+        self.prefixes.append(prefix)
+        return UnquantizedEmbeddingMethod()
+
+
+class TestBailingLmHeadPrefix(CustomTestCase):
+    def _construct(self, prefix):
+        config = SimpleNamespace(
+            tie_word_embeddings=False, vocab_size=128, hidden_size=128
+        )
+        parallel = SimpleNamespace(enable_dp_lm_head=False, tp_rank=0, tp_size=1)
+        quant_config = _RecordingQuantConfig()
+
+        # Keep Bailing's real lm_head construction and quantization dispatch,
+        # while avoiding the transformer body and distributed initialization.
+        with (
+            patch.object(
+                bailing, "BailingMoELinearModel", return_value=torch.nn.Identity()
+            ),
+            patch.object(bailing, "LogitsProcessor", return_value=torch.nn.Identity()),
+            patch.object(
+                bailing, "get_pp_group", return_value=SimpleNamespace(is_last_rank=True)
+            ),
+            patch.object(bailing, "get_parallel", return_value=parallel),
+            patch.object(embedding, "get_parallel", return_value=parallel),
+        ):
+            bailing.BailingMoELinearForCausalLM(
+                config=config, quant_config=quant_config, prefix=prefix
+            )
+
+        return quant_config.prefixes
+
+    def test_lm_head_receives_qualified_prefix(self):
+        self.assertEqual(
+            self._construct("language_model"), ["language_model.lm_head"]
+        )
+
+    def test_lm_head_prefix_is_unqualified_at_model_root(self):
+        self.assertEqual(self._construct(""), ["lm_head"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_bailing_lm_head_prefix.py
+++ b/test/registered/unit/models/test_bailing_lm_head_prefix.py
@@ -53,9 +53,7 @@ class TestBailingLmHeadPrefix(CustomTestCase):
         return quant_config.prefixes
 
     def test_lm_head_receives_qualified_prefix(self):
-        self.assertEqual(
-            self._construct("language_model"), ["language_model.lm_head"]
-        )
+        self.assertEqual(self._construct("language_model"), ["language_model.lm_head"])
 
     def test_lm_head_prefix_is_unqualified_at_model_root(self):
         self.assertEqual(self._construct(""), ["lm_head"])

--- a/test/registered/unit/models/test_bailing_lm_head_quantization.py
+++ b/test/registered/unit/models/test_bailing_lm_head_quantization.py
@@ -1,0 +1,210 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.vocab_parallel_embedding as embedding
+import sglang.srt.models.bailing_moe_linear as bailing
+from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
+from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+def _quant_config(targets, ignore=(), block=False):
+    weights = {
+        "num_bits": 8,
+        "type": "float" if block else "int",
+        "strategy": "block" if block else "channel",
+        "symmetric": True,
+        "dynamic": False,
+    }
+    if block:
+        weights["block_structure"] = [128, 128]
+    return CompressedTensorsConfig.from_config(
+        {
+            "format": "float-quantized" if block else "int-quantized",
+            "quant_method": "compressed-tensors",
+            "ignore": list(ignore),
+            "config_groups": {
+                "head": {
+                    "targets": list(targets),
+                    "weights": weights,
+                    "input_activations": {
+                        "num_bits": 8,
+                        "type": weights["type"],
+                        "strategy": "token",
+                        "symmetric": True,
+                        "dynamic": True,
+                    },
+                }
+            },
+        }
+    )
+
+
+class TestBailingLmHeadQuantization(CustomTestCase):
+    def _model(self, quant_config, prefix="", hidden_states=None):
+        config = SimpleNamespace(
+            tie_word_embeddings=False, vocab_size=128, hidden_size=128
+        )
+        parallel = SimpleNamespace(enable_dp_lm_head=False, tp_rank=0, tp_size=1)
+        # Keep the real model constructor, head, and quantization dispatch;
+        # omit the transformer body and distributed process-group setup.
+        with (
+            patch.object(
+                bailing, "BailingMoELinearModel", return_value=torch.nn.Identity()
+            ),
+            patch.object(bailing, "LogitsProcessor", return_value=torch.nn.Identity()),
+            patch.object(
+                bailing, "get_pp_group", return_value=SimpleNamespace(is_last_rank=True)
+            ),
+            patch.object(bailing, "get_parallel", return_value=parallel),
+            patch.object(embedding, "get_parallel", return_value=parallel),
+            torch.device("cuda"),
+        ):
+            model = bailing.BailingMoELinearForCausalLM(
+                config=config, quant_config=quant_config, prefix=prefix
+            )
+        if hidden_states is not None:
+            model.model = _HiddenStateModel(hidden_states)
+        return model
+
+    def _head(self, quant_config, prefix=""):
+        return self._model(quant_config, prefix=prefix).lm_head
+
+    def _processor(self):
+        processor = LogitsProcessor.__new__(LogitsProcessor)
+        torch.nn.Module.__init__(processor)
+        processor.vocab_size = 128
+        processor.logit_scale = None
+        processor.use_attn_tp_group = False
+        processor.use_tp_lm_head_all_to_all = False
+        processor.do_tensor_parallel_all_gather = False
+        processor.do_tensor_parallel_all_gather_dp_attn = False
+        processor.use_fp32_lm_head = True
+        processor.rl_on_policy_target = None
+        processor.final_logit_softcapping = None
+        processor.return_full_logits = False
+        return processor
+
+    def _load_int8_head(self, head):
+        weights = (
+            torch.arange(128 * 128, device="cuda").reshape(128, 128) % 15 - 7
+        ).to(torch.int8)
+        scales = torch.full((128, 1), 1 / 32, device="cuda")
+        head.weight.weight_loader(head.weight, weights)
+        head.weight_scale.weight_loader(head.weight_scale, scales)
+        head.quant_method.process_weights_after_loading(head)
+        return weights, scales
+
+    def test_named_targets_allocate_quantized_head(self):
+        for prefix, target in (
+            ("", "lm_head"),
+            ("language_model", "language_model.lm_head"),
+            ("language_model", "lm_head"),
+            ("language_model", "re:.*lm_head$"),
+        ):
+            with self.subTest(prefix=prefix, target=target):
+                head = self._head(_quant_config([target]), prefix=prefix)
+                self.assertIsInstance(head.quant_method, CompressedTensorsLinearMethod)
+                self.assertEqual(head.weight.dtype, torch.int8)
+                self.assertEqual(head.weight.device.type, "cuda")
+                self.assertEqual(head.weight_scale.shape, (128, 1))
+
+    def test_unquantized_head_conventions(self):
+        for quant_config in (
+            None,
+            _quant_config(["Linear"]),
+            _quant_config(["re:.*lm_head$"], ignore=["language_model.lm_head"]),
+        ):
+            with self.subTest(quant_config=quant_config):
+                head = self._head(quant_config, prefix="language_model")
+                self.assertIsInstance(head.quant_method, UnquantizedEmbeddingMethod)
+                self.assertEqual(head.weight.dtype, torch.float32)
+
+    def test_unsupported_head_quantization_is_rejected(self):
+        with self.assertRaisesRegex(NotImplementedError, "Block-quantized lm_head"):
+            self._head(_quant_config(["lm_head"], block=True))
+
+    def test_quantized_head_matches_dequantized_reference(self):
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                hidden_states = torch.arange(
+                    128, device="cuda", dtype=dtype
+                ).repeat(4, 1)
+                model = self._model(
+                    _quant_config(["language_model.lm_head"]),
+                    prefix="language_model",
+                    hidden_states=hidden_states,
+                )
+                weights, scales = self._load_int8_head(model.lm_head)
+                model.logits_processor = self._processor()
+                observed_dtypes = []
+                model.logits_processor.register_forward_pre_hook(
+                    lambda _module, args: observed_dtypes.append(args[1].dtype)
+                )
+
+                output = model(
+                    input_ids=torch.zeros(4, device="cuda", dtype=torch.long),
+                    positions=torch.zeros(4, device="cuda", dtype=torch.long),
+                    forward_batch=LogitsMetadata(forward_mode=ForwardMode.DECODE),
+                )
+
+                expected = (hidden_states.float() @ weights.float().T * scales.T).to(
+                    dtype
+                )
+                self.assertEqual(observed_dtypes, [dtype])
+                torch.testing.assert_close(
+                    output.next_token_logits, expected.float(), rtol=0, atol=0
+                )
+
+    def test_unquantized_head_matches_fp32_reference(self):
+        hidden_states = torch.arange(128, device="cuda", dtype=torch.bfloat16).repeat(
+            4, 1
+        )
+        model = self._model(None, hidden_states=hidden_states)
+        weights = torch.linspace(
+            -1, 1, 128 * 128, device="cuda", dtype=torch.float32
+        ).reshape(128, 128)
+        model.lm_head.weight.data.copy_(weights)
+        model.logits_processor = self._processor()
+        observed_dtypes = []
+        model.logits_processor.register_forward_pre_hook(
+            lambda _module, args: observed_dtypes.append(args[1].dtype)
+        )
+
+        output = model(
+            input_ids=torch.zeros(4, device="cuda", dtype=torch.long),
+            positions=torch.zeros(4, device="cuda", dtype=torch.long),
+            forward_batch=LogitsMetadata(forward_mode=ForwardMode.DECODE),
+        )
+
+        self.assertEqual(observed_dtypes, [torch.float32])
+        torch.testing.assert_close(
+            output.next_token_logits,
+            hidden_states.float() @ weights.T,
+            rtol=0,
+            atol=0,
+        )
+
+
+class _HiddenStateModel(torch.nn.Module):
+    def __init__(self, hidden_states):
+        super().__init__()
+        self.hidden_states = hidden_states
+
+    def forward(self, **_kwargs):
+        return self.hidden_states
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_bailing_lm_head_quantization.py
+++ b/test/registered/unit/models/test_bailing_lm_head_quantization.py
@@ -138,9 +138,9 @@ class TestBailingLmHeadQuantization(CustomTestCase):
     def test_quantized_head_matches_dequantized_reference(self):
         for dtype in (torch.float16, torch.bfloat16):
             with self.subTest(dtype=dtype):
-                hidden_states = torch.arange(
-                    128, device="cuda", dtype=dtype
-                ).repeat(4, 1)
+                hidden_states = torch.arange(128, device="cuda", dtype=dtype).repeat(
+                    4, 1
+                )
                 model = self._model(
                     _quant_config(["language_model.lm_head"]),
                     prefix="language_model",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

BailingMoELinearForCausalLM did not pass the model prefix to ParallelLMHead, so per-module quantization rules targeting qualified names such as `language_model.lm_head` were silently bypassed. Once the qualified prefix is routed correctly, the quantized lm_head path must also receive FP16/BF16 hidden states because the int8 scaled-GEMM kernel does not accept FP32 output tensors.

Fixes #37848

## Modifications

- Pass `add_prefix("lm_head", prefix)` to Bailing's ParallelLMHead construction.
- Preserve the hidden-state dtype when the lm_head quantization method is active; retain the FP32 path for unquantized lm_heads.
- Add CPU and CUDA-registered regression tests covering qualified prefix routing, quantization target/ignore behavior, quantized lm_head output parity, and the unquantized FP32 reference path.

## Accuracy Tests

On the A100 host, the quantized lm_head logits matched an explicit dequantized reference for both FP16 and BF16 hidden states, and the unquantized lm_head matched the FP32 reference. No full-model GSM8K run was performed because the corresponding Bailing/Ling checkpoint was not cached on the test host; the targeted numerical test directly exercises the changed lm_head path.

## Speed Tests and Profiling

No speed benchmark is applicable. This change only routes quantization metadata and selects a kernel-compatible input dtype; it does not change a numerical algorithm or kernel implementation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). The applicable hooks from the SGLang pre-commit configuration passed on A100: AST/trailing-whitespace/EOF/large-file/merge-conflict/debug/private-key checks, Ruff, Ruff format, isort, codespell, and local SGLang lint hooks.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). A100 result: `7 passed, 17 warnings, 9 subtests passed in 10.42s`.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A: internal model-construction and dtype dispatch plumbing; no user-facing behavior or configuration was added.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy parity passed for FP16/BF16 quantized lm_head outputs and the unquantized FP32 path on A100; speed benchmarking is N/A for this metadata/dispatch fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). Ruff, Ruff format, isort, codespell, compileall, and `git diff --check` passed.

A100 validation command:

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python python -m pytest -q \
  test/registered/unit/models/test_bailing_lm_head_prefix.py \
  test/registered/unit/models/test_bailing_lm_head_quantization.py
```

Result: `7 passed, 17 warnings, 9 subtests passed in 10.42s`.

Additional validation: SGLang applicable pre-commit hooks, `compileall`, and `git diff --check` passed on A100.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33857701217](https://github.com/sgl-project/sglang/actions/runs/33857701217)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33857700698](https://github.com/sgl-project/sglang/actions/runs/33857700698)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33857701108](https://github.com/sgl-project/sglang/actions/runs/33857701108)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->