### PR TITLE
[Docs] Prefer --enable-prefill-cp in Ascend parameter_tuning

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/optimization/parameter_tuning.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/optimization/parameter_tuning.mdx
@@ -187,14 +187,14 @@ These arguments and environment variables are critical for tuning prefill perfor
       <td>true</td>
     </tr>
     <tr>
-      <td>`--enable-dsa-prefill-context-parallel`</td>
+      <td>`--enable-prefill-cp`</td>
       <td><strong>(DeepSeek V3.2 DSA-specific)</strong> Enables context parallelism for the long-sequence prefill phase of DeepSeek V3.2 with DSA (DeepSeek Sparse Attention). Distributes the sequence across CP ranks to parallelize the computationally expensive DSA prefill for ultra-long contexts.</td>
       <td>Enabled</td>
     </tr>
     <tr>
-      <td>`--dsa-prefill-cp-mode`</td>
-      <td><strong>(DeepSeek V3.2 DSA-specific)</strong> Controls how the long sequence is split across context parallel ranks: `in-seq-split` divides each sequence uniformly across CP ranks, optimal for single-request prefill. `round-robin-split` (code default) distributes tokens by index mod CP size, supporting multi-batch prefill. Only effective when `--enable-dsa-prefill-context-parallel` is enabled.</td>
-      <td>`in-seq-split`</td>
+      <td>`--cp-strategy`</td>
+      <td><strong>(DeepSeek V3.2 DSA-specific)</strong> Controls how the long sequence is split across context parallel ranks: `zigzag` (formerly `in-seq-split`) divides each sequence uniformly across CP ranks, optimal for single-request prefill. `interleave` (formerly `round-robin-split`) distributes tokens by index mod CP size, supporting multi-batch prefill. Only effective when `--enable-prefill-cp` is enabled.</td>
+      <td>`zigzag`</td>
     </tr>
     <tr>
       <td>`--attn-cp-size`</td>


### PR DESCRIPTION
## Summary
- Update Ascend NPU `parameter_tuning.mdx` Prefill Optimizations table to prefer live CLI `--enable-prefill-cp` and `--cp-strategy`.
- Replace ghost / `no_cli` spellings `--enable-dsa-prefill-context-parallel` and `--dsa-prefill-cp-mode`.
- Map former mode names: `in-seq-split` → `zigzag`, `round-robin-split` → `interleave` (matches `server_args.py` help text).

## Repro
On `main` (`6e312af8c25c`):

1. `docs/docs/hardware-platforms/ascend-npus/optimization/parameter_tuning.mdx` documents `--enable-dsa-prefill-context-parallel` and `--dsa-prefill-cp-mode in-seq-split`.
2. In `python/sglang/srt/server_args.py`, both `enable_dsa_prefill_context_parallel` and `dsa_prefill_cp_mode` are `Arg(no_cli=True)` — there is no live argparse for those exact flag strings.
3. Preferred fields are `enable_prefill_cp` / `cp_strategy` with choices `zigzag` | `interleave` (`zigzag` is the former in-seq-split mode; `interleave` is the former round-robin-split mode).

## Test plan
- [x] Confirmed ghost flags are `no_cli=True` / not registered as the documented strings
- [x] Confirmed preferred CLI names and `cp_strategy` choices in `server_args.py`
- [x] Only touched the two Prefill Optimizations table rows (left `--disable-cuda-graph` untouched)
- [ ] Docs preview / maintainer review

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34079594483](https://github.com/sgl-project/sglang/actions/runs/34079594483)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34079594238](https://github.com/sgl-project/sglang/actions/runs/34079594238)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->