### PR TITLE
[MLX] Add a dense-model e2e correctness test for Apple Silicon

### DIFF
--- a/test/registered/mlx/models_e2e/test_llama_dense_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_llama_dense_mlx_correctness.py
@@ -1,0 +1,155 @@
+import importlib.util
+import json
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.kits.basic_api_contract_kit import BasicAPIContractMixin
+from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+# Registered on the CPU suite but skipped wherever mlx is absent; runs for real
+# only on Apple Silicon. Also registered under stage-b-e2e-mlx, which the
+# macOS CI lane (pr-test-mlx.yml) only dispatches via a gated workflow_dispatch.
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-b-e2e-mlx")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+
+# llama architecture (LlamaForCausalLM), served on the MLX backend through
+# mlx_lm's own llama implementation. The other models_e2e cases are all
+# mixture-of-experts (qwen2_moe, qwen3_moe, gpt_oss), so the dense decoder-only
+# MLX path is otherwise unguarded end to end.
+#
+# The 3B 4-bit repo is also the only models_e2e default that fits a base-config
+# 16 GB Apple Silicon machine; the MoE defaults need roughly 8-17 GB of weights.
+# Override with SGLANG_MLX_TEST_MODEL to point at a local copy, e.g.
+#   SGLANG_MLX_TEST_MODEL=models/Llama-3.2-3B-Instruct-4bit
+MODEL_PATH = os.environ.get(
+    "SGLANG_MLX_TEST_MODEL", "mlx-community/Llama-3.2-3B-Instruct-4bit"
+)
+
+# mem-fraction is tuned for a 16 GB Apple Silicon machine, which is the point of
+# picking a small dense model here.
+MEM_FRACTION_STATIC = os.environ.get("SGLANG_MLX_TEST_MEM_FRACTION", "0.7")
+
+# Llama 3 chat control tokens. These are template scaffolding: if one reaches the
+# response body, the chat template or the detokenizer is leaking it.
+_CHAT_CONTROL_TOKENS = (
+    "<|begin_of_text|>",
+    "<|start_header_id|>",
+    "<|end_header_id|>",
+    "<|eot_id|>",
+)
+
+_REQUEST_TIMEOUT = 120
+
+
+@unittest.skipUnless(_HAS_MLX, "requires mlx (Apple Silicon only)")
+class TestLlamaDenseMlxCorrectness(
+    BasicAPIContractMixin,
+    BasicDecodeCorrectnessMixin,
+    CustomTestCase,
+):
+    served_model_name = MODEL_PATH
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL_PATH)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "1",
+                "--disable-radix-cache",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                MEM_FRACTION_STATIC,
+                "--max-running-requests",
+                "1",
+                "--context-length",
+                "2048",
+            ],
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process is not None:
+            kill_process_tree(cls.process.pid)
+
+    def _chat(self, messages, max_tokens=32, stream=False):
+        payload = {
+            "model": MODEL_PATH,
+            "messages": messages,
+            "temperature": 0,
+            "max_tokens": max_tokens,
+        }
+        if not stream:
+            resp = requests.post(
+                f"{self.base_url}/v1/chat/completions",
+                json=payload,
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+
+        resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={**payload, "stream": True},
+            timeout=_REQUEST_TIMEOUT,
+            stream=True,
+        )
+        resp.raise_for_status()
+        chunks = []
+        for raw in resp.iter_lines(decode_unicode=True):
+            if not raw or not raw.startswith("data:"):
+                continue
+            payload_line = raw[len("data:") :].strip()
+            if payload_line == "[DONE]":
+                break
+            delta = json.loads(payload_line)["choices"][0]["delta"]
+            chunks.append(delta.get("content") or "")
+        return "".join(chunks)
+
+    def test_streaming_matches_non_streaming(self):
+        """Streamed deltas must concatenate to the non-streamed body.
+
+        Guards the incremental detokenizer against dropping, duplicating or
+        re-splitting text at a chunk boundary -- a failure mode no non-streaming
+        assertion can see, and one no other models_e2e case covers.
+        """
+        messages = [{"role": "user", "content": "Name two oceans, comma separated."}]
+        streamed = self._chat(messages, stream=True)
+        non_streamed = self._chat(messages, stream=False)
+        self.assertGreater(len(streamed), 0)
+        self.assertEqual(streamed, non_streamed)
+
+    def test_chat_control_tokens_absent(self):
+        """Template scaffolding must not survive into the response body."""
+        text = self._chat(
+            [{"role": "user", "content": "What is the capital of France? One word."}],
+            max_tokens=8,
+        )
+        for token in _CHAT_CONTROL_TOKENS:
+            self.assertNotIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`test/registered/mlx/models_e2e/` holds three cases and all three are mixture-of-experts models — `qwen2_moe`, `qwen3_moe`, `gpt_oss` — so the dense decoder-only path on the MLX backend has no end-to-end guard.

