### PR TITLE
[Intel GPU] Disable FP8 W_o/A GEMM on XPU where DeepGEMM JIT cannot build

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7735,15 +7735,29 @@ class ServerArgs:
                 "--enable-deepseek-v4-fp4-indexer requires SM100 or SM120 GPUs with "
                 "DeepGEMM FP4 indexer support."
             )
-        # FP8 W_o GEMM needs DeepGEMM JIT. Enable exactly where the runtime can run
-        # it, mirroring the forward scale split: the ue8m0 path
-        # (DEEPGEMM_SCALE_UE8M0, true sm100, default on) or an sm90 opt-in
-        # fp32-scale path (use FP4 expert ckpt). Disable in every other case.
-        if is_cuda() and envs.SGLANG_OPT_FP8_WO_A_GEMM.get():
+        self._handle_fp8_wo_a_gemm_compatibility()
+
+    def _handle_fp8_wo_a_gemm_compatibility(self) -> None:
+        """Disable the FP8 W_o/A GEMM where the runtime cannot serve it.
+
+        On CUDA, enable exactly where the runtime can run it, mirroring the
+        forward scale split: the ue8m0 path (DEEPGEMM_SCALE_UE8M0, true sm100,
+        default on) or an sm90 opt-in fp32-scale path (use FP4 expert ckpt).
+        On XPU the DeepGEMM JIT never builds, so the path is always disabled;
+        without this the first forward raises ModuleNotFoundError from the
+        ``import deep_gemm`` in the wo_a GEMM, or, for a checkpoint whose
+        ``wo_a`` is not already fp8, weight loading aborts before that. Either
+        way the operator has to set SGLANG_OPT_FP8_WO_A_GEMM=0 by hand. Other
+        backends are left alone.
+        """
+        if not envs.SGLANG_OPT_FP8_WO_A_GEMM.get():
+            return
+
+        explicit = envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set()
+        if is_cuda():
             from sglang.srt.layers import deep_gemm_wrapper
 
             sm = get_device_sm()
-            explicit = envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set()
             supported = deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
                 and is_sm90_supported()
@@ -7756,8 +7770,24 @@ class ServerArgs:
                     "detected sm%d.",
                     sm,
                 )
-            if not supported:
-                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+        elif is_xpu():
+            # DeepGEMM JIT is compiled only for CUDA and MUSA
+            # (deep_gemm_wrapper/configurer.py returns False for every other
+            # runtime), so the FP8 W_o/A path can never be served on XPU.
+            # Decide it here rather than importing the CUDA-oriented wrapper.
+            supported = False
+            if explicit:
+                logger.warning(
+                    "Disabling SGLANG_OPT_FP8_WO_A_GEMM: DeepGEMM JIT is not "
+                    "available on XPU."
+                )
+        else:
+            # Other runtimes keep whatever they had; this handler is scoped to
+            # the two backends whose support status is known here.
+            return
+
+        if not supported:
+            envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
 
     def _handle_cache_compatibility(self):
         if self.enable_hierarchical_cache and self.disable_radix_cache:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -110,32 +110,6 @@ class TestFp8WoAGemmCompatibility(CustomTestCase):
     def setUp(self):
         self.server_args = object.__new__(ServerArgs)
 
