### PR TITLE
Support Marlin MoE with DeepEP normal and low-latency dispatch

### DIFF
--- a/benchmark/bench_marlin_deepep.py
+++ b/benchmark/bench_marlin_deepep.py
@@ -1,0 +1,212 @@
+"""Compare actual Marlin HTTP serving with none and DeepEP communication.
+
+Run from the repository root with PYTHONPATH=python and a local, pinned AWQ
+checkpoint. Servers run sequentially on the same GPUs. Results include every
+repetition; the script does not assume that DeepEP is faster.
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def server_command(args, backend):
+    world = len(args.gpus.split(","))
+    command = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        args.model,
+        "--quantization",
+        "awq_marlin",
+        "--dtype",
+        "bfloat16",
+        "--tp-size",
+        str(world),
+        "--ep-size",
+        str(world),
+        "--moe-runner-backend",
+        "marlin",
+        "--moe-a2a-backend",
+        backend,
+        "--deepep-mode",
+        "auto",
+        "--attention-backend",
+        "triton",
+        "--disable-shared-experts-fusion",
+        "--cuda-graph-backend-prefill",
+        "disabled",
+        "--cuda-graph-bs-decode",
+        "1",
+        "2",
+        "4",
+        "8",
+        "16",
+        "32",
+        "64",
+        "128",
+        "--max-running-requests",
+        "128",
+        "--max-total-tokens",
+        "65536",
+        "--chunked-prefill-size",
+        "2048",
+        "--context-length",
+        "4096",
+        "--mem-fraction-static",
+        "0.75",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+    ]
+    if args.dp_attention:
+        command += ["--enable-dp-attention", "--dp-size", str(world)]
+    return command
+
+
+def wait_ready(server, base_url):
+    deadline = time.monotonic() + 600
+    while time.monotonic() < deadline:
+        if server.poll() is not None:
+            raise RuntimeError("Server exited before readiness; see server log.")
+        try:
+            with urllib.request.urlopen(base_url + "/health", timeout=2):
+                return
+        except (urllib.error.URLError, TimeoutError):
+            time.sleep(1)
+    raise TimeoutError("Server did not become ready within 600 seconds.")
+
+
+def benchmark(args, backend, env):
+    output = args.results / f"{backend}.jsonl"
+    if output.exists():
+        raise FileExistsError(f"Use a new results directory: {output} exists.")
+    for concurrency in args.concurrency:
+        for repeat in range(args.repetitions):
+            command = [
+                sys.executable,
+                "-m",
+                "sglang.benchmark.serving",
+                "--backend",
+                "sglang",
+                "--base-url",
+                f"http://127.0.0.1:{args.port}",
+                "--dataset-name",
+                "random",
+                "--random-input-len",
+                str(args.input_len),
+                "--random-output-len",
+                str(args.output_len),
+                "--random-range-ratio",
+                "1",
+                "--num-prompts",
+                str(concurrency * args.waves),
+                "--max-concurrency",
+                str(concurrency),
+                "--warmup-requests",
+                "8",
+                "--seed",
+                "42",
+                "--output-file",
+                str(output),
+                "--disable-tqdm",
+            ]
+            log = args.results / f"{backend}-c{concurrency}-r{repeat}.log"
+            with log.open("w") as stream:
+                subprocess.run(
+                    command,
+                    env=env,
+                    stdout=stream,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                    timeout=1200,
+                )
+            result = json.loads(output.read_text().splitlines()[-1])
+            if result["completed"] != concurrency * args.waves:
+                raise RuntimeError(f"Incomplete requests in {log}")
+            if result["total_output_tokens"] != result["completed"] * args.output_len:
+                raise RuntimeError(f"Unexpected generation lengths in {log}")
+            summary = {
+                key: result[key]
+                for key in (
+                    "max_concurrency",
+                    "completed",
+                    "duration",
+                    "output_throughput",
+                    "total_throughput",
+                    "mean_ttft_ms",
+                    "mean_tpot_ms",
+                )
+            }
+            print(
+                json.dumps({"backend": backend, "repeat": repeat, **summary}),
+                flush=True,
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Local pinned AWQ checkpoint")
+    parser.add_argument("--gpus", default="0,1")
+    parser.add_argument(
+        "--backends", nargs="+", choices=["none", "deepep"], default=["none", "deepep"]
+    )
+    parser.add_argument("--dp-attention", action="store_true")
+    parser.add_argument(
+        "--capacity",
+        type=int,
+        default=64,
+        help="DeepEP per-rank decode capacity; must cover the per-rank batch limit",
+    )
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--concurrency", nargs="+", type=int, default=[16, 64, 128])
+    parser.add_argument("--waves", type=int, default=8)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--input-len", type=int, default=256)
+    parser.add_argument("--output-len", type=int, default=128)
+    parser.add_argument("--results", type=Path, required=True)
+    args = parser.parse_args()
+    if max(args.concurrency) > 128:
+        parser.error("This benchmark configures a 128-request server limit.")
+    args.results.mkdir(parents=True, exist_ok=True)
+    env = os.environ | {
+        "CUDA_VISIBLE_DEVICES": args.gpus,
+        "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": str(args.capacity),
+    }
+    for backend in args.backends:
+        command = server_command(args, backend)
+        (args.results / f"{backend}-command.json").write_text(
+            json.dumps(command, indent=2)
+        )
+        with (args.results / f"{backend}-server.log").open("w") as stream:
+            server = subprocess.Popen(
+                command,
+                env=env,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            try:
+                wait_ready(server, f"http://127.0.0.1:{args.port}")
+                benchmark(args, backend, env)
+            finally:
+                if server.poll() is None:
+                    os.killpg(server.pid, signal.SIGINT)
+                    try:
+                        server.wait(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        os.killpg(server.pid, signal.SIGKILL)
+                        server.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/kernels/jit/csrc/gemm/marlin_moe/marlin_template.h
+++ b/python/sglang/kernels/jit/csrc/gemm/marlin_moe/marlin_template.h
@@ -498,7 +498,7 @@ __global__ void Marlin(
       if (mul_topk_weights) {
         idx = idx < prob_m_top_k ? idx : 0;
         scalar_t topk_weight_tmp = Dtype::float2num(topk_weights_ptr[idx]);
-        if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn) {
+        if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn && !kHasBias) {
           sh_block_topk_weights[threadIdx.x] = __hmul2(global_scale, Dtype::num2num2(topk_weight_tmp));
         } else {
           sh_block_topk_weights[threadIdx.x] = Dtype::num2num2(topk_weight_tmp);
@@ -1545,7 +1545,9 @@ __global__ void Marlin(
       }
 
       if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn) {
-        if (!mul_topk_weights) {
+        // With bias, apply the weight scale before adding the bias. Folding
+        // it into the routing weight would also scale the bias at the store.
+        if (!mul_topk_weights || kHasBias) {
           res = __hmul2(res, global_scale);
         }
       }

--- a/python/sglang/spec/README.md
+++ b/python/sglang/spec/README.md
@@ -1,0 +1,13 @@
+Status: implemented
+
+# SGLang specifications
+
+TL;DR: These documents describe proposed or implemented behavior; each document records its status.
+
+- [Marlin + DeepEP](feature-00-marlin-deepep.md): Marlin expert computation with DeepEP normal and low-latency communication.
+
+- [Marlin + DeepEP evidence](evidence/feature-00-marlin-deepep.md): Reproduction commands, numerical coverage, and H200 component timings.
+
+## Boundaries
+
+This router covers the specifications introduced here, not every SGLang subsystem.

--- a/python/sglang/spec/README.md
+++ b/python/sglang/spec/README.md
@@ -6,7 +6,7 @@ TL;DR: These documents describe proposed or implemented behavior; each document 
 
 - [Marlin + DeepEP](feature-00-marlin-deepep.md): Marlin expert computation with DeepEP normal and low-latency communication.
 
-- [Marlin + DeepEP evidence](evidence/feature-00-marlin-deepep.md): Reproduction commands, numerical coverage, and H200 component timings.
+- [Marlin + DeepEP evidence](evidence/feature-00-marlin-deepep.md): Reproduction commands, numerical coverage, and actual two-/eight-GPU H200 serving throughput.
 
 ## Boundaries
 

--- a/python/sglang/spec/evidence/feature-00-marlin-deepep.md
+++ b/python/sglang/spec/evidence/feature-00-marlin-deepep.md
@@ -2,8 +2,9 @@ Status: implemented
 
 # Marlin + DeepEP evidence
 
-TL;DR: Real two-rank H200 execution passes all five quantization families,
-including empty ranks and decode graph replay. Three TP=EP=2 server modes pass.
+TL;DR: Numerical and graph tests pass across five quantization families.
+Actual AWQ server throughput improves with DeepEP at eight-GPU EP scale;
+the two-GPU results remain workload-dependent. All repeated results are below.
 
 ## Environment
 
@@ -31,7 +32,7 @@ CUDA_VISIBLE_DEVICES=4,5 PYTHONPATH=python SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS
 ## Correctness
 
 - Host configuration, dispatcher dtype, and quantization wrappers: 22 passed.
-- Dispatch adapters: 24 passed, covering active one-token inputs, invalid
+- Dispatch adapters: 31 passed, covering active one-token inputs, invalid
   routes, biased experts, supported activations, and graph replay with changing
   valid counts (including all-zero counts).
 - Standard Marlin regressions: 6 passed (26 deselected) in 251.55 seconds,
@@ -40,7 +41,7 @@ CUDA_VISIBLE_DEVICES=4,5 PYTHONPATH=python SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS
   combinations passed. Twenty low-latency captures each replay twice,
   including uneven batches, rank-local expert skew, one empty rank, and
   both empty ranks. The same AUTO dispatcher switches modes.
-- Server normal, low_latency, auto: 3 passed in 148.09 seconds. Each uses
+- Original smoke server normal, low_latency, auto: 3 passed in 148.09 seconds. Each uses
   two tensor/expert-parallel ranks, prefill, and four decode tokens for
   single and unequal two-request batches with decode graphs enabled.
   Pytest reported 18 dependency/process-cleanup warnings, including a
@@ -54,9 +55,14 @@ scales. Reference comparisons use BF16 rounding at GEMM/activation boundaries:
 GPTQ/AWQ/MXFP4 rtol=0.04, atol=0.04; NVFP4 rtol=0.05, atol=0.25,
 plus relative L2 error below 2% for every nonempty comparison. Direct parity
 between two independently rounded kernel outputs allows twice the per-format
-absolute/relative error budget. Masked padding must be exactly zero.
+absolute/relative error budget. Standard masked routes produce zero outputs.
+Low-latency communication padding is unspecified: the adapter tests poison
+input padding, and distributed tests poison output padding with NaNs before
+both eager and captured combine, verifying that only valid rows contribute.
 
-## Component latency
+## Initial component latency (before throughput optimization)
+
+Recorded at `46d7a52a68`, before the valid-row optimizations.
 
 Rank-zero GPU event measurements, milliseconds, average of five iterations
 after one warmup. Synthetic inputs have 17/20 tokens per rank, hidden size
@@ -79,10 +85,100 @@ through combine, not an entire server request.
 | nvfp4 | normal | 0.115 | 0.264 | 0.084 | 0.462 |
 | nvfp4 | low_latency | 0.062 | 0.283 | 0.054 | 0.400 |
 
+## Actual HTTP serving throughput
+
+Checkpoint: [QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ](https://huggingface.co/QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ/tree/c58857a7f41c0920f73d1b56678640f9c02017d7),
+revision `c58857a7f41c0920f73d1b56678640f9c02017d7`. This loads real pretrained
+weights and tokenizer, not the dummy smoke model. It has 48 layers, hidden
+size 2048, MoE intermediate size 768, 128 experts, top-k eight, and AWQ4
+with group size 128 and zero points.
+
+Each pair runs sequentially on the same H200 GPUs in one host (NV18 links
+between every GPU pair). TP=EP=DP=GPU count, DP attention enabled, Marlin
+BF16, Triton attention, decode graphs enabled, prefill graphs disabled,
+normal scheduling overlap enabled, and DeepEP auto mode. The script records
+complete server commands and benchmark JSON, including resolved server args.
+Measured GPU pairs are reserved for their server. One short validation run
+on GPU 2 overlapped the end of the last two-GPU none repetition; that was
+the fastest none repetition, and its median comes from an uncontaminated
+run. The eight-GPU comparisons ran without concurrent validation work.
+
+Fixed random requests: 256 input tokens, 128 output tokens, seed 42,
+unlimited offered request rate, eight request waves, and eight warmup
+requests before each of three repetitions. Prefix cache is flushed after
+warmup by the benchmark client. Each repetition completes 128, 512, or
+1024 requests for concurrency 16, 64, or 128, with exactly the requested
+output token count. Throughput includes HTTP serving, scheduling, prefill,
+and decode. The primary metric is generated output tokens/second; total
+input-plus-output throughput is exactly three times this value here.
+
+Median of all three repetitions, output tokens/s:
+
+| GPUs | Concurrency | none | DeepEP | DeepEP change |
+| --- | ---: | ---: | ---: | ---: |
+| 2 | 16 | 2,132.9 | 2,036.6 | -4.5% |
+| 2 | 64 | 4,344.2 | 4,338.0 | -0.1% |
+| 2 | 128 | 5,496.6 | 5,650.1 | +2.8% |
+| 8 | 128 | 11,887.2 | 14,227.0 | +19.7% |
+
+All repetitions, in execution order (output tokens/s):
+
+| GPUs | Concurrency | Backend | Run 1 | Run 2 | Run 3 |
+| --- | ---: | --- | ---: | ---: | ---: |
+| 2 | 16 | none | 1,999.3 | 2,132.9 | 2,135.2 |
+| 2 | 16 | deepep | 1,892.7 | 2,036.6 | 2,040.2 |
+| 2 | 64 | none | 4,578.7 | 4,344.2 | 4,335.7 |
+| 2 | 64 | deepep | 4,608.4 | 4,325.0 | 4,338.0 |
+| 2 | 128 | none | 5,485.0 | 5,496.6 | 5,507.9 |
+| 2 | 128 | deepep | 5,650.1 | 5,648.0 | 5,655.9 |
+| 8 | 128 | none | 6,840.5 | 11,887.2 | 12,061.4 |
+| 8 | 128 | deepep | 7,478.2 | 14,227.0 | 14,293.4 |
+
+The first eight-GPU run is much slower for both backends, so the range must
+not be hidden behind the median. The two later eight-GPU runs show the same
+throughput advantage. These measurements do not establish a universal win
+at small batch sizes or on every EP configuration.
+
+Reproduce with the checked-in `benchmark/bench_marlin_deepep.py`. The exact
+model snapshot path used here is assigned below. Obtain that revision with
+`huggingface_hub.snapshot_download` if it is not already cached.
+
+```bash
+MARLIN_MODEL=/root/.cache/huggingface/hub/models--QuantTrio--Qwen3-Coder-30B-A3B-Instruct-AWQ/snapshots/c58857a7f41c0920f73d1b56678640f9c02017d7
+PYTHONPATH=python /opt/sglang/bin/python benchmark/bench_marlin_deepep.py --model "$MARLIN_MODEL" --backends none --dp-attention --capacity 64 --results /tmp/marlin-throughput/none-final
+PYTHONPATH=python /opt/sglang/bin/python benchmark/bench_marlin_deepep.py --model "$MARLIN_MODEL" --gpus 0,1,2,3,4,5,6,7 --dp-attention --capacity 16 --concurrency 128 --results /tmp/marlin-throughput/eight-gpu
+PYTHONPATH=python /opt/sglang/bin/python benchmark/bench_marlin_deepep.py --model "$MARLIN_MODEL" --backends deepep --dp-attention --capacity 64 --results /tmp/marlin-throughput/deepep-valid-only
+```
+
+Use new result directories when rerunning; the script refuses to overwrite
+benchmark JSON. It starts and stops the HTTP servers itself. Defaults used
+above are concurrency 16/64/128, eight waves, three repetitions, and lengths
+256/128. The eight-GPU command explicitly selects concurrency 128.
+
+## Profiling and fixes
+
+Initial TP=EP=2 runs with TP attention and capacity 128 showed DeepEP behind
+none at every tested concurrency. Profiling identified unnecessary padded
+expert computation, buffer initialization, single-expert reduction, and
+invalid-block scans. The implementation now compacts valid expert segments,
+builds their block schedule directly from GPU counts, selects tiles from
+expected valid rows, and restores only valid output rows. NaN-poisoned
+padding tests verify the DeepEP handle's valid-row contract.
+
+The actual baseline also exposed standard Marlin EP passing non-local `-1`
+routes to a non-EP kernel during graph capture. Both measured backends use
+the corrected common runner; the baseline is not allowed to crash or skip
+valid work. Dedicated one-token and multi-token tests cover this fix.
+
+Three separate greedy sanity prompts (64 generated tokens each) produced
+matching text for none and DeepEP in the two-GPU server checks. This is a
+limited sanity check, not a language-quality evaluation or bitwise logit
+parity claim; selected-token log probabilities differed by up to 0.322.
+
 ## Boundaries
 
-These measurements establish execution and numerical correctness on H200,
-not production throughput or a speedup over another backend. Weights are
-synthetic; the server creates a small local Qwen3 MoE with dummy AWQ weights,
-so there is no external checkpoint revision or language-quality result.
-Full pretrained checkpoint loading and multi-node execution remain unmeasured.
+Results apply to this pinned AWQ model, fixed request lengths, concurrency,
+and single-host H200 setup. The earlier component measurements use synthetic
+weights and the original implementation, and must not be treated as current
+production throughput. Language-quality benchmarks, other pretrained weight
+formats, and multi-node performance remain unmeasured.

--- a/python/sglang/spec/evidence/feature-00-marlin-deepep.md
+++ b/python/sglang/spec/evidence/feature-00-marlin-deepep.md
@@ -1,0 +1,88 @@
+Status: implemented
+
+# Marlin + DeepEP evidence
+
+TL;DR: Real two-rank H200 execution passes all five quantization families,
+including empty ranks and decode graph replay. Three TP=EP=2 server modes pass.
+
+## Environment
+
+Measured 2026-09-05 on OSS SGLang main
+`756d0e0a851c0aee706670affa90c3c47e317d15` plus this change.
+NVIDIA H200 GPUs; driver 595.71.05; CUDA toolkit 13.0; Python 3.12;
+PyTorch 2.13.0+cu130; Triton 3.7.1; sgl-deep-ep 0.1.2;
+sglang-kernel 0.4.6.post1; apache-tvm-ffi 0.1.11; pytest 9.1.1.
+Native Marlin specializations compile on first use.
+
+## Reproduction
+
+Run from the repository root with the dependencies above. These commands use
+this machine's Python environment and assign independent GPUs to each suite.
+The checked-in test files are the reproduction scripts.
+
+```bash
+PYTHONPATH=python /opt/sglang/bin/python -m pytest test/registered/unit/layers/moe/test_marlin_deepep.py test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py -q
+PYTHONPATH=python /opt/sglang/bin/python -m pytest test/registered/kernels/ops/moe/test_marlin_deepep.py -xq
+CUDA_VISIBLE_DEVICES=1 PYTHONPATH=python /opt/sglang/bin/python -m pytest test/registered/kernels/ops/moe/test_moe_wna16_marlin.py -k 'nvfp4_non_gated_matches_dequant_reference or large_non_ep_schedule' -xq
+CUDA_VISIBLE_DEVICES=2,3 PYTHONPATH=python SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=32 /opt/sglang/bin/torchrun --standalone --nproc-per-node=2 test/registered/ep/test_marlin_deepep.py
+CUDA_VISIBLE_DEVICES=4,5 PYTHONPATH=python SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=32 /opt/sglang/bin/python test/registered/ep/test_marlin_deepep_server.py
+```
+
+## Correctness
+
+- Host configuration, dispatcher dtype, and quantization wrappers: 22 passed.
+- Dispatch adapters: 24 passed, covering active one-token inputs, invalid
+  routes, biased experts, supported activations, and graph replay with changing
+  valid counts (including all-zero counts).
+- Standard Marlin regressions: 6 passed (26 deselected) in 251.55 seconds,
+  including NVFP4 with/without bias and large non-EP scheduling.
+- Distributed GPTQ4, GPTQ8, AWQ, MXFP4, NVFP4: 40 format/batch/mode
+  combinations passed. Twenty low-latency captures each replay twice,
+  including uneven batches, rank-local expert skew, one empty rank, and
+  both empty ranks. The same AUTO dispatcher switches modes.
+- Server normal, low_latency, auto: 3 passed in 148.09 seconds. Each uses
+  two tensor/expert-parallel ranks, prefill, and four decode tokens for
+  single and unequal two-request batches with decode graphs enabled.
+  Pytest reported 18 dependency/process-cleanup warnings, including a
+  multiprocessing resource tracker restart; all engine assertions passed.
+
+`python/sglang/test/marlin_deepep_utils.py` generates deterministic quantized
+weights (seed 42) and independent dequantized references. Integer fixtures
+exercise group size 128, GPTQ activation ordering, and AWQ zero points.
+FP4 fixtures use native repacking and checkpoint-normalized group/global
+scales. Reference comparisons use BF16 rounding at GEMM/activation boundaries:
+GPTQ/AWQ/MXFP4 rtol=0.04, atol=0.04; NVFP4 rtol=0.05, atol=0.25,
+plus relative L2 error below 2% for every nonempty comparison. Direct parity
+between two independently rounded kernel outputs allows twice the per-format
+absolute/relative error budget. Masked padding must be exactly zero.
+
+## Component latency
+
+Rank-zero GPU event measurements, milliseconds, average of five iterations
+after one warmup. Synthetic inputs have 17/20 tokens per rank, hidden size
+4096, intermediate size 128, four experts, top-k two, BF16 activations, and
+DeepEP capacity 32. The normal and low-latency paths represent prefill and
+decode communication respectively; timings use eager execution and include
+launch gaps. The expert column includes adapter work. Total spans dispatch
+through combine, not an entire server request.
+
+| Format | Mode | Dispatch ms | Experts ms | Combine ms | Total ms |
+| --- | --- | ---: | ---: | ---: | ---: |
+| gptq4 | normal | 0.208 | 0.389 | 0.163 | 0.759 |
+| gptq4 | low_latency | 0.070 | 0.285 | 0.065 | 0.419 |
+| gptq8 | normal | 0.136 | 0.252 | 0.106 | 0.494 |
+| gptq8 | low_latency | 0.064 | 0.284 | 0.060 | 0.409 |
+| awq | normal | 0.119 | 0.246 | 0.091 | 0.457 |
+| awq | low_latency | 0.069 | 0.276 | 0.056 | 0.401 |
+| mxfp4 | normal | 0.119 | 0.267 | 0.078 | 0.464 |
+| mxfp4 | low_latency | 0.062 | 0.326 | 0.026 | 0.414 |
+| nvfp4 | normal | 0.115 | 0.264 | 0.084 | 0.462 |
+| nvfp4 | low_latency | 0.062 | 0.283 | 0.054 | 0.400 |
+
+## Boundaries
+
+These measurements establish execution and numerical correctness on H200,
+not production throughput or a speedup over another backend. Weights are
+synthetic; the server creates a small local Qwen3 MoE with dummy AWQ weights,
+so there is no external checkpoint revision or language-quality result.
+Full pretrained checkpoint loading and multi-node execution remain unmeasured.

--- a/python/sglang/spec/feature-00-marlin-deepep.md
+++ b/python/sglang/spec/feature-00-marlin-deepep.md
@@ -47,11 +47,16 @@ Normal combine must accept Marlin results independently of DeepGEMM enablement.
 | Routing weights | Marlin applies received weights and reduces local contributions | Marlin computes unweighted expert outputs; DeepEP combine applies original weights |
 | Combine input | One locally reduced result per received token, in received order | Expert-major results in exactly the layout expected by low-latency combine |
 
-The low-latency adapter presents each valid expert row as a single-expert
-Marlin invocation entry with unit routing weight, then restores the
-expert-major output layout. Build IDs and masks on the GPU over fixed-capacity
-buffers; valid counts must not cause host reads or dynamic allocations during
-graph replay. Padding contributes zero and cannot index expert weights.
+The low-latency adapter compacts valid rows into contiguous expert segments
+on the GPU, with unit routing weights. Capacity is bounded by source capacity
+times top-k, rather than reserving source capacity for every expert. Build
+the Marlin block schedule directly from GPU expert counts and choose tiles
+from expected valid rows. The schedule contains only valid local experts;
+unused compact rows are never returned. Restore valid rows to the expert-major
+combine layout in one GPU pass. Communication padding is unspecified and
+must never be read; only rows covered by the dispatcher counts and handle
+contribute to combine. Valid counts must not cause
+host reads or dynamic allocations during graph replay.
 
 Apply each routing weight and the model's routed scaling factor exactly once.
 Preserve the checkpoint's activation, gate/up ordering, clamping, bias, scales,
@@ -61,9 +66,10 @@ the model's existing ownership and are added once.
 
 Weights and quantization metadata belong to the rank's local experts in the
 same order used by dispatch. Never apply a global-to-local expert mapping a
-second time. Empty ranks, empty experts, invalid routes, and zero-token batches
-produce the required empty or zero outputs and still participate in matching
-communication operations.
+second time. Standard EP dispatch also marks non-local routes invalid and
+must select a Marlin kernel that skips those routes. Empty ranks, empty experts, invalid routes, and zero-token batches
+produce the required empty or zero combined outputs and still participate in
+matching communication operations.
 
 Inputs and communication buffers must not be overwritten while in use.
 Marlin scratch storage must remain safe across layers, concurrent work, and
@@ -87,9 +93,12 @@ DeepEP event ordering and handle lifetime.
 
 Reproducible tests and component latency measurements live in
 [evidence/feature-00-marlin-deepep.md](evidence/feature-00-marlin-deepep.md).
-Validation uses deterministic quantized experts and two-rank H200 execution;
-the serving smoke uses a local dummy AWQ model. Pretrained checkpoint loading,
-language quality, and multi-node execution remain unmeasured.
+Validation includes deterministic quantized experts, two-rank H200 execution,
+and HTTP serving of a pinned Qwen3-Coder-30B-A3B AWQ checkpoint. Throughput
+comparisons hold hardware, parallelism, request lengths, and concurrency fixed
+within each pair. Performance remains workload-dependent; support does not
+promise that DeepEP is faster at every batch size. Multi-node execution and
+language-quality benchmarks remain unmeasured.
 
 ## Boundaries
 

--- a/python/sglang/spec/feature-00-marlin-deepep.md
+++ b/python/sglang/spec/feature-00-marlin-deepep.md
@@ -1,0 +1,103 @@
+Status: implemented
+
+# Marlin + DeepEP
+
+TL;DR: Run quantized MoE experts with Marlin while DeepEP moves tokens between
+expert-parallel ranks. Support normal, low-latency, and auto modes using BF16
+activations and the existing Marlin weight-loading and repacking paths.
+
+## User contract
+
+Select `--moe-runner-backend marlin --moe-a2a-backend deepep --dtype bfloat16`
+with a Marlin-compatible quantized MoE checkpoint and an expert-parallel
+configuration supported by the model. `--deepep-mode normal`, `low_latency`,
+and `auto` retain their existing scheduling meanings; auto supports both
+prefill and decode. Existing Marlin-compatible automatic runner selection
+must reach the same integration when the resolved layer runner is Marlin.
+
+The supported weight formats are those already handled by `MarlinMoeQuantInfo`
+and the selected checkpoint's Marlin quantization method, including integer
+GPTQ/AWQ and Marlin MXFP4/NVFP4 paths. Their existing shape, group-size,
+activation, bias, and hardware restrictions still apply. This feature does
+not expand the kernel's quantization contract.
+
+DeepEP transports BF16 activations, with no activation scales. Resolve the
+dispatcher dtype from the actual Marlin runner; reject an explicit incompatible
+dispatcher dtype. Report unsupported combinations during initialization,
+before the first dispatch, with the conflicting options in the error.
+
+## Design and invariants
+
+```text
+router -> DeepEP dispatch -> local Marlin experts -> DeepEP combine -> output
+             normal: received token rows, local expert IDs
+        low latency: expert-major rows, per-expert valid counts
+```
+
+Register the `deepep` / `marlin` fused runner path and select its adapter by
+dispatch format. Route Marlin layers through the common `FusedMoE` execution
+path. Reuse the Marlin quantization payload and kernel; keep dispatch handles,
+communication buffers, events, and combine ownership in the DeepEP dispatcher.
+Normal combine must accept Marlin results independently of DeepGEMM enablement.
+
+| Contract | Normal mode | Low-latency mode |
+| --- | --- | --- |
+| Marlin input | Received BF16 token rows and received local top-k IDs | Expert-major BF16 rows, respecting `masked_m` valid counts |
+| Expert indexing | Use received local IDs directly; ignore `-1` routes | Derive local expert IDs from the expert-major dimension; ignore padding |
+| Routing weights | Marlin applies received weights and reduces local contributions | Marlin computes unweighted expert outputs; DeepEP combine applies original weights |
+| Combine input | One locally reduced result per received token, in received order | Expert-major results in exactly the layout expected by low-latency combine |
+
+The low-latency adapter presents each valid expert row as a single-expert
+Marlin invocation entry with unit routing weight, then restores the
+expert-major output layout. Build IDs and masks on the GPU over fixed-capacity
+buffers; valid counts must not cause host reads or dynamic allocations during
+graph replay. Padding contributes zero and cannot index expert weights.
+
+Apply each routing weight and the model's routed scaling factor exactly once.
+Preserve the checkpoint's activation, gate/up ordering, clamping, bias, scales,
+zero points, and activation-order metadata. NVFP4 applies its weight global
+scale before adding bias, then applies routing weights. Shared-expert contributions retain
+the model's existing ownership and are added once.
+
+Weights and quantization metadata belong to the rank's local experts in the
+same order used by dispatch. Never apply a global-to-local expert mapping a
+second time. Empty ranks, empty experts, invalid routes, and zero-token batches
+produce the required empty or zero outputs and still participate in matching
+communication operations.
+
+Inputs and communication buffers must not be overwritten while in use.
+Marlin scratch storage must remain safe across layers, concurrent work, and
+CUDA graph captures. Low-latency decode supports CUDA graph capture and replay;
+normal mode retains the existing graph policy. The integration preserves
+DeepEP event ordering and handle lifetime.
+
+## Acceptance
+
+- Compare distributed outputs against the same quantized weights and routing
+  evaluated by standard Marlin and against a dequantized expert reference;
+  use the existing format-specific kernel tolerances and record them in tests.
+  Cover each supported quantization family, non-unit routing weights and
+  scaling, top-k greater than one, and supported activation/bias variants.
+- Exercise at least two EP ranks, multiple local experts, uneven routing,
+  empty experts/ranks, invalid routes, and a supported TP+EP configuration;
+  compare normal and low-latency results and test auto prefill-to-decode changes.
+- Verify low-latency eager/captured parity across changing valid counts and
+  repeated graph replay, plus clear initialization errors for excluded options.
+  Run server prefill/decode smoke tests and standard Marlin regression tests.
+
+Reproducible tests and component latency measurements live in
+[evidence/feature-00-marlin-deepep.md](evidence/feature-00-marlin-deepep.md).
+Validation uses deterministic quantized experts and two-rank H200 execution;
+the serving smoke uses a local dummy AWQ model. Pretrained checkpoint loading,
+language quality, and multi-node execution remain unmeasured.
+
+## Boundaries
+
+The supported scope is NVIDIA CUDA, BF16 activations, and the `deepep`
+backend. FP16 activations, FP8/NVFP4 activation transport, `deepep_v2`, other
+communication backends, `experimental_sgl_marlin`, LoRA, EPLB/elastic expert
+placement, and fused shared-expert dispatch are outside this feature.
+Configurations requiring down-GEMM communication overlap or single-/two-batch
+overlap are also excluded initially and must fail validation when requested.
+Separate shared-expert computation remains supported. No new quantization
+formats, silent runner substitutions, or compatibility paths are introduced.

--- a/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
+++ b/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
@@ -356,7 +356,10 @@ class GPTQMarlinMoEKernel:
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
-        assert get_moe_runner_backend().is_auto()
+        assert get_moe_runner_backend() in {
+            MoeRunnerBackend.AUTO,
+            MoeRunnerBackend.MARLIN,
+        }
         self.moe_runner_config = moe_runner_config
         self.runner = MoeRunner(MoeRunnerBackend.MARLIN, moe_runner_config)
 

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -103,7 +103,13 @@ class DeepEPMoE(FusedMoE):
             and quant_config is not None
             and quant_config.get_name() == "humming"
         )
-        if get_moe_a2a_backend().is_deepep_v2():
+        if (
+            get_moe_a2a_backend().is_deepep()
+            and self.moe_runner_config.runner_backend is not None
+            and self.moe_runner_config.runner_backend.is_marlin()
+        ):
+            self.deprecate_flag = True
+        elif get_moe_a2a_backend().is_deepep_v2():
             self.deprecate_flag = True
         elif is_humming:
             self.deprecate_flag = True

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -131,6 +131,63 @@ def swiglu_gpt_oss_sigmoid_alpha_contiguous(
     output.copy_(gate * torch.sigmoid(gate * gemm1_alpha) * (up + 1))
 
 
+@triton.jit
+def _align_compact_experts_kernel(
+    counts,
+    sorted_ids,
+    expert_ids,
+    total,
+    EXPERTS: tl.constexpr,
+    ROWS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    es = tl.arange(0, BLOCK_E)
+    sizes = tl.load(counts + es, es < EXPERTS, 0)
+    padded = tl.cdiv(sizes, BLOCK_M) * BLOCK_M
+    start = tl.sum(tl.where(es < expert, sizes, 0))
+    aligned_start = tl.sum(tl.where(es < expert, padded, 0))
+    count = tl.load(counts + expert)
+    rows = tl.program_id(1) * BLOCK_R + tl.arange(0, BLOCK_R)
+    tl.store(
+        sorted_ids + aligned_start + rows,
+        tl.where(rows < count, start + rows, ROWS),
+        rows < tl.cdiv(count, BLOCK_M) * BLOCK_M,
+    )
+    tl.store(
+        expert_ids + (aligned_start + rows) // BLOCK_M,
+        expert,
+        (rows < tl.cdiv(count, BLOCK_M) * BLOCK_M) & (rows % BLOCK_M == 0),
+    )
+    if expert == 0 and tl.program_id(1) == 0:
+        tl.store(total, tl.sum(padded))
+
+
+def _align_compact_experts(counts, rows, block_size):
+    """Build the schedule directly from contiguous expert segments on the GPU."""
+    experts = counts.numel()
+    size = rows + experts * (block_size - 1)
+    sorted_ids = torch.empty((size,), device=counts.device, dtype=torch.int32)
+    expert_ids = torch.empty(
+        (triton.cdiv(size, block_size),), device=counts.device, dtype=torch.int32
+    )
+    total = torch.empty((1,), device=counts.device, dtype=torch.int32)
+    _align_compact_experts_kernel[(experts, triton.cdiv(rows + block_size - 1, 256))](
+        counts,
+        sorted_ids,
+        expert_ids,
+        total,
+        experts,
+        rows,
+        block_size,
+        triton.next_power_of_2(experts),
+        256,
+    )
+    return sorted_ids, expert_ids, total
+
+
 @register_custom_op(out_shape="hidden_states")
 def fused_marlin_moe(
     hidden_states: torch.Tensor,
@@ -163,6 +220,8 @@ def fused_marlin_moe(
     activation: str = "silu",
     is_gated: bool = True,
     is_ep: bool = False,
+    expected_m: Optional[int] = None,
+    expert_num_tokens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -245,13 +304,19 @@ def fused_marlin_moe(
 
     # M block size selection logic
     # TODO: tune this further for specific models
+    tokens_per_expert = M * topk / E if expected_m is None else expected_m
     for block_size_m in [8, 16, 32, 48, 64]:
-        if M * topk / E / block_size_m < 0.9:
+        if tokens_per_expert / block_size_m < 0.9:
             break
 
     if global_num_experts == -1:
         global_num_experts = E
-    if (
+    if expert_num_tokens is not None:
+        assert topk == 1 and expert_num_tokens.numel() == E
+        sorted_token_ids, expert_ids, num_tokens_post_padded = _align_compact_experts(
+            expert_num_tokens, M, block_size_m
+        )
+    elif (
         M == 1
         and topk <= 32
         and not is_ep
@@ -294,8 +359,10 @@ def fused_marlin_moe(
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
-    # Marlin skips masked expert rows, so their shared cache must start at zero.
-    intermediate_cache13 = torch.zeros(
+    # Compact segments never read or return unused rows. Standard routing
+    # reduces masked contributions, which must instead start at zero.
+    allocate_cache = torch.empty if expert_num_tokens is not None else torch.zeros
+    intermediate_cache13 = allocate_cache(
         (M * topk_ids.shape[1] * max(gemm1_n, K),),
         device=hidden_states.device,
         dtype=hidden_states.dtype,
@@ -328,7 +395,8 @@ def fused_marlin_moe(
         moe_block_size=block_size_m,
         top_k=topk,
         mul_topk_weights=False,
-        is_ep=is_ep,
+        # The compact schedule contains only local, valid expert blocks.
+        is_ep=is_ep and expert_num_tokens is None,
         b_q_type=scalar_type1,
         size_m=M,
         size_n=gemm1_n,
@@ -370,7 +438,7 @@ def fused_marlin_moe(
     else:
         raise ValueError(f"Unsupported activation: {activation=}, with {is_gated=}")
 
-    if is_ep:
+    if is_ep and expert_num_tokens is None:
         # GEMM2 shares storage with GEMM1; skipped routes must not retain gate/up
         # values (including bias) when their contributions are reduced.
         intermediate_cache3.zero_()
@@ -393,7 +461,8 @@ def fused_marlin_moe(
         moe_block_size=block_size_m,
         top_k=1,
         mul_topk_weights=True,
-        is_ep=is_ep,
+        # The compact schedule contains only local, valid expert blocks.
+        is_ep=is_ep and expert_num_tokens is None,
         b_q_type=scalar_type2,
         size_m=M * topk,
         size_n=K,
@@ -405,6 +474,15 @@ def fused_marlin_moe(
     ).view(-1, topk, K)
 
     output = zero_copy_context.get_moe_output(hidden_states)
+    if (
+        expert_num_tokens is not None
+        and output is None
+        and not inplace
+        and (is_mxfp4_marlin or routed_scaling_factor in (None, 1.0))
+    ):
+        # One expert per compact row: the unpacker reads only valid rows,
+        # so no reduction or initialization of unused rows is necessary.
+        return intermediate_cache3.view(M, K)
     if output is None:
         output = hidden_states if inplace else torch.empty_like(hidden_states)
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -138,7 +138,7 @@ def fused_marlin_moe(
     w2: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
-    gating_output: torch.Tensor,
+    gating_output: Optional[torch.Tensor],
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     global_num_experts: int = -1,
@@ -162,6 +162,7 @@ def fused_marlin_moe(
     gemm1_alpha: Optional[float] = None,
     activation: str = "silu",
     is_gated: bool = True,
+    is_ep: bool = False,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -192,7 +193,14 @@ def fused_marlin_moe(
     """
     from sglang.srt.layers.moe.fused_moe_triton import moe_align_block_size
 
