### PR TITLE
fix: restore dense MLP token order under prefill CP

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -37,6 +37,11 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_enable_prefill_cp,
 )
 from sglang.srt.layers.aux_hidden_states import AuxHiddenStateAccumulator
+from sglang.srt.layers.cp.utils import (
+    cp_gather_after_forward,
+    cp_shard_hidden_states,
+    is_cp_v2_active,
+)
 from sglang.srt.layers.dp_attention import (
     attn_tp_all_gather_into_tensor,
     attn_tp_reduce_scatter_tensor,
@@ -390,6 +395,7 @@ class LayerScatterModes:
     mlp_mode: ScatterMode
     middle_residual_mode: ScatterMode
     layer_output_mode: ScatterMode
+    is_layer_sparse: bool = False
 
     @classmethod
     def init_new(cls, **kwargs):
@@ -400,6 +406,7 @@ class LayerScatterModes:
             mlp_mode=cls._compute_mlp_mode(context),
             middle_residual_mode=cls._compute_middle_residual_mode(context),
             layer_output_mode=cls._compute_layer_output_mode(context),
+            is_layer_sparse=context.is_layer_sparse,
         )
 
     @classmethod
@@ -471,6 +478,14 @@ def enable_dwdp():
     return get_parallel().dwdp_size > 1
 
 
+def _needs_cp_full_token_mlp(layer_scatter_modes, forward_batch):
+    return (
+        not getattr(layer_scatter_modes, "is_layer_sparse", False)
+        and layer_scatter_modes.mlp_mode == ScatterMode.FULL
+        and is_cp_v2_active(forward_batch)
+    )
+
+
 class LayerCommunicator:
     def __init__(
         self,
@@ -517,6 +532,7 @@ class LayerCommunicator:
                     mlp_mode=ScatterMode.SCATTERED,
                     middle_residual_mode=ScatterMode.SCATTERED,
                     layer_output_mode=ScatterMode.SCATTERED,
+                    is_layer_sparse=layer_scatter_modes.is_layer_sparse,
                 ),
                 input_layernorm=input_layernorm,
                 post_attention_layernorm=post_attention_layernorm,
@@ -839,13 +855,18 @@ class LayerCommunicator:
         if cache is not None:
             self._context.cache = cache
 
