### PR TITLE
[MLX] Skip Transformers arch resolution in get_resolved_model_impl

### DIFF
--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -15,6 +15,7 @@ from torch import nn
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
 from sglang.srt.configs.model_config import ModelConfig, ModelImpl
+from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.utils import get_device_sm
 
@@ -244,6 +245,17 @@ def supports_cuda_vmm_feature_transport(model_config: ModelConfig) -> bool:
 
 
 def get_resolved_model_impl(model_config: ModelConfig) -> ModelImpl:
+    if use_mlx():
+        # The MLX backend loads and runs models through mlx_lm, so inference
+        # never routes through sglang/srt/models or the Transformers fallback.
+        # Skip the Transformers-architecture compatibility gate entirely:
+        # resolving it imports the model's remote auto_map code, which the
+        # MLX path does not need and which can fail on its own (e.g. Hunyuan
+        # configs map "AutoModel" to a class name the remote module never
+        # defines). The scheduler only uses this value to detect the
+        # Transformers backend, which never applies here.
+        return ModelImpl.SGLANG
+
     resolved_model_impl = getattr(model_config, "_resolved_model_impl", None)
     if resolved_model_impl is not None:
         return resolved_model_impl

--- a/test/registered/unit/model_loader/test_get_resolved_model_impl_mlx.py
+++ b/test/registered/unit/model_loader/test_get_resolved_model_impl_mlx.py
@@ -1,0 +1,80 @@
+"""Unit tests for MLX handling in get_resolved_model_impl.
+
+The MLX backend loads models through mlx_lm and never routes inference
+through sglang/srt/models or the Transformers fallback, so the
+Transformers-architecture compatibility gate (which imports remote
+auto_map code) must be skipped there. Regression test for the Hunyuan
+auto_map crash (#32521): mlx-community/Hunyuan-7B-Instruct-4bit maps
+"AutoModel" to a class name its modeling file never defines, and the
+gate used to raise before the scheduler finished initializing.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.model_loader.utils import get_resolved_model_impl
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _hunyuan_like_model_config():
+    """Stand-in for a Hunyuan ModelConfig (unregistered arch, broken auto_map).
+
+    Mirrors mlx-community/Hunyuan-7B-Instruct-4bit: the architecture is not
+    registered in sglang or Transformers, and auto_map's "AutoModel" entry
+    names a class ("HunyuanModel") the remote module does not define (the
+    real class is "HunYuanModel", capital Y). No network access happens:
+    the MLX path must return before the auto_map is ever imported, and the
+    non-MLX gate rejects the empty-auto_map variant without imports.
+    """
+    hf_config = SimpleNamespace(
+        architectures=["HunYuanForCausalLM"],
+        model_type="hunyuan",
+        auto_map={
+            "AutoConfig": "configuration_hunyuan.HunyuanConfig",
+            "AutoModel": "modeling_hunyuan.HunyuanModel",
+            "AutoModelForCausalLM": "modeling_hunyuan.HunYuanForCausalLM",
+        },
+    )
+    return SimpleNamespace(
+        hf_config=hf_config,
+        hf_text_config=hf_config,  # text-only model
+        is_generation=True,
+        is_multimodal=False,
+        model_path="mlx-community/Hunyuan-7B-Instruct-4bit",
+        revision=None,
+        model_impl=ModelImpl.AUTO,
+        quantization=None,
+        is_embedding_gemma=False,
+    )
+
+
+class TestGetResolvedModelImplMlx(CustomTestCase):
+    def test_mlx_skips_transformers_gate_for_unregistered_arch(self):
+        model_config = _hunyuan_like_model_config()
+        with patch(
+            "sglang.srt.model_loader.utils.use_mlx", return_value=True
+        ):
+            impl = get_resolved_model_impl(model_config)
+        self.assertEqual(impl, ModelImpl.SGLANG)
+        self.assertNotEqual(impl, ModelImpl.TRANSFORMERS)
+
+    def test_non_mlx_unregistered_arch_still_gated(self):
+        model_config = _hunyuan_like_model_config()
+        # Without "AutoModel" in auto_map the gate rejects before importing
+        # any remote code, keeping this test offline.
+        model_config.hf_config.auto_map = {}
+        with patch(
+            "sglang.srt.model_loader.utils.use_mlx", return_value=False
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                get_resolved_model_impl(model_config)
+        self.assertIn("'HunYuanForCausalLM' is not a registered model", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #32521. On the MLX backend (`SGLANG_USE_MLX=1`), serving any Hunyuan model whose HF config ships an `auto_map` (e.g. `mlx-community/Hunyuan-7B-Instruct-4bit`) crashes during scheduler init, **after** `mlx_lm.load()` has already succeeded:

```
ValueError: Cannot find model module. 'HunYuanForCausalLM' is not a registered model in sglang.srt.models, nor in Transformers library, nor in the auto_map from the config.
```

Root cause chain: `kv_cache_builder` â `get_resolved_model_impl` â `resolve_transformers_arch` tries to import the config's remote `auto_map` module. Hunyuan's `auto_map` maps `"AutoModel"` to `modeling_hunyuan.HunyuanModel` (lowercase `y`), while the remote file actually defines `HunYuanModel`, so the dynamic import fails. The Transformers compatibility gate then raises â but the MLX backend never routes inference through `sglang/srt/models` or the Transformers fallback, so this gate does not apply to it at all.

## Modifications

Short-circuit `get_resolved_model_impl` on the MLX path, returning `ModelImpl.SGLANG` directly (the resolved value is only consumed to detect the Transformers backend, which never applies under MLX). This is deliberately fixed at the `get_resolved_model_impl` level rather than only in `kv_cache_builder`, because the scheduler's `init_chunked_prefill` and the multimodal processor resolve the same value and would hit the identical crash next.

No model-specific hardcoding: any model whose `auto_map` is broken or absent loads fine on MLX after this change, while the non-MLX path keeps the gate unchanged.

## Accuracy Tests

No change to model outputs: MLX inference path is untouched (the function's result is only used for Transformers-backend detection, which is moot under MLX). Verified the non-MLX gate behavior is unchanged in tests.

## Speed Tests and Profiling

Not applicable â scheduler-init-only change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidelines](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Validation

Reproduced the exact issue traceback before the fix (dynamic import of Hunyuan's remote code from config.json only â no full model download), and after the fix `get_resolved_model_impl(HunyuanConfig)` returns `ModelImpl.SGLANG` and serving init proceeds. Non-MLX mode still raises the gate error as before.

Unit tests (Apple Silicon, model-free):

```
$ python -m pytest test/registered/unit/model_loader/test_get_resolved_model_impl_mlx.py -q   # new regression tests (2)
2 passed
$ python -m pytest test/registered/unit/hardware_backend/mlx/test_mlx_remote_code_gate.py test/registered/unit/hardware_backend/mlx/test_runtime.py -q
19 passed, 1 skipped
$ python -m pytest test/registered/unit/hardware_backend/mlx/test_gpu_feature_transport.py test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py test/registered/unit/hardware_backend/mlx/test_runner_init_contract.py -q
46 passed
$ python -m pytest test/registered/unit/test_startup_weight_load.py -q
22 passed
```

Note for reviewers: as an outside contributor I can't add the `run-ci` label myself â would a maintainer kindly tag it (or run `/tag-and-rerun-ci`) so the MLX test matrix picks this up? The relevant suite is `stage-a-unit-test-mlx`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34008310119](https://github.com/sgl-project/sglang/actions/runs/34008310119)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34008309974](https://github.com/sgl-project/sglang/actions/runs/34008309974)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34008310062](https://github.com/sgl-project/sglang/actions/runs/34008310062)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->