### PR TITLE
[AMD][Spec] Enable GDN ReplaySSM target-verify on ROCm

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
+++ b/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
@@ -43,6 +43,13 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.kernels.ops.attention.fla.utils import is_tf32_supported
+from sglang.srt.utils import is_gfx95_supported
+
+# Triton only accepts TF32 input precision on Ampere-or-newer NVIDIA GPUs.
+_DEFAULT_DOT_PRECISION = "tf32" if is_tf32_supported else "ieee"
+_IS_GFX95 = is_gfx95_supported()
+
 
 @triton.jit
 def gdn_replayssm_spec_circular_kernel(
@@ -1259,9 +1266,9 @@ def gdn_replayssm_spec_decode(
     scale: float | None = None,
     use_qk_l2norm_in_kernel: bool = True,
     null_block_id: int = 0,
-    block_v: int = 64,
+    block_v: int | None = None,
     num_warps: int = 1,
-    num_stages: int = 2,
+    num_stages: int | None = None,
     nk: int = 2,
     bs_min: int = 4,
     block_v_flush: int = 64,
@@ -1269,7 +1276,7 @@ def gdn_replayssm_spec_decode(
     num_stages_flush: int = 2,
     nk_flush: int = 2,
     launch_mode: str = "both",
-    dot_precision: str = "tf32",
+    dot_precision: str = _DEFAULT_DOT_PRECISION,
 ):
     """GDN cached speculative-decode on a CIRCULAR ring cache (split-qkv varlen).
 
@@ -1286,6 +1293,26 @@ def gdn_replayssm_spec_decode(
     """
     if scale is None:
         scale = checkpoint_state.shape[-1] ** -0.5
+    batch_size = query_start_loc.shape[0] - 1
+    # At the Qwen3.5 MTP shape, one wide V tile avoids duplicating q/k and gate
+    # work across two programs on gfx950. Keep explicit tuning authoritative.
+    use_gfx95_wide_v = (
+        block_v is None
+        and num_stages is None
+        and (
+            _IS_GFX95
+            and batch_size >= 32
+            and max_cache_len == 16
+            and max_spec_len == 4
+            and q.shape[-1] == 128
+            and v.shape[-1] == 128
+        )
+    )
+    if use_gfx95_wide_v:
+        block_v, num_stages = 128, 1
+    else:
+        block_v = 64 if block_v is None else block_v
+        num_stages = 2 if num_stages is None else num_stages
     if is_flush.dtype != torch.int8:
         is_flush = is_flush.to(torch.int8)
 

--- a/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
+++ b/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
@@ -46,8 +46,6 @@ import triton.language as tl
 from sglang.kernels.ops.attention.fla.utils import is_tf32_supported
 from sglang.srt.utils import is_gfx95_supported
 
-# Triton only accepts TF32 input precision on Ampere-or-newer NVIDIA GPUs.
-_DEFAULT_DOT_PRECISION = "tf32" if is_tf32_supported else "ieee"
 _IS_GFX95 = is_gfx95_supported()
 
 
@@ -1276,7 +1274,8 @@ def gdn_replayssm_spec_decode(
     num_stages_flush: int = 2,
     nk_flush: int = 2,
     launch_mode: str = "both",
-    dot_precision: str = _DEFAULT_DOT_PRECISION,
+    # Triton only accepts TF32 input precision on Ampere-or-newer NVIDIA GPUs.
+    dot_precision: str = "tf32" if is_tf32_supported else "ieee",
 ):
     """GDN cached speculative-decode on a CIRCULAR ring cache (split-qkv varlen).
 

--- a/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
+++ b/python/sglang/kernels/ops/attention/fla/gdn_replayssm_spec_decode.py
@@ -1266,9 +1266,9 @@ def gdn_replayssm_spec_decode(
     scale: float | None = None,
     use_qk_l2norm_in_kernel: bool = True,
     null_block_id: int = 0,
-    block_v: int | None = None,
+    block_v: int = 64,
     num_warps: int = 1,
-    num_stages: int | None = None,
+    num_stages: int = 2,
     nk: int = 2,
     bs_min: int = 4,
     block_v_flush: int = 64,
@@ -1295,24 +1295,16 @@ def gdn_replayssm_spec_decode(
         scale = checkpoint_state.shape[-1] ** -0.5
     batch_size = query_start_loc.shape[0] - 1
     # At the Qwen3.5 MTP shape, one wide V tile avoids duplicating q/k and gate
-    # work across two programs on gfx950. Keep explicit tuning authoritative.
-    use_gfx95_wide_v = (
-        block_v is None
-        and num_stages is None
-        and (
-            _IS_GFX95
-            and batch_size >= 32
-            and max_cache_len == 16
-            and max_spec_len == 4
-            and q.shape[-1] == 128
-            and v.shape[-1] == 128
-        )
-    )
-    if use_gfx95_wide_v:
+    # work across two programs on gfx950.
+    if (
+        _IS_GFX95
+        and batch_size >= 32
+        and max_cache_len == 16
+        and max_spec_len == 4
+        and q.shape[-1] == 128
+        and v.shape[-1] == 128
+    ):
         block_v, num_stages = 128, 1
-    else:
-        block_v = 64 if block_v is None else block_v
-        num_stages = 2 if num_stages is None else num_stages
     if is_flush.dtype != torch.int8:
         is_flush = is_flush.to(torch.int8)
 


### PR DESCRIPTION
## Motivation

[#35544](https://github.com/sgl-project/sglang/pull/35544) added ReplaySSM speculative verify for GDN: reconstruct the draft window from a frozen checkpoint plus a circular `(d, k, g)` ring, instead of materializing full SSM state on every target step.

The merged kernel hard-codes Triton's `tl.dot(..., input_precision="tf32")`. Triton only accepts TF32 on Ampere-or-newer NVIDIA GPUs. On AMD the kernel fails at compile/launch, so `--enable-linear-replayssm-spec` cannot start on MI355X. Other FLA kernels already fall back with `is_tf32_supported` (`chunk_fwd.py`, `chunk_intra.py`); ReplaySSM did not.

Once IEEE precision is used, the default verify tile is still `block_v=64` with `num_stages=2`. Qwen3.5 GDN has `V=128`, so that tile launches two programs along V and repeats the same q/k and gate work. On gfx950, one `block_v=128` program with `num_stages=1` covers the full V dimension in a single pass.

## Modifications

- Default `dot_precision` to `"tf32"` only when `is_tf32_supported` is true; otherwise `"ieee"`. NVIDIA Ampere+ is unchanged.
- Signature defaults stay `block_v=64` and `num_stages=2`. On gfx950, for the Qwen3.5 MTP verify shape (batch ≥ 32, ring length 16, spec length 4, `K=V=128`), the function overwrites those to `block_v=128` and `num_stages=1`, even if the caller passed `64` / `2`. Serving does not pass them. Below batch 32 the signature defaults remain. The flush launch still uses `block_v_flush=64`.
- No new user-facing option.

## Correctness Tests

Compared the previous tile (`block_v=64`, `num_stages=2`) with the gfx950 tile (`block_v=128`, `num_stages=1`) on the same IEEE `tl.dot` operands and the Qwen3.5 TP2 verify shape:

- Batch size: 32
- Query heads: 8
- Value heads: 32
- Draft tokens: 4
- Ring length: 16
- Head dimension: 128
- Activations: BF16
- Checkpoint: FP32

Outputs and ring writes (`d`, `k`, `g`) matched bit-exactly. The flush / exact-fold kernels are unchanged. This comparison is tiling-only; AMD cannot run the TF32 path.

GSM8K (`sglang.test.run_eval`, 5-shot, 1314 questions, temperature 0, max new tokens 2048, TP2, real EAGLE decoding, aiter backend, page 16, fp8 KV). ReplaySSM off vs `--enable-linear-replayssm-spec` (enablement, not tile vs tile):

| | Accuracy | Invalid |
|---|---:|---:|
| baseline | 0.933 | 19/1314 (0.014) |
| this PR | 0.944 | 5/1314 (0.004) |

## Performance

### Kernel benchmark

#### Environment

- Hardware: MI355X (`gfx950`)
- Image: `rocm/sgl-dev:v0.5.18-rocm10-mi35x-20260901`
- Shape: Qwen3.5 TP2-local, 8 query heads / 32 value heads, `K=V=128`
- Draft tokens: 4
- Ring length: 16
- Batch: 32
- Triton `input_precision`: IEEE (AMD)
- Checkpoint: FP32
- Timing: Triton `do_bench`, warmup 100, repeat 500, median of 7 samples

| Tile | Latency | Speedup |
|---|---:|---:|
| `block_v=64`, `num_stages=2` (previous default) | 43.13 µs | 1.00x |
| `block_v=128`, `num_stages=1` (this PR) | **29.33 µs** | **1.47x (−32%)** |

The wide V tile removes the second V program, so q/k and gate work run once instead of twice.

### End-to-end serving benchmark

#### Environment

- Hardware: one MI355X host; TP2
- Image: `rocm/sgl-dev:v0.5.18-rocm10-mi35x-20260902`
- Model: Qwen3.5-397B-A17B-MXFP4
- Methodology: [InferenceX fixed-sequence recipe](https://github.com/SemiAnalysisAI/InferenceX/blob/9acf24caaf31d9ecc5067742d6d1415967b308ed/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh)
- Attention backend: AITER unified attention
- Linear attention backend: Triton
- SSM state: BF16 in both arms, pinned with `--mamba-ssm-dtype bfloat16`
- KV cache: FP8 E4M3
- Speculative decoding: EAGLE, three steps, top-k=1, four draft tokens
- Page size: 16
- Radix cache disabled
- Workload: random ISL/OSL 8192/1024, range ratio 1.0, with chat template
- Per concurrency: `10 × concurrency` measured requests and `2 × concurrency` warmup requests

| Concurrency | Baseline output tok/s | ReplaySSM output tok/s | Δ Output throughput | Baseline mean TPOT (ms) | ReplaySSM mean TPOT (ms) | Δ TPOT |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 555.96 | **564.32** | **+1.50%** | 5.470 | **5.402** | **−1.23%** |
| 8 | 851.66 | **869.30** | **+2.07%** | 7.653 | **7.418** | **−3.07%** |
| 16 | 1,203.23 | **1,223.88** | **+1.72%** | 11.562 | **11.354** | **−1.80%** |
| 32 | 1,549.50 | **1,583.07** | **+2.17%** | 18.619 | **18.146** | **−2.54%** |
| 64 | 1,920.71 | **1,976.99** | **+2.93%** | 31.606 | **30.614** | **−3.14%** |
| 128 | 2,304.63 | **2,335.46** | **+1.34%** | 52.690 | **52.073** | **−1.17%** |
| 256 | 2,586.56 | **2,633.69** | **+1.82%** | 94.100 | **92.439** | **−1.76%** |

Baseline is the same configuration with ReplaySSM disabled. The candidate adds only `--enable-linear-replayssm-spec`. With BF16 SSM state, ReplaySSM improves output throughput at every tested concurrency by **1.34%–2.93%** and reduces mean TPOT by **1.17%–3.14%**.

### Tiling-only ablation

This is a different probe from the InferenceX table above: original FP32 SSM serving, 32-way greedy batch of 256 tokens. ReplaySSM with IEEE and the old tile versus this PR's gfx950 tile (precision already fixed in both ReplaySSM arms):

| Arm | Mean batch latency (s) | vs no ReplaySSM | vs IEEE ReplaySSM |
|---|---:|---:|---:|
| Upstream default MTP (ReplaySSM off) | 2.894 | — | — |
| ReplaySSM, IEEE, `block_v=64` | 2.688 | −7.1% | — |
| ReplaySSM, IEEE, `block_v=128` (this PR) | **2.627** | **−9.2%** | **−2.3%** |

Enabling ReplaySSM is the larger serving win. The gfx950 tile is the extra ~2.3% on top of the precision fix, and only at batch ≥ 32.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Bit-exact kernel comparison of the gfx950 tile against the previous tile.
- [x] GSM8K A/B on Qwen3.5-397B-A17B-MXFP4 TP2 with real EAGLE.
- [x] Provide kernel and end-to-end performance measurements.
- [x] Apply IEEE on every non-TF32 device; gate the wide V tile to the tested gfx950 Qwen3.5 MTP shape.
- [x] Keep NVIDIA TF32 and the previous `block_v=64` / `num_stages=2` defaults; override the tile only on the tested gfx950 Qwen3.5 MTP shape.
- [x] Add no new user-facing option.

## Review and Merge Process

1. Obtain CODEOWNER and merge-oncall review.
2. Run the required Base and AMD CI jobs.
3. Investigate any real test failures before merging.
4. Merge after required approvals and green CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34452857031](https://github.com/sgl-project/sglang/actions/runs/34452857031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34452856885](https://github.com/sgl-project/sglang/actions/runs/34452856885)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34452857120](https://github.com/sgl-project/sglang/actions/runs/34452857120)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->