### PR TITLE
test(xpu): pin --mem-fraction-static=0.7 for DeepSeek-OCR test

### DIFF
--- a/test/registered/xpu/test_deepseek_ocr.py
+++ b/test/registered/xpu/test_deepseek_ocr.py
@@ -42,6 +42,8 @@ class TestDeepSeekOCR(CustomTestCase):
             "xpu",
             "--attention-backend",
             "intel_xpu",
+            "--mem-fraction-static",
+            "0.7",
         ]
         cls.process = popen_launch_server(
             cls.model,


### PR DESCRIPTION
## Summary
- `test/registered/xpu/test_deepseek_ocr.py::TestDeepSeekOCR::setUpClass` launches sglang without `--mem-fraction-static`, so sglang picks its device-default (0.5016 on a ~12 GB XPU tile). DeepSeek-OCR's 6.23 GB weights already consume 0.5225 of pre-model-load memory, leaving zero activation headroom under the default. `kv_cache_configurator._profile_available_bytes` correctly raises `ValueError: Loaded weights leave no GPU memory for the KV cache under --mem-fraction-static=0.5016. Raise --mem-fraction-static above 0.523`, the scheduler child dies, and the launcher reports `Server process exited with code -9`.
- Failing job for reference: `stage-b-test-1-gpu-xpu` in run [33839554440](https://github.com/sgl-project/sglang/actions/runs/33839554440/job/100968818987).
- Fix: pass `--mem-fraction-static 0.7` in the test's `common_args`. On a ~12 GB tile this leaves ~2.1 GB of activation headroom and ~3.5 GB of KV cache — comfortably above the 0.5225 floor with margin for driver overhead / future weight-size drift, while still leaving plenty of KV pool for the single `max_new_tokens=32` request this test issues.

## Test plan
- [ ] Re-run `PR Test (XPU) / stage-b-test-1-gpu-xpu` and confirm `test_deepseek_ocr.py` reaches `Ran 1 tests` (currently `Ran 0 tests` due to `setUpClass` error) and passes.
- [ ] Confirm no regression in other `test/registered/xpu/` tests scheduled to the same suite.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34039568504](https://github.com/sgl-project/sglang/actions/runs/34039568504)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34072319453](https://github.com/sgl-project/sglang/actions/runs/34072319453)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34039568500](https://github.com/sgl-project/sglang/actions/runs/34039568500)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->