### PR TITLE
[KV cache] Make KV-copy tiling configurable by subclasses

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1915,13 +1915,7 @@ class MHATokenToKVPool(KVCache):
         self.row_dim = self.head_num * self.head_dim
         self.v_row_dim = self.head_num * self.v_head_dim
 
-    def _init_kv_copy_and_warmup(self):
-        # Zero-layer pool (e.g. all-SWA model's full sub-pool) has no buffers.
-        if self.layer_num == 0:
-            self._kv_copy_config = None
-            return
-
-        # Heuristics for KV copy tiling
+    def _get_kv_copy_config(self, stride_bytes: int) -> dict[str, int]:
         _KV_COPY_STRIDE_THRESHOLD_LARGE = 8192
         _KV_COPY_STRIDE_THRESHOLD_MEDIUM = 4096
         _KV_COPY_TILE_SIZE_LARGE = 512
@@ -1930,7 +1924,6 @@ class MHATokenToKVPool(KVCache):
         _KV_COPY_NUM_WARPS_LARGE_TILE = 8
         _KV_COPY_NUM_WARPS_SMALL_TILE = 4
 
-        stride_bytes = int(self.data_strides[0].item())
         if stride_bytes >= _KV_COPY_STRIDE_THRESHOLD_LARGE:
             bytes_per_tile = _KV_COPY_TILE_SIZE_LARGE
         elif stride_bytes >= _KV_COPY_STRIDE_THRESHOLD_MEDIUM:
@@ -1941,7 +1934,7 @@ class MHATokenToKVPool(KVCache):
         # Calculate num_locs_upper to avoid large Triton specialization (e.g. 8192)
         chunk_upper = 128 if bytes_per_tile >= _KV_COPY_TILE_SIZE_LARGE else 256
 
-        self._kv_copy_config = {
+        return {
             "bytes_per_tile": bytes_per_tile,
             "byte_tiles": (stride_bytes + bytes_per_tile - 1) // bytes_per_tile,
             "num_warps": (
@@ -1951,6 +1944,16 @@ class MHATokenToKVPool(KVCache):
             ),
             "num_locs_upper": chunk_upper,
         }
+
+    def _init_kv_copy_and_warmup(self):
+        # Zero-layer pool (e.g. all-SWA model's full sub-pool) has no buffers.
+        if self.layer_num == 0:
+            self._kv_copy_config = None
+            return
+
+        stride_bytes = int(self.data_strides[0].item())
+        self._kv_copy_config = self._get_kv_copy_config(stride_bytes)
+        chunk_upper = self._kv_copy_config["num_locs_upper"]
 
         dummy_loc = torch.zeros(chunk_upper, dtype=torch.int64, device=self.device)
         copy_all_layer_kv_cache_func(

--- a/test/registered/unit/mem_cache/test_kv_copy_config.py
+++ b/test/registered/unit/mem_cache/test_kv_copy_config.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize(
+    ("stride_bytes", "expected"),
+    [
+        (
+            4095,
+            {
+                "bytes_per_tile": 128,
+                "byte_tiles": 32,
+                "num_warps": 4,
+                "num_locs_upper": 256,
+            },
+        ),
+        (
+            4096,
+            {
+                "bytes_per_tile": 256,
+                "byte_tiles": 16,
+                "num_warps": 4,
+                "num_locs_upper": 256,
+            },
+        ),
+        (
+            8192,
+            {
+                "bytes_per_tile": 512,
+                "byte_tiles": 16,
+                "num_warps": 8,
+                "num_locs_upper": 128,
+            },
+        ),
+    ],
+)
+def test_default_kv_copy_config_is_unchanged(stride_bytes, expected):
+    pool = object.__new__(MHATokenToKVPool)
+    assert pool._get_kv_copy_config(stride_bytes) == expected
+
+
+def test_kv_copy_warmup_uses_subclass_config():
+    class CustomPool(MHATokenToKVPool):
+        def _get_kv_copy_config(self, stride_bytes):
+            assert stride_bytes == 1024
+            return {
+                "bytes_per_tile": 128,
+                "byte_tiles": 8,
+                "num_warps": 4,
+                "num_locs_upper": 64,
+            }
+
+    pool = object.__new__(CustomPool)
+    pool.layer_num = 1
+    pool.data_strides = torch.tensor([1024])
+    pool.data_ptrs = torch.tensor([0])
+    pool.device = torch.device("cpu")
+
+    with patch("sglang.srt.mem_cache.memory_pool.copy_all_layer_kv_cache_func") as copy:
+        pool._init_kv_copy_and_warmup()
+
+    assert pool._kv_copy_config["num_locs_upper"] == 64
+    assert copy.call_args.args[5] == 64
+    assert copy.call_args.args[6] == pool._kv_copy_config


### PR DESCRIPTION
## Motivation

`MHATokenToKVPool._init_kv_copy_and_warmup()` currently owns both the default Triton tiling heuristic and the common warmup. An out-of-tree KV-pool subclass that needs different tiling must replace the full initializer, duplicating warmup behavior and making the extension fragile.

## Modifications

- Extract the existing heuristic into the overridable `_get_kv_copy_config(stride_bytes)` method.
- Keep the default thresholds and generated configuration unchanged.
- Keep allocation and warmup in the shared initializer.
- Add boundary tests for the existing default heuristic and a test proving that initialization consumes a subclass-provided configuration.

## Accuracy Tests

This refactor does not change KV data or the default copy configuration. The tests cover the 4 KiB and 8 KiB threshold boundaries and the subclass override path. Formatting, syntax, and registered-test checks pass locally; the checkout does not include the Torch/pytest runtime needed to execute the unit suite, so functional execution is left to CI.

## Speed Tests and Profiling

No benchmark is required for the default path because the generated tiling values and warmup call are unchanged. The hook lets platform subclasses select hardware-appropriate values without replacing common logic.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing API or CLI changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Default runtime behavior is unchanged.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33974543040](https://github.com/sgl-project/sglang/actions/runs/33974543040)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33974542907](https://github.com/sgl-project/sglang/actions/runs/33974542907)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33974543035](https://github.com/sgl-project/sglang/actions/runs/33974543035)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->