### PR TITLE
[Fix] Incorrect vision token counting

### DIFF
--- a/python/sglang/benchmark/datasets/image.py
+++ b/python/sglang/benchmark/datasets/image.py
@@ -127,9 +127,54 @@ def parse_random_image_resolution(
     return (min_width, min_height), (max_width, max_height)
 
 
+def resolve_image_placeholder(processor) -> Optional[str]:
+    """Return the model's own image placeholder string, or None if undiscoverable.
+
+    A processor may expose no chat template yet still know which token marks an
+    image, either as a string (``image_token``) or as an id (``image_token_id``).
+    """
+    token = getattr(processor, "image_token", None)
+    if isinstance(token, str) and token:
+        return token
+
+    token_id = getattr(processor, "image_token_id", None)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if token_id is None or tokenizer is None:
+        return None
+    try:
+        decoded = tokenizer.decode([token_id])
+    except Exception:  # noqa: BLE001 - unknown tokenizer; use the generic tag instead
+        return None
+    return decoded or None
+
+
+def render_with_tokenizer_template(processor, content) -> Optional[str]:
+    """Render one user turn with the processor's tokenizer template, or None.
+
+    Used when the processor itself exposes no chat template but its tokenizer
+    does, which happens for checkpoints shipping ``chat_template.jinja``.
+    """
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None or not getattr(tokenizer, "chat_template", None):
+        return None
+    try:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": content}],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+    except Exception:  # noqa: BLE001 - template may reject this content shape
+        return None
+
+
 def create_mm_data_row(
     text_prompt, images: list, images_base64, output_len, processor, backend
 ):
+    # Set when the fallback renders both prompts with the tokenizer's template, so
+    # the text-only length below is measured the same way as prompt_len. Mixing the
+    # two (templated prompt_len, bare text_prompt_len) would fold the role
+    # scaffolding into vision_prompt_len.
+    text_only_fallback = None
     try:
         if type(processor).__name__ == "Phi4MMProcessor":
             # <|endoftext10|> is the image token used in the phi-4-multimodal model.
@@ -147,12 +192,48 @@ def create_mm_data_row(
         )
     except Exception as e:
         # Note (Xinyuan): This is a workaround for an issue where some tokenizers do not support content as a list. (e.g. InternVL)
-        print(f"Error applying chat template: {e}, fallback to <image> tag")
-        # Some tokenizers do not support list content; fall back to a placeholder in the text
-        if type(processor).__name__ == "MiniCPMOProcessor":
-            prompt_str = f"(<image>./</image>){text_prompt}"
-        else:
-            prompt_str = f"<image>{text_prompt}"
+        print(f"Error applying chat template: {e}, falling back")
+        # A processor can lack a chat template while its tokenizer still carries the
+        # model's own one (some checkpoints ship chat_template.jinja, which the
+        # tokenizer picks up but a remote-code processor may not). Prefer that: it
+        # emits the model's real placeholder, once per image, plus the role
+        # scaffolding, so prompt_len stays comparable to what the server tokenizes.
+        placeholder = resolve_image_placeholder(processor)
+        text_only_fallback = render_with_tokenizer_template(processor, text_prompt)
+        prompt_str = (
+            None
+            if text_only_fallback is None
+            else render_with_tokenizer_template(processor, content_items)
+        )
+        # A template with no branch for image content renders the list as text and
+        # returns normally, so a non-None result is not evidence that placeholders
+        # were emitted; without this check that path would silently reproduce the
+        # undercount. Reject only on a verifiable shortfall:
+        #  - no resolvable placeholder means the render cannot be checked, but the
+        #    hand-built prompt could not be spelled correctly either, so keep the
+        #    render rather than discard a possibly-correct one for a certainly-generic
+        #    one;
+        #  - more placeholders than images is fine, since a template may expand one
+        #    image into per-tile placeholders.
+        if (
+            prompt_str is not None
+            and placeholder is not None
+            and prompt_str.count(placeholder) < len(images_base64)
+        ):
+            prompt_str = None
+        if prompt_str is None:
+            # No usable template: hand-build a prompt instead. The placeholder must be
+            # the one this model actually recognises, and there must be one per image,
+            # because the processor only expands vision tokens for placeholders it
+            # finds; a generic or missing tag silently yields a text-only prompt_len
+            # and collapses vision_prompt_len to a couple of tokens.
+            text_only_fallback = None
+            if type(processor).__name__ == "MiniCPMOProcessor":
+                prompt_str = f"(<image>./</image>){text_prompt}"
+            else:
+                prompt_str = (placeholder or "<image>") * len(
+                    images_base64
+                ) + text_prompt
 
     # Calculate total tokens (text + vision)
     if type(processor).__name__ in ("KimiK25Processor", "KimiK3Processor"):
@@ -185,12 +266,17 @@ def create_mm_data_row(
 
     # Calculate text-only tokens
     try:
-        # Create text-only version of the prompt
-        text_only_prompt = processor.apply_chat_template(
-            [{"role": "user", "content": text_prompt}],
-            add_generation_prompt=True,
-            tokenize=False,
-        )
+        # Create text-only version of the prompt. When the fallback above rendered
+        # prompt_str with the tokenizer's template, reuse that same rendering here so
+        # both lengths include identical scaffolding and their difference is purely
+        # vision tokens.
+        text_only_prompt = text_only_fallback
+        if text_only_prompt is None:
+            text_only_prompt = processor.apply_chat_template(
+                [{"role": "user", "content": text_prompt}],
+                add_generation_prompt=True,
+                tokenize=False,
+            )
         text_prompt_len = processor(
             text=[text_only_prompt],
             padding=False,

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -26,6 +26,7 @@ from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
 from transformers import PreTrainedTokenizerFast
 
+import sglang.benchmark.datasets.image as image_module
 from sglang.benchmark.datasets import DATASET_MAPPING, get_dataset
 from sglang.benchmark.datasets.agentic_trace import (
     DEFAULT_AGENTIC_OUTPUT_LEN,
@@ -41,7 +42,9 @@ from sglang.benchmark.datasets.generated_shared_prefix import (
 )
 from sglang.benchmark.datasets.image import (
     ImageDataset,
+    create_mm_data_row,
     parse_random_image_resolution,
+    resolve_image_placeholder,
     sample_image_requests,
 )
 from sglang.benchmark.datasets.mmmu import sample_mmmu_requests
@@ -1476,6 +1479,84 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
             "Traceback",
         ]:
             self.assertNotIn(forbidden, stderr)
+
+
+class _NoChatTemplateProcessor(DummyProcessor):
+    """Processor with no chat template of its own, as remote-code processors can be.
+
+    Its tokenizer still carries one, and it knows its image token, mirroring
+    checkpoints that ship ``chat_template.jinja``.
+    """
+
+    IMAGE_TOKEN = "<|img|>"
+
+    def __init__(self, tokenizer, *, template_drops_images=False):
+        super().__init__(tokenizer)
+        self.image_token = self.IMAGE_TOKEN
+        self.template_drops_images = template_drops_images
+
+    def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=False):
+        raise ValueError("this processor does not have a chat template")
+
+    def __call__(self, text, images=None, padding=False, return_tensors="pt"):
+        # Stand in for real vision expansion: every placeholder found becomes 4 tokens.
+        rendered = text[0]
+        n = rendered.count(self.IMAGE_TOKEN)
+        text_len = len(self.tokenizer.encode(rendered.replace(self.IMAGE_TOKEN, "")))
+        return {"input_ids": _DummyTokenTensor(text_len + 4 * n)}
+
+
+class TestImagePlaceholderFallback(CustomTestCase):
+    def setUp(self):
+        self.tokenizer = create_lightweight_tokenizer()
+        self.image = Image.new("RGB", (8, 8), (128, 128, 128))
+
+    def _row(self, processor, n_images, monkeypatched_render=None):
+        original = image_module.render_with_tokenizer_template
+        if monkeypatched_render is not None:
+            image_module.render_with_tokenizer_template = monkeypatched_render
+        try:
+            return create_mm_data_row(
+                "hello world",
+                [self.image] * n_images,
+                ["data:image/jpeg;base64,AAAA"] * n_images,
+                16,
+                processor,
+                "sglang-oai-chat",
+            )
+        finally:
+            image_module.render_with_tokenizer_template = original
+
+    def test_resolve_image_placeholder_prefers_image_token(self):
+        processor = _NoChatTemplateProcessor(self.tokenizer)
+        self.assertEqual(
+            resolve_image_placeholder(processor),
+            _NoChatTemplateProcessor.IMAGE_TOKEN,
+        )
+
+    def test_placeholder_is_none_when_processor_exposes_nothing(self):
+        self.assertIsNone(resolve_image_placeholder(DummyProcessor(self.tokenizer)))
+
+    def test_vision_tokens_counted_when_processor_has_no_chat_template(self):
+        processor = _NoChatTemplateProcessor(self.tokenizer)
+        self.assertEqual(self._row(processor, 1).vision_prompt_len, 4)
+
+    def test_vision_tokens_scale_with_image_count(self):
+        processor = _NoChatTemplateProcessor(self.tokenizer)
+        self.assertEqual(self._row(processor, 2).vision_prompt_len, 8)
+
+    def test_template_that_drops_images_is_rejected(self):
+        # A template with no image branch returns normally without emitting any
+        # placeholder; the hand-built prompt must be used instead of trusting it.
+        processor = _NoChatTemplateProcessor(self.tokenizer)
+        row = self._row(
+            processor, 1, monkeypatched_render=lambda proc, content: "hello world"
+        )
+        self.assertEqual(row.vision_prompt_len, 4)
+
+    def test_chat_backend_still_sends_raw_text(self):
+        processor = _NoChatTemplateProcessor(self.tokenizer)
+        self.assertEqual(self._row(processor, 1).prompt, "hello world")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

For any VL model whose processor ships no chat template — e.g. amd/MiniMax-M3-MXFP4 — 
bench_serving --dataset-name image reports ~2 vision tokens per request instead of the 
actual ~326, because the hardcoded <image> fallback placeholder is one the model doesn't 
recognise and so never gets expanded; the requests are genuinely multimodal, only the 
accounting is wrong. Without this PR those benchmarks keep publishing vision-token 
counts and input-token/s figures that are wrong by two orders of magnitude, with 
nothing erroring to signal it.


`create_mm_data_row()` wraps `processor.apply_chat_template()` in a `try/except`
and falls back to a hardcoded `<image>` tag. That fallback exists for processors
rejecting list-form content (e.g. InternVL), but assumes `<image>` is a
placeholder the model recognises because of which `vision_prompt_len` collapses to the couple of tokens the literal string `<image>` encodes to and not the actual number of image tokens. Nothing errors, the problem is only in the accounting: `total_input_vision_tokens`, `total_input_text_tokens` and any
input-tokens/sec figure derived from them are simply wrong.

### Why not fix the missing chat template instead?

The obvious objection: if the processor is missing a template, repair that rather than patch the fallback. The reason not to is that the loss happens outside sglang.

The checkpoint **does** ship a working template: `chat_template.jinja` whose `visible_text` macro maps `item.type == 'image'` to `]<]image[>[`
— exactly what the processor's expansion looks for. `tokenizer_config.json` has
no `chat_template` key; the standalone `.jinja` carries it. The tokenizer picks
it up, the processor does not:

```
AutoProcessor.chat_template   : None
proc.tokenizer.chat_template  : SET
sglang get_processor          : MiniMaxVLProcessor | chat_template: None
                                                   | tokenizer.chat_template: SET
```

This is not sglang's manual-construction path: plain `AutoProcessor.from_pretrained(..., trust_remote_code=True)` on transformers 5.12.1 loses it too, and the load logs the `TokenizersBackend` path rather than `"AutoProcessor failed on feature extractor"`, so `_build_processor_manually` is never entered. The template is dropped by the checkpoint's own remote-code processor, which sglang cannot fix at source — hence a defensive fallback here.

### What is changed
Five defects in the `create_mm_data_row()` fallback path in
`python/sglang/benchmark/datasets/image.py`, all of which corrupt reported
multimodal token accounting:

| # | Issue | Fix |
| --- | --- | --- |
| 1 | Fallback hardcodes `<image>`; models that don't recognize it expand no vision tokens, so `vision_prompt_len` collapses to ~2 | Prefer the tokenizer's chat template; else `resolve_image_placeholder()` — the model's own `image_token` / decoded `image_token_id` |
| 2 | Fallback emits exactly one placeholder regardless of `--image-count` | Hand-built prompt repeats the placeholder `len(images_base64)` times; templated path emits one per image |
| 3 | Fallback builds a bare string with no role scaffolding, so `prompt_len` sits far below what the server tokenizes | Templated path renders a full user turn plus generation prompt |
| 4 | `text_prompt_len` was measured with `processor.apply_chat_template()` even when `prompt_len` came from the fallback, folding scaffolding into the vision count | `text_only_fallback` reuses the same templated rendering for both lengths |
| 5 | A tokenizer template with no image branch renders the list as plain text and returns normally, silently reproducing the undercount through the new path | Guard rejects a render whose placeholder count is short of the image count |


### Effect on the request payload, by backend

For chat-completions backends (`sglang-oai-chat`, `vllm-chat`, `lmdeploy-chat`)
nothing changes: `use_raw_prompt` is true, `DatasetRow.prompt` stays
`text_prompt`, images ride separately in `image_data`, and only reported
accounting moves.

For the native backends (`sglang`, `sglang-native`) the payload **does** change:
`DatasetRow.prompt` is `prompt_str` there (image.py ~L311-314), so on the
fallback path it goes from `"<image>" + text` to a fully templated conversation.
That is the point — the old string carried a placeholder the model did not
recognise — but it is a real change to the measured workload on `/generate`, not
a no-op, and reviewers should weigh it as such.

## Accuracy Tests

Not applicable to model outputs — this touches synthetic benchmark prompt
construction only, not kernels, the forward path, or anything the server
executes.

6 new unit tests in `test/registered/bench_fn/test_benchmark_datasets_api.py`
(`TestImagePlaceholderFallback`, CPU-registered `CustomTestCase`): placeholder
resolution from `image_token` and its absence, vision tokens counted when the
processor has no chat template, counts scaling with image count, rejection of a
template that drops images, and chat backends still sending raw text. All 51
tests in that file pass.

Measured on `amd/MiniMax-M3-MXFP4` (`MiniMaxVLProcessor`, no processor-level
chat template, tokenizer template present, `image_token_id=200025` ->
`]<]image[>[`), 512x512 images:

| | `prompt_len` | `text_prompt_len` | `vision_prompt_len` |
| --- | --- | --- | --- |
| before | 5 | 2 | **3** |
| after, 1 image | 504 | 178 | **326** |
| after, 2 images | 830 | 178 | **652** |

326 per image matches MiniMax-M3's documented vision-token count for a 512x512
image (~324), and scales exactly with image count.

Reproducing needs no GPU, no accelerator vendor and no weights — the path is
`AutoProcessor` plus tokenizer string handling:

```
hf download amd/MiniMax-M3-MXFP4 --exclude "*.safetensors"   # ~22 MB
```

Models whose processor *does* carry a chat template never enter this branch; that
path is covered by the pre-existing tests in the same file, whose `DummyProcessor`
has a working `apply_chat_template`.

## Speed Tests and Profiling

Not applicable — no inference-path change. The added work is at most two
`apply_chat_template` renders per dataset row, only for models already taking
the fallback path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes for reviewers

- **Related to #37732.** That PR stops media placeholders leaking into randomly
  sampled prompt *text*; this one ensures the placeholder the benchmark inserts
  *deliberately* is the model's own and appears once per image. Different files
  (`common.py` vs `image.py`), neither depends on the other.
- **Alternatives considered.** Fixing the model repo's processor to load
  `chat_template.jinja` is the true root fix but is outside sglang and would
  leave published checkpoints broken. Diffing processor output with and without
  images was rejected: larger change, still would not repair `prompt_len`.
- **The placeholder tier is still reachable** for processors whose tokenizer also
  lacks a template, or whose template emits no placeholders — hence
  `resolve_image_placeholder` is retained rather than replaced. Weaker (no
  scaffolding) but strictly better than a hardcoded `<image>`.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33902659082](https://github.com/sgl-project/sglang/actions/runs/33902659082)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33902656311](https://github.com/sgl-project/sglang/actions/runs/33902656311)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33902657861](https://github.com/sgl-project/sglang/actions/runs/33902657861)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->