### PR TITLE
fix: support skip-rope tokenspeed MLA prefill

### DIFF
--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -186,7 +186,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         q_pe: torch.Tensor,
         k_nope: torch.Tensor,
         k_pe: torch.Tensor,
-        cos_sin_cache: torch.Tensor,
+        cos_sin_cache: Optional[torch.Tensor],
         positions: torch.Tensor,
         is_neox: bool,
         qk_nope_head_dim: int,
@@ -217,6 +217,12 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
             k_pe_expanded = k_pe.expand(-1, num_heads, -1)
         else:
             k_pe_expanded = k_pe
+
+        if cos_sin_cache is None:
+            q_fp8, k_nope_fp8, k_pe_fp8 = mla_quantize_without_rope_for_fp8(
+                q_nope, q_pe, k_nope, k_pe_expanded
+            )
+            return q_fp8, torch.cat((k_nope_fp8, k_pe_fp8), dim=-1).contiguous()
 
         _flashinfer_rope.mla_rope_quantize_fp8(
             q_rope=q_pe,
@@ -256,15 +262,16 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         k_nope = kv[..., : layer.qk_nope_head_dim]
         v_bf16 = kv[..., layer.qk_nope_head_dim :]
         q_nope = q[..., : layer.qk_nope_head_dim]
+        rotary_emb = layer.rotary_emb
 
         q_fp8, k_fp8 = self._fused_rope_fp8_quantize(
             q_nope=q_nope,
             q_pe=q_pe,
             k_nope=k_nope,
             k_pe=k_pe,
-            cos_sin_cache=layer.rotary_emb.cos_sin_cache,
+            cos_sin_cache=(None if rotary_emb is None else rotary_emb.cos_sin_cache),
             positions=positions,
-            is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
+            is_neox=getattr(rotary_emb, "is_neox_style", True),
             qk_nope_head_dim=layer.qk_nope_head_dim,
             qk_rope_head_dim=layer.qk_rope_head_dim,
         )

--- a/test/registered/unit/layers/attention/test_tokenspeed_mla_backend.py
+++ b/test/registered/unit/layers/attention/test_tokenspeed_mla_backend.py
@@ -1,0 +1,72 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention import tokenspeed_mla_backend as tokenspeed_backend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestTokenspeedMlaBackend(unittest.TestCase):
+    def test_skip_rope_fp8_quantize_packs_qk_without_rope(self):
+        original_quantize = tokenspeed_backend.mla_quantize_without_rope_for_fp8
+        captured = {}
+
+        def fake_quantize(q_nope_tensor, q_pe_tensor, k_nope_tensor, k_pe_tensor):
+            captured["k_pe"] = k_pe_tensor
+            return (
+                torch.cat((q_nope_tensor, q_pe_tensor), dim=-1),
+                k_nope_tensor,
+                k_pe_tensor,
+            )
+
+        tokenspeed_backend.mla_quantize_without_rope_for_fp8 = fake_quantize
+
+        try:
+            q_nope = torch.arange(12, dtype=torch.float32).view(2, 2, 3)
+            q_pe = torch.arange(8, dtype=torch.float32).view(2, 2, 2) + 100
+            k_nope = torch.arange(12, dtype=torch.float32).view(2, 2, 3) + 200
+            k_pe = torch.arange(4, dtype=torch.float32).view(2, 1, 2) + 300
+
+            q_out, k_out = (
+                tokenspeed_backend.TokenspeedMLABackend._fused_rope_fp8_quantize(
+                    object(),
+                    q_nope=q_nope,
+                    q_pe=q_pe,
+                    k_nope=k_nope,
+                    k_pe=k_pe,
+                    cos_sin_cache=None,
+                    positions=torch.tensor([0, 1], dtype=torch.int32),
+                    is_neox=True,
+                    qk_nope_head_dim=3,
+                    qk_rope_head_dim=2,
+                )
+            )
+        finally:
+            tokenspeed_backend.mla_quantize_without_rope_for_fp8 = original_quantize
+
+        expected_q = torch.cat((q_nope, q_pe), dim=-1)
+        expected_k_pe = k_pe.expand(-1, q_nope.shape[1], -1)
+        expected_k = torch.cat((k_nope, expected_k_pe), dim=-1)
+        torch.testing.assert_close(captured["k_pe"], expected_k_pe)
+        torch.testing.assert_close(q_out, expected_q)
+        torch.testing.assert_close(k_out, expected_k)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Handle TokenSpeed MLA prefill when an MLA layer has `rotary_emb=None`.
- For skip-RoPE layers, use the existing MLA no-RoPE FP8 quantization helper, then pack K as `[k_nope, k_pe]` for TokenSpeed FMHA.
- Add unit coverage for the no-RoPE pack path.

## Why

Kimi Linear constructs `DeepseekV2AttentionMLA` with `skip_rope=True`, which leaves `layer.rotary_emb` unset. The TokenSpeed prefill hook unconditionally read `layer.rotary_emb.cos_sin_cache`, so Kimi Linear + `--attention-backend tokenspeed_mla` crashed before serving requests.

Observed failure:

- `test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dcp.py`
- `AttributeError: 'NoneType' object has no attribute 'cos_sin_cache'`
- failing path: `tokenspeed_mla_backend.py -> prepare_prefill_qkv`

## Validation

- pre-commit hooks during commit
- `python3 -m py_compile python/sglang/srt/layers/attention/tokenspeed_mla_backend.py test/registered/unit/layers/attention/test_tokenspeed_mla_backend.py`
- `Rerun Test` on `4-gpu-b200`: https://github.com/sgl-project/sglang/actions/runs/33983925552/job/101353919307

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33983914662](https://github.com/sgl-project/sglang/actions/runs/33983914662)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33984192943](https://github.com/sgl-project/sglang/actions/runs/33984192943)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33983914550](https://github.com/sgl-project/sglang/actions/runs/33983914550)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->