### PR TITLE
[Docs] Prefer docs.sglang.io for wheel index URLs

### DIFF
--- a/docs/cookbook/autoregressive/Poolside/Laguna-XS.2.mdx
+++ b/docs/cookbook/autoregressive/Poolside/Laguna-XS.2.mdx
@@ -55,11 +55,11 @@ Laguna-XS.2 support is on `main` but not yet in a tagged release; install from t
 ```bash Command
 # Install SGLang via pip (CUDA 13) — requires Python 3.10 (nightly wheels are cp310 only)
 python3 -m pip install --upgrade pip
-python3 -m pip install --extra-index-url https://docs.sglang.ai/whl/cu130 \
+python3 -m pip install --extra-index-url https://docs.sglang.io/whl/cu130 \
   "sglang[all]==0.5.12.dev20260509+g096ad02b0"
 
 # CUDA 12: swap to the cu129 index
-python3 -m pip install --extra-index-url https://docs.sglang.ai/whl/cu129 \
+python3 -m pip install --extra-index-url https://docs.sglang.io/whl/cu129 \
   "sglang[all]==0.5.12.dev20260509+g096ad02b0"
 
 # Or use Docker (multi-arch amd64/arm64; CUDA 13, H200 / B200)

--- a/docs/docs/get-started/install.mdx
+++ b/docs/docs/get-started/install.mdx
@@ -35,8 +35,8 @@ pip install --upgrade pip
 pip install uv
 uv pip install --prerelease=allow sglang
 uv pip install --force-reinstall torch==2.13.0 torchaudio==2.11.0 torchvision --index-url https://download.pytorch.org/whl/cu129
-uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.ai/whl/cu129/
-uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.ai/whl/cu129/ --no-deps
+uv pip install --force-reinstall sglang-kernel --index-url https://docs.sglang.io/whl/cu129/
+uv pip install --force-reinstall sgl-deep-gemm --index-url https://docs.sglang.io/whl/cu129/ --no-deps
 ```
 
 ### Nightly builds
@@ -46,14 +46,14 @@ To pick up the latest features and fixes before the next stable release, install
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install --prerelease=allow --index-strategy unsafe-best-match --extra-index-url https://docs.sglang.ai/whl/cu130/ sglang
+uv pip install --prerelease=allow --index-strategy unsafe-best-match --extra-index-url https://docs.sglang.io/whl/cu130/ sglang
 ```
 
 To install a nightly build under Cuda 12, swap the index to `cu129`:
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install --prerelease=allow --index-strategy unsafe-best-match --extra-index-url https://docs.sglang.ai/whl/cu129/ sglang
+uv pip install --prerelease=allow --index-strategy unsafe-best-match --extra-index-url https://docs.sglang.io/whl/cu129/ sglang
 ```
 
 ### Quick fixes to common problems


### PR DESCRIPTION
## Summary
- Prefer the canonical `https://docs.sglang.io/whl/...` index host in get-started install docs and the Laguna-XS.2 cookbook.
- `docs.sglang.ai` currently 301-redirects to `docs.sglang.io`; update examples to the canonical host.

## Test plan
- [x] Confirmed `docs.sglang.ai/whl/...` redirects to `docs.sglang.io/whl/...`
- [x] Only touch uncovered files (skip LongCat / speculative_decoding which already have open docs PRs)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34069619499](https://github.com/sgl-project/sglang/actions/runs/34069619499)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34069619366](https://github.com/sgl-project/sglang/actions/runs/34069619366)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->