### PR TITLE
fix: reformat cosmos3_edge.py to satisfy ruff-format

### DIFF
--- a/python/sglang/srt/multimodal/processors/cosmos3_edge.py
+++ b/python/sglang/srt/multimodal/processors/cosmos3_edge.py
@@ -232,9 +232,11 @@ class Cosmos3EdgeProcessor(SGLangBaseProcessor):
         )
 
     async def _process_preprocessed_mm_data(self, base_output):
-        mm_items, input_ids, processor_output = (
-            await self.process_and_combine_mm_data_async(base_output, self.mm_tokens)
-        )
+        (
+            mm_items,
+            input_ids,
+            processor_output,
+        ) = await self.process_and_combine_mm_data_async(base_output, self.mm_tokens)
         image_grid_thw = self._get_grid_from_output_or_items(
             processor_output,
             mm_items,


### PR DESCRIPTION
## Motivation

`lint` has been failing on `main` since #33572 merged (4349538c). That PR's lint run passed on 2026-08-30 under `black`, then #37210 switched the repo to `ruff-format` on 2026-09-02, and #33572 was merged on 2026-09-04 without a fresh lint run. `pre-commit run --all-files` now reformats `python/sglang/srt/multimodal/processors/cosmos3_edge.py`, which fails lint for every open PR.

## Modifications

Apply the `ruff-format` (v0.15.1, the pre-commit pin) output to `cosmos3_edge.py`. Formatting only, no behavior change.

## Checklist

- [x] Formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33890288651](https://github.com/sgl-project/sglang/actions/runs/33890288651)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33890288261](https://github.com/sgl-project/sglang/actions/runs/33890288261)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33890288696](https://github.com/sgl-project/sglang/actions/runs/33890288696)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->