### PR TITLE
[Diffusion] Enable breakable CUDA graph for JoyEcho

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/joy_echo/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/joy_echo/denoising.py
@@ -515,7 +515,9 @@ class JoyEchoDMDDenoisingStage(LTX2AVDenoisingStage):
             ]
 
         with self._ltx2_model_forward_context(ctx, step):
-            model_video, model_audio = step.current_model(**model_kwargs)
+            model_video, model_audio = self._ltx2_call_current_model(
+                ctx, step, model_kwargs
+            )
 
         if memory_meta:
             memory_video_len = memory_meta["memory_video_len"]

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -180,6 +180,8 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
         "ideogram-v4-instant",
         "ideogram-ai/ideogram-4-fp8",
         "ideogram-ai/ideogram-4-nf4",
+        "jdopensource/joyai-echo",
+        "joyai-echo",
         "lightricks/ltx-2",
         "lightricks/ltx-2.3",
         "meituan-longcat/longcat-image",
@@ -203,6 +205,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS = frozenset(
     {
         "GlmImagePipelineConfig",
         "Ideogram4PipelineConfig",
+        "JoyEchoPipelineConfig",
         "LTX2PipelineConfig",
         "LTX23PipelineConfig",
         "LongCatImagePipelineConfig",
@@ -735,10 +738,10 @@ class ServerArgs(DisaggServerArgsMixin):
 
         logger.warning(
             "[Diffusion BCG] disabled for %s: only Ideogram-4, "
-            "Lightricks/LTX-2, LongCat-Image, MiniMax-H3, "
-            "Qwen/Qwen-Image, Qwen/Qwen-Image-2512, SANA1.5, SANA-Video, "
-            "Tongyi-MAI/Z-Image/Z-Image-Turbo, and zai-org/GLM-Image are "
-            "currently supported.",
+            "jdopensource/JoyAI-Echo, Lightricks/LTX-2, LongCat-Image, "
+            "MiniMax-H3, Qwen/Qwen-Image, Qwen/Qwen-Image-2512, SANA1.5, "
+            "SANA-Video, Tongyi-MAI/Z-Image/Z-Image-Turbo, and "
+            "zai-org/GLM-Image are currently supported.",
             pipeline_config_name,
         )
         self.enable_breakable_cuda_graph = False


### PR DESCRIPTION
## Motivation

JoyEcho (`jdopensource/JoyAI-Echo`) is a video+audio DMD diffusion model whose DiT forward is **launch/dispatch-bound** on a single B300/GB300: profiling the eager run shows the GPU is idle ~79% of wall time during denoising (busy 385ms / wall 1848ms for a 4-step run). Breakable CUDA graph (BCG) eliminates this launch overhead by replaying a captured graph, but JoyEcho was not wired into it:

1. `JoyEchoPipelineConfig` was not in the BCG supported sets, so `--enable-breakable-cuda-graph` was silently disabled with a warning.
2. The JoyEcho DMD denoising stage called `step.current_model(**model_kwargs)` directly instead of the `_ltx2_call_current_model` helper that routes the forward through the captured breakable graph (the path LTX-2 already uses).

## Modifications

- `joy_echo/denoising.py`: route the DiT forward through `self._ltx2_call_current_model(ctx, step, model_kwargs)` so it replays the captured breakable CUDA graph (matching LTX-2).
- `server_args.py`: register `JoyEchoPipelineConfig` and `jdopensource/joyai-echo` / `joyai-echo` in `BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS` / `..._MODEL_IDS`, and update the unsupported-model warning text.

No kernel arithmetic change — this only routes the existing forward through graph capture/replay.

## Reproduction command

Single GB300, `jdopensource/JoyAI-Echo`, 832x480, 121 frames, 8 steps:

```bash
# baseline (eager)
sglang generate --backend=sglang --model-path=jdopensource/JoyAI-Echo \
  --prompt "A golden retriever runs across a sunny beach, cinematic." \
  --width 832 --height 480 --num-frames 121 --fps 25 \
  --num-inference-steps 8 --guidance-scale 1.0 \
  --num-gpus 1 --seed 42 --quality lossless --save-output \
  --warmup-mode off

# this PR (BCG)
sglang generate --backend=sglang --model-path=jdopensource/JoyAI-Echo \
  --prompt "A golden retriever runs across a sunny beach, cinematic." \
  --width 832 --height 480 --num-frames 121 --fps 25 \
  --num-inference-steps 8 --guidance-scale 1.0 \
  --num-gpus 1 --seed 42 --quality lossless --save-output \
  --warmup-mode request --enable-breakable-cuda-graph \
  --warmup-resolutions 832x480 --warmup-num-frames 121
```

BCG capture succeeds: `captured 289 segment(s), 8 tensor input(s)` and no serving signature miss.

## Output: main (eager) vs this PR (BCG)

The two outputs are **byte-identical** (`md5 e05e299ad355686b74da63bb6bce9621` for both), so the generated video is unchanged — only faster. (The eager run must be measured with `--warmup-mode off`; under `request` warmup the warmup request consumes JoyEcho's multishot shot-0 seed and shifts the serving seed, which is a benchmark artifact, not a numerics change.)

| main (eager) | this PR (BCG) |
| --- | --- |
| ![eager](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-bcg/main.gif) | ![bcg](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-bcg/pr.gif) |

## Speed Tests and Profiling

Hardware: one NVIDIA GB300. Model: `jdopensource/JoyAI-Echo`, 832x480, 121 frames, 8 steps, seed=42.

| Measurement | Denoise (8 steps) | per-step |
| --- | ---: | ---: |
| Baseline (eager, warmup off) | 2718 ms | 236 ms |
| BCG (this PR) | 1540 ms | 171 ms |
| **Speedup** | **-43%** | **-27%** |

Eager profile shows GPU idle ~79% of denoise wall time (launch/dispatch-bound), which is why graph replay recovers it.

## Accuracy Tests

BCG output is **byte-identical** to the eager baseline (`md5` match, lossless) — no numerics change.

## Checklist

- [x] Format the code with pre-commit.
- [x] Provide accuracy and speed results above.
- [x] No user-facing documentation change is required.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33957677905](https://github.com/sgl-project/sglang/actions/runs/33957677905)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33957677784](https://github.com/sgl-project/sglang/actions/runs/33957677784)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33957677872](https://github.com/sgl-project/sglang/actions/runs/33957677872)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->