### PR TITLE
[Test] Accounting-contract tests for classic RadixCache (+ sanity_check)

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -683,6 +683,33 @@ class RadixCache(BasePrefixCache):
         # protected size refers to the size of the cache that is locked
         return self.protected_size_
 
+    def sanity_check(self) -> None:
+        """Recompute accounting from the tree and assert the counters agree.
+
+        Debug aid for counter drift of the kind reported in sgl-project/sglang#35270:
+        walks every node, sums key lengths by lock state, and asserts the running
+        evictable_/protected_size_ counters match. O(tree size); intended for tests
+        and idle-time diagnostics, never the serving path.
+        """
+        evictable = 0
+        protected = 0
+        stack = [self.root_node]
+        while stack:
+            node = stack.pop()
+            assert node.lock_ref >= 0, f"negative lock_ref on node id={node.id}"
+            if node is not self.root_node and node.value is not None:
+                if node.lock_ref == 0:
+                    evictable += len(node.key)
+                else:
+                    protected += len(node.key)
+            stack.extend(node.children.values())
+        assert evictable == self.evictable_size_, (
+            f"evictable drift: counter={self.evictable_size_} recomputed={evictable}"
+        )
+        assert protected == self.protected_size_, (
+            f"protected drift: counter={self.protected_size_} recomputed={protected}"
+        )
+
     def all_values_flatten(self):
         values = []
 

