### PR TITLE
[Memory] Reuse output storage across full prefill CUDA graphs

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -57,6 +57,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         cuda_graph_runner: BaseCudaGraphRunner,
         *,
         enable_memory_saver: bool = False,
+        reuse_output_buffer: bool = False,
     ) -> None:
         self._graphs: Dict[Any, torch.cuda.CUDAGraph] = {}
         self._outputs: Dict[Any, Any] = {}
@@ -66,6 +67,8 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         self._tp_group = cuda_graph_runner.model_runner.tp_group
         self._capture_stream: Optional[torch.cuda.Stream] = None
         self._precarve = GraphPoolPrecarve()
+        self._reuse_output_buffer = reuse_output_buffer
+        self._output_buffer: Optional[torch.Tensor] = None
         self._memory_saver_adapter: Optional[Any] = TorchMemorySaverAdapter.create(
             enable=enable_memory_saver
             and get_bool_env_var("SGLANG_MEMORY_SAVER_CUDA_GRAPH")
@@ -106,15 +109,28 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
 
         # Two warmups so kernels are loaded and one-time setup is paid before capture.
         # post_warmup_hook lets the attention backend reset state that warmup mutated.
-        for _ in range(2):
+        warmup_output = None
+        for warmup_step in range(2):
             self._device_module.synchronize()
             self._tp_group.barrier()
             with self._precarve.measure():
-                forward_fn()
+                output = forward_fn()
+            if self._reuse_output_buffer and warmup_step == 1:
+                warmup_output = output
+            del output
             if profiler is not None:
                 profiler.step()
             if post_warmup_hook is not None:
                 post_warmup_hook()
+
+        if self._reuse_output_buffer and self._output_buffer is None:
+            if torch.is_tensor(warmup_output) and warmup_output.ndim > 0:
+                # Prefill replays one shape at a time, so all captured graphs can
+                # write their eager-tail input into the largest shape's buffer.
+                self._output_buffer = torch.empty_like(warmup_output)
+            else:
+                self._reuse_output_buffer = False
+        del warmup_output
 
         graph = torch.cuda.CUDAGraph()
 
@@ -136,6 +152,22 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         ):
             self._precarve.mint()
             out = forward_fn()
+            if self._reuse_output_buffer:
+                output_buffer = self._output_buffer
+                assert output_buffer is not None
+                if (
+                    torch.is_tensor(out)
+                    and out.ndim == output_buffer.ndim
+                    and out.shape[1:] == output_buffer.shape[1:]
+                    and out.shape[0] <= output_buffer.shape[0]
+                    and out.dtype == output_buffer.dtype
+                    and out.device == output_buffer.device
+                ):
+                    shared_out = output_buffer[: out.shape[0]]
+                    shared_out.copy_(out)
+                    out = shared_out
+                else:
+                    self._reuse_output_buffer = False
 
         if profiler is not None:
             profiler.step()
@@ -163,4 +195,5 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
     def cleanup(self) -> None:
         self._graphs.clear()
         self._outputs.clear()
