### PR TITLE
fix(dsv4): report dynamic FP8 KV cache scales

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -116,6 +116,12 @@ def load_kv_cache_scales(*, model, kv_cache_dtype: str) -> None:
     defaulted: a fallback to ``server_args`` would be a hidden global read for
     any future caller that forgets to pass one."""
     if kv_cache_dtype == "fp8_e4m3":
+        if getattr(model, "kv_cache_scale_mode", None) == "dynamic":
+            logger.info(
+                "Using FP8 KV cache with scales generated dynamically by %s.",
+                model.__class__.__name__,
+            )
+            return
         if get_model().quantization_param_path is not None:
             if callable(getattr(model, "load_kv_cache_scales", None)):
                 model.load_kv_cache_scales(get_model().quantization_param_path)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3187,6 +3187,10 @@ class DeepseekV4Model(nn.Module):
 
 
 class DeepseekV4ForCausalLM(nn.Module):
+    # DSV4 stores per-token/per-block scales alongside its FP8 cache payload.
+    # Static checkpoint or external JSON scales do not apply to this layout.
+    kv_cache_scale_mode = "dynamic"
+
     def __init__(
         self,
         config: DeepSeekV4Config,

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -644,6 +644,9 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
 
 
 class DeepseekV4ForCausalLMDSpark(nn.Module):
+    # The draft model uses the same dynamically scaled DSV4 cache contract.
+    kv_cache_scale_mode = "dynamic"
+
     # ModelSlim NPU checkpoints carry QuaRot-aligned, MTP-local
     # embedding/head weights. The native CUDA path keeps the original DSpark
     # behavior and shares the target model's vocabulary modules.

--- a/test/registered/unit/model_executor/model_runner_components/test_load_model_utils.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_load_model_utils.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from sglang.srt.model_executor.model_runner_components.load_model_utils import (
+    load_kv_cache_scales,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(0.1, "base-a-test-cpu")
+
+
+class TestLoadKVCacheScales(CustomTestCase):
+    def test_dynamic_scale_model_skips_static_scale_warning(self):
+        class DynamicScaleModel:
+            kv_cache_scale_mode = "dynamic"
+
+        with (
+            patch(
+                "sglang.srt.model_executor.model_runner_components."
+                "load_model_utils.get_model"
+            ) as get_model,
+            self.assertLogs(
+                "sglang.srt.model_executor.model_runner_components.load_model_utils",
+                level="INFO",
+            ) as logs,
+        ):
+            load_kv_cache_scales(model=DynamicScaleModel(), kv_cache_dtype="fp8_e4m3")
+
+        get_model.assert_not_called()
+        self.assertIn("scales generated dynamically", "\n".join(logs.output))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek V4 defaults to an FP8 KV cache whose layout generates per-token/per-block scales dynamically and stores those scales alongside the cache payload. It does not use static checkpoint tensors or the legacy external quantization-parameter JSON path.

The generic post-load check sees no external JSON and warns that every KV scale defaults to 1.0. DSV4 instead generates scales dynamically with the cache payload, so this warning is incorrect.

## Modifications

- Add an explicit dynamic KV-scale capability to both target and DSpark DSV4 model classes.
- Have the generic loader report that mode at INFO and skip the inapplicable static-scale warning.
- Leave all existing static, checkpoint, and external-JSON scale behavior unchanged.

This is related to #31224, but narrower: that issue covers checkpoints with baked per-layer static scales; this PR covers DSV4's dynamic cache layout.

## Tests

- Added a registered CPU unit test verifying that dynamic-scale models skip the static-scale configuration and report dynamic mode.
- Python compilation and pre-commit hooks: passed.
- Full SGLang unit execution was unavailable on the authoring host because its Python 3.14 environment has no compatible project Torch build; CI is expected to run the registered CPU test.

## Accuracy and performance

No tensors, kernels, cache allocation, or model output change. This only corrects startup diagnostics.

## Checklist

- [x] Formatted with pre-commit.
- [x] Added a registered CPU unit test.
- [x] No documentation change needed; no user-facing option changed.
- [x] Accuracy/performance impact described above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34642754188](https://github.com/sgl-project/sglang/actions/runs/34642754188)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34642753715](https://github.com/sgl-project/sglang/actions/runs/34642753715)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34642754228](https://github.com/sgl-project/sglang/actions/runs/34642754228)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->