### PR TITLE
[Spec] Fix shadowed DFlash layer capture in Qwen3.5 text models

### DIFF
--- a/python/sglang/srt/models/qwen3_5_text.py
+++ b/python/sglang/srt/models/qwen3_5_text.py
@@ -147,16 +147,6 @@ class Qwen3_5ForCausalLM(nn.Module):
         current_platform.empty_cache()
         current_platform.synchronize()
 
-    def set_dflash_layers_to_capture(self, layers_to_capture: list[int]):
-        if not self.pp_group.is_last_rank:
-            return
-        if layers_to_capture is None:
-            raise ValueError(
-                "DFLASH requires explicit layer ids for aux hidden capture."
-            )
-        self.capture_aux_hidden_states = True
-        self.model.set_dflash_layers_to_capture(layers_to_capture)
-
     @torch.no_grad()
     def forward(
         self,

--- a/test/registered/unit/layers/moe/test_qwen35_flashinfer_fusion.py
+++ b/test/registered/unit/layers/moe/test_qwen35_flashinfer_fusion.py
@@ -201,6 +201,43 @@ def test_text_entry_wrapper_delegates_pre_capture_prepare():
     assert calls == [runner]
 
 
+def _make_text_entry_wrapper_for_dflash(num_layers=4):
+    captured_layer_ids = []
+    wrapper = SimpleNamespace(
+        pp_group=SimpleNamespace(world_size=1),
+        model=SimpleNamespace(
+            layers=[object()] * num_layers,
+            set_dflash_layers_to_capture=captured_layer_ids.append,
+        ),
+        capture_aux_hidden_states=False,
+    )
+    return wrapper, captured_layer_ids
+
+
+def test_text_entry_dflash_capture_maps_draft_layers_to_target_layers():
+    wrapper, captured_layer_ids = _make_text_entry_wrapper_for_dflash()
+
+    Qwen3_5ForCausalLM.set_dflash_layers_to_capture(wrapper, [0, 2])
+
+    assert wrapper.capture_aux_hidden_states is True
+    assert captured_layer_ids == [[1, 3]]
+
+
+@pytest.mark.parametrize("layer_ids", ([1, 0], [0, 0], [-1], [3]))
+def test_text_entry_dflash_capture_rejects_invalid_layer_ids(layer_ids):
+    wrapper, _ = _make_text_entry_wrapper_for_dflash()
+
+    with pytest.raises(ValueError, match="unique, strictly increasing"):
+        Qwen3_5ForCausalLM.set_dflash_layers_to_capture(wrapper, layer_ids)
+
+
+def test_text_entry_dflash_capture_rejects_pipeline_parallelism():
+    wrapper = SimpleNamespace(pp_group=SimpleNamespace(world_size=2))
+
+    with pytest.raises(NotImplementedError, match="requires PP=1"):
+        Qwen3_5ForCausalLM.set_dflash_layers_to_capture(wrapper, [0])
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Motivation

`Qwen3_5ForCausalLM` defines `set_dflash_layers_to_capture` twice. The later definition shadows the validated implementation, so draft-layer IDs are forwarded without the required `+1` mapping and invalid layer lists are no longer rejected.

## Modifications

- Remove the shadowing duplicate method in `python/sglang/srt/models/qwen3_5_text.py`.
- Add CPU regression coverage for draft-to-target layer mapping, invalid layer IDs, and the PP=1 requirement.

## Accuracy Tests

```text
pytest -q test/registered/unit/layers/moe/test_qwen35_flashinfer_fusion.py
16 passed
```

The focused regression verifies that draft layers `[0, 2]` are forwarded as target layers `[1, 3]`. Ruff, Ruff format, isort, and Python syntax compilation also pass for all changed Python files.

## Speed Tests and Profiling

Not applicable. This restores the intended setup behavior and does not change a hot-path kernel.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: this restores existing internal DFlash behavior.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy is covered above; performance is unaffected.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Related PRs

- #32206 fixes capture after the last decoder layer in the older `qwen3_5.py` implementation. This PR fixes a different shadowed-method bug in `qwen3_5_text.py`.
- #28261 concerns Qwen3-VL capture setup and does not overlap this change.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33943122360](https://github.com/sgl-project/sglang/actions/runs/33943122360)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33943122296](https://github.com/sgl-project/sglang/actions/runs/33943122296)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33943122281](https://github.com/sgl-project/sglang/actions/runs/33943122281)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->