### PR TITLE
feat(server): expose HiCache capacity in server info

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -187,8 +187,16 @@ message GetModelInfoResponse {
 
 message GetServerInfoRequest {}
 
+message HiCacheInfo {
+  // Realized host-tier capacity for one DP rank, in logical tokens.
+  uint64 host_total_tokens = 1;
+}
+
 message GetServerInfoResponse {
+  // Full server-info JSON, retained for backward compatibility.
   string json_info = 1;
+  // Absent when hierarchical caching is disabled.
+  HiCacheInfo hicache = 2;
 }
 
 // ---- Abort ----

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from pydantic import ValidationError
 
@@ -423,13 +423,18 @@ class RuntimeHandle:
             )
         return json.dumps(result, default=str)
 
-    def get_server_info(self) -> str:
+    def get_server_info(self) -> Tuple[str, Optional[int]]:
         result: Dict[str, Any] = self.tokenizer_manager.server_args.resolved_dict()
         result.update(self.scheduler_info)
         result["kv_events"] = describe_kv_events_publisher(
             self.tokenizer_manager.server_args
         )
-        return json.dumps(msgspec_to_builtins(result), default=str)
+        result = msgspec_to_builtins(result)
+        hicache = result.get("hicache")
+        host_total_tokens = (
+            hicache["host_total_tokens"] if hicache is not None else None
+        )
+        return json.dumps(result, default=str), host_total_tokens
 
     def health_check(self) -> bool:
         from sglang.srt.managers.tokenizer_manager import ServerStatus

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -817,6 +817,9 @@ async def server_info():
     after publication -- the model a weight update swapped in, its load format,
     an operator-set weight version -- are reported by `/model_info`, and the
     HiCache mirror by `GET /hicache/storage-backend`.
