### PR TITLE
[Perf] Keep torchvision, openai SDK and FastAPI off the scheduler imp…

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -17,12 +17,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 import aiohttp
 import numpy as np
 import torch
-import uvicorn
 import zmq
 import zmq.asyncio
 from aiohttp import ClientSession, ClientTimeout
-from fastapi import FastAPI
-from fastapi.responses import ORJSONResponse, Response
 from transformers import PretrainedConfig
 
 from sglang.srt.distributed.parallel_state import (
@@ -63,6 +60,8 @@ from sglang.srt.utils.network import (
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    import uvicorn
+
     from sglang.srt.managers.scheduler import Scheduler
 
 
@@ -150,6 +149,12 @@ class EncoderBootstrapServer:
         self._health_fail_threshold = 3
         self._health_fail_counts: Dict[str, int] = {}
         self._evicted_urls: Dict[str, float] = {}
+
+        # Lazy import: FastAPI/uvicorn are only needed once this bootstrap
+        # server actually starts, and importing them here keeps fastapi off
+        # the scheduler import path (this module is imported by the scheduler).
+        from fastapi import FastAPI
+        from fastapi.responses import ORJSONResponse, Response
 
         @asynccontextmanager
         async def lifespan(fast_api_app: FastAPI):
@@ -330,6 +335,7 @@ class EncoderBootstrapServer:
     # Lifecycle                                                          #
     # ------------------------------------------------------------------ #
     def _run_server(self):
+        import uvicorn
 
         config = uvicorn.Config(
             self.app,

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import orjson
 from partial_json_parser.core.exceptions import MalformedJSON
@@ -13,7 +15,6 @@ except ImportError:
     StructuralTag = Any
     get_model_structural_tag = None
 
-from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.environ import envs
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -25,6 +26,11 @@ from sglang.srt.function_call.utils import (
     _is_complete_json,
     _partial_json_loads,
 )
+
+if TYPE_CHECKING:
+    # Lazy: importing protocol eagerly would pull the whole openai SDK into
+    # the scheduler import path.
+    from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +423,9 @@ class BaseFormatDetector(ABC):
             return None
 
         converted_tools = [tool.model_dump() for tool in tools or []]
+        # Lazy import: keeps the openai SDK off the scheduler import path.
+        from sglang.srt.entrypoints.openai.protocol import ToolChoice
+
         converted_tool_choice = (
             tool_choice.model_dump()
             if isinstance(tool_choice, ToolChoice)

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import json
 import logging
 import re
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
-from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
@@ -13,6 +14,11 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.utils import get_schema_properties
+
+if TYPE_CHECKING:
+    # Lazy: importing protocol eagerly would pull the whole openai SDK into
+    # the scheduler import path.
+    from sglang.srt.entrypoints.openai.protocol import Tool
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import ast
 import threading
 import warnings
 from json import JSONDecodeError, JSONDecoder
 from json.decoder import WHITESPACE
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import orjson
 import partial_json_parser
 from partial_json_parser.core.options import Allow
 
-from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+if TYPE_CHECKING:
+    # Lazy: importing protocol eagerly would pull the whole openai SDK into
+    # the scheduler import path.
+    from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 
 _STANDARD_JSON_SCHEMA_TYPES = {
     "null",
@@ -444,6 +449,9 @@ def get_json_schema_constraint(
     Returns:
         JSON schema dict, or None if no valid tools found
     """
+
+    # Lazy import: keeps the openai SDK off the scheduler import path.
+    from sglang.srt.entrypoints.openai.protocol import ToolChoice
 
     if isinstance(tool_choice, ToolChoice):
         # For specific function choice, return the user's parameters schema directly

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from typing import Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type
 
 from sglang.srt.entrypoints.openai.encoding_dsv4 import dsml_token as dsv4_dsml_token
 from sglang.srt.entrypoints.openai.encoding_dsv4 import eos_token as dsv4_eos_token
@@ -10,7 +10,6 @@ from sglang.srt.entrypoints.openai.encoding_dsv4 import (
 from sglang.srt.entrypoints.openai.encoding_dsv4 import (
     thinking_start_token as dsv4_thinking_start_token,
 )
-from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.function_call.hunyuan_detector import resolve_hunyuan_tokens
 from sglang.srt.function_call.kimik3_format import (
     MESSAGE_CLOSE,
@@ -45,6 +44,12 @@ from sglang.srt.parser.inkling_tokenizer import (
     INKLING_CONTROL_TOKENS,
     MESSAGE_MODEL,
 )
+
+if TYPE_CHECKING:
+    # Only needed for the `request` type check in ReasoningParser.__init__;
+    # importing protocol eagerly would pull the whole openai SDK into the
+    # scheduler import path.
+    from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
 
 class StreamingParseResult:
@@ -2058,7 +2063,7 @@ class ReasoningParser:
         model_type: Optional[str] = None,
         stream_reasoning: bool = True,
         force_reasoning: Optional[bool] = None,
-        request: ChatCompletionRequest = None,
+        request: Optional["ChatCompletionRequest"] = None,
         tokenizer=None,
         tool_call_parser_active: bool = False,
     ):
@@ -2089,14 +2094,17 @@ class ReasoningParser:
         if force_reasoning is not None:
             kwargs["force_reasoning"] = force_reasoning
 
-        if (
-            request is not None
-            and isinstance(request, ChatCompletionRequest)
-            and request.continue_final_message
-            and request.messages[-1].role == "assistant"
-        ):
-            kwargs["continue_final_message"] = True
-            kwargs["previous_content"] = request.messages[-1].content
+        if request is not None:
+            # Lazy import: keeps the openai SDK off the scheduler import path.
+            from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+
+            if (
+                isinstance(request, ChatCompletionRequest)
+                and request.continue_final_message
+                and request.messages[-1].role == "assistant"
+            ):
+                kwargs["continue_final_message"] = True
+                kwargs["previous_content"] = request.messages[-1].content
 
         if chat_template_kwargs.get("force_nonempty_content") is True:
             kwargs["force_nonempty_content"] = True

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -60,7 +60,6 @@ from sglang.srt.arg_groups.overrides import (
     resolving_view,
 )
 from sglang.srt.environ import envs
-from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -3858,6 +3857,12 @@ class ServerArgs:
             f"Use 'auto' to detect from chat template. "
             f"Options include: {reasoning_parser_choices}.",
         )
+        # Lazy import: FunctionCallParser drags in every tool-call detector,
+        # which in turn imports the OpenAI SDK via
+        # sglang.srt.entrypoints.openai.protocol. Deferring it keeps the
+        # openai package off the scheduler/server_args import path.
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
         tool_call_parser_choices = list(FunctionCallParser.ToolCallParserEnum.keys())
         parser.add_argument(
             "--tool-call-parser",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -95,7 +95,6 @@ from starlette.routing import Mount
 from torch import nn
 from torch.library import Library
 from torch.utils._contextlib import _DecoratorContextManager
-from torchvision.io import decode_jpeg
 from typing_extensions import Literal
 
 from sglang.srt.environ import envs
@@ -1891,6 +1890,12 @@ def _load_image(
 
                 return decode_jpeg_with_fancy_upsampling(image_bytes)
             encoded_image = torch.frombuffer(image_bytes, dtype=torch.uint8)
+            # Lazy import: torchvision pulls in torch._dynamo and the full
+            # torchvision.models tree, which is expensive on the import path
+            # of `sglang.srt.managers.scheduler` and only needed for
+            # CUDA JPEG decoding here.
+            from torchvision.io import decode_jpeg
+
             image_tensor = decode_jpeg(encoded_image, device="cuda")
             return image_tensor
         except Exception as e:


### PR DESCRIPTION
…ort path

Importing sglang.srt.managers.scheduler takes ~12s on an H100 (#10492). Several heavy dependencies are only needed at request-serving time but are currently pulled in at import time:

- torchvision.io.decode_jpeg in srt/utils/common.py: importing it up front also pulls in torch._dynamo and the whole torchvision.models tree. It is only used for CUDA JPEG decoding, behind a CUDA check that already has a sibling lazy import.
- the openai SDK via srt/entrypoints/openai/protocol.py, imported at module level by server_args (FunctionCallParser is only used to list CLI choices) and by the tool-call / reasoning-parser helpers, which only need `Tool`/`ToolChoice`/`ChatCompletionRequest` for type annotations and two isinstance checks.
- fastapi/uvicorn in srt/disaggregation/encoder/receiver.py, only used once the encoder bootstrap server actually starts.

Defer these imports to their call sites and move annotation-only names behind `if TYPE_CHECKING` (with `from __future__ import annotations` where signatures reference them). After this change, importing the Scheduler no longer loads openai, fastapi, uvicorn or torchvision (torchvision still arrives later via transformers.image_utils, but without the torch._dynamo/inductor chains that torchvision.models triggers). Interleaved A/B timing on an M4 Max: median 7.01s -> 5.90s (-16%).

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34009840552](https://github.com/sgl-project/sglang/actions/runs/34009840552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34009840451](https://github.com/sgl-project/sglang/actions/runs/34009840451)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34009840518](https://github.com/sgl-project/sglang/actions/runs/34009840518)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->