### PR TITLE
[Mamba] Thin cached states by coverage instead of evicting the LRU tail

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -56,6 +56,11 @@ if TYPE_CHECKING:
     )
 
 
+# ComponentData.metadata flag: a request other than the inserter matched this
+# node's mamba state, so coverage thinning must never pick it.
+MAMBA_REUSED_KEY = "mamba_reused"
+
+
 class MambaComponent(TreeComponent):
     component_type = ComponentType.MAMBA
 
@@ -132,8 +137,14 @@ class MambaComponent(TreeComponent):
             case LRURefreshPhase.WALKDOWN:
                 return
             case LRURefreshPhase.MATCH_END:
-                if node.component_data[ct].value is not None:
-                    self.tree_core.lru_lists[ct].reset_node_mru(node)
+                cd = node.component_data[ct]
+                if cd.value is not None:
+                    lru = self.tree_core.lru_lists[ct]
+                    # The inserter's own re-match after a chunk insert lands on
+                    # the MRU node; any other match proves the state is reused.
+                    if not lru.is_mru(node):
+                        cd.metadata[MAMBA_REUSED_KEY] = True
+                    lru.reset_node_mru(node)
             case LRURefreshPhase.INSERT_END:
                 return
             case _:
@@ -446,8 +457,9 @@ class MambaComponent(TreeComponent):
         leaves the smallest gap between its neighbours keeps that path's
         checkpoint coverage spread out; a plain tail eviction strips it
         shallow-first, which is the inverse of what a branch match needs.
