### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend MiMo-V2-Flash best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/mimo_v2_flash.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/mimo_v2_flash.mdx
@@ -128,8 +128,8 @@ do
         --swa-full-tokens-ratio 0.3 \
         --disaggregation-transfer-backend ascend \
         --disable-radix-cache \
-        --disable-cuda-graph \
-        --disable-piecewise-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --dp-size 2
         break
     fi
@@ -159,7 +159,7 @@ do
         --max-running-requests 64 \
         --mem-fraction-static 0.8 \
         --swa-full-tokens-ratio 0.3 \
-        --cuda-graph-bs 1 2 4 8 12 16 20 24 28 32 \
+        --cuda-graph-bs-decode 1 2 4 8 12 16 20 24 28 32 \
         --disaggregation-transfer-backend ascend \
         --speculative-algorithm EAGLE \
         --speculative-num-steps 3 \
@@ -313,8 +313,8 @@ do
         --swa-full-tokens-ratio 0.3 \
         --disaggregation-transfer-backend ascend \
         --disable-radix-cache \
-        --disable-cuda-graph \
-        --disable-piecewise-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --dp-size 2
         break
     fi
@@ -344,7 +344,7 @@ do
         --max-running-requests 32 \
         --mem-fraction-static 0.8 \
         --swa-full-tokens-ratio 0.3 \
-        --cuda-graph-bs 1 2 4 8 12 16 \
+        --cuda-graph-bs-decode 1 2 4 8 12 16 \
         --disaggregation-transfer-backend ascend \
         --speculative-algorithm EAGLE \
         --speculative-num-steps 3 \
@@ -498,8 +498,8 @@ do
         --swa-full-tokens-ratio 0.3 \
         --disaggregation-transfer-backend ascend \
         --disable-radix-cache \
-        --disable-cuda-graph \
-        --disable-piecewise-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --dp-size 2
         break
     fi
@@ -529,7 +529,7 @@ do
         --max-running-requests 64 \
         --mem-fraction-static 0.8 \
         --swa-full-tokens-ratio 0.3 \
-        --cuda-graph-bs 1 2 4 8 12 16 20 24 28 32 \
+        --cuda-graph-bs-decode 1 2 4 8 12 16 20 24 28 32 \
         --disaggregation-transfer-backend ascend \
         --speculative-algorithm EAGLE \
         --speculative-num-steps 3 \
@@ -683,8 +683,8 @@ do
         --swa-full-tokens-ratio 0.3 \
         --disaggregation-transfer-backend ascend \
         --disable-radix-cache \
-        --disable-cuda-graph \
-        --disable-piecewise-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --dp-size 2
         break
     fi
@@ -714,7 +714,7 @@ do
         --max-running-requests 64 \
         --mem-fraction-static 0.8 \
         --swa-full-tokens-ratio 0.3 \
-        --cuda-graph-bs 1 2 4 8 12 16 20 24 28 32 \
+        --cuda-graph-bs-decode 1 2 4 8 12 16 20 24 28 32 \
         --disaggregation-transfer-backend ascend \
         --speculative-algorithm EAGLE \
         --speculative-num-steps 3 \


### PR DESCRIPTION
## What drifted
`docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/mimo_v2_flash.mdx` still documents four Prefill/Decode recipe copies with deprecated CUDA graph CLIs:

- `--disable-cuda-graph`
- `--disable-piecewise-cuda-graph`
- `--cuda-graph-bs …`

In `python/sglang/srt/server_args.py` those are deprecated aliases preferring:

- `--cuda-graph-backend-decode=disabled`
- `--cuda-graph-backend-prefill=disabled`
- `--cuda-graph-bs-decode`

(Related: tutorials already prefer decode variants; this PR only updates the best-practices recipes.)

## Local repro
```bash
gh api repos/sgl-project/sglang/contents/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/mimo_v2_flash.mdx \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n 'disable-cuda-graph|disable-piecewise-cuda-graph|--cuda-graph-bs '

gh api repos/sgl-project/sglang/contents/python/sglang/srt/server_args.py \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n 'cuda-graph-backend-decode|cuda-graph-backend-prefill|cuda-graph-bs-decode|disable-cuda-graph|disable-piecewise-cuda-graph|--cuda-graph-bs'
```

## Why
Keep Ascend MiMo-V2-Flash PD best-practice launch snippets aligned with the canonical CUDA graph backend / decode batch-size flags so copy-paste recipes do not rely on deprecated aliases.

## Change
In all four recipe copies in that one MDX only:

- Replace `--disable-cuda-graph` + `--disable-piecewise-cuda-graph` with `--cuda-graph-backend-decode=disabled` + `--cuda-graph-backend-prefill=disabled`
- Replace `--cuda-graph-bs` with `--cuda-graph-bs-decode` (same numeric lists)
- No other flags touched; tutorials path not modified

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34081274108](https://github.com/sgl-project/sglang/actions/runs/34081274108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34081273914](https://github.com/sgl-project/sglang/actions/runs/34081273914)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->