### PR TITLE
[NVFP4 MoE] Skip dead blockscale_swizzled allocation on Marlin fallback (SM80-SM90x), saves ~3.5 GiB/GPU

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2265,6 +2265,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             use_marlin_fallback = (8, 0) <= capability < (10, 0)
         else:
             use_marlin_fallback = moe_runner_backend.is_marlin()
+        self.use_marlin_fallback = use_marlin_fallback
         if not get_platform().is_blackwell and not use_marlin_fallback:
             raise ValueError(
                 "Current platform does not support NVFP4"
@@ -2396,8 +2397,14 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
         # TRTLLM replaces blockscale_swizzled with an alias to weight_scale
         # during process_weights_after_loading, so skip the expensive
-        # swizzle+allocate here to avoid GPU memory fragmentation
-        if self.enable_flashinfer_trtllm_moe:
+        # swizzle+allocate here to avoid GPU memory fragmentation.
+        # The Marlin fallback path also never reads blockscale_swizzled
+        # (the kernel consumes only the marlin-processed w13_weight_scale)
+        # and process_weights_after_loading returns early before the
+        # re-swizzle, so the copy allocated here would pin uninitialized
+        # garbage for the server's lifetime (~3.5 GiB/rank on a 48-layer
+        # 512-expert NVFP4 model at TP2).
+        if self.enable_flashinfer_trtllm_moe or self.use_marlin_fallback:
             layer.w13_blockscale_swizzled = None
         else:
             layer.w13_blockscale_swizzled = Parameter(
@@ -2417,7 +2424,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
-        if self.enable_flashinfer_trtllm_moe:
+        if self.enable_flashinfer_trtllm_moe or self.use_marlin_fallback:
             layer.w2_blockscale_swizzled = None
         else:
             layer.w2_blockscale_swizzled = Parameter(


### PR DESCRIPTION
## Summary

On the NVFP4 fused-MoE **Marlin fallback path** (SM80–SM90x, i.e. `use_marlin_fallback = (8,0) <= capability < (10,0)`), `create_weights` allocates full-size `w13_blockscale_swizzled` / `w2_blockscale_swizzled` Parameters that are:

1. built from the still-uninitialized `torch.empty` scale buffer (they hold garbage bytes forever),
2. never re-swizzled after checkpoint load (`process_weights_after_loading` returns early in the Marlin branch, before the CuteDSL re-swizzle / TRT-LLM alias),
3. never read by any kernel at runtime (`prepare_moe_nvfp4_layer_for_marlin` + the Marlin kernel consume only the processed `w13/w2_weight_scale`; unlike the MXFP4-Marlin sibling path, no `delattr` cleanup happens here).

On a 48-layer / 512-expert NVFP4 model (Qwen3.8-Flash-Next, RadixArk W4A4 gs16 checkpoint) at TP2, these dead copies pin **~3.5 GiB per rank** for the server's whole lifetime. On 48GB-class cards this alone can decide fit-vs-OOM.

## Fix

Skip the allocation on the Marlin fallback path, mirroring the existing TRT-LLM `None`-placeholder pattern (the flag computed in `__init__` is persisted as `self.use_marlin_fallback`). 10-line diff, zero numerical change — the removed tensors had no reader.

## Measurement (2× NVIDIA L20, sm_89, TP2)

| | before | after |
|---|---|---|
| `Load weight end` mem usage / rank | 41.24 GiB | **37.68 GiB** (−3.56) |
| regression suite | — | 262K-context needle, vision, code-gen all pass with byte-identical outputs |

Full root-cause walk-through with file:line references in the linked issue.

Closes #38073

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33955099356](https://github.com/sgl-project/sglang/actions/runs/33955099356)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33955099129](https://github.com/sgl-project/sglang/actions/runs/33955099129)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33955099291](https://github.com/sgl-project/sglang/actions/runs/33955099291)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->