### PR TITLE
fix(grpc): release GIL during native server shutdown

### DIFF
--- a/rust/sglang-grpc/src/lib.rs
+++ b/rust/sglang-grpc/src/lib.rs
@@ -27,10 +27,12 @@ struct GrpcServerHandle {
 #[pymethods]
 impl GrpcServerHandle {
     /// Gracefully shut down the gRPC server.
-    fn shutdown(&mut self) {
+    fn shutdown(&mut self, py: Python<'_>) {
         self.shutdown.notify_one();
         if let Some(handle) = self.join_handle.take() {
-            let _ = handle.join();
+            py.detach(move || {
+                let _ = handle.join();
+            });
         }
     }
 

--- a/test/registered/unit/entrypoints/test_grpc_shutdown.py
+++ b/test/registered/unit/entrypoints/test_grpc_shutdown.py
@@ -1,0 +1,113 @@
+"""Regression test for native gRPC shutdown while a Python RPC is active."""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+_SUBPROCESS_TEST = textwrap.dedent(
+    r"""
+    import socket
+    import threading
+    import time
+    from types import SimpleNamespace
+
+    import grpc
+
+    from sglang.srt.rust_extensions import load_rust_extension
+
+
+    _entered_health_check = threading.Event()
+    _release_health_check = threading.Event()
+
+
+    class _FakeRuntime:
+        def __init__(self):
+            self.tokenizer_manager = SimpleNamespace(
+                server_args=SimpleNamespace(),
+                model_config=SimpleNamespace(context_len=0),
+            )
+
+        def health_check(self):
+            _entered_health_check.set()
+            _release_health_check.wait(timeout=10)
+            return True
+
+
+    def _free_port():
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            return sock.getsockname()[1]
+
+
+    port = _free_port()
+    grpc_native = load_rust_extension(
+        "sglang.srt.rust_extensions._grpc",
+        mode="never",
+    )
+    handle = grpc_native.start_server(
+        host="127.0.0.1",
+        port=port,
+        runtime_handle=_FakeRuntime(),
+        worker_threads=1,
+        response_timeout_secs=10,
+    )
+    channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        health_check = channel.unary_unary(
+            "/sglang.runtime.v1.SglangService/HealthCheck",
+            request_serializer=lambda payload: payload,
+            response_deserializer=lambda payload: payload,
+        )
+        response = health_check.future(b"")
+        if not _entered_health_check.wait(timeout=5):
+            raise RuntimeError("HealthCheck did not reach the Python runtime")
+
+        def release_health_check():
+            time.sleep(0.1)
+            _release_health_check.set()
+
+        threading.Thread(target=release_health_check, daemon=True).start()
+        handle.shutdown()
+        assert response.result(timeout=5) == b"\x08\x01"
+    finally:
+        channel.close()
+        if handle.is_alive():
+            handle.shutdown()
+    """
+).strip()
+
+
+class TestNativeGrpcShutdown(CustomTestCase):
+    def test_shutdown_releases_gil_before_join(self):
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-c", _SUBPROCESS_TEST],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            self.fail(
+                "native gRPC shutdown subprocess timed out; likely GIL deadlock\n"
+                f"--- stdout ---\n{exc.stdout}\n"
+                f"--- stderr ---\n{exc.stderr}"
+            )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"native gRPC shutdown regression subprocess failed\n"
+            f"--- stdout ---\n{completed.stdout}\n"
+            f"--- stderr ---\n{completed.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

`GrpcServerHandle.shutdown()` waited for the native Rust gRPC thread with Python's GIL held. If an active RPC was inside the Python bridge, the RPC could need the GIL to return while shutdown waited for that same RPC, causing a shutdown deadlock.

This PR fixes the native gRPC lifecycle deadlock independently of the existing EAGLE work. It does not change the proto, HTTP lifecycle, health protocol, or runtime API.

## Modifications

- Pass `Python<'_>` into `GrpcServerHandle.shutdown()`.
- Preserve the existing notification, synchronous shutdown, and idempotent `join_handle.take()` behavior.
- Release the GIL with `py.detach(...)` only while joining the Rust server thread.
- Add a CPU-registered regression test that starts the real native gRPC server, routes `HealthCheck` through a fake Python runtime that intentionally blocks, and runs the shutdown scenario in a subprocess with a timeout so the old deadlock is reported diagnostically.

## Accuracy Tests

N/A — this is a shutdown lifecycle fix and does not affect model outputs or inference accuracy.

## Speed Tests and Profiling

N/A — this change only releases the GIL while synchronously joining the native server thread; it does not change the request or inference path.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p sglang-grpc --all-targets --all-features -- -D warnings`
- `cargo test --locked -p sglang-grpc` (13 passed)
- Native extension build with the setuptools-rust build context
- Standalone native gRPC shutdown smoke test with the compiled extension
- `pre-commit run --all-files`
- `git diff --check`

Environment-limited locally:

- `cargo test --locked --workspace` cannot complete on this macOS host: the full workspace hits the `sglang-server` PyO3/Python host-linking boundary. The workspace subset excluding `sglang-server` passed all `sglang-grpc` and `sglang-mm` unit tests; its existing Linux-only procfs integration test is unavailable on macOS.
- `python3 test/registered/unit/entrypoints/test_grpc_shutdown.py` is not runnable in this checkout's minimal Python environment because the full SGLang test dependencies are unavailable (`numpy` is missing). The compiled-extension smoke test exercises the same native server/RPC/shutdown sequence directly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — N/A; no user-facing or protocol documentation changed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) — N/A for this shutdown lifecycle fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33983891030](https://github.com/sgl-project/sglang/actions/runs/33983891030)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33983890884](https://github.com/sgl-project/sglang/actions/runs/33983890884)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33983890921](https://github.com/sgl-project/sglang/actions/runs/33983890921)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->