### PR TITLE
fix(vlm): isolate malformed multimodal embeddings

### DIFF
--- a/python/sglang/srt/beam_search/coordinator.py
+++ b/python/sglang/srt/beam_search/coordinator.py
@@ -250,7 +250,11 @@ class BeamCoordinator(msgspec.Struct, kw_only=True):
         return sorted(stop_ids)
 
     def maybe_select_and_relay(
-        self, batch: ScheduleBatch, batch_result, chunked_req: Optional[Req] = None
+        self,
+        batch: ScheduleBatch,
+        batch_result,
+        chunked_req: Optional[Req] = None,
+        skip_rows: Optional[set[int]] = None,
     ) -> None:
         """Per-forward relay hook: overwrite beam rows' relayed tokens with
         joint-selected ones. O(1) when no beam group is live."""
@@ -275,6 +279,7 @@ class BeamCoordinator(msgspec.Struct, kw_only=True):
                 group = req.beam_group
                 if (
                     group is None
+                    or (skip_rows is not None and i in skip_rows)
                     or group.state != BeamGroupState.DECODING
                     or group.num_generated > 0
                     or req is chunked_req  # mid-chunk leader: no selection yet
@@ -506,6 +511,15 @@ class BeamCoordinator(msgspec.Struct, kw_only=True):
         group.state = BeamGroupState.FINISHED
         group.final_results = []
         self._retire_group(group)
+
+    def abort_group_preserving_finish_reason(self, req: Req) -> None:
+        group = req.beam_group
+        if group is None or group.retired:
+            return
+        finished_reason = req.finished_reason
+        self._abort_group(group)
+        if finished_reason is not None:
+            req.finished_reason = finished_reason
 
     def _free_member_rows(self, group: BeamGroup) -> None:
         # Staged orphans are unreachable from every row, so the group-wide

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -186,6 +186,11 @@ class BaseKVSender(ABC):
         """
         pass
 
+    @abstractmethod
+    def is_transfer_quiesced(self) -> bool:
+        """Return whether transport work can no longer access request buffers."""
+        ...
+
 
 class BaseKVReceiver(ABC):
     @abstractmethod

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -432,11 +432,14 @@ class CommonKVManager(BaseKVManager):
     def _maybe_ack_drained_abort(self, room: int) -> None:
         """Send the deferred ack once an aborted room's chunks have drained
         (outstanding == 0). pop() makes it fire at most once."""
-        if self._staging_outstanding.get(room, 0) > 0:
+        if not self.is_transfer_quiesced(room):
             return
         target = self._deferred_ack_targets.pop(room, None)
         if target is not None:
             self._send_abort_ack(target[0], target[1], room)
+
+    def is_transfer_quiesced(self, room: int) -> bool:
+        return self._staging_outstanding.get(room, 0) == 0
 
     def register_deferred_ack_target(
         self, room: int, decode_ip: str, decode_port: int

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -91,6 +91,9 @@ class FakeKVSender(BaseKVSender):
     def abort(self):
         self.conclude_state = KVPoll.Failed
 
+    def is_transfer_quiesced(self) -> bool:
+        return True
+
 
 class FakeKVReceiver(BaseKVReceiver):
     def __init__(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -206,6 +206,35 @@ class KVArgsRegisterInfo:
 class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
 
+    def _count_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._staging_outstanding_lock:
+            outstanding = self._staging_outstanding.get(kv_chunk.room, 0)
+            if kv_chunk.staging_counted:
+                if outstanding <= 0:
+                    raise RuntimeError(
+                        f"Counted transfer chunk has no outstanding owner for room {kv_chunk.room}"
+                    )
+                return
+            self._staging_outstanding[kv_chunk.room] = outstanding + 1
+            kv_chunk.staging_counted = True
+
+    def _finish_counted_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._staging_outstanding_lock:
+            outstanding = self._staging_outstanding.get(kv_chunk.room)
+            if not kv_chunk.staging_counted or outstanding is None or outstanding <= 0:
+                raise RuntimeError(
+                    f"Unmatched transfer chunk finish for room {kv_chunk.room}"
+                )
+            if outstanding == 1:
+                self._staging_outstanding.pop(kv_chunk.room)
+            else:
+                self._staging_outstanding[kv_chunk.room] = outstanding - 1
+            kv_chunk.staging_counted = False
+
+    def is_transfer_quiesced(self, room: int) -> bool:
+        with self._staging_outstanding_lock:
+            return self._staging_outstanding.get(room, 0) == 0
+
     def __init__(
         self,
         args: KVArgs,
@@ -222,10 +251,11 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
             self.session_lock = threading.Lock()
-            self.start_prefill_thread()
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            self._staging_outstanding_lock = threading.Lock()
+            self.start_prefill_thread()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
             transfer_thread_pool_size = (
@@ -1671,9 +1701,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 # `outstanding == 0` means nothing is dequeued or in flight --
                 # the predicate the abort ack relies on. The flag survives
                 # re-enqueue on defer.
-                if not kv_chunk.staging_counted:
-                    self._staging_outstanding[kv_chunk.room] += 1
-                    kv_chunk.staging_counted = True
+                self._count_transfer_chunk(kv_chunk)
 
                 if (
                     kv_chunk.room not in self.request_status
@@ -1688,7 +1716,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                             MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                             thread_finish_flag=True,
                         )
-                    self._staging_outstanding.pop(kv_chunk.room, None)
+                    self._finish_counted_transfer_chunk(kv_chunk)
                     if self.enable_deferred_decode_kv_release:
                         # Skipped => nothing written for this aborted room; ack.
                         self._maybe_ack_drained_abort(kv_chunk.room)
@@ -1967,7 +1995,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 if staging_deferred:
                     continue
 
-                self._staging_outstanding[kv_chunk.room] -= 1
+                self._finish_counted_transfer_chunk(kv_chunk)
                 if self.enable_deferred_decode_kv_release:
                     # In-flight write finished; if aborted and nothing outstanding,
                     # the pages are idle -> release the held ack.
@@ -1977,7 +2005,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 # chunk. A non-last Failed chunk keeps the room (more chunks may
                 # follow), not on the last chunk alone since an earlier deferred
                 # chunk may still need to transfer.
-                if self._staging_outstanding.get(kv_chunk.room, 0) <= 0 and (
+                if self.is_transfer_quiesced(kv_chunk.room) and (
                     kv_chunk.room not in self.request_status
                     or self.check_status(kv_chunk.room) == KVPoll.Success
                     or (
@@ -1985,7 +2013,6 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         and self.check_status(kv_chunk.room) == KVPoll.Failed
                     )
                 ):
-                    self._staging_outstanding.pop(kv_chunk.room, None)
                     if kv_chunk.room in self.transfer_infos:
                         self.transfer_infos.pop(kv_chunk.room)
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
@@ -2047,7 +2074,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                                 f"Received abort notification for room {room_to_be_aborted}, "
                                 f"marked as Failed; ACK deferred until transfer drains"
                             )
-                        elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
+                        elif self.is_transfer_quiesced(room_to_be_aborted):
                             # Concluded/unknown AND quiescent: ack now. A cleared
                             # room is not automatically quiescent -- clear() can
                             # drop a room whose chunk is still transferring.
@@ -2396,14 +2423,13 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         self._record_transfer_indices(kv_indices, state_indices)
 
     def poll(self) -> KVPoll:
+        if self.conclude_state == KVPoll.Failed and not self.is_transfer_quiesced():
+            return KVPoll.Transferring
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
             # Hold Success until all staging chunks transferred: a deferred
             # chunk can still be pending, and concluding now would drop it.
-            if (
-                status == KVPoll.Success
-                and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
-            ):
+            if status == KVPoll.Success and not self.is_transfer_quiesced():
                 return KVPoll.Transferring
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
@@ -2436,6 +2462,9 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         super().abort()
         self.trace_ctx.abort(abort_info={"reason": "Aborted"})
         self.trace_ctx.trace_req_finish()
+
+    def is_transfer_quiesced(self) -> bool:
+        return self.kv_mgr.is_transfer_quiesced(self.bootstrap_room)
 
 
 class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -875,21 +875,27 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
     def _await_transfer_futures(self, futures) -> int:
         """Await a chunk's per-layer RDMA writes; return the first non-zero status.
-        cancel() is a no-op for a running future, so with deferred release on we
-        still drain the running ones before returning (no write may outlive this
-        call, which the drain-ack relies on). Off: original early-return."""
+        cancel() is a no-op for a running future, so drain every future before
+        returning or raising; no native transfer may outlive this call."""
         ret = 0
+        first_exception = None
         for future in concurrent.futures.as_completed(futures):
             try:
                 status = future.result()
             except concurrent.futures.CancelledError:
                 continue
+            except Exception as e:
+                if first_exception is None:
+                    first_exception = e
+                    for f in futures:
+                        f.cancel()
+                continue
             if status != 0 and ret == 0:
                 ret = status
                 for f in futures:
                     f.cancel()
-                if not self.enable_deferred_decode_kv_release:
-                    return ret
+        if first_exception is not None:
+            raise first_exception
         return ret
 
     def send_kvcache(
@@ -1688,6 +1694,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             )
 
         while True:
+            kv_chunk = None
+            chunk_outstanding = False
             try:
                 kv_chunk: TransferKVChunk = queue.get()
                 if self.enable_trace:
@@ -1702,6 +1710,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 # the predicate the abort ack relies on. The flag survives
                 # re-enqueue on defer.
                 self._count_transfer_chunk(kv_chunk)
+                chunk_outstanding = True
 
                 if (
                     kv_chunk.room not in self.request_status
@@ -1717,6 +1726,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                             thread_finish_flag=True,
                         )
                     self._finish_counted_transfer_chunk(kv_chunk)
+                    chunk_outstanding = False
                     if self.enable_deferred_decode_kv_release:
                         # Skipped => nothing written for this aborted room; ack.
                         self._maybe_ack_drained_abort(kv_chunk.room)
@@ -1993,9 +2003,11 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     )
 
                 if staging_deferred:
+                    chunk_outstanding = False
                     continue
 
                 self._finish_counted_transfer_chunk(kv_chunk)
+                chunk_outstanding = False
                 if self.enable_deferred_decode_kv_release:
                     # In-flight write finished; if aborted and nothing outstanding,
                     # the pages are idle -> release the held ack.
@@ -2025,10 +2037,74 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         self._staging_ctx.prefetched_rooms.discard(kv_chunk.room)
 
             except Exception as e:
-                # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
-                raise RuntimeError(
-                    f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
+                room = kv_chunk.room if kv_chunk is not None else None
+                logger.exception(
+                    "Transfer worker failed for room=%s on bootstrap_port=%s; "
+                    "failing the request and continuing",
+                    room,
+                    self.bootstrap_port,
                 )
+                if room is None:
+                    continue
+
+                transfer_infos = list(self.transfer_infos.get(room, {}).values())
+                try:
+                    try:
+                        self.record_failure(
+                            room,
+                            f"Prefill transfer worker raised an unexpected exception: {e}",
+                        )
+                        self.update_status(room, KVPoll.Failed)
+                    except Exception:
+                        logger.exception(
+                            "Failed to record transfer worker failure for room=%s", room
+                        )
+                    prefill_unique_rank = (
+                        self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+                        + self.pp_rank * self.attn_cp_size
+                        + self.attn_cp_rank
+                    )
+                    for failed_req in transfer_infos:
+                        if failed_req.is_dummy:
+                            continue
+                        try:
+                            self.sync_status_to_decode_endpoint(
+                                failed_req.endpoint,
+                                failed_req.dst_port,
+                                failed_req.room,
+                                KVPoll.Failed,
+                                prefill_unique_rank,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to notify decode of transfer failure for room=%s",
+                                room,
+                            )
+                finally:
+                    try:
+                        self.transfer_infos.pop(room, None)
+                        self.req_to_decode_prefix_len.pop(room, None)
+                        if self.enable_staging:
+                            for key in list(self._staging_ctx.prefetch_requested):
+                                if key[0] == room:
+                                    self._staging_ctx.prefetch_requested.discard(key)
+                            self._staging_ctx.prefetched_rooms.discard(room)
+                    except Exception:
+                        logger.exception(
+                            "Failed to clear transfer worker state for room=%s", room
+                        )
+                    finally:
+                        if chunk_outstanding:
+                            try:
+                                self._finish_counted_transfer_chunk(kv_chunk)
+                                chunk_outstanding = False
+                                if self.enable_deferred_decode_kv_release:
+                                    self._maybe_ack_drained_abort(room)
+                            except Exception:
+                                logger.exception(
+                                    "Failed to reconcile transfer ownership for room=%s",
+                                    room,
+                                )
 
     def start_prefill_thread(self):
         def bootstrap_thread():

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -294,6 +294,35 @@ class TransferTarget:
 class MoriKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
 
+    def _count_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._transfer_outstanding_lock:
+            outstanding = self._transfer_outstanding.get(kv_chunk.room, 0)
+            if kv_chunk.staging_counted:
+                if outstanding <= 0:
+                    raise RuntimeError(
+                        f"Counted MORI chunk has no outstanding owner for room {kv_chunk.room}"
+                    )
+                return
+            self._transfer_outstanding[kv_chunk.room] = outstanding + 1
+            kv_chunk.staging_counted = True
+
+    def _finish_counted_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._transfer_outstanding_lock:
+            outstanding = self._transfer_outstanding.get(kv_chunk.room)
+            if not kv_chunk.staging_counted or outstanding is None or outstanding <= 0:
+                raise RuntimeError(
+                    f"Unmatched MORI chunk finish for room {kv_chunk.room}"
+                )
+            if outstanding == 1:
+                self._transfer_outstanding.pop(kv_chunk.room)
+            else:
+                self._transfer_outstanding[kv_chunk.room] = outstanding - 1
+            kv_chunk.staging_counted = False
+
+    def is_transfer_quiesced(self, room: int) -> bool:
+        with self._transfer_outstanding_lock:
+            return self._transfer_outstanding.get(room, 0) == 0
+
     def __init__(
         self,
         args: KVArgs,
@@ -321,6 +350,8 @@ class MoriKVManager(CommonKVManager):
             self._transfer_timeout_ms = envs.SGLANG_MORI_TRANSFER_TIMEOUT_MS.get()
             self._room_status_notified: Dict[int, bool] = {}
             self._room_notify_lock = threading.Lock()
+            self._transfer_outstanding: Dict[int, int] = {}
+            self._transfer_outstanding_lock = threading.Lock()
             for shard, queue in enumerate(self._transfer_queues):
                 threading.Thread(
                     target=self._transfer_worker,
@@ -431,7 +462,10 @@ class MoriKVManager(CommonKVManager):
     def _transfer_worker(self, queue: FastQueue) -> None:
         while True:
             kv_chunk = queue.get()
+            chunk_outstanding = False
             try:
+                self._count_transfer_chunk(kv_chunk)
+                chunk_outstanding = True
                 self._process_transfer_chunk(kv_chunk)
             except Exception as exc:
                 failure_reason = f"transfer worker raised: {exc!r}"
@@ -452,12 +486,12 @@ class MoriKVManager(CommonKVManager):
                         )
                     except Exception:
                         pass
+            finally:
+                if chunk_outstanding:
+                    self._finish_counted_transfer_chunk(kv_chunk)
 
     def _process_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
         room = kv_chunk.room
-        if self._should_skip_transfer(room):
-            return
-
         if kv_chunk.wait_event is not None:
             kv_chunk.wait_event.synchronize()
 
@@ -506,15 +540,24 @@ class MoriKVManager(CommonKVManager):
 
         start = time.perf_counter()
         sla_ms = self._transfer_timeout_ms
+        sla_failure = None
 
         while True:
             rc = self.engine.wait_all(statuses, timeout_ms=self._wait_poll_ms)
             if rc != StatusCode.IN_PROGRESS:
                 if rc == StatusCode.SUCCESS:
-                    return None
+                    return sla_failure
                 return self._collect_transfer_failure_reason(statuses)
-            if sla_ms > 0 and (time.perf_counter() - start) * 1000 >= sla_ms:
-                return f"KV transfer exceeded SLA {sla_ms}ms"
+            if (
+                sla_failure is None
+                and sla_ms > 0
+                and (time.perf_counter() - start) * 1000 >= sla_ms
+            ):
+                sla_failure = f"KV transfer exceeded SLA {sla_ms}ms"
+                logger.error(
+                    "%s; retaining source KV until MORI reports completion",
+                    sla_failure,
+                )
 
     @staticmethod
     def _collect_transfer_failure_reason(statuses: List[TransferStatus]) -> str:
@@ -1709,6 +1752,9 @@ class MoriKVSender(CommonKVSender):
         super().clear()
         with self.kv_mgr._room_notify_lock:
             self.kv_mgr._room_status_notified.pop(self.bootstrap_room, None)
+
+    def is_transfer_quiesced(self) -> bool:
+        return self.kv_mgr.is_transfer_quiesced(self.bootstrap_room)
 
     def failure_exception(self):
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -507,9 +507,6 @@ class MoriKVManager(CommonKVManager):
             state_indices=kv_chunk.state_indices,
         )
 
-        if self._should_skip_transfer(room):
-            return
-
         failure_reason = self._wait_transfer_completion(statuses)
         if self._should_skip_transfer(room):
             return

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -397,6 +397,35 @@ class TransferStatus:
 
 
 class NixlKVManager(StagingManagerMixin, CommonKVManager):
+    def _count_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._staging_outstanding_lock:
+            outstanding = self._staging_outstanding.get(kv_chunk.room, 0)
+            if kv_chunk.staging_counted:
+                if outstanding <= 0:
+                    raise RuntimeError(
+                        f"Counted NIXL chunk has no outstanding owner for room {kv_chunk.room}"
+                    )
+                return
+            self._staging_outstanding[kv_chunk.room] = outstanding + 1
+            kv_chunk.staging_counted = True
+
+    def _finish_counted_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        with self._staging_outstanding_lock:
+            outstanding = self._staging_outstanding.get(kv_chunk.room)
+            if not kv_chunk.staging_counted or outstanding is None or outstanding <= 0:
+                raise RuntimeError(
+                    f"Unmatched NIXL chunk finish for room {kv_chunk.room}"
+                )
+            if outstanding == 1:
+                self._staging_outstanding.pop(kv_chunk.room)
+            else:
+                self._staging_outstanding[kv_chunk.room] = outstanding - 1
+            kv_chunk.staging_counted = False
+
+    def is_transfer_quiesced(self, room: int) -> bool:
+        with self._staging_outstanding_lock:
+            return self._staging_outstanding.get(room, 0) == 0
+
     def __init__(
         self,
         args: KVArgs,
@@ -497,6 +526,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            self._staging_outstanding_lock = threading.Lock()
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -1083,6 +1113,26 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 dst_mem_kind=dst_mem_kind,
             )
 
+    def _wait_for_transfer_handles(
+        self, handles: List[Any], room: int
+    ) -> Optional[Exception]:
+        first_error = None
+        while handles:
+            all_terminal = True
+            for handle in handles:
+                state = self.agent.check_xfer_state(handle)
+                if state == "ERR":
+                    if first_error is None:
+                        first_error = RuntimeError(
+                            f"NIXL transfer encountered ERR room={room}"
+                        )
+                elif state != "DONE":
+                    all_terminal = False
+            if all_terminal:
+                return first_error
+            time.sleep(0)
+        return None
+
     def transfer_worker(self, queue: FastQueue, staging_buffer=None, worker_index=0):
         # Per-worker staging strategy: lazy-created on first chunk so we
         # see kv_buffer_tensors (set by ModelRunner after engine init).
@@ -1093,25 +1143,26 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             kv_chunk: TransferKVChunk = queue.get()
             room = kv_chunk.room
             handles: List[Any] = []
+            chunk_outstanding = False
             try:
+                self._count_transfer_chunk(kv_chunk)
+                chunk_outstanding = True
                 if room not in self.request_status:
                     logger.debug(
                         "Skipping chunk for room %s because it has been cleared",
                         room,
                     )
-                    self._staging_outstanding.pop(room, None)
+                    self._finish_counted_transfer_chunk(kv_chunk)
+                    chunk_outstanding = False
                     continue
 
                 # Counted at dequeue, before the status check, so
                 # `outstanding == 0` means nothing is dequeued or in flight --
                 # the predicate the abort ack relies on. The flag survives
                 # re-enqueue on defer.
-                if not kv_chunk.staging_counted:
-                    self._staging_outstanding[room] += 1
-                    kv_chunk.staging_counted = True
-
                 if self.check_status(room) == KVPoll.Failed:
-                    self._staging_outstanding.pop(room, None)
+                    self._finish_counted_transfer_chunk(kv_chunk)
+                    chunk_outstanding = False
                     if self.enable_deferred_decode_kv_release:
                         # Skipped => nothing written for this aborted room; ack.
                         self._maybe_ack_drained_abort(room)
@@ -1124,7 +1175,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                         "has been cleared",
                         room,
                     )
