### PR TITLE
fix(compressed-tensors): refuse a quantized embedding instead of igno…

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -192,7 +192,10 @@ class CompressedTensorsConfig(QuantizationConfig):
             layer.scheme = scheme
             return CompressedTensorsLinearMethod(self)
 
-        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+        from sglang.srt.layers.vocab_parallel_embedding import (
+            ParallelLMHead,
+            VocabParallelEmbedding,
+        )
 
         if isinstance(layer, ParallelLMHead):
             scheme = self.get_lm_head_scheme(layer=layer, layer_name=prefix)
@@ -201,6 +204,32 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return None
             layer.scheme = scheme
             return CompressedTensorsLinearMethod(self)
+
+        # ParallelLMHead subclasses VocabParallelEmbedding and returned above, so
+        # only a real embedding lookup reaches here.
+        if isinstance(layer, VocabParallelEmbedding):
+            weight_quant = self.get_embedding_weight_quant(layer, layer_name=prefix)
+            if weight_quant is None:
+                # The common case: the checkpoint leaves the embedding table
+                # unquantized, and the layer's own UnquantizedEmbeddingMethod
+                # default is the right answer.
+                return None
+            # No scheme here implements the embedding lookup, so returning None
+            # would hand the layer UnquantizedEmbeddingMethod, which registers a
+            # plain `weight` that a pack-quantized checkpoint (weight_packed /
+            # weight_scale / weight_shape) can never fill. Loading then only
+            # warns, and the model serves an embedding table that was never
+            # written -- zero logits, and token id 0 for every position.
+            raise NotImplementedError(
+                f"The checkpoint quantizes the embedding table at '{prefix}' "
+                f"(num_bits={weight_quant.num_bits}, type={weight_quant.type}, "
+                f"strategy={weight_quant.strategy}, "
+                f"group_size={weight_quant.group_size}), which SGLang's "
+                "compressed-tensors support does not implement. Serving it "
+                "would leave the embedding table unloaded and generate only "
+                "token id 0. Use a checkpoint that leaves the embedding "
+                "unquantized, e.g. by adding it to the recipe's `ignore` list."
+            )
 
         from sglang.srt.layers.radix_attention import RadixAttention
 
@@ -1038,6 +1067,30 @@ class CompressedTensorsConfig(QuantizationConfig):
         return self.get_linear_scheme(
             layer=layer, layer_name=layer_name, matched_target=matched_target
         )
