### PR TITLE
[Fix] Normalize MiniCPM Lightning output across TP ranks

### DIFF
--- a/python/sglang/srt/models/minicpm.py
+++ b/python/sglang/srt/models/minicpm.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.configs.minicpm import MiniCPMHybridConfig
+from sglang.srt.distributed import tensor_model_parallel_all_reduce
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -249,6 +250,7 @@ class MiniCPMLightningMixer(nn.Module):
         self.use_output_gate = use_output_gate
         self.attention_bias = attention_bias
         self.rms_norm_eps = rms_norm_eps
+        self.tp_size = tp_size
         self.use_rope = use_rope
         self.qk_norm = qk_norm
         self.use_output_norm = use_output_norm
@@ -343,7 +345,19 @@ class MiniCPMLightningMixer(nn.Module):
         o = self.attn(q, k, v, forward_batch)
 
         if self.use_output_norm:
-            o = self.o_norm(o)
+            if self.tp_size == 1:
+                o = self.o_norm(o)
+            else:
+                # Output RMS statistics span all attention heads across TP ranks.
+                output_dtype = o.dtype
+                o = o.float()
+                variance = o.square().mean(dim=-1, keepdim=True)
+                variance = tensor_model_parallel_all_reduce(variance) / self.tp_size
+                o = (
+                    o
+                    * torch.rsqrt(variance + self.o_norm.variance_epsilon)
+                    * self.o_norm.weight
+                ).to(output_dtype)
 
         if self.use_output_gate:
             z, _ = self.z_proj(hidden_states)

--- a/test/registered/unit/models/test_minicpm_output_norm.py
+++ b/test/registered/unit/models/test_minicpm_output_norm.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.models import minicpm
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_lightning_output_norm_matches_unsharded_reference(monkeypatch, tp_size):
+    """Splitting heads across ranks must preserve full-width RMS normalization,
+    including rows where one rank's shard has zero energy."""
+    values = torch.tensor(
+        [
+            [0.0, 0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0],
+            [3.0, -1.0, 2.0, -4.0, 0.0, 0.0, 1.0, 5.0],
+        ]
+    )
+    weight = torch.tensor([1.0, 0.5, -1.0, 2.0, 0.25, 1.5, 3.0, -0.5])
+    expected = F.rms_norm(values, (8,), weight, eps=1e-6)
+    shard_width = values.shape[-1] // tp_size
+    shard_variances = [
+        shard.square().mean(-1, keepdim=True) for shard in values.chunk(tp_size, dim=-1)
+    ]
+    outputs = []
+    for rank, shard in enumerate(values.chunk(tp_size, dim=-1)):
+        remote_variance = sum(shard_variances[:rank] + shard_variances[rank + 1 :])
+        monkeypatch.setattr(
+            minicpm,
+            "tensor_model_parallel_all_reduce",
+            lambda local_variance: local_variance + remote_variance,
+        )
+        monkeypatch.setattr(
+            minicpm,
+            "QKVParallelLinear",
+            Mock(
+                return_value=Mock(return_value=(torch.zeros(2, shard_width * 3), None))
+            ),
+        )
+        monkeypatch.setattr(
+            minicpm,
+            "RowParallelLinear",
+            Mock(return_value=lambda output: (output, None)),
+        )
+        monkeypatch.setattr(
+            minicpm, "RadixAttention", Mock(return_value=Mock(return_value=shard))
+        )
+        # Keep CPU tensors on native RMSNorm dispatch on CUDA hosts.
+        monkeypatch.setattr(
+            minicpm,
+            "RMSNorm",
+            lambda hidden_size, eps: RMSNorm(hidden_size, eps=eps, force_native=True),
+        )
+        with get_parallel().override(
+            tp_size=tp_size, tp_rank=rank, attn_tp_size=tp_size, attn_tp_rank=rank
+        ):
+            mixer = minicpm.MiniCPMLightningMixer(
+                hidden_size=8,
+                num_heads=8,
+                num_kv_heads=8,
+                head_dim=1,
+                use_rope=False,
+                qk_norm=False,
+                use_output_norm=True,
+            )
+            mixer.o_norm.weight.weight_loader(mixer.o_norm.weight, weight)
+            batch = SimpleNamespace(forward_mode=SimpleNamespace(is_idle=lambda: False))
+            outputs.append(mixer(torch.arange(2), torch.zeros_like(values), batch))
+    torch.testing.assert_close(torch.cat(outputs, dim=-1), expected)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

MiniCPM's Lightning attention layers apply RMS normalization across the combined output of all attention heads. With tensor parallelism, each rank holds a subset of those heads but currently computes the normalization denominator from its own subset. Different activation magnitudes between ranks therefore produce a different result from full-width normalization.

## Modifications

Reduce the FP32 mean-square statistics across tensor-parallel ranks before applying each rank's normalization weights. The TP=1 path keeps its existing implementation.

## Accuracy Tests

The regression covers unequal and zero-energy shards at TP=1, 2, and 4. A separate check using the real SGLang collective on two RTX 5090 GPUs matched full-width PyTorch RMS normalization for FP32 and BF16 inputs.

Real TP2 MiniCPM-SALA NVFP4 activations were also checked against a full-width FP32 reference rounded to BF16. Maximum absolute errors before output gating and projection were:

| Phase | Before | After |
|---|---:|---:|
| Prefill | 2.3125 | 0.00390625 |
| Decode | 1.1875 | 0 |

Both corrected results satisfy `atol=rtol=1/128`. Separate TP2 serving smoke tests completed without request errors with decode CUDA graphs enabled.

```bash
PYTHONPATH=python python3 -m pytest -q test/registered/unit/models/test_minicpm_output_norm.py
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34047103645](https://github.com/sgl-project/sglang/actions/runs/34047103645)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34047103602](https://github.com/sgl-project/sglang/actions/runs/34047103602)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34047103676](https://github.com/sgl-project/sglang/actions/runs/34047103676)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
