### PR TITLE
fix(scheduler): enable WAR barrier on HIP/ROCm to prevent overlap scheduler race

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1872,7 +1872,9 @@ class Scheduler(
                 _redraws += 1
         # The global WAR barrier fences the scheduler's next shared-buffer write
         # on the previous forward's read of the unified memory pool.
-        self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        self._war_barrier_enabled = (
+            is_cuda() or _is_hip or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        )
         with self.device_module.StreamContext(self.schedule_stream):
             self.metrics_reporter.start_scheduler_time_accounting()
             dispatch_event_loop(self)


### PR DESCRIPTION
## Description

The WAR (Write-After-Read) barrier for the overlap scheduler uses `is_cuda()` to detect CUDA GPUs, but `is_cuda()` returns `False` on HIP/ROCm (AMD GPUs). This means the WAR barrier is silently disabled on all AMD GPU configurations unless `SGLANG_ENABLE_WAR_BARRIER=1` is set explicitly.

Without the barrier, the scheduler's next shared-buffer write can overlap with the previous forward's read of the unified memory pool, causing a race condition that manifests as **GPU Memory Access Faults** on MI300X series.

## Root Cause

`scheduler.py` line 1887:
```python
self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
```

`is_cuda()` checks for CUDA specifically — it returns `False` on HIP/ROCm. The same file already uses the correct pattern at line 1873:
```python
elif is_cuda() or _is_hip:
```

## Fix

Add `_is_hip` to the WAR barrier enable condition:
```python
self._war_barrier_enabled = is_cuda() or _is_hip or envs.SGLANG_ENABLE_WAR_BARRIER.get()
```

## Impact

- **Before**: WAR barrier disabled on all AMD GPUs → overlap scheduler race condition → GPU Memory Access Faults
- **After**: WAR barrier enabled on AMD GPUs (HIP/ROCm) by default, matching CUDA behavior
- **Workaround before fix**: `SGLANG_ENABLE_WAR_BARRIER=1` (environment variable)

## Testing

Verified on MI308X (gfx942, 8×MI308X, TP8) running GLM-5.2 with the overlap scheduler. Without the fix, GPU Memory Access Faults occurred intermittently during prefill. With `SGLANG_ENABLE_WAR_BARRIER=1` set (equivalent to this fix), the faults stopped.

## Checklist

- [x] One-line fix, mirrors existing pattern in the same file
- [x] No new imports needed (`_is_hip` already defined at line 422)
- [x] Does not affect CUDA users (is_cuda() still True for them)
- [x] Does not affect users who explicitly set SGLANG_ENABLE_WAR_BARRIER=1

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34543108921](https://github.com/sgl-project/sglang/actions/runs/34543108921)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34543108791](https://github.com/sgl-project/sglang/actions/runs/34543108791)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34543109078](https://github.com/sgl-project/sglang/actions/runs/34543109078)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->