### PR TITLE
Add num_prealloc_ready_tokens to decode load snapshot

### DIFF
--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -202,6 +202,7 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
     # num_total_tokens minus tokens still awaiting a KV transfer (equal to it
     # outside disaggregated decode).
     num_active_tokens: int = 0
+    num_prealloc_ready_tokens: int = 0
     max_total_num_tokens: int = 0
     max_running_requests: int = 0
     token_usage: float = 0.0

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -173,6 +173,7 @@ class SchedulerLoadInquirer:
         prefill_bootstrap = prefill_inflight = 0
         decode_prealloc = decode_transfer = decode_retracted = 0
         decode_prealloc_ready = 0
+        num_prealloc_ready_tokens = 0
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             mode_str = "prefill"
             prefill_bootstrap = len(self.get_disagg_prefill_bootstrap_queue().queue)
@@ -184,11 +185,13 @@ class SchedulerLoadInquirer:
             decode_retracted = len(
                 self.get_disagg_decode_prealloc_queue().retracted_queue
             )
-            decode_prealloc_ready = sum(
-                1
+            ready_reqs = [
+                decode_req.req
                 for decode_req in self.get_disagg_decode_prealloc_queue().queue
                 if decode_req.waiting_for_input
-            )
+            ]
+            decode_prealloc_ready = len(ready_reqs)
+            num_prealloc_ready_tokens = sum(req.seqlen for req in ready_reqs)
         disaggregation = DisaggregationMetrics(
             mode=mode_str,
             prefill_bootstrap_queue_reqs=prefill_bootstrap,
@@ -220,6 +223,7 @@ class SchedulerLoadInquirer:
             num_used_tokens=num_used_tokens,
             num_total_tokens=num_total_tokens,
             num_active_tokens=num_active_tokens,
+            num_prealloc_ready_tokens=num_prealloc_ready_tokens,
             max_total_num_tokens=self.max_total_num_tokens,
             max_running_requests=self.max_running_requests,
             token_usage=round(kv_token_usage, 4),


### PR DESCRIPTION
## Summary

Decode prealloc-queue entries that have finished the prefill handshake and are blocked only by decode capacity carry no admitted KV yet, so they are invisible to the existing token counters on `LoadSnapshot`. This adds `num_prealloc_ready_tokens` — the summed sequence length of these ready-but-unadmitted requests — so external load balancers can factor this backlog into placement decisions alongside the existing usage metrics.

## Test plan

- `python3 -m py_compile` on both changed files
- `black --check` and `isort --check` clean
- `pre-commit` hooks (isort, ruff, black) pass on the changed files
- Existing `test/registered/unit/managers/test_load_snapshot_backends.py`
  is unaffected since the new field has a default and is added via keyword
  args

## Original commits

- `9c4e16d77f`
- `d6aaad1f6f`


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33923960403](https://github.com/sgl-project/sglang/actions/runs/33923960403)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33923960229](https://github.com/sgl-project/sglang/actions/runs/33923960229)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33923960341](https://github.com/sgl-project/sglang/actions/runs/33923960341)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->