### PR TITLE
[Qwen4] Release loader parameter snapshot before quantization post-processing

### DIFF
--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1853,7 +1853,13 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     )
                 )
 
+        # A self-reference in the helper would keep params_dict (and pre-repack
+        # Parameters) alive until cyclic GC runs.
+        ple_warned_downcast = False
+
         def load_qwen4_exp_ple_shard(name: str, loaded_weight: torch.Tensor) -> bool:
+            nonlocal ple_warned_downcast
+
             if ".ngram_embedding.shard_" not in name:
                 return False
             import re
@@ -1900,8 +1906,8 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 emb.weight.dtype == torch.float8_e4m3fn
                 and loaded_weight.dtype != torch.float8_e4m3fn
             ):
-                if not getattr(load_qwen4_exp_ple_shard, "_warned_downcast", False):
-                    load_qwen4_exp_ple_shard._warned_downcast = True
+                if not ple_warned_downcast:
+                    ple_warned_downcast = True
                     logger.warning(
                         "PLE checkpoint shards are %s but the embedding storage "
                         "is fp8 (ple_embedding_dtype / fp8 quant config); "

--- a/test/registered/unit/models/test_qwen4_loader_lifetime.py
+++ b/test/registered/unit/models/test_qwen4_loader_lifetime.py
@@ -1,0 +1,101 @@
+import gc
+import unittest
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.models.qwen4_exp import (
+    Qwen4ExpForConditionalGeneration,
+    Qwen4ExpNGramEmbedding,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def make_model(ple_dtype=None):
+    # Exercise the real loader without constructing the distributed model.
+    model = Qwen4ExpForConditionalGeneration.__new__(Qwen4ExpForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(tie_word_embeddings=False, split_ngram_parts=2)
+    model.language_model_only = False
+    model.weight = nn.Parameter(torch.zeros(4), requires_grad=False)
+    if ple_dtype is not None:
+        ple = Qwen4ExpNGramEmbedding.__new__(Qwen4ExpNGramEmbedding)
+        nn.Module.__init__(ple)
+        ple.ngram_embedding = nn.Module()
+        ple.ngram_embedding.weight = nn.Parameter(
+            torch.zeros(4, 2, dtype=ple_dtype), requires_grad=False
+        )
+        ple.ngram_embedding.org_vocab_size = 4
+        ple.ngram_embedding.shard_indices = SimpleNamespace(
+            org_vocab_start_index=0, org_vocab_end_index=4
+        )
+        model.ple = ple
+    return model
+
+
+def ple_weights(dtype):
+    return [
+        (f"ple.ngram_embedding.shard_{i}.weight", torch.full((2, 2), i + 1.0).to(dtype))
+        for i in range(2)
+    ]
+
+
+class TestQwen4LoaderLifetime(unittest.TestCase):
+    def test_replaced_parameters_are_released_without_cyclic_gc(self):
+        for with_ple in (False, True):
+            with self.subTest(with_ple=with_ple):
+                model = make_model(torch.float32 if with_ple else None)
+                source = weakref.ref(model.weight)
+                weights = [("weight", torch.arange(4.0))]
+                expected_names = {"weight"}
+                if with_ple:
+                    weights.extend(ple_weights(torch.float32))
+                    expected_names.add("ple.ngram_embedding.weight")
+                gc_enabled = gc.isenabled()
+                gc.disable()
+                try:
+                    self.assertEqual(model.load_weights(weights), expected_names)
+                    torch.testing.assert_close(model.weight, torch.arange(4.0))
+                    # Quantization post-processing replaces loader-format Parameters
+                    # after load_weights returns. Its snapshot must not pin them.
+                    model.weight = nn.Parameter(torch.ones(4), requires_grad=False)
+                    self.assertIsNone(source())
+                finally:
+                    gc.collect()
+                    if gc_enabled:
+                        gc.enable()
+
+    def test_ple_downcast_warns_once_per_load_and_preserves_values(self):
+        model = make_model(torch.float8_e4m3fn)
+        with patch("sglang.srt.models.qwen4_exp.logger.warning") as warning:
+            for load_index in range(2):
+                self.assertEqual(
+                    model.load_weights(ple_weights(torch.bfloat16)),
+                    {"ple.ngram_embedding.weight"},
+                )
+                self.assertEqual(warning.call_count, load_index + 1)
+                self.assertIn("downcasting is lossy", warning.call_args.args[0])
+                self.assertEqual(warning.call_args.args[1], torch.bfloat16)
+                torch.testing.assert_close(
+                    model.ple.ngram_embedding.weight.float(),
+                    torch.tensor([[1.0, 1.0], [1.0, 1.0], [2.0, 2.0], [2.0, 2.0]]),
+                    rtol=0,
+                    atol=0,
+                )
+
+    def test_ple_matching_dtype_does_not_warn(self):
+        for dtype in (torch.bfloat16, torch.float8_e4m3fn):
+            with self.subTest(dtype=dtype):
+                model = make_model(dtype)
+                with patch("sglang.srt.models.qwen4_exp.logger.warning") as warning:
+                    model.load_weights(ple_weights(dtype))
+                    warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Continued in #38900, targeting `main`.** Qwen4 support PR #37500 merged into main and its old base branch was deleted. GitHub rejects reopening this PR because that base is deleted, and rejects changing the base of a closed PR, so #38900 carries the same two-file fix as one commit on current main (`12771786f23190b1845db33366eba09cb5eacf41`). This PR remains closed for that technical reason.

On September 10, @JUNQINGV587 [confirmed the nonlocal fix is “validated and load-bearing in production”](https://github.com/sgl-project/sglang/pull/38102#issuecomment-5619112638) on 2×L20 / sm_89 / TP2 / Qwen3.8-Flash-Next NVFP4 / Marlin fallback: baseline growth ~0.66 GiB/layer, fixed allocation approximately 37.66 GiB/rank across all 48 layers. These are reporter-run results. The bug was independently confirmed on current main before applying the fix, including failing lifetime subtests. #38900 preserves all evidence below and adds the refreshed CPU validation (58 tests / 54 subtests passed, with skips and environment limitations documented).

Qwen4's loader can retain every loader-format Parameter after `load_weights()` returns. On the NVFP4 Marlin path, replacing those Parameters during post-processing then keeps both old and new CUDA storage live until cyclic GC. This reproduces a Qwen4-specific retention mechanism consistent with the per-layer allocated-memory growth reported in #38074.

`load_qwen4_exp_ple_shard` reads/writes its own `_warned_downcast` attribute. Because it is nested, that reference captures the function in its own closure:

```
function -> closure tuple -> self cell -> function
                         -> params_dict cell -> {FQN: original Parameter}
```

The cycle forms even when no PLE shard or downcast warning is encountered. Its closure also captures `ple_modules`, `loaded_shard_params`, the row-copy helper and shard count. Returning from `load_weights()` leaves the cycle unreachable but alive; the snapshot pins Parameters superseded by Marlin.

Replace the function attribute with a nonlocal boolean. It still warns once per load invocation and resets on the next load. Marlin Parameter identity/layout behavior, checkpoint mapping, tensor math, and reload/update APIs are unchanged. No GC/cache cleanup or manual storage release is added.

Validation:

- Dynamically executed the complete loader method from historical `593134d17` and the original Qwen4 baseline `19b13e804`. Both retain the nested function, snapshot and replaced CPU Parameter before cyclic GC; all are released by GC. With this patch all are released before GC.
- Added a CPU regression using the normally imported Qwen4 loader and real Parameters. Both lifetime cases (with/without PLE) fail on baseline and pass with the fix. Tests also verify warning frequency across repeated loads, matching-dtype silence and loaded values. Passes with CUDA hidden.
- CUDA A/B on **1x NVIDIA L40S / SM89 / TP1**, driver 580.159.03, CUDA 13.0, PyTorch 2.13.0+cu130. Exact Qwen4 source selected by PYTHONPATH. A four-MoE-layer fixture uses real ModelOpt NVFP4 weight creation, a deterministic synthetic safetensors checkpoint, `DefaultModelLoader.load_weights_and_postprocess`, the Qwen4 loader, ModelOpt post-processing, and real Marlin repacking kernels. Cyclic GC was disabled during the observation window.

| CUDA measurement | Baseline | Fixed |
| --- | ---: | ---: |
| Allocated growth per layer | ~27 MiB | 2.5 KiB |
| Final allocated before GC | 239,097,856 B | 125,847,552 B |
| Final reserved | 274,726,912 B | 195,035,136 B |
| Peak allocated | 245,388,800 B | 160,451,072 B |
| Peak reserved | 274,726,912 B | 195,035,136 B |
| Watched obsolete Parameters alive after staging | 24/24 | 0/24 |
| Allocated bytes released by final diagnostic GC | 113,250,304 B | 0 B |

All **40 processed Parameters are bitwise identical**, with identical shapes/dtypes and loaded-name sets. Unit validation: **68 tests / 54 subtests passed**, covering loader staging, ModelOpt loading/NVFP4 scales, Qwen3.5 ModelOpt mapping and the new regression. Touched-file pre-commit checks passed.

CUDA correctness checks: **6 NVFP4 Marlin tests passed** (dense and MoE, including dequantized-reference comparisons; 29 unrelated cases deselected), and **29 Qwen4 PLE offload/norm tests passed**. Total selected suite: **103 tests / 54 subtests passed**. Author-side full-model Qwen4/ModelOpt serving tests require checkpoints not loaded in that validation; reporter full-checkpoint loading and serving results are below.

The initial investigation on main `d6e0a8cbf4e8` used a public two-layer Qwen3 NVFP4 checkpoint on L40S/TP1 and found source Parameters released after staging with approximately flat allocated memory (40 tests / 20 subtests passed). That did **not** support a generic `copy_or_rebind_param()` Marlin fix. This patch addresses the demonstrated Qwen4-specific owner instead.

This differs from #31898's temporary MXFP4 list/stack repack peak and #38073's unused swizzled-scale allocations; neither is changed here.

### Reporter validation — original 2×L20 / TP2 environment

The original #38074 reporter, @JUNQINGV587, [validated this PR on their original failure environment](https://github.com/sgl-project/sglang/issues/38074#issuecomment-5550054757): **2× NVIDIA L20 (sm_89, 48GB each), TP=2**, `lmsysorg/sglang:qwen38flashnext`, PyTorch **2.13.0+cu130**, and the **Qwen3.8-Flash-Next 48-layer NVFP4 MoE checkpoint**. These are reporter-run results.

On the identical setup, the reporter's baseline accumulated **~+0.66 GiB per layer** without reclaiming it and OOMed at **repack #9/48** (46.0 GiB allocated / 47.40 GiB device capacity). With this PR, **all 48 layers on both TP ranks completed**:

```text
load_weights END   alloc=37.00 GiB reserved=37.04 GiB
repack  #1 begin   alloc=37.00 GiB   END alloc=37.66 GiB
repack  #2 begin   alloc=36.99 GiB   END alloc=37.66 GiB
repack  #3 begin   alloc=36.99 GiB   END alloc=37.66 GiB
... flat ...
repack #48 begin   alloc=37.00 GiB   END alloc=37.66 GiB
```

Persistent allocation stayed flat at approximately **37.00 GiB**. The **~0.66 GiB** increase remained only as a transient peak inside each repack call and was released when the call returned; it no longer accumulated across layers.

The reporter confirmed successful server startup and request serving, with **`max_total_num_tokens=524288`** (262144-context). They also ran this PR's `test_qwen4_loader_lifetime.py` unchanged against their live fixed build: **3 tests / 4 subtests passed**, including the replaced-Parameter lifetime check with cyclic GC disabled and weakrefs. Their verdict: **“LGTM — fine to undraft.”**

### Limitations

- Author-side CUDA validation remains the synthetic **1×L40S / TP1** fixture described above. Its internal-FQN weights and minimal Qwen4 module tree do not exercise full model construction, expert checkpoint-name remapping, attention/PLE forward, or end-to-end serving.
- Original-environment **2×L20 / TP2 full-checkpoint model loading and serving** was validated by the #38074 reporter, as attributed above.
- The reporter offered to rerun their complete **262K-context needle / vision / code-generation** regression suite; their comment does not report that suite as rerun on this PR. No such result is claimed here.
- Full maintainer CI and review continue in #38900, whose base is `main`. This closed PR retains its deleted historical base.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33944306171](https://github.com/sgl-project/sglang/actions/runs/33944306171)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33944306060](https://github.com/sgl-project/sglang/actions/runs/33944306060)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33944306165](https://github.com/sgl-project/sglang/actions/runs/33944306165)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->