### PR TITLE
fix(npu-graph): allow text-only decode with encoder_lens=0

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -535,14 +535,21 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
-        # NOTE: cuda graph cannot handle mixed batch (encoder_len = 0)
-        # If mixed batch cannot be supported, then encoder_lens can be removed in cuda graph
-        # because the full_text_row_masked_out_mask tensor will always be ones
-        is_encoder_lens_supported = (
-            torch.all(forward_batch.encoder_lens > 0)
-            if self.is_encoder_decoder
-            else True
-        )
+        # NOTE: cuda graph cannot handle mixed batch where some requests
+        # have encoder (encoder_lens > 0) and some do not (encoder_lens = 0),
+        # because the cross-attention path differs.  However, a batch where
+        # ALL requests are text-only (encoder_lens all 0) is safe: the graph
+        # was captured with cross-attention included, and at replay time the
+        # full_text_row_masked_out_mask zeros the cross-attention output,
+        # making it equivalent to skipping.  Allow graph replay when encoder
+        # lengths are uniformly zero or uniformly positive, but not mixed.
+        if self.is_encoder_decoder:
+            encoder_lens = forward_batch.encoder_lens
+            is_encoder_lens_supported = bool(
+                (encoder_lens == 0).all() or (encoder_lens > 0).all()
+            )
+        else:
+            is_encoder_lens_supported = True
 
         requested_capture_hidden_mode = max(
             forward_batch.capture_hidden_mode,


### PR DESCRIPTION
## Problem

The `can_run()` check in `DecodeCudaGraphRunner` blocked NPU graph replay for text-only requests on encoder-decoder models (e.g. `MossVLForConditionalGeneration`, `MllamaForConditionalGeneration`, `WhisperForConditionalGeneration`) because `encoder_lens=0` failed the `torch.all(encoder_lens > 0)` guard.

This forced every text-only decode step through the eager path, costing ~40% throughput on Ascend NPU (measured 28.4 → 46.3 tok/s on MOSS-VL-Instruct-0708, 910B2C).

## Root Cause

`is_encoder_decoder_model()` includes models like MossVL, Mllama, and Whisper. For these models, `is_encoder_decoder=True` triggers the `encoder_lens > 0` check. Text-only requests have `encoder_lens=0` (no vision input), so `torch.all([0] > 0)` = `False` → `can_run()` returns `False` → graph never replayed.

## Fix

A batch where ALL requests are text-only (`encoder_lens` uniformly 0) is safe for graph replay:
- The graph was captured with cross-attention included (capture mode sets `skip_cross_attention=False`)
- At replay time, `full_text_row_masked_out_mask` zeros the cross-attention output, making it equivalent to skipping

The fix allows graph replay when `encoder_lens` are **uniformly zero OR uniformly positive**, but still rejects **mixed batches** (some 0, some >0) which would require different cross-attention behavior within the same captured graph.

```python
if self.is_encoder_decoder:
    encoder_lens = forward_batch.encoder_lens
    is_encoder_lens_supported = bool(
        (encoder_lens == 0).all() or (encoder_lens > 0).all()
    )
else:
    is_encoder_lens_supported = True
```

## Benchmark (Ascend 910B2C, MOSS-VL-Instruct-0708, bf16, single card)

| Config | Decode throughput |
|---|---|
| `--disable-cuda-graph` (baseline) | 28.4 tok/s |
| NPU graph + old check (`> 0`) | 28.4 tok/s (graph captured but never replayed) |
| **NPU graph + this fix** | **46.3 tok/s (+63%)** |

## Testing

- ✅ Text-only greedy 300 tokens: correct output, no repetition/early-EOS
- ✅ Text-only sampling 300 tokens: correct output
- ✅ Multimodal (single image): correct output
- ✅ NPU graph capture: bs [1,2,4,8,16,32] captured in 1.95s, 1.68GB
- ✅ NPU graph replay: confirmed via `npu graph: True` in decode logs

## Compatibility

- Non-encoder-decoder models: unaffected (`is_encoder_decoder=False` → always `True`)
- GPU/CUDA: unaffected (same code path, same fix applies if encoder-decoder model has text-only requests)
- Mixed batch (text + vision): still rejected (safe)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34011497389](https://github.com/sgl-project/sglang/actions/runs/34011497389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34011497512](https://github.com/sgl-project/sglang/actions/runs/34011497512)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->