### PR TITLE
[Attention] Fix tokenspeed_mla FP8 prefill for NoPE MLA layers (Kimi Linear)

### DIFF
--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -255,24 +255,40 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
         )
         k_nope = kv[..., : layer.qk_nope_head_dim]
         v_bf16 = kv[..., layer.qk_nope_head_dim :]
-        q_nope = q[..., : layer.qk_nope_head_dim]
+        enable_pdl = is_arch_support_pdl()
 
-        q_fp8, k_fp8 = self._fused_rope_fp8_quantize(
-            q_nope=q_nope,
-            q_pe=q_pe,
-            k_nope=k_nope,
-            k_pe=k_pe,
-            cos_sin_cache=layer.rotary_emb.cos_sin_cache,
-            positions=positions,
-            is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
-            qk_nope_head_dim=layer.qk_nope_head_dim,
-            qk_rope_head_dim=layer.qk_rope_head_dim,
-        )
-        v_fp8 = fp8_quantize(v_bf16, enable_pdl=is_arch_support_pdl())
+        if layer.rotary_emb is None:
+            # NoPE layer (skip_rope): plain FP8 casts, packed [nope | pe].
+            # Per-slice launches since fp8_quantize needs a power-of-2 width.
+            q_fp8 = torch.empty(q.shape, dtype=torch.float8_e4m3fn, device=q.device)
+            fp8_quantize(
+                q[..., : layer.qk_nope_head_dim],
+                out=q_fp8[..., : layer.qk_nope_head_dim],
+                enable_pdl=enable_pdl,
+            )
+            fp8_quantize(
+                q_pe, out=q_fp8[..., layer.qk_nope_head_dim :], enable_pdl=enable_pdl
+            )
+            k_fp8, v_fp8 = mla_kv_pack_quantize_fp8(
+                k_nope, k_pe, v_bf16, enable_pdl=enable_pdl
+            )
+        else:
+            q_fp8, k_fp8 = self._fused_rope_fp8_quantize(
+                q_nope=q[..., : layer.qk_nope_head_dim],
+                q_pe=q_pe,
+                k_nope=k_nope,
+                k_pe=k_pe,
+                cos_sin_cache=layer.rotary_emb.cos_sin_cache,
+                positions=positions,
+                is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
+                qk_nope_head_dim=layer.qk_nope_head_dim,
+                qk_rope_head_dim=layer.qk_rope_head_dim,
+            )
+            v_fp8 = fp8_quantize(v_bf16, enable_pdl=enable_pdl)
 
         # k_pe is shared across heads (RoPE is position-only), so head 0
         # reproduces the original [tokens, 1, qk_rope] latent layout.
