### PR TITLE
Fix #38236: accept NEXTN as an alias for EAGLE in DeepseekV4 hook

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -145,13 +145,21 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
 
     if cfg.speculative_algorithm is not None:
-        assert cfg.speculative_algorithm in (
+        # NEXTN is a documented alias for EAGLE. The global alias resolution
+        # runs later in the pipeline (handle_speculative_decoding), so normalize
+        # locally before the arch-specific check to avoid rejecting the valid
+        # CLI value --speculative-algorithm NEXTN.
+        speculative_algorithm = cfg.speculative_algorithm
+        if speculative_algorithm == "NEXTN":
+            speculative_algorithm = "EAGLE"
+
+        assert speculative_algorithm in (
             "EAGLE",
             "DSPARK",
         ), (
             f"Only EAGLE and DSPARK speculative algorithms are supported for {model_arch}"
         )
-        if cfg.speculative_algorithm == "EAGLE":
+        if speculative_algorithm == "EAGLE":
             assert cfg.speculative_eagle_topk == 1, (
                 f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
             )

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -62,6 +62,7 @@ from sglang.srt.arg_groups.serving_hook import (
     ssl_verify_of,
 )
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.arg_groups.deepseek_v4_hook import apply_deepseek_v4_defaults
 from sglang.srt.arg_groups.validation_hook import (
     check_two_batch_overlap,
 )
@@ -2562,6 +2563,76 @@ class TestDeepEPv2Args(CustomTestCase):
         args._resolved_overrides = [("test", {"moe_a2a_backend": "deepep"})]
         with envs.SGLANG_DEEPEP_V2_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(1):
             validate_deepep_v2_dispatch_token_budget(args)
+
+
+class TestDeepseekV4Hook(CustomTestCase):
+    """DeepSeek-V4 model-specific argument adjustments."""
+
+    def setUp(self):
+        # apply_deepseek_v4_defaults writes environment variables.
+        super().setUp()
+        environment = dict(os.environ)
+
+        def restore():
+            os.environ.clear()
+            os.environ.update(environment)
+
+        self.addCleanup(restore)
+
+    def _args(self, **overrides):
+        server_args = ServerArgs(model_path="dummy")
+        server_args._model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+        )
+        server_args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(backend=Backend.FULL, max_bs=512),
+            prefill=PhaseConfig(backend=Backend.FULL, max_bs=512),
+        )
+        server_args._resolved_overrides = []
+        valid = {f.name for f in dataclasses.fields(ServerArgs)}
+        for key, value in overrides.items():
+            assert key in valid, f"{key} is not a ServerArgs field"
+            setattr(server_args, key, value)
+        return server_args
+
+    def test_nextn_alias_accepted(self):
+        args = self._args(
+            speculative_algorithm="NEXTN",
+            speculative_eagle_topk=1,
+        )
+        apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
+
+    def test_eagle_accepted(self):
+        args = self._args(
+            speculative_algorithm="EAGLE",
+            speculative_eagle_topk=1,
+        )
+        apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
+
+    def test_dspark_accepted(self):
+        args = self._args(speculative_algorithm="DSPARK")
+        apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
+
+    def test_unsupported_algorithm_rejected(self):
+        args = self._args(speculative_algorithm="NGRAM")
+        with self.assertRaisesRegex(AssertionError, "Only EAGLE and DSPARK"):
+            apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
+
+    def test_eagle_topk_greater_than_one_rejected(self):
+        args = self._args(
+            speculative_algorithm="EAGLE",
+            speculative_eagle_topk=2,
+        )
+        with self.assertRaisesRegex(AssertionError, "topk == 1"):
+            apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
+
+    def test_nextn_topk_greater_than_one_rejected(self):
+        args = self._args(
+            speculative_algorithm="NEXTN",
+            speculative_eagle_topk=2,
+        )
+        with self.assertRaisesRegex(AssertionError, "topk == 1"):
+            apply_deepseek_v4_defaults(args, "DeepseekV4ForCausalLM")
 
 
 class TestHandleCrashDumpEnv(CustomTestCase):


### PR DESCRIPTION
## Summary
`--speculative-algorithm NEXTN` is a documented alias for `EAGLE`, but the DeepseekV4ForCausalLM hook rejected it with an assertion error because the global `NEXTN -> EAGLE` normalization only happens later in `handle_speculative_decoding`.

This PR normalizes `NEXTN` to `EAGLE` locally inside `apply_deepseek_v4_defaults` before the arch-specific check, so the valid CLI value is accepted.

## Changes
- `python/sglang/srt/arg_groups/deepseek_v4_hook.py`: normalize `NEXTN` to `EAGLE` before asserting allowed speculative algorithms and checking `speculative_eagle_topk == 1`.
- `test/registered/unit/server_args/test_server_args.py`: add `TestDeepseekV4Hook` covering `NEXTN`, `EAGLE`, `DSPARK` acceptance and rejection of unsupported algorithms / `topk > 1`.

## Test plan
- `python -m pytest test/registered/unit/server_args/test_server_args.py::TestDeepseekV4Hook -xvs` (6 passed)
- `python -m pytest test/registered/unit/server_args/test_server_args.py::TestDeepEPv2Args test/registered/unit/server_args/test_record_holds_the_raw_input.py -xvs` (35 passed)

Fixes #38236

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34075639646](https://github.com/sgl-project/sglang/actions/runs/34075639646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34075639533](https://github.com/sgl-project/sglang/actions/runs/34075639533)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34075639690](https://github.com/sgl-project/sglang/actions/runs/34075639690)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->