### PR TITLE
lfm2: enable overlap scheduler with no_buffer mamba radix strategy

### DIFF
--- a/python/sglang/srt/arg_groups/mamba_hook.py
+++ b/python/sglang/srt/arg_groups/mamba_hook.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from sglang.srt.arg_groups.overrides import (
+    _no_buffer_overlap_ok,
     resolving_view,
     supports_mamba_cache_extra_buffer,
 )
@@ -142,7 +143,11 @@ def validate_mamba_extra_buffer(view, model_arch: str, *, mamba_cache_chunk_size
 
 def validate_mamba_no_buffer(view, model_arch: str):
     assert view.page_size in (1, None), "no_buffer only supports page_size=1."
-    assert view.disable_overlap_schedule, (
+    # Overlap is normally unsafe with no_buffer because the radix donates the
+    # live mamba slot via copy_from; the archs in _NO_BUFFER_OVERLAP_ARCHS are
+    # whitelisted because their windowed conv state cannot race the in-flight
+    # forward (see overrides._no_buffer_overlap_ok).
+    assert view.disable_overlap_schedule or _no_buffer_overlap_ok(model_arch), (
         "no_buffer do not support overlap schedule. Try to set disable_overlap_schedule=True."
     )
     assert view.attention_backend != "trtllm_mha", (

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -543,6 +543,35 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
 )
 
 
+def _no_buffer_overlap_ok(model_arch: str) -> bool:
+    """Whether ``model_arch`` may keep the overlap scheduler with the
+    ``no_buffer`` mamba radix-cache strategy.
+
+    Overlap + ``no_buffer`` is safe only when the model's conv/mamba state is
+    a *windowed* (finite-context) short conv whose per-request state is either
+    (a) not restored from the radix cache on a prefix hit, or (b) refreshed
+    from a checkpoint that cannot race the in-flight forward. LFM2's depthwise
+    gated short conv (``causal_conv1d``) keeps a fixed-size rolling window per
+    request slot; the radix path restores it from a ``copy_from`` checkpoint
+    that is quiescent by the time the overlapped next batch launches, so the
+    ping-pong ``extra_buffer`` double-buffering (which LFM2's
+    ``ShortConvAttnBackend`` does not implement) is unnecessary. Dense hybrids
+    like LFM2 are exactly the models most hurt by disabling overlap, since the
+    synchronous loop serializes host dispatch behind every tiny decode step.
+    """
+    return model_arch in _NO_BUFFER_OVERLAP_ARCHS
+
+
+# Architectures permitted to run the overlap scheduler with the ``no_buffer``
+# mamba radix-cache strategy. Membership requires the windowed-conv safety
+# argument documented in ``_no_buffer_overlap_ok``.
+_NO_BUFFER_OVERLAP_ARCHS = frozenset(
+    {
+        "Lfm2ForCausalLM",
+    }
+)
+
+
 def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
     """Whether ``model_arch`` supports the extra_buffer strategy on the
     configured linear-attention backend (pure read)."""
@@ -590,6 +619,10 @@ def _mamba_radix_cache_resolution(view: Any) -> dict:
             view, model_arch
         ):
             declared["mamba_radix_cache_strategy"] = "extra_buffer"
+        elif wants_overlap and _no_buffer_overlap_ok(model_arch):
+            # Keep overlap on for windowed short-conv hybrids whose conv state
+            # does not need the extra_buffer ping-pong (see _no_buffer_overlap_ok).
+            declared["mamba_radix_cache_strategy"] = "no_buffer"
         else:
             declared["mamba_radix_cache_strategy"] = "no_buffer"
             declared["disable_overlap_schedule"] = True


### PR DESCRIPTION
## Summary

LFM2's overlap scheduler was **force-disabled** by the hybrid-mamba radix-cache
resolution: `Lfm2ForCausalLM` is not in `_MAMBA_EXTRA_BUFFER_ARCHS`, so
`_mamba_radix_cache_resolution` fell through to `no_buffer` **and** set
`disable_overlap_schedule=True`. SGLang then ran the synchronous `event_loop_normal`,
serializing host dispatch behind every tiny (~2 ms) dense decode step.

This PR whitelists `Lfm2ForCausalLM` (via `_NO_BUFFER_OVERLAP_ARCHS` +
`_no_buffer_overlap_ok`) to keep the overlap scheduler **on** with the `no_buffer`
strategy. LFM2's depthwise gated short conv (`causal_conv1d`) keeps a fixed-size
rolling window per request slot; the radix `no_buffer` path restores it from a
`copy_from` checkpoint that is quiescent by the time the overlapped next batch
launches, so the ping-pong `extra_buffer` double-buffering (which
`ShortConvAttnBackend` does not implement) is unnecessary. `extra_buffer` was tried
first and rejected: `ShortConvAttnBackend` lacks the track-snapshot writes the
GDN/KDA backends have, producing degenerate output (0/12 byte-parity).

## Performance (RTX 5090 / SM120, steady-decode tok/s, prefill-separated bench)

| bs | before | after | vLLM 0.28 | before gap | after gap |
|----|--------|-------|-----------|------------|-----------|
| 1  | 364.3  | 498.5 | 522.6     | -30.3%     | -4.6%     |
| 4  | 1219.3 | 1613.0| 1663.6    | -26.7%     | -3.1%     |
| 16 | 4536.2 | 6016.1| 6292.1    | -27.9%     | -4.4%     |
| 32 | 9097.3 | 12693.9| 13370.8  | -31.9%     | -5.1%     |

bs32 throughput +39%. The residual ~4-5% is per-step observability / load-snapshot
publisher overhead, tracked separately.

## Correctness (greedy, temp=0)

- Shared-prefix prompts (radix reuse): **16/16 byte-identical** vs the unmodified
  no-overlap baseline.
- Unique-salt prompts: 9/12 byte-identical; 3 diverge only after 82-180 chars of
  identical output (bf16 batch-composition nondeterminism; coherent both ways, no
  degenerate output). Contrast: `extra_buffer` was 0/12 with degenerate text.
- Same-config run-to-run: 12/12 deterministic.

## Test plan

Covered by existing hybrid/mamba arg-resolution tests; `validate_mamba_no_buffer`
assert relaxed only for whitelisted archs (default behavior unchanged for all other
models). Verified end-to-end on `LiquidAI/LFM2.5-1.2B-Instruct`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33969368735](https://github.com/sgl-project/sglang/actions/runs/33969368735)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33969368637](https://github.com/sgl-project/sglang/actions/runs/33969368637)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33969368688](https://github.com/sgl-project/sglang/actions/runs/33969368688)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->