### PR TITLE
fix(function-call): publish DeepSeek V4 calls atomically

### DIFF
--- a/python/sglang/srt/function_call/deepseekv4_detector.py
+++ b/python/sglang/srt/function_call/deepseekv4_detector.py
@@ -1,5 +1,6 @@
 import logging
 
+from sglang.srt.function_call.core_types import StreamingParseResult, ToolCallItem
 from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,128 @@ class DeepSeekV4Detector(DeepSeekV32Detector):
         self.bot_token = "<｜DSML｜tool_calls>"
         self.eot_token = "</｜DSML｜tool_calls>"
         self.function_calls_regex = r"<｜DSML｜tool_calls>(.*?)</｜DSML｜tool_calls>"
+
+    def _partial_marker_length(self, text: str) -> int:
+        """Length of a trailing prefix of a V4 tool-call marker."""
+        markers = (self.bot_token, "<｜DSML｜invoke")
+        return max(
+            (
+                size
+                for marker in markers
+                for size in range(1, min(len(text), len(marker) - 1) + 1)
+                if marker.startswith(text[-size:])
+            ),
+            default=0,
+        )
+
+    def has_tool_call(self, text: str) -> bool:
+        """Treat a trailing partial marker as protocol at generation end."""
+        return super().has_tool_call(text) or self._partial_marker_length(text) > 0
+
+    def detect_and_parse(self, text, tools) -> StreamingParseResult:
+        """Never return malformed or incomplete DSML as assistant text."""
+        wrapped_start = text.find(self.bot_token)
+        invoke_start = text.find("<｜DSML｜invoke")
+        starts = [pos for pos in (wrapped_start, invoke_start) if pos >= 0]
+
+        if not starts:
+            partial = self._partial_marker_length(text)
+            if not partial:
+                return StreamingParseResult(normal_text=text, calls=[])
+            return StreamingParseResult(
+                normal_text=text[:-partial].removesuffix("\n\n"), calls=[]
+            )
+
+        start = min(starts)
+        safe_normal = text[:start].removesuffix("\n\n")
+        parseable = text
+        if wrapped_start < 0 and invoke_start >= 0:
+            parseable = self.bot_token + text[invoke_start:] + self.eot_token
+
+        parsed = super().detect_and_parse(parseable, tools)
+        if not parsed.calls:
+            return StreamingParseResult(normal_text=safe_normal, calls=[])
+        if wrapped_start < 0:
+            parsed.normal_text = safe_normal
+        return parsed
+
+    def parse_streaming_increment(self, new_text, tools) -> StreamingParseResult:
+        """Publish V4 tool calls only after their complete DSML envelope arrives."""
+        self._buffer += new_text
+        current = self._buffer
+        wrapped_start = current.find(self.bot_token)
+        invoke_start = current.find("<｜DSML｜invoke")
+        starts = [pos for pos in (wrapped_start, invoke_start) if pos >= 0]
+
+        if not starts:
+            if current and current.isspace():
+                return StreamingParseResult()
+            partial = self._partial_marker_length(current)
+            if partial:
+                normal_text = current[:-partial]
+                self._buffer = current[-partial:]
+            else:
+                normal_text = current
+                self._buffer = ""
+            return StreamingParseResult(normal_text=normal_text)
+
+        start = min(starts)
+        normal_text = current[:start].removesuffix("\n\n")
+        is_wrapped = start == wrapped_start
+        end_token = self.eot_token if is_wrapped else self.invoke_end_token
+        end = current.find(end_token, start + 1)
+        if end < 0:
+            self._buffer = current[start:]
+            return StreamingParseResult(normal_text=normal_text)
+
+        section_end = end + len(end_token)
+        section = current[start:section_end]
+        self._buffer = current[section_end:]
+        parsed = self.detect_and_parse(section, tools)
+
+        first_index = self.current_tool_id + 1
+        calls = [
+            ToolCallItem(
+                tool_index=first_index + offset,
+                name=call.name,
+                parameters=call.parameters,
+            )
+            for offset, call in enumerate(parsed.calls)
+        ]
+        if calls:
+            self.current_tool_id += len(calls)
+
+        tail = self.parse_streaming_increment("", tools) if self._buffer else None
+        if tail is not None:
+            normal_text += tail.normal_text
+            calls.extend(tail.calls)
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def finish(self, tools) -> StreamingParseResult:
+        """Drop an incomplete V4 protocol envelope instead of flushing it."""
+        buffered = self._buffer
+        self._buffer = ""
+        self.prev_tool_call_arr = []
+        self.streamed_args_for_tool = []
+        if not buffered or buffered.isspace():
+            return StreamingParseResult()
+
+        starts = [
+            pos
+            for pos in (
+                buffered.find(self.bot_token),
+                buffered.find("<｜DSML｜invoke"),
+            )
+            if pos >= 0
+        ]
+        if starts:
+            return StreamingParseResult(
+                normal_text=buffered[: min(starts)].removesuffix("\n\n")
+            )
+        partial = self._partial_marker_length(buffered)
+        return StreamingParseResult(
+            normal_text=(buffered[:-partial] if partial else buffered)
+        )
 
     def get_structural_tag_name(self) -> str:
         return "deepseek_v4"

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -83,8 +83,8 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertNotIn(DSML, normal)
 
