### PR TITLE
[Feature] Share target embed/lm_head with the Qwen3.5 MTP draft

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1571,7 +1571,10 @@ class Qwen3_5ForCausalLM(nn.Module):
         alt_stream = get_stream("alt") if _is_cuda or _hip_use_alt_stream else None
 
         # Embedding layer
-        if self.pp_group.is_first_rank:
+        if is_nextn:
+            self.embed_tokens = PPMissingLayer()
+            logger.info("ignore embedding layer for Qwen3.5 draft")
+        elif self.pp_group.is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,
@@ -1651,6 +1654,13 @@ class Qwen3_5ForCausalLM(nn.Module):
         # Final normalization
         if self.pp_group.is_last_rank:
             self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.tie_word_embeddings:
+                self.lm_head = self.embed_tokens
+            else:
+                self.lm_head = PPMissingLayer()
+                logger.info(
+                    "lm_head is not tied to embed_tokens; using PPMissingLayer for draft"
+                )
         else:
             self.norm = PPMissingLayer()
 

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -30,7 +30,7 @@ from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_5 import QWEN3_5_KV_SCALE_MAPPER, Qwen3_5ForCausalLM
@@ -46,6 +46,37 @@ logger = logging.getLogger(__name__)
 
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+
+
+class _SharedEmbedding(nn.Module):
+    """Embedding wrapper that references the target model's weight tensor.
+
+    Used when the MTP draft model's embed_tokens was not allocated
+    (PPMissingLayer due to is_nextn patch). No new GPU memory is allocated;
+    the weight is a direct reference to the target's embedding.
+    """
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = weight
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.embedding(input_ids, self.weight)
+
+
+class _SharedHead(nn.Module):
+    """LM head wrapper that references the target model's weight tensor.
+
+    Used when the MTP draft model's lm_head was not allocated
+    (PPMissingLayer). No new GPU memory is allocated.
+    """
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = weight
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.linear(hidden_states, self.weight)
 
 
 def _mtp_quant_config(quant_config):
@@ -132,12 +163,9 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             if config.tie_word_embeddings:
                 self.lm_head = self.model.embed_tokens
             else:
-                self.lm_head = ParallelLMHead(
-                    config.vocab_size,
-                    config.hidden_size,
-                    quant_config=quant_config,
-                    prefix=add_prefix("lm_head", prefix),
-                )
+                # Do not allocate a separate lm_head; set_embed_and_head
+                # will replace it with a reference to the target's head.
+                self.lm_head = PPMissingLayer()
 
         self.logits_processor = LogitsProcessor(config)
 
@@ -157,11 +185,19 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         # A last-stage draft can share only the target lm_head under PP; retain its
         # own embedding for the first-stage half it cannot receive.
         if embed is not None:
-            del self.model.embed_tokens.weight
-            self.model.embed_tokens.weight = embed
+            # embed_tokens may be PPMissingLayer (is_nextn patch skips allocation)
+            if not hasattr(self.model.embed_tokens, "weight"):
+                self.model.embed_tokens = _SharedEmbedding(embed)
+            else:
+                del self.model.embed_tokens.weight
+                self.model.embed_tokens.weight = embed
         if head is not None and not self.config.tie_word_embeddings:
-            del self.lm_head.weight
-            self.lm_head.weight = head
+            # lm_head may be PPMissingLayer (patch skips allocation)
+            if not hasattr(self.lm_head, "weight"):
+                self.lm_head = _SharedHead(head)
+            else:
+                del self.lm_head.weight
+                self.lm_head.weight = head
         current_platform.empty_cache()
         current_platform.synchronize()
 


### PR DESCRIPTION
## Motivation

The MTP draft (is_nextn) used to build its own embed_tokens and a full ParallelLMHead, then have set_embed_and_head free them and re-point at the target's tensors. That allocate-then-free cycle does not actually reclaim the memory: the freed blocks return to PyTorch's CUDA caching allocator, not the driver, and empty_cache() does not reliably hand them back. The KV pool is sized from driver-level free memory (torch.cuda.mem_get_info) right after the draft worker is built, so it reads an understated free-memory figure and ends up far smaller than it should be while GPU memory sits idle.

Skip the allocation entirely instead:

- Qwen3_5ForCausalLM: when is_nextn, leave embed_tokens as a PPMissingLayer and, on the last rank, leave lm_head as a PPMissingLayer (or tie it to embed_tokens when tie_word_embeddings is set).
- Qwen3_5ForCausalLMMTP: stop allocating a ParallelLMHead; set_embed_and_head now wraps the target's tensors in lightweight _SharedEmbedding / _SharedHead wrappers, so the draft references the target's weights with no allocate / free cycle and no caching-allocator residue.

On Qwen3.8-27B-NVFP4-BF16-LMHead this cuts the draft's memory footprint from 5.53 GB to 0.80 GB.

The PP guards in set_embed_and_head are preserved: embed/head are None on ranks that do not own that tensor, so the wrappers are only installed when the corresponding tensor is actually available.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33980017779](https://github.com/sgl-project/sglang/actions/runs/33980017779)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33980017526](https://github.com/sgl-project/sglang/actions/runs/33980017526)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33980017970](https://github.com/sgl-project/sglang/actions/runs/33980017970)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->