### PR TITLE
[diffusion] fix: stabilize H3 reference audio across repeated requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_audio_vae/audio_vae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_audio_vae/audio_vae.py
@@ -140,8 +140,8 @@ def WNConv1d(*args, **kwargs):
     return weight_norm(nn.Conv1d(*args, **kwargs))
 
 
-@torch.jit.script
 def snake(x, alpha):
+    # Profiling JIT changes rounding after the first call when it fuses this graph.
     shape = x.shape
     x = x.reshape(shape[0], shape[1], -1)
     x = x + (alpha + 1e-9).reciprocal() * torch.sin(alpha * x).pow(2)

--- a/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_audio_vae/audio_vae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/minimax_h3_audio_vae/audio_vae.py
@@ -141,7 +141,7 @@ def WNConv1d(*args, **kwargs):
 
 
 def snake(x, alpha):
-    # Profiling JIT changes rounding after the first call when it fuses this graph.
+    # profiling JIT changes rounding after the first call when it fuses this graph
     shape = x.shape
     x = x.reshape(shape[0], shape[1], -1)
     x = x + (alpha + 1e-9).reciprocal() * torch.sin(alpha * x).pow(2)

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -40,7 +40,7 @@ logger = init_logger(__name__)
 # NPU/ascend) is read from sgl-project/ci-data-diffusion, where the GT-gen workflows
 # publish.
 SGL_TEST_FILES_CI_DATA_REPO = "sgl-project/ci-data-diffusion"
-SGL_TEST_FILES_CI_DATA_REVISION = "11783b3fbd8ebb1e3509cc4590c1fff476e65511"
+SGL_TEST_FILES_CI_DATA_REVISION = "285ffa7fa7a8afcfb90e2344e3f9d6ca12a5e2ea"
 
 # The NPU pin is kept as a separate branch so ascend GT can be bumped independently
 # when it's regenerated on its own cadence.

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
@@ -150,7 +150,5 @@ def test_audio_snake_first_call_matches_repeated_calls():
             ),
         ],
         check=True,
-        capture_output=True,
-        text=True,
         timeout=120,
     )

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """MiniMax-H3 released VAE decode contract."""
 
+import subprocess
+import sys
+import textwrap
 from unittest import mock
 
 import pytest