+
+    When hierarchical caching is enabled, `hicache.host_total_tokens` reports
+    the realized per-DP-rank host-tier capacity in logical tokens.
     """
     # Returns internal states per DP.
     internal_states: List[

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -737,6 +737,7 @@ class DataParallelController:
 
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
+        self.hicache_info = scheduler_info[0].get("hicache")
         self.startup_time = aggregate_scheduler_startup_times(
             info.get("startup_time") for info in scheduler_info
         )
@@ -848,15 +849,16 @@ def run_data_parallel_controller_process(
         scheduler_pids = [
             proc.pid for proc in controller.scheduler_procs if proc is not None
         ]
-        pipe_writer.send(
-            {
-                "status": "ready",
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
-                "startup_time": controller.startup_time,
-                SCHEDULER_PIDS_ARG: scheduler_pids,
-            }
-        )
+        scheduler_info = {
+            "status": "ready",
+            "max_total_num_tokens": controller.max_total_num_tokens,
+            "max_req_input_len": controller.max_req_input_len,
+            "startup_time": controller.startup_time,
+            SCHEDULER_PIDS_ARG: scheduler_pids,
+        }
+        if controller.hicache_info is not None:
+            scheduler_info["hicache"] = controller.hicache_info
+        pipe_writer.send(scheduler_info)
         # The primary owns routing for the expanded scheduler set.
         if server_args.node_rank == 0 and not server_args.is_ep_scale_joiner:
             controller.event_loop()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -283,6 +283,7 @@ from sglang.srt.mem_cache.common import (
     release_kv_cache,
     retraction_discard,
 )
+from sglang.srt.mem_cache.hicache_info import get_hicache_info
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
@@ -1799,6 +1800,9 @@ class Scheduler(
             "max_req_input_len": self.max_req_input_len,
             "startup_time": self.startup_time,
         }
+
+        if self.enable_hierarchical_cache:
+            result_dict["hicache"] = get_hicache_info(self.tree_cache)
 
         return result_dict
 

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -14,6 +14,10 @@ from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import EPLB_BALANCEDNESS_WINDOW_SIZES
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.mem_cache.hicache_info import (
+    build_hicache_info,
+    get_hicache_host_pool,
+)
 from sglang.srt.observability.metrics_collector import (
     DPCooperationInfo,
     QueueCount,
@@ -1156,11 +1160,8 @@ class SchedulerMetricsReporter:
         if not self.scheduler.enable_hierarchical_cache:
             return
 
-        host_pool = getattr(
-            self.scheduler.tree_cache, "token_to_kv_pool_host", None
-        ) or getattr(self.scheduler.tree_cache, "full_kv_pool_host", None)
-        assert host_pool is not None, "Host pool not found"
-        host_total = host_pool.logical_size
+        host_pool = get_hicache_host_pool(self.scheduler.tree_cache)
+        host_total = build_hicache_info(host_pool).host_total_tokens
         self.stats.hicache_host_used_tokens = host_total - host_pool.available_size()
         self.stats.hicache_host_total_tokens = host_total
 

--- a/python/sglang/srt/mem_cache/hicache_info.py
+++ b/python/sglang/srt/mem_cache/hicache_info.py
@@ -1,0 +1,44 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HiCacheInfo:
+    """Realized per-DP-rank HiCache capacity in logical tokens."""
+
+    host_total_tokens: int
+
+
+def get_hicache_host_pool(tree_cache: Any) -> Any:
+    """Return the host pool that owns the radix cache's logical token space."""
+    host_pool = getattr(tree_cache, "token_to_kv_pool_host", None)
+    if host_pool is None:
+        host_pool = getattr(tree_cache, "full_kv_pool_host", None)
+    if host_pool is None:
+        raise RuntimeError("HiCache is enabled but no host pool was found")
+    return host_pool
+
+
+def get_hicache_info(tree_cache: Any) -> HiCacheInfo:
+    """Build the public HiCache snapshot from the allocated host pool."""
+    return build_hicache_info(get_hicache_host_pool(tree_cache))
+
+
+def build_hicache_info(host_pool: Any) -> HiCacheInfo:
+    """Build the public HiCache snapshot from a resolved host pool."""
+    return HiCacheInfo(host_total_tokens=int(host_pool.logical_size))

--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -282,6 +282,7 @@ class RayDataParallelController(DataParallelController):
         if scheduler_infos:
             self.max_total_num_tokens = scheduler_infos[0]["max_total_num_tokens"]
             self.max_req_input_len = scheduler_infos[0]["max_req_input_len"]
+            self.hicache_info = scheduler_infos[0].get("hicache")
             self.startup_time = aggregate_scheduler_startup_times(
                 [self.startup_time]
                 + [info.get("startup_time") for info in scheduler_infos]

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -493,6 +493,8 @@ class RayEngine(Engine):
                 "startup_time": controller.startup_time,
             }
         ]
+        if controller.hicache_info is not None:
+            scheduler_infos[0]["hicache"] = controller.hicache_info
 
         event_loop_refs = controller.event_loop_refs
 

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -32,6 +32,12 @@ pub struct ResponseData {
     pub meta_info: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInfo {
+    pub json_info: String,
+    pub hicache_host_total_tokens: Option<u64>,
+}
+
 pub const DEFAULT_RESPONSE_CHANNEL_CAPACITY: usize = 64;
 
 type BridgeStateRef = Arc<Mutex<BridgeState>>;
@@ -274,10 +280,15 @@ impl PyBridge {
         })
     }
 
