### PR TITLE
[Diffusion][Perf] Reduce indexing overhead in Ulysses QKV packing

### DIFF
--- a/python/sglang/kernels/ops/diffusion/layout/ulysses_qkv_triton.py
+++ b/python/sglang/kernels/ops/diffusion/layout/ulysses_qkv_triton.py
@@ -4,6 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
+# The extra grid dimension only pays off for production-scale payloads.
+_CONTIGUOUS_FAST_PATH_MIN_ELEMENTS = 1 << 23
+
 
 @triton.jit
 def _pack_qkv_destination_major_kernel(
@@ -52,6 +55,40 @@ def _pack_qkv_destination_major_kernel(
     tl.store(output_ptr + output_base + 2 * head_size, v, mask=mask)
 
 
+@triton.jit
+def _pack_qkv_destination_major_contiguous_kernel(
+    output_ptr,
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    rows,
+    HEAD_SIZE: tl.constexpr,
+    FEATURES: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Keep destination in the grid so each program only divides by the
+    # compile-time local feature count, rather than recovering destination,
+    # row, head, and dim from one global element index.
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    destination = tl.program_id(1)
+    mask = offsets < rows * FEATURES
+    row = offsets // FEATURES
+    feature = offsets - row * FEATURES
+    local_head = feature // HEAD_SIZE
+    dim = feature - local_head * HEAD_SIZE
+    source_offset = (row * tl.num_programs(1) + destination) * FEATURES + feature
+    output_offset = (
+        (destination * rows + row) * (3 * FEATURES) + local_head * (3 * HEAD_SIZE) + dim
+    )
+
+    q = tl.load(q_ptr + source_offset, mask=mask)
+    k = tl.load(k_ptr + source_offset, mask=mask)
+    v = tl.load(v_ptr + source_offset, mask=mask)
+    tl.store(output_ptr + output_offset, q, mask=mask)
+    tl.store(output_ptr + output_offset + HEAD_SIZE, k, mask=mask)
+    tl.store(output_ptr + output_offset + 2 * HEAD_SIZE, v, mask=mask)
+
+
 def pack_qkv_destination_major(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -94,6 +131,34 @@ def pack_qkv_destination_major(
         )
     total_elements = rows * global_heads * head_size
     if total_elements == 0:
+        return output
+
+    features = local_heads * head_size
+    if (
+        total_elements >= _CONTIGUOUS_FAST_PATH_MIN_ELEMENTS
+        and torch.version.hip is None
+        and q.dtype in (torch.float16, torch.bfloat16)
+        and q.is_contiguous()
+        and k.is_contiguous()
+        and v.is_contiguous()
+        and world_size in (2, 4, 8)
+    ):
+        with torch.get_device_module().device(q.device):
+            block_size = 1024
+            _pack_qkv_destination_major_contiguous_kernel[
+                (triton.cdiv(rows * features, block_size), world_size)
+            ](
+                output,
+                q,
+                k,
+                v,
+                rows,
+                HEAD_SIZE=head_size,
+                FEATURES=features,
+                BLOCK_SIZE=block_size,
+                num_warps=8,
+                num_stages=1,
+            )
         return output
 
     block_size = 1024

--- a/test/registered/kernels/ops/diffusion/test_layout.py
+++ b/test/registered/kernels/ops/diffusion/test_layout.py
@@ -122,26 +122,71 @@ def test_usp_merge_heads_unsupported_inputs_use_exact_fallback():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_pack_qkv_destination_major_is_bit_exact(dtype):
-    torch.manual_seed(0)
-    rows, world_size, global_heads, head_size = 17, 4, 12, 64
-    q, k, v = (
-        torch.randn(rows, global_heads, head_size, device=DEVICE, dtype=dtype)
-        for _ in range(3)
-    )
-
+def _reference_pack_qkv(q, k, v, world_size):
+    rows, global_heads, head_size = q.shape
     local_heads = global_heads // world_size
-    expected = torch.empty(
-        world_size, rows, local_heads, 3 * head_size, device=DEVICE, dtype=dtype
+    return torch.cat(
+        [
+            tensor.reshape(rows, world_size, local_heads, head_size).permute(1, 0, 2, 3)
+            for tensor in (q, k, v)
+        ],
+        dim=-1,
     )
-    for index, tensor in enumerate((q, k, v)):
-        shards = tensor.view(rows, world_size, local_heads, head_size).permute(
-            1, 0, 2, 3
-        )
-        expected[..., index * head_size : (index + 1) * head_size].copy_(shards)
 
-    assert torch.equal(pack_qkv_destination_major(q, k, v, world_size), expected)
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_pack_qkv_destination_major_preserves_all_16bit_patterns(dtype):
+    # Exercise the large contiguous CUDA fast path with every NaN payload,
+    # infinity, signed zero, and subnormal without a floating-point comparison.
+    rows, world_size, global_heads, head_size = 2731, 4, 24, 128
+    total_elements = rows * global_heads * head_size
+    bits = torch.arange(-32768, 32768, device=DEVICE, dtype=torch.int32).to(torch.int16)
+    bits = bits.repeat((total_elements + bits.numel() - 1) // bits.numel())[
+        :total_elements
+    ]
+    qkv = tuple(
+        bits.roll(shift).reshape(rows, global_heads, head_size).view(dtype)
+        for shift in (0, 1, 17)
+    )
+
+    expected = _reference_pack_qkv(
+        *(tensor.view(torch.int16) for tensor in qkv), world_size
+    )
+    out = torch.empty(expected.shape, device=DEVICE, dtype=dtype)
+    actual = pack_qkv_destination_major(*qkv, world_size, out=out)
+
+    assert actual is out
+    assert torch.equal(actual.view(torch.int16), expected)
+
+
+def test_pack_qkv_destination_major_preserves_head_strides():
+    # Keep the shape large enough for the contiguous fast path, then make each
+    # input ineligible solely through its head stride.
+    rows, world_size, global_heads, head_size = 2731, 4, 24, 128
+    qkv = tuple(
+        torch.randn(
+            rows * global_heads * (head_size + padding),
+            device=DEVICE,
+            dtype=torch.bfloat16,
+        ).as_strided(
+            (rows, global_heads, head_size),
+            (global_heads * (head_size + padding), head_size + padding, 1),
+        )
+        for padding in (1, 2, 3)
+    )
+    assert qkv[0].numel() >= 1 << 23
+    assert all(tensor.stride(-1) == 1 for tensor in qkv)
+    assert all(tensor.stride(1) != head_size for tensor in qkv)
+    assert all(not tensor.is_contiguous() for tensor in qkv)
+
+    expected = _reference_pack_qkv(
+        *(tensor.view(torch.int16) for tensor in qkv), world_size
+    )
+    out = torch.empty(expected.shape, device=DEVICE, dtype=torch.bfloat16)
+    actual = pack_qkv_destination_major(*qkv, world_size, out=out)
+
+    assert actual is out
+    assert torch.equal(actual.view(torch.int16), expected)
 
 
 def test_pack_qkv_destination_major_validates_inputs():


### PR DESCRIPTION
## Motivation

The destination-major Ulysses QKV pack introduced in #33667 reconstructs destination, row, head, and element coordinates from every flattened index. For the large contiguous FP16/BF16 inputs used by Wan Ulysses, a two-dimensional launch can make destination a grid coordinate and compile the local head geometry as constants.

This is independent of and compatible with the receive-side changes in #37521. The packed tensor ABI consumed by the collective is unchanged.

## Modifications

- Add a CUDA fast path that packs contiguous FP16/BF16 QKV with a two-dimensional `(feature tile, destination)` launch.
- Keep `HEAD_SIZE` and destination-local `FEATURES` compile-time constants, avoiding repeated runtime recovery of destination and global head indices.
- Limit the new path to measured production-scale payloads (`>= 2^23` elements) and Ulysses degrees 2, 4, or 8. The existing kernel still handles smaller tensors, strided inputs, FP32, ROCm, and other world sizes.
- Add bitwise tests covering every 16-bit payload on the fast path and a large head-strided input that must use the fallback.

## Accuracy Tests

- `pytest -q test/registered/kernels/ops/diffusion/test_layout.py -k pack_qkv_destination_major`: **4 passed**
- The 76-case shape/dtype matrix matched the parent implementation bit for bit.
- A 4-rank H200 gate exercised `pack -> NCCL all-to-all -> FlashAttention -> output all-to-all` with FA3 and FA4 at global sequence lengths 12,092 and 27,280, plus the small-input fallback. Input and final outputs had zero bit mismatches across all ranks, including 32 repeated executions per case.

The kernel only moves 16-bit payloads. The exhaustive test compares integer views and includes all NaN payloads, infinities, signed zeros, and subnormals. These checks are stricter than tolerance-based image comparison for this data-movement change.

## Speed Tests and Profiling

Environment: NVIDIA H200, CUDA 13.0, PyTorch 2.13.0, Triton 3.7.1. The CUDA Graph microbenchmark uses a preallocated output, 20 pack calls per replay, 13 ABBA/BAAB cycles, and reports median GPU time per call.

| dtype | rows (local) | parent | this PR | reduction |
| --- | ---: | ---: | ---: | ---: |
| BF16 | 3,023 | 29.024 us | 28.523 us | 1.73% |
| FP16 | 3,023 | 29.038 us | 28.658 us | 1.31% |
| BF16 | 6,820 | 62.137 us | 61.296 us | 1.35% |
| FP16 | 6,820 | 62.138 us | 61.517 us | 1.00% |

Across all 22 matrix cases selected by the fast-path guard, median latency fell by 0.33%-1.77%. The 4-rank max-rank steady benchmark independently measured 1.18%-1.42% lower pack latency on the two Wan shapes, with every production-shape paired cycle positive. The complete attention/communication block remained within run-to-run noise because packing is a small part of that block.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: internal implementation only; public API and layout are unchanged.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33978750808](https://github.com/sgl-project/sglang/actions/runs/33978750808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33978750613](https://github.com/sgl-project/sglang/actions/runs/33978750613)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33978750642](https://github.com/sgl-project/sglang/actions/runs/33978750642)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->