### PR TITLE
fix(jit-kernel): exact fallback for fast_topk threshold-bin overflow (#36807)

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/fast_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/fast_topk.cuh
@@ -57,6 +57,9 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
   alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
   alignas(128) __shared__ int s_counter;
   alignas(128) __shared__ int s_threshold_bin_id;
+  // Exact-fallback path: refined radix digit selected in each previous
+  // round (digit p of convert_to_uint32, bits [24 - 8p, 32 - 8p)).
+  alignas(128) __shared__ int s_prefix_bins[4];
   alignas(128) __shared__ int s_num_input[2];
 
   auto& s_histogram = s_histogram_buf[0];
@@ -100,13 +103,13 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
   }
   __syncthreads();
 
-  const auto threshold_bin = s_threshold_bin_id;
-  topk -= s_histogram[threshold_bin + 1];
+  const auto coarse_threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[coarse_threshold_bin + 1];
 
   if (topk == 0) {
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto bin = static_cast<int>(convert_to_uint8(input[idx + row_start]));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
       }
@@ -123,10 +126,10 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
     for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
       const auto raw_input = input[idx + row_start];
       const auto bin = static_cast<int>(convert_to_uint8(raw_input));
-      if (bin > threshold_bin) {
+      if (bin > coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_counter, 1);
         index[pos] = idx;
-      } else if (bin == threshold_bin) {
+      } else if (bin == coarse_threshold_bin) {
         const auto pos = ::atomicAdd(&s_num_input[0], 1);
         // fuse the histogram computation here
         if (pos < int(SMEM_INPUT_SIZE)) {
@@ -135,6 +138,28 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
           const auto sub_bin = (bin >> 24) & 0xFF;
           ::atomicAdd(&s_histogram[sub_bin], 1);
         }
+      }
+    }
+    __syncthreads();
+  }
+
+  // The staging buffer is a capacity bound, not a correctness bound: a
+  // concentrated row can place far more than SMEM_INPUT_SIZE candidates in
+  // the threshold bin (sgl-project/sglang#36807). Overflowing candidates
+  // were dropped above *together with* their fused histogram contributions,
+  // so the staged subset no longer represents the threshold-bin population.
+  // Detect the overflow and refine from a full-row rescan instead; the fast
+  // path below is unchanged.
+  const bool overflow = s_num_input[0] > int(SMEM_INPUT_SIZE);
+  if (overflow) {
+    if (tx < RADIX + 1) {
+      s_histogram[tx] = 0;
+    }
+    __syncthreads();
+    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto raw = input[idx + row_start];
+      if (static_cast<int>(convert_to_uint8(raw)) == coarse_threshold_bin) {
+        ::atomicAdd(&s_histogram[(convert_to_uint32(raw) >> 24) & 0xFF], 1);
       }
     }
     __syncthreads();
@@ -153,6 +178,7 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
     run_cumsum();
     if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
       s_threshold_bin_id = tx;
+      s_prefix_bins[round] = tx;
       s_num_input[r_idx ^ 1] = 0;
       s_last_remain = topk - s_histogram[tx + 1];
     }
@@ -161,9 +187,25 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
     const auto threshold_bin = s_threshold_bin_id;
     topk -= s_histogram[threshold_bin + 1];
 
