### PR TITLE
[FP8] SM120: route FP8 linear to per-tensor (cudnn/nvjet) instead of channelwise cutlass

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -917,16 +917,15 @@ class Fp8LinearMethod(LinearMethodBase):
                 # channelwise cutlass GemmUniversal by ~1.2-2.7x across the
                 # decode/prefill M range (matches vLLM's per-tensor SM120
                 # choice). Requantize per-channel -> per-tensor (max scale)
-                # there instead. Kill switch: SGLANG_SM120_FP8_PERTENSOR=0.
-                _sm120_fp8_pertensor = (
+                # there instead.
+                use_sm120_fp8_pertensor = (
                     self.cutlass_fp8_supported
                     and not self.use_marlin
-                    and get_bool_env_var("SGLANG_SM120_FP8_PERTENSOR", "true")
                     and get_device_capability()[0] == 12
                 )
                 # cutlass sgl-kernel and marlin only support per-channel scale; aiter supports per-channel scale
                 if (
-                    (self.cutlass_fp8_supported and not _sm120_fp8_pertensor)
+                    (self.cutlass_fp8_supported and not use_sm120_fp8_pertensor)
                     or self.use_marlin
                     or (_use_aiter and self.use_aiter_fp8_per_token)
                 ):

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -87,6 +87,7 @@ from sglang.srt.runtime_context import (
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
+    get_device_capability,
     is_cpu,
     is_cuda,
     is_flashinfer_available,
@@ -911,9 +912,21 @@ class Fp8LinearMethod(LinearMethodBase):
                         layer.input_scale.data, requires_grad=False
                     )
 
+                # On SM120 (Blackwell RTX 50) the per-tensor FP8 path dispatches
+                # to the fast cudnn/nvjet SM120 kernel, which beats the
+                # channelwise cutlass GemmUniversal by ~1.2-2.7x across the
+                # decode/prefill M range (matches vLLM's per-tensor SM120
+                # choice). Requantize per-channel -> per-tensor (max scale)
+                # there instead. Kill switch: SGLANG_SM120_FP8_PERTENSOR=0.
+                _sm120_fp8_pertensor = (
+                    self.cutlass_fp8_supported
+                    and not self.use_marlin
+                    and get_bool_env_var("SGLANG_SM120_FP8_PERTENSOR", "true")
+                    and get_device_capability()[0] == 12
+                )
                 # cutlass sgl-kernel and marlin only support per-channel scale; aiter supports per-channel scale
                 if (
-                    self.cutlass_fp8_supported
+                    (self.cutlass_fp8_supported and not _sm120_fp8_pertensor)
                     or self.use_marlin
                     or (_use_aiter and self.use_aiter_fp8_per_token)
                 ):


### PR DESCRIPTION
## Motivation

On SM120 (Blackwell RTX 50), FP8 models whose checkpoints use **per-channel weight scales + static per-tensor activation scales** (e.g. `mistralai/Ministral-3-14B-Instruct-2512`) are routed by SGLang to the **channelwise cutlass `GemmUniversal`** path (`convert_to_channelwise`). That kernel is dramatically slower than the per-tensor path on this GPU.

vLLM gets its large Ministral lead by doing the opposite: it `requantize_with_max_scale` collapses per-channel -> **per-tensor** at load and runs a fast per-tensor SM120 kernel (cudnn/nvjet/sm89_xmma). This PR makes SGLang take the equivalent per-tensor route on SM120.

## Change

In `Fp8LinearMethod.process_weights_after_loading`, on SM120 (capability major == 12, `cutlass_fp8_supported`, non-marlin) skip `convert_to_channelwise` and take the per-tensor `requantize_with_max_scale` branch instead. This routes FP8 linear to `torch._scaled_mm` per-tensor -> cudnn/nvjet SM120 kernel.
\n
## Micro-benchmark (per-layer sum of the 4 Ministral GEMM shapes, per-tensor vs channelwise cutlass)

Per-tensor wins at every M:
| M | ratio (cutlass/pertensor) |
|---|---|
| 1 | 2.60x |
| 32 | 2.69x |
| 128 | 1.69x |
| 512 | 1.30x |
| 1024 | 1.23x |
| 4096 | 1.26x |

## End-to-end (Ministral-3-14B, TP=1, out_tok/s, reproducible x2)

| bs | orig SGLang | this PR | vLLM | vs vLLM |
|---|---|---|---|---|
| 1 | 46.9 | **86.6** | 74 | **+17.1%** |
| 4 | 179 | **320.2** | 283 | **+13.1%** |
| 16 | 615 | 1038.1 | 1042 | -0.3% |
| 32 | 975 | 1437.7 | 1455 | -1.2% |

Was -33%/-43%/-37%/-32% vs vLLM before.

## Accuracy

8/8 **exact** output-token match vs vLLM (temperature=0, 128 tok, 8 prompts) — per-tensor numerics are identical to vLLM (both requantize per-channel -> per-tensor max scale via `requantize_with_max_scale`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33934534043](https://github.com/sgl-project/sglang/actions/runs/33934534043)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #33934533885](https://github.com/sgl-project/sglang/actions/runs/33934533885)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33934534070](https://github.com/sgl-project/sglang/actions/runs/33934534070)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
