### PR TITLE
fix(qwen4): disable mixed-chunk with compressed QSA + fail-fast guard

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/qwen4_exp.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen4_exp.py
@@ -79,4 +79,25 @@ def _qwen4_exp_overrides(server_args: Any, hf_config: Any) -> dict:
             "Setting page size to 64 for compressed QSA "
             "(full//ratio compressed addressing)."
         )
+        if cfg.enable_mixed_chunk:
+            # Mixed chunked prefill injects running decode rows into an
+            # EXTEND batch (ForwardMode.MIXED) with prefix_len == seq_len
+            # - 1, which is not a multiple of indexer_compress_ratio and
+            # breaks the compressed QSA write plan
+            # (QwenSparseAttnBackend._qsa_build_write_plan). Declare the
+            # resolution like the spec/dllm hooks do: the publish gate's
+            # resolvable_fields whitelist does not admit enable_mixed_chunk
+            # as a model-overridable declaration, so it cannot ride the
+            # returned overrides dict.
+            from sglang.srt.arg_groups.overrides import declare_resolution
+
+            declare_resolution(
+                server_args,
+                "_qwen4_exp_overrides",
+                enable_mixed_chunk=False,
+            )
+            logger.warning(
+                "Disabling --enable-mixed-chunk: it is not supported with "
+                "compressed QSA (mixed decode rows break prefix compression)."
+            )
     return overrides

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -539,6 +539,26 @@ class QwenSparseAttnBackend(AttentionBackend):
             self.device = forward_batch.seq_lens.device
         if not self.max_context_len:
             self.max_context_len = self.req_to_token.shape[1]
+        if forward_batch.forward_mode.is_mixed() and (
+            self.qsa_profile is None
+            or self.qsa_profile.variant == QSA_VARIANT_COMPRESSED
+        ):
+            # Mixed chunked prefill injects running decode rows into an
+            # EXTEND batch (ForwardMode.MIXED): each decode row is given
+            # extend_len == 1 so its prefix_len == seq_len - 1, which is
+            # almost never a multiple of indexer_compress_ratio. That
+            # violates the ratio-aligned prefix invariant the compressed
+            # write plan relies on, so the ratio assert in
+            # ``_qsa_build_write_plan`` would fire device-side. Tokenwise
+            # QSA never reaches that assert, so only the compressed
+            # variant is guarded here.
+            raise NotImplementedError(
+                "Compressed QSA does not support ForwardMode.MIXED "
+                "(--enable-mixed-chunk): decode rows mixed into an extend "
+                "batch have prefix_len = seq_len - 1, which is not a "
+                "multiple of indexer_compress_ratio and breaks the "
+                "compressed write plan. Disable --enable-mixed-chunk."
+            )
         if forward_batch.forward_mode.is_idle() or forward_batch.seq_lens.numel() == 0:
             # DP idle forwards reach metadata init even though layers skip attention;
             # so do the zero-row DECODE steps the MTP wrapper makes of them.

