### PR TITLE
[Test] Mock health callback in prefill abort cleanup fixture

### DIFF
--- a/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
+++ b/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
@@ -60,6 +60,7 @@ class _Scheduler(SchedulerDisaggregationPrefillMixin):
         self.send_kv_chunk = Mock()
         self.output_streamer = Mock()
         self.metrics_reporter = SimpleNamespace(report_prefill_stats=Mock())
+        self.maybe_send_health_check_signal = Mock()
         self.req_to_metadata_buffer_idx_allocator = Mock()
         self.enable_hicache_storage = True
         self.chunked_req = None


### PR DESCRIPTION
## Motivation

Follow-up to #36507, based on `xinyuan/glm-5.3-flash-support`.

[CPU job 101456298849](https://github.com/sgl-project/sglang/actions/runs/34009462992/job/101456298849) fails all seven prefill-abort cleanup tests with `AttributeError: '_Scheduler' object has no attribute 'maybe_send_health_check_signal'`.

The tests introduced on main by #36988 instantiate only `SchedulerDisaggregationPrefillMixin`. The GLM branch calls the real scheduler's health-check callback after processing a prefill result, so this test double needs that collaborator too.

## Modifications

Add `self.maybe_send_health_check_signal = Mock()` to the test-only `_Scheduler` fixture. One line, one test file; no production changes, assertion changes, or registration changes.

## Validation

- Unpatched #36507 head `87de7ca9ba507093a276826aa83d52887793a4f8`: all seven tests reproduce the missing-method failure.
- Patched source: all seven tests pass on an isolated CPU-only source copy on `baizhou-nda`, with all GPUs hidden.
- Command: `CUDA_VISIBLE_DEVICES=8 PYTHONPATH=python python3 test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py -f`.
- Targeted pre-commit and `git diff --check` pass.
- Single-file CPU `/rerun-test`: [run 34023683974](https://github.com/sgl-project/sglang/actions/runs/34023683974) **passed**, testing commit `b7805652b9b633c0c54661b9918d0004e7dd6ca2` on `ubuntu-latest`. All seven tests passed; CPU job completed in 1m19s. No full CI requested.

## Accuracy Tests

Not applicable: test-fixture-only change; all abort cleanup assertions are retained.

## Speed Tests and Profiling

Not applicable: no runtime changes.

## Checklist

- [x] Formatting and applicable pre-commit checks pass.
- [x] Existing regression tests reproduced before the fix and pass afterward.
- [x] No documentation or performance updates required for this fixture-only fix.
- [x] Existing test style and registration preserved.
