### PR TITLE
Precompile GLM vision kernels before KV allocation to avoid first-image OOMs

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1174,6 +1174,143 @@ class Glm5NextForConditionalGeneration(nn.Module):
             self.config.rope_scaling or {}
         )
 
+    def precompile_kernels_after_loading(self) -> None:
+        """Compile and load the vision tower's lazily built kernels before pools exist."""
+        self._precompile_vision_attention_kernel()
+        self._precompile_vision_mlp_kernel()
+
+    def _precompile_vision_attention_kernel(self) -> None:
+        """Load the vision tower's Triton attention kernel before pools exist.
+
+        ``ModelRunner.load_model`` invokes this hook (through
+        ``maybe_precompile_model_kernels_after_loading``) once the model object
+        exists, before the KV pool and CUDA graphs claim device memory. Under
+        overlapping startup loading the real weights are committed later by
+        ``finalize_startup_weight_load``; the hook reads only the tower's
+        shape, dtype and device, never its weights.
+
+        When the vision attention backend resolves to ``triton_attn``, the
+        tower's ``context_attention_fwd`` Triton module is otherwise JIT-compiled
+        and device-loaded on the first image request, which can arrive long
+        after startup with almost no free device memory left. One tiny call
+        with the tower's specialization inputs (head_dim, dtype,
+        kv_group_num=1, is_causal=False) loads it now. Only the first pipeline
+        rank runs the vision tower (``general_mm_embed_routine`` embeds on
+        ``pp_group.is_first_rank``), so other ranks skip.
+
+        Failures are non-fatal: the device is synchronized inside the ``try``
+        so that both synchronous errors (compile or launch failures) and
+        asynchronously reported kernel errors are logged at WARNING and
+        swallowed before success is reported. A sticky device error (for
+        example an illegal memory access) still poisons the CUDA context and
+        resurfaces at the next device operation; this hook cannot recover that.
+
+        Note that the generic wrapper synchronizes the device and empties the
+        allocator cache before and after every invocation, including the ones
+        that return early here; that is a startup-only cost.
+        """
+        if self.visual is None or not self.pp_group.is_first_rank:
+            return
+        vision_attn = next(
+            (m for m in self.visual.modules() if isinstance(m, VisionAttention)),
+            None,
+        )
+        if vision_attn is None or vision_attn.qkv_backend_name != "triton_attn":
+            return
+
+        try:
+            from sglang.kernels.ops.attention.prefill_attention import (
+                context_attention_fwd,
+            )
+
+            head_dim = self.visual.hidden_size // self.visual.num_heads
+            device = self.visual.device
+            dtype = self.visual.dtype
+            dummy = torch.zeros((1, 1, head_dim), dtype=dtype, device=device)
+            start_loc = torch.zeros((1,), dtype=torch.int32, device=device)
+            seq_len = torch.ones((1,), dtype=torch.int32, device=device)
+            context_attention_fwd(
+                dummy,
+                dummy,
+                dummy,
+                torch.empty_like(dummy),
+                start_loc,
+                seq_len,
+                1,
+                is_causal=False,
+            )
+            if device.type == "cuda":
+                # Surface asynchronously reported kernel errors here, inside
+                # the handler, rather than at the wrapper's synchronize.
+                torch.cuda.synchronize(device)
+            log_info_on_rank0(
+                logger,
+                "Precompiled the vision-tower Triton attention kernel "
+                "before memory-pool allocation.",
+            )
+        except Exception:
+            logger.warning(
+                "Vision-tower attention precompile failed; the kernel will be "
+                "loaded on the first image request instead",
+                exc_info=True,
+            )
+
+    def _precompile_vision_mlp_kernel(self) -> None:
+        """Compile the vision MLP's ``torch.compile``d activation before pools exist.
+
+        ``swiglu_clamped`` is compiled with dynamo's default shape policy: the
+        first call compiles a static-shape kernel and a second, different token
+        count recompiles a dynamic-shape one. Each compile runs inductor's
+        Triton autotuning, which allocates benchmark buffers on the device.
+        Without this, the first image whose token count differs from the
+        warmup image's triggers that autotune during serving with the memory
+        pools already allocated, which fails with CUDA OOM at a high
+        ``mem_fraction_static``. Running the block MLP and the patch merger
+        (the two callers, with different gate_up widths) at two token counts
+        here settles dynamo on the dynamic kernels while memory is free; the
+        inductor cache then serves later boots. Failures are logged at WARNING
+        and swallowed, as for the attention precompile.
+        """
+        if self.visual is None or not self.pp_group.is_first_rank:
+            return
+        targets = []
+        for cls, first_linear in (
+            (Glm5NextVisionMLP, "gate_up_proj"),
+            (Glm5NextVisionPatchMerger, "proj"),
+        ):
+            module = next(
+                (m for m in self.visual.modules() if isinstance(m, cls)), None
+            )
+            if module is not None:
+                targets.append((module, getattr(module, first_linear).input_size))
+        if not targets:
+            return
+        try:
+            device = self.visual.device
+            dtype = self.visual.dtype
+            with torch.no_grad():
+                for module, in_features in targets:
+                    for tokens in (64, 4096):
+                        module(
+                            torch.zeros(
+                                (tokens, in_features), dtype=dtype, device=device
+                            )
+                        )
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            log_info_on_rank0(
+                logger,
+                "Precompiled the vision-tower MLP and patch-merger activation "
+                "kernels (static and dynamic token counts) before memory-pool "
+                "allocation.",
+            )
+        except Exception:
+            logger.warning(
+                "Vision-tower MLP precompile failed; the activation will be "
+                "compiled on the first image request instead",
+                exc_info=True,
+            )
+
     def get_input_embeddings(self) -> nn.Embedding:
         if self.model is None:
             raise AttributeError(

--- a/test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py
+++ b/test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py
@@ -24,7 +24,7 @@ from sglang.kernels.ops.attention import prefill_attention
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 _HIDDEN = 1536
 _HEADS = 12

--- a/test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py
+++ b/test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py
@@ -62,6 +62,7 @@ def _make_model():
         glm5_next.Glm5NextForConditionalGeneration
     )
     nn.Module.__init__(model)
