### PR TITLE
[HiSparse] Fix swap-in planner prefix-scan corruption below swap_in_block_size 512

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/hisparse.cuh
@@ -528,23 +528,16 @@ __global__ void load_cache_to_device_buffer_kernel(
     __syncthreads();
 
     if (warp_id == 0) {
-#ifdef USE_ROCM
-      // ROCm wavefront64: WARP_SIZE (64) > NUM_WARPS (16 at block_size=1024),
-      // so the wide-count form below would let lanes beyond this iteration's
-      // NUM_WARPS-wide window write the accumulator into s_chunk_offset
-      // positions belonging to future iterations, corrupting their reads.
-      // Bound the scan window to NUM_WARPS lanes.
+      // Lanes beyond this iteration's NUM_WARPS-wide window would write the
+      // accumulator into s_chunk_offset positions belonging to future
+      // iterations, corrupting their reads. This is only masked while
+      // WARP_SIZE <= 2 * NUM_WARPS -- true for warp32 at block_size >= 512,
+      // never for wavefront64. Bound the scan window to NUM_WARPS lanes.
       const int scan_offset = iter * NUM_WARPS + 1;
       const int scan_count = min(scan_offset + NUM_WARPS, NUM_BUFFER_CHUNKS + 1);
       total_hit_count = warp_inclusive_scan(s_chunk_offset, lane_id, scan_offset, scan_count, total_hit_count);
       total_evict_count =
           warp_inclusive_scan(s_evict_chunk_offset, lane_id, scan_offset, scan_count, total_evict_count);
-#else
-      total_hit_count =
-          warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
-      total_evict_count =
-          warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
-#endif
       if (tid == 0) {
         s_total_hits = total_hit_count;
       }
@@ -603,13 +596,10 @@ __global__ void load_cache_to_device_buffer_kernel(
     __syncthreads();
 
     if (warp_id == 0) {
-#ifdef USE_ROCM
+      // Same bounded window as the hit/evict scan above.
       const int scan_offset = iter * NUM_WARPS + 1;
       const int scan_count = min(scan_offset + NUM_WARPS, NUM_TOKEN_CHUNKS + 1);
       total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, scan_offset, scan_count, total_misses);
-#else
-      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
-#endif
     }
     __syncthreads();
 

--- a/test/registered/kernels/ops/kvcache/test_hisparse.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse.py
@@ -754,5 +754,87 @@ def test_load_cache_to_device_buffer_rocm_large_lru_writeback() -> None:
     assert torch.equal(lru_slots.cpu().view(-1), expected_lru)
 
 
+def test_load_cache_to_device_buffer_multi_iteration_planner_scan() -> None:
+    """Cover a block geometry whose planner prefix scans run for many iterations.
+
+    The hit/evict and miss scans walk NUM_BUFFER_CHUNKS and NUM_TOKEN_CHUNKS in
+    NUM_WARPS-wide steps, so a block with few warps needs several iterations.
+    block_size=128 gives 8 buffer and 4 token iterations on both warp32 and
+    wavefront64. The other cases in this file use one iteration and never
+    exercise the carry between them.
+    """
+    top_k = 512
+    hot_buffer_size = 1024
+    seq_len = 4096
+    kv_dim = 4
+    item_size_bytes = kv_dim * torch.empty((), dtype=DTYPE).element_size()
+
+    host_cache = torch.empty((seq_len, 1, kv_dim), dtype=DTYPE, pin_memory=True)
+    host_cache.copy_(
+        torch.arange(seq_len, dtype=DTYPE)
+        .view(seq_len, 1, 1)
+        .expand(seq_len, 1, kv_dim)
+    )
+    device_buffer = torch.full(
+        (hot_buffer_size + 1, 1, kv_dim), -1, dtype=DTYPE, device=DEVICE
+    )
+    # Token t < hot_buffer_size is resident in slot t.
+    device_buffer[:hot_buffer_size].copy_(host_cache[:hot_buffer_size].to(DEVICE))
+
+    device_buffer_tokens = torch.cat(
+        [
+            torch.arange(hot_buffer_size, dtype=torch.int32),
+            torch.tensor([-1], dtype=torch.int32),
+        ]
+    ).view(1, -1)
+    device_buffer_locs = torch.arange(hot_buffer_size + 1, dtype=torch.int32).view(
+        1, -1
+    )
+    lru_slots = torch.arange(hot_buffer_size, dtype=torch.int16).view(1, -1)
+    host_cache_locs = torch.arange(seq_len, dtype=torch.int64).view(1, -1)
+
+    # Alternate resident and non-resident tokens so every chunk of the scan
+    # carries a mix of hits and misses.
+    resident = torch.arange(top_k, dtype=torch.int32)
+    absent = torch.arange(hot_buffer_size, hot_buffer_size + top_k, dtype=torch.int32)
+    top_k_tokens = torch.stack([resident, absent], dim=1).view(-1)[:top_k].view(1, -1)
+
+    top_k_tokens = top_k_tokens.to(DEVICE)
+    device_buffer_tokens = device_buffer_tokens.to(DEVICE)
+    device_buffer_locs = device_buffer_locs.to(DEVICE)
+    lru_slots = lru_slots.to(DEVICE)
+    host_cache_locs = host_cache_locs.to(DEVICE)
+    out = torch.full_like(top_k_tokens, -1)
+
+    load_cache_to_device_buffer_mla(
+        top_k_tokens=top_k_tokens,
+        device_buffer_tokens=device_buffer_tokens,
+        host_cache_locs=host_cache_locs,
+        device_buffer_locs=device_buffer_locs,
+        host_cache=host_cache,
+        device_buffer=device_buffer,
+        top_k_device_locs=out,
+        req_pool_indices=torch.tensor([0], dtype=torch.int64, device=DEVICE),
+        seq_lens=torch.tensor([seq_len], dtype=torch.int32, device=DEVICE),
+        lru_slots=lru_slots,
+        item_size_bytes=item_size_bytes,
+        num_top_k=top_k,
+        hot_buffer_size=hot_buffer_size,
+        page_size=1,
+        block_size=128,
+        num_real_reqs=torch.tensor([1], dtype=torch.int32, device=DEVICE),
+    )
+    torch.cuda.synchronize()
+
+    out_locs = out.view(-1).cpu()
+    assert int(out_locs.min()) >= 0
+    # A corrupted prefix sum hands the same device slot to two top-k entries.
+    assert len(set(out_locs.tolist())) == top_k
+    assert torch.equal(
+        device_buffer[out_locs.to(DEVICE).long()].cpu(),
+        host_cache[top_k_tokens.view(-1).cpu().long()],
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`load_cache_to_device_buffer_kernel` plans each request's swap-in with two prefix scans over per-warp chunk counters — one for the hit/evict partition of the LRU buffer, one for the miss list. Warp 0 walks both in `NUM_WARPS`-wide steps, but on CUDA it was handed the full chunk count instead of the window it had just filled.

The lanes past that window read chunk counters a later iteration has not written yet, and store the running accumulator over them. That later iteration then reads a corrupted offset and indexes `s_lru_slots_out[HOT_BUFFER_SIZE - 1 - offset]` out of bounds.

Measured against `main` (`30705c004c`) on RTX 4090 (sm_89) and RTX PRO 6000 Blackwell (sm_120), `top_k=2048`, `hot_buffer_size=4096`, byte-checking every returned device loc against the host row it should hold:

| `swap_in_block_size` | `NUM_WARPS` | scan iterations | result on `main` |
| --- | --- | --- | --- |
| 1024, 992, 960 (default), 512 | 32, 31, 30, 16 | 4–8 | correct |
| 448, 320, 256, 128, 64 | 14, 10, 8, 4, 2 | 10–64 | `cudaErrorIllegalAddress` |
| 900, 1000 | 28, 31 | 5 | silent: the same device slot is handed to two top-k entries, 21–29 rows hold the wrong KV |

Both architectures behave identically, as expected for a shared-memory indexing defect.

This is reachable from a supported configuration: `_parse_sparse_config` accepts any `swap_in_block_size` in `[1, 1024]`, and the kernel op itself defaults to `block_size=256`. The documented default of 960 is unaffected, which is why this has not been reported.

## Root cause

Warp `w` at iteration `i` writes `s_chunk_offset[chunk_idx + 1]` for `chunk_idx = w + i * NUM_WARPS`, so exactly `NUM_WARPS` counters are live per iteration. Warp 0 then scans with `count = NUM_BUFFER_CHUNKS + 1`, so all `WARP_SIZE` of its lanes participate and lanes `NUM_WARPS .. WARP_SIZE-1` touch indices belonging to iterations `i+1` and beyond.

The out-of-window **writes** are not what breaks it — the next iteration's counter writes land on them before anything reads them. The out-of-window **reads** are. `warp_inclusive_scan` returns lane `WARP_SIZE-1`'s value as the accumulator carried into the next iteration:

```cpp
accumulator = __shfl_sync(FULL_WARP_MASK, val, WARP_SIZE - 1);
```

so any stale value those extra lanes pick up is added into the running total. Walking `block_size=256` (`NUM_WARPS=8`, `NUM_BUFFER_CHUNKS=128`):

- `iter=0` scans `idx 1..32`. Indices `9..32` are still zero-initialised, so the accumulator is correct, but they are written with `T0` (the total of chunks 0–7).
- `iter=1` overwrites `s[9..16]` with real counts and scans `idx 9..40`. Indices `17..32` still hold `T0`. Lanes 0–7 are unaffected, so `s[9..16]` and every offset consumed this iteration are still correct — but lane 31's total now carries sixteen extra copies of `T0`, and that is what becomes the accumulator.
- `iter=2` starts from the inflated accumulator, and every offset from chunk 17 onward is too large.

So the first incorrect offset appears one iteration after the first stale write, at chunk 17.

The stale entries are repaired in time exactly when iteration `i-1`'s scan cannot reach the region iteration `i` reads past its window, i.e.

```
(i-1) * NUM_WARPS + WARP_SIZE  <  (i+1) * NUM_WARPS + 1
        <=>   WARP_SIZE <= 2 * NUM_WARPS
        <=>   block_size >= WARP_SIZE^2 / 2
```

which is 512 on warp32 and **2048 on wavefront64**. Since `swap_in_block_size` is capped at 1024, wavefront64 has no safe value at all — including both defaults, 960 and 1024. That is why AMD hit this immediately and warp32 did not.

The inflated offset then reaches global memory: the miss pass reads `s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset]` at a negative index and uses the garbage slot id to index `req_device_buffer_locs`, which is the illegal access.

#26639 introduced the bounded window to fix this, and scoped it to ROCm deliberately ("This PR is intended to be behaviorally unchanged on CUDA"), which was the right call for a hardware-enablement PR. The bound is not wavefront-specific, though — it is what the algorithm requires at any warp width.

## Modifications

Drop the `#ifdef USE_ROCM` around both scans so the bounded window applies on CUDA as well, and rewrite the comment to state the condition rather than the wavefront64 symptom. This removes a branch rather than adding one: the CUDA arm and the preprocessor triple go away, and both platforms share the code ROCm already runs.

```cpp
const int scan_offset = iter * NUM_WARPS + 1;
const int scan_count  = min(scan_offset + NUM_WARPS, NUM_BUFFER_CHUNKS + 1);
```

With `count` narrowed to this iteration's window, the extra lanes take the `(idx < count) ? s_data[idx] : 0` fallback and neither read nor write, so the accumulator only ever carries real counts.

Add `test_load_cache_to_device_buffer_multi_iteration_planner_scan`, at `block_size=128` with `top_k=512` / `hot_buffer_size=1024` — 8 buffer and 4 token scan iterations on both warp32 and wavefront64. Every other case in that file completes its scans in a single iteration and never exercises the carry between them. It asserts that no device slot is handed to two top-k entries and that every returned loc holds the right host bytes.

**Not addressed here.** A `block_size` that is not a multiple of the warp size leaves a trailing partial warp, which takes a `warp_id` of `NUM_WARPS` and reaches `__ballot_sync` / `__shfl_sync` with lanes named in `FULL_WARP_MASK` that do not exist. That is pre-existing and untouched by this PR. With the bounded window such a block size is in fact correct — the partial warp's chunk is re-processed in full by warp 0 on the next iteration, and its partial counter lands *outside* the current window, so it is overwritten before anything reads it (verified at `block_size=900` across 24 input configurations, all byte-exact). If maintainers would rather make the invariant explicit, a `static_assert(BLOCK_SIZE % WARP_SIZE == 0)` plus a matching check in `_parse_sparse_config` is a small follow-up.

## Accuracy Tests

**The new test fails on the pre-fix kernel.** A regression test that also passes on the buggy code proves nothing, so this was checked directly. Run against `main`, `test_load_cache_to_device_buffer_multi_iteration_planner_scan` raises `AcceleratorError: CUDA error: an illegal memory access was encountered`; with this change it passes. Whole file: `11 passed, 8 skipped` (the skips are the pre-existing ROCm-only and 16B-alignment cases).

```bash
python3 test/registered/kernels/ops/kvcache/test_hisparse.py
```

**The default configuration is bit-identical.** Same seed, `top_k=2048`, `hot_buffer_size=4096`, batch 8, comparing all seven kernel outputs (`top_k_device_locs`, `lru_slots`, `device_buffer_tokens`, `device_buffer`, `miss_src`, `miss_dst`, `miss_count`) before and after:

```text
block_size=960 (default): bit-identical across all 7 outputs
block_size=1024:          bit-identical across all 7 outputs
block_size=512:           bit-identical across all 7 outputs
```

No model eval was run, deliberately: at 960 the kernel is bit-identical so model output cannot change, and the block sizes whose behaviour does change currently crash or corrupt on `main`.

## Speed Tests and Profiling

Identical work per iteration — one extra `min()` and a narrower store predicate. RTX 4090, `top_k=2048`, `hot_buffer_size=4096`, batch 8, 700 misses/request, 50 timed rounds behind a filler matmul, interleaved A/B/A/B:

```text
before  block=960   median=153.6 us   p10=153.6   p90=154.7
after   block=960   median=153.7 us   p10=153.6   p90=154.6
before  block=960   median=153.6 us   p10=152.6   p90=154.6
after   block=960   median=153.6 us   p10=152.6   p90=154.6
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

Happy to open a tracking issue if maintainers prefer one, and to prepare a cherry-pick if this is considered for a release branch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34074246730](https://github.com/sgl-project/sglang/actions/runs/34074246730)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34074246850](https://github.com/sgl-project/sglang/actions/runs/34074246850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34074246773](https://github.com/sgl-project/sglang/actions/runs/34074246773)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->