### PR TITLE
[Fix] Clear Mamba extra-buffer state on ReqKvInfo

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1583,13 +1583,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
             # alloc() doesn't see a stale ping-pong reference on the req
             # and skip allocation (which would silently reuse a freed
             # tensor on the req side while the new pool slot leaks).
-            req.mamba_ping_pong_track_buffer = None
-            req.mamba_next_track_idx = None
-            req.mamba_last_track_idx = None
-            req.mamba_last_track_seqlen = None
-            req.mamba_branching_seqlen = None
-            req.mamba_cow_src_index = None
-            req.mamba_needs_clear = False
+            req.kv.mamba_ping_pong_track_buffer = None
+            req.kv.mamba_next_track_idx = None
+            req.kv.mamba_last_track_idx = None
+            req.kv.mamba_last_track_seqlen = None
+            req.kv.mamba_cow_src_index = None
+            req.kv.mamba_needs_clear = False
 
     def clear(self):
         logger.info("Reset HybridReqToTokenPool")


### PR DESCRIPTION
## Motivation

PR #37164 moved Mamba cache ownership state from Req onto ReqKvInfo. The GLM-5.3 branch retained request-level assignments in free_mamba_cache after merging that change. Those assignments create unrelated dynamic Req attributes while leaving the real req.kv references pointing at already-freed ping-pong slots.

mamba_branching_seqlen is prefix-match scheduling metadata rather than cache ownership state, so freeing an allocation should not clear it.

## Modifications

- Clear all six extra-buffer ownership fields through req.kv.
- Remove the misplaced mamba_branching_seqlen reset from free_mamba_cache.

## Accuracy Tests

Not applicable; this does not change model math.

## Speed Tests and Profiling

Not applicable; this only corrects request cleanup after cache release.

## Checklist

- [x] Code formatted with pre-commit hooks.
- [x] No new unit test required for this mechanical ownership correction.
- [x] No documentation update required.
- [x] No accuracy or speed benchmark required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33923224080](https://github.com/sgl-project/sglang/actions/runs/33923224080)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33923223867](https://github.com/sgl-project/sglang/actions/runs/33923223867)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33923224069](https://github.com/sgl-project/sglang/actions/runs/33923224069)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->