### PR TITLE
Insert launched extend batches into the radix cache before the next batch under overlap

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -877,6 +877,8 @@ class ReqKvInfo:
     cache_protected_len: int = 0  # Tree cache owns [0, here) (matched or inserted)
     kv_committed_len: int = 0  # KV content committed up to here, <= kv_allocated_len
     kv_allocated_len: int = 0
+    # Overlap inserted the running extend at launch; the result path skips it.
+    radix_inserted_at_launch: bool = False
 
     # SWA slots in [swa_dead_lo(page_size), swa_evicted_seqlen) are already freed.
     swa_evict_floor: int = 0  # [0, here) never window-evicted (prefill-aware SWA)
@@ -1819,6 +1821,7 @@ class Req(ReqDllmMixin):
         self.indexer_topk = None
         self.last_node = None
         self.kv.cache_protected_len = 0
+        self.kv.radix_inserted_at_launch = False
         self.num_matched_prefix_tokens = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1995,6 +1995,7 @@ class Scheduler(
                 # Fence result processing behind this forward's shared reads.
                 self._apply_war_barrier()
                 self.result_queue.append((batch.copy(), batch_result))
+                self.cache_extend_batch_at_launch(batch)
             else:
                 batch_result = None
                 self._sched_idled = True
@@ -2055,6 +2056,30 @@ class Scheduler(
         # whatever result is still pending in the queue — including the
         # extend->decode boundary — so no grammar-specific overlap disable is needed.
         return disable_overlap_for_batch or need_grammar_sync
+
+    def cache_extend_batch_at_launch(self, batch: ScheduleBatch):
+        # Overlap runs a request's first decode step before its prefill result;
+        # the radix dedup in that result path would repoint prefix slots under step 1.
+        if (
+            not self.is_generation
+            or self.disaggregation_mode != DisaggregationMode.NULL
+            or not batch.forward_mode.is_extend()
+            or not self.tree_cache.supports_cache_unfinished_at_launch()
+        ):
+            return
+        decoding_reqs = batch.decoding_reqs or ()
+        for req in batch.reqs:
+            if (
+                req is self.chunked_req
+                or req in decoding_reqs
+                or req.finished()
+                or req.is_retracted
+                or req.beam_group is not None
+                or req.is_dllm()
+            ):
+                continue
+            maybe_cache_unfinished_req(req, self.tree_cache)
+            req.kv.radix_inserted_at_launch = True
 
     def _advance_pending_grammar(self):
         """Grammar barrier (spec-v2 overlap): advance the FSM over any not-yet

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -356,7 +356,10 @@ class SchedulerBatchResultProcessor:
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
-                        maybe_cache_unfinished_req(req, self.tree_cache)
+                        if req.kv.radix_inserted_at_launch:
+                            req.kv.radix_inserted_at_launch = False
+                        else:
+                            maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -495,6 +495,9 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def supports_mamba(self) -> bool:
         return False
 
+    def supports_cache_unfinished_at_launch(self) -> bool:
+        return False
+
     def supports_streaming_session(self) -> bool:
         return False
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -536,6 +536,11 @@ class RadixCache(BasePrefixCache):
         if req.last_node is not None:
             self.dec_lock_ref(req.last_node)
 
+    def supports_cache_unfinished_at_launch(self) -> bool:
+        # Subclasses layer host/storage write-through or SWA bookkeeping on
+        # insert and keep the result-time path until audited.
+        return type(self) is RadixCache
+
     def cache_unfinished_req(self, req: Req, chunked=False):
         """Cache request when it is unfinished."""
         if self.disable:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -938,6 +938,16 @@ class UnifiedRadixCache(BasePrefixCache):
             ):
                 self.session_refs.register_session_ref(req)
 
+    def supports_cache_unfinished_at_launch(self) -> bool:
+        # SWA/mamba components, host or storage write-through and session slots
+        # read request state that is only settled by the prefill result.
+        return (
+            set(self.components) == {ComponentType.FULL}
+            and self.cache_controller is None
+            and self.linker is None
+            and not getattr(self, "enable_session_radix_cache", False)
+        )
+
     def cache_unfinished_req(self, req: Req, chunked: bool = False, **kwargs) -> None:
         if self.session.try_cache_unfinished_req(req, chunked=chunked, **kwargs):
             return

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -64,6 +64,7 @@ class _PrefillReq:
         self.require_reasoning = False
         self.customized_info = None
         self.beam_group = None
+        self.kv = SimpleNamespace(radix_inserted_at_launch=False)
 
     def finished(self):
         return False


### PR DESCRIPTION
## Summary

Under overlap scheduling, a request whose prompt hits the radix cache is served with two different KV mappings for the same positions: its first decode step uses the slots the prefill just wrote, every later step uses the tree's slots. This PR makes the radix insert for a launched extend batch happen before the next batch is built, so all steps see the same mapping, matching `--disable-overlap-schedule`.

Stacked on `xinyuan/glm-5.3-flash-support` because that branch's CI is blocked on it; the race itself exists on `main` (see "Why main is green").

## The race

1. A fully cached prompt is matched only up to `len - 1` (`Req._compute_max_prefix_len`), so the last prompt token is recomputed: it gets a fresh KV slot and a 1-token extend writes fresh KV there.
2. `event_loop_overlap` runs `run_batch(next)` before `pop_and_process()` for the previous batch. The request's first decode/verify step is therefore launched while `req_to_token` still points at the fresh slot.
3. Processing the prefill result then calls `cache_unfinished_req`. The insert dedups the recomputed token against the slot the tree already holds, frees the fresh slot and rewrites `req_to_token[req, pos]` to the tree's slot.
4. Step 2+ read the tree's KV for that position, step 1 read the freshly written one. The two hold the same token in the same context but were produced by different-shaped forwards, so in bf16 they differ slightly; step 1's outputs (and, for DFLASH, the draft KV materialised from them) carry that difference forward. The result also depends on which earlier request populated the cache.

Device-side dump from a hit request (`prefix_len=5`, `extend_len=1`) on the PR head:

```
extend    out_cache_loc=[57]  req_to_token[:18]=[1,2,3,4,5,57,7,8,...]
decode#1  seq_len=6           req_to_token=[1,2,3,4,5,57,58,59,...]
decode#2  seq_len=8           req_to_token=[1,2,3,4,5, 6,58,59,...]   <- position 5 repointed 57 -> 6
```

Same server, same prompt, `--disable-overlap-schedule`: the cache-hit request reproduces the miss request's per-token logprobs bit-exactly from the first decode step on (only the extend logit itself differs, as expected for a 1-token extend). With overlap, every logprob after the first differs and the accept histogram changes. A plain Llama-3.1-8B server without speculative decoding shows the same overlap-only divergence, so this is a scheduler/radix-cache interaction, not a DFLASH bug. DFLASH exposes it because the test prompt lands on an exact bf16 tie at token 10 (`history` vs `cuisine`, both logprob -1.36332 on the hit path).

## Why main is green

The identical first-attempt failure happens on `main`: run [33928384157](https://github.com/sgl-project/sglang/actions/runs/33928384157/job/101217984714) shows `TestDFlashServerGraphPoolBorrow`, `TestDFlashServerOverlap` and `TestDFlashServerOverlapPlanStream` each printing `['...history...', '...cuisine...']` on the first attempt and passing on the `CustomTestCase` retry, and `TestDFlashServerNoCudaGraph.test_gsm8k` scoring 0.740 < 0.75 before its retry. `test_dflash.py` is byte-identical between `main` and this branch. What differs is wall time: `main` finishes the file in 1062 s against the 1200 s per-file budget; the runner for the PR run loaded weights and captured graphs about 2x slower for its first three servers (same graph counts), the retries and relaunches pushed the file past 1200 s, and the partition died `0/12`.

## CI evidence on `xinyuan/glm-5.3-flash-support`

- [Run 33947841301, `base-b-test-1-gpu-small (0)`](https://github.com/sgl-project/sglang/actions/runs/33947841301/job/101257285153) (head `2f97769375`, includes #38079): `test_greedy_determinism` first-attempt mismatch in `TestDFlashServerGraphPoolBorrow`, `TestDFlashServerOverlap`, `TestDFlashServerOverlapPlanStream`; `TestDFlashServerNoCudaGraph.test_gsm8k` 0.745 < 0.75; file TIMEOUT at 1200 s.
- [Run 33930532810, `base-b-test-1-gpu-small (0)`](https://github.com/sgl-project/sglang/actions/runs/33930532810/job/101210449699) (head `fead323b8f`): same signature.
- Verbatim mismatch every time:
  ```
  - " a city of romance, art, fashion, and history. Paris is a must-visit ... culture, architecture, and cuisine."
  + " a city of romance, art, fashion, and cuisine. Paris is a must-visit ... history, architecture, and culture."
  ```

## Fix

- `Scheduler.event_loop_overlap` calls `cache_extend_batch_at_launch(batch)` right after `run_batch` and the WAR barrier. It inserts each eligible request of an extend batch into the tree (generation mode, `DisaggregationMode.NULL`, tree opts in; skips the in-flight chunked request, decode requests of a mixed batch, finished/retracted/beam/dllm requests) and marks `req.kv.radix_inserted_at_launch`.
- The prefill result path consumes that flag instead of inserting again, so each prefill is still inserted exactly once. `reset_for_retract` clears it.
- `BasePrefixCache.supports_cache_unfinished_at_launch()` defaults to `False`. `RadixCache` returns `True` for the plain class only; `UnifiedRadixCache` returns `True` only with the FULL component alone and no HiCache controller, external linker or session radix cache. Mamba trees read `mamba_last_track_seqlen`, which the result path sets, and HiCache/storage trees write through on insert, so they keep the existing timing unchanged (this includes GLM-5.3-Flash, which uses the mamba tree).
- One existing unit-test fake (`_PrefillReq` in `test_batch_result_processor_hidden_states.py`) gains the new `kv` field. No new tests.

The insert runs while the prefill is still executing, but every device-side operation involved is issued on the compute stream after the launch, the chunked-prefill stash path has always inserted before the chunk result, and the result path already inserted slots whose KV the next batch was still computing.

## Validation (1x GB300, PR head `2f97769375` + this patch, `SGLANG_TEST_MAX_RETRY=0`)

- Minimal repro (server flags of `TestDFlashServerOverlap`; flush, 3 greedy requests, compare per-token logprobs of the cache-hit requests against the miss): before the fix 31/31 logprobs differ from the first decode step and the accept histogram changes; after the fix 0/31 differ and all texts are identical. Passed on 4 consecutive fresh servers for the overlap config, plus the plan-stream config, the graph-pool-borrow config, and plain Llama-3.1-8B without speculative decoding.
- Full `test/registered/spec/dflash/test_dflash.py` with retries disabled: `Ran 136 tests in 1132s, OK`; all seven classes pass `test_greedy_determinism` on the first attempt; GSM8K 0.780 / 0.770 / 0.765 / 0.765 / 0.770 / 0.765 / 0.760.
- Plain Llama-3.1-8B-Instruct, overlap, `sgl-eval run gsm8k` (1319 questions, temperature 0, 128 threads, heavy shared-prefix dedup): 81.20% and 81.50% with the fix vs 81.12% and 81.27% without; finish reasons stop/length 1295/24 and 1294/25 vs 1300/19; `--disable-overlap-schedule` reference 81.73%, 1297/22.
- `test/registered/unit/{mem_cache,managers,spec}` on the fixed and unfixed trees: identical pass counts (2379) and identical failure set (Rust tree-core extension not built in the image).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34094681997](https://github.com/sgl-project/sglang/actions/runs/34094681997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34094681686](https://github.com/sgl-project/sglang/actions/runs/34094681686)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34094681902](https://github.com/sgl-project/sglang/actions/runs/34094681902)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->