### PR TITLE
[MegaMoE] Experimental nvfp4xnvfp4 MegaMoE for ModelOpt NVFP4 experts

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -416,6 +416,36 @@ class ModelConfig:
         self.is_fp4_experts: bool = routed_experts_quant_method == "mxfp4"
         if self.is_fp4_experts:
             logger.info("Detected mixed checkpoint layout: routed experts are MXFP4.")
+        # Online FP8 -> MXFP4 expert requant presents a block-FP8 checkpoint to
+        # the quant method as if its routed experts were stored MXFP4.
+        self.requant_fp8_experts_to_mxfp4: bool = False
+        if envs.SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4.get():
+            if not get_platform().is_sm100:
+                # The MXFP4 expert kernels (fp8xfp4 / mxf4xmxf4) are SM100-only;
+                # SM90 MegaMoE keeps block-FP8 weights.
+                raise ValueError(
+                    "SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4 requires an SM100-class "
+                    "GPU (B200 / B300); unset it on this platform."
+                )
+            is_block_fp8 = (
+                quantization_config.get("quant_method") == "fp8"
+                and quantization_config.get("weight_block_size") is not None
+            )
+            if is_block_fp8 and not self.is_fp4_experts:
+                self.requant_fp8_experts_to_mxfp4 = True
+                self.is_fp4_experts = True
+                logger.warning(
+                    "SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4=1 (experimental): block-FP8 "
+                    "routed experts will be requantized to MXFP4 at load time. This "
+                    "is an uncalibrated round-to-nearest PTQ on top of the FP8 "
+                    "quantization; the model was not trained for MXFP4 experts. "
+                    "Validate accuracy on your workload before relying on it."
+                )
+            else:
+                logger.warning(
+                    "SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4 ignored: it needs a "
+                    "block-FP8 checkpoint whose routed experts are not already MXFP4."
+                )
 
         # DSV4 mxfp4 layout applies only when the ckpt does not opt in above.
         if is_deepseek_v4(self.hf_config) and routed_experts_quant_method is None:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1151,6 +1151,12 @@ class Envs:
     # Blackwell MegaMoE uses a whole-grid software barrier. Keep a small
     # residency margin so every cluster can launch beside other streams.
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS = EnvInt(2)
+    # EXPERIMENTAL. Requantize block-FP8 routed experts to MXFP4 (e2m1 + ue8m0
+    # g32) while loading so a plain FP8 checkpoint can drive the fp8xfp4 /
+    # mxf4xmxf4 expert kernels. Uncalibrated round-to-nearest PTQ on top of the
+    # FP8 quantization; unlike DeepSeek-V4's QAT MXFP4 experts the model was
+    # never trained for this precision. Validate accuracy before relying on it.
+    SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4 = EnvBool(False)
 
     # ===================================================================
     # Top-k kernels

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -853,7 +853,7 @@ class FusedMoE(torch.nn.Module):
         else:
             expert_data.copy_(loaded_weight)
 
