### PR TITLE
[Config] Round 6.6: a field declares what it means when nobody set it

### DIFF
--- a/python/sglang/srt/arg_groups/arg_utils.py
+++ b/python/sglang/srt/arg_groups/arg_utils.py
@@ -39,6 +39,7 @@ annotation is equivalent to ``Arg(help=that_string)``.
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import functools
 import types
@@ -54,6 +55,20 @@ from typing import (
 )
 
 A = Annotated
+
+
+class _NoFallback:
+    """Sentinel for ``Arg.fallback``: this field declares none.
+
+    ``None`` cannot serve, because ``None`` is what a field *holds* when the
+    operator did not type it -- the state a fallback answers for.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<no fallback>"
+
+
+NO_FALLBACK = _NoFallback()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -78,6 +93,19 @@ class Arg:
     # `resolution_result` and the config bags answer with the decision. The
     # field keeps what the operator passed.
     resolvable: bool = False
+    # What the field means when nobody said anything: the operator did not type
+    # it and resolution did not decide it. Not the dataclass default -- that
+    # stays `None`, because `None` is how the record spells "not typed" and the
+    # record is the wire format. This is the bottom of the read chain instead:
+    # override, then decision, then input, then this. A model family that
+    # declares the field still wins, because a decision sits above it.
+    #
+    # Only a value fixed for the life of the configuration belongs here. A
+    # default that depends on the machine (`get_device()`), on another field
+    # (`tokenizer_path` following `model_path`), or on anything impure
+    # (`random.randint`) is a decision, and decisions stay in a hook where
+    # their order is visible.
+    fallback: Any = NO_FALLBACK
 
 
 @dataclasses.dataclass(frozen=True)
@@ -190,6 +218,46 @@ def resolvable_fields(cls) -> frozenset:
         if arg is not None and arg.resolvable:
             names.add(field.name)
     return frozenset(names)
+
+
+@functools.cache
+def fallbacks_of(cls) -> dict:
+    """``{field_name: value}`` for every field of ``cls`` that declares one.
+
+    Read the same way `resolvable_fields` reads its flag, so a fallback lives
+    beside the help text of the field it belongs to rather than in whatever
+    hook used to fill it in.
+    """
+    if not dataclasses.is_dataclass(cls):
+        return {}
+    hints = get_type_hints(cls, include_extras=True)
+    out = {}
+    for field in dataclasses.fields(cls):
+        _, arg = _unwrap_annotated(hints.get(field.name, field.type))
+        if arg is not None and arg.fallback is not NO_FALLBACK:
+            out[field.name] = arg.fallback
+    return out
+
+
+def with_fallback(cls, name: str, value: Any) -> Any:
+    """``value``, or the declared fallback when nothing has answered.
+
+    The three read points of the resolved configuration call this as their last
+    step: `resolution_result` (which the config bags and `/server_info` read
+    through), and the two views a resolution pass is handed.
+
+    A container fallback is copied, so a reader that mutates what it got does
+    not edit the declaration for every other reader -- the reason a dataclass
+    spells this `default_factory`.
+    """
+    if value is not None:
+        return value
+    fallback = fallbacks_of(cls).get(name, NO_FALLBACK)
+    if fallback is NO_FALLBACK:
+        return value
+    if isinstance(fallback, (list, dict, set)):
+        return copy.deepcopy(fallback)
+    return fallback
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/srt/arg_groups/fields/schedule.py
+++ b/python/sglang/srt/arg_groups/fields/schedule.py
@@ -152,10 +152,10 @@ class Schedule:
                 "The ratio of SWA layer KV tokens / full layer KV tokens, regardless "
                 "of the number of swa:full layers. It should be between 0 and 1. "
                 "E.g. 0.5 means if each swa layer has 50 tokens, then each full "
-                "layer has 100 tokens. Unset means 0.8, unless a model family "
-                "declares its own."
+                "layer has 100 tokens."
             ),
             resolvable=True,
+            fallback=0.8,
         ),
     ] = None
     disable_hybrid_swa_memory: A[
@@ -199,11 +199,9 @@ class Schedule:
     mamba_full_memory_ratio: A[
         Optional[float],
         Arg(
-            help=(
-                "The ratio of mamba state memory to full kv cache memory. "
-                "Defaults to 0.9; a model family may declare its own."
-            ),
+            help="The ratio of mamba state memory to full kv cache memory.",
             resolvable=True,
+            fallback=0.9,
         ),
     ] = None
 

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -10,6 +10,7 @@ from sglang.srt.arg_groups.overrides import (
     attention_backends_of,
     declare_resolution,
     model_config_of,
+    resolution_result,
     resolved_view,
     resolving_view,
     use_mla_backend,
@@ -186,39 +187,17 @@ def handle_cache_compatibility(server_args: Any) -> None:
                 "both build a decode host pool."
             )
 
-    handle_generic_kv_cache_ratios(server_args)
-
     # Validate the effective ratio: model branches may declare a reset
     # (e.g. Step3p forces 1.0 under hierarchical cache) that supersedes
     # the user input before it ever takes effect.
-    if not (0 < resolved_view(server_args).swa_full_tokens_ratio <= 1.0):
+    #
+    # `resolution_result`, not the view: the views answer with what resolution
+    # has decided over what the operator typed, which is `None` while nobody
+    # has claimed the field. The effective value -- the one the pools will
+    # size against -- includes the declared fallback, and that is what a range
+    # check is about.
+    if not (0 < resolution_result(server_args, "swa_full_tokens_ratio") <= 1.0):
         raise ValueError("--swa-full-tokens-ratio should be in range (0, 1.0].")
-
-
-def handle_generic_kv_cache_ratios(server_args: Any) -> None:
-    """Supply the ratios nobody claimed.
-
-    Neither `swa_full_tokens_ratio` nor `mamba_full_memory_ratio` carries a
-    static default any more: `None` means the operator did not set it and no
-    model family declared one. Stating the value as a class default instead is
-    what made a family ask "is this field still the default?" -- a question
-    that stops being answerable the moment any other pass declares the field,
-    and that an operator who happens to type the default value gets the wrong
-    answer to.
-
-    Called from two slots, and idempotent because both arms test for `None`:
-    from `handle_cache_compatibility`, late enough that the model families have
-    had their say, and from the dummy-model short circuit, which returns long
-    before that and would otherwise leave the bags holding `None`.
-    """
-    generic: dict = {}
-    resolved = resolved_view(server_args)
-    if resolved.mamba_full_memory_ratio is None:
-        generic["mamba_full_memory_ratio"] = 0.9
-    if resolved.swa_full_tokens_ratio is None:
-        generic["swa_full_tokens_ratio"] = 0.8
-    if generic:
-        declare_resolution(server_args, "_handle_kv_cache_ratios", **generic)
 
 
 def handle_unified_memory_pool(server_args: Any) -> None:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -41,7 +41,11 @@ import math
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from sglang.srt.arg_groups import model_override_base
-from sglang.srt.arg_groups.arg_utils import field_names, resolvable_fields
+from sglang.srt.arg_groups.arg_utils import (
+    field_names,
+    resolvable_fields,
+    with_fallback,
+)
 
 # Re-exported for the callers that already import these names from here; the
 # declarations under ``model_overrides/`` import them from the base directly.
@@ -274,7 +278,13 @@ def declare_direct_writes(
 
 def resolution_result(server_args: Any, field: str, default: Any = None) -> Any:
     """What resolution decided for ``field``: the declaration if there is one,
