### PR TITLE
[Fix] Evict only the mamba slots a prefill batch will actually allocate

### DIFF
--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -19,9 +19,6 @@ from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
 )
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.common import (
-    MAMBA_STATE_PER_REQ_NO_CACHE,
-    MAMBA_STATE_PER_REQ_PREFIX_CACHE,
-    MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY,
     available_and_evictable_str,
     evict_from_tree_cache,
 )
@@ -226,6 +223,30 @@ def alloc_paged_token_slots_extend(
     return out_cache_loc
 
 
+def mamba_slots_needed(
+    *, req_to_token_pool: HybridReqToTokenPool, reqs: list[Req]
+) -> int:
+    """Mamba slots ``HybridReqToTokenPool.alloc`` takes for this batch: an
+    active state for each request without one (a COW match already holds it),
+    plus the ping-pong buffer for each request that has none yet. A chunked
+    continuation holds both, so admitting it evicts nothing."""
+    if req_to_token_pool.enable_mamba_extra_buffer:
+        ping_pong_slots = (
+            1
+            if req_to_token_pool.enable_mamba_extra_buffer_lazy
+            else req_to_token_pool.mamba_ping_pong_track_buffer_size
+        )
+    else:
+        ping_pong_slots = 0
+    needed = 0
+    for req in reqs:
+        if not req.kv.holds_mamba:
+            needed += 1
+        if req.kv.mamba_ping_pong_track_buffer is None:
+            needed += ping_pong_slots
+    return needed
+
+
 def alloc_req_slots(
     req_to_token_pool: ReqToTokenPool,
     reqs: list[Req],
@@ -244,16 +265,9 @@ def alloc_req_slots(
         mamba_available_size = (
             req_to_token_pool.mamba_allocator.schedulable_available_size()
         )
-        # Eviction headroom factor: 3x (or lazy variant) for radix COW, 1x for chunk.
-        if tree_cache.supports_mamba():
-            factor = (
-                MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY
-                if req_to_token_pool.enable_mamba_extra_buffer_lazy
-                else MAMBA_STATE_PER_REQ_PREFIX_CACHE
-            )
-        else:
-            factor = MAMBA_STATE_PER_REQ_NO_CACHE
-        mamba_state_needed = num_reqs * factor
+        mamba_state_needed = mamba_slots_needed(
+            req_to_token_pool=req_to_token_pool, reqs=reqs
+        )
         if mamba_available_size < mamba_state_needed:
             if tree_cache is not None and tree_cache.supports_mamba():
                 mamba_num = max(0, mamba_state_needed - mamba_available_size)

--- a/test/registered/unit/mem_cache/test_mamba_alloc_req_slots_demand.py
+++ b/test/registered/unit/mem_cache/test_mamba_alloc_req_slots_demand.py
@@ -1,0 +1,89 @@
+"""CPU-only tests for the mamba eviction demand of ``alloc_req_slots``.
+
+Admitting a prefill batch must evict only what ``HybridReqToTokenPool.alloc``
+will actually take. A chunked continuation already holds its active slot and
+ping-pong buffer, and a COW match already holds the active slot; charging
+every request three slots evicted up to three cached checkpoints per chunk
+under a tight pool and starved prefix reuse.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.allocation import alloc_req_slots, mamba_slots_needed
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _pool(*, extra_buffer=True, lazy=False, overlap=True):
+    return SimpleNamespace(
+        enable_mamba_extra_buffer=extra_buffer,
+        enable_mamba_extra_buffer_lazy=lazy,
+        mamba_ping_pong_track_buffer_size=2 if overlap else 1,
+    )
+
+
+def _req(*, holds_mamba: bool, has_ping_pong: bool):
+    return SimpleNamespace(
+        kv=SimpleNamespace(
+            holds_mamba=holds_mamba,
+            mamba_ping_pong_track_buffer=(
+                torch.tensor([1, 2]) if has_ping_pong else None
+            ),
+        )
+    )
+
+
+NEW = _req(holds_mamba=False, has_ping_pong=False)
+COW = _req(holds_mamba=True, has_ping_pong=False)
+CHUNKED = _req(holds_mamba=True, has_ping_pong=True)
+
+
+class TestMambaSlotsNeeded(unittest.TestCase):
+    def test_demand_counts_only_what_alloc_will_take(self):
+        pool = _pool()
+        self.assertEqual(mamba_slots_needed(req_to_token_pool=pool, reqs=[NEW]), 3)
+        self.assertEqual(mamba_slots_needed(req_to_token_pool=pool, reqs=[COW]), 2)
+        self.assertEqual(mamba_slots_needed(req_to_token_pool=pool, reqs=[CHUNKED]), 0)
+
+
+class _RecordingCache:
+    def __init__(self):
+        self.evict_params = []
+
+    def supports_mamba(self):
+        return True
+
+    def evict_for_alloc(self, params: EvictParams):
+        self.evict_params.append(params)
+
+
+def _hybrid_pool(available: int):
+    """A HybridReqToTokenPool shell: only the fields alloc_req_slots reads."""
+    pool = object.__new__(HybridReqToTokenPool)
+    pool.enable_mamba_extra_buffer = True
+    pool.enable_mamba_extra_buffer_lazy = False
+    pool.mamba_ping_pong_track_buffer_size = 2
+    pool.mamba_allocator = SimpleNamespace(schedulable_available_size=lambda: available)
+    pool.alloc = lambda reqs: list(range(1, len(reqs) + 1))
+    return pool
+
+
+class TestAllocReqSlotsEviction(unittest.TestCase):
+    def test_evicts_only_the_shortfall(self):
+        cache = _RecordingCache()
+        # a chunked continuation holds everything already: nothing to evict
+        alloc_req_slots(_hybrid_pool(available=0), [CHUNKED], cache)
+        self.assertEqual(cache.evict_params, [])
+        # a COW-matched request needs its two ping-pong slots; one is free
+        alloc_req_slots(_hybrid_pool(available=1), [COW], cache)
+        self.assertEqual(cache.evict_params, [EvictParams(num_tokens=0, mamba_num=1)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`alloc_req_slots` (`python/sglang/srt/mem_cache/allocation.py`) reserves `num_reqs * 3` Mamba slots (`* 2` under `extra_buffer_lazy`) before every prefill batch and evicts cached checkpoints down to that number. The number is a per-request headroom constant, not what `HybridReqToTokenPool.alloc` is about to take:

- a request whose prefix matched already holds its active slot from the COW at match time, so it takes 2 (the ping-pong buffer), not 3;
- a chunked-prefill continuation already holds both, so it takes 0, yet every chunk of it evicts up to 3 checkpoints;
- without the extra buffer (no_buffer) a new request takes 1.

With a tight pool (e.g. `--max-mamba-cache-size 30`, 6 running requests, 24 slots steadily held) the surplus eviction cycles through the few slots that can hold reusable checkpoints, so prefix hits are lost that the pool had room for. Found while tracing the slot lifecycle for #37066.

## Modifications

- New `mamba_slots_needed(req_to_token_pool, reqs)` computes the exact demand: `1` for each request without an active slot, plus the ping-pong buffer size (`2` with overlap, `1` without or under lazy, `0` without the extra buffer) for each request without one.
- `alloc_req_slots` evicts only the shortfall against that demand. The fail-loud `RuntimeError` on a failed row allocation is unchanged, and `HybridReqToTokenPool.alloc` still asserts if the demand were ever under-counted.
- The three `MAMBA_STATE_PER_REQ_*` constants are no longer read here; they stay in `mem_cache/common.py` for the sizing docstrings.

## Tests

New `test/registered/unit/mem_cache/test_mamba_alloc_req_slots_demand.py` (CPU), two regression cases that fail on main: the demand for new / COW-matched / chunked requests is 3 / 2 / 0 (main charges 3 for all), and `alloc_req_slots` on a `HybridReqToTokenPool` shell evicts nothing for a chunked continuation and exactly the shortfall for a COW-matched request.

E2E A/B on 1x H200, Qwen3.5-4B, NEXTN (steps 3, draft 4), `--max-mamba-cache-size 30 --chunked-prefill-size 512 --mamba-radix-cache-strategy extra_buffer`, greedy sampling so both arms see identical prompts (same prompt token totals), 6 growing conversations x 30 turns:

| arm | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| main | 0.272 | 0.301 | 0.365 | 0.313 |
| this PR | 0.321 | 0.363 | 0.441 | 0.375 |

Runs are interleaved (fix, main, main, fix on the second box) because thread timing moves the ratio by several points between runs of the same arm; the PR arm is ahead in every pair (+4.9, +6.2, +7.6 points). Prompt token totals are identical across all six runs (6,023,602).

At 12 conversations both arms sit near zero (0.010 vs 0.018): 24 of 30 slots are held by running requests, so the pool cannot retain checkpoints for 12 conversations regardless of eviction policy.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel if you have any questions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33984099763](https://github.com/sgl-project/sglang/actions/runs/33984099763)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33984099389](https://github.com/sgl-project/sglang/actions/runs/33984099389)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33984099607](https://github.com/sgl-project/sglang/actions/runs/33984099607)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->