### PR TITLE
fix(grpc): propagate cancellation and accept IPv6 bind addresses

### DIFF
--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -39,6 +39,7 @@ type BridgeStateRef = Arc<Mutex<BridgeState>>;
 #[derive(Default)]
 struct BridgeState {
     channels: HashMap<String, Sender<ResponseChunk>>,
+    openai_channels: HashSet<String>,
     pending_sends: HashSet<String>,
     ready_callbacks: HashMap<String, Py<PyAny>>,
     ready_signals: HashSet<String>,
@@ -169,6 +170,13 @@ impl PyBridge {
         Ok(py_callback.into_any())
     }
 
+    fn mark_openai_channel(&self, rid: &str) {
+        let mut state = lock_or_recover(self.state.as_ref(), "state");
+        if state.channels.contains_key(rid) {
+            state.openai_channels.insert(rid.to_string());
+        }
+    }
+
     // ------------------------------------------------------------------
     // Consolidated request submission (generate / embed / classify)
     // ------------------------------------------------------------------
@@ -231,6 +239,7 @@ impl PyBridge {
             state.pending_sends.clear();
             state.ready_callbacks.clear();
             state.ready_signals.clear();
+            state.openai_channels.clear();
             for channel_rid in rids {
                 state.terminal_errors.insert(
                     channel_rid.clone(),
@@ -241,6 +250,7 @@ impl PyBridge {
             true
         } else {
             let mut state = lock_or_recover(self.state.as_ref(), "state");
+            let is_openai = state.openai_channels.contains(rid);
             let was_active = remove_channel_refs_locked(&mut state, rid);
             if was_active {
                 state
@@ -249,7 +259,7 @@ impl PyBridge {
             } else {
                 tracing::debug!(rid, "Ignoring abort for inactive gRPC request id");
             }
-            was_active
+            was_active && !is_openai
         };
 
         if !should_call_python {
@@ -418,7 +428,9 @@ impl PyBridge {
         json_body: &[u8],
         trace_headers: &HashMap<String, String>,
     ) -> PyResult<Receiver<ResponseChunk>> {
+        let rid_owned = rid.to_string();
         self.submit_json(rid, move |py, runtime_handle, callback| {
+            self.mark_openai_channel(&rid_owned);
             let kwargs = PyDict::new(py);
             let py_bytes = PyBytes::new(py, json_body);
             kwargs.set_item("json_body", py_bytes)?;
@@ -430,7 +442,9 @@ impl PyBridge {
                 kwargs.set_item("trace_headers", py_trace_headers)?;
             }
 
-            kwargs.set_item("chunk_callback", callback)?;
+            kwargs.set_item("chunk_callback", &callback)?;
+            let is_disconnected_fn = callback.bind(py).getattr("is_disconnected")?;
+            kwargs.set_item("is_disconnected_fn", is_disconnected_fn)?;
 
             runtime_handle.call_method(py, method_name, (), Some(&kwargs))?;
             Ok(())
@@ -457,18 +471,23 @@ fn close_channel_with_error(
     error: TerminalError,
 ) {
     let mut state = lock_or_recover(state.as_ref(), "state");
+    let had_channel = state.channels.contains_key(rid);
+    let is_openai = state.openai_channels.contains(rid);
     remove_channel_refs_locked(&mut state, rid);
     state.terminal_errors.insert(rid.to_string(), error);
     drop(state);
-    let _ = runtime_handle.call_method1(py, "abort", (rid, false));
+    if had_channel && !is_openai {
+        let _ = runtime_handle.call_method1(py, "abort", (rid, false));
+    }
 }
 
 fn remove_channel_refs_locked(state: &mut BridgeState, rid: &str) -> bool {
     let had_channel = state.channels.remove(rid).is_some();
+    let had_openai_channel = state.openai_channels.remove(rid);
     let had_pending = state.pending_sends.remove(rid);
     let had_callback = state.ready_callbacks.remove(rid).is_some();
     let had_signal = state.ready_signals.remove(rid);
-    had_channel || had_pending || had_callback || had_signal
+    had_channel || had_openai_channel || had_pending || had_callback || had_signal
 }
 
 fn remove_channel_refs(rid: &str, state: &BridgeStateRef) {
@@ -708,6 +727,11 @@ struct JsonChunkCallback {
 
 #[pymethods]
 impl JsonChunkCallback {
+    fn is_disconnected(&self) -> bool {
+        let state = lock_or_recover(self.state.as_ref(), "state");
+        !state.channels.contains_key(&self.rid)
+    }
+
     /// Register before producing chunks. If a parked chunk drained before registration,
     /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
     fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {

--- a/rust/sglang-grpc/src/lib.rs
+++ b/rust/sglang-grpc/src/lib.rs
@@ -8,7 +8,7 @@ pub mod proto {
 }
 
 use pyo3::prelude::*;
-use std::net::{SocketAddr, TcpListener};
+use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tokio::time::Duration;
@@ -138,6 +138,19 @@ fn extract_tokenizer_info(runtime_handle: &Py<PyAny>) -> PyResult<TokenizerInfo>
     })
 }
 
+fn parse_bind_addr(host: &str, port: u16) -> PyResult<SocketAddr> {
+    let formatted = format!("{}:{}", host, port);
+    match formatted.parse::<SocketAddr>() {
+        Ok(addr) => Ok(addr),
+        Err(error) => host
+            .parse::<IpAddr>()
+            .map(|ip| SocketAddr::new(ip, port))
+            .map_err(|_| {
+                pyo3::exceptions::PyValueError::new_err(format!("Invalid address: {}", error))
+            }),
+    }
+}
+
 /// Start the gRPC server in a background thread with its own Tokio runtime.
 ///
 /// Args:
@@ -164,9 +177,7 @@ fn start_server(
         )
         .try_init();
 
-    let addr: SocketAddr = format!("{}:{}", host, port)
-        .parse()
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid address: {}", e)))?;
+    let addr = parse_bind_addr(&host, port)?;
     let worker_threads = worker_threads.max(1);
     let response_channel_capacity = if response_channel_capacity == 0 {
         tracing::warn!(
@@ -262,4 +273,35 @@ fn _grpc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GrpcServerHandle>()?;
     m.add_class::<ChunkSendStatus>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_bind_addr;
+    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+
+    #[test]
+    fn parse_bind_addr_accepts_ipv4_and_ipv6_hosts() {
+        assert_eq!(
+            parse_bind_addr("127.0.0.1", 40000).unwrap(),
+            SocketAddr::new(IpAddr::from([127, 0, 0, 1]), 40000)
+        );
+        assert_eq!(
+            parse_bind_addr("[::1]", 40000).unwrap(),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 40000)
+        );
+        assert_eq!(
+            parse_bind_addr("::1", 40000).unwrap(),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 40000)
+        );
+        assert_eq!(
+            parse_bind_addr("::", 40000).unwrap(),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 40000)
+        );
+    }
+
+    #[test]
+    fn parse_bind_addr_rejects_invalid_hosts() {
+        assert!(parse_bind_addr("not-an-address", 40000).is_err());
+    }
 }

--- a/test/registered/unit/entrypoints/test_grpc_openai_cancellation.py
+++ b/test/registered/unit/entrypoints/test_grpc_openai_cancellation.py
@@ -1,0 +1,172 @@
+"""Regression test for native gRPC OpenAI cancellation propagation."""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+_SUBPROCESS_TEST = textwrap.dedent(
+    r"""
+    import json
+    import socket
+    import sys
+    import threading
+    import time
+    from types import SimpleNamespace
+
+    import grpc
+
+    from sglang.srt.rust_extensions import load_rust_extension
+
+
+    _started = threading.Event()
+    _disconnected = threading.Event()
+    _abort_rids = []
+
+
+    class _FakeRuntime:
+        def __init__(self):
+            self.tokenizer_manager = SimpleNamespace(
+                server_args=SimpleNamespace(),
+                model_config=SimpleNamespace(context_len=0),
+            )
+
+        def submit_openai_chat(
+            self,
+            *,
+            json_body,
+            chunk_callback,
+            trace_headers=None,
+            is_disconnected_fn=None,
+        ):
+            _started.set()
+
+            def wait_for_disconnect():
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    if is_disconnected_fn is not None and is_disconnected_fn():
+                        _disconnected.set()
+                        return
+                    time.sleep(0.01)
+
+            threading.Thread(target=wait_for_disconnect, daemon=True).start()
+
+        def abort(self, rid="", abort_all=False):
+            _abort_rids.append((rid, abort_all))
+
+
+    def _free_port():
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            return sock.getsockname()[1]
+
+
+    def _openai_request_serializer(body):
+        encoded = json.dumps(body).encode()
+        size = len(encoded)
+        prefix = bytearray()
+        while size >= 128:
+            prefix.append((size & 127) | 128)
+            size >>= 7
+        prefix.append(size)
+        return b"\x0a" + prefix + encoded
+
+
+    scenario = sys.argv[1]
+    port = _free_port()
+    grpc_native = load_rust_extension(
+        "sglang.srt.rust_extensions._grpc",
+        mode="never",
+    )
+    handle = grpc_native.start_server(
+        host="127.0.0.1",
+        port=port,
+        runtime_handle=_FakeRuntime(),
+        worker_threads=1,
+        response_timeout_secs=1 if scenario == "server-timeout" else 10,
+    )
+    channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        call = channel.unary_stream(
+            "/sglang.runtime.v1.SglangService/ChatComplete",
+            request_serializer=_openai_request_serializer,
+            response_deserializer=lambda payload: payload,
+        )(
+            {
+                "model": "fake",
+                "messages": [{"role": "user", "content": "hello"}],
+                "rid": "engine-request-A",
+                "stream": True,
+            },
+            timeout=10,
+        )
+        if not _started.wait(timeout=5):
+            raise RuntimeError("OpenAI request did not reach the Python runtime")
+        if scenario == "client-cancel":
+            if not call.cancel():
+                raise RuntimeError("Client cancellation did not take effect")
+        else:
+            try:
+                next(call)
+            except grpc.RpcError as exc:
+                if exc.code() != grpc.StatusCode.DEADLINE_EXCEEDED:
+                    raise AssertionError(
+                        f"unexpected server timeout status: {exc.code()}"
+                    ) from exc
+            else:
+                raise AssertionError("server timeout unexpectedly returned a response")
+        if not _disconnected.wait(timeout=5):
+            raise AssertionError(
+                f"native {scenario} did not reach is_disconnected"
+            )
+        if _abort_rids:
+            raise AssertionError(
+                f"native cancellation used the wrong Python abort path: {_abort_rids!r}"
+            )
+    finally:
+        channel.close()
+        if handle.is_alive():
+            handle.shutdown()
+    """
+).strip()
+
+
+class TestNativeGrpcOpenAICancellation(CustomTestCase):
+    def _run_subprocess(self, scenario):
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-c", _SUBPROCESS_TEST, scenario],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            self.fail(
+                f"native gRPC OpenAI {scenario} subprocess timed out\n"
+                f"--- stdout ---\n{exc.stdout}\n"
+                f"--- stderr ---\n{exc.stderr}"
+            )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"native gRPC OpenAI {scenario} regression subprocess failed\n"
+            f"--- stdout ---\n{completed.stdout}\n"
+            f"--- stderr ---\n{completed.stderr}",
+        )
+
+    def test_client_disconnect_reaches_openai_python_request(self):
+        self._run_subprocess("client-cancel")
+
+    def test_response_timeout_reaches_openai_python_request(self):
+        self._run_subprocess("server-timeout")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Native gRPC cancellation and deadline handling can leave the Python callback and Rust channel state out of sync. In the OpenAI streaming path, cleanup could also attempt to abort Python with a transport request ID that does not identify the callback's request. This can leave an active callback behind or route cleanup to the wrong request. In addition, the native server bind parser does not accept bare IPv6 literals such as `::1`.

This PR makes cancellation cleanup follow the callback's actual channel state and accepts both bracketed and bare IPv6 bind addresses.

## Modifications

- Track OpenAI callback channels separately from transport request IDs.
- Expose the callback's disconnect state to the Python streaming bridge.
- Remove the OpenAI channel on cancellation/deadline without issuing an unrelated Python abort.
- Avoid duplicate or misrouted aborts when closing channels with errors.
- Accept IPv4, bracketed IPv6, and bare IPv6 bind addresses, with focused Rust parser tests.
- Add a registered CPU native gRPC regression test covering client cancellation and server deadlines.

No proto, HTTP lifecycle, runtime dependency, or user-facing API changes are included.

## Accuracy Tests

Not applicable: this is a native gRPC lifecycle and bind-address fix; it does not change model outputs. The CPU regression harness verifies that both client cancellation and server deadline cleanup complete and do not issue an abort for an unrelated transport request ID.

## Speed Tests and Profiling

Not applicable: no inference hot path or model execution code changed. The changes only affect cancellation/deadline cleanup and server startup address parsing.

## Checklist

- [x] Format and style checks pass with `pre-commit run --all-files`.
- [x] Added Rust parser tests and a registered CPU native gRPC cancellation/deadline regression test.
- [x] Documentation update is not applicable; there are no user-facing API or protocol changes.
- [x] Accuracy and speed benchmarks are not applicable for this lifecycle-only change.
- [x] Followed the SGLang code style guidance.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p sglang-grpc --all-targets --all-features -- -D warnings`
- `cargo check --locked -p sglang-grpc`
- `pre-commit run --all-files`
- `git diff --check`
- Native extension build with `SGLANG_BUILD_RUST_EXTS=grpc python setup.py build_rust --inplace`
- Direct CPU subprocess coverage of both cancellation/deadline scenarios against the built native extension
- IPv4 and IPv6 native bind smoke coverage, including bare and bracketed forms

Local limitations:

- `cargo test --locked -p sglang-grpc` and `cargo test --workspace` reach the link step but cannot link on this macOS host because the available Python environment does not provide the required Python host symbols.
- The exact registered Python test command could not import the full local runtime because `orjson` is unavailable in the combined test environment; its native subprocess scenarios were run directly against the final built extension. The full registered test is intended for the CPU CI environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34015636956](https://github.com/sgl-project/sglang/actions/runs/34015636956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34015636859](https://github.com/sgl-project/sglang/actions/runs/34015636859)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34015636946](https://github.com/sgl-project/sglang/actions/runs/34015636946)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->