### PR TITLE
[Fix] Compare bearer tokens as bytes so non-ASCII keys don't 500

### DIFF
--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -103,13 +103,22 @@ def decide_request_auth(
     def _check_bearer_token(
         authorization_header: Optional[str], expected_token: str
     ) -> bool:
-        """Check bearer token with constant-time comparison."""
+        """Check bearer token with constant-time comparison.
+
+        The comparison is done on UTF-8 bytes: ``secrets.compare_digest``
+        rejects ``str`` operands containing non-ASCII characters with
+        ``TypeError``, which would escape the middleware as a 500 instead of
+        a 401 whenever a client sends a non-ASCII token, or the server is
+        started with a non-ASCII key. Bytes keep the constant-time guarantee.
+        """
         if not authorization_header:
             return False
         parts = authorization_header.split(" ", 1)
         if len(parts) != 2 or parts[0].lower() != "bearer":
             return False
-        return secrets.compare_digest(parts[1], expected_token)
+        return secrets.compare_digest(
+            parts[1].encode("utf-8"), expected_token.encode("utf-8")
+        )
 
     # Force-auth endpoints: only admin_api_key can unlock them; if admin_api_key is unset,
     # reject them unconditionally (explicitly "not allowed").

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -303,6 +303,78 @@ class TestDecideRequestAuth(CustomTestCase):
         )
         self.assertTrue(decision.allowed)
 
+    # ==================== Non-ASCII tokens ====================
+
+    def test_non_ascii_token_is_rejected_not_raised(self):
+        """A non-ASCII bearer token must deny, not raise.
+
+        ``secrets.compare_digest`` refuses ``str`` operands with non-ASCII
+        characters ("comparing strings with non-ASCII characters is not
+        supported"), so any client sending such a token turned the 401 into an
+        unhandled ``TypeError`` — a 500 out of the middleware, which has no
+        exception handling around the auth decision.
+        """
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer \u5bc6\u94a5",
+            api_key="my-api-key",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.error_status_code, 401)
+
+    def test_non_ascii_api_key_is_usable(self):
+        """A server started with a non-ASCII --api-key must still authenticate.
+
+        Every request failed with the same ``TypeError`` regardless of the
+        token sent, so such a key could not be used at all.
+        """
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer \u5bc6\u94a5",
+            api_key="\u5bc6\u94a5",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertTrue(decision.allowed)
+
+    def test_non_ascii_api_key_wrong_token_denied(self):
+        """The non-ASCII path must still distinguish a wrong token."""
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer \u5bc6\u94a5x",
+            api_key="\u5bc6\u94a5",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertFalse(decision.allowed)
+
+    def test_non_ascii_admin_key_force_level(self):
+        """ADMIN_FORCE must behave the same way for a non-ASCII admin key."""
+        allowed = decide_request_auth(
+            method="POST",
+            path="/admin/endpoint",
+            authorization_header="Bearer \u7ba1\u7406\u5bc6\u94a5",
+            api_key=None,
+            admin_api_key="\u7ba1\u7406\u5bc6\u94a5",
+            auth_level=AuthLevel.ADMIN_FORCE,
+        )
+        self.assertTrue(allowed.allowed)
+
+        denied = decide_request_auth(
+            method="POST",
+            path="/admin/endpoint",
+            authorization_header="Bearer \u5176\u4ed6\u5bc6\u94a5",
+            api_key=None,
+            admin_api_key="\u7ba1\u7406\u5bc6\u94a5",
+            auth_level=AuthLevel.ADMIN_FORCE,
+        )
+        self.assertFalse(denied.allowed)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`_check_bearer_token` in `srt/utils/auth.py` passes `str` operands to `secrets.compare_digest`, which refuses them when either side contains non-ASCII characters:

```
TypeError: comparing strings with non-ASCII characters is not supported
```

Neither `decide_request_auth` nor `_ApiKeyASGIMiddleware.__call__` wraps the auth decision in exception handling — the only `try/except` in the module is around route matching (`auth.py:50-52`) — so this escapes the middleware as a 500 rather than becoming the 401 the code intends.