-                    self._staging_outstanding.pop(room, None)
+                    self._finish_counted_transfer_chunk(kv_chunk)
+                    chunk_outstanding = False
                     continue
 
                 # Lazily build a per-worker staging strategy bound to this
@@ -1349,23 +1401,14 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
                 if staging_deferred:
                     # Chunk has been re-enqueued; do not advance status.
+                    chunk_outstanding = False
                     continue
 
-                while handles:
-                    all_done = True
-                    for handle in handles:
-                        state = self.agent.check_xfer_state(handle)
-                        if state == "ERR":
-                            raise RuntimeError(
-                                f"NIXL transfer encountered ERR room={room}"
-                            )
-                        if state != "DONE":
-                            all_done = False
-                    if all_done:
-                        break
-                    time.sleep(0)
-
-                self._staging_outstanding[room] -= 1
+                transfer_error = self._wait_for_transfer_handles(handles, room)
+                if transfer_error is not None:
+                    raise transfer_error
+                self._finish_counted_transfer_chunk(kv_chunk)
+                chunk_outstanding = False
                 if self.enable_deferred_decode_kv_release:
                     # Handles all DONE => this room's writes landed; ack if it
                     # was aborted and nothing else is outstanding.
@@ -1381,14 +1424,13 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 # the room has concluded: Success, or a Failed *last* chunk. A
                 # non-last Failed chunk keeps the room (more chunks may follow); a
                 # late chunk for an already-Failed room is skipped at loop top.
-                if self._staging_outstanding.get(room, 0) <= 0 and (
+                if self.is_transfer_quiesced(room) and (
                     self.check_status(room) == KVPoll.Success
                     or (
                         kv_chunk.is_last_chunk
                         and self.check_status(room) == KVPoll.Failed
                     )
                 ):
-                    self._staging_outstanding.pop(room, None)
                     self.transfer_infos.pop(room, None)
                     self.req_to_decode_prefix_len.pop(room, None)
                     if self.enable_staging and self._staging_ctx is not None:
@@ -1398,6 +1440,21 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                             if k[0] == room:
                                 self._staging_ctx.prefetch_requested.discard(k)
             except Exception as e:
+                if handles:
+                    try:
+                        self._wait_for_transfer_handles(handles, room)
+                    except Exception as quiescence_error:  # noqa: BLE001
+                        logger.critical(
+                            "Cannot prove NIXL transfer quiescence for room %s; "
+                            "retaining source KV ownership",
+                            room,
+                            exc_info=quiescence_error,
+                        )
+                        self.exceptions[room] = quiescence_error
+                        self.record_failure(room, str(quiescence_error))
+                        self.update_status(room, KVPoll.Failed)
+                        chunk_outstanding = False
+                        continue
                 # Catch all exceptions to prevent silently killing this
                 # worker thread, but still propagate via failure_exception().
                 if isinstance(e, _NIXL_TRANSPORT_ERRORS):
@@ -1409,8 +1466,10 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 self.exceptions[room] = e
                 self.record_failure(room, str(e))
                 self.update_status(room, KVPoll.Failed)
-                # No ack here on purpose: the DONE barrier bails on the first
-                # ERR, so siblings may still be writing; fall back to the timeout.
+                if chunk_outstanding:
+                    self._finish_counted_transfer_chunk(kv_chunk)
+                    if self.enable_deferred_decode_kv_release:
+                        self._maybe_ack_drained_abort(room)
 
     def register_buffer_to_engine(self):
         self.kv_descs = []
@@ -2718,7 +2777,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     room_to_be_aborted, decode_ip, decode_port
                 )
                 self._maybe_ack_drained_abort(room_to_be_aborted)
-            elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
+            elif self.is_transfer_quiesced(room_to_be_aborted):
                 self._send_abort_ack(decode_ip, decode_port, room_to_be_aborted)
 
         return True
@@ -2856,10 +2915,7 @@ class NixlKVSender(CommonKVSender):
                 return timeout_result
         # Hold Success until all staging chunks transferred: a deferred chunk
         # can still be pending, and concluding now would drop it.
-        if (
-            status == KVPoll.Success
-            and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
-        ):
+        if status == KVPoll.Success and not self.is_transfer_quiesced():
             return KVPoll.Transferring  # type: ignore
         if (
             status == KVPoll.Success
@@ -2870,6 +2926,9 @@ class NixlKVSender(CommonKVSender):
                 time.perf_counter() - self._transfer_start_time
             )
         return status
+
+    def is_transfer_quiesced(self) -> bool:
+        return self.kv_mgr.is_transfer_quiesced(self.bootstrap_room)
 
     def clear(self) -> None:
         super().clear()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -43,6 +43,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    all_reduce_transfer_quiesced_attn_cp_tp_group,
     build_kv_layer_ids,
     build_staging_slot_metadata,
     get_dsv4_c128_state_indices,
@@ -928,10 +929,26 @@ class SchedulerDisaggregationPrefillMixin:
             self.attn_cp_cpu_group,
             self.attn_tp_cpu_group,
         )
+        if any(
+            req.disagg_abort_cleanup_pending
+            for req in self.disagg_prefill_inflight_queue
+        ):
+            transfer_quiesced = all_reduce_transfer_quiesced_attn_cp_tp_group(
+                [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
+                self.attn_cp_cpu_group,
+                self.attn_tp_cpu_group,
+            )
+        else:
+            transfer_quiesced = [True] * len(self.disagg_prefill_inflight_queue)
 
         undone_reqs: List[Req] = []
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
-        for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
+        for req, poll, globally_quiesced in zip(
+            self.disagg_prefill_inflight_queue,
+            polls,
+            transfer_quiesced,
+            strict=True,
+        ):
             if rids_to_check is not None:
                 if req.rid not in rids_to_check:
                     undone_reqs.append(req)
@@ -951,6 +968,14 @@ class SchedulerDisaggregationPrefillMixin:
                     )
                     undone_reqs.append(req)
                     continue
+
+            if req.disagg_abort_cleanup_pending:
+                if not globally_quiesced:
+                    undone_reqs.append(req)
+                    continue
+                if self._retire_aborted_prefill_result(req, transport_quiesced=True):
+                    done_reqs.append(req)
+                continue
 
             if req.pending_bootstrap:
                 # Parked: prefill finished before bootstrap completed.

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -63,6 +63,10 @@ from sglang.srt.managers.schedule_batch import (
     Req,
     ScheduleBatch,
 )
+from sglang.srt.managers.utils import (
+    complete_mm_embedding_validations,
+    decode_mm_embedding_errors,
+)
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     kv_to_page_num,
@@ -706,6 +710,12 @@ class SchedulerDisaggregationPrefillMixin:
 
         if copy_done is not None:
             copy_done.synchronize()
+        mm_embedding_error_tensor = result.mm_embedding_errors
+        if mm_embedding_error_tensor is not None:
+            complete_mm_embedding_validations(batch.reqs, mm_embedding_error_tensor)
+        decoded_mm_embedding_errors = decode_mm_embedding_errors(
+            mm_embedding_error_tensor
+        )
         auxiliary_output_starts = (
             self.batch_result_processor.snapshot_auxiliary_output_starts(batch, result)
         )
@@ -718,7 +728,7 @@ class SchedulerDisaggregationPrefillMixin:
             result.indexer_topk_output = None
 
         logprob_pt = 0
-        assert batch.spec_info is result.next_draft_input
+        assert decoded_mm_embedding_errors or batch.spec_info is result.next_draft_input
         draft_input = result.next_draft_input
         draft_hidden_states_cpu = None
         draft_dsa_topk_indices_cpu = None
@@ -746,9 +756,31 @@ class SchedulerDisaggregationPrefillMixin:
             if extend_logprob_start_len < extend_input_len:
                 logprob_pt += extend_input_len - extend_logprob_start_len
 
+        mm_embedding_errors = {
+            req_idx: (expected, actual)
+            for req_idx, expected, actual in decoded_mm_embedding_errors
+        }
+        failed_reqs = []
         for i, (req, next_token_id) in enumerate(
             zip(batch.reqs, next_token_ids, strict=True)
         ):
+            mm_embedding_error = mm_embedding_errors.get(i)
+            if mm_embedding_error is not None:
+                self.defer_mm_embedding_abort(req, *mm_embedding_error)
+            if mm_embedding_error is not None or req.mm_embedding_abort_pending:
+                advance_logprob_pt(i, req)
+                if req.inflight_middle_chunks > 0:
+                    req.inflight_middle_chunks -= 1
+                    req.time_stats.set_last_chunked_prefill_finish_time()
+                if (
+                    req.inflight_middle_chunks <= 0
+                    and req.mm_embedding_validation_count == 0
+                ):
+                    cleanup_finished = self._retire_aborted_prefill_result(req)
+                    if cleanup_finished and not req.finished_output:
+                        failed_reqs.append(req)
+                continue
+
             if req.inflight_middle_chunks <= 0:
                 req.time_stats.set_prefill_finished_time()
 
@@ -863,6 +895,12 @@ class SchedulerDisaggregationPrefillMixin:
                 batch,
                 auxiliary_output,
                 auxiliary_output_starts,
+            )
+
+        if failed_reqs:
+            self.output_streamer.stream_output(
+                failed_reqs,
+                any(req.return_logprob for req in failed_reqs),
             )
 
         can_run_cuda_graph = result.can_run_cuda_graph
@@ -1018,6 +1056,57 @@ class SchedulerDisaggregationPrefillMixin:
         """
         self.disagg_prefill_pending_chunk_rids.discard(req.rid)
 
+    def _retire_aborted_prefill_result(
+        self: Scheduler, req: Req, transport_quiesced: bool = False
+    ) -> bool:
+        """Release an aborted request still owned by a completed prefill batch."""
+        if not req.disagg_abort_cleanup_pending:
+            self.clear_pending_chunk_send(req)
+        owns_resources = (
+            req.kv.holds_kv or req.kv.holds_mamba or req.metadata_buffer_index >= 0
+        )
+        if not owns_resources:
+            req.disagg_abort_cleanup_pending = False
+            return False
+
+        if req.disagg_kv_sender is not None and not req.disagg_abort_cleanup_pending:
+            req.disagg_abort_cleanup_pending = True
+            try:
+                req.disagg_kv_sender.abort()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to abort KV transfer while retiring request %s",
+                    req.rid,
+                    exc_info=True,
+                )
+        if req.disagg_kv_sender is not None and not transport_quiesced:
+            if req not in self.disagg_prefill_inflight_queue:
+                self.disagg_prefill_inflight_queue.append(req)
+            return False
+        if req.disagg_kv_sender is not None:
+            assert req.disagg_kv_sender.is_transfer_quiesced()
+            try:
+                req.disagg_kv_sender.clear()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to clear KV transfer while retiring request %s",
+                    req.rid,
+                    exc_info=True,
+                )
+        if req.to_finish is not None and not req.finished():
+            req.update_finish_state()
+        maybe_release_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
+        req.pending_bootstrap = False
+        if req.mm_embedding_abort_pending:
+            self.batch_result_processor._finish_deferred_mm_embedding_abort(req)
+        else:
+            if self.enable_hicache_storage:
+                self.tree_cache.release_aborted_request(req.rid)
+            if req.kv.holds_kv or req.kv.holds_mamba:
+                release_kv_cache(req, self.tree_cache, is_insert=False)
+        req.disagg_abort_cleanup_pending = False
+        return True
+
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:
         self.clear_pending_chunk_send(req)
         error_message = (
@@ -1104,7 +1193,7 @@ class SchedulerDisaggregationPrefillMixin:
                     req.extend_range.end,
                     len(req.origin_input_ids),
                 )
-            else:
+            elif req.mm_embedding_validation_count == 0:
                 self.send_kv_chunk(req)
 
             if self.chunked_req is not None:
@@ -1122,6 +1211,8 @@ class SchedulerDisaggregationPrefillMixin:
                 running_batch.batch_is_full = False
 
     def maybe_send_cached_prefix_chunk(self: Scheduler, req: Req) -> None:
+        if req.mm_embedding_validation_count > 0:
+            return
         if not envs.SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get():
             return
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -231,6 +231,17 @@ def poll_and_all_reduce_attn_cp_tp_group(
     return _all_reduce_polls(polls, attn_cp_cpu_group)
 
 
+def all_reduce_transfer_quiesced_attn_cp_tp_group(
+    pollers,
+    attn_cp_cpu_group: dist.ProcessGroup,
+    attn_tp_cpu_group: dist.ProcessGroup,
+) -> List[bool]:
+    quiesced = [int(poller.is_transfer_quiesced()) for poller in pollers]
+    quiesced = _all_reduce_polls(quiesced, attn_tp_cpu_group)
+    quiesced = _all_reduce_polls(quiesced, attn_cp_cpu_group)
+    return [bool(value) for value in quiesced]
+
+
 def poll_and_all_reduce_with_staging(
     decode_reqs,
     staging_handler,

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -19,6 +19,12 @@ _is_xpu = is_xpu()
 
 embedding_cache: Optional[MultiModalStaticCache] = None
 
+MultimodalEmbeddingError = Tuple[int, int, int]
+
+
+class EmptyPerItemEmbeddingError(ValueError):
+    pass
+
 
 def init_mm_embedding_cache(max_size: int = 0):
     global embedding_cache
@@ -167,6 +173,63 @@ def _embedding_token_count(embedding: torch.Tensor) -> int:
     return embedding.reshape(-1, embedding.shape[-1]).shape[0]
 
 
+def _fit_embedding_length(
+    embedding: torch.Tensor, expected_tokens: int
+) -> torch.Tensor:
+    embedding = embedding.reshape(-1, embedding.shape[-1])
+    if embedding.shape[0] >= expected_tokens:
+        return embedding[:expected_tokens]
+    return torch.cat(
+        [
+            embedding,
+            embedding.new_zeros(
+                expected_tokens - embedding.shape[0], embedding.shape[1]
+            ),
+        ],
+        dim=0,
+    )
+
+
+def _retry_individual_embeddings(
+    data_embedding_func: "DataEmbeddingFunc",
+    items: List[MultimodalDataItem],
+) -> Tuple[List[Optional[torch.Tensor]], List[bool]]:
+    embeddings = []
+    count_mismatches = []
+    for item in items:
+        embedding = data_embedding_func([item])
+        if isinstance(embedding, list):
+            count_mismatches.append(len(embedding) != 1)
+            if not embedding:
+                embeddings.append(None)
+                continue
+            embedding = _flatten_embedding_result(embedding)
+        else:
+            count_mismatches.append(False)
+        embeddings.append(embedding.reshape(-1, embedding.shape[-1]))
+    return embeddings, count_mismatches
+
+
+def _split_or_retry_mismatched_combined_embedding(
+    data_embedding_func: "DataEmbeddingFunc",
+    items: List[MultimodalDataItem],
+    embedding: torch.Tensor,
+    token_counts: List[int],
+) -> Tuple[List[Optional[torch.Tensor]], List[bool]]:
+    embedding = embedding.reshape(-1, embedding.shape[-1])
+    expected_total = sum(token_counts)
+    actual_total = embedding.shape[0]
+    if actual_total == expected_total:
+        return list(torch.split(embedding, token_counts, dim=0)), [False] * len(items)
+
+    embeddings, count_mismatches = _retry_individual_embeddings(
+        data_embedding_func, items
+    )
+    if actual_total > expected_total:
+        count_mismatches = [True] * len(items)
+    return embeddings, count_mismatches
+
+
 def _discard_mismatched_cached_embedding(
     cache_key: Optional[int],
     expected_token_count: int,
@@ -244,7 +307,7 @@ def _get_chunked_embedding_full(
     extend_seq_len: int,
     input_ids: torch.Tensor,
     device: torch.device,
-) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+) -> Tuple[Optional[torch.Tensor], torch.Tensor, Optional[Tuple[int, int]]]:
     """
     Fallback: encode all items at once, cache combined result, extract chunk.
     Used for non-bundled items or EVS results.
