### PR TITLE
docker(xpu): set BUILD_TARGET_DEVICE/DPCPP_SYCL_TARGET for sgl-kernel build

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -15,6 +15,13 @@ ARG SG_LANG_BRANCH=main
 ARG SG_LANG_KERNEL_REPO=https://github.com/sgl-project/sgl-kernel-xpu.git
 ARG SG_LANG_KERNEL_BRANCH=main
 
+# sgl-kernel-xpu's DeviceDetection.cmake auto-detect can't run inside
+# `docker build` (no XPU exposed to BuildKit); short-circuit it here.
+# Override with `--build-arg BUILD_TARGET_DEVICE=cri` etc. per workflow.
+ARG BUILD_TARGET_DEVICE=bmg
+ENV BUILD_TARGET_DEVICE=${BUILD_TARGET_DEVICE}
+ENV DPCPP_SYCL_TARGET=${BUILD_TARGET_DEVICE}
+
 USER root
 
 # Pin Level-Zero UMD + IGC (rolling PPA once faulted libze on B580; see sgl-kernel-xpu#296).


### PR DESCRIPTION
## Summary
- `Release Docker Images Nightly (Intel XPU)` has failed 3 nights in a row (2026-09-04, -05, -06) — see run [34032649213](https://github.com/sgl-project/sglang/actions/runs/34032649213/job/101484955550).
- Root cause: sgl-kernel-xpu#390 (landed 2026-09-04) replaced the hard-coded `bmg` target in `cmake/BuildFlags.cmake` with runtime auto-detection via a small Level Zero probe binary (`cmake/DeviceDetection.cmake`). BuildKit exposes no `/dev/dri` inside `docker build`, so the probe binary segfaults; the CMake fallback then errors out because `BUILD_TARGET_DEVICE` isn't set, and the `sgl-kernel` wheel build inside `docker/xpu.Dockerfile` fails, aborting the whole image build. Log excerpt:
  ```
  CMake Warning at cmake/DeviceDetection.cmake:96 (message):
    Program returned non-zero exit code: Segmentation fault
  CMake Error at cmake/DeviceDetection.cmake:102 (message):
    BUILD_TARGET_DEVICE environment variable is not set
  ```
- Fix: add a `BUILD_TARGET_DEVICE` build arg (default `bmg`) and export both `DPCPP_SYCL_TARGET` and `BUILD_TARGET_DEVICE`. `DPCPP_SYCL_TARGET` short-circuits the probe entirely (fastest, safest); `BUILD_TARGET_DEVICE` is belt-and-braces for the CMake fallback branch. Runners targeting other silicon can pass `--build-arg BUILD_TARGET_DEVICE=cri` (etc.) without any Dockerfile edit.
- Companion fix on the CMake side that removes the hard-fail regardless: sgl-project/sgl-kernel-xpu#473 (fail-soft to `bmg` when neither auto-detect nor env var resolves a target). This PR is independent of that one — nightly recovers with just this change.

## Test plan
- [ ] Trigger `Release Docker Images Nightly (Intel XPU)` on this branch → build reaches the `Push intel/sglang-dev` step and succeeds.
- [ ] Confirm the built image contains a working `sgl-kernel` build for BMG.
- [ ] `docker build --build-arg BUILD_TARGET_DEVICE=cri -f docker/xpu.Dockerfile .` still works locally (build arg override honored).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34040338260](https://github.com/sgl-project/sglang/actions/runs/34040338260)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34040338120](https://github.com/sgl-project/sglang/actions/runs/34040338120)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->