### PR TITLE
[Quant] Select FlashInfer b12x NVFP4 GEMM by default on SM120

### DIFF
--- a/python/sglang/srt/arg_groups/choices.py
+++ b/python/sglang/srt/arg_groups/choices.py
@@ -182,6 +182,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutedsl",
     "flashinfer_cutlass",
     "flashinfer_trtllm",
+    "flashinfer_b12x",
     "marlin",
 ]
 

--- a/python/sglang/srt/arg_groups/fields/exec_.py
+++ b/python/sglang/srt/arg_groups/fields/exec_.py
@@ -169,7 +169,7 @@ class ExecKernel:
     fp4_gemm_runner_backend: A[
         str,
         Arg(
-            help="Choose the runner backend for NVFP4 GEMM operations. Options: 'auto' (default; selects flashinfer_cutedsl on SM100, marlin on SM80-SM90, flashinfer_cutlass otherwise (including SM120)), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), 'flashinfer_cutedsl' (FlashInfer CuTe DSL backend), 'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), 'marlin' (weight-only W4A16 fallback for SM80+). ",
+            help="Choose the runner backend for NVFP4 GEMM operations. Options: 'auto' (default; selects flashinfer_cutedsl on SM100, marlin on SM80-SM90, flashinfer_b12x on SM120/SM121, flashinfer_cutlass otherwise), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), 'flashinfer_cutedsl' (FlashInfer CuTe DSL backend), 'flashinfer_b12x' (FlashInfer CuTe DSL backend for SM120/SM121, requires CUDA 13), 'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), 'marlin' (weight-only W4A16 fallback for SM80+). ",
             cli_name="--fp4-gemm-backend",
             choices=FP4_GEMM_RUNNER_BACKEND_CHOICES,
             resolvable=True,

--- a/python/sglang/srt/layers/quantization/fp4_utils.py
+++ b/python/sglang/srt/layers/quantization/fp4_utils.py
@@ -98,6 +98,7 @@ class Fp4GemmRunnerBackend(Enum):
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
+    FLASHINFER_B12X = "flashinfer_b12x"
     MARLIN = "marlin"
 
     def is_auto(self) -> bool:
@@ -152,6 +153,8 @@ def initialize_fp4_gemm_config() -> None:
             backend = "flashinfer_cutedsl"
         elif is_cuda() and (10, 0) > get_device_capability() >= (8, 0):
             backend = "marlin"
+        elif is_cuda() and get_device_capability()[0] == 12:
+            backend = "flashinfer_b12x"
         else:
             backend = "flashinfer_cutlass"
 

--- a/python/sglang/srt/layers/quantization/fp4_utils.py
+++ b/python/sglang/srt/layers/quantization/fp4_utils.py
@@ -116,6 +116,9 @@ class Fp4GemmRunnerBackend(Enum):
     def is_flashinfer_cutedsl(self) -> bool:
         return self == Fp4GemmRunnerBackend.FLASHINFER_CUTEDSL
 
+    def is_flashinfer_b12x(self) -> bool:
+        return self == Fp4GemmRunnerBackend.FLASHINFER_B12X
+
     def is_marlin(self) -> bool:
         return self == Fp4GemmRunnerBackend.MARLIN
 
@@ -131,6 +134,7 @@ class Fp4GemmRunnerBackend(Enum):
             'flashinfer_cutlass' -> 'cutlass'
             'flashinfer_cudnn' -> 'cudnn'
             'flashinfer_cutedsl' -> 'cute-dsl'
+            'flashinfer_b12x' -> 'b12x'
         """
         if self == Fp4GemmRunnerBackend.FLASHINFER_CUTEDSL:
             return "cute-dsl"

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -107,6 +107,7 @@ def should_run_flashinfer_autotune(
     fp4_gemm_needs_autotune = model_uses_fp4 and (
         get_fp4_gemm_runner_backend().is_flashinfer_cutlass()
         or get_fp4_gemm_runner_backend().is_flashinfer_cutedsl()
+        or get_fp4_gemm_runner_backend().is_flashinfer_b12x()
     )
 
     from sglang.srt.layers.quantization.fp8_utils import (

--- a/test/registered/unit/layers/quantization/test_fp4_gemm_backend_sm120.py
+++ b/test/registered/unit/layers/quantization/test_fp4_gemm_backend_sm120.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import sglang.srt.layers.quantization.fp4_utils as fp4_utils
+import sglang.srt.model_executor.runner.flashinfer_autotune as autotune
 from sglang.srt.layers.quantization.fp4_utils import Fp4GemmRunnerBackend
 from sglang.test.test_utils import CustomTestCase
 
@@ -72,6 +73,49 @@ class TestFp4GemmBackendAuto(CustomTestCase):
         self.assertEqual(
             Fp4GemmRunnerBackend.FLASHINFER_B12X.get_flashinfer_backend(), "b12x"
         )
+
+    def test_b12x_predicate(self):
+        self.assertTrue(Fp4GemmRunnerBackend.FLASHINFER_B12X.is_flashinfer_b12x())
+        self.assertFalse(Fp4GemmRunnerBackend.FLASHINFER_CUTLASS.is_flashinfer_b12x())
+
+
+def _autotune_gate(backend, *, quantization="modelopt_fp4"):
+    """Run ``should_run_flashinfer_autotune`` with only the FP4 GEMM term live.
+
+    The MoE backend is ``triton`` and the model is NVFP4, so the MoE and FP8
+    terms are both False and the result is the FP4 GEMM term alone.
+    """
+    exec_ns = SimpleNamespace(
+        kernel=SimpleNamespace(disable_flashinfer_autotune=False),
+        deterministic=SimpleNamespace(enable_deterministic_inference=False),
+        moe=SimpleNamespace(moe_runner_backend="triton", moe_a2a_backend="none"),
+    )
+    runner = SimpleNamespace(
+        device="cuda",
+        model_config=SimpleNamespace(quantization=quantization),
+        spec_algorithm=SimpleNamespace(is_speculative=lambda: False),
+        is_draft_worker=False,
+    )
+    fp4_utils.FP4_GEMM_RUNNER_BACKEND = backend
+    try:
+        with (
+            patch.object(autotune, "get_exec", return_value=exec_ns),
+            patch("torch.cuda.get_device_capability", return_value=(12, 0)),
+        ):
+            return autotune.should_run_flashinfer_autotune(runner)
+    finally:
+        fp4_utils.FP4_GEMM_RUNNER_BACKEND = None
+
+
+class TestFp4AutotuneGate(CustomTestCase):
+    def test_b12x_keeps_the_fp4_autotune_pass(self):
+        self.assertTrue(_autotune_gate(Fp4GemmRunnerBackend.FLASHINFER_B12X))
+
+    def test_cutlass_still_autotunes(self):
+        self.assertTrue(_autotune_gate(Fp4GemmRunnerBackend.FLASHINFER_CUTLASS))
+
+    def test_marlin_does_not_autotune(self):
+        self.assertFalse(_autotune_gate(Fp4GemmRunnerBackend.MARLIN))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/quantization/test_fp4_gemm_backend_sm120.py
+++ b/test/registered/unit/layers/quantization/test_fp4_gemm_backend_sm120.py
@@ -1,0 +1,78 @@
+"""Unit test for the NVFP4 GEMM backend that ``auto`` resolves to on SM120.
+
+FlashInfer ships a dense NVFP4 GEMM built for SM120/SM121 (``mm_fp4`` backend
+``"b12x"``) and prefers it in its own ``"auto"`` order there. SGLang's
+``initialize_fp4_gemm_config`` mapped ``auto`` to ``flashinfer_cutlass`` on
+every non-SM100 Blackwell part, so the faster kernel was never selected and no
+CLI choice could ask for it. These tests pin the resolution table so a later
+edit cannot silently send SM120 back to the CUTLASS kernel, and check that the
+new choice maps to the FlashInfer API name. They mock the device probes so they
+run on CPU CI.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import sglang.srt.layers.quantization.fp4_utils as fp4_utils
+from sglang.srt.layers.quantization.fp4_utils import Fp4GemmRunnerBackend
+from sglang.test.test_utils import CustomTestCase
+
+
+def _resolve(requested, *, capability, is_sm100=False, cuda=True):
+    exec_ns = SimpleNamespace(kernel=SimpleNamespace(fp4_gemm_runner_backend=requested))
+    platform_ns = SimpleNamespace(is_sm100=is_sm100)
+    fp4_utils.FP4_GEMM_RUNNER_BACKEND = None
+    try:
+        with (
+            patch.object(fp4_utils, "get_exec", return_value=exec_ns),
+            patch.object(fp4_utils, "get_platform", return_value=platform_ns),
+            patch.object(fp4_utils, "is_cuda", return_value=cuda),
+            patch.object(fp4_utils, "get_device_capability", return_value=capability),
+        ):
+            fp4_utils.initialize_fp4_gemm_config()
+            return fp4_utils.get_fp4_gemm_runner_backend()
+    finally:
+        fp4_utils.FP4_GEMM_RUNNER_BACKEND = None
+
+
+class TestFp4GemmBackendAuto(CustomTestCase):
+    def test_sm120_auto_selects_b12x(self):
+        self.assertEqual(
+            _resolve("auto", capability=(12, 0)), Fp4GemmRunnerBackend.FLASHINFER_B12X
+        )
+
+    def test_sm121_auto_selects_b12x(self):
+        self.assertEqual(
+            _resolve("auto", capability=(12, 1)), Fp4GemmRunnerBackend.FLASHINFER_B12X
+        )
+
+    def test_sm100_auto_keeps_cutedsl(self):
+        self.assertEqual(
+            _resolve("auto", capability=(10, 0), is_sm100=True),
+            Fp4GemmRunnerBackend.FLASHINFER_CUTEDSL,
+        )
+
+    def test_sm90_auto_keeps_marlin(self):
+        self.assertEqual(
+            _resolve("auto", capability=(9, 0)), Fp4GemmRunnerBackend.MARLIN
+        )
+
+    def test_explicit_choice_wins_on_sm120(self):
+        self.assertEqual(
+            _resolve("flashinfer_cutlass", capability=(12, 0)),
+            Fp4GemmRunnerBackend.FLASHINFER_CUTLASS,
+        )
+
+    def test_b12x_maps_to_flashinfer_api_name(self):
+        self.assertEqual(
+            Fp4GemmRunnerBackend.FLASHINFER_B12X.get_flashinfer_backend(), "b12x"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On SM120 (RTX 5090, RTX PRO 6000) `--fp4-gemm-backend auto` resolves to `flashinfer_cutlass`. FlashInfer's `mm_fp4` has a backend built for SM120/SM121, `b12x`, and its own `auto` picks it first there. SGLang never passes that name and no CLI value reaches it.

Cold-weight GEMM at M=9, one RTX 5090, eight weight copies rotated inside a CUDA graph, percent of 1.792 TB/s:

| shape | cutlass | b12x |
|---|---:|---:|
| gate_up N=34816 K=5120 | 63% | 89% |
| down N=5120 K=17408 | 52% | 78% |
| lm_head N=248320 K=5120 | 65% | 92% |

Output is bit-identical between the two backends on the same quantized inputs (M=1 and M=9, max abs diff 0).

#35739 made the same change on the diffusion side (`platforms/cuda.py` defaults to `auto` on sm_120).

## Modifications

- `fp4_utils.py`: add `Fp4GemmRunnerBackend.FLASHINFER_B12X = "flashinfer_b12x"`. `initialize_fp4_gemm_config` selects it for compute capability 12.x when the backend is `auto`. SM100 (`flashinfer_cutedsl`) and SM80–90 (`marlin`) are unchanged. An explicit `--fp4-gemm-backend` overrides `auto`.
- `arg_groups/choices.py`: add `flashinfer_b12x` to `FP4_GEMM_RUNNER_BACKEND_CHOICES`.
- `arg_groups/fields/exec_.py`: `--fp4-gemm-backend` help now says `auto` picks `flashinfer_b12x` on SM120/SM121 and lists the choice.
- `flashinfer_autotune.py`: `should_run_flashinfer_autotune` enabled the FP4 term only for `flashinfer_cutlass` and `flashinfer_cutedsl`. Once `auto` resolves to b12x, an NVFP4 model on SM120 would have lost the autotune pass it gets today. FlashInfer exposes `B12xFp4GemmRunner(TunableRunner)`, so b12x is tunable; it joins the gate.
- `fp4_utils.py`: add `is_flashinfer_b12x()` beside the other backend predicates, and list the `flashinfer_b12x` -> `b12x` remap in the `get_flashinfer_backend` docstring.
- `test/registered/unit/layers/quantization/test_fp4_gemm_backend_sm120.py`: pins the `auto` table for SM120, SM121, SM100, SM90, the explicit override, and the `b12x` API name, and pins the autotune gate for b12x, cutlass, and marlin. CPU-only; device probes are mocked. Reverting the one-line autotune change fails `test_b12x_keeps_the_fp4_autotune_pass` and passes the other nine, so the gate is covered rather than merely exercised.

No weight-path change: `ModelOptFp4LinearMethod` prepares `cutlass` and `b12x` weights identically (128x4 swizzled scales, no shuffle), and `get_flashinfer_backend()` already strips the `flashinfer_` prefix.

Capability major `== 12` rather than `is_sm120` because FlashInfer 0.6.18 enables b12x on SM121 as well. b12x requires CUDA 13; the pinned 0.6.18 wheel is cu13, so there is no SGLang-side check.

## Accuracy Tests

Same weights, draft, and prompts; `cutlass` vs `b12x`; one RTX 5090; image `lmsysorg/sglang@sha256:616a3e97f45191af975896cfa644279096cb31bd408a071c2e99ca7209c3cafe` (FlashInfer 0.6.17; the same lines apply on current `main`). Target `RadixArk/Qwen3.8-27B-NVFP4`, `--speculative-algorithm DFLASH --speculative-draft-model-path incoai/Qwen3.8-27B-DFlash2 --speculative-num-draft-tokens 8`, greedy, **thinking on**, 1200 tokens, two repeats each. Outputs hashed equal, so this is a kernel swap, not a quality claim.

| prompt | cutlass tok/s | b12x tok/s | output SHA-256 |
|---|---:|---:|---|
| prose | 149.5 | 171.5 | equal |
| math | 230.1 | 264.6 | equal |
| Rust code | 191.7 | 220.2 | equal |

## Speed Tests and Profiling

`python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input-len 8192 --random-output-len 1024 --random-range-ratio 1 --num-prompts 10 --max-concurrency 1 --warmup-requests 1 --seed 7`, the shape in the Qwen3.8-27B cookbook's 5090 cells:

| backend | output tok/s | mean TPOT | accept |
|---|---:|---:|---:|
| flashinfer_cutlass | 173.0 | 4.95 ms | 4.47 |
| flashinfer_b12x | 196.2 | 4.31 ms | 4.25 |

Accept on random prompts varies by run, so the decode step was also measured directly: one streamed request, one chunk per verify step, greedy, **thinking off**, three fixed prompts, two repeats. cutlass 21.5 ms, b12x 18.8 ms per step on every prompt (prose 125.5 → 143.8 tok/s, code 259.6 → 297.7, math 279.8 → 321.1; tokens per step identical, outputs bit-identical). Torch profiler on the live server: NVFP4 GEMM per verify sub-step 2.09 → 1.52 ms, same 26 calls.

**FlashInfer autotune.** Before this PR, SM120 `auto` resolved to `flashinfer_cutlass`, so an NVFP4 model satisfied the FP4 term in `should_run_flashinfer_autotune`. Resolving to b12x would have dropped that term and silently ended the autotune pass on those GPUs, so b12x joins the gate. With the gate in place the tuner does run on SM120: `[AutoTuner]: Tuning fp4_gemm: 100%|##########| 4/4 [00:00<00:00, 62.40profile/s]`. Without it there is no autotuner line at all.

The pass makes no measurable difference to decode. One RTX 5090, identical server flags apart from `--disable-flashinfer-autotune`, `bench_serving` random 8192/1024, 10 prompts, concurrency 1, seed 7, two runs each (shown run 1 / run 2). Both arms generated 10240 output tokens, the requested cap, and both logged accept length 5.3505, so the two ran the same number of verify steps and duration is the whole comparison. The bench output records aggregates only, so this is not a claim that the text matched byte for byte.

| autotune | output tok/s | mean TPOT (ms) | median ITL (ms) |
|---|---:|---:|---:|
| on | 263.96 / 263.63 | 3.120 / 3.126 | 2.100 / 2.101 |
| off | 263.30 / 262.96 | 3.128 / 3.128 | 2.102 / 2.103 |

Autotune is ahead in both runs, by 0.25%, against a 0.13% spread between two runs of the same arm; n=2 makes that a direction, not a result, and it is far too small to matter for decode. Server start time was 50 s for both arms in run 1 and 50 s against 40 s in run 2, sampled by a 10 s poll, so any autotune startup cost is at or below the resolution of that check. The gate line preserves the behavior SM120 had before this PR; it does not buy throughput. Both the accuracy and speed tables above were taken with `--disable-flashinfer-autotune` on both sides, so the autotune gate does not affect the cutlass versus b12x comparison.

Not measured: batch > 1, prefill-heavy shapes, RTX PRO 6000, SM121. Scripts and raw outputs: https://github.com/thomgardiner/sglang-sm120-nvfp4

Open questions:

- [ ] Keep `auto` on cutlass for SM121 until someone measures a GB10?
- [ ] #36865 measured its Qwen3.8 KDA dispatch against the cutlass baseline (+0.98%). Re-measure against b12x?

## Checklist

- [x] Format your code according to pre-commit. `ruff format --check` clean; `ruff check` findings are pre-existing on `main`.
- [x] Add unit tests. Ten cases in `test_fp4_gemm_backend_sm120.py` (auto table + autotune gate).
- [x] Update documentation. The `--fp4-gemm-backend` help text now names `flashinfer_b12x` for SM120/SM121 and lists it among the choices.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

Rebased onto current `main`. Conflicts were in `server_args.py` because the FP4 choice list and help text moved to `arg_groups/choices.py` and `arg_groups/fields/exec_.py`; those are the files this revision edits.

I cannot add the `run-ci` label (not in CI_PERMISSIONS). After a Merge Oncall tags it, CI should run on this head.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34131295185](https://github.com/sgl-project/sglang/actions/runs/34131295185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34131295174](https://github.com/sgl-project/sglang/actions/runs/34131295174)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34131295066](https://github.com/sgl-project/sglang/actions/runs/34131295066)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
