### PR TITLE
[diffusion] auto-keep video DiT resident on high-memory GPUs

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/helios.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/helios.py
@@ -13,6 +13,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config import (
+    ModelDeploymentConfig,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -94,6 +97,13 @@ class HeliosT2VConfig(PipelineConfig):
     def __post_init__(self):
         self.vae_config.load_encoder = False
         self.vae_config.load_decoder = True
+
+    def get_model_deployment_config(self) -> ModelDeploymentConfig:
+        return ModelDeploymentConfig(
+            dit_layerwise_offload_modes=("memory",),
+            keep_resident_min_available_gb=120,
+            keep_resident_components=("dit", "vae"),
+        )
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
@@ -165,6 +165,8 @@ class SanaWMPipelineConfig(PipelineConfig):
             # Conservative auto-FSDP gate for the 720p world-model path. Users
             # can still force FSDP explicitly on smaller cards.
             fsdp_auto_min_available_memory_gb=60,
+            keep_resident_min_available_gb=120,
+            keep_resident_components=("dit", "vae"),
         )
 
     # --- Latent shape ---

--- a/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
@@ -175,6 +175,8 @@ class ServerArgsAutoTuner:
                 args.dit_cpu_offload
                 and "dit" in components
                 and args.explicit_residency_mode("transformer") is None
+                and not args.is_arg_explicitly_set("dit_cpu_offload")
+                and not args.is_arg_explicitly_set("dit_layerwise_offload")
                 and not explicit_dit_layerwise
             ):
                 args.dit_cpu_offload = False

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -17,6 +17,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     PipelineConfig,
 )
 from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import Cosmos3Config
+from sglang.multimodal_gen.configs.pipeline_configs.helios import (
+    HeliosDistilledConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import FastHunyuanConfig
 from sglang.multimodal_gen.configs.pipeline_configs.lingbot_world import (
     LingBotWorldCausalDMDConfig,
@@ -1595,6 +1598,13 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertEqual(sana_wm_deployment.fsdp_auto_min_available_memory_gb, 60)
         self.assertEqual(sana_wm_deployment.dit_layerwise_offload_modes, ("memory",))
+        self.assertEqual(sana_wm_deployment.keep_resident_min_available_gb, 120)
+        self.assertEqual(sana_wm_deployment.keep_resident_components, ("dit", "vae"))
+
+        helios_deployment = HeliosDistilledConfig().get_model_deployment_config()
+        self.assertEqual(helios_deployment.keep_resident_min_available_gb, 120)
+        self.assertEqual(helios_deployment.keep_resident_components, ("dit", "vae"))
+        self.assertEqual(helios_deployment.dit_layerwise_offload_modes, ("memory",))
 
         fast_hunyuan_deployment = FastHunyuanConfig().get_model_deployment_config()
         self.assertEqual(fast_hunyuan_deployment.keep_resident_min_available_gb, 60)


### PR DESCRIPTION
## Summary

Auto mode defaulted **every** video model to `dit_cpu_offload=True` regardless of device memory (`ServerArgs._adjust_offload` video branch), and the keep-resident self-heal in `ServerArgsAutoTuner.maybe_adjust_auto_component_residency_after_offload` never flipped `dit_cpu_offload` — it only handled text/image/vae offloads and the layerwise component list. So even a model that declares `keep_resident_components=("dit",)` still ran its DiT through per-layer H2D/D2H on a 275GB B300 with 267GiB free.

## Changes
- `auto_tune.py`: the keep-resident branch now flips `dit_cpu_offload=False` when the memory threshold is met and the user did **not** explicitly set `--dit-cpu-offload` / `--dit-layerwise-offload` (explicit offload and small-card behavior unchanged).
- `sana_wm.py` + `helios.py`: declare `keep_resident_min_available_gb=120` and `keep_resident_components=("dit","vae")`.

## Measured (single B300, auto mode, no flags)

| model | shape | e2e before | e2e after | output |
|---|---|---:|---:|---|
| SANA-WM_bidirectional | 1280x704, 49f, 20 steps | 13.20 s | **8.22 s (−38%)** | bit-exact (md5 = resident run) |
| Helios-Distilled | 640x384, 33f, 10 steps | 14.52 s | **13.10 s (−9.8%)** | resident DiT path |

SANA-WM denoise 7.43s → 6.56s (−12%). Auto log now shows `Disabling component offload ... dit_cpu_offload=False`.

## Test
- `test_server_args.py`: asserts the new SANA-WM + Helios deployment configs.
- 194 passed; pre-commit (isort/ruff/ruff-format) clean.

## Notes
- This is the highest-value finding from a single-GPU B300 sweep of 14 diffusion models. `torch.compile` is *not* a substitute: on SANA-WM it made denoise 11× slower (compile time counted in the denoise stage).
- Small cards (< threshold) and explicit `--dit-cpu-offload` are untouched — behavior is gated on measured free device memory and absence of explicit user flags.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33866313836](https://github.com/sgl-project/sglang/actions/runs/33866313836)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33866401159](https://github.com/sgl-project/sglang/actions/runs/33866401159)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33866313788](https://github.com/sgl-project/sglang/actions/runs/33866313788)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->