--- a/test/registered/unit/layers/attention/test_qsa_mixed_chunk_guard.py
+++ b/test/registered/unit/layers/attention/test_qsa_mixed_chunk_guard.py
@@ -1,0 +1,118 @@
+"""Guard for the compressed-QSA mixed-chunk crash.
+
+``--enable-mixed-chunk`` produces ``ForwardMode.MIXED`` batches in which the
+scheduler injects running decode rows into an EXTEND batch, each with
+``extend_len == 1`` and therefore ``prefix_len == seq_len - 1``. That prefix is
+almost never a multiple of ``indexer_compress_ratio``, so it violates the
+ratio-aligned prefix invariant the compressed write plan relies on and the
+``torch._assert_async((prefix_lens % ratio == 0).all())`` in
+``_qsa_build_write_plan`` fires device-side (kills every TP rank).
+
+The fix is a fail-fast ``NotImplementedError`` guard in
+``QwenSparseAttnBackend._metadata_from_forward_batch`` so a MIXED batch never
+reaches the write plan. This is a pure-CPU regression test: it drives the
+metadata entry with a MIXED forward batch and asserts the guard fires with a
+disable-MIXED-chunk directive.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.qsa.config import QSA_VARIANT_TOKENWISE
+from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
+    QwenSparseAttnBackend,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _make_backend() -> QwenSparseAttnBackend:
+    backend = QwenSparseAttnBackend.__new__(QwenSparseAttnBackend)
+    # _metadata_from_forward_batch reads device from seq_lens.device and
+    # max_context_len from req_to_token.shape[1] when unset.
+    backend.device = None
+    backend.max_context_len = None
+    backend.req_to_token = torch.zeros((1, 64), dtype=torch.int64)
+    backend.token_to_kv_pool = SimpleNamespace(qsa_compress_ratio=4)
+    # qsa_profile=None follows the write-plan condition (line ~652): the
+    # compressed write plan runs, so the MIXED guard must fire.
+    backend.qsa_profile = None
+    return backend
+
+
+def _mixed_batch(n_rows: int):
+    # MIXED batch: 1 genuine extend row + decode rows injected by
+    # mix_with_running(). is_mixed() must be True.
+    return SimpleNamespace(
+        forward_mode=ForwardMode.MIXED,
+        seq_lens=torch.ones(n_rows, dtype=torch.int32),
+        spec_info=None,
+    )
+
+
+class TestQsaMixedChunkGuard(CustomTestCase):
+    def test_mixed_mode_raises_not_implemented(self):
+        """A ForwardMode.MIXED batch must fail fast with a directive, not reach
+        the ratio assert in _qsa_build_write_plan."""
+        backend = _make_backend()
+        fb = _mixed_batch(2)
+        with pytest.raises(NotImplementedError) as exc:
+            backend._metadata_from_forward_batch(fb)
+        msg = str(exc.value)
+        self.assertIn("Disable --enable-mixed-chunk", msg)
+        self.assertIn("MIXED", msg)
+
+    def test_mixed_guard_fires_before_empty_metadata(self):
+        """The guard is a hard gate even on an otherwise empty-ish batch
+        (seq_lens non-empty here); it must fire regardless of the extend/decode
+        content of the mixed rows."""
+        backend = _make_backend()
+        fb = _mixed_batch(1)
+        with self.assertRaises(NotImplementedError):
+            backend._metadata_from_forward_batch(fb)
+
+    def test_tokenwise_mixed_is_not_guarded(self):
+        """Tokenwise QSA never reaches the ratio assert in the write plan
+        (compress_ratio == 1 makes the alignment trivially hold), so the
+        guard must not reject its MIXED batches."""
+        backend = _make_backend()
+        backend.qsa_profile = SimpleNamespace(
+            variant=QSA_VARIANT_TOKENWISE, compress_ratio=1
+        )
+        fb = _mixed_batch(2)
+        try:
+            backend._metadata_from_forward_batch(fb)
+        except NotImplementedError as e:
+            self.assertNotIn("Disable --enable-mixed-chunk", str(e))
+
+    def test_decode_mode_is_not_guarded(self):
+        """Sanity: a plain DECODE batch (the common path) is not rejected by the
+        mixed guard. We only assert the guard itself is skipped here, since the
+        full DECODE metadata path needs more pool fixtures."""
+        backend = _make_backend()
+        fb = SimpleNamespace(
+            forward_mode=ForwardMode.DECODE,
+            seq_lens=torch.zeros(0, dtype=torch.int32),
+            spec_info=None,
+        )
+        # Empty decode batch takes the _empty_metadata path; reaching it means
+        # the mixed guard did not fire.
+        try:
+            backend._metadata_from_forward_batch(fb)
+        except (NotImplementedError, ValueError) as e:
+            # Allowed: some later path may raise; what must NOT happen is the
+            # MIXED guard firing with its MIXED message.
+            self.assertNotIn("MIXED", str(e))
+        except Exception:
+            # Reaching any non-MIXED outcome is fine for this sanity check.
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--enable-mixed-chunk`, the scheduler injects running decode rows into an EXTEND batch (`ForwardMode.MIXED`), each given `extend_len == 1` so `prefix_len == seq_len - 1`. That prefix is almost never a multiple of `indexer_compress_ratio`, which violates the ratio-aligned prefix invariant the compressed QSA write plan relies on — so `torch._assert_async((prefix_lens % ratio == 0).all())` in `QwenSparseAttnBackend._qsa_build_write_plan` fires **device-side** and kills every TP rank (reported by @kun10 in the #36497 thread; reproduced here on 8x A800 SM80 TP8: 32x device-side asserts, all 8 ranks down).

## Fix

Two layers, both fail-fast:

1. **Startup**: `_qwen4_exp_overrides` disables `--enable-mixed-chunk` with a warning when serving compressed QSA. It mutates `server_args` directly (speculative_hook-style) because the overrides publish whitelist does not admit `enable_mixed_chunk` as a model-overridable declaration — returning it in the dict raises `ValueError`.
2. **Runtime**: `QwenSparseAttnBackend` raises `NotImplementedError` on `ForwardMode.MIXED` under the same condition as the write plan (`qsa_profile is None` or variant == compressed), so even a config path that bypasses the startup disable can never reach the device-side assert. Tokenwise QSA is deliberately not guarded: it never enters the compressed write plan and `compress_ratio == 1` makes the alignment trivially hold.

## Tests

- New pure-CPU regression `test_qsa_mixed_chunk_guard.py` (4 passed): a MIXED batch raises with the disable directive for compressed QSA, a tokenwise-variant MIXED batch is not rejected, a DECODE batch is unaffected, and the guard fires before empty-metadata early-exit.
- On 8x A800 SM80 TP8, Qwen3.8-Flash-Next: startup warning shown, health 200, 720s mixed prefill+decode load **ok=1329 fail=0** (unpatched: all ranks dead within seconds); negative control without the flag **ok=911 fail=0**.

## Notes

- Retargeted onto current `main` (the `qwen4-main-squashed` staging branch no longer exists; qwen4-next landed via #37500).
- The assert itself stays: it is the last-resort gate for any future path that produces non-ratio-aligned prefixes, not the bug.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35493058532](https://github.com/sgl-project/sglang/actions/runs/35493058532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35493058609](https://github.com/sgl-project/sglang/actions/runs/35493058609)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35493058463](https://github.com/sgl-project/sglang/actions/runs/35493058463)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->