@@ -117,3 +120,37 @@ def test_audio_vae_attention_defaults_to_local_sdpa_and_allows_fa():
     }
     assert recording_fa.input_dtype == torch.bfloat16
     assert output.dtype == torch.float32
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_audio_snake_first_call_matches_repeated_calls():
+    # A fresh process prevents earlier tests from warming a profiling JIT graph.
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import torch
+                from sglang.multimodal_gen.runtime.models.vaes.minimax_h3_audio_vae.audio_vae import Snake1d
+
+                torch.manual_seed(42)
+                activation = Snake1d(64).cuda().eval()
+                with torch.inference_mode():
+                    activation.alpha.uniform_(0.1, 2.0)
+                    x = torch.randn(2, 64, 4096, device="cuda")
+                    original_x = x.clone()
+                    original_alpha = activation.alpha.clone()
+                    first = activation(x)
+                    for _ in range(4):
+                        torch.testing.assert_close(activation(x), first, rtol=0, atol=0)
+                    torch.testing.assert_close(x, original_x, rtol=0, atol=0)
+                    torch.testing.assert_close(activation.alpha, original_alpha, rtol=0, atol=0)
+                """
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_vae_parallel_modes.py
@@ -124,7 +124,7 @@ def test_audio_vae_attention_defaults_to_local_sdpa_and_allows_fa():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_audio_snake_first_call_matches_repeated_calls():
-    # A fresh process prevents earlier tests from warming a profiling JIT graph.
+    # a fresh process prevents earlier tests from warming a profiling JIT graph
     subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Motivation

Identical MiniMax-H3 `ref2va` requests can produce different video and audio on the first and subsequent requests in the same server.

The audio encoder's scripted `snake` activation switches from its initial execution graph to a fused `TensorExprGroup` after profiling. The different floating-point rounding perturbs reference-audio conditioning, which joint audio/video denoising amplifies. The default Ref2VA synthetic warmup uses an image reference, so it does not warm this audio encoder path.

## Modifications

- Remove profiling TorchScript from the encoder activation without changing its formula or any global backend settings.
- Add a fresh-process CUDA regression test comparing the first call with repeated calls exactly, also checking that inputs and parameters remain unchanged. A fresh process prevents earlier tests from hiding the cold-call difference.
- Keep this independent of the sequential-request test harness in #38185. No diagnostic hooks, threshold changes, or new knobs.
- Refresh only the H100 Ref2VA frame GT after two independent CI runs produced byte-identical PNGs; keep the audio GT unchanged.

## Accuracy Tests

Remote H200 validation on `6c0f58b`: **10 tests passed**, pre-commit passed. The new regression test failed against the original implementation.

Real server comparison on **2x H200**, PyTorch **2.13.0+cu130**, Transformers **5.12.1**, checkpoint revision `42ed227ee7df40d41602854ae760620d6eb651fe`: Ref2VA, TP2, 4-second target, 8 requested steps, seed 42, the same video/audio reference, memory mode with DiT/text encoder layerwise offload and resident VAEs.

| Direct request-to-request comparison | Before | After |
| --- | --- | --- |
| First/middle/last video-frame SSIM | 0.826824 / 0.801041 / 0.732987 | 1 / 1 / 1 |
| Reference-audio latent max absolute difference | 5.878508e-6 | 0 |
| Audio PCM max absolute difference | 0.184578 | 0 |
| Complete MP4 bytes | Different | Identical |

Stage dumps localized the first difference to reference-audio encoding; text embeddings, reference-video latents, and initial noise were identical. After the change, three diagnostic requests matched exactly. A separate two-request run **without diagnostic instrumentation** also produced identical complete MP4 files and audio PCM.

These e2e measurements used the same production patch before rebasing this standalone PR, with the request harness from #38185. They are not a claim that the final rebased head has passed full H100 CI.

The fixed H200 outputs did not match the previous H100 video GT's SSIM threshold (0.8918 vs 0.92); performance, peak-VRAM, and audio-GT checks passed in that H200 experiment. H200 outputs were not used to replace H100 GT.

### H100 CI Baseline

The [first H100 run](https://github.com/sgl-project/sglang/actions/runs/34040811875/job/101507227805) and [rerun](https://github.com/sgl-project/sglang/actions/runs/34040811875/job/101513507507), both on source `6c0f58b`, produced **byte-identical first, middle, and last PNG frames**. Both reported SSIM 0.801429 against the old scripted-encoder GT. The checkpoint, sampling recipe, and thresholds were unchanged.

The three stable H100 frames are published in [ci-data-diffusion commit 285ffa7](https://github.com/sgl-project/ci-data-diffusion/commit/285ffa7fa7a8afcfb90e2344e3f9d6ca12a5e2ea), and this PR pins that revision. No other model's GT or consistency thresholds were changed.

On the final pin commit `e21f059`, **39 remote tests and pre-commit passed**. A remote smoke loaded all three frames and their CLIP embeddings through the pinned GT resolver with no local GT override; each downloaded PNG's Git blob hash matched the H100 CI artifact.

This confirms frame repeatability across independent server runs, not a new H100 same-session audio test: the old fixture stops after video consistency fails, and these artifacts contain no WAV. The existing audio GT remains unchanged; #38185 makes video/audio checks independent. The rerun also reported a separate Qwen-Image performance failure; its performance threshold is unchanged.

## Speed Tests and Profiling

Uninstrumented real server runs, same configuration:

| Metric | Before | After |
| --- | --- | --- |
| Request 1 e2e | 65.7466 s | 65.7376 s |
| Request 2 e2e | 65.5186 s | 65.5613 s |
| Loading peak VRAM | 15,242 MiB | 15,242 MiB |
| Runtime peak VRAM | 34,560 MiB | 34,560 MiB |

No material e2e regression was observed in this workload; this is not a throughput benchmark or a guarantee for every configuration.

## Checklist

- [x] Format with pre-commit.
- [x] Add a regression test and verify it fails before the fix.
- [x] Provide remote accuracy and e2e performance measurements.
- [x] Follow the SGLang code style guidance.
- Documentation: no public interface or configuration changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34045288397](https://github.com/sgl-project/sglang/actions/runs/34045288397)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34045288235](https://github.com/sgl-project/sglang/actions/runs/34045288235)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34045288350](https://github.com/sgl-project/sglang/actions/runs/34045288350)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
