### PR TITLE
fix: keep Qwen3 HiCache on legacy prefill CP

### DIFF
--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -63,6 +63,26 @@ def handle_context_parallelism(server_args: Any):
                     "--language-only."
                 )
 
+        # CP-v2 currently fails to make progress when dense Qwen3 runs with
+        # HiCache under KV-cache pressure. Keep this configuration on the
+        # working legacy implementation until the CP-v2 interaction is fixed
+        # (https://github.com/sgl-project/sglang/issues/38019).
+        if (
+            cfg.enable_prefill_cp
+            and cfg.enable_hierarchical_cache
+            and model_arch == "Qwen3ForCausalLM"
+            and not (platform.is_hip or platform.is_npu)
+        ):
+            declare_resolution(
+                server_args,
+                "_handle_context_parallelism",
+                use_legacy_prefill_cp=True,
+            )
+            logger.warning(
+                "Falling back to legacy prefill CP for Qwen3ForCausalLM with "
+                "HiCache due to https://github.com/sgl-project/sglang/issues/38019."
+            )
+
     if cfg.enable_prefill_cp and cfg.cp_strategy is None:
         raise ValueError(
             "--cp-strategy must be set when --enable-prefill-cp is enabled."

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -121,7 +121,15 @@ def enable_cp_v2() -> bool:
     """Return whether the strategy-based generic prefill CP path is available."""
     from sglang.srt.utils import is_hip, is_npu
 
-    return not (is_hip() or is_npu())
+    if is_hip() or is_npu():
+        return False
+
+    try:
+        use_legacy_prefill_cp = get_parallel().use_legacy_prefill_cp
+    except (AttributeError, ValueError):
+        # Unit helpers may query platform support before publishing ServerArgs.
+        use_legacy_prefill_cp = False
+    return not use_legacy_prefill_cp
 
 
 def is_cp_v2_active(forward_batch) -> bool:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1065,6 +1065,10 @@ class ServerArgs:
     dsa_prefill_cp_mode: A[str, Arg(no_cli=True), NS("parallel")] = "round-robin-split"
     enable_prefill_context_parallel: A[bool, Arg(no_cli=True), NS("parallel")] = False
     prefill_cp_mode: A[str, Arg(no_cli=True), NS("parallel")] = "in-seq-split"
+    # Temporary runtime compatibility switch for configurations that still
+    # require the legacy prefill-CP implementation. This is intentionally not
+    # exposed as a CLI option.
+    use_legacy_prefill_cp: A[bool, Arg(no_cli=True), NS("parallel")] = False
     enable_cp_decode_attn_tp: A[
         bool,
         "Enable attention tensor-parallel weight slicing during decode under context parallel (cp_size>1). Slices the replicated attention linears to the local CP partition, eliminating redundant decode GEMMs.",

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -133,6 +133,17 @@ class TestCPStrategyUnit(CustomTestCase):
     def test_npu_keeps_strategy_cp_disabled(self, _mock_is_hip, _mock_is_npu):
         self.assertFalse(enable_cp_v2())
 
+    @patch("sglang.srt.utils.is_npu", return_value=False)
+    @patch("sglang.srt.utils.is_hip", return_value=False)
+    @patch(
+        "sglang.srt.layers.cp.utils.get_parallel",
+        return_value=SimpleNamespace(use_legacy_prefill_cp=True),
+    )
+    def test_runtime_compatibility_switch_disables_cp_v2(
+        self, _mock_get_parallel, _mock_is_hip, _mock_is_npu
+    ):
+        self.assertFalse(enable_cp_v2())
+
 
 class TestPrefillCPBCGReplay(CustomTestCase):
     def tearDown(self):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1038,6 +1038,8 @@ class TestContextParallelServerArgs(CustomTestCase):
             ep_size=1,
             pp_size=1,
             enable_aiter_allreduce_fusion=False,
+            enable_hierarchical_cache=False,
+            use_legacy_prefill_cp=False,
         )
         defaults.update(overrides)
         for key, value in defaults.items():
@@ -1181,6 +1183,43 @@ class TestContextParallelServerArgs(CustomTestCase):
 
         self.assertTrue(is_cp_enabled())
         self.assertTrue(is_interleave())
+
+    @override_platform(is_hip=False, is_npu=False)
+    def test_qwen3_hicache_prefill_cp_uses_legacy_runtime(self):
+        server_args = self._new_cp_args(
+            model_path="Qwen/Qwen3-32B",
+            enable_prefill_cp=True,
+            cp_strategy="zigzag",
+            attn_cp_size=2,
+            tp_size=2,
+            enable_hierarchical_cache=True,
+        )
+        server_args._model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["Qwen3ForCausalLM"]),
+            is_multimodal=False,
+        )
+
+        handle_context_parallelism(server_args)
+
+        self.assertTrue(resolution_result(server_args, "use_legacy_prefill_cp"))
+
+    @override_platform(is_hip=False, is_npu=False)
+    def test_qwen3_without_hicache_keeps_cp_v2_runtime(self):
+        server_args = self._new_cp_args(
+            model_path="Qwen/Qwen3-32B",
+            enable_prefill_cp=True,
+            cp_strategy="zigzag",
+            attn_cp_size=2,
+            tp_size=2,
+        )
+        server_args._model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["Qwen3ForCausalLM"]),
+            is_multimodal=False,
+        )
+
+        handle_context_parallelism(server_args)
+
+        self.assertFalse(resolution_result(server_args, "use_legacy_prefill_cp"))
 
 
 class TestPortArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary

- detect dense Qwen3 prefill CP with HiCache during server-argument resolution
- persist an internal compatibility decision in the parallel runtime config so spawned workers use the legacy prefill-CP path
- keep CP-v2 canonical for every other model and configuration

## Why

Issue #38019 reports that the Qwen3-32B HiCache + zigzag prefill-CP test stops making progress under KV-cache pressure after CP-v2 became canonical in #36223. The same registered test passed on a main lineage before #36223 and fails on a later main lineage that contains it.

This draft contains the smallest reversible mitigation: keep only Qwen3ForCausalLM + HiCache + prefill CP on the previously working legacy implementation while the CP-v2 and HiCache retraction interaction is investigated.

Refs #38019

## Validation

- exact 4x H100 rerun passed on commit da1f8a5b48: [workflow 33926299338](https://github.com/sgl-project/sglang/actions/runs/33926299338)
  - TestUnifiedQwen3HiCacheCP.test_gsm8k: 1/1 passed in 141.337s
  - GSM8K accuracy: 0.965, threshold: 0.7
  - no KV cache pool is full or Retract requests messages
- pre-commit changed-file hooks passed: AST, isort, ruff, ruff-format, codespell, and registered-test registry validation
- added unit coverage for the Qwen3 + HiCache selection and the runtime CP-v2 compatibility switch
- local pytest collection was blocked by the host Python environment: Python 3.9 is too old for the repository, while the available Python 3.11 environment has missing or conflicting dependencies