### PR TITLE
[GLM-5.3] Add H200 serving recipe E2E coverage

### DIFF
--- a/test/registered/models_e2e/test_glm53_flash_h200.py
+++ b/test/registered/models_e2e/test_glm53_flash_h200.py
@@ -1,0 +1,119 @@
+"""H200 per-commit coverage for the GLM-5.3-Flash serving recipes.
+
+Runs the Low Latency and High Throughput TP8/EP8 recipes on eight H200 GPUs.
+Both recipes must retain GSM8K accuracy; the Low Latency recipe also checks
+EAGLE speculative acceptance and single-request decode performance.
+"""
+
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    _wait_for_gpu_idle_in_ci,
+    popen_launch_server,
+    try_cached_model,
+)
+
+register_cuda_ci(est_time=2400, stage="base-c", runner_config="8-gpu-h200")
+
+MODEL_PATH = "zai-org/GLM-5.3-Flash"
+SERVER_LAUNCH_TIMEOUT = 3600
+GPU_IDLE_TIMEOUT = 120
+
+COMMON_SERVER_ARGS = [
+    "--tp-size",
+    "8",
+    "--ep-size",
+    "8",
+    "--dsa-prefill-backend",
+    "tilelang",
+    "--dsa-decode-backend",
+    "tilelang",
+    "--kv-cache-dtype",
+    "bf16",
+    "--moe-runner-backend",
+    "deep_gemm",
+    "--reasoning-parser",
+    "glm45",
+    "--tool-call-parser",
+    "glm47",
+]
+
+
+def _stop_server(process):
+    if process:
+        kill_process_tree(process.pid)
+        _wait_for_gpu_idle_in_ci(timeout=GPU_IDLE_TIMEOUT)
+
+
+class _GLM53FlashH200Base(CustomTestCase):
+    server_args: list[str]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = None
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=cls.server_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        _stop_server(getattr(cls, "process", None))
+
+
+class TestGLM53FlashH200LowLatency(
+    SpecDecodingMixin,
+    GSM8KMixin,
+    _GLM53FlashH200Base,
+):
+    gsm8k_score_threshold = 0.93
+    # Match the established DSA+MTP accuracy workload. The generic 200-question,
+    # 5-shot defaults leave a single question worth 0.5 percentage points and
+    # make this tight quality floor unnecessarily sensitive to kernel numerics.
+    gsm8k_num_examples = 500
+    gsm8k_num_shots = 20
+    accept_length_thres = 4.0
+    bs_1_speed_thres = 200
+    server_args = [
+        *COMMON_SERVER_ARGS,
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "5",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "6",
+        "--speculative-adaptive",
+    ]
+
+
+class TestGLM53FlashH200HighThroughput(
+    GSM8KMixin,
+    _GLM53FlashH200Base,
+):
+    gsm8k_score_threshold = 0.93
+    gsm8k_num_examples = 500
+    gsm8k_num_shots = 20
+    server_args = [
+        *COMMON_SERVER_ARGS,
+        "--enable-dp-attention",
+        "--dp-size",
+        "8",
+        "--moe-a2a-backend",
+        "deepep",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models_e2e/test_glm53_flash_h200.py
+++ b/test/registered/models_e2e/test_glm53_flash_h200.py
@@ -19,7 +19,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=2400, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=2400, stage="extra-b", runner_config="8-gpu-h200")
 
 MODEL_PATH = "zai-org/GLM-5.3-Flash"
 SERVER_LAUNCH_TIMEOUT = 3600


### PR DESCRIPTION
## Motivation

Add GLM-5.3-Flash H200 E2E coverage to #36507 alongside the existing B200 recipes.

This PR is based on `xinyuan/glm-5.3-flash-support` at `f0796864541afa82f5e82b10a44fdad43b0962f9`, not main.

## Modifications

- Add only `test/registered/models_e2e/test_glm53_flash_h200.py`, registered in `extra-b` on `8-gpu-h200`.
- Cover Low Latency and High Throughput; intentionally omit DFlash/DFlash2 coverage.
- Use TP8/EP8 for both recipes, DP8 with DP attention and DeepEP for High Throughput, TileLang for both DSA prefill/decode, and BF16 KV cache.
- Preserve the other B200 recipe settings, including EAGLE 5 steps / top-k 1 / 6 draft tokens with adaptive speculation for Low Latency.
- Keep GSM8K at 500 examples, 20 shots, and accuracy threshold 0.93. Keep Low Latency speculative acceptance threshold 4.0 and set its bs=1 speed threshold to **200 tok/s**, as requested for H200.
- Leave the B200 test and production code unchanged.

## Accuracy Tests

- Passed: `python3.12 scripts/lint/check_registered_tests.py`.
- Passed: `pre-commit run --files test/registered/models_e2e/test_glm53_flash_h200.py` (including Python AST, lint, format, and CI registry checks).
- Passed: `git diff --check`.
- Reviewed the new file against the B200 reference; differences are limited to the requested H200 configuration, threshold, names/docstring, and omission of DFlash2.
- Actual 8xH200 model E2E has **not** been run; no accuracy pass is claimed.

## Speed Tests and Profiling

No H200 speed measurement yet; 200 tok/s is the requested test threshold, not a measured result. No full CI was requested or triggered; validation should use only targeted `rerun-test` or a suitable devbox.

## Checklist

- [x] Format code with pre-commit.
- [x] Add registered E2E test coverage using the existing GSM8K and speculative-decoding mixins.
- [x] Follow the existing model E2E fixture and cleanup conventions.
- [ ] Run the new test on 8xH200 and provide accuracy/speed results.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33929955549](https://github.com/sgl-project/sglang/actions/runs/33929955549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33929955410](https://github.com/sgl-project/sglang/actions/runs/33929955410)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33929955575](https://github.com/sgl-project/sglang/actions/runs/33929955575)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->