+    // Overflow fallback: rescan the full row; a candidate qualifies iff its
+    // coarse fp16 bin and its refined radix digits so far all match.
+    const int scan_len = overflow ? length : num_input;
     if (topk == 0) {
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
-        const auto idx = s_input_idx[r_idx][i];
+      for (int i = tx; i < scan_len; i += BLOCK_SIZE) {
+        int idx;
+        if (overflow) {
+          idx = i;
+          const auto raw = input[idx + row_start];
+          if (static_cast<int>(convert_to_uint8(raw)) != coarse_threshold_bin) continue;
+          const auto key = convert_to_uint32(raw);
+          bool ok = true;
+          for (int p = 0; p < round; ++p) {
+            if (((key >> (24 - 8 * p)) & 0xFF) != s_prefix_bins[p]) { ok = false; break; }
+          }
+          if (!ok) continue;
+        } else {
+          idx = s_input_idx[r_idx][i];
+        }
         const auto offset = 24 - round * 8;
         const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) & 0xFF;
         if (bin > threshold_bin) {
@@ -179,9 +221,23 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
         s_histogram[tx] = 0;
       }
       __syncthreads();
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
-        const auto idx = s_input_idx[r_idx][i];
-        const auto raw_input = input[idx + row_start];
+      for (int i = tx; i < scan_len; i += BLOCK_SIZE) {
+        int idx;
+        float raw_input;
+        if (overflow) {
+          idx = i;
+          raw_input = input[idx + row_start];
+          if (static_cast<int>(convert_to_uint8(raw_input)) != coarse_threshold_bin) continue;
+          const auto key = convert_to_uint32(raw_input);
+          bool ok = true;
+          for (int p = 0; p < round; ++p) {
+            if (((key >> (24 - 8 * p)) & 0xFF) != s_prefix_bins[p]) { ok = false; break; }
+          }
+          if (!ok) continue;
+        } else {
+          idx = s_input_idx[r_idx][i];
+          raw_input = input[idx + row_start];
+        }
         const auto offset = 24 - round * 8;
         const auto bin = (convert_to_uint32(raw_input) >> offset) & 0xFF;
         if (bin > threshold_bin) {
@@ -193,6 +249,12 @@ SGL_DEVICE void radix_select_topk(const float* __restrict__ input, int* __restri
             if (pos > 0) {
               index[kTopK - pos] = idx;
             }
+          } else if (overflow) {
+            // Next round rescans the full row: only the fused histogram
+            // contribution is needed, no staging.
+            const auto key = convert_to_uint32(raw_input);
+            const auto sub_bin = (key >> (offset - 8)) & 0xFF;
+            ::atomicAdd(&s_histogram[sub_bin], 1);
           } else {
             const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
             if (pos < int(SMEM_INPUT_SIZE)) {

--- a/test/registered/kernels/ops/elementwise/test_fast_topk_regression.py
+++ b/test/registered/kernels/ops/elementwise/test_fast_topk_regression.py
@@ -1,0 +1,94 @@
+"""Regression tests for sgl-project/sglang#36807 (JIT fast_topk overflow).
+
+A concentrated row (e.g. 10.0 + 0.1*N(0,1)) puts ~16-34K candidates into the
+coarse fp16 threshold bin, far past the 4096-entry smem staging buffer. The
+buggy kernel silently drops the overflow (plus its fused histogram counts) and
+still returns exactly-k in-range, non-duplicate indices — wrong and unstable.
+
+Place in test/registered/kernels/ops/elementwise/ alongside test_fast_topk.py
+(same _check_topk_values semantics), or run standalone with:
+    PYTHONPATH=<sglang-src>/python pytest test_fast_topk_regression.py
+
+Before the fix these tests FAIL (wrong rows / unstable selections); after the
+exact-fallback fix they PASS.
+"""
+import pytest
+import torch
+
+from sglang.kernels.ops.elementwise.fast_topk import fast_topk
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+def _check_topk_values(score, lengths, indices, topk, row_starts):
+    """Selected indices must pick exactly the top-k value multiset.
+
+    Order is unspecified and tie-breaking may differ from torch.topk, so we
+    compare sorted score values, not index sets. Mirrors test_fast_topk.py.
+    """
+    for b in range(score.shape[0]):
+        start = int(row_starts[b]) if row_starts is not None else 0
+        length = int(lengths[b])
+        section = score[b, start : start + length]
+        row = indices[b]
+        if length <= topk:
+            assert torch.equal(
+                row[:length].cpu(), torch.arange(length, dtype=torch.int32)
+            )
+            assert (row[length:] == -1).all()
+            continue
+        assert (row >= 0).all(), "long rows must fill every slot"
+        picked = section[row.long()]
+        expected = torch.topk(section, topk).values
+        assert torch.equal(
+            picked.sort(descending=True).values, expected.sort(descending=True).values
+        ), f"row {b}: top-{topk} value multiset mismatch"
+
+
+@pytest.mark.parametrize("topk", [512, 2048])
+@pytest.mark.parametrize("length", [30938, 65504])
+def test_fast_topk_threshold_bin_overflow(topk, length):
+    # Regression for sgl-project/sglang#36807 (mochgolf): concentrated scores
+    # overflow the 4096-entry staging buffer; selection must stay exact.
+    torch.manual_seed(0)
+    batch = 4
+    score = 10.0 + 0.1 * torch.randn(batch, length, dtype=torch.float32, device="cuda")
+    lengths = torch.full((batch,), length, dtype=torch.int32, device="cuda")
+    indices = fast_topk(score, lengths, topk)
+    _check_topk_values(score, lengths, indices, topk, None)
+
+
+@pytest.mark.parametrize("topk", [512, 2048])
+def test_fast_topk_non_overflow_control(topk):
+    # N(0,1) rows at the same length never overflow: selection stays exact.
+    torch.manual_seed(0)
+    batch, length = 4, 65504
+    score = torch.randn(batch, length, dtype=torch.float32, device="cuda")
+    lengths = torch.full((batch,), length, dtype=torch.int32, device="cuda")
+    indices = fast_topk(score, lengths, topk)
+    _check_topk_values(score, lengths, indices, topk, None)
+
+
+@pytest.mark.parametrize("topk", [512, 2048])
+@pytest.mark.parametrize("length", [30938, 65504])
+def test_fast_topk_overflow_stable_across_runs(topk, length):
+    # The overflow used to be unstable (which candidates survive depends on
+    # atomic arrival order). The fixed kernel must pick the same set every run.
+    torch.manual_seed(0)
+    batch = 4
+    score = 10.0 + 0.1 * torch.randn(batch, length, dtype=torch.float32, device="cuda")
+    lengths = torch.full((batch,), length, dtype=torch.int32, device="cuda")
+    first = (
+        score.gather(1, fast_topk(score, lengths, topk).long())
+        .sort(dim=1, descending=True)
+        .values
+    )
+    for _ in range(5):
+        got = (
+            score.gather(1, fast_topk(score, lengths, topk).long())
+            .sort(dim=1, descending=True)
+            .values
+        )
+        assert torch.equal(got, first), "top-k selection unstable across runs"


### PR DESCRIPTION
## Motivation

`radix_select_topk` in `fast_topk.cuh` treats "at most SMEM_INPUT_SIZE candidates in the threshold bin" as a correctness assumption. The coarse fp16 binning (~2 mantissa bits per bin) lets a concentrated row place far more candidates in one bin — 16K at L=30,938 and 34K at L=65,504 for QSA k=512 (reported in #36807 by @mochgolf). Overflowing candidates are dropped *together with* their fused histogram contributions, so the staged subset no longer represents the threshold-bin population and refinement silently selects from a truncated set: wrong top-k, run-to-run unstable, and no error is surfaced since the output still looks like exactly-k valid indices.

## Fix

Keep the fast path unchanged. Detect the overflow (`s_num_input[0] > SMEM_INPUT_SIZE`), then refine by rescanning the full row, filtering candidates by the coarse bin plus the refined radix digits selected in previous rounds (`s_prefix_bins`). No API change, no smem layout change, CUDA-graph / PDL safe.

The coarse-stage threshold selection itself stays exact: it runs on the full first-pass histogram *before* any staging truncation, and kTopK (512/2048) < SMEM_INPUT_SIZE (4096) makes a post-truncation boundary unreachable.

## Tests

- New regression `test_fast_topk_regression.py` (registered CUDA CI): concentrated rows at L=30,938 / 65,504 x k in {512, 2048} **fail on the unpatched source** (8 failed / 2 passed — wrong rows and unstable selections) and **pass with the fix** (10 passed); non-overflow N(0,1) controls unchanged.
- Existing `test_fast_topk.py`: 23 passed (no regression).
- End-to-end smoke on 8x A800 (SM80), TP8, Qwen3.8-Flash-Next: health 200, CUDA-graph capture (32 batch sizes) + replay OK, and a 42K-token long-context request answered correctly through the QSA `fast_topk` path (needle retrieval at the compressed attention layer).

## Performance

No measurable regression on non-overflow inputs (kernel micro-benchmark medians within run-to-run noise).

## Notes

- Complements #37786 (padded-extend-plan OOB); different root cause, different path.
- `fast_topk.cuh` now lives on main (imported by `python/sglang/srt/layers/attention/qsa/kernel.py` and `qsa_indexer.py`), so this patch applies directly to `main` with no stacking. Note that main's copy is still the unfixed one — the staging-overflow path this PR guards is live on main today.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35550493885](https://github.com/sgl-project/sglang/actions/runs/35550493885)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35550493756](https://github.com/sgl-project/sglang/actions/runs/35550493756)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35550494071](https://github.com/sgl-project/sglang/actions/runs/35550494071)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->

## Scope note

This fixes the JIT kernel (`python/sglang/kernels/jit/csrc/elementwise/fast_topk.cuh`) only. The AOT kernel (`python/sglang/kernels/aot/csrc/elementwise/topk.cu`) shares the same staging-overflow pattern and is being handled separately (see the #36807 discussion).