### PR TITLE
[Fix] Read DSA tail request index from ReqKvInfo

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1415,7 +1415,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             def _dsa_tail_payload():
                 return get_dsa_tail_state_indices(
                     self.token_to_kv_pool,
-                    decode_req.req.req_pool_idx,
+                    decode_req.req.kv.req_pool_idx,
                     seq_len,
                 )
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1259,7 +1259,7 @@ class SchedulerDisaggregationPrefillMixin:
             def _dsa_tail_payload():
                 return get_dsa_tail_state_indices(
                     self.token_to_kv_pool_allocator.get_kvcache(),
-                    req.req_pool_idx,
+                    req.kv.req_pool_idx,
                     seq_len,
                 )
 


### PR DESCRIPTION
## Motivation

PR #37094 moved `req_pool_idx` from `Req` into `ReqKvInfo`. The GLM-5.3 branch added the PD-disaggregation DSA-tail payload builders before that ownership move, and the later merge retained two request-level reads.

Reaching either DSA-tail payload currently raises `AttributeError` because `Req` no longer defines `req_pool_idx`.

## Modifications

- Read the decode-side DSA-tail row from `decode_req.req.kv.req_pool_idx`.
- Read the prefill-side DSA-tail row from `req.kv.req_pool_idx`.

## Accuracy Tests

Not applicable; this corrects request metadata lookup before transfer and does not change model math.

## Speed Tests and Profiling

Not applicable; this is a two-field ownership correction with no hot-path structural change.

## Validation

- `git diff --check`
- Python syntax compilation for both changed modules
- Pre-commit AST, Ruff, formatting, codespell, and repository hygiene checks

The local Python 3.9 environment does not include pytest, so execution coverage is left to CI.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No new test is included for this mechanical ownership correction.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is required.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to metadata field access.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Stacked on #36507.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33924001518](https://github.com/sgl-project/sglang/actions/runs/33924001518)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33924001291](https://github.com/sgl-project/sglang/actions/runs/33924001291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33924001525](https://github.com/sgl-project/sglang/actions/runs/33924001525)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->