### PR TITLE
[Docs] Prefer --mamba-radix-cache-strategy in Qwen3.8 cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -260,7 +260,7 @@ checkpoint's calibration scales automatically.
   is NVFP4-packed; the BF16 and FP8 checkpoints keep a dense head).
   The Ascend comparison in #35629 used a 910C with BF16 target weights,
   `--tp-size 2 --attention-backend ascend --mamba-ssm-dtype bfloat16
-  --mamba-scheduler-strategy extra_buffer`, and disabled RadixCache for both
+  --mamba-radix-cache-strategy extra_buffer`, and disabled RadixCache for both
   baseline and DFlash2 to exclude cache warm-up and prefix reuse. The DFlash2
   run added the three flags shown above.
   Accuracy used zero-shot GSM8K with greedy sampling, `max_new_tokens=2048`,


### PR DESCRIPTION
## Summary
- In `docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx`, replace deprecated `--mamba-scheduler-strategy` with `--mamba-radix-cache-strategy` in the Ascend NPU DFlash2 comparison snippet.
- `server_args.py` registers `--mamba-scheduler-strategy` as a `DeprecatedAliasStoreAction` for `--mamba-radix-cache-strategy`.

## Test plan
- [x] Confirmed alias mapping in `python/sglang/srt/server_args.py`
- [x] Confirmed no remaining `--mamba-scheduler-strategy` in this file
- [x] Same-doc tip already documents `--mamba-radix-cache-strategy extra_buffer_lazy`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34075434179](https://github.com/sgl-project/sglang/actions/runs/34075434179)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34075434079](https://github.com/sgl-project/sglang/actions/runs/34075434079)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->