### PR TITLE
fix(nixl): prevent early staging buffer reuse and duplicate sends

### DIFF
--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -34,6 +34,10 @@ class TransferKVChunk:
     staging_counted: bool = False
     # Mori early-send: CUDA event to synchronize before RDMA (optional).
     wait_event: Optional[object] = None
+    # Protocol progress belongs to the work item, so a staging deferral can
+    # retry unfinished destinations without replaying completed KV/aux/state.
+    # Values are destination session identities, never transport handles.
+    completed_destinations: set[str] = dataclasses.field(default_factory=set)
 
 
 def pack_list_of_buffers(buffers: List[bytes]) -> bytes:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1083,6 +1083,20 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 dst_mem_kind=dst_mem_kind,
             )
 
+    def _wait_for_transfer_handles(self, handles: List[Any], room: int) -> None:
+        """Wait for the submitted group using the existing NIXL error policy."""
+        while handles:
+            all_done = True
+            for handle in handles:
+                state = self.agent.check_xfer_state(handle)
+                if state == "ERR":
+                    raise RuntimeError(f"NIXL transfer encountered ERR room={room}")
+                if state != "DONE":
+                    all_done = False
+            if all_done:
+                return
+            time.sleep(0)
+
     def transfer_worker(self, queue: FastQueue, staging_buffer=None, worker_index=0):
         # Per-worker staging strategy: lazy-created on first chunk so we
         # see kv_buffer_tensors (set by ModelRunner after engine init).
@@ -1093,6 +1107,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             kv_chunk: TransferKVChunk = queue.get()
             room = kv_chunk.room
             handles: List[Any] = []
+            submitted_destinations = set()
             try:
                 if room not in self.request_status:
                     logger.debug(
@@ -1153,6 +1168,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 for req in reqs_to_be_processed:
                     assert room == req.room
                     if req.is_dummy():
+                        continue
+                    if req.agent_name in kv_chunk.completed_destinations:
                         continue
 
                     assert req.agent_name in self.decode_kv_args_table
@@ -1304,6 +1321,11 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
                         if kv_xfer_handle is not None:
                             handles.append(kv_xfer_handle)
+                            if use_staging:
+                                # The next destination gathers into this same
+                                # worker buffer. Its previous asynchronous
+                                # reader must finish before that overwrite.
+                                self._wait_for_transfer_handles([kv_xfer_handle], room)
 
                     if kv_chunk.is_last_chunk:
                         dst_info = self.decode_kv_args_table[req.agent_name]
@@ -1347,23 +1369,20 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                         )
                         handles.append(aux_xfer_handle)
 
+                    submitted_destinations.add(req.agent_name)
+
+                # A partial fanout may already have posted KV, aux or state
+                # before another destination defers. Drain those handles even
+                # on requeue, then preserve the completed destinations on the
+                # common work item. This also protects DCP pack regions from
+                # being reused by a different room while these reads are live.
+                self._wait_for_transfer_handles(handles, room)
+                if self.enable_staging:
+                    kv_chunk.completed_destinations.update(submitted_destinations)
+
                 if staging_deferred:
                     # Chunk has been re-enqueued; do not advance status.
                     continue
-
-                while handles:
-                    all_done = True
-                    for handle in handles:
-                        state = self.agent.check_xfer_state(handle)
-                        if state == "ERR":
-                            raise RuntimeError(
-                                f"NIXL transfer encountered ERR room={room}"
-                            )
-                        if state != "DONE":
-                            all_done = False
-                    if all_done:
-                        break
-                    time.sleep(0)
 
                 self._staging_outstanding[room] -= 1
                 if self.enable_deferred_decode_kv_release:
@@ -1986,8 +2005,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             retried on the next pop.
           - oversized chunk (will never fit) -> raise RuntimeError.
           - staging successfully posted -> return ``(handle, False)``. The
-            caller appends the handle to the per-chunk handle list and
-            busy-polls it to DONE alongside other handles.
+            caller waits for this handle before the next gather can reuse
+            the worker's source buffer.
           - send_kvcache_staged returned None (chunk cannot fit; decode buffer
             too small, kv_buffer_tensors missing, etc.) -> raise RuntimeError
             instead of falling back to the slice path.

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -621,6 +621,137 @@ class TestNixlTransferWorker(CustomTestCase):
         )
         self.assertEqual(submitted_counts_at_poll, [3, 3, 3])
 
