### PR TITLE
[HiCache] Credit the hugetlb pool in the host-memory preflight

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -1164,7 +1164,7 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_HUGEPAGE_SIZE</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use huge pages for host KV cache allocations (HiCache / disaggregation offload). Valid values: <code>2MB</code> (2 MiB pages via <code>MAP_HUGE_2MB</code>) or <code>1GB</code> (1 GiB pages via <code>MAP_HUGE_1GB</code>). Requires huge pages to be pre-allocated on the host OS (<code>/proc/sys/vm/nr_hugepages</code> or <code>/sys/kernel/mm/hugepages</code>). If the allocation fails, the allocator logs a warning and falls back to regular page-size mmap automatically.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use huge pages for host KV cache allocations (HiCache / disaggregation offload). Valid values: <code>2MB</code> (2 MiB pages via <code>MAP_HUGE_2MB</code>) or <code>1GB</code> (1 GiB pages via <code>MAP_HUGE_1GB</code>). Requires huge pages to be pre-allocated on the host OS (<code>/proc/sys/vm/nr_hugepages</code> or <code>/sys/kernel/mm/hugepages</code>). The host-memory preflight credits the free hugetlb pool of that size, so reserving huge pages for the host pool does not make the check fail; with <code>1GB</code> pages reserve one extra page per host buffer, since every mapping is rounded up to a whole page. If the allocation fails, the allocator logs a warning and falls back to regular page-size mmap automatically.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set (uses OS default page size)</td>
     </tr>
     <tr>

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -212,7 +212,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.gpu_device = device_buffers[0].device if device_buffers else device
 
         requested_bytes = self.layer_num * num_host_pages * self.item_bytes
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(self.allocator, self.gpu_device)
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for V4 paged pool {pool_name}. "
@@ -630,7 +630,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
         self.size_per_token = self.state_page_bytes
 
         requested_bytes = self.layer_num * num_host_pages * self.state_page_bytes
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(self.allocator, self.gpu_device)
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for V4 state pool {pool_name}. "

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -4,7 +4,7 @@ import abc
 import logging
 import threading
 from functools import wraps
-from typing import Optional
+from typing import Optional, Union
 
 import psutil
 import torch
@@ -12,7 +12,9 @@ import torch
 from sglang.srt.distributed.parallel_state import get_world_group
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.mem_cache.pool_host.common import (
+    HostTensorAllocator,
     _cuda_host_unregister,
+    device_uses_allocator,
     get_allocator_from_storage,
 )
 from sglang.srt.runtime_context import get_parallel
@@ -48,14 +50,32 @@ def ranks_per_host() -> int:
     return max(world_group.world_size // get_parallel().nnodes, 1)
 
 
-def host_memory_budget_bytes() -> int:
+def host_memory_budget_bytes(
+    allocator: Optional[HostTensorAllocator] = None,
+    device: Optional[Union[str, torch.device]] = None,
+) -> int:
     """Host RAM this rank may claim for a HiCache pool.
 
     psutil reports the whole machine, so co-located ranks each see the same free
     memory; without the split every rank sizes its pool against all of it and
     the host is oversubscribed by the number of ranks it holds.
+
+    When ``allocator`` maps MAP_HUGETLB (SGLANG_HUGEPAGE_SIZE) the pool may
+    come from the kernel's hugetlb pool instead, which MemAvailable excludes.
+    The two are alternatives, not a sum: one mapping is served entirely by one
+    or the other, so the larger of them is the budget, and the reserve stays
+    on plain RAM. The credit needs ``device`` to dispatch to the allocator
+    (npu/musa pin through torch). It is only as safe as the fallback is loud:
+    a mapping the hugetlb pool cannot serve (rounding up to whole pages, a
+    neighbour's reservation, a cgroup limit) is logged at ERROR and lands on
+    plain RAM the budget did not account for; refusing that fallback is a
+    separate knob.
     """
     free = psutil.virtual_memory().available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+    if allocator is not None and device is not None and device_uses_allocator(device):
+        hugetlb = allocator.free_hugetlb_bytes()
+        if hugetlb:
+            free = max(free, hugetlb)
     return free // ranks_per_host()
 
 
@@ -172,7 +192,9 @@ class HostKVCache(abc.ABC):
 
         # Verify there is enough available host memory.
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(
+            self.allocator, self.device_pool.device
+        )
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory available. Requesting "

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -4,11 +4,12 @@ import json
 import logging
 import os
 from collections import defaultdict
+from typing import Union
 
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.storage.mmap import alloc_mmap
+from sglang.srt.mem_cache.storage.mmap import alloc_mmap, hugetlb_pool_free_bytes
 from sglang.srt.runtime_context import get_memory
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,17 @@ class HostTensorAllocator:
         self.dtype = dtype
         self.dims = dims
         return alloc_mmap(dims, dtype)
+
+    def free_hugetlb_bytes(self) -> int:
+        """Free hugetlb-pool bytes allocate() could map from, else 0.
+
+        Only the base allocate() maps MAP_HUGETLB (alloc_mmap honors
+        SGLANG_HUGEPAGE_SIZE). A subclass that overrides allocate() gets its
+        memory elsewhere and is credited nothing unless it overrides this too.
+        """
+        if type(self).allocate is not HostTensorAllocator.allocate:
+            return 0
+        return hugetlb_pool_free_bytes()
 
 
 class ShmHostTensorAllocator(HostTensorAllocator):
@@ -257,3 +269,11 @@ ALLOC_MEMORY_FUNCS = defaultdict(
         "musa": alloc_with_pin_memory,
     },
 )
