### PR TITLE
Fix DSV4 C4 top-k v2 dispatch with raw indices

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -439,6 +439,70 @@ def topk_transform_flashinfer_fused(
     )
 
 
+def _run_c4_topk_transform(
+    *,
+    dsa_topk_backend: DSATopKBackend,
+    flashinfer_topk_transform: Callable[..., None],
+    logits: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    c4_sparse_page_indices: torch.Tensor,
+    page_size: int,
+    topk_metadata: torch.Tensor,
+    raw_indices: Optional[torch.Tensor],
+) -> None:
+    if dsa_topk_backend.is_torch():
+        topk_transform_pytorch_vectorized(
+            logits,
+            c4_seq_lens,
+            page_table,
+            c4_sparse_page_indices,
+            page_size,
+            raw_indices,
+        )
+    elif dsa_topk_backend.is_flashinfer():
+        flashinfer_topk_transform(
+            logits,
+            c4_seq_lens,
+            page_table,
+            c4_sparse_page_indices,
+            page_size,
+            raw_indices,
+        )
+    elif dsa_topk_backend.should_use_topk_v2():
+        if raw_indices is not None:
+            # Sparse-prefill consumes request-local raw C4 positions, while the
+            # attention path consumes KV-pool page indices. Top-k v2 supports
+            # both output modes independently; use it for both instead of
+            # falling back to the legacy top-k v1 kernel solely because the raw
+            # output buffer is present.
+            topk_transform_paged_v2(
+                logits,
+                c4_seq_lens,
+                None,
+                raw_indices,
+                page_size,
+                topk_metadata,
+            )
+        topk_transform_paged_v2(
+            logits,
+            c4_seq_lens,
+            page_table,
+            c4_sparse_page_indices,
+            page_size,
+            topk_metadata,
+        )
+    else:
+        topk_transform_paged(
+            logits,
+            c4_seq_lens,
+            page_table,
+            c4_sparse_page_indices,
+            page_size,
+            raw_indices,
+        )
+
+
 class C4IndexerBackendMixin:
     def __init__(self):
         super().__init__()
@@ -850,48 +914,24 @@ class C4IndexerBackendMixin:
 
         def run_topk_transform(rows: slice, logits: torch.Tensor) -> None:
             row_raw_indices = raw_indices[rows] if raw_indices is not None else None
-            if self.dsa_topk_backend.is_torch():
-                topk_transform_pytorch_vectorized(
-                    logits,
-                    c4_seq_lens[rows],
-                    page_table[rows],
-                    c4_sparse_page_indices[rows],
-                    indexer_metadata.c4_page_size,
-                    row_raw_indices,
-                )
-            elif self.dsa_topk_backend.is_flashinfer():
-                self.flashinfer_topk_transform(
-                    logits,
-                    c4_seq_lens[rows],
-                    page_table[rows],
-                    c4_sparse_page_indices[rows],
-                    indexer_metadata.c4_page_size,
-                    row_raw_indices,
-                )
-            elif self.dsa_topk_backend.should_use_topk_v2() and raw_indices is None:
-                topk_transform_paged_v2(
-                    logits,
-                    c4_seq_lens[rows],
-                    page_table[rows],
-                    c4_sparse_page_indices[rows],
-                    indexer_metadata.c4_page_size,
-                    # The cached plan routes rows by their index in the full
-                    # range, so a chunk needs one built over its own rows.
-                    (
-                        indexer_metadata.topk_metadata
-                        if rows == all_rows or not is_hip()
-                        else plan_topk_v2(c4_seq_lens[rows])
-                    ),
-                )
-            else:
-                topk_transform_paged(
-                    logits,
-                    c4_seq_lens[rows],
-                    page_table[rows],
-                    c4_sparse_page_indices[rows],
-                    indexer_metadata.c4_page_size,
-                    row_raw_indices,
-                )
+            # The cached plan routes rows by their index in the full range, so a
+            # chunk needs one built over its own rows.
+            topk_metadata = (
+                indexer_metadata.topk_metadata
+                if rows == all_rows or not is_hip()
+                else plan_topk_v2(c4_seq_lens[rows])
+            )
+            _run_c4_topk_transform(
+                dsa_topk_backend=self.dsa_topk_backend,
+                flashinfer_topk_transform=self.flashinfer_topk_transform,
+                logits=logits,
+                c4_seq_lens=c4_seq_lens[rows],
+                page_table=page_table[rows],
+                c4_sparse_page_indices=c4_sparse_page_indices[rows],
+                page_size=indexer_metadata.c4_page_size,
+                topk_metadata=topk_metadata,
+                raw_indices=row_raw_indices,
+            )
 
         if nonpaged_plan is not None:
             assert isinstance(q_indexer, torch.Tensor)

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -26,7 +26,11 @@ from sglang.srt.layers.attention.dsa_backend import (
     DeepseekSparseAttnBackend,
     DSAMetadata,
 )
