### PR TITLE
[AMD] Remove invalid escape warning in RPD utils

### DIFF
--- a/python/sglang/srt/utils/rpd_utils.py
+++ b/python/sglang/srt/utils/rpd_utils.py
@@ -314,37 +314,6 @@ def rpd_to_chrome_trace(
     except:
         print("Did not find SMI data")
 
-    # Create the (global) memory counter
-    """
-    sizes = {}    # address -> size
-    totalSize = 0
-    exp = re.compile("^ptr\((.*)\)\s+size\((.*)\)$")
-    exp2 = re.compile("^ptr\((.*)\)$")
-    for row in connection.execute("SELECT rocpd_api.end/1000.0 as ts, B.string, '1'  FROM rocpd_api INNER JOIN rocpd_string A ON A.id=rocpd_api.apiName_id INNER JOIN rocpd_string B ON B.id=rocpd_api.args_id WHERE A.string='hipFree' UNION ALL SELECT rocpd_api.start/1000.0, B.string, '0' FROM rocpd_api INNER JOIN rocpd_string A ON A.id=rocpd_api.apiName_id INNER JOIN rocpd_string B ON B.id=rocpd_api.args_id WHERE A.string='hipMalloc' ORDER BY ts asc"):
-        try:
-            if row[2] == '0':  #malloc
-                m = exp.match(row[1])
-                if m:
-                    size = int(m.group(2), 16)
-                    totalSize = totalSize + size
-                    sizes[m.group(1)] = size
-                    outfile.write(',{"pid":"0","name":"Allocated Memory","ph":"C","ts":%s,"args":{"depth":%s}}\n'%(row[0],totalSize))
-            else:              #free
-                m = exp2.match(row[1])
-                if m:
-                    try:    # Sometimes free addresses are not valid or listed
-                        size = sizes[m.group(1)]
-                        sizes[m.group(1)] = 0
-                        totalSize = totalSize - size;
-                        outfile.write(',{"pid":"0","name":"Allocated Memory","ph":"C","ts":%s,"args":{"depth":%s}}\n'%(row[0],totalSize))
-                    except KeyError:
-                        pass
-        except ValueError:
-            outfile.write("")
-    if T_end > 0:
-        outfile.write(',{"pid":"0","name":"Allocated Memory","ph":"C","ts":%s,"args":{"depth":%s}}\n'%(T_end,totalSize))
-    """
-
     # Create "faux calling stack frame" on gpu ops traceS
     stacks = {}  # Call stacks built from UserMarker entres.     Key is 'pid,tid'
     currentFrame = {}  # "Current GPU frame" (id, name, start, end).    Key is 'pid,tid'


### PR DESCRIPTION
## Motivation

Python 3.14 reports invalid escape sequence warnings while compiling rpd_utils.py because a disabled triple-quoted code block still contains regex escapes such as \( and \s. Treating SyntaxWarning as an error prevents the module from compiling.

The block is not executed and has been disabled as a string literal, so keeping it only adds parser warnings and maintenance noise.

## Modifications

Remove the disabled global memory-counter block from rpd_utils.py. This does not change runtime behavior.

## Accuracy Tests

Not applicable. The removed block was unreachable.

Validation performed:

- Python 3.14 compilation with SyntaxWarning treated as an error
- Ruff checks for F and E9 rules
- git diff --check

## Speed Tests and Profiling

Not applicable. This change only removes unreachable code.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No unit test is needed for unreachable-code removal; compilation with warnings-as-errors covers the regression.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to unreachable-code removal.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33946802422](https://github.com/sgl-project/sglang/actions/runs/33946802422)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33946802324](https://github.com/sgl-project/sglang/actions/runs/33946802324)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33946802452](https://github.com/sgl-project/sglang/actions/runs/33946802452)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->