### PR TITLE
fix(dsa): bind KV index translator to EAGLE draft backends

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -309,6 +309,7 @@ class DeepseekSparseAttnBackend(
         super().__init__()
         self.forward_metadata: DSAMetadata
         self.device = model_runner.device
+        self.kv_index_translator = model_runner.kv_index_translator
         assert isinstance(model_runner.page_size, int)
         self.real_page_size = model_runner.page_size
         self.num_splits = (

--- a/test/registered/unit/layers/attention/test_kv_translate_ownership.py
+++ b/test/registered/unit/layers/attention/test_kv_translate_ownership.py
@@ -196,5 +196,32 @@ class TestWrapperBackendsForwardTranslator(CustomTestCase):
                 self.assertIs(wrapper.kv_index_translator, translator)
 
 
+class TestDSABackendBindsTranslator(CustomTestCase):
+    """DSA draft backends are created after the runner's generic bind pass."""
+
+    def test_constructor_binds_owning_runner_translator(self):
+        source = dict(_iter_sources())["dsa_backend.py"]
+        module = ast.parse(source)
+        backend = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "DeepseekSparseAttnBackend"
+        )
+        init = next(
+            node
+            for node in backend.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+
+        assignments = {
+            ast.unparse(node) for node in ast.walk(init) if isinstance(node, ast.Assign)
+        }
+        self.assertIn(
+            "self.kv_index_translator = model_runner.kv_index_translator",
+            assignments,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- bind every `DeepseekSparseAttnBackend` to its owning model runner's `KVIndexTranslator` during construction
- add a regression test for the DSA backend ownership contract

## Root cause

`ModelRunner.init_attention_backends()` binds the translator to the main attention backends. EAGLE constructs its specialized draft and draft-extend DSA backends afterward, so they miss that bind pass and retain the `AttentionBackend` class default `None`.

The ROCm FP8 MHA one-shot prefix-read path unconditionally uses the current backend's translator to produce kernel-facing KV ids. A late-created EAGLE DSA backend therefore crashes in `translate_dcp_read_ids()` before any translation can occur.

Binding in the DSA constructor follows the same ownership pattern used by the other attention backends and ensures that main, draft, and draft-extend instances all use the translator built from their own runner's KV pool. It also preserves passthrough behavior for static pools.

Fixes #38029.

## Validation

```text
python3 -m pytest test/registered/unit/layers/attention/test_kv_translate_ownership.py -q
6 passed, 7 subtests passed
```

Runtime reproduction on MI350X, TP4/EP4, GLM-5.3, EAGLE 3/1/4, TileLang DSA, and FP8 KV:

- before: request 1 completed, all TP schedulers then raised `AttributeError` because `kv_index_translator` was `None`
- after: repeated cached-prefix requests completed and the server remained healthy with no scheduler exception

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33900826842](https://github.com/sgl-project/sglang/actions/runs/33900826842)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33900826327](https://github.com/sgl-project/sglang/actions/runs/33900826327)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33900826666](https://github.com/sgl-project/sglang/actions/runs/33900826666)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->