### PR TITLE
[Mamba] Add prefix cache checkpoint miss metrics

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1103,6 +1103,10 @@ class Req(ReqDllmMixin):
         # match, it will be the tracked seqlen in the ping pong buffer for the
         # right prefill pass.
         self.mamba_branching_seqlen: Optional[int] = None
+        # Full-KV tokens that could not be reused because the matching Mamba
+        # checkpoint was unavailable. Reported once on the first prefill pass.
+        self.mamba_cache_miss_tokens = 0
+        self._mamba_cache_miss_reported = False
         # Total cached prefix length (on-device prefix_indices + host_hit_length),
         # capped at the max allowed prefix. Set during prefix matching at schedule
         # time and used to estimate uncached tokens / sort by longest prefix for
@@ -1834,6 +1838,8 @@ class Req(ReqDllmMixin):
         self.kv.mamba_last_track_idx = None
         self.kv.mamba_last_track_seqlen = None
         self.mamba_branching_seqlen = None
+        self.mamba_cache_miss_tokens = 0
+        self._mamba_cache_miss_reported = False
         self.kv.mamba_cow_src_index = None
         self.kv.mamba_needs_clear = False
         self.already_computed = 0

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -58,6 +58,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InitLoadBackParams,
     InsertParams,
     MatchPrefixParams,
