### PR TITLE
[Spec] Publish single-layer EAGLE shared-read event after replay

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -613,18 +613,18 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on (draft extend
-        # is the EAGLE-family last shared-read phase; last write wins the mailbox).
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.shared_read_done_event = read_done
-
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             out = self._replay_graph(shape_key, forward_batch)
+
+        # The replay still reads the scheduler-shared KV state. Publish the
+        # read-done event only after replay so the scheduler's WAR barrier
+        # cannot reuse or release a row while this graph is in flight.
+        read_done = self.device_module.Event()
+        read_done.record()
+        self.model_runner.shared_read_done_event = read_done
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:raw_bs],

--- a/test/registered/unit/spec/test_eagle_draft_extend_shared_read_event.py
+++ b/test/registered/unit/spec/test_eagle_draft_extend_shared_read_event.py
@@ -1,0 +1,122 @@
+"""Regression test for the EAGLE draft-extend shared-read fence."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative import eagle_draft_extend_cuda_graph_runner as runner_module
+from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+    EAGLEDraftExtendCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _RecordingEvent:
+    def __init__(self, trace):
+        self.trace = trace
+
+    def record(self):
+        self.trace.append("read_done")
+
+
+class _RecordingDevice:
+    def __init__(self, trace):
+        self.trace = trace
+
+    def Event(self):
+        return _RecordingEvent(self.trace)
+
+
+class _RecordingAttentionBackend:
+    def __init__(self, trace):
+        self.trace = trace
+
+    def init_forward_metadata_out_graph(self, forward_batch):
+        self.trace.append("metadata")
+
+
+class TestEagleDraftExtendSharedReadEvent(CustomTestCase):
+    def test_event_is_published_after_graph_replay(self):
+        trace = []
+        runner = EAGLEDraftExtendCudaGraphRunner.__new__(
+            EAGLEDraftExtendCudaGraphRunner
+        )
+        runner.device_module = _RecordingDevice(trace)
+        runner.deepep_adapter = SimpleNamespace(replay=lambda: None)
+        runner.buffers = SimpleNamespace(
+            input_ids=torch.empty(1, dtype=torch.int64),
+            seq_lens=torch.empty(1, dtype=torch.int64),
+            out_cache_loc=torch.empty(1, dtype=torch.int64),
+            positions=torch.empty(1, dtype=torch.int64),
+            req_pool_indices=torch.empty(1, dtype=torch.int64),
+            extend_seq_lens=torch.empty(1, dtype=torch.int32),
+            num_correct_drafts=torch.empty(1, dtype=torch.int32),
+            num_accept_tokens=torch.empty(1, dtype=torch.int32),
+            select_index=torch.empty(1, dtype=torch.int64),
+            hidden_states=None,
+            global_num_tokens_gpu=None,
+            global_num_tokens_for_logprob_gpu=None,
+            seq_lens_cpu=torch.empty(1, dtype=torch.int64),
+        )
+        runner.require_mlp_tp_gather = False
+        runner.require_gathered_buffer = False
+        runner.captured_req_width = 1
+        runner.capture_bs = [1]
+        runner.seq_len_fill_value = 1
+        runner.extend_seq_lens_cpu = [1]
+        runner.forward_mode = ForwardMode.DRAFT_EXTEND_V2
+        runner.draft_extend_attn_backend = _RecordingAttentionBackend(trace)
+        runner.model_runner = SimpleNamespace(
+            device_timer=None,
+            shared_read_done_event=None,
+            spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
+        )
+        runner._make_graph_key = lambda bs: bs
+
+        def replay_graph(shape_key, forward_batch):
+            trace.append("replay")
+            return LogitsProcessorOutput(
+                next_token_logits=torch.zeros(1, 4),
+                hidden_states=torch.zeros(1, 2),
+            )
+
+        runner._replay_graph = replay_graph
+        forward_batch = SimpleNamespace(
+            batch_size=1,
+            input_ids=torch.tensor([1], dtype=torch.int64),
+            seq_lens=torch.tensor([2], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([2], dtype=torch.int64),
+            seq_lens_sum=2,
+            out_cache_loc=torch.tensor([0], dtype=torch.int64),
+            positions=torch.tensor([2], dtype=torch.int64),
+            req_pool_indices=torch.tensor([0], dtype=torch.int64),
+            extend_seq_lens=None,
+            extend_seq_lens_cpu=None,
+            out_cache_loc_dsv4=None,
+            spec_info=SimpleNamespace(
+                num_correct_drafts=torch.tensor([0], dtype=torch.int32),
+                num_accept_tokens=torch.tensor([1], dtype=torch.int32),
+                hidden_states=None,
+            ),
+        )
+
+        def copy_group(dst, src):
+            for dst_tensor, src_tensor in zip(dst, src):
+                dst_tensor.copy_(src_tensor)
+
+        with patch.object(runner_module, "_grouped_foreach_copy_", copy_group):
+            runner.execute(forward_batch, torch.tensor([0], dtype=torch.int64))
+
+        self.assertEqual(trace, ["metadata", "replay", "read_done"])
+        self.assertIsNotNone(runner.model_runner.shared_read_done_event)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When overlap scheduling runs single-layer EAGLE draft-extend, the shared-read event is published before the CUDA graph replay. The scheduler uses this event as a WAR barrier before reusing shared request/KV rows, so the graph can still be reading a row after the barrier has passed. This can leave speculative gather state inconsistent when a constrained request is inserted during decode. Refs #37936.

## Modifications

- Publish `shared_read_done_event` after the draft-extend CUDA graph replay, matching the final replay fence used by multi-layer EAGLE.
- Add a CPU regression test that records metadata, replay, and event-publication order.

## Accuracy Tests

- No model math, sampling, or output transformation changed.
- A100 runtime stress with EAGLE: one 2500-token decode plus 16 concurrent forced empty-object tool-call requests completed; all 16 tool requests returned HTTP 200, the long decode completed 2500 tokens, and health remained HTTP 200. No async CUDA assertion, NCCL abort, or Xid message appeared in the service log. This used an A100-compatible Llama/EAGLE test model, not the V100/Qwen configuration from #37936.
- Focused unit tests run on the A100 host:
  - `test_eagle_draft_extend_shared_read_event.py`
  - `test_eagle_draft_cuda_graph_runner.py` (3 tests)

## Speed Tests and Profiling

- Not benchmarked; this is a synchronization-order fix.

## Checklist

- [x] Format code according to pre-commit style; the configured pre-commit hooks passed on both changed files, including isort, ruff, ruff-format, codespell, AST, and registered-test checks.
- [x] Add unit tests according to the test conventions.
- [x] Documentation update is not needed for this internal synchronization fix.
- [x] Runtime validation is included above; no speed benchmark is applicable.
- [x] Follow the SGLang code style guidance.