### PR TITLE
[Fix] Skip SSE comments in serving benchmark

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -321,6 +321,11 @@ async def async_request_openai_completions(
                         if not chunk_bytes:
                             continue
 
+                        # SSE comments (for example, keepalive pings) are not
+                        # JSON data events and must not be parsed as such.
+                        if chunk_bytes.startswith(b":"):
+                            continue
+
                         chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
                         latency = time.perf_counter() - st
                         if chunk == "[DONE]":
@@ -504,6 +509,11 @@ async def async_request_openai_chat_completions(
                         async for chunk_bytes in response.content:
                             chunk_bytes = chunk_bytes.strip()
                             if not chunk_bytes:
+                                continue
+
+                            # SSE comments (for example, keepalive pings) are not
+                            # JSON data events and must not be parsed as such.
+                            if chunk_bytes.startswith(b":"):
                                 continue
 
                             chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")

--- a/test/registered/bench_fn/test_bench_serving_reasoning_stream.py
+++ b/test/registered/bench_fn/test_bench_serving_reasoning_stream.py
@@ -20,6 +20,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from sglang.benchmark.serving import (
     RequestFuncInput,
     async_request_openai_chat_completions,
+    async_request_openai_completions,
     calculate_metrics,
     set_global_args,
 )
@@ -50,7 +51,10 @@ class _SSEHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-cache")
         self.end_headers()
         for chunk in self.chunks:
-            self.wfile.write(b"data: " + json.dumps(chunk).encode() + b"\n\n")
+            if isinstance(chunk, bytes):
+                self.wfile.write(chunk)
+            else:
+                self.wfile.write(b"data: " + json.dumps(chunk).encode() + b"\n\n")
             self.wfile.flush()
             time.sleep(self.chunk_delay_s)
         self.wfile.write(b"data: [DONE]\n\n")
@@ -121,10 +125,18 @@ class TestBenchServingReasoningStream(CustomTestCase):
                 print_requests=False,
                 tokenizer="",
                 header=None,
+                return_logprob=False,
+                top_logprobs_num=0,
+                cache_report=False,
             )
         )
 
-    def _run(self, chunks):
+    def _run(
+        self,
+        chunks,
+        request_func=async_request_openai_chat_completions,
+        endpoint="chat/completions",
+    ):
         port = _free_port()
 
         class Handler(_SSEHandler):
@@ -137,7 +149,7 @@ class TestBenchServingReasoningStream(CustomTestCase):
         try:
             req = RequestFuncInput(
                 prompt="hello",
-                api_url=f"http://127.0.0.1:{port}/v1/chat/completions",
+                api_url=f"http://127.0.0.1:{port}/v1/{endpoint}",
                 prompt_len=1,
                 output_len=64,
                 model="dummy-model",
@@ -145,7 +157,7 @@ class TestBenchServingReasoningStream(CustomTestCase):
                 image_data=None,
                 extra_request_body={},
             )
-            return asyncio.run(async_request_openai_chat_completions(req))
+            return asyncio.run(request_func(req))
         finally:
             server.shutdown()
             server.server_close()
@@ -223,6 +235,41 @@ class TestBenchServingReasoningStream(CustomTestCase):
         self.assertEqual(out.generated_text, "thinking")
         self.assertGreater(out.ttft, 0.0)
         self.assertEqual(out.output_len, 1)
+
+    def test_sse_comments_are_ignored_for_chat_completions(self):
+        chunks = [
+            b":\n\n",
+            _make_chunk(content="hello "),
+            b": keep-alive\n\n",
+            _make_chunk(content="world", completion_tokens=2),
+        ]
+        out = self._run(chunks)
+
+        self.assertTrue(out.success, msg=f"request failed: {out.error}")
+        self.assertEqual(out.generated_text, "hello world")
+        self.assertEqual(len(out.itl), 1)
+        self.assertEqual(out.output_len, 2)
+
+    def test_sse_comments_are_ignored_for_completions(self):
+        chunks = [
+            b":\n\n",
+            {"choices": [{"text": "hello "}]},
+            b": keep-alive\n\n",
+            {
+                "choices": [{"text": "world"}],
+                "usage": {"completion_tokens": 2},
+            },
+        ]
+        out = self._run(
+            chunks,
+            request_func=async_request_openai_completions,
+            endpoint="completions",
+        )
+
+        self.assertTrue(out.success, msg=f"request failed: {out.error}")
+        self.assertEqual(out.generated_text, "hello world")
+        self.assertEqual(len(out.itl), 1)
+        self.assertEqual(out.output_len, 2)
 
     def test_content_only_stream_unchanged(self):
         chunks = [


### PR DESCRIPTION
## Motivation

OpenAI-compatible servers may emit SSE comment frames such as `:` or `: keep-alive` while a request is running. This is common during a long prefill. The serving benchmark currently passes those comments to `json.loads`, causing the warmup or benchmark request to fail with `JSONDecodeError`.

This was reproduced against a llama.cpp OpenAI-compatible server with a 150K-token prompt.

## Modifications

- Skip SSE comment lines in the OpenAI Completions streaming client.
- Skip SSE comment lines in the OpenAI Chat Completions streaming client.
- Extend the mock SSE test server to emit raw SSE frames.
- Add regression tests for both completions endpoints using `:` and `: keep-alive` comments.

## Accuracy Tests

No model output path is changed. The affected CPU test file passes:

```text
PYTHONPATH=python python test/registered/bench_fn/test_bench_serving_reasoning_stream.py
Ran 12 tests in 6.156s
OK
```

`python -m compileall` and `git diff --check` also pass for the modified files.

## Speed Tests and Profiling

Streaming integration test against llama.cpp:

```text
Input tokens: 150000
Output tokens: 1024
Successful requests: 1/1
TTFT: 830.41 ms
Mean TPOT: 18.89 ms
Mean ITL: 18.89 ms
Output throughput: 50.80 tok/s
```

The same request previously failed during warmup when llama.cpp emitted an SSE keepalive comment.

## Checklist

- [x] Code follows the existing style and passes `git diff --check`.
- [x] Added CPU regression tests.
- [x] Documentation is not needed because this restores standard SSE compatibility without changing the CLI.
- [x] Accuracy and speed implications are documented above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33859858367](https://github.com/sgl-project/sglang/actions/runs/33859858367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33859857988](https://github.com/sgl-project/sglang/actions/runs/33859857988)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33859858251](https://github.com/sgl-project/sglang/actions/runs/33859858251)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->