--- a/test/registered/unit/mem_cache/test_radix_cache_accounting.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_accounting.py
@@ -1,0 +1,144 @@
+"""
+Accounting-contract tests for the classic RadixCache.
+
+The running evictable_/protected_size_ counters must always agree with a
+recomputation from the tree (see RadixCache.sanity_check). This guards the
+class of drift reported in sgl-project/sglang#35270, where the idle
+pool-invariant check tripped on an over-counted evictable size.
+
+All tests run on CPU via create_simulated: no model, no GPU, deterministic
+seeds. Usage:
+    python -m pytest test/registered/unit/mem_cache/test_radix_cache_accounting.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+import random
+import unittest
+from array import array
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+
+def _make_cache(page_size=32):
+    mock_allocator = MagicMock()
+    mock_allocator.device = torch.device("cpu")
+    return RadixCache.create_simulated(
+        mock_allocator=mock_allocator, page_size=page_size
+    )
+
+
+def _key(ids):
+    return RadixKey(array("q", ids))
+
+
+class TestAccountingContract(unittest.TestCase):
+    def test_empty_tree_is_balanced(self):
+        cache = _make_cache()
+        cache.sanity_check()
+        self.assertEqual(cache.evictable_size(), 0)
+        self.assertEqual(cache.protected_size(), 0)
+
+    def test_insert_match_lock_unlock_evict_sequence(self):
+        # One shared page-aligned prefix, a divergent tail, then release
+        # everything and drain the tree: counters must return to zero.
+        cache = _make_cache()
+        shared = list(range(1024))
+        cache.insert(InsertParams(key=_key(shared + list(range(1000, 1064)))))
+        res = cache.match_prefix(MatchPrefixParams(key=_key(shared)))
+        cache.inc_lock_ref(res.last_device_node)
+        cache.sanity_check()
+        cache.dec_lock_ref(res.last_device_node)
+        cache.sanity_check()
+        cache.evict(EvictParams(num_tokens=10**9))
+        cache.sanity_check()
+        self.assertEqual(cache.evictable_size(), 0)
+        self.assertEqual(cache.protected_size(), 0)
+
+    def test_split_during_hold_then_scrambled_release(self):
+        # Lock a node, force a split inside the held region via a partial
+        # match, then release and evict in a different order. The inherited
+        # lock_refs on split halves must still balance exactly.
+        cache = _make_cache()
+        base = list(range(2048))
+        cache.insert(InsertParams(key=_key(base)))
+        res = cache.match_prefix(MatchPrefixParams(key=_key(base)))
+        cache.inc_lock_ref(res.last_device_node)
+        # partial match ends mid-node -> split
+        cache.match_prefix(MatchPrefixParams(key=_key(base[:1024] + [9999] * 32)))
+        cache.sanity_check()
+        cache.dec_lock_ref(res.last_device_node)
+        cache.sanity_check()
+        cache.evict(EvictParams(num_tokens=10**9))
+        cache.sanity_check()
+        self.assertEqual(cache.evictable_size(), 0)
+
+    def test_remask_style_duplicate_inserts(self):
+        # Re-inserting identical page-aligned keys (e.g. diffusion remask
+        # rewrites) must be accounting-neutral.
+        cache = _make_cache()
+        ids = list(range(4096))
+        for _ in range(3):
+            cache.insert(InsertParams(key=_key(ids)))
+            cache.sanity_check()
+        self.assertEqual(cache.evictable_size(), 4096)
+
+    def test_sanity_check_catches_drift(self):
+        # Prove the detector detects: corrupt the counter by one page and
+        # the check must raise instead of staying green.
+        cache = _make_cache()
+        cache.insert(InsertParams(key=_key(list(range(128)))))
+        cache.sanity_check()
+        cache.evictable_size_ += 32
+        with self.assertRaises(AssertionError):
+            cache.sanity_check()
+
+    def test_model_based_random_ops(self):
+        # Paired lock/unlock, splits, evictions and duplicate inserts over
+        # shared page-aligned prefixes. Deterministic seeds.
+        for seed in (11, 22, 33):
+            rng = random.Random(seed)
+            cache = _make_cache()
+            base = [rng.randrange(0, 60) for _ in range(4096)]
+            held = []
+            for _ in range(300):
+                r = rng.random()
+                if r < 0.35:
+                    plen = rng.choice([0, 1024, 2048, 3072])
+                    tail = [rng.randrange(0, 200) for _ in range(64)]
+                    cache.insert(InsertParams(key=_key(base[:plen] + tail)))
+                elif r < 0.55:
+                    plen = rng.choice([0, 1024, 2048, 3072, 4096])
+                    res = cache.match_prefix(
+                        MatchPrefixParams(key=_key(base[:plen]))
+                    )
+                    node = res.last_device_node
+                    if node is not None and node is not cache.root_node:
+                        cache.inc_lock_ref(node)
+                        held.append(node)
+                elif r < 0.70 and held:
+                    node = held.pop(rng.randrange(len(held)))
+                    cache.dec_lock_ref(node)
+                elif r < 0.85:
+                    cache.evict(EvictParams(num_tokens=rng.choice([32, 128, 512])))
+                else:
+                    plen = rng.choice([1024, 2048])
+                    cache.insert(InsertParams(key=_key(base[:plen])))
+                cache.sanity_check()
+            for node in held:
+                cache.dec_lock_ref(node)
+            cache.sanity_check()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

In #35270, the idle pool-invariant check trips on an over-counted `evictable` size (e.g. `total=469952, available=96, evictable=470016` — 160 tokens more than the pool holds), killing the scheduler after all requests succeed. The classic `RadixCache` — unlike the SWA/Mamba/unified trees — has no `sanity_check()` that recomputes accounting from the tree, so there is no in-repo way to assert the running `evictable_/protected_size_` counters against ground truth.

## Modifications

- Add `RadixCache.sanity_check()`: walks the tree, sums key lengths by lock state, asserts the counters agree and that no `lock_ref` went negative. O(tree size); for tests and idle-time diagnostics, never the serving path.
- Add `test/registered/unit/mem_cache/test_radix_cache_accounting.py` (CPU-only, deterministic seeds, `register_cpu_ci`): empty-tree balance, insert/match/lock/evict drain-to-zero, split-during-hold with scrambled release order, remask-style duplicate inserts, seeded model-based op sequences calling `sanity_check()` after every step, plus a negative test proving the detector raises on a corrupted counter.

No behavior change — test-only plus one debug method.

## Verification

```
python -m pytest test/registered/unit/mem_cache/test_radix_cache_accounting.py -v
6 passed in ~3.4s (CPU, no GPU)
```

## Note on #35270 root cause

While writing these tests I hammered the counter with paired insert/match/split/lock/evict patterns (thousands of ops, page-aligned shared prefixes mimicking the dLLM workload shape) and could not move it: the counter is provably balanced for every paired call pattern, including splits during holds. That suggests the production trigger is an unpaired scheduler-level pattern specific to the dLLM flow rather than the tree core. These tests lock the contract so the trigger, once minimized to a CPU repro, fails loudly here first. Happy to extend the suite in that direction.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33910574491](https://github.com/sgl-project/sglang/actions/runs/33910574491)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33910574167](https://github.com/sgl-project/sglang/actions/runs/33910574167)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33910574619](https://github.com/sgl-project/sglang/actions/runs/33910574619)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->