### PR TITLE
[GLM-5.3] Remove serving lifecycle changes split to #37316

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1096,12 +1096,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         preallocated_reqs = []
         indices_to_remove = set()
 
-        # The all-waiting shortcut stops receiver polling, so enforce its timeout here.
-        prealloc_timeout = float(
-            getattr(getattr(self, "kv_manager", None), "waiting_timeout", 0.0)
-        )
-        prealloc_now = time.perf_counter()
-
         # We need to make sure that the sum of inflight tokens and allocatable tokens is greater than maximum input+output length of each inflight request
         # Otherwise it is possible for one request running decode out of memory, while all other requests are in the transfer queue that cannot be retracted.
         retractable_tokens = sum(
@@ -1137,47 +1131,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             )
             self.queue.sort(key=lambda r: r.req.priority * priority_sign)
 
+        # First, remove all failed requests from the queue
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
-
-            bootstrap_done_time = getattr(
-                getattr(decode_req.req, "time_stats", None),
-                "bootstrap_done_time",
-                0.0,
-            )
-            prealloc_timed_out = (
-                not isinstance(decode_req.req.finished_reason, FINISH_ABORT)
-                and prealloc_timeout > 0
-                and getattr(decode_req, "waiting_for_input", False)
-                and bootstrap_done_time > 0
-                and prealloc_now - bootstrap_done_time > prealloc_timeout
-            )
-            if prealloc_timed_out:
-                elapsed = prealloc_now - bootstrap_done_time
-                error_message = (
-                    f"Decode preallocation timed out after {elapsed:.1f}s "
-                    f"(timeout={prealloc_timeout:.1f}s) for request "
-                    f"rank={self.tp_rank} {decode_req.req.rid=} "
-                    f"{decode_req.req.bootstrap_room=}"
-                )
-                logger.error(error_message)
-                prepare_abort(
-                    decode_req.req,
-                    error_message,
-                    status_code=HTTPStatus.GATEWAY_TIMEOUT,
-                )
-                if self.scheduler.metrics_reporter.enable_metrics:
-                    self.scheduler.metrics_collector.increment_prealloc_failed_reqs()
-
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
                 if not getattr(decode_req.req, "finished_output", False):
                     self.scheduler.output_streamer.stream_output(
                         [decode_req.req],
                         decode_req.req.return_logprob,
                     )
-                if prealloc_timed_out:
-                    decode_req.kv_receiver.abort()
                 decode_req.kv_receiver.clear()
                 decode_req.kv_receiver = None
                 failed_reqs.append(decode_req)

--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -1887,7 +1887,6 @@ class MMReceiverBase(ABC):
         self, request_obj, mm_processor, prompt, need_wait_for_mm_inputs=True
     ):
         req_id = None
-        encode_task = None
         try:
             # ``self.encode_urls`` is shared by reference with the bootstrap
             # server (when running) so it always reflects the current set.
@@ -1950,21 +1949,7 @@ class MMReceiverBase(ABC):
         except asyncio.TimeoutError:
             elapsed = time.monotonic() - send_time
             logger.warning(f"[{req_id}] Embedding recv timeout after {elapsed:.3f}s")
-            await self._abort_encode_and_cleanup(encode_task, req_id)
             return None