-    def test_malformed_partial_json_falls_back_to_raw_value(self):
-        """A partial non-string parameter must not escape as MalformedJSON."""
+    def test_incomplete_call_is_not_published(self):
+        """A truncated call must not publish its name or partial arguments."""
         detector = DeepSeekV4Detector()
         result = detector.parse_streaming_increment(
             f'<{DSML}tool_calls>\n<{DSML}invoke name="get_weather">\n'
@@ -92,7 +92,37 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             self.tools,
         )
 
-        self.assertEqual([c.name for c in result.calls if c.name], ["get_weather"])
+        self.assertEqual(result.calls, [])
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(detector.finish(self.tools).calls, [])
+
+    def test_complete_call_is_published_atomically(self):
+        detector = DeepSeekV4Detector()
+        text = _weather_call()
+        split = text.index("SF")
+
+        first = detector.parse_streaming_increment(text[:split], self.tools)
+        second = detector.parse_streaming_increment(text[split:], self.tools)
+
+        self.assertEqual(first.calls, [])
+        self.assertEqual(len(second.calls), 1)
+        self.assertEqual(second.calls[0].name, "get_weather")
+
+    def test_malformed_complete_dsml_does_not_leak(self):
+        text = _wrapped(_invoke("get_weather", "{bad}"))
+        result = DeepSeekV4Detector().detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.calls, [])
+        self.assertNotIn(DSML, result.normal_text)
+
+    def test_partial_marker_at_end_does_not_leak(self):
+        text = f"safe text\n\n<{DSML}tool_c"
+        detector = DeepSeekV4Detector()
+
+        self.assertTrue(detector.has_tool_call(text))
+        result = detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "safe text")
+        self.assertEqual(result.calls, [])
 
     def test_non_streaming_parses_every_tool_calls_section(self):
         """A turn with two tool_calls sections must yield both calls."""
@@ -102,9 +132,8 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertEqual(len(result.calls), 2)
 
-    def test_parse_error_neither_swallows_nor_duplicates(self):
-        """An unexpected parse error must not empty the turn, and the dropped
-        buffer must not come back on the next delta."""
+    def test_parse_error_drops_protocol_without_duplication(self):
+        """An unexpected parse error must not expose the protocol buffer."""
         detector = DeepSeekV4Detector()
 
         with patch.object(
@@ -116,7 +145,8 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             self.assertEqual(detector._buffer, "")
             second = detector.parse_streaming_increment(" tail", self.tools)
 
-        self.assertIn("get_weather", first.normal_text)
+        self.assertNotIn("get_weather", first.normal_text)
+        self.assertNotIn(DSML, first.normal_text)
         self.assertNotIn("get_weather", second.normal_text)
         # No half-formed call: the failure can land between a tool's name and its
         # arguments, so an argument-less named call must not reach the client.

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2128,7 +2128,9 @@ class TestDeepSeekV4Detector(unittest.TestCase):
                             call.parameters
                         )
 
-        self.assertGreater(num_tool_call_chunks, 8)
+        # DeepSeek V4 holds the protocol envelope until it is complete, so a
+        # truncated stream cannot publish a name without valid arguments.
+        self.assertEqual(num_tool_call_chunks, 1)
 
         self.assertEqual(len(tool_calls_by_index), 1)
         self.assertEqual(tool_calls_by_index[0]["name"], "get_favorite_tourist_spot")


### PR DESCRIPTION
## Motivation

DeepSeek V4 currently inherits the incremental V3.2 parser, which publishes a function name as soon as an opening invoke tag appears and may publish provisional arguments before the closing DSML envelope. If generation is truncated, the client can therefore receive a tool call that never became a complete transaction. The non-streaming exception path can also return malformed DSML as ordinary assistant content.

Current main already uses the model-native XGrammar structural tag and request schema. This PR deliberately leaves that generation behavior unchanged and fixes only the response boundary.

## Modifications

- Buffer DeepSeek V4 DSML until the complete wrapper (or standalone invoke) arrives.
- Publish each completed call atomically with stable tool indices.
- Treat a trailing partial V4 marker as protocol rather than assistant content.
- Drop incomplete or malformed DSML at stream end instead of flushing it as text or a partial call.
- Preserve prose before and after valid tool transactions. DeepSeek V3.2 behavior is unchanged.

Related open work: #36154 preserves mixed post-call text, and #36748 defers one class of partial non-string values. This change is scoped to the separate incomplete-transaction boundary in V4.

## Tests

- Added regressions for truncated calls, atomic completion, malformed complete DSML, partial end markers, and parser exceptions.
- Updated the existing V4 streaming test to assert one atomic call.
- Focused import-isolated behavior harness: passed.
- Python compilation and pre-commit hooks: passed.
- Full SGLang unit execution was unavailable on the authoring host because its Python 3.14 environment has no compatible project Torch build; CI is expected to run the registered CPU tests.

## Accuracy and performance

No model-forward or constrained-generation changes. Valid tool arguments are identical; their streaming publication is delayed until the closing DSML envelope so incomplete calls cannot escape.

## Checklist

- [x] Formatted with pre-commit.
- [x] Added registered CPU unit tests.
- [x] No documentation change needed; no option or public format changed.
- [x] Accuracy/performance impact described above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34642746414](https://github.com/sgl-project/sglang/actions/runs/34642746414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34642746011](https://github.com/sgl-project/sglang/actions/runs/34642746011)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34642746228](https://github.com/sgl-project/sglang/actions/runs/34642746228)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->