### PR TITLE
[GLM-5.3] Fix qkvbfg fusion being disabled by the global quant config

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 from copy import deepcopy
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import numpy
 import torch
@@ -123,6 +123,47 @@ def is_layer_skipped(
 
     assert is_skipped is not None
     return is_skipped
+
+
+def are_linear_prefixes_unquantized(
+    quant_config: Optional[QuantizationConfig],
+    prefixes: Iterable[str],
+) -> bool:
+    """Whether every linear layer in ``prefixes`` would be built unquantized.
+
+    A model-level ``quant_config`` only says the checkpoint carries *some*
+    quantized weights, not that any given layer is one of them -- FP8
+    checkpoints routinely quantize the experts and leave attention in BF16.
+    Callers that swap in a hand-fused module the quant methods cannot feed must
+    therefore ask per layer instead of testing ``quant_config is None``, so
+    resolve each prefix the way the real layer would and accept only
+    ``None`` / ``UnquantizedLinearMethod``.
+    """
+    if quant_config is None:
+        return True
+
+    from sglang.srt.layers.linear import LinearBase
+    from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+
+    # Weightless stand-in: LinearBase.__init__ allocates nothing (create_weights
+    # lives in the subclasses), and quant_config=None keeps constructing the
+    # probe from recursing back into get_quant_method.
+    probe = LinearBase(input_size=1, output_size=1, quant_config=None)
+    for prefix in prefixes:
+        try:
+            quant_method = quant_config.get_quant_method(probe, prefix=prefix)
+        except Exception:
+            # Configs are free to match on the layer's class, which the probe
+            # only approximates -- compressed-tensors raises outright when a
+            # target matches nothing. The caller's fused path is an
+            # optimization, so answering "not provably unquantized" costs a few
+            # GEMM launches, while letting the probe raise costs the model.
+            return False
+        if quant_method is not None and not isinstance(
+            quant_method, UnquantizedLinearMethod
+        ):
+            return False
+    return True
 
 
 def per_tensor_dequantize(

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.utils import are_linear_prefixes_unquantized
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils.common import PPMissingLayer
@@ -336,7 +337,26 @@ class Glm5NextLinearAttention(nn.Module):
         projection_size = self.head_dim * self.num_heads
         self.conv_size = config.linear_attn_config["short_conv_kernel_size"]
 
-        self.do_fuse_qkvbfg = quant_config is None and head_shard_size == self.tp_size
+        # A global quant_config does not mean these six projections are
+        # quantized: GLM-5.3-Flash ships FP8 experts with BF16 attention. Ask
+        # per prefix, since the fused modules can only eat unquantized weights.
+        self.do_fuse_qkvbfg = (
+            head_shard_size == self.tp_size
+            and are_linear_prefixes_unquantized(
+                quant_config,
+                [
+                    f"{prefix}.{name}"
+                    for name in (
+                        "qkv_proj",
+                        "f_a_proj",
+                        "f_b_proj",
+                        "b_proj",
+                        "g_a_proj",
+                        "g_b_proj",
+                    )
+                ],
+            )
+        )
         if self.do_fuse_qkvbfg:
             self.qkvb_sizes = [
                 projection_size,
@@ -350,7 +370,12 @@ class Glm5NextLinearAttention(nn.Module):
                 self.hidden_size,
                 self.qkvb_sizes,
                 self.fg_sizes,
-                quant_config=quant_config,
+                # The gate above already proved the source weights are
+                # unquantized. This name exists in no checkpoint, so an ignore
+                # list written in terms of the real ones is not guaranteed to
+                # cover it -- handing it the global config risks quantizing a
+                # layer whose source weights are BF16.
+                quant_config=None,
                 prefix=f"{prefix}.fused_qkvbfg_a_proj",
             )
             self.split_sizes = [


### PR DESCRIPTION
Adapation on main brach for the previous fix: https://github.com/sgl-project/sglang/pull/37744, see also in https://github.com/sgl-project/sglang/issues/38253

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34077869191](https://github.com/sgl-project/sglang/actions/runs/34077869191)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34077869058](https://github.com/sgl-project/sglang/actions/runs/34077869058)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34077869381](https://github.com/sgl-project/sglang/actions/runs/34077869381)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->