### PR TITLE
[Fix] set_mla_kv_buffer: reshape non-contiguous MLA latent slices

### DIFF
--- a/python/sglang/kernels/ops/kvcache/set_mla_kv_buffer.py
+++ b/python/sglang/kernels/ops/kvcache/set_mla_kv_buffer.py
@@ -109,9 +109,19 @@ def set_mla_kv_buffer(
     if n_loc == 0:
         return
 
-    src_nope = cache_k_nope.view(n_loc, -1) if cache_k_nope.dim() != 2 else cache_k_nope
-    src_rope = cache_k_rope.view(n_loc, -1) if cache_k_rope.dim() != 2 else cache_k_rope
-    buf = kv_buffer.view(kv_buffer.shape[0], -1) if kv_buffer.dim() != 2 else kv_buffer
+    # reshape (not view): cache_k_nope/rope can arrive as a non-contiguous
+    # strided slice of the packed MLA latent at longer chunked prefill, where
+    # .view() raises; reshape() copies only in that case and is a no-op on the
+    # common contiguous path.
+    src_nope = (
+        cache_k_nope.reshape(n_loc, -1) if cache_k_nope.dim() != 2 else cache_k_nope
+    )
+    src_rope = (
+        cache_k_rope.reshape(n_loc, -1) if cache_k_rope.dim() != 2 else cache_k_rope
+    )
+    buf = (
+        kv_buffer.reshape(kv_buffer.shape[0], -1) if kv_buffer.dim() != 2 else kv_buffer
+    )
 
     nope_bytes = src_nope.shape[-1] * src_nope.element_size()
     rope_bytes = src_rope.shape[-1] * src_rope.element_size()


### PR DESCRIPTION
## Motivation

`set_mla_kv_buffer` (the SM90+ TMA store wrapper) calls `.view(n_loc, -1)` on `cache_k_nope` / `cache_k_rope`. At longer chunked prefill these arrive as a **non-contiguous strided slice** of the packed MLA latent row, and `.view()` raises:

```
RuntimeError: view size is not compatible with input tensor's size and stride
```

Hit in practice serving Kimi Linear 48B with `--chunked-prefill-size 8192` at input lengths >= 8192.

## Modifications

`.view(...)` -> `.reshape(...)` for the three reshapes. `reshape()` copies only when the source is non-contiguous and is a no-op on the common contiguous path, so the hot path is unaffected.

## Checklist

- [x] Format your code: ruff format / ruff check clean on the touched file.
- [x] The fix is a 3-line mechanical substitution with an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011R3AiTDnYwMwqcZecLSRPz

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34010008649](https://github.com/sgl-project/sglang/actions/runs/34010008649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34010008459](https://github.com/sgl-project/sglang/actions/runs/34010008459)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34010008532](https://github.com/sgl-project/sglang/actions/runs/34010008532)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->