### PR TITLE
fix(moe): cast filtered-activation expert_ids to int32 for torch.compile

### DIFF
--- a/python/sglang/kernels/ops/activation/activation.py
+++ b/python/sglang/kernels/ops/activation/activation.py
@@ -134,6 +134,11 @@ def run_activation(
     if expert_ids is None:
         _run_activation_inplace(op_name, input, out)
     else:
+        # The JIT kernel indexes expert ids as int32. Routing ids may arrive as
+        # int64 (e.g. from torch.topk) and torch.compile realizes them at their
+        # true dtype, so normalize here instead of asserting downstream.
+        if expert_ids.dtype != torch.int32:
+            expert_ids = expert_ids.to(torch.int32)
         _run_activation_filtered_inplace(op_name, input, out, expert_ids, expert_step)
     return out
 

--- a/test/registered/kernels/ops/activation/test_activation.py
+++ b/test/registered/kernels/ops/activation/test_activation.py
@@ -166,6 +166,36 @@ def test_activation_filter_expert_none_skipped(op_name: str) -> None:
     torch.testing.assert_close(out_filtered, out_unfiltered, atol=0.0, rtol=0.0)
 
 
+def test_activation_filter_expert_int64_under_torch_compile() -> None:
+    """torch.topk routing ids remain usable after AOTAutograd realizes int64."""
+    shape = (32, 512)
+    dtype = torch.bfloat16
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    expert_ids = torch.zeros((shape[0],), dtype=torch.int64, device="cuda")
+    expert_ids[::3] = -1
+    out = torch.full(
+        shape[:-1] + (shape[-1] // 2,),
+        float("nan"),
+        dtype=dtype,
+        device="cuda",
+    )
+
+    def compiled_activation(input, output, routing_ids):
+        return run_activation("silu", input, output, routing_ids, 1)
+
+    result = torch.compile(compiled_activation, fullgraph=True)(x, out, expert_ids)
+    assert result is out
+
+    skipped = expert_ids == -1
+    assert torch.isnan(out[skipped]).all()
+    torch.testing.assert_close(
+        out[~skipped],
+        _reference("silu", x)[~skipped],
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
 UNARY_SHAPES = get_ci_test_range(
     full_range=[
         (7, 16),


### PR DESCRIPTION
## Problem

Running a filtered MoE model (e.g. `baidu/Unlimited-OCR`) with `--enable-torch-compile` crashes during CUDA-graph capture:

```
RuntimeError: Failed at .../kernels/jit/csrc/elementwise/activation.cuh:233: expert_ids must have dtype int32
Exception: Capture cuda graph failed: ... expert_ids must have dtype int32
```

## Root cause

The compiled `inplace_fused_experts` custom op forces `filter_expert=True` and reaches the non-TMA path where `expert_ids` is `topk_ids.view(-1)`. `topk_ids` is int64 (from `torch.topk`), and under torch.compile AOTAutograd realizes it at its true dtype, while the JIT activation kernel (`run_activation_filtered`) asserts `is_type<int32_t>(expert_ids)`. Eager avoids this path, so the crash only reproduces with `--enable-torch-compile`.

## Fix

Normalize `expert_ids` to int32 in `run_activation` before the filtered dispatch, instead of asserting downstream. No-op when the dtype is already int32 (the normal eager path).

## Validation

- Before: `--enable-torch-compile` on Unlimited-OCR dies in graph capture with the int32 assertion.
- After: server boots, all decode CUDA graphs capture, greedy output coherent.

## Note

Measured on RTX 5090, torch.compile gives no end-to-end gain for this model (SGL runtime torch.compile `579/1558/4176/6455` vs non-compile `594/1516/4061/6382` at bs 1/4/16/32) — the fix just removes the hard crash so the flag is usable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33947959511](https://github.com/sgl-project/sglang/actions/runs/33947959511)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33947959469](https://github.com/sgl-project/sglang/actions/runs/33947959469)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33947959505](https://github.com/sgl-project/sglang/actions/runs/33947959505)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->