### PR TITLE
feat(kv-events): advertise per-rank publisher endpoints

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -427,7 +427,7 @@ class RuntimeHandle:
         result: Dict[str, Any] = self.tokenizer_manager.server_args.resolved_dict()
         result.update(self.scheduler_info)
         result["kv_events"] = describe_kv_events_publisher(
-            self.tokenizer_manager.server_args
+            self.tokenizer_manager.server_args, self.scheduler_info
         )
         return json.dumps(msgspec_to_builtins(result), default=str)
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -835,7 +835,9 @@ async def server_info():
             # Structured KV-event publisher descriptor for KV-aware routers.
             # `None` when publishing is disabled or misconfigured; see
             # `runtime_context.describe_kv_events_publisher` for the contract.
-            "kv_events": describe_kv_events_publisher(server_args),
+            "kv_events": describe_kv_events_publisher(
+                server_args, _global_state.scheduler_info
+            ),
         }
     )
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -20,7 +20,7 @@ import signal
 import threading
 import time
 from enum import Enum, auto
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import psutil
 import setproctitle
@@ -50,6 +50,7 @@ from sglang.srt.observability.req_time_stats import DPControllerReqTimeStats
 from sglang.srt.observability.startup_time import aggregate_scheduler_startup_times
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.runtime_context import (
+    describe_kv_events_publisher,
     get_device,
     get_disagg,
     get_exec,
@@ -70,6 +71,7 @@ from sglang.srt.utils.common import (
 from sglang.srt.utils.network import (
     NetworkAddress,
     bind_port,
+    get_local_ip_auto,
     get_zmq_socket,
     get_zmq_socket_on_host,
 )
@@ -80,6 +82,54 @@ from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 logger = logging.getLogger(__name__)
 
 SCHEDULER_PIDS_ARG = "scheduler_pids"
+_KV_EVENT_BIND_HOSTS = frozenset({"*", "0.0.0.0", "::"})
+
+
+def build_kv_event_publishers(
+    *,
+    endpoint_host: str,
+    endpoint_port_base: int,
+    node_hosts: Dict[int, str],
+    nnodes: int,
+    dp_size: int,
+    tp_size: int,
+    pp_size: int,
+    attn_cp_size: int,
+    enable_dp_attention: bool,
+) -> List[Dict[str, object]]:
+    """Build dialable per-rank endpoints for a wildcard KV-event publisher."""
+    if endpoint_host.strip("[]") not in _KV_EVENT_BIND_HOSTS:
+        return []
+
+    if enable_dp_attention:
+        nnodes_per_pp_rank = max(nnodes // pp_size, 1)
+        tp_size_per_node = tp_size // nnodes_per_pp_rank
+        attn_tp_size = tp_size // dp_size // attn_cp_size
+        publisher_nodes = [
+            (dp_rank * attn_cp_size * attn_tp_size) // tp_size_per_node
+            for dp_rank in range(dp_size)
+        ]
+    else:
+        # Each pure-DP replica spans the same TP group. Its publisher is the
+        # pp=0/attn-tp=0 scheduler, which is on node 0 for every replica.
+        publisher_nodes = [0] * dp_size
+
+    missing_nodes = sorted(set(publisher_nodes).difference(node_hosts))
+    if missing_nodes:
+        raise RuntimeError(
+            "Missing advertised KV-event hosts for node ranks "
+            + ", ".join(str(rank) for rank in missing_nodes)
+        )
+
+    return [
+        {
+            "dp_rank": dp_rank,
+            "endpoint": NetworkAddress(
+                node_hosts[node_rank], endpoint_port_base + dp_rank
+            ).to_tcp(),
+        }
+        for dp_rank, node_rank in enumerate(publisher_nodes)
+    ]
 
 
 class LoadBalanceMethod(Enum):
@@ -151,6 +201,22 @@ class DataParallelController:
             get_parallel().load_balance_method
         )
         self.run_scheduler_process_func = run_scheduler_process_func
+
+        descriptor = describe_kv_events_publisher(server_args)
+        self._needs_kv_event_node_hosts = bool(
+            server_args.nnodes > 1
+            and descriptor is not None
+            and descriptor["endpoint_host"].strip("[]") in _KV_EVENT_BIND_HOSTS
+        )
+        self._kv_event_host = (
+            get_local_ip_auto()
+            if self._needs_kv_event_node_hosts
+            and (server_args.node_rank == 0 or get_parallel().enable_dp_attention)
+            else None
+        )
+        self._kv_event_node_hosts: Dict[int, str] = {}
+        if self._kv_event_host is not None:
+            self._kv_event_node_hosts[server_args.node_rank] = self._kv_event_host
 
         # Init inter-process communication
         self.context = zmq.Context(1 + get_parallel().dp_size)
@@ -478,7 +544,11 @@ class DataParallelController:
             connected_clients = 0
             while connected_clients < expected_clients:
                 # Wait for client handshake
-                client_rank = sock_recv(rep_socket)
+                client_rank, kv_event_host = self._parse_node_registration(
+                    sock_recv(rep_socket)
+                )
+                if kv_event_host is not None:
+                    self._kv_event_node_hosts[client_rank] = kv_event_host
                 logger.debug(f"Received handshake from node {client_rank}")
 
                 # Send worker ports to client
@@ -506,7 +576,11 @@ class DataParallelController:
         keeps ownership of every socket."""
         while True:
             try:
-                client_rank = sock_recv(rep_socket)
+                client_rank, kv_event_host = self._parse_node_registration(
+                    sock_recv(rep_socket)
+                )
+                if kv_event_host is not None:
+                    self._kv_event_node_hosts[client_rank] = kv_event_host
             except Exception:
                 logger.exception(
                     "Failed to recv/decode handshake in reply thread; continue"
@@ -528,7 +602,15 @@ class DataParallelController:
 
         try:
             # Send handshake with our node rank
-            sock_send(req_socket, wrap_as_pickle(str(node_rank)))
+            registration = (
+                {
+                    "node_rank": node_rank,
+                    "kv_event_host": self._kv_event_host,
+                }
+                if self._kv_event_host is not None
+                else str(node_rank)
+            )
+            sock_send(req_socket, wrap_as_pickle(registration))
 
             # Receive worker ports
             worker_ports = sock_recv(req_socket)
@@ -541,6 +623,32 @@ class DataParallelController:
             )
         finally:
             req_socket.close()
+
+    @staticmethod
+    def _parse_node_registration(registration) -> tuple[int, Optional[str]]:
+        if isinstance(registration, dict):
+            return int(registration["node_rank"]), registration.get("kv_event_host")
+        return int(registration), None
+
+    def get_kv_event_publishers(self) -> List[Dict[str, object]]:
+        if self.server_args.node_rank != 0 or not self._needs_kv_event_node_hosts:
+            return []
+
+        descriptor = describe_kv_events_publisher(self.server_args)
+        if descriptor is None:
+            return []
+        parallel = get_parallel()
+        return build_kv_event_publishers(
+            endpoint_host=descriptor["endpoint_host"],
+            endpoint_port_base=descriptor["endpoint_port_base"],
+            node_hosts=self._kv_event_node_hosts,
+            nnodes=self.server_args.nnodes,
+            dp_size=parallel.dp_size,
+            tp_size=self.server_args.tp_size,
+            pp_size=parallel.pp_size,
+            attn_cp_size=parallel.attn_cp_size,
+            enable_dp_attention=parallel.enable_dp_attention,
+        )
 
     def _joiner_local_tp_span(self, server_args: ServerArgs) -> int:
         return server_args.tp_size
@@ -848,15 +956,16 @@ def run_data_parallel_controller_process(
         scheduler_pids = [
             proc.pid for proc in controller.scheduler_procs if proc is not None
         ]
-        pipe_writer.send(
-            {
-                "status": "ready",
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
-                "startup_time": controller.startup_time,
-                SCHEDULER_PIDS_ARG: scheduler_pids,
-            }
-        )
+        init_info = {
+            "status": "ready",
+            "max_total_num_tokens": controller.max_total_num_tokens,
+            "max_req_input_len": controller.max_req_input_len,
+            "startup_time": controller.startup_time,
+            SCHEDULER_PIDS_ARG: scheduler_pids,
+        }
+        if publishers := controller.get_kv_event_publishers():
+            init_info["kv_events"] = {"publishers": publishers}
+        pipe_writer.send(init_info)
         # The primary owns routing for the expanded scheduler set.
         if server_args.node_rank == 0 and not server_args.is_ep_scale_joiner:
             controller.event_loop()

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -2041,16 +2041,19 @@ def is_ep_scale_joiner() -> bool:
     return get_exec().moe.ep_join_mode == "scale"
 
 
-def describe_kv_events_publisher(server_args: Any) -> Optional[dict]:
+def describe_kv_events_publisher(
+    server_args: Any, scheduler_info: Optional[dict] = None
+) -> Optional[dict]:
     """Return a structured description of this server's KV-event
     publisher, or `None` if publishing is disabled / misconfigured.
 
     This is the wire contract surfaced under the `kv_events` key on
     `/server_info` so KV-aware routers (e.g. the SGLang model
     gateway) can subscribe per-worker without operator-supplied port
-    coordination. The router constructs the per-DP-rank SUB endpoint
-    as tcp://<worker_host>:<endpoint_port_base + dp_rank> for
-    every rank reported in dp_size.
+    coordination. Consumers should use the dialable per-rank endpoints in
+    ``publishers`` when present. Otherwise, they construct each SUB endpoint
+    as tcp://<worker_host>:<endpoint_port_base + dp_rank> for every rank
+    reported in dp_size.
 
     Returned descriptor shape:
 
@@ -2073,6 +2076,14 @@ def describe_kv_events_publisher(server_args: Any) -> Optional[dict]:
                                               # DCP shards within a rank
                                               # rather than adding
                                               # publishers
+            "publishers": [                  # optional dialable endpoints;
+                {
+                    "dp_rank": 0,
+                    "endpoint": "tcp://node0:5557",
+                },
+                ...,
+            ],                                 # present for multi-node
+                                               # wildcard publishers
             "load_endpoint_port_base": <resolved>,
                                               # base TCP port of the load
                                               # range (load rank r = base
@@ -2147,6 +2158,10 @@ def describe_kv_events_publisher(server_args: Any) -> Optional[dict]:
         "block_size": kv_event_block_size_of(resolved),
         "dp_size": resolved.dp_size,
     }
+    if scheduler_info is not None:
+        runtime_kv_events = scheduler_info.get("kv_events")
+        if isinstance(runtime_kv_events, dict) and runtime_kv_events.get("publishers"):
+            descriptor["publishers"] = runtime_kv_events["publishers"]
     # Load range, from the same resolver SchedulerLoadPublisher binds
     # with (so the two can't drift). The decline reason is logged once at
     # startup, not here — this runs per /server_info request.

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -59,6 +59,7 @@ def _call_server_info_with(
     server_args: ServerArgs,
     internal_states: list[dict] | None = None,
     config_updates: dict | None = None,
+    scheduler_info: dict | None = None,
 ) -> dict:
     """Invoke `http_server.server_info()` against a stub global state.
 
@@ -81,7 +82,7 @@ def _call_server_info_with(
     tokenizer_manager = _stub_tokenizer_manager(server_args, _fake_internal_state)
     stub_state = SimpleNamespace(
         tokenizer_manager=tokenizer_manager,
-        scheduler_info={"max_req_input_len": 1024},
+        scheduler_info={"max_req_input_len": 1024, **(scheduler_info or {})},
     )
     prior_state = http_server.get_global_state()
     http_server.set_global_state(stub_state)
@@ -135,6 +136,24 @@ class TestServerInfoKvEventsField(CustomTestCase):
                 "load_topic": "load",
             },
         )
+
+    def test_multi_node_publishers_are_returned_as_dialable_rank_endpoints(self):
+        args = ServerArgs(
+            model_path="dummy",
+            kv_events_config='{"publisher": "zmq", "endpoint": "tcp://*:5557"}',
+            page_size=64,
+            dp_size=2,
+        )
+        publishers = [
+            {"dp_rank": 0, "endpoint": "tcp://10.0.0.1:5557"},
+            {"dp_rank": 1, "endpoint": "tcp://10.0.0.2:5558"},
+        ]
+
+        info = _call_server_info_with(
+            args, scheduler_info={"kv_events": {"publishers": publishers}}
+        )
+
+        self.assertEqual(info["kv_events"]["publishers"], publishers)
 
     def test_load_port_skips_an_overlapping_replay_range(self):
         # Conventional replay = kv + 1: the load range must be advertised

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -26,10 +26,37 @@ from sglang.srt.managers.data_parallel_controller import (
     DataParallelController,
     DPBudget,
     LoadBalanceMethod,
+    build_kv_event_publishers,
 )
 from sglang.srt.managers.load_snapshot import LoadSnapshot
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+
+
+class TestKvEventPublisherDiscovery(CustomTestCase):
+    def test_maps_dp_attention_publishers_to_their_nodes(self):
+        publishers = build_kv_event_publishers(
+            endpoint_host="*",
+            endpoint_port_base=5557,
+            node_hosts={0: "10.0.0.1", 1: "10.0.0.2"},
+            nnodes=2,
+            dp_size=8,
+            tp_size=8,
+            pp_size=1,
+            attn_cp_size=1,
+            enable_dp_attention=True,
+        )
+
+        self.assertEqual(
+            publishers,
+            [
+                {
+                    "dp_rank": rank,
+                    "endpoint": f"tcp://10.0.0.{1 if rank < 4 else 2}:{5557 + rank}",
+                }
+                for rank in range(8)
+            ],
+        )
 
 
 _BASE_LOAD = msgspec.structs.replace(


### PR DESCRIPTION
## Motivation

`/server_info` and native gRPC `GetServerInfo` currently expose one KV-event host plus a base port. That is sufficient on one node, but multi-node DP-attention publishers live on different hosts. A consumer that substitutes the frontend host for every DP rank silently misses events from remote nodes.

This removes the need for downstream launchers to supply a separate per-rank host list, such as the workaround in [ai-dynamo/dynamo#14014](https://github.com/ai-dynamo/dynamo/pull/14014).

## Modifications

- Advertise an optional `kv_events.publishers` list containing a dialable endpoint for every global DP rank.
- Exchange each node's advertised IP through the existing multi-node DP-controller startup handshake.
- Map DP-attention publisher ranks to their owning nodes using the same `(dp, cp, tp)` rank layout used to launch schedulers.
- Return the new field from both HTTP `/server_info` and native gRPC `GetServerInfo`.
- Preserve the existing `endpoint_host`, `endpoint_port_base`, and single-node fallback contract.

Example:

```json
{
  "kv_events": {
    "endpoint_host": "*",
    "endpoint_port_base": 5557,
    "dp_size": 8,
    "publishers": [
      {"dp_rank": 0, "endpoint": "tcp://10.0.0.1:5557"},
      {"dp_rank": 4, "endpoint": "tcp://10.0.0.2:5561"}
    ]
  }
}
```

## Accuracy Tests

Not applicable; this does not change model execution or outputs.

Targeted CPU tests in the cached SGLang test image:

```text
pytest -q test/registered/unit/managers/test_data_parallel_controller.py test/registered/unit/entrypoints/test_server_info.py
48 passed, 12 subtests passed
```

## Speed Tests and Profiling

Not applicable; the added work runs once during multi-node startup and only when KV-event publishing is configured. No serving hot path changes.

## Checklist

- [x] Ran pre-commit on all changed files.
- [x] Added focused unit coverage for topology mapping and server-info propagation.
- [x] Documented the additive wire contract in `describe_kv_events_publisher`.
- [x] Followed the existing SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33900876207](https://github.com/sgl-project/sglang/actions/runs/33900876207)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33900876052](https://github.com/sgl-project/sglang/actions/runs/33900876052)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33900876288](https://github.com/sgl-project/sglang/actions/runs/33900876288)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->