### PR TITLE
[Kernel] Add fused MoE Triton configs for Qwen3.8-Flash-Next FP8 on NVIDIA H200 NVL (TP2+EP2)

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -84,6 +84,7 @@ def get_model_config(
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5MoeForCausalLM",
         "Qwen3_5MoeForConditionalGeneration",
+        "Qwen4ExpForConditionalGeneration",
         "InternS2PreviewForConditionalGeneration",
         "MellumForCausalLM",
     ]:

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=640,device_name=NVIDIA_H200_NVL,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=640,device_name=NVIDIA_H200_NVL,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Motivation

Serving `Qwen/Qwen3.8-Flash-Next-FP8` with `--tp 2 --ep-size 2` on NVIDIA **H200 NVL** logs:

```
Using default MoE kernel config. Performance might be sub-optimal! Config file not found at
.../configs/triton_3_7_1/E=256,N=640,device_name=NVIDIA_H200_NVL,dtype=fp8_w8a8,block_shape=[128, 128].json
```

There is currently no `NVIDIA_H200_NVL` config in the repo at all (the H200 NVL reports a different device name than the SXM H200, so the existing `NVIDIA_H200` files are not picked up), and the default heuristic config (`64/128/128/32, 4 warps, 3 stages`) is noticeably slower than a tuned one for this shape. This PR adds a tuned config for the up-projection (w13) kernel and a small fix so the tuner can parse this model at all.

## Modifications

1. **`benchmark/kernels/fused_moe_triton/common_utils.py`** (separate commit): add `Qwen4ExpForConditionalGeneration` (model_type `qwen4_exp`, used by Qwen3.8-Flash-Next) to the Qwen MoE branch of `get_model_config()`. Without it the model falls through to the Mixtral default branch, which reads `num_local_experts` and raises `AttributeError`. With the Qwen branch, `E = num_experts // ep_size = 512 // 2 = 256`, `topk = num_experts_per_tok = 10`, `N = moe_intermediate_size = 640`, `block_shape = [128, 128]`, which reproduces exactly the config filename the server looks up at serve time (see the log above).
2. **`python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=640,device_name=NVIDIA_H200_NVL,dtype=fp8_w8a8,block_shape=[128, 128].json`**: tuned up-projection config for M = 1 … 4096 (the tuner's default batch-size grid).

No `_down.json` is included yet: the separate down-kernel tuner (`tuning_fused_moe_triton_sep.py`) needs real routing dumps (`--topk-ids-dir`) from a running server. With only the up config present, `get_moe_configs(..., down_moe=True)` falls back to reusing the tuned up config for the down projection (without TMA), which is still better than the heuristic default. A `_down` config based on real routing dumps is planned as a follow-up PR.

## Accuracy Tests

N/A. Kernel launch configuration only; no numerical change.

## Speed Tests and Profiling

**Environment**: NVIDIA H200 NVL 141 GB (single GPU, otherwise idle during tuning), driver 580.173, CUDA 13.0, Triton 3.7.1, torch 2.13.0+cu130, container `lmsysorg/sglang:qwen38flashnext` (sglang commit `593134d`; that branch is the one that registers the `qwen4_exp` HF config, so the tuner scripts from this PR's tree were run against that image's `sglang` package). `ray[default]` 2.58.0 was installed into the container for the tuner.

**Commands** (repo root mounted at `/work`, HF cache at `/root/.cache/huggingface`):

```bash
# baseline (default heuristic config)
python3 benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
  --model Qwen/Qwen3.8-Flash-Next-FP8 --tp-size 2 --ep-size 2 --dtype fp8_w8a8

# tuning: 1,280 candidates after the block_k filter x 18 batch sizes, 12,505 s wall clock
python3 benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
  --model Qwen/Qwen3.8-Flash-Next-FP8 --tp-size 2 --ep-size 2 --dtype fp8_w8a8 --tune

# re-benchmark with the tuned file picked up via SGLANG_MOE_CONFIG_DIR
SGLANG_MOE_CONFIG_DIR=/moe-configs python3 benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
  --model Qwen/Qwen3.8-Flash-Next-FP8 --tp-size 2 --ep-size 2 --dtype fp8_w8a8
```

Kernel time reported by the tuner's benchmark mode (fused up+down MoE, CUDA-graph replay, mean of 100 iterations, µs). Config columns are `BLOCK_SIZE_M/BLOCK_SIZE_N/BLOCK_SIZE_K/GROUP_SIZE_M/num_warps/num_stages`.

| Batch (M) | Default config | Default µs | Tuned config | Tuned µs | Speedup |
|---|---|---|---|---|---|
| 1 | 64/128/128/32/4/3 | 30.40 | 16/64/128/32/4/4 | 26.76 | 1.14x |
| 2 | 64/128/128/32/4/3 | 46.87 | 16/64/128/1/4/3 | 40.23 | 1.17x |
| 4 | 64/128/128/32/4/3 | 81.03 | 16/64/128/32/4/3 | 67.02 | 1.21x |
| 8 | 64/128/128/32/4/3 | 128.29 | 16/64/128/1/4/3 | 106.64 | 1.20x |
| 16 | 64/128/128/32/4/3 | 203.57 | 16/64/128/1/4/3 | 166.79 | 1.22x |
| 24 | 64/128/128/32/4/3 | 258.05 | 16/64/128/1/4/3 | 211.28 | 1.22x |
| 32 | 64/128/128/32/4/3 | 296.35 | 16/64/128/16/4/3 | 242.77 | 1.22x |
| 48 | 64/128/128/32/4/3 | 352.75 | 16/64/128/1/4/3 | 285.90 | 1.23x |
| 64 | 64/128/128/32/4/3 | 377.44 | 16/64/128/16/4/3 | 311.02 | 1.21x |
| 96 | 64/128/128/32/4/3 | 401.95 | 16/64/128/16/4/3 | 331.21 | 1.21x |
| 128 | 64/128/128/32/4/3 | 413.13 | 16/64/128/16/4/3 | 342.93 | 1.20x |
| 256 | 64/128/128/32/4/3 | 430.73 | 16/64/128/16/4/3 | 362.01 | 1.19x |
| 512 | 64/128/128/32/4/3 | 443.79 | 32/64/128/16/4/3 | 389.48 | 1.14x |
| 1024 | 64/128/128/32/4/3 | 483.17 | 64/64/128/16/4/3 | 458.40 | 1.05x |
| 1536 | 64/128/128/32/4/3 | 561.12 | 64/64/128/1/4/3 | 541.10 | 1.04x |
| 2048 | 64/128/128/32/4/3 | 749.42 | 64/128/128/16/4/4 | 733.77 | 1.02x |
| 3072 | 64/128/128/32/4/3 | 882.94 | 64/64/128/1/4/3 | 860.53 | 1.03x |
| 4096 | 64/128/128/32/4/3 | 1124.83 | 64/128/128/16/4/3 | 1110.07 | 1.01x |

The gain is largest in the decode-sized range (M ≤ 256: 1.14–1.23x), where the default `BLOCK_SIZE_M=64` wastes most of each tile; at prefill sizes (M ≥ 1024) the tuned config converges to the default shape and the gain is 1–5%.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A: config file + tuner model table)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33956696728](https://github.com/sgl-project/sglang/actions/runs/33956696728)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33956696793](https://github.com/sgl-project/sglang/actions/runs/33956696793)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33956696735](https://github.com/sgl-project/sglang/actions/runs/33956696735)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->