### PR TITLE
[Fix] Correct MiniCPM fused top-k synchronization and selection

### DIFF
--- a/python/sglang/srt/layers/attention/minicpm/fuse_kernel.py
+++ b/python/sglang/srt/layers/attention/minicpm/fuse_kernel.py
@@ -5,8 +5,8 @@ import tilelang
 import tilelang.language as T
 import tilelang.math
 
+# Shared Q/K tiles need block barriers before cross-warp MMA operand loads.
 _pass_configs = {
-    tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
     tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
     tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
 }

--- a/python/sglang/srt/layers/attention/minicpm/fuse_kernel.py
+++ b/python/sglang/srt/layers/attention/minicpm/fuse_kernel.py
@@ -153,12 +153,12 @@ def _fused_attn_pooling_online_topk(
                 active = cache_len + 1 >= dense_len
                 q_current_seqlen = T.if_then_else(active, q_current_seqlen, 0)
                 k_current_seqlen = T.if_then_else(active, k_current_seqlen, 0)
-            if is_causal:
-                actual_pooled_k_len = (
-                    k_current_seqlen - 1 + pad_len
-                ) // block_stride + 1
-            else:
-                actual_pooled_k_len = (1 + cache_len + block_size - 1) // block_size
+            # The local-block boost selects the token's own block even before
+            # its compressed row exists; the clamp bounds padded rows' pool rounds.
+            query_token_pos = cache_len + (
+                T.min(original_q_idx, q_current_seqlen - 1) if is_causal else 0
+            )
+            actual_pooled_k_len = query_token_pos // block_size + 1
             effective_pooled_k_len = T.min(actual_pooled_k_len, pooled_k_len)
 
             T.fill(topk_index_shared, -1)

--- a/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
+++ b/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
@@ -367,10 +367,6 @@ def compressed_attention_tilelang(
             topk_values,
         )
 
-        # Note: q_idx masking is handled inside the kernel via causal_mask
-        # which sets scores to -1e9 for K blocks beyond the causal boundary.
-        # These blocks won't be selected in topk due to their low scores.
-
         # Sort with -1 values at the end (match original behavior)
         # Replace -1 with large value, sort, then replace back
         large_val = pooled_k_len + 1000  # Any value larger than max valid index

--- a/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
+++ b/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
@@ -308,9 +308,7 @@ def compressed_attention_tilelang(
     fused_kernel=None,
     max_cache_len=-1,
 ) -> torch.Tensor:
-    """
-    使用 tilelang online topk kernel 计算 compressed attention topk indices
-    """
+    """Compute top-k block indices with the TileLang fused kernel."""
     with torch.no_grad():
         batch_size = cu_seqlens_q.shape[0] - 1
 
@@ -367,16 +365,12 @@ def compressed_attention_tilelang(
             topk_values,
         )
 
-        # Sort with -1 values at the end (match original behavior)
-        # Replace -1 with large value, sort, then replace back
+        # Indices arrive sorted by descending score: truncate to output_topk
+        # before the index sort (-1 entries last).
         large_val = pooled_k_len + 1000  # Any value larger than max valid index
-        topk_for_sort = topk_indices.clone()
-        topk_for_sort[topk_for_sort == -1] = large_val
-        topk_idx = topk_for_sort.sort(-1).values
+        sel = topk_indices[:, :, :output_topk]
+        topk_idx = torch.where(sel == -1, large_val, sel).sort(-1).values
         topk_idx[topk_idx == large_val] = -1
-
-        # Truncate to output_topk (same as original: min(topk, num_blocks))
-        topk_idx = topk_idx[:, :, :output_topk].contiguous()
 
         return topk_idx
 

--- a/test/registered/kernels/ops/test_minicpm_fused_topk.py
+++ b/test/registered/kernels/ops/test_minicpm_fused_topk.py
@@ -11,6 +11,7 @@ from tilelang import tvm
 
 from sglang.srt.layers.attention.minicpm.fuse_kernel import (
     _fused_attn_pooling_online_topk,
+    fused_attn_pooling_online_topk_decode,
     fused_attn_pooling_online_topk_prefill,
 )
 from sglang.srt.layers.attention.minicpm.sparse_utils import (
@@ -73,6 +74,24 @@ def _run_topk(kernel, q, k, cu_seqlens_q, cu_seqlens_k, cache_lens):
         fused_kernel=kernel,
         max_cache_len=_MAX_CACHE_LEN,
     )
+
+
+def _make_decode_inputs(seq_len: int, seed: int = 0) -> tuple[torch.Tensor, ...]:
+    num_k = (seq_len - _KERNEL_SIZE) // _KERNEL_STRIDE + 1
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn(
+        (1, _HEADS, _DIM), dtype=torch.bfloat16, device="cuda", generator=generator
+    )
+    k = torch.randn(
+        (num_k, _HEAD_KV, _DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+    cu_seqlens_k = torch.tensor([0, num_k], dtype=torch.int32, device="cuda")
+    cache_lens = torch.tensor([seq_len - 1], dtype=torch.int32, device="cuda")
+    return q, k, cu_seqlens_q, cu_seqlens_k, cache_lens
 
 
 _PREFILL_GRID = 256
@@ -158,6 +177,67 @@ def test_prefill_topk_subscribed_rows_select_only_causal_blocks():
 
     topk_idx = _run_topk(check_candidates, q, k, cu_seqlens_q, cu_seqlens_k, cache_lens)
     assert (topk_idx >= 0).sum(-1).eq(_SPARSE_TOPK).all()
+
+
+@pytest.mark.parametrize("seq_len", [6500, 8500, 12000])
+def test_decode_topk_keeps_forced_blocks_beyond_output_topk(seq_len):
+    """Forced init/local blocks must survive truncation to the output capacity."""
+    q, k, cu_seqlens_q, cu_seqlens_k, cache_lens = _make_decode_inputs(seq_len)
+    kernel = _kernel(fused_attn_pooling_online_topk_decode)
+    topk_idx = _run_topk(kernel, q, k, cu_seqlens_q, cu_seqlens_k, cache_lens)
+
+    last_block = (seq_len - 1) // _BLOCK_SIZE
+    sel = topk_idx[:, 0]
+    forced = torch.cat(
+        [
+            torch.arange(_INIT_BLOCKS, device="cuda"),
+            torch.arange(last_block - _LOCAL_BLOCKS, last_block + 1, device="cuda"),
+        ]
+    )
+    assert (sel[:, None, :] == forced[None, :, None]).any(-1).all()
+
+
+def test_decode_topk_matches_unforced_score_reference():
+    """Score truncation must retain the full winning set before block-ID sorting."""
+    seq_len = 8500
+    num_k = (seq_len - _KERNEL_SIZE) // _KERNEL_STRIDE + 1
+    num_blocks = (seq_len + _BLOCK_SIZE - 1) // _BLOCK_SIZE
+    q = torch.zeros(1, _HEADS, _DIM, dtype=torch.bfloat16)
+    q[:, :, :2] = 16
+    q[:, _GROUPS:, :2] = -16
+    key_rows = torch.arange(num_k)
+    k = torch.zeros(num_k, _HEAD_KV, _DIM, dtype=torch.bfloat16)
+    # Both components are BF16-exact; their dot product is +/- key_row / 8.
+    k[:, :, 0] = (key_rows // 128)[:, None]
+    k[:, :, 1] = ((key_rows % 128) / 128)[:, None]
+
+    logits = torch.einsum(
+        "qhgd,khd->hqgk",
+        q.double().reshape(1, _HEAD_KV, _GROUPS, _DIM),
+        k.double(),
+    ) / (_DIM**0.5)
+    probabilities = logits.softmax(-1).sum(2)
+    key_starts = key_rows * _KERNEL_STRIDE
+    block_starts = torch.arange(num_blocks) * _BLOCK_SIZE
+    overlaps = (key_starts[:, None] < block_starts[None, :] + _BLOCK_SIZE) & (
+        key_starts[:, None] + _KERNEL_SIZE > block_starts[None, :]
+    )
+    scores = probabilities[..., None].masked_fill(~overlaps, float("-inf")).amax(2)
+    assert (scores[0, 0].diff() > 0).all()
+    assert (scores[1, 0].diff() < 0).all()
+    ranked = scores.sort(dim=-1, descending=True).values
+    assert (ranked[..., _OUTPUT_TOPK - 1] > 1.04 * ranked[..., _OUTPUT_TOPK]).all()
+    expected = scores.topk(_OUTPUT_TOPK, dim=-1).indices.sort(-1).values.to(torch.int32)
+
+    kernel = fused_attn_pooling_online_topk_decode(
+        batch_size=1,
+        **dict(_KERNEL_KWARGS, init_blocks=0, local_blocks=0),
+    )
+    cu_q = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, num_k], dtype=torch.int32, device="cuda")
+    cache = torch.tensor([seq_len - 1], dtype=torch.int32, device="cuda")
+    actual = _run_topk(kernel, q.cuda(), k.cuda(), cu_q, cu_k, cache)
+    assert torch.equal(actual.cpu(), expected)
 
 
 def _tir_nodes(statement, predicate):

--- a/test/registered/kernels/ops/test_minicpm_fused_topk.py
+++ b/test/registered/kernels/ops/test_minicpm_fused_topk.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import functools
+
 import pytest
 import tilelang.math
+import torch
 from tilelang import tvm
 
 from sglang.srt.layers.attention.minicpm.fuse_kernel import (
     _fused_attn_pooling_online_topk,
+    fused_attn_pooling_online_topk_prefill,
+)
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    compressed_attention_tilelang,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -46,6 +53,111 @@ _KERNEL_KWARGS = dict(
     local_blocks=_LOCAL_BLOCKS,
     dtype_str="bfloat16",
 )
+
+
+@functools.cache
+def _kernel(factory, **overrides):
+    return factory(batch_size=1, **_KERNEL_KWARGS, **overrides)
+
+
+def _run_topk(kernel, q, k, cu_seqlens_q, cu_seqlens_k, cache_lens):
+    return compressed_attention_tilelang(
+        q,
+        k,
+        _BLOCK_SIZE,
+        _SPARSE_TOPK,
+        _KERNEL_TOPK,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        cache_lens=cache_lens,
+        fused_kernel=kernel,
+        max_cache_len=_MAX_CACHE_LEN,
+    )
+
+
+_PREFILL_GRID = 256
+
+
+def _run_prefill_topk(seq_len: int, seed: int = 0) -> torch.Tensor:
+    num_k = (seq_len - _KERNEL_SIZE) // _KERNEL_STRIDE + 1
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn(
+        (seq_len, _HEADS, _DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    k = torch.randn(
+        (num_k, _HEAD_KV, _DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    cu_seqlens_q = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    cu_seqlens_k = torch.tensor([0, num_k], dtype=torch.int32, device="cuda")
+    kernel = _kernel(
+        fused_attn_pooling_online_topk_prefill, max_seqlen_q_grid=_PREFILL_GRID
+    )
+    return _run_topk(kernel, q, k, cu_seqlens_q, cu_seqlens_k, None)
+
+
+@pytest.mark.parametrize("seq_len", [78, 200])
+def test_prefill_topk_selects_each_tokens_own_block(seq_len):
+    """Select each token's own block even before its compressed row exists."""
+    topk_idx = _run_prefill_topk(seq_len)
+    own = torch.arange(seq_len, device="cuda") // _BLOCK_SIZE
+    assert (topk_idx == own[None, :, None]).any(-1).all()
+
+
+# Chunked prefill past the sparse capacity (_SPARSE_TOPK * _BLOCK_SIZE tokens):
+# every new token has more causally visible blocks than output slots.
+_CHUNK_CACHE_LEN = _SPARSE_TOPK * _BLOCK_SIZE
+_CHUNK_NEW_LEN = 384
+_CHUNK_TOTAL_LEN = _CHUNK_CACHE_LEN + _CHUNK_NEW_LEN
+
+
+def test_prefill_topk_subscribed_rows_select_only_causal_blocks():
+    """Raw kernel candidates must not include blocks past the token's own."""
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    direction = torch.ones(_DIM, dtype=torch.bfloat16, device="cuda")
+    q = (
+        5.0 * direction
+        + 0.1
+        * torch.randn(
+            (_CHUNK_NEW_LEN, _HEADS, _DIM),
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+    ).contiguous()
+    num_k = (_CHUNK_TOTAL_LEN - _KERNEL_SIZE) // _KERNEL_STRIDE + 1
+    k = 0.01 * torch.randn(
+        (num_k, _HEAD_KV, _DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    num_blocks = _CHUNK_TOTAL_LEN // _BLOCK_SIZE
+    rows_per_block = _BLOCK_SIZE // _KERNEL_STRIDE
+    # This key is visible in block b - 1 but also overlaps block b.
+    for future_block in range(_SPARSE_TOPK + 1, num_blocks):
+        k[rows_per_block * future_block - 1] = 50.0 * direction
+    cu_seqlens_q = torch.tensor([0, _CHUNK_NEW_LEN], dtype=torch.int32, device="cuda")
+    cu_seqlens_k = torch.tensor([0, num_k], dtype=torch.int32, device="cuda")
+    cache_lens = torch.tensor([_CHUNK_CACHE_LEN], dtype=torch.int32, device="cuda")
+
+    kernel = _kernel(
+        fused_attn_pooling_online_topk_prefill, max_seqlen_q_grid=_CHUNK_NEW_LEN
+    )
+    pos = _CHUNK_CACHE_LEN + torch.arange(_CHUNK_NEW_LEN, device="cuda")
+    own = (pos // _BLOCK_SIZE)[None, :, None]
+
+    def check_candidates(q, k, cu_q, cu_k, cache, indices, values):
+        kernel(q, k, cu_q, cu_k, cache, indices, values)
+        assert ((indices <= own) | (indices < 0)).all()
+
+    topk_idx = _run_topk(check_candidates, q, k, cu_seqlens_q, cu_seqlens_k, cache_lens)
+    assert (topk_idx >= 0).sum(-1).eq(_SPARSE_TOPK).all()
 
 
 def _tir_nodes(statement, predicate):

--- a/test/registered/kernels/ops/test_minicpm_fused_topk.py
+++ b/test/registered/kernels/ops/test_minicpm_fused_topk.py
@@ -1,0 +1,139 @@
+"""Fused top-k selection kernels for the MiniCPM sparse attention path."""
+
+from __future__ import annotations
+
+import pytest
+import tilelang.math
+from tilelang import tvm
+
+from sglang.srt.layers.attention.minicpm.fuse_kernel import (
+    _fused_attn_pooling_online_topk,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+_HEADS = 32
+_HEAD_KV = 2
+_GROUPS = _HEADS // _HEAD_KV
+_DIM = 128
+_KERNEL_SIZE = 32
+_KERNEL_STRIDE = 16
+_BLOCK_SIZE = 64
+_INIT_BLOCKS = 1
+_LOCAL_BLOCKS = 2048 // _BLOCK_SIZE
+_SPARSE_TOPK = 64 + _LOCAL_BLOCKS
+_MAX_CACHE_LEN = 40960
+
+_POOLED_K_LEN = (_MAX_CACHE_LEN + _BLOCK_SIZE - 1) // _BLOCK_SIZE
+_OUTPUT_TOPK = min(_SPARSE_TOPK, _POOLED_K_LEN)
+_KERNEL_TOPK = tilelang.math.next_power_of_2(_OUTPUT_TOPK)
+
+_KERNEL_KWARGS = dict(
+    groups=_GROUPS,
+    heads=_HEADS,
+    dim=_DIM,
+    topk=_KERNEL_TOPK,
+    pooled_k_len=tilelang.math.next_power_of_2(_POOLED_K_LEN),
+    m_block_dim=_GROUPS,
+    block_M=_GROUPS,
+    block_stride=_BLOCK_SIZE // _KERNEL_STRIDE,
+    pad_len=_KERNEL_SIZE // _KERNEL_STRIDE - 1,
+    num_offs=_KERNEL_SIZE // _KERNEL_STRIDE + _BLOCK_SIZE // _KERNEL_STRIDE - 1,
+    kernel_stride=_KERNEL_STRIDE,
+    block_size=_BLOCK_SIZE,
+    init_blocks=_INIT_BLOCKS,
+    local_blocks=_LOCAL_BLOCKS,
+    dtype_str="bfloat16",
+)
+
+
+def _tir_nodes(statement, predicate):
+    nodes = []
+
+    def collect(node):
+        if predicate(node):
+            nodes.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(statement, collect)
+    return nodes
+
+
+def _tir_statements(statement):
+    if isinstance(statement, tvm.tirx.SeqStmt):
+        for child in statement.seq:
+            yield from _tir_statements(child)
+    elif (
+        isinstance(statement, tvm.tirx.AttrStmt)
+        and statement.attr_key == "lexical_alloc_scope"
+    ):
+        yield from _tir_statements(statement.body)
+    else:
+        yield statement
+
+
+def test_fused_topk_synchronizes_shared_mma_inputs():
+    """Shared input writes must complete before other warps load MMA operands."""
+    factory = _fused_attn_pooling_online_topk
+    function = factory.get_tir(
+        batch_size=1,
+        max_seqlen_q_grid=1,
+        is_causal=False,
+        **_KERNEL_KWARGS,
+    )
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_120"})
+    with tvm.transform.PassContext(opt_level=3, config=factory.pass_configs), target:
+        artifact = tilelang.lower(function, target=target, enable_device_compile=False)
+
+    tir = tvm.tirx
+    load_op = tvm.ir.Op.get("tl.ptx_ldmatrix")
+    sync_op = tvm.ir.Op.get("tirx.tvm_storage_sync")
+    producer_consumer_edges = []
+    for function in artifact.device_mod.functions.values():
+        sequences = _tir_nodes(
+            function.body, lambda node: isinstance(node, tir.SeqStmt)
+        )
+        for sequence in sequences:
+            pending_shared_write = False
+            synchronized = False
+            for statement in _tir_statements(sequence):
+                loads = _tir_nodes(
+                    statement,
+                    lambda node: (
+                        isinstance(node, tir.Call) and node.op.same_as(load_op)
+                    ),
+                )
+                stores = _tir_nodes(
+                    statement,
+                    lambda node: (
+                        isinstance(node, tir.BufferStore)
+                        and node.buffer.scope().startswith("shared")
+                        and node.buffer.dtype == "bfloat16"
+                    ),
+                )
+                if stores and not loads:
+                    pending_shared_write = True
+                    synchronized = False
+                elif isinstance(statement, tir.Evaluate) and isinstance(
+                    statement.value, tir.Call
+                ):
+                    call = statement.value
+                    if call.op.same_as(sync_op) and call.args[0].value.startswith(
+                        "shared"
+                    ):
+                        synchronized = True
+                if loads and not stores and pending_shared_write:
+                    producer_consumer_edges.append((len(loads), synchronized))
+                    pending_shared_write = False
+
+    # Statistics and pooled scoring each read the shared Q/K tiles once per loop.
+    assert len(producer_consumer_edges) == 2, producer_consumer_edges
+    assert all(count == 2 and synced for count, synced in producer_consumer_edges), (
+        producer_consumer_edges
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

MiniCPM's fused top-k selector can select incorrect blocks for sparse attention:

- Cross-warp MMA loads can read shared Q/K tiles before their writes are synchronized.
- Overlapping compression windows can give future blocks a score, allowing them to displace causal candidates.
- Sorting block IDs before truncating the kernel's power-of-two candidate buffer can discard higher-scoring candidates, including forced blocks.

## Modifications

- Re-enable compiler-inserted shared-memory synchronization.
- Limit candidates to each query's current block and earlier blocks, keeping the current block eligible before its compressed row exists.
- Truncate candidates in score order, then sort the retained IDs with padding at the end.

## Accuracy Tests

Offline validation checks both shared-input producer/consumer barriers in the production kernel's lowered IR for `sm_120` with the pinned TileLang 0.1.12, with the old source failing and the fix passing. Numerical regressions cover causal boundaries, forced blocks, and the complete selected set for ordinary candidates with separated scores, using an independent softmax-and-pooling reference.

A real MiniCPM-SALA NVFP4 service on one RTX 5090 GPU captured the selector's inputs and outputs during chunked prefill and decode for a 12288-token request. Replaying the same inputs with one selection fix reverted at a time reproduced these errors:

| Case | Reverted fix | Before | After |
|---|---|---|---|
| Query at position 8895, in block 138 | Causal bound | Selected future block 139 | Future block excluded |
| First decode query, at position 12288 | Score-order truncation | Dropped recent blocks 161–192 | All those forced blocks retained |

The corrected replay matched the service's selections and passed independent score-reference checks. Separate serving smoke tests completed without request errors with decode CUDA graphs enabled.

```bash
PYTHONPATH=python python3 -m pytest -q test/registered/kernels/ops/test_minicpm_fused_topk.py
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34047103833](https://github.com/sgl-project/sglang/actions/runs/34047103833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34047103770](https://github.com/sgl-project/sglang/actions/runs/34047103770)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34047103849](https://github.com/sgl-project/sglang/actions/runs/34047103849)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

