### PR TITLE
Support NoPE layers in the tokenspeed_mla FP8 prefill hook

### DIFF
--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -186,7 +186,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         q_pe: torch.Tensor,
         k_nope: torch.Tensor,
         k_pe: torch.Tensor,
-        cos_sin_cache: torch.Tensor,
+        cos_sin_cache: Optional[torch.Tensor],
         positions: torch.Tensor,
         is_neox: bool,
         qk_nope_head_dim: int,
@@ -194,6 +194,11 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Fused RoPE + FP8 quantize that also packs nope+pe along the last
         dim, so FMHA consumes contig FP8 Q/K without an extra concat or cast.
+
+        ``cos_sin_cache`` is None for NoPE layers (models built with
+        ``skip_rope``, e.g. Kimi Linear / Kimi-K3 MLA). Those keep the FP8
+        quantize and the packed layout, only the rotation is dropped —
+        mirroring the ``cos_sin_cache is None`` branch in :meth:`forward_decode`.
         """
         num_heads = q_nope.shape[1]
         seq_len = q_nope.shape[0]
@@ -217,6 +222,14 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
             k_pe_expanded = k_pe.expand(-1, num_heads, -1)
         else:
             k_pe_expanded = k_pe
+
+        if cos_sin_cache is None:
+            # NoPE layer: quantize straight into the packed buffers.
+            q_fp8[..., :qk_nope_head_dim].copy_(q_nope)
+            q_fp8[..., qk_nope_head_dim:].copy_(q_pe)
+            k_fp8[..., :qk_nope_head_dim].copy_(k_nope)
+            k_fp8[..., qk_nope_head_dim:].copy_(k_pe_expanded)
+            return q_fp8, k_fp8
 
         _flashinfer_rope.mla_rope_quantize_fp8(
             q_rope=q_pe,
@@ -262,7 +275,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
             q_pe=q_pe,
             k_nope=k_nope,
             k_pe=k_pe,
-            cos_sin_cache=layer.rotary_emb.cos_sin_cache,
+            cos_sin_cache=getattr(layer.rotary_emb, "cos_sin_cache", None),
             positions=positions,
             is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
             qk_nope_head_dim=layer.qk_nope_head_dim,

--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -180,8 +180,8 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
                         enable_ex2_emulation=enable_ex2_emulation,
                     )
 
+    @staticmethod
     def _fused_rope_fp8_quantize(
-        self,
         q_nope: torch.Tensor,
         q_pe: torch.Tensor,
         k_nope: torch.Tensor,
@@ -195,10 +195,8 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         """Fused RoPE + FP8 quantize that also packs nope+pe along the last
         dim, so FMHA consumes contig FP8 Q/K without an extra concat or cast.
 
