### PR TITLE
[Docs] Use --speculative-algorithm in Intern-S2-Preview MTP tip

### DIFF
--- a/docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx
+++ b/docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx
@@ -53,7 +53,7 @@ import { InternS2PreviewDeployment } from "/src/snippets/autoregressive/intern-s
 - Use `tp>=2` for the NVIDIA deployment commands.
 - Use `--reasoning-parser qwen3` to separate reasoning content from final content in streaming responses.
 - Use `--tool-call-parser qwen3_coder` when serving tool-calling workloads.
-- Add `--mamba-radix-cache-strategy extra_buffer` with `--speculative-algo 'NEXTN'` to enable MTP.
+- Add `--mamba-radix-cache-strategy extra_buffer` with `--speculative-algorithm NEXTN` to enable MTP.
 - If weight loading is slow, add `--model-loader-extra-config='{"enable_multithread_load": "true", "num_threads": 64}'`.
 
 ## 4. Model Invocation

--- a/docs/src/snippets/autoregressive/intern-s2-preview-deployment.jsx
+++ b/docs/src/snippets/autoregressive/intern-s2-preview-deployment.jsx
@@ -78,7 +78,7 @@ export const InternS2PreviewDeployment = () => {
     if (toolcall === 'enabled') flags.push('  --tool-call-parser qwen3_coder');
     if (mtp === 'enabled') {
       flags.push('  --mamba-radix-cache-strategy extra_buffer');
-      flags.push("  --speculative-algo 'NEXTN'");
+      flags.push("  --speculative-algorithm NEXTN");
       flags.push('  --speculative-eagle-topk 1');
       flags.push('  --speculative-num-steps 3');
       flags.push('  --speculative-num-draft-tokens 4');


### PR DESCRIPTION
## Summary
The Intern-S2-Preview cookbook tip and deployment playground used a ghost CLI flag `--speculative-algo`. The live server argument is `--speculative-algorithm` (field `speculative_algorithm` in `python/sglang/srt/server_args.py`); `NEXTN` remains a valid builtin. Align both docs with sibling Intern-S2-Mobius / other deployment snippets.

## Changes
- `docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx`: `--speculative-algo 'NEXTN'` → `--speculative-algorithm NEXTN`
- `docs/src/snippets/autoregressive/intern-s2-preview-deployment.jsx`: same rename in generated MTP command

## Local repro
Against `main` @ `d7f235daca1e56eb42d3b81a8f91c5748a3160b9`:

```bash
# 1) Ghost flag is not registered (no alias either)
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/d7f235daca1e56eb42d3b81a8f91c5748a3160b9/python/sglang/srt/server_args.py \
  | rg -n 'speculative_algorithm|--speculative-algo'
# expect: field speculative_algorithm / help text; no standalone --speculative-algo

# 2) Docs still document the ghost spelling
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/d7f235daca1e56eb42d3b81a8f91c5748a3160b9/docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx \
  | rg -n "speculative-algo"
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/d7f235daca1e56eb42d3b81a8f91c5748a3160b9/docs/src/snippets/autoregressive/intern-s2-preview-deployment.jsx \
  | rg -n "speculative-algo"

# 3) Sibling Mobius docs already use the correct flag
curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/d7f235daca1e56eb42d3b81a8f91c5748a3160b9/docs/cookbook/autoregressive/InternLM/Intern-S2-Mobius.mdx \
  | rg -n "speculative-algorithm NEXTN"
```

## Test plan
- [x] Grep `server_args.py` for `speculative_algorithm` / absence of `--speculative-algo`
- [x] Confirm `NEXTN` listed in speculative algorithm builtins
- [x] Diff only the two Intern-S2-Preview doc files above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33861901460](https://github.com/sgl-project/sglang/actions/runs/33861901460)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33861901339](https://github.com/sgl-project/sglang/actions/runs/33861901339)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->