### PR TITLE
[AMD] Enable tc_piecewise prefill CUDA graphs for DeepSeek-V4 on MI355X

### DIFF
--- a/python/sglang/kernels/ops/attention/deepseek_v4_rope.py
+++ b/python/sglang/kernels/ops/attention/deepseek_v4_rope.py
@@ -281,7 +281,9 @@ def apply_rotary_emb_triton(
             n_heads = 1
         freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
         if positions is not None:
-            assert positions.shape == (batch_size,)
+            # Scalar compare: the tuple form goes through Dynamo's cmp_eq polyfill,
+            # which needs a concrete bool and so specializes the token dimension.
+            assert positions.shape[0] == batch_size
         else:
             assert freqs_real.shape[0] == batch_size
         BLOCK_M = 32

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     aiter_can_use_preshuffle_paged_mqa,
 )
 from sglang.srt.utils import is_hip, is_xpu
+from sglang.srt.utils.custom_op import register_custom_op
 
 from .utils import make_name
 
@@ -390,6 +391,40 @@ class CompressorPrefillPlan(NamedTuple):
         return False
 
 
+# Wrapped for the same reason as _jit_main_q_norm_rope_custom_op in elementwise.py.
+# The op also absorbs the decode/prefill module selection, which Dynamo never sees.
+@register_custom_op(op_name="dsv4_jit_compress_forward", mutates_args=["out"])
+def _jit_compress_forward_custom_op(
+    kv_score_buffer: torch.Tensor,
+    kv_score_input: torch.Tensor,
+    out: torch.Tensor,
+    ape: torch.Tensor,
+    plan_a: torch.Tensor,
+    plan_b: Optional[torch.Tensor],
+    head_dim: int,
+    compress_ratio: int,
+    is_decode: bool,
+    is_online: bool,
+) -> None:
+    if is_online:
+        assert compress_ratio == 128 and head_dim == 512
+        module = _jit_compress_128_online_module(512, kv_score_buffer.dtype)
+    else:
+        module = _jit_compress_module(
+            head_dim,
+            kv_score_buffer.dtype,
+            kv_score_input.dtype,
+            out.dtype,
+            compress_ratio,
+        )
+    fn = module.decode if is_decode else module.prefill
+    # CompressorDecodePlan carries one plan tensor, CompressorPrefillPlan two.
+    if plan_b is None:
+        fn(kv_score_buffer, kv_score_input, out, ape, plan_a)
+    else:
+        fn(kv_score_buffer, kv_score_input, out, ape, plan_a, plan_b)
+
+
 def compress_forward(
     kv_score_buffer: torch.Tensor,
     kv_score_input: torch.Tensor,
@@ -405,30 +440,71 @@ def compress_forward(
         num_q_tokens = plan[1].shape[0]  # NOTE: decode = bs, prefill = dynamic
         out = kv_score_input.new_empty((num_q_tokens, head_dim))
     assert plan.compress_ratio == compress_ratio
-    if is_online:
-        assert compress_ratio == 128 and head_dim == 512
-        module = _jit_compress_128_online_module(512, kv_score_buffer.dtype)
-    else:
-        if _is_xpu:
-            decode_fn, prefill_fn = _XPU_COMPRESS_FNS[compress_ratio]
-        else:
-            dtype_in, dtype_out = kv_score_input.dtype, out.dtype
-            module = _jit_compress_module(
-                head_dim, kv_score_buffer.dtype, dtype_in, dtype_out, compress_ratio
-            )
-
-    if _is_xpu:
-        fn = decode_fn if plan.is_decode else prefill_fn
-    else:
-        fn = module.decode if plan.is_decode else module.prefill
-
     # C4/C128 kernels use the same InputFloat type for APE and kv_score_input.
     # Keep the model parameter in FP32 but convert it to the kernel input dtype
     # at the fused-kernel boundary.
     if ape.dtype != kv_score_input.dtype:
         ape = ape.to(dtype=kv_score_input.dtype)
-    fn(kv_score_buffer, kv_score_input, out, ape, *plan[1:3])
+    if _is_xpu:
+        if is_online:
+            assert compress_ratio == 128 and head_dim == 512
+            module = _jit_compress_128_online_module(512, kv_score_buffer.dtype)
+            fn = module.decode if plan.is_decode else module.prefill
+        else:
+            decode_fn, prefill_fn = _XPU_COMPRESS_FNS[compress_ratio]
+            fn = decode_fn if plan.is_decode else prefill_fn
+        fn(kv_score_buffer, kv_score_input, out, ape, *plan[1:3])
+    else:
+        # isinstance, not plan.is_decode: Dynamo cannot evaluate a property on a
+        # NamedTupleVariable and aborts the trace. is_decode is a per-class constant,
+        # so the isinstance check is equivalent.
+        _jit_compress_forward_custom_op(
+            kv_score_buffer,
+            kv_score_input,
+            out,
+            ape,
+            plan[1],
+            plan[2] if len(plan) > 2 else None,
+            head_dim,
+            compress_ratio,
+            isinstance(plan, CompressorDecodePlan),
+            is_online,
+        )
     return out
+
+
+@register_custom_op(
+    op_name="dsv4_jit_compress_norm_rope_store", mutates_args=["kvcache"]
+)
+def _jit_compress_norm_rope_store_custom_op(
+    kv: torch.Tensor,
+    plan_c: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    freq_cis: torch.Tensor,
+    out_loc: torch.Tensor,
+    kvcache: torch.Tensor,
+    is_decode: bool,
+    compress_ratio: int,
+    page_size: int,
+    use_fp4: bool,
+    bf16_store: bool,
+) -> None:
+    module = _jit_compress_norm_rope_module(
+        kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store
+    )
+    fn = module.forward_fp4 if use_fp4 else module.forward
+    fn(
+        kv,
+        plan_c,
+        norm_weight,
+        norm_eps,
+        freq_cis,
+        out_loc,
+        kvcache,
+        is_decode,
+        compress_ratio,
+    )
 
 
 def compress_norm_rope_store(
@@ -486,13 +562,11 @@ def compress_norm_rope_store(
             use_fp4,
         )
     else:
-        module = _jit_compress_norm_rope_module(
-            kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store
-        )
-        fn = module.forward_fp4 if use_fp4 else module.forward
         if norm_weight.dtype != kv.dtype:
             norm_weight = norm_weight.to(dtype=kv.dtype)
-        fn(
+        # See _jit_compress_forward_custom_op for why the call is wrapped and why the
+        # decode flag comes from isinstance rather than plan.is_decode.
+        _jit_compress_norm_rope_store_custom_op(
             kv,
             plan[1],
             norm_weight,
@@ -500,6 +574,9 @@ def compress_norm_rope_store(
             freq_cis,
             out_loc,
             kvcache,
-            plan.is_decode,
+            isinstance(plan, CompressorDecodePlan),
             plan.compress_ratio,
+            page_size,
+            use_fp4,
+            bf16_store,
         )

--- a/python/sglang/kernels/ops/attention/dsv4/compress_old.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress_old.py
@@ -11,6 +11,7 @@ from sglang.kernels.jit.utils import (
     make_cpp_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.utils.custom_op import register_custom_op
 
 from .utils import make_name
 
@@ -268,6 +269,30 @@ def compress_forward(
     return out
 
 
+# Wrapped for the same reason as _jit_main_q_norm_rope_custom_op in elementwise.py:
+# Dynamo cannot trace the JIT module's `Function.__call__` under fullgraph.
+@register_custom_op(op_name="dsv4_jit_norm_rope_inplace", mutates_args=["kv"])
+def _jit_norm_rope_inplace_custom_op(
+    kv: torch.Tensor,
+    weight: torch.Tensor,
+    positions: torch.Tensor,
+    freq_cis: torch.Tensor,
+    mode: int,
+    eps: float,
+    compress_ratio: int,
+) -> None:
+    module = norm_rope_module(kv.dtype, kv.shape[-1], freq_cis.shape[-1])
+    module.forward(
+        kv,
+        weight,
+        positions,
+        freq_cis,
+        mode,
+        eps,
+        compress_ratio,
+    )
+
+
 def compress_fused_norm_rope_inplace(
     kv: torch.Tensor,
     weight: torch.Tensor,
@@ -276,8 +301,7 @@ def compress_fused_norm_rope_inplace(
     plan: Union[CompressorDecodePlan, CompressorPrefillPlan],
 ) -> None:
     freq_cis = torch.view_as_real(freq_cis).flatten(-2)
-    module = norm_rope_module(kv.dtype, kv.shape[-1], freq_cis.shape[-1])
-    module.forward(
+    _jit_norm_rope_inplace_custom_op(
         kv,
         weight,
         plan[1],
@@ -296,8 +320,7 @@ def fused_norm_rope_inplace(
     positions: torch.Tensor,
 ) -> None:
     freq_cis = torch.view_as_real(freq_cis).flatten(-2)
-    module = norm_rope_module(kv.dtype, kv.shape[-1], freq_cis.shape[-1])
-    module.forward(
+    _jit_norm_rope_inplace_custom_op(
         kv,
         weight,
         positions,

--- a/python/sglang/kernels/ops/attention/dsv4/elementwise.py
+++ b/python/sglang/kernels/ops/attention/dsv4/elementwise.py
@@ -9,6 +9,7 @@ from sglang.kernels.jit.utils import (
     make_cpp_args,
 )
 from sglang.srt.utils import is_hip, is_xpu
+from sglang.srt.utils.custom_op import register_custom_op
 
 from .utils import make_name
 
@@ -141,6 +142,26 @@ def fused_rope_inplace(
     module.forward(q, k, freqs_real, positions, inverse)
 
 
+# load_jit() modules expose their entry point as a `Function` instance, which Dynamo
+# cannot trace; under the fullgraph piecewise prefill backend that break is fatal
+# rather than a benign split. A custom op makes the call opaque, as fp8_wo_a.py does
+# for its own JIT kernel. Deliberately not a @register_split_op: these kernels are
+# small, and a split point per kernel would shred the graph and give back the speedup
+# piecewise exists to provide.
+@register_custom_op(op_name="dsv4_jit_main_q_norm_rope", mutates_args=["q_output"])
+def _jit_main_q_norm_rope_custom_op(
+    q_input: torch.Tensor,
+    q_output: torch.Tensor,
+    freqs_real: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+) -> None:
+    module = _jit_main_q_norm_rope_module(
+        q_input.dtype, q_input.shape[-1], freqs_real.shape[-1]
+    )
+    module.forward(q_input, q_output, freqs_real, positions, eps)
+
+
 def fused_q_norm_rope(
     q_input: torch.Tensor,
     q_output: torch.Tensor,
@@ -149,13 +170,10 @@ def fused_q_norm_rope(
     positions: torch.Tensor,
 ) -> None:
     freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    head_dim = q_input.shape[-1]
-    rope_dim = freqs_real.shape[-1]
     if _is_xpu:
         fused_q_norm_rope_xpu(q_input, q_output, freqs_real, positions, eps)
     else:
-        module = _jit_main_q_norm_rope_module(q_input.dtype, head_dim, rope_dim)
-        module.forward(q_input, q_output, freqs_real, positions, eps)
+        _jit_main_q_norm_rope_custom_op(q_input, q_output, freqs_real, positions, eps)
 
 
 def fused_q_indexer_rope_hadamard_quant(
@@ -264,6 +282,26 @@ def fused_q_indexer_rope_hadamard_fp4_quant(
     return (q_fp4, q_sf), weights_out
 
 
+# Same treatment as _jit_main_q_norm_rope_custom_op above, K side.
+@register_custom_op(
+    op_name="dsv4_jit_main_k_norm_rope_flashmla", mutates_args=["kvcache"]
+)
+def _jit_main_k_norm_rope_flashmla_custom_op(
+    kv: torch.Tensor,
+    kv_weight: torch.Tensor,
+    freqs_real: torch.Tensor,
+    positions: torch.Tensor,
+    out_loc: torch.Tensor,
+    kvcache: torch.Tensor,
+    eps: float,
+    page_size: int,
+) -> None:
+    module = _jit_main_k_norm_rope_flashmla_module(
+        kv.dtype, kv.shape[-1], freqs_real.shape[-1], page_size
+    )
+    module.forward(kv, kv_weight, freqs_real, positions, out_loc, kvcache, eps)
+
+
 def fused_k_norm_rope_flashmla(
     kv: torch.Tensor,
     kv_weight: torch.Tensor,
@@ -275,14 +313,11 @@ def fused_k_norm_rope_flashmla(
     page_size: int,
 ) -> None:
     freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    head_dim = kv.shape[-1]
-    rope_dim = freqs_real.shape[-1]
     if _is_xpu:
         fused_k_norm_rope_flashmla_xpu(
             kv, kv_weight, freqs_real, positions, out_loc, kvcache, eps, page_size
         )
     else:
-        module = _jit_main_k_norm_rope_flashmla_module(
-            kv.dtype, head_dim, rope_dim, page_size
+        _jit_main_k_norm_rope_flashmla_custom_op(
+            kv, kv_weight, freqs_real, positions, out_loc, kvcache, eps, page_size
         )
-        module.forward(kv, kv_weight, freqs_real, positions, out_loc, kvcache, eps)

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_hip.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_hip.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple, Union
 
 import torch
 
+from sglang.srt.utils.custom_op import register_custom_op
+
 if TYPE_CHECKING:
     from sglang.kernels.ops.attention.dsv4.compress import (
         CompressorDecodePlan,
@@ -173,6 +175,10 @@ def _alloc_logits(
     if (
         is_decode
         or n > _LOGITS_BUDGET_ELEMS
+        # Short-circuit before the capture probe: it returns a runtime bool that
+        # Dynamo cannot put in the graph, which is fatal under fullgraph piecewise.
+        # Tracing wants the same plain allocation as capture does.
+        or torch.compiler.is_compiling()
         or torch.cuda.is_current_stream_capturing()
     ):
         return torch.empty(
@@ -284,6 +290,55 @@ def prepare_fp4_prefill_workspace(
     return workspace
 
 
+# FlyDSL JIT-compiles this kernel lazily inside forward, so Dynamo traces the whole
+# compiler and dies building a types.FunctionType (gb0007) -- fatal under fullgraph
+# piecewise prefill. Keep the launch opaque, as the FP8 sibling already does; the
+# output stays caller-allocated so Dynamo still sees its shape. Decode needs no
+# wrapper: it is captured, not traced.
+@register_custom_op(
+    op_name="dsv4_aiter_fp4_paged_mqa_logits_prefill", mutates_args=["out"]
+)
+def _fp4_paged_mqa_logits_prefill_launch(
+    q_payload: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_payload: torch.Tensor,
+    k_scale: torch.Tensor,
+    page_table: torch.Tensor,
+    weights: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    local_starts: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    cta_info: Optional[torch.Tensor],
+    out: torch.Tensor,
+    max_seq_len: int,
+    n_ctas: int,
+    parallel_unit_num: int,
+    weight_scale: float,
+) -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_logits_fp4_prefill
+
+    pinned = {} if cta_info is None else {"cta_info": cta_info, "n_ctas": n_ctas}
+    flydsl_pa_mqa_logits_fp4_prefill(
+        q_payload,
+        q_scale,
+        k_payload,
+        k_scale,
+        page_table,
+        weights,
+        row_to_batch,
+        local_starts,
+        c4_seq_lens,
+        max_seq_len,
+        parallel_unit_num=parallel_unit_num,
+        **pinned,
+        weight_scale=weight_scale,
+        block_k=256,
+        kv_block_size=_KV_BLOCK_SIZE,
+        num_warps=4,
+        out=out,
+    )
+
+
 def aiter_fp4_paged_mqa_logits(
     *,
     q_fp4: torch.Tensor,
@@ -299,10 +354,7 @@ def aiter_fp4_paged_mqa_logits(
     prefill_workspace: Optional[FP4PrefillWorkspace] = None,
 ) -> torch.Tensor:
     """Compute FP4 Q/K indexer logits with the decode or prefill FlyDSL kernel."""
-    from aiter.ops.flydsl import (
-        flydsl_pa_mqa_logits_fp4,
-        flydsl_pa_mqa_logits_fp4_prefill,
-    )
+    from aiter.ops.flydsl import flydsl_pa_mqa_logits_fp4
 
     num_tokens = q_fp4.shape[0]
     c4_seq_lens = _as_int32_1d(c4_seq_lens)
@@ -403,7 +455,7 @@ def aiter_fp4_paged_mqa_logits(
             }
             row_to_batch = workspace.row_to_batch
             local_starts = workspace.local_starts
-        logits = flydsl_pa_mqa_logits_fp4_prefill(
+        _fp4_paged_mqa_logits_prefill_launch(
             q_payload,
             q_scale,
             k_payload,
@@ -413,10 +465,12 @@ def aiter_fp4_paged_mqa_logits(
             row_to_batch,
             local_starts,
             c4_seq_lens,
+            pinned.get("cta_info"),
+            logits,
             max_seq_len,
-            parallel_unit_num=max(_PREFILL_BASE_CTA_TARGET, num_tokens),
-            **pinned,
-            **common,
+            pinned.get("n_ctas", 0),
+            max(_PREFILL_BASE_CTA_TARGET, num_tokens),
+            weight_scale,
         )
 
     return logits

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_schedule_hip.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_schedule_hip.py
@@ -104,12 +104,15 @@ def _prefill_schedule_prep_kernel(
         any_fits = tl.sum((chunks + (s_max - 1)) // s_max) <= P
         lo = 1
         hi = s_max
-        for _ in tl.static_range(32):
-            searching = lo < hi
-            mid = tl.where(searching, (lo + hi) // 2, lo)
+        # Keep one reduction/division body in the generated code and stop as
+        # soon as the search converges. Unrolling 32 rounds builds a large
+        # kernel and repeats reductions after lo == hi (typical windows need
+        # only 8-12 rounds).
+        while lo < hi:
+            mid = lo + (hi - lo) // 2
             fits = tl.sum((chunks + (mid - 1)) // mid) <= P
-            lo = tl.where(searching & (fits == 0), mid + 1, lo)
-            hi = tl.where(searching & fits, mid, hi)
+            lo = tl.where(fits, lo, mid + 1)
+            hi = tl.where(fits, mid, hi)
         # No s fits: give every row its own CTA and let the grid clip, matching
         # the reference's max_chunks fallback.
         safe = tl.where(any_fits, lo, tl.maximum(tl.max(chunks), 1)).to(tl.int32)

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -76,6 +76,13 @@ def topk_transform_paged(
 _PLAN_METADATA_INTS_PER_BATCH = 2
 
 
+@register_custom_op(op_name="dsv4_topk_plan_v2", mutates_args=["metadata"])
+def _topk_plan_v2_jit(
+    seq_lens: torch.Tensor, metadata: torch.Tensor, static_threshold: int
+) -> None:
+    _jit_topk_v2_module().topk_plan(seq_lens, metadata, static_threshold)
+
+
 def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
     """Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
 
@@ -86,11 +93,26 @@ def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Ten
     Producers of padded rows must clamp their lengths to 0 (0 selects the
     trivial all-(-1) output path, which is safe).
     """
-    module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
     metadata = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
-    module.topk_plan(seq_lens, metadata, static_threshold)
+    _topk_plan_v2_jit(seq_lens, metadata, static_threshold)
     return metadata
+
+
+# `scores` is masked in place by the kernel, so it is a mutated arg too.
+@register_custom_op(
+    op_name="dsv4_topk_transform_ragged_v2", mutates_args=["scores", "out_indices"]
+)
+def _topk_transform_ragged_v2_jit(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    row_starts: Optional[torch.Tensor],
+    out_offsets: torch.Tensor,
+    out_indices: torch.Tensor,
+) -> None:
+    _jit_topk_v2_module().topk_transform_ragged(
+        scores, seq_lens, row_starts, out_offsets, out_indices
+    )
 
 
 def topk_transform_ragged_v2(
@@ -126,8 +148,9 @@ def topk_transform_ragged_v2(
             row_starts,
         )
         return
-    module = _jit_topk_v2_module()
-    module.topk_transform_ragged(scores, seq_lens, row_starts, out_offsets, out_indices)
+    _topk_transform_ragged_v2_jit(
+        scores, seq_lens, row_starts, out_offsets, out_indices
+    )
 
 
 # The JIT module exposes a bare tvm_ffi Function; Dynamo cannot trace its __call__,

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -12,6 +12,7 @@ from sglang.kernels.jit.utils import (
     make_cpp_args,
 )
 from sglang.srt.utils import is_xpu
+from sglang.srt.utils.custom_op import register_custom_op
 
 from .utils import make_name
 
@@ -129,6 +130,26 @@ def topk_transform_ragged_v2(
     module.topk_transform_ragged(scores, seq_lens, row_starts, out_offsets, out_indices)
 
 
+# The JIT module exposes a bare tvm_ffi Function; Dynamo cannot trace its __call__,
+# which is fatal under the fullgraph piecewise prefill backend. Keep the launch opaque
+# behind a custom op. Only `page_indices` is written -- the kernel takes `scores` as
+# `const float*`. The XPU branch already goes through a registered op.
+@register_custom_op(
+    op_name="dsv4_topk_transform_paged_v2", mutates_args=["out_page_indices"]
+)
+def _topk_transform_paged_v2_jit(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: Optional[torch.Tensor],
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    metadata: torch.Tensor,
+) -> None:
+    _jit_topk_v2_module().topk_transform_paged(
+        scores, seq_lens, page_tables, out_page_indices, page_size, metadata
+    )
+
+
 def topk_transform_paged_v2(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -180,8 +201,7 @@ def topk_transform_paged_v2(
             metadata,
         )
         return
-    module = _jit_topk_v2_module()
-    module.topk_transform_paged(
+    _topk_transform_paged_v2_jit(
         scores,
         seq_lens,
         page_tables,

--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -223,10 +223,9 @@ def disable_tc_piecewise_cudagraph_if_incompatible(server_args: Any):
             ),
         ),
         ("DLLM (diffusion LLM)", lambda: cfg.dllm_algorithm is not None),
-        (
-            "CPU offload / hierarchical cache",
-            lambda: cfg.cpu_offload_gb > 0 or cfg.enable_hierarchical_cache,
-        ),
+        # Hierarchical cache used to be listed here too; its per-layer wait is
+        # now hoisted out of the traced region (KVCache.hoist_layer_transfer_wait).
+        ("CPU offload", lambda: cfg.cpu_offload_gb > 0),
         (
             "deterministic inference",
             lambda: cfg.enable_deterministic_inference,

--- a/python/sglang/srt/compilation/compile.py
+++ b/python/sglang/srt/compilation/compile.py
@@ -210,6 +210,18 @@ def install_torch_compiled(
                     _mark_dynamic_on_value(val, dims)
         _mark_dynamic_forward_batch(ba.arguments.get("forward_batch"))
 
+        # The prefill runner compiles once per captured shape (dozens of buckets),
+        # well past Dynamo's default limit of 8, and capture then aborts with
+        # FailOnRecompileLimitHit. 1024 matches what torch_compile_decoration.py
+        # already sets on the full-torch-compile path.
+        torch._dynamo.config.accumulated_cache_size_limit = max(
+            getattr(torch._dynamo.config, "accumulated_cache_size_limit", 0), 1024
+        )
+        if hasattr(torch._dynamo.config, "cache_size_limit"):
+            torch._dynamo.config.cache_size_limit = max(
+                torch._dynamo.config.cache_size_limit, 1024
+            )
+
         # Avoid cross-instance cache reuse
         torch._dynamo.eval_frame.remove_from_cache(unbound_fwd.__code__)
 

--- a/python/sglang/srt/compilation/compile.py
+++ b/python/sglang/srt/compilation/compile.py
@@ -143,6 +143,10 @@ def _mark_dynamic_forward_batch(forward_batch) -> None:
     for name, value in vars(forward_batch).items():
         if not isinstance(value, torch.Tensor) or value.ndim == 0:
             continue
+        if name == "moe_real_num_tokens_gpu":
+            # This axis is the fixed DP group size, not a token/batch axis.
+            torch._dynamo.mark_static(value, 0)
+            continue
         dims = _runtime_dynamic_dim_for_argument(name)
         _mark_dynamic_on_value(value, dims)
 

--- a/python/sglang/srt/compilation/cuda_piecewise_backend.py
+++ b/python/sglang/srt/compilation/cuda_piecewise_backend.py
@@ -18,6 +18,9 @@ from sglang.srt.compilation.compile_phase import (
     is_in_torch_compile_warmup,
 )
 from sglang.srt.compilation.weak_ref_tensor import weak_ref_tensors
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    get_tc_piecewise_forward_context,
+)
 from sglang.srt.model_executor.runner_utils.pool import (
     graph_pool_capture_scope,
     graph_pool_replay_scope,
@@ -89,6 +92,9 @@ class CUDAPiecewiseBackend:
         self.compiled_graph_for_general_shape = compiled_graph_for_general_shape  # noqa
 
         self.sym_shape_indices = sym_shape_indices
+        # A static piece may capture only the first observed runner bucket.
+        # Other contexts retain the original eager behavior for this piece.
+        self._static_context_bucket: Optional[int] = None
 
         # the entries for different shapes that we need to either
         # compile or capture cudagraph
@@ -110,20 +116,48 @@ class CUDAPiecewiseBackend:
             # save the hash of the inductor graph for the next run
             self.sglang_backend.compiler_manager.save_to_file()
 
+    def _runtime_shape_key(self, args) -> Optional[int]:
+        if self.sym_shape_indices:
+            # Preserve the existing behavior for already working symbolic pieces.
+            return args[self.sym_shape_indices[0]]
+
+        # A first trace can be fully static. The enclosing prefill runner still
+        # knows its padded local token bucket. Read that host-side context only
+        # here, after Dynamo; do not generalize persistent KV tensors to obtain
+        # an arbitrary SymInt that need not be the token count.
+        context = get_tc_piecewise_forward_context()
+        if context is None:
+            return None
+        num_tokens = context.num_tokens
+        if num_tokens is None:
+            # Capture/warmup currently leaves context.num_tokens unset.
+            batch = context.forward_batch
+            input_ids = getattr(batch, "input_ids", None)
+            if input_ids is None:
+                return None
+            num_tokens = input_ids.shape[0]
+        if type(num_tokens) is not int or num_tokens <= 0:
+            return None
+        if (
+            self._static_context_bucket is not None
+            and num_tokens != self._static_context_bucket
+        ):
+            return None
+        return num_tokens
+
     def __call__(self, *args) -> Any:
         if not self.first_run_finished:
             self.first_run_finished = True
             self.check_for_ending_compilation()
             return self.compiled_graph_for_general_shape(*args)
 
-        if len(self.sym_shape_indices) == 0:
-            return self.compiled_graph_for_general_shape(*args)
-
-        runtime_shape = args[self.sym_shape_indices[0]]
+        runtime_shape = self._runtime_shape_key(args)
         if runtime_shape not in self.concrete_size_entries:
             # we don't need to do anything for this shape
             return self.compiled_graph_for_general_shape(*args)
 
+        if not self.sym_shape_indices and self._static_context_bucket is None:
+            self._static_context_bucket = runtime_shape
         entry = self.concrete_size_entries[runtime_shape]
 
         if entry.runnable is None:

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -221,7 +221,35 @@ def reg_reduce_scatter_tensor(
     group = _groups[group_name]()
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
+    # Backend choice belongs inside the op: aiter's custom all-reduce resolves its
+    # JIT module on first use, which shells out to shutil.which -- untraceable, and
+    # only reachable at shapes small enough for the custom path, so tracing it
+    # blows up deep into a piecewise sweep rather than on the first shape.
+    if group._maybe_aiter_reduce_scatter(output, input):
+        return
     group._reduce_scatter_tensor(output, input)
+
+
+@register_custom_op(mutates_args=["output"])
+@register_split_op()
+def reg_reduce_scatterv(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    sizes: Optional[List[int]],
+    group_name: str,
+) -> None:
+    """Uneven reduce-scatter, kept opaque to Dynamo.
+
+    The pynccl path calls ncclReduce through a ctypes function pointer inside a
+    context manager, which Dynamo cannot trace and cannot break out of under
+    fullgraph. Split op as well: the loop trip count comes from `sizes` and the
+    arguments are raw data_ptr()s, so capturing it would bake in both.
+    """
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    group._reduce_scatterv(output, input, sizes)
 
 
 @register_custom_op(mutates_args=["output"])
@@ -1089,8 +1117,6 @@ class GroupCoordinator:
         if _is_npu or _is_cpu:
             # TODO: add optimized reduce_scatter_tensor kernel for cpu
             self._reduce_scatter_tensor(output, input)
-        elif self._maybe_aiter_reduce_scatter(output, input):
-            return
         else:
             reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
 
@@ -1167,38 +1193,45 @@ class GroupCoordinator:
         torch.distributed.reduce_scatter(output, input_list, group=self.device_group)
         return output
 
+    def _reduce_scatterv(
+        self,
+        output: torch.Tensor,
+        input_: torch.Tensor,
+        sizes: Optional[List[int]],
+    ) -> None:
+        pynccl_comm = self.pynccl_comm
+        with pynccl_comm.change_state(enable=True):
+            assert pynccl_comm is not None and not pynccl_comm.disabled, (
+                "pynccl is required for reduce_scatterv"
+            )
+            pynccl_comm.reduce_scatter(output, input_, sizes=sizes)
+
     def reduce_scatterv(
         self,
         input_: torch.Tensor,
         output: Optional[torch.Tensor] = None,
         sizes: Optional[List[int]] = None,
     ) -> torch.Tensor:
+        # Shape math and allocation stay here so the op itself only mutates a
+        # caller-owned output and needs no fake impl beyond the default.
         world_size = self.world_size
-        pynccl_comm = self.pynccl_comm
 
-        with pynccl_comm.change_state(enable=True):
-            assert pynccl_comm is not None and not pynccl_comm.disabled, (
-                "pynccl is required for reduce_scatterv"
-            )
+        if sizes is not None:
+            assert len(sizes) == world_size
+            assert input_.shape[0] == sum(sizes)
+            chunk_size = sizes[self.rank_in_group]
+        else:
+            assert input_.shape[0] % world_size == 0
+            chunk_size = input_.shape[0] // world_size
+        output_shape = (chunk_size,) + input_.shape[1:]
 
-            if sizes is not None:
-                assert len(sizes) == world_size
-                assert input_.shape[0] == sum(sizes)
-                chunk_size = sizes[self.rank_in_group]
-            else:
-                assert input_.shape[0] % world_size == 0
-                chunk_size = input_.shape[0] // world_size
-            output_shape = (chunk_size,) + input_.shape[1:]
+        if output is None:
+            output = torch.empty(output_shape, dtype=input_.dtype, device=input_.device)
+        else:
+            assert output.shape == output_shape
 
-            if output is None:
-                output = torch.empty(
-                    output_shape, dtype=input_.dtype, device=input_.device
-                )
-            else:
-                assert output.shape == output_shape
-
-            pynccl_comm.reduce_scatter(output, input_, sizes=sizes)
-            return output
+        reg_reduce_scatterv(output, input_, sizes, group_name=self.unique_name)
+        return output
 
     def _all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
         # Aiter custom all-gather (ROCm). Set SGLANG_USE_AITER_AG=0 to disable.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -47,6 +47,13 @@ class EnvField:
 
     def __init__(self, default: Any, secret: bool = False):
         self.default = default
+        # get() is traced by Dynamo (models read envs in their forwards), which
+        # cannot trace `callable()`. Moving the check out of get() is not enough:
+        # Dynamo mis-models an lru_cache default as a bound method carrying `self`
+        # at the *attribute load*, so calling it fails too. functools.partial is safe.
+        self._default_factory = (
+            functools.partial(default) if callable(default) else None
+        )
         # NOTE: environ can only accept str values, so we need a flag to indicate
         # whether the env var is explicitly set to None.
         self._set_to_none = False
@@ -62,7 +69,9 @@ class EnvField:
     def _resolve_default(self) -> Any:
         # Support a callable default for lazily/platform-computed defaults
         # (e.g. EnvBool(_default_hip)); evaluated only when the env is unset.
-        return self.default() if callable(self.default) else self.default
+        if self._default_factory is None:
+            return self.default
+        return self._default_factory()
 
     def get(self) -> Any:
         value = os.getenv(self.name)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1489,6 +1489,9 @@ class Envs:
     # tuned batched_gemm_bf16 (gfx95). Off by default; see deepseek_v4.py
     # _apply_wo_a_bf16_matmul.
     SGLANG_OPT_USE_AITER_BATCHED_GEMM = EnvBool(False)
+    # Keep DSv4 prefill attention graphs while running TP8/DP8 MoE on the
+    # compact real-token union between captured pieces (ROCm, no A2A only).
+    SGLANG_DSV4_TC_COMPACT_MOE = EnvBool(False)
     SGLANG_OPT_BF16_FP32_GEMM_ALGO = EnvStr("cublas")
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_USE_MULTI_STREAM_OVERLAP = EnvBool(True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -35,6 +35,9 @@ from sglang.srt.layers.attention.dsv4.metadata import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    is_in_tc_piecewise_cuda_graph,
+)
 from sglang.srt.runtime_context import (
     get_exec,
     get_parallel,
@@ -42,7 +45,7 @@ from sglang.srt.runtime_context import (
 )
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
-from sglang.srt.utils import ceil_align
+from sglang.srt.utils import ceil_align, get_bool_env_var
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -351,6 +354,92 @@ class DSV4AttnMetadata:
         self.c128_flashmla_metadata = _create_flashmla_metadata()
 
 
+# Fill values for the tail rows of each metadata tensor; anything not listed defaults
+# to 0. 0 is the inert slot: request-pool row 0 is reserved (free_slots starts at 1)
+# and req_to_token is zero-initialised, so it resolves to the KV pool's null slot.
+_METADATA_PAD_VALUES = {
+    "c4_sparse_page_indices": -1,
+    "c4_sparse_raw_indices": -1,
+    "page_table": 0,
+    "pf_state_slot": 0,
+    "pf_chunk_start": 0,
+    "pf_cu_q": 0,
+    "pf_final_pos": 0,
+    # -1 is the "no page" sentinel these are allocated with; 0 is a real page.
+    "swa_page_indices": -1,
+    "c128_page_indices": -1,
+    # flash_mla requires the clamp1 lengths to be >= 1; the *_raw lengths keep 0 so
+    # the indexer and top-k take their trivial path.
+    "swa_topk_lengths": 1,
+    "c4_topk_lengths_clamp1": 1,
+    "c128_topk_lengths_clamp1": 1,
+    "c4_sparse_topk_lengths": 1,
+    # Raw uint8 CompressPlan/WritePlan structs; an all-0xFF row is compress_v2.cuh's
+    # invalid() sentinel, which every consumer early-returns on.
+    "plan_c": 0xFF,
+    "plan_w": 0xFF,
+}
+
+
+def _refresh_metadata_rows_in_place(dst, src, _depth: int = 0) -> None:
+    """Copy src's rows into dst's tensors without replacing any of them.
+
+    dst is the object the captured graph recorded addresses for, so every tensor has
+    to stay put; only the contents may change. When src is shorter than the bucket the
+    tail rows still execute, so they are filled from _METADATA_PAD_VALUES rather than
+    left pointing at a real request's state. Tensors are matched by attribute name.
+    """
+    if _depth > 4 or dst is None or src is None:
+        return
+    for name in list(vars(dst)):
+        d = getattr(dst, name, None)
+        s_ = getattr(src, name, None)
+        if isinstance(d, torch.Tensor) and isinstance(s_, torch.Tensor):
+            if d.ndim == 0 or s_.ndim == 0 or d.shape[1:] != s_.shape[1:]:
+                continue
+            n = min(d.shape[0], s_.shape[0])
+            if n == 0:
+                continue
+            d[:n].copy_(s_[:n])
+            if d.shape[0] > n:
+                d[n:].fill_(_METADATA_PAD_VALUES.get(name, 0))
+        elif _is_namedtuple(d) and _is_namedtuple(s_) and type(d) is type(s_):
+            # CompressorPrefillPlan is a NamedTuple: neither a Tensor nor an object
+            # with a __dict__, so both other branches miss it. Left unrefreshed, every
+            # replay runs the compressor against the capture batch's plan -- indices
+            # stay in bounds, so it silently reads the wrong rows on every layer.
+            _refresh_namedtuple_rows_in_place(d, s_, _depth + 1)
+        elif hasattr(d, "__dict__") and hasattr(s_, "__dict__"):
+            _refresh_metadata_rows_in_place(d, s_, _depth + 1)
+
+
+def _is_namedtuple(obj) -> bool:
+    return isinstance(obj, tuple) and hasattr(obj, "_fields")
+
+
+def _refresh_namedtuple_rows_in_place(dst, src, _depth: int = 0) -> None:
+    """Row-refresh the tensor fields of a NamedTuple pair.
+
+    The tuple is immutable but its tensors are not, and it is the tensors the captured
+    graph recorded addresses for. Non-tensor fields are capture-time constants.
+    """
+    if _depth > 4:
+        return
+    for name in dst._fields:
+        d = getattr(dst, name, None)
+        s_ = getattr(src, name, None)
+        if not (isinstance(d, torch.Tensor) and isinstance(s_, torch.Tensor)):
+            continue
+        if d.ndim == 0 or s_.ndim == 0 or d.shape[1:] != s_.shape[1:]:
+            continue
+        n = min(d.shape[0], s_.shape[0])
+        if n == 0:
+            continue
+        d[:n].copy_(s_[:n])
+        if d.shape[0] > n:
+            d[n:].fill_(_METADATA_PAD_VALUES.get(name, 0))
+
+
 @dataclass
 class DSV4Metadata:
     core_attn_metadata: DSV4AttnMetadata
@@ -576,6 +665,11 @@ class DeepseekV4HipRadixBackend(
         )
         seq_lens_casual = _expanded.seq_lens_casual
         req_pool_indices_repeated = _expanded.req_pool_indices_repeated
+        if num_tokens < req_pool_indices_repeated.shape[0]:
+            # The shared expansion repeats the last live request in padded rows.
+            # HIP graph stores must use inert slot 0 instead, so padding cannot
+            # overwrite a live request's SWA/compressor state on replay.
+            req_pool_indices_repeated[num_tokens:].zero_()
         core_attn_metadata = self.make_core_attn_metadata(
             req_to_token=self.req_to_token,
             req_pool_indices_repeated=req_pool_indices_repeated,
@@ -1007,6 +1101,48 @@ class DeepseekV4HipRadixBackend(
             workspace=metadata.fp4_prefill_workspace,
         )
 
+    # Opt into the captured-metadata contract, as the CUDA backend already does:
+    # capture builds one metadata object per bucket and replay refreshes it in place,
+    # so the addresses the captured kernels recorded stay valid and Dynamo's shape
+    # guards keep holding. Without it, replay reads stale metadata.
+    use_captured_forward_metadata_for_breakable_cuda_graph = not get_bool_env_var(
+        "SGLANG_PIECEWISE_NO_CAPTURED_METADATA"
+    )
+
+    def init_forward_metadata_for_breakable_cuda_graph_capture(
+        self, forward_batch: ForwardBatch
+    ):
+        """Build this bucket's metadata and hand it back for the runner to keep."""
+        self.init_forward_metadata(forward_batch)
+        return self.forward_metadata
+
+    def prepare_forward_metadata_for_breakable_cuda_graph_replay(
+        self,
+        capture_metadata,
+        forward_batch: ForwardBatch,
+        *,
+        static_forward_batch: Optional[ForwardBatch] = None,
+    ) -> None:
+        """Refresh the captured metadata in place from the live batch.
+
+        Build against the padded batch so the shapes match what capture recorded, then
+        copy the contents into the captured object rather than swapping it out -- the
+        recorded kernels read those addresses. Mirrors
+        DSV4Metadata.refresh_for_breakable_cuda_graph_replay_ on the CUDA side.
+        """
+        src_batch = (
+            static_forward_batch if static_forward_batch is not None else forward_batch
+        )
+        self.init_forward_metadata(src_batch)
+        fresh = self.forward_metadata
+        if capture_metadata is None or fresh is None:
+            return
+        # Not DSV4Metadata.copy_: it requires an exact shape match and a served batch
+        # rarely fills the bucket, so it would raise on every replay and the fallback
+        # would rebuild the metadata, losing the address stability this exists for.
+        _refresh_metadata_rows_in_place(capture_metadata, fresh)
+        self.forward_metadata = capture_metadata
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -1155,7 +1291,14 @@ class DeepseekV4HipRadixBackend(
 
         assert self.swa_page_size % SWA_WINDOW == 0 and self.page_size % 128 == 0
         assert seq_lens_cpu is not None
-        max_seq_len = int(seq_lens_cpu.max().item())
+        # max_seq_len sizes the page table's second dimension; taking it from the live
+        # batch moves that shape batch to batch and fails Dynamo's guard on it. The
+        # other CUDA-graph paths already pin it to MAX_SEQ_LEN_FOR_CAPTURE.
+        max_seq_len = (
+            self.MAX_SEQ_LEN_FOR_CAPTURE
+            if is_in_tc_piecewise_cuda_graph()
+            else int(seq_lens_cpu.max().item())
+        )
 
         if forward_batch.forward_mode.is_decode_or_idle():
             # DSv4 bakes this step's KV write target (c4/c128) into metadata,
@@ -1199,16 +1342,22 @@ class DeepseekV4HipRadixBackend(
             is_draft = (
                 forward_batch.forward_mode.is_draft_extend_v2() or self.is_draft_worker
             )
+            # Under tc_piecewise, ask for compressor plans padded to the bucket's
+            # token count: plans trimmed to their live length move with every batch
+            # and fail Dynamo's shape guard.
             metadata = self.init_forward_metadata_prefill(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
                 seq_lens_cpu=seq_lens_cpu.tolist(),
                 out_cache_loc=forward_batch.out_cache_loc,
+                # Keep the live count separate from graph-buffer capacity so
+                # the expansion can identify padded rows.
                 num_tokens=sum(extend_seq_lens_cpu),
                 extend_seq_lens=extend_seq_lens,
                 extend_seq_lens_cpu=extend_seq_lens_cpu,
                 need_compress=not is_draft,
+                use_prefill_cuda_graph=is_in_tc_piecewise_cuda_graph(),
                 exact_num_tokens=is_draft,
             )
         else:
@@ -1382,6 +1531,11 @@ class DeepseekV4HipRadixBackend(
         device = q.device
         positions = forward_batch.positions.to(torch.int64)
         T = q.shape[0]
+        # Bound, not equality: Dynamo treats positions.shape[0] and T as unrelated
+        # symbols and would otherwise resolve the slice by specializing the token
+        # dimension. `==` would be wrong -- positions can be a padded buffer while T
+        # is the live count, and claiming they match folds the slice away.
+        torch._check(positions.shape[0] >= T)
         positions = positions[:T]
 
         c128_pi = getattr(core_attn_metadata, "c128_page_indices", None)
@@ -1487,6 +1641,18 @@ class DeepseekV4HipRadixBackend(
             positions_full = forward_batch.positions.to(torch.int64)[
                 : state_slot_full.shape[0]
             ].contiguous()
+        elif state_slot.shape[0] > T:
+            # pf_* arrive padded to the graph bucket while q/positions do not: DSv4
+            # attention is a split op that runs eager on the live token count. Slice
+            # back to it, or _prefill_lengths_kernel's unmasked load of positions past
+            # the live count corrupts the indptr for the real rows too.
+            state_slot = state_slot[:T]
+            chunk_start = chunk_start[:T]
+            cu_q = cu_q[:T]
+            final_pos = final_pos[:T]
+            state_slot_full = state_slot
+            final_pos_full = final_pos
+            positions_full = positions
 
         kpre_i, kpre_p, kext_i, kext_p = runtime.build_prefill_indices(
             compress_ratio=compress_ratio,
@@ -1527,6 +1693,10 @@ class DeepseekV4HipRadixBackend(
             _ring_final_pos = final_pos_full if _cp_active else final_pos
             _ring_positions = positions_full if _cp_active else positions
             n_real = _ring_state_slot.shape[0]
+            # The slice is load-bearing: kv can be longer than state_slot. Dynamo
+            # treats n_real and kv.shape[0] as unrelated symbols, so without the bound
+            # it resolves the slice by specializing the token dimension.
+            torch._check(n_real <= kv.shape[0])
             runtime.store_swa_into_unified(
                 kv=kv[:n_real],
                 state_slot=_ring_state_slot,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -54,6 +54,7 @@ from sglang.srt.runtime_context import (
 )
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.utils import add_prefix, is_cuda, is_hip, is_xpu
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -140,6 +141,37 @@ def fp8_paged_mqa_logits_torch(
     return scores
 
 
+# aiter's kernel is a Triton JIT function whose launcher Dynamo cannot trace, which
+# is fatal under the fullgraph piecewise prefill backend. A custom op keeps the launch
+# opaque; the output allocation stays outside so Dynamo still sees its shape.
+@register_custom_op(op_name="dsv4_aiter_fp8_paged_mqa_logits", mutates_args=["logits"])
+def _aiter_fp8_paged_mqa_logits_custom_op(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+    kv_block_size: int,
+) -> None:
+    from aiter.ops.triton.attention.pa_mqa_logits import (
+        deepgemm_fp8_paged_mqa_logits,
+    )
+
+    deepgemm_fp8_paged_mqa_logits(
+        q_fp8,
+        kvcache_fp8,
+        weight,
+        logits,
+        seq_lens,
+        page_table,
+        max_seq_len,
+        KVBlockSize=kv_block_size,
+        Preshuffle=aiter_can_use_preshuffle_paged_mqa(),
+    )
+
+
 def _aiter_fp8_paged_mqa_logits(
     q_fp8: torch.Tensor,
     kvcache_fp8: torch.Tensor,
@@ -151,10 +183,6 @@ def _aiter_fp8_paged_mqa_logits(
     clean_logits: bool = False,
 ) -> torch.Tensor:
     """Wrapper adapting aiter's deepgemm_fp8_paged_mqa_logits to SGLang's interface."""
-    from aiter.ops.triton.attention.pa_mqa_logits import (
-        deepgemm_fp8_paged_mqa_logits,
-    )
-
     batch_size = q_fp8.shape[0]
     next_n = q_fp8.shape[1]
     total_tokens = batch_size * next_n
@@ -166,7 +194,7 @@ def _aiter_fp8_paged_mqa_logits(
         dtype=torch.float32,
         device=q_fp8.device,
     )
-    deepgemm_fp8_paged_mqa_logits(
+    _aiter_fp8_paged_mqa_logits_custom_op(
         q_fp8,
         kvcache_fp8,
         weight,
@@ -174,8 +202,7 @@ def _aiter_fp8_paged_mqa_logits(
         _sl.to(torch.int32),
         page_table.to(torch.int32),
         max_seq_len,
-        KVBlockSize=kv_block_size,
-        Preshuffle=aiter_can_use_preshuffle_paged_mqa(),
+        kv_block_size,
     )
     return logits
 
@@ -784,6 +811,9 @@ class C4IndexerBackendMixin:
 
         query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
 
+        # Kept as a branch chain on purpose: collapsing it into one F.pad removes a
+        # token-dimension specialization but returns a fresh tensor in the
+        # already-matching case, and something downstream relies on tensor identity.
         def match_num_queries(tensor: torch.Tensor, value: int) -> torch.Tensor:
             if tensor.shape[0] == query_rows:
                 return tensor

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -821,7 +821,24 @@ def _dp_gather_via_all_gatherv(
     get_tp_group().all_gatherv(local_real, sizes=sizes, output=global_tokens)
 
 
+@torch._dynamo.assume_constant_result
+def _record_compiled_prefill_dp_gather() -> None:
+    # Record this on the host during tracing. Repeated traces set the same
+    # latch; DpFlags.__setattr__ stays outside the graph and the result is None.
+    get_flags().dp.prefill_graph_has_dp_gather = True
+
+
 def _note_dp_gather_in_prefill_graph() -> None:
+    if torch.compiler.is_compiling():
+        from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+            is_in_tc_piecewise_cuda_graph,
+        )
+
+        if is_in_tc_piecewise_cuda_graph():
+            _record_compiled_prefill_dp_gather()
+        # The capture flag changes between precompile/capture/replay. Reading
+        # it here would guard the trace on the phase and discard captured graphs.
+        return
     dp = get_flags().dp
     if dp.capturing_prefill_graph:
         dp.prefill_graph_has_dp_gather = True

--- a/python/sglang/srt/layers/moe/dsv4_tc_compact.py
+++ b/python/sglang/srt/layers/moe/dsv4_tc_compact.py
@@ -1,0 +1,164 @@
+"""Compact TP-MoE bridge between DeepSeek-V4 prefill graph pieces."""
+
+from __future__ import annotations
+
+import copy
+from typing import Optional
+
+import torch
+
+from sglang.srt.compilation.compilation_config import register_split_op
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import DpPaddingMode
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    get_tc_piecewise_forward_context,
+)
+from sglang.srt.runtime_context import get_exec, get_forward, get_parallel
+from sglang.srt.utils import is_hip
+from sglang.srt.utils.custom_op import register_custom_op
+
+_IS_HIP = is_hip()
+
+
+def compact_moe_enabled() -> bool:
+    """The initial implementation is restricted to one ROCm TP8/DP8 group."""
+    if not envs.SGLANG_DSV4_TC_COMPACT_MOE.get() or not _IS_HIP:
+        return False
+    parallel = get_parallel()
+    return (
+        parallel.tp_size == 8
+        and parallel.attn_dp_size == 8
+        and parallel.attn_tp_size == 1
+        and parallel.moe_ep_size == 1
+        and parallel.pp_size == 1
+        and parallel.attn_cp_size == 1
+        and get_exec().kernel.attention_backend == "dsv4"
+        and get_moe_a2a_backend().is_none()
+        and not get_exec().overlap.enable_two_batch_overlap
+        and get_exec().graph.cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE
+    )
+
+
+def run_compact_dp_moe(
+    hidden_local: torch.Tensor,
+    input_ids_local: Optional[torch.Tensor],
+    output_local: torch.Tensor,
+    *,
+    counts: list[int],
+    local_rank: int,
+    tp_group,
+    moe_layer,
+    forward_batch,
+    counts_gpu: Optional[torch.Tensor] = None,
+    layer_id: Optional[int] = None,
+) -> None:
+    """Run a SUM_LEN MoE between graph pieces, writing a fixed local output.
+
+    Counts are the synchronized, unpadded CPU token counts. All collective sizes
+    are resolved here, outside CUDA graph capture. The original ForwardBatch and
+    the outer graph's DP allocation metadata are left unchanged.
+    """
+    if hidden_local.is_cuda and torch.cuda.is_current_stream_capturing():
+        raise RuntimeError("DSv4 compact MoE must execute as a split graph operation")
+    if hidden_local.ndim != 2 or output_local.shape != hidden_local.shape:
+        raise ValueError("Compact MoE expects matching [local_bucket, hidden] buffers")
+    if len(counts) != tp_group.world_size or not 0 <= local_rank < len(counts):
+        raise ValueError("Compact MoE requires the full TP group's token counts")
+    if any(type(count) is not int or count < 0 for count in counts):
+        raise ValueError("Compact MoE counts must be nonnegative Python integers")
+    local_tokens = counts[local_rank]
+    if local_tokens > hidden_local.shape[0]:
+        raise ValueError("Real local token count exceeds the attention bucket")
+    total_tokens = sum(counts)
+    output_local.zero_()
+    if total_tokens == 0:
+        return
+
+    packed_hidden = hidden_local.new_empty((total_tokens, hidden_local.shape[1]))
+    tp_group.all_gatherv(
+        hidden_local[:local_tokens].contiguous(), sizes=counts, output=packed_hidden
+    )
+
+    packed_ids = None
+    if getattr(moe_layer, "is_hash", False):
+        if input_ids_local is None or input_ids_local.shape[0] < local_tokens:
+            raise ValueError(
+                "Hash-routed MoE requires the corresponding local token IDs"
+            )
+        packed_ids = input_ids_local.new_empty((total_tokens,))
+        tp_group.all_gatherv(
+            input_ids_local[:local_tokens].contiguous(), sizes=counts, output=packed_ids
+        )
+
+    compact_batch = copy.copy(forward_batch)
+    compact_batch.global_num_tokens_cpu = list(counts)
+    compact_batch.global_num_tokens_gpu = counts_gpu
+    compact_batch.global_dp_buffer_len = total_tokens
+    compact_batch.dp_padding_mode = DpPaddingMode.SUM_LEN
+    compact_batch.dp_local_start_pos = None
+    compact_batch.dp_local_num_tokens = None
+
+    # A replicated shared expert must be added after the TP sum. Other shared
+    # experts (including the recipe's fused shared expert) stay in the TP MoE.
+    shared_local = None
+    separate_shared = bool(
+        getattr(moe_layer, "_shared_expert_tp1", False)
+        and getattr(moe_layer, "shared_experts", None) is not None
+    )
+    if separate_shared and local_tokens:
+        shared_local = moe_layer._forward_shared_experts(hidden_local[:local_tokens])
+
+    with get_forward().scoped(mlp_reduce_scatter=True, fuse_mlp_allreduce=False):
+        partial = moe_layer(
+            packed_hidden,
+            compact_batch,
+            input_ids=packed_ids,
+            input_ids_global=packed_ids,
+            skip_shared_experts=separate_shared,
+        )
+    if partial.shape != packed_hidden.shape:
+        raise RuntimeError(
+            "Compact MoE must return one partial TP output per real token"
+        )
+    tp_group.reduce_scatterv(
+        partial,
+        output=output_local[:local_tokens],
+        # Equal sizes use one NCCL reduce-scatter rather than the variable-size
+        # implementation's grouped reduction to each rank.
+        sizes=None if all(count == counts[0] for count in counts) else counts,
+    )
+    if shared_local is not None:
+        output_local[:local_tokens].add_(shared_local)
+
+
+@register_custom_op(mutates_args=["output_local"])
+@register_split_op()
+def dsv4_tc_compact_moe_with_output(
+    hidden_local: torch.Tensor,
+    input_ids_local: Optional[torch.Tensor],
+    real_counts_gpu: torch.Tensor,
+    output_local: torch.Tensor,
+    layer_id: int,
+) -> None:
+    context = get_tc_piecewise_forward_context()
+    if context is None or context.dp_moe_layers is None:
+        raise RuntimeError("Missing DSv4 compact-MoE forward context")
+    batch = context.forward_batch
+    counts = batch.moe_real_num_tokens_cpu
+    if counts is None:
+        raise RuntimeError("Real DP counts were not preserved before graph padding")
+    run_compact_dp_moe(
+        hidden_local,
+        input_ids_local,
+        output_local,
+        counts=counts,
+        counts_gpu=real_counts_gpu,
+        local_rank=get_parallel().attn_dp_rank,
+        tp_group=get_tp_group(),
+        moe_layer=context.dp_moe_layers[layer_id],
+        forward_batch=batch,
+        layer_id=layer_id,
+    )

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -398,7 +398,13 @@ def prepare_mlp_sync_batch_raw(
     )
     breakable_prefill = check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE)
     full_prefill = check_cuda_graph_backend(Phase.PREFILL, Backend.FULL)
-    coordinated_prefill = breakable_prefill or full_prefill
+    # TC_PIECEWISE belongs here too: this verdict gates can_run_graph, so without it
+    # the prefill graph is captured at startup and then never replayed.
+    coordinated_prefill = (
+        breakable_prefill
+        or full_prefill
+        or check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
+    )
     prefill_graph_runner = (
         model_runner.prefill_cuda_graph_runner if coordinated_prefill else None
     )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1812,6 +1812,9 @@ class KVCache(abc.ABC):
     # Whether get_cpu_copy/load_cpu_copy carry the recurrent state. False when the
     # state lives on the request pool instead, and the caller has to move it.
     cpu_copy_carries_mamba: bool = False
+    # Set by hoist_layer_transfer_wait(); see there.
+    _hoisted_layer_transfer_counter: Optional[LayerDoneCounter] = None
+    hoisted_layer_transfer: bool = False
 
     @abc.abstractmethod
     def __init__(
@@ -1914,7 +1917,32 @@ class KVCache(abc.ABC):
         raise NotImplementedError()
 
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
+        if self.hoisted_layer_transfer:
+            self._hoisted_layer_transfer_counter = layer_transfer_counter
+            return
         self.layer_transfer_counter = layer_transfer_counter
+
+    def hoist_layer_transfer_wait(self) -> None:
+        """Move HiCache's per-layer wait to the forward boundary.
+
+        The wait is `current_stream().wait_event(...)` on an event the cache
+        controller records on its own stream -- uncapturable, and traced as
+        `layer_transfer_counter is None` because the controller registers only
+        after capture, so every captured shape misses its guard on the first
+        real batch. Keeping the counter off `layer_transfer_counter` compiles
+        those waits away; `wait_all_layer_transfers` waits once outside the
+        graph instead. Costs the layer-wise overlap; ordering holds because the
+        controller records the per-layer events in order on one stream.
+        """
+        self.hoisted_layer_transfer = True
+        self._hoisted_layer_transfer_counter = self.layer_transfer_counter
+        self.layer_transfer_counter = None
+
+    def wait_all_layer_transfers(self) -> None:
+        """Wait for a hoisted HiCache load. No-op unless hoisted and loading."""
+        counter = self._hoisted_layer_transfer_counter
+        if counter is not None:
+            counter.wait_until(counter.num_layers - 1)
 
     def get_cpu_copy(self, indices, mamba_indices=None, req_pool_index=None):
         raise NotImplementedError()
@@ -4015,10 +4043,20 @@ class HybridLinearKVPool(KVCache):
         return self.full_attention_layer_id_mapping[layer_id]
 
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
-        self.layer_transfer_counter = layer_transfer_counter
+        super().register_layer_transfer_counter(layer_transfer_counter)
         # The layer-wise wait logic is executed at the Hybrid LinearPool level;
         # no additional wait is needed in the full_kv_pool
         self.full_kv_pool.register_layer_transfer_counter(None)
+
+    def hoist_layer_transfer_wait(self) -> None:
+        # HiCacheController unwraps this pool and registers on full_kv_pool, so
+        # that is where the hoisted counter has to land.
+        super().hoist_layer_transfer_wait()
+        self.full_kv_pool.hoist_layer_transfer_wait()
+
+    def wait_all_layer_transfers(self) -> None:
+        super().wait_all_layer_transfers()
+        self.full_kv_pool.wait_all_layer_transfers()
 
     def _wait_for_layer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
@@ -5283,7 +5321,7 @@ class MHATokenToKOnlyPool(KVCache):
     def register_layer_transfer_counter(
         self, layer_transfer_counter: LayerDoneCounter
     ) -> None:
-        self.layer_transfer_counter = layer_transfer_counter
+        super().register_layer_transfer_counter(layer_transfer_counter)
 
     def get_key_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
@@ -5451,7 +5489,7 @@ class MiniMaxSparseKVPool(KVCache):
     def register_layer_transfer_counter(
         self, layer_transfer_counter: LayerDoneCounter
     ) -> None:
-        self.layer_transfer_counter = layer_transfer_counter
+        super().register_layer_transfer_counter(layer_transfer_counter)
 
     def get_kv_cache_quant_method(self) -> Any:
         # The base unwrap chain only knows full_kv_pool/swa_kv_pool; the dense

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -148,7 +148,7 @@ class SWAKVPool(BaseSWAKVPool):
 
     def register_layer_transfer_counter(self, layer_transfer_counter):
         # Wait happens at this wrapper. Inner pools must not wait again.
-        self.layer_transfer_counter = layer_transfer_counter
+        super().register_layer_transfer_counter(layer_transfer_counter)
         self.full_kv_pool.register_layer_transfer_counter(None)
         self.swa_kv_pool.register_layer_transfer_counter(None)
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1407,15 +1407,28 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # Larger prefills fall back to eager and keep the memory-efficient
         # SUM_LEN. global_num_tokens is identical across ranks (all-gathered),
         # so the decision is consistent cluster-wide.
+        # `> 0`: when require_mlp_tp_gather() is false global_num_tokens holds only
+        # this rank's count, so an idle rank would take MAX_LEN with a maximum of 0
+        # and get rewritten into a 0-token EXTEND batch, whose extend_seq_lens of
+        # [0] indexes an empty hidden_states at -1.
         prefill_cg = get_exec().graph.cuda_graph_config.prefill
+        prefill_graph_bucket = None
         if (
             self.can_run_dp_prefill_cuda_graph
             and self.is_extend_in_batch
             and prefill_cg.bs
-            and max(global_num_tokens) <= max(prefill_cg.bs)
+            and 0 < max(global_num_tokens) <= max(prefill_cg.bs)
             and not prefill_graph_tolerates_sum_len()
         ):
             dp_padding_mode = DpPaddingMode.MAX_LEN
+            # Pad straight to the capture bucket. The graph runner pads to it
+            # again on the way in, and that second padding never reaches the DP
+            # buffer lengths derived here. Replay-only backends never notice;
+            # tc_piecewise runs the model code and reads the stale local length
+            # against bucket-sized positions.
+            prefill_graph_bucket = min(
+                bs for bs in prefill_cg.bs if bs >= max(global_num_tokens)
+            )
         self.dp_padding_mode = dp_padding_mode
 
         if dp_padding_mode.is_max_len():
@@ -1423,7 +1436,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # all_gather_into_tensor to gather hidden states, where transferred
             # tokens should be padded to the same length. We will also use
             # reduce-scatter instead of all-reduce after MLP.
-            max_num_tokens = max(global_num_tokens)
+            max_num_tokens = (
+                prefill_graph_bucket
+                if prefill_graph_bucket is not None
+                else max(global_num_tokens)
+            )
             global_num_tokens = [max_num_tokens] * sync_group_size
             buffer_len = max_num_tokens * sync_group_size
         else:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -600,6 +600,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     dp_local_start_pos: Optional[torch.Tensor] = None  # cached info at runtime
     dp_local_num_tokens: Optional[torch.Tensor] = None  # cached info at runtime
     global_dp_buffer_len: Optional[int] = None
+    # Unpadded token counts for the DSv4 compact MoE split. The ordinary DP
+    # counts below are overwritten by MAX_LEN attention-graph padding.
+    moe_real_num_tokens_cpu: Optional[List[int]] = None
+    moe_real_num_tokens_gpu: Optional[torch.Tensor] = None
 
     # For Qwen2-VL
     mrope_positions: torch.Tensor = None
@@ -1372,6 +1376,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
     def prepare_mlp_sync_batch(self, model_runner: ModelRunner):
         from sglang.srt.batch_overlap.two_batch_overlap import TboForwardBatchPreparer
+        from sglang.srt.layers.moe.dsv4_tc_compact import compact_moe_enabled
 
         assert self.global_num_tokens_cpu is not None
         assert self.global_num_tokens_for_logprob_cpu is not None
@@ -1385,6 +1390,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # make sure that the padded length is divisible by attn_tp_size because we may need reduce-scatter across attn_tp dim.
             # there is no reduce-scatter in LM logprob, so we do not need to adjust the padded length for logprob
             global_num_tokens[i] = ceil_align(global_num_tokens[i], attn_tp_size)
+
+        if compact_moe_enabled() and self.is_extend_in_batch:
+            self.moe_real_num_tokens_cpu = list(global_num_tokens)
+            # attn_tp_size is one in this mode, so the existing device counts
+            # already match these values. Keep storage independent of the
+            # padded-count copy performed at the end of this method.
+            self.moe_real_num_tokens_gpu = self.global_num_tokens_gpu.clone()
 
         dp_padding_mode = DpPaddingMode.get_dp_padding_mode(
             self.is_extend_in_batch, global_num_tokens

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1778,6 +1778,11 @@ class ModelRunner:
         else:
             ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
         with ctx_mgr:
+            # Hoisted HiCache wait; see KVCache.hoist_layer_transfer_wait. Runs
+            # on the forward stream before any graph replay, and is a plain
+            # return unless a load is actually in flight.
+            self.token_to_kv_pool.wait_all_layer_transfers()
+
             mode_check = (
                 forward_batch.forward_mode.is_cpu_graph
                 if self.device == "cpu"

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -21,10 +21,6 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    get_server_return_hidden_states_mode,
-)
 from sglang.srt.model_executor.graph_memory_usage import (
     merge_graph_memory_usage,
     merge_graph_time_usage,
@@ -340,24 +336,6 @@ def capture_prefill_graph(
     # init_lm_head so graphs capture the final embedding weights.
     if model_runner.is_draft_worker and not force_for_draft_worker:
         return result(None)
-
-    # Skip prefill CG for EAGLE target on tc_piecewise when the fixed server
-    # capture ceiling is below FULL. EAGLE target prefill requests FULL, so a
-    # NULL or LAST graph is dead; capturing it can perturb FP4/TRTLLM-MoE
-    # state and corrupt decode replay (see #28386 and #28870). BCG and FullCG
-    # capture FULL for EAGLE targets in PrefillCudaGraphRunner.__init__, so
-    # they do not need this skip.
-    if (
-        model_runner.spec_algorithm.is_eagle()
-        and not model_runner.is_draft_worker
-        and get_server_return_hidden_states_mode() < CaptureHiddenMode.FULL
-        and check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
-    ):
-        logger.info(
-            "Disable prefill CUDA graph for EAGLE target on tc_piecewise "
-            "to avoid FP4/MoE decode-replay corruption (#28386)."
-        )
-        return result(eager_runner)
 
     if (
         model_runner.lora_manager is not None

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -444,6 +444,13 @@ def capture_prefill_graph(
         model_runner.dsa_indexers,
         model_runner.mha_companion_layers,
     ) = model_runner.get_cuda_graph_layers(layer_model)
+    from sglang.srt.layers.moe.dsv4_tc_compact import compact_moe_enabled
+
+    model_runner.dp_moe_layers = (
+        [getattr(layer, "mlp", None) for layer in layer_model.layers]
+        if compact_moe_enabled()
+        else None
+    )
     (
         model_runner.attention_layers,
         model_runner.mha_companion_layers,

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -346,10 +346,20 @@ class EagerRunner(BaseRunner):
                 and not isinstance(pcg_runner, EagerRunner)
                 and not cp_active
             ):
-                # HIP PCG eager fallback: enter the PCG context so Dynamo guards
-                # and PCG-specific MoE/attention paths stay consistent.
+                # HIP PCG eager fallback: set the PCG forward context so the
+                # PCG-specific MoE/attention paths stay consistent, but under
+                # TC_PIECEWISE skip enable_tc_piecewise_cuda_graph() -- it dispatches
+                # to the compiled forward, where a fallback batch's arbitrary shape
+                # would evict the captured buckets from the Dynamo cache.
+                _eager_use_compiled = (
+                    get_exec().graph.cuda_graph_config.prefill.backend != "tc_piecewise"
+                )
                 with (
-                    enable_tc_piecewise_cuda_graph(),
+                    (
+                        enable_tc_piecewise_cuda_graph()
+                        if _eager_use_compiled
+                        else contextlib.nullcontext()
+                    ),
                     set_tc_piecewise_forward_context(
                         forward_batch,
                         model_runner.attention_layers,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -390,6 +390,14 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         )
         self.moe_layers = self.model_runner.moe_layers
         self.moe_fusions = self.model_runner.moe_fusions
+        self.dp_moe_layers = getattr(self.model_runner, "dp_moe_layers", None)
+        self._compact_moe_counts_gpu = (
+            torch.zeros(
+                get_parallel().attn_dp_size, dtype=torch.int64, device=self.device
+            )
+            if self.dp_moe_layers is not None
+            else None
+        )
         self.dsa_indexers = getattr(self.model_runner, "dsa_indexers", None)
 
         self.dp_size = get_parallel().dp_size
@@ -704,6 +712,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 num_tokens=num_tokens,
                 raw_num_tokens=raw_num_tokens,
                 full_graph=self._is_full_backend,
+                dp_moe_layers=self.dp_moe_layers,
             ),
         ):
             yield
@@ -1424,6 +1433,10 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
+            if self._compact_moe_counts_gpu is not None:
+                self._compact_moe_counts_gpu.fill_(num_tokens)
+                forward_batch.moe_real_num_tokens_cpu = [num_tokens] * self.dp_size
+                forward_batch.moe_real_num_tokens_gpu = self._compact_moe_counts_gpu
         return forward_batch, self.model_runner.attn_backend
 
     def capture(self) -> None:
@@ -1667,6 +1680,14 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 hidden_states=self.static_draft_hidden_states[:static_num_tokens],
             )
 
+        if self._compact_moe_counts_gpu is not None:
+            if (
+                forward_batch.moe_real_num_tokens_cpu is None
+                or forward_batch.moe_real_num_tokens_gpu is None
+            ):
+                raise RuntimeError("Compact MoE graph replay is missing real DP counts")
+            self._compact_moe_counts_gpu.copy_(forward_batch.moe_real_num_tokens_gpu)
+
         static_forward_batch = ForwardBatch(
             forward_mode=pcg_forward_mode,
             batch_size=bs,
@@ -1708,6 +1729,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             global_num_tokens_for_logprob_cpu=forward_batch.global_num_tokens_for_logprob_cpu,
             dp_padding_mode=forward_batch.dp_padding_mode,
             global_dp_buffer_len=forward_batch.global_dp_buffer_len,
+            moe_real_num_tokens_cpu=forward_batch.moe_real_num_tokens_cpu,
+            moe_real_num_tokens_gpu=self._compact_moe_counts_gpu,
             mrope_positions=mrope_positions,
             spec_algorithm=forward_batch.spec_algorithm,
             spec_info=padded_spec_info,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1407,6 +1407,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 positions=_slot("positions"),
                 global_num_tokens_gpu=global_num_tokens_gpu,
                 global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+                global_num_tokens_for_logprob_cpu=global_num_tokens_for_logprob_cpu,
                 global_num_tokens_cpu=global_num_tokens_cpu,
                 dp_padding_mode=DpPaddingMode.get_default_mode_in_cuda_graph(),
                 global_dp_buffer_len=global_dp_buffer_len,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -413,6 +413,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self._capture_lora = False
         self.enable_cp_bcg_capture = False
         self.prefill_cp_bcg_input: Optional[PrefillCPBCGInput] = None
+        if self.prefill_backend_name == Backend.TC_PIECEWISE:
+            # Must happen before the compile pass below traces the model: the
+            # per-layer HiCache waits have to be gone from the graph, not just
+            # inert at replay time.
+            model_runner.token_to_kv_pool.hoist_layer_transfer_wait()
         # TcPiecewise does its compile pass during backend construction.
         # Wrap only that path with the prefill CUDA graph failure hint.
         try:

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -319,22 +319,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         # --- capture modes --------------------------------------------
         self.capture_forward_mode = ForwardMode.EXTEND
-        # Hidden-state capture mode cases:
-        # - Breakable EAGLE draft: LAST.
-        # - EAGLE target: FULL.
-        # - Return-hidden-states or DFLASH: FULL.
-        # - Otherwise: NULL.
+        # EAGLE prefill asks for FULL on the target (it feeds the draft) and
+        # LAST on the draft, regardless of the prefill backend: a graph captured
+        # below the requested mode is rejected on every replay.
         is_eagle = model_runner.spec_algorithm.is_eagle()
-        is_breakable_eagle_draft = (
-            self.prefill_backend_name == Backend.BREAKABLE
-            and is_eagle
-            and model_runner.is_draft_worker
-        )
-        if is_breakable_eagle_draft:
+        if is_eagle and model_runner.is_draft_worker:
             self.capture_hidden_mode = CaptureHiddenMode.LAST
-        elif (is_eagle and not model_runner.is_draft_worker) or (
-            model_runner.spec_algorithm.is_dflash_family()
-        ):
+        elif is_eagle or model_runner.spec_algorithm.is_dflash_family():
             self.capture_hidden_mode = CaptureHiddenMode.FULL
         else:
             self.capture_hidden_mode = self.return_hidden_states_mode

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -143,6 +143,7 @@ from sglang.srt.utils import (
     is_npu,
     require_attn_tp_gather,
     require_gathered_buffer,
+    require_mlp_sync,
     require_mlp_tp_gather,
 )
 from sglang.srt.utils.aiter import maybe_pre_warm_aiter_chip_info
@@ -728,7 +729,14 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             forward_batch.dp_padding_mode.is_max_len(),
             forward_batch.global_num_tokens_cpu,
         )
-        set_is_extend_in_batch(False)
+        # Prefill graphs only serve EXTEND batches, so True is the semantically
+        # correct value -- but only prepare_mlp_sync_batch actually writes this
+        # flag at serving time, and it runs only when require_mlp_sync(). Without
+        # it the global keeps the False default, so capturing under an
+        # unconditional True makes Dynamo's guard disagree with every real prefill
+        # under plain TP and invalidates all captured shapes on first replay.
+        # Mirror what serving will do instead of asserting what it ought to be.
+        set_is_extend_in_batch(require_mlp_sync())
 
         with self._prefill_forward_context(forward_batch):
             pp_proxy_tensors = self._capture_pp_proxy_tensors(num_tokens)
@@ -812,7 +820,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             fb.dp_padding_mode.is_max_len(),
             fb.global_num_tokens_cpu,
         )
-        set_is_extend_in_batch(False)
+        # See _run_forward.
+        set_is_extend_in_batch(require_mlp_sync())
 
         with (
             forward_context(
@@ -1314,20 +1323,29 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         def _slot(name):
             return registry.get_slot(name).slice_for(bs, num_tokens)
 
+        # The dummy batch never returns logprobs, so its logprob token count is
+        # one per request -- the same invariant the scheduler asserts in
+        # _dp_gather_info. Reusing num_tokens here makes the logits-side DP
+        # gather read num_tokens rows out of a pruned_states that only has bs,
+        # which walks off the end of the buffer.
         if self.require_mlp_tp_gather:
             global_num_tokens_cpu = [num_tokens] * self.dp_size
+            global_num_tokens_for_logprob_cpu = [bs] * self.dp_size
         elif self.require_attn_tp_gather:
             global_num_tokens_cpu = [num_tokens]
+            global_num_tokens_for_logprob_cpu = [bs]
         else:
             global_num_tokens_cpu = None
+            global_num_tokens_for_logprob_cpu = None
 
         if global_num_tokens_cpu is not None:
             global_dp_buffer_len = sum(global_num_tokens_cpu)
-            num_tokens_tensor = torch.tensor(
+            global_num_tokens_gpu = torch.tensor(
                 global_num_tokens_cpu, dtype=torch.int32, device=self.device
             )
-            global_num_tokens_gpu = num_tokens_tensor
-            global_num_tokens_for_logprob_gpu = num_tokens_tensor
+            global_num_tokens_for_logprob_gpu = torch.tensor(
+                global_num_tokens_for_logprob_cpu, dtype=torch.int32, device=self.device
+            )
         else:
             global_dp_buffer_len = None
             global_num_tokens_gpu = None

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -101,6 +101,9 @@ from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend impor
 from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
     FullCudaGraphBackend,
 )
+from sglang.srt.model_executor.runner_backend.tc_piecewise_cuda_graph_backend import (
+    TcPiecewiseCudaGraphBackend,
+)
 from sglang.srt.model_executor.runner_backend.utils import (
     resolve_prefill_backend,
 )
@@ -135,6 +138,7 @@ from sglang.srt.runtime_context import (
 from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.utils import (
     get_available_gpu_memory,
+    get_bool_env_var,
     is_cuda,
     is_npu,
     require_attn_tp_gather,
@@ -532,12 +536,18 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     dtype=model_runner.dtype,
                 )
 
-        # Some attention backends (e.g. DSV4) opt into a captured-metadata
-        # contract under BCG: capture-time builds a per-bucket metadata
-        # object the backend then refreshes in place at replay. We honor
-        # the contract only when the backend is Breakable; FullCG and
-        # TC_PIECEWISE use the eager init_forward_metadata path.
-        if isinstance(self.backend, BreakableCudaGraphBackend):
+        # Some attention backends (e.g. DSV4) opt into a captured-metadata contract:
+        # capture builds one metadata object per bucket, the backend refreshes it in
+        # place at replay. TC_PIECEWISE needs it too -- rebuilding metadata per batch
+        # moves the shapes Dynamo guards on, and the recompiled entry holds no CUDA
+        # graph, so prefill silently runs eager.
+        _wants_captured_metadata = isinstance(
+            self.backend, BreakableCudaGraphBackend
+        ) or (
+            isinstance(self.backend, TcPiecewiseCudaGraphBackend)
+            and not get_bool_env_var("SGLANG_PIECEWISE_NO_CAPTURED_METADATA")
+        )
+        if _wants_captured_metadata:
             self.use_captured_attn_metadata = model_runner.attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
         else:
             self.use_captured_attn_metadata = False

--- a/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
@@ -53,7 +53,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_parallel,
 )
-from sglang.srt.utils import is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -185,28 +184,22 @@ class TcPiecewiseCudaGraphBackend(BaseCudaGraphBackend):
                 )
 
                 with enable_torch_compile_warmup():
-                    if is_hip():
-                        # AMD: single Dynamo trace is sufficient; the capture
-                        # phase does per-shape JIT kernel warmup before each
-                        # CUDA graph recording.  The N-iteration loop is
-                        # redundant and extremely slow on ROCm (~30 min).
-                        cuda_graph_runner._run_dummy_forward(
-                            num_tokens=cuda_graph_runner.capture_num_tokens[-1]
-                        )
-                    else:
-                        compile_range = (
-                            tqdm.tqdm(
-                                list(reversed(cuda_graph_runner.capture_num_tokens))
+                    # Every captured shape gets its own trace, on AMD too: tracing
+                    # once at the largest shape and relying on dynamic shapes does not
+                    # hold, since the guard specializes to the traced shape and a
+                    # recompile inside the capture window leaves the captured graphs
+                    # unreplayable.
+                    compile_range = (
+                        tqdm.tqdm(list(reversed(cuda_graph_runner.capture_num_tokens)))
+                        if get_parallel().tp_rank == 0
+                        else reversed(cuda_graph_runner.capture_num_tokens)
+                    )
+                    for num_tokens in compile_range:
+                        if get_parallel().tp_rank == 0:
+                            compile_range.set_description(
+                                f"Compiling num tokens ({num_tokens=})"
                             )
-                            if get_parallel().tp_rank == 0
-                            else reversed(cuda_graph_runner.capture_num_tokens)
-                        )
-                        for num_tokens in compile_range:
-                            if get_parallel().tp_rank == 0:
-                                compile_range.set_description(
-                                    f"Compiling num tokens ({num_tokens=})"
-                                )
-                            cuda_graph_runner._run_dummy_forward(num_tokens=num_tokens)
+                        cuda_graph_runner._run_dummy_forward(num_tokens=num_tokens)
 
                 # Qwen3-VL deepstack embeddings are produced only after
                 # visual encoding. First trace the tensor branch above, then

--- a/python/sglang/srt/model_executor/runner_backend_utils/tc_piecewise_cuda_graph/context_manager.py
+++ b/python/sglang/srt/model_executor/runner_backend_utils/tc_piecewise_cuda_graph/context_manager.py
@@ -73,6 +73,7 @@ class TcPiecewiseForwardContext:
     quant_config: Any = None
     moe_layers: Optional[List[Any]] = field(default=None)
     moe_fusions: Optional[List[Any]] = field(default=None)
+    dp_moe_layers: Optional[List[Any]] = field(default=None)
     dsa_indexers: Optional[List[Any]] = field(default=None)
     num_tokens: Optional[int] = None
     raw_num_tokens: Optional[int] = None
@@ -102,6 +103,7 @@ def set_tc_piecewise_forward_context(
     num_tokens: Optional[int] = None,
     raw_num_tokens: Optional[int] = None,
     full_graph: bool = False,
+    dp_moe_layers: Optional[List[Any]] = None,
 ):
     global _tc_piecewise_forward_context
     _tc_piecewise_forward_context = TcPiecewiseForwardContext(
@@ -111,6 +113,7 @@ def set_tc_piecewise_forward_context(
         quant_config=quant_config,
         moe_layers=moe_layers,
         moe_fusions=moe_fusions,
+        dp_moe_layers=dp_moe_layers,
         dsa_indexers=dsa_indexers,
         num_tokens=num_tokens,
         raw_num_tokens=raw_num_tokens,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -891,7 +891,7 @@ class DeepseekV2MoE(nn.Module):
             )
 
         if not self._enable_a2a_moe:
-            if self._can_dual_stream_graph(hidden_states):
+            if not skip_shared_experts and self._can_dual_stream_graph(hidden_states):
                 fwd = get_forward()
                 return dsv2_flashinfer_moe_dual_stream_graph(
                     hidden_states,
@@ -900,7 +900,8 @@ class DeepseekV2MoE(nn.Module):
                     fwd.mlp_reduce_scatter,
                 )
             elif (
-                self.alt_stream is not None
+                not skip_shared_experts
+                and self.alt_stream is not None
                 and self.num_fused_shared_experts == 0
                 and hidden_states.shape[0] > 0
                 and get_is_capture_mode()

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2329,7 +2329,19 @@ class DeepseekV4DecoderLayer(nn.Module):
             else:
                 x_quant = None
 
-        with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
+        # When CP decode attention TP is off (the default) maybe_use_decode_attn_tp
+        # degrades to a bare `yield`, so skipping it is equivalent -- but it keeps
+        # self_attn out of a _GeneratorContextManager, inside which Dynamo refuses to
+        # graph break and tc_piecewise prefill fails to compile.
+        if get_cp_decode_attn_tp_ctx().is_enabled:
+            with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
+                hidden_states = self.self_attn(
+                    x=hidden_states,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    x_quant=x_quant,
+                )
+        else:
             hidden_states = self.self_attn(
                 x=hidden_states,
                 positions=positions,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -93,6 +93,10 @@ from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
+from sglang.srt.layers.moe.dsv4_tc_compact import (
+    compact_moe_enabled,
+    dsv4_tc_compact_moe_with_output,
+)
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
@@ -127,6 +131,7 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
 )
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     get_tc_piecewise_forward_context,
+    is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_load
 from sglang.srt.model_loader.weight_utils import (
@@ -2426,6 +2431,18 @@ class DeepseekV4DecoderLayer(nn.Module):
         input_ids: Optional[torch.Tensor],
         input_ids_global: Optional[torch.Tensor],
     ) -> torch.Tensor:
+        if compact_moe_enabled() and is_in_tc_piecewise_cuda_graph():
+            output_local = torch.empty_like(hidden_states)
+            assert forward_batch.moe_real_num_tokens_gpu is not None
+            dsv4_tc_compact_moe_with_output(
+                hidden_states,
+                input_ids,
+                forward_batch.moe_real_num_tokens_gpu,
+                output_local,
+                self.layer_id,
+            )
+            return output_local
+
         _use_cp = self.dsa_enable_prefill_cp and dsa_use_prefill_cp(forward_batch)
         _use_tp_moe_gather = (
             not _use_cp
@@ -3094,7 +3111,11 @@ class DeepseekV4Model(nn.Module):
                     hidden_states.shape[0], self.hc_mult, self.hidden_size
                 )
 
-        if get_parallel().attn_dp_size > 1 and get_moe_a2a_backend().is_none():
+        if compact_moe_enabled() and is_in_tc_piecewise_cuda_graph():
+            # Hash-routed layers gather the matching compact IDs in the split
+            # bridge, together with the real hidden rows.
+            input_ids_global = None
+        elif get_parallel().attn_dp_size > 1 and get_moe_a2a_backend().is_none():
             input_ids_global = torch.empty(
                 (get_global_dp_buffer_len(), 1),
                 dtype=input_ids.dtype,

--- a/test/registered/e2e/models/test_inkling_small_nvfp4.py
+++ b/test/registered/e2e/models/test_inkling_small_nvfp4.py
@@ -149,12 +149,10 @@ class TestInklingSmallNvfp4DsparkDeterministic(CustomTestCase):
     prefix restored from the radix cache that does not reproduce a fresh
     prefill -- rather than the float noise a loose threshold would hide.
 
-    DSPARK drives the decode loop because the spec-side mamba/sconv save is
-    otherwise unreachable: that gate lives in PrefillCudaGraphRunner, and EAGLE
-    targets disable the prefill graph outright (#28386), so the MTP class in
-    test_unified_radix_cache_kl_hybrid_bitexact.py never reaches it. Reverting
-    #34043 reads 1.10e-01 on prefill_cache_hit here and exactly 0 without
-    speculation.
+    DSPARK drives the decode loop because the spec-side mamba/sconv save gate
+    lives in PrefillCudaGraphRunner, and this is the configuration that
+    exercises it here. Reverting #34043 reads 1.10e-01 on prefill_cache_hit
+    here and exactly 0 without speculation.
 
     Runs its own server: the accuracy case above has to stay on the production
     numerics, so it cannot share this one.

--- a/test/registered/kernel/ops/attention/test_fp4_indexer_schedule_hip.py
+++ b/test/registered/kernel/ops/attention/test_fp4_indexer_schedule_hip.py
@@ -1,0 +1,115 @@
+"""FP4 schedule metadata and page padding must follow live replay inputs."""
+
+import itertools
+import sys
+
+import pytest
+import torch
+import triton
+
+from sglang.kernels.ops.attention.dsv4.fp4_indexer_schedule_hip import (
+    _prefill_schedule_prep_kernel,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
+pytestmark = pytest.mark.skipif(
+    torch.version.hip is None or not torch.cuda.is_available(),
+    reason="ROCm GPU required",
+)
+
+
+def _reference(ends, parallel_units, smax):
+    chunks = [(max(length, 0) + 255) // 256 for length in ends]
+    # Exhaustive ascending search is independent of the kernel's binary search.
+    safe = next(
+        (
+            s
+            for s in range(1, smax + 1)
+            if sum((c + s - 1) // s for c in chunks) <= parallel_units
+        ),
+        max(max(chunks), 1),
+    )
+    counts = [(chunk + safe - 1) // safe for chunk in chunks]
+    incl = list(itertools.accumulate(counts))
+    excl = [prefix - count for prefix, count in zip(incl, counts)]
+    return (
+        chunks
+        + incl
+        + excl
+        + list(range(len(ends)))
+        + [0] * len(ends)
+        + [safe, sum(counts)]
+    )
+
+
+@pytest.mark.parametrize(
+    "tokens,parallel_units,smax",
+    [(1, 1, 1), (17, 17, 2), (257, 512, 1024), (4096, 4096, 1024)],
+)
+def test_prefill_schedule_replay(tokens, parallel_units, smax):
+    # The 17-row case cannot fit within smax, despite P >= T as in production.
+    lengths = [
+        256 * (4 + i % 11) if smax == 2 else (i * 7919) % 262145 for i in range(tokens)
+    ]
+    lengths[0] = -17
+    updated = [
+        256 * (2 + i % 5) if value <= 0 else value // 2
+        for i, value in enumerate(lengths)
+    ]
+    ends = torch.tensor(lengths, dtype=torch.int32, device="cuda")
+    storage = torch.full((5 * tokens + 6,), -777, dtype=torch.int32, device="cuda")
+    body = storage[2:-2]
+    outputs = [body[i * tokens : (i + 1) * tokens] for i in range(5)]
+    rows, width = tokens + 2, 257 if tokens == 257 else 5
+    padded_width = (width + 3) // 4 * 4 + 4
+    source = torch.arange(rows * (width + 7), dtype=torch.int32, device="cuda").view(
+        rows, width + 7
+    )
+    destination = torch.full(
+        (rows, padded_width + 11), -777, dtype=torch.int32, device="cuda"
+    )
+    page, padded = source[:, :width], destination[:, :padded_width]
+    expected_page = torch.full(destination.shape, -777, dtype=torch.int32)
+    expected_page[:, :padded_width] = 0
+    expected_page[:, :width] = page.cpu()
+
+    def launch():
+        tiles = triton.cdiv(padded_width, 256)
+        _prefill_schedule_prep_kernel[(1 + rows * tiles,)](
+            ends,
+            *outputs,
+            body[5 * tokens :],
+            page,
+            padded,
+            page.stride(0),
+            padded.stride(0),
+            tokens,
+            parallel_units,
+            smax,
+            width,
+            padded_width,
+            tiles,
+            BLOCK_K=256,
+            BLOCK_T=max(16, triton.next_power_of_2(tokens)),
+            PT_BLOCK=256,
+        )
+
+    launch()  # Compile before capture.
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+    for values in (lengths, updated, [0] * tokens, lengths):
+        ends.copy_(torch.tensor(values, dtype=torch.int32, device="cuda"))
+        graph.replay()
+        expected = [-777] * 2 + _reference(values, parallel_units, smax) + [-777] * 2
+        torch.testing.assert_close(
+            storage.cpu(), torch.tensor(expected, dtype=torch.int32), rtol=0, atol=0
+        )
+        # Check every row, including rows beyond T and untouched stride gaps.
+        torch.testing.assert_close(destination.cpu(), expected_page, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/unit/compilation/test_cuda_piecewise_static_bucket.py
+++ b/test/registered/unit/compilation/test_cuda_piecewise_static_bucket.py
@@ -1,0 +1,124 @@
+"""Static first-bucket graphs must replay even without a SymInt argument."""
+
+import contextlib
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+@pytest.fixture
+def backend_module(monkeypatch):
+    # This GPU-only dependency rejects CPU imports. These tests never capture
+    # or create weak tensors: exercise the real backend with existing fake graphs.
+    package = importlib.import_module("sglang.srt.compilation")
+    names = ("cuda_piecewise_backend", "weak_ref_tensor")
+    missing = object()
+    saved_modules = {
+        name: sys.modules.get(f"{package.__name__}.{name}", missing) for name in names
+    }
+    saved_attrs = {name: vars(package).get(name, missing) for name in names}
+    weak_refs = ModuleType("sglang.srt.compilation.weak_ref_tensor")
+    weak_refs.weak_ref_tensors = Mock(side_effect=AssertionError("unexpected capture"))
+    try:
+        sys.modules[weak_refs.__name__] = weak_refs
+        # Import a separate backend so an already cached module is never patched.
+        sys.modules.pop(f"{package.__name__}.cuda_piecewise_backend", None)
+        module = importlib.import_module(f"{package.__name__}.cuda_piecewise_backend")
+        monkeypatch.setattr(module, "is_in_torch_compile_warmup", lambda: False)
+        monkeypatch.setattr(module, "graph_pool_replay_scope", contextlib.nullcontext)
+        yield module
+    finally:
+        # import_module also writes the child module onto its parent package.
+        # Restore both caches, including absence, to avoid leaking the GPU stub.
+        for name in names:
+            fullname = f"{package.__name__}.{name}"
+            if saved_modules[name] is missing:
+                sys.modules.pop(fullname, None)
+            else:
+                sys.modules[fullname] = saved_modules[name]
+            if saved_attrs[name] is missing:
+                vars(package).pop(name, None)
+            else:
+                setattr(package, name, saved_attrs[name])
+
+
+def _backend(module, *, sym_shape_indices=()):
+    backend = module.CUDAPiecewiseBackend.__new__(module.CUDAPiecewiseBackend)
+    backend.first_run_finished = True
+    backend.sym_shape_indices = list(sym_shape_indices)
+    backend._static_context_bucket = None
+    backend.compiled_graph_for_general_shape = Mock(return_value=object())
+    backend.compile_config = SimpleNamespace(get_enable_debug_mode=lambda: False)
+    backend.concrete_size_entries = {
+        size: module.ConcreteSizeEntry(
+            runtime_shape=size,
+            need_to_compile=False,
+            use_cudagraph=True,
+            compiled=True,
+            cudagraph=SimpleNamespace(replay=Mock()),
+            output=object(),
+        )
+        for size in (4096, 8192)
+    }
+    return backend
+
+
+def _context(size, *, explicit=True):
+    return SimpleNamespace(
+        num_tokens=size if explicit else None,
+        raw_num_tokens=17,
+        forward_batch=SimpleNamespace(
+            input_ids=torch.empty(size, dtype=torch.int64, device="cpu")
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "explicit", [True, False], ids=["serve", "capture-input-shape"]
+)
+def test_static_piece_replays_only_its_first_bucket(
+    backend_module, monkeypatch, explicit
+):
+    backend = _backend(backend_module)
+    context = _context(8192, explicit=explicit)
+    monkeypatch.setattr(
+        backend_module, "get_tc_piecewise_forward_context", lambda: context
+    )
+    entry = backend.concrete_size_entries[8192]
+
+    # An unrelated persistent dimension must not become the token-bucket key.
+    assert backend(89929) is entry.output
+    backend.compiled_graph_for_general_shape.assert_not_called()
+    context = _context(4096, explicit=explicit)
+    assert backend(89929) is backend.compiled_graph_for_general_shape.return_value
+    context = None
+    assert backend(89929) is backend.compiled_graph_for_general_shape.return_value
+    context = _context(8192, explicit=explicit)
+    assert backend(89929) is entry.output
+    assert entry.cudagraph.replay.call_count == 2
+    backend.concrete_size_entries[4096].cudagraph.replay.assert_not_called()
+    assert backend.compiled_graph_for_general_shape.call_count == 2
+
+
+def test_symbolic_piece_keeps_its_argument_key(backend_module, monkeypatch):
+    backend = _backend(backend_module, sym_shape_indices=(1,))
+    monkeypatch.setattr(
+        backend_module, "get_tc_piecewise_forward_context", lambda: _context(8192)
+    )
+    entry = backend.concrete_size_entries[4096]
+
+    assert backend(89929, 4096) is entry.output
+    entry.cudagraph.replay.assert_called_once_with()
+    backend.compiled_graph_for_general_shape.assert_not_called()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_dsv4_tc_compact.py
+++ b/test/registered/unit/layers/moe/test_dsv4_tc_compact.py
@@ -1,0 +1,315 @@
+"""DP graph padding must not become MoE work or displace hash-routing IDs.
+
+The collective fixture represents an external variable-size TP transport.
+Expected outputs come from rank-labelled token records, independently of the
+bridge's packing/scattering implementation. No server or GPU is used.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers import dp_attention as dp_module  # noqa: E402
+from sglang.srt.layers.dp_attention import DpPaddingMode  # noqa: E402
+from sglang.srt.layers.moe import dsv4_tc_compact as compact  # noqa: E402
+from sglang.srt.model_executor import forward_batch_info as batch_module  # noqa: E402
+from sglang.srt.model_executor.forward_batch_info import (  # noqa: E402
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.runtime_context import get_flags, get_forward  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _rank_records(counts, hidden_size=4):
+    ids = [1000 * rank + torch.arange(count) for rank, count in enumerate(counts)]
+    hidden = [
+        torch.stack([tokens.float() + col / 4 for col in range(hidden_size)], dim=1)
+        for tokens in ids
+    ]
+    return hidden, ids
+
+
+class _ReferenceTransport:
+    """CPU transport oracle; checks that callers send only their live prefix."""
+
+    def __init__(self, case, rank, counts, hidden, ids):
+        self.case = case
+        self.rank_in_group = rank
+        self.world_size = len(counts)
+        self.counts = list(counts)
+        self.hidden = hidden
+        self.ids = ids
+
+    def all_gatherv(self, input_, *, sizes, output):
+        self.case.assertEqual(list(sizes), self.counts)
+        source = self.hidden if input_.is_floating_point() else self.ids
+        expected_local = source[self.rank_in_group].reshape_as(input_)
+        torch.testing.assert_close(input_, expected_local, rtol=0, atol=0)
+        output.copy_(torch.cat(source).reshape_as(output))
+        return output
+
+    def reduce_scatterv(self, input_, *, output, sizes):
+        if sizes is None:
+            self.case.assertEqual(len(set(self.counts)), 1)
+        else:
+            self.case.assertEqual(list(sizes), self.counts)
+        self.case.assertEqual(input_.shape[0], sum(self.counts))
+        self.case.assertEqual(output.shape[0], self.counts[self.rank_in_group])
+        # Every rank's fake expert contributes (rank+1) times the same token
+        # function. This emulates SUM reduction and makes a missing/duplicate
+        # reduction observable instead of accidentally accepting a local copy.
+        reduced = input_ / (self.rank_in_group + 1) * sum(range(1, self.world_size + 1))
+        first = sum(self.counts[: self.rank_in_group])
+        output.copy_(reduced[first : first + output.shape[0]])
+        return output
+
+
+class _TokenExpert:
+    def __init__(
+        self,
+        case,
+        rank,
+        counts,
+        ids,
+        *,
+        has_ids=True,
+        separate_shared=False,
+    ):
+        self.case, self.rank, self.counts = case, rank, counts
+        self.ids = ids
+        self.is_hash = has_ids
+        self._shared_expert_tp1 = separate_shared
+        self.shared_experts = object() if separate_shared else None
+
+    def _forward_shared_experts(self, hidden):
+        return hidden * 3 + 7
+
+    def __call__(
+        self, hidden, batch, *, input_ids, input_ids_global, skip_shared_experts
+    ):
+        self.case.assertEqual(hidden.shape[0], sum(self.counts))
+        self.case.assertEqual(batch.global_num_tokens_cpu, list(self.counts))
+        self.case.assertEqual(batch.global_num_tokens_gpu.tolist(), list(self.counts))
+        self.case.assertEqual(batch.global_dp_buffer_len, sum(self.counts))
+        self.case.assertTrue(batch.dp_padding_mode.is_sum_len())
+        self.case.assertIsNone(batch.dp_local_start_pos)
+        self.case.assertIsNone(batch.dp_local_num_tokens)
+        self.case.assertTrue(get_forward().mlp_reduce_scatter)
+        self.case.assertFalse(get_forward().fuse_mlp_allreduce)
+        self.case.assertEqual(skip_shared_experts, self._shared_expert_tp1)
+        if self.is_hash:
+            expected_ids = torch.cat(self.ids)
+            torch.testing.assert_close(input_ids, expected_ids, rtol=0, atol=0)
+            torch.testing.assert_close(input_ids_global, expected_ids, rtol=0, atol=0)
+            token_term = input_ids.to(hidden.dtype).reshape(-1, 1)
+        else:
+            self.case.assertIsNone(input_ids)
+            self.case.assertIsNone(input_ids_global)
+            token_term = 0
+        return (hidden * 2 + token_term) * (self.rank + 1)
+
+
+class TestDsv4TcCompactMoe(CustomTestCase):
+    def _case(self, counts, rank, *, has_ids=True, separate_shared=False):
+        bucket, width = max(max(counts), 4), 4
+        hidden, ids = _rank_records(counts, width)
+        local = torch.full((bucket, width), -9876.0)
+        local[: counts[rank]].copy_(hidden[rank])
+        local_ids = torch.full((bucket,), -9876, dtype=torch.int64)
+        local_ids[: counts[rank]].copy_(ids[rank])
+        output = torch.full_like(local, float("nan"))
+        metadata = SimpleNamespace(
+            global_num_tokens_cpu=[bucket] * len(counts),
+            global_num_tokens_gpu=torch.full((len(counts),), bucket),
+            global_dp_buffer_len=bucket * len(counts),
+            dp_padding_mode=DpPaddingMode.MAX_LEN,
+            dp_local_start_pos=torch.tensor(999),
+            dp_local_num_tokens=torch.tensor(bucket),
+        )
+        expert = _TokenExpert(
+            self,
+            rank,
+            counts,
+            ids,
+            has_ids=has_ids,
+            separate_shared=separate_shared,
+        )
+        group = _ReferenceTransport(self, rank, counts, hidden, ids)
+        with get_forward().scoped(mlp_reduce_scatter=False, fuse_mlp_allreduce=True):
+            compact.run_compact_dp_moe(
+                local,
+                local_ids if has_ids else None,
+                output,
+                counts=counts,
+                local_rank=rank,
+                tp_group=group,
+                moe_layer=expert,
+                forward_batch=metadata,
+                counts_gpu=torch.tensor(counts),
+            )
+            self.assertFalse(get_forward().mlp_reduce_scatter)
+            self.assertTrue(get_forward().fuse_mlp_allreduce)
+        self.assertEqual(metadata.global_num_tokens_cpu, [bucket] * len(counts))
+        torch.testing.assert_close(
+            metadata.global_num_tokens_gpu, torch.full((len(counts),), bucket)
+        )
+        self.assertTrue(metadata.dp_padding_mode.is_max_len())
+        token_term = ids[rank].reshape(-1, 1) if has_ids else 0
+        expected = (hidden[rank] * 2 + token_term) * sum(range(1, len(counts) + 1))
+        if separate_shared:
+            expected = expected + hidden[rank] * 3 + 7
+        torch.testing.assert_close(output[: counts[rank]], expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            output[counts[rank] :],
+            torch.zeros_like(output[counts[rank] :]),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_ragged_hash_routing_keeps_rank_order_and_clears_idle_tails(self):
+        for counts, ranks in (
+            ([3, 0, 1, 4, 0, 2, 0, 1], (0, 1, 3, 7)),
+            ([2] * 8, (3,)),
+            ([0] * 8, (0,)),
+        ):
+            for rank in ranks:
+                with self.subTest(counts=counts, rank=rank):
+                    self._case(counts, rank)
+
+    def test_non_hash_experts_do_not_fabricate_ids(self):
+        self._case([1, 0, 2, 0, 0, 1, 0, 3], 2, has_ids=False)
+
+    def test_replicated_shared_expert_is_added_once_after_tp_reduction(self):
+        self._case([3, 0, 1, 4, 0, 2, 0, 1], 7, separate_shared=True)
+
+    def test_dp_gather_tracking_keeps_one_graph_across_tc_capture_phases(self):
+        from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+            enable_tc_piecewise_cuda_graph,
+        )
+
+        graphs = []
+
+        def backend(graph, _inputs):
+            graphs.append(graph)
+            return graph.forward
+
+        def body(hidden):
+            dp_module._note_dp_gather_in_prefill_graph()
+            return hidden + 1
+
+        torch._dynamo.reset()
+        self.addCleanup(torch._dynamo.reset)
+        hidden = torch.zeros(4)
+        dp = get_flags().dp
+        with dp.override(
+            capturing_prefill_graph=False, prefill_graph_has_dp_gather=False
+        ):
+            compiled = torch.compile(body, backend=backend, fullgraph=True)
+            with enable_tc_piecewise_cuda_graph():
+                for capturing in (False, True, True, False):
+                    dp.capturing_prefill_graph = capturing
+                    torch.testing.assert_close(compiled(hidden), hidden + 1)
+            self.assertEqual(len(graphs), 1)
+            self.assertTrue(dp.prefill_graph_has_dp_gather)
+
+        # The same capture flag must stay inert in ordinary torch.compile,
+        # while an eager CUDA-graph capture still records the gather.
+        torch._dynamo.reset()
+        with dp.override(
+            capturing_prefill_graph=True, prefill_graph_has_dp_gather=False
+        ):
+            compiled = torch.compile(body, backend=backend, fullgraph=True)
+            torch.testing.assert_close(compiled(hidden), hidden + 1)
+            self.assertFalse(dp.prefill_graph_has_dp_gather)
+            dp_module._note_dp_gather_in_prefill_graph()
+            self.assertTrue(dp.prefill_graph_has_dp_gather)
+
+    def test_true_counts_survive_graph_padding_and_idle_conversion(self):
+        counts = [0, 3, 1, 0, 0, 2, 0, 0]
+        for rank, mode in [(0, ForwardMode.IDLE), (1, ForwardMode.MIXED)]:
+            with self.subTest(rank=rank, mode=mode):
+                n = counts[rank]
+                bs = int(n > 0)
+                lengths = torch.tensor([n] if n else [], dtype=torch.int32)
+                batch = ForwardBatch(
+                    forward_mode=mode,
+                    batch_size=bs,
+                    input_ids=torch.arange(n, dtype=torch.int64),
+                    req_pool_indices=torch.zeros(bs, dtype=torch.int64),
+                    seq_lens=lengths.clone(),
+                    orig_seq_lens=lengths.clone(),
+                    seq_lens_cpu=lengths.clone(),
+                    out_cache_loc=torch.arange(n),
+                    seq_lens_sum=n,
+                    positions=torch.arange(n),
+                    is_extend_in_batch=True,
+                    can_run_dp_prefill_cuda_graph=True,
+                    global_num_tokens_cpu=list(counts),
+                    global_num_tokens_gpu=torch.tensor(counts),
+                    global_num_tokens_for_logprob_cpu=list(counts),
+                    global_num_token_non_padded_cpu=n,
+                )
+                runner = SimpleNamespace(
+                    model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+                    is_draft_worker=False,
+                    attn_tp_sequence_sharded=lambda _: False,
+                    attn_backend=SimpleNamespace(
+                        get_cpu_graph_seq_len_fill_value=lambda: 1
+                    ),
+                )
+                execution = SimpleNamespace(
+                    graph=SimpleNamespace(
+                        cuda_graph_config=SimpleNamespace(
+                            prefill=SimpleNamespace(
+                                bs=[4, 8], backend=compact.Backend.TC_PIECEWISE
+                            )
+                        )
+                    )
+                )
+                with (
+                    patch.object(compact, "compact_moe_enabled", return_value=True),
+                    patch.object(batch_module, "_is_cpu", True),
+                    patch.object(
+                        batch_module,
+                        "get_parallel",
+                        return_value=SimpleNamespace(attn_tp_size=1, attn_dp_rank=rank),
+                    ),
+                    patch.object(batch_module, "get_exec", return_value=execution),
+                    patch.object(batch_module, "mambaish_config", return_value=None),
+                    patch.object(batch_module, "set_dp_buffer_len"),
+                    patch.object(batch_module, "set_is_extend_in_batch"),
+                    patch.object(dp_module, "get_attention_dp_size", return_value=8),
+                    patch.object(
+                        batch_module,
+                        "prefill_graph_tolerates_sum_len",
+                        return_value=False,
+                    ),
+                ):
+                    # The actual preparation method pads buffers and fabricates
+                    # idle EXTEND rows. Only topology/external allocation hooks
+                    # are replaced; no preparation behavior is mocked.
+                    batch.prepare_mlp_sync_batch(runner)
+                self.assertEqual(batch.global_num_tokens_cpu, [4] * 8)
+                batch.global_num_tokens_gpu.fill_(99)
+                batch.global_num_tokens_cpu[0] = 99
+                self.assertEqual(batch.moe_real_num_tokens_cpu, counts)
+                torch.testing.assert_close(
+                    batch.moe_real_num_tokens_gpu, torch.tensor(counts)
+                )
+                self.assertEqual(batch.input_ids.shape[0], 4)
+                if mode.is_idle():
+                    self.assertEqual(batch.forward_mode, ForwardMode.EXTEND)
+                    self.assertEqual(batch.global_num_token_non_padded_cpu, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -27,6 +27,44 @@ _INDEXER = "sglang.srt.layers.attention.dsv4.indexer"
 
 
 class TestDSV4PagedIndexerMetadata(CustomTestCase):
+    def test_hip_prefill_padding_uses_inert_request_slot(self):
+        from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
+            DeepseekV4HipRadixBackend,
+        )
+
+        # Exercise the shared expansion and HIP adapter, stopping before the
+        # downstream GPU attention/compressor work.
+        backend = SimpleNamespace(
+            req_to_token=torch.empty(0),
+            make_core_attn_metadata=lambda **metadata: SimpleNamespace(**metadata),
+            _attach_unified_kv_prefill_meta=lambda *args, **kwargs: None,
+        )
+        for capacity in (3, 6):
+            with self.subTest(capacity=capacity):
+                req_ids = torch.tensor([7, 11], dtype=torch.int32)
+                metadata = DeepseekV4HipRadixBackend.init_forward_metadata_prefill(
+                    backend,
+                    max_seq_len=16,
+                    req_pool_indices=req_ids,
+                    seq_lens=torch.tensor([9, 12], dtype=torch.int32),
+                    seq_lens_cpu=[9, 12],
+                    out_cache_loc=torch.zeros(capacity, dtype=torch.int64),
+                    num_tokens=3,
+                    extend_seq_lens=torch.tensor([2, 1], dtype=torch.int32),
+                    extend_seq_lens_cpu=[2, 1],
+                    need_compress=False,
+                    use_prefill_cuda_graph=True,
+                ).core_attn_metadata
+                self.assertEqual(
+                    metadata.req_pool_indices_repeated.tolist(),
+                    [7, 7, 11] + [0] * (capacity - 3),
+                )
+                self.assertEqual(
+                    metadata.seq_lens_casual.tolist(),
+                    [8, 9, 12] + [1] * (capacity - 3),
+                )
+                self.assertEqual(req_ids.tolist(), [7, 11])
+
     def test_sm120_fp4_forces_deep_gemm_metadata(self):
         expected = torch.tensor([[0, 0], [1, 0]], dtype=torch.int32)
         deep_gemm = SimpleNamespace(

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -227,7 +227,9 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
             server_args=SimpleNamespace(),
             model=SimpleNamespace(),
             model_config=SimpleNamespace(context_len=8192, num_hidden_layers=1),
+            layer_info=SimpleNamespace(start_layer=0, end_layer=1),
             req_to_token_pool=SimpleNamespace(size=1),
+            get_cuda_graph_layers=lambda _layer_model: ([object()], [], [], [], [None]),
         )
         language_model = SimpleNamespace(layers=[object()])
 
@@ -235,11 +237,6 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
             patch.object(graph_setup, "check_cuda_graph_backend", return_value=False),
             patch.object(
                 graph_setup, "resolve_language_model", return_value=language_model
-            ),
-            patch.object(
-                graph_setup,
-                "compute_attention_and_moe_layers",
-                return_value=([object()], [], [], [], []),
             ),
             patch.object(
                 graph_setup,
@@ -275,7 +272,7 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         self.assertEqual(tuple(trimmed["hidden_states"].shape), (3, 4))
         self.assertEqual(tuple(trimmed["residual"].shape), (3, 4))
 
-    def test_static_batch_preserves_consumed_multimodal_embeddings(self):
+    def _make_load_runner(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner.capture_num_tokens = [4]
         runner.buffer_registry = _FakeBatchRegistry()
@@ -290,6 +287,11 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         runner._next_token_logits_buffer = lambda _rows: None
         runner._prefill_logits_buffer_rows = lambda _batch: 1
         runner._prepare_forward_metadata_for_replay = lambda *_args: None
+        runner._compact_moe_counts_gpu = None
+        return runner
+
+    def test_static_batch_preserves_consumed_multimodal_embeddings(self):
+        runner = self._make_load_runner()
 
         mm_input_embeds = torch.randn(3, 8)
         forward_batch = ForwardBatch(
@@ -316,6 +318,41 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         static_batch = runner.load_batch(forward_batch)
 
         self.assertIs(static_batch.mm_input_embeds, mm_input_embeds)
+
+    def test_compact_dp_replay_refreshes_fixed_count_buffer(self):
+        """Changing real DP lengths must update, not replace, captured storage."""
+        runner = self._make_load_runner()
+        runner._compact_moe_counts_gpu = torch.zeros(8, dtype=torch.int64)
+        address = runner._compact_moe_counts_gpu.data_ptr()
+        for counts in ([3, 0, 1, 0, 2, 0, 0, 0], [0, 2, 0, 1, 0, 0, 0, 3]):
+            with self.subTest(counts=counts):
+                batch = ForwardBatch(
+                    forward_mode=ForwardMode.MIXED,
+                    batch_size=1,
+                    input_ids=torch.arange(3, dtype=torch.int64),
+                    req_pool_indices=torch.zeros(1, dtype=torch.int64),
+                    seq_lens=torch.tensor([3], dtype=torch.int32),
+                    out_cache_loc=torch.arange(3, dtype=torch.int64),
+                    seq_lens_sum=3,
+                    positions=torch.arange(3, dtype=torch.int64),
+                    extend_seq_lens_cpu=[3],
+                    extend_prefix_lens_cpu=[0],
+                    global_num_tokens_cpu=[4] * 8,
+                    global_num_tokens_gpu=torch.full((8,), 4),
+                    global_forward_mode=ForwardMode.MIXED,
+                    moe_real_num_tokens_cpu=list(counts),
+                    moe_real_num_tokens_gpu=torch.tensor(counts),
+                )
+                static = runner.load_batch(batch)
+                self.assertEqual(static.moe_real_num_tokens_gpu.data_ptr(), address)
+                self.assertEqual(static.moe_real_num_tokens_cpu, counts)
+                torch.testing.assert_close(
+                    static.moe_real_num_tokens_gpu, torch.tensor(counts)
+                )
+                self.assertEqual(batch.global_num_tokens_cpu, [4] * 8)
+                torch.testing.assert_close(
+                    static.global_num_tokens_gpu, torch.full((8,), 4)
+                )
 
     def test_eagle_target_full_reaches_graph_construction(self):
         override = get_context().override_server_args(
@@ -564,19 +601,20 @@ class _StopInit(Exception):
 
 
 class TestPrefillCudaGraphRunnerCaptureHiddenMode(CustomTestCase):
-    """The hidden-state capture mode PrefillCudaGraphRunner.__init__ pins.
+    """An EAGLE draft must capture LAST for tc_piecewise replay."""
 
-    EAGLE prefill requests FULL on the target and LAST on the draft; a graph
-    captured below the requested mode is rejected by can_run_graph on every
-    replay, so the mode must not depend on the prefill backend.
-    """
-
-    @staticmethod
-    def _eagle_capture_hidden_mode(*, is_draft_worker):
+    def test_eagle_draft_tc_piecewise_captures_last(self):
+        override = get_context().override_server_args(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(bs=[4], backend=Backend.TC_PIECEWISE)
+            ),
+        )
+        override.install()
+        self.addCleanup(override.restore)
         model_runner = SimpleNamespace(
             device="cpu",
             gpu_id=0,
-            is_draft_worker=is_draft_worker,
+            is_draft_worker=True,
             is_generation=True,
             lora_manager=None,
             spec_algorithm=SimpleNamespace(
@@ -589,49 +627,16 @@ class TestPrefillCudaGraphRunnerCaptureHiddenMode(CustomTestCase):
             req_to_token_pool=SimpleNamespace(size=8),
         )
 
-        captured = {}
-
-        def stop(self):
-            captured["runner"] = self
-            raise _StopInit
-
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         with (
             get_parallel().override(attn_tp_size=1, attn_tp_rank=0),
-            patch.object(PrefillCudaGraphRunner, "_is_mamba_track_enabled", stop),
-        ):
-            try:
-                PrefillCudaGraphRunner(model_runner)
-            except _StopInit:
-                pass
-
-        return captured["runner"].capture_hidden_mode
-
-    def _install_config(self, backend):
-        override = get_context().override_server_args(
-            cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(bs=[4], backend=backend)
+            patch.object(
+                PrefillCudaGraphRunner, "_is_mamba_track_enabled", side_effect=_StopInit
             ),
-        )
-        override.install()
-        self.addCleanup(override.restore)
-
-    def test_eagle_target_captures_full_on_every_backend(self):
-        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE, Backend.FULL):
-            with self.subTest(backend=backend):
-                self._install_config(backend)
-                self.assertEqual(
-                    self._eagle_capture_hidden_mode(is_draft_worker=False),
-                    CaptureHiddenMode.FULL,
-                )
-
-    def test_eagle_draft_worker_captures_last_on_every_backend(self):
-        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE):
-            with self.subTest(backend=backend):
-                self._install_config(backend)
-                self.assertEqual(
-                    self._eagle_capture_hidden_mode(is_draft_worker=True),
-                    CaptureHiddenMode.LAST,
-                )
+            self.assertRaises(_StopInit),
+        ):
+            PrefillCudaGraphRunner.__init__(runner, model_runner)
+        self.assertEqual(runner.capture_hidden_mode, CaptureHiddenMode.LAST)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -23,7 +23,7 @@ from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
-from sglang.srt.runtime_context import get_context
+from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -201,29 +201,63 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
 
         self.assertIs(capture.runner, prefill_runner)
 
-    def test_eagle_target_tc_piecewise_skips_last_mode_capture(self):
+    def test_eagle_target_tc_piecewise_still_captures_prefill_graph(self):
+        """The EAGLE target now captures FULL on tc_piecewise too, so a
+        sub-FULL server ceiling leaves no dead graph behind and the capture must
+        not fall back to eager."""
         eager_runner = object()
-        # The server-side hidden-state ceiling and graph config are bag leaves.
+        prefill_runner = object()
+        # Bag leaves; the hidden-state ceiling is held below FULL on purpose.
         override = get_context().override_server_args(
+            enable_lora=False,
             enable_return_hidden_states=True,
             return_hidden_states_mode="last",
             cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(backend=Backend.TC_PIECEWISE)
+                prefill=SimpleNamespace(bs=[1], backend=Backend.TC_PIECEWISE)
             ),
         )
         override.install()
         self.addCleanup(override.restore)
         model_runner = SimpleNamespace(
+            device="cuda",
+            gpu_id=0,
             is_draft_worker=False,
+            lora_manager=None,
             spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
+            server_args=SimpleNamespace(),
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(context_len=8192, num_hidden_layers=1),
+            req_to_token_pool=SimpleNamespace(size=1),
         )
+        language_model = SimpleNamespace(layers=[object()])
 
-        capture = capture_prefill_graph(
-            model_runner=model_runner,
-            eager_runner=eager_runner,
-        )
+        with (
+            patch.object(graph_setup, "check_cuda_graph_backend", return_value=False),
+            patch.object(
+                graph_setup, "resolve_language_model", return_value=language_model
+            ),
+            patch.object(
+                graph_setup,
+                "compute_attention_and_moe_layers",
+                return_value=([object()], [], [], [], []),
+            ),
+            patch.object(
+                graph_setup,
+                "get_available_gpu_memory",
+                side_effect=[10.0, 9.5],
+            ),
+            patch.object(
+                graph_setup,
+                "PrefillCudaGraphRunner",
+                return_value=prefill_runner,
+            ),
+        ):
+            capture = capture_prefill_graph(
+                model_runner=model_runner,
+                eager_runner=eager_runner,
+            )
 
-        self.assertIs(capture.runner, eager_runner)
+        self.assertIs(capture.runner, prefill_runner)
 
     def test_pp_proxy_output_is_trimmed_to_raw_prefill_tokens(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
@@ -523,6 +557,81 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         )
         forward_batch.extend_prefix_lens_cpu = [9, 1]
         self.assertFalse(runner.can_run_graph(forward_batch))
+
+
+class _StopInit(Exception):
+    """Ends __init__ right after the capture-mode block, before buffers."""
+
+
+class TestPrefillCudaGraphRunnerCaptureHiddenMode(CustomTestCase):
+    """The hidden-state capture mode PrefillCudaGraphRunner.__init__ pins.
+
+    EAGLE prefill requests FULL on the target and LAST on the draft; a graph
+    captured below the requested mode is rejected by can_run_graph on every
+    replay, so the mode must not depend on the prefill backend.
+    """
+
+    @staticmethod
+    def _eagle_capture_hidden_mode(*, is_draft_worker):
+        model_runner = SimpleNamespace(
+            device="cpu",
+            gpu_id=0,
+            is_draft_worker=is_draft_worker,
+            is_generation=True,
+            lora_manager=None,
+            spec_algorithm=SimpleNamespace(
+                is_eagle=lambda: True,
+                is_dflash_family=lambda: False,
+            ),
+            server_args=SimpleNamespace(tp_size=1, enable_pdmux=False),
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(is_multimodal=False),
+            req_to_token_pool=SimpleNamespace(size=8),
+        )
+
+        captured = {}
+
+        def stop(self):
+            captured["runner"] = self
+            raise _StopInit
+
+        with (
+            get_parallel().override(attn_tp_size=1, attn_tp_rank=0),
+            patch.object(PrefillCudaGraphRunner, "_is_mamba_track_enabled", stop),
+        ):
+            try:
+                PrefillCudaGraphRunner(model_runner)
+            except _StopInit:
+                pass
+
+        return captured["runner"].capture_hidden_mode
+
+    def _install_config(self, backend):
+        override = get_context().override_server_args(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(bs=[4], backend=backend)
+            ),
+        )
+        override.install()
+        self.addCleanup(override.restore)
+
+    def test_eagle_target_captures_full_on_every_backend(self):
+        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE, Backend.FULL):
+            with self.subTest(backend=backend):
+                self._install_config(backend)
+                self.assertEqual(
+                    self._eagle_capture_hidden_mode(is_draft_worker=False),
+                    CaptureHiddenMode.FULL,
+                )
+
+    def test_eagle_draft_worker_captures_last_on_every_backend(self):
+        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE):
+            with self.subTest(backend=backend):
+                self._install_config(backend)
+                self.assertEqual(
+                    self._eagle_capture_hidden_mode(is_draft_worker=True),
+                    CaptureHiddenMode.LAST,
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -8,6 +8,7 @@ import torch
 
 import sglang.srt.model_executor.model_runner_components.cuda_graph_setup as graph_setup
 import sglang.srt.model_executor.runner.prefill_cuda_graph_runner as runner_module
+from sglang.srt.layers.logits_processor import LogitsMetadata
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
@@ -23,7 +24,7 @@ from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
-from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.srt.runtime_context import get_context, get_flags, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -289,6 +290,51 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         runner._prepare_forward_metadata_for_replay = lambda *_args: None
         runner._compact_moe_counts_gpu = None
         return runner
+
+    def test_capture_logits_gather_uses_request_rows_not_token_bucket(self):
+        # No-logprob capture needs one LM-head row per request. Losing the CPU
+        # counts instead allocates [token_bucket * dp_size, vocab_size] logits.
+        runner = self._make_load_runner()
+        runner.device = torch.device("cpu")
+        runner.max_bs = runner._capture_req_slots = 3
+        runner.dp_size = 8
+        runner.require_mlp_tp_gather = True
+        runner.require_attn_tp_gather = False
+        runner.capture_hidden_mode = CaptureHiddenMode.FULL
+        runner._capture_lora = False
+        runner.tbo_plugin = SimpleNamespace(capture_one_batch_size=lambda *a, **k: None)
+        runner.model_runner.model_config = SimpleNamespace(context_len=16)
+        runner.model_runner.attn_backend = object()
+
+        for backend, context_len, expected_requests in (
+            (Backend.TC_PIECEWISE, 16, 1),
+            (Backend.TC_PIECEWISE, 2, 2),
+            (Backend.FULL, 16, 3),
+        ):
+            with (
+                self.subTest(backend=backend, context_len=context_len),
+                get_parallel().override(attn_dp_rank=0),
+                get_flags().dp.override(
+                    buffer_hidden_size=4,
+                    buffer_dtype=torch.bfloat16,
+                    buffer_device=torch.device("cpu"),
+                ),
+            ):
+                runner.prefill_backend_name = backend
+                runner.model_runner.model_config.context_len = context_len
+                batch, _ = runner.capture_prepare(num_tokens=4)
+                metadata = LogitsMetadata.from_forward_batch(batch)
+                metadata.compute_dp_attention_metadata()
+
+                self.assertEqual(batch.batch_size, expected_requests)
+                self.assertEqual(
+                    metadata.gathered_buffer.shape, (8 * expected_requests, 4)
+                )
+                self.assertEqual(metadata.dp_local_num_tokens.item(), expected_requests)
+                # The logits allocation must not change the transformer's DP
+                # padding or its counts, including FULL's sentinel request slots.
+                self.assertEqual(batch.global_dp_buffer_len, 32)
+                self.assertEqual(batch.global_num_tokens_cpu, [4] * 8)
 
     def test_static_batch_preserves_consumed_multimodal_embeddings(self):
         runner = self._make_load_runner()

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -202,61 +202,6 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
 
         self.assertIs(capture.runner, prefill_runner)
 
-    def test_eagle_target_tc_piecewise_still_captures_prefill_graph(self):
-        """The EAGLE target now captures FULL on tc_piecewise too, so a
-        sub-FULL server ceiling leaves no dead graph behind and the capture must
-        not fall back to eager."""
-        eager_runner = object()
-        prefill_runner = object()
-        # Bag leaves; the hidden-state ceiling is held below FULL on purpose.
-        override = get_context().override_server_args(
-            enable_lora=False,
-            enable_return_hidden_states=True,
-            return_hidden_states_mode="last",
-            cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(bs=[1], backend=Backend.TC_PIECEWISE)
-            ),
-        )
-        override.install()
-        self.addCleanup(override.restore)
-        model_runner = SimpleNamespace(
-            device="cuda",
-            gpu_id=0,
-            is_draft_worker=False,
-            lora_manager=None,
-            spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
-            server_args=SimpleNamespace(),
-            model=SimpleNamespace(),
-            model_config=SimpleNamespace(context_len=8192, num_hidden_layers=1),
-            layer_info=SimpleNamespace(start_layer=0, end_layer=1),
-            req_to_token_pool=SimpleNamespace(size=1),
-            get_cuda_graph_layers=lambda _layer_model: ([object()], [], [], [], [None]),
-        )
-        language_model = SimpleNamespace(layers=[object()])
-
-        with (
-            patch.object(graph_setup, "check_cuda_graph_backend", return_value=False),
-            patch.object(
-                graph_setup, "resolve_language_model", return_value=language_model
-            ),
-            patch.object(
-                graph_setup,
-                "get_available_gpu_memory",
-                side_effect=[10.0, 9.5],
-            ),
-            patch.object(
-                graph_setup,
-                "PrefillCudaGraphRunner",
-                return_value=prefill_runner,
-            ),
-        ):
-            capture = capture_prefill_graph(
-                model_runner=model_runner,
-                eager_runner=eager_runner,
-            )
-
-        self.assertIs(capture.runner, prefill_runner)
-
     def test_pp_proxy_output_is_trimmed_to_raw_prefill_tokens(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner.raw_num_tokens = 3
@@ -400,16 +345,7 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
                     static.global_num_tokens_gpu, torch.full((8,), 4)
                 )
 
-    def test_eagle_target_full_reaches_graph_construction(self):
-        override = get_context().override_server_args(
-            enable_return_hidden_states=True,
-            return_hidden_states_mode="last",
-            cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(backend=Backend.FULL)
-            ),
-        )
-        override.install()
-        self.addCleanup(override.restore)
+    def test_eagle_target_reaches_graph_construction(self):
         model_runner = SimpleNamespace(
             is_draft_worker=False,
             lora_manager=None,
@@ -417,18 +353,29 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
             spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
         )
 
-        with (
-            patch.object(
-                graph_setup,
-                "resolve_language_model",
-                side_effect=RuntimeError("reached graph construction"),
-            ),
-            self.assertRaisesRegex(RuntimeError, "reached graph construction"),
-        ):
-            capture_prefill_graph(
-                model_runner=model_runner,
-                eager_runner=object(),
-            )
+        for backend in (Backend.FULL, Backend.TC_PIECEWISE):
+            # Both backends must pass the EAGLE setup gate despite a server
+            # ceiling of LAST. Stop at model resolution before allocating GPUs.
+            with (
+                self.subTest(backend=backend),
+                get_context().override_server_args(
+                    enable_return_hidden_states=True,
+                    return_hidden_states_mode="last",
+                    cuda_graph_config=SimpleNamespace(
+                        prefill=SimpleNamespace(backend=backend)
+                    ),
+                ),
+                patch.object(
+                    graph_setup,
+                    "resolve_language_model",
+                    side_effect=RuntimeError("reached graph construction"),
+                ),
+                self.assertRaisesRegex(RuntimeError, "reached graph construction"),
+            ):
+                capture_prefill_graph(
+                    model_runner=model_runner,
+                    eager_runner=object(),
+                )
 
     def test_prefix_chunk_capacity_is_aggregate_and_can_be_overridden(self):
         graph_config = SimpleNamespace(
@@ -640,49 +587,6 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         )
         forward_batch.extend_prefix_lens_cpu = [9, 1]
         self.assertFalse(runner.can_run_graph(forward_batch))
-
-
-class _StopInit(Exception):
-    """Ends __init__ right after the capture-mode block, before buffers."""
-
-
-class TestPrefillCudaGraphRunnerCaptureHiddenMode(CustomTestCase):
-    """An EAGLE draft must capture LAST for tc_piecewise replay."""
-
-    def test_eagle_draft_tc_piecewise_captures_last(self):
-        override = get_context().override_server_args(
-            cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(bs=[4], backend=Backend.TC_PIECEWISE)
-            ),
-        )
-        override.install()
-        self.addCleanup(override.restore)
-        model_runner = SimpleNamespace(
-            device="cpu",
-            gpu_id=0,
-            is_draft_worker=True,
-            is_generation=True,
-            lora_manager=None,
-            spec_algorithm=SimpleNamespace(
-                is_eagle=lambda: True,
-                is_dflash_family=lambda: False,
-            ),
-            server_args=SimpleNamespace(tp_size=1, enable_pdmux=False),
-            model=SimpleNamespace(),
-            model_config=SimpleNamespace(is_multimodal=False),
-            req_to_token_pool=SimpleNamespace(size=8),
-        )
-
-        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
-        with (
-            get_parallel().override(attn_tp_size=1, attn_tp_rank=0),
-            patch.object(
-                PrefillCudaGraphRunner, "_is_mamba_track_enabled", side_effect=_StopInit
-            ),
-            self.assertRaises(_StopInit),
-        ):
-            PrefillCudaGraphRunner.__init__(runner, model_runner)
-        self.assertEqual(runner.capture_hidden_mode, CaptureHiddenMode.LAST)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -209,6 +209,58 @@ class TestDeepseekV2Gate(_FusionGateCase):
             )
 
 
+class TestDeepseekSharedExpertExecution(CustomTestCase):
+    """A caller adding replicated shared output must get routed output only."""
+
+    def test_skip_shared_excludes_both_dual_stream_routes(self):
+        import torch
+
+        from sglang.srt.layers.moe import mega_moe
+        from sglang.srt.models import deepseek_v2
+
+        hidden = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        for graph_eligible, capture_mode, ordinary_addend in (
+            (True, False, 1000),
+            (False, True, 100),
+        ):
+            model = SimpleNamespace(
+                _enable_a2a_moe=False,
+                _can_dual_stream_graph=lambda _: graph_eligible,
+                alt_stream=object(),
+                num_fused_shared_experts=0,
+                layer_id=0,
+                # These callbacks stand in for GPU execution branches. Their
+                # different outputs make an incorrect branch visible, rather
+                # than asserting only that a mock happened to be called.
+                forward_normal=lambda x, *_args, **kw: (
+                    x + (10 if kw["skip_shared_experts"] else 1)
+                ),
+                forward_normal_dual_stream=lambda x, *_args, **_kw: x + 100,
+            )
+            with (
+                self.subTest(graph_eligible=graph_eligible, capture_mode=capture_mode),
+                unittest.mock.patch.object(
+                    mega_moe, "should_use_mega_moe", return_value=False
+                ),
+                unittest.mock.patch.object(
+                    deepseek_v2, "get_is_capture_mode", return_value=capture_mode
+                ),
+                unittest.mock.patch.object(
+                    deepseek_v2,
+                    "dsv2_flashinfer_moe_dual_stream_graph",
+                    side_effect=lambda x, *_args: x + 1000,
+                ),
+            ):
+                routed_only = deepseek_v2.DeepseekV2MoE.forward(
+                    model, hidden, skip_shared_experts=True
+                )
+                ordinary = deepseek_v2.DeepseekV2MoE.forward(
+                    model, hidden, skip_shared_experts=False
+                )
+                torch.testing.assert_close(routed_only, hidden + 10)
+                torch.testing.assert_close(ordinary, hidden + ordinary_addend)
+
+
 class TestGlmMoeLiteGate(_FusionGateCase):
     def _config(self, **kw):
         base = dict(architectures=["Glm4MoeLiteForCausalLM"], n_shared_experts=1)

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -1,5 +1,6 @@
 """Unit tests for sglang.srt.environ: EnvField semantics and the deprecated-env registry."""
 
+import functools
 import os
 import re
 import subprocess
@@ -8,7 +9,7 @@ import unittest
 import warnings
 from contextlib import ExitStack
 
-from sglang.srt.environ import _DEPRECATED_ENVS, _DeprecatedEnv, envs
+from sglang.srt.environ import _DEPRECATED_ENVS, EnvBool, _DeprecatedEnv, envs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
@@ -97,6 +98,29 @@ class TestEnvField(unittest.TestCase):
             warnings.simplefilter("always")
             self.assertIs(envs.SGLANG_TEST_RETRACT.get(), False)
         self.assertIn("Invalid value", str(caught[0].message))
+
+    def test_callable_default_traces_under_torch_compile(self):
+        # get() runs inside compiled model forwards, so resolving a callable
+        # default must stay traceable. lru_cache specifically: Dynamo models
+        # such a function loaded from an instance attribute as a bound method
+        # carrying `self`. A plain function default traces fine either way.
+        import torch
+
+        @functools.lru_cache(maxsize=1)
+        def default_factory():
+            return True
+
+        field = EnvBool(default_factory)
+        # Envs turns off _allow_set_name after its body, so a field built out
+        # here never gets a name from __set_name__.
+        field.name = "SGLANG_TEST_CALLABLE_DEFAULT"
+        field.clear()
+
+        @torch.compile(fullgraph=True, backend="eager", dynamic=False)
+        def probe(x):
+            return x + 1 if field.get() else x - 1
+
+        self.assertEqual(probe(torch.zeros(())).item(), 1.0)
 
 
 class TestDeprecatedEnvRegistry(unittest.TestCase):


### PR DESCRIPTION
Enables `--cuda-graph-backend-prefill tc_piecewise` for DeepSeek-V4 on
MI355X with DP attention, EAGLE/MTP and HiCache. Adds an opt-in compact
TP-MoE path that preserves local attention graph buckets and synchronization
while removing padded tokens from MoE work: real DP counts `[8192, 0, ...]`
produce 8192 MoE rows per TP shard instead of 65536.

## Implementation

- Make HIP kernel launches traceable and refresh captured attention metadata
  in place, including padded tails and compressor plans.
  Use the shared causal-prefill expansion, then point HIP padding at inert
  request slot 0 before building core metadata so replay cannot overwrite a
  live request's SWA/compressor state.
- Keep EAGLE target prefill graphs and hoist HiCache transfer waits before
  graph execution, avoiding guards on later controller registration.
- Preserve real DP counts before MAX_LEN padding. A graph split performs
  variable-size gather, eager MoE and reduce-scatter on real tokens, then
  writes a fixed local output buffer. Hash routing preserves token-ID order;
  shared experts and TP partial outputs are summed once.
- Capture and replay the static first bucket when Dynamo emits no SymInt
  input. Record compiled DP gathers without guarding on the changing capture
  phase, retaining the shared-bucket requirement for graphs with collectives.
- Pass the already computed `global_num_tokens_for_logprob_cpu` into the
  dummy `ForwardBatch` in `capture_prepare()`. Without this one-line fix,
  logits metadata falls back to the transformer token bucket instead of the
  request-row count. The 7680 bucket then requests
  `7680 × 8 × 129280 × 2 bytes = 14.79 GiB` for the BF16 full-vocabulary
  logits gather. The recorded OOM stack identifies this logits allocation;
  it is not evidence of a 14.79 GiB MoE workspace. Transformer padding and
  counts remain unchanged.

- Stop the HIP FP4-indexer schedule binary search once it converges instead
  of executing 32 unrolled division/reduction rounds. Keep exact split-factor
  selection and the no-fit fallback, including live graph-replay inputs.

## Selecting compact MoE

```bash
export SGLANG_DSV4_TC_COMPACT_MOE=1
# Add --cuda-graph-backend-prefill tc_piecewise to the server arguments.
```

The CLI option selects the graph backend. The environment variable separately
enables compact MoE and defaults to false. Its gate requires HIP, `dsv4`
attention, TP8/attention-DP8/attention-TP1, EP1, PP1/CP1, no A2A and no TBO.
EP and NVIDIA dispatch are unchanged; the static-bucket, compiler bookkeeping
and capture metadata fixes are in shared code.

## FP4 schedule validation

A native MI355X microbenchmark using three ABBA blocks reduced the
single-kernel graph/event interval from 18.002 to 11.978 us at 257 rows
and from 34.660 to 18.639 us at 4096 rows (-33.46% / -46.22%). These intervals
include host replay submission gaps. Twelve independent-reference harness
cases and four GPU regression cases passed. Across eight comparable cold
specializations, JIT plus first-launch wall time fell from 5732.46 to
673.06 ms; this is not model startup time or an E2E speedup claim.

A separate experiment combining the loop with 43 buckets reduced capture
overhead but observed -2.63% total E2E throughput in one different-node pair.
Its automatic-default policy and associated CPU tests
are excluded from this PR; the prefill bucket defaults remain unchanged.
Further audit found that the AgentX client uses UUID4 session IDs as routing
keys, so the server/client seeds alone do not fix routing input across runs.
The schedule change is validated independently of that bucket experiment.

## AgentX results with HiCache enabled

MI355X ×8, DSv4-Pro FP4, TP8/DP8/EP1, depth-3 MTP with simulated acceptance
length 2.49, memory fraction 0.80, upstream ROCm image `20260911`
(`ab9750fb35` + this PR's overlay), W10 and 3600 seconds per point:

| Concurrency | Graph off, total tok/s | Compact, total tok/s | Difference |
|---|---:|---:|---:|
| 64 | 193,131 | 196,862 | +1.93% |
| 128 | 257,288 | 259,012 | +0.67% |

These are single runs with different server seeds and unpinned device KV
capacities: compact had 3.90%/1.36% more capacity at c64/c128. They do not
establish a repeatable end-to-end graph gain or identify its cause. The c64
logs retained substantial free full-KV capacity, so the pool difference alone
also does not explain the result. Mean prefill-forward time improved by
6.2%/3.1%; c128 TTFT p90/p95 increased by 9.6%/10.6%, alongside a longer
queue tail. Most measured prefix hits were in device memory. Attributing
the difference from the older results below to HiCache requires a matched
HiCache on/off comparison on the same software and hardware configuration.

The compact-disabled arm originally failed on the logits allocation described
above. After the row-count repair, image0911 overlay validation completed all
58 default prefill buckets with compact disabled, HiCache enabled, memory
fraction 0.80 and automatic KV sizing (10,099,456 tokens/rank). The server
started and passed generation smoke checks at 256/4096/8192 input tokens.
Thus the original OOM does not establish that compact MoE is required to start
this configuration. Compact still removes padded MoE work during serving.

A further c64 comparison pinned both arms to 10,145,280 KV tokens/rank and
server/client seed 42. All 3,807 Python source files and the harness matched;
only the prefill backend and compact switch differed. Each server ran two
W10/1800-second repetitions, flushing all eight DP caches before each:

| Repetition | Graph off, total tok/s | Compact, total tok/s | Difference |
|---|---:|---:|---:|
| 1 | 182,874.05 | 191,871.37 | +4.92% |
| 2 | 189,133.42 | 192,617.36 | +1.84% |

Pooling successful tokens and full profiling phase wall time gives +3.36%.
The runs completed 5,489/5,630 requests with zero errors and 28 duration/grace
cancellations per arm. Both used the same source overlay plus the logits fix;
this is not a GPU run of every file in the rebased main tree. OFF and compact
used different identical-model nodes without crossover. Repetitions reused
the same server and retained JIT state. OFF itself varied by 3.42%, so these
two observations are not a confidence interval. TTFT p99 also varied: compact
was worse in repetition 1 and nearly unchanged in repetition 2. The 1800-second
results should be compared within this experiment, not directly against the
older 3600-second runs.

## Historical AgentX validation with HiCache disabled

MI355X ×8, DSv4-Pro FP4, TP8/DP8/EP1, MTP, memory fraction 0.80, c64, W10 and
3600 seconds, using the same `mori-0908` image, recipe and dataset across arms:

| Metric | Graph off | Original tc_piecewise | Compact tc_piecewise |
|---|---:|---:|---:|
| Total throughput, tok/s | 155,063.86 | 132,223.55 | **175,436.02** |
| Output throughput, tok/s | 1,263.13 | 1,062.62 | **1,444.31** |
| TTFT p50, ms | 1,747.06 | 2,087.71 | **1,307.02** |
| TPOT p50, ms | 39.75 | 48.78 | **33.47** |

For this configuration, compact improved total throughput by **32.68% over
original ON** and **13.14% over OFF**. All 3380 observed global prefills used
the real MoE row counts and replayed the surrounding pieces, with agreement
across eight ranks. The compact run completed 5414 profiling requests with
zero request errors and 16 duration/grace cancellations. Each arm completed
707 warmup requests; throughput includes the drain/cancel grace window.

There was one run per arm. Original ON and compact shared a node; OFF used
another identical node. Client seed was 42; server seeds were not fixed.
The KV pool was 11,225,600 tokens/rank. Capture memory increased from
18.35–18.77 to 25.07–25.49 GB/rank, and compact capture took about 1248 seconds.

This GPU validation used `4c5dd715fc` + repairs `c76008c3d1`, covering all
58 default buckets, real eight-rank collectives, buffer lifetime, and 48
target single-token checks with zero reference mismatches. Those token
checks are narrower than full-generation accuracy. These historical numbers
and the image0911 checks are not GPU measurements of the rebased main tree.

## Earlier enablement checks

GSM8K, 200 questions, 5-shot, MI355X ×8. Each pair used the same build and
arguments apart from prefill graph selection; values are accuracy / seconds.

| Configuration | Off | On |
|---|---|---|
| TP8 | 0.970 / 16.165 | 0.985 / 13.948 |
| TP8 + FP4 indexer | 0.965 / 21.674 | 0.975 / 14.077 |
| DP8 + EP8 | 0.965 / 25.565 | 0.965 / 16.812 |
| DP8 + EP8 + EAGLE/MTP | 0.965 / 22.479 | 0.965 / 15.634 |
| DP8 + EP8 + MoRI A2A | 0.965 / 100.007 | 0.965 / 94.900 |
| DP8 + EAGLE + FP4 indexer + HiCache | 0.965 / 14.196 | 0.955 / 5.852 |

These enablement checks do not establish EP/NVIDIA AgentX performance or
compact MoE support beyond its EP1 gate.

## Current code validation

The branch is linear on main `14b647cf27`, with head `6de00020bc` and no
merge commit. **320 CPU tests and 92 subtests passed** across server arguments,
compact MoE, static buckets, prefill runner, shared experts, environment and
MegaMoE padding; all commit hooks passed. Four native ROCm GPU cases validate
an independent exhaustive schedule oracle, no-fit and zero/negative lengths,
strided page padding, guard regions, and input updates between graph replays.
Only test registry metadata and its directory changed after that GPU run;
the executable test AST and kernel source still match the validated inputs. The CPU suite also
checks live request IDs and inert padding through the real shared expansion
and HIP adapter. FULL/TC EAGLE setup coverage shares one parameterized check;
the constructor-interruption test was removed. Focused regressions cover token order,
shared reduction, real counts, stable replay buffers, one Dynamo graph across
precompile/capture/replay, and logits request-row sizing for TC single-request,
TC context-split and Full graph capture.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
