### PR TITLE
fix: legacy SGL_ env vars silently dropped when the rewritten name is itself deprecated

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1833,10 +1833,10 @@ _DEPRECATED_ENVS: Dict[str, _DeprecatedEnv] = {
 
 
 def _handle_deprecated_envs():
-    for old_name, deprecation in _DEPRECATED_ENVS.items():
-        deprecation.apply(old_name)
-
-    # Rewrite the legacy SGL_ prefix to SGLANG_ (names not covered above).
+    # Rewrite the legacy SGL_ prefix to SGLANG_ first, so a rewritten name
+    # that is itself in the registry (e.g. SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK
+    # -> SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK) still gets its forwarding
+    # below instead of being silently dropped.
     for key, value in list(os.environ.items()):
         if key.startswith("SGL_") and key not in _DEPRECATED_ENVS:
             new_key = key.replace("SGL_", "SGLANG_", 1)
@@ -1844,6 +1844,9 @@ def _handle_deprecated_envs():
                 f"Environment variable {key} is deprecated, please use {new_key}"
             )
             os.environ[new_key] = value
+
+    for old_name, deprecation in _DEPRECATED_ENVS.items():
+        deprecation.apply(old_name)
 
 
 def third_party_cache_defaults() -> Dict[str, str]:

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -153,6 +153,26 @@ class TestDeprecatedEnvRegistry(unittest.TestCase):
         self._apply(old_name, _DEPRECATED_ENVS[old_name])
         self.assertIs(envs.SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK.get(), False)
 
+    def test_legacy_sgl_prefix_chains_into_registry_forwarding(self):
+        # SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK must survive both hops:
+        # the SGL_ -> SGLANG_ prefix rewrite, then the registry's inverted
+        # forwarding to SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK. Needs a
+        # fresh import because _handle_deprecated_envs() runs at import.
+        command = [
+            sys.executable,
+            "-c",
+            "from sglang.srt.environ import envs; "
+            "print(envs.SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK.get())",
+        ]
+        env = {k: v for k, v in os.environ.items() if "TP_MEMORY_INBALANCE" not in k}
+        env["SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK"] = "1"
+        output = (
+            subprocess.check_output(command, env=env, stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
+        self.assertEqual(output, "False")
+
     def test_ms_to_s_transform(self):
         old_name = "SGLANG_QUEUED_TIMEOUT_MS"
         os.environ[old_name] = "1500"


### PR DESCRIPTION
## Motivation

Setting the legacy env var `SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1` is silently ignored: the TP memory imbalance check stays enabled, and the deprecation warning tells the user to switch to `SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK`, which is itself deprecated.

Root cause: `_handle_deprecated_envs()` in `python/sglang/srt/environ.py` applies the `_DEPRECATED_ENVS` registry **before** rewriting legacy `SGL_`-prefixed names to `SGLANG_`. A legacy name whose rewritten form is itself in the registry gets rewritten only after the registry pass that would forward it (inverted, via `_invert_bool`) to `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK` has already run, so the forwarding never happens.

Repro on current main:

```
$ SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 python -W always -c \
    "from sglang.srt.environ import envs; print(envs.SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK.get())"
UserWarning: Environment variable SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK is deprecated, please use SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK
True          # check still enabled; the setting was dropped
```

After this PR the same command prints `False`, with both warnings chaining to the final name.

## Modifications

- `_handle_deprecated_envs()`: run the `SGL_` -> `SGLANG_` prefix rewrite first, then the registry pass, so a rewritten name that is itself in the registry still gets its forwarding. No behavior change for names that only need one hop.
- `test/registered/unit/test_environ.py`: add `test_legacy_sgl_prefix_chains_into_registry_forwarding`, a fresh-import subprocess test (module-level `_handle_deprecated_envs()` runs at import, so the existing in-process `_apply` pattern cannot cover ordering).

## Accuracy Tests

N/A (env-var handling only; no model or kernel code touched).

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to pre-commit (all hooks pass on the two changed files).
- [x] Add unit tests (`test_environ.py`: 13 passed + new test failing before the fix, 14 passed after).
- [ ] Update documentation (no docs reference these env vars' interaction).
- [x] N/A accuracy/speed benchmarks.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #34036777478](https://github.com/sgl-project/sglang/actions/runs/34036777478)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #34036777356](https://github.com/sgl-project/sglang/actions/runs/34036777356)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #34036777466](https://github.com/sgl-project/sglang/actions/runs/34036777466)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->