### PR TITLE
[OpenAI] Mirror chat_template_kwargs thinking / enable_thinking toggle keys

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -824,6 +824,29 @@ def _has_message_level_tools(messages: Any) -> bool:
     )
 
 
+# Chat templates read one of two keys for the reasoning toggle: "thinking"
+# (deepseek-v3, kimi_k2) or "enable_thinking" (qwen3, glm45, nemotron_3,
+# interns1). Clients that send only the other one -- sgl-eval's --thinking /
+# --no-thinking and its per-benchmark defaults send `thinking` -- otherwise
+# leave the template at its default (thinking on for Qwen3.5), so the request
+# silently runs in the wrong mode. Mirror the missing key, never overwrite.
+_THINKING_TOGGLE_KEYS = ("thinking", "enable_thinking")
+
+
+def mirror_thinking_toggle_keys(chat_template_kwargs):
+    if not isinstance(chat_template_kwargs, dict):
+        return chat_template_kwargs
+    present = [k for k in _THINKING_TOGGLE_KEYS if k in chat_template_kwargs]
+    if len(present) != 1:
+        return chat_template_kwargs
+    value = chat_template_kwargs[present[0]]
+    if not isinstance(value, bool):
+        return chat_template_kwargs
+    for key in _THINKING_TOGGLE_KEYS:
+        chat_template_kwargs.setdefault(key, value)
+    return chat_template_kwargs
+
+
 class ChatCompletionRequest(BaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
@@ -1041,6 +1064,7 @@ class ChatCompletionRequest(BaseModel):
             ctk.setdefault("enable_thinking", thinking)
             values["chat_template_kwargs"] = ctk
 
+        mirror_thinking_toggle_keys(values.get("chat_template_kwargs"))
         return values
 
     @model_validator(mode="before")
@@ -1677,6 +1701,7 @@ class ResponsesRequest(BaseModel):
                 "enable_thinking": False,
                 **existing,
             }
+        mirror_thinking_toggle_keys(values.get("chat_template_kwargs"))
         return values
 
     @model_validator(mode="before")

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -287,6 +287,51 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.chat_template_kwargs.get("thinking"))
         self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
 
+    def test_chat_template_kwargs_thinking_mirrors_enable_thinking(self):
+        """A client that only knows the deepseek/kimi key (e.g. sgl-eval's
+        --no-thinking) must still toggle qwen3/glm templates."""
+        messages = [{"role": "user", "content": "Hello"}]
+        for value in (True, False):
+            request = ChatCompletionRequest(
+                model="test-model",
+                messages=messages,
+                chat_template_kwargs={"thinking": value},
+            )
+            self.assertEqual(
+                request.chat_template_kwargs,
+                {"thinking": value, "enable_thinking": value},
+            )
+            request = ChatCompletionRequest(
+                model="test-model",
+                messages=messages,
+                chat_template_kwargs={"enable_thinking": value},
+            )
+            self.assertEqual(
+                request.chat_template_kwargs,
+                {"thinking": value, "enable_thinking": value},
+            )
+
+    def test_chat_template_kwargs_thinking_keys_not_overwritten(self):
+        """Both keys present, or a non-boolean value: leave the request alone."""
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            chat_template_kwargs={"thinking": True, "enable_thinking": False},
+        )
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking": True, "enable_thinking": False},
+        )
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            chat_template_kwargs={"thinking": "auto", "other": 1},
+        )
+        self.assertEqual(request.chat_template_kwargs, {"thinking": "auto", "other": 1})
+        request = ChatCompletionRequest(model="test-model", messages=messages)
+        self.assertIsNone(request.chat_template_kwargs)
+
     def test_chat_completion_reasoning_effort_none_from_reasoning_dict(self):
         """Test reasoning_effort='none' via nested reasoning dict"""
         messages = [{"role": "user", "content": "Hello"}]

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -231,6 +231,26 @@ class ThinkingControlTestCase(CustomTestCase):
         )
         self.assertTrue(req.chat_template_kwargs["enable_thinking"])
 
+    def test_single_thinking_key_is_mirrored(self):
+        req = ResponsesRequest(
+            model="x",
+            input="hi",
+            store=False,
+            chat_template_kwargs={"thinking": False},
+        )
+        self.assertEqual(
+            req.chat_template_kwargs, {"thinking": False, "enable_thinking": False}
+        )
+        req = ResponsesRequest(
+            model="x",
+            input="hi",
+            store=False,
+            chat_template_kwargs={"enable_thinking": True, "thinking": False},
+        )
+        self.assertEqual(
+            req.chat_template_kwargs, {"enable_thinking": True, "thinking": False}
+        )
+
 
 class ResponsesResponseFromRequestTestCase(CustomTestCase):
     def test_requested_text_format_is_echoed(self):


