### PR TITLE
[HiCache] Read host memory once per TP group before splitting the budget

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -9,7 +9,7 @@ from typing import Optional
 import psutil
 import torch
 
-from sglang.srt.distributed.parallel_state import get_world_group
+from sglang.srt.distributed.parallel_state import get_tp_group, get_world_group
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
@@ -35,7 +35,8 @@ def ranks_per_host() -> int:
     Derived as world_size // nnodes: the launcher slices ranks uniformly
     across nodes (resolution asserts divisibility), so no hostname collective
     is needed — a collective here would have to be issued the same number of
-    times on every rank, and ranks build different numbers of host pools.
+    times on every rank, and ranks on different pipeline stages build
+    different numbers of host pools.
     """
     if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
         return 1
@@ -48,15 +49,52 @@ def ranks_per_host() -> int:
     return max(world_group.world_size // get_parallel().nnodes, 1)
 
 
+def host_memory_sync_group() -> Optional[torch.distributed.ProcessGroup]:
+    """CPU group whose ranks read host memory together before any of them allocates.
+
+    The tensor-parallel group of one pipeline stage: its ranks build the same
+    host pools in the same order, so a collective issued once per pool is
+    matched on every rank. The world group gives no such guarantee (pipeline
+    stages own different layers and build different pools), so co-located
+    stages still read independently of each other. None outside a multi-rank
+    distributed run, where the local reading is used as is.
+    """
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return None
+    try:
+        tp_group = get_tp_group()
+    except AssertionError:
+        return None
+    if tp_group.world_size <= 1:
+        return None
+    return tp_group.cpu_group
+
+
 def host_memory_budget_bytes() -> int:
     """Host RAM this rank may claim for a HiCache pool.
 
     psutil reports the whole machine, so co-located ranks each see the same free
     memory; without the split every rank sizes its pool against all of it and
     the host is oversubscribed by the number of ranks it holds.
