### PR TITLE
[CI][NPU] Fix pr-test-npu failing at Install dependencies with set: Illegal option -o pipefail

### DIFF
--- a/.github/workflows/_npu-pr-test-stage.yml
+++ b/.github/workflows/_npu-pr-test-stage.yml
@@ -192,6 +192,7 @@ jobs:
           UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
           GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
           RUSTUP_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local:8082"
+        shell: bash
         run: |
           set -euo pipefail
           cp ~/.cache/modelscope/hub/datasets/otavia/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json /tmp


### PR DESCRIPTION
## Motivation

Since #37990 was merged (2026-09-05 12:58 UTC), **every** `pr-test-npu` run fails at the `Install dependencies` step about 1 minute in, and all remaining NPU jobs are cascade-skipped. Example: https://github.com/sgl-project/sglang/actions/runs/33970347999/job/101318577758

```
/__w/_temp/xxx.sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 1.
```

## Root Cause

#37990 rewrote the `Install dependencies` step in `_npu-pr-test-stage.yml` to start with `set -euo pipefail` (plus `[[ ]]` conditionals), but did not declare `shell: bash` for that step.

The self-hosted k8s NPU runners execute steps without an explicit `shell:` as `sh -e` (dash on Ubuntu), which does not support `set -o pipefail` — so the script aborts on its very first line.

## Modification

Add `shell: bash` to the `Install dependencies` step, matching the existing convention of the `Run test` step in the same file.

Verified all other `run:` steps in this template either already declare `shell: bash` or contain no bash-only syntax, and `_npu-single-node-test-stage.yml` is unaffected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33971592182](https://github.com/sgl-project/sglang/actions/runs/33971592182)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33971592017](https://github.com/sgl-project/sglang/actions/runs/33971592017)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->