### PR TITLE
[Qwen4-Exp] Load nvidia/Qwen3.8-Flash-Next-NVFP4 (ModelOpt MIXED_PRECISION) on qwen4-main-squashed

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1443,7 +1443,10 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["quantization"] = quant_method
             quantization = quant_method
         if (
-            (quantization in ("fp8", "modelopt_fp4") or quantization is None)
+            (
+                quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")
+                or quantization is None
+            )
             and server_args.moe_a2a_backend == "none"
             and server_args.moe_runner_backend == "auto"
         ):

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1421,6 +1421,18 @@ def _qwen3vl_overrides(server_args: Any, hf_config: Any) -> dict:
     return {}
 
 
+def _mixed_precision_moe_quant_algos(hf_config: Any) -> set:
+    """quant_algo values ModelOpt MIXED_PRECISION assigns to `*.experts` layers."""
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if not isinstance(quantization_config, dict):
+        return set()
+    return {
+        str(info.get("quant_algo", "")).upper()
+        for name, info in quantization_config.get("quantized_layers", {}).items()
+        if ".experts" in name and isinstance(info, dict)
+    }
+
+
 @_register_for(
     "Qwen3MoeForCausalLM",
     "Qwen3VLMoeForConditionalGeneration",
@@ -1442,7 +1454,23 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["quantization"] = quant_method
             quantization = quant_method
-        if (
+        has_w4a16_moe_layers = (
+            quantization == "modelopt_mixed"
+            and "W4A16_NVFP4" in _mixed_precision_moe_quant_algos(hf_config)
+        )
+        if has_w4a16_moe_layers:
+            # trtllm-gen only has the W4A4 NVFP4 MoE path.
+            if server_args.moe_runner_backend not in ("auto", "marlin"):
+                raise ValueError(
+                    "W4A16_NVFP4 MoE layers require --moe-runner-backend=marlin."
+                )
+            if server_args.moe_runner_backend == "auto":
+                overrides["moe_runner_backend"] = "marlin"
+                logger.info(
+                    "Use marlin as MoE runner backend for "
+                    f"{hf_config.architectures[0]} with W4A16_NVFP4 MoE layers"
+                )
+        elif (
             (
                 quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")
                 or quantization is None

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2335,6 +2335,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 moe_runner_backend = MoeRunnerBackend.TRITON
 
         if (
+            moe_runner_backend.is_flashinfer_cutlass()
+            or moe_runner_backend.is_flashinfer_cutedsl()
+        ):
+            # Neither runner has an fp8 MoE path; they get pinned globally for
+            # NVFP4 experts on sm120, so run this layer's fp8 experts on triton.
+            logger.info(
+                "Fp8MoEMethod has no %s path; using triton for its fp8 experts.",
+                moe_runner_backend.name,
+            )
+            moe_runner_backend = MoeRunnerBackend.TRITON
+
+        if (
             moe_runner_backend.is_deep_gemm()
             or moe_runner_backend.is_triton()
             or moe_runner_backend.is_aiter()

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -739,11 +739,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         nvfp4_config: ModelOptFp4Config,
         nvfp4a16_config: ModelOptFp4Config,
         mxfp8_config: Fp8Config,
+        fp8_block_config: Fp8Config,
     ) -> None:
         super().__init__(kv_cache_quant_algo, exclude_modules, packed_modules_mapping)
         self.quantized_layers = quantized_layers
         self.fp8_config = fp8_config
         self.mxfp8_config = mxfp8_config
+        self.fp8_block_config = fp8_block_config
         self.nvfp4_config = nvfp4_config
         self.nvfp4a16_config = nvfp4a16_config
 
@@ -800,6 +802,9 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             exclude_modules = quantization_section.get("exclude_modules")
             quantized_layers = quantization_section.get("quantized_layers", {})
 
+        # ModelOpt emits `ignore: []` or omits it; is_layer_skipped iterates it.
+        exclude_modules = list(exclude_modules or [])
+
         if quant_algo != "MIXED_PRECISION":
             raise ValueError(
                 "ModelOptMixedPrecisionConfig only supports MIXED_PRECISION checkpoints."
@@ -834,6 +839,13 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=True,
         )
+        # ModelOpt FP8_BLOCK_SCALES: 128x128 block fp8 with weight_scale_inv.
+        fp8_block_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            packed_modules_mapping=packed_modules_mapping,
+        )
         nvfp4_config = ModelOptFp4Config(
             is_checkpoint_nvfp4_serialized=True,
             kv_cache_quant_algo=kv_cache_quant_algo,
@@ -857,6 +869,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             quantized_layers=quantized_layers,
             fp8_config=fp8_config,
             mxfp8_config=mxfp8_config,
+            fp8_block_config=fp8_block_config,
             nvfp4_config=nvfp4_config,
             nvfp4a16_config=nvfp4a16_config,
         )
@@ -915,8 +928,16 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             candidates.append(
                 "language_model.model." + prefix[len("model.language_model.") :]
             )
+            candidates.append("model." + prefix[len("model.language_model.") :])
+        elif prefix.startswith("model."):
+            # VL models such as Qwen4-Exp name the text stack `model.layers.*`
+            # while ModelOpt keys it `model.language_model.layers.*`.
+            candidates.append("model.language_model." + prefix[len("model.") :])
 
         return tuple(dict.fromkeys(candidates))
+
+    def resolve_quant_algo(self, prefix: str) -> Optional[str]:
+        return self._resolve_quant_algo(prefix)
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
@@ -937,6 +958,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "FP8_BLOCK_SCALES":
+                return Fp8LinearMethod(self.fp8_block_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
             if quant_algo == "NVFP4":
@@ -966,6 +989,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return ModelOptFp8MoEMethod(self.fp8_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)
+            if quant_algo == "FP8_BLOCK_SCALES":
+                return Fp8MoEMethod(self.fp8_block_config)
             if quant_algo == "NVFP4":
                 return ModelOptNvFp4FusedMoEMethod(self.nvfp4_config)
             if quant_algo == "W4A16_NVFP4":

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import logging
 import math
 from dataclasses import dataclass, field
@@ -1817,6 +1818,12 @@ class KVCacheConfigurator:
         # KV pool budget = currently-free GPU memory minus the non-static runtime
         # slack (pre_model_load_memory * (1 - mem_fraction_static)). Whatever is
         # already resident (model weights, etc.) is thus charged against it.
+        # Weight-loading temporaries can still be referenced at this point, and
+        # empty_cache() (which get_available_gpu_memory already calls) cannot
+        # reclaim referenced blocks. Without collecting first, the KV budget is
+        # measured against an understated free-memory figure and the pool can be
+        # sized orders of magnitude too small while GPU memory sits idle.
+        gc.collect()
         available_gpu_memory = get_available_gpu_memory(
             self.device,
             self.gpu_id,

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -54,12 +54,14 @@ def _mtp_quant_config(quant_config):
     # Serialized Qwen3.5 ModelOpt checkpoints keep embedded MTP weights in
     # BF16. Disable quantization for those checkpoints; non-serialized
     # modelopt_fp4 still converts MoE expert weights on load.
+    if quant_config and quant_config.get_name() == "modelopt_mixed":
+        # MIXED_PRECISION lists mtp.* layers only when the MTP head is quantized.
+        if any(name.startswith("mtp.") for name in quant_config.quantized_layers):
+            return quant_config
+        return None
     if quant_config and (
-        quant_config.get_name() == "modelopt_mixed"
-        or (
-            quant_config.get_name() == "modelopt_fp4"
-            and quant_config.is_checkpoint_nvfp4_serialized
-        )
+        quant_config.get_name() == "modelopt_fp4"
+        and quant_config.is_checkpoint_nvfp4_serialized
     ):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -43,6 +43,9 @@ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptMixedPrecisionConfig,
+)
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
@@ -66,6 +69,24 @@ from sglang.srt.utils import logger
 # Decode/verify-sized batches only: at prefill sizes both chains are compute
 # bound and serializing them on one stream is faster than contending.
 _QSA_INDEXER_OVERLAP_TOKEN_THRESHOLD = 1024
+
+
+def _ple_table_is_fp8(
+    config: Qwen4ExpTextConfig,
+    quant_config: Optional[QuantizationConfig],
+    prefix: str,
+) -> bool:
+    """fp8 PLE shards: declared by config, an fp8 checkpoint, or a ModelOpt
+    MIXED_PRECISION entry for the ngram table (nvidia/*-Flash-Next-NVFP4)."""
+    if config.ple_embedding_dtype == "float8_e4m3fn":
+        return True
+    if quant_config is None:
+        return False
+    if quant_config.get_name() == "fp8":
+        return True
+    if isinstance(quant_config, ModelOptMixedPrecisionConfig):
+        return quant_config.resolve_quant_algo(prefix) == "FP8"
+    return False
 
 
 def _get_ple_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -432,6 +453,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         embedding_dim: int,
         ple_layer_index: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.config = config
@@ -488,13 +510,13 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
+        ngram_prefix = f"{prefix}.ngram_embedding" if prefix else "ngram_embedding"
         self.ngram_embedding = VocabParallelEmbedding(
             padded_vocab_size,
             self.head_dim_per_ngram,
             params_dtype=(
                 torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                if _ple_table_is_fp8(config, quant_config, ngram_prefix)
                 else torch.bfloat16
             ),
             output_dtype=torch.bfloat16,
@@ -890,6 +912,7 @@ class Qwen4ExpPLELayer(nn.Module):
             self.ple_embed_dim,
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
+            prefix=f"{prefix}.ple_embedding" if prefix else "ple_embedding",
         )
         if config.ple_offload_embedding:
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(

--- a/test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py
+++ b/test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py
@@ -1,0 +1,38 @@
+"""Fp8MoEMethod builds a triton runner when the global MoE runner backend is
+flashinfer_cutlass or flashinfer_cutedsl, which have no fp8 MoE path."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import sglang.srt.layers.quantization.fp8 as fp8
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestFp8MoeRunnerFallback(CustomTestCase):
+    def _runner_backend_for(self, global_backend):
+        method = fp8.Fp8MoEMethod.__new__(fp8.Fp8MoEMethod)
+        with patch.object(fp8, "get_moe_runner_backend", return_value=global_backend):
+            method.create_moe_runner(layer=None, moe_runner_config=MoeRunnerConfig())
+        return method.runner.runner_backend
+
+    def test_flashinfer_cutlass_falls_back_to_triton(self):
+        self.assertTrue(
+            self._runner_backend_for(MoeRunnerBackend.FLASHINFER_CUTLASS).is_triton()
+        )
+
+    def test_flashinfer_cutedsl_falls_back_to_triton(self):
+        self.assertTrue(
+            self._runner_backend_for(MoeRunnerBackend.FLASHINFER_CUTEDSL).is_triton()
+        )
+
+    def test_triton_is_kept(self):
+        self.assertTrue(self._runner_backend_for(MoeRunnerBackend.TRITON).is_triton())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -18,7 +18,12 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.quantization.fp8 import (
+    Fp8Config,
+    Fp8LinearMethod,
+    Fp8MoEMethod,
+)
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -904,6 +909,56 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(
             quant_config._resolve_quant_algo("model.layers.2.mixer.qkv_proj"),
             "FP8",
+        )
+
+    def test_mixed_precision_resolves_vl_language_model_keys(self):
+        # nvidia/Qwen3.8-Flash-Next-NVFP4 keys the text stack as
+        # `model.language_model.*` while Qwen4-Exp modules are `model.*`.
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.language_model.layers.3.mlp.experts": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    },
+                    "model.language_model.layers.1.ple.ple_embedding.ngram_embedding": {
+                        "quant_algo": "FP8"
+                    },
+                    "mtp.layers.0.mlp.experts": {
+                        "quant_algo": "FP8_BLOCK_SCALES",
+                        "group_size": 128,
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(quant_config.exclude_modules, [])
+        moe = FusedMoE.__new__(FusedMoE)
+        self.assertIsInstance(
+            quant_config.get_quant_method(moe, "mtp.layers.0.mlp.experts"),
+            Fp8MoEMethod,
+        )
+        self.assertEqual(
+            quant_config.get_quant_method(
+                moe, "mtp.layers.0.mlp.experts"
+            ).quant_config.weight_block_size,
+            [128, 128],
+        )
+        self.assertEqual(
+            quant_config.resolve_quant_algo("model.layers.3.mlp.experts"), "NVFP4"
+        )
+        self.assertEqual(
+            quant_config.resolve_quant_algo(
+                "model.layers.1.ple.ple_embedding.ngram_embedding"
+            ),
+            "FP8",
+        )
+        self.assertIsNone(
+            quant_config.resolve_quant_algo("model.layers.1.ple.key_proj")
+        )
+        self.assertIsNone(
+            quant_config.resolve_quant_algo("model.layers.3.mlp.shared_expert")
         )
 
 

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -934,17 +934,6 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         )
 
         self.assertEqual(quant_config.exclude_modules, [])
-        moe = FusedMoE.__new__(FusedMoE)
-        self.assertIsInstance(
-            quant_config.get_quant_method(moe, "mtp.layers.0.mlp.experts"),
-            Fp8MoEMethod,
-        )
-        self.assertEqual(
-            quant_config.get_quant_method(
-                moe, "mtp.layers.0.mlp.experts"
-            ).quant_config.weight_block_size,
-            [128, 128],
-        )
         self.assertEqual(
             quant_config.resolve_quant_algo("model.layers.3.mlp.experts"), "NVFP4"
         )
@@ -954,12 +943,11 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
             ),
             "FP8",
         )
-        self.assertIsNone(
-            quant_config.resolve_quant_algo("model.layers.1.ple.key_proj")
+        mtp_method = quant_config.get_quant_method(
+            FusedMoE.__new__(FusedMoE), "mtp.layers.0.mlp.experts"
         )
-        self.assertIsNone(
-            quant_config.resolve_quant_algo("model.layers.3.mlp.shared_expert")
-        )
+        self.assertIsInstance(mtp_method, Fp8MoEMethod)
+        self.assertEqual(mtp_method.quant_config.weight_block_size, [128, 128])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -467,7 +467,20 @@ class TestWrapperEntryClassGates(_FusionGateCase):
         )
 
         # The normalization the constructor applies, shared with the gate.
-        self.assertIsNone(_mtp_quant_config(_quant("modelopt_mixed")))
+        mixed_bf16_mtp = SimpleNamespace(
+            get_name=lambda: "modelopt_mixed",
+            quantized_layers={"model.layers.0.mlp.experts": {"quant_algo": "NVFP4"}},
+        )
+        self.assertIsNone(_mtp_quant_config(mixed_bf16_mtp))
+        # MIXED_PRECISION checkpoints that quantize the MTP head keep it.
+        mixed_fp8_mtp = SimpleNamespace(
+            get_name=lambda: "modelopt_mixed",
+            quantized_layers={
+                "model.layers.0.mlp.experts": {"quant_algo": "NVFP4"},
+                "mtp.layers.0.mlp.experts": {"quant_algo": "FP8_BLOCK_SCALES"},
+            },
+        )
+        self.assertIs(_mtp_quant_config(mixed_fp8_mtp), mixed_fp8_mtp)
         serialized = SimpleNamespace(
             get_name=lambda: "modelopt_fp4", is_checkpoint_nvfp4_serialized=True
         )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2323,6 +2323,40 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         with patch.object(overrides_module, "is_sm100_supported", return_value=False):
             self.assertEqual(_qwen3_moe_family_overrides(None, None), {})
 
+    def test_qwen3_moe_family_mixed_precision_moe_runner(self):
+        from sglang.srt.arg_groups.overrides import _qwen3_moe_family_overrides
+
+        def _mixed(expert_algo):
+            return SimpleNamespace(
+                architectures=["Qwen4ExpForConditionalGeneration"],
+                quantization_config={
+                    "quant_method": "modelopt_mixed",
+                    "quantized_layers": {
+                        "model.language_model.layers.0.mlp.experts": {
+                            "quant_algo": expert_algo
+                        }
+                    },
+                },
+            )
+
+        args = SimpleNamespace(
+            quantization="modelopt_mixed",
+            _quantization_explicitly_unset=False,
+            moe_a2a_backend="none",
+            moe_runner_backend="auto",
+        )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            # W4A4 experts take trtllm-gen like modelopt_fp4; W4A16 has no
+            # trtllm-gen kernel and goes to marlin.
+            self.assertEqual(
+                _qwen3_moe_family_overrides(args, _mixed("NVFP4")),
+                {"moe_runner_backend": "flashinfer_trtllm"},
+            )
+            self.assertEqual(
+                _qwen3_moe_family_overrides(args, _mixed("W4A16_NVFP4")),
+                {"moe_runner_backend": "marlin"},
+            )
+
     def test_step3p_declarations_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _step3p_overrides
 


### PR DESCRIPTION
## Motivation

#37752 makes `nvidia/Qwen3.8-Flash-Next-NVFP4` load, but it is stacked on #37500 (`qwen4-main-squashed-rebased`). This PR is the same change rebased onto `qwen4-main-squashed` (#36497). The two #37752 commits are cherry-picked with their original authorship; the port notes are in the commit messages and repeated below.

#36845 and #36806 needed no rebase: both were merged straight into `qwen4-main-squashed` and are its two tip commits (`99c9362e66`, `78c5024e9d`).

The NVIDIA export (revision `fab0aecb`) is a ModelOpt MIXED_PRECISION checkpoint. `RadixArk/Qwen3.8-Flash-Next-NVFP4` is not.

| part | quant | checkpoint metadata |
|---|---|---|
| routed experts (48 layers) | NVFP4 g16 | `quantized_layers["model.language_model.layers.N.mlp.experts"]` |
| PLE n-gram table | FP8 per-tensor | `quantized_layers["model.language_model.layers.1.ple.ple_embedding.ngram_embedding"]`, 128 fp8 `shard_N.weight` + `weight_scale` |
| MTP experts | FP8_BLOCK_SCALES g128 | `quantized_layers["mtp.layers.0.mlp.experts"]`, `weight_scale_inv` |
| everything else | bf16 | 292-entry glob `ignore` list |

`config.json` carries `quantization_config` (`quant_method: modelopt`, `quant_algo: MIXED_PRECISION`) and no `text_config.ple_embedding_dtype`. On `qwen4-main-squashed` the server dies while loading weights:

```
ValueError: fp8 PLE auto-switch is unsupported with ple_offload_embedding; set text_config.ple_embedding_dtype="float8_e4m3fn" instead
```

With `--no-ple-offload-embedding` it dies at CUDA-graph capture instead:

```
NotImplementedError: Unsupported moe_runner_backend for NVFP4 MoE: MoeRunnerBackend.FLASHINFER_TRTLLM. Use --moe-runner-backend flashinfer_cutlass instead.
```

## Modifications

Commits 1 and 2 are #37752:

- `ModelOptMixedPrecisionConfig`: resolve `model.language_model.*` keys against the `model.*` prefixes Qwen4-Exp modules use; default `exclude_modules` to `[]`; map `FP8_BLOCK_SCALES` to the 128x128 block `Fp8LinearMethod` / `Fp8MoEMethod`; expose `resolve_quant_algo()`.
- `Qwen4ExpNGramEmbedding`: use fp8 table storage when the mixed config marks the ngram table FP8, so the pinned-host offload path sees fp8 storage up front.
- Qwen3 MoE family override: default `modelopt_mixed` to `flashinfer_trtllm` on sm100 when the expert layers are NVFP4/FP8; route `W4A16_NVFP4` experts to marlin, or reject an explicit non-marlin runner.
- `_mtp_quant_config`: keep the mixed config for the MTP head when it lists `mtp.*` layers.

Port differences, forced by what `qwen4-main-squashed` has:

- The Qwen3 MoE override is still inline in `python/sglang/srt/arg_groups/overrides.py` (this branch has no `arg_groups/model_overrides/qwen3_moe.py`), so the change and its test target that file.
- `ModelOptMixedPrecisionConfig` has no `fp8_pb_wo_config` here, so a 128x128 block `Fp8Config` is added as `fp8_block_config` and only `FP8_BLOCK_SCALES` maps to it.
- The override test mocks with `patch.object(overrides_module, "is_sm100_supported", ...)`, the idiom this branch's test file already uses.

Commits 3 and 4 came out of validating on 1x RTX PRO 6000 (sm120). They are separate so either can be dropped or moved:

- Commit 3: `Fp8MoEMethod.create_moe_runner` resolves `flashinfer_cutlass` / `flashinfer_cutedsl` to triton. The MoE runner backend is global. sm120 has no trtllm-gen, so NVFP4 experts need `--moe-runner-backend flashinfer_cutlass`, and for that backend `Fp8MoEMethod` created no runner at all; the FP8_BLOCK_SCALES MTP head then died in the draft CUDA-graph warmup with `AttributeError: 'Fp8MoEMethod' object has no attribute 'runner'`. On sm100 the override picks `flashinfer_trtllm`, which `Fp8MoEMethod` supports, so #37752 never hit this. Unit test: `test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py`.
- Commit 4: cherry-pick of #36583 (`gc.collect()` before profiling the KV budget). `qwen4-main-squashed` predates it. Without it, loader temporaries still referenced at profiling time understate free memory by about 6 GiB on a 96 GB card, and the pinned mamba pool plus KV no longer fit (`Loaded weights leave no GPU memory for the KV cache under --mem-fraction-static=0.93`). This is not specific to the checkpoint. Drop it here if the base branch picks it up from main.

## Accuracy Tests

1x RTX PRO 6000 Blackwell (96 GB, sm120), TP1, `lmsysorg/sglang:qwen38flashnext` with this branch overlaid (`sglang-kernel 0.4.6.post1` matches this branch's pin; the image ships flashinfer 0.6.18, the branch pins 0.6.17). GSM8K is the chat endpoint, 200 questions, thinking off, greedy, `max_tokens=1024`, at 64 concurrent requests (no MTP) or 16 (MTP).

Common flags: `--fp4-gemm-backend flashinfer_cutlass --moe-runner-backend flashinfer_cutlass --ple-offload-embedding --page-size 64 --chunked-prefill-size 4096 --context-length 262144 --mamba-radix-cache-strategy extra_buffer_lazy --mamba-ssm-dtype bfloat16 --reasoning-parser qwen3`, env `SGLANG_OPT_MAMBA_SKIP_DECODE_LOCK=1`, no `--quantization` (resolved from the checkpoint). No MTP adds `--max-running-requests 64 --max-mamba-cache-size 192 --mem-fraction-static 0.93`. MTP adds `--speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --max-running-requests 16 --max-mamba-cache-size 48 --mem-fraction-static 0.96`.

| checkpoint | PLE offload | MTP | startup (launch to ready) | GSM8K (200, no think) | accept len |
|---|---|---|---|---|---|
| nvidia/Qwen3.8-Flash-Next-NVFP4 | on | off | 134 s (weights 61 s) | 0.965 (197 stop / 3 length) | - |
| nvidia/Qwen3.8-Flash-Next-NVFP4 | on | on | 112 s (weights 59 s + draft 11 s) | 0.975 (197 stop / 3 length) | 3.35 |

Both boots log `quant=modelopt_mixed, quant_algo=MIXED_PRECISION`, keep 81.35 GB of weights on the GPU with the fp8 ngram table pinned in host RAM (scheduler RSS about 71 GB), and resolve the linear-attention kernels to triton. The MTP boot logs `Fp8MoEMethod has no FLASHINFER_CUTLASS path; using triton for its fp8 experts.` Pools: no MTP has 192 mamba slots (10.58 GB) and a 97,600-token KV pool, with 5.25 GB free after graph capture and 4.0 GB left at peak; MTP has 48 slots, 3.59 GB of intermediate SSM state and a 169,664-token KV pool, with 4.12 GB free after capture and 2.9 GB left at peak. Neither server log has an error.

Unit tests in the same container, plus `pre-commit run --files <changed files>`, all pass:

```
test/registered/unit/model_loader/test_modelopt_loader.py -k MixedPrecision        10 passed
test/registered/unit/test_model_overrides.py -k qwen3_moe                           2 passed
test/registered/unit/models/test_shared_experts_fusion_gates.py                    25 passed
test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py            3 passed
```

## Speed Tests and Profiling

`bench_serving --backend sglang-oai --dataset-name random --random-input-len 1024 --random-output-len 256 --random-range-ratio 1 --request-rate inf --flush-cache`, same servers as above:

| config | concurrency (prompts) | output tok/s | mean TTFT | mean TPOT |
|---|---|---|---|---|
| no MTP, 64 | 16 (32) | 536.8 | 1,159 ms | 25.3 ms |
| no MTP, 64 | 64 (192) | 881.3 | 3,318 ms | 54.8 ms |
| MTP, 16 | 1 (8) | 154.4 | 162 ms | 5.86 ms |
| MTP, 16 | 16 (32) | 669.5 | 727 ms | 19.1 ms |

`RadixArk/Qwen3.8-Flash-Next-NVFP4` on the `qwen4-main-squashed-rebased` image with the same flags (#37995) measured GSM8K 97.0-97.5 and TPOT 5.8-5.9 ms at concurrency 1 with MTP, and GSM8K 97.0-98.0 and 856-861 tok/s at 64 without. The NVIDIA export lands in the same place.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5B2WK8ciABmJ8pMBtGcgN

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33963603943](https://github.com/sgl-project/sglang/actions/runs/33963603943)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33963603948](https://github.com/sgl-project/sglang/actions/runs/33963603948)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33963604062](https://github.com/sgl-project/sglang/actions/runs/33963604062)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->