+
+    def get_embedding_weight_quant(
+        self, layer: torch.nn.Module, layer_name: Optional[str] = None
+    ) -> Optional[QuantizationArgs]:
+        """The weight quantization a config group declares for this embedding.
+
+        ``None`` when the checkpoint leaves the embedding table alone, which is
+        the ordinary case: llm-compressor recipes target ``Linear`` and quantize
+        the embedding only when asked to. A config group targeting ``Embedding``
+        matches here through ``find_matched_target``'s module-class pass, which
+        substring-matches the target against ``VocabParallelEmbedding``.
+
+        ``find_matched_target`` raises for a module no target names at all, so
+        that is caught: an embedding nothing targets is simply not quantized.
+        """
+        if layer_name is None or not self.target_scheme_map:
+            return None
+        try:
+            scheme_dict = self.get_scheme_dict(layer, layer_name=layer_name)
+        except ValueError:
+            return None
+        if scheme_dict is None:
+            return None
+        return cast(Optional[QuantizationArgs], scheme_dict.get("weights"))
 
     def get_scheme_dict(
         self,

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_embedding.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_embedding.py
@@ -1,0 +1,150 @@
+"""Unit tests for compressed-tensors quantized-embedding handling — CPU-only."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.test.test_utils import CustomTestCase
+
+# What llm-compressor writes for a 4-bit group-quantized embedding table, as
+# found in checkpoints that quantize `Embedding` alongside `Linear`.
+_INT4_GROUP_WEIGHTS = {
+    "num_bits": 4,
+    "type": "int",
+    "strategy": "group",
+    "group_size": 64,
+    "symmetric": True,
+    "dynamic": False,
+}
+
+
+def _config(targets, ignore=()):
+    return CompressedTensorsConfig.from_config(
+        {
+            "format": "pack-quantized",
+            "quant_method": "compressed-tensors",
+            "ignore": list(ignore),
+            "config_groups": {
+                "group_0": {
+                    "format": "pack-quantized",
+                    "targets": list(targets),
+                    "weights": _INT4_GROUP_WEIGHTS,
+                    "input_activations": None,
+                }
+            },
+        }
+    )
+
+
+class _Embedding(VocabParallelEmbedding):
+    """isinstance-compatible stand-in.
+
+    The real ``__init__`` builds vocab shards from the live TP topology, which a
+    CPU unit test has no reason to stand up; only the class identity matters for
+    the dispatch under test.
+    """
+
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+
+
+class _Head(ParallelLMHead):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+
+
+_GET_LM_HEAD_SCHEME = (
+    "sglang.srt.layers.quantization.compressed_tensors.compressed_tensors."
+    "CompressedTensorsConfig.get_lm_head_scheme"
+)
+
+
+class TestQuantizedEmbeddingIsRefused(CustomTestCase):
+    """No scheme here implements the embedding lookup, so a checkpoint that
+    quantizes the embedding table must fail loudly rather than fall back to
+    UnquantizedEmbeddingMethod and serve a table nothing can fill."""
+
+    def test_quantized_embedding_raises(self):
+        config = _config(["Linear", "Embedding"])
+        with self.assertRaises(NotImplementedError) as ctx:
+            config.get_quant_method(_Embedding(), prefix="model.embed_tokens")
+        message = str(ctx.exception)
+        self.assertIn("model.embed_tokens", message)
+        # The message has to carry the scheme, or the user cannot tell which
+        # part of their recipe to change.
+        self.assertIn("num_bits=4", message)
+        self.assertIn("group_size=64", message)
+
+    def test_embedding_targeted_by_name_raises(self):
+        # A recipe may name the module instead of its type.
+        config = _config(["Linear", "re:.*embed_tokens"])
+        with self.assertRaises(NotImplementedError):
+            config.get_quant_method(_Embedding(), prefix="model.embed_tokens")
+
+
+class TestUnquantizedEmbeddingStillWorks(CustomTestCase):
+    """The ordinary case must keep working: recipes target `Linear` and leave
+    the embedding table alone, and find_matched_target raises for a module no
+    target names — so the branch has to swallow that rather than propagate it."""
+
+    def test_linear_only_config_returns_none(self):
+        config = _config(["Linear"])
+        self.assertIsNone(
+            config.get_quant_method(_Embedding(), prefix="model.embed_tokens")
+        )
+
+    def test_ignored_embedding_returns_none(self):
+        config = _config(["Linear", "Embedding"], ignore=["model.embed_tokens"])
+        self.assertIsNone(
+            config.get_quant_method(_Embedding(), prefix="model.embed_tokens")
+        )
+
+    def test_no_layer_name_returns_none(self):
+        config = _config(["Linear", "Embedding"])
+        self.assertIsNone(config.get_quant_method(_Embedding(), prefix=None))
+
+
+class TestLmHeadIsUnaffected(CustomTestCase):
+    """ParallelLMHead subclasses VocabParallelEmbedding, so it must be answered
+    by the head path and never reach the embedding branch."""
+
+    def test_head_uses_lm_head_scheme(self):
+        config = _config(["Linear", "Embedding"])
+        with patch(_GET_LM_HEAD_SCHEME, return_value=None) as mock_resolve:
+            self.assertIsNone(config.get_quant_method(_Head(), prefix="lm_head"))
+        mock_resolve.assert_called_once()
+
+
+class TestGetEmbeddingWeightQuant(CustomTestCase):
+    def test_returns_the_declared_args(self):
+        config = _config(["Linear", "Embedding"])
+        weight_quant = config.get_embedding_weight_quant(
+            _Embedding(), layer_name="model.embed_tokens"
+        )
+        self.assertIsNotNone(weight_quant)
+        self.assertEqual(weight_quant.num_bits, 4)
+        self.assertEqual(weight_quant.group_size, 64)
+
+    def test_returns_none_when_untargeted(self):
+        config = _config(["Linear"])
+        self.assertIsNone(
+            config.get_embedding_weight_quant(
+                _Embedding(), layer_name="model.embed_tokens"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Serving a compressed-tensors checkpoint that quantizes its embedding table currently produces a working-looking server whose every generated token is id 0, with no error at any point. Reported in #38143.

CompressedTensorsConfig.get_quant_method answers for LinearBase, ParallelLMHead, RadixAttention and FusedMoE. A plain VocabParallelEmbedding falls through all four and returns None, so the layer installs its UnquantizedEmbeddingMethod default and registers a bf16 weight.

A checkpoint that quantizes the embedding stores weight_packed / weight_scale / weight_shape and no weight, e.g.

"group_0": {
  "targets": ["Embedding"],
  "format": "pack-quantized",
  "weights": {"num_bits": 4, "type": "int", "strategy": "group", "group_size": 64}
}
embed_tokens.weight_packed   I32   [200064, 768]
embed_tokens.weight_scale    BF16  [200064, 96]
embed_tokens.weight_shape    I64   [2]

Nothing can fill the weight parameter that was actually created, and nothing notices: load_weights emits three Parameter ... not found in params_dict warnings and carries on. The embedding table is then served exactly as torch.empty left it. Freshly allocated device memory comes back zeroed, so hidden states are zero, every logit is zero, and argmax lands on index 0 for every position — a run of NUL bytes out of the API, with the server reporting success throughout.

## Modifications

Answer `VocabParallelEmbedding` explicitly in get_quant_method and raise `NotImplementedError` when a config group declares a weight quantization for it. 

`ParallelLMHead` subclasses `VocabParallelEmbedding` but is answered by the branch above and returns unconditionally, so only a real embedding lookup reaches the new one.

A helper, `get_embedding_weight_quant`, resolves the declared quantization. It catches the `ValueError` that `find_matched_target` raises for a module no target names — this is load-bearing, and worth flagging for review: unlike the equivalent in vLLM, SGLang's `find_matched_target` raises instead of returning `None`, so a naive lookup here would abort startup for every compressed-tensors model, since the ordinary recipe targets `Linear` and never mentions the embedding. Two of the tests exist purely to pin that path.

Behaviour is unchanged whenever the embedding is not quantized (the overwhelmingly common case), when it is listed in `ignore`, and for every other layer type.

This is deliberately a refusal, not an implementation. Supporting the lookup — vLLM does it in `CompressedTensorsEmbeddingWNA16Int`, dequant-gathering only the rows a batch touches, so the memory saving survives into inference — is a larger change, and it should be its own issue. Happy to open one if there is interest.

## Accuracy Tests

Not applicable: no model output changes. The change only converts an unsupported configuration from silently-wrong output into a startup error; every configuration that loads today loads unchanged.

## Speed Tests and Profiling

Not applicable: the new branch runs once per embedding layer at model construction, and is a no-op for unquantized embeddings.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34040944326](https://github.com/sgl-project/sglang/actions/runs/34040944326)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34040944220](https://github.com/sgl-project/sglang/actions/runs/34040944220)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34040944294](https://github.com/sgl-project/sglang/actions/runs/34040944294)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->