### PR TITLE
[NPU] Enable short-conv hybrid models (LFM2/LFM2-MoE) with sgl_kernel…

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -471,18 +471,23 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                 Lfm2VlConfig,
             )
             if isinstance(mamba2_config(runner.model_config), short_conv_cfgs):
-                if is_npu():
-                    # The model conv layers call
-                    # get_attn_backend().conv_state_metadata() unconditionally,
-                    # but the Ascend hybrid/mamba backend has no such method.
-                    # Fail here (before model execution) with a clear message
-                    # rather than an AttributeError deep in the first conv layer.
+                if _is_npu and isinstance(
+                    mamba2_config(runner.model_config), ZayaConfig
+                ):
+                    # ZAYA1's pure-torch cca_extend/cca_decode paths assume the
+                    # channel-major conv-state pool (slots, channels, window),
+                    # but the NPU MambaPool allocates window-major states
+                    # (slots, window, channels) via _init_npu_conv_state, so
+                    # CCA fails on the first conv layer. LFM2 models dispatch
+                    # to the layout-aware sgl_kernel_npu v2 conv1d wrappers and
+                    # are supported; fail here (before model execution) with a
+                    # clear message for ZAYA1.
                     raise NotImplementedError(
-                        "Short-conv hybrid models (ZAYA1 CCA, LFM2 / LFM2-MoE) "
-                        "are not yet supported on NPU: the conv-state sidecar "
-                        "(ShortConvAttnBackend.conv_state_metadata) has no Ascend "
-                        "implementation. Add an Ascend conv-state backend before "
-                        "serving these models on NPU."
+                        "ZAYA1 CCA is not yet supported on NPU: the "
+                        "cca_extend/cca_decode paths assume the channel-major "
+                        "conv-state pool, but the NPU MambaPool allocates "
+                        "window-major states. Add a layout-aware CCA path "
+                        "before serving ZAYA1 on NPU."
                     )
                 from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
                     ShortConvHybridAttnBackend,

