### PR TITLE
[Docs] Drop deprecated --prefill-round-robin-balance from Ascend DeepSeek-R1

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_r1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_r1.mdx
@@ -176,7 +176,6 @@ do
         --speculative-num-steps 2 \
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 3 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --tokenizer-worker-num 4 \
@@ -489,7 +488,6 @@ do
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 4 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -697,7 +695,6 @@ do
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 2 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -901,7 +898,6 @@ do
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 4 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -1105,7 +1101,6 @@ do
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 4 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -1307,7 +1302,6 @@ do
         --speculative-eagle-topk 1 \
         --speculative-num-draft-tokens 4 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \


### PR DESCRIPTION
## Summary

Ascend DeepSeek-R1 best practices still pass `--prefill-round-robin-balance` in six decode/disaggregation launch snippets. That flag is a `DeprecatedAction` no-op in `python/sglang/srt/server_args.py` (deprecation warning only; does not store a value). Round-robin balancing is already configured with `--load-balance-method round_robin` in each of those snippets.

This docs-only change removes the deprecated flag (×6) and keeps `--load-balance-method round_robin`.

## Repro

```bash
# flag is DeprecatedAction (warn-only no-op):
rg -n 'prefill-round-robin-balance' python/sglang/srt/server_args.py
# docs still advertise it alongside the live replacement:
rg -n 'prefill-round-robin-balance|load-balance-method round_robin' \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_r1.mdx
```

## Test plan

- [x] Confirmed `--prefill-round-robin-balance` is `DeprecatedAction` on main
- [x] Confirmed each of the six snippets already has `--load-balance-method round_robin`
- [x] Patched file has 0 remaining `--prefill-round-robin-balance` and 6× `--load-balance-method round_robin`
- [ ] Docs preview of Ascend DeepSeek-R1 best practices no longer shows the deprecated flag

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33860398704](https://github.com/sgl-project/sglang/actions/runs/33860398704)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33860398354](https://github.com/sgl-project/sglang/actions/runs/33860398354)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->