### PR TITLE
[NPU] Enable NGRAM speculative decoding on Ascend NPUs

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -985,7 +985,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
 
 def _handle_ngram(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
-    if cfg.device not in ("cuda", "cpu"):
+    if cfg.device not in ("cuda", "cpu", "npu"):
         raise ValueError(
             "Ngram speculative decoding only supports CUDA or CPU devices."
         )

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -13,6 +13,7 @@ from sglang.srt.mem_cache.memory_pool import (
     unwrap_write_loc,
 )
 from sglang.srt.utils import get_bool_env_var
+from sglang.srt.utils.async_probe import maybe_detect_oob
 from sglang.srt.utils.common import is_npu
 
 if TYPE_CHECKING:
@@ -146,6 +147,26 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         # implementation relies on self.data_strides / self.data_ptrs, which the
         # NPU paged buffer layout never builds.
         self._kv_copy_config = None
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        # The base tiled copy requires _kv_copy_config, which the NPU paged
+        # buffer layout never builds (see _init_kv_copy_and_warmup). Relocate
+        # slots with plain indexing, viewing each layer as flat
+        # [num_slots, head_num, head_dim] like get_cpu_copy / load_cpu_copy.
+        if self.layer_num == 0:
+            return
+        size_limit = self.size + self.page_size
+        maybe_detect_oob(tgt_loc, 0, size_limit, "move_kv_cache tgt_loc")
+        maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
+        for local_layer_id in range(self.layer_num):
+            k_layer = self.k_buffer[local_layer_id].view(
+                -1, self.head_num, self.head_dim
+            )
+            v_layer = self.v_buffer[local_layer_id].view(
+                -1, self.head_num, self.v_head_dim
+            )
+            k_layer[tgt_loc] = k_layer[src_loc]
+            v_layer[tgt_loc] = v_layer[src_loc]
 
     # for disagg
     def get_contiguous_buf_infos(self):

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -3,7 +3,14 @@ from typing import List, Optional
 
 import numpy as np
 import torch
-from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
+try:
+    from sgl_kernel.speculative import (
+        reconstruct_indices_from_tree_mask as _reconstruct_indices_from_tree_mask_kernel,
+    )
+except ImportError:
+    # sgl_kernel ships CUDA-only binaries; on other platforms (e.g. NPU) the
+    # host implementation defined below fills in.
+    _reconstruct_indices_from_tree_mask_kernel = None
 
 from sglang.kernels.ops.speculative.cache_locs import (
     assign_extend_cache_locs_func as assign_extend_cache_locs_func,
@@ -70,6 +77,61 @@ def _derive_tree_links(
                 next_sibling[b, i] = earliest_child_of.get(parent, -1)
                 earliest_child_of[parent] = i
     return torch.from_numpy(next_token), torch.from_numpy(next_sibling)
+
+
+def _reconstruct_indices_from_tree_mask_host(
+    tree_mask,
+    seq_lens,
+    positions,
+    retrieve_index,
+    retrieve_next_token,
+    retrieve_next_sibling,
+    bs,
+    draft_token_num,
+) -> None:
+    """Host fallback for platforms without the sgl_kernel CUDA kernel (e.g. NPU).
+
+    Produces the same outputs as the kernel into the caller's preallocated
+    device tensors: ``retrieve_index`` (draft slot identity), ``positions``
+    (tree depth + seq_len), and the tree links (via :func:`_derive_tree_links`).
+    """
+    d = draft_token_num
+    mask = (
+        tree_mask.detach()
+        .reshape(-1)[: bs * d * d]
+        .reshape(bs, d, d)
+        .to("cpu", torch.bool)
+        .numpy()
+    )
+    node_order = np.arange(d)
+    depths = (mask & (node_order < node_order[:, None])).sum(-1)
+
+    next_token, next_sibling = _derive_tree_links(mask, bs, d)
+    seqs = np.asarray(seq_lens.detach().to("cpu").tolist(), dtype=np.int64)
+
+    dev = positions.device
+    positions.copy_(
+        torch.from_numpy(depths.reshape(-1) + np.repeat(seqs, d))
+        .to(dev)
+        .reshape(positions.shape)
+    )
+    retrieve_index.copy_(
+        torch.arange(bs * d, dtype=torch.int64).to(dev).reshape(retrieve_index.shape)
+    )
+    retrieve_next_token.copy_(
+        next_token.to(dev).reshape(retrieve_next_token.shape)
+    )
+    retrieve_next_sibling.copy_(
+        next_sibling.to(dev).reshape(retrieve_next_sibling.shape)
+    )
+
+
+def reconstruct_indices_from_tree_mask(*args, **kwargs):
+    """Dispatch to the sgl_kernel CUDA kernel when available, else to the host
+    fallback (see :func:`_reconstruct_indices_from_tree_mask_host`)."""
+    if _reconstruct_indices_from_tree_mask_kernel is not None:
+        return _reconstruct_indices_from_tree_mask_kernel(*args, **kwargs)
+    return _reconstruct_indices_from_tree_mask_host(*args, **kwargs)
 
 
 class NGRAMWorker(BaseSpecWorker):


### PR DESCRIPTION
## Motivation

NGRAM speculative decoding is currently restricted to CUDA/CPU devices
(`_handle_ngram` raises `"Ngram speculative decoding only supports CUDA or CPU
devices."`). The restriction is an allowlist check rather than a fundamental
dependency: with three platform-scoped changes, the full NGRAM path (draft
lookup → chain build → target verify → accept-path KV relocation) runs
end-to-end on Ascend 910C.

This extends speculative-decoding coverage on NPUs, complementing the ongoing
DFlash2 NPU enablement (#35629) and the NGRAM roadmap (#21052). It is opt-in
and changes nothing for CUDA/CPU users: the sgl_kernel kernel is still
preferred whenever it is importable.

## Changes

1. **`srt/arg_groups/speculative_hook.py`** — allow `"npu"` in the `_handle_ngram`
   device check.

2. **`srt/speculative/ngram_worker.py`** — `reconstruct_indices_from_tree_mask`
   lives in the CUDA-only `sgl_kernel` package, so the import fails on NPUs.
   Import it behind `try/except ImportError` and add a host fallback producing
   the same four outputs into the caller's preallocated device tensors (slot
   identity, tree depth + seq_len positions, and the tree links). The link
   derivation reuses the existing host `_derive_tree_links` (already used by
   the grammar path); the verify call site is unchanged — a module-level
   dispatcher prefers the kernel whenever it is importable.

3. **`srt/hardware_backend/npu/memory_pool_npu.py`** — the speculative accept
   path calls `move_kv_cache(tgt_loc, src_loc)`, but the base tiled-copy
   implementation requires `_kv_copy_config`, which the NPU paged buffer layout
   never builds (see the existing `_init_kv_copy_and_warmup` override there).
   Add an NPU-native `move_kv_cache` that relocates slots with plain indexing,
   viewing each layer as flat `[num_slots, head_num, head_dim]` — the same
   convention `get_cpu_copy`/`load_cpu_copy` already use for both buffer
   layouts.

## Operating constraints on 910C / CANN 9.0.0 (not addressed here)

- **Chain verify only for now**: tree verify (`max_bfs_breadth > 1`) requires
  `page_size == 1`, which the FIA kernel rejects (`blockSize` must be a
  multiple of 16 in [16, 1024]; see #25169). With
  `--speculative-ngram-max-bfs-breadth 1` the feature works end-to-end;
  lifting the kernel constraint is follow-up work.
- **Use `--page-size 128`**: page_size 16 silently corrupts output on the
  ascend backend (silent corruption reported in 38196), 128 is correct.
- On 910C we additionally worked around a separate vendor-kernel crash in
  `sgl_kernel_npu.norm.split_qkv_rmsnorm_rope` (hit by any Qwen3 NPU run) by
  using the non-fused path locally; that is unrelated to NGRAM and will be
  reported separately.

## Validation

- Hardware: 2× Ascend 910C (64 GB HBM each, single-card run), CANN 9.0.0
- Stack: python 3.11.9, torch 2.10.0 + torch_npu 2.10.0, sgl-kernel-npu 2026.6.1,
  triton-ascend 3.2.1.dev; sglang source build from main (~2026-09-05)
- Functional: Qwen3-0.6B bf16 served with `--attention-backend ascend
  --disable-overlap-schedule --disable-cuda-graph --speculative-algorithm NGRAM
  --speculative-num-draft-tokens 4 --speculative-ngram-max-bfs-breadth 1
  --page-size 128`; chat completions return coherent text (greedy), server
  stable across repeated requests, native `move_kv_cache` invoked on every
  accept step.
- Benchmark (`sglang.bench_serving`, random 128/64, 32 prompts, concurrency 8,
  request-rate 4; warm runs): decode latency (Median TPOT) drops from
  ~28.0 ms to ~13.6 ms (−51%) with NGRAM on; output throughput is flat
  (~139 tok/s both ways on this host-bound 0.6B setup); TTFT +15–25 ms
  (per-request n-gram state init).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34021246070](https://github.com/sgl-project/sglang/actions/runs/34021246070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34021245998](https://github.com/sgl-project/sglang/actions/runs/34021245998)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34021246050](https://github.com/sgl-project/sglang/actions/runs/34021246050)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->