### PR TITLE
[Docs] Prefer --cuda-graph-*-decode over deprecated aliases

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/mimo_v2_flash.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/mimo_v2_flash.mdx
@@ -26,7 +26,7 @@ v0.5.16 or a later version.
 | Expert Parallelism            | `--moe-a2a-backend deepep \`<br/>`--deepep-mode low_latency`                                   |
 | PD Disaggregation             | `--disaggregation-mode prefill \`<br/>`--disaggregation-transfer-backend ascend`              |
 | Quantization                  | `--quantization modelslim`                                                                    |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs`; e.g., `--cuda-graph-bs 1 2 4 8 12 16 20 24 28 32` |
+| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 1 2 4 8 12 16 20 24 28 32` |
 | Speculative Decoding          | `--speculative-algorithm EAGLE \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4 \`<br/>`--enable-multi-layer-eagle` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=0`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |

--- a/docs/docs/sglang-diffusion/disaggregation.mdx
+++ b/docs/docs/sglang-diffusion/disaggregation.mdx
@@ -223,7 +223,7 @@ sglang serve \
   --model-path ./zai-org/GLM-Image/vision_language_encoder/ \
   --tokenizer-path ./zai-org/GLM-Image/processor/ \
   --enable-multimodal \
-  --cuda-graph-max-bs 28 \
+  --cuda-graph-max-bs-decode 28 \
   --device npu \
   --attention-backend ascend \
   --disable-fast-image-processor \


### PR DESCRIPTION
## Summary
Prefer the canonical decode CUDA graph flags in docs that still use deprecated aliases.

In `python/sglang/srt/server_args.py`:
- `--cuda-graph-max-bs` is a `DeprecatedAliasStoreAction` for `--cuda-graph-max-bs-decode`
- `--cuda-graph-bs` is a `DeprecatedAliasStoreAction` for `--cuda-graph-bs-decode`

### Changes
- `docs/docs/sglang-diffusion/disaggregation.mdx`: AR encoder `sglang serve` snippet uses `--cuda-graph-max-bs-decode`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/mimo_v2_flash.mdx`: NPU Graph feature table prefers `--cuda-graph-bs-decode` / `--cuda-graph-max-bs-decode`

## Test plan
- [ ] Confirm aliases still resolve in `server_args.py` deprecated registrations
- [ ] Docs render; flag names match canonical decode variants

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34074006100](https://github.com/sgl-project/sglang/actions/runs/34074006100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34074005970](https://github.com/sgl-project/sglang/actions/runs/34074005970)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->