### PR TITLE
[Test] Fix DSV4 pool sizing fixture on GLM-5.3 branch

### DIFF
--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -1045,11 +1045,11 @@ class TestSWAPoolFloor(CustomTestCase):
         self.assertEqual(config.swa_max_total_num_tokens, 3072)
 
     def _dsv4_sizes(self, max_tokens, page_size):
-        """Exercise the DSV4 size arithmetic without a full V4 model fixture:
-        _compute_dsv4_sizes reads only these five attributes."""
+        """Exercise non-unified DSV4 size arithmetic without a full model fixture."""
         from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
 
         cfg = object.__new__(DSV4PoolConfigurator)
+        cfg._unified = False
         cfg.swa_ratio = 0.1
         cfg.sliding_window_size = 128
         cfg.swa_page_size = 128


### PR DESCRIPTION
## Motivation

Follow-up to #36507, targeting `xinyuan/glm-5.3-flash-support`.

The [CPU CI job](https://github.com/sgl-project/sglang/actions/runs/33999784417/job/101396552331) fails in `TestSWAPoolFloor.test_dsv4_accepts_pool_above_floor` because the test constructs `DSV4PoolConfigurator` with `object.__new__`, bypassing the constructor that initializes `_unified`. The pool-size calculation now reads that attribute.

Current main has already reverted the relevant production change through #38163. This PR fixes the fixture on #36507, which still contains that code; it is not a redundant main-targeted fix.

## Modifications

- Initialize `_unified = False` in the non-unified DSV4 sizing fixture.
- Clarify the fixture docstring instead of maintaining an attribute count.
- No production changes, assertion changes, or CI registration changes.

## Validation

CPU-only validation on an isolated source copy on `baizhou-nda`, with GPUs hidden (`CUDA_VISIBLE_DEVICES=8` on an eight-GPU host) and `PYTHONPATH=python`:

- Before the patch, `python3 test/registered/unit/model_executor/test_pool_configurator.py TestSWAPoolFloor -v` reproduced the exact missing-`_unified` error: 4 tests, 1 error.
- After the patch, `python3 test/registered/unit/model_executor/test_pool_configurator.py -v` passed all 39 tests.
- Targeted `pre-commit run --files test/registered/unit/model_executor/test_pool_configurator.py` passed.
- `git diff --check` passed.

## Accuracy Tests

Not applicable: test-fixture-only change; no model output changes.

## Speed Tests and Profiling

Not applicable: no production or performance changes. No full CI was requested.

## Checklist

- [x] Formatting and applicable pre-commit checks pass.
- [x] Existing regression test reproduced before the fix and passes afterward.
- [x] Fixture documentation updated.
- [x] Accuracy/performance impact assessed as not applicable.
- [x] Existing test conventions preserved.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34009416118](https://github.com/sgl-project/sglang/actions/runs/34009416118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34009415843](https://github.com/sgl-project/sglang/actions/runs/34009415843)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34009416162](https://github.com/sgl-project/sglang/actions/runs/34009416162)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->