-    def _maybe_load_fp8_shared_expert_as_fp4(
+    def _maybe_load_fp8_expert_as_fp4(
         self,
         param: torch.nn.Parameter,
         loaded_weight: torch.Tensor,
@@ -863,13 +863,20 @@ class FusedMoE(torch.nn.Module):
         shard_dim: int,
         tp_rank: int,
     ) -> bool:
+        # Block-FP8 shard -> MXFP4 params. Reached by the fused shared expert of
+        # a mixed FP8/MXFP4 checkpoint and, with requant_fp8_experts_to_mxfp4,
+        # by every routed expert of a plain block-FP8 checkpoint.
         if (
-            not self._has_fused_shared
-            or expert_id < self._num_local_routed
-            or self.quant_config is None
+            self.quant_config is None
             or not getattr(self.quant_config, "is_fp4_experts", False)
             or shard_id not in ("w1", "w2", "w3")
         ):
+            return False
+        is_shared_slot = self._has_fused_shared and expert_id >= self._num_local_routed
+        requant_routed = getattr(
+            self.quant_config, "requant_fp8_experts_to_mxfp4", False
+        )
+        if not is_shared_slot and not requant_routed:
             return False
 
         is_weight = (
@@ -877,9 +884,12 @@ class FusedMoE(torch.nn.Module):
             and "scale" not in weight_name
             and loaded_weight.dtype == torch.float8_e4m3fn
         )
+        # Block-FP8 scale_inv is fp32 in DSV4-style files and bf16 in Qwen3.5's.
         is_scale = "weight_scale_inv" in weight_name and loaded_weight.dtype in (
             torch.float8_e8m0fnu,
             torch.float32,
+            torch.bfloat16,
+            torch.float16,
         )
         if not is_weight and not is_scale:
             return False
@@ -906,20 +916,22 @@ class FusedMoE(torch.nn.Module):
                 return True
 
         logging.getLogger(__name__).warning_once(
-            "Loading FP8 shared expert weights into FP4 fused MoE weights. "
-            "The shared expert is quantized at load time and may differ "
-            "slightly from a checkpoint that stores shared experts directly "
-            "in FP4."
+            "Loading FP8 expert weights into FP4 fused MoE weights. "
+            "The expert is requantized to MXFP4 at load time and may differ "
+            "slightly from a checkpoint that stores it directly in FP4."
         )
 
         weight_block_size = getattr(self.quant_config, "weight_block_size", None)
         if weight_block_size is None:
             raise ValueError(
-                "Loading FP8 shared expert weights into FP4 fused MoE weights "
+                "Loading FP8 expert weights into FP4 fused MoE weights "
                 "requires block-FP8 weight_block_size."
             )
+        # Dequant + RTN requant on the target device: the CPU path over
+        # hundreds of experts per rank adds minutes to model load.
+        device = weight_param.data.device
         fp4_weight, fp4_scale = quantize_block_fp8_weight_to_mxfp4(
-            fp8_weight, fp8_scale, weight_block_size
+            fp8_weight.to(device), fp8_scale.to(device), weight_block_size
         )
 
         weight_data = weight_param.data[expert_id]
@@ -1219,7 +1231,7 @@ class FusedMoE(torch.nn.Module):
         if is_transposed:
             shard_dim = int(not shard_dim)
 
-        if self._maybe_load_fp8_shared_expert_as_fp4(
+        if self._maybe_load_fp8_expert_as_fp4(
             param=param,
             loaded_weight=loaded_weight,
             weight_name=weight_name,

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -86,6 +86,22 @@ def _configure_mega_moe_deep_gemm_num_sms(deep_gemm):
         deep_gemm.set_num_sms(current_num_sms)
 
 
+def _check_mega_moe_shapes(hidden: int, intermediate: int, mma_type: str) -> None:
+    # DeepGEMM's symmetric buffer stores one scale row per token for both the
+    # hidden and the intermediate activations and requires 16-byte TMA
+    # alignment of every row (layout/mega_moe.cuh), so both sizes must be a
+    # multiple of 16 * scale_group.
+    scale_group = 16 if mma_type == "nvfp4xnvfp4" else 32
+    align = 16 * scale_group
+    if hidden % align != 0 or intermediate % align != 0:
+        raise ValueError(
+            f"DeepGEMM MegaMoE ({mma_type}) needs hidden_size and "
+            f"moe_intermediate_size to be multiples of {align}; got "
+            f"hidden_size={hidden}, moe_intermediate_size={intermediate}. "
+            "Use another --moe-a2a-backend for this model."
+        )
+
+
 def _get_mega_moe_symm_buffer(
     group,
     num_experts: int,
@@ -122,14 +138,20 @@ def _get_mega_moe_symm_buffer(
     return buf
 
 
+def is_mega_moe_experts_ready(experts) -> bool:
+    # SM90 has its own FP8-only kernel; MXFP4 mega weights cannot feed it.
+    if not getattr(experts, "_mega_moe_weights_built", False):
+        return False
+    if _device_sm == 90:
+        return is_sm90_fp8_mega_moe_available(experts)
+    return True
+
+
 def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool:
     if not get_moe_a2a_backend().is_megamoe():
         return False
-    if not getattr(moe.experts, "_mega_moe_weights_built", False):
+    if not is_mega_moe_experts_ready(moe.experts):
         return False
-    if _device_sm == 90:
-        if not is_sm90_fp8_mega_moe_available(moe.experts):
-            return False
     if get_is_capture_mode():
         return True
 
@@ -186,10 +208,6 @@ def _run_mega_routed(
     input_ids_global: Optional[torch.Tensor],
     num_tokens: int,
 ) -> torch.Tensor:
-    import deep_gemm
-
-    from sglang.srt.distributed.parallel_state import get_moe_ep_group
-
     hidden_size = moe.config.hidden_size
 
     if num_tokens > 0:
@@ -214,10 +232,45 @@ def _run_mega_routed(
         topk_ids = None
         topk_weights = None
 
+    return run_mega_routed_experts(
+        moe.experts,
+        hidden_states,
+        topk_ids,
+        topk_weights,
+        hidden_size=hidden_size,
+        intermediate_size=moe.config.moe_intermediate_size,
+        top_k=moe.config.num_experts_per_tok + moe.num_fused_shared_experts,
+        num_tokens=num_tokens,
+        activation_clamp=getattr(moe.config, "swiglu_limit", None),
+        routed_scaling_factor=(
+            1.0
+            if moe.experts.should_fuse_routed_scaling_factor_in_topk
+            else float(moe.routed_scaling_factor)
+        ),
+    )
+
+
+def run_mega_routed_experts(
+    experts,
+    hidden_states: torch.Tensor,
+    topk_ids: Optional[torch.Tensor],
+    topk_weights: Optional[torch.Tensor],
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_tokens: int,
+    activation_clamp: Optional[float] = None,
+    routed_scaling_factor: float = 1.0,
+) -> torch.Tensor:
+    # Model-agnostic MegaMoE entry: rows are this rank's tokens, the result is
+    # fully combined. `experts` must have been through build_mega_moe_experts_weights.
+    import deep_gemm
+
+    from sglang.srt.distributed.parallel_state import get_moe_ep_group
+
     ep_group = get_moe_ep_group().device_group
-    num_experts = moe.experts.num_experts
-    top_k = moe.config.num_experts_per_tok + moe.num_fused_shared_experts
-    intermediate_size = moe.config.moe_intermediate_size
+    num_experts = experts.num_experts
     num_max_tokens_per_rank = (
         envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
     )
@@ -228,6 +281,8 @@ def _run_mega_routed(
         f"cuda_graph_max_bs / chunked_prefill_size accordingly"
     )
 
+    if _device_sm != 90:
+        _check_mega_moe_shapes(hidden_size, intermediate_size, _mega_moe_mma_type())
     buf = _get_mega_moe_symm_buffer(
         ep_group,
         num_experts=num_experts,
@@ -246,12 +301,15 @@ def _run_mega_routed(
 
     if _device_sm == 90:
         return run_sm90_mega_routed(
-            moe,
+            experts,
             hidden_states,
             topk_ids_in,
             topk_weights_in,
             buf,
             num_tokens,
+            hidden_size=hidden_size,
+            activation_clamp=activation_clamp,
+            routed_scaling_factor=routed_scaling_factor,
         )
 
     mma_type = _mega_moe_mma_type()
@@ -290,22 +348,21 @@ def _run_mega_routed(
         dtype=torch.bfloat16,
         device=hidden_states.device,
     )
-    swiglu_limit = getattr(moe.config, "swiglu_limit", None)
     with _configure_mega_moe_deep_gemm_num_sms(deep_gemm):
         deep_gemm.fp8_fp4_mega_moe(
             y,
-            moe.experts.mega_l1_weights,
-            moe.experts.mega_l2_weights,
+            experts.mega_l1_weights,
+            experts.mega_l2_weights,
             buf,
             recipe=(1, 1, 32),
             activation="swiglu",
-            activation_clamp=swiglu_limit,
+            activation_clamp=activation_clamp,
             fast_math=True,
         )
     y = y[:num_tokens]
 
-    if not moe.experts.should_fuse_routed_scaling_factor_in_topk:
-        y.mul_(moe.routed_scaling_factor)
+    if routed_scaling_factor != 1.0:
+        y.mul_(routed_scaling_factor)
     return y
 
 

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -45,7 +45,11 @@ if TYPE_CHECKING:
 _MEGA_MOE_SYMM_BUFFER: dict = {}
 
 
-def _mega_moe_mma_type() -> str:
+def _mega_moe_mma_type(experts=None) -> str:
+    # NVFP4 (e2m1 + UE4M3 g16 + per-tensor alphas) is a checkpoint property of
+    # the expert layer; the MXFP4 W4A8 / W4A4 choice is a server-wide flag.
+    if experts is not None and getattr(experts, "_mega_moe_nvfp4", False):
+        return "nvfp4xnvfp4"
     return "mxf4xmxf4" if get_exec().moe.enable_w4a4_mxfp4_megamoe else "fp8xfp4"
 
 
@@ -109,10 +113,12 @@ def _get_mega_moe_symm_buffer(
     num_topk: int,
     hidden: int,
     intermediate_hidden: int,
+    mma_type: Optional[str] = None,
 ) -> SymmBuffer:
     import deep_gemm
 
-    mma_type = _mega_moe_mma_type()
+    if mma_type is None:
+        mma_type = _mega_moe_mma_type()
     key = (
         id(group),
         num_max_tokens_per_rank,
@@ -281,8 +287,9 @@ def run_mega_routed_experts(
         f"cuda_graph_max_bs / chunked_prefill_size accordingly"
     )
 
+    mma_type = _mega_moe_mma_type(experts)
     if _device_sm != 90:
-        _check_mega_moe_shapes(hidden_size, intermediate_size, _mega_moe_mma_type())
+        _check_mega_moe_shapes(hidden_size, intermediate_size, mma_type)
     buf = _get_mega_moe_symm_buffer(
         ep_group,
         num_experts=num_experts,
@@ -290,6 +297,7 @@ def run_mega_routed_experts(
         num_topk=top_k,
         hidden=hidden_size,
         intermediate_hidden=intermediate_size,
+        mma_type=mma_type,
     )
 
     if num_tokens > 0:
@@ -312,8 +320,32 @@ def run_mega_routed_experts(
             routed_scaling_factor=routed_scaling_factor,
         )
 
-    mma_type = _mega_moe_mma_type()
-    if mma_type == "mxf4xmxf4":
+    mega_kwargs = {"recipe": (1, 1, 32)}
+    if mma_type == "nvfp4xnvfp4":
+        # Per-token FP32 outer scale lands in buf.x_scales; the kernel applies
+        # it with the per-expert weight alphas in the L1 epilogue and the
+        # (input_scale * weight_scale_2) alpha in the L2 epilogue.
+        deep_gemm.mega_moe_pre_dispatch(
+            hidden_states,
+            topk_ids_in,
+            topk_weights_in,
+            buf.x,
+            buf.x_sf,
+            buf.topk_idx,
+            buf.topk_weights,
+            num_tokens=num_tokens,
+            group_size=16,
+            mma_type=mma_type,
+            buf_x_scales=buf.x_scales,
+        )
+        mega_kwargs = {
+            "recipe": (1, 1, 16),
+            "use_x_scales": True,
+            "l1_alphas": experts.mega_l1_alphas,
+            "l2_alphas": experts.mega_l2_alphas,
+            "l2_act_scales": experts.mega_l2_act_scales,
+        }
+    elif mma_type == "mxf4xmxf4":
         # FP4 path goes through DeepGEMM's mega_moe_pre_dispatch which
         # handles the E2M1 packing variant. The jit implementation
         # only emits FP8.
@@ -354,10 +386,10 @@ def run_mega_routed_experts(
             experts.mega_l1_weights,
             experts.mega_l2_weights,
             buf,
-            recipe=(1, 1, 32),
             activation="swiglu",
             activation_clamp=activation_clamp,
             fast_math=True,
+            **mega_kwargs,
         )
     y = y[:num_tokens]
 

--- a/python/sglang/srt/layers/moe/mega_moe_sm90.py
+++ b/python/sglang/srt/layers/moe/mega_moe_sm90.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -23,8 +23,6 @@ from sglang.srt.models.deepseek_common.utils import _device_sm
 
 if TYPE_CHECKING:
     from deep_gemm import SymmBuffer
-
-    from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
 
 
 def is_sm90_fp8_mega_moe_available(experts) -> bool:
@@ -42,19 +40,18 @@ def is_sm90_fp8_mega_moe_available(experts) -> bool:
 
 
 def run_sm90_mega_routed(
-    moe: DeepseekV2MoE,
+    experts,
     hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     buf: SymmBuffer,
     num_tokens: int,
+    *,
+    hidden_size: int,
+    activation_clamp: Optional[float] = None,
+    routed_scaling_factor: float = 1.0,
 ) -> torch.Tensor:
     import deep_gemm
-
-    if moe.experts.should_fuse_routed_scaling_factor_in_topk:
-        routed_scaling_factor = 1.0
-    else:
-        routed_scaling_factor = float(moe.routed_scaling_factor)
 
     deep_gemm.mega_moe_pre_dispatch_sm90(
         hidden_states,
@@ -70,18 +67,18 @@ def run_sm90_mega_routed(
     )
 
     y = torch.empty(
-        (max(num_tokens, 1), moe.config.hidden_size),
+        (max(num_tokens, 1), hidden_size),
         dtype=torch.bfloat16,
         device=hidden_states.device,
     )
     deep_gemm.fp8_mega_moe(
         y,
-        moe.experts.mega_l1_weights,
-        moe.experts.mega_l2_weights,
+        experts.mega_l1_weights,
+        experts.mega_l2_weights,
         buf,
         recipe=(128, 128, 128),
         activation="swiglu",
-        activation_clamp=getattr(moe.config, "swiglu_limit", None),
+        activation_clamp=activation_clamp,
         fast_math=True,
     )
     y = y[:num_tokens]

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -249,6 +249,9 @@ class Fp8Config(QuantizationConfig):
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
         # model_loader from ModelConfig. Default False off the DSV4 path.
         self.is_fp4_experts = is_fp4_experts
+        # FP8 routed experts in the checkpoint, MXFP4 params in memory; the
+        # FusedMoE loader requantizes each expert as it streams in.
+        self.requant_fp8_experts_to_mxfp4 = False
         self.dequant_fp4_to_fp8 = False
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         if is_checkpoint_fp8_serialized:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1496,7 +1496,11 @@ def quantize_block_fp8_weight_to_mxfp4(
         *fp8_weight_dequant.shape[:-1],
         fp8_weight_dequant.shape[-1] // mxfp4_block_size,
     )
-    return fp4_weight, fp4_scale.contiguous().view(torch.float8_e8m0fnu)
+    # An all-zero group yields exponent byte 0 (2^-127), which is an fp32
+    # subnormal and trips DeepGEMM's UE8M0 layout check once the scale is
+    # widened to fp32; its values are zero, so any scale is exact.
+    fp4_scale = fp4_scale.contiguous().clamp_(min=1)
+    return fp4_weight, fp4_scale.view(torch.float8_e8m0fnu)
 
 
 def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import (
+    get_moe_a2a_backend,
     is_flashinfer_cutedsl_v1_path,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
@@ -2491,6 +2492,55 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         w2_input_scale._sglang_require_global_experts = True
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
+    def _build_mega_moe_weights(self, layer: torch.nn.Module) -> None:
+        # DeepGEMM nvfp4xnvfp4 layout: e2m1 weights + UE4M3 g16 scales, plus the
+        # per-local-expert alphas applied in the L1/L2 epilogues. Activations are
+        # quantized per token at dispatch, so w13_input_scale is not used.
+        import deep_gemm
+        from deep_gemm.utils.math import transform_ue4m3_sf_into_required_layout
+
+        assert layer.moe_runner_config.is_gated, "MegaMoE NVFP4 needs a gated MLP"
+        n1 = layer.w13_weight.shape[1]
+        n2 = layer.w2_weight.shape[1]
+        w13_sf = transform_ue4m3_sf_into_required_layout(
+            layer.w13_weight_scale.data.view(torch.float8_e4m3fn), n1
+        )
+        w2_sf = transform_ue4m3_sf_into_required_layout(
+            layer.w2_weight_scale.data.view(torch.float8_e4m3fn), n2
+        )
+        l1_pair, l2_pair = deep_gemm.transform_weights_for_mega_moe(
+            (layer.w13_weight.data.view(torch.int8), w13_sf),
+            (layer.w2_weight.data.view(torch.int8), w2_sf),
+            mma_type="nvfp4xnvfp4",
+        )
+
+        num_local = layer.num_local_experts
+        ones = torch.ones(num_local, dtype=torch.float32, device=l1_pair[0].device)
+        g1_gate, g1_up = _compute_gemm1_alphas(layer.w13_weight_scale_2, ones, True)
+        # float2 per local expert: (gate alpha, up alpha).
+        l1_alphas = torch.stack([g1_gate, g1_up], dim=1).contiguous()
+        w2_input_scale = layer.w2_input_scale.to(torch.float32)
+        if w2_input_scale.numel() != num_local:
+            start = layer.moe_ep_rank * num_local
+            w2_input_scale = w2_input_scale[start : start + num_local]
+        l2_act_scales = (1.0 / w2_input_scale).contiguous()
+        l2_alphas = (
+            w2_input_scale * layer.w2_weight_scale_2.to(torch.float32)
+        ).contiguous()
+
+        layer.mega_l1_weights = l1_pair
+        layer.mega_l2_weights = l2_pair
+        layer.mega_l1_alphas = l1_alphas
+        layer.mega_l2_alphas = l2_alphas
+        layer.mega_l2_act_scales = l2_act_scales
+        # Repoint the params at the mega tensors so the checkpoint layout is freed.
+        layer.w13_weight.data = l1_pair[0]
+        layer.w13_weight_scale.data = l1_pair[1]
+        layer.w2_weight.data = l2_pair[0]
+        layer.w2_weight_scale.data = l2_pair[1]
+        layer._mega_moe_nvfp4 = True
+        layer._mega_moe_weights_built = True
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Transform packed FP4 MoE weights and scales for the selected backend."""
         if getattr(layer, "inference_moe_w13_interleaved", False) and not getattr(
@@ -2504,6 +2554,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 layer.w13_weight_scale.data, up_first=up_first
             )
             layer._w13_deinterleaved = True
+
+        if get_moe_a2a_backend().is_megamoe():
+            self._build_mega_moe_weights(layer)
+            return
 
         # GEMM1 scale processing is deferred until the input scale is known;
         # see _compute_gemm1_alphas, which splits w13's gate/up weight scales.
@@ -2852,6 +2906,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
 
         self._moe_runner_backend = moe_runner_backend
+
+        if get_moe_a2a_backend().is_megamoe():
+            # MegaMoE runs the experts through deep_gemm directly and never
+            # reaches FusedMoE.forward, so no runner / fused a2a func is needed.
+            self.runner = None
+            return
 
         if moe_runner_backend.is_flashinfer_cutedsl():
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl  # noqa: F401 – triggers @register_fused_func

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -214,6 +214,9 @@ def _get_quantization_config(
 
         if isinstance(quant_config, Fp8Config):
             quant_config.is_fp4_experts = model_config.is_fp4_experts
+            quant_config.requant_fp8_experts_to_mxfp4 = (
+                model_config.requant_fp8_experts_to_mxfp4
+            )
             quant_config.dequant_fp4_to_fp8 = envs.SGLANG_DSV4_FP4_DEQUANT.get()
             # Handle hybrid NVFP4 moe (nvidia/DeepSeek-V4-Pro-NVFP4)
             nvfp4_meta = model_config.nvfp4_moe_meta

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -383,6 +383,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                         or get_moe_a2a_backend().is_mori()
                         or get_moe_a2a_backend().is_deepep_v2()
                         or get_moe_a2a_backend().is_flashinfer()
+                        or get_moe_a2a_backend().is_megamoe()
                     )
                     else {}
                 ),
@@ -412,6 +413,14 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             )
             self.top_k = config.num_experts_per_tok
         self.is_nextn = is_nextn
+        # DeepGEMM MegaMoE: fused EP dispatch + grouped GEMMs + combine over the
+        # EP symmetric buffer, replacing the FusedMoE call. Needs MXFP4 routed
+        # experts (checkpoint or SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4) and the
+        # per-rank token cap SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.
+        self._use_mega_moe = get_moe_a2a_backend().is_megamoe()
+        self._mega_top_k = config.num_experts_per_tok + self.num_fused_shared_experts
+        self._mega_intermediate_size = config.moe_intermediate_size
+        self._mega_hidden_size = config.hidden_size
 
     def get_moe_weights(self):
         return [
@@ -631,6 +640,71 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
 
         return final_hidden_states
 
+    def _forward_mega_moe(
+        self, hidden_states: torch.Tensor, forward_batch: Optional[ForwardBatch]
+    ) -> torch.Tensor:
+        # Same contract as _forward_deepep: rows are this rank's tokens, the
+        # routed output comes back fully combined, no TP all-reduce afterwards.
+        from sglang.srt.layers.moe.mega_moe import (
+            is_mega_moe_experts_ready,
+            run_mega_routed_experts,
+        )
+
+        if not is_mega_moe_experts_ready(self.experts):
+            raise RuntimeError(
+                "moe_a2a_backend=megamoe needs MegaMoE expert weights on this "
+                "model: on SM100 load an MXFP4-expert checkpoint or set "
+                "SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4=1 on a block-FP8 checkpoint; "
+                "on SM90 load a block-FP8 checkpoint with a DeepGEMM that ships "
+                "fp8_mega_moe."
+            )
+
+        num_tokens = hidden_states.shape[0]
+        shared_output = None
+        topk_ids = None
+        topk_weights = None
+        if num_tokens > 0:
+            router_logits, _ = self.gate(hidden_states)
+            shared_output = self._forward_shared_experts(hidden_states)
+            topk_output = self.topk(
+                hidden_states,
+                router_logits,
+                num_token_non_padded=(
+                    forward_batch.num_token_non_padded
+                    if forward_batch is not None
+                    else None
+                ),
+                expert_location_dispatch_info=(
+                    ExpertLocationDispatchInfo.init_new(layer_id=self.layer_id)
+                    if not self.is_nextn
+                    else None
+                ),
+            )
+            if self.enable_shared_expert_fusion:
+                topk_output = self._append_shared_to_topk_output(
+                    topk_output, hidden_states
+                )
+            assert TopKOutputChecker.format_is_standard(topk_output), (
+                "MegaMoE pre-dispatch consumes raw topk ids/weights; "
+                "pick a MoE runner backend that emits standard TopK output"
+            )
+            topk_ids = topk_output.topk_ids
+            topk_weights = topk_output.topk_weights
+
+        final_hidden_states = run_mega_routed_experts(
+            self.experts,
+            hidden_states,
+            topk_ids,
+            topk_weights,
+            hidden_size=self._mega_hidden_size,
+            intermediate_size=self._mega_intermediate_size,
+            top_k=self._mega_top_k,
+            num_tokens=num_tokens,
+        )
+        if shared_output is not None:
+            final_hidden_states.add_(shared_output)
+        return final_hidden_states
+
     @property
     def supports_deferred_finalize(self) -> bool:
         return bool(
@@ -748,6 +822,9 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
         if defer_finalize and num_tokens == 0:
             raise RuntimeError("Qwen deferred finalize does not support M=0")
+
+        if self._use_mega_moe:
+            return self._forward_mega_moe(hidden_states, forward_batch)
 
         if (
             get_moe_a2a_backend().is_deepep()

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -48,7 +48,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.topk import TopK, TopKOutputChecker
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -293,12 +293,19 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             )
             self.top_k = config.num_experts_per_tok
 
+        self._use_mega_moe = get_moe_a2a_backend().is_megamoe()
+        self._mega_top_k = config.num_experts_per_tok
+        self._mega_intermediate_size = config.moe_intermediate_size
+        self._mega_hidden_size = config.hidden_size
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
 
+        if self._use_mega_moe:
+            return self._forward_mega_moe(hidden_states, forward_batch)
         if (
             not is_deepep_class_backend()
             and not get_moe_a2a_backend().is_ascend_fuseep()
@@ -364,6 +371,60 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             topk_output=topk_output,
         )
         return final_hidden_states
+
+    def _forward_mega_moe(
+        self, hidden_states: torch.Tensor, forward_batch: Optional[ForwardBatch]
+    ) -> torch.Tensor:
+        # Same contract as forward_deepep: rows are this rank's tokens, the
+        # routed output comes back fully combined, no TP all-reduce afterwards.
+        from sglang.srt.layers.moe.mega_moe import (
+            is_mega_moe_experts_ready,
+            run_mega_routed_experts,
+        )
+
+        if not is_mega_moe_experts_ready(self.experts):
+            raise RuntimeError(
+                "moe_a2a_backend=megamoe needs MegaMoE expert weights on this "
+                "model: on SM100 load an MXFP4-expert checkpoint or set "
+                "SGLANG_FP8_MOE_EXPERTS_REQUANT_MXFP4=1 on a block-FP8 checkpoint; "
+                "on SM90 load a block-FP8 checkpoint with a DeepGEMM that ships "
+                "fp8_mega_moe."
+            )
+
+        num_tokens = hidden_states.shape[0]
+        topk_ids = None
+        topk_weights = None
+        if num_tokens > 0:
+            router_logits, _ = self.gate(hidden_states)
+            topk_output = self.topk(
+                hidden_states,
+                router_logits,
+                num_token_non_padded=(
+                    forward_batch.num_token_non_padded
+                    if forward_batch is not None
+                    else None
+                ),
+                expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
+                    layer_id=self.layer_id,
+                ),
+            )
+            assert TopKOutputChecker.format_is_standard(topk_output), (
+                "MegaMoE pre-dispatch consumes raw topk ids/weights; "
+                "pick a MoE runner backend that emits standard TopK output"
+            )
+            topk_ids = topk_output.topk_ids
+            topk_weights = topk_output.topk_weights
+
+        return run_mega_routed_experts(
+            self.experts,
+            hidden_states,
+            topk_ids,
+            topk_weights,
+            hidden_size=self._mega_hidden_size,
+            intermediate_size=self._mega_intermediate_size,
+            top_k=self._mega_top_k,
+            num_tokens=num_tokens,
+        )
 
     def op_gate(self, state):
         if is_non_idle_and_non_empty(

--- a/test/registered/unit/layers/moe/test_mega_moe_deepgemm_api.py
+++ b/test/registered/unit/layers/moe/test_mega_moe_deepgemm_api.py
@@ -191,6 +191,8 @@ class TestDeepGemmMegaMoeApi(CustomTestCase):
                 "_configure_mega_moe_deep_gemm_num_sms",
                 return_value=nullcontext(),
             ),
+            # Toy shapes; the alignment rule has its own test below.
+            patch.object(mega_moe, "_check_mega_moe_shapes"),
             patch.object(
                 mega_moe.ExpertLocationDispatchInfo,
                 "init_new",
@@ -213,6 +215,83 @@ class TestDeepGemmMegaMoeApi(CustomTestCase):
         call = deep_gemm.mega_moe_pre_dispatch.call_args
         self.assertEqual(call.kwargs.get("mma_type"), "mxf4xmxf4")
         self.assertNotIn("use_fp4_acts", call.kwargs)
+
+    def test_run_mega_routed_experts_generic_entry(self):
+        deep_gemm = ModuleType("deep_gemm")
+        deep_gemm.fp8_fp4_mega_moe = MagicMock()
+        buffer = SimpleNamespace(
+            x=object(),
+            x_sf=object(),
+            topk_idx=object(),
+            topk_weights=object(),
+        )
+        experts = SimpleNamespace(
+            num_experts=8,
+            mega_l1_weights=object(),
+            mega_l2_weights=object(),
+        )
+        hidden_states = torch.zeros((3, 4), dtype=torch.bfloat16)
+        topk_ids = torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int64)
+        topk_weights = torch.full((3, 2), 0.5, dtype=torch.bfloat16)
+
+        with (
+            patch.dict(sys.modules, {"deep_gemm": deep_gemm}),
+            patch.object(mega_moe, "_device_sm", 100),
+            patch.object(mega_moe, "_mega_moe_mma_type", return_value="fp8xfp4"),
+            patch.object(mega_moe, "mega_moe_pre_dispatch") as pre_dispatch,
+            patch.object(
+                mega_moe, "_get_mega_moe_symm_buffer", return_value=buffer
+            ) as get_buffer,
+            patch.object(
+                mega_moe,
+                "_configure_mega_moe_deep_gemm_num_sms",
+                return_value=nullcontext(),
+            ),
+            # Toy shapes; the alignment rule has its own test below.
+            patch.object(mega_moe, "_check_mega_moe_shapes"),
+            patch(
+                "sglang.srt.distributed.parallel_state.get_moe_ep_group",
+                return_value=SimpleNamespace(device_group=object()),
+            ),
+        ):
+            out = mega_moe.run_mega_routed_experts(
+                experts,
+                hidden_states,
+                topk_ids,
+                topk_weights,
+                hidden_size=4,
+                intermediate_size=8,
+                top_k=2,
+                num_tokens=3,
+                activation_clamp=7.0,
+                routed_scaling_factor=1.0,
+            )
+
+        self.assertEqual(out.shape, (3, 4))
+        self.assertEqual(out.dtype, torch.bfloat16)
+        buf_call = get_buffer.call_args
+        self.assertEqual(buf_call.kwargs.get("num_topk"), 2)
+        self.assertEqual(buf_call.kwargs.get("hidden"), 4)
+        self.assertEqual(buf_call.kwargs.get("intermediate_hidden"), 8)
+        # The kernel wants int32 ids and fp32 weights regardless of the router dtype.
+        ids_arg, weights_arg = pre_dispatch.call_args.args[1:3]
+        self.assertEqual(ids_arg.dtype, torch.int32)
+        self.assertEqual(weights_arg.dtype, torch.float32)
+        mega_call = deep_gemm.fp8_fp4_mega_moe.call_args
+        self.assertIs(mega_call.args[1], experts.mega_l1_weights)
+        self.assertIs(mega_call.args[2], experts.mega_l2_weights)
+        self.assertEqual(mega_call.kwargs.get("activation_clamp"), 7.0)
+
+    def test_shape_check_rejects_unaligned_intermediate(self):
+        # Qwen3-30B-A3B: intermediate 768 leaves a 24-byte scale row.
+        with self.assertRaisesRegex(ValueError, "multiples of 512"):
+            mega_moe._check_mega_moe_shapes(2048, 768, "fp8xfp4")
+        mega_moe._check_mega_moe_shapes(4096, 1536, "fp8xfp4")
+        mega_moe._check_mega_moe_shapes(4096, 1024, "mxf4xmxf4")
+        # 768 is a multiple of 256, so the NVFP4 (g16) rule accepts it.
+        mega_moe._check_mega_moe_shapes(2048, 768, "nvfp4xnvfp4")
+        with self.assertRaisesRegex(ValueError, "multiples of 256"):
+            mega_moe._check_mega_moe_shapes(2048, 384, "nvfp4xnvfp4")
 
     def test_mxf4_l1_uses_packed_gate_up_interleave(self):
         source = torch.arange(32).reshape(1, 32)


### PR DESCRIPTION
## Motivation

Stacked on #38080 (Qwen MegaMoE + online FP8 -> MXFP4 requant); only the top commit belongs to this PR. Marked experimental.

DeepGEMM 0.1.7 ships an `nvfp4xnvfp4` variant of `fp8_fp4_mega_moe` (e2m1 weights with UE4M3 g16 scales, per-token FP32 activation scales via `use_x_scales`, per-expert `l1_alphas` / `l2_alphas` / `l2_act_scales` applied in the epilogues). sglang does not use it, so ModelOpt NVFP4 checkpoints such as Qwen3.5-397B-A17B-NVFP4 cannot run `--moe-a2a-backend megamoe`. This PR wires that kernel so the NVFP4 checkpoint gets the same single-kernel dispatch / GEMM / combine path that the MXFP4 checkpoints have.

The kernel's Python-side contract (alpha layout, `x_scales` semantics, `recipe=(1, 1, 16)`) is not documented upstream; it was derived from the DeepGEMM sources and validated end to end against the FlashInfer a2a + CuteDSL NVFP4 path (below). Feedback on whether this should wait for a documented DeepGEMM API is welcome.

## Modifications

- `layers/moe/mega_moe.py`: `_mega_moe_mma_type(experts)` returns `nvfp4xnvfp4` when the expert layer was built for NVFP4 (a checkpoint property, unlike the server-wide MXFP4 W4A8 / W4A4 flag); the symmetric buffer is keyed on that type. `run_mega_routed_experts` runs `deep_gemm.mega_moe_pre_dispatch` with `group_size=16` and `buf_x_scales`, and passes `recipe=(1, 1, 16)`, `use_x_scales=True` and the alphas to `fp8_fp4_mega_moe`.
- `quantization/modelopt_quant.py`: `ModelOptNvFp4FusedMoEMethod._build_mega_moe_weights` converts the loaded weights with `transform_ue4m3_sf_into_required_layout` + `deep_gemm.transform_weights_for_mega_moe(mma_type="nvfp4xnvfp4")`, and builds `l1_alphas = (gate, up) from w13_weight_scale_2` (via the existing `_compute_gemm1_alphas`), `l2_act_scales = 1 / w2_input_scale`, `l2_alphas = w2_input_scale * w2_weight_scale_2` for the local experts. Under megamoe `process_weights_after_loading` stops after that, and `create_moe_runner` skips runner creation because `FusedMoE.forward` is never reached (the TRT-LLM runner otherwise fails with "requires a fused func for a2a backend megamoe").

```
python3 -m sglang.launch_server --model Qwen/Qwen3.5-397B-A17B-NVFP4 \
  --quantization modelopt_fp4 --tp 4 --dp 4 --ep 4 --enable-dp-attention \
  --moe-dense-tp-size 1 --moe-a2a-backend megamoe
```

## Accuracy Tests

Qwen3.5-397B-A17B-NVFP4 (V2 export), 1x GB300 node (4 GPUs), TP4 / EP4 / DP4 with DP attention, `trtllm_mha`, FP8 KV cache, no MTP, `lmsysorg/sglang:nightly-dev-cu13-20260901` container (DeepGEMM 0.1.7, FlashInfer 0.6.18).

GSM8K via `python3 -m sglang.test.run_eval --eval-name gsm8k --num-examples 200 --num-shots 5 --max-tokens 16384 --temperature 0.6 --top-p 0.95 --top-k 20`:

| path | GSM8K |
|---|---|
| `--moe-a2a-backend flashinfer --moe-runner-backend flashinfer_cutedsl` (baseline) | 0.985 |
| `--moe-a2a-backend megamoe` (this PR) | 0.985 |

Throughput (`bench_serving --dataset-name random --random-input-len 1024 --random-output-len 1024 --num-prompts 3C`):

| max concurrency | FlashInfer a2a + CuteDSL, total tok/s (ITL p50) | MegaMoE NVFP4, total tok/s (ITL p50) | delta |
|---|---|---|---|
| 16 | 3,232 (9.7 ms) | 3,106 (10.0 ms) | -4% |
| 64 | 9,056 (13.4 ms) | 8,993 (13.5 ms) | -1% |
| 256 | 24,308 (18.9 ms) | 24,945 (18.1 ms) | +3% |

On one NVLink node the two paths are within noise of each other; the fused kernel's advantage over the unfused DeepEP + DeepGEMM path (#38080) does not carry over against the FlashInfer a2a + CuteDSL stack. The PR is offered for completeness of the megamoe backend across checkpoint formats rather than as a speedup.

Unit tests (CPU): `test/registered/unit/layers/moe/test_mega_moe_deepgemm_api.py`; `ruff format --check` / `ruff check --select=F401,F821,UP037` (the repo pre-commit hooks) clean on the touched files.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34161416530](https://github.com/sgl-project/sglang/actions/runs/34161416530)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34161416352](https://github.com/sgl-project/sglang/actions/runs/34161416352)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34161416469](https://github.com/sgl-project/sglang/actions/runs/34161416469)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->