-    otherwise what the caller supplied.
+    otherwise what the caller supplied, otherwise the field's declared
+    fallback.
+
+    The fallback is last because it is what the field means when nobody said
+    anything -- an operator who types a value and a pass that decides one both
+    sit above it. It is read from the declaration rather than filled in by a
+    pass, so there is no slot to place and no second call to make idempotent.
 
     This is what the config projection reads. Reading the field instead would
     work whatever the caller passed onto the record -- and
@@ -289,8 +299,8 @@ def resolution_result(server_args: Any, field: str, default: Any = None) -> Any:
             return declared[field]
     raw = getattr(server_args, "_raw_input", None)
     if raw is not None and field in raw:
-        return raw[field]
-    return getattr(server_args, field, default)
+        return with_fallback(type(server_args), field, raw[field])
+    return with_fallback(type(server_args), field, getattr(server_args, field, default))
 
 
 def resolution_projection(server_args: Any) -> Dict[str, Any]:

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -106,14 +106,6 @@ def run_resolution_pipeline(server_args: Any) -> None:
 
     handle_hardware_runtime_validation()
     if cfg.model_path.lower() in ["none", "dummy"]:
-        # A model that resolves nothing still has to leave every bag holding a
-        # value. The two KV-cache ratios default to None on the record and are
-        # normally filled after the model families run, well past this point.
-        from sglang.srt.arg_groups.kv_cache_hook import (
-            handle_generic_kv_cache_ratios,
-        )
-
-        handle_generic_kv_cache_ratios(server_args)
         return
 
     from sglang.srt.arg_groups.model_path_hook import (

--- a/test/registered/unit/server_args/test_declared_fallbacks.py
+++ b/test/registered/unit/server_args/test_declared_fallbacks.py
@@ -1,0 +1,184 @@
+"""A field can declare what it means when nobody said anything.
+
+`Arg(fallback=...)` is the value a field takes when the operator did not type
+it and resolution did not decide it. It is not the dataclass default: that
+stays `None`, because `None` is how the record spells "not typed" and the
+record is what crosses a process boundary.
+
+The point of the tests below is that the three surfaces keep disagreeing, on
+purpose:
+
+* the **record** still holds `None` -- so a model family asking "did anyone set
+  this?" still gets an answer, and the wire format is unchanged;
+* the **views** a resolution pass reads still answer `None` -- so a family's
+  `if cfg.x is None` fires and its declaration lands;
+* the **effective** surface -- `resolution_result`, the projection, and the
+  config bags every runtime reader goes through -- answers with the fallback.
+
+That last split is the whole design. Putting the fallback in the views instead
+would make `if cfg.swa_full_tokens_ratio is None` in `model_overrides/inkling.py`
+never fire, and the family's 0.1 would be silently replaced by the generic 0.8.
+"""
+
+import dataclasses
+import unittest
+from typing import Optional, get_args, get_type_hints
+
+from sglang.srt.arg_groups.arg_utils import (
+    NO_FALLBACK,
+    A,
+    Arg,
+    fallbacks_of,
+    with_fallback,
+)
+from sglang.srt.arg_groups.model_override_base import resolved_view
+from sglang.srt.arg_groups.overrides import (
+    declare_resolution,
+    resolution_result,
+    resolving_view,
+)
+from sglang.srt.runtime_context import get_schedule, publish, reset_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+def _resolved(**kwargs) -> ServerArgs:
+    server_args = ServerArgs(model_path="dummy", **kwargs)
+    server_args.resolve_once()
+    return server_args
+
+
+class TestAFallbackIsWhatNobodySaid(CustomTestCase):
+    def test_the_effective_value_is_the_declared_fallback(self):
+        server_args = _resolved()
+        self.assertEqual(resolution_result(server_args, "swa_full_tokens_ratio"), 0.8)
+        self.assertEqual(resolution_result(server_args, "mamba_full_memory_ratio"), 0.9)
+
+    def test_the_record_still_says_the_operator_typed_nothing(self):
+        # The fallback is not the dataclass default. A child process that
+        # unpickles this record has to be able to tell "unset" from "set to
+        # the value resolution would have picked anyway".
+        server_args = _resolved()
+        self.assertIsNone(server_args.swa_full_tokens_ratio)
+        self.assertIsNone(server_args.mamba_full_memory_ratio)
+
+    def test_what_the_operator_typed_wins(self):
+        server_args = _resolved(swa_full_tokens_ratio=0.25)
+        self.assertEqual(resolution_result(server_args, "swa_full_tokens_ratio"), 0.25)
+
+    def test_a_value_the_operator_typed_that_equals_the_fallback_is_still_input(self):
+        server_args = _resolved(swa_full_tokens_ratio=0.8)
+        self.assertEqual(server_args.swa_full_tokens_ratio, 0.8)
+        self.assertEqual(resolution_result(server_args, "swa_full_tokens_ratio"), 0.8)
+
+    def test_a_decision_wins(self):
+        server_args = _resolved()
+        declare_resolution(server_args, "a_model_family", swa_full_tokens_ratio=0.1)
+        self.assertEqual(resolution_result(server_args, "swa_full_tokens_ratio"), 0.1)
+
+    def test_the_published_bag_answers_with_the_fallback(self):
+        # Every runtime reader goes through the bags, so this is the surface
+        # that decides how the pools are sized.
+        reset_context()
+        self.addCleanup(reset_context)
+        publish(ServerArgs(model_path="dummy"), role="engine")
+        self.assertEqual(get_schedule().swa_full_tokens_ratio, 0.8)
+        self.assertEqual(get_schedule().mamba_full_memory_ratio, 0.9)
+
+    def test_the_dummy_short_circuit_leaves_no_bag_holding_none(self):
+        # The dummy path returns before most of the pipeline. It used to have
+        # to call the ratio pass by hand on the way out; a declared fallback
+        # needs no slot, so there is nothing left to forget.
+        reset_context()
+        self.addCleanup(reset_context)
+        publish(ServerArgs(model_path="none"), role="engine")
+        self.assertIsNotNone(get_schedule().swa_full_tokens_ratio)
+        self.assertIsNotNone(get_schedule().mamba_full_memory_ratio)
+
+
+class TestAPassDecidingStillSeesUnset(CustomTestCase):
+    """The views are the Decision-over-Input surface, not the Effect surface.
+
+    `model_overrides/inkling.py` and `model_overrides/deepseek_v4.py` both ask
+    `if cfg.swa_full_tokens_ratio is None` and declare 0.1 when it is. If a
+    fallback answered here, that branch would be dead and the family's value
+    would never be declared.
+    """
+
+    def test_the_resolving_view_answers_none(self):
+        server_args = _resolved()
+        self.assertIsNone(resolving_view(server_args).swa_full_tokens_ratio)
+
+    def test_the_resolved_view_answers_none(self):
+        server_args = _resolved()
+        self.assertIsNone(resolved_view(server_args).mamba_full_memory_ratio)
+
+    def test_a_family_that_tests_is_none_still_fires(self):
+        server_args = _resolved()
+        cfg = resolving_view(server_args)
+        declared = {}
+        if cfg.swa_full_tokens_ratio is None:  # the family's exact shape
+            declared["swa_full_tokens_ratio"] = 0.1
+        self.assertEqual(declared, {"swa_full_tokens_ratio": 0.1})
+
+
+class TestTheDeclarationIsTheOnlyPlaceTheValueLives(CustomTestCase):
+    def test_the_declared_set_is_what_the_record_carries(self):
+        self.assertEqual(
+            fallbacks_of(ServerArgs),
+            {"swa_full_tokens_ratio": 0.8, "mamba_full_memory_ratio": 0.9},
+        )
+
+    def test_a_fallback_field_is_optional_and_defaults_to_none(self):
+        # `None` is what the fallback answers for. A field that defaults to
+        # anything else can never reach it, so the declaration would be dead.
+        hints = get_type_hints(ServerArgs, include_extras=True)
+        for name in fallbacks_of(ServerArgs):
+            field = next(f for f in dataclasses.fields(ServerArgs) if f.name == name)
+            with self.subTest(field=name):
+                self.assertIsNone(field.default, f"{name} must default to None")
+                inner = get_args(hints[name])[0]
+                self.assertIn(
+                    type(None),
+                    get_args(inner),
+                    f"{name} must be Optional[...] to hold its unset state",
+                )
+
+    def test_the_help_text_does_not_restate_the_value(self):
+        # The value used to be written twice: as a literal in the hook that
+        # filled it, and as prose in the help. Two copies drift.
+        hints = get_type_hints(ServerArgs, include_extras=True)
+        for name, value in fallbacks_of(ServerArgs).items():
+            arg = next(a for a in get_args(hints[name])[1:] if isinstance(a, Arg))
+            with self.subTest(field=name):
+                self.assertNotIn(str(value), arg.help)
+
+
+class TestWithFallback(CustomTestCase):
+    def test_a_container_fallback_is_copied_per_read(self):
+        @dataclasses.dataclass
+        class Cfg:
+            paths: A[Optional[list], Arg(help="x", fallback=[])] = None
+
+        first = with_fallback(Cfg, "paths", None)
+        first.append("mutated")
+        self.assertEqual(with_fallback(Cfg, "paths", None), [])
+
+    def test_a_field_without_a_declaration_is_untouched(self):
+        self.assertIsNone(with_fallback(ServerArgs, "tokenizer_path", None))
+
+    def test_a_non_dataclass_has_no_fallbacks(self):
+        self.assertEqual(fallbacks_of(int), {})
+
+    def test_the_sentinel_is_not_none(self):
+        # `None` cannot mark "declares no fallback": it is the state a
+        # fallback exists to answer for.
+        self.assertIsNot(NO_FALLBACK, None)
+        self.assertNotEqual(Arg().fallback, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sixth, stacked on #38113. The series moved configuration out of `ServerArgs`
and split it into three surfaces: the record (what the operator typed, `None`
means not typed), the declaration stash (what resolution decided), and the
config bags (what is in effect). This one gives a field a way to say what it
means when nobody said anything at all.

## The problem

`swa_full_tokens_ratio` and `mamba_full_memory_ratio` default to `None` on the
record, which is right -- it is what lets a model family ask "did anyone set
this?" But something then has to supply the generic value, and that was
`handle_generic_kv_cache_ratios`: a pass whose entire body is

```python
if resolved.mamba_full_memory_ratio is None:
    generic["mamba_full_memory_ratio"] = 0.9
if resolved.swa_full_tokens_ratio is None:
    generic["swa_full_tokens_ratio"] = 0.8
```

It costs more than it looks:

- **a slot** -- it has to run after the model families, or it beats them;
- **a second call site** -- the dummy-model short circuit returns long before
  that slot, so the pipeline called it again by hand on the way out, and the
  pass had to be idempotent for that to be safe;
- **two copies of the value** -- the literal in the hook, and prose in the help
  text a file away (`"Unset means 0.8"`). Both fields had drifted into saying
  it twice.

## The change

```python
swa_full_tokens_ratio: A[
    Optional[float],
    Arg(help="...", resolvable=True, fallback=0.8),
] = None
```

The dataclass default stays `None`. A fallback is not a default: the record is
the wire format, and a child process has to keep being able to tell "unset"
from "set to the value resolution would have picked anyway".

The pass is deleted, both call sites with it, and the dummy short circuit is a
bare `return` again. Nothing has to run for a field to mean what it says.

## Which surface it lives on, and why that is the whole design

Precedence becomes **override -> decision -> input -> fallback**, applied in
`resolution_result` -- which the projection, `/server_info` and every config bag
read through.

Deliberately **not** in `resolving_view` / `resolved_view`. Those are the
decision-over-input surface a pass reads *while it is deciding*, and two model
families branch on exactly this:

```python
# model_overrides/inkling.py, and the same shape in deepseek_v4.py
if cfg.swa_full_tokens_ratio is None:
    overrides["swa_full_tokens_ratio"] = 0.1
```

A fallback answering there is not "the generic value, later" -- a `__getattr__`
layer is read-time, so there is no later. Every read during resolution would
already get 0.8 and the branch would never fire. Running `_inkling_overrides`
against both versions:

```
--- fallback on the effective surface only (this PR) ---
  cfg.swa_full_tokens_ratio during resolution = None
  family declared swa = 0.1   mamba = 0.1
--- fallback also on the view a pass reads ---
  cfg.swa_full_tokens_ratio during resolution = 0.8
  family declared swa = None  mamba = None      <- the key never lands
```

So "resolution first, then the fallback" holds -- not because a step was
appended to the pipeline, but because of which surface the value lives on.

Exactly one reader consults the effective surface during resolution: the range
check on the ratio, which wants the value the pools will be sized against. It
asks `resolution_result` directly, which is what its comment already claimed it
was doing. It sits at pipeline line 343; the model families are at 237, so a
family's declaration is already in the stash when it runs -- the same slot the
deleted pass occupied.

## What may be declared this way, and what may not

Across every hook, `if x is None: x = ...` appears at **55 sites over 29
fields**. They are not one thing:

| | count | examples | declarable |
|---|---|---|---|
| unconditional constant | 5 | the two ratios, `grammar_backend="xgrammar"`, `mm_process_config={}`, `custom_weight_loader=[]` | **yes** |
| unconditional, computed from another field | 4 | `tokenizer_path=model_path`, `device=get_device()`, `served_model_name`, `speculative_draft_model_quantization` | needs a `fallback="dotted.path"` form; not in this PR |
| **conditional decision** | ~20 | `chunked_prefill_size` across seven memory tiers, `max_bs` across eight, `max_running_requests` at 48 or 256 by model family | **no, and it should not be** |

The rule: only a value fixed for the life of the configuration belongs in a
declaration. One that depends on the machine, on another field, or on anything
impure (`random_seed = random.randint(...)`) is a decision, and decisions stay
in a hook where their order is visible. This PR converts the two ratios only.

## Verification

- 16 launch shapes resolved on both sides, real model and dummy: **7,904 field
  readings, and the only difference is `random_seed`** -- a fresh
  `random.randint` per process, equally random on both sides.
- The CLI registers the same **507 options** with the same defaults, choices and
  actions.
- `test_declared_fallbacks.py`, 17 cases. One of them pins the inverse of the
  dead-branch above: what a pass sees while deciding is still `None`.
- Config surface on this branch: 644 passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34020180264](https://github.com/sgl-project/sglang/actions/runs/34020180264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34020180359](https://github.com/sgl-project/sglang/actions/runs/34020180359)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34020180346](https://github.com/sgl-project/sglang/actions/runs/34020180346)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->