+    model.encoder_only = True
     model.visual = _FakeVisionTower()
     model.pp_group = SimpleNamespace(is_first_rank=True)
     return model

--- a/test/registered/unit/models/test_glm5_next_vision_precompile.py
+++ b/test/registered/unit/models/test_glm5_next_vision_precompile.py
@@ -1,0 +1,202 @@
+"""Argument-contract tests for the GLM-5-Next vision-tower precompile hook.
+
+These tests verify what ``precompile_kernels_after_loading`` passes to
+``context_attention_fwd`` and when it declines to call it: the q/k/v/o shape
+``(1, 1, head_dim)`` in the tower's dtype and device, int32 ``b_start_loc`` and
+``b_seq_len``, ``max_input_len=1``, ``is_causal=False``; no call for
+language-only models, for non-Triton vision backends, or on pipeline ranks
+other than the first; a synchronous failure is logged at WARNING and swallowed.
+
+They do not run Triton: the kernel entry point is a recording stub and the
+vision tower is a fake, so nothing here shows that the hook's call and a real
+vision call share one compiled kernel. That is the GPU test's job
+(``test_glm5_next_vision_precompile_gpu.py``).
+"""
+
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+import sglang.srt.models.glm5_next as glm5_next
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeVisionAttention(nn.Module):
+    def __init__(self, backend: str):
+        super().__init__()
+        self.qkv_backend_name = backend
+
+
+class _FakeVisionTower(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int, backend: str):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.attn = _FakeVisionAttention(backend)
+        self.proj = nn.Linear(2, 2, bias=False).to(torch.bfloat16)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.proj.weight.device
+
+
+class _RecordingActivationModule(nn.Module):
+    """Stands in for the block MLP or the patch merger: records the token
+    counts it is run at and exposes the first linear's input width."""
+
+    def __init__(self, first_linear: str, in_features: int, calls: list):
+        nn.Module.__init__(self)
+        setattr(self, first_linear, SimpleNamespace(input_size=in_features))
+        self.calls = calls
+        self.in_features = in_features
+
+    def forward(self, x):
+        self.calls.append((tuple(x.shape), x.dtype, x.device))
+        return x
+
+
+class _RecordingMLP(_RecordingActivationModule, glm5_next.Glm5NextVisionMLP):
+    def __init__(self, in_features, calls):
+        _RecordingActivationModule.__init__(self, "gate_up_proj", in_features, calls)
+
+
+class _RecordingMerger(_RecordingActivationModule, glm5_next.Glm5NextVisionPatchMerger):
+    def __init__(self, in_features, calls):
+        _RecordingActivationModule.__init__(self, "proj", in_features, calls)
+
+
+def _make_model(visual, is_first_rank: bool = True):
+    model = glm5_next.Glm5NextForConditionalGeneration.__new__(
+        glm5_next.Glm5NextForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.visual = visual
+    model.pp_group = SimpleNamespace(is_first_rank=is_first_rank)
+    return model
+
+
+class TestGlm5NextVisionPrecompile(CustomTestCase):
+    def _run_hook(self, model, stub):
+        prefill_attention = ModuleType("sglang.kernels.ops.attention.prefill_attention")
+        prefill_attention.context_attention_fwd = stub
+        with patch.dict(
+            sys.modules,
+            {"sglang.kernels.ops.attention.prefill_attention": prefill_attention},
+        ), patch.object(glm5_next, "VisionAttention", _FakeVisionAttention):
+            model.precompile_kernels_after_loading()
+
+    def test_triton_backend_precompiles_with_vision_head_dim(self):
+        calls = []
+
+        def stub(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="triton_attn")
+        self._run_hook(_make_model(visual), stub)
+
+        self.assertEqual(len(calls), 1)
+        args, kwargs = calls[0]
+        q, k, v, o, start_loc, seq_len, max_input_len = args
+        for t in (q, k, v, o):
+            self.assertEqual(tuple(t.shape), (1, 1, 128))
+            self.assertEqual(t.dtype, torch.bfloat16)
+            self.assertEqual(t.device, visual.device)
+        self.assertEqual(start_loc.dtype, torch.int32)
+        self.assertEqual(start_loc.tolist(), [0])
+        self.assertEqual(seq_len.dtype, torch.int32)
+        self.assertEqual(seq_len.tolist(), [1])
+        self.assertEqual(max_input_len, 1)
+        self.assertEqual(kwargs, {"is_causal": False})
+
+    def test_language_only_model_skips(self):
+        calls = []
+        self._run_hook(_make_model(None), lambda *a, **k: calls.append(a))
+        self.assertEqual(calls, [])
+
+    def test_non_triton_vision_backend_skips(self):
+        calls = []
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="fa3")
+        self._run_hook(_make_model(visual), lambda *a, **k: calls.append(a))
+        self.assertEqual(calls, [])
+
+    def test_non_first_pipeline_rank_skips(self):
+        # Only the first PP rank embeds images (general_mm_embed_routine), so a
+        # later rank must not compile or hold the vision kernel.
+        calls = []
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="triton_attn")
+        self._run_hook(
+            _make_model(visual, is_first_rank=False), lambda *a, **k: calls.append(a)
+        )
+        self.assertEqual(calls, [])
+
+    def test_mlp_and_merger_run_at_two_token_counts(self):
+        # Two distinct token counts make dynamo compile the static kernel and
+        # then settle on the dynamic one before the pools exist.
+        mlp_calls, merger_calls = [], []
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="fa3")
+        visual.mlp = _RecordingMLP(3072, mlp_calls)
+        visual.merger = _RecordingMerger(1536, merger_calls)
+        self._run_hook(_make_model(visual), lambda *a, **k: None)
+        self.assertEqual(
+            [shape for shape, _, _ in mlp_calls], [(64, 3072), (4096, 3072)]
+        )
+        self.assertEqual(
+            [shape for shape, _, _ in merger_calls], [(64, 1536), (4096, 1536)]
+        )
+        for _, dtype, device in mlp_calls + merger_calls:
+            self.assertEqual(dtype, torch.bfloat16)
+            self.assertEqual(device, visual.device)
+
+    def test_mlp_precompile_skips_without_the_modules_or_off_first_rank(self):
+        calls = []
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="fa3")
+        self._run_hook(_make_model(visual), lambda *a, **k: None)  # no modules
+        visual.mlp = _RecordingMLP(3072, calls)
+        self._run_hook(_make_model(visual, is_first_rank=False), lambda *a, **k: None)
+        self.assertEqual(calls, [])
+
+    def test_mlp_failure_is_logged_not_raised(self):
+        class _Failing(_RecordingMLP):
+            def forward(self, x):
+                raise RuntimeError("mlp compile failed")
+
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="fa3")
+        visual.mlp = _Failing(3072, [])
+        with self.assertLogs(glm5_next.logger, level="WARNING") as logs:
+            self._run_hook(_make_model(visual), lambda *a, **k: None)
+        self.assertTrue(
+            any("MLP precompile failed" in line for line in logs.output), logs.output
+        )
+
+    def test_kernel_failure_is_logged_not_raised(self):
+        def stub(*args, **kwargs):
+            raise RuntimeError("compile failed")
+
+        visual = _FakeVisionTower(hidden_size=1536, num_heads=12, backend="triton_attn")
+        with self.assertLogs(glm5_next.logger, level="WARNING") as logs:
+            self._run_hook(_make_model(visual), stub)
+        self.assertTrue(
+            any(
+                "precompile failed" in line and "RuntimeError: compile failed" in line
+                for line in logs.output
+            ),
+            logs.output,
+        )
+        self.assertFalse(
+            any(line.startswith("ERROR") for line in logs.output), logs.output
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_glm5_next_vision_precompile.py
+++ b/test/registered/unit/models/test_glm5_next_vision_precompile.py
@@ -81,6 +81,7 @@ def _make_model(visual, is_first_rank: bool = True):
         glm5_next.Glm5NextForConditionalGeneration
     )
     nn.Module.__init__(model)
