### PR TITLE
[diffusion] fix: do not interleave comfy-kitchen MXFP8 scales twice

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp8.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp8.py
@@ -21,6 +21,7 @@ from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
 )
 from sglang.srt.layers.quantization.fp8 import Fp8Config as SRTFp8Config
 from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod as SRTFp8LinearMethod
+from sglang.srt.layers.utils import copy_or_rebind_param
 
 
 class MXFP8Config(SRTFp8Config, QuantizationConfig):
@@ -76,7 +77,41 @@ class MXFP8Config(SRTFp8Config, QuantizationConfig):
             return UnquantizedLinearMethod()
         if current_platform.is_npu():
             return NPUMXFP8LinearMethod(self)
-        return SRTFp8LinearMethod(self)
+        return ComfyMXFP8LinearMethod(self)
 
 
-__all__ = ["MXFP8Config"]
+class ComfyMXFP8LinearMethod(SRTFp8LinearMethod):
+    """Load MXFP8 scales that the checkpoint already stores swizzled.
+
+    ``comfy-kitchen`` serializes MXFP8 block scales in the ``SWIZZLE_32_4_4``
+    byte order that FlashInfer's cutlass and cutedsl kernels consume, but
+    safetensors keeps their logical ``[N, K // 32]`` shape.  Nothing in the file
+    distinguishes those bytes from row-major scales, so
+    :meth:`Fp8LinearMethod._process_mxfp8_linear_weight_scale` interleaves them a
+    second time.  The second permutation is silent -- the checkpoint loads, the
+    kernels run at full speed, and the sample decodes to noise.
+
+    Only checkpoints that carry comfy layer markers take this path;
+    :class:`MXFP8Config` resolved from a ``config.json`` has
+    ``layer_markers is None`` and keeps SRT's behaviour byte for byte.
+    """
+
+    def _process_mxfp8_linear_weight_scale(self, layer: torch.nn.Module) -> None:
+        backend = self.mxfp8_dense_backend
+        if (
+            self.use_mxfp8
+            and self.quant_config.layer_markers is not None
+            and backend is not None
+            and (backend.is_flashinfer_cutlass() or backend.is_flashinfer_cutedsl())
+        ):
+            # Hand FlashInfer the serialized bytes flattened, not re-interleaved.
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv_swizzled",
+                layer.weight_scale_inv.data.contiguous().view(-1),
+            )
+            return
+        super()._process_mxfp8_linear_weight_scale(layer)
+
+
+__all__ = ["ComfyMXFP8LinearMethod", "MXFP8Config"]

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -82,7 +82,10 @@ from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
     ModelOptFp8LinearMethod,
     _prepare_nvfp4_weight_bytes,
 )
-from sglang.multimodal_gen.runtime.layers.quantization.mxfp8 import MXFP8Config
+from sglang.multimodal_gen.runtime.layers.quantization.mxfp8 import (
+    ComfyMXFP8LinearMethod,
+    MXFP8Config,
+)
 from sglang.multimodal_gen.runtime.loader.component_loaders import transformer_loader
 from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader import (
     TransformerLoader,
@@ -1087,6 +1090,60 @@ class TestTransformerQuantHelpers(unittest.TestCase):
             )
 
         self.assertIsInstance(method, NPUMXFP8LinearMethod)
