### PR TITLE
fix: gather CP-sharded tokens before TP-sharded dense MLP under prefill CP

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -425,11 +425,17 @@ class LayerScatterModes:
                 return ScatterMode.MOE_FULL
             return ScatterMode.FULL
         else:
-            return (
-                ScatterMode.SCATTERED
-                if enable_moe_dense_fully_dp()
-                else ScatterMode.FULL
-            )
+            if enable_moe_dense_fully_dp():
+                return ScatterMode.SCATTERED
+            # A TP-sharded dense MLP reduces over the whole TP group, which spans
+            # every CP rank; a CP-sharded prefill must gather tokens across CP
+            # first or the all-reduce sums different tokens' partial outputs.
+            # MLA/DSA CP models do this in DSACPLayerCommunicator instead.
+            if _generic_prefill_cp_shards_tokens() and not (
+                is_dsa_enable_prefill_cp() or is_mla_prefill_cp_enabled()
+            ):
+                return ScatterMode.MOE_FULL
+            return ScatterMode.FULL
 
     @classmethod
     def _should_gather_for_tbo(cls, context: _LayerModeComputationContext):
@@ -465,6 +471,15 @@ class LayerScatterModes:
 
 def enable_moe_dense_fully_dp():
     return get_parallel().moe_dense_tp_size == 1
+
+
+def _generic_prefill_cp_shards_tokens() -> bool:
+    """Whether the strategy prefill CP path shards prefill tokens across CP ranks."""
+    # Local import: module-level CP helper imports here are circular (#27014).
+    from sglang.srt.layers.cp.utils import enable_cp_v2
+
+    parallel = get_parallel()
+    return parallel.attn_cp_size > 1 and parallel.enable_prefill_cp and enable_cp_v2()
 
 
 def enable_dwdp():
@@ -890,7 +905,10 @@ class LayerCommunicator:
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at
         # TP_ATTN_FULL size, causing a shape mismatch.
-        if is_enable_moe_cp_allgather():
+        if (
+            is_enable_moe_cp_allgather()
+            or self.layer_scatter_modes.mlp_mode == ScatterMode.MOE_FULL
+        ):
             return False
 
         # Fusing makes the next layer's residual+LN absorb the post-experts

--- a/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
+++ b/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
@@ -11,10 +11,10 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-def _fake_communicator():
+def _fake_communicator(mlp_mode=ScatterMode.TP_ATTN_FULL):
     return types.SimpleNamespace(
         _speculative_algo=None,
-        layer_scatter_modes=types.SimpleNamespace(mlp_mode=ScatterMode.TP_ATTN_FULL),
+        layer_scatter_modes=types.SimpleNamespace(mlp_mode=mlp_mode),
         is_last_layer=False,
         _context=types.SimpleNamespace(tp_size=4),
     )