-        ``cos_sin_cache`` is None for NoPE layers (models built with
-        ``skip_rope``, e.g. Kimi Linear / Kimi-K3 MLA). Those keep the FP8
-        quantize and the packed layout, only the rotation is dropped —
-        mirroring the ``cos_sin_cache is None`` branch in :meth:`forward_decode`.
+        ``cos_sin_cache`` is None for NoPE layers (``skip_rope``); they keep the
+        FP8 quantize and the packed layout, only the rotation is dropped.
         """
         num_heads = q_nope.shape[1]
         seq_len = q_nope.shape[0]
@@ -270,14 +268,15 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         v_bf16 = kv[..., layer.qk_nope_head_dim :]
         q_nope = q[..., : layer.qk_nope_head_dim]
 
+        rotary_emb = layer.rotary_emb
         q_fp8, k_fp8 = self._fused_rope_fp8_quantize(
             q_nope=q_nope,
             q_pe=q_pe,
             k_nope=k_nope,
             k_pe=k_pe,
-            cos_sin_cache=getattr(layer.rotary_emb, "cos_sin_cache", None),
+            cos_sin_cache=None if rotary_emb is None else rotary_emb.cos_sin_cache,
             positions=positions,
-            is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
+            is_neox=True if rotary_emb is None else rotary_emb.is_neox_style,
             qk_nope_head_dim=layer.qk_nope_head_dim,
             qk_rope_head_dim=layer.qk_rope_head_dim,
         )

--- a/test/registered/attention/unittests/mla/test_tokenspeed_mla.py
+++ b/test/registered/attention/unittests/mla/test_tokenspeed_mla.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 
+from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.kits.attention_unittest.attention_methods.mla_attention import (
     MLAAttentionCase,
@@ -179,6 +180,85 @@ class TestTokenspeedMLAAttentionBackendCorrectness(CustomTestCase):
                     rtol=2e-1,
                     **MLA_SHAPE_KWARGS,
                 )
+
+
+class TestTokenspeedMLANoPEPrefillQuantize(CustomTestCase):
+    """NoPE MLA layers must still get packed FP8 prefill Q/K.
+
+    Layers built with ``skip_rope`` carry no rotary embedding, so the prefill
+    quantize runs with ``cos_sin_cache=None``. It must return the same packed
+    ``[nope | pe]`` FP8 layout as the RoPE path, and the head-0 pe slice it
+    writes to the KV cache must equal the plain FP8 cast of the unroped
+    ``k_pe`` that the decode path reads back.
+    """
+
+    T = 7
+    NUM_HEADS = 4
+    QK_NOPE_HEAD_DIM = 128
+    QK_ROPE_HEAD_DIM = 64
+    KV_LORA_RANK = 512
+
+    def test_nope_prefill_quantize_packs_without_rope(self):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        head_dim = self.QK_NOPE_HEAD_DIM + self.QK_ROPE_HEAD_DIM
+
+        q_nope = torch.randn(
+            self.T,
+            self.NUM_HEADS,
+            self.QK_NOPE_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        q_pe = torch.randn(
+            self.T,
+            self.NUM_HEADS,
+            self.QK_ROPE_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        k_nope = torch.randn(
+            self.T,
+            self.NUM_HEADS,
+            self.QK_NOPE_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        # k_pe reaches the backend as the strided tail of the latent cache.
+        latent_cache = torch.randn(
+            self.T,
+            1,
+            self.KV_LORA_RANK + self.QK_ROPE_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        k_pe = latent_cache[:, :, self.KV_LORA_RANK :]
+
+        q_fp8, k_fp8 = TokenspeedMLABackend._fused_rope_fp8_quantize(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            k_nope=k_nope,
+            k_pe=k_pe,
+            cos_sin_cache=None,
+            positions=torch.arange(self.T, device=device),
+            is_neox=True,
+            qk_nope_head_dim=self.QK_NOPE_HEAD_DIM,
+            qk_rope_head_dim=self.QK_ROPE_HEAD_DIM,
+        )
+
+        for name, out in (("q", q_fp8), ("k", k_fp8)):
+            with self.subTest(tensor=name):
+                self.assertEqual(out.shape, (self.T, self.NUM_HEADS, head_dim))
+                self.assertEqual(out.dtype, torch.float8_e4m3fn)
+                self.assertTrue(out.is_contiguous())
+
+        fp8 = torch.float8_e4m3fn
+        nope = self.QK_NOPE_HEAD_DIM
+        self.assertTrue(torch.equal(q_fp8[..., :nope], q_nope.to(fp8)))
+        self.assertTrue(torch.equal(q_fp8[..., nope:], q_pe.to(fp8)))
+        self.assertTrue(torch.equal(k_fp8[..., :nope], k_nope.to(fp8)))
+        # The slice prepare_prefill_qkv writes into the KV cache; the decode
+        # NoPE path reads it back as a plain cast of the unroped k_pe.
+        self.assertTrue(torch.equal(k_fp8[:, 0:1, nope:], k_pe.to(fp8)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Three `extra-b-test-4-gpu-b200` jobs fail on main ([run 33962519343](https://github.com/sgl-project/sglang/actions/runs/33962519343)): `test_kimi_linear_dcp4.py`, `test_kimi_linear_dcp_dspark4.py`, `test_unified_radix_cache_kl_dcp.py`, all Kimi Linear on `tokenspeed_mla` + `fp8_e4m3` under DCP. Every TP rank crashes during prefill and the server is SIGKILLed:

```
File ".../layers/attention/tokenspeed_mla_backend.py", line 265, in prepare_prefill_qkv
    cos_sin_cache=layer.rotary_emb.cos_sin_cache,
AttributeError: 'NoneType' object has no attribute 'cos_sin_cache'
```

Surfaced by #35770, which taught `resolve_attn_backend()` to unwrap `HybridLinearAttnBackend.full_attn_backend`. Kimi Linear is hybrid KDA/MLA, so prefill used to resolve to the wrapper, which has no `prepare_prefill_qkv` hook, and took the BF16 path guarded by `if self.rotary_emb is not None`. It now resolves to `TokenspeedMLABackend`, whose hook dereferences `layer.rotary_emb` unconditionally, and Kimi Linear builds its MLA layers with `skip_rope=True`, which leaves `rotary_emb` as `None`.

## Modifications

`_fused_rope_fp8_quantize` gains a NoPE branch: when `cos_sin_cache` is `None`, keep the FP8 quantize and the packed `[nope | pe]` layout, drop only the rotation. It is an early return, so RoPE layers are unaffected.

The `cos_sin_cache` and `is_neox_style` reads become `None` checks rather than `getattr` defaults, and `_fused_rope_fp8_quantize` becomes a `@staticmethod` with a unit case, since nothing PR-gated covered this path.

## Test Plan

| Test | Result |
|---|---|
| `dcp/test_kimi_linear_dcp4.py` | OK, 3 tests |
| `dcp/test_kimi_linear_dcp_dspark4.py` | OK, GSM8K 0.905 (threshold 0.88) |
| `radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dcp.py` | OK, avg_kl_div 0.0078 (threshold 0.01) |
| `attention/unittests/mla/test_tokenspeed_mla.py` | OK |

`test_kimi_linear_dcp4.py` was also reproduced red by stashing the patch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33984976309](https://github.com/sgl-project/sglang/actions/runs/33984976309)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33984976221](https://github.com/sgl-project/sglang/actions/runs/33984976221)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33984976307](https://github.com/sgl-project/sglang/actions/runs/33984976307)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->