-        Forks, locked, session-referenced and leaf holders are boundaries,
-        never victims. Returns x when there is nothing better to thin.
+        Forks, locked, session-referenced, reused (matched by another request)
+        and leaf holders are boundaries, never victims. Returns x when there is
+        nothing better to thin.
         """
         ct = self.component_type
         root = self.tree_core.root_node
@@ -482,7 +494,10 @@ class MambaComponent(TreeComponent):
         for i, (_, node) in enumerate(holders):
             cd = node.component_data[ct]
             if node is not x and (
-                len(node.children) != 1 or cd.lock_ref > 0 or cd.session_ref > 0
+                len(node.children) != 1
+                or cd.lock_ref > 0
+                or cd.session_ref > 0
+                or cd.metadata.get(MAMBA_REUSED_KEY)
             ):
                 continue
             lo = holders[i - 1][0] if i > 0 else prev_depth

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -408,10 +408,26 @@ class MambaComponent(TreeComponent):
                 lru.cursor_next() if enabled else lru.get_prev_no_lock(x)
             )
             return x.id
+        victim = self._thinning_victim(x)
+        if victim is not x:
+            # x stays at the LRU tail so the next step re-evaluates its chain.
+            self._tombstone_device_state(victim, tracker, device_frees, host_frees)
+            return None
         if not enabled:
             x_next = lru.get_prev_no_lock(x)
+        self._tombstone_device_state(x, tracker, device_frees, host_frees)
+        self._evict_device_cursor = lru.cursor_next() if enabled else x_next
+        return None
+
+    def _tombstone_device_state(
+        self,
+        node: UnifiedTreeNode,
+        tracker: dict[ComponentType, int],
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+    ) -> None:
         self.tree_core._evict_component_and_detach_lru(
-            x,
+            node,
             self,
             target=EvictLayer.DEVICE,
             tracker=tracker,
@@ -419,10 +435,62 @@ class MambaComponent(TreeComponent):
             host_frees=host_frees,
         )
         self.tree_core._cascade_evict(
-            x, self, tracker, device_frees=device_frees, host_frees=host_frees
+            node, self, tracker, device_frees=device_frees, host_frees=host_frees
         )
-        self._evict_device_cursor = lru.cursor_next() if enabled else x_next
-        return None
+
+    def _thinning_victim(self, x: UnifiedTreeNode) -> UnifiedTreeNode:
+        """Pick which state of the LRU-oldest node's chain to drop.
+
+        The states below x on its single-child chain belong to the same cold
+        path and are the next to age out, so dropping the one whose removal
+        leaves the smallest gap between its neighbours keeps that path's
+        checkpoint coverage spread out; a plain tail eviction strips it
+        shallow-first, which is the inverse of what a branch match needs.
+        Forks, locked, session-referenced and leaf holders are boundaries,
+        never victims. Returns x when there is nothing better to thin.
+        """
+        ct = self.component_type
+        root = self.tree_core.root_node
+        if len(x.children) != 1:
+            return x
+        depth = 0
+        node = x
+        while node is not root:
+            depth += len(node.key)
+            node = node.parent
+        # Nearest state holder above x (else the root) bounds its gap.
+        prev_depth = 0
+        d = depth
+        node = x
+        while node.parent is not root:
+            d -= len(node.key)
+            node = node.parent
+            if node.component_data[ct].value is not None:
+                prev_depth = d
+                break
+        # (depth, node) for every state holder on the chain, x first.
+        holders = [(depth, x)]
+        node = x
+        while len(node.children) == 1:
+            node = next(iter(node.children.values()))
+            depth += len(node.key)
+            if node.component_data[ct].value is not None:
+                holders.append((depth, node))
+        chain_end = depth
+        victim = x
+        best_gap = None
+        for i, (_, node) in enumerate(holders):
+            cd = node.component_data[ct]
+            if node is not x and (
+                len(node.children) != 1 or cd.lock_ref > 0 or cd.session_ref > 0
+            ):
+                continue
+            lo = holders[i - 1][0] if i > 0 else prev_depth
+            hi = holders[i + 1][0] if i + 1 < len(holders) else chain_end
+            if best_gap is None or hi - lo < best_gap:
+                best_gap = hi - lo
+                victim = node
+        return victim
 
     def _evict_device_end(self) -> None:
         """Clear the device-eviction walk cursor state."""

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -312,6 +312,12 @@ class UnifiedLRUList:
     def in_list(self, node: Optional[UnifiedTreeNode]):
         return node is not None and node.id in self.cache
 
+    def is_mru(self, node: UnifiedTreeNode) -> bool:
+        """Whether a member node is the most-recently-used of its partition."""
+        assert node.id in self.cache
+        prev = node.lru_prev[self._pt]
+        return prev is self.head or prev is self.mid
+
     def get_prev_no_lock(self, node: UnifiedTreeNode, check_id: bool = True):
         if check_id:
             assert node.id in self.cache

--- a/rust/sglang-radix-tree/src/components/mamba.rs
+++ b/rust/sglang-radix-tree/src/components/mamba.rs
@@ -57,6 +57,80 @@ fn least_common_multiple(lhs: usize, rhs: usize) -> usize {
 }
 
 impl MambaComponent {
+    /// Pick which state of the LRU-oldest node's chain to drop.
+    ///
+    /// The states below `x` on its single-child chain belong to the same cold
+    /// path and are the next to age out, so dropping the one whose removal
+    /// leaves the smallest gap between its neighbours keeps that path's
+    /// checkpoint coverage spread out; a plain tail eviction strips it
+    /// shallow-first, which is the inverse of what a branch match needs.
+    /// Forks, locked, load-back-pinned and leaf holders are boundaries, never
+    /// victims. Returns `x` when there is nothing better to thin.
+    fn thinning_victim<K: ChildKeyType>(tree_core: &UnifiedTreeCore<K>, x: NodeIdx_) -> NodeIdx_ {
+        let arena = &tree_core.arena;
+        if arena.node(x).children.len() != 1 {
+            return x;
+        }
+        let mut depth = 0;
+        let mut cur = x;
+        while let Some(parent) = arena.node(cur).parent {
+            depth += arena.node(cur).key.atom_len();
+            cur = parent;
+        }
+        // Nearest state holder above x (else the root) bounds its gap.
+        let mut prev_depth = 0;
+        let mut d = depth;
+        cur = x;
+        while let Some(parent) = arena.node(cur).parent {
+            if arena.node(parent).is_root() {
+                break;
+            }
+            d -= arena.node(cur).key.atom_len();
+            if arena.has_device_value(parent, MAMBA) {
+                prev_depth = d;
+                break;
+            }
+            cur = parent;
+        }
+        // (depth, node) for every state holder on the chain, x first.
+        let mut holders: Vec<(usize, NodeIdx_)> = vec![(depth, x)];
+        cur = x;
+        while arena.node(cur).children.len() == 1 {
+            let child = *arena.node(cur).children.values().next().unwrap();
+            depth += arena.node(child).key.atom_len();
+            if arena.has_device_value(child, MAMBA) {
+                holders.push((depth, child));
+            }
+            cur = child;
+        }
+        let chain_end = depth;
+        let mut victim = x;
+        let mut best_gap: Option<usize> = None;
+        for (i, &(_, node_id)) in holders.iter().enumerate() {
+            let node = arena.node(node_id);
+            if node_id != x
+                && (node.children.len() != 1
+                    || node.device_lock_ref(MAMBA) > 0
+                    || node.is_load_back_pending())
+            {
+                continue;
+            }
+            let lo = if i > 0 { holders[i - 1].0 } else { prev_depth };
+            let hi = if i + 1 < holders.len() {
+                holders[i + 1].0
+            } else {
+                chain_end
+            };
+            if best_gap.is_none_or(|best| hi - lo < best) {
+                best_gap = Some(hi - lo);
+                victim = node_id;
+            }
+        }
+        victim
+    }
+}
+
+impl MambaComponent {
     // Tier-selected mamba slot read for the lock paths; `host` picks the host slot.
     fn has_value<K: ChildKeyType>(node: &Node<K>, host: bool) -> bool {
         if host {
@@ -391,16 +465,28 @@ impl<K: ChildKeyType> TreeComponent<K> for MambaComponent {
             if tree_core.evictable_device_leaves.contains(x) {
                 break Some(x);
             }
-            // Internal nodes are tombstoned inline (no IO).
+            // Internal nodes are tombstoned inline (no IO). A thinned victim
+            // keeps x at the LRU tail so the next step re-evaluates its chain.
+            let victim = Self::thinning_victim(tree_core, x);
+            if victim != x {
+                cursor = Some(x);
+            }
             tree_core.evict_component_and_detach_lru_(
-                x,
+                victim,
                 ct,
                 device_frees,
                 host_frees,
                 EvictLayer::Device,
                 Some(tracker),
             );
-            tree_core.cascade_evict_(x, ct, tracker, device_frees, host_frees, EvictLayer::Device);
+            tree_core.cascade_evict_(
+                victim,
+                ct,
+                tracker,
+                device_frees,
+                host_frees,
+                EvictLayer::Device,
+            );
             break None;
         };
         tree_core.component_state_mut(MAMBA).evict_device_cursor = cursor;

--- a/rust/sglang-radix-tree/src/components/mamba.rs
+++ b/rust/sglang-radix-tree/src/components/mamba.rs
@@ -64,8 +64,9 @@ impl MambaComponent {
     /// leaves the smallest gap between its neighbours keeps that path's
     /// checkpoint coverage spread out; a plain tail eviction strips it
     /// shallow-first, which is the inverse of what a branch match needs.
-    /// Forks, locked, load-back-pinned and leaf holders are boundaries, never
-    /// victims. Returns `x` when there is nothing better to thin.
+    /// Forks, locked, load-back-pinned, reused (matched by another request)
+    /// and leaf holders are boundaries, never victims. Returns `x` when there
+    /// is nothing better to thin.
     fn thinning_victim<K: ChildKeyType>(tree_core: &UnifiedTreeCore<K>, x: NodeIdx_) -> NodeIdx_ {
         let arena = &tree_core.arena;
         if arena.node(x).children.len() != 1 {
@@ -111,7 +112,8 @@ impl MambaComponent {
             if node_id != x
                 && (node.children.len() != 1
                     || node.device_lock_ref(MAMBA) > 0
-                    || node.is_load_back_pending())
+                    || node.is_load_back_pending()
+                    || node.mamba_reused)
             {
                 continue;
             }
@@ -176,6 +178,11 @@ impl<K: ChildKeyType> TreeComponent<K> for MambaComponent {
             LRURefreshPhase::Walkdown => {}
             LRURefreshPhase::MatchEnd => {
                 if tree_core.arena.has_device_value(node_id, MAMBA) {
+                    // The inserter's own re-match after a chunk insert lands on
+                    // the MRU node; any other match proves the state is reused.
+                    if !tree_core.device_lru_list(MAMBA).is_mru(node_id) {
+                        tree_core.arena.node_mut(node_id).mamba_reused = true;
+                    }
                     tree_core.device_lru_list_mut(MAMBA).reset_node_mru(node_id);
                 }
             }

--- a/rust/sglang-radix-tree/src/node.rs
+++ b/rust/sglang-radix-tree/src/node.rs
@@ -179,6 +179,9 @@ pub struct Node<K: ChildKeyType> {
     pub write_through_pending_id: Option<usize>,
     /// Load-back anchor currently reading this node's host slots.
     pub load_back_pending_id: Option<NodeId>,
+    /// Set once a request other than the inserter matched this node's mamba
+    /// state; coverage thinning never picks such a node.
+    pub mamba_reused: bool,
     /// Monotonic access tick for LRU ordering (exact; not wall-clock).
     pub last_access_counter: i64,
     /// Tick stamped at construction.
@@ -392,6 +395,7 @@ impl<K: ChildKeyType> Node<K> {
             hash_value: Some(Vec::new()),
             write_through_pending_id: None,
             load_back_pending_id: None,
+            mamba_reused: false,
             last_access_counter: 0,
             creation_counter: 0,
             hit_count: 0,
@@ -414,6 +418,7 @@ impl<K: ChildKeyType> Node<K> {
             hash_value: None,
             write_through_pending_id: None,
             load_back_pending_id: None,
+            mamba_reused: false,
             last_access_counter: 0,
             creation_counter: 0,
             hit_count: 0,

--- a/rust/sglang-radix-tree/src/tests/components/mamba.rs
+++ b/rust/sglang-radix-tree/src/tests/components/mamba.rs
@@ -1227,6 +1227,73 @@ fn mamba_device_eviction_skips_a_load_back_pinned_node() {
     tc.evict_device_end(MAMBA);
 }
 
+// One device-eviction round of one slot; returns the freed mamba slots.
+fn evict_one_mamba_slot(tc: &mut UnifiedTreeCore<Vec<i64>>) -> Vec<i64> {
+    tc.evict_device_start(MAMBA, /* request_cnt = */ 1);
+    let (next, step) = tc.evict_device_next_node(MAMBA, &HashMap::new());
+    tc.evict_device_end(MAMBA);
+    assert_eq!(next, None);
+    step.device_frees[&MAMBA]
+        .iter()
+        .map(|t| t.int64_value(&[0]))
+        .collect()
+}
+
+#[test]
+fn mamba_device_eviction_thins_a_cold_chain_to_alternate_states() {
+    // Eight single-token holders; the shallowest is the LRU tail. Plain tail
+    // eviction would free 1, 2, 3, 4; thinning keeps the coverage spread.
+    let mut tc = mamba_core(/* page_size = */ 1);
+    let nodes = chain::<8>(&mut tc);
+    for (i, &node) in nodes.iter().enumerate() {
+        set_mamba_device(&mut tc, node, i as i64 + 1);
+    }
+
+    let freed: Vec<Vec<i64>> = (0..4).map(|_| evict_one_mamba_slot(&mut tc)).collect();
+
+    assert_eq!(freed, vec![vec![1], vec![3], vec![5], vec![7]]);
+    let survivors: Vec<usize> = (0..8)
+        .filter(|&i| tc.arena.has_device_value(nodes[i], MAMBA))
+        .collect();
+    assert_eq!(survivors, vec![1, 3, 5, 7]);
+    assert_eq!(tc.mamba_evictable_size(), 4);
+}
+
+#[test]
+fn mamba_device_eviction_victim_minimizes_the_merged_gap() {
+    // Depths 4, 5, 6, 10: removing depth 5 merges a gap of 2, the others 5,
+    // so the LRU tail at depth 4 is spared. A locked depth 5 is a boundary
+    // instead, and the tie between depths 4 and 6 falls back to the tail.
+    for locked in [false, true] {
+        let mut tc = mamba_core(/* page_size = */ 1);
+        let root = tc.arena.root();
+        let mut parent = root;
+        let mut nodes = Vec::new();
+        for (i, key_len) in [4usize, 1, 1, 4].iter().enumerate() {
+            let key: Vec<i64> = vec![i as i64; *key_len];
+            let node = tc
+                .arena
+                .alloc_child(
+                    parent, key, /* priority = */ 0, /* extra_key = */ None,
+                )
+                .unwrap();
+            set_mamba_device(&mut tc, node, i as i64 + 1);
+            nodes.push(node);
+            parent = node;
+        }
+        if locked {
+            tc.arena
+                .node_mut(nodes[1])
+                .set_lock_ref_(ValueSlotIdx::device(MAMBA), 1);
+        }
+
+        let freed = evict_one_mamba_slot(&mut tc);
+
+        assert_eq!(freed, vec![if locked { 1 } else { 2 }], "locked={locked}");
+        assert!(tc.arena.has_device_value(nodes[1], MAMBA) || !locked);
+    }
+}
+
 #[test]
 fn mamba_host_eviction_skips_a_load_back_pinned_node() {
     let mut tc = mamba_core(/* page_size = */ 1);

--- a/rust/sglang-radix-tree/src/tests/components/mamba.rs
+++ b/rust/sglang-radix-tree/src/tests/components/mamba.rs
@@ -1266,21 +1266,7 @@ fn mamba_device_eviction_victim_minimizes_the_merged_gap() {
     // instead, and the tie between depths 4 and 6 falls back to the tail.
     for locked in [false, true] {
         let mut tc = mamba_core(/* page_size = */ 1);
-        let root = tc.arena.root();
-        let mut parent = root;
-        let mut nodes = Vec::new();
-        for (i, key_len) in [4usize, 1, 1, 4].iter().enumerate() {
-            let key: Vec<i64> = vec![i as i64; *key_len];
-            let node = tc
-                .arena
-                .alloc_child(
-                    parent, key, /* priority = */ 0, /* extra_key = */ None,
-                )
-                .unwrap();
-            set_mamba_device(&mut tc, node, i as i64 + 1);
-            nodes.push(node);
-            parent = node;
-        }
+        let nodes = uneven_chain(&mut tc);
         if locked {
             tc.arena
                 .node_mut(nodes[1])
@@ -1292,6 +1278,50 @@ fn mamba_device_eviction_victim_minimizes_the_merged_gap() {
         assert_eq!(freed, vec![if locked { 1 } else { 2 }], "locked={locked}");
         assert!(tc.arena.has_device_value(nodes[1], MAMBA) || !locked);
     }
+}
+
+// Depths 4, 5, 6, 10 with slots 1..=4; the LRU tail is the shallowest node.
+fn uneven_chain(tc: &mut UnifiedTreeCore<Vec<i64>>) -> Vec<NodeIdx_> {
+    let mut parent = tc.arena.root();
+    let mut nodes = Vec::new();
+    for (i, key_len) in [4usize, 1, 1, 4].iter().enumerate() {
+        let key: Vec<i64> = vec![i as i64; *key_len];
+        let node = tc
+            .arena
+            .alloc_child(
+                parent, key, /* priority = */ 0, /* extra_key = */ None,
+            )
+            .unwrap();
+        set_mamba_device(tc, node, i as i64 + 1);
+        nodes.push(node);
+        parent = node;
+    }
+    nodes
+}
+
+#[test]
+fn mamba_state_matched_by_another_request_is_never_thinned() {
+    // A MATCH_END on a non-MRU node marks the state reused; thinning then
+    // spares depth 5 although it is the min-gap victim, and the tail goes.
+    let mut tc = mamba_core(/* page_size = */ 1);
+    let nodes = uneven_chain(&mut tc);
+    let mamba = mamba_component();
+    mamba.refresh_lru(&mut tc, LRURefreshPhase::MatchEnd, nodes[1]);
+    assert!(tc.arena.node(nodes[1]).mamba_reused);
+
+    assert_eq!(evict_one_mamba_slot(&mut tc), vec![1]);
+    assert!(tc.arena.has_device_value(nodes[1], MAMBA));
+}
+
+#[test]
+fn mamba_inserter_re_match_on_the_mru_node_does_not_mark_reuse() {
+    let mut tc = mamba_core(/* page_size = */ 1);
+    let nodes = uneven_chain(&mut tc);
+    let mamba = mamba_component();
+    mamba.refresh_lru(&mut tc, LRURefreshPhase::MatchEnd, nodes[3]);
+    assert!(!tc.arena.node(nodes[3]).mamba_reused);
+
+    assert_eq!(evict_one_mamba_slot(&mut tc), vec![2]);
 }
 
 #[test]

--- a/rust/sglang-radix-tree/src/unified_lru_list.rs
+++ b/rust/sglang-radix-tree/src/unified_lru_list.rs
@@ -144,6 +144,11 @@ impl UnifiedLRUList {
         self.cell_mut_(b).prev = a;
     }
 
+    /// Whether a member node is the most-recently-used one; panics if not a member.
+    pub fn is_mru(&self, node_id: NodeIdx_) -> bool {
+        self.cell_(Self::cell_of_(node_id)).prev == HEAD
+    }
+
     /// Insert a node as the most-recently-used; panics if already a member.
     pub fn insert_mru(&mut self, node_id: NodeIdx_) {
         self.add_node_(Self::cell_of_(node_id));

--- a/test/registered/unit/mem_cache/test_mamba_eviction_thinning.py
+++ b/test/registered/unit/mem_cache/test_mamba_eviction_thinning.py
@@ -1,0 +1,177 @@
+"""CPU-only unit tests for coverage-preserving Mamba device eviction."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import unittest
+from array import array
+from collections import defaultdict
+
+import torch
+
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components.mamba_component import (
+    MambaComponent,
+)
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    ComponentType,
+)
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedLRUList, UnifiedTreeNode
+from sglang.test.test_utils import CustomTestCase
+
+MAMBA = ComponentType.MAMBA
+
+
+class _FakeTreeCore:
+    tree_components = (ComponentType.FULL, MAMBA)
+    enable_session_radix_cache = False
+
+    def __init__(self):
+        self.root_node = UnifiedTreeNode(self.tree_components)
+        self.evictable_device_leaves = set()
+        self.component_evictable_size_ = {MAMBA: 0}
+        self.component_protected_size_ = {MAMBA: 0}
+        self.lru_lists = {MAMBA: UnifiedLRUList(MAMBA, self.tree_components)}
+        self.host_lru_lists = {
+            MAMBA: UnifiedLRUList(MAMBA, self.tree_components, use_host_ptr=True)
+        }
+        self.cascaded = []
+        self._is_tracking_unbacked_tokens = False
+        self._tracked_unbacked_tokens = 0
+
+    def _evict_component_and_detach_lru(self, node, component, *args, **kwargs):
+        return UnifiedTreeCore._evict_component_and_detach_lru(
+            self, node, component, *args, **kwargs
+        )
+
+    def _cascade_evict(self, node, component, tracker, device_frees, host_frees):
+        self.cascaded.append(node)
+
+
+def _build_chain(key_lens):
+    """A root-to-leaf chain, one mamba state per node, inserted into the LRU
+    in chain order so the shallowest node is the LRU tail. State slot i is the
+    node's 1-based chain position."""
+    core = _FakeTreeCore()
+    component = object.__new__(MambaComponent)
+    component.tree_core = core
+    nodes = []
+    parent = core.root_node
+    for index, key_len in enumerate(key_lens):
+        node = UnifiedTreeNode(core.tree_components)
+        node.parent = parent
+        node.key = RadixKey(token_ids=array("q", [index] * key_len))
+        node.component_data[ComponentType.FULL].value = torch.tensor([index])
+        node.component_data[MAMBA].value = torch.tensor([index + 1])
+        parent.children[index] = node
+        core.component_evictable_size_[MAMBA] += 1
+        core.lru_lists[MAMBA].insert_mru(node)
+        nodes.append(node)
+        parent = node
+    return component, nodes, core
+
+
+def _evict_one(component):
+    """One eviction round of one slot; returns (leaf id or None, freed slots)."""
+    device_frees = defaultdict(list)
+    host_frees = defaultdict(list)
+    tracker = {ComponentType.FULL: 0, MAMBA: 0}
+    component._evict_device_start(1)
+    node_id = component._evict_device_next_node(tracker, device_frees, host_frees)
+    component._evict_device_end()
+    return node_id, [int(v.item()) for v in device_frees[MAMBA]]
+
+
+class TestMambaEvictionThinning(CustomTestCase):
+    def test_uniform_chain_is_thinned_to_alternate_states(self):
+        """Regression for #36935: under pool pressure a cold chain used to lose
+        its states shallow-first, so a branch matching its prefix found no
+        checkpoint. Thinning drops every other state instead, so the survivors
+        stay spread along the chain."""
+        component, nodes, core = _build_chain([1] * 8)
+
+        freed = [_evict_one(component)[1] for _ in range(4)]
+
+        self.assertEqual(freed, [[1], [3], [5], [7]])
+        survivors = [n for n in nodes if n.component_data[MAMBA].value is not None]
+        self.assertEqual(survivors, [nodes[1], nodes[3], nodes[5], nodes[7]])
+        self.assertEqual(core.component_evictable_size_[MAMBA], 4)
+        self.assertTrue(
+            all(
+                node.component_data[ComponentType.FULL].value is not None
+                for node in nodes
+            )
+        )
+
+    def test_victim_minimizes_the_merged_gap(self):
+        """Depths 4, 5, 6, 10: removing the node at 5 merges a gap of 2, the
+        others 5, so the tail (depth 4) is spared although it is LRU-oldest."""
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+
+        _, freed = _evict_one(component)
+
+        self.assertEqual(freed, [2])
+        self.assertIsNotNone(nodes[0].component_data[MAMBA].value)
+        self.assertEqual(core.cascaded, [nodes[1]])
+
+    def test_locked_holder_is_a_boundary_not_a_victim(self):
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+        nodes[1].component_data[MAMBA].lock_ref = 1
+
+        _, freed = _evict_one(component)
+
+        # With depth 5 pinned, depths 4 and 6 tie at a gap of 5; the tail wins.
+        self.assertEqual(freed, [1])
+        self.assertIsNotNone(nodes[1].component_data[MAMBA].value)
+
+    def test_session_referenced_holder_is_never_thinned(self):
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+        nodes[1].component_data[MAMBA].session_ref = 1
+
+        _, freed = _evict_one(component)
+
+        self.assertEqual(freed, [1])
+        self.assertIsNotNone(nodes[1].component_data[MAMBA].value)
+
+    def test_fork_below_the_tail_ends_the_chain(self):
+        """A fork holder bounds the chain and keeps its own state; the tail is
+        the only candidate, so it is evicted as before."""
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+        sibling = UnifiedTreeNode(core.tree_components)
+        sibling.parent = nodes[1]
+        sibling.key = RadixKey(token_ids=array("q", [99]))
+        nodes[1].children["fork"] = sibling
+
+        _, freed = _evict_one(component)
+
+        self.assertEqual(freed, [1])
+        self.assertIsNotNone(nodes[1].component_data[MAMBA].value)
+
+    def test_ancestor_holder_bounds_the_tail_gap(self):
+        """Depths 1, 2, 3 under a hot holder at depth 1: the tail at 2 has gap
+        3 - 1 = 2 and the node at 3 has gap 4 - 2 = 2, so the tie keeps the
+        shallow-first order; without the ancestor bound the tail's gap would
+        read 3 and the deeper node would be dropped instead."""
+        component, nodes, core = _build_chain([1, 1, 1, 1])
+        # Refresh the shallowest node so the LRU tail is the second one.
+        core.lru_lists[MAMBA].reset_node_mru(nodes[0])
+
+        _, freed = _evict_one(component)
+
+        self.assertEqual(freed, [2])
+
+    def test_device_leaf_at_the_tail_is_still_deleted_as_a_leaf(self):
+        component, nodes, core = _build_chain([1, 1])
+        core.evictable_device_leaves.add(nodes[1])
+        core.lru_lists[MAMBA].reset_node_mru(nodes[0])
+
+        node_id, freed = _evict_one(component)
+
+        self.assertEqual(node_id, nodes[1].id)
+        self.assertEqual(freed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_mamba_eviction_thinning.py
+++ b/test/registered/unit/mem_cache/test_mamba_eviction_thinning.py
@@ -12,10 +12,12 @@ import torch
 
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache.components.mamba_component import (
+    MAMBA_REUSED_KEY,
     MambaComponent,
 )
 from sglang.srt.mem_cache.unified_cache.components.tree_component import (
     ComponentType,
+    LRURefreshPhase,
 )
 from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedLRUList, UnifiedTreeNode
@@ -161,6 +163,34 @@ class TestMambaEvictionThinning(CustomTestCase):
         _, freed = _evict_one(component)
 
         self.assertEqual(freed, [2])
+
+    def test_state_matched_by_another_request_is_never_thinned(self):
+        """Regression for the shared-prefix hit-rate drop: a group's boundary
+        state is refreshed to MRU by every member's match, but a geometry-only
+        victim rule could still thin it because a member's private tail sits
+        right below it. A MATCH_END on a non-MRU node marks the state reused,
+        and reused states are boundaries for thinning."""
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+        # A later request matches depth 5 (not the MRU node, which is depth 10).
+        component.refresh_lru(LRURefreshPhase.MATCH_END, nodes[1], core.root_node)
+        self.assertTrue(nodes[1].component_data[MAMBA].metadata[MAMBA_REUSED_KEY])
+
+        _, freed = _evict_one(component)
+
+        # Depth 5 would be the min-gap victim (2 vs 5); it is spared, and the
+        # remaining candidates tie so the tail goes as before.
+        self.assertEqual(freed, [1])
+        self.assertIsNotNone(nodes[1].component_data[MAMBA].value)
+
+    def test_inserter_re_match_on_the_mru_node_does_not_mark_reuse(self):
+        """cache_unfinished_req re-matches the node it just inserted; that
+        match must not protect the state or thinning would never apply to an
+        in-flight chain."""
+        component, nodes, core = _build_chain([4, 1, 1, 4])
+        component.refresh_lru(LRURefreshPhase.MATCH_END, nodes[-1], core.root_node)
+
+        self.assertNotIn(MAMBA_REUSED_KEY, nodes[-1].component_data[MAMBA].metadata)
+        self.assertEqual(_evict_one(component)[1], [2])
 
     def test_device_leaf_at_the_tail_is_still_deleted_as_a_leaf(self):
         component, nodes, core = _build_chain([1, 1])

--- a/test/registered/unit/mem_cache/test_rust_tree_core_integration.py
+++ b/test/registered/unit/mem_cache/test_rust_tree_core_integration.py
@@ -1523,6 +1523,32 @@ def test_mamba_path_cap_evicts_excess_states_through_the_adapter():
     assert core.mamba_evictable_size() == 1
 
 
+def test_mamba_eviction_walk_thins_the_cold_chain_through_the_adapter():
+    """Second round frees the slot at depth 3, not the LRU-oldest at depth 2:
+    the walk thins the cold chain by coverage instead of shallow-first."""
+    core = _mamba_tree_core()
+    for depth, slot in enumerate([7, 8, 9, 10], start=1):
+        _mamba_insert(
+            core, list(range(1, depth + 1)), list(range(10, 10 + depth)), slot
+        )
+
+    def evict_one():
+        tracker = {ComponentType.MAMBA: 0}
+        device_frees: dict = {}
+        host_frees: dict = {}
+        core.evict_device_start(ComponentType.MAMBA, 1)
+        step = core.evict_device_next_node(ComponentType.MAMBA, tracker)
+        _accumulate_step(step, tracker, device_frees, host_frees)
+        core.evict_device_end(ComponentType.MAMBA)
+        assert step.node_id is None
+        return torch.cat(device_frees[ComponentType.MAMBA]).tolist()
+
+    assert evict_one() == [7]
+    assert evict_one() == [9]
+    assert core.mamba_evictable_size() == 2
+    core.sanity_check([], [])
+
+
 def test_eagle_with_mamba_falls_back_to_the_unigram_binding():
     core = _mamba_tree_core(is_eagle=True)
     assert core.is_eagle is False


### PR DESCRIPTION
## Motivation

Refs #36935 (and the LRU-pressure half of #30314's discussion).

On a hybrid Mamba/GDN model every chunked-prefill boundary donates one Mamba state into the radix tree, so a long prompt pushes `len / chunked_prefill_size` states through the Mamba LRU. The LRU evicts a path's states **shallow-first** (they were inserted first), which is the inverse of what a branch match needs: a request that shares a 40k prefix and diverges mid-way is gated on the Mamba state at the divergence point, and the shallow states are exactly the ones that are gone. With the KV fully resident, `cached_tokens` drops to 0 with no error.

Reproduced on upstream main (Qwen3.5-4B, 1xH200, `extra_buffer`, 3.3M-token KV pool so KV is never the constraint), 3 distinct 32k chains then fork chain 0 at 8192 and re-send every chain, `--max-mamba-cache-size 48 --max-running-requests 4 --chunked-prefill-size 2048`:

| request | main | this PR |
|---|---:|---:|
| fork chain 0 @ 8192 | 0 | 8192 |
| repeat chain 0 | 8192 (branch point inserted by the fork) | 8192 |
| repeat chain 1 | 0 | 16384 |
| repeat chain 2 | 0 | 28672 |

## Modifications

`MambaComponent._evict_device_next_node` (Python) and `MambaComponent::evict_device_next_node` (Rust tree core) pick the eviction victim by coverage instead of taking the LRU tail:

- The LRU tail `x` still selects the path (the coldest one), so LRU fairness between paths is unchanged.
- On `x`'s single-child chain, the state whose removal leaves the smallest gap between its neighbouring states is tombstoned. Uniformly spaced chunk states therefore thin to every other state, then every fourth, so the chain keeps checkpoints spread over its whole depth instead of losing them from the root down.
- Forks, locked, load-back-pinned (Rust), session-referenced (Python), leaf holders and **reused** states are boundaries, never victims. When `x` has no chain-mate to thin, `x` itself is evicted exactly as before. Device-leaf deletion (`evictable_device_leaves`) is untouched.
- When the victim is not `x`, the walk cursor stays on `x` so the next step re-evaluates the same chain; one allocator mutation per step is preserved.

**Reused states.** A geometry-only rule would also thin states that other requests actually match: on a shared-prefix workload the group's boundary state is MRU (refreshed by every member's `MATCH_END`), yet it can have the smallest gap because a member's private tail state sits right below it. So `refresh_lru(MATCH_END)` now marks a state as reused when the matched node is not the LRU's MRU node (the inserter's own re-match after a chunk insert always lands on the MRU node, so it does not mark), and thinning never picks a reused state. Python keeps the flag in `ComponentData.metadata`, Rust in `Node.mamba_reused`; `UnifiedLRUList.is_mru` is added on both sides.

No new flag; `--mamba-max-states-per-path` and the branching-point insert are unchanged.

### Scope

This changes *which* state of the coldest path is dropped. When demand exceeds the pool by more than a whole path (e.g. 6 chains x 17 states on 44 free slots), the coldest path is still consumed entirely before the next one is touched, so the saturated rows of #36935 stay at 0. Bounding per-path demand is a separate decision and is not in this PR.

## Accuracy Tests

- `test/registered/unit/mem_cache/test_mamba_eviction_thinning.py` (new, CPU): thinning order on a uniform chain (`[1],[3],[5],[7]`), min-gap victim on a non-uniform chain, locked / session-referenced / fork / reused holders as boundaries, the inserter's MRU re-match not marking reuse, ancestor-holder bound, and the unchanged leaf-deletion path. The thinning and reuse cases fail on main.
- `test/registered/unit/mem_cache/test_rust_tree_core_integration.py::test_mamba_eviction_walk_thins_the_cold_chain_through_the_adapter` (new): the compiled Rust extension frees slot 9 on the second round, not the LRU-oldest 8.
- `rust/sglang-radix-tree/src/tests/components/mamba.rs`: four new native tests mirroring the above.
- 1xH200, same command on `upstream/main` d7f235dac and this branch: `pytest test/registered/unit/mem_cache -k "mamba or unified or hybrid"` -> main 1583 passed / 1258 skipped / 0 failed; this branch 1590 passed (= main + new) / 1258 skipped / 0 failed. `test_rust_tree_core_integration.py` 101 passed. `cargo test --locked` 835 passed. `cargo fmt --check` and the radix-tree clippy hook are clean.

## Speed Tests and Profiling

1xH200, Qwen3.5-4B, `--mamba-radix-cache-strategy extra_buffer --max-mamba-cache-size 96 --max-running-requests 8 --chunked-prefill-size 2048 --enable-cache-report`, KV pool 3.3M tokens (never the constraint). Same box and boot flags for both trees; `/flush_cache` between runs.

**Idle-then-resume** (the failure mode of #36935: a session goes cold, other traffic evicts part of its states, then it comes back with a compacted or branched prompt). Sequentially, four times: build session A (120k tokens, 60 chunk states), run an unrelated 120k filler session so A loses half of its states, then resume A with a branch at 40% (48k). `--max-mamba-cache-size 96 --max-running-requests 1 --chunked-prefill-size 2048`, 128 output tokens, per-resume numbers identical across the four sessions.

| model | | main | this PR |
|---|---|---:|---:|
| Qwen3.5-4B | resume cached tokens | 0 | 45,056 (37.6%) |
| | resume latency | 3.89 s | 3.11 s |
| | resume input throughput | 30,822 tok/s | 38,623 tok/s |
| Qwen3.8-27B (bf16) | resume cached tokens | 0 | 45,056 (37.6%) |
| | resume latency | 16.66 s | 12.40 s |
| | resume input throughput | 7,204 tok/s | 9,679 tok/s |

On main the filler evicts A's states shallow-first (2k..60k), so the 48k branch point has no checkpoint left and the whole 120k is re-prefilled; with this PR A keeps every other state, the branch lands on the 44k checkpoint and only 75k is re-prefilled.

**Branch reuse** (the workload of #36935): 6 distinct 32k chains at concurrency 2, then every chain forked at 8192, then every chain continued with a 2048-token tail; 128 output tokens per request. Hit rate = `cached_tokens / prompt_tokens` over the fork + continue phases.

| | main | this PR |
|---|---:|---:|
| fork phase hit rate | 16.7% | 25.0% |
| fork phase mean latency | 1.555 s | 1.463 s |
| continue phase hit rate | 23.5% | 23.5% |
| reuse phases hit rate | 20.2% | 24.2% |
| reuse phases input throughput | 43,277 tok/s | 44,561 tok/s |
| reuse phases total throughput | 43,441 tok/s | 44,730 tok/s |

The gain is the fork hit rate (4 of 6 forks found a checkpoint on main, 6 of 6 here; 25% is the ceiling with the fork at 25% of the prompt). Throughput and latency move only 3-6% because an 8k hit saves 0.2 s of prefill on a 4B model on an H200; the same hit is seconds on the 27B / RTX PRO 6000 setup in #36935. With 8 chains at the same pool (demand > 2x the free slots) both trees are at 0% (the scope limit above).

**Shared prefix, no regression** (`sglang.benchmark.serving --dataset-name generated-shared-prefix`, 8 groups x 8 prompts, 16k system prompt, 4k question, 128 output, concurrency 8, seed 42), three runs each:

| run | main hit rate / input tok/s / mean TTFT | this PR hit rate / input tok/s / mean TTFT |
|---|---|---|
| 1 | 63.2% / 85,359 / 1040 ms | 63.6% / 85,749 / 816 ms |
| 2 | 60.7% / 82,213 / 843 ms | 65.0% / 88,008 / 996 ms |
| 3 | 63.2% / 85,037 / 816 ms | 62.7% / 84,377 / 801 ms |

Without the reused-state guard the same shared-prefix runs dropped to 40.4-50.4% hit rate (the geometry-only rule thinned the group boundary states); the guard is what makes this PR neutral there.

The victim search walks the LRU-tail node's chain once per tombstone (O(states on that path), at most `len / chunked_prefill_size`), only when the Mamba pool has to evict. No change on the allocation fast path.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.
