### PR TITLE
[Qwen3.8-Flash-Next] Streamline QSA prefill selection

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/kernel.py
+++ b/python/sglang/srt/layers/attention/qsa/kernel.py
@@ -73,6 +73,179 @@ def qsa_fast_topk(
     return output
 
 
+@triton.jit(do_not_specialize=["ss_b"])
+def _pack_qsa_prefill_compressed_keys_kernel(
+    compressed_k,
+    token_slot_table,
+    sequence_lengths,
+    compressed_cu_seqlens,
+    output,
+    sk_n: tl.constexpr,
+    sk_h: tl.constexpr,
+    sk_d: tl.constexpr,
+    ss_b,
+    ss_t: tl.constexpr,
+    so_n: tl.constexpr,
+    so_h: tl.constexpr,
+    so_d: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Pack one request's compressed-cache rows into its ragged segment."""
+
+    request = tl.program_id(0)
+    row_block = tl.program_id(1)
+    head = tl.program_id(2)
+    rows = row_block * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    dims = tl.arange(0, BLOCK_D)
+    num_blocks = tl.load(sequence_lengths + request) // COMPRESS_RATIO
+    valid_rows = rows < num_blocks
+    raw_slots = tl.load(
+        token_slot_table + request * ss_b + rows * COMPRESS_RATIO * ss_t,
+        mask=valid_rows,
+        other=0,
+    ).to(tl.int64)
+    compressed_slots = raw_slots // COMPRESS_RATIO
+    packed_rows = tl.load(compressed_cu_seqlens + request).to(tl.int64) + rows
+    mask = valid_rows[:, None] & (dims[None, :] < HEAD_DIM)
+    src = compressed_slots[:, None] * sk_n + head * sk_h + dims[None, :] * sk_d
+    dst = packed_rows[:, None] * so_n + head * so_h + dims[None, :] * so_d
+    tl.store(output + dst, tl.load(compressed_k + src, mask=mask), mask=mask)
+
+
+def qsa_pack_prefill_compressed_keys(
+    compressed_k: torch.Tensor,
+    token_slot_table: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compressed_cu_seqlens: torch.Tensor,
+    output: torch.Tensor,
+    compress_ratio: int,
+) -> torch.Tensor:
+    """Gather page-fragmented compressed keys without a host readback."""
+
+    if output.shape[0] == 0:
+        return output
+    batch = sequence_lengths.shape[0]
+    num_kv_heads, head_dim = compressed_k.shape[1:]
+    block_rows = 8
+    max_blocks = token_slot_table.shape[1] // compress_ratio
+    _pack_qsa_prefill_compressed_keys_kernel[
+        (batch, triton.cdiv(max_blocks, block_rows), num_kv_heads)
+    ](
+        compressed_k,
+        token_slot_table,
+        sequence_lengths,
+        compressed_cu_seqlens,
+        output,
+        compressed_k.stride(0),
+        compressed_k.stride(1),
+        compressed_k.stride(2),
+        token_slot_table.stride(0),
+        token_slot_table.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=head_dim,
+        BLOCK_ROWS=block_rows,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+        num_warps=4,
+    )
+    return output
+
+
+QSA_PREFILL_ALL_VISIBLE_MAX_BATCH = 256
+_QSA_PREFILL_ALL_VISIBLE_BLOCK_N = 512
+
+
+@triton.jit(do_not_specialize=["batch"])
+def _qsa_prefill_all_visible_indices_kernel(
+    query_positions,
+    token_to_batch_idx,
+    sequence_lengths,
+    output,
+    batch,
+    TOKEN_TOPK: tl.constexpr,
+    FINAL_TOPK: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SEQUENCE_WIDTH: tl.constexpr,
+):
+    """Materialize every causally visible logical token index."""
+
+    row = tl.program_id(0)
+    column_tile = tl.program_id(1)
+
+    query_position = tl.load(query_positions + row)
+    request = tl.load(token_to_batch_idx + row)
+    sequence_lanes = tl.arange(0, SEQUENCE_WIDTH)
+    sequence_values = tl.load(
+        sequence_lengths + sequence_lanes,
+        mask=sequence_lanes < batch,
+        other=0,
+    )
+    sequence_length = tl.sum(tl.where(sequence_lanes == request, sequence_values, 0))
+    visible = tl.minimum(query_position + 1, sequence_length.to(tl.int64))
+    visible = tl.minimum(tl.maximum(visible, 0), TOKEN_TOPK)
+
+    columns = column_tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    values = tl.where(columns.to(tl.int64) < visible, columns, -1)
+    tl.store(
+        output + row.to(tl.int64) * FINAL_TOPK + columns,
+        values,
+        mask=columns < FINAL_TOPK,
+    )
+
+
+def qsa_prefill_all_visible_indices(
+    query_positions: torch.Tensor,
+    token_to_batch_idx: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    output: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+) -> torch.Tensor:
+    """Write the QSA short-context result with one asynchronous Triton launch."""
+
+    rows = query_positions.numel()
+    final_topk = token_topk + compress_ratio - 1
+    if query_positions.ndim != 1 or token_to_batch_idx.ndim != 1:
+        raise ValueError("QSA all-visible positions and request ids must be 1-D")
+    if token_to_batch_idx.numel() != rows:
+        raise ValueError(
+            "QSA all-visible positions and request ids must have equal size"
+        )
+    if sequence_lengths.ndim != 1:
+        raise ValueError("QSA all-visible sequence lengths must be 1-D")
+    if sequence_lengths.shape[0] > QSA_PREFILL_ALL_VISIBLE_MAX_BATCH:
+        raise ValueError("QSA all-visible batch exceeds the Triton selection width")
+    if output.shape != (rows, final_topk):
+        raise ValueError(
+            f"QSA all-visible output must be [{rows}, {final_topk}], got {output.shape}"
+        )
+    if output.dtype != torch.int32 or not output.is_contiguous():
+        raise ValueError("QSA all-visible output must be contiguous int32")
+    if rows == 0:
+        return output
+
+    _qsa_prefill_all_visible_indices_kernel[
+        (rows, triton.cdiv(final_topk, _QSA_PREFILL_ALL_VISIBLE_BLOCK_N))
+    ](
+        query_positions,
+        token_to_batch_idx,
+        sequence_lengths,
+        output,
+        sequence_lengths.shape[0],
+        TOKEN_TOPK=token_topk,
+        FINAL_TOPK=final_topk,
+        BLOCK_N=_QSA_PREFILL_ALL_VISIBLE_BLOCK_N,
+        SEQUENCE_WIDTH=QSA_PREFILL_ALL_VISIBLE_MAX_BATCH,
+        num_warps=4,
+    )
+    return output
+
+
 def _rerank_qsa_topk_candidates(
     logits: torch.Tensor,
     candidates: torch.Tensor,
@@ -344,11 +517,14 @@ def qsa_sparse_attention_reference(
 
 
 __all__ = [
+    "QSA_PREFILL_ALL_VISIBLE_MAX_BATCH",
     "average_pool_qsa_keys",
     "expand_qsa_block_indices",
     "torch_expand_qsa_block_indices",
     "triton_expand_qsa_block_indices",
     "qsa_fast_topk",
+    "qsa_pack_prefill_compressed_keys",
+    "qsa_prefill_all_visible_indices",
     "qsa_sparse_attention",
     "qsa_sparse_attention_reference",
 ]

--- a/python/sglang/srt/layers/attention/qsa/metadata.py
+++ b/python/sglang/srt/layers/attention/qsa/metadata.py
@@ -11,7 +11,10 @@ from typing import Optional, Tuple
 import msgspec
 import torch
 
-from sglang.srt.layers.attention.qsa.kernel import qsa_fast_topk
+from sglang.srt.layers.attention.qsa.kernel import (
+    qsa_fast_topk,
+    qsa_pack_prefill_compressed_keys,
+)
 
 
 def build_qsa_row_ranges(
@@ -90,6 +93,12 @@ class QSAIndexerMetadata(msgspec.Struct, frozen=True):
     compress_group_ring_locs: Optional[torch.Tensor] = None
     extend_rope_matrix: Optional[torch.Tensor] = None
     graph_ring_group_locs: Optional[torch.Tensor] = None
+    prefill_compressed_cu_seqlens: Optional[torch.Tensor] = None
+    prefill_row_starts: Optional[torch.Tensor] = None
+    prefill_row_ends: Optional[torch.Tensor] = None
+    prefill_compressed_scratch: Optional[torch.Tensor] = None
+    prefill_all_visible: bool = False
+    prefill_all_visible_scratch: Optional[torch.Tensor] = None
 
     def get_seqlens_int32(self) -> torch.Tensor:
         return self.sequence_lengths.to(torch.int32)
@@ -133,48 +142,37 @@ class QSAIndexerMetadata(msgspec.Struct, frozen=True):
         its assigned pages, in block order.
         """
 
-        pool = self.token_to_kv_pool
-        ratio = self.compress_ratio
-        compressed_buffer = pool.get_qsa_compressed_k_buffer(layer_id)
-        parts = []
         sequence_lengths = self.sequence_lengths.to(torch.int32)
-        sequence_lengths_list = sequence_lengths.tolist()
-        for sequence_id in range(len(sequence_lengths_list)):
-            complete_blocks = int(sequence_lengths_list[sequence_id]) // ratio
-            if complete_blocks == 0:
-                continue
-            # DSV4-style addressing: a group's compressed slot is its first
-            # raw slot // ratio (the page-aligned allocator keeps the group
-            # contiguous in one page), read straight off the request's
-            # token-slot row.
-            compressed_locs = (
-                self.token_slot_table[
-                    sequence_id, : complete_blocks * ratio : ratio
-                ].long()
-                // ratio
-            )
-            parts.append(compressed_buffer.index_select(0, compressed_locs))
-        compressed_keys = (
-            torch.cat(parts, dim=0)
-            if parts
-            else compressed_buffer.new_empty(
-                (0, pool.qsa_index_kv_heads, pool.qsa_index_head_dim)
-            )
-        )
         num_valid_tokens = self.token_to_batch_idx.numel()
         if positions.numel() < num_valid_tokens:
             raise ValueError(
                 "QSA prefill positions are shorter than the request mapping: "
                 f"positions={positions.numel()}, mapping={num_valid_tokens}"
             )
-        positions = positions[:num_valid_tokens]
-        row_starts, row_ends, _ = build_qsa_row_ranges(
+        if (
+            self.prefill_compressed_cu_seqlens is None
+            or self.prefill_row_starts is None
+            or self.prefill_row_ends is None
+            or self.prefill_compressed_scratch is None
+        ):
+            raise RuntimeError(
+                "QSA prefill pack metadata was not initialized by the attention backend"
+            )
+        compressed_buffer = self.token_to_kv_pool.get_qsa_compressed_k_buffer(layer_id)
+        compressed_keys = qsa_pack_prefill_compressed_keys(
+            compressed_buffer,
+            self.token_slot_table,
             sequence_lengths,
-            positions.to(sequence_lengths.device),
-            self.token_to_batch_idx.to(sequence_lengths.device),
+            self.prefill_compressed_cu_seqlens,
+            self.prefill_compressed_scratch,
             self.compress_ratio,
         )
-        return compressed_keys, row_starts, row_ends, sequence_lengths
+        return (
+            compressed_keys,
+            self.prefill_row_starts,
+            self.prefill_row_ends,
+            sequence_lengths,
+        )
 
     def get_decode_mqa_inputs(
         self, layer_id: int

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.qsa.kernel import (
     average_pool_qsa_keys,
     expand_qsa_block_indices,
     qsa_fast_topk,
+    qsa_prefill_all_visible_indices,
 )
 from sglang.srt.layers.attention.qsa.metadata import (
     build_group_ring_slots,
@@ -21,7 +22,6 @@ from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.layers.utils import MultiPlatformOp
-from sglang.srt.model_executor.runner import get_is_capture_mode
 
 # Bound the dominant FP32 [query_rows, compressed_keys] prefill workspace.
 # Top-k is row-independent, so large scheduler chunks can be scored in smaller
@@ -178,12 +178,9 @@ class QSAIndexer(MultiPlatformOp):
                 qsa_index_q_norm_rope_store,
             )
 
-            if not get_is_capture_mode() and hasattr(
-                self.rotary_emb, "_ensure_cos_sin_cache_length"
-            ):
-                self.rotary_emb._ensure_cos_sin_cache_length(
-                    int(positions.max().item())
-                )
+            # ModelRunner expands every RoPE cache to the serving context
+            # bound after loading and before any graph capture. Reading the
+            # maximum position back to the host here serializes every QSA layer.
             key_state_buffer = pool.get_qsa_key_state_buffer(self.layer_id)
             q = qsa_index_q_norm_rope_store(
                 qk,
@@ -412,10 +409,8 @@ class QSAIndexer(MultiPlatformOp):
         )
         if num_positions != tensor.shape[0]:
             raise ValueError("QSA RoPE positions must match the token dimension")
-        if not get_is_capture_mode() and hasattr(
-            self.rotary_emb, "_ensure_cos_sin_cache_length"
-        ):
-            self.rotary_emb._ensure_cos_sin_cache_length(int(positions.max().item()))
+        # RoPE capacity is reserved once by ModelRunner after model loading.
+        # Keep this per-layer path device-asynchronous.
 
         # Let the exact Qwen4-Exp RoPE instance compose regular or three-axis
         # multimodal positions.  Its public cache view repeats cos/sin to the
@@ -436,6 +431,22 @@ class QSAIndexer(MultiPlatformOp):
             self.rotary_emb.is_neox_style,
         )
         return torch.cat([rotated, tensor[..., rotary_dim:]], dim=-1)
+
+    def select_prefill_all_visible_tokens(
+        self,
+        query_positions: torch.Tensor,
+        token_to_batch_idx: torch.Tensor,
+        sequence_lengths: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        return qsa_prefill_all_visible_indices(
+            query_positions,
+            token_to_batch_idx,
+            sequence_lengths,
+            output,
+            self.token_topk,
+            self.compress_ratio,
+        )
 
     def select_prefill_tokens(
         self,
@@ -628,6 +639,22 @@ class QSAIndexer(MultiPlatformOp):
                 max_model_len,
                 logical_positions,
                 indexer_metadata.get_seqlens_int32(),
+            )
+
+        if getattr(indexer_metadata, "prefill_all_visible", False):
+            # fast_topk explicitly leaves result order unspecified. Sparse
+            # attention consumes the selected set, so the ascending canonical
+            # range is a valid representation when every visible token wins.
+            output = indexer_metadata.prefill_all_visible_scratch
+            if output is None:
+                raise RuntimeError(
+                    "QSA all-visible prefill scratch was not initialized"
+                )
+            return self.select_prefill_all_visible_tokens(
+                logical_positions,
+                indexer_metadata.get_token_to_batch_idx(),
+                indexer_metadata.get_seqlens_int32(),
+                output,
             )
 
         compressed_keys, row_starts, row_ends, sequence_lengths = (

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -22,11 +22,15 @@ from sglang.srt.layers.attention.qsa.config import (
     is_qwen_qsa,
     parse_qsa_profile,
 )
-from sglang.srt.layers.attention.qsa.kernel import qsa_sparse_attention
+from sglang.srt.layers.attention.qsa.kernel import (
+    QSA_PREFILL_ALL_VISIBLE_MAX_BATCH,
+    qsa_sparse_attention,
+)
 from sglang.srt.layers.attention.qsa.metadata import (
     QSAIndexerMetadata,
     build_group_ring_slots,
     build_pending_ring_slots,
+    build_qsa_row_ranges,
     build_rope_position_matrix,
     compressed_decode_view,
 )
@@ -236,6 +240,12 @@ class QwenSparseAttnBackend(AttentionBackend):
             Tuple[int, int, torch.dtype, torch.device],
             Tuple[torch.Tensor, torch.Tensor],
         ] = {}
+        self._qsa_prefill_compressed_scratch: Dict[
+            Tuple[int, int, torch.dtype, torch.device], torch.Tensor
+        ] = {}
+        self._qsa_prefill_indices_scratch: Dict[
+            Tuple[int, torch.device], torch.Tensor
+        ] = {}
         self._graph_seq_lens = None
         self._graph_token_to_batch = None
         self._graph_cu_seqlens_q = None
@@ -259,6 +269,17 @@ class QwenSparseAttnBackend(AttentionBackend):
         if forward_mode is None:
             return False
         return forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2()
+
+    @staticmethod
+    def _can_use_qsa_prefill_all_visible(
+        max_length: int,
+        num_sequences: int,
+        token_topk: int,
+    ) -> bool:
+        return (
+            max_length <= token_topk
+            and num_sequences <= QSA_PREFILL_ALL_VISIBLE_MAX_BATCH
+        )
 
     def _require_chain_speculation(self, forward_mode, spec_info) -> None:
         if forward_mode is None or not forward_mode.is_target_verify():
@@ -649,10 +670,43 @@ class QwenSparseAttnBackend(AttentionBackend):
         else:
             sequence_lengths = forward_batch.seq_lens.to(torch.int32)
             batch_size = sequence_lengths.numel()
-            if forward_batch.seq_lens_cpu is not None:
-                max_length = int(forward_batch.seq_lens_cpu[:batch_size].max())
-            else:
-                max_length = int(sequence_lengths.max())
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            if seq_lens_cpu is None and not forward_batch.forward_mode.is_decode():
+                prefix_lens_cpu = getattr(forward_batch, "extend_prefix_lens_cpu", None)
+                extend_lens_cpu = getattr(forward_batch, "extend_seq_lens_cpu", None)
+                if (
+                    prefix_lens_cpu is not None
+                    and extend_lens_cpu is not None
+                    and not (
+                        isinstance(prefix_lens_cpu, torch.Tensor)
+                        and prefix_lens_cpu.device.type != "cpu"
+                    )
+                    and not (
+                        isinstance(extend_lens_cpu, torch.Tensor)
+                        and extend_lens_cpu.device.type != "cpu"
+                    )
+                    and len(prefix_lens_cpu) >= batch_size
+                    and len(extend_lens_cpu) >= batch_size
+                ):
+                    seq_lens_cpu = tuple(
+                        int(prefix_lens_cpu[i]) + int(extend_lens_cpu[i])
+                        for i in range(batch_size)
+                    )
+            if seq_lens_cpu is None and not forward_batch.forward_mode.is_decode():
+                raise ValueError(
+                    "QSA prefill metadata requires scheduler-maintained CPU "
+                    "sequence or extend lengths"
+                )
+            if (
+                isinstance(seq_lens_cpu, torch.Tensor)
+                and seq_lens_cpu.device.type != "cpu"
+            ):
+                raise ValueError("QSA seq_lens_cpu must be host-resident")
+            max_length = (
+                int(sequence_lengths.max())
+                if seq_lens_cpu is None
+                else max(int(seq_lens_cpu[i]) for i in range(batch_size))
+            )
             row_req_pool_indices = forward_batch.req_pool_indices[:batch_size]
             token_slot_table = self.req_to_token[
                 row_req_pool_indices.long(), :max_length
@@ -767,6 +821,62 @@ class QwenSparseAttnBackend(AttentionBackend):
                             sequence_ids=group_sequence_ids.long(),
                             compress_ratio=self.compress_ratio,
                         )
+        prefill_compressed_cu_seqlens = None
+        prefill_row_starts = None
+        prefill_row_ends = None
+        prefill_compressed_scratch = None
+        prefill_all_visible = False
+        prefill_all_visible_scratch = None
+        if (
+            (
+                self.qsa_profile is None
+                or self.qsa_profile.variant == QSA_VARIANT_COMPRESSED
+            )
+            and not speculative_paged
+            and not forward_batch.forward_mode.is_decode()
+        ):
+            num_sequences = int(sequence_lengths.numel())
+            if seq_lens_cpu is None or len(seq_lens_cpu) < num_sequences:
+                raise ValueError(
+                    "QSA prefill pack requires the scheduler's CPU sequence lengths"
+                )
+            pool = self.token_to_kv_pool
+            prefill_all_visible = self._can_use_qsa_prefill_all_visible(
+                max_length,
+                num_sequences,
+                pool.qsa_token_topk,
+            )
+            if prefill_all_visible:
+                prefill_all_visible_scratch = self._get_qsa_prefill_indices_scratch(
+                    token_to_batch_idx.numel(),
+                    pool.qsa_token_topk + self.compress_ratio - 1,
+                    sequence_lengths.device,
+                )
+            else:
+                packed_blocks = sum(
+                    int(seq_lens_cpu[i]) // self.compress_ratio
+                    for i in range(num_sequences)
+                )
+                query_positions = forward_batch.positions.flatten()[
+                    : token_to_batch_idx.numel()
+                ]
+                (
+                    prefill_row_starts,
+                    prefill_row_ends,
+                    prefill_compressed_cu_seqlens,
+                ) = build_qsa_row_ranges(
+                    sequence_lengths,
+                    query_positions,
+                    token_to_batch_idx,
+                    self.compress_ratio,
+                )
+                prefill_compressed_scratch = self._get_qsa_prefill_compressed_scratch(
+                    packed_blocks,
+                    pool.qsa_index_kv_heads,
+                    pool.qsa_index_head_dim,
+                    pool.qsa_compressed_flat.dtype,
+                    pool.qsa_compressed_flat.device,
+                )
         indexer_metadata = QSAIndexerMetadata(
             sequence_lengths=sequence_lengths,
             token_to_batch_idx=token_to_batch_idx,
@@ -786,6 +896,12 @@ class QwenSparseAttnBackend(AttentionBackend):
             pending_ring_slots=pending_ring_slots,
             compress_group_ring_locs=compress_group_ring_locs,
             extend_rope_matrix=extend_rope_matrix,
+            prefill_compressed_cu_seqlens=prefill_compressed_cu_seqlens,
+            prefill_row_starts=prefill_row_starts,
+            prefill_row_ends=prefill_row_ends,
+            prefill_compressed_scratch=prefill_compressed_scratch,
+            prefill_all_visible=prefill_all_visible,
+            prefill_all_visible_scratch=prefill_all_visible_scratch,
         )
         return QwenSparseAttnMetadata(
             sequence_lengths=sequence_lengths,
@@ -1512,6 +1628,42 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
+
+    def _get_qsa_prefill_compressed_scratch(
+        self,
+        capacity: int,
+        num_kv_heads: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        key = (num_kv_heads, head_dim, dtype, device)
+        buffer = self._qsa_prefill_compressed_scratch.get(key)
+        if buffer is None or buffer.shape[0] < capacity:
+            buffer = torch.empty(
+                (capacity, num_kv_heads, head_dim),
+                dtype=dtype,
+                device=device,
+            )
+            self._qsa_prefill_compressed_scratch[key] = buffer
+        return buffer[:capacity]
+
+    def _get_qsa_prefill_indices_scratch(
+        self,
+        capacity: int,
+        width: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        key = (width, device)
+        buffer = self._qsa_prefill_indices_scratch.get(key)
+        if buffer is None or buffer.shape[0] < capacity:
+            buffer = torch.empty(
+                (capacity, width),
+                dtype=torch.int32,
+                device=device,
+            )
+            self._qsa_prefill_indices_scratch[key] = buffer
+        return buffer[:capacity]
 
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)

--- a/test/registered/kernels/ops/attention/test_qsa_prefill_compressed_pack.py
+++ b/test/registered/kernels/ops/attention/test_qsa_prefill_compressed_pack.py
@@ -1,0 +1,197 @@
+"""QSA prefill synchronization and compressed-key pack tests."""
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.qsa.kernel import (
+    qsa_pack_prefill_compressed_keys,
+    qsa_prefill_all_visible_indices,
+)
+from sglang.srt.layers.attention.qsa.metadata import QSAIndexerMetadata
+from sglang.srt.layers.attention.qsa.qsa_indexer import QSAIndexer
+from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
+    QwenSparseAttnBackend,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def _forbidden_calls(function, names: set[str]) -> list[str]:
+    tree = ast.parse(textwrap.dedent(inspect.getsource(function)))
+    return [
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in names
+    ]
+
+
+def test_qsa_prefill_hot_paths_have_no_explicit_host_materialization():
+    hot_paths = (
+        QSAIndexer.project_qk,
+        QSAIndexer.apply_rope,
+        QSAIndexerMetadata.get_prefill_mqa_inputs,
+        QwenSparseAttnBackend._metadata_from_forward_batch,
+    )
+    for function in hot_paths:
+        assert not _forbidden_calls(
+            function, {"item", "tolist", "cpu"}
+        ), function.__qualname__
+    for function in (QSAIndexer.project_qk, QSAIndexer.apply_rope):
+        assert not _forbidden_calls(function, {"max"}), function.__qualname__
+
+
+def test_qsa_prefill_pack_has_no_eager_gather_chain():
+    assert not _forbidden_calls(
+        QSAIndexerMetadata.get_prefill_mqa_inputs,
+        {"tolist", "index_select", "cat"},
+    )
+
+
+def _fragmented_slot_table(sequence_lens, page_size=64):
+    max_length = max(sequence_lens)
+    table = torch.zeros(
+        (len(sequence_lens), max_length), dtype=torch.int32, device="cuda"
+    )
+    next_page = 3
+    max_page = 0
+    for request, length in enumerate(sequence_lens):
+        cursor = 0
+        while cursor < length:
+            page = next_page
+            next_page += 2 + (request & 1)
+            count = min(page_size, length - cursor)
+            table[request, cursor : cursor + count] = page * page_size + torch.arange(
+                count, dtype=torch.int32, device="cuda"
+            )
+            cursor += count
+            max_page = max(max_page, page)
+    return table, max_page
+
+
+@pytest.mark.parametrize(
+    "sequence_lens",
+    (
+        (1, 2, 3),
+        (3, 4, 7),
+        (33,),
+        (83, 42),
+        (76, 68, 67),
+        (33, 45, 56, 64, 68, 75, 88, 101),
+        (8192,),
+    ),
+)
+def test_qsa_prefill_compressed_pack_matches_indirect_gather(sequence_lens):
+    ratio, heads, head_dim, page_size = 4, 1, 128, 64
+    slot_table, max_page = _fragmented_slot_table(sequence_lens, page_size)
+    compressed_rows = (max_page + 1) * (page_size // ratio)
+    compressed_k = torch.randn(
+        compressed_rows,
+        heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    block_lens = [length // ratio for length in sequence_lens]
+    cu_cpu = [0]
+    for length in block_lens:
+        cu_cpu.append(cu_cpu[-1] + length)
+    seq = torch.tensor(sequence_lens, dtype=torch.int32, device="cuda")
+    cu = torch.tensor(cu_cpu, dtype=torch.int32, device="cuda")
+    output = torch.empty(
+        (cu_cpu[-1], heads, head_dim), dtype=compressed_k.dtype, device="cuda"
+    )
+
+    packed = qsa_pack_prefill_compressed_keys(
+        compressed_k, slot_table, seq, cu, output, ratio
+    )
+    assert packed.data_ptr() == output.data_ptr()
+    expected = []
+    for request, block_count in enumerate(block_lens):
+        raw_slots = slot_table[request, : block_count * ratio : ratio]
+        expected.append(compressed_k.index_select(0, raw_slots.long() // ratio))
+    expected_packed = torch.cat(expected) if expected else output.clone()
+    torch.testing.assert_close(packed, expected_packed, rtol=0, atol=0)
+
+
+def test_qsa_prefill_compressed_scratch_is_reused():
+    backend = QwenSparseAttnBackend.__new__(QwenSparseAttnBackend)
+    backend._qsa_prefill_compressed_scratch = {}
+    device = torch.device("cuda")
+    large = backend._get_qsa_prefill_compressed_scratch(
+        1024, 1, 128, torch.bfloat16, device
+    )
+    small = backend._get_qsa_prefill_compressed_scratch(
+        52, 1, 128, torch.bfloat16, device
+    )
+    assert small.data_ptr() == large.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "sequence_lens,query_ranges",
+    (
+        ((1, 3, 4), None),
+        ((33,), None),
+        ((80, 36), None),
+        ((76, 68, 67), None),
+        ((1024, 2048), ((1008, 1024), (2032, 2048))),
+        ((2047, 2048), ((2039, 2047), (2040, 2048))),
+    ),
+)
+def test_qsa_prefill_all_visible_indices_matches_reference(sequence_lens, query_ranges):
+    token_topk, compress_ratio = 2048, 4
+    ranges = (
+        tuple((0, length) for length in sequence_lens)
+        if query_ranges is None
+        else query_ranges
+    )
+    position_parts = []
+    request_parts = []
+    for request, (start, end) in enumerate(ranges):
+        position_parts.append(
+            torch.arange(start, end, dtype=torch.int64, device="cuda")
+        )
+        request_parts.append(
+            torch.full((end - start,), request, dtype=torch.int32, device="cuda")
+        )
+    positions = torch.cat(position_parts)
+    request_ids = torch.cat(request_parts)
+    lengths = torch.tensor(sequence_lens, dtype=torch.int32, device="cuda")
+    output = torch.empty(
+        (positions.numel(), token_topk + compress_ratio - 1),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    actual = qsa_prefill_all_visible_indices(
+        positions,
+        request_ids,
+        lengths,
+        output,
+        token_topk,
+        compress_ratio,
+    )
+    columns = torch.arange(output.shape[1], dtype=torch.int32, device="cuda")
+    row_lengths = lengths.index_select(0, request_ids.long()).long()
+    visible = torch.minimum(positions + 1, row_lengths).clamp(max=token_topk)
+    expected = torch.where(
+        columns[None, :] < visible[:, None], columns[None, :], -1
+    ).contiguous()
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_qsa_prefill_indices_scratch_is_reused():
+    backend = QwenSparseAttnBackend.__new__(QwenSparseAttnBackend)
+    backend._qsa_prefill_indices_scratch = {}
+    device = torch.device("cuda")
+    large = backend._get_qsa_prefill_indices_scratch(1024, 2051, device)
+    small = backend._get_qsa_prefill_indices_scratch(52, 2051, device)
+    assert small.data_ptr() == large.data_ptr()

--- a/test/registered/kernels/test_qsa.py
+++ b/test/registered/kernels/test_qsa.py
@@ -1451,6 +1451,45 @@ def test_qsa_extend_rope_matrix_uses_mrope_coordinates():
     assert torch.equal(got, mrope.transpose(0, 1))
 
 
+def test_qsa_short_extend_prepares_all_visible_scratch_and_skips_pack():
+    runner, pool, req_pool = _make_qsa_runner_and_pool()
+    backend = QwenSparseAttnBackend(runner)
+    num_tokens = 8
+    positions = torch.arange(num_tokens, dtype=torch.int64)
+    forward_batch = SimpleNamespace(
+        token_to_kv_pool=pool,
+        req_to_token_pool=req_pool,
+        req_pool_indices=torch.tensor([1], dtype=torch.int32),
+        seq_lens=torch.tensor([num_tokens], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([num_tokens], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        extend_seq_lens=torch.tensor([num_tokens], dtype=torch.int32),
+        extend_prefix_lens=torch.zeros(1, dtype=torch.int32),
+        positions=positions,
+        mrope_positions=None,
+        input_ids=torch.zeros(num_tokens, dtype=torch.int32),
+        out_cache_loc=torch.arange(num_tokens, dtype=torch.int32),
+        _original_forward_mode=None,
+    )
+
+    backend.init_forward_metadata(forward_batch)
+    metadata = backend.forward_metadata.indexer_metadata
+
+    assert metadata.prefill_all_visible
+    assert metadata.prefill_all_visible_scratch.shape == (num_tokens, FINAL_TOPK)
+    assert metadata.prefill_compressed_scratch is None
+    assert metadata.prefill_compressed_cu_seqlens is None
+    assert metadata.prefill_row_starts is None
+    assert metadata.prefill_row_ends is None
+
+
+def test_qsa_all_visible_host_guard_boundaries():
+    eligible = QwenSparseAttnBackend._can_use_qsa_prefill_all_visible
+    assert eligible(TOKEN_TOPK, 128, TOKEN_TOPK)
+    assert not eligible(TOKEN_TOPK + 1, 128, TOKEN_TOPK)
+    assert not eligible(TOKEN_TOPK, 257, TOKEN_TOPK)
+
+
 def test_qsa_speculative_pseudo_extend_is_rejected():
     runner, pool, req_pool = _make_qsa_runner_and_pool()
     backend = QwenSparseAttnBackend(runner)
@@ -1674,6 +1713,10 @@ class _DispatchIndexer:
         self.selected = "prefill"
         return torch.tensor([1])
 
+    def select_prefill_all_visible_tokens(self, *args):
+        self.selected = "all_visible"
+        return torch.tensor([3])
+
     def select_decode_tokens(self, *args):
         self.selected = "decode"
         return torch.tensor([2])
@@ -1690,6 +1733,8 @@ class _DispatchMetadata:
     compress_member_rows = None
     decode_logical_positions = None
     pending_ring_slots = None
+    prefill_all_visible = False
+    prefill_all_visible_scratch = None
     # Consumed by the real _pending_ring_slots helper the dispatch indexer
     # borrows: one token row owned by request slot 1.
     token_to_batch_idx = torch.zeros(2, dtype=torch.int32)
@@ -1849,6 +1894,26 @@ def test_qsa_forward_cuda_dispatches_prefill_and_decode_mqa():
     assert indexer.selected == "decode"
     assert indexer.logical_positions.tolist() == [6]
     assert decode_result.item() == 2
+
+
+def test_qsa_forward_cuda_dispatches_all_visible_before_prefill_mqa():
+    indexer = _DispatchIndexer()
+    metadata = _DispatchMetadata()
+    metadata.prefill_all_visible = True
+    metadata.prefill_all_visible_scratch = torch.empty(1, FINAL_TOPK, dtype=torch.int32)
+    inputs = torch.zeros(1, 16)
+    positions = torch.zeros(1, dtype=torch.int64)
+
+    result = QSAIndexer.forward_cuda(
+        indexer,
+        inputs,
+        positions,
+        SimpleNamespace(forward_mode=_ForwardMode(False)),
+        metadata,
+    )
+
+    assert indexer.selected == "all_visible"
+    assert result.item() == 3
 
 
 def test_qsa_fast_topk_returns_sequence_relative_indices():


### PR DESCRIPTION
## Motivation

QSA prefill currently reads sequence lengths and RoPE positions back to the host in per-layer code, gathers compressed keys request by request, and repeats row-range preparation. It also runs MQA scoring and top-k when the entire visible context fits in the selection budget.

This PR removes that preparation overhead while keeping the existing long-context MQA and sparse attention kernels. In the completed 4x GB200 experiment below, the patch reduced single-request 8K/1K TTFT by 19.40% and improved total token throughput at concurrency 256 by 17.22%.

## Modifications

- Pack compressed indexer keys from the token slot table in one Triton launch instead of a per-request Python `index_select`/`cat` chain.
- Prepare compressed sequence offsets and row ranges once per forward; reuse capacity-based scratch buffers across QSA layers. Use scheduler-maintained CPU lengths to size prefill metadata.
- Remove per-layer `positions.max().item()` RoPE capacity checks. `ModelRunner` already reserves the serving context and speculative margin after loading the model.
- For ordinary compressed prefill with a maximum full sequence length at or below the token budget and at most 256 requests, directly write all causally visible logical indices. Projection and key/ring-cache updates still execute before this shortcut; decode and speculative selection retain their existing dispatch.
- Add tests for fragmented-page gathers, incomplete compression groups, short-context suffix queries, scratch reuse, host-readback regressions, and dispatch boundaries.

The pack path uses full sequence lengths, including prefixes. The all-visible guard also uses the full context, not just the current chunk length. This PR does not require a zero prefix.

## Accuracy Tests

Completed evaluations used `Qwen/Qwen3.8-Flash-Next-FP8`, TP4/EP4, EvalScope 1.10.0, temperature 0, max output 32768, concurrency 32, and thinking enabled.

| Evaluation | Original | Patched | Notes |
| --- | ---: | ---: | --- |
| MMMU-Pro, standard 4 options | 1467/1730 (84.7977%) | 1478/1730 (85.4335%) | Full dataset; all 1730 actual API inputs match |
| GSM8K | 1290/1319 (97.8014%), historical FP8 run | 1290/1319 (97.8014%) | Original was not rerun in this campaign; historical concurrency was 512, patched concurrency was 32 |

Prediction and review counts were audited with no duplicate or missing items and no API errors. MMMU-Pro had 33 original and 37 patched responses reach the generation cap without a final answer; all remain in the denominator as incorrect. Paired MMMU-Pro results: 1421 both correct, 46 original-only, 57 patched-only, 206 both incorrect. For GSM8K, all historical/patched API inputs match; 5 questions change in each direction.

These results show no aggregate accuracy regression on the evaluated datasets, not bitwise output equivalence or a statistically established accuracy improvement. Server seeds were automatically generated and differed between the two runs; benchmark/evaluation input seeds were 42. Only 1/10 single-request performance outputs were text-identical.

The original standalone `test_qsa_prefill_compressed_pack.py` completed **17 passed** on the GPU test host. This does not imply that the full `test_qsa.py` suite ran.

## Speed Tests and Profiling

**Environment:** 4x NVIDIA GB200 (SM100), `Qwen/Qwen3.8-Flash-Next-FP8`, TP4/EP4, PyTorch 2.13.0+cu130, static memory fraction 0.9, chunked prefill 8192, FlashInfer linear-attention prefill/decode, BF16 SSM state. Prefill CUDA graphs were disabled by the multimodal compatibility check in both runs; decode CUDA graphs remained enabled. FlashInfer allreduce fusion failed its allocation preflight and was skipped in both runs.

**Method:** native `/generate`, `random-ids` with `--tokenize-prompt` to send integer token IDs directly; exact 8192 input / 1024 output tokens for every request, seed 42, temperature 0, ignore EOS, 2 warmup requests, and cache flush before timing. Profiling was disabled for all numbers in this table. Total throughput includes input and output tokens. Concurrency is the client limit, not a constant GPU batch size.

| Version | Concurrency | Requests | Total tokens/s | Mean TTFT (ms) | Mean TPOT (ms) | Mean E2E (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Original | 1 | 10/10 | 1909.81 | 224.59 | 4.4962 | 4824.16 |
| Patched | 1 | 10/10 | 1928.18 | 181.03 | 4.4937 | 4778.08 |
| Original | 256 | 512/512 | 31236.54 | 34116.81 | 40.2184 | 75260.20 |
| Patched | 256 | 512/512 | 36614.09 | 26856.69 | 36.4845 | 64180.30 |

- Concurrency 1: TTFT **-19.40%**, total throughput **+0.96%**. Median TTFT 224.04 -> 181.58 ms; p95 230.08 -> 185.38 ms. The full 8192-token prefill exceeds the all-visible shortcut's 2048-token budget.
- Concurrency 256: total throughput **+17.22%**, TTFT **-21.28%**, TPOT **-9.28%**.
- All requests completed with exact input/output lengths and zero errors. This is one measured round per configuration, not a multi-round significance study. TTFT includes scheduling and queueing and is not a kernel-only metric.

**Benchmark baseline:** [lmsysorg/sglang:qwen38flashnext](https://hub.docker.com/layers/lmsysorg/sglang/qwen38flashnext/images/sha256-c93d57460ce7fca986c7c8150b5a2231b540ca226d17ef5563ac0dcee506c136). **Original** uses this Docker image as-is; **Patched** uses the same image with the patch applied.

Both versions also completed separate exact 8K/1K single-request CPU+GPU Torch Profiler captures on all four ranks. Profiler-instrumented timings and the earlier text-retokenized measurements are excluded from the table. No Nsight Compute hardware counters were collected. No multi-chunk/prefix-cache-hit serving benchmark or per-change performance ablation is claimed here.

Related work: FlashInfer's [paged scorer](https://github.com/flashinfer-ai/flashinfer/pull/4899) could eventually remove the need for compressed-key packing when integrated into this backend. This PR improves the currently used packed-prefill path; it does not introduce a new sparse-selection algorithm.

## Local validation

- Repository pre-commit hooks passed for all six changed files, including formatting, import/lint checks, Python AST checks, and registered-test validation.
- `git diff --check` passed; all six changed Python files passed AST parsing and compilation.
- The local checkout is on macOS without CUDA/Triton, so GPU/model tests were not rerun here. The GPU and model results above come from the Docker image comparison.

## Checklist

- [x] Format code with the repository pre-commit hooks.
- [x] Add registered regression tests.
- [x] Provide completed accuracy and speed results with their measured baseline and limitations.
- [x] Document behavior and scope in the PR; no public API or launch option is added.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829688429](https://github.com/sgl-project/sglang/actions/runs/34829688429)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829688196](https://github.com/sgl-project/sglang/actions/runs/34829688196)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829688302](https://github.com/sgl-project/sglang/actions/runs/34829688302)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->