@@ -31,7 +31,9 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
     Qwen3-30B-A3B with --tp-size 4 --ep-size 2.
     """
 
-    def _should_fuse(self, *, moe_ep_size, moe_tp_size):
+    def _should_fuse(
+        self, *, moe_ep_size, moe_tp_size, mlp_mode=ScatterMode.TP_ATTN_FULL
+    ):
         forward_batch = types.SimpleNamespace(
             input_ids=types.SimpleNamespace(shape=(8,))
         )
@@ -48,7 +50,7 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
             ),
         ):
             return LayerCommunicator.should_fuse_mlp_allreduce_with_next_layer(
-                _fake_communicator(), forward_batch
+                _fake_communicator(mlp_mode), forward_batch
             )
 
     def test_hybrid_ep_tp_does_not_fuse(self):
@@ -59,6 +61,16 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
 
     def test_pure_ep_still_fuses(self):
         self.assertTrue(self._should_fuse(moe_ep_size=4, moe_tp_size=1))
+
+    def test_moe_full_layer_does_not_fuse(self):
+        # Fusion skips postprocess_layer, which holds the CP scatter; a dense
+        # MOE_FULL layer (moe_dp_size == attn_cp_size) is not caught by the
+        # is_enable_moe_cp_allgather gate.
+        self.assertFalse(
+            self._should_fuse(
+                moe_ep_size=1, moe_tp_size=4, mlp_mode=ScatterMode.MOE_FULL
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_layer_scatter_modes_cp_dense_mlp.py
+++ b/test/registered/unit/layers/test_layer_scatter_modes_cp_dense_mlp.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers import communicator as comm
+from sglang.srt.layers.communicator import LayerScatterModes, ScatterMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDenseMlpScatterModeUnderPrefillCP(CustomTestCase):
+    """A TP-sharded dense MLP under prefill CP must gather tokens across CP ranks
+    before its all-reduce, or CP pairs sum partial outputs of different tokens
+    (issue #38019: Qwen3-32B emitted garbage that never reached EOS)."""
+
+    def test_dense_mlp_gathers_across_cp(self):
+        with (
+            patch.object(comm, "_generic_prefill_cp_shards_tokens", return_value=True),
+            patch.object(comm, "is_dsa_enable_prefill_cp", return_value=False),
+            patch.object(comm, "is_mla_prefill_cp_enabled", return_value=False),
+            patch.object(comm, "enable_moe_dense_fully_dp", return_value=False),
+        ):
+            modes = LayerScatterModes.init_new(
+                layer_id=1,
+                num_layers=4,
+                is_layer_sparse=False,
+                is_previous_layer_sparse=False,
+                is_next_layer_sparse=False,
+            )
+        self.assertEqual(modes.mlp_mode, ScatterMode.MOE_FULL)
+        self.assertEqual(modes.layer_output_mode, ScatterMode.TP_ATTN_FULL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make `LayerScatterModes` mark the dense MLP boundary `MOE_FULL` when strategy prefill CP actually shards tokens (`attn_cp_size > 1`, `--enable-prefill-cp`, generic CP-v2 platform), so the existing moe_cp all-gather runs before a TP-sharded dense MLP and the scatter after it
- refuse to fuse the MLP all-reduce into the next layer for `MOE_FULL` layers (fusion skips the postprocess scatter)
- add a unit test for the dense-layer scatter mode under prefill CP and a fusion-gate case for `MOE_FULL` layers

Replaces the workaround in #38070, which kept Qwen3 + HiCache on the legacy prefill-CP implementation.

## Root cause

`Qwen3ForCausalLM` (and every other dense MHA model) builds its MLP with `RowParallelLinear` over the whole TP group, which spans all CP ranks. Since #36223 made strategy prefill CP canonical, a CP-sharded prefill batch reaches that MLP with each CP pair holding a different half of the tokens, and the `down_proj` all-reduce sums partial outputs of unrelated tokens. `LayerScatterModes._compute_mlp_mode` returned `FULL` for dense layers, and `process_group_sizes[FULL] == attn_tp_size`, so `LayerCommunicator` performed no CP gather. MoE layers already handle this through `MOE_FULL`; MLA/DSA models through `DSACPLayerCommunicator`.

Before #36223 this test passed only because `Qwen3ForCausalLM` was outside the CP-v2 allowlist and `qwen3.py` has no legacy CP code: `--enable-prefill-cp` was a no-op and every CP rank prefilled the full sequence.

The corrupted hidden states produce generations that never emit EOS. With `max_new_tokens=16000` and `--max-total-tokens 14000`, every request runs to the cap, which is the KV-pool-full retraction loop seen in #38019 (each retraction frees 2.3K-6K tokens in the failing CI log). HiCache is incidental: the same configuration without HiCache reproduces.

## Validation

1x GB300 node, Qwen3-32B, `--tp-size 4 --attn-cp-size 2 --enable-prefill-cp --cp-strategy zigzag` (trtllm_mha):

| arm | GSM8K (200 q, few-shot) | output probe (20 q, max_new 2048) |
| --- | --- | --- |
| main, no HiCache | 0.075 (invalid 0.115) | mean 640 tokens, 5/20 hit the length cap, completions repeat the question |
| this PR, no HiCache | 0.935 | mean 356 tokens, 20/20 stop |
| this PR, HiCache flags from the registered test | 0.940, 0 retractions | mean 356 tokens, 20/20 stop |
| this PR, `test_unified_radix_cache_kl_cp.py` (4 tests) | `Ran 4 tests in 274 s OK`, multiturn avg KL 0.0039 (threshold 0.005) | CI on main hit the 60 min stage timeout |

- new unit test fails on unfixed main and passes with this PR; existing `test_layer_communicator_fusion_gate.py` and `test_cp_strategy_unit.py` pass
- pre-commit hooks on changed files (isort, ruff, ruff-format, registered-test registry) pass

The change affects every model with dense layers when prefill CP is enabled on the generic CP path (no behavior change when prefill CP is off, in decode, for `--attn-cp-size` without `--enable-prefill-cp`, or for MLA/DSA CP). Please also run `test/registered/cp/test_gqa_prefill_cp.py` and `test/registered/cp/test_gpt_oss_4gpu_mxfp4_cp.py` to confirm the MoE path is unaffected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33931724547](https://github.com/sgl-project/sglang/actions/runs/33931724547)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33931724550](https://github.com/sgl-project/sglang/actions/runs/33931724550)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33931724809](https://github.com/sgl-project/sglang/actions/runs/33931724809)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->