+    model.encoder_only = True
     model.visual = visual
     model.pp_group = SimpleNamespace(is_first_rank=is_first_rank)
     return model

--- a/test/registered/unit/models/test_glm5_next_vision_precompile.py
+++ b/test/registered/unit/models/test_glm5_next_vision_precompile.py
@@ -90,10 +90,13 @@ class TestGlm5NextVisionPrecompile(CustomTestCase):
     def _run_hook(self, model, stub):
         prefill_attention = ModuleType("sglang.kernels.ops.attention.prefill_attention")
         prefill_attention.context_attention_fwd = stub
-        with patch.dict(
-            sys.modules,
-            {"sglang.kernels.ops.attention.prefill_attention": prefill_attention},
-        ), patch.object(glm5_next, "VisionAttention", _FakeVisionAttention):
+        with (
+            patch.dict(
+                sys.modules,
+                {"sglang.kernels.ops.attention.prefill_attention": prefill_attention},
+            ),
+            patch.object(glm5_next, "VisionAttention", _FakeVisionAttention),
+        ):
             model.precompile_kernels_after_loading()
 
     def test_triton_backend_precompiles_with_vision_head_dim(self):

--- a/test/registered/unit/models/test_glm5_next_vision_precompile_gpu.py
+++ b/test/registered/unit/models/test_glm5_next_vision_precompile_gpu.py
@@ -1,0 +1,157 @@
+"""GPU check that the GLM-5-Next vision precompile hook loads the real kernel.
+
+Runs ``precompile_kernels_after_loading`` against the real Triton
+``context_attention_fwd`` entry point, then issues one call shaped like the
+vision tower's own: several variable-length image sequences, ``q``/``k``
+contiguous (as ``_apply_qk_norm_head_size`` and RoPE leave them) and ``v`` a
+strided view of the fused qkv projection buffer (``pass_strided_qkv``). The
+test asserts through Triton's per-device kernel cache on ``_fwd_kernel``
+(``JITFunction.device_caches[device] -> (kernel_cache, ...)``, Triton 3.7)
+and through ``triton.knobs.runtime.kernel_load_start_hook`` that the
+representative call neither compiles nor device-loads a new specialization,
+and checks its output against an SDPA reference.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+import sglang.srt.models.glm5_next as glm5_next
+from sglang.kernels.ops.attention import prefill_attention
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+_HIDDEN = 1536
+_HEADS = 12
+_HEAD_DIM = _HIDDEN // _HEADS
+_SEQ_LENS = [612, 1035, 288]  # not multiples of the kernel's block size
+
+
+class _FakeVisionAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.qkv_backend_name = "triton_attn"
+
+
+class _FakeVisionTower(nn.Module):
+    """Only what the hook reads: hidden_size, num_heads, dtype, device."""
+
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = _HIDDEN
+        self.num_heads = _HEADS
+        self.attn = _FakeVisionAttention()
+        self.proj = nn.Linear(2, 2, bias=False).to(device="cuda", dtype=torch.bfloat16)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.proj.weight.device
+
+
+def _make_model():
+    model = glm5_next.Glm5NextForConditionalGeneration.__new__(
+        glm5_next.Glm5NextForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.visual = _FakeVisionTower()
+    model.pp_group = SimpleNamespace(is_first_rank=True)
+    return model
+
+
+def _kernel_cache() -> dict:
+    jit_fn = prefill_attention._fwd_kernel
+    caches = getattr(jit_fn, "device_caches", None)
+    assert caches is not None, (
+        "triton JITFunction has no device_caches; the cache layout assumed "
+        "here is Triton 3.7's (kernel_cache, kernel_key_cache, target, backend, binder)"
+    )
+    return caches[torch.cuda.current_device()][0]
+
+
+def _vision_qkv():
+    """Return (q, k, v, cu_seqlens, seq_lens, max_seqlen) in the tower's layout."""
+    total = sum(_SEQ_LENS)
+    gen = torch.Generator(device="cuda").manual_seed(0)
+    qkv = torch.randn(
+        (1, total, 3 * _HIDDEN), generator=gen, device="cuda", dtype=torch.bfloat16
+    )
+    q, k, v = qkv.split([_HIDDEN, _HIDDEN, _HIDDEN], dim=-1)
+    q = q.reshape(total, _HEADS, _HEAD_DIM)
+    k = k.reshape(total, _HEADS, _HEAD_DIM)
+    v = v.reshape(total, _HEADS, _HEAD_DIM)
+    # qk-norm and RoPE hand the backend fresh contiguous q/k; v is still the
+    # strided view into the fused projection output.
+    q = q.contiguous()
+    k = k.contiguous()
+    assert v.stride(0) == 3 * _HIDDEN and not v.is_contiguous()
+    seq_lens = torch.tensor(_SEQ_LENS, device="cuda", dtype=torch.int32)
+    cu_seqlens = torch.zeros(len(_SEQ_LENS) + 1, device="cuda", dtype=torch.int32)
+    cu_seqlens[1:] = torch.cumsum(seq_lens, dim=0)
+    return q, k, v, cu_seqlens, seq_lens, max(_SEQ_LENS)
+
+
+def _reference(q, k, v, cu_seqlens):
+    out = torch.empty_like(q)
+    bounds = cu_seqlens.tolist()
+    for start, end in zip(bounds[:-1], bounds[1:]):
+        qs = q[start:end].float().transpose(0, 1)
+        ks = k[start:end].float().transpose(0, 1)
+        vs = v[start:end].float().transpose(0, 1)
+        o = torch.nn.functional.scaled_dot_product_attention(qs, ks, vs)
+        out[start:end] = o.transpose(0, 1).to(out.dtype)
+    return out
+
+
+class TestGlm5NextVisionPrecompileGpu(CustomTestCase):
+    def setUp(self):
+        import triton.knobs as knobs
+
+        self._loads = []
+        self._hook = knobs.runtime.kernel_load_start_hook
+        self._hook.add(self._on_load)
+
+    def tearDown(self):
+        self._hook.remove(self._on_load)
+
+    def _on_load(self, module, function, name, metadata_group, hash):
+        self._loads.append(name)
+
+    def test_hook_loads_the_kernel_the_vision_call_reuses(self):
+        cache = _kernel_cache()
+        entries_before = len(cache)
+
+        with patch.object(glm5_next, "VisionAttention", _FakeVisionAttention):
+            _make_model().precompile_kernels_after_loading()
+        torch.cuda.synchronize()
+
+        entries_after_hook = len(cache)
+        self.assertGreaterEqual(entries_after_hook, 1)
+        # Another test in this process may already have compiled it.
+        self.assertIn(entries_after_hook - entries_before, (0, 1))
+        loads_after_hook = len(self._loads)
+
+        q, k, v, cu_seqlens, seq_lens, max_seqlen = _vision_qkv()
+        out = torch.empty_like(q)
+        prefill_attention.context_attention_fwd(
+            q, k, v, out, cu_seqlens, seq_lens, max_seqlen, is_causal=False
+        )
+        torch.cuda.synchronize()
+
+        self.assertEqual(len(cache), entries_after_hook)
+        self.assertEqual(len(self._loads), loads_after_hook)
+        torch.testing.assert_close(
+            out, _reference(q, k, v, cu_seqlens), atol=2e-2, rtol=2e-2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The first image request can run out of GPU memory while compiling or loading vision kernels, after the KV cache and CUDA graphs have consumed the available headroom. A small warmup image also does not necessarily compile the dynamic MLP activation used by larger images.

This PR precompiles GLM-5-Next vision attention and MLP activations after loading the model but before allocating the KV pool. The request-time forward implementation is unchanged.

Replaces #37539, which was closed when the base branch for #36507 was deleted after its merge as `97c6978369`.

## Modifications

- Add the existing model-runner precompile hook to `Glm5NextForConditionalGeneration`.
- Run the vision block MLP and patch merger at 64 and 4096 tokens so compilation covers both token counts before serving.
- For the Triton attention backend, launch the tower's attention specialization using small tensors with the production dtype and head geometry.
- Skip unavailable modules and non-first pipeline ranks; skip attention precompile for non-Triton backends. Log precompile failures at WARNING.

## Accuracy Tests

Author validation at `65113b94a8` on main `afe90a8bc9` on one RTX PRO 6000 Blackwell Max-Q (SM120): 9 tests passed. Targets: `test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py`, `test/registered/unit/models/test_glm5_next_vision_precompile.py`.

Author CPU validation at `0b0f330542`: 8 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `65113b94a8` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

Author tests at `da3fb1841c` on SGLang main `dcebe8c473`: nine CPU/GPU tests passed on RTX PRO 6000 Blackwell Max-Q (SM120), including the real Triton vision-kernel reuse and SDPA comparison. Other GPU or serving results below refer to their stated earlier revisions.

CPU recording subclasses verify the MLP and merger calls, token counts, dtype/device, skip conditions and warning behavior. The attention test substitutes a recording kernel to check its arguments. Author-reported CPU result: 8 passed.

```bash
CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python python -m pytest -q test/registered/unit/models/test_glm5_next_vision_precompile.py
PYTHONPATH=python python -m pytest -q test/registered/kernel/vision/test_glm5_next_vision_precompile_gpu.py
```

The GPU regression runs the real attention precompile, then a strided three-sequence vision-attention call. It compares outputs with SDPA and checks Triton's cache and device-load hook to require no new specialization or device load on the second call. Author-reported pass on one RTX PRO 6000 Blackwell, Triton 3.7.1; that run preceded the expanded MLP CPU cases.

Author-observed serving failure: a first 3840x2160 image on a fresh compilation cache triggered MLP autotuning and OOM at memory fraction 0.99. No exact-head full-model reproduction log is attached, and the attention GPU regression does not itself validate the MLP autotune path.

## Speed Tests and Profiling

The hook adds startup compilation and small forward calls before pool allocation. No isolated startup-duration or serving-speed benchmark for this revision.

## Checklist

- [x] Format changed code and add CPU/GPU regression coverage.
- [x] Distinguish attention-kernel validation from the MLP serving observation.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282255605](https://github.com/sgl-project/sglang/actions/runs/34282255605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282255467](https://github.com/sgl-project/sglang/actions/runs/34282255467)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282255613](https://github.com/sgl-project/sglang/actions/runs/34282255613)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->