### PR TITLE
[Rust] Gate health on startup warmup completion

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2205,6 +2205,10 @@ def _execute_server_warmup(server_args: ServerArgs):
     url = server_args.url()
     if get_serving().api_key:
         headers["Authorization"] = f"Bearer {get_serving().api_key}"
+    if envs.SGLANG_RUST_SERVER.get():
+        # The Rust listener binds before this request so /model_info is
+        # available, but health stays 503 until this marked request succeeds.
+        headers["x-sglang-startup-warmup"] = "1"
 
     ssl_verify = ssl_verify_of(server_args)
 

--- a/python/sglang/srt/rust_server/config.py
+++ b/python/sglang/srt/rust_server/config.py
@@ -62,6 +62,7 @@ def _build_server_args(scheduler: Scheduler) -> ServerArgs:
         tokenizer_worker_num=get_serving().tokenizer_worker_num,
         detokenizer_worker_num=get_serving().detokenizer_worker_num,
         skip_tokenizer_init=get_serving().skip_tokenizer_init,
+        skip_server_warmup=get_serving().skip_server_warmup,
         incremental_streaming_output=get_serving().incremental_streaming_output,
         disaggregation_mode=disaggregation_mode,
         model_config=ext.ModelConfig(

--- a/rust/sglang-server/src/api_server/app.rs
+++ b/rust/sglang-server/src/api_server/app.rs
@@ -2,9 +2,17 @@
 //! registers its routes here, and [`serve`] runs the assembled app on the
 //! pre-bound listener until shutdown.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
-use axum::Router;
+use axum::{
+    Router,
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
 
 use super::disaggregation::bootstrap as pd_bootstrap;
 use super::{common, log, native_api, openai};
@@ -26,6 +34,57 @@ pub(super) struct AppState {
     pub(super) chat_formatter: Option<openai::ChatFormatter>,
     /// Response heartbeat (bumped per drained ring frame).
     pub(super) response_activity: ActivityCounter,
+    /// Whether the main process's startup warmup has completed. The listener
+    /// binds before warmup so `/model_info` is available to construct that
+    /// request, but health endpoints must not advertise readiness yet.
+    pub(super) startup_readiness: StartupReadiness,
+}
+
+pub(super) struct StartupReadiness(AtomicBool);
+
+impl StartupReadiness {
+    fn new(skip_server_warmup: bool) -> Self {
+        Self(AtomicBool::new(skip_server_warmup))
+    }
+
+    pub(super) fn is_ready(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+
+    fn record_warmup_status(&self, status: axum::http::StatusCode) {
+        if status.is_success() {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+}
+
+impl Default for StartupReadiness {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+/// Private marker attached by the main process to its startup warmup request.
+/// The middleware flips readiness only after that request returns successfully.
+const STARTUP_WARMUP_HEADER: &str = "x-sglang-startup-warmup";
+
+async fn mark_startup_ready(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let is_startup_warmup = req.headers().contains_key(STARTUP_WARMUP_HEADER)
+        && matches!(
+            req.uri().path(),
+            "/generate" | "/encode" | "/v1/chat/completions"
+        );
+    let response = next.run(req).await;
+    if is_startup_warmup && response.status().is_success() {
+        state
+            .startup_readiness
+            .record_warmup_status(response.status());
+    }
+    response
 }
 
 pub async fn serve(
@@ -47,6 +106,7 @@ pub async fn serve(
         server_args: server_args.clone(),
         chat_formatter,
         response_activity,
+        startup_readiness: StartupReadiness::new(server_args.skip_server_warmup),
     });
     // Each endpoint module registers its own routes and merges here.
     let router = Router::new()
@@ -61,6 +121,10 @@ pub async fn serve(
     // No body limit, matching the Python server.
     let mut app = router
         .layer(axum::extract::DefaultBodyLimit::disable())
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            mark_startup_ready,
+        ))
         .with_state(state);
 
     // Prefill-only KV bootstrap registry. Merged AFTER `with_state` — its
@@ -100,5 +164,25 @@ pub async fn serve(
         _ = shutdown.recv_async() => {
             tracing::info!("shutdown: stopping accepts, aborting in-flight handlers");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn startup_readiness_requires_successful_warmup_unless_skipped() {
+        let readiness = StartupReadiness::new(false);
+        assert!(!readiness.is_ready());
+
+        readiness.record_warmup_status(StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!readiness.is_ready());
+
+        readiness.record_warmup_status(StatusCode::OK);
+        assert!(readiness.is_ready());
+
+        assert!(StartupReadiness::new(true).is_ready());
     }
 }

--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -96,8 +96,8 @@ pub(super) fn native_error(code: StatusCode, message: &str, stream: bool) -> Res
 /// restart. The deep-probe handler is built once with
 /// `SGLANG_HEALTH_CHECK_TIMEOUT` frozen in and serves `/health_generate`
 /// always; `SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION` (default true, mirroring
-/// Python) decides whether `/health` shares it or is a plain 200 (routing the
-/// request already proves the frontend is up).
+/// Python) decides whether `/health` shares it or, after startup warmup, is a
+/// plain 200 (routing the request proves the frontend is up).
 fn health_routes() -> Router<Arc<AppState>> {
     let timeout = std::time::Duration::from_secs(
         environ::env_i64("SGLANG_HEALTH_CHECK_TIMEOUT", 20).max(0) as u64,
@@ -106,11 +106,19 @@ fn health_routes() -> Router<Arc<AppState>> {
     let health = if environ::env_bool("SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION", true) {
         probe.clone()
     } else {
-        get(|| async { StatusCode::OK.into_response() })
+        get(health_without_generation)
     };
     Router::new()
         .route("/health", health)
         .route("/health_generate", probe)
+}
+
+async fn health_without_generation(State(state): State<Arc<AppState>>) -> Response {
+    if state.startup_readiness.is_ready() {
+        StatusCode::OK.into_response()
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE.into_response()
+    }
 }
 
 /// Sentinel host that makes the KV connector no-op. Parity with
@@ -120,7 +128,8 @@ const FAKE_BOOTSTRAP_HOST: &str = "2.2.2.2";
 /// `GET /health_generate` — deep health: confirm the scheduler → detok path is
 /// producing output. 200 if the response heartbeat advances within `timeout`
 /// (from `SGLANG_HEALTH_CHECK_TIMEOUT`, frozen at router build), else 503.
-/// (`/health` uses the same handler when its env gate is on.)
+/// It also returns 503 until startup warmup completes. (`/health` uses the same
+/// handler when its env gate is on.)
 ///
 /// Fires a pre-tokenized 1-token probe (`input_ids = [0]`, skips the tokenizer) so
 /// an idle pipeline produces a frame, then watches the *global*
@@ -131,6 +140,10 @@ async fn health_generate(
     State(state): State<Arc<AppState>>,
     timeout: std::time::Duration,
 ) -> Response {
+    if !state.startup_readiness.is_ready() {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
+
     let baseline = state
         .response_activity
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -607,6 +620,21 @@ mod tests {
                 e2e_latency: None,
             },
         )
+    }
+
+    #[tokio::test]
+    async fn health_is_unavailable_before_startup_warmup_finishes() {
+        let state = Arc::new(AppState {
+            senders: senders(),
+            response_buf: 8,
+            server_args: Arc::new(crate::message::config::ServerArgs::default()),
+            chat_formatter: None,
+            response_activity: Default::default(),
+            startup_readiness: Default::default(),
+        });
+
+        let response = health_generate(State(state), Duration::ZERO).await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[test]

--- a/rust/sglang-server/src/api_server/openai/test_utils.rs
+++ b/rust/sglang-server/src/api_server/openai/test_utils.rs
@@ -104,6 +104,7 @@ pub(super) fn app_state(senders: Senders) -> Arc<super::AppState> {
         server_args: server_args(),
         chat_formatter: None,
         response_activity: Default::default(),
+        startup_readiness: Default::default(),
     })
 }
 

--- a/rust/sglang-server/src/message/config.rs
+++ b/rust/sglang-server/src/message/config.rs
@@ -119,6 +119,9 @@ pub struct ServerArgs {
     /// Token-ids-in / token-ids-out mode: no tokenizer load, raw `output_ids`
     /// frames.
     pub skip_tokenizer_init: bool,
+    /// Start accepting health checks immediately instead of waiting for the
+    /// main process's startup warmup request to finish.
+    pub skip_server_warmup: bool,
     /// Streamed `/generate` frames carry per-step deltas instead of cumulative
     /// text. Matches the Python `TokenizerManager`.
     pub incremental_streaming_output: bool,
@@ -171,6 +174,7 @@ impl ServerArgs {
         tokenizer_worker_num,
         detokenizer_worker_num,
         skip_tokenizer_init,
+        skip_server_warmup,
         incremental_streaming_output,
         disaggregation_mode,
         model_config,
@@ -202,6 +206,7 @@ impl ServerArgs {
         tokenizer_worker_num: usize,
         detokenizer_worker_num: usize,
         skip_tokenizer_init: bool,
+        skip_server_warmup: bool,
         incremental_streaming_output: bool,
         disaggregation_mode: DisaggregationMode,
         model_config: ModelConfig,
@@ -231,6 +236,7 @@ impl ServerArgs {
             tokenizer_worker_num,
             detokenizer_worker_num,
             skip_tokenizer_init,
+            skip_server_warmup,
             incremental_streaming_output,
             disaggregation_mode,
             model_config,
@@ -268,6 +274,7 @@ impl Default for ServerArgs {
             tokenizer_worker_num: 1,
             detokenizer_worker_num: 1,
             skip_tokenizer_init: false,
+            skip_server_warmup: false,
             incremental_streaming_output: false,
             disaggregation_mode: DisaggregationMode::Null,
             model_config: ModelConfig::default(),


### PR DESCRIPTION
[by Codex]

## Summary

- Align Rust frontend readiness with the Python frontend: a successful health response must mean startup warmup has completed.
- Keep Rust `/health` and `/health_generate` at 503 until startup warmup has completed successfully.
- Mark the main process's language, embedding, or multimodal warmup request and flip Rust readiness only after that request returns 2xx.
- Preserve `--skip-server-warmup`: when it is explicitly set, Rust starts ready.
- Leave `test_openai_completion_rust.py` unchanged; radix cache and normal server warmup remain enabled.

## CI impact

This fixes a recurring flake in `test/registered/openai_server/basic/test_openai_completion_rust.py` that has broken pre-merge CI for many unrelated changes. I found the same failure in at least eight pre-merge runs across seven PRs: #28403, #30315, #33068, #35599, #37284, #37601 (twice), and #37820. The test compares Python and Rust frontend logprobs exactly, so the readiness race could fail an otherwise healthy PR without any relevant code changes.

## Error and root cause

The Python frontend keeps both health endpoints at 503 while `ServerStatus` is `Starting`, and changes the status only after startup warmup succeeds. The Rust listener is intentionally bound before the main process runs `_execute_server_warmup`, because the warmup path first queries `/model_info`. However, the Rust health handler previously submitted its own one-token scheduler probe immediately and returned 200 when that probe made progress. Rust could therefore advertise readiness earlier than Python: `popen_launch_server` could observe a healthy server and send the parity test's completion while the real eight-token startup warmup was still running.

With radix cache enabled, this race changed which request populated or reused the shared prompt prefix. The Python launch commonly evaluated the completion with `#new-token: 3, #cached-token: 2/3`, while the raced Rust launch evaluated the full prompt with `#new-token: 5/6, #cached-token: 0`, or co-batched it with warmup. The output tokens were the same, but the different forward-pass shape could produce bitwise-different logprobs on the CI GPU. Radix cache exposed the startup race; it was not the underlying bug.

This behavior originated with the native Rust health handlers in #32876. The parity test was added in #33103. The earlier flake caused by default prefill CUDA graphs (#33352) was a separate issue and was fixed by #34146.

## Why this works

The main process adds an internal marker header only to the startup warmup request. Rust middleware recognizes that marker only on the three actual warmup routes (`/generate`, `/encode`, and `/v1/chat/completions`) and records readiness after a successful response. Both health modes check the same atomic readiness state before returning 200 or running a generation probe. Therefore Rust now follows the Python frontend's `ServerStatus.Starting` contract: health remains 503 during warmup and a health success implies that startup warmup has completed.

If warmup fails, readiness remains false. If warmup is explicitly skipped, the launch-time flag initializes readiness true.

## Validation

- Mandatory full pre-commit command passed, including Rust workspace clippy and rustfmt.
- Focused Rust tests passed for readiness transitions and pre-warmup health returning 503.
- ComputeLab L40S: unchanged `test_openai_completion_rust.py` passed with normal warmup and radix cache enabled (`1 passed`, 421.484 s).
- The Rust run log showed startup warmup first (`POST /generate` 200, 6 new / 0 cached), then health (`GET /health_generate` 200), then the tested completion (3 new / 2 cached), matching the Python request shape.

Failure being addressed: https://github.com/sgl-project/sglang/actions/runs/33831875719/job/100902930637?pr=35599

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34100216762](https://github.com/sgl-project/sglang/actions/runs/34100216762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34414379326](https://github.com/sgl-project/sglang/actions/runs/34414379326)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34100215649](https://github.com/sgl-project/sglang/actions/runs/34100215649)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->