### PR TITLE
[Feature] Skip local vision encoder init for qwen3 in language-only EPD

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -327,6 +327,7 @@ class ModelConfig:
         encoder_only: bool = False,
         language_only: bool = False,
         language_model_only: bool = False,
+        skip_local_encoder_init: bool = False,
         disable_hybrid_swa_memory: bool = False,
         model_config_parser: str = "auto",
         speculative_algorithm: Optional[str] = None,
@@ -618,6 +619,7 @@ class ModelConfig:
 
         self.hf_config.encoder_only = encoder_only
         self.hf_config.language_only = language_only
+        self.hf_config.skip_local_encoder_init = skip_local_encoder_init
         # Checkpoints declare this one themselves (hf_transformers/processor.py),
         # so the flag may only turn it on: writing the default back would build a
         # vision tower with no weights to fill.
@@ -671,6 +673,11 @@ class ModelConfig:
             is_multi_layer_eagle=cfg.enable_multi_layer_eagle,
             language_only=cfg.language_only,
             language_model_only=cfg.language_model_only,
+            skip_local_encoder_init=(
+                cfg.language_only
+                and bool(cfg.encoder_urls)
+                and not cfg.enable_adaptive_dispatch_to_encoder
+            ),
             encoder_only=cfg.encoder_only,
             is_draft_model=is_draft_model,
             is_draft_quantization_explicit=(

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2128,7 +2128,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
         self.deepstack_visual_indexes = (
-            self.visual.deepstack_visual_indexes if self.visual is not None else []
+            []
+            if self.language_model_only
+            else config.vision_config.deepstack_visual_indexes
         )
 
     def get_hidden_dim(self, module_name: str, layer_idx: int):
@@ -2290,7 +2292,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
         self.deepstack_visual_indexes = (
-            self.visual.deepstack_visual_indexes if self.visual is not None else []
+            []
+            if self.language_model_only
+            else config.vision_config.deepstack_visual_indexes
         )
 
         self.num_fused_shared_experts = 0

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1295,7 +1295,10 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         self.use_data_parallel = get_mm().mm_enable_dp_encoder
 
         self.language_model_only = getattr(config, "language_model_only", False)
-        if self.language_model_only:
+        self.skip_local_encoder_init = getattr(
+            config, "skip_local_encoder_init", False
+        )
+        if self.language_model_only or self.skip_local_encoder_init:
             self.visual = None
         else:
             self.visual = Qwen3VLMoeVisionModel(
@@ -1416,6 +1419,11 @@ class Qwen3VLForConditionalGeneration(nn.Module):
     def _get_visual_feature(
         self, items: List[MultimodalDataItem], grid_thw: torch.Tensor
     ) -> torch.Tensor:
+        if self.skip_local_encoder_init:
+            raise RuntimeError(
+                "Local vision encoder is disabled in language-only mode; "
+                "multimodal embeddings must be provided by the encoder server."
+            )
         assert grid_thw.dim() == 2, grid_thw.dim()
         if self.use_data_parallel:
             return run_dp_sharded_mrope_vision_model(


### PR DESCRIPTION
## Motivation

In EPD (encoder-prefill-decode) serving a language-only worker receives multimodal embeddings from the encoder server and never runs the vision tower locally, yet it still built the full vision model -- wasting memory and load time.

Add a `skip_local_encoder_init` flag on ModelConfig, derived from `language_only and encoder_urls and not enable_adaptive_dispatch_to_encoder`. When set, qwen3_vl / qwen3_5 leave `self.visual` as None and `_get_visual_feature` raises a clear error on any stray multimodal input instead of crashing on a missing visual. The deepstack index lookup in qwen3_5 is also keyed off `language_model_only` so it no longer dereferences the (now absent) visual.

On Qwen3.8-27B-NVFP4-BF16-LMHead this frees ~0.86 GB of GPU memory on a language-only worker.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33979812822](https://github.com/sgl-project/sglang/actions/runs/33979812822)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33979812638](https://github.com/sgl-project/sglang/actions/runs/33979812638)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33979812879](https://github.com/sgl-project/sglang/actions/runs/33979812879)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->