-    pub fn get_server_info(&self) -> PyResult<String> {
+    pub fn get_server_info(&self) -> PyResult<ServerInfo> {
         Python::attach(|py| {
             let result = self.runtime_handle.call_method0(py, "get_server_info")?;
-            result.extract::<String>(py)
+            let (json_info, hicache_host_total_tokens) =
+                result.extract::<(String, Option<u64>)>(py)?;
+            Ok(ServerInfo {
+                json_info,
+                hicache_host_total_tokens,
+            })
         })
     }
 

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -11,7 +11,7 @@ use tokio_stream::Stream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 
-use crate::bridge::{PyBridge, ResponseChunk, TerminalError};
+use crate::bridge::{PyBridge, ResponseChunk, ServerInfo, TerminalError};
 use crate::proto;
 use crate::utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
@@ -212,6 +212,15 @@ fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 
         .get("status_code")
         .and_then(|value| value.parse::<i32>().ok())
         .unwrap_or(default)
+}
+
+fn build_server_info_response(info: ServerInfo) -> proto::GetServerInfoResponse {
+    proto::GetServerInfoResponse {
+        json_info: info.json_info,
+        hicache: info
+            .hicache_host_total_tokens
+            .map(|host_total_tokens| proto::HiCacheInfo { host_total_tokens }),
+    }
 }
 
 #[tonic::async_trait]
@@ -594,7 +603,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         &self,
         _request: Request<proto::GetServerInfoRequest>,
     ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
-        let json_info = tokio::task::spawn_blocking({
+        let info = tokio::task::spawn_blocking({
             let bridge = self.bridge.clone();
             move || bridge.get_server_info()
         })
@@ -602,7 +611,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         .map_err(|e| Status::internal(format!("Task join error: {}", e)))?
         .map_err(|e| pyerr_to_status(e, "Failed to get server info"))?;
 
-        Ok(Response::new(proto::GetServerInfoResponse { json_info }))
+        Ok(Response::new(build_server_info_response(info)))
     }
 
     async fn list_models(

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,8 +1,8 @@
 use super::{
-    DEFAULT_GRPC_MAX_MESSAGE_SIZE, openai_status_code, resolve_max_message_size,
-    terminal_error_status,
+    DEFAULT_GRPC_MAX_MESSAGE_SIZE, build_server_info_response, openai_status_code,
+    resolve_max_message_size, terminal_error_status,
 };
-use crate::bridge::TerminalError;
+use crate::bridge::{ServerInfo, TerminalError};
 use std::collections::HashMap;
 use tonic::Code;
 
@@ -36,6 +36,21 @@ fn terminal_error_status_maps_abort_to_cancelled() {
     });
 
     assert_eq!(status.code(), Code::Cancelled);
+}
+
+#[test]
+fn server_info_maps_optional_hicache_capacity() {
+    let response = build_server_info_response(ServerInfo {
+        json_info: r#"{"hicache":{"host_total_tokens":8192}}"#.to_string(),
+        hicache_host_total_tokens: Some(8192),
+    });
+    assert_eq!(response.hicache.unwrap().host_total_tokens, 8192);
+
+    let response = build_server_info_response(ServerInfo {
+        json_info: "{}".to_string(),
+        hicache_host_total_tokens: None,
+    });
+    assert!(response.hicache.is_none());
 }
 
 // SAFETY: env vars are process-global; bundle all SGLANG_TONIC_PAYLOAD cases into one

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,9 +1,12 @@
 import asyncio
 import enum