+    def _run_staging_fanout(self, *, defer_second=False, mixed_first=False):
+        room = 24
+        mgr = self._make_manager(room)
+        mgr.enable_staging = True
+        mgr._staging_ctx = PrefillStagingContext()
+        template_req = mgr.transfer_infos[room]["agent"]
+        template_dst = mgr.decode_kv_args_table["agent"]
+        mgr.transfer_infos[room] = {}
+        mgr.decode_kv_args_table = {}
+        for rank, peer in enumerate(("a", "b")):
+            mgr.transfer_infos[room][peer] = TransferInfo(
+                **{**vars(template_req), "agent_name": peer}
+            )
+            mgr.decode_kv_args_table[peer] = SimpleNamespace(
+                **{
+                    **vars(template_dst),
+                    "decode_tp_size": 2,
+                    "decode_tp_rank": rank,
+                    "staging_base_ptr": 0x1000,
+                    "staging_total_size": 4096,
+                    "dst_kv_item_len": 4,
+                    "dst_state_data_ptrs": [0],
+                    "dst_state_item_lens": [4],
+                    "dst_state_dim_per_tensor": [1],
+                    "dst_state_layer_ids": [0],
+                }
+            )
+        if mixed_first:
+            mgr.decode_kv_args_table["a"].decode_tp_size = 1
+            mgr.decode_kv_args_table["a"].kv_xfer_segments = [object()]
+
+        chunk = self._make_chunk(room, [1], is_last_chunk=True)
+        chunk.state_indices = [0]
+        pending = [chunk]
+        handles = []
+        reads = []
+        live_at_dequeue = []
+        source = [None]
+
+        def get():
+            live_at_dequeue.append([h for h in handles if not h["done"]])
+            if not pending:
+                raise SystemExit()
+            return pending.pop(0)
+
+        def post(peer, kind):
+            handle = dict(peer=peer, kind=kind, polls=0, done=False)
+            handles.append(handle)
+            return handle
+
+        def staged(peer, *args, **kwargs):
+            # Model a destination-specific gather into the worker's one buffer.
+            # NIXL reads it asynchronously, when this handle completes below.
+            source[0] = peer
+            return post(peer, "staged")
+
+        def check(handle):
+            if handle["done"]:
+                return "DONE"
+            handle["polls"] += 1
+            if handle["polls"] == 1:
+                return "PROC"
+            if handle["kind"] == "staged":
+                reads.append((handle["peer"], source[0]))
+            handle["done"] = True
+            return "DONE"
+
+        ready_calls = defaultdict(int)
+
+        def ready(req, *args, **kwargs):
+            ready_calls[req.agent_name] += 1
+            if defer_second and req.agent_name == "b" and ready_calls["b"] == 1:
+                return False, 0, -1, 0, -1
+            return True, 0, 0, 0, 0
+
+        strategy = SimpleNamespace(
+            check_ready=ready, staging_buffer=FakeStagingBuffer()
+        )
+        mgr._try_create_staging_strategy = lambda buffer: strategy
+        mgr.send_kvcache_staged = staged
+        mgr.send_kvcache_mixed = lambda peer, *args: [
+            post(peer, "mixed-vram"),
+            post(peer, "mixed-dram"),
+        ]
+        mgr.send_aux = lambda peer, *args: post(peer, "aux")
+        mgr.maybe_send_extra = lambda peer, *args, **kwargs: [post(peer, "state")]
+        mgr.agent = SimpleNamespace(check_xfer_state=check)
+        queue = SimpleNamespace(get=get, put=pending.append)
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.disaggregation.common.staging_buffer": _fake_staging_buffer_module()
+            },
+        ):
+            with self.assertRaises(SystemExit):
+                mgr.transfer_worker(queue, staging_buffer=strategy.staging_buffer)
+
+        self.assertEqual(mgr.exceptions, {})
+        self.assertEqual(mgr.request_status[room], KVPoll.Success)
+        self.assertEqual(mgr._staging_outstanding.get(room, 0), 0)
+        return handles, reads, live_at_dequeue
+
+    def test_staging_fanout_preserves_each_destinations_source(self):
+        _, reads, _ = self._run_staging_fanout()
+        self.assertEqual(reads, [("a", "a"), ("b", "b")])
+
+    def test_staging_fanout_deferral_does_not_replay_completed_destination(self):
+        handles, reads, live = self._run_staging_fanout(defer_second=True)
+        self.assertEqual(
+            [(h["peer"], h["kind"]) for h in handles],
+            [
+                (peer, kind)
+                for peer in ("a", "b")
+                for kind in ("staged", "state", "aux")
+            ],
+        )
+        self.assertEqual(reads, [("a", "a"), ("b", "b")])
+        self.assertTrue(all(not pending for pending in live))
+
+    def test_staging_fanout_deferral_drains_mixed_handles_before_next_dequeue(self):
+        handles, reads, live = self._run_staging_fanout(
+            defer_second=True, mixed_first=True
+        )
+        self.assertTrue(all(not pending for pending in live))
+        self.assertEqual(
+            [(h["peer"], h["kind"]) for h in handles],
+            [("a", kind) for kind in ("mixed-vram", "mixed-dram", "state", "aux")]
+            + [("b", kind) for kind in ("staged", "state", "aux")],
+        )
+        self.assertEqual(reads, [("b", "b")])
+
 
 class TestNixlNotifications(CustomTestCase):
     def _make_manager(self, messages, required=None):