Two ways to reach it on a server started with `--api-key`:

**1. A client sends a non-ASCII bearer token.** Should be a plain 401; instead the request 500s. Any HTTP client can trigger this, and an unauthenticated caller distinguishing a 500 from a 401 also learns something about the server it should not.

**2. The server is started with a non-ASCII `--api-key` or `--admin-api-key`.** Then *every* request fails the same way regardless of what token it sends, so such a key cannot be used at all. Nothing in the CLI or docs restricts keys to ASCII.

Reproduction against the pure decision function (no server needed — the module docstring notes it is deliberately torch-free for exactly this):

```python
from sglang.srt.utils.auth import AuthLevel, decide_request_auth

decide_request_auth(
    method="POST",
    path="/v1/chat/completions",
    authorization_header="Bearer 密钥",   # any non-ASCII token
    api_key="my-api-key",
    admin_api_key=None,
    auth_level=AuthLevel.NORMAL,
)
```

Before:

```
TypeError: comparing strings with non-ASCII characters is not supported
  File "python/sglang/srt/utils/auth.py", line 112, in _check_bearer_token
```

After: `AuthDecision(allowed=False, error_status_code=401)`.

## Modifications

`python/sglang/srt/utils/auth.py` — compare UTF-8 bytes instead of `str`:

```python
return secrets.compare_digest(
    parts[1].encode("utf-8"), expected_token.encode("utf-8")
)
```

`compare_digest` accepts bytes without the ASCII restriction and keeps the constant-time guarantee, which is the reason it is used here rather than `==`. The docstring now records why the encode is there, so it does not look removable.

Nothing else changes: ASCII tokens, missing headers, non-`bearer` schemes, `OPTIONS`, the `/health` and `/metrics` prefixes, and all three auth levels behave exactly as before.

## Accuracy Tests

Not applicable — no kernel or model forward code is touched.

## Speed Tests and Profiling

Not applicable. The added work is two `str.encode` calls on the request path, only where a token comparison was already happening.

## Tests

Added four cases to `test/registered/unit/utils/test_auth.py`:

- `test_non_ascii_token_is_rejected_not_raised` — denial instead of `TypeError`, with a 401 status
- `test_non_ascii_api_key_is_usable` — a non-ASCII `api_key` now authenticates a matching token
- `test_non_ascii_api_key_wrong_token_denied` — the non-ASCII path still tells a wrong token apart
- `test_non_ascii_admin_key_force_level` — same for `ADMIN_FORCE` with a non-ASCII admin key

Reverting the one-line fix turns exactly those four red, while the 26 existing cases stay green either way:

```
with fix:        Ran 30 tests — OK
fix reverted:    Ran 30 tests — FAILED (errors=4)
                 test_non_ascii_admin_key_force_level
                 test_non_ascii_api_key_is_usable
                 test_non_ascii_api_key_wrong_token_denied
                 test_non_ascii_token_is_rejected_not_raised
```

A note on how I ran them: this is a macOS box, and `pip install -e python/` cannot complete here because `sgl-deep-ep` ships Linux-only wheels and `tvm_ffi` has no macOS resolution, so `pytest test/registered/unit/utils/test_auth.py` fails at collection on `sglang.test.test_utils` — before reaching any assertion. I loaded `auth.py` directly and ran the test file's own classes against it, which works precisely because the module is torch-free by design. `ruff format --check` and `isort --check-only` are clean on both files; `ruff check` reports 9 findings that I confirmed via `git stash` are identical on an unmodified checkout, so they are pre-existing and not from this change.

## Checklist

- [x] Format your code according to the pre-commit configuration (`ruff format`, `isort`)
- [x] Add unit tests
- [ ] Update documentation — no user-facing behaviour to document; this restores the documented 401
- [ ] Accuracy and speed benchmarks — not applicable, see above

AI assistance was used for this change; I reviewed every changed line and ran the commands above locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33963367806](https://github.com/sgl-project/sglang/actions/runs/33963367806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33963367681](https://github.com/sgl-project/sglang/actions/runs/33963367681)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33963367822](https://github.com/sgl-project/sglang/actions/runs/33963367822)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->