### PR TITLE
[MLX] Dispose of retracted request state at retract time (fixes #33547)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -1678,6 +1678,30 @@ class MlxModelRunner:
         """Check if a request has active state."""
         return req_id in self._req_caches
 
+    def discard_request(self, req_id: str) -> None:
+        """Drop all runner state for *req_id* without syncing to the pool.
+
+        Retract/abort disposal path. The scheduler has already freed the
+        request's req_to_token row and KV slots
+        (``release_kv_cache(..., is_insert=False)``), and the row can be
+        reused by a new prefill before the next forward runs — reading it
+        to sync the dirty decode tail would scatter KV through slots that
+        may already belong to another request (issue #33547). A pure
+        discard is therefore the only safe disposal.
+
+        Unlike :meth:`remove_request`, this never syncs. That is correct
+        only for retracted/aborted requests, whose slots are freed; the
+        finish path keeps using :meth:`remove_request`, where the
+        radix-held slots remain valid targets for the final flush.
+        """
+        self._req_token_ids.pop(req_id, None)
+        self._req_sampling.pop(req_id, None)
+        cache = self._req_caches.pop(req_id, None)
+        if cache is not None:
+            self._release_cache(cache)
+        self._req_pool_idx.pop(req_id, None)
+        self._req_synced_offset.pop(req_id, None)
+
     def remove_request(self, req_id: str):
         """Sync remaining decode KV to pool, then release request state."""
         if not self.disable_radix_cache:

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -174,6 +174,35 @@ class MlxTpModelWorker(TpModelWorker):
             # insert. Any older tracked slot is released during component cleanup.
             req.kv.mamba_last_track_seqlen = None
 
+    def prepare_for_retraction(self, req) -> None:
+        """Dispose of MLX runner state when the scheduler retracts a request.
+
+        Retraction (or the OOM-abort inside ``retract_decode``) frees the
+        request's req_to_token row and KV slots immediately — without the
+        finish path's pre-release hook — and requeues the request to restart
+        from scratch. The runner's private decode cache must be dropped at
+        that moment, for two reasons:
+
+        * ``flush_all_decode_kv`` on a later *extend* forward would otherwise
+          read the freed row for this rid. ``_cleanup_stale_rids`` only
+          disposes on *decode* forwards, so an extend forward in between is
+          unprotected; once the row is reused by a new prefill, the read
+          yields the new owner's slot ids and the retracted request's dirty
+          decode KV is scattered over the new owner's pool slots,
+          silently corrupting its output (issue #33547).
+        * A requeued request must re-route as a fresh ``"prefill"``
+          (``has_request`` is False), rebuilding from its cached prefix,
+          instead of extending the now-orphaned private cache against a
+          freed row.
+
+        This is a pure discard — no pool sync: the retracted request's KV
+        slots are already freed, so a sync would be exactly the poisoning
+        write described above. The finish path is unaffected and keeps its
+        own flush semantics via the stale-rid cleanup.
+        """
+        self._mlx_runner.discard_request(req.rid)
+        self._mlx_active_rids.discard(req.rid)
+
     def _route_extend_request(self, rid: str, decoding_rids: set[str]) -> str:
         """Classify a request within an extend / mixed batch.
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4015,6 +4015,19 @@ class Scheduler(
                 else None
             )
             retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode()
+            # Retraction frees each request's req_to_token row and KV slots
+            # without the finish path's pre-release hook. Notify the model
+            # worker so backend-private per-request state (e.g. the MLX
+            # runner's decode caches) is disposed before the freed row can be
+            # reused by a later prefill; otherwise a stale rid can sync its
+            # decode KV through the reused row on the next extend forward
+            # (issue #33547).
+            prepare_retraction = getattr(self.tp_worker, "prepare_for_retraction", None)
+            if callable(prepare_retraction):
+                for req in retracted_reqs:
+                    prepare_retraction(req)
+                for req in reqs_to_abort:
+                    prepare_retraction(req)
             new_available_tokens = self.token_to_kv_pool_allocator.available_size()
             new_token_gained = new_available_tokens - old_available_tokens
             mamba_num_gained = (

--- a/test/registered/unit/hardware_backend/mlx/test_retract_kv_row_reuse.py
+++ b/test/registered/unit/hardware_backend/mlx/test_retract_kv_row_reuse.py
@@ -1,0 +1,352 @@
+"""Retracted requests must not survive into the next extend flush.
+
+Regression guard for issue #33547: when the scheduler retracts a decoding
+request R under memory pressure, it frees R's ``req_to_token`` row and KV
+slots immediately (``release_kv_cache(..., is_insert=False)``) and requeues
+R. The MLX runner's private decode cache for R stays in ``_req_caches``
+until ``_cleanup_stale_rids`` disposes of it — but that cleanup only runs
+on *decode* forwards. If the next forward is an *extend* (e.g. a new
+prefill), ``flush_all_decode_kv`` iterates every rid in ``_req_caches``,
+including the retracted R, and ``_sync_decode_kv_to_pool(R)`` reads
+``req_to_token[R_row]`` — a row the scheduler may already have reused for
+a new request P. The read yields P's slot ids and R's dirty decode KV is
+scattered over P's pool slots, silently corrupting P's attention state.
+
+(Naively moving ``_cleanup_stale_rids`` to the extend path is not a fix:
+decode-mode rids legitimately absent from an extend batch would be
+evicted too, killing live requests.)
+
+The fix is a retract-time disposal hook: the scheduler notifies the model
+worker right after ``retract_decode()``, and the MLX worker discards the
+rid's runner state *without syncing* (the slots are freed; a sync would
+be exactly the poisoning write above). These tests cover:
+
+  * the end-to-end pollution scenario through the worker's extend path
+    (red before the fix: R's decode KV lands in reused-row slots);
+  * the hook's pure-discard semantics (no pool write, full state pop,
+    idempotent);
+  * requeue routing: a retracted request re-enters as a fresh prefill;
+  * the scheduler-side wiring of the hook.
+
+They drive a real ``MlxModelRunner`` state dict and a real small
+``MlxAttentionKVPool`` with only the model-loading surface mocked, so no
+model weights are needed. Apple-Silicon-only where ``mlx`` is imported.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_mlx_ci(est_time=10, suite="stage-a-unit-test-mlx")
+
+_IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "Apple-Silicon-only (drives the real MLX runner state dicts)"
+
+
+class TestSchedulerRetractWiring(CustomTestCase):
+    """The scheduler must notify the worker at retract time (no mlx needed)."""
+
+    def test_update_running_batch_notifies_worker_on_retract(self):
+        from sglang.srt.managers.scheduler import Scheduler
+        import inspect
+
+        src = inspect.getsource(Scheduler.update_running_batch)
+        self.assertIn(
+            "prepare_for_retraction",
+            src,
+            "Scheduler.update_running_batch lost its retract-time disposal "
+            "hook. Without it, backend-private per-request state (e.g. the "
+            "MLX runner's decode caches) survives retraction and can poison "
+            "a reused req_to_token row on the next extend flush "
+            "(issue #33547).",
+        )
+
+    def test_mlx_worker_exposes_prepare_for_retraction(self):
+        if not (_IS_APPLE_SILICON and _HAS_MLX):
+            self.skipTest(_SKIP_REASON)
+        from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+        self.assertTrue(
+            callable(getattr(MlxTpModelWorker, "prepare_for_retraction", None)),
+            "MlxTpModelWorker must expose prepare_for_retraction for the "
+            "scheduler's retract-time disposal hook.",
+        )
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestRetractKvRowReuse(CustomTestCase):
+    """The pollution scenario and the disposal-hook semantics."""
+
+    # Marker values make pool writes attributable: R's dirty decode KV is
+    # RETRACT_MARKER everywhere; valid pool data (P's radix prefix) is
+    # OWNER_MARKER. Anything else stays zero.
+    RETRACT_MARKER = 777.0
+    OWNER_MARKER = 111.0
+
+    @classmethod
+    def setUpClass(cls):
+        # The worker reads --mlx-enable-sampling off the device config bag,
+        # which fails closed before a publish; the retract paths are
+        # orthogonal to sampling.
+        from sglang.srt.runtime_context import get_context
+
+        cls._config = get_context().override_server_args(mlx_enable_sampling=False)
+        cls._config.install()
+        cls.addClassCleanup(cls._config.restore)
+
+    # ---------- fixtures ----------
+
+    @staticmethod
+    def _make_runner():
+        """Real MlxModelRunner state dicts + real pool; model surface mocked.
+
+        Only the weight-loading / forward surface is faked (prefill_start,
+        cache_state_arrays); every field the retract/flush paths touch
+        (_req_caches, _req_pool_idx, _req_synced_offset, the pool, the
+        req_to_token mirror) is the real implementation.
+        """
+        import mlx.core as mx
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+        from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_pool import (
+            MlxAttentionKVPool,
+        )
+
+        runner = object.__new__(MlxModelRunner)
+        runner.disable_radix_cache = False
+        runner._attention_kv_pool = MlxAttentionKVPool(
+            pool_size=16, num_layers=1, n_kv_heads=2, head_dim=4, dtype=mx.float32
+        )
+        # Scheduler-owned req_to_token mirror: 4 rows x 64 positions.
+        runner._req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.full((4, 64), -1, dtype=torch.int64)
+        )
+        runner._req_caches = {}
+        runner._req_pool_idx = {}
+        runner._req_synced_offset = {}
+        runner._req_token_ids = {}
+        runner._req_sampling = {}
+        runner._cache_pool = []
+        runner._cache_layout = SimpleNamespace(
+            full_attention_layer_indices=[0],
+            first_attention_layer_index=0,
+            has_auxiliary_state=False,
+        )
+
+        def _fake_prefill_start(**kwargs):
+            return SimpleNamespace(
+                lazy_token=mx.array([0], dtype=mx.int32),
+                cache=[TestRetractKvRowReuse._cache_layer(offset=0, value=0.0)],
+                req_id=kwargs["req_id"],
+                lazy_logprobs=None,
+            )
+
+        runner.prefill_start = _fake_prefill_start
+        runner.cache_state_arrays = lambda caches: []
+        return runner
+
+    @staticmethod
+    def _cache_layer(offset, value):
+        """One attention cache adapter entry: keys/values (1, H, S, D), offset."""
+        import mlx.core as mx
+
+        return SimpleNamespace(
+            keys=mx.full((1, 2, 16, 4), value, dtype=mx.float32),
+            values=mx.full((1, 2, 16, 4), value, dtype=mx.float32),
+            offset=offset,
+        )
+
+    def _seed_retracted_request(self, runner):
+        """R: prefill 2 tokens (slots 1,2) + 3 unsynced decode steps.
+
+        The scheduler wrote R's row 0 as [1,2,3,4,5]; R's synced prefix ends
+        at offset 2, so cache positions [2:5] hold committed-but-unsynced
+        decode KV (the RETRACT_MARKER payload).
+        """
+        runner._req_to_token_pool.req_to_token[0, 0:5] = torch.arange(
+            1, 6, dtype=torch.int64
+        )
+        runner._req_caches["R"] = [self._cache_layer(offset=5, value=self.RETRACT_MARKER)]
+        runner._req_pool_idx["R"] = 0
+        runner._req_synced_offset["R"] = 2
+        runner._req_token_ids["R"] = [1, 1, 2]
+        runner._req_sampling["R"] = None
+
+    def _reuse_row_for_new_prefill(self, runner):
+        """P: radix-hits a 2-token prefix (slots 1,2) + 3 fresh tokens.
+
+        P reuses row 0. The freed slots come back from the allocator's free
+        list, so row 0 ends up [1,2,3,4,5] again — the collision that makes
+        the stale read plausible instead of exotic. Slots 1,2 carry valid
+        pool KV (P's borrowed prefix); slots 3,4,5 are P's fresh slots.
+        """
+        runner._req_to_token_pool.req_to_token[0, 0:5] = torch.arange(
+            1, 6, dtype=torch.int64
+        )
+        import mlx.core as mx
+
+        fill = mx.full((2, 4), self.OWNER_MARKER, dtype=mx.float32)
+        runner._attention_kv_pool.set_kv(0, mx.array([1, 2], dtype=mx.int32), fill, fill)
+
+    def _assert_pool_free_of_retract_kv(self, runner):
+        """No buffer position may contain the retracted request's KV."""
+        import mlx.core as mx
+
+        pool = runner._attention_kv_pool
+        mx.eval(*pool.all_buffers())
+        for buf in pool.all_buffers():
+            flat = buf.reshape(-1)
+            self.assertNotIn(
+                self.RETRACT_MARKER,
+                flat.tolist(),
+                "Retracted request's decode KV reached the shared pool: "
+                "flush_all_decode_kv synced through a reused req_to_token "
+                "row (issue #33547).",
+            )
+
+    @staticmethod
+    def _worker(runner):
+        from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+        worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        worker._mlx_runner = runner
+        worker._mlx_active_rids = set()
+        worker._mlx_pool_initialized = True
+        return worker
+
+    @staticmethod
+    def _extend_batch_with_prefill():
+        """A minimal EXTEND batch whose single request routes to prefill."""
+
+        class _Req:
+            rid = "P"
+            prefix_indices = torch.tensor([1, 2], dtype=torch.long)
+            fill_ids = [9, 9, 7, 7, 7]
+
+            def get_fill_ids(self):
+                return self.fill_ids
+
+            kv = SimpleNamespace(req_pool_idx=0)
+            extend_range = None
+            full_untruncated_fill_ids = fill_ids
+
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            reqs=[_Req()],
+            extend_lens=[3],
+            decoding_reqs=None,
+            sampling_info=None,
+            return_logprob=False,
+            input_ids=torch.arange(3, dtype=torch.long),
+            out_cache_loc=torch.tensor([3, 4, 5], dtype=torch.long),
+        )
+        return batch
+
+    # ---------- THE REGRESSION ----------
+
+    def test_retracted_rid_does_not_flush_into_reused_row_on_extend(self):
+        """End-to-end: retract -> row reused -> extend forward -> pool clean.
+
+        Before the fix there is no retract-time disposal, so R survives in
+        _req_caches past the row reuse, and the extend forward's
+        flush_all_decode_kv syncs R through the reused row: R's decode KV
+        (RETRACT_MARKER) is scattered over slots 3,4,5 — which now belong
+        to the new prefill P.
+        """
+        runner = self._make_runner()
+        worker = self._worker(runner)
+        self._seed_retracted_request(runner)
+        worker._mlx_active_rids = {"R"}
+
+        # Scheduler retracts R (row + slots freed) and a new prefill reuses
+        # the row before the next forward runs.
+        self._reuse_row_for_new_prefill(runner)
+
+        # The retract-time disposal hook (present only after the fix).
+        hook = getattr(worker, "prepare_for_retraction", None)
+        if callable(hook):
+            hook(SimpleNamespace(rid="R"))
+
+        # Next forward is an extend (P's prefill), the previously
+        # unprotected mode for stale rids.
+        worker.async_forward_batch_generation_mlx(self._extend_batch_with_prefill())
+
+        self._assert_pool_free_of_retract_kv(runner)
+
+    # ---------- hook semantics ----------
+
+    def test_prepare_for_retraction_discards_state_without_sync(self):
+        """The hook is a pure discard: full state pop, zero pool writes."""
+        runner = self._make_runner()
+        worker = self._worker(runner)
+        self._seed_retracted_request(runner)
+        worker._mlx_active_rids = {"R"}
+
+        worker.prepare_for_retraction(SimpleNamespace(rid="R"))
+
+        self.assertFalse(runner.has_request("R"))
+        self.assertNotIn("R", runner._req_pool_idx)
+        self.assertNotIn("R", runner._req_synced_offset)
+        self.assertNotIn("R", runner._req_token_ids)
+        self.assertNotIn("R", runner._req_sampling)
+        # The cache list was recycled, not leaked.
+        self.assertEqual(len(runner._cache_pool), 1)
+        # Nothing was synced: the dirty decode tail must not reach the pool.
+        self._assert_pool_free_of_retract_kv(runner)
+        # Idempotent: retract bookkeeping may race with stale-rid cleanup.
+        worker.prepare_for_retraction(SimpleNamespace(rid="R"))
+
+    def test_discard_request_is_pure_discard(self):
+        """Runner-level contract for the disposal primitive (no sync)."""
+        runner = self._make_runner()
+        self._seed_retracted_request(runner)
+
+        runner.discard_request("R")
+
+        self.assertFalse(runner.has_request("R"))
+        self.assertNotIn("R", runner._req_pool_idx)
+        self._assert_pool_free_of_retract_kv(runner)
+        # Idempotent.
+        runner.discard_request("R")
+
+    def test_retracted_request_requeues_as_fresh_prefill(self):
+        """After disposal, the requeued request must route to prefill.
+
+        Without the hook the stale has_request() would route it as a
+        continuation and extend the orphaned private cache against a
+        freed (and possibly reused) req_to_token row.
+        """
+        worker = self._worker(self._make_runner())
+        worker._mlx_runner._req_caches["R"] = [self._cache_layer(5, 0.0)]
+        self.assertEqual(worker._route_extend_request("R", set()), "continuation")
+
+        worker.prepare_for_retraction(SimpleNamespace(rid="R"))
+
+        self.assertEqual(worker._route_extend_request("R", set()), "prefill")
+
+    def test_prepare_for_retraction_drops_active_rid_membership(self):
+        """Disposal also clears _mlx_active_rids so the later decode-mode
+        stale-rid cleanup never re-processes the rid through the syncing
+        remove_request path."""
+        runner = self._make_runner()
+        worker = self._worker(runner)
+        self._seed_retracted_request(runner)
+        worker._mlx_active_rids = {"R", "Q"}
+
+        worker.prepare_for_retraction(SimpleNamespace(rid="R"))
+
+        self.assertEqual(worker._mlx_active_rids, {"Q"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #33547. On the MLX backend, a retracted request's committed-but-unsynced decode KV can be flushed into a **reused `req_to_token` row**, silently corrupting a live request's pool slots:

1. Request R decodes and has committed-but-unsynced positions (pool sync is lazy).
2. R is retracted under memory pressure; the scheduler frees its `req_to_token` row immediately (`update_running_batch` â `retract_decode()` â `release_req` â `release_kv_cache`). R stays in the MLX runner's `_req_caches`, because `_cleanup_stale_rids` only runs on a decode forward (`is_decode()` gate, `tp_worker.py`).
3. If an extend forward runs first, `flush_all_decode_kv` walks every rid in `_req_caches` including R. `_sync_decode_kv_to_pool(R)` reads the freed-and-reused row, gets the new owner's slot ids, and scatters R's decode KV into the live request's slots.

The repro test included here demonstrates the corruption directly: a marker tensor (777.0) queued as R's dirty decode KV ends up in the new owner P's pool slots 3/4/5 on the extend flush, before the fix.

## Modifications

Retract-time disposal hook (the option the issue sketches as the safe fix), rather than touching the flush path â that path is being reworked by #30578, and a row-ownership guard inside the flush would collide with it:

- `scheduler.py` â after `retract_decode()` returns, notify the worker via an optional `prepare_for_retraction` hook (probed with `getattr`; non-MLX workers are unaffected). `update_running_batch` is the only non-disaggregation retract entry point (`retract_all` is PD-disagg only).
- `mlx/tp_worker.py` â `prepare_for_retraction(req)` drops the rid via `discard_request` and removes it from `_mlx_active_rids`. A retracted-and-requeued request is correctly re-routed as a fresh prefill on its next arrival.
- `mlx/model_runner.py` â new `discard_request(rid)`: pure, idempotent disposal with **no sync** (the finish path keeps its existing semantics: `remove_request` still syncs, `prepare_for_kv_cache_release` still flushes). This distinction matters because on retract the slots are already freed â syncing would itself be the polluting write.

The naive alternative (running `_cleanup_stale_rids` on extends) is deliberately avoided: a decode-mode rid can legitimately be absent from an extend batch, so it would evict live requests.

## Accuracy Tests

No model-output change in normal operation; the change only removes stale-state flushes that were writing into the wrong request's slots. Covered by a 7-case regression suite (`test_retract_kv_row_reuse.py`, model-free, real `MlxModelRunner` state + real small `MlxAttentionKVPool` with only the model-load/forward surface mocked):

1. **Main repro** â retracted rid's decode KV no longer lands in the reused row's new owner slots (red â green).
2. Disposal performs no pool sync (pure discard).
3. Idempotent disposal.
4. Requeued request re-routes as prefill (not continuation).
5. `_mlx_active_rids` consistency after retract.
6. Scheduler wiring guard (hook is optional; absent on non-MLX workers).
7. `discard_request` unit contract.

## Speed Tests and Profiling

Not applicable â retract-path-only bookkeeping (O(retracted rids) dict removals).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidelines](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Validation

- New suite: 7 failed on unmodified main â 7 passed with this change.
- No regressions: MLX unit directory (`test_tp_worker_routing`, `test_mlx_runner_pool_contract`, `test_runtime`, `test_scheduler_mixin`, `test_runner_init_contract`, `test_attention_patching`, `test_windowed_kv_cache`, `test_sliding_window_attention`, `test_swa_radix_pool`) 113 passed + 1 skipped; `test/registered/unit/managers/` full 637 passed (3 unrelated pre-existing failures verified identical on a clean baseline).

## Relationship to #30578

This change is a semantic subset of the retract-hook part of #30578 (which additionally implements generation-based ownership guards and reworks the extend-branch flush). It can land independently and first; the textual overlap in `scheduler.py`/`tp_worker.py` resolves trivially on rebase (same hook, same insertion point), and `discard_request` can merge with that PR's pure-discard `remove_request` variant when both are in.

Note: as an outside contributor I can't add the `run-ci` label â would a maintainer tag it so the MLX matrix runs? (@jlee5814 since you surfaced and analyzed the mechanism â corrections welcome.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34010477204](https://github.com/sgl-project/sglang/actions/runs/34010477204)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34010477116](https://github.com/sgl-project/sglang/actions/runs/34010477116)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34010477294](https://github.com/sgl-project/sglang/actions/runs/34010477294)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->