### PR TITLE
[AMD][DSv4] Replace fixed FP4 indexer logits slab with adaptive workspace

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -554,7 +554,7 @@ SGLang supports various environment variables that can be used to configure its 
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>When the maximum kv len in current prefill batch exceeds this value, the sparse mla kernel will be applied, else it falls back to dense MHA implementation. Default to the index topk of model (2048 for DeepSeek V3.2). <code>SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD</code> is a deprecated alias.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>2048</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>512</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSA_TOPK_BROADCAST</code></td>
@@ -724,6 +724,16 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSV4_FP4_EXPERTS</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Whether DeepSeek V4 experts use FP4. Set to <code>false</code> when using an FP4-to-FP8 converted DeepSeek V4 checkpoint.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSV4_FP4_LOGITS_BUDGET_MB</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Upper bound, rather than a fixed allocation size, for the persistent HIP FP4 indexer logits workspace. The actual allocation is reduced to the configured workload and runtime-memory budget. Set to <code>0</code> for automatic sizing without an additional absolute ceiling.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>2048</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSV4_FP4_LOGITS_FREE_MEM_FRACTION</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Fraction of the DeepSeek V4 runtime-memory headroom that may be reserved for the HIP FP4 indexer logits workspace.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>0.2</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSV4_REASONING_EFFORT</code></td>

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_hip.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_hip.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple, Union
 
 import torch
