### PR TITLE
[Docs] Use --speculative-algorithm in Qwen3.5 cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -243,7 +243,7 @@ sglang serve \
   --tp 8 \
   --reasoning-parser qwen3 \
   --tool-call-parser qwen3_coder \
-  --speculative-algo NEXTN \
+  --speculative-algorithm NEXTN \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
@@ -871,7 +871,7 @@ SGLANG_USE_CUDA_IPC_TRANSPORT=1 python -m sglang.launch_server \
   --tp 8 \
   --reasoning-parser qwen3 \
   --tool-call-parser qwen3_coder \
-  --speculative-algo NEXTN \
+  --speculative-algorithm NEXTN \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \


### PR DESCRIPTION
## Summary
- Replace ghost `--speculative-algo` with the live CLI flag `--speculative-algorithm` in the Qwen3.5 cookbook NEXTN MTP launch examples (NVIDIA serve snippet and H200 latency benchmark launch).
- `speculative_algorithm` is the ServerArgs field; there is no `--speculative-algo` alias. Sibling docs (e.g. Intern-S2-Mobius, qwen35-deployment playground) already use `--speculative-algorithm NEXTN`.

## Test plan
- [x] Confirmed `--speculative-algo` is absent from `python/sglang/srt/server_args.py` (no DeprecatedAlias).
- [x] Confirmed `--speculative-algorithm` / field `speculative_algorithm` exists; NEXTN is an accepted algorithm value used elsewhere in-tree.
- [x] Diff limited to two command blocks in `docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33864243577](https://github.com/sgl-project/sglang/actions/runs/33864243577)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33864243243](https://github.com/sgl-project/sglang/actions/runs/33864243243)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->