-    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+    if gating_output is not None:
+        assert hidden_states.shape[0] == gating_output.shape[0], (
+            "Number of tokens mismatch"
+        )
+    assert hidden_states.shape[0] == topk_ids.shape[0] == topk_weights.shape[0], (
+        "Number of routed tokens mismatch"
+    )
+    is_ep = is_ep or expert_map is not None
     assert hidden_states.shape[1] == w1.shape[1] * 16, "Hidden size mismatch w1"
     assert hidden_states.shape[1] == w2.shape[2] // (num_bits // 2), (
         "Hidden size mismatch w2"
@@ -246,7 +254,7 @@ def fused_marlin_moe(
     if (
         M == 1
         and topk <= 32
-        and expert_map is None
+        and not is_ep
         # The JIT kernel is int32-only; torch-native topk emits int64 -- let
         # that (test-only) shape take the generic path instead of casting.
         and topk_ids.dtype == torch.int32
@@ -320,7 +328,7 @@ def fused_marlin_moe(
         moe_block_size=block_size_m,
         top_k=topk,
         mul_topk_weights=False,
-        is_ep=expert_map is not None,
+        is_ep=is_ep,
         b_q_type=scalar_type1,
         size_m=M,
         size_n=gemm1_n,
@@ -362,7 +370,9 @@ def fused_marlin_moe(
     else:
         raise ValueError(f"Unsupported activation: {activation=}, with {is_gated=}")
 
-    if expert_map is not None:
+    if is_ep:
+        # GEMM2 shares storage with GEMM1; skipped routes must not retain gate/up
+        # values (including bias) when their contributions are reduced.
         intermediate_cache3.zero_()
 
     intermediate_cache3 = moe_wna16_marlin_gemm(
@@ -383,7 +393,7 @@ def fused_marlin_moe(
         moe_block_size=block_size_m,
         top_k=1,
         mul_topk_weights=True,
-        is_ep=expert_map is not None,
+        is_ep=is_ep,
         b_q_type=scalar_type2,
         size_m=M * topk,
         size_n=K,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -188,6 +188,11 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             deepep_mode=get_deepep_mode(),
             async_finish=True,
             return_recv_hook=True,
+            **(
+                {"runner_backend": moe_runner_config.runner_backend}
+                if a2a_backend.is_deepep()
+                else {}
+            ),
         )
     elif a2a_backend.is_deepep_v2():
         return DeepEPv2Dispatcher(

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -47,6 +47,9 @@ class MoeRunnerConfig:
     params_dtype: Optional[torch.dtype] = None
     routing_method_type: Optional[RoutingMethodType] = None
 
+    # Set by MoeRunner after the quantization method resolves the backend.
+    runner_backend: Optional[MoeRunnerBackendLike] = None
+
     # Runner configuration
     activation: str = "silu"
     is_gated: bool = True

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -18,6 +18,9 @@ from sglang.srt.layers.moe.utils import MoeRunnerBackend
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
+        CombineInput,
+        DeepEPLLDispatchOutput,
+        DeepEPNormalDispatchOutput,
         StandardCombineInput,
         StandardDispatchOutput,
     )
@@ -118,9 +121,7 @@ def fused_experts_none_to_marlin(
     quant_info: MarlinMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
-    from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import fused_marlin_moe
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
-    from sglang.srt.layers.quantization.marlin_utils import marlin_make_workspace
 
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
@@ -139,6 +140,32 @@ def fused_experts_none_to_marlin(
             router_logits=topk_output.router_logits,
         )
 
+    return StandardCombineInput(
+        hidden_states=_run_marlin(
+            hidden_states,
+            topk_output.topk_ids,
+            topk_output.topk_weights,
+            quant_info,
+            runner_config,
+        )
+    )
+
+
+def _run_marlin(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    quant_info: MarlinMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    *,
+    is_ep: bool = False,
+) -> torch.Tensor:
+    from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import fused_marlin_moe
+    from sglang.srt.layers.quantization.marlin_utils import marlin_make_workspace
+
+    if hidden_states.shape[0] == 0:
+        return torch.empty_like(hidden_states)
+
     if runner_config.is_gated:
         assert runner_config.activation in {
             "silu",
@@ -154,9 +181,6 @@ def fused_experts_none_to_marlin(
     workspace = marlin_make_workspace(hidden_states.device, max_blocks_per_sm=4)
 
     marlin_hidden_states = hidden_states
-    # Avoid aliasing the MoE input buffer until Marlin output semantics are
-    # fully validated across shared-expert and overlap paths.
-    marlin_inplace = False
     if (
         quant_info.weight_bits == 4
         and quant_info.w13_qzeros is None
@@ -169,7 +193,6 @@ def fused_experts_none_to_marlin(
         # activation path. The fp16 + E8M0 path is intentionally not generated
         # in sgl-kernel, so upcast activations here and cast the result back.
         marlin_hidden_states = hidden_states.to(torch.bfloat16)
-        marlin_inplace = False
 
     output = fused_marlin_moe(
         hidden_states=marlin_hidden_states,
@@ -177,9 +200,9 @@ def fused_experts_none_to_marlin(
         w2=quant_info.w2_qweight,
         w1_scale=quant_info.w13_scales,
         w2_scale=quant_info.w2_scales,
-        gating_output=topk_output.router_logits,
-        topk_weights=topk_output.topk_weights,
-        topk_ids=topk_output.topk_ids,
+        gating_output=None,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
         global_num_experts=quant_info.global_num_experts,
         expert_map=quant_info.expert_map,
         g_idx1=quant_info.w13_g_idx,
@@ -195,7 +218,7 @@ def fused_experts_none_to_marlin(
         workspace=workspace,
         num_bits=quant_info.weight_bits,
         is_k_full=quant_info.is_k_full,
-        inplace=marlin_inplace,
+        inplace=False,
         routed_scaling_factor=runner_config.routed_scaling_factor,
         clamp_limit=(
             runner_config.gemm1_clamp_limit
@@ -205,11 +228,149 @@ def fused_experts_none_to_marlin(
         gemm1_alpha=runner_config.gemm1_alpha,
         activation=runner_config.activation,
         is_gated=runner_config.is_gated,
+        is_ep=is_ep,
     ).to(hidden_states.dtype)
 
-    return StandardCombineInput(
-        hidden_states=output,
+    return output
+
+
+def validate_deepep_marlin(
+    config: MoeRunnerConfig, *, lora_enabled: bool = False
+) -> None:
+    """Validate the resolved runner, including quantization's automatic choice."""
+    from sglang.srt.arg_groups.model_override_base import resolved_view
+    from sglang.srt.runtime_context import get_server_args
+    from sglang.srt.utils import is_cuda
+
+    if not is_cuda():
+        raise ValueError("Marlin + DeepEP requires NVIDIA CUDA.")
+    if config.runner_backend != MoeRunnerBackend.MARLIN:
+        raise ValueError("DeepEP supports marlin, not experimental_sgl_marlin.")
+    if config.params_dtype != torch.bfloat16:
+        raise ValueError("Marlin + DeepEP requires --dtype bfloat16.")
+    if lora_enabled:
+        raise ValueError("Marlin + DeepEP does not support --enable-lora.")
+    if config.num_fused_shared_experts:
+        raise ValueError("Marlin + DeepEP requires separate shared-expert computation.")
+    if (config.is_gated and config.activation not in {"silu", "situ"}) or (
+        not config.is_gated and config.activation not in {"silu", "relu2"}
+    ):
+        raise ValueError(f"Unsupported Marlin activation: {config.activation}.")
+    if config.apply_router_weight_on_input or config.no_combine:
+        raise ValueError("Marlin + DeepEP requires output routing weights and combine.")
+
+    view = resolved_view(get_server_args())
+    for option in (
+        "enable_lora",
+        "enable_eplb",
+        "elastic_ep_backend",
+        "enable_single_batch_overlap",
+        "enable_two_batch_overlap",
+        "enable_waterfill",
+        "ep_num_redundant_experts",
+    ):
+        if getattr(view, option):
+            raise ValueError(
+                f"Marlin + DeepEP does not support --{option.replace('_', '-')}."
+            )
+    if view.init_expert_location != "trivial":
+        raise ValueError("Marlin + DeepEP requires --init-expert-location trivial.")
+    if view.deepep_dispatcher_output_dtype not in {"auto", "bf16"}:
+        raise ValueError(
+            "Marlin + DeepEP requires --deepep-dispatcher-output-dtype bf16 or auto."
+        )
+
+
+@triton.jit
+def _deepep_ll_topk_kernel(
+    counts,
+    ids,
+    weights,
+    capacity: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    row = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    valid = row < tl.load(counts + expert)
+    offset = expert * capacity + row
+    tl.store(ids + offset, tl.where(valid, expert, -1), row < capacity)
+    tl.store(weights + offset, tl.where(valid, 1.0, 0.0), row < capacity)
+
+
+def _deepep_ll_topk(hidden_states: torch.Tensor, masked_m: torch.Tensor):
+    """Describe expert-major rows without reading valid counts on the host."""
+    experts, capacity, _ = hidden_states.shape
+    ids = torch.empty(
+        (experts * capacity, 1), device=hidden_states.device, dtype=torch.int32
     )
+    weights = torch.empty_like(ids, dtype=torch.float32)
+    if capacity:
+        _deepep_ll_topk_kernel[(experts, triton.cdiv(capacity, 256))](
+            masked_m,
+            ids,
+            weights,
+            capacity,
+            BLOCK=256,
+        )
+    return ids, weights
+
+
+@register_fused_func("deepep", "marlin")
+def fused_experts_deepep_to_marlin(
+    dispatch_output: DeepEPNormalDispatchOutput | DeepEPLLDispatchOutput,
+    quant_info: MarlinMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> CombineInput:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        DeepEPLLCombineInput,
+        DeepEPNormalCombineInput,
+        DispatchOutputFormat,
+    )
+
+    hidden_states = dispatch_output.hidden_states
+    if (
+        hidden_states.dtype != torch.bfloat16
+        or dispatch_output.hidden_states_scale is not None
+    ):
+        raise ValueError("Marlin + DeepEP expects BF16 activations without scales.")
+
+    # Dispatch has already assigned local experts. A second global-to-local
+    # mapping would silently select another rank's weights.
+    quant_info = replace(quant_info, expert_map=None, global_num_experts=-1)
+    if dispatch_output.format == DispatchOutputFormat.DEEPEP_NORMAL:
+        output = _run_marlin(
+            hidden_states,
+            dispatch_output.topk_ids,
+            dispatch_output.topk_weights,
+            quant_info,
+            runner_config,
+            is_ep=True,
+        )
+        return DeepEPNormalCombineInput(
+            output,
+            dispatch_output.topk_ids,
+            dispatch_output.topk_weights,
+        )
+    if dispatch_output.format == DispatchOutputFormat.DEEPEP_LL:
+        topk_ids, topk_weights = _deepep_ll_topk(
+            hidden_states, dispatch_output.masked_m
+        )
+        output = _run_marlin(
+            hidden_states.reshape(-1, hidden_states.shape[-1]),
+            topk_ids,
+            topk_weights,
+            quant_info,
+            runner_config,
+            is_ep=True,
+        )
+        # DeepEP applies the original routing weights while combining. These
+        # expert outputs were computed with unit weights, not the source top-k.
+        return DeepEPLLCombineInput(
+            output.view(hidden_states.shape),
+            dispatch_output.topk_ids,
+            dispatch_output.topk_weights,
+        )
+    raise ValueError(f"Unsupported Marlin dispatch format: {dispatch_output.format}")
 
 
 # ===== TO BE REFACTORED ====

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -147,6 +147,12 @@ def fused_experts_none_to_marlin(
             topk_output.topk_weights,
             quant_info,
             runner_config,
+            # Standard EP dispatch already maps non-local routes to -1.
+            is_ep=(
+                runner_config.num_local_experts is not None
+                and runner_config.num_experts is not None
+                and runner_config.num_local_experts < runner_config.num_experts
+            ),
         )
     )
 
@@ -159,6 +165,8 @@ def _run_marlin(
     runner_config: MoeRunnerConfig,
     *,
     is_ep: bool = False,
+    expected_m: Optional[int] = None,
+    expert_num_tokens: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import fused_marlin_moe
     from sglang.srt.layers.quantization.marlin_utils import marlin_make_workspace
@@ -229,6 +237,8 @@ def _run_marlin(
         activation=runner_config.activation,
         is_gated=runner_config.is_gated,
         is_ep=is_ep,
+        expected_m=expected_m,
+        expert_num_tokens=expert_num_tokens,
     ).to(hidden_states.dtype)
 
     return output
@@ -282,37 +292,82 @@ def validate_deepep_marlin(
 
 
 @triton.jit
-def _deepep_ll_topk_kernel(
+def _deepep_ll_copy_kernel(
+    expert_rows,
+    compact_rows,
     counts,
     ids,
-    weights,
-    capacity: tl.constexpr,
-    BLOCK: tl.constexpr,
+    CAPACITY: tl.constexpr,
+    HIDDEN: tl.constexpr,
+    EXPERTS: tl.constexpr,
+    PACK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_E: tl.constexpr,
 ):
     expert = tl.program_id(0)
-    row = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
-    valid = row < tl.load(counts + expert)
-    offset = expert * capacity + row
-    tl.store(ids + offset, tl.where(valid, expert, -1), row < capacity)
-    tl.store(weights + offset, tl.where(valid, 1.0, 0.0), row < capacity)
+    row = tl.program_id(1) * 8 + tl.arange(0, 8)
+    experts = tl.arange(0, BLOCK_E)
+    sizes = tl.load(counts + experts, experts < EXPERTS, 0)
+    start = tl.sum(tl.where(experts < expert, sizes, 0))
+    valid = (row < CAPACITY) & (row < tl.load(counts + expert))
+    col = tl.arange(0, BLOCK_H)
+    expert_offset = (expert * CAPACITY + row[:, None]) * HIDDEN + col[None, :]
+    compact_offset = (start + row[:, None]) * HIDDEN + col[None, :]
+    mask = valid[:, None] & (col[None, :] < HIDDEN)
+    if PACK:
+        value = tl.load(expert_rows + expert_offset, mask, 0)
+        tl.store(compact_rows + compact_offset, value, mask)
+        tl.store(ids + start + row, expert, valid)
+    else:
+        value = tl.load(compact_rows + compact_offset, mask, 0)
+        # DeepEP combine reads only dispatched rows through its handle.
+        tl.store(expert_rows + expert_offset, value, mask)
 
 
-def _deepep_ll_topk(hidden_states: torch.Tensor, masked_m: torch.Tensor):
-    """Describe expert-major rows without reading valid counts on the host."""
-    experts, capacity, _ = hidden_states.shape
-    ids = torch.empty(
-        (experts * capacity, 1), device=hidden_states.device, dtype=torch.int32
-    )
-    weights = torch.empty_like(ids, dtype=torch.float32)
+def _deepep_ll_pack(hidden_states: torch.Tensor, masked_m: torch.Tensor, topk: int):
+    """Compact valid expert rows into a graph-safe worst-case routing capacity."""
+    experts, capacity, hidden = hidden_states.shape
+    # Capacity already includes all source ranks. A source token visits at
+    # most topk experts, so allocating capacity for every expert wastes space.
+    rows = capacity * min(experts, topk)
+    compact = hidden_states.new_empty((rows, hidden))
+    ids = torch.full((rows, 1), -1, device=hidden_states.device, dtype=torch.int32)
+    weights = torch.ones((rows, 1), device=hidden_states.device, dtype=torch.float32)
     if capacity:
-        _deepep_ll_topk_kernel[(experts, triton.cdiv(capacity, 256))](
+        _deepep_ll_copy_kernel[(experts, triton.cdiv(capacity, 8))](
+            hidden_states,
+            compact,
             masked_m,
             ids,
-            weights,
             capacity,
-            BLOCK=256,
+            hidden,
+            experts,
+            True,
+            triton.next_power_of_2(hidden),
+            triton.next_power_of_2(experts),
         )
-    return ids, weights
+    return compact, ids, weights
+
+
+def _deepep_ll_unpack(
+    compact: torch.Tensor, hidden_states: torch.Tensor, counts: torch.Tensor
+):
+    output = torch.empty_like(hidden_states)
+    experts, capacity, hidden = hidden_states.shape
+    if capacity:
+        _deepep_ll_copy_kernel[(experts, triton.cdiv(capacity, 8))](
+            output,
+            compact,
+            counts,
+            counts,
+            capacity,
+            hidden,
+            experts,
+            False,
+            triton.next_power_of_2(hidden),
+            triton.next_power_of_2(experts),
+        )
+    return output
 
 
 @register_fused_func("deepep", "marlin")
@@ -352,21 +407,23 @@ def fused_experts_deepep_to_marlin(
             dispatch_output.topk_weights,
         )
     if dispatch_output.format == DispatchOutputFormat.DEEPEP_LL:
-        topk_ids, topk_weights = _deepep_ll_topk(
-            hidden_states, dispatch_output.masked_m
+        compact, topk_ids, topk_weights = _deepep_ll_pack(
+            hidden_states, dispatch_output.masked_m, dispatch_output.topk_ids.shape[1]
         )
         output = _run_marlin(
-            hidden_states.reshape(-1, hidden_states.shape[-1]),
+            compact,
             topk_ids,
             topk_weights,
             quant_info,
             runner_config,
             is_ep=True,
+            expected_m=dispatch_output.expected_m,
+            expert_num_tokens=dispatch_output.masked_m,
         )
         # DeepEP applies the original routing weights while combining. These
         # expert outputs were computed with unit weights, not the source top-k.
         return DeepEPLLCombineInput(
-            output.view(hidden_states.shape),
+            _deepep_ll_unpack(output, hidden_states, dispatch_output.masked_m),
             dispatch_output.topk_ids,
             dispatch_output.topk_weights,
         )

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -60,6 +60,11 @@ class MoeRunner:
         self.runner_backend = runner_backend
         self.config = config
         self.lora_enabled = lora_enabled
+        config.runner_backend = runner_backend
+        if get_moe_a2a_backend().is_deepep() and runner_backend.is_marlin():
+            from sglang.srt.layers.moe.moe_runner.marlin import validate_deepep_marlin
+
+            validate_deepep_marlin(config, lora_enabled=lora_enabled)
 
         # --moe-runner-backend hpc_ops makes the standard dispatcher keep
         # global expert ids (skip_local_expert_mapping), so every MoE layer
@@ -256,6 +261,8 @@ class MoeRunner:
     def set_overlap_args(
         self, down_gemm_overlap_args: DownGemmOverlapArgs, meta_overlap_args: dict
     ):
+        if get_moe_a2a_backend().is_deepep() and self.runner_backend.is_marlin():
+            raise ValueError("Marlin + DeepEP does not support down-GEMM overlap.")
         self.down_gemm_overlap_args = down_gemm_overlap_args
         self.meta_overlap_args = meta_overlap_args
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -24,6 +24,7 @@ from sglang.srt.layers.moe.topk import TopKOutput
 from sglang.srt.layers.moe.utils import (
     DeepEPMode,
     DispatcherOutputDtype,
+    MoeRunnerBackendLike,
     get_deepep_config,
     get_deepep_output_dtype,
     is_tbo_enabled,
@@ -371,6 +372,7 @@ class _DeepEPDispatcherImplBase:
         hidden_size: int,
         params_dtype: torch.dtype,
         deepep_mode: DeepEPMode,
+        runner_backend: Optional[MoeRunnerBackendLike] = None,
     ):
         if not use_deepep:
             raise ImportError(
@@ -386,6 +388,7 @@ class _DeepEPDispatcherImplBase:
         self.hidden_size = hidden_size
         self.params_dtype = params_dtype
         self.deepep_mode = deepep_mode
+        self.runner_backend = runner_backend
 
         self.params_bytes = 2
         # A large value will lead to large memory occupation, thus users should change it accordingly
@@ -629,7 +632,12 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         topk_weights: torch.Tensor,
     ):
 
-        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM or _use_aiter or _is_npu:
+        if (
+            (self.runner_backend is not None and self.runner_backend.is_marlin())
+            or deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            or _use_aiter
+            or _is_npu
+        ):
             output = hidden_states
         else:
             raise NotImplementedError()  # triton runner was supported but it's temporarily disabled
@@ -897,6 +905,7 @@ class DeepEPDispatcher(BaseDispatcher):
         deepep_mode: DeepEPMode = DeepEPMode.AUTO,
         async_finish: bool = False,
         return_recv_hook: bool = False,
+        runner_backend: Optional[MoeRunnerBackendLike] = None,
     ):
         super().__init__()
 
@@ -911,6 +920,7 @@ class DeepEPDispatcher(BaseDispatcher):
             hidden_size=hidden_size,
             params_dtype=params_dtype,
             deepep_mode=deepep_mode,
+            runner_backend=runner_backend,
         )
 
         if self.deepep_mode.enable_low_latency():

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -290,7 +290,8 @@ def get_deepep_output_dtype(self) -> DispatcherOutputDtype:
     """
     Automatically choose the dispatch output dtype for DeepEP.
 
-    The decision follows several checks in priority order:
+    A resolved Marlin runner requires BF16, regardless of its weight scales.
+    Other runners follow these checks in priority order:
     0. Parse server argument.
     1. Parse deprecated environment variables.
     2. If quant_config contains input_global_scale → NVFP4 path.
@@ -301,8 +302,20 @@ def get_deepep_output_dtype(self) -> DispatcherOutputDtype:
     7. Otherwise → FP8 (the default for most models like DeepSeek-V3).
     """
 
-    # 0. Parse server argument.
+    # Marlin's activation contract is independent of the weight format and
+    # must use the resolved layer runner, including automatic selection.
     server_args = get_server_args()
+    runner_backend = getattr(self, "runner_backend", None)
+    if runner_backend is not None and runner_backend.is_marlin():
+        requested = get_exec().moe.deepep_dispatcher_output_dtype
+        if requested not in {"auto", "bf16"}:
+            raise ValueError(
+                "Marlin + DeepEP requires --deepep-dispatcher-output-dtype bf16 "
+                f"or auto, got {requested}."
+            )
+        return DispatcherOutputDtype.BF16
+
+    # 0. Parse server argument.
     if server_args and get_exec().moe.deepep_dispatcher_output_dtype != "auto":
         return DispatcherOutputDtype(get_exec().moe.deepep_dispatcher_output_dtype)
 

--- a/python/sglang/srt/layers/quantization/awq/schemes/awq_moe.py
+++ b/python/sglang/srt/layers/quantization/awq/schemes/awq_moe.py
@@ -129,7 +129,10 @@ class AWQMoEScheme(AWQMoESchemeBase):
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
-        assert get_moe_runner_backend().is_auto()
+        assert get_moe_runner_backend() in {
+            MoeRunnerBackend.AUTO,
+            MoeRunnerBackend.MARLIN,
+        }
         self.moe_runner_config = moe_runner_config
         self.kernel.runner = MoeRunner(MoeRunnerBackend.MARLIN, moe_runner_config)
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -449,7 +449,13 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
         from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
             fused_marlin_moe,
         )
-        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+        from sglang.srt.layers.moe.token_dispatcher import (
+            DispatchOutputChecker,
+            StandardCombineInput,
+        )
+
+        if DispatchOutputChecker.format_is_deepep(dispatch_output):
+            return self.runner.run(dispatch_output, self.get_marlin_quant_info(layer))
 
         assert self.moe_runner_config.activation == "silu", (
             "Only SiLU activation is supported."

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1505,8 +1505,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 x, (0, self.hidden_pad), mode="constant", value=0.0
             )
         quant_info = build_marlin_moe_quant_info(layer)
-        return self.runner.run(
+        output = self.runner.run(
             dispatch_output._replace(hidden_states=x_padded), quant_info
+        )
+        return output._replace(
+            hidden_states=output.hidden_states[..., : x.shape[-1]].contiguous()
         )
 
     def _apply_sm120_cutlass(self, layer, dispatch_output):
@@ -1569,6 +1572,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # topk_ids/topk_weights directly and have no `.topk_output` to unpack.
         if _use_aiter and DispatchOutputChecker.format_is_deepep(dispatch_output):
             return self._apply_aiter(layer, dispatch_output)
+
+        if self.use_marlin:
+            return self._apply_marlin(layer, dispatch_output)
 
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
@@ -1639,10 +1645,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 swiglu_limit=moe_runner_config.swiglu_limit,
             )
             return StandardCombineInput(hidden_states=output)
-
-        if self.use_marlin:
-            assert TopKOutputChecker.format_is_standard(topk_output)
-            return self._apply_marlin(layer, dispatch_output)
 
         if self._fi_kernel == "cutlass_sm90":
             return self._apply_sm90_cutlass(layer, dispatch_output)

--- a/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
@@ -171,12 +171,6 @@ class Mxfp4MarlinMoEMethod:
         layer: Module,
         dispatch_output: DispatchOutput,
     ) -> CombineInput:
-        from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
-        from sglang.srt.layers.moe.topk import TopKOutputChecker
-
-        topk_output = dispatch_output.topk_output
-        if not TopKOutputChecker.format_is_standard(topk_output):
-            raise ValueError(f"Unsupported topk output format: {topk_output.format}")
         hidden_states = dispatch_output.hidden_states
         target_hidden_size = layer.w13_weight.shape[1] * 16
         if hidden_states.shape[-1] == target_hidden_size:
@@ -195,4 +189,8 @@ class Mxfp4MarlinMoEMethod:
             quant_info=quant_info,
         )
 
-        return StandardCombineInput(hidden_states=runner_output.hidden_states)
+        return runner_output._replace(
+            hidden_states=runner_output.hidden_states[
+                ..., : hidden_states.shape[-1]
+            ].contiguous()
+        )

--- a/python/sglang/test/marlin_deepep_utils.py
+++ b/python/sglang/test/marlin_deepep_utils.py
@@ -1,0 +1,198 @@
+"""Small deterministic quantized experts for Marlin/DeepEP correctness tests."""
+
+from types import SimpleNamespace
+
+import torch
+from sgl_kernel.scalar_type import scalar_types
+
+from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
+from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+    prepare_moe_mxfp4_layer_for_marlin,
+    prepare_moe_nvfp4_layer_for_marlin,
+)
+from sglang.test.test_marlin_utils import awq_marlin_quantize, marlin_quantize
+
+
+def make_experts(
+    format, experts=4, hidden=256, intermediate=128, *, gated=True, bias=False
+):
+    """Return the kernel payload and independent dequantized matrices/biases."""
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+    sizes = [(intermediate * (2 if gated else 1), hidden), (hidden, intermediate)]
+    refs, payload = [], []
+    biases = [
+        torch.randn(experts, n, device="cuda", dtype=dtype) / 20 if bias else None
+        for n, _ in sizes
+    ]
+    if format in {"gptq4", "gptq8", "awq"}:
+        quant_type = {
+            "gptq4": scalar_types.uint4b8,
+            "gptq8": scalar_types.uint8b128,
+            "awq": scalar_types.uint4,
+        }[format]
+        for n, k in sizes:
+            columns = []
+            for _ in range(experts):
+                w = torch.randn(k, n, device="cuda", dtype=dtype) / 20
+                if format == "awq":
+                    ref, q, scale, zero = awq_marlin_quantize(w, quant_type, 128)
+                    values = (ref.T, q, scale, zero, None, None)
+                else:
+                    ref, q, scale, g_idx, sort, _ = marlin_quantize(
+                        w, quant_type, 128, k > 128, torch.randperm(k)
+                    )
+                    values = (ref.T, q, scale, None, g_idx, sort)
+                columns.append(values)
+            stacked = [
+                torch.stack(v).contiguous() if v[0] is not None else None
+                for v in zip(*columns)
+            ]
+            refs.append(stacked[0])
+            payload.append(stacked[1:])
+        w13, scale13, zeros13, g_idx13, sort13 = payload[0]
+        w2, scale2, zeros2, g_idx2, sort2 = payload[1]
+        info = MarlinMoeQuantInfo(
+            w13_qweight=w13,
+            w2_qweight=w2,
+            w13_scales=scale13,
+            w2_scales=scale2,
+            w13_g_idx_sort_indices=sort13,
+            w2_g_idx_sort_indices=sort2,
+            weight_bits=8 if format == "gptq8" else 4,
+            w13_qzeros=zeros13,
+            w2_qzeros=zeros2,
+            w13_g_idx=g_idx13,
+            w2_g_idx=g_idx2,
+        )
+        if bias:
+            from sglang.srt.layers.quantization.marlin_utils import marlin_permute_bias
+
+            info.w13_bias, info.w2_bias = [
+                torch.stack([marlin_permute_bias(row) for row in v]) for v in biases
+            ]
+    else:
+        layer = torch.nn.Module()
+        layer.params_dtype = dtype
+        layer.quant_config = SimpleNamespace(group_size=16)
+        layer.moe_runner_config = SimpleNamespace(is_gated=gated)
+        layer.intermediate_size_per_partition = intermediate
+        values = torch.tensor(
+            [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6],
+            device="cuda",
+            dtype=dtype,
+        )
+        for i, (prefix, (n, k)) in enumerate(zip(("w13", "w2"), sizes)):
+            codes = torch.randint(
+                0, 16, (experts, n, k), device="cuda", dtype=torch.uint8
+            )
+            packed = codes[..., ::2] | (codes[..., 1::2] << 4)
+            group = 32 if format == "mxfp4" else 16
+            # Power-of-two scales are exactly representable in both formats.
+            # Match the roughly 0.05 RMS weights used by the integer fixtures.
+            exponents = torch.randint(-7, -4, (experts, n, k // group), device="cuda")
+            scale = (2.0**exponents).to(dtype)
+            ref = values[codes.long()] * scale.repeat_interleave(group, -1)
+            refs.append(ref)
+            if format == "mxfp4":
+                scale = (exponents + 127).to(torch.uint8).view(torch.float8_e8m0fnu)
+            else:
+                # NVFP4 checkpoints normalize group scales into the FP8
+                # range and carry the small outer scale separately.
+                scale = (scale * 4096).to(torch.float8_e4m3fn)
+                setattr(
+                    layer,
+                    prefix + "_weight_scale_2",
+                    torch.full((experts,), 1 / 4096, device="cuda", dtype=dtype),
+                )
+            setattr(
+                layer,
+                prefix + "_weight",
+                torch.nn.Parameter(packed, requires_grad=False),
+            )
+            setattr(
+                layer,
+                prefix + "_weight_scale",
+                torch.nn.Parameter(scale, requires_grad=False),
+            )
+            if bias:
+                setattr(
+                    layer,
+                    prefix + ("_weight_bias" if format == "mxfp4" else "_bias"),
+                    biases[i],
+                )
+        prepare = (
+            prepare_moe_mxfp4_layer_for_marlin
+            if format == "mxfp4"
+            else prepare_moe_nvfp4_layer_for_marlin
+        )
+        prepare(layer)
+        info = MarlinMoeQuantInfo(
+            w13_qweight=layer.w13_weight,
+            w2_qweight=layer.w2_weight,
+            w13_scales=layer.w13_weight_scale,
+            w2_scales=layer.w2_weight_scale,
+            w13_g_idx_sort_indices=None,
+            w2_g_idx_sort_indices=None,
+            weight_bits=4,
+            w13_global_scale=getattr(layer, "w13_weight_scale_2", None),
+            w2_global_scale=getattr(layer, "w2_weight_scale_2", None),
+            w13_bias=getattr(
+                layer, "w13_weight_bias" if format == "mxfp4" else "w13_bias", None
+            ),
+            w2_bias=getattr(
+                layer, "w2_weight_bias" if format == "mxfp4" else "w2_bias", None
+            ),
+        )
+    return info, (*refs, *biases)
+
+
+def reference(hidden, ids, weights, matrices, config):
+    w1, w2, b1, b2 = matrices
+    output = torch.zeros_like(hidden, dtype=torch.float32)
+    for expert in range(w1.shape[0]):
+        gate_up = hidden.float() @ w1[expert].float().T
+        if b1 is not None:
+            gate_up += b1[expert].float()
+        # The two GEMMs store BF16 activations. Keep FP32 accumulation in
+        # the reference, then round at the same mathematical boundaries.
+        gate_up = gate_up.to(hidden.dtype).float()
+        if config.is_gated:
+            gate, up = gate_up.chunk(2, dim=-1)
+            if config.activation == "situ":
+                beta = config.gemm1_alpha or 4.0
+                activated = beta * torch.tanh(gate / beta) * torch.sigmoid(gate) * up
+            else:
+                activated = torch.nn.functional.silu(gate) * up
+        elif config.activation == "relu2":
+            activated = torch.relu(gate_up).square()
+        else:
+            activated = torch.nn.functional.silu(gate_up)
+        result = activated.to(hidden.dtype).float() @ w2[expert].float().T
+        if b2 is not None:
+            result += b2[expert].float()
+        for slot in range(ids.shape[1]):
+            route_weight = torch.where(ids[:, slot] == expert, weights[:, slot], 0)
+            output += (result * route_weight[:, None]).to(hidden.dtype).float()
+    # MXFP4's model folds scaling into top-k, matching its existing kernel.
+    if config.routed_scaling_factor is not None:
+        output *= config.routed_scaling_factor
+    return output.to(hidden.dtype)
+
+
+def reference_tolerances(format):
+    # Match the existing fused-Marlin dequantized-reference tests, including
+    # NVFP4's extra scale-rounding error (test_moe_wna16_marlin.py).
+    return (
+        {"rtol": 0.05, "atol": 0.25}
+        if format == "nvfp4"
+        else {"rtol": 0.04, "atol": 0.04}
+    )
+
+
+def assert_reference_close(output, expected, format):
+    torch.testing.assert_close(output, expected, **reference_tolerances(format))
+    error = (output.float() - expected.float()).norm()
+    relative_error = (error / expected.float().norm().clamp_min(1e-12)).item()
+    assert relative_error < 0.02, f"Relative L2 error {relative_error:.6f} exceeds 2%"
+    return relative_error

--- a/test/registered/ep/test_marlin_deepep.py
+++ b/test/registered/ep/test_marlin_deepep.py
@@ -1,0 +1,210 @@
+"""Two-rank Marlin/DeepEP correctness and component timing on synthetic weights.
+
+Run directly with torchrun --standalone --nproc-per-node=2. No checkpoint download.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import fields, replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.moe import utils as moe_utils
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.marlin import (
+    fused_experts_deepep_to_marlin,
+    fused_experts_none_to_marlin,
+)
+from sglang.srt.layers.moe.token_dispatcher import deepep
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.utils import DeepEPMode, MoeRunnerBackend
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.marlin_deepep_utils import (
+    assert_reference_close,
+    make_experts,
+    reference,
+    reference_tolerances,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="2-gpu-large")
+
+
+def test_distributed():
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc-per-node=2",
+            str(Path(__file__).resolve()),
+        ],
+        check=True,
+        timeout=1200,
+        env=os.environ | {"SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "32"},
+    )
+
+
+def main():
+    rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    world = dist.get_world_size()
+    assert world == 2
+    hidden, experts = 4096, 4
+    config = MoeRunnerConfig(params_dtype=torch.bfloat16)
+    dispatcher = deepep.DeepEPDispatcher(
+        group=group,
+        router_topk=2,
+        num_experts=experts,
+        num_local_experts=experts // world,
+        hidden_size=hidden,
+        params_dtype=torch.bfloat16,
+        deepep_mode=DeepEPMode.AUTO,
+        async_finish=True,
+        return_recv_hook=True,
+        runner_backend=MoeRunnerBackend.MARLIN,
+    )
+    for format in ("gptq4", "gptq8", "awq", "mxfp4", "nvfp4"):
+        info, matrices = make_experts(format, experts=experts, hidden=hidden)
+        local = replace(
+            info,
+            **{
+                f.name: getattr(info, f.name).chunk(world)[rank].contiguous()
+                for f in fields(info)
+                if isinstance(getattr(info, f.name), torch.Tensor)
+            },
+        )
+        config.routed_scaling_factor = None if format == "mxfp4" else 1.7
+        for tokens, skew in (
+            (17 + rank * 3, False),
+            (9, True),
+            (0 if rank else 7, True),
+            (0, False),
+        ):
+            torch.manual_seed(100 + rank)
+            x = torch.randn(tokens, hidden, device="cuda", dtype=torch.bfloat16) / 4
+            ids = torch.stack(
+                (
+                    torch.arange(tokens, device="cuda") % experts,
+                    (torch.arange(tokens, device="cuda") + 1) % experts,
+                ),
+                -1,
+            ).long()
+            if skew:
+                ids[:] = torch.tensor([0, 1], device="cuda")
+            weights = torch.rand(tokens, 2, device="cuda") * 1.3
+            topk = StandardTopKOutput(weights, ids, None)
+            expected = reference(x, ids, weights, matrices, config)
+            standard = fused_experts_none_to_marlin(
+                StandardDispatchOutput(x, None, topk), info, config
+            ).hidden_states
+            assert_reference_close(standard, expected, format)
+            for normal in (True, False):
+
+                def run():
+                    dispatched = dispatcher.dispatch(x, topk)
+                    result = fused_experts_deepep_to_marlin(dispatched, local, config)
+                    return dispatcher.combine(result)
+
+                with patch.object(
+                    deepep, "get_is_extend_in_batch", return_value=normal
+                ):
+                    # Compile each local expert shape before timed collectives.
+                    out = run()
+                    torch.cuda.synchronize()
+                    assert_reference_close(out, expected, format)
+                    # Both kernels are independently checked against the reference;
+                    # comparing two rounded results allows both error budgets.
+                    torch.testing.assert_close(
+                        out,
+                        standard,
+                        **{
+                            key: 2 * value
+                            for key, value in reference_tolerances(format).items()
+                        },
+                    )
+                    if tokens and not skew:
+                        timings = []
+                        for _ in range(6):
+                            dist.barrier()
+                            events = [
+                                torch.cuda.Event(enable_timing=True) for _ in range(4)
+                            ]
+                            events[0].record()
+                            dispatched = dispatcher.dispatch(x, topk)
+                            events[1].record()
+                            result = fused_experts_deepep_to_marlin(
+                                dispatched, local, config
+                            )
+                            events[2].record()
+                            out = dispatcher.combine(result)
+                            events[3].record()
+                            torch.cuda.synchronize()
+                            timings.append(
+                                [
+                                    events[i].elapsed_time(events[i + 1])
+                                    for i in range(3)
+                                ]
+                            )
+                        if rank == 0:
+                            ms = torch.tensor(timings[1:]).mean(0).tolist()
+                            print(
+                                json.dumps(
+                                    dict(
+                                        format=format,
+                                        mode="normal" if normal else "low_latency",
+                                        tokens_per_rank=[17, 20],
+                                        dispatch_ms=ms[0],
+                                        experts_ms=ms[1],
+                                        combine_ms=ms[2],
+                                        total_ms=sum(ms),
+                                    )
+                                ),
+                                flush=True,
+                            )
+                    if not normal:
+                        # End-to-end captured dispatch + experts + combine.
+                        graph = torch.cuda.CUDAGraph()
+                        dist.barrier()
+                        with torch.cuda.graph(graph):
+                            captured = run()
+                        for _ in range(2):
+                            graph.replay()
+                            torch.cuda.synchronize()
+                            assert_reference_close(captured, expected, format)
+        dist.barrier()
+    deepep.DeepEPBuffer._state().buffer = None
+    dist.destroy_process_group()
+    if rank == 0:
+        print(
+            "Marlin + DeepEP distributed correctness and graph replay passed",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    if "LOCAL_RANK" not in os.environ:
+        test_distributed()
+    else:
+        # Supply application configuration; collectives, kernels, events and
+        # graph replay execute on the actual GPUs.
+        with (
+            patch.object(moe_utils, "get_server_args", return_value=None),
+            patch.object(
+                moe_utils,
+                "get_exec",
+                return_value=SimpleNamespace(
+                    moe=SimpleNamespace(deepep_dispatcher_output_dtype="auto")
+                ),
+            ),
+        ):
+            main()

--- a/test/registered/ep/test_marlin_deepep.py
+++ b/test/registered/ep/test_marlin_deepep.py
@@ -113,6 +113,17 @@ def main():
                 def run():
                     dispatched = dispatcher.dispatch(x, topk)
                     result = fused_experts_deepep_to_marlin(dispatched, local, config)
+                    if not normal:
+                        # Communication padding is unspecified. Poison it to prove
+                        # that eager and captured combine read only valid rows.
+                        capacity = result.hidden_states.shape[1]
+                        padding = (
+                            torch.arange(capacity, device=x.device)[None, :]
+                            >= dispatched.masked_m[:, None]
+                        )
+                        result.hidden_states.masked_fill_(
+                            padding[..., None], float("nan")
+                        )
                     return dispatcher.combine(result)
 
                 with patch.object(

--- a/test/registered/ep/test_marlin_deepep_server.py
+++ b/test/registered/ep/test_marlin_deepep_server.py
@@ -1,0 +1,106 @@
+"""Prefill/decode smoke test using a small local AWQ MoE and TP=EP=2.
+
+The model uses dummy weights: this checks execution, not language quality.
+"""
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=180, stage="base-b", runner_config="2-gpu-large")
+
+
+def run(mode):
+    import sglang as sgl
+
+    with tempfile.TemporaryDirectory(prefix="marlin-deepep-model-") as directory:
+        config = dict(
+            architectures=["Qwen3MoeForCausalLM"],
+            model_type="qwen3_moe",
+            hidden_size=4096,
+            intermediate_size=512,
+            moe_intermediate_size=512,
+            num_hidden_layers=2,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            num_experts=4,
+            num_experts_per_tok=2,
+            decoder_sparse_step=1,
+            mlp_only_layers=[],
+            norm_topk_prob=True,
+            hidden_act="silu",
+            max_position_embeddings=512,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            vocab_size=128,
+            tie_word_embeddings=False,
+            torch_dtype="bfloat16",
+            bos_token_id=1,
+            eos_token_id=2,
+            quantization_config=dict(
+                quant_method="awq",
+                bits=4,
+                group_size=128,
+                zero_point=True,
+                version="gemm",
+            ),
+        )
+        Path(directory, "config.json").write_text(json.dumps(config))
+        engine = sgl.Engine(
+            model_path=directory,
+            load_format="dummy",
+            skip_tokenizer_init=True,
+            dtype="bfloat16",
+            quantization="awq_marlin",
+            tp_size=2,
+            ep_size=2,
+            moe_runner_backend="marlin",
+            moe_a2a_backend="deepep",
+            deepep_mode=mode,
+            disable_shared_experts_fusion=True,
+            attention_backend="triton",
+            mem_fraction_static=0.15,
+            max_total_tokens=1024,
+            context_length=256,
+            cuda_graph_bs_decode=[1, 2, 4],
+            cuda_graph_backend_prefill="disabled",
+            disable_overlap_schedule=True,
+            log_level="warning",
+        )
+        try:
+            for prompts in ([[1, 3, 5, 7]], [[1, 4, 6], [1, 8, 9, 10, 11]]):
+                output = engine.generate(
+                    input_ids=prompts,
+                    sampling_params=dict(
+                        temperature=0, max_new_tokens=4, ignore_eos=True
+                    ),
+                )
+                assert len(output) == len(prompts)
+                for result in output:
+                    assert len(result["output_ids"]) == 4, result
+            print(f"Marlin + DeepEP {mode}: prefill/decode smoke passed", flush=True)
+        finally:
+            engine.shutdown()
+
+
+@pytest.mark.parametrize("mode", ["normal", "low_latency", "auto"])
+def test_server(mode):
+    run(mode)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=["normal", "low_latency", "auto"], default=None
+    )
+    parser.add_argument("-f", action="store_true")  # CI's fail-fast flag.
+    mode = parser.parse_args().mode
+    if mode is None:
+        raise SystemExit(pytest.main([__file__, "-v", "-s"]))
+    run(mode)

--- a/test/registered/kernels/ops/moe/test_marlin_deepep.py
+++ b/test/registered/kernels/ops/moe/test_marlin_deepep.py
@@ -1,0 +1,127 @@
+"""Marlin's DeepEP adapters: real kernels, masking, weighting and graph replay."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.marlin import (
+    fused_experts_deepep_to_marlin,
+    fused_experts_none_to_marlin,
+)
+from sglang.srt.layers.moe.token_dispatcher import (
+    DeepEPLLDispatchOutput,
+    DeepEPNormalDispatchOutput,
+    StandardDispatchOutput,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.marlin_deepep_utils import (
+    assert_reference_close,
+    make_experts,
+    reference,
+    reference_tolerances,
+)
+
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-large")
+
+
+@pytest.mark.parametrize("format", ["gptq4", "gptq8", "awq", "mxfp4", "nvfp4"])
+@pytest.mark.parametrize("tokens", [0, 1, 17])
+def test_normal(format, tokens):
+    info, matrices = make_experts(format)
+    config = MoeRunnerConfig(routed_scaling_factor=1.7 if format != "mxfp4" else None)
+    x = torch.randn(tokens, 256, device="cuda", dtype=torch.bfloat16)
+    ids = torch.randint(0, 4, (tokens, 2), device="cuda")
+    ids[:, 1] = -1
+    weights = torch.rand(tokens, 2, device="cuda") * 1.3
+    if tokens > 1:
+        ids[0] = -1  # A fully masked row must be zero, including shared scratch.
+    dispatch = DeepEPNormalDispatchOutput(x, None, ids, weights, [])
+    # A deliberately wrong mapping detects accidental double mapping.
+    ep_info = replace(
+        info, expert_map=torch.tensor([3, 2, 1, 0], device="cuda"), global_num_experts=4
+    )
+    result = fused_experts_deepep_to_marlin(dispatch, ep_info, config).hidden_states
+    expected = reference(x, ids, weights, matrices, config)
+    assert_reference_close(result, expected, format)
+    if tokens > 1:
+        assert torch.count_nonzero(result[0]) == 0
+    valid_ids = ids.clamp_min(0)
+    valid_weights = weights.masked_fill(ids < 0, 0)
+    standard = fused_experts_none_to_marlin(
+        StandardDispatchOutput(
+            x, None, StandardTopKOutput(valid_weights, valid_ids, None)
+        ),
+        info,
+        config,
+    )
+    torch.testing.assert_close(
+        result, standard.hidden_states, **reference_tolerances(format)
+    )
+
+
+@pytest.mark.parametrize("format", ["gptq4", "gptq8", "awq", "mxfp4", "nvfp4"])
+def test_low_latency_graph(format):
+    info, matrices = make_experts(format, bias=True)
+    config = MoeRunnerConfig(routed_scaling_factor=1.7 if format != "mxfp4" else None)
+    x = torch.randn(4, 17, 256, device="cuda", dtype=torch.bfloat16)
+    counts = torch.tensor([1, 0, 17, 3], device="cuda", dtype=torch.int32)
+    ids = torch.tensor([[0, 2]], device="cuda")
+    weights = torch.tensor([[0.2, 0.7]], device="cuda")
+    dispatch = DeepEPLLDispatchOutput(x, None, ids, weights, counts, 17)
+
+    def run():
+        return fused_experts_deepep_to_marlin(dispatch, info, config).hidden_states
+
+    for _ in range(3):
+        run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    for new_counts in ([1, 0, 17, 3], [0, 7, 2, 17], [0, 0, 0, 0]):
+        counts.copy_(torch.tensor(new_counts, device="cuda", dtype=torch.int32))
+        x.normal_()
+        graph.replay()
+        eager = run()
+        torch.testing.assert_close(captured, eager, **reference_tolerances(format))
+        local_ids = torch.arange(4, device="cuda").repeat_interleave(17).view(-1, 1)
+        valid = torch.arange(17, device="cuda")[None, :] < counts[:, None]
+        expected = reference(
+            x.flatten(0, 1), local_ids, valid.reshape(-1, 1).float(), matrices, config
+        ).view_as(x)
+        assert_reference_close(captured, expected, format)
+        assert torch.count_nonzero(captured[~valid]) == 0
+
+
+@pytest.mark.parametrize(
+    "format,gated,activation",
+    [
+        ("gptq4", False, "relu2"),
+        ("gptq8", False, "silu"),
+        ("nvfp4", False, "relu2"),
+        ("mxfp4", True, "situ"),
+    ],
+)
+def test_activation_and_bias(format, gated, activation):
+    info, matrices = make_experts(format, gated=gated, bias=True)
+    config = MoeRunnerConfig(is_gated=gated, activation=activation)
+    x = torch.randn(7, 256, device="cuda", dtype=torch.bfloat16)
+    ids = torch.tensor(
+        [[0, 2], [1, -1], [2, 3], [-1, -1], [0, 1], [1, 2], [3, 0]], device="cuda"
+    )
+    weights = torch.rand(7, 2, device="cuda")
+    output = fused_experts_deepep_to_marlin(
+        DeepEPNormalDispatchOutput(x, None, ids, weights, []), info, config
+    )
+    torch.testing.assert_close(
+        output.hidden_states,
+        reference(x, ids, weights, matrices, config),
+        **reference_tolerances(format),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/kernels/ops/moe/test_marlin_deepep.py
+++ b/test/registered/kernels/ops/moe/test_marlin_deepep.py
@@ -62,10 +62,29 @@ def test_normal(format, tokens):
     )
 
 
+@pytest.mark.parametrize("tokens", [1, 17])
+def test_standard_expert_parallel_masked_routes(tokens):
+    info, matrices = make_experts("awq")
+    config = MoeRunnerConfig(num_experts=8, num_local_experts=4)
+    x = torch.randn(tokens, 256, device="cuda", dtype=torch.bfloat16)
+    ids = torch.randint(0, 4, (tokens, 2), device="cuda", dtype=torch.int32)
+    ids[:, 1] = -1
+    weights = torch.rand(tokens, 2, device="cuda")
+    output = fused_experts_none_to_marlin(
+        StandardDispatchOutput(x, None, StandardTopKOutput(weights, ids, None)),
+        info,
+        config,
+    ).hidden_states
+    assert_reference_close(output, reference(x, ids, weights, matrices, config), "awq")
+
+
 @pytest.mark.parametrize("format", ["gptq4", "gptq8", "awq", "mxfp4", "nvfp4"])
-def test_low_latency_graph(format):
+@pytest.mark.parametrize("scaled", [False, True])
+def test_low_latency_graph(format, scaled):
     info, matrices = make_experts(format, bias=True)
-    config = MoeRunnerConfig(routed_scaling_factor=1.7 if format != "mxfp4" else None)
+    config = MoeRunnerConfig(
+        routed_scaling_factor=1.7 if scaled and format != "mxfp4" else None
+    )
     x = torch.randn(4, 17, 256, device="cuda", dtype=torch.bfloat16)
     counts = torch.tensor([1, 0, 17, 3], device="cuda", dtype=torch.int32)
     ids = torch.tensor([[0, 2]], device="cuda")
@@ -81,19 +100,30 @@ def test_low_latency_graph(format):
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured = run()
-    for new_counts in ([1, 0, 17, 3], [0, 7, 2, 17], [0, 0, 0, 0]):
+    for new_counts in (
+        [1, 0, 17, 3],
+        [0, 7, 2, 17],
+        [17, 17, 0, 0],
+        [0, 0, 17, 17],
+        [0, 0, 0, 0],
+    ):
         counts.copy_(torch.tensor(new_counts, device="cuda", dtype=torch.int32))
         x.normal_()
         graph.replay()
         eager = run()
-        torch.testing.assert_close(captured, eager, **reference_tolerances(format))
         local_ids = torch.arange(4, device="cuda").repeat_interleave(17).view(-1, 1)
         valid = torch.arange(17, device="cuda")[None, :] < counts[:, None]
         expected = reference(
             x.flatten(0, 1), local_ids, valid.reshape(-1, 1).float(), matrices, config
         ).view_as(x)
-        assert_reference_close(captured, expected, format)
-        assert torch.count_nonzero(captured[~valid]) == 0
+        torch.testing.assert_close(
+            captured[valid], eager[valid], **reference_tolerances(format)
+        )
+        assert_reference_close(captured[valid], expected[valid], format)
+        # Neither expert computation nor combine may depend on input padding.
+        x.masked_fill_(~valid[..., None], float("nan"))
+        graph.replay()
+        assert_reference_close(captured[valid], expected[valid], format)
 
 
 @pytest.mark.parametrize(

--- a/test/registered/kernels/ops/moe/test_moe_wna16_marlin.py
+++ b/test/registered/kernels/ops/moe/test_moe_wna16_marlin.py
@@ -588,7 +588,8 @@ def test_fused_marlin_moe_nvfp4_non_gated_padded_intermediate_launches():
     not (is_sm80_supported() or is_sm90_supported()),
     reason="NVFP4 Marlin MoE numeric test requires CUDA SM80, SM86, or SM90",
 )
-def test_fused_marlin_moe_nvfp4_non_gated_matches_dequant_reference():
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_fused_marlin_moe_nvfp4_non_gated_matches_dequant_reference(has_bias):
     torch.manual_seed(0)
 
     m = 17
@@ -640,6 +641,11 @@ def test_fused_marlin_moe_nvfp4_non_gated_matches_dequant_reference():
     layer.w2_weight_scale_2 = torch.nn.Parameter(
         torch.stack(w2_gscale_l), requires_grad=False
     )
+    if has_bias:
+        bias1 = torch.randn(e, intermediate_size, device="cuda", dtype=dtype) / 20
+        bias2 = torch.randn(e, hidden_size, device="cuda", dtype=dtype) / 20
+        layer.w13_bias = torch.nn.Parameter(bias1, requires_grad=False)
+        layer.w2_bias = torch.nn.Parameter(bias2, requires_grad=False)
     prepare_moe_nvfp4_layer_for_marlin(layer)
 
     # Scale activations down so relu² doesn't blow up intermediate magnitudes;
@@ -660,6 +666,8 @@ def test_fused_marlin_moe_nvfp4_non_gated_matches_dequant_reference():
         topk_ids=topk_ids,
         w1_global_scale=layer.w13_weight_scale_2,
         w2_global_scale=layer.w2_weight_scale_2,
+        w1_bias=getattr(layer, "w13_bias", None),
+        w2_bias=getattr(layer, "w2_bias", None),
         workspace=layer.workspace,
         num_bits=4,
         is_k_full=True,
@@ -675,8 +683,12 @@ def test_fused_marlin_moe_nvfp4_non_gated_matches_dequant_reference():
         for route_idx in range(topk):
             expert_id = topk_ids[token_idx, route_idx]
             intermediate = hidden_states[token_idx] @ w13_ref[expert_id].T
+            if has_bias:
+                intermediate += bias1[expert_id]
             intermediate = torch.square(torch.relu(intermediate))
             routed = intermediate @ w2_ref[expert_id].T
+            if has_bias:
+                routed += bias2[expert_id]
             output_ref[token_idx] += routed * topk_weights[token_idx, route_idx]
     output_ref *= routed_scaling_factor
 

--- a/test/registered/unit/layers/moe/test_marlin_deepep.py
+++ b/test/registered/unit/layers/moe/test_marlin_deepep.py
@@ -1,0 +1,194 @@
+"""Initialization contracts for the resolved Marlin + DeepEP runner."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe import utils
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.marlin import validate_deepep_marlin
+from sglang.srt.layers.moe.token_dispatcher import deepep
+from sglang.srt.layers.moe.utils import DispatcherOutputDtype, MoeRunnerBackend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def args(**kwargs):
+    values = dict(
+        enable_lora=False,
+        enable_eplb=False,
+        elastic_ep_backend=None,
+        enable_single_batch_overlap=False,
+        enable_two_batch_overlap=False,
+        init_expert_location="trivial",
+        deepep_dispatcher_output_dtype="auto",
+        enable_waterfill=False,
+        ep_num_redundant_experts=0,
+    )
+    return SimpleNamespace(**(values | kwargs))
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [
+        ("enable_lora", True),
+        ("enable_eplb", True),
+        ("elastic_ep_backend", "mooncake"),
+        ("enable_single_batch_overlap", True),
+        ("enable_two_batch_overlap", True),
+        ("init_expert_location", "random"),
+        ("deepep_dispatcher_output_dtype", "fp8"),
+    ],
+)
+def test_reject_unsupported_options(option, value):
+    config = MoeRunnerConfig(
+        runner_backend=MoeRunnerBackend.MARLIN, params_dtype=torch.bfloat16
+    )
+    with (
+        patch(
+            "sglang.srt.runtime_context.get_server_args",
+            return_value=args(**{option: value}),
+        ),
+        patch("sglang.srt.utils.is_cuda", return_value=True),
+    ):
+        with pytest.raises(ValueError):
+            validate_deepep_marlin(config)
+
+
+def test_validate_resolved_runner():
+    config = MoeRunnerConfig(
+        runner_backend=MoeRunnerBackend.MARLIN, params_dtype=torch.bfloat16
+    )
+    with (
+        patch("sglang.srt.runtime_context.get_server_args", return_value=args()),
+        patch("sglang.srt.utils.is_cuda", return_value=True),
+    ):
+        validate_deepep_marlin(config)
+        for changes in (
+            dict(params_dtype=torch.float16),
+            dict(num_fused_shared_experts=1),
+            dict(apply_router_weight_on_input=True),
+            dict(runner_backend=MoeRunnerBackend.EXPERIMENTAL_SGL_MARLIN),
+        ):
+            with pytest.raises(ValueError):
+                validate_deepep_marlin(replace(config, **changes))
+
+
+@pytest.mark.parametrize("requested", ["auto", "bf16", "fp8", "nvfp4"])
+def test_dtype_uses_actual_runner(requested):
+    dispatcher = SimpleNamespace(
+        runner_backend=MoeRunnerBackend.MARLIN,
+        quant_config={"input_global_scale": torch.ones(1)},
+    )
+    with (
+        patch.object(
+            utils,
+            "get_exec",
+            return_value=SimpleNamespace(
+                moe=SimpleNamespace(deepep_dispatcher_output_dtype=requested)
+            ),
+        ),
+        patch.object(utils, "get_server_args", return_value=None),
+    ):
+        if requested in {"auto", "bf16"}:
+            assert (
+                utils.get_deepep_output_dtype(dispatcher) == DispatcherOutputDtype.BF16
+            )
+        else:
+            with pytest.raises(ValueError, match="bf16"):
+                utils.get_deepep_output_dtype(dispatcher)
+
+
+def test_normal_combine_without_deepgemm():
+    impl = object.__new__(deepep._DeepEPDispatcherImplNormal)
+    impl.runner_backend = MoeRunnerBackend.MARLIN
+    impl.async_finish = False
+    x = torch.randn(3, 8)
+    with patch.object(deepep.deep_gemm_wrapper, "ENABLE_JIT_DEEPGEMM", False):
+        output, event = impl.combine_a(x, None, None)
+    assert output is x
+    assert event is None
+
+
+def test_auto_quantization_resolves_marlin():
+    from sglang.srt.layers.moe.moe_runner import runner
+    from sglang.srt.layers.moe.moe_runner.marlin import fused_experts_deepep_to_marlin
+    from sglang.srt.layers.moe.utils import MoeA2ABackend
+
+    config = MoeRunnerConfig(params_dtype=torch.bfloat16)
+    with (
+        patch.object(runner, "get_moe_a2a_backend", return_value=MoeA2ABackend.DEEPEP),
+        patch.object(
+            runner, "get_moe_runner_backend", return_value=MoeRunnerBackend.AUTO
+        ),
+        patch("sglang.srt.runtime_context.get_server_args", return_value=args()),
+        patch("sglang.srt.utils.is_cuda", return_value=True),
+    ):
+        instance = runner.MoeRunner(MoeRunnerBackend.MARLIN, config)
+        assert config.runner_backend == MoeRunnerBackend.MARLIN
+        assert instance.fused_func is fused_experts_deepep_to_marlin
+        with pytest.raises(ValueError, match="overlap"):
+            instance.set_overlap_args(object(), {})
+
+
+@pytest.mark.parametrize("mode", ["normal", "low_latency"])
+@pytest.mark.parametrize("method_name", ["mxfp4", "mxfp4_marlin"])
+def test_mxfp4_preserves_deepep_combine_format_and_width(mode, method_name):
+    from unittest.mock import Mock
+
+    from sglang.srt.layers.moe.token_dispatcher import (
+        DeepEPLLCombineInput,
+        DeepEPLLDispatchOutput,
+        DeepEPNormalCombineInput,
+        DeepEPNormalDispatchOutput,
+    )
+    from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+    from sglang.srt.layers.quantization.mxfp4_marlin_moe import Mxfp4MarlinMoEMethod
+
+    ids = torch.tensor([[0, 1]])
+    weights = torch.tensor([[0.3, 0.7]])
+    if mode == "normal":
+        dispatch = DeepEPNormalDispatchOutput(
+            torch.zeros(5, 128), None, ids, weights, []
+        )
+        combine_type = DeepEPNormalCombineInput
+    else:
+        dispatch = DeepEPLLDispatchOutput(
+            torch.zeros(2, 5, 128), None, ids, weights, torch.tensor([1, 3]), 5
+        )
+        combine_type = DeepEPLLCombineInput
+    layer = SimpleNamespace(
+        w13_weight=torch.empty(2, 16, 32),
+        w2_weight=torch.empty(2, 8, 64),
+        w13_weight_scale=torch.empty(2, 1, 256),
+        w2_weight_scale=torch.empty(2, 1, 128),
+        dispatcher=SimpleNamespace(),
+    )
+    runner = Mock()
+
+    def compute(dispatched, quant_info):
+        assert dispatched.hidden_states.shape[-1] == 256
+        return combine_type(torch.ones_like(dispatched.hidden_states), ids, weights)
+
+    runner.run.side_effect = compute
+    if method_name == "mxfp4":
+        method = object.__new__(Mxfp4MoEMethod)
+        method.hidden_size, method.hidden_pad, method.runner = 256, 128, runner
+        output = method._apply_marlin(layer, dispatch)
+    else:
+        method = object.__new__(Mxfp4MarlinMoEMethod)
+        method.runner = runner
+        output = method.apply(layer, dispatch)
+    assert isinstance(output, combine_type)
+    assert output.hidden_states.shape == dispatch.hidden_states.shape
+    assert output.hidden_states.is_contiguous()
+    assert output.topk_ids is ids
+    assert output.topk_weights is weights
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Enable quantized MoE experts to run with Marlin while DeepEP handles expert-parallel token dispatch and combine. Support BF16 normal, low-latency, and auto modes, including automatic quantization-method selection of Marlin.

## Modifications

- Share Marlin execution between standard dispatch and both DeepEP layouts. Preserve local expert indexing, routing weights, routed scaling, empty ranks, and low-latency graph replay.
- Compact valid low-latency expert rows on the GPU and build their block schedule directly from expert counts. Size tiles from expected valid rows and avoid unused-row initialization, redundant single-expert reduction, and invalid-block scans.
- Follow DeepEP's valid-row contract for communication padding; tests poison unused input/output rows with NaNs to verify that they cannot affect combined results.
- Resolve BF16 transport from the actual layer runner, preserve GPTQ/AWQ/MXFP4/NVFP4 payloads, and reject unsupported combinations early.
- Fix NVFP4 global-scale ordering with bias. Fix standard Marlin EP selecting a non-EP kernel for dispatch's non-local `-1` routes, which otherwise crashes the actual baseline during graph capture.
- Add a feature spec, reproducible evidence, and `benchmark/bench_marlin_deepep.py` for sequential HTTP server comparisons on the same GPUs.

## Accuracy Tests

Validated on H200 with PyTorch 2.13.0+cu130, Triton 3.7.1, sgl-deep-ep 0.1.2, and sglang-kernel 0.4.6.post1:

- 22 unit/dtype/wrapper tests and six standard Marlin regressions passed.
- 31 GPU adapter tests passed, including masked standard EP routes, biases, routed scaling, graph replay with changing counts, full compact-buffer capacity, and poisoned input padding.
- 40 two-rank distributed format/batch/mode cases passed across GPTQ4, GPTQ8, AWQ, MXFP4, and NVFP4. Twenty low-latency captures replay twice, including empty ranks and NaN-poisoned output padding before combine.
- The original dummy AWQ server smoke passed normal, low_latency, and auto. Real pretrained AWQ HTTP serving now also completes on two and eight GPUs.
- Three two-GPU greedy sanity prompts produced matching text (192 generated tokens); this is not a language-quality or bitwise-logit equivalence claim.
- Ruff lint/format, isort, and whitespace checks passed.

Exact commands, tolerances, and limitations are in [the evidence document](https://github.com/ByronHsu/sglang/blob/feat/marlin-deepep/python/sglang/spec/evidence/feature-00-marlin-deepep.md).

## Speed Tests and Profiling

Actual HTTP serving of `QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ`, pinned to `c58857a7f41c0920f73d1b56678640f9c02017d7`. Each pair uses identical H200 GPUs, TP=EP=DP=GPU count, DP attention, BF16 Marlin, Triton attention, decode graphs, and DeepEP auto mode. Fixed 256-token inputs and 128-token outputs; eight request waves and three repetitions. Every request completed with the requested output length.

Median generated output tokens/s:

| GPUs | Concurrency | none | DeepEP | Change |
| --- | ---: | ---: | ---: | ---: |
| 2 | 16 | 2,132.9 | 2,036.6 | -4.5% |
| 2 | 64 | 4,344.2 | 4,338.0 | -0.1% |
| 2 | 128 | 5,496.6 | 5,650.1 | +2.8% |
| 8 | 128 | 11,887.2 | 14,227.0 | +19.7% |

DeepEP has a clear advantage at eight-GPU EP scale, a modest gain at two-GPU concurrency 128, and no universal small-batch advantage. Both eight-GPU first runs were substantially slower; the evidence retains all repetitions and notes a short validation overlap on an unused GPU during the last two-GPU baseline run. No language-quality benchmark or multi-node performance claim is made.

## Checklist

- [x] Format code and check imports/lint.
- [x] Add unit, GPU, distributed, and server coverage.
- [x] Document the feature and reproducible evidence.
- [x] Provide correctness and actual HTTP throughput results with limitations.
- [x] Follow SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33982692924](https://github.com/sgl-project/sglang/actions/runs/33982692924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33982692685](https://github.com/sgl-project/sglang/actions/runs/33982692685)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33982692832](https://github.com/sgl-project/sglang/actions/runs/33982692832)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->