### PR TITLE
[Fix] Concatenate multi-part text in system/assistant chat messages

### DIFF
--- a/python/sglang/srt/parser/conversation.py
+++ b/python/sglang/srt/parser/conversation.py
@@ -638,13 +638,14 @@ def generate_chat_conv(
             if isinstance(message.content, str):
                 conv.system_message = message.content
             elif isinstance(message.content, list):
-                if (
-                    len(message.content) != 1
-                    or getattr(message.content[0], "type", None) != "text"
-                ):
-                    raise ValueError("The system message should be a single text.")
-                else:
-                    conv.system_message = getattr(message.content[0], "text", "")
+                system_text = ""
+                for content in message.content:
+                    if getattr(content, "type", None) != "text":
+                        raise ValueError(
+                            "The system message should only contain text parts."
+                        )
+                    system_text += getattr(content, "text", "")
+                conv.system_message = system_text
         elif msg_role == "user":
             # Handle the various types of Chat Request content types here.
             if isinstance(message.content, str):
@@ -709,15 +710,12 @@ def generate_chat_conv(
             if isinstance(message.content, str):
                 parsed_content = message.content
             elif isinstance(message.content, list):
-                if (
-                    len(message.content) != 1
-                    or getattr(message.content[0], "type", None) != "text"
-                ):
-                    raise ValueError(
-                        "The assistant's response should be a single text."
-                    )
-                else:
-                    parsed_content = getattr(message.content[0], "text", "")
+                for content in message.content:
+                    if getattr(content, "type", None) != "text":
+                        raise ValueError(
+                            "The assistant message should only contain text parts."
+                        )
+                    parsed_content += getattr(content, "text", "")
             conv.append_message(conv.roles[1], parsed_content)
         else:
             raise ValueError(f"Unknown role: {msg_role}")

--- a/test/registered/unit/parser/test_conversation.py
+++ b/test/registered/unit/parser/test_conversation.py
@@ -777,6 +777,49 @@ class TestGenerateChatConv(CustomTestCase):
         conv = generate_chat_conv(request, "chatml")
         self.assertEqual(conv.system_message, "System text")
 
+    def test_system_message_multi_part_text(self):
+        """Test system message with multiple text parts is concatenated."""
+        request = self._make_request(
+            [
+                ChatCompletionMessageGenericParam(
+                    role="system",
+                    content=[
+                        ChatCompletionMessageContentTextPart(
+                            type="text", text="You are "
+                        ),
+                        ChatCompletionMessageContentTextPart(
+                            type="text", text="helpful."
+                        ),
+                    ],
+                ),
+                ChatCompletionMessageUserParam(role="user", content="Hi"),
+            ]
+        )
+        conv = generate_chat_conv(request, "chatml")
+        self.assertEqual(conv.system_message, "You are helpful.")
+
+    def test_system_message_mixed_parts_raises(self):
+        """Test that system message mixing text and non-text parts raises."""
+        request = self._make_request(
+            [
+                ChatCompletionMessageGenericParam(
+                    role="system",
+                    content=[
+                        ChatCompletionMessageContentTextPart(type="text", text="Hi"),
+                        ChatCompletionMessageContentImagePart(
+                            type="image_url",
+                            image_url=ChatCompletionMessageContentImageURL(
+                                url="http://example.com/img.jpg"
+                            ),
+                        ),
+                    ],
+                ),
+                ChatCompletionMessageUserParam(role="user", content="Hi"),
+            ]
+        )
+        with self.assertRaises(ValueError):
+            generate_chat_conv(request, "chatml")
+
     def test_system_message_invalid_list_raises(self):
         """Test that system message with non-text content raises ValueError."""
         request = self._make_request(
@@ -829,6 +872,46 @@ class TestGenerateChatConv(CustomTestCase):
         )
         conv = generate_chat_conv(request, "chatml")
         self.assertEqual(conv.messages[1][1], "Hello!")
+
+    def test_assistant_message_multi_part_text(self):
+        """Test assistant message with multiple text parts is concatenated."""
+        request = self._make_request(
+            [
+                ChatCompletionMessageUserParam(role="user", content="Hi"),
+                ChatCompletionMessageGenericParam(
+                    role="assistant",
+                    content=[
+                        ChatCompletionMessageContentTextPart(type="text", text="Hel"),
+                        ChatCompletionMessageContentTextPart(type="text", text="lo!"),
+                    ],
+                ),
+                ChatCompletionMessageUserParam(role="user", content="How are you?"),
+            ]
+        )
+        conv = generate_chat_conv(request, "chatml")
+        self.assertEqual(conv.messages[1][1], "Hello!")
+
+    def test_assistant_mixed_parts_raises(self):
+        """Test that assistant message mixing text and non-text parts raises."""
+        request = self._make_request(
+            [
+                ChatCompletionMessageUserParam(role="user", content="Hi"),
+                ChatCompletionMessageGenericParam(
+                    role="assistant",
+                    content=[
+                        ChatCompletionMessageContentTextPart(type="text", text="Hi"),
+                        ChatCompletionMessageContentImagePart(
+                            type="image_url",
+                            image_url=ChatCompletionMessageContentImageURL(
+                                url="http://example.com/img.jpg"
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        )
+        with self.assertRaises(ValueError):
+            generate_chat_conv(request, "chatml")
 
     def test_assistant_invalid_list_raises(self):
         """Test that assistant message with non-text content raises ValueError."""


### PR DESCRIPTION
## Motivation

Fixes #37845.

`generate_chat_conv` rejected `system`/`assistant` messages whose content is a list with more than one text part (`"The system message should be a single text."`), while the same text split into parts in a `user` message is concatenated and accepted. The same content should not be rejected depending on the role — several clients split long system prompts into multiple text parts.

## Modifications

- `python/sglang/srt/parser/conversation.py`: `system` and `assistant` list content now concatenates all text parts, matching the existing `user`-message behavior. Non-text parts are still rejected (message reworded to "should only contain text parts").
- `test/registered/unit/parser/test_conversation.py`: 4 regression tests — multi-part text concatenation and mixed text/non-text rejection for both roles.

## Accuracy Tests

Not applicable — no changes to kernels or model forward code. Previously accepted inputs render identically; the change only makes previously rejected multi-part `system`/`assistant` content render by concatenation. Covered by the new CPU-only unit tests.

## Speed Tests and Profiling

Not applicable — string concatenation in prompt rendering only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
