### PR TITLE
[sglang-miles] Fix empty logprob tensors in mixed scoring/decode batches

### DIFF
--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -164,7 +164,7 @@ def get_token_ids_logprobs_raw(
     if stage == LogprobStage.DECODE:
         for i, token_ids in enumerate(token_ids_logprobs_list):
             if token_ids is None or isinstance(token_ids, PerPositionTokenIds):
-                vals.append([])
+                vals.append(logprobs.new_empty(0) if no_copy_to_cpu else [])
                 idxs.append([])
             else:
                 token_ids_tensor = torch.tensor(token_ids, dtype=torch.long).to(

--- a/test/registered/unit/layers/test_per_position_logprobs.py
+++ b/test/registered/unit/layers/test_per_position_logprobs.py
@@ -5,6 +5,7 @@ import torch
 
 from sglang.srt.layers.logprob_processor import (
     LogprobStage,
+    OutputLogprobProcessor,
     get_token_ids_logprobs_chunk,
     get_token_ids_logprobs_raw,
 )
@@ -78,6 +79,20 @@ def test_sparse_and_flat_requests_share_one_batch_without_position_drift():
     assert values[1][1] == pytest.approx(logprobs[3, [8, 1]].tolist())
     assert values[2][0] == pytest.approx(logprobs[4, [4, 7]].tolist())
     assert indices[1] == [[3], [8, 1]]
+
+
+def test_mixed_decode_keeps_empty_values_as_tensors_for_host_normalization():
+    logprobs = torch.randn(3, 13).log_softmax(-1)
+    ids = [PerPositionTokenIds([[2, 5]]), None, [4, 7]]
+    result = OutputLogprobProcessor().compute_logprobs(
+        logprobs, [0, 0, 0], ids, torch.tensor([1, 2, 3])
+    )
+    # Both prefill/decode result consumers call tolist() after asynchronous D2H.
+    assert all(torch.is_tensor(value) for value in result.token_ids_logprobs_val)
+    values = [value.tolist() for value in result.token_ids_logprobs_val]
+    assert values[:2] == [[], []]
+    assert values[2] == pytest.approx(logprobs[2, [4, 7]].tolist())
+    assert result.token_ids_logprobs_idx == [[], [], [4, 7]]
 
 
 @pytest.mark.parametrize("boundaries", [(12,), (24,), (30,), (12, 24, 30)])


### PR DESCRIPTION
## Problem and fix

**Stacked on #38119** (`codex/rebase-sglang-27421`), which replaces #27421 and owns the per-position scoring feature. Merge #38119 first, then retarget this PR to `sglang-miles`.

In a mixed scoring/generation batch, entries without decode candidates return Python lists even when `no_copy_to_cpu=True`. Downstream host normalization expects tensors and calls `.tolist()`, so it can crash on those empty entries.

Return an empty tensor in the no-copy path, preserving an empty list for callers requesting CPU values. The regression combines per-position, absent, and flat requested IDs in one output batch.

**Incremental scope: 2 files, +16/-1; one production line changed plus a regression test.** The sparse API, position tracking, efficient gather, and request validation are in #38119.

Companion Miles PR: https://github.com/radixark/miles/pull/3116.

## Validation

- Regression reproduced on #38119 without this fix; passes with it.
- Combined stack: **77 passed, 7 GPU-only tests skipped, 6 subtests passed**, covering sparse scoring, request validation, fast input logprobs, chunk stitching, and io_struct.
- Applicable pre-commit checks passed. The final combined source tree matches the tested rebase tree `33989b53c684`.
- Full-model GPU validation was not repeated for this restructuring.

Earlier combined-feature qualification on Qwen3.6-35B-A3B recorded zero dense/sparse score difference across two lengths, two logprob offsets, and concurrency 1/8. Mixed traffic completed 128 generation plus 160 scoring requests without a serving crash; a 512-position sparse workload sustained 12.7 requests/s on one H200.

Those measurements required `--chunked-prefill-size -1 --disable-radix-cache --prefill-max-requests 1`. Broader batched/chunked prefill showed a discrepancy in both dense and sparse scoring on that hybrid-model runtime; this stack does not resolve it. The request-interface limitations are documented in #38119.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829665438](https://github.com/sgl-project/sglang/actions/runs/34829665438)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829665272](https://github.com/sgl-project/sglang/actions/runs/34829665272)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829665446](https://github.com/sgl-project/sglang/actions/runs/34829665446)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->