### PR TITLE
[Bugfix][VLM] Prevent server SIGQUIT by zero-padding short multimodal embeddings

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1289,6 +1289,10 @@ class Envs:
     # For pre-tokenized (list[int]) multimodal prompts,
     # preserve the user's original tokens to avoid retokenization drift.
     SGLANG_MM_AVOID_RETOKENIZE = EnvBool(True)
+    # When multimodal embedding length is shorter than the number of placeholder tokens
+    # in input_ids, pad missing tokens with zeros as a compromise instead of raising a fatal
+    # RuntimeError that causes the scheduler process to SIGQUIT the server.
+    SGLANG_MM_PAD_SHORT_EMBEDDING = EnvBool(True)
 
     # ===================================================================
     # Multimodal CUDA IPC transport

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import MultimodalDataItem
 from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalStaticCache
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
@@ -679,9 +680,32 @@ def _adjust_embedding_length(
                 num_multimodal = num_mm_tokens_in_input_ids // embedding.shape[0]
                 embedding = embedding[-num_multimodal:, :]
         else:
-            raise RuntimeError(
-                f"Insufficient multimodal embedding length: {num_mm_tokens_in_input_ids=} vs {num_mm_tokens_in_embedding=}. This is an internal error"
-            )
+            if envs.SGLANG_MM_PAD_SHORT_EMBEDDING.get():
+                pad_len = num_mm_tokens_in_input_ids - num_mm_tokens_in_embedding
+                logger.error(
+                    f"Insufficient multimodal embedding length: "
+                    f"num_mm_tokens_in_input_ids={num_mm_tokens_in_input_ids} vs "
+                    f"num_mm_tokens_in_embedding={num_mm_tokens_in_embedding}. "
+                    f"Padding missing {pad_len} tokens with zeros as a compromise to prevent "
+                    f"server crash (SGLANG_MM_PAD_SHORT_EMBEDDING=True)."
+                )
+                if embedding.dim() == 2:
+                    pad = torch.zeros(
+                        (pad_len, embedding.shape[1]),
+                        dtype=embedding.dtype,
+                        device=embedding.device,
+                    )
+                else:
+                    pad = torch.zeros(
+                        (pad_len, *embedding.shape[1:]),
+                        dtype=embedding.dtype,
+                        device=embedding.device,
+                    )
+                embedding = torch.cat([embedding, pad], dim=0)
+            else:
+                raise RuntimeError(
+                    f"Insufficient multimodal embedding length: {num_mm_tokens_in_input_ids=} vs {num_mm_tokens_in_embedding=}. This is an internal error"
+                )
     return embedding
 
 

--- a/test/registered/unit/managers/test_mm_embedding_length.py
+++ b/test/registered/unit/managers/test_mm_embedding_length.py
@@ -119,10 +119,38 @@ def test_adjust_embedding_length_crops_overlong_embedding():
     torch.testing.assert_close(result, embedding[-3:], rtol=0, atol=0)
 
 
-def test_adjust_embedding_length_rejects_short_embedding():
+def test_adjust_embedding_length_pads_short_embedding_by_default():
+    embedding = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    logger = Mock()
+
+    result = mm_utils._adjust_embedding_length(embedding, 5, logger)
+
+    assert result.shape == (5, 4)
+    torch.testing.assert_close(result[:2], embedding)
+    torch.testing.assert_close(result[2:], torch.zeros(3, 4, dtype=torch.float32))
+    logger.error.assert_called_once()
+    assert "Padding missing 3 tokens with zeros" in logger.error.call_args[0][0]
+
+
+def test_adjust_embedding_length_pads_short_3d_embedding():
+    embedding = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    logger = Mock()
+
+    result = mm_utils._adjust_embedding_length(embedding, 4, logger)
+
+    assert result.shape == (4, 3, 4)
+    torch.testing.assert_close(result[:2], embedding)
+    torch.testing.assert_close(result[2:], torch.zeros(2, 3, 4, dtype=torch.float32))
+    logger.error.assert_called_once()
+
+
+def test_adjust_embedding_length_rejects_short_embedding_when_disabled():
     embedding = torch.zeros(2, 4)
 
-    with pytest.raises(RuntimeError, match="Insufficient multimodal embedding length"):
+    with (
+        envs.SGLANG_MM_PAD_SHORT_EMBEDDING.override(False),
+        pytest.raises(RuntimeError, match="Insufficient multimodal embedding length"),
+    ):
         mm_utils._adjust_embedding_length(embedding, 3, Mock())
 
 


### PR DESCRIPTION
Fixes #38022

### Motivation
Issue #38022 reports that when multimodal embedding length is shorter than the placeholder tokens in `input_ids` (`num_mm_tokens_in_input_ids > num_mm_tokens_in_embedding`), `_adjust_embedding_length()` in `sglang/srt/managers/mm_schedule.py` unconditionally raises `RuntimeError: Insufficient multimodal embedding length`.

Because this occurs inside `get_embedding_and_mask()` during the model forward execution path within `run_batch()`, the unhandled exception propagates up to `run_scheduler_process()`:
```python
except Exception:
    logger.error(f"Scheduler hit an exception: {traceback}")
    parent_process.send_signal(signal.SIGQUIT)
```
This terminates the multi-GPU engine instance. Furthermore, client retries propagate this error across nodes in a cluster, resulting in widespread service disruptions.

In contrast, the opposite skew (`num_mm_tokens_in_input_ids < num_mm_tokens_in_embedding`) is already handled gracefully by slicing from the end as a compromise (`embedding = embedding[-num_mm_tokens_in_input_ids:, :]`).

### Modifications
1. **Registered `SGLANG_MM_PAD_SHORT_EMBEDDING` in `Envs`**:
   - Registered under the `Multimodal processing` block in `python/sglang/srt/environ.py` as `EnvBool(True)`.
2. **Graceful Zero-Padding in `_adjust_embedding_length()`**:
   - In `python/sglang/srt/managers/mm_schedule.py`, when `num_mm_tokens_in_input_ids > num_mm_tokens_in_embedding` and `envs.SGLANG_MM_PAD_SHORT_EMBEDDING.get()` is True:
     - Log an error with token counts (`logger.error`).
     - Pad the missing rows in `embedding` with zeros matching the tensor's dtype and device, allowing tensor placement to succeed and the batch forward pass to complete cleanly without killing the server.
   - Preserved the `raise RuntimeError` path when `SGLANG_MM_PAD_SHORT_EMBEDDING` is explicitly set to `False`.
3. **Unit Tests**:
   - Added unit tests in `test/registered/unit/managers/test_mm_embedding_length.py` testing 2D and 3D tensor zero-padding behavior by default, and verified that setting `envs.SGLANG_MM_PAD_SHORT_EMBEDDING.override(False)` correctly raises `RuntimeError`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33989804925](https://github.com/sgl-project/sglang/actions/runs/33989804925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33989804723](https://github.com/sgl-project/sglang/actions/runs/33989804723)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33989804823](https://github.com/sgl-project/sglang/actions/runs/33989804823)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->