### PR TITLE
Fix OTel tracing context lost in multi-tokenizer router processes

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -61,6 +61,10 @@ from sglang.srt.managers.load_snapshot import (
     zmq_reader_owner,
 )
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.observability.trace import (
+    get_global_tracing_enabled,
+    process_tracing_init,
+)
 from sglang.srt.runtime_context import (
     get_disagg,
 )
@@ -437,6 +441,21 @@ class MultiHttpWorkerDetokenizerMixin:
             self.soft_watchdog.feed()
 
 
+def _init_router_tracing(server_args: ServerArgs) -> None:
+    """Init OTel in this router process if tracing is enabled.
+
+    Routers pickle request objects carrying a TraceReqContext; if this
+    process has no initialized tracer provider, __setstate__ permanently
+    disables tracing and all scheduler-side spans are dropped.
+    """
+    if server_args.enable_trace and not get_global_tracing_enabled():
+        process_tracing_init(
+            server_args.otlp_traces_endpoint,
+            "sglang",
+            trace_modules=server_args.trace_modules,
+        )
+
+
 class MultiTokenizerRouter:
     """A router between tokenizer managers and the scheduler/detokenizer manager.
 
@@ -450,6 +469,7 @@ class MultiTokenizerRouter:
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
+        _init_router_tracing(server_args)
         self.server_args = server_args
         self.startup_time: Optional[Dict[str, Any]] = None
         context = zmq.asyncio.Context(3)
@@ -641,6 +661,7 @@ def run_multi_detokenizer_router_process(
     kill_itself_when_parent_died()
     setproctitle.setproctitle("sglang::detokenizer_router")
     configure_logger(server_args)
+    _init_router_tracing(server_args)
     parent_process = psutil.Process().parent()
 
     router = None

--- a/test/registered/observability/test_tracing.py
+++ b/test/registered/observability/test_tracing.py
@@ -46,11 +46,11 @@ from sglang.test.test_utils import (
 logger = logging.getLogger(__name__)
 
 # CI registration
-register_cuda_ci(est_time=113, stage="extra-a", runner_config="1-gpu-small")
+register_cuda_ci(est_time=125, stage="extra-a", runner_config="1-gpu-small")
 # Backend-specific: the span assertions require PREFILL_FORWARD/DECODE_FORWARD
 # to be emitted from the scheduler forward path, which ROCm reaches through its
 # own attention backend and graph replay.
-register_amd_ci(est_time=113, suite="stage-b-test-1-gpu-small-amd")
+register_amd_ci(est_time=125, suite="stage-b-test-1-gpu-small-amd")
 
 
 # ============================================================================
@@ -588,6 +588,68 @@ class TestTraceServerAsync(TestTraceServer):
     test_trace_level_2 = None
     test_batch_request = None
     test_parallel_sample = None
+
+
+class TestTraceServerMultiTokenizer(TestTraceServer):
+    """Regression: router processes must init OTel, otherwise the pickled
+    TraceReqContext is disabled in-flight and scheduler-side spans
+    (prefill_forward, decode_forward) never reach the collector."""
+
+    # Extra env for the server process; the async variant below overrides it.
+    server_env = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.collector = LightweightOtlpCollector()
+        cls.collector.start()
+        time.sleep(0.2)
+
+        cls.process = popen_launch_server(
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-trace",
+                "--otlp-traces-endpoint",
+                "127.0.0.1:4317",
+                "--tokenizer-worker-num",
+                "2",
+                "--detokenizer-worker-num",
+                "2",
+            ],
+            env=cls.server_env,
+        )
+
+        response = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
+        assert response.status_code == 200
+
+        cls.collector.clear()
+
+    def test_trace_level_3(self):
+        """Assert the scheduler-side spans survive the router round-trip."""
+        self._send_request_and_wait("Explain quantum computing", trace_level=3)
+        self.assertTrue(
+            self.collector.has_all_spans(
+                [
+                    RequestStage.PREFILL_FORWARD.stage_name,
+                    RequestStage.DECODE_FORWARD.stage_name,
+                ]
+            ),
+            f"Scheduler-side spans missing: got {sorted(self.collector.get_span_names())}",
+        )
+
+    # Only run trace_level_3, the most comprehensive check.
+    test_trace_level_0 = None
+    test_trace_level_1 = None
+    test_trace_level_2 = None
+    test_batch_request = None
+    test_parallel_sample = None
+
+
+class TestTraceServerMultiTokenizerAsync(TestTraceServerMultiTokenizer):
+    """Same router regression check under SGLANG_TRACE_ASYNC=1."""
+
+    server_env = {"SGLANG_TRACE_ASYNC": "1"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Motivation

Fix #38210

With `--tokenizer-worker-num > 1`  `--detokenizer-worker-num > 1`, every request passes through the `MultiTokenizerRouter` (main server process) and scheduler outputs pass through the `MultiDetokenizerRouter` subprocess. Neither process ever calls `process_tracing_init`, so with the default full-pickle IPC the routers materialize request objects whose pickled `TraceReqContext` gets permanently disabled by `__setstate__` (no tracer provider initialized in that process; no exporter daemon either under `SGLANG_TRACE_ASYNC=1`). The scheduler then rebuilds a `TraceNullContext` and all scheduler-side spans (`prefill_waiting`, `prefill_forward`, `decode_forward` ... ) are silently dropped, only the HTTP-side spans survive.

## Modifications

- Call `process_tracing_init(...)` in `MultiTokenizerRouter.__init__` and `run_multi_detokenizer_router_process` when `--enable-trace` is set, guarded by `get_global_tracing_enabled()` so the call is idempotent. The routers create no spans of their own, so this only provides the tracer provider/exporter that the request-context round-trip needs.
- Add `TestTraceServerMultiTokenizer` to `test/registered/observability/test_tracing.py`: starts the server with `--tokenizer-worker-num 2 --detokenizer-worker-num 2` and asserts the level-3 spans, including `prefill_forward` / `decode_forward`.

## Accuracy Tests

No model output changes.

Manually verified with `--tokenizer-worker-num > 1`  and `--detokenizer-worker-num > 1` that scheduler-side spans (`prefill_forward`, `decode_forward` ... ) reach the OTLP collector again, both in standalone and PD-disaggregated deployments, with `SGLANG_TRACE_LEVEL=1` and `SGLANG_TRACE_ASYNC=1`.
## Speed Tests and Profiling

no performance impact (initialization only runs when `--enable-trace` is set; the routers create no spans).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35219499710](https://github.com/sgl-project/sglang/actions/runs/35219499710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35219499309](https://github.com/sgl-project/sglang/actions/runs/35219499309)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35219499564](https://github.com/sgl-project/sglang/actions/runs/35219499564)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->