+
+    The split is only right for a reading taken before any co-located rank
+    allocates. Ranks reach a pool's sizing guard at different times; one that
+    arrives after its peers have pinned their pools sees that memory gone from
+    ``available`` while still dividing by the full rank count, so the peers
+    are charged twice and the guard fails on a host with room to spare. The
+    group-wide minimum fixes that: the collective is a barrier, so no rank
+    allocates before all of them have read, and the minimum is the latest
+    reading, which already reflects every pool the group built before this one.
     """
-    free = psutil.virtual_memory().available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-    return free // ranks_per_host()
+    free = psutil.virtual_memory().available
+    sync_group = host_memory_sync_group()
+    if sync_group is not None:
+        reading = torch.tensor(free, dtype=torch.int64)
+        torch.distributed.all_reduce(
+            reading, op=torch.distributed.ReduceOp.MIN, group=sync_group
+        )
+        free = int(reading.item())
+    return (free - HICACHE_HOST_MEMORY_RESERVE_BYTES) // ranks_per_host()
 
 
 def sync_fixed_hicache_size(size: int, host_size: int) -> int:

--- a/test/registered/unit/mem_cache/test_mem_pool_host.py
+++ b/test/registered/unit/mem_cache/test_mem_pool_host.py
@@ -276,6 +276,117 @@ class TestHostMemoryBudget(CustomTestCase):
         ):
             self.assertEqual(base.ranks_per_host(), 8)
 
+    def _budget_in_group(self, own_reading, peer_readings, ranks=8):
+        # The reduce stands in for the gloo collective: every rank of the
+        # sync group contributes its own psutil reading and all of them get
+        # the minimum back.
+        fake_group = object()
+        seen = {}
+
+        def fake_all_reduce(tensor, op, group):
+            seen["op"] = op
+            seen["group"] = group
+            seen["dtype"] = tensor.dtype
+            tensor.fill_(min([int(tensor.item()), *peer_readings]))
+
+        fake_mem = unittest.mock.Mock(available=own_reading)
+        with (
+            unittest.mock.patch.object(base, "ranks_per_host", return_value=ranks),
+            unittest.mock.patch.object(
+                base.psutil, "virtual_memory", return_value=fake_mem
+            ),
+            unittest.mock.patch.object(
+                base, "host_memory_sync_group", return_value=fake_group
+            ),
+            unittest.mock.patch.object(
+                base.torch.distributed, "all_reduce", side_effect=fake_all_reduce
+            ),
+        ):
+            budget = base.host_memory_budget_bytes()
+        return budget, seen, fake_group
+
+    def test_budget_is_sized_from_the_group_wide_minimum_reading(self):
+        # Co-located ranks reach a pool's sizing guard at different times; the
+        # split is only right when all of them size against one reading taken
+        # before any of them allocates, and the lowest reading is the one that
+        # already reflects every pool the group built earlier.
+        gib = 1024**3
+        reserve = base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+        budget, seen, fake_group = self._budget_in_group(
+            own_reading=reserve + 64 * gib,
+            peer_readings=[reserve + 96 * gib, reserve + 40 * gib],
+        )
+        self.assertEqual(budget, 40 * gib // 8)
+        self.assertEqual(seen["op"], torch.distributed.ReduceOp.MIN)
+        self.assertIs(seen["group"], fake_group)
+        # Byte counts must not go through a float that rounds them.
+        self.assertEqual(seen["dtype"], torch.int64)
+
+    def test_budget_reads_locally_without_a_sync_group(self):
+        fake_mem = unittest.mock.Mock(available=self._AVAILABLE)
+        with (
+            unittest.mock.patch.object(base, "ranks_per_host", return_value=8),
+            unittest.mock.patch.object(
+                base.psutil, "virtual_memory", return_value=fake_mem
+            ),
+            unittest.mock.patch.object(
+                base, "host_memory_sync_group", return_value=None
+            ),
+            unittest.mock.patch.object(
+                base.torch.distributed, "all_reduce"
+            ) as all_reduce,
+        ):
+            budget = base.host_memory_budget_bytes()
+        all_reduce.assert_not_called()
+        self.assertEqual(
+            budget, (self._AVAILABLE - base.HICACHE_HOST_MEMORY_RESERVE_BYTES) // 8
+        )
+
+    def test_sync_group_is_the_tp_cpu_group(self):
+        # TP ranks of one pipeline stage build the same host pools in the same
+        # order, so a collective issued once per pool is matched on all of
+        # them; pipeline stages are not (they own different layers).
+        cpu_group = object()
+        fake_tp_group = unittest.mock.Mock(world_size=8, cpu_group=cpu_group)
+        with (
+            unittest.mock.patch.object(
+                torch.distributed, "is_initialized", return_value=True
+            ),
+            unittest.mock.patch.object(
+                base, "get_tp_group", return_value=fake_tp_group
+            ),
+        ):
+            self.assertIs(base.host_memory_sync_group(), cpu_group)
+
+    def test_single_rank_has_no_sync_group(self):
+        fake_tp_group = unittest.mock.Mock(world_size=1, cpu_group=object())
+        with (
+            unittest.mock.patch.object(
+                torch.distributed, "is_initialized", return_value=True
+            ),
+            unittest.mock.patch.object(
+                base, "get_tp_group", return_value=fake_tp_group
+            ),
+        ):
+            self.assertIsNone(base.host_memory_sync_group())
+
+    def test_no_sync_group_before_distributed_init(self):
+        with unittest.mock.patch.object(
+            torch.distributed, "is_initialized", return_value=False
+        ):
+            self.assertIsNone(base.host_memory_sync_group())
+
+    def test_no_sync_group_before_the_tp_group_is_built(self):
+        with (
+            unittest.mock.patch.object(
+                torch.distributed, "is_initialized", return_value=True
+            ),
+            unittest.mock.patch.object(
+                base, "get_tp_group", side_effect=AssertionError("not initialized")
+            ),
+        ):
+            self.assertIsNone(base.host_memory_sync_group())
+
 
 class TestHostPoolGroup(CustomTestCase):
     @staticmethod


### PR DESCRIPTION
## Motivation

Fixes #38156.

`host_memory_budget_bytes()` (#35540) splits `psutil.virtual_memory().available - 10 GiB` by `ranks_per_host()` so that co-located ranks do not oversubscribe the host. The split is only right for a reading taken before any co-located rank allocates. Each rank reads `available` when it reaches the guard, and TP ranks reach it seconds apart: pinning a large host pool is slow and nothing synchronizes the ranks between pools. A rank that arrives after `k` peers have pinned their pools sees `available` reduced by `k × pool` while still dividing by the full rank count, so the peers' pools are charged twice and the guard raises `ValueError: Not enough host memory available` on a host with room for all of them. With a sidecar pool (DSA indexer, MiniMax index-K, mamba) this repeats on the second guard after the first pool is pinned everywhere. On a tp8 host with 1772 GiB and `--hicache-size 176` (8 × 164 GiB KV + 8 × 33 GiB indexer, 86 GiB to spare) the start is intermittent; see the issue for the arithmetic.

## Modifications

- `host_memory_sync_group()`: the TP `cpu_group` of a multi-rank run, `None` otherwise. TP ranks of one pipeline stage build the same host pools in the same order, so a collective issued once per pool is matched on every rank; the world group gives no such guarantee (pipeline stages own different layers and build different pools), which is why #35540 avoided a collective there.
- `host_memory_budget_bytes()`: reduce the reading to the group-wide `MIN` over that group before subtracting the reserve and splitting. The collective is a barrier, so no rank allocates before all of them have read, and the minimum is the latest reading, which already reflects every pool the group built earlier. Same pattern as `sync_fixed_hicache_size()` in the same constructor (PP-group `MIN`) and `get_available_gpu_memory(distributed=True)`. Single-rank and non-distributed behavior is unchanged; the six guards that call the helper are untouched.
- Unit tests (`test_mem_pool_host.py`, `TestHostMemoryBudget`): the budget is sized from the group-wide minimum with `ReduceOp.MIN` on an `int64` tensor over the sync group; no collective and the local reading without a group; the sync group is the TP `cpu_group` for multi-rank runs and `None` for single-rank runs, before distributed init, and before the TP group is built. Also exercised end to end on a real 3-process gloo group with divergent per-rank readings over two pool rounds: every rank gets the same minimum-derived budget, and a single-process run with sglang's real `_TP` at world size 1 never issues the collective.

Known limits, unchanged by this PR: with several pipeline stages on one host the stages still race each other (the window shrinks to the stage); with a TP group spanning hosts the minimum may come from a peer host, which is conservative; `ranks_per_host()` still counts only the ranks of this process group, so data-parallel replicas launched as separate groups are not accounted for.

## Accuracy Tests

Not applicable: this changes only the host-pool sizing guards, not model forward paths.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33991104005](https://github.com/sgl-project/sglang/actions/runs/33991104005)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33991103784](https://github.com/sgl-project/sglang/actions/runs/33991103784)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33991103904](https://github.com/sgl-project/sglang/actions/runs/33991103904)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->