+
+
+def device_uses_allocator(device: Union[str, torch.device]) -> bool:
+    """Whether allocations for ``device`` go through the HostTensorAllocator.
+
+    npu/musa allocate with torch.empty(pin_memory=True) and never see it.
+    """
+    return ALLOC_MEMORY_FUNCS[device] is alloc_with_host_register

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -94,7 +94,9 @@ class DSAIndexerPoolHost(HostKVCache):
 
         buf_elem_size = self.page_num * self.layer_num * self.indexer_page_stride_size
         requested_bytes = buf_elem_size * self.indexer_dtype.itemsize
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(
+            self.allocator, self.device_pool.device
+        )
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for DSA indexer hierarchical cache. "

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -96,7 +96,9 @@ class MambaPoolHost(HostKVCache):
             )
 
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(
+            self.allocator, self.device_pool.device
+        )
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory available. Requesting "

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -733,7 +733,9 @@ class MHATokenToKOnlyPoolHost(HostKVCache):
         self.size_per_token = self.get_size_per_token()
 
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_memory_budget_bytes()
+        available_bytes = host_memory_budget_bytes(
+            self.allocator, self.device_pool.device
+        )
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for MiniMax index-K hierarchical cache. "

--- a/python/sglang/srt/mem_cache/storage/mmap/__init__.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/__init__.py
@@ -3,9 +3,10 @@
 
 """Mmap allocator storage backend helpers for SGLang HiCache."""
 
-from .mmap_allocator import alloc_mmap, alloc_shm
+from .mmap_allocator import alloc_mmap, alloc_shm, hugetlb_pool_free_bytes
 
 __all__ = [
     "alloc_mmap",
     "alloc_shm",
+    "hugetlb_pool_free_bytes",
 ]

--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -44,6 +44,66 @@ _MAP_FAILED = ctypes.c_void_p(-1).value
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
 _PROT_RW = mmap.PROT_READ | mmap.PROT_WRITE
 