--- a/python/sglang/srt/layers/attention/mamba/causal_conv1d.py
+++ b/python/sglang/srt/layers/attention/mamba/causal_conv1d.py
@@ -18,12 +18,13 @@ from sglang.kernels.ops.mamba.causal_conv1d_triton import (
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_update as _causal_conv1d_update_triton,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_npu
 
 # The compiled causal conv1d is CUDA-only -- the sgl_kernel wheel never built it
 # for ROCm / MUSA either, so the old import probe always fell through to Triton
 # there. Select that fallback directly instead of via a failed import.
 _HAS_CONV1D_KERNEL = is_cuda()
+_IS_NPU = is_npu()
 
 if _HAS_CONV1D_KERNEL:
     from sglang.kernels.ops.mamba import (
@@ -38,6 +39,18 @@ def _get_seq_lens_cpu(query_start_loc, x):
     if query_start_loc is not None:
         return (query_start_loc[1:] - query_start_loc[:-1]).cpu().tolist()
     return [x.shape[-1]]
+
+
+if _IS_NPU:
+    # NPU implementations for the short-conv hybrid models (LFM2 / LFM2-MoE)
+    # live in sgl_kernel_npu as causal_conv1d_fn_v2 (varlen prefill) and
+    # causal_conv1d_update_npu_v2 (decode, dispatching to the
+    # causal_conv1d_update_v2 Triton kernel with a torch fallback); bind them
+    # here with the sglang-side convention (weight: (dim, width)).
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_fn_v2 as _causal_conv1d_fn_npu,
+        causal_conv1d_update_npu_v2 as _causal_conv1d_update_npu,
+    )
 
 
 def causal_conv1d_fn(
@@ -81,6 +94,18 @@ def causal_conv1d_fn(
 
     out: (batch, dim, seqlen)
     """
+    if _IS_NPU:
+        return _causal_conv1d_fn_npu(
+            x,
+            weight,
+            bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            conv_states=conv_states,
+            pad_slot_id=pad_slot_id,
+            activation=activation,
+        )
     # Use Triton when: (1) there is no compiled conv1d kernel for this device,
     # or (2) input is non-contiguous and seq_lens_cpu is pre-computed by caller.
     # The Triton kernel accepts arbitrary strides, avoiding a .contiguous()
@@ -157,6 +182,20 @@ def causal_conv1d_update(
             indices 0 and 3
     out: (batch, dim) or (batch, dim, seqlen)
     """
+    if _IS_NPU:
+        if cache_seqlens is not None:
+            raise NotImplementedError(
+                "circular-buffer conv-state updates are not supported on NPU"
+            )
+        return _causal_conv1d_update_npu(
+            x,
+            conv_state,
+            weight,
+            bias,
+            activation,
+            conv_state_indices=conv_state_indices,
+            pad_slot_id=pad_slot_id,
+        )
     use_triton = not _HAS_CONV1D_KERNEL
     if use_triton:
         return _causal_conv1d_update_triton(

--- a/test/registered/npu/test_causal_conv1d_npu.py
+++ b/test/registered/npu/test_causal_conv1d_npu.py
@@ -1,0 +1,228 @@
+"""Tests for the NPU dispatch of sglang's causal_conv1d entry points.
+
+On NPU, ``sglang.srt.layers.attention.mamba.causal_conv1d`` routes
+``causal_conv1d_fn`` / ``causal_conv1d_update`` to sgl_kernel_npu's v2
+wrappers (AscendC op fast path + Triton/torch fallbacks), which speak
+the NPU MambaPool's window-major conv-state layout
+``(slots, width - 1, dim)`` -- see ``_init_npu_conv_state``. These tests
+pin that contract for the short-conv hybrid models (LFM2 / LFM2-MoE):
+
+- prefill: packed varlen x of shape (dim, cu_seq) with a window-major
+  pool; pad slots must not be read from or written to;
+- decode: x of shape (batch, dim) with int64 conv_state_indices
+  containing pad entries (the dtype ShortConvAttnBackend hands out);
+- cache_seqlens (circular buffer) must raise NotImplementedError;
+- the NPU branch actually dispatches to the v2 wrappers (monkeypatched
+  recording probe).
+
+All references run on CPU in fp32 (fp32 F.conv1d on NPU can produce
+NaNs), matching the sibling tests in sgl_kernel_npu.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.utils import is_npu
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=60, suite="base-b-test-1-npu-a3")
+
+pytestmark = pytest.mark.skipif(not is_npu(), reason="NPU-only test")
+
+if is_npu():
+    import torch_npu  # noqa: F401  makes torch.npu available
+
+    import sglang.srt.layers.attention.mamba.causal_conv1d as cc
+    from sglang.srt.layers.attention.mamba.causal_conv1d import (
+        causal_conv1d_fn,
+        causal_conv1d_update,
+    )
+
+device = "npu"
+torch.manual_seed(17)
+
+DIM, WIDTH = 128, 3  # LFM2 conv_kernel == 3
+STATE_LEN = WIDTH - 1
+PAD = -1  # PAD_SLOT_ID
+
+
+def _dev(t, dtype=torch.bfloat16):
+    return t.to(dtype).to(device).contiguous()
+
+
+def _ref_prefill_row(toks, init, weight, bias, silu):
+    """toks: (dim, L); init: (dim, STATE_LEN). CPU fp32 reference."""
+    virt = torch.cat([init, toks], dim=1)
+    out = F.conv1d(
+        virt.unsqueeze(0),
+        weight.unsqueeze(1),
+        bias,
+        groups=toks.shape[0],
+    )[0]
+    if silu:
+        out = F.silu(out)
+    return out, virt[:, -STATE_LEN:]
+
+
+def test_npu_dispatch_goes_to_v2_wrappers(monkeypatch):
+    """The NPU branch must call the sgl_kernel_npu v2 wrappers."""
+    calls = {"fn": 0, "update": 0}
+    real_fn, real_update = cc._causal_conv1d_fn_npu, cc._causal_conv1d_update_npu
+
+    def rec_fn(*a, **k):
+        calls["fn"] += 1
+        return real_fn(*a, **k)
+
+    def rec_update(*a, **k):
+        calls["update"] += 1
+        return real_update(*a, **k)
+
+    monkeypatch.setattr(cc, "_causal_conv1d_fn_npu", rec_fn)
+    monkeypatch.setattr(cc, "_causal_conv1d_update_npu", rec_update)
+
+    x = _dev(torch.randn(DIM, 4) * 0.3)
+    w = _dev(torch.randn(DIM, WIDTH) * 0.3)
+    pool = _dev(torch.randn(4, STATE_LEN, DIM) * 0.3)
+    qsl = torch.tensor([0, 4], device=device, dtype=torch.int32)
+    idx = torch.tensor([2], device=device, dtype=torch.int64)
+    causal_conv1d_fn(
+        x,
+        w,
+        None,
+        query_start_loc=qsl,
+        cache_indices=idx,
+        has_initial_state=torch.zeros(1, dtype=torch.bool, device=device),
+        conv_states=pool,
+        activation=None,
+    )
+    causal_conv1d_update(
+        _dev(torch.randn(2, DIM) * 0.3),
+        pool,
+        w,
+        None,
+        activation=None,
+        conv_state_indices=torch.tensor([0, 3], device=device, dtype=torch.int64),
+    )
+    torch.npu.synchronize()
+    assert calls == {"fn": 1, "update": 1}
+
+
+@pytest.mark.parametrize("silu", [False, True])
+def test_npu_prefill_varlen_window_major(silu):
+    """causal_conv1d_fn on NPU: packed varlen + window-major pool + pads."""
+    lens, starts = [5, 2, 1], [0, 5, 7, 8]
+    cu = starts[-1]
+    x = _dev(torch.randn(DIM, cu) * 0.3)
+    x0 = x.clone()
+    pool = _dev(torch.randn(6, STATE_LEN, DIM) * 0.3)
+    pool0 = pool.clone()
+    w = _dev(torch.randn(DIM, WIDTH) * 0.3)
+    bias = _dev(torch.randn(DIM) * 0.3)
+    qsl = torch.tensor(starts, device=device, dtype=torch.int32)
+    # row 1 is a pad request: its outputs are unspecified, but it must
+    # not corrupt any real pool slot.
+    idx = torch.tensor([1, PAD, 4], device=device, dtype=torch.int64)
+    hi = torch.tensor([True, False, True], device=device, dtype=torch.bool)
+
+    out = causal_conv1d_fn(
+        x,
+        w,
+        bias,
+        query_start_loc=qsl,
+        cache_indices=idx,
+        has_initial_state=hi,
+        conv_states=pool,
+        activation="silu" if silu else None,
+    )
+    torch.npu.synchronize()
+    assert out.shape == (DIM, cu)
+
+    wc, bc = w.cpu().float(), bias.cpu().float()
+    for i, slot in [(0, 1), (2, 4)]:
+        toks = x0[:, starts[i] : starts[i + 1]].cpu().float()
+        init = (
+            pool0[slot].cpu().float().t()
+            if hi[i]
+            else torch.zeros(DIM, STATE_LEN)
+        )
+        ref_out, ref_final = _ref_prefill_row(toks, init, wc, bc, silu)
+        torch.testing.assert_close(
+            out[:, starts[i] : starts[i + 1]].cpu().float(),
+            ref_out,
+            atol=2e-2,
+            rtol=2e-2,
+        )
+        # pool is window-major: stored rows are (STATE_LEN, DIM)
+        torch.testing.assert_close(
+            pool[slot].cpu().float(), ref_final.t(), atol=2e-2, rtol=2e-2
+        )
+    # slot 0 is the reserved dummy write target for pads; every slot that
+    # is neither claimed nor the dummy must be bit-identical.
+    untouched = [s for s in range(6) if s not in (0, 1, 4)]
+    torch.testing.assert_close(
+        pool[untouched].float(), pool0[untouched].float(), atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.parametrize("silu", [False, True])
+def test_npu_decode_window_major(silu):
+    """causal_conv1d_update on NPU: (batch, dim) + int64 indices + pads."""
+    batch = 4
+    x = _dev(torch.randn(batch, DIM) * 0.3)
+    x0 = x.clone()
+    pool = _dev(torch.randn(6, STATE_LEN, DIM) * 0.3)
+    pool0 = pool.clone()
+    w = _dev(torch.randn(DIM, WIDTH) * 0.3)
+    bias = _dev(torch.randn(DIM) * 0.3)
+    idx = torch.tensor([1, 3, PAD, 5], device=device, dtype=torch.int64)
+
+    out = causal_conv1d_update(
+        x, pool, w, bias, activation="silu" if silu else None,
+        conv_state_indices=idx,
+    )
+    torch.npu.synchronize()
+    assert out.shape == (batch, DIM)
+
+    wc, bc = w.cpu().float(), bias.cpu().float()
+    for row, slot in [(0, 1), (1, 3), (3, 5)]:
+        state = pool0[slot].cpu().float().t()  # (DIM, STATE_LEN)
+        win = torch.cat([state, x0[row].cpu().float().unsqueeze(1)], dim=1)
+        ref = F.conv1d(
+            win.unsqueeze(0), wc.unsqueeze(1), bc, groups=DIM
+        )[0][:, -1]
+        if silu:
+            ref = F.silu(ref)
+        torch.testing.assert_close(
+            out[row].cpu().float(), ref, atol=2e-2, rtol=2e-2
+        )
+        torch.testing.assert_close(
+            pool[slot].cpu().float(), win[:, -STATE_LEN:].t(),
+            atol=2e-2, rtol=2e-2,
+        )
+    untouched = [s for s in range(6) if s not in (1, 3, 5)]
+    torch.testing.assert_close(
+        pool[untouched].float(), pool0[untouched].float(), atol=0.0, rtol=0.0
+    )
+
+
+def test_npu_update_rejects_cache_seqlens():
+    """Circular-buffer updates are not supported on NPU: fail clearly."""
+    x = _dev(torch.randn(2, DIM) * 0.3)
+    pool = _dev(torch.randn(6, STATE_LEN, DIM) * 0.3)
+    w = _dev(torch.randn(DIM, WIDTH) * 0.3)
+    with pytest.raises(NotImplementedError, match="circular-buffer"):
+        causal_conv1d_update(
+            x,
+            pool,
+            w,
+            None,
+            cache_seqlens=torch.ones(2, dtype=torch.int32, device=device),
+            conv_state_indices=torch.tensor(
+                [0, 1], device=device, dtype=torch.int64
+            ),
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
…_npu v2 conv1d ops

Remove the NPU guard that rejected short-conv hybrid models in attn_backend_wrapper, and route causal_conv1d_fn / causal_conv1d_update to sgl_kernel_npu's v2 ops
(causal_conv1d_fn_v2 / causal_conv1d_update_npu_v2). The v2 ops target the window-major [layers, pool, window, channels] MambaPool conv-state layout, keep pad-slot handling inside the kernel (NPU-graph-capture safe on the decode path), and cover varlen prefill with CANN conv1d.

Validated on Ascend 910C with LFM2.5-8B-A1B (GSM8K 0.88, chat API, max-tokens 4096) and LFM2.5-VL-1.6B (MMMU val 40.2).

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34100130164](https://github.com/sgl-project/sglang/actions/runs/34100130164)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34100129946](https://github.com/sgl-project/sglang/actions/runs/34100129946)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34100130086](https://github.com/sgl-project/sglang/actions/runs/34100130086)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->