### PR TITLE
fix: load IQuestLoopCoder gate projection weights

### DIFF
--- a/python/sglang/srt/models/iquest_loopcoder.py
+++ b/python/sglang/srt/models/iquest_loopcoder.py
@@ -452,7 +452,7 @@ class IQuestLoopCoderForCausalLM(nn.Module):
                 continue
 
             # Handle gate_projections weights
-            if name.startswith("gate_projections."):
+            if name.startswith("model.gate_projections."):
                 if name.endswith(".weight"):
                     sglang_name = name.replace(".weight", ".gate_proj.weight")
                 elif name.endswith(".bias"):

--- a/test/registered/unit/models/test_iquest_loopcoder_weight_loading.py
+++ b/test/registered/unit/models/test_iquest_loopcoder_weight_loading.py
@@ -1,0 +1,143 @@
+"""Regression tests for IQuestLoopCoder checkpoint weight loading."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.linear import MergedColumnParallelLinear, QKVParallelLinear
+from sglang.srt.models.iquest_loopcoder import (
+    IQuestLoopCoderForCausalLM,
+    LoopGateProjection,
+)
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class TestIQuestLoopCoderWeightLoading(CustomTestCase):
+    def _make_minimal_model(self, named_parameters):
+        model = object.__new__(IQuestLoopCoderForCausalLM)
+        model.named_parameters = lambda: iter(named_parameters)
+        return model
+
+    @staticmethod
+    def _fill(param, value):
+        with torch.no_grad():
+            param.fill_(value)
+
+    def test_canonical_gate_weight_and_bias_load_tp_shards(self):
+        for tp_size, tp_rank in ((1, 0), (2, 0), (2, 1)):
+            with (
+                self.subTest(tp_size=tp_size, tp_rank=tp_rank),
+                get_parallel().override(tp_size=tp_size, tp_rank=tp_rank),
+            ):
+                gates = {}
+                named_parameters = []
+                weights = []
+                expected = {}
+                shard_size = 4 // tp_size
+
+                for layer, start in ((0, 20), (79, 2000)):
+                    gate = LoopGateProjection(total_num_heads=4, head_dim=2)
+                    self._fill(gate.gate_proj.weight, -3)
+                    self._fill(gate.gate_proj.bias, -4)
+                    gates[layer] = gate
+
+                    weight = torch.arange(
+                        start, start + 8, dtype=torch.float32
+                    ).reshape(4, 2)
+                    bias = torch.arange(start, start + 4, dtype=torch.float32)
+                    named_parameters.extend(
+                        [
+                            (
+                                f"model.gate_projections.{layer}.gate_proj.weight",
+                                gate.gate_proj.weight,
+                            ),
+                            (
+                                f"model.gate_projections.{layer}.gate_proj.bias",
+                                gate.gate_proj.bias,
+                            ),
+                        ]
+                    )
+                    weights.extend(
+                        [
+                            (f"model.gate_projections.{layer}.weight", weight),
+                            (f"model.gate_projections.{layer}.bias", bias),
+                        ]
+                    )
+                    expected[layer] = (
+                        weight[tp_rank * shard_size : (tp_rank + 1) * shard_size],
+                        bias[tp_rank * shard_size : (tp_rank + 1) * shard_size],
+                    )
+
+                model = self._make_minimal_model(named_parameters)
+                model.load_weights(weights)
+
+                for layer, gate in gates.items():
+                    expected_weight, expected_bias = expected[layer]
+                    torch.testing.assert_close(
+                        gate.gate_proj.weight, expected_weight, rtol=0, atol=0
+                    )
+                    torch.testing.assert_close(
+                        gate.gate_proj.bias, expected_bias, rtol=0, atol=0
+                    )
+
+    def test_tp1_qkv_and_mlp_gate_up_mappings(self):
+        with get_parallel().override(tp_size=1, tp_rank=0):
+            qkv_proj = QKVParallelLinear(
+                hidden_size=2,
+                head_size=2,
+                total_num_heads=2,
+                total_num_kv_heads=2,
+                bias=False,
+                prefix="model.layers.0.self_attn.qkv_proj",
+            )
+            gate_up_proj = MergedColumnParallelLinear(
+                input_size=2,
+                output_sizes=[3, 3],
+                bias=False,
+                prefix="model.layers.0.mlp.gate_up_proj",
+            )
+            self._fill(qkv_proj.weight, -5)
+            self._fill(gate_up_proj.weight, -6)
+
+            q_weight = torch.arange(0, 8, dtype=torch.float32).reshape(4, 2)
+            k_weight = torch.arange(10, 18, dtype=torch.float32).reshape(4, 2)
+            v_weight = torch.arange(20, 28, dtype=torch.float32).reshape(4, 2)
+            gate_weight = torch.arange(30, 36, dtype=torch.float32).reshape(3, 2)
+            up_weight = torch.arange(40, 46, dtype=torch.float32).reshape(3, 2)
+
+            model = self._make_minimal_model(
+                [
+                    (
+                        "model.layers.0.self_attn.qkv_proj.weight",
+                        qkv_proj.weight,
+                    ),
+                    (
+                        "model.layers.0.mlp.gate_up_proj.weight",
+                        gate_up_proj.weight,
+                    ),
+                ]
+            )
+            model.load_weights(
+                [
+                    ("model.layers.0.self_attn.q_proj.weight", q_weight),
+                    ("model.layers.0.self_attn.k_proj.weight", k_weight),
+                    ("model.layers.0.self_attn.v_proj.weight", v_weight),
+                    ("model.layers.0.mlp.gate_proj.weight", gate_weight),
+                    ("model.layers.0.mlp.up_proj.weight", up_weight),
+                ]
+            )
+
+        torch.testing.assert_close(
+            qkv_proj.weight, torch.cat((q_weight, k_weight, v_weight)), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            gate_up_proj.weight, torch.cat((gate_weight, up_weight)), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The released IQuestLoopCoder checkpoint stores its mixed-attention gate tensors as
`model.gate_projections.<layer>.weight` and `.bias` ([pinned weight index](https://huggingface.co/IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct/blob/61e8589747f6987ec7725e4ffe205f7a84561bd2/model.safetensors.index.json)).
The loader's special case checks `gate_projections.` without `model.`, so those
keys miss it. They then match the generic MLP `gate_proj` substring mapping and
are silently skipped instead of populating the gate parameters.

## Modifications

- Match the canonical `model.gate_projections.` prefix before stacked-parameter
  mapping. Keep the existing weight/bias remapping and parameter loaders.
- Add a CPU-registered regression using the actual model loader and small real
  linear layers: first/last gate weights and biases, TP=1 and both TP=2 shards,
  and Q/K/V plus MLP gate/up mapping controls. Loaded tensors must match exactly.
- No forward, cache, quantization, dependency, or public API changes.

## Accuracy Tests

Executed on Linux with Python 3.12.3 / PyTorch 2.13.0, using the same dependencies
and test file in separate upstream and patched source snapshots. GPUs were hidden
with `CUDA_VISIBLE_DEVICES=99` (`torch.cuda.device_count() == 0`) for the CPU
registered tests.

- `python3 test/registered/unit/models/test_iquest_loopcoder_weight_loading.py -v`:
  unchanged upstream fails the gate-value assertions in all three TP subcases;
  the QKV/MLP control passes. The patched source passes **2/2 tests**.
- `python3 test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py -v`:
  **4/4 tests passed** on the patched snapshot.

Additional local CPU smoke using the 160 gate tensors from the pinned checkpoint:

- FP32/BF16 and serial TP=1 / TP=2 rank overrides: **960 parameter-copy comparisons**, all exact. This is shard-loader coverage, not distributed TP execution.
- **24 forward comparisons** against the released head-wise einsum/bias/sigmoid expression, using real gate weights and synthetic packed-QKV queries for layers 0/79 and token counts 1/32.
- Maximum absolute error: FP32 `1.1920929e-7` (`atol=rtol=1e-5`); BF16 `0.00390625` (`atol=0.008`, `rtol=0.01`). Both passed the predeclared tolerances. This fixture smoke itself used no GPU or speed measurements.

Full-model native SGLang validation used the pinned IQuest checkpoint revision
`61e8589747f6987ec7725e4ffe205f7a84561bd2` on two A100 GPUs with TP=2, BF16,
FlashInfer attention, and the same server flags for both source snapshots:

- Patched source (`93c223e8ca67f5e3b4d031856b2539f1291f210b`): GSM8K, 200 scored examples, 5-shot, score **0.840**; **200/200** responses, **0** empty responses, **0** invalid extracted answers, and **0** request-error lines.
- Base source (`6cee9285a3dd43e1f0270818aef7bf01a0568863`): GSM8K, 200 scored examples, 5-shot, score **0.830**; **200/200** responses, **0** empty responses, **0** invalid extracted answers, and **0** request-error lines.

These are end-to-end observations, not a claim that this loader-only change
improves model accuracy. The patched source intentionally loads weights that the
base source skipped. Both variants reached readiness and completed the same
request audit; each also emitted the same nonfatal custom all-reduce JIT fallback
warning in this environment.

## Speed Tests and Profiling

Executed with `python -m sglang.bench_serving` against the same local pinned
ShareGPT dataset, `--tokenize-prompt`, seed `20260906`, exact 256-token inputs
and 64-token outputs, concurrency 1 and 8, and three rounds per concurrency.
Every completed round passed the exact request/token/error audit: fixed source
6/6 rounds and base source 6/6 rounds, with 10 requests at concurrency 1 and
40 requests at concurrency 8.

| Concurrency | Source | Median TTFT (ms) | Median TPOT (ms) | Output throughput (tok/s) | Request throughput (req/s) |
| --- | --- | ---: | ---: | ---: | ---: |
| 1 | patched | 211.603 | 63.688 | 15.098 | 0.23591 |
| 1 | base | 212.513 | 64.107 | 15.072 | 0.23550 |
| 8 | patched | 905.307 | 66.818 | 99.675 | 1.55743 |
| 8 | base | 904.482 | 66.806 | 99.680 | 1.55749 |

The measured differences are within run-to-run noise (at most about 0.7% for
the listed latency/throughput medians), and no speed improvement is claimed;
the forward path is unchanged. The combined runner completed all patched-source
measurements, then the base measurements were run with the same frozen commands
after a fresh GPU-idle check because the first base preflight observed transient
GPU-release state.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Full `pre-commit run --all-files` passed; `git diff --check` passed.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Registered CPU regression passed, with an observed old-source assertion failure.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A: no user-facing configuration or API changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Full-model GSM8K accuracy and end-to-end speed measurements completed on the pinned checkpoint with patched/base comparison and raw request audits above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). One production-line change, existing loaders reused, `CustomTestCase` and CPU CI registration used.

## Review and Merge Process

Please enable the registered CPU CI when reviewing. The author has read-only
upstream permissions and cannot apply the `run-ci` label. CI results and maintainer
approval remain required; they are not represented by the local checks above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34020116335](https://github.com/sgl-project/sglang/actions/runs/34020116335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34020116196](https://github.com/sgl-project/sglang/actions/runs/34020116196)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34020116378](https://github.com/sgl-project/sglang/actions/runs/34020116378)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