+# Hugetlb pools as the kernel exposes them: one sysfs directory per page size.
+_HUGEPAGE_SYSFS_DIR = "/sys/kernel/mm/hugepages"
+_HUGEPAGE_SIZES = {"2MB": 2 * 1024 * 1024, "1GB": 1024 * 1024 * 1024}
+_HUGEPAGE_MMAP_FLAGS = {
+    2 * 1024 * 1024: _MAP_HUGETLB | _MAP_HUGE_2MB,
+    1024 * 1024 * 1024: _MAP_HUGETLB | _MAP_HUGE_1GB,
+}
+
+
+def hugepage_size_requested() -> int:
+    """Hugepage size in bytes that SGLANG_HUGEPAGE_SIZE asks alloc_mmap() for.
+
+    0 when the variable is unset or unrecognized (the latter with a warning),
+    in which case alloc_mmap() maps plain pages. Re-read per call, not cached,
+    so that envs.SGLANG_HUGEPAGE_SIZE.override() works in tests.
+    """
+    raw = envs.SGLANG_HUGEPAGE_SIZE.get() or ""
+    key = raw.strip().upper()
+    if key == "":
+        return 0
+    size = _HUGEPAGE_SIZES.get(key)
+    if size is None:
+        logger.warning(
+            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'. "
+            "Falling back to plain page-size mmap.",
+            raw,
+        )
+        return 0
+    return size
+
+
+def _hugetlb_count(pool_dir: str, counter: str) -> int:
+    with open(os.path.join(pool_dir, counter)) as f:
+        return int(f.read().strip())
+
+
+def hugetlb_pool_free_bytes() -> int:
+    """Bytes a new alloc_mmap() mapping could take from the hugetlb pool, else 0.
+
+    That is the pool of the size SGLANG_HUGEPAGE_SIZE names, and only while
+    libc is loadable: without it alloc_mmap() maps plain pages before ever
+    trying hugetlb. Read from sysfs, which reports every pool size (the whole
+    hugetlb pool is excluded from MemAvailable). Pages a mapping has reserved
+    but not yet faulted in still count as free, so only ``free - resv`` can
+    back a new mapping.
+    """
+    size = hugepage_size_requested()
+    if size == 0 or _libc is None:
+        return 0
+    pool_dir = os.path.join(_HUGEPAGE_SYSFS_DIR, f"hugepages-{size // 1024}kB")
+    try:
+        free = _hugetlb_count(pool_dir, "free_hugepages")
+        resv = _hugetlb_count(pool_dir, "resv_hugepages")
+    except (OSError, ValueError) as e:
+        logger.warning(
+            "Cannot read the hugetlb pool at %s (%s); not crediting it.", pool_dir, e
+        )
+        return 0
+    return max(free - resv, 0) * size
+
 
 @functools.cache
 def _has_madv_populate_write() -> bool:
@@ -118,24 +178,10 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
 
     The tensor owns the mapping; munmap fires when the tensor is freed.
     """
-    # Re-read per call (not cached) so that envs.SGLANG_HUGEPAGE_SIZE.override()
-    # works correctly in tests.
-    hugepage_size = (envs.SGLANG_HUGEPAGE_SIZE.get() or "").strip().upper()
+    hugepage_size = hugepage_size_requested()
     n_bytes = math.prod(dims) * torch.empty([], dtype=dtype).element_size()
-
-    if hugepage_size == "":
-        page_size, extra_flags = mmap.PAGESIZE, 0
-    elif hugepage_size == "2MB":
-        page_size, extra_flags = 2 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_2MB
-    elif hugepage_size == "1GB":
-        page_size, extra_flags = 1024 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_1GB
-    else:
-        logger.warning(
-            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'. "
-            "Falling back to plain page-size mmap.",
-            envs.SGLANG_HUGEPAGE_SIZE.get(),
-        )
-        page_size, extra_flags = mmap.PAGESIZE, 0
+    page_size = hugepage_size or mmap.PAGESIZE
+    extra_flags = _HUGEPAGE_MMAP_FLAGS.get(hugepage_size, 0)
 
     alloc_bytes = math.ceil(n_bytes / page_size) * page_size
 
@@ -144,7 +190,7 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
             logger.error(
                 "Hugepage mmap requested but libc.so.6 could not be loaded; "
                 "falling back to plain mmap. SGLANG_HUGEPAGE_SIZE=%s will be ignored.",
-                hugepage_size,
+                envs.SGLANG_HUGEPAGE_SIZE.get(),
             )
         else:
             try:
@@ -157,7 +203,7 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
                     "Hugepage mmap via libc failed (%s); falling back to plain mmap. "
                     "SGLANG_HUGEPAGE_SIZE=%s will be ignored.",
                     e,
-                    hugepage_size,
+                    envs.SGLANG_HUGEPAGE_SIZE.get(),
                 )
         alloc_bytes = math.ceil(n_bytes / mmap.PAGESIZE) * mmap.PAGESIZE
 

--- a/test/registered/unit/mem_cache/test_hicache_host_register.py
+++ b/test/registered/unit/mem_cache/test_hicache_host_register.py
@@ -195,10 +195,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         memory_pool_host,
                         "host_memory_budget_bytes",
                         return_value=1024**3,
-                    ),
+                    ) as budget,
                     mock.patch.dict(ALLOC_MEMORY_FUNCS, {torch.device("cpu"): alloc}),
                 ):
-                    DeepSeekV4PagedHostPool(
+                    pool = DeepSeekV4PagedHostPool(
                         pool_name="test",
                         device_buffers=device_buffers,
                         item_bytes=11,
@@ -207,6 +207,7 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         layout=layout,
                     )
 
+                budget.assert_called_once_with(pool.allocator, torch.device("cpu"))
                 self.assertEqual(
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     3 * 11,
@@ -228,10 +229,10 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         memory_pool_host,
                         "host_memory_budget_bytes",
                         return_value=1024**3,
-                    ),
+                    ) as budget,
                     mock.patch.dict(ALLOC_MEMORY_FUNCS, {torch.device("cpu"): alloc}),
                 ):
-                    DeepSeekV4StateHostPool(
+                    pool = DeepSeekV4StateHostPool(
                         pool_name="test",
                         state_pools=state_pools,
                         num_host_pages=4,
@@ -239,6 +240,7 @@ class TestHiCacheHostRegister(unittest.TestCase):
                         layout=layout,
                     )
 
+                budget.assert_called_once_with(pool.allocator, torch.device("cpu"))
                 self.assertEqual(
                     alloc.call_args.kwargs["registration_granularity_bytes"],
                     2 * 2 * 3,

--- a/test/registered/unit/mem_cache/test_mem_pool_host.py
+++ b/test/registered/unit/mem_cache/test_mem_pool_host.py
@@ -12,7 +12,8 @@ from sglang.srt.mem_cache.memory_pool_host import (
     DeepSeekV4PagedHostPool,
     LogicalHostPool,
 )
-from sglang.srt.mem_cache.pool_host import HostPoolGroup, PoolEntry, base
+from sglang.srt.mem_cache.pool_host import HostPoolGroup, PoolEntry, base, common
+from sglang.srt.mem_cache.pool_host.common import ALLOC_MEMORY_FUNCS
 from sglang.srt.mem_cache.pool_host.mamba import MambaPoolHost
 from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
 from sglang.srt.runtime_context import get_context
@@ -275,6 +276,112 @@ class TestHostMemoryBudget(CustomTestCase):
             ),
         ):
             self.assertEqual(base.ranks_per_host(), 8)
+
+    def _budget_for(self, allocator, device, available, ranks=8):
+        fake_mem = unittest.mock.Mock(available=available)
+        with (
+            unittest.mock.patch.object(base, "ranks_per_host", return_value=ranks),
+            unittest.mock.patch.object(
+                base.psutil, "virtual_memory", return_value=fake_mem
+            ),
+        ):
+            return base.host_memory_budget_bytes(allocator, device)
+
+    def test_hugetlb_pool_is_an_alternative_budget(self):
+        # One mapping is served entirely by the hugetlb pool or entirely by
+        # plain pages, so the larger of the two is the budget; the reserve is
+        # for the OS and applies to plain RAM only.
+        gib = 1024**3
+        reserve = base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+        allocator = unittest.mock.Mock(
+            free_hugetlb_bytes=unittest.mock.Mock(return_value=96 * gib)
+        )
+        budget = self._budget_for(allocator, "cuda", available=reserve + 64 * gib)
+        self.assertEqual(budget, 96 * gib // 8)
+
+    def test_plain_pages_win_when_the_hugetlb_pool_is_smaller(self):
+        gib = 1024**3
+        reserve = base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+        allocator = unittest.mock.Mock(
+            free_hugetlb_bytes=unittest.mock.Mock(return_value=16 * gib)
+        )
+        budget = self._budget_for(allocator, "cuda", available=reserve + 64 * gib)
+        self.assertEqual(budget, 64 * gib // 8)
+
+    def test_no_hugetlb_credit_for_pin_memory_devices(self):
+        # npu/musa allocate with torch.empty(pin_memory=True) and never see the
+        # allocator, so what it could map from hugetlb does not apply.
+        gib = 1024**3
+        reserve = base.HICACHE_HOST_MEMORY_RESERVE_BYTES
+        allocator = unittest.mock.Mock(
+            free_hugetlb_bytes=unittest.mock.Mock(return_value=96 * gib)
+        )
+        budget = self._budget_for(allocator, "npu", available=reserve + 64 * gib)
+        self.assertEqual(budget, 64 * gib // 8)
+        allocator.free_hugetlb_bytes.assert_not_called()
+
+    def test_plain_budget_is_reported_as_is_without_a_hugetlb_pool(self):
+        # A host below the reserve keeps its negative budget, and the failure
+        # message that shows it, when there is no hugetlb pool to credit.
+        gib = 1024**3
+        allocator = unittest.mock.Mock(
+            free_hugetlb_bytes=unittest.mock.Mock(return_value=0)
+        )
+        budget = self._budget_for(allocator, "cuda", available=4 * gib)
+        self.assertEqual(
+            budget, (4 * gib - base.HICACHE_HOST_MEMORY_RESERVE_BYTES) // 8
+        )
+
+    def test_guard_passes_its_allocator_and_device(self):
+        device_pool = MHATokenToKVPool(
+            size=4,
+            page_size=2,
+            dtype=torch.float16,
+            head_num=2,
+            head_dim=4,
+            layer_num=2,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+
+        def plain_alloc(dims, dtype, device, pin_memory, allocator, **kwargs):
+            return torch.empty(dims, dtype=dtype)
+
+        with (
+            unittest.mock.patch.object(
+                base, "host_memory_budget_bytes", return_value=1024**3
+            ) as budget,
+            unittest.mock.patch.dict(ALLOC_MEMORY_FUNCS, {"cpu": plain_alloc}),
+        ):
+            pool = MHATokenToKVPoolHost(
+                device_pool=device_pool,
+                host_to_device_ratio=2.0,
+                host_size=0,
+                page_size=2,
+                layout="layer_first",
+                pin_memory=False,
+                device="cpu",
+                allocator_type="default",
+            )
+        budget.assert_called_once_with(pool.allocator, device_pool.device)
+
+
+class TestHostTensorAllocatorHugetlb(CustomTestCase):
+    def test_only_the_mmap_allocator_reports_the_hugetlb_pool(self):
+        # Only the base allocate() maps MAP_HUGETLB; an allocator that gets its
+        # memory elsewhere must not be credited with a pool it never touches.
+        gib = 1024**3
+
+        class Elsewhere(common.HostTensorAllocator):
+            def allocate(self, dims, dtype, device):
+                raise NotImplementedError
+
+        with unittest.mock.patch.object(
+            common, "hugetlb_pool_free_bytes", return_value=4 * gib
+        ):
+            self.assertEqual(common.HostTensorAllocator().free_hugetlb_bytes(), 4 * gib)
+            self.assertEqual(common.ShmHostTensorAllocator().free_hugetlb_bytes(), 0)
+            self.assertEqual(Elsewhere().free_hugetlb_bytes(), 0)
 
 
 class TestHostPoolGroup(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -9,13 +9,15 @@ import ctypes
 import ctypes.util
 import mmap
 import os
+import tempfile
 import unittest
 import unittest.mock
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.pool_host.common import ShmHostTensorAllocator
-from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm
+from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm, mmap_allocator
 from sglang.srt.mem_cache.storage.mmap.mmap_allocator import _mmap_prefaulted
 
 
@@ -159,6 +161,91 @@ class TestMmapAllocator(unittest.TestCase):
         with self.assertRaises(AssertionError) as ctx:
             allocator.allocate((2, 2), torch.float32, device="cuda")
         self.assertIn("only supports CPU allocations", str(ctx.exception))
+
+
+class TestHugetlbPool(unittest.TestCase):
+    """What the host-pool preflight may credit from the kernel's hugetlb pool."""
+
+    @staticmethod
+    def _sysfs(root, free_2mb=None, free_1gb=None, resv_2mb=0, resv_1gb=0):
+        for name, free, resv in (
+            ("hugepages-2048kB", free_2mb, resv_2mb),
+            ("hugepages-1048576kB", free_1gb, resv_1gb),
+        ):
+            if free is None:
+                continue
+            os.makedirs(os.path.join(root, name))
+            for counter, value in (("free_hugepages", free), ("resv_hugepages", resv)):
+                with open(os.path.join(root, name, counter), "w") as f:
+                    f.write(f"{value}\n")
+
+    def test_hugepage_size_requested_parses_the_env(self):
+        for raw, expected in {"": 0, "2MB": 2 * 1024**2, " 1gb ": 1024**3}.items():
+            with self.subTest(raw=raw), envs.SGLANG_HUGEPAGE_SIZE.override(raw):
+                self.assertEqual(mmap_allocator.hugepage_size_requested(), expected)
+
+    def test_unrecognized_hugepage_size_means_plain_pages(self):
+        with (
+            envs.SGLANG_HUGEPAGE_SIZE.override("4MB"),
+            self.assertLogs(mmap_allocator.logger, "WARNING"),
+        ):
+            self.assertEqual(mmap_allocator.hugepage_size_requested(), 0)
+
+    def test_hugetlb_pool_free_bytes_reads_the_requested_pool(self):
+        # sysfs keeps one pool per page size; MemAvailable excludes all of them.
+        with tempfile.TemporaryDirectory() as root:
+            self._sysfs(root, free_2mb=6144, free_1gb=3)
+            with unittest.mock.patch.object(
+                mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root
+            ):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    self.assertEqual(
+                        mmap_allocator.hugetlb_pool_free_bytes(), 6144 * 2 * 1024**2
+                    )
+                with envs.SGLANG_HUGEPAGE_SIZE.override("1GB"):
+                    self.assertEqual(
+                        mmap_allocator.hugetlb_pool_free_bytes(), 3 * 1024**3
+                    )
+
+    def test_hugetlb_pool_free_bytes_excludes_pages_reserved_by_other_mappings(self):
+        # A mapping reserves its pages at mmap time and faults them in
+        # afterwards; until then sysfs still counts them as free. Co-located
+        # ranks populate their pools concurrently, so only free - resv can back
+        # a new mapping.
+        with tempfile.TemporaryDirectory() as root:
+            self._sysfs(root, free_2mb=6144, resv_2mb=1000)
+            with (
+                unittest.mock.patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root),
+                envs.SGLANG_HUGEPAGE_SIZE.override("2MB"),
+            ):
+                self.assertEqual(
+                    mmap_allocator.hugetlb_pool_free_bytes(),
+                    (6144 - 1000) * 2 * 1024**2,
+                )
+
+    def test_hugetlb_pool_free_bytes_is_zero_when_mmap_would_not_use_hugetlb(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._sysfs(root, free_2mb=6144)
+            with unittest.mock.patch.object(
+                mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root
+            ):
+                with (
+                    self.subTest(why="not requested"),
+                    envs.SGLANG_HUGEPAGE_SIZE.override(""),
+                ):
+                    self.assertEqual(mmap_allocator.hugetlb_pool_free_bytes(), 0)
+                with (
+                    self.subTest(why="libc unavailable"),
+                    envs.SGLANG_HUGEPAGE_SIZE.override("2MB"),
+                    unittest.mock.patch.object(mmap_allocator, "_libc", None),
+                ):
+                    self.assertEqual(mmap_allocator.hugetlb_pool_free_bytes(), 0)
+                with (
+                    self.subTest(why="no pool of that size"),
+                    envs.SGLANG_HUGEPAGE_SIZE.override("1GB"),
+                    self.assertLogs(mmap_allocator.logger, "WARNING"),
+                ):
+                    self.assertEqual(mmap_allocator.hugetlb_pool_free_bytes(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #34972.

The HiCache host-pool sizing guards check the requested pool against `psutil.virtual_memory().available`, i.e. the kernel's `MemAvailable`, which excludes reserved hugepages by design. With `SGLANG_HUGEPAGE_SIZE=2MB|1GB` the pool is mapped `MAP_HUGETLB` from the kernel's hugetlb pool, so reserving hugepages for the pool shrinks the very budget the guard measures and the start fails on a host whose hugetlb pool is entirely free. On our tp8 H200 node (1772 GiB, 1582 GiB reserved as 2 MiB pages for the L2 pool) the failure is `ValueError: Not enough host memory available. Requesting 176.71 GB but only have 105.82 GB free.` with `HugePages_Free == HugePages_Total`; the same configuration starts with the reservation removed, on 4 KiB pages.

Prior art: #35048 by @luke-edward and #27267 by @jeynmann identified the same defect; both are currently conflicting with `main`. This PR is the minimal preflight fix on current `main`: no new modes or environment variables, `alloc_mmap()` keeps its hugetlb-then-fallback behavior, and the credit is granted only where the allocation demonstrably comes from the hugetlb pool. If maintainers prefer the mode-based design of #27267, I am happy to close this in its favor; a `required` mode that refuses the silent fallback is a separate concern and is left to that PR.

## Modifications

- `storage/mmap/mmap_allocator.py`: `hugepage_size_requested()` is the single parser of `SGLANG_HUGEPAGE_SIZE` (`alloc_mmap()` now uses it; its control flow and fallback behavior are unchanged). `hugetlb_pool_free_bytes()` reports what a new mapping could take from the hugetlb pool of that size, read from sysfs (`hugepages-<kB>kB/`, one pool per page size; `/proc/meminfo` shows only the default size) as `free_hugepages - resv_hugepages`: pages a mapping has reserved but not yet faulted in still count as free, and co-located ranks populate their pools concurrently. It is 0 whenever `alloc_mmap()` would not map from the pool: hugepages not requested, libc not loadable (plain mmap before any hugetlb attempt), or sysfs unreadable.
- `pool_host/common.py`: `HostTensorAllocator.free_hugetlb_bytes()` returns that pool only when `allocate()` is the base implementation, the one that calls `alloc_mmap()`. Allocators that get their memory elsewhere (`ShmHostTensorAllocator`, `MooncakeHostTensorAllocator`, `UMBPHostTensorAllocator`) override `allocate()` and are credited nothing without further changes. `device_uses_allocator()` says whether `ALLOC_MEMORY_FUNCS[device]` dispatches to the allocator at all; npu/musa allocate with `torch.empty(pin_memory=True)` and never touch it.
- `pool_host/base.py`: `host_memory_budget_bytes(allocator, device)` takes the larger of `available − reserve` and the creditable hugetlb pool, then splits by `ranks_per_host()` as before. The two budgets are alternatives, not a sum: one mapping is served entirely by the hugetlb pool or entirely by plain pages. The reserve stays on plain RAM; the hugetlb pool is dedicated. Without a creditable pool the plain budget is returned as is, so the existing failure message is unchanged.
- The six sizing guards (`HostKVCache`, `DSAIndexerPoolHost`, `MHATokenToKOnlyPoolHost`, `MambaPoolHost`, `DeepSeekV4PagedHostPool`, `DeepSeekV4StateHostPool`) pass their allocator and device.
- Docs: two sentences under `SGLANG_HUGEPAGE_SIZE` in `environment_variables.mdx`, including the advice to reserve one extra 1 GiB page per host buffer.
- Unit tests: `test_mmap_allocator.py` (`TestHugetlbPool`: env parsing, sysfs reading per pool size from a temp dir, `resv` subtraction, the zero cases), `test_mem_pool_host.py` (`TestHostMemoryBudget`: hugetlb as the alternative budget without the reserve, plain pages win when larger, no credit for pin-memory devices, negative plain budget kept as is, the guard passes its allocator and device; `TestHostTensorAllocatorHugetlb`: only the mmap allocator reports the pool) and the two DeepSeek V4 pool tests in `test_hicache_host_register.py` now assert the same wiring.

Behavior without `SGLANG_HUGEPAGE_SIZE` is unchanged. With an unrecognized value the warning is now logged once more, from the guard.

Limits, stated in the docstring: the credit is only as safe as the fallback is loud. A mapping the hugetlb pool cannot serve (per-mapping rounding to whole pages, which matters with 1 GiB pages and per-layer buffers; a neighbour's reservation; a hugetlb cgroup limit) is logged at ERROR by `alloc_mmap()` and lands on plain RAM the budget did not account for. Refusing that fallback is the `required` mode of #27267 and is deliberately not part of this PR. The sysfs counters are host-global while `numactl --membind` is applied per scheduler; with the default even split of `nr_hugepages` across nodes the per-rank result is the same, and MemAvailable has the same blindness today.

Relation to #38157, which changes the same function: that PR reduces the psutil reading to the TP group-wide minimum before the split. Whichever lands second should take the reading behind the reduce as `max(available - reserve, hugetlb)`, so that a late rank does not see its peers' populated pools missing from `free_hugepages` while still dividing by the full rank count. The credit adds no collectives.

## Accuracy Tests

Not applicable: host-pool sizing guards only, no model forward changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34026482101](https://github.com/sgl-project/sglang/actions/runs/34026482101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34026481996](https://github.com/sgl-project/sglang/actions/runs/34026481996)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34026482087](https://github.com/sgl-project/sglang/actions/runs/34026482087)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->