### PR TITLE
[MLX] Kill already-orphaned MLX workers instead of watching PID 1

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/parent_watchdog.py
+++ b/python/sglang/srt/hardware_backend/mlx/parent_watchdog.py
@@ -26,6 +26,13 @@ def start_parent_death_watcher() -> None:
     blocking native call (e.g. an MLX/Metal ``mx.eval`` / ``.tolist()``).
     """
     original_ppid = os.getppid()
+    # Already orphaned: macOS reparents to launchd the moment the parent exits,
+    # so no NOTE_EXIT is left to wait for and watching PID 1 would block forever.
+    # Comparing against 1 is safe here -- unlike the Linux PDEATHSIG path, an
+    # sglang worker is never spawned directly by launchd.
+    if original_ppid == 1:
+        os.kill(os.getpid(), signal.SIGKILL)
+        return
 
     def _watch_parent():
         kq = select.kqueue()

--- a/test/registered/unit/hardware_backend/mlx/test_parent_watchdog.py
+++ b/test/registered/unit/hardware_backend/mlx/test_parent_watchdog.py
@@ -1,0 +1,133 @@
+"""Tests for the macOS parent-death watchdog."""
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+from sglang.srt.hardware_backend.mlx import parent_watchdog
+from sglang.test.ci.ci_register import register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+# Loads the watchdog straight from its source file: it only needs os/select/
+# signal/threading, so the child skips the ~5 s `import sglang` and the orphan
+# window stays short enough to keep the test cheap.
+_CHILD_SCRIPT = """
+import importlib.util, os, sys, time
+
+module_path, pid_path = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("parent_watchdog", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+if os.fork() == 0:
+    tmp = pid_path + ".tmp"
+    with open(tmp, "w") as f:
+        f.write(str(os.getpid()))
+    os.replace(tmp, pid_path)
+    # Install only once actually orphaned, so the case under test is reached by
+    # a precondition rather than by racing the parent's exit.
+    while os.getppid() != 1:
+        time.sleep(0.01)
+    module.start_parent_death_watcher()
+    time.sleep(60)
+    os._exit(0)
+os._exit(0)
+"""
+
+
+@unittest.skipUnless(sys.platform == "darwin", "kqueue watchdog is macOS-only")
+class TestParentDeathWatcher(CustomTestCase):
+    def test_already_orphaned_self_kills(self):
+        """An orphan must die even if it installs the watchdog after losing its parent.
+
+        macOS reparents an orphan to launchd as soon as the parent exits, so a
+        watchdog installed after that point sees ppid 1. Registering NOTE_EXIT on
+        PID 1 succeeds and then blocks forever, so the worker used to survive as
+        an orphan holding unified memory and its port.
+        """
+        with (
+            mock.patch.object(parent_watchdog.os, "getppid", return_value=1),
+            mock.patch.object(parent_watchdog.os, "kill") as mock_kill,
+            mock.patch.object(parent_watchdog.threading, "Thread") as mock_thread,
+        ):
+            parent_watchdog.start_parent_death_watcher()
+
+        mock_kill.assert_called_once_with(os.getpid(), signal.SIGKILL)
+        # No thread, or it would be parked on a NOTE_EXIT for launchd that never fires.
+        mock_thread.assert_not_called()
+
+    def test_live_parent_starts_watcher_without_killing(self):
+        """A worker with a living parent must be watched, not killed."""
+        with (
+            mock.patch.object(parent_watchdog.os, "getppid", return_value=4242),
+            mock.patch.object(parent_watchdog.os, "kill") as mock_kill,
+            mock.patch.object(parent_watchdog.threading, "Thread") as mock_thread,
+        ):
+            parent_watchdog.start_parent_death_watcher()
+
+        mock_kill.assert_not_called()
+        mock_thread.assert_called_once()
+        self.assertTrue(mock_thread.call_args.kwargs["daemon"])
+        mock_thread.return_value.start.assert_called_once()
+
+    def test_orphaned_child_process_is_reaped(self):
+        """End-to-end: a process orphaned before installing the watchdog must not leak."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = os.path.join(tmpdir, "child.pid")
+            intermediate = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    _CHILD_SCRIPT,
+                    parent_watchdog.__file__,
+                    pid_path,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            intermediate.wait(timeout=60)
+
+            child_pid = self._read_pid(pid_path)
+            self.addCleanup(self._force_kill, child_pid)
+            self.assertTrue(
+                self._wait_until_gone(child_pid, timeout=30),
+                msg=f"orphaned pid {child_pid} survived; the watchdog did not fire",
+            )
+
+    def _read_pid(self, pid_path, timeout=60):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                return int(open(pid_path).read())
+            except (FileNotFoundError, ValueError):
+                time.sleep(0.05)
+        self.fail(f"child never reported its pid to {pid_path}")
+
+    @staticmethod
+    def _wait_until_gone(pid, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return True
+            time.sleep(0.05)
+        return False
+
+    @staticmethod
+    def _force_kill(pid):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`start_parent_death_watcher()` silently no-ops when the parent is *already* gone by the time it installs. The orphaned worker then goes on to load the model anyway and stays resident indefinitely, holding weights and its KV pool with no parent left to serve.

**Scoping it honestly:** the normal path is unaffected. `shutdown()` reaps children explicitly, and once the watchdog is installed it works correctly. To hit this you need an *unclean* parent death — a crash or SIGKILL — during the child's startup window. macOS and the MLX backend only; Linux is fine.

That window is the spawned interpreter's `import sglang`, about 5 s on an M4, which is wide enough that ordinary startup failures land inside it: a failed init on another rank, a port conflict, an impatient Ctrl-C during a slow launch.

### Measured

Launcher SIGKILLed the moment its workers appeared, i.e. while they were still importing. On `main`:

```
t=  0.0s  pid 39325 rss=0.01GB, pid 39326 rss=0.01GB, pid 39327 rss=0.01GB
t= 15.0s  pid 39325 rss=0.01GB, pid 39326 rss=0.88GB, pid 39327 rss=0.85GB
t= 45.0s  pid 39325 rss=0.01GB, pid 39326 rss=1.48GB, pid 39327 rss=0.71GB
t= 50.0s  pid 39325 rss=0.01GB,                       pid 39327 rss=0.63GB
t= 95.1s  pid 39325 rss=0.01GB,                       pid 39327 rss=0.63GB
=== WORKERS STILL ALIVE AFTER 100s ===
```

The orphans load the model with nothing to serve (`0.01 -> 0.88 -> 1.48 GB`), and **two of the three never exit**. That is with `Qwen3-0.6B-4bit` at `--mem-fraction-static 0.6`; the resident figure is weights plus KV pool, so it scales with the model and the fraction.

With this patch they are gone in under 10 s, at the ~0.5 GB torch/mlx import footprint, before any weights load:

```
t=  5.0s  pid 39410 rss=0.01GB, pid 39411 rss=0.51GB, pid 39412 rss=0.50GB
t= 10.0s  all workers gone
```

There *is* a partial self-healing path, but it cannot be relied on: `pipe_writer.send(scheduler.get_init_info())` (`scheduler.py:5761`) writes to a pipe the dead parent held, and the resulting `BrokenPipeError` takes the process down. It saved one of the three above — pid 39326, after it had already loaded 1.48 GB. The `finally` block does not help either, since `release_host_resources()` is gated on `scheduler.gracefully_exit`.

### Mechanism

macOS reparents an orphan to launchd **the moment** its parent exits, not when it is reaped. So if the parent died before the watchdog installs:

1. `original_ppid = os.getppid()` returns **1**
2. registering `EVFILT_PROC` / `NOTE_EXIT` on PID 1 **succeeds** — launchd exists
3. the race guard `os.getppid() != original_ppid` compares `1 != 1`, so it does not fire
4. the watcher thread blocks waiting for **launchd to exit**, i.e. forever

The existing guard only covers the window *inside* the function, between reading `getppid()` and registering the watch. It cannot see a parent that was already gone on entry, because `getppid()` is poisoned to 1 before the comparison is made.

Why the orphan reaches full residency rather than dying at import: the watchdog is installed from `configure_scheduler_process()` at the top of `run_scheduler_process` (`scheduler.py:5723`) and runs in a **daemon thread**, so the main thread carries straight on into `Scheduler(...)` (`scheduler.py:5754`) and loads the model. The same entry-point ordering holds for `detokenizer_manager.py:542`, `data_parallel_controller.py:825` and `sidecar.py:62`.

The Linux side of `kill_itself_when_parent_died()` already handles this class of bug, by capturing the pid before arming `PDEATHSIG` and re-checking after; `multimodal_gen` even has a test for it (`test_reparent_to_init_self_kills`). The darwin path never got the equivalent.

## Modifications

Treat ppid 1 on entry as already-orphaned and self-`SIGKILL` before starting the watcher thread:

```python
original_ppid = os.getppid()
# Already orphaned: macOS reparents to launchd the moment the parent exits,
# so no NOTE_EXIT is left to wait for and watching PID 1 would block forever.
# Comparing against 1 is safe here -- unlike the Linux PDEATHSIG path, an
# sglang worker is never spawned directly by launchd.
if original_ppid == 1:
    os.kill(os.getpid(), signal.SIGKILL)
    return
```

**One design question I'd like your call on.** The Linux path deliberately avoids `== 1`, and says why: *"Comparing to the captured pid instead of `== 1` avoids self-killing when PID 1 is the real parent (e.g. running as a container's init process)."* That concern does not apply here — every caller of `kill_itself_when_parent_died()` is a process sglang spawned itself, so launchd is never the real parent, and a process whose real parent is launchd has nothing to watch anyway. The fully general alternative is to capture the ppid in the launcher and pass it down to each worker, but that touches every call site. I went with the narrow fix; happy to do the plumbing version instead if you'd prefer it.

Also adds `test/registered/unit/hardware_backend/mlx/test_parent_watchdog.py`. `parent_watchdog.py` had **no test coverage at all** — no file in `test/` referenced it.

- `test_already_orphaned_self_kills` — the regression guard. Also asserts no watcher thread is started, since a thread parked on launchd's `NOTE_EXIT` is the leak.
- `test_live_parent_starts_watcher_without_killing` — the negative branch: a worker with a living parent must be watched, not killed. Guards against the predicate degrading to always-true.
- `test_orphaned_child_process_is_reaped` — end-to-end with real processes. The child waits until `os.getppid() == 1` before installing the watchdog, so the case under test is reached by a precondition rather than by racing the parent's exit. It loads `parent_watchdog.py` by file path (the module is pure stdlib), keeping the child off the ~5 s `import sglang` path.

## Accuracy Tests

Per `.claude/rules/unit-test-admission.md`, verified the cases fail pre-fix and pass post-fix:

```
########## PRE-FIX ##########
test_already_orphaned_self_kills                 FAILED
test_live_parent_starts_watcher_without_killing  PASSED
test_orphaned_child_process_is_reaped            FAILED
2 failed, 1 passed in 37.15s

########## WITH FIX ##########
3 passed in 6.65s
```

The negative-branch case passes in both, as it should.

Full suite on Apple Silicon (M4, macOS 15.1, Python 3.12.7, mlx 0.32.2, torch 2.13.0) — **22/22 files passed**, up from 21 (CI runs this lane on `macos-26`):

```
$ python test/run_suite.py --hw mlx --suite stage-a-unit-test-mlx
{"file": "test/registered/unit/hardware_backend/mlx/test_parent_watchdog.py", "passed": true, "elapsed": 7}
```

Registration resolves on the model-free lane:

```
test/registered/unit/hardware_backend/mlx/test_parent_watchdog.py
  backend=HWBackend.MLX suite=stage-a-unit-test-mlx est=1.0
```

Nothing here needs a model or a network, so it satisfies the lane's `HF_HUB_OFFLINE=1` guarantee. The end-to-end launcher measurement above was run by hand and is not part of the suite — it needs a model, which `stage-a` deliberately forbids.

## Speed Tests and Profiling

N/A — a 4-line guard on a startup path, plus one test file. Adds ~7 s to `stage-a-unit-test-mlx`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — n/a, no user-facing behavior change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34035838671](https://github.com/sgl-project/sglang/actions/runs/34035838671)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34035838607](https://github.com/sgl-project/sglang/actions/runs/34035838607)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34035838821](https://github.com/sgl-project/sglang/actions/runs/34035838821)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->