### PR TITLE
[HiCache] Remove duplicate benchmark result fields

### DIFF
--- a/benchmark/hicache/bench_serving.py
+++ b/benchmark/hicache/bench_serving.py
@@ -619,14 +619,6 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
             "concurrency": metrics.concurrency,
-            "input_throughput": metrics.input_throughput,
-            "output_throughput": metrics.output_throughput,
-            "fixed_output_len": args.fixed_output_len,
-            "random_input_len": args.random_input_len,
-            "random_output_len": args.random_output_len,
-            "random_range_ratio": args.random_range_ratio,
-            "duration": benchmark_duration,
-            "completed": metrics.completed,
         }
     else:
         print(f"Error running benchmark for request rate: {request_rate}")


### PR DESCRIPTION
## Motivation

The HiCache serving benchmark result dictionary repeats eight literal keys. Python silently keeps only the later values, and each duplicate uses the same expression as its earlier entry. The repetition therefore adds maintenance risk without changing the serialized result.

## Modifications

Remove the later duplicate entries for throughput, request-shape arguments, duration, and completed requests from `benchmark/hicache/bench_serving.py`.

## Accuracy Tests

```text
python -m py_compile benchmark/hicache/bench_serving.py
AST duplicate-literal-key check: 0 duplicates
ruff check benchmark/hicache/bench_serving.py
ruff format --check benchmark/hicache/bench_serving.py
isort --check-only benchmark/hicache/bench_serving.py
```

All checks pass. The retained entries use the same expressions as the removed duplicates, so the emitted result is unchanged.

## Speed Tests and Profiling

Not applicable. This is a behavior-preserving cleanup outside the benchmark hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable: the output is unchanged; duplicate-key removal is covered by the AST validation above.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: there is no user-facing behavior change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable: retained and removed entries are expression-identical.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33940829328](https://github.com/sgl-project/sglang/actions/runs/33940829328)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33940829218](https://github.com/sgl-project/sglang/actions/runs/33940829218)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