+
+    def test_comfy_mxfp8_scales_are_not_interleaved_twice(self):
+        config = MXFP8Config(
+            is_checkpoint_fp8_serialized=True,
+            layer_markers={"blocks.0.attn.out_proj": {"format": "mxfp8"}},
+        )
+        method = config.get_quant_method(
+            LinearBase(input_size=64, output_size=32), "blocks.0.attn.out_proj"
+        )
+        self.assertIsInstance(method, ComfyMXFP8LinearMethod)
+        self.assertIsInstance(method, SRTFp8LinearMethod)
+        # Renaming the SRT hook would silently restore the double interleave.
+        self.assertTrue(
+            hasattr(SRTFp8LinearMethod, "_process_mxfp8_linear_weight_scale")
+        )
+
+        checkpoint_scale = torch.arange(64, dtype=torch.uint8).reshape(32, 2)
+        layer = torch.nn.Module()
+        layer.weight_scale_inv = torch.nn.Parameter(
+            checkpoint_scale.clone(), requires_grad=False
+        )
+        method.mxfp8_dense_backend = SimpleNamespace(
+            is_flashinfer_cutlass=lambda: True,
+            is_flashinfer_cutedsl=lambda: False,
+        )
+
+        method._process_mxfp8_linear_weight_scale(layer)
+
+        self.assertEqual(layer.weight_scale_inv_swizzled.shape, torch.Size([64]))
+        torch.testing.assert_close(
+            layer.weight_scale_inv_swizzled.data, checkpoint_scale.flatten()
+        )
+
+    def test_config_driven_mxfp8_keeps_srt_scale_processing(self):
+        config = MXFP8Config(is_checkpoint_fp8_serialized=True)
+        method = config.get_quant_method(
+            LinearBase(input_size=64, output_size=32), "blocks.0.attn.out_proj"
+        )
+        self.assertIsNone(config.layer_markers)
+        self.assertIsInstance(method, ComfyMXFP8LinearMethod)
+
+        layer = torch.nn.Module()
+        layer.weight_scale_inv = torch.nn.Parameter(
+            torch.arange(64, dtype=torch.uint8).reshape(32, 2), requires_grad=False
+        )
+        method.mxfp8_dense_backend = SimpleNamespace(
+            is_flashinfer_cutlass=lambda: True,
+            is_flashinfer_cutedsl=lambda: False,
+        )
+        with patch.object(
+            SRTFp8LinearMethod, "_process_mxfp8_linear_weight_scale"
+        ) as srt_hook:
+            method._process_mxfp8_linear_weight_scale(layer)
+        srt_hook.assert_called_once_with(layer)
 
     def test_comfy_full_precision_fp8_dequantizes_before_linear(self):
         layer = torch.nn.Module()


### PR DESCRIPTION
## Motivation

`comfy-kitchen` serializes MXFP8 block scales **already in the `SWIZZLE_32_4_4` byte
order** that FlashInfer's cutlass / cutedsl kernels consume, while safetensors keeps
their logical `[N, K // 32]` shape. Nothing in the file distinguishes those bytes from
row-major scales, so `Fp8LinearMethod._process_mxfp8_linear_weight_scale`
(`python/sglang/srt/layers/quantization/fp8.py`, cutlass/cutedsl branch) runs
`block_scale_interleave` over bytes that are already interleaved.

The second permutation is **silent**. No exception, no warning, no shape mismatch: the
checkpoint loads, the kernels run at full speed, and the sample decodes to dark,
low-amplitude colour noise. A user has no signal to distinguish this from a bad prompt
or a bad checkpoint.

## Modifications

- Add `ComfyMXFP8LinearMethod`, a thin `Fp8LinearMethod` subclass that hands FlashInfer
  the serialized scale bytes flattened instead of re-interleaving them.
- Route `MXFP8Config.get_quant_method` through it.

Blast radius is limited to comfy checkpoints by construction. `layer_markers` is only
ever populated by `resolve_comfy_checkpoint_quantization`
(`runtime/utils/quantization_utils.py`), which is also the sole construction site of
`MXFP8Config` with markers; `MXFP8Config.from_config` (the `config.json` path) leaves it
`None`. The same predicate already gates `checkpoint_uses_native_qkv_layout` in
`MXFP8Config.__init__`. For every non-comfy MXFP8 checkpoint, and for every backend
other than cutlass / cutedsl, the call falls through to `super()` unchanged.