+        self._output_buffer = None
         self._pool = None

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -47,6 +47,33 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.runner.shape_key import ShapeKey
 
 
+def _allocate_output_buffer(output: Any) -> Optional[torch.Tensor]:
+    if not torch.is_tensor(output) or output.ndim == 0:
+        return None
+    return torch.empty_like(output)
+
+
+def _output_fits_buffer(output: Any, output_buffer: torch.Tensor) -> bool:
+    return (
+        torch.is_tensor(output)
+        and output.ndim == output_buffer.ndim
+        and output.shape[1:] == output_buffer.shape[1:]
+        and output.shape[0] <= output_buffer.shape[0]
+        and output.dtype == output_buffer.dtype
+        and output.device == output_buffer.device
+    )
+
+
+def _copy_output_to_buffer(
+    output: Any, output_buffer: torch.Tensor
+) -> Optional[torch.Tensor]:
+    if not _output_fits_buffer(output, output_buffer):
+        return None
+    shared_output = output_buffer[: output.shape[0]]
+    shared_output.copy_(output)
+    return shared_output
+
+
 class FullCudaGraphBackend(BaseCudaGraphBackend):
     """One torch.cuda.CUDAGraph per shape; attention metadata is
     captured inside the graph. Memory-saver-aware.
@@ -123,7 +150,11 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             if post_warmup_hook is not None:
                 post_warmup_hook()
 
-        self._initialize_output_buffer(warmup_output)
+        if self._reuse_output_buffer and self._output_buffer is None:
+            # Prefill captures the largest shape first and replays one shape at
+            # a time, so all graphs can share this eager-tail input buffer.
+            self._output_buffer = _allocate_output_buffer(warmup_output)
+            self._reuse_output_buffer = self._output_buffer is not None
         del warmup_output
 
         graph = torch.cuda.CUDAGraph()
@@ -145,46 +176,20 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx(cuda_graph=graph, pool=self._pool, stream=self._capture_stream),
         ):
             self._precarve.mint()
-            out = self._copy_output_to_buffer(forward_fn())
+            out = forward_fn()
+            if self._reuse_output_buffer:
+                output_buffer = self._output_buffer
+                assert output_buffer is not None
+                shared_output = _copy_output_to_buffer(out, output_buffer)
+                self._reuse_output_buffer = shared_output is not None
+                if shared_output is not None:
+                    out = shared_output
 
         if profiler is not None:
             profiler.step()
 
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = out
-
-    def _initialize_output_buffer(self, output: Any) -> None:
-        if not self._reuse_output_buffer or self._output_buffer is not None:
-            return
-        if not torch.is_tensor(output) or output.ndim == 0:
-            self._reuse_output_buffer = False
-            return
-        # Prefill captures the largest shape first and replays one shape at a
-        # time, so all graphs can share this eager-tail input buffer.
-        self._output_buffer = torch.empty_like(output)
-
-    def _copy_output_to_buffer(self, output: Any) -> Any:
-        if not self._reuse_output_buffer:
-            return output
-        output_buffer = self._output_buffer
-        assert output_buffer is not None
-        if not self._output_fits_buffer(output, output_buffer):
-            self._reuse_output_buffer = False
-            return output
-        shared_output = output_buffer[: output.shape[0]]
-        shared_output.copy_(output)
-        return shared_output
-
-    @staticmethod
-    def _output_fits_buffer(output: Any, output_buffer: torch.Tensor) -> bool:
-        return (
-            torch.is_tensor(output)
-            and output.ndim == output_buffer.ndim
-            and output.shape[1:] == output_buffer.shape[1:]
-            and output.shape[0] <= output_buffer.shape[0]
-            and output.dtype == output_buffer.dtype
-            and output.device == output_buffer.device
-        )
 
     def can_run(self, forward_batch: ForwardBatch, shape_key: ShapeKey) -> bool:
         return shape_key in self._graphs

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -123,13 +123,7 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             if post_warmup_hook is not None:
                 post_warmup_hook()
 
-        if self._reuse_output_buffer and self._output_buffer is None:
-            if torch.is_tensor(warmup_output) and warmup_output.ndim > 0:
-                # Prefill replays one shape at a time, so all captured graphs can
-                # write their eager-tail input into the largest shape's buffer.
-                self._output_buffer = torch.empty_like(warmup_output)
-            else:
-                self._reuse_output_buffer = False
+        self._initialize_output_buffer(warmup_output)
         del warmup_output
 
         graph = torch.cuda.CUDAGraph()
@@ -151,29 +145,46 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx(cuda_graph=graph, pool=self._pool, stream=self._capture_stream),
         ):
             self._precarve.mint()
-            out = forward_fn()
-            if self._reuse_output_buffer:
-                output_buffer = self._output_buffer
-                assert output_buffer is not None
-                if (
-                    torch.is_tensor(out)
-                    and out.ndim == output_buffer.ndim
-                    and out.shape[1:] == output_buffer.shape[1:]
-                    and out.shape[0] <= output_buffer.shape[0]
-                    and out.dtype == output_buffer.dtype
-                    and out.device == output_buffer.device
-                ):
-                    shared_out = output_buffer[: out.shape[0]]
-                    shared_out.copy_(out)
-                    out = shared_out
-                else:
-                    self._reuse_output_buffer = False
+            out = self._copy_output_to_buffer(forward_fn())
 
         if profiler is not None:
             profiler.step()
 
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = out
+
+    def _initialize_output_buffer(self, output: Any) -> None:
+        if not self._reuse_output_buffer or self._output_buffer is not None:
+            return
+        if not torch.is_tensor(output) or output.ndim == 0:
+            self._reuse_output_buffer = False
+            return
+        # Prefill captures the largest shape first and replays one shape at a
+        # time, so all graphs can share this eager-tail input buffer.
+        self._output_buffer = torch.empty_like(output)
+
+    def _copy_output_to_buffer(self, output: Any) -> Any:
+        if not self._reuse_output_buffer:
+            return output
+        output_buffer = self._output_buffer
+        assert output_buffer is not None
+        if not self._output_fits_buffer(output, output_buffer):
+            self._reuse_output_buffer = False
+            return output
+        shared_output = output_buffer[: output.shape[0]]
+        shared_output.copy_(output)
+        return shared_output
+
+    @staticmethod
+    def _output_fits_buffer(output: Any, output_buffer: torch.Tensor) -> bool:
+        return (
+            torch.is_tensor(output)
+            and output.ndim == output_buffer.ndim
+            and output.shape[1:] == output_buffer.shape[1:]
+            and output.shape[0] <= output_buffer.shape[0]
+            and output.dtype == output_buffer.dtype
+            and output.device == output_buffer.device
+        )
 
     def can_run(self, forward_batch: ForwardBatch, shape_key: ShapeKey) -> bool:
         return shape_key in self._graphs

--- a/python/sglang/srt/model_executor/runner_backend/utils.py
+++ b/python/sglang/srt/model_executor/runner_backend/utils.py
@@ -122,6 +122,7 @@ def resolve_prefill_backend(
         return FullCudaGraphBackend(
             cuda_graph_runner,
             enable_memory_saver=get_exec().features.enable_memory_saver,
+            reuse_output_buffer=True,
         )
     # Default: tc_piecewise.
     return TcPiecewiseCudaGraphBackend(cuda_graph_runner)

--- a/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
+++ b/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
@@ -24,6 +24,8 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
+
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
     FullCudaGraphBackend,
@@ -59,6 +61,8 @@ def _make_backend(runner):
     backend._precarve = SimpleNamespace(
         measure=contextlib.nullcontext, mint=mock.Mock()
     )
+    backend._reuse_output_buffer = False
+    backend._output_buffer = None
     backend._memory_saver_adapter = None
     backend._cuda_graph_runner = runner
     backend._device_module = runner.device_module
@@ -106,6 +110,32 @@ class TestCaptureOneNoProfiling(CustomTestCase):
         # Graph + output are recorded against the shape key.
         self.assertEqual(backend._graphs[shape_key], "GRAPH")
         self.assertIs(backend._outputs[shape_key], sentinel_out)
+
+    def test_prefill_shapes_share_one_output_storage(self):
+        runner = _make_runner(enable_profile=False, profiler=None, mode_name="EXTEND")
+        backend = _make_backend(runner)
+        backend._reuse_output_buffer = True
+
+        outputs = iter(
+            [
+                torch.ones((4, 2)),
+                torch.ones((4, 2)),
+                torch.ones((4, 2)),
+                torch.ones((2, 2)),
+                torch.ones((2, 2)),
+                torch.ones((2, 2)),
+            ]
+        )
+        with mock.patch("torch.cuda.CUDAGraph", side_effect=["GRAPH4", "GRAPH2"]):
+            backend.capture_one(ShapeKey(size=4), lambda: next(outputs))
+            backend.capture_one(ShapeKey(size=2), lambda: next(outputs))
+
+        large = backend._outputs[ShapeKey(size=4)]
+        small = backend._outputs[ShapeKey(size=2)]
+        self.assertEqual(large.shape, (4, 2))
+        self.assertEqual(small.shape, (2, 2))
+        self.assertEqual(large.data_ptr(), small.data_ptr())
+        self.assertEqual(backend._output_buffer.shape, (4, 2))
 
     def test_enable_flag_set_but_no_profiler_attr_does_not_step(self):
         # The runner advertises the flag but never created a profiler; the


### PR DESCRIPTION
## Motivation

Full prefill CUDA graphs capture multiple bucket shapes but retain separate output storage for every captured graph. These graphs replay serially, so compatible shapes can share the largest bucket's output storage instead of reserving one output buffer per shape.

## Modifications

- Add opt-in output-buffer reuse to `FullCudaGraphBackend`.
- Enable reuse only for the full prefill backend; decode behavior remains unchanged.
- Allocate storage from the first, largest captured shape and expose smaller compatible outputs as views of it.
- Fall back to independent outputs when tensor rank, trailing shape, dtype, or device is incompatible.
- Add CPU unit coverage proving two prefill shapes share the same storage.

The process-wide CUDA graph capture stream from the original change is already present on current main, so this PR does not duplicate those runner and runtime-context changes.

## Accuracy Tests

Not applicable. The captured output is copied into an equivalent tensor view with the same shape, dtype, and device; model computation is unchanged.

## Speed Tests and Profiling

Not run. This PR changes capture-time memory ownership and makes no latency or throughput claim.

## Tests

- PASS: `uv run pytest -q test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py` (5 passed).
- PASS: `with-proxy uv run pre-commit run --files python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py python/sglang/srt/model_executor/runner_backend/utils.py test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py`.
- PASS: `git diff --check origin/main...HEAD`.
- NOT RUN: GPU CUDA-graph capture or memory benchmark; no suitable GPU validation environment was used for this port.

## Original commits

- `108d337f6a`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33906873475](https://github.com/sgl-project/sglang/actions/runs/33906873475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33906873217](https://github.com/sgl-project/sglang/actions/runs/33906873217)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33906873375](https://github.com/sgl-project/sglang/actions/runs/33906873375)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->