### PR TITLE
PD: Make option for custom mem pool generic (backend agnostic)

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -143,17 +143,17 @@ PD Disaggregation with Mooncake supports the following environment variables for
 To enable NVLink transport for KV cache transfers with the mooncake backend (recommended for NVL72 deployments), set the following environment variables. Note that auxiliary data transfer will still use TCP as a temporary workaround.
 
 ```bash Command
-export SGLANG_MOONCAKE_CUSTOM_MEM_POOL=NVLINK
+export SGLANG_CUSTOM_MEM_POOL=NVLINK
 export MC_FORCE_MNNVL=True
 ```
 
 To utilize Intra-Node NVLink for KV cache transfers with the Mooncake backend (recommended for A100, H20, H100, etc.), set the following environment variables. Please note that auxiliary data still needs to be transferred via TCP.
 
 ```bash
-export SGLANG_MOONCAKE_CUSTOM_MEM_POOL=INTRA_NODE_NVLINK
+export SGLANG_CUSTOM_MEM_POOL=INTRA_NODE_NVLINK
 export MC_INTRANODE_NVLINK=true
 ```
-The `SGLANG_MOONCAKE_CUSTOM_MEM_POOL` environment variable enables the custom memory pool. Supported values are `NVLINK` (or `True`), `BAREX`, and `INTRA_NODE_NVLINK`.
+The `SGLANG_CUSTOM_MEM_POOL` environment variable enables the custom memory pool. Supported values are `NVLINK` (or `True`), `BAREX`, and `INTRA_NODE_NVLINK`. The former name `SGLANG_MOONCAKE_CUSTOM_MEM_POOL` is still accepted with a deprecation warning.
 
 #### Prefill Server Configuration
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
@@ -431,6 +431,16 @@ python -m sglang.launch_server \
   --disaggregation-transfer-backend nixl \
   --port 30000
 ```
+
+#### NVLink (MNNVL) KV Transfer
+
+On multi-node NVLink systems (e.g. GB200/GB300 NVL72), set `SGLANG_CUSTOM_MEM_POOL=NVLINK` on both the prefill and decode servers. The KV cache is then allocated as fabric-exportable memory (`cuMemCreate` with `CU_MEM_HANDLE_TYPE_FABRIC`), and NIXL's UCX backend uses MNNVL for KV transfers automatically; no Mooncake-specific knobs such as `MC_FORCE_MNNVL` are needed.
+
+```bash
+export SGLANG_CUSTOM_MEM_POOL=NVLINK
+```
+
+The allocator is currently provided by the `mooncake-transfer-engine` package, which must be installed even when NIXL is the transfer backend.
 
 ## ASCEND
 

--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -617,8 +617,8 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
     </tr>
 <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MOONCAKE_CUSTOM_MEM_POOL</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Configure the custom memory pool type for Mooncake. Supports <code>NVLINK</code>, <code>BAREX</code>, <code>INTRA_NODE_NVLINK</code>. If set to <code>true</code>, it defaults to <code>NVLINK</code>.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_CUSTOM_MEM_POOL</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Allocate the KV cache from a custom memory pool for PD disaggregation, with either the Mooncake or the NIXL transfer backend. Supports <code>NVLINK</code> (cuMemCreate fabric memory for MNNVL), <code>BAREX</code> and <code>INTRA_NODE_NVLINK</code> (Mooncake only). If set to <code>true</code>, it defaults to <code>NVLINK</code>. <code>SGLANG_MOONCAKE_CUSTOM_MEM_POOL</code> is a deprecated alias.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
     </tr>
 </tbody>

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -159,7 +159,7 @@ sgl-eval run mmmu_pro \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },

--- a/docs/src/snippets/configs/Qwen/qwen3.8.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8.jsx
@@ -262,7 +262,7 @@ export const config = {
                 "SGLANG_DISAGGREGATION_WAITING_TIMEOUT=100000",
                 "SGLANG_USE_MESSAGE_QUEUE_BROADCASTER=0",
                 "SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S=3600",
-                "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+                "SGLANG_CUSTOM_MEM_POOL=True",
                 "SGLANG_DISAGG_STAGING_BUFFER=1"] },
         { id: "nixl", label: "NiXL" },
       ],

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -365,7 +365,7 @@ sgl-eval run mmmu_pro \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },

--- a/docs/src/snippets/configs/poolside/laguna-m1.jsx
+++ b/docs/src/snippets/configs/poolside/laguna-m1.jsx
@@ -180,7 +180,7 @@ sgl-eval run gsm8k \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },

--- a/docs/src/snippets/configs/tencent/hy3.jsx
+++ b/docs/src/snippets/configs/tencent/hy3.jsx
@@ -202,7 +202,7 @@ sgl-eval run aime26 \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },

--- a/docs/src/snippets/configs/tencent/hy4-preview.jsx
+++ b/docs/src/snippets/configs/tencent/hy4-preview.jsx
@@ -229,7 +229,7 @@ sgl-eval run gsm8k \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb300"] } },

--- a/docs/src/snippets/configs/thinkingmachines/inkling-small.jsx
+++ b/docs/src/snippets/configs/thinkingmachines/inkling-small.jsx
@@ -166,7 +166,7 @@ export const config = {
             "MC_FORCE_MNNVL=1",
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },
       ],

--- a/docs/src/snippets/configs/thinkingmachines/inkling.jsx
+++ b/docs/src/snippets/configs/thinkingmachines/inkling.jsx
@@ -163,7 +163,7 @@ export const config = {
             "MC_FORCE_MNNVL=1",
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
           ],
           envWhen: { hw: ["gb200", "gb300"] } },
       ],

--- a/docs/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -211,7 +211,7 @@ sgl-eval run aime25 \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb300"] } },

--- a/docs/src/snippets/configs/zai-org/glm-5.3.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3.jsx
@@ -225,7 +225,7 @@ sgl-eval run aime25 \\
           env: [
             "NCCL_MNNVL_ENABLE=1",
             "NCCL_CUMEM_ENABLE=1",
-            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True",
+            "SGLANG_CUSTOM_MEM_POOL=True",
             "MC_FORCE_MNNVL=1",
           ],
           envWhen: { hw: ["gb300"] } },

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1768,7 +1768,7 @@ def post_capture_kv_sizing_planned(server_args: Any) -> bool:
         return False
     if cfg.enable_memory_saver:
         return False
-    if envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is not None:
+    if envs.SGLANG_CUSTOM_MEM_POOL.get() is not None:
         return False
 
     if (

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -705,7 +705,7 @@ def _get_custom_mem_pool(device: str):
         logger.info(
             "Staging buffer using cudaMalloc (no custom mem pool). "
             "This works for all GPU architectures. "
-            "For NVLink/MNNVL transport, set SGLANG_MOONCAKE_CUSTOM_MEM_POOL."
+            "For NVLink/MNNVL transport, set SGLANG_CUSTOM_MEM_POOL."
         )
     return custom_mem_pool, pool_type
 

--- a/python/sglang/srt/disaggregation/mooncake/utils.py
+++ b/python/sglang/srt/disaggregation/mooncake/utils.py
@@ -96,7 +96,7 @@ def check_mooncake_custom_mem_pool_enabled() -> Tuple[bool, Optional[str]]:
     Returns:
         Tuple of (enable_custom_mem_pool, custom_mem_pool_type)
     """
-    custom_mem_pool_type = envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get()
+    custom_mem_pool_type = envs.SGLANG_CUSTOM_MEM_POOL.get()
 
     if custom_mem_pool_type is not None:
         # Handle boolean True as NVLINK

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -322,7 +322,7 @@ class MetadataBuffers:
         elif self.custom_mem_pool:
             # TODO(shangming): Fix me (use 'cuda') when nvlink_transport of Mooncake is bug-free
             device = "cpu"
-        elif envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() == "INTRA_NODE_NVLINK":
+        elif envs.SGLANG_CUSTOM_MEM_POOL.get() == "INTRA_NODE_NVLINK":
             device = "cuda"
         with (
             torch.cuda.use_mem_pool(self.custom_mem_pool)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -193,6 +193,10 @@ class EnvIntWithAlias(_DeprecatedEnvFallback, EnvInt):
     pass
 
 
+class EnvStrWithAlias(_DeprecatedEnvFallback, EnvStr):
+    pass
+
+
 class EnvFloat(EnvField):
     def parse(self, value: str) -> float:
         try:
@@ -744,7 +748,10 @@ class Envs:
     # TODO(yangminl): remove SGLANG_STAGING_USE_TORCH and the torch fallback in
     # staging_buffer.py once Triton kernels are fully validated in production.
     SGLANG_STAGING_USE_TORCH = EnvBool(False)
-    SGLANG_MOONCAKE_CUSTOM_MEM_POOL = EnvStr(None)
+    # KV-cache allocator for PD transfer; shared by the Mooncake and NIXL backends.
+    SGLANG_CUSTOM_MEM_POOL = EnvStrWithAlias(
+        None, deprecated_name="SGLANG_MOONCAKE_CUSTOM_MEM_POOL"
+    )
     ENABLE_ASCEND_TRANSFER_WITH_MOONCAKE = EnvBool(False)
     ASCEND_NPU_PHY_ID = EnvInt(-1)
     SGLANG_MOONCAKE_SEND_AUX_TCP = EnvBool(False)
@@ -1731,7 +1738,7 @@ def _invert_bool(value: str) -> str:
 # The single registry for deprecated environment variables, processed once at
 # import by _handle_deprecated_envs(). Add new deprecations here instead of
 # ad-hoc warnings. For a rename where the old name must keep working through a
-# descriptor, use EnvBoolWithAlias / EnvIntWithAlias instead.
+# descriptor, use EnvBoolWithAlias / EnvIntWithAlias / EnvStrWithAlias instead.
 _DEPRECATED_ENVS: Dict[str, _DeprecatedEnv] = {
     # Renamed: the value is forwarded to the replacement.
     "SGLANG_GC_LOG": _DeprecatedEnv(replacement="SGLANG_LOG_GC"),

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -92,12 +92,11 @@ def maybe_init_custom_mem_pool(
     Returns:
         Tuple of (enable_custom_mem_pool, custom_mem_pool, custom_mem_pool_type)
     """
-    enable_custom_mem_pool = (
-        True if envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is not None else False
-    )
+    enable_custom_mem_pool = envs.SGLANG_CUSTOM_MEM_POOL.get() is not None
 
     if enable_custom_mem_pool:
-        # Currently, only mooncake requires a custom mem pool for MNNVL/Barex PD disaggregation
+        # The allocator ships in the mooncake package, but the pool it returns is
+        # transfer-backend-agnostic; the NIXL backend registers the same memory.
         from sglang.srt.disaggregation.mooncake.utils import (
             init_mooncake_custom_mem_pool,
         )

--- a/test/registered/disaggregation/test_disaggregation_aarch64.py
+++ b/test/registered/disaggregation/test_disaggregation_aarch64.py
@@ -25,7 +25,7 @@ class TestDisaggregationMooncakeAARCH64Accuracy(PDDisaggregationServerBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        os.environ["SGLANG_MOONCAKE_CUSTOM_MEM_POOL"] = "true"
+        os.environ["SGLANG_CUSTOM_MEM_POOL"] = "true"
         os.environ["MC_FORCE_MNNVL"] = "true"
         cls.model = QWEN3_8B_MODEL_PATH
 
@@ -41,7 +41,7 @@ class TestDisaggregationMooncakeAARCH64Accuracy(PDDisaggregationServerBase):
 
     @classmethod
     def tearDownClass(cls):
-        os.environ.pop("SGLANG_MOONCAKE_CUSTOM_MEM_POOL")
+        os.environ.pop("SGLANG_CUSTOM_MEM_POOL")
         os.environ.pop("MC_FORCE_MNNVL")
         super().tearDownClass()
 

--- a/test/registered/unit/mem_cache/test_mem_cache_utils.py
+++ b/test/registered/unit/mem_cache/test_mem_cache_utils.py
@@ -189,7 +189,7 @@ class TestGetEvictionStrategy(unittest.TestCase):
 
 
 class TestMaybeInitCustomMemPool(unittest.TestCase):
-    @patch("sglang.srt.mem_cache.utils.envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get")
+    @patch("sglang.srt.mem_cache.utils.envs.SGLANG_CUSTOM_MEM_POOL.get")
     def test_disabled_by_default(self, mock_env_get):
         mock_env_get.return_value = None
         enabled, pool, pool_type = maybe_init_custom_mem_pool("cuda:0")
@@ -197,7 +197,7 @@ class TestMaybeInitCustomMemPool(unittest.TestCase):
         self.assertIsNone(pool)
         self.assertIsNone(pool_type)
 
-    @patch("sglang.srt.mem_cache.utils.envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get")
+    @patch("sglang.srt.mem_cache.utils.envs.SGLANG_CUSTOM_MEM_POOL.get")
     def test_enabled_via_env(self, mock_env_get):
         mock_env_get.return_value = "enabled"
         mock_init = MagicMock()


### PR DESCRIPTION
## Motivation

`SGLANG_MOONCAKE_CUSTOM_MEM_POOL` selects the KV-cache allocator (fabric `cuMemCreate` memory for NVLink transfers), but it is not Mooncake-specific: the pool belongs to the KV cache, and the NIXL backend registers the same memory. Verified on GB200: with `--disaggregation-transfer-backend nixl` and this variable set to `NVLINK`, KV transfers run over MNNVL with no connector changes. The Mooncake-scoped name is misleading for NIXL users, and `arg_groups/overrides.py` already reads it as a backend-neutral memory fact.

## Modifications

- Rename to `SGLANG_CUSTOM_MEM_POOL`; keep `SGLANG_MOONCAKE_CUSTOM_MEM_POOL` as a deprecated alias (`DeprecationWarning`) via a new `EnvStrWithAlias`, mirroring `EnvBoolWithAlias` / `EnvIntWithAlias`. Default unchanged (`None`).
- Update all readers (`mem_cache/utils.py`, `disaggregation/{utils,mooncake/utils,common/staging_handler}.py`, `arg_groups/overrides.py`), the affected tests, the env-var reference, and the cookbook configs.
- Document NVLink (MNNVL) KV transfer for the NIXL backend in `pd_disaggregation.mdx`.

Related: #23074. Follow-up: a native allocator on `cuda_vmm_utils` so NIXL users no longer need `mooncake-transfer-engine` for the allocator.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33891651206](https://github.com/sgl-project/sglang/actions/runs/33891651206)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33891650540](https://github.com/sgl-project/sglang/actions/runs/33891650540)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33891651013](https://github.com/sgl-project/sglang/actions/runs/33891651013)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->