Two unit tests in `python/sglang/multimodal_gen/test/unit/test_transformer_quant.py`,
both CPU-only and free of checkpoint fixtures:

- `test_comfy_mxfp8_scales_are_not_interleaved_twice` — a comfy-marked config yields
  `ComfyMXFP8LinearMethod` and its scale bytes survive load in order. It also asserts
  that `Fp8LinearMethod._process_mxfp8_linear_weight_scale` still exists, so renaming
  the SRT hook fails loudly instead of silently restoring the double interleave.
- `test_config_driven_mxfp8_keeps_srt_scale_processing` — a `config.json`-driven config
  still delegates to SRT.

The existing `test_minimax_h3_global_mxfp8_metadata_selects_srt_per_layer` continues to
pass: `ComfyMXFP8LinearMethod` is a `Fp8LinearMethod`.

## Accuracy Tests

Measured on an RTX 5090 (sm_120) with a MiniMax-H3 Ref2VA MXFP8 single file
(`rzgar/...minimax_h3_ref2va_mxfp8.safetensors`, 47.6 GB), one real attention weight
matrix, compared against the dequantized reference:

| scale handling | cosine | relative L2 |
| --- | ---: | ---: |
| checkpoint bytes flattened (this PR) | 0.999641 | 0.02679 |
| `block_scale_interleave` applied again (today) | 0.739481 | 0.77703 |

End to end on a fixed-seed 768p Ref2VA request: before the fix the run completed in
746.16 s and decoded to colour noise; after the fix the same request produces a valid
video. A locally converted INT8 checkpoint through the same pipeline was clean
throughout, which isolates the fault to the MXFP8 loading path rather than the prompt,
reference, text encoder, VAE or model code.

## Speed Tests and Profiling

No measurable change. The edit is on the load path only, and it replaces a
`block_scale_interleave` call with a `view(-1)`. The fixed-seed request above ran
746.16 s before and after within run-to-run noise; nothing in the forward path is
touched.

## Checklist

- [x] Formatted. `pre-commit` itself could not be installed on this machine (no PyPI
      egress), so the configured hooks were run individually and all pass on both files:
      `isort --check-only` (7.x and 8.x), `ruff check --select=F401,F821,UP037`,
      `ruff format --diff`, and `black --check` as a cross-check.
- [x] Unit tests added, in the existing `multimodal_gen` unit test file next to the
      other MXFP8 tests. That file uses plain `unittest.TestCase`; `CustomTestCase` and
      `register_*_ci` apply to registered suites under `test/registered/`, not here.
- [ ] Documentation — not applicable. No user-facing interface, flag or default
      changes; this restores correct output for checkpoints that already load today.
- [x] Accuracy results above. Speed: unchanged, load-path only.
- [x] Code style: no duplication, no device synchronization, no in-place argument
      mutation beyond what the base method already does, config class kept at the top of
      the file.

## Notes for reviewers

`block_scale_interleave` "may pad and/or reshape scales". Every Linear in the checkpoint
tested here has `N % 128 == 0`, so flatten-only matches. If comfy-kitchen ever
serializes an unpadded scale block for a shape FlashInfer would pad, this path needs the
padding applied without the permutation. Happy to add a shape guard if you would prefer
to fail loudly there rather than assume.

Found while evaluating self-describing single-file MiniMax-H3 checkpoints on a single
RTX 5090 32 GB (sm_120, driver 616.56, Windows 11 + WSL2 + Docker, TP=1) against
`20621aa14bda7726a8a968f326198eac61717fef`. `mxfp8.py` is byte-identical between that
commit and current `main`, and the cutlass/cutedsl branch in `srt/.../fp8.py` is
unchanged, so the bug reproduces on `main`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33899718636](https://github.com/sgl-project/sglang/actions/runs/33899718636)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33899718297](https://github.com/sgl-project/sglang/actions/runs/33899718297)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33899718529](https://github.com/sgl-project/sglang/actions/runs/33899718529)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->