@@ -268,20 +331,36 @@ def _get_chunked_embedding_full(
             )
             embedding_per_req = None
 
-    if embedding_per_req is None:
+    fresh_embedding = embedding_per_req is None
+    if fresh_embedding:
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(embedding_items_per_req, device)
         embedding = data_embedding_func(embedding_items_per_req)
+        per_item_count_mismatch = False
         if isinstance(embedding, list):
             # This path caches the combined per-request embedding, so the
             # per-item form is flattened here.
-            embedding = _flatten_embedding_result(embedding)
+            per_item_count_mismatch = len(embedding) != len(embedding_items_per_req)
+            if per_item_count_mismatch:
+                retry_embeddings, _ = _retry_individual_embeddings(
+                    data_embedding_func, embedding_items_per_req
+                )
+                if any(embedding is None for embedding in retry_embeddings):
+                    raise EmptyPerItemEmbeddingError
+                embedding = _flatten_embedding_result(retry_embeddings)
+            else:
+                embedding = _flatten_embedding_result(embedding)
         embedding_per_req = (
             EmbeddingResult(embedding=embedding)
             if isinstance(embedding, torch.Tensor)
             else embedding
         )
-        embedding_cache.set(embedding_items_hash, embedding_per_req)
+        expected_token_count = sum(end - start + 1 for start, end in items_offset)
+        actual_token_count = _embedding_token_count(embedding_per_req.embedding)
+        if isinstance(embedding_per_req, EVSEmbeddingResult) or (
+            actual_token_count == expected_token_count and not per_item_count_mismatch
+        ):
+            embedding_cache.set(embedding_items_hash, embedding_per_req)
     else:
         _acknowledge_deferred_cuda_ipc_cache_hits(embedding_items_per_req)
 
@@ -303,7 +382,20 @@ def _get_chunked_embedding_full(
         extend_seq_len=extend_seq_len,
         items_offset=items_offset,
     )
-    return embedding_per_req_chunk, input_ids
+    error = None
+    if (
+        fresh_embedding
+        and not isinstance(embedding_per_req, EVSEmbeddingResult)
+        and (actual_token_count != expected_token_count or per_item_count_mismatch)
+    ):
+        error = (expected_token_count, actual_token_count)
+        expected_chunk_tokens = _count_mm_tokens_in_extend(
+            [extend_prefix_len], [extend_seq_len], [items_offset]
+        )
+        embedding_per_req_chunk = _fit_embedding_length(
+            embedding_per_req_chunk, expected_chunk_tokens
+        )
+    return embedding_per_req_chunk, input_ids, error
 
 
 @dataclass
@@ -324,7 +416,10 @@ def _batch_encode_per_image_misses(
     data_embedding_func: DataEmbeddingFunc,
     per_image_requests: List[PerImageRequestInfo],
     device: torch.device,
-) -> Dict[Tuple[Optional[int], int], torch.Tensor]:
+) -> Tuple[
+    Dict[Tuple[Optional[int], int], torch.Tensor],
+    Dict[Tuple[Optional[int], int], Tuple[int, int]],
+]:
     """
     Collect cache misses across ALL per-image requests, deduplicate by hash and
     expected token count, encode in a single ViT call, and populate the cache.
@@ -337,6 +432,7 @@ def _batch_encode_per_image_misses(
     """
     unique_misses: Dict[Tuple[Optional[int], int], Tuple[MultimodalDataItem, int]] = {}
     hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor] = {}
+    malformed_embeddings: Dict[Tuple[Optional[int], int], Tuple[int, int]] = {}
 
     # Phase 1a: find overlapping items per request and collect cache misses
     for req_info in per_image_requests:
@@ -379,30 +475,55 @@ def _batch_encode_per_image_misses(
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(miss_items, device)
         all_miss_embedding = data_embedding_func(miss_items)
-
         if isinstance(all_miss_embedding, list):
             # Per-item embeddings: no split needed, and each cache entry owns
             # its storage (a torch.split view would pin the whole concatenated
             # buffer for as long as any single item stays cached). Mirrors
             # _get_chunked_embedding_by_item.
-            assert len(all_miss_embedding) == len(miss_items), (
-                f"per-item embedding count {len(all_miss_embedding)} != "
-                f"cache-miss item count {len(miss_items)}"
-            )
-            split_embeddings = [
-                emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
-            ]
+            per_item_count_mismatch = len(all_miss_embedding) != len(miss_items)
+            if per_item_count_mismatch:
+                split_embeddings, _ = _retry_individual_embeddings(
+                    data_embedding_func, miss_items
+                )
+                count_mismatches = [True] * len(miss_items)
+            else:
+                split_embeddings = [
+                    emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
+                ]
+                count_mismatches = [False] * len(miss_items)
         else:
-            all_miss_embedding = all_miss_embedding.reshape(
-                -1, all_miss_embedding.shape[-1]
+            split_embeddings, count_mismatches = (
+                _split_or_retry_mismatched_combined_embedding(
+                    data_embedding_func,
+                    miss_items,
+                    all_miss_embedding,
+                    token_counts,
+                )
             )
-            split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
-        for cache_key, emb in zip(ordered_cache_keys, split_embeddings):
-            embedding_cache.set(cache_key[0], EmbeddingResult(embedding=emb))
+        template = next((emb for emb in split_embeddings if emb is not None), None)
+        if template is None:
+            raise EmptyPerItemEmbeddingError
+        for cache_key, emb, count_mismatch in zip(
+            ordered_cache_keys, split_embeddings, count_mismatches, strict=True
+        ):
+            expected_token_count = cache_key[1]
+            actual_token_count = 0 if emb is None else _embedding_token_count(emb)
+            if count_mismatch or actual_token_count != expected_token_count:
+                malformed_embeddings[cache_key] = (
+                    expected_token_count,
+                    actual_token_count,
+                )
+                emb = (
+                    template.new_zeros((expected_token_count, template.shape[-1]))
+                    if emb is None
+                    else _fit_embedding_length(emb, expected_token_count)
+                )
+            else:
+                embedding_cache.set(cache_key[0], EmbeddingResult(embedding=emb))
             # Keep a local ref (no extra GPU memory) so assembly never fails due to LRU eviction.
             hash_to_embedding[cache_key] = emb
 
-    return hash_to_embedding
+    return hash_to_embedding, malformed_embeddings
 
 
 def _get_chunked_embedding_by_item(
@@ -412,7 +533,7 @@ def _get_chunked_embedding_by_item(
     extend_prefix_len: int,
     extend_seq_len: int,
     device: torch.device,
-) -> Optional[torch.Tensor]:
+) -> Tuple[Optional[torch.Tensor], Optional[Tuple[int, int]]]:
     """
     Per-image chunk-aware encoding for one request.
     Items must already be split per-image (each item has exactly one offset).
@@ -421,7 +542,7 @@ def _get_chunked_embedding_by_item(
     chunk_end = extend_prefix_len + extend_seq_len  # exclusive
 
     if extend_seq_len <= 0:
-        return None
+        return None, None
 
     overlapping = []
     for idx, (item, (start, end)) in enumerate(
@@ -431,10 +552,11 @@ def _get_chunked_embedding_by_item(
             overlapping.append((idx, item, start, end))
 
     if not overlapping:
-        return None
+        return None, None
 
     cached_embeddings = {}
     miss_items = []
+    malformed = None
     for idx, item, start, end in overlapping:
         expected_token_count = end - start + 1
         cached = embedding_cache.get_single(item.hash)
@@ -457,29 +579,50 @@ def _get_chunked_embedding_by_item(
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(miss_item_list, device)
         all_miss_embedding = data_embedding_func(miss_item_list)
-
         if isinstance(all_miss_embedding, list):
             # Per-item embeddings: no split needed, and each cache entry owns
             # its storage (a torch.split view would pin the whole concatenated
             # buffer for as long as any single item stays cached).
-            assert len(all_miss_embedding) == len(miss_items), (
-                f"per-item embedding count {len(all_miss_embedding)} != "
-                f"cache-miss item count {len(miss_items)}"
-            )
-            split_embeddings = [
-                emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
-            ]
+            if len(all_miss_embedding) != len(miss_items):
+                split_embeddings, _ = _retry_individual_embeddings(
+                    data_embedding_func, miss_item_list
+                )
+                count_mismatches = [True] * len(miss_items)
+            else:
+                split_embeddings = [
+                    emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
+                ]
+                count_mismatches = [False] * len(miss_items)
         else:
-            all_miss_embedding = all_miss_embedding.reshape(
-                -1, all_miss_embedding.shape[-1]
-            )
             # Split output by per-item token count
             token_counts = [end - start + 1 for _, _, start, end in miss_items]
-            split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
+            split_embeddings, count_mismatches = (
+                _split_or_retry_mismatched_combined_embedding(
+                    data_embedding_func,
+                    miss_item_list,
+                    all_miss_embedding,
+                    token_counts,
+                )
+            )
 
-        for (idx, item, _, _), emb in zip(miss_items, split_embeddings):
+        template = next((emb for emb in split_embeddings if emb is not None), None)
+        if template is None:
+            raise EmptyPerItemEmbeddingError
+        for (idx, item, start, end), emb, count_mismatch in zip(
+            miss_items, split_embeddings, count_mismatches, strict=True
+        ):
+            expected_token_count = end - start + 1
+            actual_token_count = 0 if emb is None else _embedding_token_count(emb)
+            if count_mismatch or actual_token_count != expected_token_count:
+                malformed = (expected_token_count, actual_token_count)
+                emb = (
+                    template.new_zeros((expected_token_count, template.shape[-1]))
+                    if emb is None
+                    else _fit_embedding_length(emb, expected_token_count)
+                )
+            else:
+                embedding_cache.set(item.hash, EmbeddingResult(embedding=emb))
             cached_embeddings[idx] = emb
-            embedding_cache.set(item.hash, EmbeddingResult(embedding=emb))
 
     chunk_slices = []
     for idx, _, start, end in overlapping:
@@ -490,7 +633,11 @@ def _get_chunked_embedding_by_item(
         local_end = overlap_end - start + 1  # exclusive for slicing
         chunk_slices.append(emb[local_start:local_end])
 
-    return torch.cat(chunk_slices, dim=0)
+    chunk = torch.cat(chunk_slices, dim=0)
+    expected_chunk_tokens = _count_mm_tokens_in_extend(
+        [extend_prefix_len], [extend_seq_len], [items_offset]
+    )
+    return _fit_embedding_length(chunk, expected_chunk_tokens), malformed
 
 
 def _assemble_per_image_chunk(
@@ -530,7 +677,7 @@ def _get_chunked_prefill_embedding(
     extend_length: List[int],
     items_offset_list: List[List[Tuple[int, int]]],
     input_ids: torch.Tensor,
-) -> tuple[torch.Tensor | None, torch.Tensor]:
+) -> tuple[torch.Tensor | None, torch.Tensor, List[MultimodalEmbeddingError]]:
     """
     Chunked prefill embedding: encode items across all requests and extract
     per-request chunks. Images from all requests are batched into a single
@@ -544,6 +691,8 @@ def _get_chunked_prefill_embedding(
     per_image_requests = []  # batched ViT encoding
     full_path_requests = []  # per-request encoding (EVS etc.)
     all_chunks: List[Tuple[int, torch.Tensor]] = []
+    empty_chunks: List[Tuple[int, int]] = []
+    errors: List[MultimodalEmbeddingError] = []
 
     for i in range(max_iterations):
         if items_size[i] == items_size[i + 1]:
@@ -574,16 +723,31 @@ def _get_chunked_prefill_embedding(
             if _is_hip or _is_npu or _is_xpu:
                 # ROCm CI regressed with one large cross-request ViT batch; keep
                 # the previous per-request path on HIP/NPU/XPU while CUDA uses batching.
-                chunk = _get_chunked_embedding_by_item(
-                    data_embedding_func,
-                    embedding_items_per_req,
-                    items_offset,
-                    extend_prefix_len,
-                    extend_seq_len,
-                    device,
-                )
+                try:
+                    chunk, error = _get_chunked_embedding_by_item(
+                        data_embedding_func,
+                        embedding_items_per_req,
+                        items_offset,
+                        extend_prefix_len,
+                        extend_seq_len,
+                        device,
+                    )
+                except EmptyPerItemEmbeddingError:
+                    expected = sum(end - start + 1 for start, end in items_offset)
+                    errors.append((i, expected, 0))
+                    empty_chunks.append(
+                        (
+                            i,
+                            _count_mm_tokens_in_extend(
+                                [extend_prefix_len], [extend_seq_len], [items_offset]
+                            ),
+                        )
+                    )
+                    continue
                 if chunk is not None:
                     all_chunks.append((i, chunk))
+                if error is not None:
+                    errors.append((i, *error))
             else:
                 per_image_requests.append(req_info)
         else:
@@ -591,10 +755,45 @@ def _get_chunked_prefill_embedding(
 
     # Phase 1: batch encode all per-image cache misses in ONE ViT call
     hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor] = {}
+    malformed_embeddings: Dict[Tuple[Optional[int], int], Tuple[int, int]] = {}
     if per_image_requests:
-        hash_to_embedding = _batch_encode_per_image_misses(
-            data_embedding_func, per_image_requests, device
-        )
+        try:
+            hash_to_embedding, malformed_embeddings = _batch_encode_per_image_misses(
+                data_embedding_func, per_image_requests, device
+            )
+        except EmptyPerItemEmbeddingError:
+            healthy_requests = []
+            for req_info in per_image_requests:
+                has_uncached_item = False
+                for _idx, item, start, end in req_info.overlapping:
+                    expected_item_tokens = end - start + 1
+                    cached = embedding_cache.get_single(item.hash)
+                    if (
+                        cached is None
+                        or _embedding_token_count(cached.embedding)
+                        != expected_item_tokens
+                    ):
+                        has_uncached_item = True
+                        break
+                    hash_to_embedding[(item.hash, expected_item_tokens)] = (
+                        cached.embedding
+                    )
+                if not has_uncached_item:
+                    healthy_requests.append(req_info)
+                    continue
+                expected = sum(end - start + 1 for start, end in req_info.items_offset)
+                errors.append((req_info.req_idx, expected, 0))
+                empty_chunks.append(
+                    (
+                        req_info.req_idx,
+                        _count_mm_tokens_in_extend(
+                            [req_info.extend_prefix_len],
+                            [req_info.extend_seq_len],
+                            [req_info.items_offset],
+                        ),
+                    )
+                )
+            per_image_requests = healthy_requests
 
     # Phase 2: assemble per-request chunks in original request order
     for req_info in per_image_requests:
@@ -605,28 +804,68 @@ def _get_chunked_prefill_embedding(
             req_info.extend_seq_len,
         )
         if chunk is not None:
+            malformed = next(
+                (
+                    malformed_embeddings[(item.hash, end - start + 1)]
+                    for _idx, item, start, end in req_info.overlapping
+                    if (item.hash, end - start + 1) in malformed_embeddings
+                ),
+                None,
+            )
+            if malformed is not None:
+                errors.append((req_info.req_idx, *malformed))
+                expected_chunk_tokens = _count_mm_tokens_in_extend(
+                    [req_info.extend_prefix_len],
+                    [req_info.extend_seq_len],
+                    [req_info.items_offset],
+                )
+                chunk = _fit_embedding_length(chunk, expected_chunk_tokens)
             all_chunks.append((req_info.req_idx, chunk))
 
     for req_info in full_path_requests:
-        chunk_embedding, input_ids = _get_chunked_embedding_full(
-            data_embedding_func,
-            req_info.items,
-            req_info.items_offset,
-            req_info.extend_prefix_len,
-            req_info.extend_seq_len,
-            input_ids,
-            device,
-        )
+        try:
+            chunk_embedding, input_ids, error = _get_chunked_embedding_full(
+                data_embedding_func,
+                req_info.items,
+                req_info.items_offset,
+                req_info.extend_prefix_len,
+                req_info.extend_seq_len,
+                input_ids,
+                device,
+            )
+        except EmptyPerItemEmbeddingError:
+            expected = sum(end - start + 1 for start, end in req_info.items_offset)
+            errors.append((req_info.req_idx, expected, 0))
+            empty_chunks.append(
+                (
+                    req_info.req_idx,
+                    _count_mm_tokens_in_extend(
+                        [req_info.extend_prefix_len],
+                        [req_info.extend_seq_len],
+                        [req_info.items_offset],
+                    ),
+                )
+            )
+            continue
         if chunk_embedding is not None:
             all_chunks.append((req_info.req_idx, chunk_embedding))
+        if error is not None:
+            errors.append((req_info.req_idx, *error))
+
+    if all_chunks:
+        template = all_chunks[0][1]
+        all_chunks.extend(
+            (req_idx, template.new_zeros((token_count, template.shape[-1])))
+            for req_idx, token_count in empty_chunks
+        )
 
     # Sort by original request index to maintain correct output order
     all_chunks.sort(key=lambda x: x[0])
     embedding_list = [chunk for _, chunk in all_chunks]
 
     if len(embedding_list) == 0:
-        return None, input_ids
-    return torch.concat(embedding_list, dim=0), input_ids
+        return None, input_ids, errors
+    return torch.concat(embedding_list, dim=0), input_ids, errors
 
 
 def _get_multimodal_mask(
@@ -694,7 +933,12 @@ def get_embedding_and_mask(
     prefix_length: List[int],
     extend_length: List[int],
     items_offset_list: List[List[Tuple[int, int]]],
-) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor]:
+) -> Tuple[
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor,
+    List[MultimodalEmbeddingError],
+]:
     """
     Generate multimodal embeddings and create a mask for identifying their positions in the input sequence.
 
@@ -726,7 +970,7 @@ def get_embedding_and_mask(
         embedding_items, items_size, prefix_length, extend_length, items_offset_list
     )
     if embedding is None:
-        embedding, input_ids = _get_chunked_prefill_embedding(
+        embedding, input_ids, errors = _get_chunked_prefill_embedding(
             data_embedding_func,
             embedding_items,
             items_size,
@@ -736,7 +980,9 @@ def get_embedding_and_mask(
             input_ids,
         )
         if embedding is None:
-            return None, None, input_ids
+            return None, None, input_ids, errors
+    else:
+        errors = []
     # 2. Get mask
     if _is_npu:
         torch.npu.current_stream().synchronize()
@@ -752,4 +998,4 @@ def get_embedding_and_mask(
             "MM placeholder count derived from offsets does not match input_ids",
         )
     embedding = _adjust_embedding_length(embedding, num_mm_tokens_in_input_ids, logger)
-    return embedding, special_multimodal_mask, input_ids
+    return embedding, special_multimodal_mask, input_ids, errors

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -10,7 +10,6 @@ from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalSta
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
 from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.utils import is_hip, is_npu, is_xpu
-from sglang.srt.utils.async_probe import maybe_assert_sum
 from sglang.utils import logger
 
 _is_hip = is_hip()
@@ -986,11 +985,5 @@ def get_embedding_and_mask(
     if input_ids is not original_input_ids:
         # EVS rewrites placeholder spans after pruning, making the original offsets stale.
         num_mm_tokens_in_input_ids = special_multimodal_mask.sum().item()
-    else:
-        maybe_assert_sum(
-            special_multimodal_mask,
-            num_mm_tokens_in_input_ids,
-            "MM placeholder count derived from offsets does not match input_ids",
-        )
     embedding = _adjust_embedding_length(embedding, num_mm_tokens_in_input_ids, logger)
     return embedding, special_multimodal_mask, input_ids, errors

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -218,15 +218,12 @@ def _split_or_retry_mismatched_combined_embedding(
 ) -> Tuple[List[Optional[torch.Tensor]], List[bool]]:
     embedding = embedding.reshape(-1, embedding.shape[-1])
     expected_total = sum(token_counts)
-    actual_total = embedding.shape[0]
-    if actual_total == expected_total:
+    if embedding.shape[0] == expected_total:
         return list(torch.split(embedding, token_counts, dim=0)), [False] * len(items)
 
     embeddings, count_mismatches = _retry_individual_embeddings(
         data_embedding_func, items
     )
-    if actual_total > expected_total:
-        count_mismatches = [True] * len(items)
     return embeddings, count_mismatches
 
 
@@ -482,10 +479,9 @@ def _batch_encode_per_image_misses(
             # _get_chunked_embedding_by_item.
             per_item_count_mismatch = len(all_miss_embedding) != len(miss_items)
             if per_item_count_mismatch:
-                split_embeddings, _ = _retry_individual_embeddings(
+                split_embeddings, count_mismatches = _retry_individual_embeddings(
                     data_embedding_func, miss_items
                 )
-                count_mismatches = [True] * len(miss_items)
             else:
                 split_embeddings = [
                     emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
@@ -584,10 +580,9 @@ def _get_chunked_embedding_by_item(
             # its storage (a torch.split view would pin the whole concatenated
             # buffer for as long as any single item stays cached).
             if len(all_miss_embedding) != len(miss_items):
-                split_embeddings, _ = _retry_individual_embeddings(
+                split_embeddings, count_mismatches = _retry_individual_embeddings(
                     data_embedding_func, miss_item_list
                 )
-                count_mismatches = [True] * len(miss_items)
             else:
                 split_embeddings = [
                     emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -386,6 +386,45 @@ def _scatter_mm_embedding(
     dest.index_copy_(0, rows[:num_src_rows], src)
 
 
+def _fit_mm_embedding_to_request_masks(
+    embedding: torch.Tensor,
+    mask: torch.Tensor,
+    expected_counts: List[int],
+    input_id_slices: List[Tuple[int, int]],
+    errors: List[Tuple[int, int, int]],
+) -> Tuple[torch.Tensor, List[Tuple[int, int, int]]]:
+    actual_counts = torch.stack(
+        [mask[start:end].sum() for start, end in input_id_slices]
+    ).tolist()
+    mismatched = [
+        i
+        for i, (expected, actual) in enumerate(zip(expected_counts, actual_counts))
+        if expected != actual
+    ]
+    if not mismatched:
+        return embedding, errors
+
+    chunks = list(torch.split(embedding, expected_counts, dim=0))
+    for i in mismatched:
+        chunks[i] = chunks[i][: actual_counts[i]]
+        if chunks[i].shape[0] < actual_counts[i]:
+            chunks[i] = torch.cat(
+                (
+                    chunks[i],
+                    chunks[i].new_zeros(
+                        actual_counts[i] - chunks[i].shape[0], chunks[i].shape[1]
+                    ),
+                )
+            )
+
+    errors_by_request = {req_idx: error for req_idx, *error in errors}
+    for i in mismatched:
+        errors_by_request[i] = (expected_counts[i], actual_counts[i])
+    return torch.cat(chunks, dim=0), [
+        (req_idx, *error) for req_idx, error in errors_by_request.items()
+    ]
+
+
 def embed_mm_inputs(
     mm_inputs_list: List[MultimodalInputs],
     extend_prefix_lens: List[int],
@@ -396,6 +435,7 @@ def embed_mm_inputs(
     data_embedding_func_mapping: Dict[Modality, DataEmbeddingFunc] = None,
     placeholder_tokens: dict[Modality, List[int]] = None,
     use_deepstack: Dict[Modality, bool] = {},
+    input_id_slices: Optional[List[Tuple[int, int]]] = None,
 ) -> Optional[torch.Tensor]:
     """
     Embed multimodal inputs and integrate them with text token embeddings.
@@ -414,6 +454,12 @@ def embed_mm_inputs(
     other_info = {}
     if mm_inputs_list is None:
         return None
+    if input_id_slices is None:
+        input_id_slices = []
+        start = 0
+        for length in extend_seq_lens:
+            input_id_slices.append((start, start + length))
+            start += length
 
     # 1. Calculate the multimodal data which exists in input_ids, with the help of pad_values
     # we assume that multimodal data are represented with its pad_values in input_ids
@@ -469,6 +515,31 @@ def embed_mm_inputs(
                 extend_length=extend_seq_lens,
                 items_offset_list=items_offsets,
             )
+
+            if embedding is not None and mask is not None:
+                expected_counts = [
+                    sum(
+                        max(
+                            min(item_end + 1, prefix + length)
+                            - max(item_start, prefix),
+                            0,
+                        )
+                        for item_start, item_end in offsets
+                    )
+                    for prefix, length, offsets in zip(
+                        extend_prefix_lens,
+                        extend_seq_lens,
+                        items_offsets,
+                        strict=True,
+                    )
+                ]
+                embedding, embedding_errors = _fit_mm_embedding_to_request_masks(
+                    embedding,
+                    mask,
+                    expected_counts,
+                    input_id_slices,
+                    embedding_errors,
+                )
 
             if use_deepstack.get(modality, None) and embedding is not None:
                 embedding, deepstack_embedding = (
@@ -677,6 +748,23 @@ def general_mm_embed_routine(
                 for i, seq_len in enumerate(forward_batch.extend_seq_lens_cpu)
                 if forward_batch.mm_inputs[i] is not None
             ]
+            mm_batch_indices = [
+                i
+                for i, mm_input in enumerate(forward_batch.mm_inputs)
+                if mm_input is not None
+            ]
+            token_starts = []
+            start = 0
+            for seq_len in forward_batch.extend_seq_lens_cpu:
+                token_starts.append(start)
+                start += seq_len
+            input_id_slices = [
+                (
+                    token_starts[i],
+                    token_starts[i] + forward_batch.extend_seq_lens_cpu[i],
+                )
+                for i in mm_batch_indices
+            ]
             server_args = get_server_args()
             # Makes VLM profiles directly attributable: this range includes
             # encoder/ViT execution and multimodal feature placement, while
@@ -707,6 +795,7 @@ def general_mm_embed_routine(
                         data_embedding_func_mapping=data_embedding_funcs,
                         placeholder_tokens=placeholder_tokens,
                         use_deepstack=use_deepstack,
+                        input_id_slices=input_id_slices,
                     )
 
             # add for qwen3_vl deepstack
@@ -741,11 +830,6 @@ def general_mm_embed_routine(
                                             "cpu", non_blocking=True
                                         )
                                     )
-            mm_batch_indices = [
-                i
-                for i, mm_input in enumerate(forward_batch.mm_inputs)
-                if mm_input is not None
-            ]
             forward_batch.mm_embedding_errors = [
                 (mm_batch_indices[req_idx], expected, actual)
                 for req_idx, expected, actual in other_info.get(

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -459,7 +459,7 @@ def embed_mm_inputs(
                     flatten_nested_list([item.offsets for item in mm_items])
                 )
 
-            embedding, mask, input_ids = get_embedding_and_mask(
+            embedding, mask, input_ids, embedding_errors = get_embedding_and_mask(
                 data_embedding_func=embedder,
                 embedding_items=items,
                 placeholder_tensor=placeholder_tensor,
@@ -480,6 +480,7 @@ def embed_mm_inputs(
             modalities += [modality]
             embeddings += [embedding]
             masks += [mask]
+            other_info.setdefault("mm_embedding_errors", []).extend(embedding_errors)
 
     # 3. Get input embeddings
     vocab_size = input_embedding.num_embeddings
@@ -622,6 +623,11 @@ def _embed_mm_inputs_with_split(
                 ][offset : offset + req_len]
             offset += req_len
 
+        for req_idx, expected, actual in sub_info.get("mm_embedding_errors", []):
+            other_info.setdefault("mm_embedding_errors", []).append(
+                (group_req_indices[req_idx], expected, actual)
+            )
+
     return input_embeds, other_info
 
 
@@ -735,6 +741,17 @@ def general_mm_embed_routine(
                                             "cpu", non_blocking=True
                                         )
                                     )
+            mm_batch_indices = [
+                i
+                for i, mm_input in enumerate(forward_batch.mm_inputs)
+                if mm_input is not None
+            ]
+            forward_batch.mm_embedding_errors = [
+                (mm_batch_indices[req_idx], expected, actual)
+                for req_idx, expected, actual in other_info.get(
+                    "mm_embedding_errors", []
+                )
+            ]
             forward_batch.mm_inputs = None
             forward_batch.mm_input_embeds = input_embeds
         else:

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
@@ -144,6 +145,18 @@ class RelayPayload:
     # ngram delays the draft extend (ngram update)
     accept_tokens: Optional[torch.Tensor] = None
     accept_lens: Optional[torch.Tensor] = None
+
+    def select_rows(self, keep: torch.Tensor) -> RelayPayload:
+        return RelayPayload(
+            **{
+                field.name: (
+                    getattr(self, field.name)[keep.to(getattr(self, field.name).device)]
+                    if isinstance(getattr(self, field.name), torch.Tensor)
+                    else getattr(self, field.name)
+                )
+                for field in dataclasses.fields(self)
+            }
+        )
 
     @classmethod
     def from_ngram(cls, draft_input: NgramVerifyInput) -> RelayPayload:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1062,6 +1062,9 @@ class Req(ReqDllmMixin):
         # set to_finish instead of directly setting finished_reason.
         # Note: We should never set finished_reason in the middle, the req will get filtered and never respond
         self.to_finish: Optional[BaseFinishReason] = None
+        self.disagg_abort_cleanup_pending = False
+        self.mm_embedding_abort_pending = False
+        self.mm_embedding_validation_count = 0
         self.stream = stream
         self.eos_token_ids = eos_token_ids
         self.vocab_size = vocab_size
@@ -2407,6 +2410,34 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def batch_size(self):
         return len(self.reqs)
+
+    def mm_embedding_validation_indices(self) -> List[int]:
+        if (
+            not self.forward_mode.is_extend_without_speculative()
+            or self.multimodal_inputs is None
+            or self.prefix_lens is None
+            or self.extend_lens is None
+        ):
+            return []
+        indices = []
+        for i, (mm_input, start, length) in enumerate(
+            zip(
+                self.multimodal_inputs,
+                self.prefix_lens,
+                self.extend_lens,
+                strict=True,
+            )
+        ):
+            if mm_input is None:
+                continue
+            end = start + length
+            if any(
+                item_start < end and item_end >= start
+                for item in mm_input.mm_items
+                for item_start, item_end in item.offsets
+            ):
+                indices.append(i)
+        return indices
 
     def is_empty(self):
         return len(self.reqs) == 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2434,7 +2434,7 @@ class Scheduler(
             ),
             output_streamer=self.output_streamer,
             beam_coordinator=self.beam_coordinator,
-            abort_request=self.abort_request,
+            abort_request=self.defer_mm_embedding_abort,
         )
 
     def init_req_max_new_tokens(self, req):
@@ -3343,10 +3343,17 @@ class Scheduler(
         req = self._pending_chunked_abort_req
         if req is None:
             return
-        if self.chunked_req is not req:
+        mm_abort_ready = (
+            req.mm_embedding_abort_pending and req.mm_embedding_validation_count == 0
+        )
+        if self.chunked_req is not req and not mm_abort_ready:
             # Already past chunked prefill; the running-batch abort path handles
             # it. Drop the marker once the request is actually gone.
-            if req.finished() or not req.kv.holds_kv:
+            if (
+                req.finished()
+                or not req.kv.holds_kv
+                or req.disagg_abort_cleanup_pending
+            ):
                 self._pending_chunked_abort_req = None
                 return
             # The request moved to another scheduler queue after abort_request
@@ -3355,8 +3362,18 @@ class Scheduler(
             self.abort_request(AbortReq(rid=req.rid))
             return
 
-        prepare_abort(req, "Aborted")
-        req.time_stats.trace_ctx.abort(abort_info={"reason": "Aborted"})
+        if req.inflight_middle_chunks > 0 or req.mm_embedding_validation_count > 0:
+            self.chunked_req = None
+            return
+
+        if req.finished():
+            self.chunked_req = None
+            self._pending_chunked_abort_req = None
+            return
+
+        abort_reason = req.to_finish or FINISH_ABORT()
+        prepare_abort(req, abort_reason.message, status_code=abort_reason.status_code)
+        req.time_stats.trace_ctx.abort(abort_info={"reason": abort_reason.message})
         req.to_finish = None
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.clear_pending_chunk_send(req)
@@ -3372,6 +3389,27 @@ class Scheduler(
         self._pending_chunked_abort_req = None
         self.ipc_channels.send_to_tokenizer.send_output(_make_abort_req(req), req)
         logger.debug(f"Abort chunked prefill request. {req.rid=}")
+
+    def defer_mm_embedding_abort(
+        self, req: Req, expected_tokens: int, actual_tokens: int
+    ) -> None:
+        req.skip_radix_cache_insert = True
+        if req.mm_embedding_abort_pending:
+            return
+        req.mm_embedding_abort_pending = True
+        if not req.finished() and req.to_finish is None:
+            req.to_finish = FINISH_ABORT(
+                message=(
+                    "Invalid multimodal embedding output: "
+                    f"expected {expected_tokens} tokens, got {actual_tokens}. "
+                    "This is an internal error."
+                ),
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+        req.hidden_states_tensor = None
+        req.output_dsa_topk_indices = None
+        if self.chunked_req is req or req.inflight_middle_chunks > 0:
+            self._pending_chunked_abort_req = req
 
     def _build_hisparse_decode_batch(self, reqs):
         """Build a ScheduleBatch for hisparse requests transitioning from staging to decode."""
@@ -3636,6 +3674,12 @@ class Scheduler(
         if self.enable_priority_preemption or self.is_hybrid_swa:
             # Reset batch_is_full to try preemption with a prefill adder.
             running_batch.batch_is_full = False
+
+        if (
+            self.chunked_req is not None
+            and self.chunked_req.mm_embedding_validation_count > 0
+        ):
+            return None, running_batch
 
         if (
             running_batch.batch_is_full or len(self.waiting_queue) == 0
@@ -4140,6 +4184,10 @@ class Scheduler(
         if batch.forward_mode.is_prebuilt():
             return self._run_batch_prebuilt(batch)
 
+        if batch.forward_mode.is_extend():
+            for req_idx in batch.mm_embedding_validation_indices():
+                batch.reqs[req_idx].mm_embedding_validation_count += 1
+
         # PD prefill: early-send cached prefix KV, overlapping the suffix forward.
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             for req in batch.reqs:
@@ -4187,7 +4235,23 @@ class Scheduler(
                             batch, **fwd_kwargs
                         )
                         if batch.spec_algorithm.is_none():
-                            self.future_map.publish(future_indices, batch.seq_lens + 1)
+                            publish_indices = future_indices
+                            publish_seq_lens = batch.seq_lens + 1
+                            if batch_result.mm_embedding_errors is not None:
+                                keep = self._mm_embedding_success_mask(
+                                    batch_result, len(batch.reqs), future_indices.device
+                                )
+                                publish_indices = publish_indices[keep]
+                                publish_seq_lens = publish_seq_lens[keep]
+                            self.future_map.publish(publish_indices, publish_seq_lens)
+                        elif batch_result.mm_embedding_errors is not None:
+                            keep = self._mm_embedding_success_mask(
+                                batch_result, len(batch.reqs), future_indices.device
+                            )
+                            self.future_map.publish(
+                                future_indices[keep],
+                                batch_result.new_seq_lens[keep],
+                            )
                         # Park any refs the worker wants kept alive 2 iters
                         # (cross-stream tensor lifetime; pinned in the same
                         # ring slot as the SB attr snapshot).
@@ -4320,24 +4384,26 @@ class Scheduler(
                 with self.forward_stream_ctx:
                     self.forward_stream.wait_stream(self.schedule_stream)
                     resolve_forward_inputs(batch, self.future_map)
-                    pooler_output, can_run_cuda_graph = (
+                    pooler_output, can_run_cuda_graph, mm_embedding_errors = (
                         self.tp_worker.forward_batch_embedding(batch)
                     )
                     ret = EmbeddingBatchResult(
                         embeddings=pooler_output.embeddings,
                         pooled_hidden_states=pooler_output.pooled_hidden_states,
                         can_run_cuda_graph=can_run_cuda_graph,
+                        mm_embedding_errors=mm_embedding_errors,
                     )
                     ret.copy_to_cpu()
             else:
                 resolve_forward_inputs(batch, self.future_map)
-                pooler_output, can_run_cuda_graph = (
+                pooler_output, can_run_cuda_graph, mm_embedding_errors = (
                     self.tp_worker.forward_batch_embedding(batch)
                 )
                 ret = EmbeddingBatchResult(
                     embeddings=pooler_output.embeddings,
                     pooled_hidden_states=pooler_output.pooled_hidden_states,
                     can_run_cuda_graph=can_run_cuda_graph,
+                    mm_embedding_errors=mm_embedding_errors,
                 )
 
         self._maybe_report_active_ranks()
@@ -4375,9 +4441,17 @@ class Scheduler(
         batch_result: GenerationBatchResult,
     ) -> None:
         """Stash this iter's relay payload for next iter's resolve_forward_inputs."""
+        keep = None
+        if batch_result.mm_embedding_errors is not None:
+            keep = Scheduler._mm_embedding_success_mask(
+                batch_result, len(batch.reqs), future_indices.device
+            )
+            future_indices = future_indices[keep]
         if self.spec_algorithm.is_ngram():
             if batch_result.next_draft_input is not None:
                 payload = RelayPayload.from_ngram(batch_result.next_draft_input)
+                if keep is not None:
+                    payload = payload.select_rows(keep)
                 self.future_map.stash(future_indices, payload)
             return
         if batch_result.next_draft_input is not None:
@@ -4386,14 +4460,28 @@ class Scheduler(
             payload = RelayPayload(bonus_tokens=batch_result.next_token_ids)
         else:
             return
+        if keep is not None:
+            payload = payload.select_rows(keep)
         if batch.beam_tail is not None:
             # The worker sliced the tail off before sampling, so sampled tokens
             # cover only the reqs-aligned rows; the coordinator relays the rest.
             future_indices = future_indices[: batch.beam_tail.num_base_rows]
         self.future_map.stash(future_indices, payload)
+        beam_skip_rows = None
+        if keep is not None and any(req.beam_group is not None for req in batch.reqs):
+            beam_skip_rows = set(torch.nonzero(~keep).flatten().cpu().tolist())
         self.beam_coordinator.maybe_select_and_relay(
-            batch, batch_result, chunked_req=self.chunked_req
+            batch,
+            batch_result,
+            chunked_req=self.chunked_req,
+            skip_rows=beam_skip_rows,
         )
+
+    @staticmethod
+    def _mm_embedding_success_mask(
+        result: GenerationBatchResult, batch_size: int, device: torch.device
+    ) -> torch.Tensor:
+        return result.mm_embedding_errors[:batch_size, 1].to(device=device) == 0
 
     def _copy_auxiliary_output_to_cpu(
         self,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -274,6 +274,7 @@ from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
 from sglang.srt.managers.utils import (
     EmbeddingBatchResult,
     GenerationBatchResult,
+    has_mm_embedding_failures,
     is_health_check_generate_req,
     validate_input_length,
 )
@@ -4244,13 +4245,9 @@ class Scheduler(
                                 publish_indices = publish_indices[keep]
                                 publish_seq_lens = publish_seq_lens[keep]
                             self.future_map.publish(publish_indices, publish_seq_lens)
-                        elif batch_result.mm_embedding_errors is not None:
-                            keep = self._mm_embedding_success_mask(
-                                batch_result, len(batch.reqs), future_indices.device
-                            )
-                            self.future_map.publish(
-                                future_indices[keep],
-                                batch_result.new_seq_lens[keep],
+                        else:
+                            self._publish_speculative_overlap_result(
+                                batch, future_indices, batch_result
                             )
                         # Park any refs the worker wants kept alive 2 iters
                         # (cross-stream tensor lifetime; pinned in the same
@@ -4433,6 +4430,22 @@ class Scheduler(
         if pending is not None:
             self.ipc_channels.send_to_tokenizer.send_output(pending)
             model_runner._pending_elastic_scale_update = None
+
+    def _publish_speculative_overlap_result(
+        self,
+        batch: ScheduleBatch,
+        future_indices: torch.Tensor,
+        batch_result: GenerationBatchResult,
+    ) -> None:
+        if not has_mm_embedding_failures(batch_result.mm_embedding_errors):
+            return
+        keep = self._mm_embedding_success_mask(
+            batch_result, len(batch.reqs), future_indices.device
+        )
+        self.future_map.publish(
+            future_indices[keep],
+            batch_result.new_seq_lens[keep],
+        )
 
     def _relay_forward_payload(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -23,6 +23,10 @@ from sglang.srt.managers.schedule_batch import (
     ScheduleBatch,
     mamba_lazy_spec_in_window,
 )
+from sglang.srt.managers.utils import (
+    complete_mm_embedding_validations,
+    decode_mm_embedding_errors,
+)
 from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
@@ -261,6 +265,12 @@ class SchedulerBatchResultProcessor:
         if self.is_generation:
             if result.copy_done is not None:
                 result.copy_done.synchronize()
+            mm_embedding_error_tensor = result.mm_embedding_errors
+            if mm_embedding_error_tensor is not None:
+                complete_mm_embedding_validations(batch.reqs, mm_embedding_error_tensor)
+            decoded_mm_embedding_errors = decode_mm_embedding_errors(
+                mm_embedding_error_tensor
+            )
             auxiliary_output_starts = self.snapshot_auxiliary_output_starts(
                 batch, result
             )
@@ -297,8 +307,16 @@ class SchedulerBatchResultProcessor:
 
             # Check finish conditions
             logprob_pt = 0
+            mm_embedding_errors = {
+                req_idx: (expected, actual)
+                for req_idx, expected, actual in decoded_mm_embedding_errors
+            }
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
+                mm_embedding_error = mm_embedding_errors.get(i)
+                deferred_mm_abort = (
+                    mm_embedding_error is not None or req.mm_embedding_abort_pending
+                )
                 if (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
@@ -311,11 +329,38 @@ class SchedulerBatchResultProcessor:
                         capture_hidden_mode=prefill_hidden_capture_mode,
                         extend_input_len=extend_input_len_per_req[i],
                         store=(
-                            not req.finished()
+                            not deferred_mm_abort
+                            and not req.finished()
                             and not req.is_retracted
                             and req.inflight_middle_chunks <= 0
                         ),
                     )
+
+                if deferred_mm_abort:
+                    if mm_embedding_error is not None:
+                        self.abort_request(req, *mm_embedding_error)
+                    if batch.return_logprob:
+                        assert extend_input_len_per_req is not None
+                        assert extend_logprob_start_len_per_req is not None
+                        extend_input_len = extend_input_len_per_req[i]
+                        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
+                        if extend_logprob_start_len < extend_input_len:
+                            logprob_pt += self.logprob_result_processor.calculate_num_input_logprobs(
+                                req,
+                                extend_input_len,
+                                extend_logprob_start_len,
+                            )
+                    if req.inflight_middle_chunks > 0:
+                        req.inflight_middle_chunks -= 1
+                        req.time_stats.set_last_chunked_prefill_finish_time()
+                        if req.inflight_middle_chunks > 0:
+                            skip_stream_req = req
+                    if (
+                        req.inflight_middle_chunks <= 0
+                        and req.mm_embedding_validation_count == 0
+                    ):
+                        self._finish_deferred_mm_embedding_abort(req)
+                    continue
 
                 if (
                     req.finished() and req.inflight_middle_chunks <= 0
@@ -414,6 +459,12 @@ class SchedulerBatchResultProcessor:
         else:  # embedding or reward model
             if result.copy_done is not None:
                 result.copy_done.synchronize()
+            mm_embedding_error_tensor = result.mm_embedding_errors
+            if mm_embedding_error_tensor is not None:
+                complete_mm_embedding_validations(batch.reqs, mm_embedding_error_tensor)
+            decoded_mm_embedding_errors = decode_mm_embedding_errors(
+                mm_embedding_error_tensor
+            )
 
             embeddings = self._convert_embeddings(result=result)
             phs = result.pooled_hidden_states
@@ -425,8 +476,24 @@ class SchedulerBatchResultProcessor:
                     phs = phs.cpu().detach()
 
             # Check finish conditions
+            mm_embedding_errors = {
+                req_idx: (expected, actual)
+                for req_idx, expected, actual in decoded_mm_embedding_errors
+            }
             for i, req in enumerate(batch.reqs):
                 if req.is_retracted:
+                    continue
+                mm_embedding_error = mm_embedding_errors.get(i)
+                if mm_embedding_error is not None:
+                    self.abort_request(req, *mm_embedding_error)
+                if mm_embedding_error is not None or req.mm_embedding_abort_pending:
+                    if req.inflight_middle_chunks > 0:
+                        req.inflight_middle_chunks -= 1
+                    if (
+                        req.inflight_middle_chunks <= 0
+                        and req.mm_embedding_validation_count == 0
+                    ):
+                        self._finish_deferred_mm_embedding_abort(req)
                     continue
 
                 req.embedding = embeddings[i]
@@ -463,6 +530,26 @@ class SchedulerBatchResultProcessor:
                 can_run_cuda_graph=can_run_cuda_graph,
                 dp_cooperation_info=batch.dp_cooperation_info,
             )
+
+    def _finish_deferred_mm_embedding_abort(self, req: Req) -> None:
+        if not req.mm_embedding_abort_pending:
+            return
+        self.beam_coordinator.abort_group_preserving_finish_reason(req)
+        if not req.finished():
+            req.update_finish_state()
+        if get_memory().hicache_storage_backend is not None:
+            self.tree_cache.release_aborted_request(req.rid)
+        if isinstance(self.draft_worker, BaseSpecWorker):
+            self.draft_worker.note_request_finished(
+                rid=req.rid,
+                natural_stop=False,
+            )
+        if req.multimodal_inputs is not None and req.session is None:
+            req.multimodal_inputs.release_features()
+        if req.kv.holds_kv or req.kv.holds_mamba:
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+        req.mm_embedding_abort_pending = False
+        req.time_stats.set_completion_time()
 
     def _convert_embeddings(self, *, result: EmbeddingBatchResult) -> list:
         is_sparse = envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set()

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -17,6 +17,7 @@ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sglang.srt.managers.utils import (
+    MM_EMBEDDING_ERRORS_KEY,
     GenerationBatchResult,
     get_logprob_dict_from_result,
     get_logprob_from_pp_outputs,
@@ -42,6 +43,9 @@ if TYPE_CHECKING:
 
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
     """Check if output send/recv can be skipped for this batch."""
+    overlaps_mm_placeholder = bool(
+        batch is not None and batch.mm_embedding_validation_indices()
+    )
     return (
         envs.SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM.get()
         and batch is not None
@@ -49,7 +53,19 @@ def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
         and len(batch.reqs) == 1
         and not batch.contains_last_prefill_chunk
         and not batch.return_logprob
+        and not overlaps_mm_placeholder
     )
+
+
+def _pp_filter_failed_rows(
+    indices: torch.Tensor,
+    values: torch.Tensor,
+    mm_embedding_errors: Optional[torch.Tensor],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mm_embedding_errors is None:
+        return indices, values
+    keep = mm_embedding_errors[: indices.shape[0], 1].to(indices.device) == 0
+    return indices[keep], values[keep.to(values.device)]
 
 
 @dataclass
@@ -246,6 +262,7 @@ class SchedulerPPMixin:
                 self._pp_commit_comm_work(send_transfer_work)
                 tmbs[mb_id] = transferred_rids
 
+                self.process_pending_chunked_abort()
                 self.process_prefill_chunk(
                     last_batch=self.last_batch, running_batch=self.running_batch
                 )
@@ -777,6 +794,8 @@ class SchedulerPPMixin:
         tensor_dict = {
             "next_token_ids": result.next_token_ids,
         }
+        if result.mm_embedding_errors is not None:
+            tensor_dict[MM_EMBEDDING_ERRORS_KEY] = result.mm_embedding_errors
 
         # Draft extend runs only on the last stage, but every rank needs its relayed
         # output to fill PD auxiliary buffers.
@@ -933,7 +952,6 @@ class SchedulerPPMixin:
                     logits_output = LogitsProcessorOutput(next_token_logits=None)
                 logits_output.auxiliary_device_output = auxiliary_output
         next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
-
         # Rebind the last stage's ring proposal as batch.spec_info so the PD result
         # processor sees the same object on every rank.
         next_draft_input = None
@@ -950,22 +968,33 @@ class SchedulerPPMixin:
             )
             batch.spec_info = next_draft_input
 
+        mm_embedding_errors = pp_outputs.tensors.get(MM_EMBEDDING_ERRORS_KEY)
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion
         # of mixed-chunk batches (which gather via mix_running_indices).
-        self.future_map.stash(
-            batch.req_pool_indices,
-            RelayPayload(
-                bonus_tokens=next_token_ids,
-                topk_p=None if next_draft_input is None else next_draft_input.topk_p,
-                topk_index=(
-                    None if next_draft_input is None else next_draft_input.topk_index
-                ),
-                hidden_states=(
-                    None if next_draft_input is None else next_draft_input.hidden_states
-                ),
+        stash_indices, stash_token_ids = _pp_filter_failed_rows(
+            batch.req_pool_indices, next_token_ids, mm_embedding_errors
+        )
+        relay_payload = RelayPayload(
+            bonus_tokens=next_token_ids,
+            topk_p=None if next_draft_input is None else next_draft_input.topk_p,
+            topk_index=(
+                None if next_draft_input is None else next_draft_input.topk_index
+            ),
+            hidden_states=(
+                None if next_draft_input is None else next_draft_input.hidden_states
             ),
         )
+        if mm_embedding_errors is not None:
+            keep = (
+                mm_embedding_errors[: next_token_ids.shape[0], 1].to(
+                    next_token_ids.device
+                )
+                == 0
+            )
+            relay_payload = relay_payload.select_rows(keep)
+        relay_payload.bonus_tokens = stash_token_ids
+        self.future_map.stash(stash_indices, relay_payload)
         batch.input_ids = None
         output_result = GenerationBatchResult(
             logits_output=logits_output,
@@ -975,7 +1004,9 @@ class SchedulerPPMixin:
             extend_input_len_per_req=extend_input_len_per_req,
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
+            mm_embedding_errors=mm_embedding_errors,
         )
+        output_result.copy_mm_embedding_errors_to_cpu()
         output_result.copy_auxiliary_output_to_cpu()
         return output_result
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -41,6 +41,11 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
+from sglang.srt.managers.utils import (
+    MM_EMBEDDING_ERRORS_KEY,
+    merge_mm_embedding_error_tensors,
+    synchronize_mm_embedding_errors,
+)
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import (
@@ -77,6 +82,20 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _mm_embedding_validation_indices(
+    batch: Optional[ScheduleBatch], forward_batch: ForwardBatch
+) -> List[int]:
+    if batch is not None:
+        return batch.mm_embedding_validation_indices()
+    if not forward_batch.forward_mode.is_extend_without_speculative():
+        return []
+    return [
+        i
+        for i, mm_input in enumerate(forward_batch.mm_inputs or [])
+        if mm_input is not None
+    ]
 
 
 class BaseTpWorker(ABC):
@@ -305,8 +324,20 @@ class BaseTpWorker(ABC):
             self.model_runner,
             return_hidden_states_before_norm=False,
         )
+        validated_indices = batch.mm_embedding_validation_indices()
         output = self.model_runner.forward(forward_batch)
-        return output.logits_output, output.can_run_graph
+        if forward_batch.mm_embedding_errors is not None:
+            output.mm_embedding_errors = synchronize_mm_embedding_errors(
+                output.mm_embedding_errors,
+                len(batch.reqs),
+                torch.device(self.device),
+                validated_indices,
+            )
+        return (
+            output.logits_output,
+            output.can_run_graph,
+            output.mm_embedding_errors,
+        )
 
 
 class TpModelWorker(BaseTpWorker):
@@ -624,10 +655,30 @@ class TpModelWorker(BaseTpWorker):
         if self.is_dllm():
             return self._forward_batch_generation_dllm(forward_batch, batch)
 
+        batch_size = len(batch.reqs) if batch is not None else forward_batch.batch_size
+        validated_indices = _mm_embedding_validation_indices(batch, forward_batch)
+        has_mm_inputs = bool(validated_indices)
+
         if self.pp_group.is_last_rank:
+            pp_embedding_errors = (
+                pp_proxy_tensors.tensors.get(MM_EMBEDDING_ERRORS_KEY)
+                if pp_proxy_tensors is not None
+                else None
+            )
             out = self.model_runner.forward(
                 forward_batch,
                 pp_proxy_tensors=pp_proxy_tensors,
+            )
+            local_mm_embedding_errors = None
+            if has_mm_inputs:
+                local_mm_embedding_errors = synchronize_mm_embedding_errors(
+                    out.mm_embedding_errors,
+                    batch_size,
+                    torch.device(self.device),
+                    validated_indices,
+                )
+            mm_embedding_errors = merge_mm_embedding_error_tensors(
+                pp_embedding_errors, local_mm_embedding_errors
             )
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
             batch_result = GenerationBatchResult(
@@ -636,6 +687,7 @@ class TpModelWorker(BaseTpWorker):
                 expert_distribution_metrics=out.expert_distribution_metrics,
                 routed_experts_output=out.routed_experts_output,
                 indexer_topk_output=out.indexer_topk_output,
+                mm_embedding_errors=mm_embedding_errors,
             )
 
             capture_pre_sample_logits(batch, forward_batch, logits_output)
@@ -691,18 +743,38 @@ class TpModelWorker(BaseTpWorker):
 
             return batch_result
         else:
+            pp_embedding_errors = (
+                pp_proxy_tensors.tensors.get(MM_EMBEDDING_ERRORS_KEY)
+                if pp_proxy_tensors is not None
+                else None
+            )
             out = self.model_runner.forward(
                 forward_batch,
                 pp_proxy_tensors=pp_proxy_tensors,
             )
             pp_proxy_tensors, can_run_cuda_graph = out.logits_output, out.can_run_graph
+            local_mm_embedding_errors = None
+            if has_mm_inputs:
+                local_mm_embedding_errors = synchronize_mm_embedding_errors(
+                    out.mm_embedding_errors,
+                    batch_size,
+                    torch.device(self.device),
+                    validated_indices,
+                )
+            mm_embedding_errors = merge_mm_embedding_error_tensors(
+                pp_embedding_errors, local_mm_embedding_errors
+            )
+            if mm_embedding_errors is not None:
+                pp_proxy_tensors.tensors[MM_EMBEDDING_ERRORS_KEY] = mm_embedding_errors
             return GenerationBatchResult(
                 pp_hidden_states_proxy_tensors=pp_proxy_tensors,
                 can_run_cuda_graph=can_run_cuda_graph,
                 expert_distribution_metrics=out.expert_distribution_metrics,
+                mm_embedding_errors=mm_embedding_errors,
             )
 
     def forward_batch_split_prefill(self, batch: ScheduleBatch):
+        validated_indices = batch.mm_embedding_validation_indices()
         if batch.split_index == 0:
             forward_batch = ForwardBatch.init_new(
                 batch,
@@ -714,6 +786,14 @@ class TpModelWorker(BaseTpWorker):
         out = self.model_runner.forward(
             batch.split_forward_batch, split_forward_count=batch.split_forward_count
         )
+        mm_embedding_errors = out.mm_embedding_errors
+        if batch.split_forward_batch.mm_embedding_errors is not None:
+            mm_embedding_errors = synchronize_mm_embedding_errors(
+                mm_embedding_errors,
+                len(batch.reqs),
+                torch.device(self.device),
+                validated_indices,
+            )
         logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
         if logits_output:
             next_token_ids = self.model_runner.sample(
@@ -725,6 +805,7 @@ class TpModelWorker(BaseTpWorker):
             logits_output=logits_output,
             can_run_cuda_graph=can_run_cuda_graph,
             expert_distribution_metrics=out.expert_distribution_metrics,
+            mm_embedding_errors=mm_embedding_errors,
         )
         batch_result.next_token_ids = next_token_ids
         return batch_result

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -15,7 +15,11 @@ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers import io_struct
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
-from sglang.srt.runtime_context import get_spec, max_speculative_num_draft_tokens
+from sglang.srt.runtime_context import (
+    get_parallel,
+    get_spec,
+    max_speculative_num_draft_tokens,
+)
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 
@@ -56,6 +60,7 @@ class GenerationBatchResult:
     accept_length_per_req_cpu: Optional[List[int]] = None
     dllm_algo_state: Optional[List[Any]] = None
     can_run_cuda_graph: bool = False
+    mm_embedding_errors: Optional[torch.Tensor] = None
 
     # PP skip output comm: True when output send/recv was skipped and
     # next_token_ids are placeholder zeros. Used by process_batch_result_prefill
@@ -161,6 +166,7 @@ class GenerationBatchResult:
                 self.logits_output.hidden_states
             )
         self.next_token_ids = _async_d2h(self.next_token_ids)
+        self.copy_mm_embedding_errors_to_cpu()
 
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)
@@ -186,6 +192,10 @@ class GenerationBatchResult:
 
         self.copy_done.record()
 
+    def copy_mm_embedding_errors_to_cpu(self) -> None:
+        if self.mm_embedding_errors is not None and not self.mm_embedding_errors.is_cpu:
+            self.mm_embedding_errors = _async_d2h(self.mm_embedding_errors)
+
     def copy_auxiliary_output_to_cpu(self) -> None:
         if self.logits_output is None or self.auxiliary_host_output is not None:
             return
@@ -209,7 +219,106 @@ class GenerationBatchResult:
                 "extend_logprob_start_len_per_req", None
             ),
             can_run_cuda_graph=can_run_cuda_graph,
+            mm_embedding_errors=next_pp_outputs.tensors.get(MM_EMBEDDING_ERRORS_KEY),
         )
+
+
+MM_EMBEDDING_ERRORS_KEY = "mm_embedding_errors"
+
+
+def decode_mm_embedding_errors(
+    errors: Optional[torch.Tensor],
+) -> List[tuple[int, int, int]]:
+    if errors is None:
+        return []
+    rows = errors.tolist() if errors.is_cpu else errors.cpu().tolist()
+    return [
+        (req_idx, expected, actual)
+        for req_idx, (_validated, failed, expected, actual) in enumerate(rows)
+        if failed
+    ]
+
+
+def complete_mm_embedding_validations(reqs: List[Req], result: torch.Tensor) -> None:
+    rows = result.tolist() if result.is_cpu else result.cpu().tolist()
+    for req, (validated, _failed, _expected, _actual) in zip(reqs, rows, strict=True):
+        if validated:
+            assert req.mm_embedding_validation_count > 0
+            req.mm_embedding_validation_count -= 1
+
+
+def synchronize_mm_embedding_errors(
+    errors: Optional[List[tuple[int, int, int]]],
+    batch_size: int,
+    device: torch.device,
+    validated_indices: List[int],
+) -> torch.Tensor:
+    validated = torch.zeros(batch_size, dtype=torch.int64, device=device)
+    validated[validated_indices] = 1
+    local_failure = torch.zeros(batch_size, dtype=torch.int64, device=device)
+    local_details = torch.zeros((batch_size, 2), dtype=torch.int64, device=device)
+    for req_idx, expected, actual in errors or []:
+        local_failure[req_idx] = 1
+        local_details[req_idx] = torch.tensor((expected, actual), device=device)
+
+    parallel = get_parallel()
+    groups = []
+    for group in (parallel.attn_tp_group, parallel.attn_cp_group):
+        if group.world_size > 1 and all(
+            group.device_group is not existing.device_group for existing in groups
+        ):
+            groups.append(group)
+
+    failure = local_failure.clone()
+    for group in groups:
+        torch.distributed.all_reduce(
+            failure, op=torch.distributed.ReduceOp.MAX, group=group.device_group
+        )
+
+    if not groups:
+        return torch.cat(
+            (validated.unsqueeze(1), failure.unsqueeze(1), local_details), dim=1
+        )
+
+    rank = torch.distributed.get_rank()
+    owner = torch.where(
+        local_failure.bool(),
+        torch.full_like(local_failure, rank),
+        torch.full_like(local_failure, torch.iinfo(torch.int64).max),
+    )
+    for group in groups:
+        torch.distributed.all_reduce(
+            owner, op=torch.distributed.ReduceOp.MIN, group=group.device_group
+        )
+
+    details = torch.where(
+        (owner == rank).unsqueeze(1), local_details, torch.zeros_like(local_details)
+    )
+    for group in groups:
+        torch.distributed.all_reduce(
+            details, op=torch.distributed.ReduceOp.SUM, group=group.device_group
+        )
+    return torch.cat((validated.unsqueeze(1), failure.unsqueeze(1), details), dim=1)
+
+
+def merge_mm_embedding_error_tensors(
+    incoming: Optional[torch.Tensor], local: Optional[torch.Tensor]
+) -> Optional[torch.Tensor]:
+    if incoming is None:
+        return local
+    if local is None:
+        return incoming
+    incoming = incoming.to(local.device)
+    use_incoming = incoming[:, 1].bool().unsqueeze(1)
+    details = torch.where(use_incoming, incoming[:, 2:], local[:, 2:])
+    return torch.cat(
+        (
+            torch.maximum(incoming[:, :1], local[:, :1]),
+            torch.maximum(incoming[:, 1:2], local[:, 1:2]),
+            details,
+        ),
+        dim=1,
+    )
 
 
 def validate_input_length(
@@ -316,6 +425,7 @@ class EmbeddingBatchResult:
     pooled_hidden_states: Optional[torch.Tensor] = None
     copy_done: Optional[torch.cuda.Event] = None
     can_run_cuda_graph: bool = False
+    mm_embedding_errors: Optional[torch.Tensor] = None
 
     @torch.profiler.record_function("copy_embedding_to_cpu")
     def copy_to_cpu(self):
@@ -338,6 +448,9 @@ class EmbeddingBatchResult:
                 ]
             else:
                 self.pooled_hidden_states = _async_d2h(self.pooled_hidden_states)
+
+        if self.mm_embedding_errors is not None:
+            self.mm_embedding_errors = _async_d2h(self.mm_embedding_errors)
 
         self.copy_done.record()
 

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -239,6 +239,10 @@ def decode_mm_embedding_errors(
     ]
 
 
+def has_mm_embedding_failures(errors: Optional[torch.Tensor]) -> bool:
+    return errors is not None and bool(errors[:, 1].any().item())
+
+
 def complete_mm_embedding_validations(reqs: List[Req], result: torch.Tensor) -> None:
     rows = result.tolist() if result.is_cpu else result.cpu().tolist()
     for req, (validated, _failed, _expected, _actual) in zip(reqs, rows, strict=True):

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -159,7 +159,7 @@ def free_kv_row_segments(
 
 
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
-    if getattr(req, "skip_radix_cache_insert", False):
+    if req.skip_radix_cache_insert or req.mm_embedding_validation_count > 0:
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)
@@ -269,7 +269,11 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     effective_kv_committed_len = req.effective_kv_committed_len()
     tree_cache.cache_finished_req(
         req,
-        is_insert=is_insert and not getattr(req, "skip_radix_cache_insert", False),
+        is_insert=(
+            is_insert
+            and not req.skip_radix_cache_insert
+            and req.mm_embedding_validation_count == 0
+        ),
         kv_len_to_handle=effective_kv_committed_len,
     )
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -552,6 +552,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
     # For multimodal
     mm_input_embeds: Optional[torch.Tensor] = None
+    mm_embedding_errors: Optional[List[Tuple[int, int, int]]] = None
 
     # Encoder-decoder cross-attention mask
     cross_attention_custom_mask: Optional[torch.Tensor] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -20,7 +20,7 @@ import inspect
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -280,6 +280,7 @@ class ModelRunnerOutput:
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
     routed_experts_output: Optional[TopkCaptureOutput] = None
     indexer_topk_output: Optional[TopkCaptureOutput] = None
+    mm_embedding_errors: Optional[List[Tuple[int, int, int]]] = None
 
 
 def resolve_draft_attention_backend(
@@ -1691,6 +1692,7 @@ class ModelRunner:
         if get_exec().moe.elastic_ep_backend is not None:
             self.maybe_join_ep_ranks()
 
+        output.mm_embedding_errors = forward_batch.mm_embedding_errors
         return output
 
     def _maybe_execute_deferred_mamba_cow_and_clear(

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -26,6 +26,7 @@ from sglang.srt.lora.layers import unwrap_lora_layer
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
@@ -1893,7 +1894,9 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._tp_sync.sync(SpecTpSyncSite.DFLASH_TARGET, next_token_ids)
             new_seq_lens = batch.seq_lens
             batch_output.new_seq_lens = new_seq_lens
-            if on_publish is not None and batch_output.mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                batch_output.mm_embedding_errors
+            ):
                 on_publish(batch_output.new_seq_lens)
 
             if logits_output.hidden_states is None:

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1893,7 +1893,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._tp_sync.sync(SpecTpSyncSite.DFLASH_TARGET, next_token_ids)
             new_seq_lens = batch.seq_lens
             batch_output.new_seq_lens = new_seq_lens
-            if on_publish is not None:
+            if on_publish is not None and batch_output.mm_embedding_errors is None:
                 on_publish(batch_output.new_seq_lens)
 
             if logits_output.hidden_states is None:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -16,6 +16,7 @@ from sglang.srt.lora.layers import unwrap_lora_layer
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
@@ -546,7 +547,9 @@ class DSparkWorkerV2(BaseSpecWorker):
         self._tp_sync.sync(SpecTpSyncSite.DSPARK_TARGET, next_token_ids)
         new_seq_lens = batch.seq_lens
         batch_output.new_seq_lens = new_seq_lens
-        if on_publish is not None and batch_output.mm_embedding_errors is None:
+        if on_publish is not None and not has_mm_embedding_failures(
+            batch_output.mm_embedding_errors
+        ):
             on_publish(batch_output.new_seq_lens)
 
         if logits_output.hidden_states is None:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -546,7 +546,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         self._tp_sync.sync(SpecTpSyncSite.DSPARK_TARGET, next_token_ids)
         new_seq_lens = batch.seq_lens
         batch_output.new_seq_lens = new_seq_lens
-        if on_publish is not None:
+        if on_publish is not None and batch_output.mm_embedding_errors is None:
             on_publish(batch_output.new_seq_lens)
 
         if logits_output.hidden_states is None:

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -664,4 +664,5 @@ def run_eagle_verify(
         routed_experts_output=forward_batch_output.routed_experts_output,
         indexer_topk_output=forward_batch_output.indexer_topk_output,
         extra_keep_alive_refs=[verify_forward_batch],
+        mm_embedding_errors=forward_batch_output.mm_embedding_errors,
     )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1191,7 +1191,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # Extend processed L prompt tokens; next verify iter expects same L.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
-            if on_publish is not None:
+            if on_publish is not None and batch_output.mm_embedding_errors is None:
                 on_publish(batch_output.new_seq_lens)
 
             # A rank that does not host the draft (prefill-side PP builds it only on

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -35,6 +35,7 @@ from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
@@ -1191,7 +1192,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # Extend processed L prompt tokens; next verify iter expects same L.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
-            if on_publish is not None and batch_output.mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                batch_output.mm_embedding_errors
+            ):
                 on_publish(batch_output.new_seq_lens)
 
             # A rank that does not host the draft (prefill-side PP builds it only on

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -759,7 +759,7 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft-extend so the fence is at target-end.
-            if on_publish is not None:
+            if on_publish is not None and batch_output.mm_embedding_errors is None:
                 on_publish(batch_output.new_seq_lens)
 
             # Draft prefill seed (no forward).

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -36,6 +36,7 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
@@ -759,7 +760,9 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft-extend so the fence is at target-end.
-            if on_publish is not None and batch_output.mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                batch_output.mm_embedding_errors
+            ):
                 on_publish(batch_output.new_seq_lens)
 
             # Draft prefill seed (no forward).

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -999,7 +999,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             # Extend processed L prompt tokens; next verify iter expects same L.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
-            if on_publish is not None:
+            if on_publish is not None and batch_output.mm_embedding_errors is None:
                 on_publish(batch_output.new_seq_lens)
 
             # Chain-style MTP needs FULL to get all-token hidden states;

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -33,6 +33,7 @@ from sglang.srt.layers.moe.utils import (
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -999,7 +1000,9 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             # Extend processed L prompt tokens; next verify iter expects same L.
             batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
-            if on_publish is not None and batch_output.mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                batch_output.mm_embedding_errors
+            ):
                 on_publish(batch_output.new_seq_lens)
 
             # Chain-style MTP needs FULL to get all-token hidden states;

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -13,6 +13,7 @@ from sglang.srt.layers.logprob_processor import compute_spec_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import has_mm_embedding_failures
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.runtime_context import (
@@ -514,7 +515,9 @@ class NGRAMWorker(BaseSpecWorker):
                     accept_index=accept_index,
                 )
 
-            if on_publish is not None and mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                mm_embedding_errors
+            ):
                 on_publish(new_seq_lens)
 
             self._update_ngram_corpus(batch)
@@ -548,7 +551,9 @@ class NGRAMWorker(BaseSpecWorker):
             accept_tokens = accept_tokens.flatten()
             next_token_ids = predict
 
-            if on_publish is not None and mm_embedding_errors is None:
+            if on_publish is not None and not has_mm_embedding_failures(
+                mm_embedding_errors
+            ):
                 on_publish(new_seq_lens)
 
         # Construct the next draft input

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -439,11 +439,13 @@ class NGRAMWorker(BaseSpecWorker):
 
         verify_input: NgramVerifyInput = batch.spec_info
         accept_lens = torch.ones(bs, dtype=torch.int32, device=self.device)
+        mm_embedding_errors = None
 
         if batch.forward_mode.is_target_verify():
             batch_result = self.target_worker.forward_batch_generation(
                 batch, pp_proxy_tensors=pp_proxy_tensors, is_verify=True
             )
+            mm_embedding_errors = batch_result.mm_embedding_errors
 
             logits_output, can_run_cuda_graph = (
                 batch_result.logits_output,
@@ -512,7 +514,7 @@ class NGRAMWorker(BaseSpecWorker):
                     accept_index=accept_index,
                 )
 
-            if on_publish is not None:
+            if on_publish is not None and mm_embedding_errors is None:
                 on_publish(new_seq_lens)
 
             self._update_ngram_corpus(batch)
@@ -531,6 +533,7 @@ class NGRAMWorker(BaseSpecWorker):
             batch_result = self.target_worker.forward_batch_generation(
                 batch, pp_proxy_tensors=pp_proxy_tensors
             )
+            mm_embedding_errors = batch_result.mm_embedding_errors
             logits_output, predict, can_run_cuda_graph = (
                 batch_result.logits_output,
                 batch_result.next_token_ids,
@@ -545,7 +548,7 @@ class NGRAMWorker(BaseSpecWorker):
             accept_tokens = accept_tokens.flatten()
             next_token_ids = predict
 
-            if on_publish is not None:
+            if on_publish is not None and mm_embedding_errors is None:
                 on_publish(new_seq_lens)
 
         # Construct the next draft input
@@ -566,4 +569,5 @@ class NGRAMWorker(BaseSpecWorker):
             new_seq_lens=new_seq_lens,
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
+            mm_embedding_errors=mm_embedding_errors,
         )

--- a/python/sglang/srt/speculative/uno_worker_v2.py
+++ b/python/sglang/srt/speculative/uno_worker_v2.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.managers.utils import (
+    GenerationBatchResult,
+    has_mm_embedding_failures,
+)
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -433,7 +436,9 @@ class UnoWorkerV2(BaseSpecWorker):
             forward_width=self.forward_width,
         )
 
-        if on_publish is not None:
+        if on_publish is not None and not has_mm_embedding_failures(
+            result.mm_embedding_errors
+        ):
             on_publish(result.new_seq_lens)
         return result
 

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -332,6 +332,48 @@ def test_mixed_fresh_embeddings_isolate_short_request_and_preserve_shape():
     assert mm_schedule.embedding_cache.get_single(bad_item.hash) is None
 
 
+def test_overlong_combined_result_only_rejects_mismatched_retry():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    good_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=3000,
+        feature=torch.zeros(1),
+        offsets=[(0, 3)],
+    )
+    bad_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=3001,
+        feature=torch.zeros(1),
+        offsets=[(0, 5)],
+    )
+    good_embedding = torch.arange(4 * HIDDEN, dtype=torch.float32).reshape(4, HIDDEN)
+    bad_embedding = torch.full((2, HIDDEN), 2.0)
+    encoder = Mock(
+        side_effect=[
+            torch.zeros(11, HIDDEN),
+            good_embedding,
+            bad_embedding,
+        ]
+    )
+
+    embedding, _, errors = mm_schedule._get_chunked_prefill_embedding(
+        encoder,
+        [good_item, bad_item],
+        [0, 1, 2],
+        [0, 0],
+        [4, 6],
+        [[(0, 3)], [(0, 5)]],
+        torch.zeros(10, dtype=torch.long),
+    )
+
+    assert errors == [(1, 6, 2)]
+    assert torch.equal(embedding[:4], good_embedding)
+    assert torch.equal(embedding[4:6], bad_embedding)
+    assert torch.equal(embedding[6:], torch.zeros(4, HIDDEN))
+    assert mm_schedule.embedding_cache.get_single(good_item.hash) is not None
+    assert mm_schedule.embedding_cache.get_single(bad_item.hash) is None
+
+
 if __name__ == "__main__":
     import sys
 

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -113,7 +113,7 @@ def _run_by_item_chunks(encoder):
     return [
         mm_schedule._get_chunked_embedding_by_item(
             encoder, items, ITEM_OFFSETS, prefix_len, extend_len, _CPU
-        )
+        )[0]
         for prefix_len, extend_len in CHUNKS
     ]
 
@@ -124,7 +124,7 @@ def _run_full_chunks(encoder):
     input_ids = torch.zeros(TOTAL_LEN, dtype=torch.long)
     outs = []
     for prefix_len, extend_len in CHUNKS:
-        chunk, _ = mm_schedule._get_chunked_embedding_full(
+        chunk, _, _ = mm_schedule._get_chunked_embedding_full(
             encoder, items, ITEM_OFFSETS, prefix_len, extend_len, input_ids, _CPU
         )
         outs.append(chunk)
@@ -198,10 +198,11 @@ def test_by_item_mismatched_cache_entry_is_reencoded():
     )
     encoder = Mock(side_effect=_encoder_list)
 
-    chunk = mm_schedule._get_chunked_embedding_by_item(
+    chunk, error = mm_schedule._get_chunked_embedding_by_item(
         encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, _CPU
     )
 
+    assert error is None
     assert chunk.shape == (sum(_num_tokens(item) for item in items), HIDDEN)
     encoder.assert_called_once()
     assert mm_schedule.embedding_cache.get_single(first_item.hash).embedding.shape[
@@ -226,8 +227,11 @@ def test_batched_mismatched_cache_entry_is_reencoded():
     )
     encoder = Mock(side_effect=_encoder_list)
 
-    embeddings = mm_schedule._batch_encode_per_image_misses(encoder, [request], _CPU)
+    embeddings, errors = mm_schedule._batch_encode_per_image_misses(
+        encoder, [request], _CPU
+    )
 
+    assert errors == {}
     assert embeddings[(first_item.hash, _num_tokens(first_item))].shape == (
         _num_tokens(first_item),
         HIDDEN,
@@ -251,8 +255,11 @@ def test_batched_colliding_hashes_with_different_lengths_are_not_deduplicated():
     ]
     encoder = Mock(side_effect=_encoder_list)
 
-    embeddings = mm_schedule._batch_encode_per_image_misses(encoder, requests, _CPU)
+    embeddings, errors = mm_schedule._batch_encode_per_image_misses(
+        encoder, requests, _CPU
+    )
 
+    assert errors == {}
     first_key = (items[0].hash, _num_tokens(items[0]))
     second_key = (items[1].hash, _num_tokens(items[1]))
     assert embeddings[first_key].shape == (_num_tokens(items[0]), HIDDEN)
@@ -274,15 +281,55 @@ def test_full_mismatched_cache_entry_is_reencoded(caplog):
     encoder = Mock(side_effect=_encoder_tensor)
 
     with caplog.at_level(logging.WARNING, logger=mm_schedule.logger.name):
-        chunk, _ = mm_schedule._get_chunked_embedding_full(
+        chunk, _, error = mm_schedule._get_chunked_embedding_full(
             encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, input_ids, _CPU
         )
 
+    assert error is None
     assert chunk.shape == (sum(_num_tokens(item) for item in items), HIDDEN)
     encoder.assert_called_once()
     assert "Discarding cached multimodal embedding" in caplog.text
     assert "expected_tokens=15" in caplog.text
     assert "cached_tokens=1" in caplog.text
+
+
+def test_mixed_fresh_embeddings_isolate_short_request_and_preserve_shape():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    good_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=2000,
+        feature=torch.zeros(1),
+        offsets=[(0, 3)],
+    )
+    bad_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=2001,
+        feature=torch.zeros(1),
+        offsets=[(0, 5)],
+    )
+    good_embedding = torch.ones(4, HIDDEN)
+    bad_embedding = torch.full((2, HIDDEN), 2.0)
+
+    embedding, _, errors = mm_schedule._get_chunked_prefill_embedding(
+        lambda items: [
+            good_embedding if item.hash == good_item.hash else bad_embedding
+            for item in items
+        ],
+        [good_item, bad_item],
+        [0, 1, 2],
+        [0, 0],
+        [4, 6],
+        [[(0, 3)], [(0, 5)]],
+        torch.zeros(10, dtype=torch.long),
+    )
+
+    assert errors == [(1, 6, 2)]
+    assert embedding.shape == (10, HIDDEN)
+    torch.testing.assert_close(embedding[:4], good_embedding)
+    torch.testing.assert_close(embedding[4:6], bad_embedding)
+    torch.testing.assert_close(embedding[6:], torch.zeros(4, HIDDEN))
+    assert mm_schedule.embedding_cache.get_single(good_item.hash) is not None
+    assert mm_schedule.embedding_cache.get_single(bad_item.hash) is None
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_mooncake_transfer_worker_recovery.py
+++ b/test/registered/unit/disaggregation/test_mooncake_transfer_worker_recovery.py
@@ -1,0 +1,112 @@
+import concurrent.futures
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_failed_future_waits_for_running_sibling_before_releasing_ownership(raises):
+    manager = MooncakeKVManager.__new__(MooncakeKVManager)
+    manager.enable_deferred_decode_kv_release = False
+    manager._staging_outstanding = {}
+    manager._staging_outstanding_lock = threading.Lock()
+    chunk = SimpleNamespace(room=7, staging_counted=False)
+    manager._count_transfer_chunk(chunk)
+    sibling_started = threading.Event()
+    release_sibling = threading.Event()
+    await_finished = threading.Event()
+    results = []
+    errors = []
+
+    def blocked_transfer():
+        sibling_started.set()
+        release_sibling.wait()
+        return 0
+
+    def failed_transfer():
+        sibling_started.wait()
+        if raises:
+            raise RuntimeError("layer transfer failed")
+        return 17
+
+    def await_and_reconcile(futures):
+        try:
+            results.append(manager._await_transfer_futures(futures))
+        except Exception as error:
+            errors.append(error)
+        finally:
+            manager._finish_counted_transfer_chunk(chunk)
+            await_finished.set()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(blocked_transfer),
+            executor.submit(failed_transfer),
+        ]
+        waiter = threading.Thread(target=await_and_reconcile, args=(futures,))
+        waiter.start()
+        try:
+            assert sibling_started.wait(timeout=1)
+            assert not await_finished.wait(timeout=0.1)
+            assert not manager.is_transfer_quiesced(chunk.room)
+        finally:
+            release_sibling.set()
+        waiter.join(timeout=1)
+
+    assert await_finished.is_set()
+    assert manager.is_transfer_quiesced(chunk.room)
+    if raises:
+        assert results == []
+        assert [str(error) for error in errors] == ["layer transfer failed"]
+    else:
+        assert results == [17]
+        assert errors == []
+
+
+def test_worker_exception_releases_ownership_and_continues_polling():
+    room = 8
+    failed_req = SimpleNamespace(
+        is_dummy=False,
+        endpoint="127.0.0.1",
+        dst_port=9000,
+        room=room,
+    )
+    manager = MooncakeKVManager.__new__(MooncakeKVManager)
+    manager.enable_trace = False
+    manager.request_status = {room: KVPoll.WaitingForInput}
+    manager.check_status = Mock(side_effect=RuntimeError("worker failed"))
+    manager.bootstrap_port = 8998
+    manager.transfer_infos = {room: {0: failed_req}}
+    manager.req_to_decode_prefix_len = {room: 0}
+    manager.record_failure = Mock()
+    manager.update_status = Mock()
+    manager.sync_status_to_decode_endpoint = Mock()
+    manager.attn_tp_rank = 0
+    manager.attn_dp_rank = 0
+    manager.pp_size = 1
+    manager.attn_cp_size = 1
+    manager.pp_rank = 0
+    manager.attn_cp_rank = 0
+    manager.enable_staging = False
+    manager.enable_deferred_decode_kv_release = False
+    manager._staging_outstanding = {}
+    manager._staging_outstanding_lock = threading.Lock()
+    chunk = SimpleNamespace(room=room, staging_counted=False)
+    queue = SimpleNamespace(get=Mock(side_effect=[chunk, SystemExit()]))
+
+    with pytest.raises(SystemExit):
+        manager.transfer_worker(queue, executor=Mock())
+
+    assert queue.get.call_count == 2
+    assert manager.is_transfer_quiesced(room)
+    manager.record_failure.assert_called_once()
+    manager.update_status.assert_called_once_with(room, KVPoll.Failed)
+    manager.sync_status_to_decode_endpoint.assert_called_once()

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -472,6 +472,7 @@ class TestNixlTransferWorker(CustomTestCase):
         mgr.enable_deferred_decode_kv_release = False
         mgr._staging_ctx = None
         mgr._staging_outstanding = defaultdict(int)
+        mgr._staging_outstanding_lock = threading.Lock()
         mgr.is_mla_backend = False
         mgr.is_hybrid_mla_backend = False
         mgr.attn_tp_size = 1

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -7,6 +7,7 @@ worker polls check_xfer_state), so the ack must come from the transfer worker
 after its DONE barrier -- never from the bootstrap thread for an active room.
 """
 
+import threading
 import unittest
 from unittest.mock import MagicMock
 
@@ -25,6 +26,8 @@ def _prefill_mgr(cls=CommonKVManager, enabled=True):
     mgr.enable_deferred_decode_kv_release = enabled
     mgr._deferred_ack_targets = {}
     mgr._staging_outstanding = {}
+    if cls is NixlKVManager:
+        mgr._staging_outstanding_lock = threading.Lock()
     mgr.request_status = {}
     mgr._sent = []
     # Capture acks instead of opening a socket.

--- a/test/registered/unit/disaggregation/test_prefill_mm_abort_cleanup.py
+++ b/test/registered/unit/disaggregation/test_prefill_mm_abort_cleanup.py
@@ -1,0 +1,111 @@
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sglang.srt.disaggregation import prefill
+from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="stage-a-test-cpu-intel")
+
+
+@pytest.mark.parametrize("poll", [KVPoll.Success, KVPoll.Failed])
+def test_pending_mm_abort_cleanup_waits_for_global_transport_quiescence(poll):
+    error = FINISH_ABORT(message="Multimodal embedding count mismatch")
+    sender = SimpleNamespace(
+        is_transfer_quiesced=Mock(return_value=True),
+        clear=Mock(),
+        get_transfer_metric=Mock(return_value=None),
+    )
+    req = SimpleNamespace(
+        rid="request",
+        disagg_abort_cleanup_pending=True,
+        disagg_kv_sender=sender,
+        kv=SimpleNamespace(holds_kv=True, holds_mamba=False),
+        metadata_buffer_index=-1,
+        pending_bootstrap=False,
+        mm_embedding_abort_pending=True,
+        finished_reason=error,
+        to_finish=None,
+        return_logprob=False,
+        bootstrap_host=None,
+        time_stats=SimpleNamespace(
+            set_completion_time=Mock(),
+            set_prefill_kv_transfer_finish_time=Mock(),
+        ),
+    )
+    releases = []
+
+    def finish_deferred(aborted_req):
+        releases.append(aborted_req)
+        aborted_req.kv.holds_kv = False
+        aborted_req.mm_embedding_abort_pending = False
+
+    scheduler = SimpleNamespace(
+        disagg_prefill_inflight_queue=[req],
+        attn_cp_cpu_group=None,
+        attn_tp_cpu_group=None,
+        output_streamer=SimpleNamespace(stream_output=Mock()),
+        req_to_metadata_buffer_idx_allocator=Mock(),
+        batch_result_processor=SimpleNamespace(
+            _finish_deferred_mm_embedding_abort=Mock(side_effect=finish_deferred)
+        ),
+        enable_hicache_storage=False,
+        tree_cache=Mock(),
+        metrics_reporter=SimpleNamespace(enable_metrics=False),
+        handle_pending_bootstrap=Mock(),
+        handle_inflight_transfer_failure=Mock(
+            side_effect=lambda failed_req: releases.append(failed_req)
+        ),
+        _retire_aborted_prefill_result=None,
+    )
+    scheduler._retire_aborted_prefill_result = MethodType(
+        SchedulerDisaggregationPrefillMixin._retire_aborted_prefill_result,
+        scheduler,
+    )
+
+    with (
+        patch.object(
+            prefill,
+            "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[poll],
+        ),
+        patch.object(
+            prefill,
+            "all_reduce_transfer_quiesced_attn_cp_tp_group",
+            side_effect=[[False], [True]],
+            create=True,
+        ),
+        patch.object(
+            prefill,
+            "release_kv_cache",
+            side_effect=lambda *_a, **_k: releases.append(req),
+        ),
+    ):
+        first_done = (
+            SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler
+            )
+        )
+        assert first_done == []
+        assert scheduler.disagg_prefill_inflight_queue == [req]
+        assert req.disagg_abort_cleanup_pending
+        assert req.finished_reason is error
+        assert releases == []
+        sender.clear.assert_not_called()
+
+        second_done = (
+            SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler
+            )
+        )
+
+    assert second_done == [req]
+    assert scheduler.disagg_prefill_inflight_queue == []
+    assert not req.disagg_abort_cleanup_pending
+    assert req.finished_reason is error
+    assert releases == [req]
+    sender.clear.assert_called_once_with()

--- a/test/registered/unit/disaggregation/test_sender_quiescence_contract.py
+++ b/test/registered/unit/disaggregation/test_sender_quiescence_contract.py
@@ -1,0 +1,141 @@
+import inspect
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+mori_module = ModuleType("mori")
+mori_cpp = ModuleType("mori.cpp")
+mori_io = ModuleType("mori.io")
+mori_cpp.TransferStatus = type("TransferStatus", (), {})
+for name in (
+    "BackendType",
+    "EngineDesc",
+    "IOEngine",
+    "IOEngineConfig",
+    "MemoryDesc",
+    "MemoryLocationType",
+    "PollCqMode",
+    "RdmaBackendConfig",
+    "StatusCode",
+):
+    setattr(mori_io, name, type(name, (), {}))
+sys.modules.setdefault("mori", mori_module)
+sys.modules.setdefault("mori.cpp", mori_cpp)
+sys.modules.setdefault("mori.io", mori_io)
+
+from sglang.srt.disaggregation.ascend.conn import AscendKVSender  # noqa: E402
+from sglang.srt.disaggregation.common.conn import CommonKVSender  # noqa: E402
+from sglang.srt.disaggregation.fake.conn import FakeKVSender  # noqa: E402
+from sglang.srt.disaggregation.mooncake.conn import (  # noqa: E402
+    MooncakeKVManager,
+    MooncakeKVSender,
+)
+from sglang.srt.disaggregation.mori.conn import (  # noqa: E402
+    MoriKVManager,
+    MoriKVSender,
+)
+from sglang.srt.disaggregation.nixl.conn import (  # noqa: E402
+    NixlKVManager,
+    NixlKVSender,
+)
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _assert_sender_tracks_chunk_ownership(manager_type, sender_type, counter_name):
+    manager = manager_type.__new__(manager_type)
+    setattr(manager, counter_name, {})
+    manager._staging_outstanding_lock = threading.Lock()
+    chunk = SimpleNamespace(room=11, staging_counted=False)
+    sender = sender_type.__new__(sender_type)
+    sender.bootstrap_room = chunk.room
+    sender.kv_mgr = manager
+
+    manager._count_transfer_chunk(chunk)
+    assert not sender.is_transfer_quiesced()
+
+    manager._finish_counted_transfer_chunk(chunk)
+    assert sender.is_transfer_quiesced()
+
+
+def test_every_concrete_sender_implements_quiescence_contract():
+    assert inspect.isabstract(CommonKVSender)
+    for sender_type in (
+        FakeKVSender,
+        MooncakeKVSender,
+        AscendKVSender,
+        NixlKVSender,
+        MoriKVSender,
+    ):
+        assert not inspect.isabstract(sender_type), sender_type.__name__
+
+
+def test_fake_sender_is_synchronously_quiesced():
+    assert FakeKVSender.__new__(FakeKVSender).is_transfer_quiesced()
+
+
+def test_mooncake_sender_tracks_worker_ownership_until_completion():
+    _assert_sender_tracks_chunk_ownership(
+        MooncakeKVManager, MooncakeKVSender, "_staging_outstanding"
+    )
+
+
+def test_nixl_sender_tracks_worker_ownership_until_completion():
+    _assert_sender_tracks_chunk_ownership(
+        NixlKVManager, NixlKVSender, "_staging_outstanding"
+    )
+
+
+def test_nixl_error_waits_for_every_sibling_handle_to_finish():
+    manager = NixlKVManager.__new__(NixlKVManager)
+    states = {
+        "failed": ["ERR", "ERR"],
+        "sibling": ["PENDING", "DONE"],
+    }
+    manager.agent = SimpleNamespace(
+        check_xfer_state=Mock(side_effect=lambda handle: states[handle].pop(0))
+    )
+
+    error = manager._wait_for_transfer_handles(["failed", "sibling"], room=12)
+
+    assert isinstance(error, RuntimeError)
+    assert "room=12" in str(error)
+    assert manager.agent.check_xfer_state.call_count == 4
+
+
+def test_mori_sender_tracks_worker_ownership_until_completion():
+    manager = MoriKVManager.__new__(MoriKVManager)
+    manager._transfer_outstanding = {}
+    manager._transfer_outstanding_lock = threading.Lock()
+    chunk = SimpleNamespace(room=13, staging_counted=False)
+    sender = MoriKVSender.__new__(MoriKVSender)
+    sender.bootstrap_room = chunk.room
+    sender.kv_mgr = manager
+
+    manager._count_transfer_chunk(chunk)
+    assert not sender.is_transfer_quiesced()
+
+    manager._finish_counted_transfer_chunk(chunk)
+    assert sender.is_transfer_quiesced()
+
+
+def test_mori_abort_after_submission_still_waits_for_completion():
+    manager = MoriKVManager.__new__(MoriKVManager)
+    manager._should_skip_transfer = Mock(side_effect=[False, False, True])
+    manager._submit_kv_transfer = Mock(return_value=(["status"], ["target"]))
+    manager._wait_transfer_completion = Mock(return_value=None)
+    chunk = SimpleNamespace(
+        room=14,
+        wait_event=None,
+        prefill_kv_indices=[],
+        index_slice=slice(0, 0),
+        is_last_chunk=False,
+        prefill_aux_index=None,
+        state_indices=None,
+    )
+
+    manager._process_transfer_chunk(chunk)
+
+    manager._wait_transfer_completion.assert_called_once_with(["status"])

--- a/test/registered/unit/disaggregation/test_sender_quiescence_contract.py
+++ b/test/registered/unit/disaggregation/test_sender_quiescence_contract.py
@@ -123,7 +123,7 @@ def test_mori_sender_tracks_worker_ownership_until_completion():
 
 def test_mori_abort_after_submission_still_waits_for_completion():
     manager = MoriKVManager.__new__(MoriKVManager)
-    manager._should_skip_transfer = Mock(side_effect=[False, False, True])
+    manager._should_skip_transfer = Mock(side_effect=[False, True])
     manager._submit_kv_transfer = Mock(return_value=(["status"], ["target"]))
     manager._wait_transfer_completion = Mock(return_value=None)
     chunk = SimpleNamespace(

--- a/test/registered/unit/managers/test_mm_embed_scatter.py
+++ b/test/registered/unit/managers/test_mm_embed_scatter.py
@@ -93,7 +93,7 @@ def test_embed_mm_inputs_isolates_offset_mask_count_mismatch():
     input_embedding = nn.Embedding(128, 4)
     input_embedding.weight.data.zero_()
 
-    with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(False):
+    with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(True):
         actual, other_info = embed_mm_inputs(
             mm_inputs_list=mm_inputs,
             extend_prefix_lens=[0, 0],

--- a/test/registered/unit/managers/test_mm_embed_scatter.py
+++ b/test/registered/unit/managers/test_mm_embed_scatter.py
@@ -1,7 +1,14 @@
 import pytest
 import torch
+from torch import nn
 
-from sglang.srt.managers.mm_utils import _scatter_mm_embedding
+from sglang.srt.environ import envs
+from sglang.srt.managers.mm_utils import _scatter_mm_embedding, embed_mm_inputs
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu-intel")
@@ -53,6 +60,51 @@ def test_scatter_row_count_mismatch_fails_loud():
     mask_heavy[2:6] = True
     with pytest.raises((RuntimeError, IndexError)):
         _scatter_mm_embedding(dest=dest, mask=mask_heavy, src=torch.ones(1, 4))
+
+
+def test_embed_mm_inputs_isolates_offset_mask_count_mismatch():
+    bad_embedding = torch.tensor(
+        [[10.0, 11.0, 12.0, 13.0], [20.0, 21.0, 22.0, 23.0], [30.0, 31.0, 32.0, 33.0]]
+    )
+    good_embedding = torch.tensor([[40.0, 41.0, 42.0, 43.0], [50.0, 51.0, 52.0, 53.0]])
+    mm_inputs = [
+        MultimodalInputs(
+            mm_items=[
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    pad_value=100,
+                    offsets=[(0, 2)],
+                    precomputed_embeddings=bad_embedding,
+                )
+            ]
+        ),
+        MultimodalInputs(
+            mm_items=[
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    pad_value=101,
+                    offsets=[(0, 1)],
+                    precomputed_embeddings=good_embedding,
+                )
+            ]
+        ),
+    ]
+    input_ids = torch.tensor([100, 100, 0, 101, 101, 0])
+    input_embedding = nn.Embedding(128, 4)
+    input_embedding.weight.data.zero_()
+
+    with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(False):
+        actual, other_info = embed_mm_inputs(
+            mm_inputs_list=mm_inputs,
+            extend_prefix_lens=[0, 0],
+            extend_seq_lens=[3, 3],
+            input_ids=input_ids,
+            input_embedding=input_embedding,
+            data_embedding_func_mapping={Modality.IMAGE: lambda _items: None},
+        )
+
+    assert other_info["mm_embedding_errors"] == [(0, 3, 2)]
+    assert torch.equal(actual[3:5], good_embedding)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_mm_embedding_error_sync.py
+++ b/test/registered/unit/managers/test_mm_embedding_error_sync.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.managers.utils import (
+    complete_mm_embedding_validations,
+    has_mm_embedding_failures,
+    merge_mm_embedding_error_tensors,
+    synchronize_mm_embedding_errors,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu-intel")
+
+
+def _single_rank_parallel():
+    group = SimpleNamespace(world_size=1, device_group=None)
+    return SimpleNamespace(attn_tp_group=group, attn_cp_group=group)
+
+
+def test_valid_mm_validation_allows_early_publication_and_completes():
+    with patch(
+        "sglang.srt.managers.utils.get_parallel", return_value=_single_rank_parallel()
+    ):
+        result = synchronize_mm_embedding_errors(None, 2, torch.device("cpu"), [0])
+
+    assert result is not None
+    assert not has_mm_embedding_failures(result)
+    reqs = [
+        SimpleNamespace(mm_embedding_validation_count=1),
+        SimpleNamespace(mm_embedding_validation_count=0),
+    ]
+    complete_mm_embedding_validations(reqs, result)
+    assert [req.mm_embedding_validation_count for req in reqs] == [0, 0]
+
+
+def test_failed_mm_validation_blocks_early_publication():
+    with patch(
+        "sglang.srt.managers.utils.get_parallel", return_value=_single_rank_parallel()
+    ):
+        result = synchronize_mm_embedding_errors(
+            [(1, 3, 2)], 2, torch.device("cpu"), [0, 1]
+        )
+
+    assert has_mm_embedding_failures(result)
+
+
+def test_pp_merge_preserves_request_scoped_failure_and_validations():
+    incoming = torch.tensor([[1, 0, 0, 0], [0, 1, 3, 2]])
+    local = torch.tensor([[0, 0, 0, 0], [1, 0, 0, 0]])
+
+    result = merge_mm_embedding_error_tensors(incoming, local)
+
+    assert torch.equal(result, torch.tensor([[1, 0, 0, 0], [1, 1, 3, 2]]))

--- a/test/registered/unit/managers/test_mm_embedding_length.py
+++ b/test/registered/unit/managers/test_mm_embedding_length.py
@@ -65,7 +65,7 @@ def test_get_embedding_and_mask_uses_offset_count_without_readback():
         patch.object(mm_utils, "_get_precomputed_embedding", return_value=embedding),
         patch.object(mm_utils, "_get_multimodal_mask", return_value=mask),
     ):
-        result, result_mask, result_input_ids = mm_utils.get_embedding_and_mask(
+        result, result_mask, result_input_ids, errors = mm_utils.get_embedding_and_mask(
             data_embedding_func=Mock(),
             embedding_items=[],
             placeholder_tensor=torch.tensor([1]),
@@ -80,6 +80,7 @@ def test_get_embedding_and_mask_uses_offset_count_without_readback():
     assert result is embedding
     assert result_mask is mask
     assert result_input_ids is input_ids
+    assert errors == []
 
 
 def test_get_embedding_and_mask_async_asserts_offset_count():
@@ -140,11 +141,11 @@ def test_get_embedding_and_mask_falls_back_after_input_ids_rewrite():
         patch.object(
             mm_utils,
             "_get_chunked_prefill_embedding",
-            return_value=(embedding, rewritten_input_ids),
+            return_value=(embedding, rewritten_input_ids, []),
         ),
         patch.object(mm_utils, "_get_multimodal_mask", return_value=mask),
     ):
-        result, result_mask, result_input_ids = mm_utils.get_embedding_and_mask(
+        result, result_mask, result_input_ids, errors = mm_utils.get_embedding_and_mask(
             data_embedding_func=Mock(),
             embedding_items=[],
             placeholder_tensor=torch.tensor([1]),
@@ -160,6 +161,7 @@ def test_get_embedding_and_mask_falls_back_after_input_ids_rewrite():
     assert result is embedding
     assert result_mask is mask
     assert result_input_ids is rewritten_input_ids
+    assert errors == []
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_mm_embedding_length.py
+++ b/test/registered/unit/managers/test_mm_embedding_length.py
@@ -83,7 +83,7 @@ def test_get_embedding_and_mask_uses_offset_count_without_readback():
     assert errors == []
 
 
-def test_get_embedding_and_mask_async_asserts_offset_count():
+def test_get_embedding_and_mask_does_not_async_assert_offset_count():
     input_ids = torch.zeros(8, dtype=torch.long)
     input_ids[2:5] = 1
     embedding = torch.arange(12, dtype=torch.float32).reshape(3, 4)
@@ -104,10 +104,7 @@ def test_get_embedding_and_mask_async_asserts_offset_count():
             items_offset_list=[[(2, 4)]],
         )
 
-    assert_async.assert_called_once()
-    condition, message = assert_async.call_args.args
-    assert condition.item()
-    assert "derived from offsets" in message
+    assert_async.assert_not_called()
 
 
 def test_adjust_embedding_length_crops_overlong_embedding():

--- a/test/registered/unit/managers/test_mm_embedding_publication.py
+++ b/test/registered/unit/managers/test_mm_embedding_publication.py
@@ -1,0 +1,82 @@
+import sys
+from importlib.machinery import ModuleSpec
+from importlib.util import find_spec
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+if find_spec("flashinfer") is None:
+    flashinfer = ModuleType("flashinfer")
+    flashinfer.__spec__ = ModuleSpec("flashinfer", loader=None)
+    flashinfer.top_k = Mock()
+    sys.modules["flashinfer"] = flashinfer
+
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.srt.managers.utils import GenerationBatchResult  # noqa: E402
+from sglang.srt.speculative.uno_worker_v2 import UnoWorkerV2  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=3, suite="stage-a-test-cpu-intel")
+
+
+def _run_uno_prefill(mm_embedding_errors, events):
+    result = GenerationBatchResult(
+        next_token_ids=torch.tensor([7, 8]),
+        mm_embedding_errors=mm_embedding_errors,
+    )
+    worker = object.__new__(UnoWorkerV2)
+    worker._target_worker = SimpleNamespace(
+        forward_batch_generation=Mock(return_value=result)
+    )
+    worker.forward_width = 2
+    batch = SimpleNamespace(reqs=[object(), object()], seq_lens=torch.tensor([5, 6]))
+    result = worker._forward_prefill(
+        batch,
+        lambda seq_lens: events.append(("worker", None, seq_lens.clone())),
+    )
+    return batch, result
+
+
+def _publish_from_scheduler(batch, result, events):
+    scheduler = object.__new__(Scheduler)
+    scheduler.future_map = SimpleNamespace(
+        publish=lambda indices, seq_lens: events.append(
+            ("scheduler", indices.clone(), seq_lens.clone())
+        )
+    )
+    Scheduler._publish_speculative_overlap_result(
+        scheduler,
+        batch,
+        torch.tensor([10, 20]),
+        result,
+    )
+
+
+def test_mixed_uno_prefill_defers_publication_until_failed_request_is_filtered():
+    events = []
+    errors = torch.tensor([[1, 1, 3, 2], [1, 0, 0, 0]])
+
+    batch, result = _run_uno_prefill(errors, events)
+    assert events == []
+
+    _publish_from_scheduler(batch, result, events)
+    assert len(events) == 1
+    source, indices, seq_lens = events[0]
+    assert source == "scheduler"
+    assert torch.equal(indices, torch.tensor([20]))
+    assert torch.equal(seq_lens, torch.tensor([6]))
+
+
+def test_valid_uno_prefill_keeps_worker_publication_without_late_republish():
+    events = []
+    errors = torch.tensor([[1, 0, 0, 0], [1, 0, 0, 0]])
+
+    batch, result = _run_uno_prefill(errors, events)
+    _publish_from_scheduler(batch, result, events)
+
+    assert len(events) == 1
+    source, indices, seq_lens = events[0]
+    assert source == "worker"
+    assert indices is None
+    assert torch.equal(seq_lens, torch.tensor([5, 6]))


### PR DESCRIPTION
## Motivation

A multimodal embedding/placeholder cardinality mismatch can reach `_scatter_mm_embedding` with more source rows than destination mask rows. The poison index used by the O(num_tokens) `index_copy_` implementation then triggers `IndexKernel.cu: index_copy_(): index out of bounds`, poisoning the CUDA context and terminating the scheduler. This was observed in production using only stack and count metadata; no request content was captured.

Malformed requests must fail individually without corrupting valid neighbors or releasing KV/state buffers while native disaggregation transfers still reference them.

## Modifications

- Validate fresh embedding lengths and actual per-request placeholder mask counts before scatter.
- Fit only malformed request-owned rows and propagate count-only request errors through TP, PP, overlap scheduling, speculative workers, beam search, and disaggregated prefill.
- Preserve valid mixed-batch rows and prevent malformed requests from entering later speculative iterations.
- Keep the O(num_tokens) scatter implementation and valid-path behavior.
- Add sender quiescence contracts and ensure Mooncake, NIXL, and Mori drain submitted native transfer work before releasing source buffers.
- Keep transfer workers alive and reconcile ownership after request-level failures.

No request bodies, token IDs, media hashes, offsets, embeddings, or customer content are logged.

## Accuracy Tests

Valid neighboring requests remain bitwise unchanged. Malformed requests return an internal multimodal embedding error instead of producing output or crashing the CUDA context.

Targeted and relevant suites: 112 tests passed with 2 subtests passed. The exact pre-fix regression reproduced `index_copy_(): index out of bounds`; the fixed test passes with async assertions enabled. Backend quiescence and transfer-drain ordering tests pass.

## Speed Tests and Profiling

The valid scatter remains O(num_tokens) and does not restore the expanded `masked_scatter_` allocation. Actual per-request mask validation adds one batched device-to-host count readback per multimodal modality. Malformed-only retries and fitting do not affect valid requests. No end-to-end throughput benchmark has been run yet.

## Checklist

- [x] Format code with pre-commit
- [x] Add focused unit tests
- [ ] Update documentation, not required for this internal behavior change
- [ ] Provide GPU performance results
- [x] Follow SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33899388620](https://github.com/sgl-project/sglang/actions/runs/33899388620)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33899388279](https://github.com/sgl-project/sglang/actions/runs/33899388279)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33899388524](https://github.com/sgl-project/sglang/actions/runs/33899388524)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->