### PR TITLE
docs: fix outdated server flags in advanced-feature docs

### DIFF
--- a/docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx
+++ b/docs/docs/advanced_features/cuda_graph_for_multi_modal_encoder.mdx
@@ -61,13 +61,12 @@ SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
 python3 -m sglang.launch_server \
   --model Qwen/Qwen3-VL-8B-Instruct
 ```
-Or you can run CUDA Graph for ViT together with Piecewise CUDA Graph feature by both setting env variable `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` and setting `--enable-piecewise-cuda-graph`, for example:
+Or you can run CUDA Graph for ViT together with the Piecewise CUDA Graph feature (enabled by default) by setting env variable `SGLANG_VIT_ENABLE_CUDA_GRAPH=1`, for example:
 ```shell Command
 SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
 python3 -m sglang.launch_server \
   --model Qwen/Qwen3-VL-8B-Instruct \
   --piecewise-cuda-graph-max-tokens 4096 \
-  --enable-piecewise-cuda-graph \
   --piecewise-cuda-graph-compiler eager
 ```
 

--- a/docs/docs/advanced_features/lora.mdx
+++ b/docs/docs/advanced_features/lora.mdx
@@ -159,7 +159,7 @@ lora1 = "algoprog/fact-generation-llama-3.1-8b-instruct-lora"  # rank - 64, targ
 lora0_new = "philschmid/code-llama-3-1-8b-text-to-sql-lora"  # rank - 256, target modules - q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj
 
 
-# The `--target-lora-modules` param below is technically not needed, as the server will infer it from lora0 which already has all the target modules specified.
+# The `--lora-target-modules` param below is technically not needed, as the server will infer it from lora0 which already has all the target modules specified.
 # We are adding it here just to demonstrate usage.
 server_process, port = launch_server_cmd(
     """
@@ -167,7 +167,7 @@ server_process, port = launch_server_cmd(
     --enable-lora \
     --cuda-graph-max-bs-decode 2 \
     --max-loras-per-batch 2 \
-    --max-lora-rank 256
+    --max-lora-rank 256 \
     --lora-target-modules all
     --log-level warning
     """

--- a/docs/docs/advanced_features/observability.mdx
+++ b/docs/docs/advanced_features/observability.mdx
@@ -15,7 +15,7 @@ See [Production Metrics](../references/production_metrics) and [Production Reque
 ## Logging
 
 By default, SGLang does not log any request contents. You can log them by using `--log-requests`.
-You can control the verbosity by using `--log-request-level`.
+You can control the verbosity by using `--log-requests-level`.
 See [Logging](./server_arguments#logging) for more details.
 
 You can change verbosity at runtime:

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -3064,7 +3064,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-retries`</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-attempts`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill retries that will skip the bootstrap wait.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>


### PR DESCRIPTION
Four docs fixes, each cross-checked against the registered flags in `python/sglang/srt/server_args.py`:

1. `observability.mdx`: `--log-request-level` → `--log-requests-level` (the registered flag; the `--log-requests` help text itself says "The verbosity is decided by --log-requests-level")
2. `cuda_graph_for_multi_modal_encoder.mdx`: the example passed the nonexistent `--enable-piecewise-cuda-graph` flag — piecewise CUDA graph is enabled by default (`piecewise_cuda_graph.mdx` states the old flag is deprecated); removed it and the stray continuation
3. `lora.mdx`: `--target-lora-modules` → `--lora-target-modules` in the comment, and added two missing shell line-continuations that broke the example command mid-way
4. `server_arguments.mdx`: `--optimistic-prefill-retries` → `--optimistic-prefill-attempts` (registered field `optimistic_prefill_attempts`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33917182392](https://github.com/sgl-project/sglang/actions/runs/33917182392)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33917182103](https://github.com/sgl-project/sglang/actions/runs/33917182103)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->