### PR TITLE
[Speculative] Add a device-neutral extend-cache location fallback

### DIFF
--- a/python/sglang/kernels/ops/speculative/cache_locs.py
+++ b/python/sglang/kernels/ops/speculative/cache_locs.py
@@ -429,6 +429,36 @@ def assign_extend_cache_locs_uniform_func(
     )
 
 
+def _assign_extend_cache_locs_torch(
+    req_pool_indices: torch.Tensor,
+    req_to_token: torch.Tensor,
+    start_offset: torch.Tensor,
+    end_offset: torch.Tensor,
+    batch_size: int,
+    draft_token_num: int,
+    device,
+) -> torch.Tensor:
+    lengths = end_offset[:batch_size] - start_offset[:batch_size]
+    output_size = batch_size * draft_token_num
+    batch_indices = torch.repeat_interleave(
+        torch.arange(batch_size, dtype=torch.int64, device=device),
+        lengths,
+        output_size=output_size,
+    )
+    segment_offsets = torch.repeat_interleave(
+        torch.cumsum(lengths, dim=0) - lengths,
+        lengths,
+        output_size=output_size,
+    )
+    token_offsets = (
+        start_offset[:batch_size][batch_indices]
+        + torch.arange(output_size, dtype=torch.int64, device=device)
+        - segment_offsets
+    )
+    request_indices = req_pool_indices[:batch_size][batch_indices]
+    return req_to_token[request_indices.long(), token_offsets.long()].to(torch.int64)
+
+
 def assign_extend_cache_locs_func(
     req_pool_indices: torch.Tensor,
     req_to_token: torch.Tensor,
@@ -488,3 +518,13 @@ def assign_extend_cache_locs_func(
         )
 
         return out_cache_loc
+
+    return _assign_extend_cache_locs_torch(
+        req_pool_indices=req_pool_indices,
+        req_to_token=req_to_token,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        batch_size=batch_size,
+        draft_token_num=draft_token_num,
+        device=device,
+    )

--- a/test/registered/unit/spec/test_cache_locs_fallback.py
+++ b/test/registered/unit/spec/test_cache_locs_fallback.py
@@ -1,0 +1,41 @@
+import torch
+
+from sglang.kernels.ops.speculative import cache_locs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_assign_extend_cache_locs_fallback_preserves_variable_ranges(monkeypatch):
+    for platform_flag in (
+        "_is_cuda",
+        "_is_hip",
+        "_is_musa",
+        "_is_xpu",
+        "_is_npu",
+        "_is_cpu",
+    ):
+        monkeypatch.setattr(cache_locs, platform_flag, False)
+
+    req_to_token = torch.tensor(
+        [
+            [10, 11, 12, 13, 14],
+            [20, 21, 22, 23, 24],
+            [30, 31, 32, 33, 34],
+        ],
+        dtype=torch.int32,
+    )
+    output = cache_locs.assign_extend_cache_locs_func(
+        req_pool_indices=torch.tensor([2, 0, 1]),
+        req_to_token=req_to_token,
+        start_offset=torch.tensor([1, 2, 0]),
+        end_offset=torch.tensor([3, 3, 3]),
+        batch_size=3,
+        draft_token_num=2,
+        device="cpu",
+    )
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([31, 32, 12, 20, 21, 22], dtype=torch.int64),
+    )


### PR DESCRIPTION
## Motivation

`assign_extend_cache_locs_func` has specialized implementations for CUDA-like devices, NPU, and CPU, but no implementation for other out-of-tree devices. Those platforms currently fall through without returning cache locations.

## Modifications

- Add a device-neutral PyTorch fallback for platforms without a specialized kernel.
- Preserve each request's variable `start_offset` and `end_offset` range.
- Keep the result on-device as `int64`.
- Pass `output_size` to `repeat_interleave` so the fallback does not need a host synchronization to determine the output shape.
- Leave every existing specialized path unchanged.
- Add a regression test with unequal per-request ranges and reordered request-pool rows.

## Accuracy Tests

The regression test checks the exact flattened cache locations and output dtype. Formatting, syntax, and registered-test checks pass locally; the checkout does not include the Torch/pytest runtime needed to execute the unit suite, so functional execution is left to CI.

## Speed Tests and Profiling

Existing CUDA-like, NPU, and CPU paths are unchanged. The fallback is used only by platforms that previously had no implementation, and its output size is supplied explicitly to avoid a shape-related host synchronization.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing API or CLI changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Existing device paths are unchanged.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33974530974](https://github.com/sgl-project/sglang/actions/runs/33974530974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33974530883](https://github.com/sgl-project/sglang/actions/runs/33974530883)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33974530987](https://github.com/sgl-project/sglang/actions/runs/33974530987)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->