### PR TITLE
[function_call] gemma4: streaming tool_index follows call order, not tools-list position

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -377,9 +377,13 @@ class Gemma4Detector(BaseFormatDetector):
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
-                                        ),
+                                        # Streaming index is the position of the
+                                        # call within this response, not the
+                                        # tool's position in the tools list;
+                                        # otherwise two parallel calls of the same
+                                        # function share index 0 and OpenAI
+                                        # clients merge their arguments.
+                                        tool_index=self.current_tool_id,
                                         name=func_name,
                                         parameters="",
                                     )
@@ -408,9 +412,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
-                                    ),
+                                    tool_index=self.current_tool_id,
                                     parameters=json.dumps(
                                         arguments, ensure_ascii=False
                                     ),

--- a/test/registered/unit/function_call/test_gemma4_detector.py
+++ b/test/registered/unit/function_call/test_gemma4_detector.py
@@ -1,0 +1,115 @@
+"""Unit tests for Gemma4Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.gemma4_detector import Gemma4Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+Q = '<|"|>'  # Gemma4 string delimiter
+
+
+class TestGemma4Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Gemma4Detector()
+
+    @staticmethod
+    def _call(name, args):
+        body = ",".join(f"{k}:{Q}{v}{Q}" for k, v in args.items())
+        return f"<|tool_call>call:{name}{{{body}}}<tool_call|>"
+
+    @staticmethod
+    def _collect(detector, text, tools, chunk=7):
+        """Feed text in small chunks; return {tool_index: (name, arguments)}."""
+        seen = {}
+        for i in range(0, len(text), chunk):
+            for call in detector.parse_streaming_increment(text[i : i + chunk], tools).calls:
+                entry = seen.setdefault(call.tool_index, {"name": None, "args": ""})
+                if call.name:
+                    entry["name"] = call.name
+                entry["args"] += call.parameters or ""
+        return {k: (v["name"], json.loads(v["args"] or "{}")) for k, v in seen.items()}
+
+    # ==================== Non-streaming ====================
+
+    def test_detect_and_parse_single(self):
+        text = self._call("get_weather", {"city": "Hà Nội", "unit": "celsius"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(
+            json.loads(result.calls[0].parameters), {"city": "Hà Nội", "unit": "celsius"}
+        )
+
+    def test_detect_and_parse_parallel(self):
+        text = self._call("get_weather", {"city": "A"}) + self._call("get_weather", {"city": "B"})
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual([c.name for c in result.calls], ["get_weather", "get_weather"])
+        self.assertEqual([json.loads(c.parameters)["city"] for c in result.calls], ["A", "B"])
+
+    # ==================== Streaming ====================
+
+    def test_streaming_single_tool_call(self):
+        text = self._call("search", {"query": "sglang"})
+        calls = self._collect(Gemma4Detector(), text, self.tools)
+        self.assertEqual(calls, {0: ("search", {"query": "sglang"})})
+
+    def test_streaming_parallel_same_function_gets_distinct_indices(self):
+        # Two calls of the same function must stream as index 0 and 1.
+        # Before the fix both used the tool's position in the tools list
+        # (index 0), so OpenAI clients merged their arguments into one call.
+        text = self._call("get_weather", {"city": "Hà Nội"}) + self._call(
+            "get_weather", {"city": "Đà Nẵng"}
+        )
+        calls = self._collect(Gemma4Detector(), text, self.tools)
+        self.assertEqual(
+            calls,
+            {0: ("get_weather", {"city": "Hà Nội"}), 1: ("get_weather", {"city": "Đà Nẵng"})},
+        )
+
+    def test_streaming_parallel_different_functions_follow_call_order(self):
+        # "search" is second in the tools list but first in the response:
+        # streaming index must follow call order, not tools-list position.
+        text = self._call("search", {"query": "x"}) + self._call("get_weather", {"city": "Y"})
+        calls = self._collect(Gemma4Detector(), text, self.tools)
+        self.assertEqual(
+            calls, {0: ("search", {"query": "x"}), 1: ("get_weather", {"city": "Y"})}
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--tool-call-parser gemma4` and `stream=true`, a response containing two parallel calls of the **same** function streams both calls with `index: 0` (different `id`s). OpenAI-compatible clients aggregate streamed tool-call deltas by `index`, so the two calls are merged into one entry whose `arguments` is the concatenation of both JSON objects, e.g.

```
get_weatherget_weather({"city": "Hà Nội", "unit": "celsius"}{"city": "Đà Nẵng", "unit": "celsius"})
```

Root cause: `Gemma4Detector.parse_streaming_increment` fills `ToolCallItem.tool_index` from `self._tool_indices` (the tool's position in the request's `tools` list) instead of the position of the call within the response. `serving_chat` forwards `tool_index` as the streamed `index`, so:

- two calls of the same function → both `index 0`;
- a single call of the second tool in the list → `index 1` instead of `0`.

Non-streaming (`detect_and_parse`) is unaffected because `serving_chat` assigns indices itself there.

## Modifications

- `gemma4_detector.py`: use `self.current_tool_id` for the streaming `tool_index` (both the name item and the arguments item), matching `BaseFormatDetector`.
- `test/registered/unit/function_call/test_gemma4_detector.py`: CPU unit test covering non-streaming and streaming parsing; the parallel-same-function, parallel-different-function and second-tool cases fail before this change (3/5) and pass after.

## Accuracy / performance

Parsing only; no model or kernel change. Verified end-to-end on Gemma 4 26B-A4B: streaming with two parallel `get_weather` calls now yields `index 0` and `1` with intact JSON arguments.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgtYWafiF1VUEEdUMHFgV1

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34022131361](https://github.com/sgl-project/sglang/actions/runs/34022131361)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34022131179](https://github.com/sgl-project/sglang/actions/runs/34022131179)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34022131436](https://github.com/sgl-project/sglang/actions/runs/34022131436)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->