-        except asyncio.CancelledError:
-            await self._abort_encode_and_cleanup(encode_task, req_id)
-            raise
-
-    async def _abort_encode_and_cleanup(self, encode_task, req_id):
-        if encode_task is not None and not encode_task.done():
-            encode_task.cancel()
-            try:
-                await encode_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        if req_id is not None:
-            self._cleanup_mooncake_buffer(req_id)
 
     async def _recv_mm_data(self, req_id, recv_socket, mm_processor, prompt):
         """zmq_to_tokenizer receive: embedding parts arrive as 2-frame ZMQ

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -805,11 +805,6 @@ class PrefillAdder:
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
 
-    def chunk_budget_exhausted(self) -> bool:
-        return (
-            self.rem_chunk_tokens is not None and self.rem_chunk_tokens < self.page_size
-        )
-
     def budget_state(self):
         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
         if not no_token and self.is_hybrid_swa:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3549,7 +3549,6 @@ class Scheduler(
             running_batch.filter_batch()
             if running_batch.is_empty():
                 running_batch.batch_is_full = False
-                running_batch.is_prefill_only = False
 
         if self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
@@ -3780,9 +3779,6 @@ class Scheduler(
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
-            if adder.chunk_budget_exhausted():
-                break
-
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
 
@@ -4584,7 +4580,7 @@ class Scheduler(
             )
 
     def maybe_send_health_check_signal(self):
-        while self.return_health_check_ipcs:
+        if self.return_health_check_ipcs:
             # Return some signal for the health check.
             # This is used to prevent the health check signal being blocked by long context prefill.
             # However, one minor issue is that this code path does not check the status of detokenizer manager.

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -541,11 +541,6 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="The number of bootstrap failed requests.",
             labelnames=labels.keys(),
         )
-        self.num_prealloc_failed_reqs = Counter(
-            name="sglang:num_prealloc_failed_reqs_total",
-            documentation="The number of decode preallocation requests that timed out.",
-            labelnames=labels.keys(),
-        )
         self.num_transfer_failed_reqs = Counter(
             name="sglang:num_transfer_failed_reqs_total",
             documentation="The number of transfer failed requests.",
@@ -1186,9 +1181,6 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
 
     def increment_bootstrap_failed_reqs(self) -> None:
         self.num_bootstrap_failed_reqs.labels(**self.labels).inc(1)
-
-    def increment_prealloc_failed_reqs(self) -> None:
-        self.num_prealloc_failed_reqs.labels(**self.labels).inc(1)
 
     def increment_transfer_failed_reqs(self) -> None:
         self.num_transfer_failed_reqs.labels(**self.labels).inc(1)

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -24,11 +24,7 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 class FakeReceiver:
     def __init__(self):
         self.clear_called = False
-        self.abort_called = False
         self.conclude_state = None
-
-    def abort(self):
-        self.abort_called = True
 
     def clear(self):
         self.clear_called = True
@@ -189,66 +185,6 @@ class TestDecodeQueueCleanup(CustomTestCase):
         self.assertEqual(queue.queue, [])
         self.assertTrue(all(r is not decode_req for r in queue.pending_reqs))
         self.assertIsNone(decode_req.kv_receiver)
-
-    @patch("sglang.srt.disaggregation.decode.prepare_abort")
-    @patch("sglang.srt.disaggregation.decode.time.perf_counter", return_value=111.0)
-    def test_prealloc_timeout_aborts_and_clears_receiver(
-        self, _mock_now, mock_prepare_abort
-    ):
-        receiver = FakeReceiver()
-        req = SimpleNamespace(
-            rid="timed-out-prealloc",
-            bootstrap_room=17,
-            finished_reason=None,
-            finished_output=False,
-            return_logprob=False,
-            time_stats=SimpleNamespace(bootstrap_done_time=100.0),
-        )
-        decode_req = SimpleNamespace(
-            req=req,
-            kv_receiver=receiver,
-            waiting_for_input=True,
-        )
-
-        def mark_aborted(aborted_req, *_args, **_kwargs):
-            aborted_req.finished_reason = FINISH_ABORT("preallocation timeout")
-
-        mock_prepare_abort.side_effect = mark_aborted
-
-        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
-        queue.tp_rank = 0
-        queue.pp_size = 1
-        queue.queue = [decode_req]
-        queue.pending_reqs = [decode_req]
-        queue.retracted_queue = []
-        queue.kv_manager = SimpleNamespace(waiting_timeout=10.0)
-        queue._resolve_pending_reqs = MagicMock()
-        queue._update_handshake_waiters = MagicMock()
-        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
-        queue._allocatable_token_budgets = MagicMock(return_value=0)
-        queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
-
-        scheduler = MagicMock()
-        scheduler.running_batch.reqs = []
-        scheduler.enable_priority_scheduling = False
-        scheduler.enable_hisparse = False
-        scheduler.metrics_reporter.enable_metrics = True
-        queue.scheduler = scheduler
-
-        preallocated, failed = queue.pop_preallocated()
-
-        self.assertEqual(preallocated, [])
-        self.assertEqual(failed, [decode_req])
-        self.assertEqual(queue.queue, [])
-        self.assertEqual(queue.pending_reqs, [])
-        self.assertTrue(receiver.abort_called)
-        self.assertTrue(receiver.clear_called)
-        self.assertIsNone(decode_req.kv_receiver)
-        scheduler.output_streamer.stream_output.assert_called_once_with(
-            [req], req.return_logprob
-        )
-        scheduler.metrics_collector.increment_prealloc_failed_reqs.assert_called_once_with()
-        mock_prepare_abort.assert_called_once()
 
     def test_swa_reclaim_failure_rejects_only_request(self):
         receiver = FakeReceiver()

--- a/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_abort_race.py
@@ -33,11 +33,11 @@ def _make_scheduler(pending_req, *, chunked_req, running_reqs) -> Scheduler:
     sched.chunked_req = chunked_req
     sched._pending_chunked_abort_req = pending_req
     sched.waiting_queue = []
-    sched.mm_receiver = None
     sched.dllm_config = None
     sched.grammar_manager = Mock()
     sched.disaggregation_mode = None
     sched.enable_hicache_storage = False
+    sched.mm_receiver = None
     sched.ps = SimpleNamespace(pp_size=1)
     sched.running_batch = SimpleNamespace(reqs=running_reqs)
     sched.last_batch = None


### PR DESCRIPTION
## Summary

- Remove the decode preallocation timeout/metric and encoder cancellation cleanup that were split into #37316.
- Remove the chunk-budget, prefill-state, and health-signal scheduler changes plus their remaining test delta.
- Keep the GLM-specific DSA tail transfer and KPool truncation-alignment logic intact.

## Scope note

The tokenizer-manager lifecycle changes and RID-cleanup tests from #37316 already match current main after the latest main merge, so this PR does not revert or duplicate those main changes.

## Validation

- `git diff --check`
- `python3 -m compileall -q` on all changed Python files
- `python scripts/lint/check_no_bare_pytest_main.py` on all changed files using Python 3.12
- pre-commit hooks passed except the wrapper invocation of `check-no-bare-pytest-main`, whose Python 3.9 interpreter cannot parse the checker itself; the same checker passed directly under Python 3.12
- Compared all nine #37316 paths against current main: only the GLM-specific hunks in `decode.py` and `scheduler.py` remain

Runtime CPU tests were not completed locally because the host lacks the full SGLang development dependency set; pytest collection stopped at a missing `psutil` dependency.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33918103211](https://github.com/sgl-project/sglang/actions/runs/33918103211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33918103051](https://github.com/sgl-project/sglang/actions/runs/33918103051)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33918103233](https://github.com/sgl-project/sglang/actions/runs/33918103233)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->