### PR TITLE
Add optional MiniMax H3 taeh3 decoding

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -245,6 +245,28 @@ The first launch resolves every selected source through the normal Hub path. If
 a repository requires authentication, export a Hugging Face token in the
 server environment; no manual pre-download is required.
 
+### Optional: approximate TAEHV `taeh3` decoder
+
+For latency-sensitive preview or realtime applications, install
+[TAEHV](https://github.com/madebyollin/taehv) and pass its MiniMax-H3-specific
+`taeh3.pth` checkpoint:
+
+```bash
+sglang serve \
+  --model-path MiniMaxAI/MiniMax-H3 \
+  --model-variant fl2va \
+  --num-gpus 4 \
+  --ulysses-degree 4 \
+  --vae-config.taehv-checkpoint-path /models/taeh3.pth \
+  --port 30010
+```
+
+This opt-in path changes only visual decoding. It passes H3's 24-channel
+diffusion latents directly to TAEHV with the `taeh3` architecture; the H3 audio
+VAE is unchanged. Do not use `taehv.pth`, which targets Hunyuan Video rather
+than MiniMax H3. TAEHV is faster and smaller than the full H3 visual VAE, but it
+is an approximate decoder and can lose fine detail.
+
 For MiniMax-H3, `--performance-mode speed` deliberately keeps the DiT eager.
 The current `torch.compile` path changes the model's numerical output, so no
 recommended lossless preset enables it implicitly. An explicit

--- a/python/sglang/multimodal_gen/configs/models/vaes/base.py
+++ b/python/sglang/multimodal_gen/configs/models/vaes/base.py
@@ -93,6 +93,7 @@ class VAEConfig(ModelConfig):
     use_parallel_decode: bool = True
     parallel_decode_mode: str = AUTO_PARALLEL_DECODE_MODE
     auto_parallel_decode_min_latent_elements_per_rank: int = 4096
+    taehv_checkpoint_path: str | None = None
 
     def __post_init__(self):
         self.blend_num_frames = (
@@ -214,6 +215,13 @@ class VAEConfig(ModelConfig):
             dest=f"{prefix.replace('-', '_')}.parallel_decode_mode",
             default=None,
             help="Parallel decode mode for VAE",
+        )
+        parser.add_argument(
+            f"--{prefix}.taehv-checkpoint-path",
+            type=str,
+            dest=f"{prefix.replace('-', '_')}.taehv_checkpoint_path",
+            default=None,
+            help="Optional model-specific TAEHV checkpoint for approximate video decoding.",
         )
 
         return parser

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
@@ -258,6 +258,53 @@ class MiniMaxH3DecodingStage(DecodingStage):
         self.video_vae = video_vae
         self.audio_vae = audio_vae
         self._compiled_audio_vae_decode = ActiveTargetCompiledCallable()
+        self._taehv_decoder = None
+        self._taehv_decoder_key = None
+
+    def _get_taehv_decoder(
+        self,
+        checkpoint_path: str,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        key = (checkpoint_path, device, dtype)
+        if self._taehv_decoder is not None and self._taehv_decoder_key == key:
+            return self._taehv_decoder
+        try:
+            from taehv import TAEHV
+        except ImportError as exc:
+            raise RuntimeError(
+                "MiniMax H3 TAEHV decoding requires the `taehv` package"
+            ) from exc
+        decoder = TAEHV(checkpoint_path=checkpoint_path, arch_name="taeh3")
+        decoder = decoder.eval().requires_grad_(False).to(device=device, dtype=dtype)
+        self._taehv_decoder = decoder
+        self._taehv_decoder_key = key
+        return decoder
+
+    def _decode_taehv_video(
+        self,
+        latents: torch.Tensor,
+        *,
+        checkpoint_path: str,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        decoder = self._get_taehv_decoder(
+            checkpoint_path,
+            device=latents.device,
+            dtype=dtype,
+        )
+        latents_ntchw = latents.transpose(1, 2).to(dtype=dtype)
+        frames_ntchw = _required_tensor(
+            decoder.decode_video(
+                latents_ntchw,
+                parallel=True,
+                show_progress_bar=False,
+            ),
+            "TAEHV.decode_video",
+        )
+        return frames_ntchw.transpose(1, 2)
 
     @property
     def role_affinity(self) -> RoleType:
@@ -377,38 +424,47 @@ class MiniMaxH3DecodingStage(DecodingStage):
             self.video_vae = selected_video_vae
             if selected_video_vae.training:
                 selected_video_vae.eval()
-            visual_arch_config = server_args.pipeline_config.vae_config.arch_config
-            visual_decode_latent = _reverse_normalize_latents(
-                visual_latent,
-                mean_values=visual_arch_config.latents_mean,
-                std_values=visual_arch_config.latents_std,
-                name="video_vae",
-            )
+            vae_config = server_args.pipeline_config.vae_config
+            taehv_checkpoint_path = vae_config.taehv_checkpoint_path
             video_vae_dtype = resolve_decode_precision(server_args, "video_vae")
             visual_autocast_enabled = autocast_enabled_for_device(
                 visual_latent, video_vae_dtype, server_args.disable_autocast
             )
-            if visual_autocast_enabled:
+            if visual_autocast_enabled and taehv_checkpoint_path is None:
                 selected_video_vae.prepare_decoder_autocast_weights(video_vae_dtype)
             with autocast_context(
                 video_vae_dtype,
                 server_args.disable_autocast,
                 enabled=visual_autocast_enabled,
             ):
-                video_decode = self._get_vae_decode_fn(
-                    selected_video_vae,
-                    server_args,
-                    decode_fn=selected_video_vae.decode_base,
-                )
-                with set_forward_context(current_timestep=0, attn_metadata=None):
-                    visual_frames = video_decode(visual_decode_latent)
-                visual_frames = selected_video_vae.processor.revert_tensor(
-                    visual_frames
-                )
-                visual_frames = _required_tensor(
-                    visual_frames,
-                    "video_vae.processor.revert_tensor",
-                )
+                if taehv_checkpoint_path is not None:
+                    visual_frames = self._decode_taehv_video(
+                        visual_latent,
+                        checkpoint_path=taehv_checkpoint_path,
+                        dtype=video_vae_dtype,
+                    )
+                else:
+                    visual_arch_config = vae_config.arch_config
+                    visual_decode_latent = _reverse_normalize_latents(
+                        visual_latent,
+                        mean_values=visual_arch_config.latents_mean,
+                        std_values=visual_arch_config.latents_std,
+                        name="video_vae",
+                    )
+                    video_decode = self._get_vae_decode_fn(
+                        selected_video_vae,
+                        server_args,
+                        decode_fn=selected_video_vae.decode_base,
+                    )
+                    with set_forward_context(current_timestep=0, attn_metadata=None):
+                        visual_frames = video_decode(visual_decode_latent)
+                    visual_frames = selected_video_vae.processor.revert_tensor(
+                        visual_frames
+                    )
+                    visual_frames = _required_tensor(
+                        visual_frames,
+                        "video_vae.processor.revert_tensor",
+                    )
                 visual_frames = _canonical_visual_video_frames(
                     visual_frames, batch_size=int(visual_latent.shape[0])
                 )

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_taehv.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_taehv.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.stages.decoding import (
+    MiniMaxH3DecodingStage,
+)
+
+
+class _FakeTAEHV:
+    instances = []
+
+    def __init__(self, *, checkpoint_path, arch_name):
+        self.checkpoint_path = checkpoint_path
+        self.arch_name = arch_name
+        self.decode_inputs = []
+        self.device = None
+        self.dtype = None
+        self.instances.append(self)
+
+    def eval(self):
+        return self
+
+    def requires_grad_(self, value):
+        assert value is False
+        return self
+
+    def to(self, *, device, dtype):
+        self.device = device
+        self.dtype = dtype
+        return self
+
+    def decode_video(self, latents, *, parallel, show_progress_bar):
+        self.decode_inputs.append(latents.clone())
+        assert parallel is True
+        assert show_progress_bar is False
+        batch, _, _, height, width = latents.shape
+        return torch.full((batch, 5, 3, height * 16, width * 16), 0.25)
+
+
+def test_h3_taehv_uses_taeh3_architecture_and_diffusion_latents(monkeypatch):
+    _FakeTAEHV.instances.clear()
+    monkeypatch.setitem(sys.modules, "taehv", SimpleNamespace(TAEHV=_FakeTAEHV))
+    stage = MiniMaxH3DecodingStage(video_vae=None, audio_vae=None)
+    latents = torch.arange(1 * 24 * 7 * 2 * 3, dtype=torch.float32).reshape(
+        1, 24, 7, 2, 3
+    )
+
+    frames = stage._decode_taehv_video(
+        latents,
+        checkpoint_path="/models/taeh3.pth",
+        dtype=torch.float32,
+    )
+
+    decoder = _FakeTAEHV.instances[0]
+    assert decoder.checkpoint_path == "/models/taeh3.pth"
+    assert decoder.arch_name == "taeh3"
+    assert frames.shape == (1, 3, 5, 32, 48)
+    assert torch.equal(decoder.decode_inputs[0], latents.transpose(1, 2))
+
+    cached = stage._get_taehv_decoder(
+        "/models/taeh3.pth", device=latents.device, dtype=torch.float32
+    )
+    assert cached is decoder
+    assert len(_FakeTAEHV.instances) == 1


### PR DESCRIPTION
## Summary

Add an opt-in low-latency visual decode path for MiniMax H3 using the model-specific TAEHV `taeh3` architecture and checkpoint. The default full H3 VAE path is unchanged.

## Changes

- Add `--vae-config.taehv-checkpoint-path` as an optional external decoder checkpoint.
- Instantiate TAEHV explicitly with `arch_name="taeh3"` so MiniMax H3 never selects the generic Hunyuan Video architecture.
- Pass H3 24-channel diffusion latents directly, convert NCTHW to NTCHW for TAEHV, and convert decoded frames back.
- Keep the H3 audio VAE unchanged.
- Cache the loaded decoder and keep the `taehv` package optional.
- Document that H3 requires `taeh3.pth`; `taehv.pth` is incompatible.

## Checkpoint identity

The H100 validation downloaded `taeh3.pth` from madebyollin/taehv commit `011dfc2112197741c540e0bdd5b7b67bcc930771`.

- `taeh3.pth` SHA-256: `af92965c2d7986a89a757e7cccd26f9eeeff0c3f0d5495eb168aeb2d6d9be9ba`
- `taehv.pth` SHA-256: `3866076f74b50087d5ba4d145191480ad51a08a316c8e95a7233284945cfc26e`

The distinct hashes and the unit assertion on `arch_name="taeh3"` make the selected architecture explicit.

## H100 benchmark

Ten paired 5-second T2VA requests at 1344x768, 124 frames, 24 fps, actual NFE 5, TP8 on 8x H100 80GB. Prompt, seed, model revision, request geometry, and audio path were held constant.

| Metric | Full H3 VAE | TAEHV taeh3 | Change |
|---|---:|---:|---:|
| Visual decode mean | 804.4 ms | 149.1 ms | 5.39x faster, -81.5% latency |
| End-to-end mean | 6.981 s | 6.186 s | 1.128x throughput, -11.4% latency |

## Validation

- Container unit suite: 7 passed.
- `ruff check` passes for all changed Python files.
- `black --check` passes for all changed Python files.
- Python 3.11 `py_compile` passes.
- Ten A/B outputs matched on dimensions, frame count, frame rate, audio sample rate, channel count, and decoded audio SHA-256.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33865539676](https://github.com/sgl-project/sglang/actions/runs/33865539676)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33865539417](https://github.com/sgl-project/sglang/actions/runs/33865539417)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33865539477](https://github.com/sgl-project/sglang/actions/runs/33865539477)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->