### PR TITLE
[Fix] Only allow cancelling background responses in /v1/responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -193,6 +193,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         ] = {}
 
         self.background_tasks: dict[str, asyncio.Task] = {}
+        self.background_response_ids: set[str] = set()
 
     @staticmethod
     def _has_response_tool(request: ResponsesRequest, *tool_types: str) -> bool:
@@ -501,6 +502,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 )
                 async with self.response_store_lock:
                     self.response_store[response.id] = response
+                    self.background_response_ids.add(response.id)
 
                 # Run the request in the background
                 task = asyncio.create_task(
@@ -1436,6 +1438,17 @@ class OpenAIServingResponses(OpenAIServingChat):
             response = self.response_store.get(response_id)
             if response is None:
                 return self._make_not_found_error(response_id)
+
+            # Only background responses can be cancelled
+            if response_id not in self.background_response_ids:
+                return self.create_error_response(
+                    message=(
+                        "Responses can only be cancelled if they were created with "
+                        "`background=true`."
+                    ),
+                    err_type="invalid_request_error",
+                    status_code=400,
+                )
 
             prev_status = response.status
             if prev_status not in ("queued", "in_progress"):

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1012,6 +1012,36 @@ class CancelIdempotencyTestCase(CustomTestCase):
             self.assertIs(out, resp, status)
             self.assertEqual(out.status, status)
 
+    def test_cancelling_foreground_response_returns_400(self):
+        """Foreground responses (background=False) cannot be cancelled."""
+        from fastapi.responses import ORJSONResponse
+
+        from sglang.srt.entrypoints.openai.protocol import ResponsesResponse
+
+        serving = make_serving()
+        # Create a foreground response (background defaults to False)
+        resp = ResponsesResponse.from_request(
+            ResponsesRequest(model="x", input="hi", background=False, store=True),
+            sampling_params={},
+            model_name="x",
+            created_time=0,
+            output=[],
+            status="completed",
+            usage=None,
+        )
+        serving.response_store[resp.id] = resp
+        # Note: resp.id is NOT added to background_response_ids since it's foreground
+
+        out = asyncio.run(serving.cancel_responses(resp.id))
+
+        # Should return a 400 error response, not the response itself
+        self.assertIsInstance(out, ORJSONResponse)
+        self.assertEqual(out.status_code, 400)
+
+        # Verify error message mentions background requirement
+        error_content = out.body.decode("utf-8")
+        self.assertIn("background=true", error_content)
+
 
 class StreamingLogprobsRejectionTestCase(CustomTestCase):
     def test_stream_with_logprobs_include_rejected(self):


### PR DESCRIPTION
## Motivation

The OpenAI Responses API only allows `POST /v1/responses/{id}/cancel` for responses created with `background=true`. `cancel_responses` currently gates only on `response.status`, so a completed foreground response returns HTTP 200 with the unchanged object instead of a 400 invalid-request error.

Fixes #38002

## Modifications

- `OpenAIServingResponses.__init__`: add `background_response_ids: set[str]`.
- Background create path: record the response id in that set when the response is stored (under the existing `response_store_lock`).
- `cancel_responses`: after the not-found check, return `create_error_response(..., err_type="invalid_request_error", status_code=400)` with the message `Responses can only be cancelled if they were created with background=true.` when the id is not in the set. Existing behaviour for background responses (terminal state is a no-op, otherwise cancel) is unchanged.

Checking `response_id in self.background_tasks` was not sufficient on its own: tasks are popped from that dict on completion, so a finished background response would be indistinguishable from a foreground one and a second cancel would wrongly 400. The set has the same lifetime as `response_store`, which also has no eviction today.

- Unit test `test_cancelling_foreground_response_returns_400` added to `CancelIdempotencyTestCase` in `test/registered/unit/entrypoints/openai/test_serving_responses.py`, following the existing `make_serving()` pattern.

## Accuracy Tests

Not applicable, no model or kernel code touched.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Note: I could not run the unit test locally (no CUDA-capable machine to install `sglang` into), so I am relying on CI for it.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qnxf2u2kSBxRM1AT7kD8BD

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35628358397](https://github.com/sgl-project/sglang/actions/runs/35628358397)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35628358074](https://github.com/sgl-project/sglang/actions/runs/35628358074)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35628358038](https://github.com/sgl-project/sglang/actions/runs/35628358038)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->