### PR TITLE
[MiMo-VL] Avoid sorting vision window indices

### DIFF
--- a/python/sglang/srt/models/mimo_vl.py
+++ b/python/sglang/srt/models/mimo_vl.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.attention.vision import (
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.quantization import QuantizationConfig
 from sglang.srt.models.qwen2_5_vl import Qwen2_5_VisionPatchMerger, Qwen2_5_VLMLP
+from sglang.srt.models.utils import permute_inv
 from sglang.srt.runtime_context import get_mm, get_server_args
 from sglang.srt.utils import add_prefix
 
@@ -410,9 +411,7 @@ class MiMoVisionTransformer(nn.Module):
         window_index_1d_col = self.get_window_index_1d(grid_thw, col=True).to(
             device=x.device
         )
-        reverse_window_index_1d_col = torch.argsort(window_index_1d_col).to(
-            device=x.device
-        )
+        reverse_window_index_1d_col = permute_inv(window_index_1d_col)
 
         rotary_pos_emb = rotary_pos_emb.to(device=x.device)
         emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)


### PR DESCRIPTION
## Motivation

MiMo-VL sorts its column-window permutation on GPU to recover the original token order. Since the index is a permutation, SGLang's existing `permute_inv` helper can construct the inverse directly without sorting.

## Modifications

Use `permute_inv` for the MiMo vision window index, matching the Qwen2.5-VL and MuseGlimmer paths.

## Accuracy Tests

- `permute_inv` matched `torch.argsort` exactly for eight image, video, and mixed-grid cases on each of eight H200 GPUs.
- MiMo-V2.5 TP8/DP2/FA3 two-image request on eight H200 GPUs: passed (HTTP 200, 1,333 image tokens, server remained healthy).

## Speed Tests and Profiling

Inverse-construction CUDA-event time on eight H200 GPUs with PyTorch 2.13.0+cu130. Each GPU ran 12 rounds per variant with alternating execution order; values are medians across the eight per-GPU medians.

| indices | `argsort` | `permute_inv` | latency reduction |
| ---: | ---: | ---: | ---: |
| 196 | 32.21 µs | 20.20 µs | 37.3% |
| 4,704 | 76.48 µs | 20.13 µs | 73.7% |
| 150,528 | 97.58 µs | 19.86 µs | 79.6% |

For all 64 inverse-only case/GPU comparisons, the candidate's maximum round time was below the baseline's minimum. These are component measurements, not model end-to-end latency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A: this one-line call-site change reuses an existing helper; focused parity and MiMo integration validation are listed above.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: internal implementation only.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34017609053](https://github.com/sgl-project/sglang/actions/runs/34017609053)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34017608987](https://github.com/sgl-project/sglang/actions/runs/34017608987)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34017609060](https://github.com/sgl-project/sglang/actions/runs/34017609060)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->