### PR TITLE
fix(b12x): derive scratch capacity from scheduler contract

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -66,9 +66,11 @@ if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
 
 
-def _b12x_max_tokens() -> int:
-    """Upper bound on tokens in a single MoE call (prefill is chunked)."""
-    return envs.SGLANG_B12X_MAX_TOKENS.get()
+def _b12x_forward_contract():
+    """The scheduler-owned, resolved row domain for this backend."""
+    from sglang.srt.runtime_context import get_moe_forward_contract
+
+    return get_moe_forward_contract()
 
 
 def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
@@ -207,11 +209,17 @@ def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
     return plan, scratch
 
 
-def _make_launcher(*, plan, scratch, experts):
+def _make_launcher(*, plan, scratch, experts, max_tokens):
     """W4A16 bind-and-run closure over the load-time frozen plan."""
     from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
+        live_tokens = max(1, int(a.shape[0]))
+        if live_tokens > max_tokens:
+            raise RuntimeError(
+                "b12x MoE row-count invariant violated before frozen-plan bind: "
+                f"live_tokens={live_tokens}, derived_capacity={max_tokens}"
+            )
         fused_moe.run(
             binding=plan.bind(
                 scratch=scratch,
@@ -258,13 +266,17 @@ def _plan_a8_arena(*, experts, top_k, device, swiglu_limit, counts, quant_mode):
     key = f"b12x:moe_a8_arena:{device}"
     cached = buffers.get(key)
     if cached is not None and cached[0] == fingerprint:
-        return cached[1]
+        return cached[1], cached[2]
+    # W4A8 chooses its workspace plan from the exact live token count.
+    # Size across every count admitted by the resolved runtime contract, not
+    # just the sparse decode/power-of-two warmup ladder.
+    arena_counts = tuple(range(1, max(counts) + 1))
     caps = fused_moe.Caps(
         max_tokens=max(counts),
         num_topk=top_k,
         device=device,
         weight_plan=experts.plan,
-        core_token_counts=tuple(counts),
+        core_token_counts=arena_counts,
         route_num_experts=0,
         route_logits_dtype=None,
         quant_mode=quant_mode,
@@ -272,19 +284,26 @@ def _plan_a8_arena(*, experts, top_k, device, swiglu_limit, counts, quant_mode):
         swiglu_limit=swiglu_limit,
         frozen=True,
     )
-    arena = torch.empty(
-        int(fused_moe.required_nbytes(caps)), dtype=torch.uint8, device=device
-    )
-    buffers[key] = (fingerprint, arena)
-    return arena
+    required_bytes = int(fused_moe.required_nbytes(caps))
+    arena = torch.empty(required_bytes, dtype=torch.uint8, device=device)
+    buffers[key] = (fingerprint, arena, required_bytes)
+    return arena, required_bytes
 
 
-def _make_launcher_a8(*, arena, experts, top_k, device, swiglu_limit, quant_mode):
+def _make_launcher_a8(
+    *, arena, arena_bytes, experts, top_k, device, swiglu_limit, quant_mode, max_tokens
+):
     """W4A8 bind-and-run closure; plans at the live token count per call."""
     from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
         m = max(1, int(a.shape[0]))
+        if m > max_tokens:
+            raise RuntimeError(
+                "b12x MoE row-count invariant violated before arena bind: "
+                f"live_tokens={m}, derived_capacity={max_tokens}. The resolved "
+                "scheduler/model contract changed after runner initialization."
+            )
         caps = fused_moe.Caps(
             max_tokens=m,
             num_topk=top_k,
@@ -298,6 +317,13 @@ def _make_launcher_a8(*, arena, experts, top_k, device, swiglu_limit, quant_mode
             swiglu_limit=swiglu_limit,
             frozen=True,
         )
+        live_required_bytes = int(fused_moe.required_nbytes(caps))
+        if live_required_bytes > arena_bytes:
+            raise RuntimeError(
+                "b12x workspace invariant violated before arena bind: "
+                f"live_tokens={m}, required_bytes={live_required_bytes}, "
+                f"reserved_bytes={arena_bytes}"
+            )
         plan = fused_moe.plan(caps)
         fused_moe.run(
             binding=plan.bind(
@@ -430,9 +456,11 @@ class Mxfp4B12xMoEMethod:
             intermediate=intermediate,
             quant_mode=quant_mode,
         )
-        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+        contract = _b12x_forward_contract()
+        max_tokens = contract.max_rows
+        counts = _core_token_counts(max_tokens, spec_tokens)
         if quant_mode != "w4a16":
-            arena = _plan_a8_arena(
+            arena, workspace_bytes = _plan_a8_arena(
                 experts=experts,
                 top_k=int(layer.top_k),
                 device=device,
@@ -442,11 +470,13 @@ class Mxfp4B12xMoEMethod:
             )
             self._launch = _make_launcher_a8(
                 arena=arena,
+                arena_bytes=workspace_bytes,
                 experts=experts,
                 top_k=int(layer.top_k),
                 device=device,
                 swiglu_limit=self._swiglu_limit,
                 quant_mode=quant_mode,
+                max_tokens=max_tokens,
             )
             plan_or_arena = arena
         else:
@@ -457,7 +487,12 @@ class Mxfp4B12xMoEMethod:
                 swiglu_limit=self._swiglu_limit,
                 counts=counts,
             )
-            self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+            self._launch = _make_launcher(
+                plan=plan,
+                scratch=scratch,
+                experts=experts,
+                max_tokens=max_tokens,
+            )
             plan_or_arena = (plan, scratch)
         # The prepared weights alias the checkpoint storage (REUSE_SOURCE for
         # 128-aligned fp4_e8m0_k32; w4a8_mx repacks likewise discard the

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -222,6 +222,17 @@ class BaseMultimodalProcessor(ABC):
     # Models opt in by assigning a non-zero default. A user-provided server
     # argument overrides this value; zero disables storage and cache-key work.
     auto_mm_preprocess_cache_size_mb = 0
+
+    @classmethod
+    def max_language_model_forward_overshoot(cls, hf_config):
+        """Maximum rows a scheduler may add past a nominal prefill cut.
+
+        Multimodal processors whose atomic spans can move the cut must declare
+        this. ``None`` means unknown, so MoE backends that need a finite shape
+        domain can fail closed instead of guessing from checkpoint fields.
+        """
+        return None
+
     # Processors opt out only when their preprocessing is not thread-safe. The
     # worker pool gives each thread its own `copy.deepcopy` of the HF processor
     # and injects it, and the single function it runs --

--- a/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v4_vl.py
@@ -152,6 +152,13 @@ def build_image_block(n_llm_h: int, n_llm_w: int, start_pos: int):
 class DeepseekV4VLImageProcessor(BaseMultimodalProcessor):
     models = [DeepseekV4ForCausalLM]
 
+    @classmethod
+    def max_language_model_forward_overshoot(cls, hf_config):
+        # A prefill cut strictly inside one indivisible image block may move
+        # to its end. safe_resize guarantees the full block is no larger than
+        # vision_max_n_token, including alignment and sentinels.
+        return max(int(hf_config.vision_max_n_token) - 1, 0)
+
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
         image_token_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1280,6 +1280,96 @@ def get_schedule() -> _ConfigBag:
     return _CONTEXT.config_bag("schedule")
 
 
+@dataclasses.dataclass(frozen=True)
+class MoeForwardContract:
+    """Resolved maximum row domain shared by schedulers and MoE backends."""
+
+    max_rows: int
+    prefill_rows: int
+    prefill_base_rows: int
+    multimodal_overshoot_rows: int
+    decode_rows: int
+    decode_batch_size: int
+    speculative_tokens_per_request: int
+
+
+def get_moe_forward_contract() -> MoeForwardContract:
+    """Resolve the complete scheduler-admitted MoE row domain once.
+
+    Backends consume this value; they must not reconstruct it independently.
+    Multimodal overshoot belongs to the selected processor's explicit
+    contract, not a model-family guess in the backend.
+    """
+    cached = _CONTEXT.resources.buffers.get("moe:forward_contract")
+    if cached is not None:
+        return cached
+
+    schedule = get_schedule()
+    graph = get_exec().graph.cuda_graph_config
+    prefill_base = max(
+        int(schedule.max_prefill_tokens or 0),
+        int(schedule.chunked_prefill_size or 0),
+    )
+    if prefill_base <= 0:
+        raise ValueError(
+            "MoE forward contract requires a finite resolved prefill bound; "
+            "set --max-prefill-tokens or --chunked-prefill-size"
+        )
+
+    model_config = process_model_config()
+    multimodal_overshoot = 0
+    if model_config.is_multimodal:
+        from sglang.srt.managers.multimodal_processor import get_mm_processor_cls
+
+        processor_cls = get_mm_processor_cls(
+            model_config.hf_config, get_server_args(), model_config
+        )
+        if processor_cls is None:
+            raise ValueError(
+                "MoE forward contract cannot resolve the active multimodal processor"
+            )
+        resolver = getattr(processor_cls, "max_language_model_forward_overshoot", None)
+        multimodal_overshoot = (
+            None if resolver is None else resolver(model_config.hf_config)
+        )
+        if multimodal_overshoot is None:
+            raise ValueError(
+                f"multimodal processor {processor_cls.__name__} does not declare "
+                "max_language_model_forward_overshoot"
+            )
+        multimodal_overshoot = int(multimodal_overshoot)
+        if multimodal_overshoot < 0:
+            raise ValueError("multimodal forward overshoot cannot be negative")
+
+    spec = get_spec()
+    tokens_per_request = (
+        int(spec.max_speculative_num_draft_tokens or 1)
+        if spec.speculative_algorithm
+        else 1
+    )
+    decode_graph = getattr(graph, "decode", None) if graph is not None else None
+    decode_bs = max(
+        int(schedule.max_running_requests or 0),
+        int(getattr(decode_graph, "max_bs", 0) or 0),
+    )
+    if decode_bs <= 0:
+        raise ValueError("MoE forward contract requires a finite decode batch bound")
+
+    prefill_rows = prefill_base + multimodal_overshoot
+    decode_rows = decode_bs * tokens_per_request
+    contract = MoeForwardContract(
+        max_rows=max(prefill_rows, decode_rows),
+        prefill_rows=prefill_rows,
+        prefill_base_rows=prefill_base,
+        multimodal_overshoot_rows=multimodal_overshoot,
+        decode_rows=decode_rows,
+        decode_batch_size=decode_bs,
+        speculative_tokens_per_request=tokens_per_request,
+    )
+    _CONTEXT.resources.buffers["moe:forward_contract"] = contract
+    return contract
+
+
 def get_memory() -> _ConfigBag:
     return _CONTEXT.config_bag("memory")
 

--- a/test/registered/unit/test_moe_forward_contract.py
+++ b/test/registered/unit/test_moe_forward_contract.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt import runtime_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(0.1, "base-a-test-cpu")
+
+
+class TestMoeForwardContract(CustomTestCase):
+    def setUp(self):
+        runtime_context.get_resources().buffers.pop("moe:forward_contract", None)
+
+    def tearDown(self):
+        runtime_context.get_resources().buffers.pop("moe:forward_contract", None)
+
+    def test_uses_aggregate_prefill_and_speculative_decode_bounds(self):
+        schedule = SimpleNamespace(
+            max_prefill_tokens=16384,
+            chunked_prefill_size=8192,
+            max_running_requests=2,
+        )
+        graph = SimpleNamespace(decode=SimpleNamespace(max_bs=64))
+        spec = SimpleNamespace(
+            speculative_algorithm="DSPARK",
+            max_speculative_num_draft_tokens=3,
+        )
+        model_config = SimpleNamespace(is_multimodal=False)
+
+        with (
+            patch.object(runtime_context, "get_schedule", return_value=schedule),
+            patch.object(
+                runtime_context,
+                "get_exec",
+                return_value=SimpleNamespace(
+                    graph=SimpleNamespace(cuda_graph_config=graph)
+                ),
+            ),
+            patch.object(runtime_context, "get_spec", return_value=spec),
+            patch.object(
+                runtime_context, "process_model_config", return_value=model_config
+            ),
+        ):
+            contract = runtime_context.get_moe_forward_contract()
+
+        self.assertEqual(contract.prefill_base_rows, 16384)
+        self.assertEqual(contract.prefill_rows, 16384)
+        self.assertEqual(contract.decode_rows, 192)
+        self.assertEqual(contract.max_rows, 16384)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

The B12X Vision branch sizes its shared W4A8 arena from a launcher-owned token value and a sparse decode/power-of-two count ladder. SGLang can aggregate prefill beyond the per-request chunk, and DeepSeek V4 Vision can move a cut to the end of an indivisible image span. A valid admitted request can therefore select a B12X plan requiring more workspace than was reserved.

Observed on 2x DGX Spark with this exact base commit: the launcher supplied 8,192 rows while aggregate prefill admitted 16,384. One request required 412,183,756 bytes with only 400,008,864 reserved, terminating both ranks.

## Modifications

- Resolve one scheduler-owned maximum MoE row contract from aggregate prefill, multimodal alignment overshoot, decode graph/running-request limits, and speculative width.
- Make multimodal processors declare their maximum forward overshoot; DeepSeek V4 Vision derives 383 rows from its 384-token image-block limit. Unknown multimodal processors fail closed.
- Size the W4A8 arena over every exact admitted row count via B12X required_nbytes.
- Check exact live W4A8 bytes before bind and enforce the live-row bound for W4A8 and W4A16.
- Add a CPU regression for aggregate-prefill and speculative-decode resolution.

## Validation

Downstream live qualification was performed from official base 452239a with only this source correction applied:

- Resolved contract: 16,767 rows (16,384 aggregate prefill + 383 vision overshoot); decode bound 192.
- Maximum B12X arena: 725,810,344 bytes.
- Two-node TP2 service completed direct generation, structured tool calls, a full agent tool loop, and two concurrent agent tool loops.
- Zero fallback, OOM, NCCL error, restart, or invariant violation.

Local Python compilation and all pre-commit hooks pass. The registered CPU test was not executed locally because the authoring host's Python 3.14 environment has no compatible project Torch build; CI can run it.

## Accuracy and performance

No kernel numerics change. Initialization reserves the exact worst-case workspace admitted by the scheduler; live checks are host-side integer comparisons before B12X bind.

## Checklist

- [x] Formatted with pre-commit.
- [x] Added a registered CPU unit test.
- [x] Included exact live reproducer and qualification evidence.
- [x] No user option is added.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829696788](https://github.com/sgl-project/sglang/actions/runs/34829696788)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829696628](https://github.com/sgl-project/sglang/actions/runs/34829696628)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829696931](https://github.com/sgl-project/sglang/actions/runs/34829696931)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->