### PR TITLE
[Fix] Keep request-first precedence for `reasoning_effort` with `--default-chat-template-kwargs`

### DIFF
--- a/docs/docs/basic_usage/openai_api_completions.mdx
+++ b/docs/docs/basic_usage/openai_api_completions.mdx
@@ -196,7 +196,7 @@ python -m sglang.launch_server \
 2. The value in `--default-chat-template-kwargs`
 3. The model's chat-template default
 
-`reasoning_effort` follows a separate normalization path, so the precedence list above does not apply to it. Configure `reasoning_effort` in either the server defaults or individual requests, not both.
+`reasoning_effort` follows the same request-first precedence: a value in the request, either the top-level `reasoning_effort` field or `chat_template_kwargs.reasoning_effort`, wins over `--default-chat-template-kwargs`, which in turn overrides the chat template's own default.
 
 The accepted keys are model-specific. For example, Qwen3 uses `enable_thinking`, while other model families may use `thinking` or may not expose a reasoning toggle. The reasoning parser controls how reasoning tokens are separated from the response; it does not by itself enable reasoning in the chat template.
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1209,6 +1209,14 @@ class OpenAIServingChat(OpenAIServingBase):
         if self.default_chat_template_kwargs:
             ctk = dict(request.chat_template_kwargs or {})
             for k, v in self.default_chat_template_kwargs.items():
+                if k == "reasoning_effort" and request.reasoning_effort is not None:
+                    # The request already chose an effort, either through the
+                    # top-level field or through a chat_template_kwargs value
+                    # that _convert_to_internal_request has moved onto the
+                    # request. Filling the default here would let the later
+                    # chat_template_kwargs merge overwrite the request's value,
+                    # so keep the same request-first precedence as other keys.
+                    continue
                 ctk.setdefault(k, v)
             request.chat_template_kwargs = ctk
             effort = ctk.get("reasoning_effort")

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -881,6 +881,56 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(kwargs["reasoning_effort"], "medium")
         self.assertEqual(req.chat_template_kwargs["reasoning_effort"], "medium")
 
+    def test_request_reasoning_effort_beats_default_after_conversion(self):
+        # Request-first precedence must hold for reasoning_effort too, whether
+        # the request sets it in chat_template_kwargs (which
+        # _convert_to_internal_request moves onto the request) or as the
+        # top-level field. Before the fix the server default was merged back
+        # into chat_template_kwargs and overwrote the request's value at
+        # template time.
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "medium"}
+
+        cases = [
+            ({"reasoning_effort": "xhigh"}, None, "xhigh"),
+            (None, "low", "low"),
+        ]
+        for template_kwargs, top_level, expected in cases:
+            with self.subTest(template_kwargs=template_kwargs, top_level=top_level):
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "user", "content": "What is 2+2?"}],
+                    reasoning_effort=top_level,
+                    chat_template_kwargs=template_kwargs,
+                )
+
+                self.chat._convert_to_internal_request(req)
+
+                kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
+                self.assertEqual(req.reasoning_effort, expected)
+                self.assertEqual(kwargs["reasoning_effort"], expected)
+
+    def test_default_reasoning_effort_applies_when_request_unset_after_conversion(
+        self,
+    ):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "medium"}
+
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+        )
+
+        self.chat._convert_to_internal_request(req)
+
+        kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
+        self.assertEqual(req.reasoning_effort, "medium")
+        self.assertEqual(kwargs["reasoning_effort"], "medium")
+
     def test_k2_selected_terminator_reaches_sampling_params(self):
         self.tm._config_overrides["reasoning_parser"] = "k2_horizon"
         self.chat = OpenAIServingChat(self.tm, self.template_manager)


### PR DESCRIPTION
## Motivation
`--default-chat-template-kwargs` is documented as a default that an explicit request value overrides. That holds for keys like `enable_thinking`, but not for `reasoning_effort`: a request's `reasoning_effort` (top-level field or `chat_template_kwargs`) is silently replaced by the server default. Root cause and end-to-end reproduction are in #38104.

In short, `_convert_to_internal_request` moves the request's `reasoning_effort` from `chat_template_kwargs` onto `request.reasoning_effort` before `_process_messages` merges the defaults, so `setdefault` inserts the server value, and the final `extra_template_kwargs.update(request.chat_template_kwargs)` overwrites the request's choice.

## Modifications
- `serving_chat.py::_process_messages`: skip the `reasoning_effort` default when `request.reasoning_effort` is already set (by the top-level field or by the value moved from `chat_template_kwargs`). Defaults still apply when the request does not specify an effort; the Hunyuan normalization path is untouched.
- `test_serving_chat.py`: two tests through `_convert_to_internal_request` — the request value wins for both input forms, and the default still applies when the request is unset. The first one fails on `main`.
- Docs: replace the "either the server defaults or individual requests, not both" caveat in `openai_api_completions.mdx` with the actual request-first precedence.

## Accuracy Tests
Not applicable (no model/kernel change). `test/registered/unit/entrypoints/openai/test_serving_chat.py`: 137 passed.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [x] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results (N/A — request-routing fix only).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33945592482](https://github.com/sgl-project/sglang/actions/runs/33945592482)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33945592341](https://github.com/sgl-project/sglang/actions/runs/33945592341)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33945592443](https://github.com/sgl-project/sglang/actions/runs/33945592443)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->