### PR DESCRIPTION
## Motivation

Chat templates use one of two keys for the reasoning toggle: `thinking` (DeepSeek-V3, Kimi-K2) or `enable_thinking` (Qwen3 / Qwen3.5, GLM-4.5, Nemotron-3, InternS1). `ChatCompletionRequest.normalize_reasoning_inputs` already writes both keys when the toggle comes from the top-level `thinking` / `reasoning_effort` fields, but a client that supplies only one of the two keys directly in `chat_template_kwargs` is passed through unchanged. If the served model's template reads the other key, the request silently runs in the template's default mode.

[sgl-eval](https://github.com/sgl-project/sgl-eval), which `sglang.test.run_eval --api sgl_eval` and the GB300 / nightly accuracy tests shell out to, is such a client: `--thinking` / `--no-thinking` only set `chat_template_kwargs.thinking`, so `--no-thinking` has no effect against a Qwen3.5 server.

Measurements on Qwen3.5-397B-A17B-NVFP4-V2 (sglang, 4x GB300, TP4/EP4/DP4), sgl-eval `gsm8k`, 200 examples, `max_tokens=16384`, temperature 0.6 / top-p 0.95 / top-k 20 (from `generation_config.json`), same server for every row:

| request (unpatched server) | template mode actually used | score | truncated |
|---|---|---|---|
| sgl-eval `--no-thinking` (`chat_template_kwargs={"thinking": false}`) | thinking on (key ignored) | 0.950 | 9.0% |
| sgl-eval `--chat-template-kwarg enable_thinking=false` | thinking off | 0.890 | 0.0% |
| sgl-eval `--thinking` (`{"thinking": true}`) | thinking on | 0.945 | 7.0% |
| sgl-eval default (no `chat_template_kwargs`) | thinking on (template default) | 0.950 | 8.5% |

The truncated samples are generations that loop inside the reasoning block on the zero-shot answer-format instruction until `max_tokens`; the point here is only that the first row should have behaved like the second.

## Modifications

- `protocol.py`: add `mirror_thinking_toggle_keys()`. When `chat_template_kwargs` contains exactly one of `thinking` / `enable_thinking` with a boolean value, mirror it into the other key via `setdefault`. Requests carrying both keys, or a non-boolean value, are left untouched. Applied in `ChatCompletionRequest.normalize_reasoning_inputs` and `ResponsesRequest.normalize_reasoning_to_thinking`, after the existing top-level normalization, so an explicit caller value always wins.
- Unit tests in `test_protocol.py` and `test_responses_protocol.py` covering the mirror in both directions, the both-keys-present case, non-boolean values, and requests without `chat_template_kwargs`.

## Accuracy Tests

- Unit: `test/registered/unit/entrypoints/openai/{test_protocol,test_responses_protocol,test_serving_chat}.py` (186 passed, 89 subtests) and `test/registered/unit/bench/test_simple_eval_gsm8k.py` (13 passed), run in the `lmsysorg/sglang:nightly-dev-cu13-20260901` container; `black --check` clean.
- End-to-end on the patched server (same setup as above), sgl-eval `--no-thinking`: 0.900 / 0.0% truncated, matching the explicit `enable_thinking=false` run (0.890 / 0.0%) instead of the unpatched 0.950 / 9.0%. `--thinking` on the patched server: 0.935 / 11.0% truncated (thinking on, unchanged, as Qwen3.5's template default is already on).

## Notes

- sgl-eval's default for `gsm8k` sends no `chat_template_kwargs` at all (its registry marks the benchmark `thinking: False` but only emits the key when it is `True`), so Qwen-family models still run that benchmark in thinking mode. This PR does not change that default.
- The low absolute GSM8K scores above come from sgl-eval's zero-shot prompt and are addressed separately in sgl-project/sgl-eval#46 (standard 8-shot CoT examples: 0.970-0.985 with <=2.5% truncation on the same server, thinking on or off).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33922432974](https://github.com/sgl-project/sglang/actions/runs/33922432974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33922432842](https://github.com/sgl-project/sglang/actions/runs/33922432842)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33922433024](https://github.com/sgl-project/sglang/actions/runs/33922433024)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->