### PR TITLE
[diffusion] fix host-resident vocab tables loaded on GPU

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -180,9 +180,21 @@ def _install_host_gather_hooks(
     """Run this module's gather on the host, move only the result."""
 
     def _inputs_to_host(_module, args, kwargs):
+        # Move only integer (vocab-index) tensors to the host table; floating
+        # inputs (e.g. RoPE freqs a VL encoder feeds the same module) must stay
+        # on the compute device or the gather mixes cpu/cuda tensors.
         if not args or not torch.is_tensor(args[0]):
             return None
-        return (args[0].to("cpu"),) + args[1:], kwargs
+        if not (args[0].dtype in (torch.long, torch.int, torch.int32, torch.int64)):
+            return None
+        moved = tuple(
+            a.to("cpu")
+            if torch.is_tensor(a)
+            and a.dtype in (torch.long, torch.int, torch.int32, torch.int64)
+            else a
+            for a in args
+        )
+        return moved, kwargs
 
     def _output_to_device(_module, _args, output):
         if not torch.is_tensor(output):

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -150,11 +150,16 @@ def _host_resident_tables(model: torch.nn.Module) -> List[torch.nn.Module]:
 def detach_host_resident_tables(
     model: torch.nn.Module,
 ) -> List[Tuple[torch.nn.Module, torch.Tensor]]:
-    """Swap large vocab tables for placeholders so a `.to(device)` skips them."""
+    """Park large vocab tables on the host so a `.to(device)` skips them."""
     detached = []
     for module in _host_resident_tables(model):
         weight = module.weight
-        detached.append((module, weight.data))
+        # Most loaders leave the table on the host, but model-owned loading
+        # paths may already have placed it on the accelerator.  The input hook
+        # below always sends indices to the host, so retaining accelerator data
+        # here would restore a CUDA weight and create a CPU-index/CUDA-weight
+        # mismatch in the embedding gather.
+        detached.append((module, weight.data.to("cpu")))
         weight.data = torch.empty(0, dtype=weight.dtype, device=weight.device)
     return detached
 
@@ -180,21 +185,9 @@ def _install_host_gather_hooks(
     """Run this module's gather on the host, move only the result."""
 
     def _inputs_to_host(_module, args, kwargs):
-        # Move only integer (vocab-index) tensors to the host table; floating
-        # inputs (e.g. RoPE freqs a VL encoder feeds the same module) must stay
-        # on the compute device or the gather mixes cpu/cuda tensors.
         if not args or not torch.is_tensor(args[0]):
             return None
-        if not (args[0].dtype in (torch.long, torch.int, torch.int32, torch.int64)):
-            return None
-        moved = tuple(
-            a.to("cpu")
-            if torch.is_tensor(a)
-            and a.dtype in (torch.long, torch.int, torch.int32, torch.int64)
-            else a
-            for a in args
-        )
-        return moved, kwargs
+        return (args[0].to("cpu"),) + args[1:], kwargs
 
     def _output_to_device(_module, _args, output):
         if not torch.is_tensor(output):

--- a/python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py
+++ b/python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py
@@ -97,3 +97,27 @@ class TestDetachAndRestore:
             restore_host_resident_tables(detached, "cpu")
         assert detached == []
         assert not model.embed._forward_pre_hooks
+
+    def test_float_inputs_are_not_moved_to_host(self):
+        # regression for Qwen3VL: a VL encoder can feed floating tensors (RoPE
+        # freqs / position embeddings) into the same module; moving them to the
+        # host table mixed cpu/cuda tensors and crashed index_select.
+        model = _Declared()
+        with patch(THRESHOLD_PATH, 1024):
+            restore_host_resident_tables(detach_host_resident_tables(model), "cpu")
+        # forward a float tensor: the hook must pass it through untouched
+        # (nn.Embedding would reject it, so assert the hook leaves dtype/device)
+        hook = next(iter(model.embed._forward_pre_hooks.values()))
+        out = hook(model.embed, (torch.randn(2, 3),), {})
+        assert out is None  # not an integer index -> hook declines to rewrite
+
+    def test_integer_inputs_are_moved_and_floats_skipped(self):
+        model = _Declared()
+        with patch(THRESHOLD_PATH, 1024):
+            restore_host_resident_tables(detach_host_resident_tables(model), "cpu")
+        hook = next(iter(model.embed._forward_pre_hooks.values()))
+        ids = torch.tensor([[1, 2]])
+        freqs = torch.randn(2, 4)
+        moved, _ = hook(model.embed, (ids, freqs), {})
+        assert moved[0].device.type == "cpu"
+        assert moved[1] is freqs  # float tensor left in place

--- a/python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py
+++ b/python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 import torch
 
 from sglang.multimodal_gen.runtime.managers.memory_managers import layerwise_offload
@@ -98,26 +99,21 @@ class TestDetachAndRestore:
         assert detached == []
         assert not model.embed._forward_pre_hooks
 
-    def test_float_inputs_are_not_moved_to_host(self):
-        # regression for Qwen3VL: a VL encoder can feed floating tensors (RoPE
-        # freqs / position embeddings) into the same module; moving them to the
-        # host table mixed cpu/cuda tensors and crashed index_select.
-        model = _Declared()
-        with patch(THRESHOLD_PATH, 1024):
-            restore_host_resident_tables(detach_host_resident_tables(model), "cpu")
-        # forward a float tensor: the hook must pass it through untouched
-        # (nn.Embedding would reject it, so assert the hook leaves dtype/device)
-        hook = next(iter(model.embed._forward_pre_hooks.values()))
-        out = hook(model.embed, (torch.randn(2, 3),), {})
-        assert out is None  # not an integer index -> hook declines to rewrite
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_a_device_resident_table_is_parked_on_the_host(self):
+        model = _Declared().to("cuda")
+        ids = torch.tensor([[1, 2, 3], [4, 5, 6]], device="cuda")
+        with torch.no_grad():
+            expected = model.embed(ids)
 
-    def test_integer_inputs_are_moved_and_floats_skipped(self):
-        model = _Declared()
         with patch(THRESHOLD_PATH, 1024):
-            restore_host_resident_tables(detach_host_resident_tables(model), "cpu")
-        hook = next(iter(model.embed._forward_pre_hooks.values()))
-        ids = torch.tensor([[1, 2]])
-        freqs = torch.randn(2, 4)
-        moved, _ = hook(model.embed, (ids, freqs), {})
-        assert moved[0].device.type == "cpu"
-        assert moved[1] is freqs  # float tensor left in place
+            detached = detach_host_resident_tables(model)
+            assert model.embed.weight.numel() == 0
+            model.to("cuda")
+            restore_host_resident_tables(detached, "cuda")
+
+        with torch.no_grad():
+            actual = model.embed(ids)
+        assert model.embed.weight.device.type == "cpu"
+        assert actual.device.type == "cuda"
+        assert torch.equal(actual, expected)


### PR DESCRIPTION
## Summary

Layerwise offload keeps declared large vocabulary tables on the host and moves embedding indices to the host before the gather. However, `detach_host_resident_tables` retained `weight.data` on its current device. Model-owned loading paths can place the embedding on the accelerator before layerwise offload is configured, so restore put the weight back on CUDA while the pre-hook moved the indices to CPU:

```
RuntimeError: Expected all tensors to be on the same device, but got index is on cpu,
different from other tensors on cuda:0 (wrapper_CUDA__index_select)
```

## Fix

- Normalize the detached vocabulary-table storage to CPU before installing the placeholder.
- Keep the gather hook contract narrow: move only the embedding input (`args[0]`) to the host and move the result back to the compute device.
- Replace the previous direct-hook tests with a CUDA regression that starts with a GPU-resident `nn.Embedding`, performs the real forward after detach/restore, and checks the weight remains on CPU while the result returns to CUDA.


## Reproduction

The regression requires a CUDA GPU. Fetch the PR first:

```bash
git fetch https://github.com/sgl-project/sglang.git \
  refs/pull/38012/head:refs/remotes/pr/38012
```

To reproduce the original CPU-index/CUDA-weight failure on the previous PR head:

```bash
git switch --detach e405db08c4ebdd541fb15179f0ed55db2b8225d3
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python python - <<'PY'
from unittest.mock import patch

import torch

from sglang.multimodal_gen.runtime.managers.memory_managers import layerwise_offload
from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
    detach_host_resident_tables,
    restore_host_resident_tables,
)


class Model(torch.nn.Module):
    host_resident_table_names = ["embed"]

    def __init__(self):
        super().__init__()
        self.embed = torch.nn.Embedding(4096, 64)


model = Model().to("cuda")
ids = torch.tensor([[1, 2, 3]], device="cuda")
threshold = f"{layerwise_offload.__name__}.HOST_RESIDENT_TABLE_MIN_BYTES"
with patch(threshold, 1024):
    detached = detach_host_resident_tables(model)
    model.to("cuda")
    restore_host_resident_tables(detached, "cuda")

model(ids)
PY
```

Expected result: `RuntimeError: Expected all tensors to be on the same device ... index is on cpu ... tensors on cuda:0`.

To verify the fix on the updated PR head:

```bash
git switch --detach refs/remotes/pr/38012
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python pytest -q \
  python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py::TestDetachAndRestore::test_a_device_resident_table_is_parked_on_the_host
```

Expected result: `1 passed`.


## H200 validation

Validated on one otherwise idle NVIDIA H200 (GPU 1), using the same regression test against three revisions:

| Revision | Result |
| --- | --- |
| latest `main` (`f1f2380d2b`) | fails with the exact CPU-index/CUDA-weight `index_select` error |
| previous PR head (`e405db08c4`) | fails with the same error |
| updated PR | passes |

Related suites on latest `main` plus this patch:

```
pytest -q \
  python/sglang/multimodal_gen/test/unit/test_host_resident_vocab_table.py \
  python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py \
  python/sglang/multimodal_gen/test/unit/test_component_residency.py

174 passed
```

Pre-commit passes for both changed files.

The original `fal/ideogram-v4-fast` end-to-end command could not be rerun on this H200 because its `ideogram-ai/ideogram-4-nf4-diffusers` dependency is gated for the machine account. The GPU regression above reproduces the exact failing embedding operation without relying on that checkpoint.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33938911526](https://github.com/sgl-project/sglang/actions/runs/33938911526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33938911426](https://github.com/sgl-project/sglang/actions/runs/33938911426)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33938911495](https://github.com/sgl-project/sglang/actions/runs/33938911495)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->