-from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
+from sglang.srt.layers.attention.dsv4.indexer import (
+    C4IndexerBackendMixin,
+    _run_c4_topk_transform,
+    topk_transform_pytorch_vectorized,
+)
 from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.linear import LinearBase
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
@@ -298,6 +302,70 @@ class TestDSAIndexer(CustomTestCase):
         self.config = DEFAULT_CONFIG.copy()
         self.device = "cuda"
         self.dtype = torch.bfloat16
+
+    def test_c4_paged_topk_v2_fills_raw_indices_without_v1_fallback(self):
+        from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
+
+        batch_size = 3
+        seq_len = 4096
+        topk = 2048
+        page_size = 64
+        torch.manual_seed(37892)
+        scores = torch.randn(
+            batch_size, seq_len, dtype=torch.float32, device=self.device
+        )
+        expected_scores = scores.clone()
+        seq_lens = torch.tensor(
+            [seq_len, seq_len - 17, seq_len // 2],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        page_table = (
+            torch.arange(
+                (seq_len + page_size - 1) // page_size,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            + 1000
+        )
+        page_table = page_table.unsqueeze(0).expand(batch_size, -1).contiguous()
+        raw_indices = torch.full(
+            (batch_size, topk), -1, dtype=torch.int32, device=self.device
+        )
+        page_indices = torch.full_like(raw_indices, -1)
+        topk_metadata = plan_topk_v2(seq_lens)
+        torch.cuda.synchronize()
+
+        with envs.SGLANG_OPT_USE_TOPK_V2.override(True):
+            _run_c4_topk_transform(
+                dsa_topk_backend=DSATopKBackend.SGL_KERNEL,
+                flashinfer_topk_transform=topk_transform_pytorch_vectorized,
+                logits=scores,
+                c4_seq_lens=seq_lens,
+                page_table=page_table,
+                c4_sparse_page_indices=page_indices,
+                page_size=page_size,
+                topk_metadata=topk_metadata,
+                raw_indices=raw_indices,
+            )
+        torch.cuda.synchronize()
+
+        # Legacy top-k v1 only supports topk <= 1024. Using topk=2048 makes this
+        # a real dispatch regression test without mocking kernel calls.
+        page_bias = int(page_table[0, 0]) * page_size
+        for row in range(batch_size):
+            length = int(seq_lens[row])
+            expected = set(
+                torch.topk(expected_scores[row, :length], topk, sorted=False)
+                .indices.cpu()
+                .tolist()
+            )
+            actual_raw = set(raw_indices[row].cpu().tolist())
+            self.assertEqual(actual_raw, expected)
+
+            expected_pages = {idx + page_bias for idx in expected}
+            actual_pages = set(page_indices[row].cpu().tolist())
+            self.assertEqual(actual_pages, expected_pages)
 
     def _init_model_runner(self, config_override=None):
         """Initialize model runner with optional config override."""


### PR DESCRIPTION
## Summary

Fixes #37892.

DSV4 paged prefill can request both outputs from the C4 top-k transform:

- request-local raw C4 positions for sparse prefill / capture paths
- page-table-transformed KV slots for the attention path

The previous dispatch only used `topk_transform_paged_v2` when `raw_indices is None`. In the paged-prefill path `raw_indices` is present, so the default `sgl-kernel` backend fell back to the legacy top-k v1 kernel and could crash on GB300 long-context prefill.

This change keeps the default `sgl-kernel` backend on top-k v2 even when raw indices are requested: it runs v2 once in raw-index mode, then once in page-table mode. Torch and FlashInfer backends keep their existing single-call behavior.

## Testing

- `python3 -m py_compile python/sglang/srt/layers/attention/dsv4/indexer.py test/registered/kernels/ops/attention/test_dsa_indexer.py`
- pre-commit hooks from `git commit` passed, including ruff and ruff-format
- GB300 PR branch `93c62095a`: `PYTHONPATH=/scratch/sglang-pr37991/python python3 -m pytest test/registered/kernels/ops/attention/test_dsa_indexer.py -k c4_paged_topk_v2_fills_raw_indices_without_v1_fallback -s` passed, 1 selected / 13 deselected
- GB300 4-GPU repro on exact main `b168f905c8` before the fix: 32K benchmark crashes in `topk_v1.cuh:348` with CUDA illegal memory access
- GB300 4-GPU FlashInfer top-k workaround: same 64 x 32768-token benchmark passed
- GB300 4-GPU equivalent patch on exact main `b168f905c8`, default `sgl-kernel` top-k: same 64 x 32768-token benchmark passed, 64/64 successful requests, no `topk_v1` / illegal-memory / fatal error
- GB300 CUDA/JIT micro-regression: `topk_transform_paged_v2` raw mode matches `torch.topk` selected-index set, and page-table mode matches the corresponding physical-slot transform

Note: the PR branch is rebased onto current `upstream/main` (`d7f235daca` when created). The full GB300 model benchmark above was run on the same fix applied to exact main `b168f905c8`, before `upstream/main` advanced.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33861479271](https://github.com/sgl-project/sglang/actions/runs/33861479271)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33865977574](https://github.com/sgl-project/sglang/actions/runs/33865977574)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33861479370](https://github.com/sgl-project/sglang/actions/runs/33861479370)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->