-        kv_a_fp8 = fp8_quantize(kv_a, enable_pdl=is_arch_support_pdl())
+        kv_a_fp8 = fp8_quantize(kv_a, enable_pdl=enable_pdl)
         k_pe_fp8 = k_fp8[:, 0:1, layer.qk_nope_head_dim :]
         self.token_to_kv_pool.set_mla_kv_buffer(
             layer.attn_mha,

--- a/test/registered/attention/unittests/mla/test_tokenspeed_mla.py
+++ b/test/registered/attention/unittests/mla/test_tokenspeed_mla.py
@@ -1,8 +1,10 @@
 import importlib.util
 import unittest
+from types import SimpleNamespace
 
 import torch
 
+from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.kits.attention_unittest.attention_methods.mla_attention import (
     MLAAttentionCase,
@@ -179,6 +181,97 @@ class TestTokenspeedMLAAttentionBackendCorrectness(CustomTestCase):
                     rtol=2e-1,
                     **MLA_SHAPE_KWARGS,
                 )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestTokenspeedMLANoPEPrefill(CustomTestCase):
+    """prepare_prefill_qkv with rotary_emb=None (skip_rope, e.g. Kimi Linear)."""
+
+    T = 37  # not a multiple of any kernel block size
+    NUM_HEADS = 4
+    QK_NOPE_HEAD_DIM = 128
+    QK_ROPE_HEAD_DIM = 64
+    V_HEAD_DIM = 128
+    KV_LORA_RANK = 512
+
+    def _assert_fp8_equal(self, out: torch.Tensor, ref_bf16: torch.Tensor):
+        fp8 = torch.float8_e4m3fn
+        self.assertEqual(out.dtype, fp8)
+        self.assertEqual(out.shape, ref_bf16.shape)
+        self.assertTrue(
+            torch.equal(out.view(torch.uint8), ref_bf16.to(fp8).view(torch.uint8))
+        )
+
+    def test_nope_prefill_skips_rope_and_packs_fp8(self):
+        device = torch.device("cuda")
+        bf16 = torch.bfloat16
+        T, H = self.T, self.NUM_HEADS
+        nope, rope = self.QK_NOPE_HEAD_DIM, self.QK_ROPE_HEAD_DIM
+        v_dim, lora = self.V_HEAD_DIM, self.KV_LORA_RANK
+        torch.manual_seed(0)
+
+        # Same shapes and views forward_normal_prepare passes to the hook.
+        q = torch.randn(T, H, nope + rope, dtype=bf16, device=device)
+        q_pe = q[..., nope:]
+        latent_cache = torch.randn(T, 1, lora + rope, dtype=bf16, device=device)
+        kv_a = latent_cache[:, 0, :lora].contiguous()
+        k_pe = latent_cache[:, :, lora:]
+        kv_b_weight = 0.05 * torch.randn(
+            H * (nope + v_dim), lora, dtype=bf16, device=device
+        )
+        positions = torch.arange(T, device=device)
+        out_cache_loc = torch.randperm(4 * T, device=device)[:T]
+
+        layer = SimpleNamespace(
+            kv_b_proj=lambda x: (x @ kv_b_weight.t(), None),
+            num_local_heads=H,
+            qk_nope_head_dim=nope,
+            qk_rope_head_dim=rope,
+            v_head_dim=v_dim,
+            rotary_emb=None,
+            attn_mha=SimpleNamespace(layer_id=0),
+        )
+
+        kv_writes = []
+        backend = TokenspeedMLABackend.__new__(TokenspeedMLABackend)
+        backend.token_to_kv_pool = SimpleNamespace(
+            set_mla_kv_buffer=lambda *args: kv_writes.append(args)
+        )
+
+        def _no_rope(**_):
+            self.fail("NoPE layer must not enter the fused RoPE path")
+
+        backend._fused_rope_fp8_quantize = _no_rope
+
+        q_fp8, k_fp8, v_fp8 = backend.prepare_prefill_qkv(
+            q=q,
+            q_pe=q_pe,
+            kv_a=kv_a,
+            k_pe=k_pe,
+            positions=positions,
+            layer=layer,
+            forward_batch=SimpleNamespace(out_cache_loc=out_cache_loc),
+        )
+
+        kv = layer.kv_b_proj(kv_a)[0].view(T, H, nope + v_dim)
+        k_ref = torch.cat([kv[..., :nope], k_pe.expand(-1, H, -1)], dim=-1)
+        v_ref = kv[..., nope:]
+        for name, out, ref in (
+            ("q", q_fp8, q),
+            ("k", k_fp8, k_ref),
+            ("v", v_fp8, v_ref),
+        ):
+            with self.subTest(tensor=name):
+                self.assertTrue(out.is_contiguous())
+                self._assert_fp8_equal(out, ref)
+
+        # KV cache receives the FP8 latent and the unrotated k_pe.
+        self.assertEqual(len(kv_writes), 1)
+        attn_layer, loc, cache_k_nope, cache_k_rope = kv_writes[0]
+        self.assertIs(attn_layer, layer.attn_mha)
+        self.assertIs(loc, out_cache_loc)
+        self._assert_fp8_equal(cache_k_nope, kv_a.unsqueeze(1))
+        self._assert_fp8_equal(cache_k_rope, k_pe)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Three `extra-b-test-4-gpu-b200` jobs fail on main ([run 33962519343](https://github.com/sgl-project/sglang/actions/runs/33962519343)): `test_kimi_linear_dcp4.py`, `test_kimi_linear_dcp_dspark4.py` and `test_unified_radix_cache_kl_dcp.py`, all Kimi Linear on `tokenspeed_mla` + `fp8_e4m3` under DCP. Every TP rank crashes in prefill:

```
File ".../layers/attention/tokenspeed_mla_backend.py", line 265, in prepare_prefill_qkv
    cos_sin_cache=layer.rotary_emb.cos_sin_cache,
AttributeError: 'NoneType' object has no attribute 'cos_sin_cache'
```

Root cause (as diagnosed in #38152, credit to @mmangkad): #35770 taught `resolve_attn_backend()` to unwrap `HybridLinearAttnBackend.full_attn_backend`. Kimi Linear's MLA layers are NoPE (`skip_rope=True`, so `rotary_emb is None`). They used to resolve to the wrapper, which has no `prepare_prefill_qkv` hook, and fell through to the BF16 path guarded by `if self.rotary_emb is not None`. They now resolve to `TokenspeedMLABackend`, whose hook assumed RoPE.

This is an alternative to #38152. That PR adds a `cos_sin_cache is None` branch inside `_fused_rope_fp8_quantize` that fills the packed buffers with four strided `.copy_()` casts, makes `positions` / `is_neox` dead parameters on that branch, and turns the method into a `@staticmethod` so the test can call it. This PR keeps `_fused_rope_fp8_quantize` as the RoPE kernel wrapper it is and handles NoPE one level up, with kernels the backend already has.

## Modifications

`prepare_prefill_qkv` branches once on `layer.rotary_emb is None`:

- **NoPE**: with no rotation, Q is a plain cast into the packed `[nope | pe]` layout: `fp8_quantize` on the nope and pe slices with `out=` views of one FP8 buffer (one launch each, since the row kernel needs a power-of-2 width and 192 is not one). K and V go through `mla_kv_pack_quantize_fp8`, which is exactly `cat(k_nope, broadcast k_pe) + FP8 quantize` for K plus FP8 quantize for V, and which `pack_prefix_chunk_kv` in the same backend already uses. Three saturating Triton launches instead of the four torch `.copy_()` casts plus the separate V quantize in #38152.
- **RoPE**: unchanged, same call into `_fused_rope_fp8_quantize`, whose signature is untouched.
- The FP8 KV-cache write is shared and unchanged: head 0 of the packed K is the unrotated `k_pe`, so the decode path reads back what it expects.

Test: `TestTokenspeedMLANoPEPrefill` drives the real `prepare_prefill_qkv` with `rotary_emb=None` through a stub layer and KV pool. It asserts the fused RoPE path is never entered, checks packed Q/K/V bit-for-bit against a torch reference (`torch.equal` on the FP8 bytes; both sides are round-to-nearest saturating casts), and checks the latent and unrotated `k_pe` that land in the KV cache. Only Triton kernels run on this branch, so the existing `1-gpu-large` registration of the file now exercises it too, not just `4-gpu-b200`.

## Test Plan

On a 1x B200 (SM100, `tokenspeed_mla` + flashinfer 0.6.18 installed), at this PR's head:

| Check | Result |
|---|---|
| `attention/unittests/mla/test_tokenspeed_mla.py -k NoPE` (new test) | passed, 3 subtests |
| same test with `tokenspeed_mla_backend.py` reverted to main `77aee202` | fails with the production error, `AttributeError: 'NoneType' object has no attribute 'cos_sin_cache'` at line 265 |
| `attention/unittests/mla/test_tokenspeed_mla.py` (full file) | 2 passed; the 11 pre-existing `TestTokenspeedMLAAttentionBackendCorrectness` cases sub-skip on this image because its `tokenspeed_mla` wheel rejects the kit head dims `(576, 512)`, unrelated to this change |
| `kernels/ops/attention/test_mla_kv_pack_quantize_fp8.py` (the reused pack kernel) | 130 passed |
| pre-commit (isort, ruff, ruff-format, codespell, CI registry checks) | passed |

Not run here: the three `extra-b-test-4-gpu-b200` e2e tests need 4 GPUs and Kimi Linear weights. They are the regression that motivated this PR and #38152 reports them green with the equivalent semantic fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33992165526](https://github.com/sgl-project/sglang/actions/runs/33992165526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33992165451](https://github.com/sgl-project/sglang/actions/runs/33992165451)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33992165518](https://github.com/sgl-project/sglang/actions/runs/33992165518)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->