+
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+    fp4_logits_width_from_page_table,
+    guarded_page_table_width,
+)
 
 if TYPE_CHECKING:
     from sglang.kernels.ops.attention.dsv4.compress import (
@@ -31,15 +35,6 @@ _PREFILL_BASE_CTA_TARGET = 1024
 # AITER varctx cta_info row: [batch_packed, chunk_start, chunk_count, ctx_len].
 _DECODE_CTA_INFO_WIDTH = 4
 
-# Budget for the pooled prefill logits block, in MiB. Rows are split to fit it
-# (see `logits_rows_per_chunk`), so this caps the indexer's transient footprint
-# independently of context length and chunked-prefill size; smaller budgets only
-# buy more row chunks. 2 GiB covers 4096 rows over ~512K tokens of context.
-_LOGITS_BUDGET_ELEMS = (
-    int(os.environ.get("SGLANG_DSV4_FP4_LOGITS_BUDGET_MB", "2048")) * 2**20 // 4
-)
-_LOGITS_POOL: dict = {}
-
 
 class FP4DecodeWorkspace(NamedTuple):
     guarded_page_table: torch.Tensor
@@ -63,6 +58,13 @@ class FP4PrefillWorkspace(NamedTuple):
     # cta_info kernel reads. Pinned with the workspace so a refresh allocates
     # nothing and the buffers never return to the graph memory pool.
     schedule_buffers: Optional[PrefillScheduleBuffers] = None
+
+
+class FP4PrefillChunkPlan(NamedTuple):
+    start: int
+    stop: int
+    workspace: FP4PrefillWorkspace
+    topk_metadata: Optional[torch.Tensor]
 
 
 class FP4KWriteMetadata(NamedTuple):
@@ -131,7 +133,7 @@ def _decode_cta_count(num_queries: int, max_seq_len: int) -> int:
 
 def _guarded_pages(logical_width: int) -> int:
     """Page columns after padding for 256-token scheduling."""
-    return max(4, (logical_width + 3) // 4 * 4)
+    return guarded_page_table_width(logical_width)
 
 
 def _guard_page_table(page_table: torch.Tensor, out: Optional[torch.Tensor] = None):
@@ -143,46 +145,9 @@ def _guard_page_table(page_table: torch.Tensor, out: Optional[torch.Tensor] = No
     return pad_page_table(page_table, out=out)
 
 
-def logits_rows_per_chunk(page_table: torch.Tensor) -> int:
-    """Rows whose logits fit the pooled block, for callers that loop by row."""
-    width = _guarded_pages(page_table.shape[1]) * _KV_BLOCK_SIZE
-    return max(1, _LOGITS_BUDGET_ELEMS // width)
-
-
-def _alloc_logits(
-    num_tokens: int, max_seq_len: int, device: torch.device, is_decode: bool
-) -> torch.Tensor:
-    """Hand out the [num_tokens, max_seq_len] fp32 scratch the logits kernel fills.
-
-    Prefill rectangles are served from one fixed-size pooled block. A fresh
-    `torch.empty` per call would instead feed the caching allocator a
-    monotonically growing size sequence -- the width tracks context length, and
-    an agentic session's context only ever grows -- so every request is slightly
-    larger than any cached block, none can be reused, and each strands a whole
-    segment. `reserved` then climbs while `allocated` stays flat, and that
-    stranded memory is invisible to allocators that bypass torch: Triton kernel
-    scratch fails with HSA_STATUS_ERROR_OUT_OF_RESOURCES instead of surfacing as
-    a clean torch OOM. Serving every rectangle out of one block keeps the
-    request size constant, so the block is always reused and nothing strands.
-
-    Decode keeps the plain allocation: it is captured against the graph memory
-    pool (bounded, separate from the fragmenting general pool), and creating the
-    pooled block mid-capture would hand out graph-pool memory to later replays.
-    """
-    n = num_tokens * max_seq_len
-    if (
-        is_decode
-        or n > _LOGITS_BUDGET_ELEMS
-        or torch.cuda.is_current_stream_capturing()
-    ):
-        return torch.empty(
-            (num_tokens, max_seq_len), dtype=torch.float32, device=device
-        )
-    buf = _LOGITS_POOL.get(device)
-    if buf is None:
-        buf = torch.empty(_LOGITS_BUDGET_ELEMS, dtype=torch.float32, device=device)
-        _LOGITS_POOL[device] = buf
-    return buf[:n].view(num_tokens, max_seq_len)
+def fp4_logits_max_seq_len(page_table: torch.Tensor) -> int:
+    """Return the padded output width required by the FP4 score kernel."""
+    return fp4_logits_width_from_page_table(page_table.shape[1])
 
 
 def prepare_fp4_decode_workspace(
@@ -232,8 +197,7 @@ def prepare_fp4_prefill_workspace(
     fall back to AITER's prefill scheduler, which frees the scratch its own
     schedule kernel reads, so a captured build would replay against recycled
     graph-pool memory. Callers instead refresh this workspace per step and let
-    the graph read only the pinned ``cta_info`` / ``logits`` / page-table
-    buffers.
+    the graph read only the pinned ``cta_info`` and page-table buffers.
     """
     from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
         CTA_INFO_WIDTH,
@@ -246,9 +210,19 @@ def prepare_fp4_prefill_workspace(
     )
 
     c4_seq_lens = _as_int32_1d(c4_seq_lens)
+    rows, _, padded_width = padded_page_table_shape(page_table)
+    expected_cta_count = max(_PREFILL_BASE_CTA_TARGET, rows)
+    if workspace is not None and (
+        workspace.guarded_page_table.shape != (rows, padded_width + 4)
+        or workspace.guarded_page_table.device != page_table.device
+        or workspace.row_to_batch.shape != (rows,)
+        or workspace.local_starts.shape != (rows,)
+        or workspace.cta_info.shape[0] != expected_cta_count
+        or workspace.max_seq_len != padded_width * _KV_BLOCK_SIZE
+    ):
+        workspace = None
     if workspace is None:
-        rows, _, padded_width = padded_page_table_shape(page_table)
-        cta_count = max(_PREFILL_BASE_CTA_TARGET, rows)
+        cta_count = expected_cta_count
         device = page_table.device
         buffers = PrefillScheduleBuffers(rows, device)
         workspace = FP4PrefillWorkspace(
@@ -297,6 +271,7 @@ def aiter_fp4_paged_mqa_logits(
     is_decode: bool,
     decode_workspace: Optional[FP4DecodeWorkspace] = None,
     prefill_workspace: Optional[FP4PrefillWorkspace] = None,
+    logits_out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Compute FP4 Q/K indexer logits with the decode or prefill FlyDSL kernel."""
     from aiter.ops.flydsl import (
@@ -309,7 +284,12 @@ def aiter_fp4_paged_mqa_logits(
     workspace = decode_workspace if is_decode else prefill_workspace
     # A workspace is bound to one row count. DP padding or truncated activations
     # can leave it stale, in which case fall back to building the schedule here.
-    if workspace is not None and workspace.guarded_page_table.shape[0] != num_tokens:
+    expected_max_seq_len = fp4_logits_max_seq_len(page_table)
+    if workspace is not None and (
+        workspace.guarded_page_table.shape[0] != num_tokens
+        or workspace.guarded_page_table.device != page_table.device
+        or workspace.max_seq_len != expected_max_seq_len
+    ):
         workspace = None
     # Built on the fallback path below; kept in scope so the schedule scratch
     # outlives the logits kernel that reads it.
@@ -351,11 +331,26 @@ def aiter_fp4_paged_mqa_logits(
         fallback_schedule = (cta_info, cta_count, buffers)
     q_payload = q_fp4.view(torch.uint8)
     k_payload = k_payload.view(torch.uint8)
-    # Scored write-once and dead when the caller's top-k returns, so the pooled
-    # block can be handed straight to the next call: a pinned cta_info makes the
-    # kernel skip its -inf pre-fill and the length-aware top-k reads only
-    # [0, c4_seq_len), so neither ever observes the previous chunk's leftovers.
-    logits = _alloc_logits(num_tokens, max_seq_len, q_fp4.device, is_decode)
+    if logits_out is None:
+        logits = torch.empty(
+            (num_tokens, max_seq_len), dtype=torch.float32, device=q_fp4.device
+        )
+    else:
+        expected_shape = (num_tokens, max_seq_len)
+        if (
+            logits_out.shape != expected_shape
+            or logits_out.dtype is not torch.float32
+            or logits_out.device != q_fp4.device
+            or not logits_out.is_contiguous()
+        ):
+            raise ValueError(
+                "Managed FP4 logits output must be contiguous FP32 on the Q "
+                f"device with shape {expected_shape}; got shape "
+                f"{tuple(logits_out.shape)}, dtype={logits_out.dtype}, "
+                f"device={logits_out.device}, "
+                f"contiguous={logits_out.is_contiguous()}"
+            )
+        logits = logits_out
     common = {
         "weight_scale": weight_scale,
         "block_k": 256,

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_schedule_hip.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_indexer_schedule_hip.py
@@ -22,14 +22,14 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import MAX_FUSED_ROWS
+
 _KV_BLOCK_SIZE = 64
 
 # Rows are query tokens: tens to a few hundred for MTP target-verify, up to the
 # chunked-prefill size for EXTEND. The prep kernel holds one row per lane, so
 # past this it hands back to AITER's torch preamble -- a prefill that wide is
 # compute-bound and does not care about ~30 extra launches.
-MAX_FUSED_ROWS = 4096
-
 # Columns per page-table tile. The padded table is the row's page count rounded
 # up to a multiple of 4, plus 4 more for the scheduler's one-chunk lookahead.
 _PT_BLOCK = 256

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -75,7 +75,11 @@ def topk_transform_paged(
 _PLAN_METADATA_INTS_PER_BATCH = 2
 
 
-def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
+def plan_topk_v2(
+    seq_lens: torch.Tensor,
+    static_threshold: int = 0,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
     """Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
 
     IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE. The device
@@ -87,7 +91,24 @@ def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Ten
     """
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
-    metadata = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
+    expected_shape = (bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
+    if out is None:
+        metadata = seq_lens.new_empty(*expected_shape)
+    else:
+        if (
+            out.shape != expected_shape
+            or out.dtype != seq_lens.dtype
+            or out.device != seq_lens.device
+            or not out.is_contiguous()
+        ):
+            raise ValueError(
+                "top-k v2 plan output must match the sequence lengths: "
+                f"expected shape={expected_shape}, dtype={seq_lens.dtype}, "
+                f"device={seq_lens.device}; got shape={tuple(out.shape)}, "
+                f"dtype={out.dtype}, device={out.device}, "
+                f"contiguous={out.is_contiguous()}"
+            )
+        metadata = out
     module.topk_plan(seq_lens, metadata, static_threshold)
     return metadata
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1451,6 +1451,10 @@ class Envs:
     # Per-rank local query rows (after DP-attention sharding when enabled),
     # not request ISL.
     SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS = EnvInt(8192)
+    # The HIP FP4 indexer's persistent logits workspace is workload-sized and
+    # bounded by both this ceiling and a fraction of runtime memory headroom.
+    SGLANG_DSV4_FP4_LOGITS_BUDGET_MB = EnvInt(512)
+    SGLANG_DSV4_FP4_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -51,7 +51,11 @@ if TYPE_CHECKING:
     from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
         FP4DecodeWorkspace,
         FP4KWriteMetadata,
+        FP4PrefillChunkPlan,
         FP4PrefillWorkspace,
+    )
+    from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+        FP4LogitsWorkspace,
     )
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
@@ -365,6 +369,12 @@ class DSV4Metadata:
     fp4_prefill_workspace: Optional[FP4PrefillWorkspace] = field(
         default=None, repr=False
     )
+    # Capacity-driven row chunks own matching schedule addresses. The list is
+    # prepared once per forward and reused by every C4 layer.
+    fp4_prefill_chunk_plans: Optional[List[FP4PrefillChunkPlan]] = field(
+        default=None, repr=False
+    )
+    fp4_prefill_chunk_rows: int = field(default=0, repr=False)
     # Derived by the first C4 layer of a forward and reused by the rest.
     fp4_k_write_metadata: Optional[FP4KWriteMetadata] = field(default=None, repr=False)
     # AITER's rope kernels require int64 positions while the core metadata keeps
@@ -485,6 +495,67 @@ class DeepseekV4HipRadixBackend(
         self.is_dspark_draft = (
             self.is_draft_worker and model_runner.spec_algorithm.is_dspark()
         )
+        self.fp4_logits_workspace: Optional[FP4LogitsWorkspace] = None
+        pool_config = getattr(model_runner, "memory_pool_config", None)
+        workspace_bytes = (
+            getattr(pool_config, "dsv4_fp4_logits_workspace_bytes", 0)
+            if pool_config is not None
+            else 0
+        )
+        workspace_max_seq_len = (
+            getattr(
+                pool_config,
+                "dsv4_fp4_logits_workspace_max_seq_len",
+                0,
+            )
+            if pool_config is not None
+            else 0
+        )
+        if (
+            self.enable_deepseek_v4_fp4_indexer
+            and not self.is_draft_worker
+            and speculative_num_steps == 0
+            and workspace_bytes > 0
+            and workspace_max_seq_len > 0
+        ):
+            from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+                FP4LogitsWorkspace,
+                FP4LogitsWorkspacePlan,
+                limit_plan_to_available_memory,
+            )
+
+            def create_fp4_logits_workspace() -> FP4LogitsWorkspace:
+                from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+
+                row_bytes = workspace_max_seq_len * 4
+                plan = FP4LogitsWorkspacePlan(
+                    capacity_bytes=workspace_bytes,
+                    desired_bytes=workspace_bytes,
+                    max_seq_len=workspace_max_seq_len,
+                    max_query_rows=max(workspace_bytes // row_bytes, 1),
+                    rows_at_max_width=max(workspace_bytes // row_bytes, 1),
+                    limiting_reason="pool_config",
+                )
+                free_bytes, _ = torch.cuda.mem_get_info(self.device)
+                # The configured bytes were already deducted from the static
+                # token-pool budget, so do not apply a second safety haircut.
+                plan = limit_plan_to_available_memory(
+                    plan, free_bytes, safety_fraction=1.0
+                )
+                logger.info(
+                    "DSV4 FP4 logits workspace: %.2f MiB, %d rows at max "
+                    "C4 width %d (limit=%s)",
+                    plan.capacity_bytes / (1 << 20),
+                    plan.rows_at_max_width,
+                    plan.max_seq_len,
+                    plan.limiting_reason,
+                )
+                with model_runner.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+                    return FP4LogitsWorkspace(plan=plan, device=self.device)
+
+            self.fp4_logits_workspace = model_runner.get_or_create_runtime_workspace(
+                "dsv4_fp4_logits", create_fp4_logits_workspace
+            )
         self.target_verify_num_draft_tokens = self.speculative_num_draft_tokens
         if self.is_dspark_draft:
             assert self.speculative_num_draft_tokens is not None
@@ -928,7 +999,7 @@ class DeepseekV4HipRadixBackend(
         AITER's prefill scheduler frees the scratch that its schedule kernel
         reads, so recording the build into a graph would leave every replay
         reading recycled graph-pool memory. Only the pinned buffers it fills
-        (cta_info / logits / guarded page table) may be read from the graph.
+        (cta_info / guarded page table) may be read from the graph.
         """
         metadata = self.forward_metadata
         if not self._fp4_workspaces_enabled(metadata):
@@ -947,14 +1018,77 @@ class DeepseekV4HipRadixBackend(
             return
 
         from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
+            fp4_logits_max_seq_len,
             prepare_fp4_prefill_workspace,
+        )
+        from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+            MAX_FUSED_ROWS,
         )
 
         indexer_metadata = metadata.indexer_metadata
-        metadata.fp4_prefill_workspace = prepare_fp4_prefill_workspace(
-            indexer_metadata.page_table,
-            indexer_metadata.compressed_seq_lens,
-            workspace=metadata.fp4_prefill_workspace,
+        page_table = indexer_metadata.page_table
+        c4_seq_lens = indexer_metadata.compressed_seq_lens
+        total_rows = c4_seq_lens.shape[0]
+        if total_rows == 0:
+            metadata.fp4_prefill_workspace = None
+            metadata.fp4_prefill_chunk_plans = []
+            metadata.fp4_prefill_chunk_rows = 0
+            return
+
+        chunk_rows = total_rows
+        if self.fp4_logits_workspace is not None:
+            chunk_rows = min(
+                total_rows,
+                self.fp4_logits_workspace.rows_per_chunk(
+                    fp4_logits_max_seq_len(page_table),
+                    max_rows=MAX_FUSED_ROWS,
+                ),
+            )
+
+        from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
+            FP4PrefillChunkPlan,
+        )
+
+        previous = metadata.fp4_prefill_chunk_plans or []
+        chunk_plans = []
+        build_topk = self.dsa_topk_backend.should_use_topk_v2()
+        if build_topk:
+            from sglang.kernels.ops.attention.dsv4 import plan_topk_v2
+
+        for chunk_id, start in enumerate(range(0, total_rows, chunk_rows)):
+            end = min(start + chunk_rows, total_rows)
+            old_workspace = (
+                previous[chunk_id].workspace if chunk_id < len(previous) else None
+            )
+            old_topk_metadata = (
+                previous[chunk_id].topk_metadata if chunk_id < len(previous) else None
+            )
+            if old_topk_metadata is not None and old_topk_metadata.shape != (
+                end - start + 1,
+                2,
+            ):
+                old_topk_metadata = None
+            chunk_plans.append(
+                FP4PrefillChunkPlan(
+                    start=start,
+                    stop=end,
+                    workspace=prepare_fp4_prefill_workspace(
+                        page_table[start:end],
+                        c4_seq_lens[start:end],
+                        workspace=old_workspace,
+                    ),
+                    topk_metadata=(
+                        plan_topk_v2(c4_seq_lens[start:end], out=old_topk_metadata)
+                        if build_topk
+                        else None
+                    ),
+                )
+            )
+
+        metadata.fp4_prefill_chunk_plans = chunk_plans
+        metadata.fp4_prefill_chunk_rows = chunk_rows
+        metadata.fp4_prefill_workspace = (
+            chunk_plans[0].workspace if len(chunk_plans) == 1 else None
         )
 
     def init_forward_metadata_out_graph(

--- a/python/sglang/srt/layers/attention/dsv4/fp4_logits_workspace.py
+++ b/python/sglang/srt/layers/attention/dsv4/fp4_logits_workspace.py
@@ -1,0 +1,337 @@
+"""Bounded logits workspace for the DeepSeek-V4 HIP FP4 indexer.
+
+The FP4 indexer materializes an FP32 ``[query_rows, c4_context]`` tensor
+between its score and top-k kernels.  The storage is deliberately persistent:
+reallocating a slightly wider tensor for every growing-context forward leaves
+unusable size classes in the caching allocator.  Unlike the old module-global
+2 GiB slab, this workspace has an explicit owner, a workload-aware capacity,
+and a stream-ordered lease lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+FP32_BYTES = 4
+KV_BLOCK_SIZE = 64
+PAGE_TABLE_GROUP = 4
+MAX_FUSED_ROWS = 4096
+
+
+def guarded_page_table_width(logical_width: int) -> int:
+    """Page columns after 256-token scheduling alignment."""
+    if logical_width < 0:
+        raise ValueError(f"logical_width must be non-negative, got {logical_width}")
+    return max(
+        PAGE_TABLE_GROUP, -(-logical_width // PAGE_TABLE_GROUP) * PAGE_TABLE_GROUP
+    )
+
+
+def fp4_logits_width_from_page_table(logical_width: int) -> int:
+    """Return the padded C4 logits width for a page-table width."""
+    return guarded_page_table_width(logical_width) * KV_BLOCK_SIZE
+
+
+def fp4_logits_width_for_context(context_len: int, page_size: int) -> int:
+    """Return the largest padded C4 logits width for a full-token context."""
+    if context_len <= 0:
+        raise ValueError(f"context_len must be positive, got {context_len}")
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    logical_pages = -(-context_len // page_size)
+    return fp4_logits_width_from_page_table(logical_pages)
+
+
+@dataclass(frozen=True)
+class FP4LogitsWorkspacePlan:
+    """Resolved capacity and the geometry used to derive it."""
+
+    capacity_bytes: int
+    desired_bytes: int
+    max_seq_len: int
+    max_query_rows: int
+    rows_at_max_width: int
+    limiting_reason: str
+
+    @property
+    def capacity_elems(self) -> int:
+        return self.capacity_bytes // FP32_BYTES
+
+
+def plan_fp4_logits_workspace(
+    *,
+    max_seq_len: int,
+    max_query_rows: int,
+    runtime_headroom_bytes: int,
+    free_memory_fraction: float,
+    max_workspace_bytes: Optional[int],
+    max_fused_rows: int = MAX_FUSED_ROWS,
+) -> FP4LogitsWorkspacePlan:
+    """Plan a persistent workspace without exceeding runtime headroom.
+
+    The capacity is rounded down to complete rows at the widest supported
+    context.  A configured MB value is a ceiling, not the amount allocated.
+    """
+    if max_seq_len <= 0:
+        raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+    if max_query_rows <= 0:
+        raise ValueError(f"max_query_rows must be positive, got {max_query_rows}")
+    if runtime_headroom_bytes <= 0:
+        raise ValueError(
+            f"runtime_headroom_bytes must be positive, got {runtime_headroom_bytes}"
+        )
+    if not 0.0 < free_memory_fraction <= 1.0:
+        raise ValueError(
+            f"free_memory_fraction must be in (0, 1], got {free_memory_fraction}"
+        )
+    if max_workspace_bytes is not None and max_workspace_bytes <= 0:
+        raise ValueError(
+            f"max_workspace_bytes must be positive or None, got {max_workspace_bytes}"
+        )
+    if max_fused_rows <= 0:
+        raise ValueError(f"max_fused_rows must be positive, got {max_fused_rows}")
+
+    row_bytes = max_seq_len * FP32_BYTES
+    desired_rows = min(max_query_rows, max_fused_rows)
+    desired_bytes = desired_rows * row_bytes
+    candidates = [
+        ("workload", desired_bytes),
+        ("runtime_headroom", int(runtime_headroom_bytes * free_memory_fraction)),
+    ]
+    if max_workspace_bytes is not None:
+        candidates.append(("user_ceiling", max_workspace_bytes))
+
+    limiting_reason, raw_capacity = min(candidates, key=lambda item: item[1])
+    rows_at_max_width = raw_capacity // row_bytes
+    if rows_at_max_width < 1:
+        raise ValueError(
+            "The DeepSeek-V4 FP4 logits workspace cannot hold one row at the "
+            f"configured maximum context: row={row_bytes / (1 << 20):.2f} MiB, "
+            f"budget={raw_capacity / (1 << 20):.2f} MiB. Increase runtime "
+            "headroom or SGLANG_DSV4_FP4_LOGITS_BUDGET_MB."
+        )
+
+    capacity_bytes = min(rows_at_max_width, desired_rows) * row_bytes
+    return FP4LogitsWorkspacePlan(
+        capacity_bytes=capacity_bytes,
+        desired_bytes=desired_bytes,
+        max_seq_len=max_seq_len,
+        max_query_rows=max_query_rows,
+        rows_at_max_width=capacity_bytes // row_bytes,
+        limiting_reason=limiting_reason,
+    )
+
+
+def limit_plan_to_available_memory(
+    plan: FP4LogitsWorkspacePlan,
+    available_bytes: int,
+    *,
+    safety_fraction: float = 0.8,
+) -> FP4LogitsWorkspacePlan:
+    """Shrink a profiled plan if live free memory is unexpectedly lower."""
+    if available_bytes <= 0:
+        raise ValueError(f"available_bytes must be positive, got {available_bytes}")
+    if not 0.0 < safety_fraction <= 1.0:
+        raise ValueError(f"safety_fraction must be in (0, 1], got {safety_fraction}")
+    live_cap = int(available_bytes * safety_fraction)
+    if plan.capacity_bytes <= live_cap:
+        return plan
+    row_bytes = plan.max_seq_len * FP32_BYTES
+    live_rows = live_cap // row_bytes
+    if live_rows < 1:
+        raise RuntimeError(
+            "Live free memory cannot safely hold one DeepSeek-V4 FP4 logits row: "
+            f"row={row_bytes} bytes, free={available_bytes} bytes"
+        )
+    capacity_bytes = live_rows * row_bytes
+    return FP4LogitsWorkspacePlan(
+        capacity_bytes=capacity_bytes,
+        desired_bytes=plan.desired_bytes,
+        max_seq_len=plan.max_seq_len,
+        max_query_rows=plan.max_query_rows,
+        rows_at_max_width=live_rows,
+        limiting_reason="live_free_memory",
+    )
+
+
+class FP4LogitsLease:
+    """A borrowed workspace view valid through the consumer's top-k enqueue."""
+
+    def __init__(
+        self,
+        workspace: FP4LogitsWorkspace,
+        tensor: torch.Tensor,
+        stream,
+    ):
+        self._workspace = workspace
+        self.tensor = tensor
+        self._stream = stream
+        self._released = False
+
+    def __enter__(self) -> torch.Tensor:
+        return self.tensor
+
+    def release(self) -> None:
+        if not self._released:
+            self._workspace._release(self._stream)
+            self._released = True
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.release()
+
+
+class FP4LogitsWorkspace:
+    """One bounded arena whose reuse is ordered across CUDA/HIP streams."""
+
+    def __init__(
+        self,
+        *,
+        plan: FP4LogitsWorkspacePlan,
+        device: torch.device | str,
+    ):
+        self.plan = plan
+        self.device = torch.device(device)
+        self._condition = threading.Condition()
+        self._in_use = False
+        self._closed = False
+        self._last_stream = None
+        self._reuse_event = (
+            torch.cuda.Event(blocking=False) if self.device.type == "cuda" else None
+        )
+        self._storage: Optional[torch.Tensor] = torch.empty(
+            plan.capacity_elems,
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+    @property
+    def capacity_bytes(self) -> int:
+        return self.plan.capacity_bytes
+
+    @property
+    def data_ptr(self) -> int:
+        storage = self._require_storage()
+        return storage.data_ptr()
+
+    def rows_per_chunk(
+        self, max_seq_len: int, *, max_rows: int = MAX_FUSED_ROWS
+    ) -> int:
+        """Return a strict whole-row chunk size for ``max_seq_len``."""
+        if max_seq_len <= 0:
+            raise ValueError(f"max_seq_len must be positive, got {max_seq_len}")
+        if max_seq_len > self.plan.max_seq_len:
+            raise RuntimeError(
+                "Runtime FP4 logits width exceeds the workspace plan: "
+                f"runtime={max_seq_len}, planned={self.plan.max_seq_len}"
+            )
+        if max_rows <= 0:
+            raise ValueError(f"max_rows must be positive, got {max_rows}")
+        rows = self.plan.capacity_elems // max_seq_len
+        if rows < 1:
+            required = max_seq_len * FP32_BYTES
+            raise RuntimeError(
+                "The FP4 logits workspace cannot hold one runtime row: "
+                f"required={required} bytes, capacity={self.capacity_bytes} bytes"
+            )
+        return min(rows, max_rows)
+
+    def acquire(
+        self,
+        rows: int,
+        max_seq_len: int,
+        *,
+        stream=None,
+    ) -> FP4LogitsLease:
+        """Borrow a shaped view and order it after the prior stream consumer."""
+        if rows <= 0:
+            raise ValueError(f"rows must be positive, got {rows}")
+        if max_seq_len <= 0 or max_seq_len > self.plan.max_seq_len:
+            raise RuntimeError(
+                "FP4 logits lease width is outside the workspace plan: "
+                f"runtime={max_seq_len}, planned={self.plan.max_seq_len}"
+            )
+        required_elems = rows * max_seq_len
+        if required_elems > self.plan.capacity_elems:
+            raise RuntimeError(
+                "FP4 logits lease exceeds the planned capacity: "
+                f"required={required_elems * FP32_BYTES} bytes, "
+                f"capacity={self.capacity_bytes} bytes"
+            )
+        if self.device.type == "cuda":
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "The eager FP4 logits workspace must not be used during graph capture"
+                )
+            if stream is None:
+                stream = torch.cuda.current_stream(self.device)
+
+        with self._condition:
+            while self._in_use and not self._closed:
+                self._condition.wait()
+            storage = self._require_storage()
+            self._in_use = True
+            prior_stream = self._last_stream
+
+        try:
+            if (
+                prior_stream is not None
+                and stream is not None
+                and not self._same_stream(prior_stream, stream)
+            ):
+                # Record lazily at the old stream's current tail. Same-stream
+                # reuse already has the required producer -> top-k -> producer
+                # ordering and pays no event operations.
+                event = self._reuse_event
+                event.record(prior_stream)
+                stream.wait_event(event)
+            tensor = storage[:required_elems].view(rows, max_seq_len)
+            return FP4LogitsLease(self, tensor, stream)
+        except Exception:
+            with self._condition:
+                self._in_use = False
+                self._condition.notify()
+            raise
+
+    def _release(self, stream) -> None:
+        if self.device.type == "cuda":
+            if stream is None:
+                stream = torch.cuda.current_stream(self.device)
+        with self._condition:
+            self._last_stream = stream
+            self._in_use = False
+            self._condition.notify()
+
+    def close(self) -> None:
+        """Release the arena after all enqueued consumers have completed."""
+        with self._condition:
+            if self._closed:
+                return
+            if self._in_use:
+                raise RuntimeError(
+                    "Cannot close an FP4 logits workspace with an active lease"
+                )
+            self._closed = True
+            last_stream = self._last_stream
+        event = self._reuse_event
+        if self.device.type == "cuda" and last_stream is not None:
+            event.record(last_stream)
+            event.synchronize()
+        self._storage = None
+        self._reuse_event = None
+
+    @staticmethod
+    def _same_stream(lhs, rhs) -> bool:
+        lhs_handle = getattr(lhs, "cuda_stream", None)
+        rhs_handle = getattr(rhs, "cuda_stream", None)
+        if lhs_handle is not None and rhs_handle is not None:
+            return lhs_handle == rhs_handle
+        return lhs is rhs
+
+    def _require_storage(self) -> torch.Tensor:
+        if self._closed or self._storage is None:
+            raise RuntimeError("The FP4 logits workspace is closed")
+        return self._storage

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -26,7 +26,7 @@ from sglang.kernels.ops.attention.dsv4 import (
 from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
     aiter_fp4_paged_mqa_logits,
     aiter_q_indexer_fp4,
-    logits_rows_per_chunk,
+    fp4_logits_max_seq_len,
 )
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
@@ -34,6 +34,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import MAX_FUSED_ROWS
 from sglang.srt.layers.attention.dsv4.metadata import (
     _SM120_INDEXER_M_CHUNK,
     NonPagedIndexerPlan,
@@ -848,7 +849,11 @@ class C4IndexerBackendMixin:
 
         all_rows = slice(0, _c4sl.shape[0])
 
-        def run_topk_transform(rows: slice, logits: torch.Tensor) -> None:
+        def run_topk_transform(
+            rows: slice,
+            logits: torch.Tensor,
+            topk_metadata: Optional[torch.Tensor] = None,
+        ) -> None:
             row_raw_indices = raw_indices[rows] if raw_indices is not None else None
             if self.dsa_topk_backend.is_torch():
                 topk_transform_pytorch_vectorized(
@@ -878,9 +883,13 @@ class C4IndexerBackendMixin:
                     # The cached plan routes rows by their index in the full
                     # range, so a chunk needs one built over its own rows.
                     (
-                        indexer_metadata.topk_metadata
-                        if rows == all_rows or not is_hip()
-                        else plan_topk_v2(c4_seq_lens[rows])
+                        topk_metadata
+                        if topk_metadata is not None
+                        else (
+                            indexer_metadata.topk_metadata
+                            if rows == all_rows or not is_hip()
+                            else plan_topk_v2(c4_seq_lens[rows])
+                        )
                     ),
                     row_raw_indices,
                 )
@@ -907,6 +916,13 @@ class C4IndexerBackendMixin:
         elif use_aiter_fp4:
             q_fp4, q_scale = q
             is_decode = forward_batch.forward_mode.is_decode()
+            fp4_logits_workspace = getattr(self, "fp4_logits_workspace", None)
+            use_managed_logits = (
+                not is_decode
+                and fp4_logits_workspace is not None
+                and not torch.cuda.is_current_stream_capturing()
+            )
+            logits_max_seq_len = fp4_logits_max_seq_len(page_table)
             # Hoisted: these await this layer's KV transfer, which every chunk
             # would otherwise re-await.
             k_payload = token_to_kv_pool.get_index_k_fp4_payload_buffer(
@@ -914,37 +930,75 @@ class C4IndexerBackendMixin:
             )
             k_scale = token_to_kv_pool.get_index_k_fp4_scale_buffer(c4_indexer.layer_id)
 
-            def run_fp4_indexer(rows: slice) -> None:
-                logits = aiter_fp4_paged_mqa_logits(
-                    q_fp4=q_fp4[rows],
-                    q_scale=q_scale[rows],
-                    k_payload=k_payload,
-                    k_scale=k_scale,
-                    weights=weights[rows],
-                    page_table=page_table[rows],
-                    c4_seq_lens=c4_seq_lens[rows],
-                    weight_scale=c4_indexer.weight_scale,
-                    is_decode=is_decode,
-                    decode_workspace=metadata.fp4_decode_workspace,
-                    prefill_workspace=metadata.fp4_prefill_workspace,
-                )
-                run_topk_transform(rows, logits)
+            chunk_plans = getattr(metadata, "fp4_prefill_chunk_plans", None)
+
+            def run_fp4_indexer(rows: slice, chunk_id: int) -> None:
+                start = rows.start or 0
+                stop = rows.stop if rows.stop is not None else query_rows
+                prefill_workspace = metadata.fp4_prefill_workspace
+                planned_topk = None
+                if (
+                    not is_decode
+                    and chunk_plans is not None
+                    and chunk_id < len(chunk_plans)
+                ):
+                    candidate = chunk_plans[chunk_id]
+                    if candidate.start == start and candidate.stop == stop:
+                        prefill_workspace = candidate.workspace
+                        planned_topk = candidate.topk_metadata
+
+                def score_and_topk(logits_out: Optional[torch.Tensor]) -> None:
+                    logits = aiter_fp4_paged_mqa_logits(
+                        q_fp4=q_fp4[rows],
+                        q_scale=q_scale[rows],
+                        k_payload=k_payload,
+                        k_scale=k_scale,
+                        weights=weights[rows],
+                        page_table=page_table[rows],
+                        c4_seq_lens=c4_seq_lens[rows],
+                        weight_scale=c4_indexer.weight_scale,
+                        is_decode=is_decode,
+                        decode_workspace=metadata.fp4_decode_workspace,
+                        prefill_workspace=prefill_workspace,
+                        logits_out=logits_out,
+                    )
+                    run_topk_transform(rows, logits, planned_topk)
+
+                if use_managed_logits:
+                    with fp4_logits_workspace.acquire(
+                        stop - start,
+                        logits_max_seq_len,
+                        stream=torch.cuda.current_stream(q_fp4.device),
+                    ) as logits_out:
+                        score_and_topk(logits_out)
+                else:
+                    score_and_topk(None)
 
             # The scores are the layer's largest transient and their width tracks
             # context length, so prefill splits the rows into whatever fits the
-            # pooled logits block and reduces each chunk before the next one
-            # reuses it. Rows are scored and reduced independently, so this
+            # managed logits workspace and reduces each chunk before the next
+            # one reuses it. Rows are scored and reduced independently, so this
             # matches a single pass. Decode's rectangle is bounded by its capture
             # shapes, so it always stays whole.
             rows_per_chunk = (
-                query_rows if is_decode else logits_rows_per_chunk(page_table)
+                fp4_logits_workspace.rows_per_chunk(
+                    logits_max_seq_len, max_rows=MAX_FUSED_ROWS
+                )
+                if use_managed_logits
+                else query_rows
             )
+            planned_chunk_rows = getattr(metadata, "fp4_prefill_chunk_rows", 0)
+            if chunk_plans and planned_chunk_rows > 0:
+                rows_per_chunk = min(rows_per_chunk, planned_chunk_rows)
             if rows_per_chunk >= query_rows:
-                run_fp4_indexer(all_rows)
+                run_fp4_indexer(all_rows, 0)
             else:
-                for start in range(0, query_rows, max(1, rows_per_chunk)):
+                for chunk_id, start in enumerate(
+                    range(0, query_rows, max(1, rows_per_chunk))
+                ):
                     run_fp4_indexer(
-                        slice(start, min(start + rows_per_chunk, query_rows))
+                        slice(start, min(start + rows_per_chunk, query_rows)),
+                        chunk_id,
                     )
         else:
             c4_indexer_kv_cache = token_to_kv_pool.get_index_k_with_scale_buffer(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import contextlib
 import inspect
 import logging
+import threading
 import time
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -380,6 +381,8 @@ class ModelRunner:
         self.forward_pass_id = 0
         self._pending_elastic_scale_update = None
         self.init_new_workspace = False
+        self._runtime_workspaces: Dict[str, Any] = {}
+        self._runtime_workspaces_lock = threading.Lock()
         self.draft_model_idx = draft_model_idx
         self.enable_hisparse = get_memory().enable_hisparse
         self._sampling_observer: Optional[SamplingObserver] = None
@@ -908,6 +911,27 @@ class ModelRunner:
         self._unified_memory_pool = result.unified_memory_pool
 
         self._init_post_memory_pool_components()
+
+    def get_or_create_runtime_workspace(
+        self, name: str, factory: Callable[[], Any]
+    ) -> Any:
+        """Return one model-runner-owned workspace shared by backend clones."""
+        with self._runtime_workspaces_lock:
+            workspace = self._runtime_workspaces.get(name)
+            if workspace is None:
+                workspace = factory()
+                self._runtime_workspaces[name] = workspace
+            return workspace
+
+    def close_runtime_workspaces(self) -> None:
+        """Close and forget persistent compute workspaces owned by this runner."""
+        with self._runtime_workspaces_lock:
+            workspaces = list(self._runtime_workspaces.values())
+            self._runtime_workspaces.clear()
+        for workspace in workspaces:
+            close = getattr(workspace, "close", None)
+            if close is not None:
+                close()
 
     def _init_post_memory_pool_components(self):
         """Post-pool component wiring, split out of alloc_memory_pool so forks

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -14,6 +14,7 @@ Two entry points, same core computation:
 from __future__ import annotations
 
 import logging
+import math
 from bisect import bisect_right
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
@@ -33,7 +34,15 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+    FP4LogitsWorkspacePlan,
+    fp4_logits_width_for_context,
+    plan_fp4_logits_workspace,
+)
+from sglang.srt.mem_cache.allocation_sizing import (
+    get_alloc_len_per_decode,
+    get_req_to_token_extra_context_len,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
     get_compress_state_write_pad,
@@ -48,6 +57,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
     get_spec,
+    max_prefill_buffer_tokens,
     max_speculative_num_draft_tokens,
 )
 from sglang.srt.utils.common import (
@@ -77,6 +87,8 @@ class MemoryPoolConfig:
     c128_max_total_num_tokens: int = 0
     c4_state_pool_size: int = 0
     c128_state_pool_size: int = 0
+    dsv4_fp4_logits_workspace_bytes: int = 0
+    dsv4_fp4_logits_workspace_max_seq_len: int = 0
 
     mem_fraction_static: Optional[float] = None
 
@@ -88,6 +100,12 @@ class MemoryPoolConfig:
     unified_total_bytes: Optional[int] = None
 
     def __post_init__(self):
+        if self.dsv4_fp4_logits_workspace_bytes < 0:
+            raise ValueError("dsv4_fp4_logits_workspace_bytes must be non-negative")
+        if self.dsv4_fp4_logits_workspace_max_seq_len < 0:
+            raise ValueError(
+                "dsv4_fp4_logits_workspace_max_seq_len must be non-negative"
+            )
         if self.max_total_num_tokens <= 0:
             msg = "Not enough memory. Please try to increase --mem-fraction-static."
             if self.mem_fraction_static is not None:
@@ -977,6 +995,22 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.disaggregation_decode_extra_slots = (
             get_disagg().disaggregation_decode_extra_slots or 0
         )
+        self.fp4_logits_workspace_enabled = bool(
+            _is_hip
+            and not kvc.is_draft_worker
+            and kvc.server_args.enable_deepseek_v4_fp4_indexer
+            and 4 in self.compression_ratios
+            and (self.disaggregation_mode != "decode" or self.is_speculative)
+        )
+        self.fp4_logits_workspace_plan: Optional[FP4LogitsWorkspacePlan] = None
+        fp4_workspace_context_len = (
+            self.context_len + get_req_to_token_extra_context_len()
+        )
+        self.fp4_logits_workspace_max_seq_len = (
+            fp4_logits_width_for_context(fp4_workspace_context_len, kvc.page_size)
+            if self.fp4_logits_workspace_enabled
+            else 0
+        )
         if get_memory().enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
@@ -1050,6 +1084,72 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 logger.info(
                     "DSV4 compressed attention: online c128 enabled (ring_size=1)"
                 )
+
+    def _plan_fp4_logits_workspace(
+        self, available_bytes: int
+    ) -> Optional[FP4LogitsWorkspacePlan]:
+        if not getattr(self, "fp4_logits_workspace_enabled", False):
+            return None
+
+        schedule = get_schedule()
+        mem_fraction_static = schedule.mem_fraction_static
+        if mem_fraction_static is None:
+            mem_fraction_static = 0.9
+        # ``available_bytes`` is the static-pool budget after preserving runtime
+        # slack. Reconstruct a conservative share of that slack without another
+        # device query; the allocation is checked once against live free memory
+        # when the runner creates the workspace.
+        runtime_headroom_bytes = int(
+            available_bytes
+            * max(0.0, 1.0 - mem_fraction_static)
+            / max(mem_fraction_static, 1.0e-6)
+        )
+        free_memory_fraction = envs.SGLANG_DSV4_FP4_LOGITS_FREE_MEM_FRACTION.get()
+        if not 0.0 < free_memory_fraction <= 1.0:
+            raise ValueError(
+                "SGLANG_DSV4_FP4_LOGITS_FREE_MEM_FRACTION must be in (0, 1], "
+                f"got {free_memory_fraction}"
+            )
+        # At mem_fraction_static=1 there is no nominal activation headroom, but
+        # this persistent workspace is charged directly against the token pool.
+        # Reserve at least one maximum-width row from that static budget.
+        row_bytes = self.fp4_logits_workspace_max_seq_len * 4
+        runtime_headroom_bytes = max(
+            runtime_headroom_bytes,
+            math.ceil(row_bytes / free_memory_fraction),
+        )
+
+        prefill_buffer_rows = max_prefill_buffer_tokens()
+        if prefill_buffer_rows <= 0:
+            prefill_buffer_rows = schedule.max_prefill_tokens or 1
+        max_prefill_rows = (
+            1 if self.disaggregation_mode == "decode" else prefill_buffer_rows
+        )
+        # CP round-robin reindexes query rows before the local indexer runs.
+        max_prefill_rows = ceil_div(
+            max_prefill_rows, max(get_parallel().attn_cp_size, 1)
+        )
+        max_query_rows = max_prefill_rows
+        if self.requested_max_running_requests_per_worker is not None:
+            verify_rows = self.requested_max_running_requests_per_worker * max(
+                self.online_c128_mtp_max_draft_tokens, 1
+            )
+            max_query_rows = max(max_query_rows, verify_rows)
+
+        ceiling_mb = envs.SGLANG_DSV4_FP4_LOGITS_BUDGET_MB.get()
+        if ceiling_mb < 0:
+            raise ValueError(
+                "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB must be non-negative "
+                f"(0 selects auto), got {ceiling_mb}"
+            )
+        max_workspace_bytes = ceiling_mb * (1 << 20) if ceiling_mb else None
+        return plan_fp4_logits_workspace(
+            max_seq_len=self.fp4_logits_workspace_max_seq_len,
+            max_query_rows=max_query_rows,
+            runtime_headroom_bytes=runtime_headroom_bytes,
+            free_memory_fraction=free_memory_fraction,
+            max_workspace_bytes=max_workspace_bytes,
+        )
 
     def _assert_ring_serves_draft_tokens(self, num_draft_tokens: int) -> None:
         """A verify batch writes its whole optimistic tail into the ring, so ring
@@ -1221,6 +1321,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
 
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens
+        fp4_plan = getattr(self, "fp4_logits_workspace_plan", None)
         swa = sizes.swa_max_total_num_tokens
         logger.info(
             f"DSV4 pool sizes: full={full}, swa={swa}, "
@@ -1237,6 +1338,12 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c128_max_total_num_tokens=sizes.c128_max_total_num_tokens,
             c4_state_pool_size=sizes.c4_state_pool_size,
             c128_state_pool_size=sizes.c128_state_pool_size,
+            dsv4_fp4_logits_workspace_bytes=(
+                fp4_plan.capacity_bytes if fp4_plan is not None else 0
+            ),
+            dsv4_fp4_logits_workspace_max_seq_len=(
+                fp4_plan.max_seq_len if fp4_plan is not None else 0
+            ),
         )
 
     def finalize_with_max_running_requests(
@@ -1273,11 +1380,20 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             max_running_requests_per_worker
         )
 
+        self.fp4_logits_workspace_plan = self._plan_fp4_logits_workspace(
+            available_bytes
+        )
+        fp4_logits_workspace_bytes = (
+            self.fp4_logits_workspace_plan.capacity_bytes
+            if self.fp4_logits_workspace_plan is not None
+            else 0
+        )
         available_bytes_for_tokens = max(
             available_bytes
             - c128_state_fixed_bytes
             - swa_ring_fixed_bytes
-            - c4_state_fixed_bytes,
+            - c4_state_fixed_bytes
+            - fp4_logits_workspace_bytes,
             0,
         )
         full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
@@ -1290,6 +1406,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
             f"swa_ring_fixed={swa_ring_fixed_bytes / (1 << 30):.2f} GB, "
             f"c4_state_fixed={c4_state_fixed_bytes / (1 << 30):.2f} GB, "
+            f"fp4_logits_workspace={fp4_logits_workspace_bytes / (1 << 20):.2f} MiB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)
@@ -1302,6 +1419,16 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         assert page_size % 128 == 0, (
             "page_size must be multiple of 128 for compressed attention"
         )
+        # A token-capped configuration bypasses byte profiling. Still resolve
+        # the workspace from the equivalent token-pool footprint so the runner
+        # receives the same explicit capacity contract.
+        if getattr(self, "fp4_logits_workspace_plan", None) is None:
+            estimated_available_bytes = max(
+                int(max_total_num_tokens * self.bytes_per_full_token), 1
+            )
+            self.fp4_logits_workspace_plan = self._plan_fp4_logits_workspace(
+                estimated_available_bytes
+            )
         sizes = self._compute_dsv4_sizes(max_total_num_tokens, page_size)
         return self._to_config(sizes)
 

--- a/test/manual/bench_dsv4_fp4_logits_workspace_hip.py
+++ b/test/manual/bench_dsv4_fp4_logits_workspace_hip.py
@@ -1,0 +1,123 @@
+"""MI35x endurance benchmark for the adaptive DSV4 FP4 logits workspace.
+
+This isolates the score-output/top-k lifetime that caused #37660: contexts grow
+monotonically while every row chunk reuses one stable allocation.  It reports
+allocated/reserved memory and latency for each geometry; run the full model
+nightlies for end-to-end score-kernel measurements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+    FP4LogitsWorkspace,
+    fp4_logits_width_for_context,
+    plan_fp4_logits_workspace,
+)
+from sglang.srt.utils import is_gfx95_supported, is_hip
+
+
+def benchmark(
+    *,
+    contexts: list[int],
+    row_counts: list[int],
+    budget_mb: int,
+    iterations: int,
+) -> list[dict]:
+    device = torch.device("cuda")
+    max_width = fp4_logits_width_for_context(max(contexts), 256)
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    plan = plan_fp4_logits_workspace(
+        max_seq_len=max_width,
+        max_query_rows=max(row_counts),
+        runtime_headroom_bytes=free_bytes,
+        free_memory_fraction=0.2,
+        max_workspace_bytes=budget_mb << 20,
+    )
+    workspace = FP4LogitsWorkspace(plan=plan, device=device)
+    results = []
+    try:
+        for context_len in contexts:
+            width = fp4_logits_width_for_context(context_len, 256)
+            for rows in row_counts:
+                chunk_rows = min(rows, workspace.rows_per_chunk(width))
+                torch.cuda.synchronize()
+                allocated_before = torch.cuda.memory_allocated(device)
+                reserved_before = torch.cuda.memory_reserved(device)
+                started = time.perf_counter()
+                checksum = None
+                for _ in range(iterations):
+                    for start in range(0, rows, chunk_rows):
+                        count = min(chunk_rows, rows - start)
+                        with workspace.acquire(count, width) as logits:
+                            # Model the producer write and immediate top-k
+                            # consumer without allocating another full rectangle.
+                            logits.zero_()
+                            checksum = torch.topk(
+                                logits,
+                                k=min(512, width),
+                                dim=-1,
+                            ).indices
+                torch.cuda.synchronize()
+                elapsed_ms = (time.perf_counter() - started) * 1000 / iterations
+                results.append(
+                    {
+                        "context": context_len,
+                        "rows": rows,
+                        "width": width,
+                        "chunk_rows": chunk_rows,
+                        "chunks": -(-rows // chunk_rows),
+                        "latency_ms": elapsed_ms,
+                        "workspace_mb": workspace.capacity_bytes / (1 << 20),
+                        "allocated_delta_mb": (
+                            torch.cuda.memory_allocated(device) - allocated_before
+                        )
+                        / (1 << 20),
+                        "reserved_delta_mb": (
+                            torch.cuda.memory_reserved(device) - reserved_before
+                        )
+                        / (1 << 20),
+                        "checksum": int(checksum[0, 0].item()),
+                    }
+                )
+    finally:
+        workspace.close()
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--contexts",
+        type=int,
+        nargs="+",
+        default=[8192, 131072, 524288, 1048576],
+    )
+    parser.add_argument("--rows", type=int, nargs="+", default=[1, 64, 256, 512])
+    parser.add_argument("--budget-mb", type=int, default=512)
+    parser.add_argument("--iterations", type=int, default=3)
+    args = parser.parse_args()
+
+    if not is_hip() or not is_gfx95_supported():
+        print("[skip] requires a gfx95 HIP GPU")
+        return
+    print(
+        json.dumps(
+            benchmark(
+                contexts=args.contexts,
+                row_counts=args.rows,
+                budget_mb=args.budget_mb,
+                iterations=args.iterations,
+            ),
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/amd/test_deepseek_v4_flash_fp4.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp4.py
@@ -48,6 +48,7 @@ COMMON_ENV_VARS = {
 # FP4 variant
 FP4_ENV_VARS = {
     "SGLANG_DSV4_FP4_EXPERTS": "true",
+    "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB": "64",
 }
 
 
@@ -68,6 +69,7 @@ class TestDeepseekV4Fp4(CustomTestCase):
             "--disable-radix-cache",
             "--attention-backend",
             "dsv4",
+            "--enable-deepseek-v4-fp4-indexer",
             "--max-running-requests",
             "256",
             "--page-size",

--- a/test/registered/amd/test_deepseek_v4_pro_fp4_cp.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp4_cp.py
@@ -49,6 +49,7 @@ COMMON_ENV_VARS = {
 # FP4 variant (matches test_deepseek_v4_pro_fp4.py; V4-Pro also auto-detects it).
 FP4_ENV_VARS = {
     "SGLANG_DSV4_FP4_EXPERTS": "true",
+    "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB": "64",
 }
 
 
@@ -79,6 +80,7 @@ class TestDeepseekV4ProFp4CPInterleave(CustomTestCase):
             "--disable-radix-cache",
             "--attention-backend",
             "dsv4",
+            "--enable-deepseek-v4-fp4-indexer",
             "--max-running-requests",
             "256",
             "--page-size",

--- a/test/registered/amd/test_deepseek_v4_pro_fp4_cp_tbo.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp4_cp_tbo.py
@@ -63,6 +63,7 @@ COMMON_ENV_VARS = {
 # FP4 variant (matches test_deepseek_v4_pro_fp4.py; V4-Pro also auto-detects it).
 FP4_ENV_VARS = {
     "SGLANG_DSV4_FP4_EXPERTS": "true",
+    "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB": "64",
 }
 
 
@@ -98,6 +99,7 @@ class TestDeepseekV4ProFp4CPInterleaveTbo(CustomTestCase):
             "--disable-radix-cache",
             "--attention-backend",
             "dsv4",
+            "--enable-deepseek-v4-fp4-indexer",
             "--max-running-requests",
             "256",
             "--page-size",

--- a/test/registered/amd/test_deepseek_v4_pro_fp4_mtp.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp4_mtp.py
@@ -49,6 +49,7 @@ COMMON_ENV_VARS = {
 
 FP4_ENV_VARS = {
     "SGLANG_DSV4_FP4_EXPERTS": "true",
+    "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB": "64",
 }
 
 
@@ -69,6 +70,7 @@ class TestDeepseekV4ProFp4MTP(CustomTestCase):
             "--disable-radix-cache",
             "--attention-backend",
             "dsv4",
+            "--enable-deepseek-v4-fp4-indexer",
             # MTP / EAGLE speculative decoding (NextN head from the base model).
             "--speculative-algorithm",
             "EAGLE",

--- a/test/registered/amd/test_deepseek_v4_pro_fp4_tbo.py
+++ b/test/registered/amd/test_deepseek_v4_pro_fp4_tbo.py
@@ -64,6 +64,9 @@ COMMON_ENV_VARS = {
 # FP4 variant
 FP4_ENV_VARS = {
     "SGLANG_DSV4_FP4_EXPERTS": "true",
+    # Keep the test's persistent indexer scratch small enough to exercise
+    # capacity-driven row chunking under TBO.
+    "SGLANG_DSV4_FP4_LOGITS_BUDGET_MB": "64",
 }
 
 
@@ -91,6 +94,7 @@ class TestDeepseekV4ProFp4Tbo(CustomTestCase):
             "--disable-radix-cache",
             "--attention-backend",
             "dsv4",
+            "--enable-deepseek-v4-fp4-indexer",
             "--kv-cache-dtype",
             "fp8_e4m3",
             "--max-running-requests",

--- a/test/registered/kernels/ops/attention/test_fp4_indexer_hip.py
+++ b/test/registered/kernels/ops/attention/test_fp4_indexer_hip.py
@@ -37,6 +37,10 @@ from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
     prepare_fp4_k_write_metadata,
     prepare_fp4_prefill_workspace,
 )
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+    FP4LogitsWorkspace,
+    plan_fp4_logits_workspace,
+)
 from sglang.srt.utils import get_device, is_gfx95_supported, is_hip
 from sglang.test.ci.ci_register import register_amd_ci
 
@@ -624,7 +628,14 @@ def _build_logits_case(
     }
 
 
-def _run_logits(case, *, is_decode: bool, decode_ws=None, prefill_ws=None):
+def _run_logits(
+    case,
+    *,
+    is_decode: bool,
+    decode_ws=None,
+    prefill_ws=None,
+    logits_out=None,
+):
     return aiter_fp4_paged_mqa_logits(
         q_fp4=case["q_fp4"],
         q_scale=case["q_scale"],
@@ -637,6 +648,7 @@ def _run_logits(case, *, is_decode: bool, decode_ws=None, prefill_ws=None):
         is_decode=is_decode,
         decode_workspace=decode_ws,
         prefill_workspace=prefill_ws,
+        logits_out=logits_out,
     )
 
 
@@ -751,9 +763,6 @@ def test_pinned_schedule_matches_unpinned_logits(is_decode: bool) -> None:
             case["page_table"], case["c4_seq_lens"]
         )
         pinned = _run_logits(case, is_decode=False, prefill_ws=workspace)
-    # Prefill scores are views of one pooled block, so the second call would
-    # otherwise hand back the same memory and compare it against itself.
-    pinned = pinned.clone()
     unpinned = _run_logits(case, is_decode=is_decode)
 
     seq_len = case["seq_len"]
@@ -775,33 +784,62 @@ def test_stale_workspace_row_count_falls_back_to_inline_schedule() -> None:
     torch.testing.assert_close(with_stale[:, :seq_len], without[:, :seq_len])
 
 
-def test_prefill_logits_come_from_one_pooled_block() -> None:
-    """Prefill must score into one constant-size block, not a per-call rectangle.
-
-    The logits width tracks context length, so a fresh allocation per call feeds
-    the caching allocator a growing size sequence: each request outgrows every
-    cached block and strands a segment, until an allocator that bypasses torch
-    (Triton kernel scratch) is refused. One pooled block keeps the request size
-    constant, which is what makes the blocks reusable.
-    """
+def test_prefill_logits_use_explicit_output_storage() -> None:
+    """The adapter writes a caller-owned view without hidden global pooling."""
     torch.manual_seed(14)
-    narrow = _run_logits(_build_logits_case(2, 256), is_decode=False)
-    wide = _run_logits(_build_logits_case(4, 512), is_decode=False)
+    case = _build_logits_case(2, 256)
+    workspace = prepare_fp4_prefill_workspace(case["page_table"], case["c4_seq_lens"])
+    out = torch.empty(
+        (2, workspace.max_seq_len), dtype=torch.float32, device=get_device()
+    )
 
-    assert narrow.shape != wide.shape
-    assert narrow.data_ptr() == wide.data_ptr()
+    logits = _run_logits(
+        case,
+        is_decode=False,
+        prefill_ws=workspace,
+        logits_out=out,
+    )
+
+    assert logits.data_ptr() == out.data_ptr()
+    _assert_logits_agree(logits, case)
+
+
+def test_managed_workspace_orders_cross_stream_reuse() -> None:
+    """A second stream must observe the first consumer before overwriting."""
+    width = 512
+    plan = plan_fp4_logits_workspace(
+        max_seq_len=width,
+        max_query_rows=2,
+        runtime_headroom_bytes=1 << 20,
+        free_memory_fraction=1.0,
+        max_workspace_bytes=None,
+    )
+    workspace = FP4LogitsWorkspace(plan=plan, device=get_device())
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+    try:
+        with torch.cuda.stream(stream_a):
+            with workspace.acquire(2, width, stream=stream_a) as out:
+                out.fill_(1)
+        with torch.cuda.stream(stream_b):
+            with workspace.acquire(2, width, stream=stream_b) as out:
+                out.add_(1)
+                observed = out.sum()
+        stream_b.synchronize()
+        assert observed.item() == 2 * 2 * width
+    finally:
+        workspace.close()
 
 
 def test_row_chunks_reproduce_the_unsplit_batch() -> None:
     """Rows are scored and reduced independently, which is what lets callers chunk.
 
-    ``forward_c4_indexer`` splits prefill rows to whatever fits the pooled block,
-    so a chunk must score its rows exactly as an unsplit call would.
+    ``forward_c4_indexer`` splits prefill rows to whatever fits the managed
+    workspace, so a chunk must score its rows exactly as an unsplit call would.
     """
     torch.manual_seed(15)
     batch, chunk_rows = 6, 2
     case = _build_logits_case(batch, 512)
-    # Cloned: the chunk calls below score into the same pooled block.
     full = _run_logits(case, is_decode=False).clone()
 
     for start in range(0, batch, chunk_rows):

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -34,6 +34,7 @@ from sglang.kernels.ops.attention.dsv4.topk import (
     topk_transform_paged_v2,
     topk_transform_ragged_v2,
 )
+from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -159,6 +160,25 @@ def _plan(seq_lens):
     metadata = plan_topk_v2(seq_lens)
     torch.cuda.synchronize()
     return metadata
+
+
+def test_plan_topk_v2_refreshes_stable_output_address():
+    """Graph-owned callers can refresh plan contents without rebinding pointers."""
+    seq_lens = torch.tensor([64, 1024, 17], dtype=torch.int32, device="cuda")
+    out = torch.zeros((4, 2), dtype=torch.int32, device="cuda")
+    returned = plan_topk_v2(seq_lens, out=out)
+    assert returned.data_ptr() == out.data_ptr()
+
+    updated_lens = torch.tensor([2048, 1, 511], dtype=torch.int32, device="cuda")
+    plan_topk_v2(updated_lens, out=out)
+    if is_hip():
+        # The AMD top-k v2 planner is intentionally a no-op; only stable
+        # address forwarding is part of its contract there.
+        assert out.count_nonzero().item() == 0
+        return
+    expected = plan_topk_v2(updated_lens)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, expected)
 
 
 def _run(scores, seq_lens, page_table, inv_cpu, k):

--- a/test/registered/unit/layers/test_dsv4_fp4_logits_workspace.py
+++ b/test/registered/unit/layers/test_dsv4_fp4_logits_workspace.py
@@ -1,0 +1,179 @@
+"""CPU contract tests for the DSV4 HIP FP4 logits workspace."""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.fp4_logits_workspace import (
+    FP4LogitsWorkspace,
+    fp4_logits_width_for_context,
+    fp4_logits_width_from_page_table,
+    limit_plan_to_available_memory,
+    plan_fp4_logits_workspace,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestFP4LogitsWorkspacePlan(unittest.TestCase):
+    def test_context_width_uses_c4_page_geometry(self):
+        self.assertEqual(fp4_logits_width_from_page_table(1), 256)
+        self.assertEqual(fp4_logits_width_from_page_table(5), 512)
+        self.assertEqual(fp4_logits_width_for_context(131072, 256), 32768)
+
+    def test_small_workload_does_not_allocate_the_ceiling(self):
+        plan = plan_fp4_logits_workspace(
+            max_seq_len=32768,
+            max_query_rows=64,
+            runtime_headroom_bytes=8 << 30,
+            free_memory_fraction=0.2,
+            max_workspace_bytes=2 << 30,
+        )
+        self.assertEqual(plan.capacity_bytes, 64 * 32768 * 4)
+        self.assertEqual(plan.rows_at_max_width, 64)
+        self.assertEqual(plan.limiting_reason, "workload")
+
+    def test_runtime_headroom_and_user_ceiling_are_hard_bounds(self):
+        by_headroom = plan_fp4_logits_workspace(
+            max_seq_len=32768,
+            max_query_rows=4096,
+            runtime_headroom_bytes=512 << 20,
+            free_memory_fraction=0.25,
+            max_workspace_bytes=2 << 30,
+        )
+        self.assertLessEqual(by_headroom.capacity_bytes, 128 << 20)
+        self.assertEqual(by_headroom.limiting_reason, "runtime_headroom")
+
+        by_ceiling = plan_fp4_logits_workspace(
+            max_seq_len=32768,
+            max_query_rows=4096,
+            runtime_headroom_bytes=8 << 30,
+            free_memory_fraction=0.5,
+            max_workspace_bytes=64 << 20,
+        )
+        self.assertEqual(by_ceiling.capacity_bytes, 64 << 20)
+        self.assertEqual(by_ceiling.limiting_reason, "user_ceiling")
+
+    def test_budget_must_hold_one_maximum_width_row(self):
+        with self.assertRaisesRegex(ValueError, "cannot hold one row"):
+            plan_fp4_logits_workspace(
+                max_seq_len=1 << 20,
+                max_query_rows=8,
+                runtime_headroom_bytes=1 << 20,
+                free_memory_fraction=0.25,
+                max_workspace_bytes=None,
+            )
+
+    def test_live_free_memory_only_shrinks_the_plan(self):
+        plan = plan_fp4_logits_workspace(
+            max_seq_len=1024,
+            max_query_rows=1024,
+            runtime_headroom_bytes=64 << 20,
+            free_memory_fraction=1.0,
+            max_workspace_bytes=4 << 20,
+        )
+        shrunk = limit_plan_to_available_memory(plan, 2 << 20, safety_fraction=0.5)
+        self.assertEqual(shrunk.capacity_bytes, 1 << 20)
+        self.assertEqual(shrunk.limiting_reason, "live_free_memory")
+
+    def test_explicitly_reserved_one_row_survives_live_check(self):
+        plan = plan_fp4_logits_workspace(
+            max_seq_len=1024,
+            max_query_rows=1,
+            runtime_headroom_bytes=4096,
+            free_memory_fraction=1.0,
+            max_workspace_bytes=None,
+        )
+        checked = limit_plan_to_available_memory(
+            plan, plan.capacity_bytes, safety_fraction=1.0
+        )
+        self.assertIs(checked, plan)
+
+
+class TestFP4LogitsWorkspace(unittest.TestCase):
+    def setUp(self):
+        self.plan = plan_fp4_logits_workspace(
+            max_seq_len=16,
+            max_query_rows=8,
+            runtime_headroom_bytes=4096,
+            free_memory_fraction=1.0,
+            max_workspace_bytes=None,
+        )
+        self.workspace = FP4LogitsWorkspace(plan=self.plan, device=torch.device("cpu"))
+
+    def tearDown(self):
+        self.workspace.close()
+
+    def test_rows_per_chunk_is_strict_and_capped(self):
+        self.assertEqual(self.workspace.rows_per_chunk(16), 8)
+        self.assertEqual(self.workspace.rows_per_chunk(8, max_rows=4), 4)
+        with self.assertRaisesRegex(RuntimeError, "exceeds the workspace plan"):
+            self.workspace.rows_per_chunk(self.plan.capacity_elems + 1)
+
+    def test_sequential_leases_reuse_the_same_storage(self):
+        with self.workspace.acquire(2, 16) as first:
+            first.fill_(3)
+            first_ptr = first.data_ptr()
+        with self.workspace.acquire(4, 8) as second:
+            self.assertEqual(second.data_ptr(), first_ptr)
+            self.assertTrue(torch.equal(second, torch.full_like(second, 3)))
+
+    def test_oversized_lease_is_rejected_without_allocating(self):
+        ptr = self.workspace.data_ptr
+        with self.assertRaisesRegex(RuntimeError, "exceeds the planned capacity"):
+            self.workspace.acquire(9, 16)
+        self.assertEqual(self.workspace.data_ptr, ptr)
+
+    def test_close_is_idempotent_and_rejects_future_use(self):
+        self.workspace.close()
+        self.workspace.close()
+        with self.assertRaisesRegex(RuntimeError, "closed"):
+            self.workspace.acquire(1, 16)
+
+    def test_capture_domain_is_rejected(self):
+        self.workspace.device = torch.device("cuda")
+        with mock.patch("torch.cuda.is_current_stream_capturing", return_value=True):
+            with self.assertRaisesRegex(RuntimeError, "graph capture"):
+                self.workspace.acquire(1, 16)
+        self.workspace.device = torch.device("cpu")
+
+    def test_cross_stream_reuse_waits_for_consumer_event(self):
+        class FakeStream:
+            def __init__(self):
+                self.waited = []
+
+            def wait_event(self, event):
+                self.waited.append(event)
+
+        class FakeEvent:
+            def __init__(self, *args, **kwargs):
+                self.recorded_on = []
+                self.synchronized = False
+
+            def record(self, stream):
+                self.recorded_on.append(stream)
+
+            def synchronize(self):
+                self.synchronized = True
+
+        stream_a = FakeStream()
+        stream_b = FakeStream()
+        self.workspace.device = torch.device("cuda")
+        self.workspace._reuse_event = FakeEvent()
+        with mock.patch("torch.cuda.is_current_stream_capturing", return_value=False):
+            with self.workspace.acquire(1, 16, stream=stream_a):
+                pass
+            event = self.workspace._reuse_event
+            with self.workspace.acquire(1, 16, stream=stream_b):
+                pass
+            with self.workspace.acquire(1, 16, stream=stream_b):
+                pass
+            self.assertEqual(event.recorded_on, [stream_a])
+            self.assertEqual(stream_b.waited, [event])
+        self.workspace.device = torch.device("cpu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
     get_memory,
     get_parallel,
@@ -83,6 +84,8 @@ def _make_model_runner(
     disaggregation_mode="null",
     max_running_requests=None,
     disaggregation_decode_extra_slots=0,
+    enable_deepseek_v4_fp4_indexer=False,
+    mem_fraction_static=0.9,
     kv_lora_rank=512,
     qk_rope_head_dim=64,
     swa_kv_lora_rank=128,
@@ -150,6 +153,8 @@ def _make_model_runner(
         disaggregation_mode=disaggregation_mode,
         max_running_requests=max_running_requests,
         disaggregation_decode_extra_slots=disaggregation_decode_extra_slots,
+        enable_deepseek_v4_fp4_indexer=enable_deepseek_v4_fp4_indexer,
+        mem_fraction_static=mem_fraction_static,
         enable_hisparse=False,
         enable_hierarchical_cache=False,
         enable_dsa_cache_layer_split=False,
@@ -184,6 +189,17 @@ def _configure_dsa_model(model_runner):
     hf_config.architectures = ["GlmMoeDsaForCausalLM"]
     hf_config.index_topk = 2048
     hf_config.index_head_dim = 128
+
+
+def _configure_dsv4_model(model_runner):
+    mc = model_runner.model_config
+    mc.hf_config.architectures = ["DeepseekV4ForCausalLM"]
+    mc.qk_nope_head_dim = 448
+    mc.qk_rope_head_dim = 64
+    mc.index_head_dim = 128
+    mc.compress_ratios = [4, 128] * 16
+    mc.window_size = 128
+    mc.context_len = 131072
 
 
 KV_SIZE = 2  # bf16
@@ -855,6 +871,88 @@ class TestDSAIndexerAllocationPolicy(CustomTestCase):
             cfg = DefaultPoolConfigurator(mr)
 
         self.assertEqual(cfg._cell_size, (576 + 132) * num_layers)
+
+
+class TestDSV4FP4LogitsWorkspaceBudget(CustomTestCase):
+    def _config(
+        self,
+        *,
+        enabled: bool,
+        mem_fraction_static: float = 0.9,
+        attn_cp_size: int = 1,
+    ):
+        mr = _make_model_runner(
+            self,
+            is_hybrid_swa=True,
+            page_size=256,
+            chunked_prefill_size=8192,
+            max_running_requests=256,
+            enable_deepseek_v4_fp4_indexer=enabled,
+            mem_fraction_static=mem_fraction_static,
+        )
+        _configure_dsv4_model(mr)
+        # The configurator consumes the runner-owned resolved server args. Keep
+        # this focused fixture independent of namespace publication details.
+        mr.server_args = SimpleNamespace(enable_deepseek_v4_fp4_indexer=enabled)
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=attn_cp_size),
+            patch("sglang.srt.model_executor.pool_configurator._is_hip", True),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+            # 256 request slots make the fixed C128 state pool several GiB;
+            # leave enough room that this test isolates the FP4 logits bias.
+            config = cfg.calculate_pool_sizes(16 << 30, 256)
+        return cfg, config
+
+    def test_workspace_is_workload_sized_and_charged_to_pool_budget(self):
+        cfg, config = self._config(enabled=True)
+        self.assertGreater(config.dsv4_fp4_logits_workspace_bytes, 0)
+        self.assertLess(
+            config.dsv4_fp4_logits_workspace_bytes,
+            envs.SGLANG_DSV4_FP4_LOGITS_BUDGET_MB.get() << 20,
+        )
+        self.assertEqual(
+            config.dsv4_fp4_logits_workspace_max_seq_len,
+            cfg.fp4_logits_workspace_max_seq_len,
+        )
+        self.assertGreater(
+            config.dsv4_fp4_logits_workspace_max_seq_len,
+            131072 // 4,
+        )
+
+        _, disabled = self._config(enabled=False)
+        self.assertEqual(disabled.dsv4_fp4_logits_workspace_bytes, 0)
+        self.assertGreater(disabled.max_total_num_tokens, config.max_total_num_tokens)
+
+    def test_full_static_fraction_still_reserves_one_workspace_row(self):
+        _, config = self._config(enabled=True, mem_fraction_static=1.0)
+        row_bytes = config.dsv4_fp4_logits_workspace_max_seq_len * 4
+        self.assertGreaterEqual(config.dsv4_fp4_logits_workspace_bytes, row_bytes)
+
+    def test_context_parallel_plans_only_local_query_rows(self):
+        _, cp1 = self._config(enabled=True, attn_cp_size=1)
+        _, cp64 = self._config(enabled=True, attn_cp_size=64)
+        self.assertLess(
+            cp64.dsv4_fp4_logits_workspace_bytes,
+            cp1.dsv4_fp4_logits_workspace_bytes,
+        )
+
+    def test_zero_workspace_ceiling_selects_auto(self):
+        with envs.SGLANG_DSV4_FP4_LOGITS_BUDGET_MB.override(0):
+            _, config = self._config(enabled=True)
+        self.assertGreater(config.dsv4_fp4_logits_workspace_bytes, 0)
+
+    def test_negative_workspace_ceiling_is_rejected(self):
+        with (
+            envs.SGLANG_DSV4_FP4_LOGITS_BUDGET_MB.override(-1),
+            self.assertRaisesRegex(ValueError, "must be non-negative"),
+        ):
+            self._config(enabled=True)
 
 
 class TestFactory(CustomTestCase):


### PR DESCRIPTION
## Motivation

[#37660](https://github.com/sgl-project/sglang/pull/37660) stopped the HIP FP4 indexer's growing-allocation OOR by keeping one module-global 2 GiB logits slab per device. That fixes fragmentation, but every process reserves the full slab even for small workloads; the allocation is not charged to KV-pool sizing, has no model/stream ownership, and aliases concurrent streams. Its row chunking also invalidates the full-row schedule workspace, rebuilding schedule and top-k metadata in every C4 layer.

This PR keeps stable storage, but makes its capacity explicit, workload-aware, pool-accounted, and stream-safe. It follows the row-budgeting direction of [#35217](https://github.com/sgl-project/sglang/pull/35217) while preserving a persistent allocation to avoid reintroducing allocator churn. It builds on the fused scheduler from [#37764](https://github.com/sgl-project/sglang/pull/37764).

## Changes

- Add a model-runner-owned `FP4LogitsWorkspace` instead of the device-global slab.
  - Capacity is the whole-row-aligned minimum of local workload demand, runtime headroom, and the operator ceiling.
  - The exact bytes are deducted from DSV4 KV-pool sizing.
  - Default ceiling: 512 MiB; `SGLANG_DSV4_FP4_LOGITS_BUDGET_MB=0` selects fully automatic sizing.
  - CP planning uses local query rows; decode-only/non-C4 ranks allocate nothing.
- Pass explicit `logits_out` storage into the AITER FP4 adapter. Managed eager prefill never falls back to an oversized allocation.
- Lease the workspace through score + top-k.
  - Same-stream reuse relies on stream ordering and performs no event operations.
  - Only an actual stream transition records the reusable event and waits on it.
- Build chunk-specific page-table/schedule and top-k-v2 plans once per forward, then reuse their stable addresses across C4 layers and graph replays.
- Keep graph-captured logits graph-owned.
- Add workspace, memory-budget, explicit-output, cross-stream, stable-plan, CP/TBO/MTP, and endurance coverage.

## MI355X A/B

Image: `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260903`

DeepSeek-V4-Pro, 8x MI355X, TP8/DP8, MTP 3/1/4, FP4 indexer, context limit 1M, `mem_fraction_static=0.85`, local chunk 1024. Same node; exact decode shapes were warmed before three measured repetitions.

| Policy | Workspace / rank | KV tokens / rank |
|---|---:|---:|
| auto | 1025.0 MiB | 8,429,056 |
| 512 MiB ceiling | 511.5 MiB | 8,471,552 |

The 512 MiB default saves 513.5 MiB/rank and adds 42,496 KV tokens/rank (+0.50%).

| ISL | Concurrency | Auto output tok/s | 512 MiB output tok/s | 512 delta |
|---:|---:|---:|---:|---:|
| 256K | 128 | 3575.18 | 3631.79 | +1.58% |
| 256K | 256 | 4817.42 | 4760.82 | -1.18% |
| 786K | 128 | 1470.79 | 1470.26 | -0.04% |
| 786K | 256 | 1827.73 | 1881.54 | +2.94% |

Geometric-mean throughput delta: **+0.82%** for the 512 MiB policy. Kernel-warmed cold-KV prefill was 1.04% slower at 256K and 1.06% slower at 786K, so the persistent-memory reduction does not create a material throughput regression.

## Validation

- `pre-commit run --files ...`: pass
- Adaptive workspace CPU contracts: 12 passed
- Full pool-configurator suite in the ROCm image: 40 passed
- MI355X explicit-output + cross-stream tests: 2 passed
- MI355X stable top-k plan-address test: 1 passed
- Long-context jobs completed successfully at 256K/786K and concurrency 128/256

This is intentionally a draft while CI and broader accuracy coverage run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34667876258](https://github.com/sgl-project/sglang/actions/runs/34667876258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34667876135](https://github.com/sgl-project/sglang/actions/runs/34667876135)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34667876126](https://github.com/sgl-project/sglang/actions/runs/34667876126)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->