### PR TITLE
fix(vlm): rebuild streaming-session fill after multimodal padding

### DIFF
--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -319,7 +319,8 @@ class Session:
         if last_req is not None:
             new_req.multimodal_inputs = last_req.multimodal_inputs
         new_req.tokenizer = tokenizer
-        if carry_fill is not None:
+        # Incoming multimodal padding may rewrite origin IDs without changing length.
+        if carry_fill is not None and req.mm_inputs is None:
             new_req.full_untruncated_fill_ids = carry_fill
 
         if abort:

--- a/test/registered/unit/mem_cache/test_session_token_share_unit.py
+++ b/test/registered/unit/mem_cache/test_session_token_share_unit.py
@@ -16,8 +16,20 @@ import unittest
 from array import array
 from types import SimpleNamespace
 
+import torch
+
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+)
+from sglang.srt.managers.schedule_batch import (
+    FINISH_LENGTH,
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    MultimodalProcessorOutput,
+)
 from sglang.srt.sampling.sampling_params import SamplingParams
-from sglang.srt.session.session_controller import Session
+from sglang.srt.session.session_controller import Session, SessionController
 from sglang.test.test_utils import CustomTestCase
 
 VOCAB = 1 << 20
@@ -56,12 +68,41 @@ class TestSessionTokenShare(CustomTestCase):
     def setUp(self):
         self.session = Session(capacity_of_str_len=0, session_id="s", streaming=True)
 
-    def _create(self, rid, input_ids, max_new_tokens=8):
+    def _create(self, rid, input_ids, max_new_tokens=8, parent=None):
+        recv = _recv(rid, input_ids, max_new_tokens=max_new_tokens)
+        recv.session_params.rid = parent
         return self.session.create_req(
-            _recv(rid, input_ids, max_new_tokens=max_new_tokens),
+            recv,
             tokenizer=None,
             vocab_size=VOCAB,
         )
