### PR TITLE
chore: add code owners for the Rust radix tree core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,7 @@
 /python/sglang/srt/managers/tokenizer_manager_score_mixin.py @sundar24295s @chanh @fortunecookiee
 /python/sglang/srt/mem_cache @merrymercy @Ying1123 @hnyls2002 @xiezhq-hermann @hanming-lu @yizhang2077 @hzh0425 @ispobock @alphabetc1 @huangtingwei9988
 /python/sglang/srt/mem_cache/allocator @hnyls2002 @ispobock @alphabetc1
+/python/sglang/srt/mem_cache/rust_tree_core @Jialin @ispobock @alphabetc1
 /python/sglang/srt/mem_cache/storage/mooncake_store @huangtingwei9988
 /python/sglang/srt/mem_cache/embedding_*.py @liusy58
 /python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_embedding_store.py @liusy58
@@ -67,6 +68,7 @@
 /python/sglang/srt/weight_cache @liusy58 @QiuMike @alexnails
 /python/sglang/kernels/aot @ispobock @BBuf @yizhang2077 @merrymercy @FlamingoPg @HaiShaw
 /python/sglang/kernels/aot/csrc/musa @yeahdongcn
+/rust/sglang-radix-tree @Jialin @ispobock @alphabetc1
 /sgl-model-gateway @slin1237 @CatherineSue
 /sgl-model-gateway/benches @slin1237
 /sgl-model-gateway/bindings/python @CatherineSue @key4ng @slin1237


### PR DESCRIPTION
## Motivation

The Rust radix tree core has no dedicated code owners today:

- `rust/sglang-radix-tree/` is not covered by any CODEOWNERS entry (nothing under `/rust` is), so changes to the crate request no reviewers.
- `python/sglang/srt/mem_cache/rust_tree_core/` only inherits the broad `mem_cache` line.

## Modifications

Add @Jialin (author of the crate, #32710 / #37290), @ispobock and @alphabetc1 as owners of the two paths above. Other `/rust` crates are intentionally left untouched.

## Checklist

- [x] CODEOWNERS only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33888114937](https://github.com/sgl-project/sglang/actions/runs/33888114937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33888114614](https://github.com/sgl-project/sglang/actions/runs/33888114614)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->