### PR TITLE
fix: correct small text issues in server args docstrings and messages

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_tensor.py
@@ -30,7 +30,7 @@ class MXFP4QuantizeUtil:
         """Converting a tensor to a quantized format based on MXFP4 quantization. Only E4M3 is supported.
         Args:
             input (torch.Tensor): The input tensor to be quantized.
-            block_sizes (dict | None): The block sizes for quantization.
+            block_size (int | None): The block size for quantization.
         """
 
         def cast_fp4(x):

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -851,22 +851,22 @@ def multinomial_with_seed(
     logprobs: torch.Tensor, seed: torch.Tensor, positions: torch.Tensor
 ) -> torch.Tensor:
     """
-    Samples n elements from an input tensor `inputs` of shape (n, m) using
+    Samples n elements from an input tensor `logprobs` of shape (n, m) using
     a unique random seed for each row. This is a deterministic batched alternative to
     `torch.multinomial`.
 
     Args:
-        inputs: A float tensor of shape (n, m) representing n categorical
+        logprobs: A float tensor of shape (n, m) representing n categorical
                 distributions with m categories each. The values are treated
                 as weights and do not need to sum to 1.
         seed:   An integer tensor of shape (n,) containing the random seed
-                for each corresponding row in `inputs`.
+                for each corresponding row in `logprobs`.
         positions: The positions of the tokens in the sequence. Used for deterministic sampling
                 to get the unique seed for each position.
 
     Returns:
         A tensor of shape (n,) where the i-th element is an index sampled
-        from the distribution in `inputs[i]` using `seed[i]`.
+        from the distribution in `logprobs[i]` using `seed[i]`.
     """
     n, m = logprobs.shape
     seed = seed.to(torch.uint64)

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -267,7 +267,7 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             for token_id in self.logit_bias:
                 if not 0 <= int(token_id) < vocab_size:
                     raise ValueError(
-                        f"logit_bias must has keys in [0, {vocab_size - 1}], got "
+                        f"logit_bias must have keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1331,7 +1331,7 @@ class ServerArgs:
     ] = "default"
     chat_template: A[
         Optional[str],
-        "The buliltin chat template name or the path of the chat template file. This is only used for OpenAI-compatible API server.",
+        "The builtin chat template name or the path of the chat template file. This is only used for OpenAI-compatible API server.",
         NS("serving"),
     ] = None
     hf_chat_template_name: A[
@@ -1341,7 +1341,7 @@ class ServerArgs:
     ] = None
     completion_template: A[
         Optional[str],
-        "The buliltin completion template name or the path of the completion template file. This is only used for OpenAI-compatible API server. only for code completion currently.",
+        "The builtin completion template name or the path of the completion template file. This is only used for OpenAI-compatible API server. only for code completion currently.",
         NS("serving"),
     ] = None
     file_storage_path: A[
@@ -4241,7 +4241,7 @@ def prepare_server_args(argv: List[str]) -> ServerArgs:
     Prepare the server arguments from the command line arguments.
 
     Args:
-        args: The command line arguments. Typically, it should be `sys.argv[1:]`
+        argv: The command line arguments. Typically, it should be `sys.argv[1:]`
             to ensure compatibility with `parse_args` when no arguments are passed.
 
     Returns:


### PR DESCRIPTION
A batch of small user-facing text corrections, all in `python/sglang/srt`:

Docstring/signature mismatches:
- `sampler.multinomial_with_seed(logprobs, …)` documented an `inputs` parameter — the body reads `logprobs.shape`; renamed in the docstring
- `prepare_server_args(argv)` documented `args`
- `Mxfp4Tensor.quantize(input, block_size: Optional[int])` documented `block_sizes (dict | None)` — name and type both wrong

Typo fixes:
- "The **buliltin** chat/completion template name" → "builtin" (renders into `--chat-template` / `--completion-template` help text)
- "logit_bias must **has** keys" → "must have keys" (raised to API users on invalid logit_bias)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33917185326](https://github.com/sgl-project/sglang/actions/runs/33917185326)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33917184945](https://github.com/sgl-project/sglang/actions/runs/33917184945)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33917185246](https://github.com/sgl-project/sglang/actions/runs/33917185246)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->