+
+    def _create_mm(self, rid, parent=None):
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(1, 2)],
+            feature=torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        )
+        item.set_hash(17)
+        recv = _recv(rid, [50, 9, 9, 51])
+        recv.session_params.rid = parent
+        recv.mm_inputs = MultimodalProcessorOutput(mm_items=[item], im_token_id=9)
+        req = self.session.create_req(recv, tokenizer=None, vocab_size=VOCAB)
+        self.assertFalse(req.finished())
+        mm = MultimodalInputs.from_processor_output(recv.mm_inputs)
+        SessionController.adjust_mm_offsets(recv, req, mm)
+        origin = req.origin_input_ids
+        # Match scheduler admission: GLM-style padding replaces the origin array.
+        req.origin_input_ids = array(
+            "q",
+            MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
+                origin, mm
+            ),
+        )
+        self.assertIsNot(req.origin_input_ids, origin)
+        self.assertEqual(len(req.origin_input_ids), len(origin))
+        req.extend_image_inputs(mm)
+        return req, item
 
     def _decode_and_finish(self, req, output, baked=None):
         """Simulate decode then a successful finish.
@@ -75,7 +116,107 @@ class TestSessionTokenShare(CustomTestCase):
         req.output_ids.extend(output[:baked])
         req._refresh_fill_ids()
         req.output_ids.extend(output[baked:])
-        self.session.finish_req(req)
+        req.finished_reason = FINISH_LENGTH(len(req.output_ids))
+        if self.session.streaming:
+            self.session.finish_req(req)
+
+    def test_mm_padding_refresh_and_text_carry(self):
+        for streaming in (True, False):
+            with self.subTest(streaming=streaming):
+                self.session = Session(0, session_id="s", streaming=streaming)
+                r1 = self._create("r1", [100, 101])
+                self._decode_and_finish(r1, [1, 2, 3], baked=2)
+
+                r2, item = self._create_mm("r2", parent="r1")
+                expected = [100, 101, 1, 2, 3, 50, item.pad_value, item.pad_value, 51]
+                self.assertEqual(item.offsets, [(6, 7)])
+                self.assertEqual(list(r2.origin_input_ids), expected)
+                self.assertEqual(
+                    list(r2.origin_input_ids_unpadded),
+                    [100, 101, 1, 2, 3, 50, 9, 9, 51],
+                )
+                r2._refresh_fill_ids()
+                r2.set_extend_range(5, len(expected))
+                self.assertEqual(list(r2.get_fill_ids()), expected)
+                self.assertEqual(list(r2.get_fill_ids()[5:]), expected[5:])
+
+                r2.output_ids.extend([4, 5])
+                r2._refresh_fill_ids()
+                fill = r2.full_untruncated_fill_ids
+                r2._refresh_fill_ids()
+                self.assertIs(r2.full_untruncated_fill_ids, fill)
+                r2.set_extend_range(5, len(expected) + 2)
+                self.assertEqual(list(r2.get_fill_ids()), expected + [4, 5])
+                self.assertEqual(list(r2.origin_input_ids), expected)
+                self._decode_and_finish(r2, [6], baked=0)
+
+                r3 = self._create("r3", [60], parent="r2")
+                self.assertEqual(list(r3.origin_input_ids), expected + [4, 5, 6, 60])
+                if streaming:
+                    self.assertIs(r3.origin_input_ids, r2.origin_input_ids)
+                    self.assertIs(r3.full_untruncated_fill_ids, fill)
+                else:
+                    self.assertIsNot(r3.origin_input_ids, r2.origin_input_ids)
+                r3._refresh_fill_ids()
+                self.assertEqual(r3.full_untruncated_fill_ids, r3.origin_input_ids)
+                self.assertIs(r3.multimodal_inputs.mm_items[0], item)
+
+    def test_abort_around_mm_turn_preserves_committed_history(self):
+        for previous_mm in (False, True):
+            with self.subTest(previous_mm=previous_mm):
+                self.session = Session(0, session_id="s", streaming=True)
+                if previous_mm:
+                    r1, item = self._create_mm("r1")
+                    feature = item.feature
+                    offsets = item.offsets[:]
+                else:
+                    r1 = self._create("r1", [100, 101])
+                self._decode_and_finish(r1, [1, 2, 3], baked=2)
+                origin = list(r1.origin_input_ids)
+                unpadded = list(r1.origin_input_ids_unpadded)
+                committed = (
+                    self.session.committed_origin_len,
+                    self.session.committed_unpadded_len,
+                    self.session.committed_fill_len,
+                )
+                mm = r1.multimodal_inputs
+
+                if previous_mm:
+                    r2 = self._create("r2", [70, 71])
+                    self.assertIs(
+                        r2.full_untruncated_fill_ids, r1.full_untruncated_fill_ids
+                    )
+                else:
+                    r2, _ = self._create_mm("r2")
+                r2.output_ids.extend([6, 7])
+                r2._refresh_fill_ids()
+                self.session.abort_req()
+                self.assertIs(self.session.req_nodes["r1"].req, r1)
+                self.assertEqual(
+                    (
+                        self.session.committed_origin_len,
+                        self.session.committed_unpadded_len,
+                        self.session.committed_fill_len,
+                    ),
+                    committed,
+                )
+
+                r3 = self._create("r3", [60])
+                self.assertEqual(list(r3.origin_input_ids), origin + [1, 2, 3, 60])
+                self.assertEqual(
+                    list(r3.origin_input_ids_unpadded), unpadded + [1, 2, 3, 60]
+                )
+                r3._refresh_fill_ids()
+                self.assertEqual(r3.full_untruncated_fill_ids, r3.origin_input_ids)
+                self.assertIs(r3.multimodal_inputs, mm)
+                if previous_mm:
+                    self.assertEqual(len(mm.mm_items), 1)
+                    self.assertIs(mm.mm_items[0], item)
+                    self.assertIs(item.feature, feature)
+                    self.assertEqual(item.offsets, offsets)
+                    torch.testing.assert_close(
+                        feature, torch.arange(8, dtype=torch.float32).reshape(2, 4)
+                    )
 
     def test_normal_multi_turn_share_and_carry(self):
         in1, out1 = list(range(100, 110)), [1, 2, 3]


### PR DESCRIPTION
## Motivation
Streaming sessions can carry a fill array from the previous turn. When a new multimodal turn replaces the origin IDs during padding without changing their length, the length-based fill refresh preserves stale, unpadded IDs. The resulting placeholder mask can disagree with multimodal offsets.

## Modifications
Skip fill-array handover when the incoming turn has multimodal inputs. The first refresh rebuilds from the padded origin. Text-only turns, including turns inheriting earlier media, retain the existing carry optimization.

The functional change is one condition in Session.create_req. Regression coverage exercises real session assembly, offset adjustment, padding, fill refresh, repeated output append, copy-based sessions, and token-history rollback around multimodal turns.

## Tests
- Before the fix, the new streaming regression stages raw image token 9 instead of pad value 1000017.
- After the fix: 13 focused session tests and 4 subtests pass.
- Repository pre-commit passes for both changed files.
- CPU tests ran against upstream source 320bdd1ee2 in an isolated CUDA image on a B300 host, with upstream-pinned transformers 5.12.1 and tokenizers 0.22.2. No full model or multi-rank serving test was run.

## Accuracy
Preserves padded token IDs and appends generated tokens exactly once. This fixes a reproduced session correctness defect; it is not a claim that this path caused a particular production incident. Existing multimodal metadata ownership across aborted MM-to-MM turns is separate and unchanged.

## Speed
A turn with incoming media rebuilds its fill array once. Text-only continuation keeps its existing zero-copy carry behavior; decode refresh remains incremental.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33924681743](https://github.com/sgl-project/sglang/actions/runs/33924681743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33924681578](https://github.com/sgl-project/sglang/actions/runs/33924681578)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33924681658](https://github.com/sgl-project/sglang/actions/runs/33924681658)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->