-        return self._communicate_with_all_reduce_and_layer_norm_fn(
+        hidden_states, residual = self._communicate_with_all_reduce_and_layer_norm_fn(
             hidden_states=hidden_states,
             residual=residual,
             forward_batch=forward_batch,
             layernorm=self.post_attention_layernorm,
             context=self._context,
         )
+        if _needs_cp_full_token_mlp(self.layer_scatter_modes, forward_batch):
+            # Full-TP linears reduce across ranks from different CP groups. Give
+            # every TP rank the same global token rows before entering the MLP.
+            hidden_states = cp_gather_after_forward(hidden_states, forward_batch)
+        return hidden_states, residual
 
     def postprocess_layer(
         self,
@@ -857,13 +878,16 @@ class LayerCommunicator:
             return self._sp_variant.postprocess_layer(
                 hidden_states, residual, forward_batch
             )
-        return self._communicate_summable_tensor_pair_fn(
+        hidden_states, residual = self._communicate_summable_tensor_pair_fn(
             hidden_states=hidden_states,
             residual=residual,
             forward_batch=forward_batch,
             context=self._context,
             allow_reduce_scatter=self.allow_reduce_scatter,
         )
+        if _needs_cp_full_token_mlp(self.layer_scatter_modes, forward_batch):
+            hidden_states = cp_shard_hidden_states(hidden_states, forward_batch)
+        return hidden_states, residual
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
         if not self.allow_reduce_scatter:
@@ -891,6 +915,11 @@ class LayerCommunicator:
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at
         # TP_ATTN_FULL size, causing a shape mismatch.
         if is_enable_moe_cp_allgather():
+            return False
+
+        # This fusion skips postprocess_layer, which must restore CP-local token
+        # rows after a full-TP MLP.
+        if _needs_cp_full_token_mlp(self.layer_scatter_modes, forward_batch):
             return False
 
         # Fusing makes the next layer's residual+LN absorb the post-experts

--- a/python/sglang/srt/models/nemotron_h_utils.py
+++ b/python/sglang/srt/models/nemotron_h_utils.py
@@ -62,6 +62,7 @@ def _build_layer_scatter_modes(is_sparse: bool = False) -> LayerScatterModes:
         mlp_mode=mlp_mode,
         middle_residual_mode=middle_residual_mode,
         layer_output_mode=ScatterMode.TP_ATTN_FULL,
+        is_layer_sparse=is_sparse,
     )
 
 

--- a/test/registered/unit/layers/test_layer_communicator_cp.py
+++ b/test/registered/unit/layers/test_layer_communicator_cp.py
@@ -1,0 +1,167 @@
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers import communicator as comm
+from sglang.srt.layers.communicator import (
+    LayerCommunicator,
+    LayerScatterModes,
+    ScatterMode,
+)
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _fake_communicator():
+    return types.SimpleNamespace(
+        _sp_variant=None,
+        _speculative_algo=None,
+        layer_scatter_modes=LayerScatterModes(
+            layer_input_mode=ScatterMode.TP_ATTN_FULL,
+            attn_mode=ScatterMode.TP_ATTN_FULL,
+            mlp_mode=ScatterMode.FULL,
+            middle_residual_mode=ScatterMode.TP_ATTN_FULL,
+            layer_output_mode=ScatterMode.TP_ATTN_FULL,
+        ),
+        is_last_layer=False,
+        allow_reduce_scatter=False,
+        post_attention_layernorm=object(),
+        _context=types.SimpleNamespace(tp_size=4),
+        _communicate_with_all_reduce_and_layer_norm_fn=lambda **kwargs: (
+            kwargs["hidden_states"],
+            kwargs["residual"],
+        ),
+        _communicate_summable_tensor_pair_fn=lambda **kwargs: (
+            kwargs["hidden_states"],
+            kwargs["residual"],
+        ),
+    )
+
+
+class TestLayerCommunicatorContextParallel(CustomTestCase):
+    def setUp(self):
+        self.forward_batch = types.SimpleNamespace(
+            input_ids=types.SimpleNamespace(shape=(8,))
+        )
+
+    def test_prepare_mlp_materializes_global_token_order(self):
+        communicator = _fake_communicator()
+        hidden_states = torch.tensor([[1.0], [2.0]])
+        residual = torch.tensor([[10.0], [20.0]])
+
+        with (
+            patch.object(comm, "is_cp_v2_active", return_value=True),
+            patch.object(
+                comm,
+                "cp_gather_after_forward",
+                side_effect=lambda tensor, _batch: tensor.flip(0),
+            ),
+        ):
+            hidden_states, residual = LayerCommunicator.prepare_mlp(
+                communicator, hidden_states, residual, self.forward_batch
+            )
+
+        torch.testing.assert_close(hidden_states, torch.tensor([[2.0], [1.0]]))
+        torch.testing.assert_close(residual, torch.tensor([[10.0], [20.0]]))
+
+    def test_postprocess_layer_restores_cp_local_token_order(self):
+        communicator = _fake_communicator()
+        hidden_states = torch.tensor([[1.0], [2.0], [3.0], [4.0]])
+        residual = torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+
+        with (
+            patch.object(comm, "is_cp_v2_active", return_value=True),
+            patch.object(
+                comm,
+                "cp_shard_hidden_states",
+                side_effect=lambda tensor, _batch: tensor[::2],
+            ),
+        ):
+            hidden_states, residual = LayerCommunicator.postprocess_layer(
+                communicator, hidden_states, residual, self.forward_batch
+            )
+
+        torch.testing.assert_close(hidden_states, torch.tensor([[1.0], [3.0]]))
+        torch.testing.assert_close(
+            residual, torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+        )
+
+    def test_sparse_full_mlp_keeps_existing_cp_communication(self):
+        communicator = _fake_communicator()
+        communicator.layer_scatter_modes.is_layer_sparse = True
+        hidden_states = torch.tensor([[1.0], [2.0]])
+        residual = torch.tensor([[10.0], [20.0]])
+
+        with (
+            patch.object(comm, "is_cp_v2_active", return_value=True),
+            patch.object(
+                comm,
+                "cp_gather_after_forward",
+                side_effect=lambda tensor, _batch: tensor.flip(0),
+            ),
+            patch.object(
+                comm,
+                "cp_shard_hidden_states",
+                side_effect=lambda tensor, _batch: tensor[::2],
+            ),
+        ):
+            prepared_hidden_states, prepared_residual = LayerCommunicator.prepare_mlp(
+                communicator, hidden_states, residual, self.forward_batch
+            )
+            hidden_states, residual = LayerCommunicator.postprocess_layer(
+                communicator,
+                prepared_hidden_states,
+                prepared_residual,
+                self.forward_batch,
+            )
+
+        torch.testing.assert_close(hidden_states, torch.tensor([[1.0], [2.0]]))
+        torch.testing.assert_close(residual, torch.tensor([[10.0], [20.0]]))
+
+    def test_full_tp_mlp_does_not_fuse_while_cp_is_active(self):
+        communicator = _fake_communicator()
+
+        with (
+            patch.object(comm, "is_cp_v2_active", return_value=True),
+            patch.object(comm, "is_enable_moe_cp_allgather", return_value=False),
+            patch.object(comm, "apply_flashinfer_allreduce_fusion", return_value=True),
+            patch.object(
+                comm,
+                "get_attn_tp_context",
+                return_value=types.SimpleNamespace(input_scattered=False),
+            ),
+            get_parallel().override(moe_ep_size=1, moe_tp_size=4, tp_size=4),
+        ):
+            should_fuse = LayerCommunicator.should_fuse_mlp_allreduce_with_next_layer(
+                communicator, self.forward_batch
+            )
+
+        self.assertFalse(should_fuse)
+
+    def test_inactive_cp_leaves_mlp_boundary_unchanged(self):
+        communicator = _fake_communicator()
+        hidden_states = torch.tensor([[1.0], [2.0]])
+        residual = torch.tensor([[10.0], [20.0]])
+
+        with patch.object(comm, "is_cp_v2_active", return_value=False):
+            prepared_hidden_states, prepared_residual = LayerCommunicator.prepare_mlp(
+                communicator, hidden_states, residual, self.forward_batch
+            )
+            output_hidden_states, output_residual = LayerCommunicator.postprocess_layer(
+                communicator,
+                prepared_hidden_states,
+                prepared_residual,
+                self.forward_batch,
+            )
+
+        torch.testing.assert_close(output_hidden_states, hidden_states)
+        torch.testing.assert_close(output_residual, residual)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

After #36223 made strategy-based prefill CP the default CUDA path, the dense Qwen3-32B TP4/CP2 HiCache test produced corrupted generations and timed out. Each CP group carried different token rows into a dense MLP whose RowParallelLinear reduces over the full TP group, so the collective silently summed unrelated tokens.

This fixes the dense CP v2 path without restoring or falling back to CP v1.

## Modifications

- Materialize global token order before dense full-TP MLPs while strategy-based prefill CP is active.
- Reshard the MLP output to the CP-local token layout afterward; keep residual CP-local.
- Disable cross-layer MLP all-reduce fusion for this case because it skips the required post-layer reshard.
- Track sparse layers explicitly so existing MoE communication is unchanged.
- Leave HIP/NPU behavior unchanged because strategy-based CP is inactive on those platforms.
- Add CPU regression coverage for gather, reshard, fusion gating, inactive CP, and sparse FULL behavior.

## Accuracy Tests

Local:
- `test/registered/unit/layers/test_layer_communicator_cp.py`: 5 passed
- `test/registered/unit/layers/test_layer_communicator_fusion_gate.py`: 3 passed
- `test/registered/cp/test_cp_strategy_unit.py`: 26 passed

4xH100 regression requested after PR creation:
- `test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py`

## Speed Tests and Profiling

Not run locally. This correctness fix adds a CP gather and reshard around dense full-TP MLPs only. Sparse/MoE and inactive CP paths are unchanged.

## Checklist

- [x] Format code with pre-commit.
- [x] Add registered CPU unit tests.
- [x] Preserve AMD/NPU and sparse/MoE behavior.
- [ ] Confirm the original 4xH100 accuracy regression test.
- [x] Documentation is not needed for this internal correctness fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33931107279](https://github.com/sgl-project/sglang/actions/runs/33931107279)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33931106665](https://github.com/sgl-project/sglang/actions/runs/33931106665)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33931106900](https://github.com/sgl-project/sglang/actions/runs/33931106900)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->