+    MatchResult,
     zero_match_result,
 )
 from sglang.srt.mem_cache.multi_ended_allocator import (
@@ -138,6 +139,22 @@ def estimate_prefill_extend_tile_metrics(
     }
 
 
+def get_mamba_cache_miss_tokens(match_result: MatchResult) -> int:
+    """Return Full-KV tokens blocked by a missing reusable Mamba checkpoint."""
+    if match_result.mamba_branching_seqlen is None:
+        return 0
+
+    mamba_boundary_len = len(match_result.device_indices) + match_result.host_hit_length
+    if match_result.full_kv_hit_length <= mamba_boundary_len:
+        return 0
+
+    return max(
+        min(match_result.mamba_branching_seqlen, match_result.full_kv_hit_length)
+        - mamba_boundary_len,
+        0,
+    )
+
+
 def match_prefix_for_req(
     tree_cache: BasePrefixCache,
     req: Req,
@@ -193,6 +210,7 @@ def match_prefix_for_req(
     req.num_matched_prefix_tokens = min(
         len(req.prefix_indices) + req.host_hit_length, max_len
     )
+    req.mamba_cache_miss_tokens = get_mamba_cache_miss_tokens(match_result)
     if match_result.mamba_branching_seqlen is not None:
         req.mamba_branching_seqlen = match_result.mamba_branching_seqlen
     if match_result.cache_protected_len is not None:

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -98,6 +98,8 @@ class PrefillStats:
     log_host_hit_tokens: int = 0
     log_storage_hit_tokens: int = 0
     num_pending_tokens: int = 0
+    mamba_cache_miss_requests: int = 0
+    mamba_cache_miss_tokens: int = 0
 
     @classmethod
     def from_adder(
@@ -107,6 +109,17 @@ class PrefillStats:
         enable_priority_scheduling: bool = False,
         num_pending_tokens: int = 0,
     ):
+        mamba_cache_miss_requests = 0
+        mamba_cache_miss_tokens = 0
+        for req in adder.can_run_list:
+            if getattr(req, "_mamba_cache_miss_reported", False):
+                continue
+            miss_tokens = getattr(req, "mamba_cache_miss_tokens", 0)
+            if miss_tokens > 0:
+                mamba_cache_miss_requests += 1
+                mamba_cache_miss_tokens += miss_tokens
+                req._mamba_cache_miss_reported = True
+
         return cls(
             log_input_tokens=adder.log_input_tokens,
             log_hit_tokens=adder.log_hit_tokens,
@@ -121,6 +134,8 @@ class PrefillStats:
             ),
             num_new_seqs=len(adder.can_run_list),
             num_pending_tokens=num_pending_tokens,
+            mamba_cache_miss_requests=mamba_cache_miss_requests,
+            mamba_cache_miss_tokens=mamba_cache_miss_tokens,
         )
 
 
@@ -682,6 +697,10 @@ class SchedulerMetricsReporter:
                 prefill_compute_tokens=prefill_stats.log_input_tokens,
                 prefill_cache_tokens=prefill_stats.log_hit_tokens,
                 dp_cooperation_info=dp_cooperation_info,
+            )
+            self.metrics_collector.increment_mamba_cache_miss(
+                num_requests=prefill_stats.mamba_cache_miss_requests,
+                num_tokens=prefill_stats.mamba_cache_miss_tokens,
             )
             if self.enable_mfu_metrics:
                 flops, read_bytes, write_bytes = self._estimate_prefill_perf(batch)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -908,6 +908,22 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         # Pre-seed every mode at 0 so per-tier ratio charts get a complete operand set
         for mode in ("input", "device_hit", "host_hit", "storage_hit"):
             self.prefill_effective_tokens_total.labels(**labels, mode=mode)
+        self.mamba_cache_miss_requests_total = Counter(
+            name="sglang:mamba_cache_miss_requests_total",
+            documentation=(
+                "Number of prefill admissions where Full-KV cache was available "
+                "beyond the reusable Mamba checkpoint boundary."
+            ),
+            labelnames=labels.keys(),
+        )
+        self.mamba_cache_miss_tokens_total = Counter(
+            name="sglang:mamba_cache_miss_tokens_total",
+            documentation=(
+                "Number of page-aligned Full-KV prefix tokens skipped because "
+                "the corresponding Mamba checkpoint was unavailable."
+            ),
+            labelnames=labels.keys(),
+        )
         self.forward_execution_seconds_total = Counter(
             name="sglang:forward_execution_seconds_total",
             documentation=(
@@ -1285,6 +1301,12 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
                 self.prefill_effective_tokens_total.labels(
                     **self.labels, mode=mode
                 ).inc(delta)
+
+    def increment_mamba_cache_miss(self, num_requests: int, num_tokens: int) -> None:
+        if num_requests > 0:
+            self.mamba_cache_miss_requests_total.labels(**self.labels).inc(num_requests)
+        if num_tokens > 0:
+            self.mamba_cache_miss_tokens_total.labels(**self.labels).inc(num_tokens)
 
     def increment_forward_execution_seconds(
         self,

--- a/test/registered/unit/observability/test_mamba_cache_metrics.py
+++ b/test/registered/unit/observability/test_mamba_cache_metrics.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.schedule_policy import (
+    get_mamba_cache_miss_tokens,
+    match_prefix_for_req,
+)
+from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
+from sglang.srt.mem_cache.base_prefix_cache import MatchResult
+from sglang.srt.observability.metrics_collector import SchedulerMetricsCollector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _RecordingMetric:
+    def __init__(self):
+        self.values = []
+
+    def labels(self, **_labels):
+        return self
+
+    def inc(self, value):
+        self.values.append(value)
+
+
+def _match_result(*, branching_seqlen=None, full_kv_hit_length=0, device_len=0):
+    return MatchResult(
+        device_indices=torch.empty((device_len,), dtype=torch.int64),
+        last_device_node=None,
+        last_host_node=None,
+        best_match_node=None,
+        mamba_branching_seqlen=branching_seqlen,
+        full_kv_hit_length=full_kv_hit_length,
+    )
+
+
+def test_mamba_cache_miss_tokens_uses_reusable_boundary():
+    result = _match_result(
+        branching_seqlen=8192,
+        full_kv_hit_length=10000,
+        device_len=2048,
+    )
+
+    assert get_mamba_cache_miss_tokens(result) == 6144
+
+
+def test_mamba_cache_miss_tokens_ignores_non_mamba_misses():
+    assert get_mamba_cache_miss_tokens(_match_result(full_kv_hit_length=10000)) == 0
+    assert (
+        get_mamba_cache_miss_tokens(
+            _match_result(branching_seqlen=8192, full_kv_hit_length=0)
+        )
+        == 0
+    )
+
+
+def test_match_prefix_records_mamba_cache_miss_on_request():
+    result = _match_result(
+        branching_seqlen=8192,
+        full_kv_hit_length=10000,
+        device_len=2048,
+    )
+
+    class _TreeCache:
+        def swa_reprefill_tail_tokens(self):
+            return 0
+
+        def match_prefix(self, _params):
+            return result
+
+    req = SimpleNamespace(
+        origin_input_ids=[1, 2, 3],
+        output_ids=[],
+        extra_key=None,
+        cache_salt=None,
+        kv=SimpleNamespace(cache_protected_len=0),
+        _compute_max_prefix_len=lambda input_len: input_len,
+    )
+
+    match_prefix_for_req(_TreeCache(), req)
+
+    assert req.mamba_cache_miss_tokens == 6144
+
+
+def test_prefill_stats_reports_each_request_once():
+    miss_req = SimpleNamespace(
+        mamba_cache_miss_tokens=6144,
+        _mamba_cache_miss_reported=False,
+    )
+    clean_req = SimpleNamespace(
+        mamba_cache_miss_tokens=0,
+        _mamba_cache_miss_reported=False,
+    )
+    adder = SimpleNamespace(
+        can_run_list=[miss_req, clean_req],
+        log_input_tokens=1,
+        log_hit_tokens=2,
+        reprocessed_log_input_tokens=0,
+        reprocessed_log_hit_tokens=0,
+        log_device_hit_tokens=2,
+        log_host_hit_tokens=0,
+        log_storage_hit_tokens=0,
+        new_token_ratio=1.0,
+    )
+
+    first = PrefillStats.from_adder(adder, [])
+    second = PrefillStats.from_adder(adder, [])
+
+    assert (first.mamba_cache_miss_requests, first.mamba_cache_miss_tokens) == (1, 6144)
+    assert (second.mamba_cache_miss_requests, second.mamba_cache_miss_tokens) == (0, 0)
+
+
+def test_scheduler_metrics_collector_increments_mamba_cache_miss_counters():
+    collector = object.__new__(SchedulerMetricsCollector)
+    collector.labels = {"model_name": "test"}
+    collector.mamba_cache_miss_requests_total = _RecordingMetric()
+    collector.mamba_cache_miss_tokens_total = _RecordingMetric()
+
+    collector.increment_mamba_cache_miss(num_requests=2, num_tokens=12288)
+
+    assert collector.mamba_cache_miss_requests_total.values == [2]
+    assert collector.mamba_cache_miss_tokens_total.values == [12288]


### PR DESCRIPTION
## Motivation

Hybrid Mamba prefix matching can find a Full-KV prefix beyond the reusable Mamba
checkpoint boundary. The match is then gated back to the shorter joint prefix,
but the lost reuse is indistinguishable from a cold request in production. Refs
#36935.

## Modifications

- Derive the page-aligned Full-KV tokens blocked by a missing Mamba checkpoint
  from the existing `mamba_branching_seqlen` match signal.
- Carry the observation through the first prefill admission for each request,
  avoiding duplicate counts from cache-agnostic pre-matching and chunked
  prefill.
- Expose two scheduler Prometheus counters:
  - `sglang:mamba_cache_miss_requests_total`
  - `sglang:mamba_cache_miss_tokens_total`
- No cache behavior, checkpoint policy, or model computation changes.

## Accuracy Tests

- No model math, sampling, or output transformation changed.
- A100 focused tests:
  - `test_mamba_cache_metrics.py` (5 passed)
  - `test_unified_radix_cache_unittest.py -k "mamba_branching or MambaCheckpointGrid"` (5 passed, 54 skipped)
  - `test_forward_pass_metrics.py test_prefill_adder.py` (43 passed, 12 subtests passed)

## Speed Tests and Profiling

- Not benchmarked; this is an observability-only change.

## Checklist

- [x] Format code according to pre-commit style; the configured hooks passed on all changed files, including isort, ruff, ruff-format, codespell, AST, and registered-test checks.
- [x] Add unit tests according to the test conventions.
- [x] Documentation update is not needed; the Prometheus metric help text documents both counters.
- [x] Runtime validation is included above; no speed benchmark is applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33882679101](https://github.com/sgl-project/sglang/actions/runs/33882679101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33882678760](https://github.com/sgl-project/sglang/actions/runs/33882678760)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33882679191](https://github.com/sgl-project/sglang/actions/runs/33882679191)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->