### PR TITLE
[Perf] Skip TP all-reduce of sampled token ids when world size is 1

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -96,9 +96,9 @@ class _SamplingMaskCapture(NamedTuple):
 class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
-        self.tp_sync_group = get_tp_group().device_group
+        self.tp_sync_group = get_tp_group()
         if is_dp_attention_enabled():
-            self.tp_sync_group = get_parallel().attn_tp_group.device_group
+            self.tp_sync_group = get_parallel().attn_tp_group
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -648,6 +648,12 @@ class Sampler(nn.Module):
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
         if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+            if self.tp_sync_group.world_size == 1:
+                return
+            device_group = self.tp_sync_group.device_group
+            if device_group is None:
+                return
+
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
             # the last all-reduce, the last lm_head matmul, and all sampling kernels.
@@ -658,7 +664,7 @@ class Sampler(nn.Module):
             torch.distributed.all_reduce(
                 batch_next_token_ids,
                 op=dist.ReduceOp.MIN,
-                group=self.tp_sync_group,
+                group=device_group,
             )
 
     def compute_logprobs_only(


### PR DESCRIPTION
## Motivation

The sampler all-reduces the sampled token ids across the TP group to mask nondeterminism from operators that are not guaranteed to be bit-identical across ranks. With a single rank the reduce is a no-op, but the collective still allocates GPU memory for the communication. On small-memory cards that allocation can push the process past its limit and OOM, so skip it entirely.

Store the TP group (not just its device_group) on the Sampler and bail out of the all-reduce when world_size == 1 or the device group is absent.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33979945064](https://github.com/sgl-project/sglang/actions/runs/33979945064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33979944732](https://github.com/sgl-project/sglang/actions/runs/33979944732)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33979944880](https://github.com/sgl-project/sglang/actions/runs/33979944880)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->