+import json
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.srt.mem_cache.hicache_info import HiCacheInfo
+from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -109,6 +112,22 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             [[1], [2], [3]],
         )
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
+
+
+class TestGrpcServerInfo(CustomTestCase):
+    def test_returns_hicache_in_json_and_typed_bridge_value(self):
+        handle = RuntimeHandle.__new__(RuntimeHandle)
+        handle.tokenizer_manager = SimpleNamespace(
+            server_args=ServerArgs(model_path="dummy")
+        )
+        handle.scheduler_info = {
+            "hicache": HiCacheInfo(host_total_tokens=8192),
+        }
+
+        json_info, host_total_tokens = handle.get_server_info()
+
+        self.assertEqual(host_total_tokens, 8192)
+        self.assertEqual(json.loads(json_info)["hicache"], {"host_total_tokens": 8192})
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -30,6 +30,7 @@ from sglang.srt.arg_groups.validation_hook import check_load_publish_args
 from sglang.srt.entrypoints import http_server
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.mem_cache.hicache_info import HiCacheInfo
 from sglang.srt.runtime_context import publish, reset_context
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -59,6 +60,7 @@ def _call_server_info_with(
     server_args: ServerArgs,
     internal_states: list[dict] | None = None,
     config_updates: dict | None = None,
+    scheduler_info: dict | None = None,
 ) -> dict:
     """Invoke `http_server.server_info()` against a stub global state.
 
@@ -81,7 +83,9 @@ def _call_server_info_with(
     tokenizer_manager = _stub_tokenizer_manager(server_args, _fake_internal_state)
     stub_state = SimpleNamespace(
         tokenizer_manager=tokenizer_manager,
-        scheduler_info={"max_req_input_len": 1024},
+        scheduler_info=(
+            {"max_req_input_len": 1024} if scheduler_info is None else scheduler_info
+        ),
     )
     prior_state = http_server.get_global_state()
     http_server.set_global_state(stub_state)
@@ -434,6 +438,20 @@ class TestServerInfoControlPlaneUpdates(CustomTestCase):
             self.assertEqual(overlaid["weight_version"], "v2")
         finally:
             reset_context()
+
+
+class TestServerInfoHiCacheField(CustomTestCase):
+    def test_hicache_dataclass_is_exposed_as_json_object(self):
+        info = _call_server_info_with(
+            ServerArgs(model_path="dummy"),
+            scheduler_info={
+                "max_req_input_len": 1024,
+                "hicache": HiCacheInfo(host_total_tokens=8192),
+            },
+        )
+
+        self.assertEqual(info["hicache"], {"host_total_tokens": 8192})
+        json.dumps(info)
 
 
 class TestServerInfoExistingFieldsPreserved(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_hicache_info.py
+++ b/test/registered/unit/mem_cache/test_hicache_info.py
@@ -1,0 +1,54 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.mem_cache.hicache_info import get_hicache_info
+from sglang.srt.mem_cache.hicache_storage import PoolName
+from sglang.srt.mem_cache.pool_host.group import HostPoolGroup, PoolEntry
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiCacheInfo(unittest.TestCase):
+    def test_uses_primary_logical_host_capacity(self):
+        anchor_pool = SimpleNamespace(
+            layout="layer_first",
+            page_size=64,
+            device="cpu",
+            size=1024,
+            logical_size=8192,
+            can_use_write_back_jit=False,
+        )
+        host_pool_group = HostPoolGroup(
+            [
+                PoolEntry(
+                    name=PoolName.KV,
+                    host_pool=anchor_pool,
+                    device_pool=None,
+                    layer_mapper=lambda layer_id: layer_id,
+                    is_primary_index_anchor=True,
+                )
+            ]
+        )
+        tree_cache = SimpleNamespace(
+            token_to_kv_pool_host=host_pool_group,
+            full_kv_pool_host=SimpleNamespace(logical_size=4096),
+        )
+
+        self.assertEqual(get_hicache_info(tree_cache).host_total_tokens, 8192)
+
+    def test_supports_full_pool_fallback(self):
+        tree_cache = SimpleNamespace(
+            token_to_kv_pool_host=None,
+            full_kv_pool_host=SimpleNamespace(logical_size=4096),
+        )
+
+        self.assertEqual(get_hicache_info(tree_cache).host_total_tokens, 4096)
+
+    def test_missing_host_pool_fails_fast(self):
+        with self.assertRaisesRegex(RuntimeError, "no host pool"):
+            get_hicache_info(SimpleNamespace())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose the realized HiCache host-tier token capacity through both HTTP server info and the typed gRPC `GetServerInfo` response. This lets control-plane consumers use SGLang's allocated capacity directly instead of reproducing model- and cache-specific sizing formulas.

Related: https://github.com/ai-dynamo/dynamo/issues/14312

### How This Was Implemented

- Add a frozen `HiCacheInfo` snapshot sourced from the allocated host pool's `logical_size`, sharing the host-pool resolution path with Prometheus metrics.
- Carry the snapshot through scheduler startup metadata, including multiprocessing, Ray, and DP-attention controller paths.
- Serialize the dataclass as `hicache.host_total_tokens` in `/server_info` and the deprecated `/get_server_info` alias.
- Add an optional `HiCacheInfo hicache` message to `GetServerInfoResponse` while retaining the full `json_info` field for backward compatibility.

<details>
<summary>Walkthrough</summary>

#### Mental model

The host pool owns the authoritative capacity after all cache-specific allocation decisions have completed. Server-info consumers receive a snapshot of that realized logical token count rather than a value reconstructed from `hicache_size`, model architecture, page size, or parallelism flags.

```mermaid
flowchart LR
    A[Allocated HiCache host pool] -->|logical_size| B[HiCacheInfo startup snapshot]
    B --> C[HTTP server_info JSON]
    B --> D[gRPC bridge]
    D --> E[GetServerInfoResponse.hicache]
    B --> F[DP controller aggregation]
    F --> C
    F --> D
```

#### State and ordering

The scheduler builds `HiCacheInfo` only after the tree cache and its host pools are fully initialized. `host_total_tokens` is per DP rank, matching SGLang's existing per-rank `max_total_num_tokens` server-info convention; DP controller paths propagate the first scheduler's snapshot because ranks are initialized from the same cache configuration.

`logical_size` is intentional: DCP host pools widen physical capacity into the logical token space, and DeepSeek V4 exposes its model-specific allocation through the primary anchor of `HostPoolGroup`. Both therefore report the value the radix/controller layer can actually address.

#### Request lifecycle

At scheduler startup, HiCache-enabled workers resolve the primary host pool and create the immutable snapshot. HTTP recursively converts the dataclass into builtins, while the gRPC runtime returns the same JSON plus the scalar needed to populate the optional typed protobuf field; when HiCache is disabled, the HTTP key is absent and the protobuf message has no presence.

The shared host-pool helper is also used by the existing HiCache Prometheus accounting so metrics and server-info cannot select different pools. Missing host pools fail during startup when HiCache is enabled instead of silently publishing a fabricated capacity.

#### Boundaries and limitations

This change does not add page size, GPU KV capacity, or `max_total_num_tokens` to the typed message because those remain available in the backward-compatible server-info JSON. It also does not report L3 storage capacity: storage backends can be shared, remote, heterogeneous, or byte-addressed, so they do not have a reliable per-worker logical-token capacity.

</details>

### Validation

- `python -m pytest -q test/registered/unit/mem_cache/test_hicache_info.py test/registered/unit/entrypoints/test_server_info.py test/registered/unit/entrypoints/test_grpc_bridge.py` — 36 passed, 12 subtests passed.
- `cargo test --release -p sglang-grpc` — 14 passed.
- `cargo clippy --release -p sglang-grpc -- -D warnings`.
- `cargo fmt --manifest-path rust/sglang-grpc/Cargo.toml -- --check`, Ruff format/lint, isort, and `scripts/lint/check_registered_tests.py`.
- Live `Qwen/Qwen3-0.6B` launch on one NVIDIA L4 with `--enable-hierarchical-cache --hicache-size 1 --page-size 64 --grpc-port 50151`: allocation log, `/server_info`, `/get_server_info`, gRPC typed field, and gRPC JSON all reported `8768` logical host tokens.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829663065](https://github.com/sgl-project/sglang/actions/runs/34829663065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829662809](https://github.com/sgl-project/sglang/actions/runs/34829662809)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829663078](https://github.com/sgl-project/sglang/actions/runs/34829663078)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->