### PR TITLE
[Refactor] Replace defensive getattr with direct field access

### DIFF
--- a/python/sglang/srt/configs/hybrid_arch.py
+++ b/python/sglang/srt/configs/hybrid_arch.py
@@ -115,8 +115,9 @@ def kimi_linear_config(model_config: ModelConfig):
 
 def glm5_next_config(model_config: ModelConfig):
     hf_config = model_config.hf_config
-    if getattr(hf_config, "model_type", None) == "glm5_next" and not getattr(
-        model_config, "is_draft_model", False
+    if (
+        getattr(hf_config, "model_type", None) == "glm5_next"
+        and not model_config.is_draft_model
     ):
         return hf_config.get_text_config()
     return None

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1009,7 +1009,7 @@ class CommonKVManager(BaseKVManager):
         returned unchanged.
         """
         start_layer = self.kv_args.prefill_start_layer
-        end_layer = getattr(self.kv_args, "prefill_end_layer", None)
+        end_layer = self.kv_args.prefill_end_layer
         assert end_layer is not None, (
             "KVArgs.prefill_end_layer must be set when using compressed-MLA PD with PP"
         )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1525,13 +1525,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 src_ptrs,
                 dst_ptrs,
                 self.kv_args.prefill_start_layer,
-                getattr(self.kv_args, "prefill_end_layer", None),
+                self.kv_args.prefill_end_layer,
             )
             dst_item_lens = slice_dsa_tail_dst_ptrs_for_pp(
                 src_ptrs,
                 dst_item_lens,
                 self.kv_args.prefill_start_layer,
-                getattr(self.kv_args, "prefill_end_layer", None),
+                self.kv_args.prefill_end_layer,
             )
             transfer_blocks = build_dsa_tail_transfer_blocks(
                 src_ptrs,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2119,13 +2119,13 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             src_data_ptrs,
             dst_data_ptrs,
             self.kv_args.prefill_start_layer,
-            getattr(self.kv_args, "prefill_end_layer", None),
+            self.kv_args.prefill_end_layer,
         )
         dst_item_lens = slice_dsa_tail_dst_ptrs_for_pp(
             src_data_ptrs,
             dst_item_lens,
             self.kv_args.prefill_start_layer,
-            getattr(self.kv_args, "prefill_end_layer", None),
+            self.kv_args.prefill_end_layer,
         )
         transfer_blocks = build_dsa_tail_transfer_blocks(
             src_data_ptrs,

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -179,11 +179,11 @@ def can_dsa_prefill_cp_round_robin_split(forward_batch: "ForwardBatch"):
 def cp_zigzag_full_plan_rows(
     forward_batch: "ForwardBatch", device: torch.device
 ) -> torch.Tensor | None:
-    cp_meta = getattr(forward_batch, "attn_cp_metadata", None)
+    cp_meta = forward_batch.attn_cp_metadata
     if cp_meta is None or getattr(cp_meta, "zigzag_index", None) is None:
         return None
     if (
-        getattr(forward_batch, "extend_seq_lens_cpu", None) is None
+        forward_batch.extend_seq_lens_cpu is None
         or getattr(cp_meta, "split_list", None) is None
     ):
         return None

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -9,10 +9,14 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.cp.zigzag import ZigzagContextParallelMetadata
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     attn_cp_all_gather_into_tensor,
     is_allocation_symmetric,
+)
+from sglang.srt.layers.utils.cp_utils import (
+    ContextParallelMetadata as LegacyZigzagCPMetadata,
 )
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -180,11 +184,12 @@ def cp_zigzag_full_plan_rows(
     forward_batch: "ForwardBatch", device: torch.device
 ) -> torch.Tensor | None:
     cp_meta = forward_batch.attn_cp_metadata
-    if cp_meta is None or getattr(cp_meta, "zigzag_index", None) is None:
+    if not isinstance(cp_meta, (ZigzagContextParallelMetadata, LegacyZigzagCPMetadata)):
         return None
     if (
-        forward_batch.extend_seq_lens_cpu is None
-        or getattr(cp_meta, "split_list", None) is None
+        cp_meta.zigzag_index is None
+        or cp_meta.split_list is None
+        or forward_batch.extend_seq_lens_cpu is None
     ):
         return None
 

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -47,13 +47,14 @@ def is_glm_dsa_cache_layer_split_enabled(model_runner: "ModelRunner") -> bool:
     Layer split is a prefill-CP-only optimization for DSA (DeepSeek Sparse
     Attention) MLA models (e.g. GLM-5.2). Draft workers keep the full cache.
     """
+    from sglang.srt.configs.hybrid_arch import mambaish_config
     from sglang.srt.configs.model_config import is_deepseek_dsa
 
     return (
         not model_runner.is_draft_worker
         and get_parallel().enable_dsa_cache_layer_split
         and model_runner.use_mla_backend
-        and not getattr(model_runner, "mambaish_config", None)
+        and mambaish_config(model_runner.model_config) is None
         and is_deepseek_dsa(model_runner.model_config.hf_config)
     )
 


### PR DESCRIPTION
## Summary
- `ModelRunner` has no `mambaish_config` attribute, so `getattr(model_runner, "mambaish_config", None)` was always `None` and the DSA cache-layer-split gate never excluded hybrid mambaish models. Use `mambaish_config(model_runner.model_config)` instead.
- Replace other defensive `getattr` on always-present typed fields (`ModelConfig.is_draft_model`, `ForwardBatch` dataclass fields, `KVArgs.prefill_end_layer`) with direct access.

## Test plan
- [ ] Confirm `is_glm_dsa_cache_layer_split_enabled` still returns false for hybrid mambaish configs and true for GLM DSA MLA prefill-CP.
- [ ] Sanity-check PD DSA tail transfer still passes `prefill_end_layer` through mooncake/nixl/common conn paths.


Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33921518748](https://github.com/sgl-project/sglang/actions/runs/33921518748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33921518540](https://github.com/sgl-project/sglang/actions/runs/33921518540)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33921518800](https://github.com/sgl-project/sglang/actions/runs/33921518800)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->