### PR TITLE
[Profiler] Add SGLANG_PROFILE_BY_STAGE_DECODE_MIN_BS to defer the decode-stage capture

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -433,6 +433,10 @@ class Envs:
     SGLANG_PROFILE_WITH_STACK = EnvBool(True)
     SGLANG_PROFILE_RECORD_SHAPES = EnvBool(True)
     SGLANG_PROFILE_V2 = EnvBool(False)
+    # profile_by_stage: do not start the decode-stage capture until a decode batch
+    # reaches this many requests (0 = first decode batch). Lets a batch-size bench
+    # capture steady-state full-admission decode steps instead of the ramp-up.
+    SGLANG_PROFILE_BY_STAGE_DECODE_MIN_BS = EnvInt(0)
     SGLANG_ENABLE_NVTX_SCHEDULER = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_ENABLE_NVTX"
     )

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -421,8 +421,12 @@ class SchedulerProfilerManager:
             elif batch.forward_mode.is_decode():
                 if self.profiler_decode_ct == 0:
                     if self.profile_in_progress:
-                        # force trace flush
+                        # force trace flush (a prefill capture must not absorb decode steps)
                         self._stop_profile(stage=ForwardMode.EXTEND)
+                    min_bs = envs.SGLANG_PROFILE_BY_STAGE_DECODE_MIN_BS.get()
+                    if min_bs > 0 and batch.batch_size() < min_bs:
+                        # Wait for full admission before capturing the decode stage
+                        return
                     self._start_profile(batch.forward_mode)
                 self.profiler_decode_ct += 1
                 if self.profiler_decode_ct > self.profiler_target_decode_ct:


### PR DESCRIPTION
## Motivation

With `profile_by_stage`, the scheduler starts the decode-stage trace on the very first decode batch. On a batch-size benchmark that first decode batch is still ramping up toward full admission, so the captured decode steps are not representative of steady state.

## Modifications

- Add `SGLANG_PROFILE_BY_STAGE_DECODE_MIN_BS` (`EnvInt`, default `0`). When `> 0`, `SchedulerProfilerManager._profile_batch_predicate` keeps returning without starting the decode capture until a decode batch has at least that many requests. The default preserves existing behavior (capture from the first decode batch).
- Clarify the comment on the forced prefill-trace flush that precedes the decode capture.

No change to the default profiling path, `SGLANG_PROFILE_V2`, or the non-stage profiler.

## Original commits

- `81271aca77`

## Accuracy Tests

Not applicable (profiler-only change, no numerics).

## Benchmarking and Profiling

Used on an internal setup to capture `profile_by_stage` decode traces at a fixed target batch size; with the variable set, the decode trace starts only once the running batch reaches the requested size.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] **For reviewers: Approve** after all major concerns are addressed. Then `/tag-and-rerun-ci` to trigger CI. Merge when CI passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33924164482](https://github.com/sgl-project/sglang/actions/runs/33924164482)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33924164040](https://github.com/sgl-project/sglang/actions/runs/33924164040)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33924164340](https://github.com/sgl-project/sglang/actions/runs/33924164340)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->