### PR TITLE
[Fix] Muse Glimmer: resolve quantized_layers prefixes for ModelOpt MIXED_PRECISION checkpoints

### DIFF
--- a/python/sglang/srt/models/muse_glimmer.py
+++ b/python/sglang/srt/models/muse_glimmer.py
@@ -931,23 +931,6 @@ class MuseGlimmerForConditionalGeneration(MuseGlimmerForCausalLM):
     checkpoint_uses_vendor_names = True
     builds_vision_tower = True
 
-    # The vendor export names its decoder ``model.language_model.*`` while this
-    # implementation builds ``model.*``. ``load_weights`` already bridges that for the
-    # tensors (see ``_vendor_weight_name``), but a ModelOpt MIXED_PRECISION checkpoint
-    # carries a second name-keyed structure that nothing translated: the
-    # ``quantized_layers`` map in ``hf_quant_config.json``, which assigns FP8 or
-    # W4A16_NVFP4 per individual layer.
-    #
-    # ``ModelOptMixedPrecisionConfig._quantized_layer_prefix_candidates`` only bridges
-    # ``language_model.model.`` <-> ``model.language_model.``; neither matches this
-    # model's plain ``model.``. Every lookup then returns None, the linears are built
-    # unquantized, and the NVFP4-packed weights no longer fit:
-    #
-    #   AssertionError: param_data.shape=[4096, 6656] != loaded_weight.shape=[4096, 3328]
-    #
-    # Derived from ``_VENDOR_RENAMES`` rather than repeated, so the two cannot drift.
-    # ``self_attn.gate_proj -> self_attn.output_gate_proj`` is required: without it that
-    # one projection stays unquantized and fails with the same assertion.
     hf_to_sglang_mapper = WeightsMapper(
         orig_to_new_prefix={
             "model.language_model.": "model.",

--- a/python/sglang/srt/models/muse_glimmer.py
+++ b/python/sglang/srt/models/muse_glimmer.py
@@ -57,7 +57,7 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from sglang.srt.models.utils import apply_qk_norm, permute_inv
+from sglang.srt.models.utils import WeightsMapper, apply_qk_norm, permute_inv
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix, is_cuda
 
@@ -930,6 +930,31 @@ class MuseGlimmerForConditionalGeneration(MuseGlimmerForCausalLM):
 
     checkpoint_uses_vendor_names = True
     builds_vision_tower = True
+
+    # The vendor export names its decoder ``model.language_model.*`` while this
+    # implementation builds ``model.*``. ``load_weights`` already bridges that for the
+    # tensors (see ``_vendor_weight_name``), but a ModelOpt MIXED_PRECISION checkpoint
+    # carries a second name-keyed structure that nothing translated: the
+    # ``quantized_layers`` map in ``hf_quant_config.json``, which assigns FP8 or
+    # W4A16_NVFP4 per individual layer.
+    #
+    # ``ModelOptMixedPrecisionConfig._quantized_layer_prefix_candidates`` only bridges
+    # ``language_model.model.`` <-> ``model.language_model.``; neither matches this
+    # model's plain ``model.``. Every lookup then returns None, the linears are built
+    # unquantized, and the NVFP4-packed weights no longer fit:
+    #
+    #   AssertionError: param_data.shape=[4096, 6656] != loaded_weight.shape=[4096, 3328]
+    #
+    # Derived from ``_VENDOR_RENAMES`` rather than repeated, so the two cannot drift.
+    # ``self_attn.gate_proj -> self_attn.output_gate_proj`` is required: without it that
+    # one projection stays unquantized and fails with the same assertion.
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+            "model.vision_": "vision_",
+        },
+        orig_to_new_substr=dict(_VENDOR_RENAMES),
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
## Problem

`nvidia/Muse-Glimmer-30B-NVFP4` cannot be loaded. Weight loading aborts with:

```
Muse Glimmer: unexpected checkpoint weight model.layers.0.mlp.down_proj.weight_scale
Muse Glimmer: unexpected checkpoint weight model.layers.0.mlp.down_proj.weight_scale_2
  File "sglang/srt/models/muse_glimmer.py", line 913, in load_weights
      param.weight_loader(param, loaded_weight, shard_id)
  File "sglang/srt/layers/linear.py", line 751, in weight_loader
      assert param_data.shape == loaded_weight.shape
AssertionError
```

Forcing `--quantization modelopt_fp4` fails identically, so this is not a
quantization-selection problem.

## Root cause

The vendor export names its decoder `model.language_model.*` while this
implementation builds `model.*`. `load_weights` already bridges that for the
**tensors** via `_vendor_weight_name`.

A ModelOpt `MIXED_PRECISION` checkpoint, however, carries a **second**
name-keyed structure that nothing translates: the `quantized_layers` map in
`hf_quant_config.json`, which assigns `FP8` or `W4A16_NVFP4` **per individual
layer**. For this checkpoint that is 393 entries, and genuinely mixed — e.g.
`mlp.gate_proj` is FP8 in 7 layers and W4A16_NVFP4 in 45.

`ModelOptMixedPrecisionConfig._quantized_layer_prefix_candidates` only bridges
`language_model.model.` ↔ `model.language_model.`. Neither form matches this
model's plain `model.`, so `_resolve_quant_algo` returns `None` for **every**
linear. The layers are then built unquantized, and the NVFP4-packed weights no
longer fit:

```
AssertionError: param_data.shape=[4096, 6656] != loaded_weight.shape=[4096, 3328]
```

3328 = 6656/2 — two 4-bit values per byte.

## Fix

Declare `hf_to_sglang_mapper` on `MuseGlimmerForConditionalGeneration`. This is
the intended hook: `model_loader/loader.py` applies it to the quantization
config only (`quant_config.apply_weight_name_mapper`), never to the weight
stream, so it cannot collide with `_vendor_weight_name`.

The mapper is **derived from `_VENDOR_RENAMES`** rather than repeating it, so
the two cannot drift apart. The substring rule
`self_attn.gate_proj -> self_attn.output_gate_proj` is not optional padding: an
earlier version of this patch mapped only the two prefixes, after which exactly
that one projection stayed unquantized and failed with the same assertion.

## Verification

| | before | after |
|---|---|---|
| `unexpected checkpoint weight` warnings | 36+ | **0** |
| `AssertionError` | yes | **none** |
| weights loaded | no | **yes** — `quant=modelopt_mixed`, 24.52 GB, 84.6 s |
| KV cache | — | Full 649,800 tokens, SWA 519,840 |
| server | — | `The server is fired up and ready to roll!` |

Tested on an NVIDIA GB10 (sm_121, unified memory), CUDA 13 aarch64 build,
sglang 3.29.7, `--mem-fraction-static 0.60 --context-length 32768
--tool-call-parser muse --reasoning-parser muse`. The model then served
requests normally (12.2 tok/s single-stream, which is a property of the
hardware, not of this change).

The diff applies to current `main`; the anchors (`_VENDOR_RENAMES`,
`checkpoint_uses_vendor_names = True`) are unchanged there.

## Notes

Two things that cost time and may help others:

- Through an OpenAI-compatible front end the failure surfaces only as
  `rpc error: EOF`. The traceback appears only when `sglang.launch_server` is
  started directly.
- The `weight_scale_2` warnings are a symptom, not the cause — they are the
  NVFP4 double-quantization scales that have no parameter to land on once the
  layer has been built unquantized.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33905909827](https://github.com/sgl-project/sglang/actions/runs/33905909827)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33905912593](https://github.com/sgl-project/sglang/actions/runs/33905912593)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33905909505](https://github.com/sgl-project/sglang/actions/runs/33905909505)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->