### PR TITLE
[GLM-5.3] Extract KPool-specific DSA backend helpers

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_kpool.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.attention.dsa.kpool_plan import (
+    init_kpool_extend_metadata,
+    init_kpool_write_plan,
+    init_kpool_write_plan_capture,
+    init_pooled_paged_mqa_metadata,
+    update_kpool_write_plan,
+    update_pooled_paged_mqa_metadata,
+)
+from sglang.srt.utils import is_cuda
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (
+        PrecomputedMetadata,
+    )
+    from sglang.srt.layers.attention.dsa.dsa_topk_backend import TopkTransformMethod
+    from sglang.srt.layers.attention.dsa_backend import _DSA_IMPL_T, DSAMetadata
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+
+
+def _is_kpool_metadata_fusion_supported(
+    index_kpool: int, page_size: int, index_topk: int
+) -> bool:
+    return (
+        index_kpool > 1
+        and page_size == 64
+        and page_size % index_kpool == 0
+        and index_topk % index_kpool == 0
+    )
+
+
+@dataclass
+class _KPoolForwardInputs:
+    full_real_page_table: Optional[torch.Tensor] = None
+    full_seqlens_expanded: Optional[torch.Tensor] = None
+    cp_overrides: dict = field(default_factory=dict)
+
+
+class DeepseekSparseAttnBackendKPoolMixin:
+    """KPool-specific metadata and tail handling for the DSA backend."""
+
+    def _check_kpool_tail_backend(
+        self,
+        topk_indices: Optional[torch.Tensor],
+        dsa_impl: _DSA_IMPL_T,
+        phase: str,
+    ) -> None:
+        if (
+            topk_indices is None
+            or self.dsa_index_kpool <= 1
+            or dsa_impl in ("fa3", "tilelang", "trtllm")
+        ):
+            return
+        raise NotImplementedError(
+            "index_kpool > 1 appends tail tokens to topk_indices and is "
+            f"currently only supported by the FA3/TileLang/TRTLLM DSA {phase} "
+            "backend."
+        )
+
+    def _resolve_kpool_tail_backend(
+        self,
+        topk_indices: Optional[torch.Tensor],
+        dsa_impl: _DSA_IMPL_T,
+    ) -> _DSA_IMPL_T:
+        if (
+            topk_indices is None
+            or self.dsa_index_kpool <= 1
+            or dsa_impl != "flashmla_sparse"
+        ):
+            return dsa_impl
+        if self.device_sm_major >= 10:
+            return "trtllm"
+        if self.device_sm_major == 9:
+            return "fa3"
+        return dsa_impl
+
+    def _kpool_slots_per_page(self) -> int:
+        return getattr(self.token_to_kv_pool, "slots_per_page", self.real_page_size)
+
+    def _build_kpool_paged_mqa_schedule_metadata(self) -> bool:
+        if self.device_sm_major == 9:
+            return self.num_q_heads in (32, 64)
+        return True
+
+    def _init_kpool_metadata(
+        self,
+        metadata: DSAMetadata,
+        forward_batch: ForwardBatch,
+        topk_transform_method: Optional[TopkTransformMethod] = None,
+        kpool_inputs: Optional[_KPoolForwardInputs] = None,
+    ) -> DSAMetadata:
+        if self.dsa_index_kpool <= 1:
+            return metadata
+
+        forward_mode = forward_batch.forward_mode
+        slots_per_page = self._kpool_slots_per_page()
+        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
+        if forward_mode.is_extend_without_speculative():
+            assert topk_transform_method is not None
+            assert kpool_inputs is not None
+            return init_kpool_extend_metadata(
+                metadata,
+                forward_batch,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                slots_per_page=slots_per_page,
+                topk_transform_method=topk_transform_method,
+                full_real_page_table=kpool_inputs.full_real_page_table,
+                full_seqlens_expanded=kpool_inputs.full_seqlens_expanded,
+                **kpool_inputs.cp_overrides,
+            )
+
+        if forward_mode.is_decode_or_idle():
+            metadata = init_pooled_paged_mqa_metadata(
+                metadata,
+                metadata.cache_seqlens_int32,
+                forward_mode,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+            return init_kpool_write_plan(
+                metadata,
+                forward_batch,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                real_page_table=metadata.real_page_table,
+                num_draft_tokens=1,
+                write_start=(forward_batch.seq_lens - 1).to(torch.int32),
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        if forward_mode.is_target_verify():
+            return init_kpool_write_plan(
+                metadata,
+                forward_batch,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                real_page_table=metadata.real_page_table,
+                num_draft_tokens=self.speculative_num_draft_tokens,
+                write_start=forward_batch.seq_lens.to(torch.int32),
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        if forward_mode.is_draft_extend_v2():
+            spec_info = forward_batch.spec_info
+            effective_n_per_batch = (
+                spec_info.num_accept_tokens
+                if spec_info is not None
+                and getattr(spec_info, "num_accept_tokens", None) is not None
+                else None
+            )
+            return init_kpool_write_plan(
+                metadata,
+                forward_batch,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                real_page_table=metadata.real_page_table,
+                num_draft_tokens=self.speculative_num_draft_tokens,
+                write_start=(
+                    forward_batch.seq_lens - self.speculative_num_draft_tokens
+                ).to(torch.int32),
+                slots_per_page=slots_per_page,
+                effective_n_per_batch=effective_n_per_batch,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        return metadata
+
+    def _init_kpool_metadata_capture(
+        self, metadata: DSAMetadata, bs: int, forward_mode: ForwardMode
+    ) -> DSAMetadata:
+        if self.dsa_index_kpool <= 1:
+            return metadata
+
+        slots_per_page = self._kpool_slots_per_page()
+        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
+        if forward_mode.is_decode_or_idle():
+            metadata = init_pooled_paged_mqa_metadata(
+                metadata,
+                metadata.cache_seqlens_int32,
+                forward_mode,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        if (
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+        ):
+            is_decode = forward_mode.is_decode_or_idle()
+            is_v2 = forward_mode.is_draft_extend_v2()
+            metadata = init_kpool_write_plan_capture(
+                metadata,
+                max_bs=bs,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                num_draft_tokens=(
+                    1 if is_decode else self.speculative_num_draft_tokens
+                ),
+                device=self.device,
+                is_verify=not is_decode,
+                slots_per_page=slots_per_page,
+                is_v2=is_v2,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        return metadata
+
+    def _update_kpool_metadata_replay(
+        self,
+        metadata: DSAMetadata,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        forward_mode: ForwardMode,
+        effective_n_per_batch: Optional[torch.Tensor] = None,
+        include_deep_gemm_schedule: bool = True,
+    ) -> None:
+        if self.dsa_index_kpool <= 1:
+            return
+
+        slots_per_page = self._kpool_slots_per_page()
+        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
+        if forward_mode.is_decode_or_idle():
+            update_pooled_paged_mqa_metadata(
+                metadata,
+                metadata.cache_seqlens_int32,
+                forward_mode,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        if not (
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+        ):
+            return
+
+        is_decode = forward_mode.is_decode_or_idle()
+        is_v2 = forward_mode.is_draft_extend_v2()
+        if is_decode:
+            write_start = seq_lens.to(torch.int32) - 1
+        elif is_v2:
+            write_start = seq_lens.to(torch.int32) - self.speculative_num_draft_tokens
+        else:
+            # Target verify: write_start == seq_lens exactly; the plan kernel
+            # casts on load, so skip the per-replay int32 alloc + conversion.
+            write_start = seq_lens
+        update_kpool_write_plan(
+            metadata,
+            write_start=write_start,
+            req_pool_indices=req_pool_indices,
+            real_page_table=metadata.real_page_table,
+            pool_size=self.dsa_index_kpool,
+            real_page_size=self.real_page_size,
+            num_draft_tokens=(1 if is_decode else self.speculative_num_draft_tokens),
+            forward_mode=forward_mode,
+            slots_per_page=slots_per_page,
+            effective_n_per_batch=effective_n_per_batch,
+            include_deep_gemm_schedule=include_deep_gemm_schedule,
+        )
+
+    def _update_kpool_metadata_from_precomputed(
+        self,
+        metadata: DSAMetadata,
+        precomputed: PrecomputedMetadata,
+        forward_mode: ForwardMode,
+    ) -> None:
+        if self.dsa_index_kpool <= 1:
+            return
+
+        slots_per_page = self._kpool_slots_per_page()
+        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
+        if forward_mode.is_decode_or_idle():
+            update_pooled_paged_mqa_metadata(
+                metadata,
+                precomputed.cache_seqlens,
+                forward_mode,
+                pool_size=self.dsa_index_kpool,
+                real_page_size=self.real_page_size,
+                slots_per_page=slots_per_page,
+                build_schedule_metadata=build_schedule_metadata,
+            )
+
+        if not (forward_mode.is_decode_or_idle() or forward_mode.is_target_verify()):
+            return
+
+        is_verify = forward_mode.is_target_verify()
+        write_start = precomputed.cache_seqlens.to(torch.int32)
+        write_start = (
+            write_start - self.speculative_num_draft_tokens
+            if is_verify
+            else write_start - 1
+        )
+        update_kpool_write_plan(
+            metadata,
+            write_start=write_start,
+            req_pool_indices=precomputed.req_pool_indices,
+            real_page_table=metadata.real_page_table,
+            pool_size=self.dsa_index_kpool,
+            real_page_size=self.real_page_size,
+            num_draft_tokens=self.speculative_num_draft_tokens if is_verify else 1,
+            forward_mode=forward_mode,
+            slots_per_page=slots_per_page,
+        )
+
+    def _copy_kpool_metadata_from_sibling(
+        self, metadata: DSAMetadata, src_metadata: DSAMetadata
+    ) -> None:
+        """Copy KPool metadata derived from identical inputs from a sibling."""
+        if self.dsa_index_kpool <= 1 or not is_cuda():
+            return
+
+        if metadata.pooled_cache_seqlens_int32 is not None:
+            metadata.pooled_cache_seqlens_int32.copy_(
+                src_metadata.pooled_cache_seqlens_int32
+            )
+        if metadata.pooled_real_page_table is not None:
+            metadata.pooled_real_page_table.copy_(src_metadata.pooled_real_page_table)
+        if metadata.pooled_paged_mqa_schedule_metadata is not None:
+            metadata.pooled_paged_mqa_schedule_metadata.copy_(
+                src_metadata.pooled_paged_mqa_schedule_metadata
+            )
+
+        dst_plan = metadata.kpool_write_plan
+        src_plan = src_metadata.kpool_write_plan
+        if dst_plan is None:
+            return
+        dst_plan.req.copy_(src_plan.req)
+        dst_plan.write_start.copy_(src_plan.write_start)
+        dst_plan.tail_logical_start.copy_(src_plan.tail_logical_start)
+        dst_plan.write_loc.copy_(src_plan.write_loc)
+        if dst_plan.pool_seqlens_per_q is not None:
+            dst_plan.pool_seqlens_per_q.copy_(src_plan.pool_seqlens_per_q)
+        if dst_plan.seqlens_per_q is not None:
+            dst_plan.seqlens_per_q.copy_(src_plan.seqlens_per_q)
+        if dst_plan.pool_schedule_metadata is not None:
+            dst_plan.pool_schedule_metadata.copy_(src_plan.pool_schedule_metadata)
+        if dst_plan.effective_n_per_batch is not None:
+            dst_plan.effective_n_per_batch.copy_(src_plan.effective_n_per_batch)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -56,6 +56,11 @@ from sglang.srt.configs.model_config import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dsa.dsa_backend_kpool import (
+    DeepseekSparseAttnBackendKPoolMixin,
+    _is_kpool_metadata_fusion_supported,
+    _KPoolForwardInputs,
+)
 from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (
     DeepseekSparseAttnBackendMTPPrecomputeMixin,
     PrecomputedMetadata,
@@ -69,13 +74,7 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
 from sglang.srt.layers.attention.dsa.kpool_plan import (
     KPoolExtendPlan,
     KPoolWritePlan,
-    init_kpool_extend_metadata,
-    init_kpool_write_plan,
-    init_kpool_write_plan_capture,
-    init_pooled_paged_mqa_metadata,
     refresh_kpool_pool_schedule_from,
-    update_kpool_write_plan,
-    update_pooled_paged_mqa_metadata,
 )
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
@@ -211,17 +210,6 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
 _PLAN_TOPK_V2 = None
 
 
-def _is_kpool_metadata_fusion_supported(
-    index_kpool: int, page_size: int, index_topk: int
-) -> bool:
-    return (
-        index_kpool > 1
-        and page_size == 64
-        and page_size % index_kpool == 0
-        and index_topk % index_kpool == 0
-    )
-
-
 def _get_plan_topk_v2():
     """Lazy, cached resolver for the JIT top-k v2 plan refresher.
 
@@ -328,13 +316,6 @@ class DSAMetadata:
     kpool_write_plan: Optional[KPoolWritePlan] = None
 
 
-@dataclass
-class _KPoolForwardInputs:
-    full_real_page_table: Optional[torch.Tensor] = None
-    full_seqlens_expanded: Optional[torch.Tensor] = None
-    cp_overrides: dict = field(default_factory=dict)
-
-
 @torch.compile
 def _compiled_cat(tensors: list[torch.Tensor], dim: int = -1) -> torch.Tensor:
     return torch.cat(tensors, dim=dim)
@@ -408,7 +389,9 @@ _DSA_IMPL_T: TypeAlias = Literal[
 
 
 class DeepseekSparseAttnBackend(
-    DeepseekSparseAttnBackendMTPPrecomputeMixin, AttentionBackend
+    DeepseekSparseAttnBackendKPoolMixin,
+    DeepseekSparseAttnBackendMTPPrecomputeMixin,
+    AttentionBackend,
 ):
     # kv_indptr/qo_indptr are preallocated at (req pool + 1); an extend batch
     # can never carry more seqs than the pool.
@@ -832,41 +815,6 @@ class DeepseekSparseAttnBackend(
             "num_kv_splits": self.aiter_dsa_max_split_per_batch,
         }
 
-    def _check_kpool_tail_backend(
-        self,
-        topk_indices: Optional[torch.Tensor],
-        dsa_impl: _DSA_IMPL_T,
-        phase: str,
-    ) -> None:
-        if (
-            topk_indices is None
-            or self.dsa_index_kpool <= 1
-            or dsa_impl in ("fa3", "tilelang", "trtllm")
-        ):
-            return
-        raise NotImplementedError(
-            "index_kpool > 1 appends tail tokens to topk_indices and is "
-            f"currently only supported by the FA3/TileLang/TRTLLM DSA {phase} "
-            "backend."
-        )
-
-    def _resolve_kpool_tail_backend(
-        self,
-        topk_indices: Optional[torch.Tensor],
-        dsa_impl: _DSA_IMPL_T,
-    ) -> _DSA_IMPL_T:
-        if (
-            topk_indices is None
-            or self.dsa_index_kpool <= 1
-            or dsa_impl != "flashmla_sparse"
-        ):
-            return dsa_impl
-        if self.device_sm_major >= 10:
-            return "trtllm"
-        if self.device_sm_major == 9:
-            return "fa3"
-        return dsa_impl
-
     def _pad_trtllm_sparse_page_table(
         self, page_table_1: torch.Tensor
     ) -> Tuple[torch.Tensor, int]:
@@ -986,245 +934,6 @@ class DeepseekSparseAttnBackend(
             0, max_seqlen_k, page_size, device=page_table.device, dtype=torch.int32
         )
         return page_table[:, strided_indices] // page_size
-
-    def _kpool_slots_per_page(self) -> int:
-        return getattr(self.token_to_kv_pool, "slots_per_page", self.real_page_size)
-
-    def _build_kpool_paged_mqa_schedule_metadata(self) -> bool:
-        if self.device_sm_major == 9:
-            return self.num_q_heads in (32, 64)
-        return True
-
-    def _init_kpool_metadata(
-        self,
-        metadata: DSAMetadata,
-        forward_batch: ForwardBatch,
-        topk_transform_method: Optional[TopkTransformMethod] = None,
-        kpool_inputs: Optional[_KPoolForwardInputs] = None,
-    ) -> DSAMetadata:
-        if self.dsa_index_kpool <= 1:
-            return metadata
-
-        forward_mode = forward_batch.forward_mode
-        slots_per_page = self._kpool_slots_per_page()
-        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
-        if forward_mode.is_extend_without_speculative():
-            assert topk_transform_method is not None
-            assert kpool_inputs is not None
-            return init_kpool_extend_metadata(
-                metadata,
-                forward_batch,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                slots_per_page=slots_per_page,
-                topk_transform_method=topk_transform_method,
-                full_real_page_table=kpool_inputs.full_real_page_table,
-                full_seqlens_expanded=kpool_inputs.full_seqlens_expanded,
-                **kpool_inputs.cp_overrides,
-            )
-
-        if forward_mode.is_decode_or_idle():
-            metadata = init_pooled_paged_mqa_metadata(
-                metadata,
-                metadata.cache_seqlens_int32,
-                forward_mode,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-            return init_kpool_write_plan(
-                metadata,
-                forward_batch,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                real_page_table=metadata.real_page_table,
-                num_draft_tokens=1,
-                write_start=(forward_batch.seq_lens - 1).to(torch.int32),
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        if forward_mode.is_target_verify():
-            return init_kpool_write_plan(
-                metadata,
-                forward_batch,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                real_page_table=metadata.real_page_table,
-                num_draft_tokens=self.speculative_num_draft_tokens,
-                write_start=forward_batch.seq_lens.to(torch.int32),
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        if forward_mode.is_draft_extend_v2():
-            spec_info = forward_batch.spec_info
-            effective_n_per_batch = (
-                spec_info.num_accept_tokens
-                if spec_info is not None
-                and getattr(spec_info, "num_accept_tokens", None) is not None
-                else None
-            )
-            return init_kpool_write_plan(
-                metadata,
-                forward_batch,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                real_page_table=metadata.real_page_table,
-                num_draft_tokens=self.speculative_num_draft_tokens,
-                write_start=(
-                    forward_batch.seq_lens - self.speculative_num_draft_tokens
-                ).to(torch.int32),
-                slots_per_page=slots_per_page,
-                effective_n_per_batch=effective_n_per_batch,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        return metadata
-
-    def _init_kpool_metadata_capture(
-        self, metadata: DSAMetadata, bs: int, forward_mode: ForwardMode
-    ) -> DSAMetadata:
-        if self.dsa_index_kpool <= 1:
-            return metadata
-
-        slots_per_page = self._kpool_slots_per_page()
-        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
-        if forward_mode.is_decode_or_idle():
-            metadata = init_pooled_paged_mqa_metadata(
-                metadata,
-                metadata.cache_seqlens_int32,
-                forward_mode,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        if (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
-        ):
-            is_decode = forward_mode.is_decode_or_idle()
-            is_v2 = forward_mode.is_draft_extend_v2()
-            metadata = init_kpool_write_plan_capture(
-                metadata,
-                max_bs=bs,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                num_draft_tokens=(
-                    1 if is_decode else self.speculative_num_draft_tokens
-                ),
-                device=self.device,
-                is_verify=not is_decode,
-                slots_per_page=slots_per_page,
-                is_v2=is_v2,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        return metadata
-
-    def _update_kpool_metadata_replay(
-        self,
-        metadata: DSAMetadata,
-        seq_lens: torch.Tensor,
-        req_pool_indices: torch.Tensor,
-        forward_mode: ForwardMode,
-        effective_n_per_batch: Optional[torch.Tensor] = None,
-        include_deep_gemm_schedule: bool = True,
-    ) -> None:
-        if self.dsa_index_kpool <= 1:
-            return
-
-        slots_per_page = self._kpool_slots_per_page()
-        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
-        if forward_mode.is_decode_or_idle():
-            update_pooled_paged_mqa_metadata(
-                metadata,
-                metadata.cache_seqlens_int32,
-                forward_mode,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        if not (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
-        ):
-            return
-
-        is_decode = forward_mode.is_decode_or_idle()
-        is_v2 = forward_mode.is_draft_extend_v2()
-        if is_decode:
-            write_start = seq_lens.to(torch.int32) - 1
-        elif is_v2:
-            write_start = seq_lens.to(torch.int32) - self.speculative_num_draft_tokens
-        else:
-            # Target verify: write_start == seq_lens exactly; the plan kernel
-            # casts on load, so skip the per-replay int32 alloc + conversion.
-            write_start = seq_lens
-        update_kpool_write_plan(
-            metadata,
-            write_start=write_start,
-            req_pool_indices=req_pool_indices,
-            real_page_table=metadata.real_page_table,
-            pool_size=self.dsa_index_kpool,
-            real_page_size=self.real_page_size,
-            num_draft_tokens=(1 if is_decode else self.speculative_num_draft_tokens),
-            forward_mode=forward_mode,
-            slots_per_page=slots_per_page,
-            effective_n_per_batch=effective_n_per_batch,
-            include_deep_gemm_schedule=include_deep_gemm_schedule,
-        )
-
-    def _update_kpool_metadata_from_precomputed(
-        self,
-        metadata: DSAMetadata,
-        precomputed: PrecomputedMetadata,
-        forward_mode: ForwardMode,
-    ) -> None:
-        if self.dsa_index_kpool <= 1:
-            return
-
-        slots_per_page = self._kpool_slots_per_page()
-        build_schedule_metadata = self._build_kpool_paged_mqa_schedule_metadata()
-        if forward_mode.is_decode_or_idle():
-            update_pooled_paged_mqa_metadata(
-                metadata,
-                precomputed.cache_seqlens,
-                forward_mode,
-                pool_size=self.dsa_index_kpool,
-                real_page_size=self.real_page_size,
-                slots_per_page=slots_per_page,
-                build_schedule_metadata=build_schedule_metadata,
-            )
-
-        if not (forward_mode.is_decode_or_idle() or forward_mode.is_target_verify()):
-            return
-
-        is_verify = forward_mode.is_target_verify()
-        write_start = precomputed.cache_seqlens.to(torch.int32)
-        write_start = (
-            write_start - self.speculative_num_draft_tokens
-            if is_verify
-            else write_start - 1
-        )
-        update_kpool_write_plan(
-            metadata,
-            write_start=write_start,
-            req_pool_indices=precomputed.req_pool_indices,
-            real_page_table=metadata.real_page_table,
-            pool_size=self.dsa_index_kpool,
-            real_page_size=self.real_page_size,
-            num_draft_tokens=self.speculative_num_draft_tokens if is_verify else 1,
-            forward_mode=forward_mode,
-            slots_per_page=slots_per_page,
-        )
 
     def init_forward_metadata_out_graph(
         self,
@@ -2811,41 +2520,6 @@ class DeepseekSparseAttnBackend(
         ):
             return False
         return True
-
-    def _copy_kpool_metadata_from_sibling(
-        self, metadata: DSAMetadata, src_metadata: DSAMetadata
-    ) -> None:
-        """Copy KPool metadata derived from identical inputs from a sibling."""
-        if self.dsa_index_kpool <= 1 or not is_cuda():
-            return
-
-        if metadata.pooled_cache_seqlens_int32 is not None:
-            metadata.pooled_cache_seqlens_int32.copy_(
-                src_metadata.pooled_cache_seqlens_int32
-            )
-        if metadata.pooled_real_page_table is not None:
-            metadata.pooled_real_page_table.copy_(src_metadata.pooled_real_page_table)
-        if metadata.pooled_paged_mqa_schedule_metadata is not None:
-            metadata.pooled_paged_mqa_schedule_metadata.copy_(
-                src_metadata.pooled_paged_mqa_schedule_metadata
-            )
-
-        dst_plan = metadata.kpool_write_plan
-        src_plan = src_metadata.kpool_write_plan
-        if dst_plan is None:
-            return
-        dst_plan.req.copy_(src_plan.req)
-        dst_plan.write_start.copy_(src_plan.write_start)
-        dst_plan.tail_logical_start.copy_(src_plan.tail_logical_start)
-        dst_plan.write_loc.copy_(src_plan.write_loc)
-        if dst_plan.pool_seqlens_per_q is not None:
-            dst_plan.pool_seqlens_per_q.copy_(src_plan.pool_seqlens_per_q)
-        if dst_plan.seqlens_per_q is not None:
-            dst_plan.seqlens_per_q.copy_(src_plan.seqlens_per_q)
-        if dst_plan.pool_schedule_metadata is not None:
-            dst_plan.pool_schedule_metadata.copy_(src_plan.pool_schedule_metadata)
-        if dst_plan.effective_n_per_batch is not None:
-            dst_plan.effective_n_per_batch.copy_(src_plan.effective_n_per_batch)
 
     def _copy_replay_metadata_from_sibling(
         self,


### PR DESCRIPTION
## Summary

Mechanical follow-up to #36507, based on `xinyuan/glm-5.3-flash-support` at `8bb234c06810b60936ea5af6968e8af57ecf6f15`.

Move KPool-only backend implementation from `dsa_backend.py` into the requested `python/sglang/srt/layers/attention/dsa/dsa_backend_kpool.py`.

The new `DeepseekSparseAttnBackendKPoolMixin` contains nine existing methods:

- `_check_kpool_tail_backend`, `_resolve_kpool_tail_backend`
- `_kpool_slots_per_page`, `_build_kpool_paged_mqa_schedule_metadata`
- `_init_kpool_metadata`, `_init_kpool_metadata_capture`
- `_update_kpool_metadata_replay`, `_update_kpool_metadata_from_precomputed`
- `_copy_kpool_metadata_from_sibling`

Also relocate `_KPoolForwardInputs` and `_is_kpool_metadata_fusion_supported`, preserving access through their original module imports. The parent backend inherits the mixin, matching the existing MTP mixin organization.

No behavior changes: signatures, decorators, defaults, function bodies and call sites are preserved. Shared metadata, generic dispatch, CUDA graph logic, TRTLLM padding, and mixed KPool/non-KPool paths stay in the main backend. Its file length drops by 326 lines.

## Validation

- AST equivalence for all nine moved methods and both helper definitions; remaining parent class unchanged except removal of those methods and addition of the mixin base.
- All applicable pre-commit hooks passed.
- Reproducible transform completed with `PASS: transform reproduces the commit exactly.`
- Independent read-only review found no MRO collisions, missing runtime globals, new platform dependencies, runtime import cycle, or affected repository monkeypatches.
- H200 devbox: actual DSA module import, mixin dispatch, Hopper/Blackwell tail fallback and fusion-geometry smoke passed.
- On the temporary H200 devbox, seven targeted unit files passed: **60 passed, 4 skipped, 6 subtests passed**, identical to the unchanged base. The four skips are AMD gfx950-only tests. `test_dsa_kpool_multi_pool.py` passed all **3 CUDA tests** on both base and extraction.
- No full CI / run-ci requested; full-model GLM E2E was not rerun.

## Mechanical Move

Transform script and verification scaffold: https://gist.github.com/Fridge003/45de4886ff95ae6a6236f793197036ff

Run from a clone containing both the base and target commits. Requires Python >=3.10 and pre-commit on PATH. Download both files from the gist together:

```bash
proof_dir=$(mktemp -d)
gh gist clone 45de4886ff95ae6a6236f793197036ff "$proof_dir"
python3 "$proof_dir/transform_glm53_kpool_backend.py"
```

The scaffold creates an isolated verification worktree, runs the transform, and compares its full tree to `412fa99a318e20e3b749f72c4fe228c48840f0a6`. Changed Python files run all applicable pre-commit hooks. The subsequent whole-tree scaffold check skips unrelated baseline formatter rewrites and Rust builds; it is not a full CI run.

## Merge ordering

This PR is independent of sibling #38058 and the CP cleanup #38060; all target #36507 directly. This commit intentionally contains no CP removal so it remains a pure mechanical move.

Merge CP cleanup first, then rebase/replay this extraction. The two PRs have a known content conflict in `dsa_backend.py` around the moved KPool inputs/initialization; resolve it by extracting the CP-cleaned definitions, without reintroducing `cp_overrides`. Regenerate the proof after rebasing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33921554896](https://github.com/sgl-project/sglang/actions/runs/33921554896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33921554781](https://github.com/sgl-project/sglang/actions/runs/33921554781)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33921554857](https://github.com/sgl-project/sglang/actions/runs/33921554857)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->