### PR TITLE
[Docs] Use --checkpoint-engine-wait-weights-before-ready in checkpoint engine docs

### DIFF
--- a/docs/docs/advanced_features/checkpoint_engine.mdx
+++ b/docs/docs/advanced_features/checkpoint_engine.mdx
@@ -25,7 +25,7 @@ pip install 'checkpoint-engine[p2p]'
 
 The system consists of two main components:
 
-1. **SGLang Server**: Runs with `--wait-for-initial-weights` flag to wait for weights before becoming ready
+1. **SGLang Server**: Runs with `--checkpoint-engine-wait-weights-before-ready` flag to wait for weights before becoming ready
 2. **Checkpoint Engine Workers**: Separate processes (managed by torchrun) that load and distribute model weights
 
 The checkpoint engine uses a parameter server architecture with support for:
@@ -43,7 +43,7 @@ python -m sglang.launch_server \
     --model-path Qwen/Qwen3-8B \
     --tp 8 \
     --load-format dummy \
-    --wait-for-initial-weights
+    --checkpoint-engine-wait-weights-before-ready
 ```
 
 **Terminal 2 - Run Checkpoint Engine:**
@@ -75,7 +75,7 @@ python -m sglang.launch_server \
     --model-path Qwen/Qwen3-8B \
     --tp 8 \
     --load-format dummy \
-    --wait-for-initial-weights \
+    --checkpoint-engine-wait-weights-before-ready \
     --host [IP]
 ```
 
@@ -110,7 +110,7 @@ python -m sglang.launch_server \
     --model-path Qwen/Qwen3-8B \
     --tp 8 \
     --load-format dummy \
-    --wait-for-initial-weights \
+    --checkpoint-engine-wait-weights-before-ready \
     --host [IP]
 ```
 
@@ -147,7 +147,7 @@ python -m sglang.launch_server \
     --model-path Qwen/Qwen3-8B \
     --tp 8 \
     --load-format dummy \
-    --wait-for-initial-weights \
+    --checkpoint-engine-wait-weights-before-ready \
     --host [IP] \
     --dist-init-addr [IP]:9120 \
     --nnodes 2 \
@@ -185,7 +185,7 @@ python -m sglang.launch_server \
     --model-path Qwen/Qwen3-8B \
     --tp 8 \
     --load-format dummy \
-    --wait-for-initial-weights \
+    --checkpoint-engine-wait-weights-before-ready \
     --host [IP] \
     --dist-init-addr [IP]:9120 \
     --nnodes 2 \
@@ -220,7 +220,7 @@ torchrun --nproc-per-node 8 \
 ### SGLang Server Options
 
 - `--load-format dummy`: Use dummy format for initial loading (allows overlapping with other tasks)
-- `--wait-for-initial-weights`: Wait for checkpoint engine to provide weights before becoming ready
+- `--checkpoint-engine-wait-weights-before-ready`: Wait for checkpoint engine to provide weights before becoming ready
 - `--host`: Host address for multi-node setups
 - `--dist-init-addr`: Distributed initialization address for tensor parallelism
 


### PR DESCRIPTION
## Summary
- `docs/docs/advanced_features/checkpoint_engine.mdx` used ghost `--wait-for-initial-weights` (7×).
- Real CLI from `ServerArgs.checkpoint_engine_wait_weights_before_ready` is `--checkpoint-engine-wait-weights-before-ready`.
- Matches `examples/checkpoint_engine/update.py`, which already uses the correct flag.

## Test plan
- [x] Confirmed no `--wait-for-initial-weights` in `server_args.py` argparse
- [x] Confirmed field `checkpoint_engine_wait_weights_before_ready` → kebab CLI
- [ ] Docs render / mintlify lint

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34075793479](https://github.com/sgl-project/sglang/actions/runs/34075793479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34075793299](https://github.com/sgl-project/sglang/actions/runs/34075793299)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->