### PR TITLE
fix: wait for HiCache load-back before hybrid MLA KV reads

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4035,6 +4035,8 @@ class HybridLinearKVPool(KVCache):
         dst_dtype: Optional[torch.dtype] = None,
     ):
         assert self.use_mla, "get_mla_kv_buffer called when use_mla is False"
+        # Wait for HiCache load-back here; the inner pool's counter is disabled.
+        self._wait_for_layer(layer.layer_id)
         # Read door -- same kernel-facing contract as the write door: `loc` is
         # a read-index tensor already translated at its production site
         # (fetch_mha_one_shot_kv_indices / prepare_chunked_kv_indices); the

--- a/test/registered/unit/mem_cache/test_full_loc_fast_path.py
+++ b/test/registered/unit/mem_cache/test_full_loc_fast_path.py
@@ -26,6 +26,7 @@ import unittest
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -242,7 +243,7 @@ class _RecordingMLAPool(_RecordingPool):
         self.mla_set_calls.append(loc)
 
 
-class TestHybridLinearMLARouting(unittest.TestCase):
+class TestHybridLinearMLARouting(CustomTestCase):
     """MLA-side door contract of `HybridLinearKVPool`: `set_mla_kv_buffer`
     forwards `loc` untouched -- writes are kernel-facing since the ForwardBatch
     rebind."""
@@ -268,6 +269,23 @@ class TestHybridLinearMLARouting(unittest.TestCase):
 
         self.assertEqual(len(pool.full_kv_pool.mla_set_calls), 1)
         self.assertIs(pool.full_kv_pool.mla_set_calls[0], loc)
+
+    def test_get_mla_kv_buffer_waits_before_layer_remap(self):
+        pool = self._make_bare_pool()
+        pool.start_layer = 4
+        pool.full_attention_layer_id_mapping = {6: 0}
+        calls = []
+        pool.layer_transfer_counter = types.SimpleNamespace(
+            wait_until=lambda layer_id: calls.append(("wait", layer_id))
+        )
+
+        def read(layer, loc, dst_dtype=None):
+            calls.append(("read", layer.layer_id))
+
+        pool.full_kv_pool.get_mla_kv_buffer = read
+        layer = types.SimpleNamespace(layer_id=6)
+        pool.get_mla_kv_buffer(layer, None)
+        self.assertEqual(calls, [("wait", 2), ("read", 0)])
 
 
 class TestMlaWriteDoorsUnderDcp(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Attention forward must wait for the corresponding layer's HiCache load-back to complete before reading its KV data. `MLATokenToKVPool` already performs this wait before reading MLA KV data.

However, when used inside `HybridLinearKVPool`, this inner wait is disabled because the hybrid wrapper owns synchronization. `HybridLinearKVPool.get_mla_kv_buffer()` forwards the read without the required outer wait, allowing KV data to be read before asynchronous load-back completes.

## Modifications

- Wait for layer load-back before remapping the layer ID and reading MLA KV data.
- Add a CPU regression test verifying that the correct layer is waited on before the read.

## Tests

We ran an additional GPU correctness test on B300 using a two-layer FP8 MLA cache wrapped by `HybridLinearKVPool`, with 16K tokens and a page size of 64.

Random KV data was backed up to host memory, then the device buffers were cleared. We started asynchronous load-back and immediately called `get_mla_kv_buffer()` to read layer 0, then compared the returned data against the original data.

Across 20 trials:
- Before the fix: 20/20 reads returned incorrect data.
- After the fix: 0/20 reads returned incorrect data.

The PR also adds a CPU regression test that records the wait and read calls, checking that the hybrid wrapper waits for the correct layer before forwarding the read.

In end-to-end serving, Q and suffix KV projections typically run before cached-prefix reads, giving HiCache load-back more time to complete, so this bug may not surface consistently. Overall, our fix and the added test restore a robust correctness safeguard that already exists in `MLATokenToKVPool` but was missing from `HybridLinearKVPool`.

## Checklist

- [x] Formatting: pre-commit checks passed.
- [x] Unit tests: added focused regression coverage.
- [x] Documentation: N/A; no API or configuration changes.
- [x] Accuracy/speed benchmarks: N/A; this is a correctness fix with no steady-state performance impact expected.
- [x] Followed SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34032121194](https://github.com/sgl-project/sglang/actions/runs/34032121194)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34032121174](https://github.com/sgl-project/sglang/actions/runs/34032121174)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34032121210](https://github.com/sgl-project/sglang/actions/runs/34032121210)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->