### PR TITLE
[GLM-5.2] Support DSA index-topk sharing with two-batch overlap

### DIFF
--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -60,6 +60,7 @@ def handle_model_specific_adjustments(server_args: Any):
 
     cfg = resolving_view(server_args)
     from sglang.srt.configs.model_config import (
+        dsa_has_index_topk_sharing,
         get_mimo_v2_fused_qkv_expected_tp_size,
         is_deepseek_dsa,
     )
@@ -181,19 +182,37 @@ def handle_model_specific_adjustments(server_args: Any):
             # The "dsa" attention fill moved to the override registry
             # (arg_groups/overrides.py: _deepseek_family_overrides).
 
-            index_topk_freq = getattr(hf_config, "index_topk_freq", 1) or 1
-            index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
-            if cfg.enable_two_batch_overlap and (
-                index_topk_freq > 1
-                or (index_topk_pattern is not None and "S" in index_topk_pattern)
-            ):
-                raise ValueError(
-                    "--enable-two-batch-overlap is not supported with DSA "
-                    "index-topk sharing (index_topk_freq > 1 or an "
-                    "index_topk_pattern containing shared layers): the TBO op "
-                    "path does not propagate topk indices across layers, so "
-                    "shared layers would run sparse attention without indices."
-                )
+            if cfg.enable_two_batch_overlap:
+                if cfg.enable_hisparse:
+                    raise ValueError(
+                        "--enable-two-batch-overlap is not supported with "
+                        "--enable-hisparse for DSA models: the two TBO "
+                        "sub-batches cannot safely share HiSparse's mutable "
+                        "prefetch buffers and events."
+                    )
+                if cfg.enable_return_indexer_topk:
+                    raise ValueError(
+                        "--enable-two-batch-overlap is not supported with "
+                        "--enable-return-indexer-topk for DSA models: both "
+                        "TBO sub-batches currently write the same capture "
+                        "buffer rows."
+                    )
+
+            if cfg.enable_two_batch_overlap and dsa_has_index_topk_sharing(hf_config):
+                # DP attention keeps tokens attention-local across layers, so
+                # the per-sub-batch carry needs no resharding. CP reshard, the
+                # PP merged-indices handoff, and spec seed capture would each
+                # consume indices of the unsplit batch and stay rejected.
+                if (
+                    cfg.pp_size > 1
+                    or cfg.enable_prefill_cp
+                    or cfg.speculative_algorithm is not None
+                ):
+                    raise ValueError(
+                        "--enable-two-batch-overlap with DSA index-topk "
+                        "sharing is not supported with pipeline parallelism, "
+                        "--enable-prefill-cp, or speculative decoding."
+                    )
 
             if (
                 not get_platform().is_npu and not get_platform().is_xpu

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -51,6 +51,7 @@ from sglang.srt.utils import BumpAllocator, empty_context, get_bool_env_var, is_
 
 if TYPE_CHECKING:
     from sglang.srt.batch_overlap.single_batch_overlap import CombineOverlapArgs
+    from sglang.srt.layers.attention.index_topk_share import IndexTopKShareState
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
 
@@ -931,7 +932,10 @@ def model_forward_maybe_tbo(
     input_data_scatter_mode: ScatterMode,
     residual: Optional[torch.Tensor],
     zero_allocator: Optional[BumpAllocator] = None,
+    index_topk_share: Optional[IndexTopKShareState] = None,
 ):
+    # DSA topk indices are per-token: each TBO sub-batch must thread its own
+    # token-sliced carry, never the parent state.
     inputs = dict(
         positions=positions,
         hidden_states=hidden_states,
@@ -939,6 +943,8 @@ def model_forward_maybe_tbo(
         residual=residual,
         zero_allocator=zero_allocator,
     )
+    if index_topk_share is not None:
+        inputs["index_topk_share"] = index_topk_share
     layer_input_scatter_mode = layers[0].layer_scatter_modes.layer_input_mode
     operations_strategy = OperationsStrategy.init_new_tbo(
         layers, forward_batch.global_forward_mode
@@ -999,6 +1005,7 @@ def _model_forward_tbo_split_inputs(
     zero_allocator: Optional[BumpAllocator],
     input_data_scatter_mode: ScatterMode,
     layer_input_scatter_mode: ScatterMode,
+    index_topk_share: Optional[IndexTopKShareState] = None,
 ) -> List[Dict]:
     tbo_splitter_scatter_mode = ScatterMode.TP_ATTN_FULL
     context = CommunicateContext.init_new()
@@ -1019,6 +1026,7 @@ def _model_forward_tbo_split_inputs(
         positions=positions,
         forward_batch=forward_batch,
         zero_allocator=zero_allocator,
+        index_topk_share=index_topk_share,
     )
 
     def _post_transform(hidden_states, residual, forward_batch, **kwargs):
@@ -1047,6 +1055,7 @@ def _model_forward_tbo_split_inputs_raw(
     positions: torch.Tensor,
     forward_batch: ForwardBatch,
     zero_allocator: Optional[BumpAllocator],
+    index_topk_share: Optional[IndexTopKShareState] = None,
 ) -> List[Dict]:
     return [
         dict(
@@ -1056,6 +1065,7 @@ def _model_forward_tbo_split_inputs_raw(
                 positions=positions,
                 output_forward_batch=output_forward_batch,
                 tbo_subbatch_index=tbo_subbatch_index,
+                index_topk_share=index_topk_share,
             ),
             **(
                 dict(zero_allocator=zero_allocator)
@@ -1075,6 +1085,7 @@ def _model_forward_filter_inputs(
     positions: torch.Tensor,
     output_forward_batch: ForwardBatch,
     tbo_subbatch_index: int,
+    index_topk_share: Optional[IndexTopKShareState] = None,
 ) -> Dict:
     token_slice = slice(*output_forward_batch.tbo_parent_token_range)
     hidden_states = hidden_states[token_slice]
@@ -1094,13 +1105,20 @@ def _model_forward_filter_inputs(
         res[: x.shape[0]] = x
         return res
 
-    return dict(
+    outputs = dict(
         hidden_states=_pad(hidden_states),
         residual=_pad(residual),
         positions=_pad(positions),
         forward_batch=output_forward_batch,
         tbo_subbatch_index=tbo_subbatch_index,
     )
+    if index_topk_share is not None:
+        outputs["index_topk_share"] = index_topk_share.for_tbo_child(
+            forward_batch=output_forward_batch,
+            token_range=output_forward_batch.tbo_parent_token_range,
+            padded_num_tokens=padded_len,
+        )
+    return outputs
 
 
 def _model_forward_tbo_merge_outputs(output_a, output_b, original_len):

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -253,6 +253,15 @@ def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
     return max(layer_id - 1, 0) % freq != 0
 
 
+def dsa_has_index_topk_sharing(config: PretrainedConfig) -> bool:
+    """Return whether any DSA layer reuses another layer's top-k indices."""
+    assert is_deepseek_dsa(config)
+    return any(
+        dsa_layer_skips_topk(config, layer_id)
+        for layer_id in range(config.num_hidden_layers)
+    )
+
+
 def get_dsa_index_n_heads(config: PretrainedConfig) -> int:
     assert is_deepseek_dsa(config)
     return config.index_n_heads

--- a/python/sglang/srt/layers/attention/index_topk_share.py
+++ b/python/sglang/srt/layers/attention/index_topk_share.py
@@ -48,6 +48,34 @@ class IndexTopKShareState:
     def update(self, topk_indices: Optional[torch.Tensor]) -> None:
         self._topk_indices = topk_indices
 
+    def for_tbo_child(
+        self,
+        forward_batch: ForwardBatch,
+        token_range: tuple[int, int],
+        padded_num_tokens: int,
+    ) -> IndexTopKShareState:
+        topk_indices = self._topk_indices
+        if topk_indices is not None:
+            start, end = token_range
+            assert 0 <= start <= end <= topk_indices.shape[0], (
+                f"invalid TBO token range {token_range} for topk indices with "
+                f"{topk_indices.shape[0]} rows"
+            )
+            num_tokens = end - start
+            assert num_tokens <= padded_num_tokens, (
+                f"TBO child has {num_tokens} topk rows but its padded token "
+                f"length is only {padded_num_tokens}"
+            )
+            topk_indices = topk_indices[start:end]
+            if num_tokens < padded_num_tokens:
+                # -1 marks padded rows, the same sentinel the DSA backends use.
+                padded = topk_indices.new_full(
+                    (padded_num_tokens, *topk_indices.shape[1:]), -1
+                )
+                padded[:num_tokens] = topk_indices
+                topk_indices = padded
+        return IndexTopKShareState(forward_batch, topk_indices)
+
     def publish(self) -> None:
         if self._topk_indices is None or not self.should_publish:
             return

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -43,6 +43,7 @@ from sglang.srt.batch_overlap.two_batch_overlap import (
 )
 from sglang.srt.configs.model_config import (
     compute_mla_mscale_scaling,
+    dsa_has_index_topk_sharing,
     dsa_layer_skips_topk,
     get_dsa_index_head_dim,
     get_dsa_index_n_heads,
@@ -2046,22 +2047,30 @@ class DeepseekV2AttentionMLA(
         return resolve_rocm_forward_method(handler(self, forward_batch))
 
     def op_prepare(self, state):
+        index_topk_share = state.get("index_topk_share")
         state.attn_intermediate_state = self.forward_prepare(
             positions=state.positions,
             hidden_states=state.pop("hidden_states_after_comm_pre_attn"),
             forward_batch=state.forward_batch,
             zero_allocator=state.zero_allocator,
+            prev_topk_indices=(
+                None if index_topk_share is None else index_topk_share.topk_indices
+            ),
         )
 
     def op_core(self, state):
         result = self.forward_core(state.pop("attn_intermediate_state"))
         # forward_core may return (hidden_states, topk_indices) for DSA models
-        # with index cache enabled. In the TBO path, topk_indices is not
-        # propagated between layers, so we discard it here.
+        # with index cache enabled. The share state carries the indices to the
+        # next layer's op_prepare; a None result clears it so no stale rows leak.
         if isinstance(result, tuple):
-            state.hidden_states_after_attn = result[0]
+            hidden_states, topk_indices = result
         else:
-            state.hidden_states_after_attn = result
+            hidden_states, topk_indices = result, None
+        index_topk_share = state.get("index_topk_share")
+        if index_topk_share is not None:
+            index_topk_share.update(topk_indices)
+        state.hidden_states_after_attn = hidden_states
 
     def forward(
         self,
@@ -2574,6 +2583,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
         zero_allocator: BumpAllocator,
         tbo_subbatch_index: Optional[int] = None,
+        index_topk_share: Optional[IndexTopKShareState] = None,
     ):
         state.hidden_states_after_comm_pre_attn, state.residual_after_input_ln = (
             self.layer_communicator.prepare_attn(hidden_states, residual, forward_batch)
@@ -2588,6 +2598,8 @@ class DeepseekV2DecoderLayer(nn.Module):
                 tbo_subbatch_index=tbo_subbatch_index,
             )
         )
+        if index_topk_share is not None:
+            state.index_topk_share = index_topk_share
 
     def op_comm_prepare_mlp(self, state):
         state.hidden_states_mlp_input, state.residual_after_comm_pre_mlp = (
@@ -2605,6 +2617,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             state.forward_batch,
         )
 
+        index_topk_share = state.get("index_topk_share")
         output = dict(
             positions=state.positions,
             hidden_states=hidden_states,
@@ -2613,15 +2626,17 @@ class DeepseekV2DecoderLayer(nn.Module):
             zero_allocator=state.zero_allocator,
             tbo_subbatch_index=state.tbo_subbatch_index,
         )
+        expected_state_keys = {
+            "positions",
+            "forward_batch",
+            "zero_allocator",
+            "tbo_subbatch_index",
+        }
+        if index_topk_share is not None:
+            output["index_topk_share"] = index_topk_share
+            expected_state_keys.add("index_topk_share")
 
-        state.clear(
-            expect_keys={
-                "positions",
-                "forward_batch",
-                "zero_allocator",
-                "tbo_subbatch_index",
-            }
-        )
+        state.clear(expect_keys=expected_state_keys)
         return output
 
 
@@ -2640,6 +2655,9 @@ class DeepseekV2Model(nn.Module):
         self.padding_id = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.first_k_dense_replace = config.first_k_dense_replace
+        self.dsa_index_share_active = self.use_dsa and dsa_has_index_topk_sharing(
+            config
+        )
         self.pp_group = get_pp_group()
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
@@ -2912,6 +2930,9 @@ class DeepseekV2Model(nn.Module):
                     normal_end_layer - 1
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
+                index_topk_share=(
+                    index_topk_share if self.dsa_index_share_active else None
+                ),
             )
 
         if not self.pp_group.is_last_rank:


### PR DESCRIPTION
## Motivation

GLM-5.2 (`GlmMoeDsaForCausalLM`) uses DSA with **index-topk sharing**: only 21 of its 78 layers run the lightning indexer to compute fresh top-k indices (`index_topk_freq=4`, `index_skip_topk_offset=3`); the other 57 layers reuse the indices produced by the most recent indexing layer. GLM-5.3 keeps essentially the same model structure, so everything in this PR applies to it in the same way.

SGLang already supports TBO, and this PR does not reimplement any of it — DSA models that compute fresh top-k indices in every layer run with `--enable-two-batch-overlap` as is. What the existing TBO path lacked is the cross-layer index carry that sharing models need: `op_core` discarded the `topk_indices` returned by `forward_core`, so on GLM-5.2 the 57 shared layers would have run sparse attention without indices. Server startup therefore hard-rejected `--enable-two-batch-overlap` for any DSA model with index-topk sharing, which blocked TBO for GLM-5.2 entirely. On multi-node large-EP decode deployments this leaves the cross-node DeepEP dispatch/combine latency fully exposed.

This PR adds the missing piece on top of the existing TBO implementation: the per-layer index-topk carry is threaded through the TBO sub-batch pipeline, so each sub-batch keeps its own carry across layers. That enables TBO for GLM-5.2 and other sharing configs (`index_topk_pattern`, LongCat `cli_factor`). On a 2×8×H200 EP16 deployment, TBO now improves per-GPU decode throughput by up to **+11.8%** at high concurrency, with GSM8K accuracy unchanged.

## Modifications

- `layers/attention/index_topk_share.py`: add `IndexTopKShareState.for_tbo_child()` — a per-sub-batch carry sliced to the sub-batch token range and re-padded with the `-1` invalid-row sentinel.
- `batch_overlap/two_batch_overlap.py`: thread an optional `index_topk_share` through the TBO input split, so each sub-batch gets its own independent carry.
- `models/deepseek_v2.py`: the TBO operations now read `prev_topk_indices` from the carry, write fresh indices back (previously discarded), and pass the carry layer to layer.
- `configs/model_config.py`: add the `dsa_has_index_topk_sharing()` helper.
- `arg_groups/model_hook.py`: replace the blanket rejection — TBO with index-topk sharing is now allowed for pure TP/EP and DP attention; still rejected with PP / prefill-CP / speculative decoding.

## Accuracy Tests

GSM8K (5-shot, 200 questions, greedy `temperature=0`, `benchmark/gsm8k/bench_sglang.py --parallel 32`) against the same 2×8×H200 EP16 deployment described below, toggling only `--enable-two-batch-overlap`. Two runs per config:

| Config | Accuracy (run 1) | Accuracy (run 2) |
| --- | --- | --- |
| TBO off (baseline) | 0.960 | 0.955 |
| TBO on (this PR) | 0.955 | 0.960 |

The two configs produce the same score distribution; the difference is within run-to-run noise.

## Speed Tests and Profiling

**Setup**: GLM-5.2-FP8, 2 nodes × 8 × NVIDIA H200 (141 GB), cross-node DeepEP over RDMA. The two runs differ only in `--enable-two-batch-overlap`:

```bash
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=512 \
sglang serve --model-path GLM-5.2-FP8 \
    --tp 16 --dp 16 --ep 16 --nnodes 2 --node-rank <0|1> --dist-init-addr <node0-ip>:25000 \
    --enable-dp-attention --enable-dp-lm-head --moe-a2a-backend deepep \
    --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.78 \
    --disable-prefill-cuda-graph \
    [--enable-two-batch-overlap]
```

**Workload**: concurrency sweep at a realistic prompt shape. Each point sends one wave of `N` requests with input 1024 / output 2048 tokens (`random-ids`, no shared prefix), so after the initial prefill ramp the full batch decodes together until the end of the run:

```bash
python -m sglang.benchmark.serving --backend sglang --dataset-name random-ids \
    --random-input-len 1024 --random-output-len 2048 --random-range-ratio 1.0 \
    --num-prompts <N> --max-concurrency <N>
```

**Metric**: server-side steady-state generation throughput per GPU — `last_gen_throughput` (tok/s) from `/get_server_info`, sampled at the end of the run and averaged over the 16 DP ranks. Client-side end-to-end throughput is not used as the A/B metric: at thousands of concurrent streams the benchmark client itself spends substantial time receiving and processing the streamed responses, so its numbers reflect client-side bottlenecks rather than the server's actual throughput.

| Concurrency | bs / rank | TBO off (tok/s/GPU) | TBO on (tok/s/GPU) | TBO gain | TBO off total (tok/s) | TBO on total (tok/s) |
| --- | --- | --- | --- | --- | --- | --- |
| 2048 | 128 | 1787 | 1671 | −6.5% | 28,586 | 26,740 |
| 2304 | 144 | 1777 | 1718 | −3.3% | 28,432 | 27,481 |
| 2560 | 160 | 1850 | 1866 | +0.9% | 29,595 | 29,862 |
| 2816 | 176 | 1917 | 1983 | +3.4% | 30,670 | 31,723 |
| 3072 | 192 | 1982 | 2059 | +3.9% | 31,709 | 32,943 |
| 3328 | 208 | 1948 | 2124 | +9.0% | 31,164 | 33,977 |
| 3584 | 224 | 1986 | 2196 | +10.6% | 31,778 | 35,133 |
| 3840 | 240 | 2019 | 2256 | **+11.8%** | 32,297 | 36,101 |
| 4096 | 256 | 2114 | 2348 | +11.1% | 33,832 | 37,576 |

<img width="2160" height="870" alt="WecomSave_ca7fcde99deaa0590e866fb6a4a869d1" src="https://github.com/user-attachments/assets/418d5c15-4c40-4fb5-90cc-3ad82488f01d" />


The crossover follows from what TBO overlaps: it hides the **cross-node DeepEP dispatch/combine latency** behind the other sub-batch's compute, so it only pays off on large-EP (multi-node) deployments where the exposed inter-node a2a is a large share of each decode step — on small-EP / intra-node setups there is little communication worth hiding. The cost side is fixed: below ~150 requests per rank decode is weight-bound and the split batch reads the MoE weights twice per step, hence the −6.5% loss at 128/rank. On this 2-node EP16 deployment TBO breaks even around 144–160 requests per rank, and the gain grows to +11.8% as the batch approaches the KV-capacity limit (~287 requests per rank at this sequence length). TBO remains opt-in: enable it for large-EP high-concurrency decode, leave it off for small-batch / latency-sensitive serving.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33871652455](https://github.com/sgl-project/sglang/actions/runs/33871652455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33871652232](https://github.com/sgl-project/sglang/actions/runs/33871652232)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33871652402](https://github.com/sgl-project/sglang/actions/runs/33871652402)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->