-    @patch("sglang.srt.server_args.is_xpu", return_value=True)
-    @patch("sglang.srt.server_args.is_cuda", return_value=False)
-    def test_explicit_xpu_setting_is_disabled_with_warning(
-        self, _mock_is_cuda, _mock_is_xpu
-    ):
-        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(True):
-            with self.assertLogs(server_args_module.logger, level="WARNING") as logs:
-                self.server_args._handle_fp8_wo_a_gemm_compatibility()
-
-            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
-            self.assertIn("not available on XPU", logs.output[0])
-
-    @patch("sglang.srt.server_args.is_xpu", return_value=True)
-    @patch("sglang.srt.server_args.is_cuda", return_value=False)
-    def test_implicit_xpu_default_is_disabled_without_warning(
-        self, _mock_is_cuda, _mock_is_xpu
-    ):
-        with patch.dict(os.environ):
-            os.environ.pop("SGLANG_OPT_FP8_WO_A_GEMM", None)
-            self.assertTrue(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
-
-            with self.assertNoLogs(server_args_module.logger, level="WARNING"):
-                self.server_args._handle_fp8_wo_a_gemm_compatibility()
-
-            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
-
     @patch("sglang.srt.server_args.is_xpu", return_value=False)
     @patch("sglang.srt.server_args.is_cuda", return_value=False)
     def test_other_runtimes_are_left_untouched(self, _mock_is_cuda, _mock_is_xpu):
@@ -160,14 +134,6 @@ class TestFp8WoAGemmCompatibility(CustomTestCase):
 
             self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
             self.assertIn("detected sm80", logs.output[0])
-
-    def test_disabled_flag_short_circuits_before_any_probe(self):
-        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(False):
-            with patch("sglang.srt.server_args.is_cuda") as mock_is_cuda:
-                self.server_args._handle_fp8_wo_a_gemm_compatibility()
-
-            mock_is_cuda.assert_not_called()
-            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
 
 
 class TestMmEncoderDataParallelLogging(CustomTestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -106,6 +106,70 @@ class TestPrepareServerArgs(CustomTestCase):
             os.unlink(config_file)
 
 
+class TestFp8WoAGemmCompatibility(CustomTestCase):
+    def setUp(self):
+        self.server_args = object.__new__(ServerArgs)
+
+    @patch("sglang.srt.server_args.is_xpu", return_value=True)
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    def test_explicit_xpu_setting_is_disabled_with_warning(
+        self, _mock_is_cuda, _mock_is_xpu
+    ):
+        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(True):
+            with self.assertLogs(server_args_module.logger, level="WARNING") as logs:
+                self.server_args._handle_fp8_wo_a_gemm_compatibility()
+
+            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+            self.assertIn("not available on XPU", logs.output[0])
+
+    @patch("sglang.srt.server_args.is_xpu", return_value=True)
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    def test_implicit_xpu_default_is_disabled_without_warning(
+        self, _mock_is_cuda, _mock_is_xpu
+    ):
+        with patch.dict(os.environ):
+            os.environ.pop("SGLANG_OPT_FP8_WO_A_GEMM", None)
+            self.assertTrue(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+
+            with self.assertNoLogs(server_args_module.logger, level="WARNING"):
+                self.server_args._handle_fp8_wo_a_gemm_compatibility()
+
+            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+
+    @patch("sglang.srt.server_args.is_xpu", return_value=False)
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    def test_other_runtimes_are_left_untouched(self, _mock_is_cuda, _mock_is_xpu):
+        # Scoping guard: CPU, ROCm, NPU and MUSA kept their own settings before
+        # the XPU arm existed and must keep them now.
+        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(True):
+            with self.assertNoLogs(server_args_module.logger, level="WARNING"):
+                self.server_args._handle_fp8_wo_a_gemm_compatibility()
+
+            self.assertTrue(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+
+    @patch("sglang.srt.server_args.get_device_sm", return_value=80)
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    @patch("sglang.srt.layers.deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0", False)
+    @patch("sglang.srt.layers.deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM", False)
+    def test_cuda_path_still_disables_when_deepgemm_is_unsupported(
+        self, _mock_is_cuda, _mock_get_device_sm
+    ):
+        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(True):
+            with self.assertLogs(server_args_module.logger, level="WARNING") as logs:
+                self.server_args._handle_fp8_wo_a_gemm_compatibility()
+
+            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+            self.assertIn("detected sm80", logs.output[0])
+
+    def test_disabled_flag_short_circuits_before_any_probe(self):
+        with envs.SGLANG_OPT_FP8_WO_A_GEMM.override(False):
+            with patch("sglang.srt.server_args.is_cuda") as mock_is_cuda:
+                self.server_args._handle_fp8_wo_a_gemm_compatibility()
+
+            mock_is_cuda.assert_not_called()
+            self.assertFalse(envs.SGLANG_OPT_FP8_WO_A_GEMM.get())
+
+
 class TestMmEncoderDataParallelLogging(CustomTestCase):
     def test_logs_when_encoder_dp_has_no_parallelism(self):
         server_args = ServerArgs(


### PR DESCRIPTION
## Motivation

`SGLANG_OPT_FP8_WO_A_GEMM` defaults to on (`environ.py:1276`, `EnvBool(True)`), but the FP8 `W_o`/A GEMM it selects cannot be served on XPU:

- `deep_gemm_wrapper/configurer.py:24-25` returns `False` for any runtime that is neither CUDA nor MUSA, so `ENABLE_JIT_DEEPGEMM` is `False` on XPU;
- the `deep_gemm` package is not in the XPU wheel at all.

Observed in an XPU image built from this branch's base commit:

```
$ python -c "import deep_gemm"
ModuleNotFoundError: No module named 'deep_gemm'
$ python -c "from sglang.srt.layers import deep_gemm_wrapper as w; \
             print(w.ENABLE_JIT_DEEPGEMM, w.DEEPGEMM_SCALE_UE8M0)"
False False
```

Nothing turned the flag off, though. The compatibility handling in `ServerArgs` ran under `if is_cuda() and envs.SGLANG_OPT_FP8_WO_A_GEMM.get():`, so on Intel GPUs the default survived startup and the failure surfaced later. Where it lands depends on the checkpoint:

| `wo_a` dtype in the checkpoint | where it fails |
| --- | --- |
| already fp8 — e.g. DeepSeek-V4-Flash-0731, whose `wo_a` tensors read `F8_E4M3` in the safetensors header | weights load and `post_load_weights` succeeds, then the **first forward** raises `ModuleNotFoundError: No module named 'deep_gemm'` at the unconditional `import deep_gemm` in `deepseek_v4.py:1339-1340` |
| anything else | **weight loading** aborts before that, `deepseek_v4.py:2958`: `ValueError: SGLANG_OPT_FP8_WO_A_GEMM is enabled but <name> has dtype torch.bfloat16, expected torch.float8_e4m3fn. ... rerun with SGLANG_OPT_FP8_WO_A_GEMM=0.` |

The first row is the common case. It was observed on 2026-09-03 on eight Intel Arc Pro B70, TP8, DeepSeek-V4-Flash, on an image built from source at this branch's base commit with no environment overrides: `ModuleNotFoundError: No module named 'deep_gemm'` on all eight schedulers. Serving on XPU therefore requires the operator to know to put `SGLANG_OPT_FP8_WO_A_GEMM=0` on the launch line — that manual step is the only thing between a default configuration and a failed start.

Verified the fix the same way: relaunched with no `SGLANG_OPT_FP8_WO_A_GEMM` override in the environment at all — the server reached ready in 90 seconds, where the unfixed build failed as above.

Why it survived: the guard was written from the CUDA side, where the answer genuinely varies by SM, and no lane exercises it on XPU. Grepping the variable across the tree finds references in `environ.py`, `server_args.py` and `deepseek_v4.py` only — no XPU arm anywhere.

## Modifications

Extract the handling into `_handle_fp8_wo_a_gemm_compatibility()` and give XPU an arm that disables the flag up front, warning only when the operator opted in explicitly (`envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set()`), so a default launch stays quiet. Deciding it locally also avoids importing the DeepGEMM wrapper on a runtime where its answer is a known constant.

What deliberately did not change:

- the CUDA arm's `DEEPGEMM_SCALE_UE8M0` / sm90-opt-in logic is moved verbatim;
- every other runtime hits `else: return` and keeps whatever it had, so CPU, ROCm, NPU and MUSA resolve the flag identically before and after;
- the early `return` when the flag is already off runs before any platform probe, so nothing is imported or queried in that case;
- the `ValueError` in `deepseek_v4.py` is untouched — it still fires for anyone who forces the flag on with an unsupported checkpoint.

Blast radius: XPU only. The observable change there is that a default launch no longer fails.

**Alternative considered.** Gating on `deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM` rather than on `is_xpu()` would cover every DeepGEMM-less runtime in one branch, and it is feasible — the wrapper imports cleanly on XPU, as the output above shows. It is not what this PR does, because it would also change the resolved value of the flag on ROCm, NPU and CPU, and this change has no way to test those. Happy to switch to the device-agnostic form if that is preferred.

## Accuracy Tests

No model output changes. On XPU the arm turns off a path that has no XPU kernel and whose Python module is absent; with the flag off, `deepseek_v4.py:2904` routes the fp8 `wo_a` weights through `_dequant_fp8_wo_a_streaming`, which is exactly the path XPU already reached via the manual `=0`. The CUDA decision logic is moved without edit.

Five unit tests added to `test/registered/unit/server_args/test_server_args.py`, registered CPU-only (`base-a-test-cpu`, no accelerator required):

| test | asserts |
| --- | --- |
| `test_explicit_xpu_setting_is_disabled_with_warning` | an explicit opt-in on XPU is disabled and warns |
| `test_implicit_xpu_default_is_disabled_without_warning` | the default is disabled silently |
| `test_other_runtimes_are_left_untouched` | a runtime that is neither CUDA nor XPU keeps its setting, with no warning |
| `test_cuda_path_still_disables_when_deepgemm_is_unsupported` | the pre-existing SM-based CUDA disable still fires (`detected sm80`) |
| `test_disabled_flag_short_circuits_before_any_probe` | `is_cuda` is never called when the flag is already off |

Observed:

```
$ python -m pytest test/registered/unit/server_args/test_server_args.py -k Fp8WoAGemm -q
5 passed, 125 deselected, 20 warnings in 8.57s
```

Mutation check — same command, two one-line reversions applied in isolation:

| mutation | result |
| --- | --- |
| XPU arm made unreachable (`elif is_xpu():` → `elif False:`), i.e. the pre-change behaviour for XPU | `2 failed, 3 passed` — both XPU tests |
| the early `return` for an already-disabled flag removed | `1 failed, 4 passed` — the short-circuit test |

`test_other_runtimes_are_left_untouched` passes under both mutations by design: it pins the scope of the change rather than the change itself.

## Speed Tests and Profiling

This PR makes no speed claim, and none is offered. It resolves one boolean once at startup. On XPU that boolean was already being forced to `0` on every launch, so the served configuration is unchanged — what changes is that it no longer has to be set by hand.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Two boxes left unchecked on purpose: no user-facing documentation describes this variable's per-runtime support, so there is nothing to update; and a speed benchmark would have nothing to measure, per the section above. Accuracy is addressed above rather than by a benchmark run.

## Notes for reviewers

- CI has not run: no `run-ci` label is applied yet, and applying it needs someone in `.github/CI_PERMISSIONS.json`. The new tests are registered CPU-only, so `base-a-test-cpu` is the lane that would exercise them.
- This is the first of several small, independent Intel GPU changes split out of a larger DeepSeek-V4 XPU enablement branch. It stands alone and depends on none of the others.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34318557552](https://github.com/sgl-project/sglang/actions/runs/34318557552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34318557571](https://github.com/sgl-project/sglang/actions/runs/34318557571)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