There is a second problem with that set. Its 4-bit defaults are roughly:

| test | default model | approx. weights |
| --- | --- | --- |
| `test_qwen3_moe_mlx_correctness` | `mlx-community/Qwen3-30B-A3B-4bit` | ~17 GB |
| `test_gpt_oss_mlx_correctness` | `mlx-community/gpt-oss-20b-MXFP4-Q8` | ~12 GB |
| `test_qwen2_moe_mlx_correctness` | `mlx-community/Qwen1.5-MoE-A2.7B-Chat-4bit` | ~8 GB |

None of these run on a base-config 16 GB Apple Silicon machine, so a contributor on one cannot exercise any of `models_e2e` locally. Since `stage-b-e2e-mlx` is dispatched only through a gated `workflow_dispatch` on a self-hosted runner, that leaves the lane hard to validate before pushing.

This adds a dense case defaulting to `mlx-community/Llama-3.2-3B-Instruct-4bit` (~1.8 GB), which makes `models_e2e` reachable on a 16 GB machine.

## Modifications

One new file, `test/registered/mlx/models_e2e/test_llama_dense_mlx_correctness.py`, following the existing `models_e2e` conventions: `register_cpu_ci(base-a-test-cpu)` + `register_mlx_ci(stage-b-e2e-mlx)`, `@unittest.skipUnless(_HAS_MLX, ...)` so it skips off Apple Silicon, one `popen_launch_server` in `setUpClass` shared across methods, and `SGLANG_MLX_TEST_MODEL` / `SGLANG_MLX_TEST_MEM_FRACTION` overrides.

It composes `BasicAPIContractMixin` and `BasicDecodeCorrectnessMixin` rather than restating their probes, the same way `test_basic_sanity.py` and the `models_e2e` DeepSeek V4 cases do. That gives the MLX backend the health / `/v1` surface / gibberish-ratio / repetition-blowup / temp-0 determinism / degenerate-single-token coverage the CUDA and AMD sanity lanes already have, and it means the kits stay the single place those probes are defined.

On top of the kits it adds the two checks no kit currently provides:

- `test_streaming_matches_non_streaming` — the concatenated streaming deltas must equal the non-streamed body at `temperature=0`. I checked every kit under `python/sglang/test/kits/`; none asserts streamed-vs-non-streamed text equality, so an incremental detokenizer that drops, duplicates or re-splits text at a chunk boundary is currently invisible. Since `detokenizer_manager.py` is backend-agnostic this arguably belongs in a shared kit so every backend inherits it — happy to move it there instead if you'd prefer, I kept it local to avoid widening a first patch.
- `test_chat_control_tokens_absent` — no Llama 3 template token (`<|begin_of_text|>`, `<|start_header_id|>`, `<|end_header_id|>`, `<|eot_id|>`) may appear in the response body.

## Accuracy Tests

No runtime or model code is touched. The test is the check.

Run on Apple Silicon (M4, 16 GB, macOS 15.1, mlx 0.32.2, mlx-lm 0.31.3, torch 2.13.0, transformers 5.12.1):

```
$ python -m pytest test/registered/mlx/models_e2e/test_llama_dense_mlx_correctness.py -v
test_ascii_ratio PASSED                       test_health PASSED
test_basic_math PASSED                        test_health_generate PASSED
test_capital_france PASSED                    test_max_token_one PASSED
test_chat_control_tokens_absent PASSED        test_no_repetition_blowup PASSED
test_color_completion PASSED                  test_openai_chat_completion PASSED
test_determinism_temp_zero PASSED             test_openai_completion PASSED
test_get_model_info PASSED                    test_streaming_matches_non_streaming PASSED
test_get_server_info PASSED

15 passed in 63.82s (0:01:03)
```

Every kit probe passes unmodified on the MLX backend — no per-backend threshold override or skip was needed.

CI registration resolves on both lanes, checked by calling `collect_tests` directly rather than trusting the decorators:

```
registered/mlx/models_e2e/test_llama_dense_mlx_correctness.py
  backend=CPU suite=base-a-test-cpu est=1.0
  backend=MLX suite=stage-b-e2e-mlx est=1.0
```

## Speed Tests and Profiling

N/A — test-only change. 64 s wall clock with the model cached; the first run additionally downloads ~1.8 GB.

One note: I set `est_time=1` to match all three sibling `models_e2e` cases, though the measured cost is 64 s. Happy to set a realistic value here, or across the four files together, if you'd rather the LPT partitioner see the true number.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — n/a, no user-facing behavior change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34025234593](https://github.com/sgl-project/sglang/actions/runs/34025234593)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34025234502](https://github.com/sgl-project/sglang/actions/runs/34025234502)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34025234524](https://github.com/sgl-project/sglang/actions/runs/34025234524)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->