### PR DESCRIPTION
Closes #38099.

## Motivation

### Summary

While investigating incorrect output in a production deployment with separate prefill and decode workers, we found two defects in NIXL staging sends.

A worker uses one staging buffer to prepare the key/value (KV) cache data for each destination. It can prepare B's data while A's asynchronous transfer is still reading that buffer. If B instead has to wait for staging space, the worker puts the entire data chunk back in its queue and can resend A, including its attached state and metadata.

This PR fixes those two send-path defects. They are plausible contributors to the production symptoms, but the particular production failure has not been reproduced with this patch alone.

## Modifications

- Wait for a staged KV transfer to finish before the next destination can overwrite its source buffer.
- Wait for all transfers already submitted before continuing after a staging retry, including additional state, metadata and transfers spanning different memory types.
- Record completed destinations on the existing `TransferKVChunk`, so a retry processes only unfinished destinations.
- Add three regression tests for source overwrite, duplicate sends and unfinished transfers at the next queue iteration.

The change uses the existing NIXL completion states. Other paths that prepare data in separate buffer regions still wait for their transfers before reusing those regions. Handling unfinished transfers after a transport error remains separate work in #36612 and #36707.

## Accuracy Tests

### Validation

Tested against `db89f639ef475821e6669958cfe22caf914df022`:

- The three added regressions fail on the original code and pass with the fix.
- `test_nixl_backend_basic.py`: 47 passed, plus 2 subtests.
- `test_nixl_deferred_kv_release.py`, `test_nixl_sender_failure_cleanup.py` and `test_disaggregation_wire.py`: 42 passed, plus 10 subtests.
- All applicable pre-commit hooks passed for the three changed files, including formatting, lint and registered-test checks. `git diff --check` also passed.

An additional local review ran four checks through the actual staged-send method, including another request running between retries and repeated waits for space. All four passed with the fix. Three multi-destination cases failed on the original code; the single-destination case passed on both. These extra checks are local review artifacts, not part of the PR's test file.

These tests check the real worker logic on macOS/Python 3.13. Triton imports are stubbed for the CPU tests, `torch.compile` is disabled, and GPU operations and transfers are simulated. Separately, a local implementation of these fixes has already been deployed to production and load-tested on real GPUs, with normal operation reported. That deployment includes other fixes; the exact minimal patch in this PR has not had a standalone GPU comparison.

## Speed Tests and Profiling

The deployed local implementation has undergone production GPU load testing. An isolated before/after throughput comparison for this exact upstream patch has not been run.

Waiting for completion reduces overlap between destinations sharing the source buffer. The current placement also waits for staged KV before sending the final state and metadata, so a single-destination request may lose some overlap too.

A targeted GPU test with a destination temporarily lacking staging space would provide additional coverage for the retry behavior. Separate source buffers could restore overlap, but would require a larger change.

## Checklist

- [x] Format the changed code and run the repository's lint checks.
- [x] Add regression tests and run the relevant CPU tests.
- [x] Deploy the local implementation and run production GPU load tests.
- [ ] Run the targeted multi-destination regressions on real GPUs for this exact upstream patch.
- [ ] Provide an isolated before/after GPU throughput comparison with the same model and deployment settings.
- [x] Link the companion bug report: #38099.

Related: #36893 (similar Mooncake retry issue), #36612 and #36707 (error handling), and #37697 (out-of-order decode completion).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33943413770](https://github.com/sgl-project/sglang/actions/runs/33943413770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33943413643](https://github.com/sgl-project/sglang/actions/runs/33943413643)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33943413697](https://github.com/sgl-project/sglang/actions/runs/33943413697)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->