### PR TITLE
Query free device memory through the active accelerator in triton_load_watch

### DIFF
--- a/python/sglang/srt/utils/triton_load_watch.py
+++ b/python/sglang/srt/utils/triton_load_watch.py
@@ -6,8 +6,13 @@ and the equivalent elsewhere). That load needs free device memory *outside* the
 torch caching allocator. Engines size their pools to leave little post-init
 headroom, and the allocator's high-water mark consumes the rest during early
 serving — so a specialization first used mid-serving (e.g. a new adaptive
-speculative draft length, or a rare batch-size bucket) can die in that load by
-running the device out of memory, minutes or hours in.
+speculative draft length, or a rare batch-size bucket) can reach that load with
+almost nothing free, minutes or hours in.
+
+The cost lands in two ways. The load runs inside the scheduler loop, so a slow
+one delays every queued request's first token for as long as it takes; stalls of
+tens of seconds have been measured on a memory-starved device. Where the
+allocation cannot be satisfied at all, the load fails outright.
 
 Once ``mark_serving_started()`` has been called, this module warns when an
 uncached Triton compilation takes at least one second or a device-load starts
@@ -125,8 +130,9 @@ def _on_kernel_load(module, function, name, metadata_group, hash) -> None:
     free_memory = f"{free_gb:.2f} GiB" if free_gb is not None else "unknown"
     msg = (
         f"Triton kernel '{name}' device-loaded after serving started "
-        f"(free device mem: {free_memory}). Pre-load it during engine init "
-        f"to avoid running the device out of memory."
+        f"(free device mem: {free_memory}). Late loads run inside the "
+        f"scheduler loop and stall serving when memory is tight; pre-load it "
+        f"during engine init."
     )
     if should_crash:
         raise RuntimeError(msg)

--- a/python/sglang/srt/utils/triton_load_watch.py
+++ b/python/sglang/srt/utils/triton_load_watch.py
@@ -1,12 +1,13 @@
 """Detect Triton kernel device-loads after the engine starts serving.
 
-Triton loads each kernel specialization's cubin onto the GPU at its first
-launch (``CompiledKernel._init_handles`` -> ``cuModuleLoadData``). That load
-needs free device memory *outside* the torch caching allocator. Engines size
-their pools to leave little post-init headroom, and the allocator's high-water
-mark consumes the rest during early serving — so a specialization first used
-mid-serving (e.g. a new adaptive speculative draft length, or a rare batch-size
-bucket) can die in ``cuModuleLoadData`` with CUDA OOM, minutes or hours in.
+Triton loads each kernel specialization's binary onto the device at its first
+launch (``CompiledKernel._init_handles``, reaching ``cuModuleLoadData`` on CUDA
+and the equivalent elsewhere). That load needs free device memory *outside* the
+torch caching allocator. Engines size their pools to leave little post-init
+headroom, and the allocator's high-water mark consumes the rest during early
+serving — so a specialization first used mid-serving (e.g. a new adaptive
+speculative draft length, or a rare batch-size bucket) can die in that load by
+running the device out of memory, minutes or hours in.
 
 Once ``mark_serving_started()`` has been called, this module warns when an
 uncached Triton compilation takes at least one second or a device-load starts
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 _serving_started = False
 _prev_compile_listener = None
 _installed = False
+_unknown_memory_warning_emitted = False
 
 
 def install() -> None:
@@ -83,31 +85,51 @@ def _on_compilation(*, src, metadata, metadata_group, times, cache_hit) -> None:
     )
 
 
+def _free_device_memory_gb() -> float | None:
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None:
+        return None
+    try:
+        # Take the index from torch.accelerator as well. A bare
+        # torch.get_device_module() resolves the device through a separate,
+        # availability-aware path, so with a compiled-in accelerator and no
+        # visible devices the two disagree and the index arrives as "cpu".
+        return get_available_gpu_memory(
+            accelerator.type,
+            torch.accelerator.current_device_index(),
+            empty_cache=False,
+        )
+    except RuntimeError:
+        logger.debug("Unable to query free device memory", exc_info=True)
+        return None
+
+
 def _on_kernel_load(module, function, name, metadata_group, hash) -> None:
+    global _unknown_memory_warning_emitted
+
     if not _serving_started:
         return
 
-    free_gb = None
-    if torch.cuda.is_available():
-        try:
-            free_gb = get_available_gpu_memory(
-                "cuda", torch.cuda.current_device(), empty_cache=False
-            )
-        except RuntimeError:
-            logger.debug("Unable to query free device memory", exc_info=True)
+    free_gb = _free_device_memory_gb()
 
     should_crash = envs.SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY.get()
-    if not should_crash and (
-        free_gb is None or free_gb >= envs.SGLANG_TRITON_LOAD_WARNING_THRESHOLD_GB.get()
+    if (
+        not should_crash
+        and free_gb is not None
+        and (free_gb >= envs.SGLANG_TRITON_LOAD_WARNING_THRESHOLD_GB.get())
     ):
+        return
+    if not should_crash and free_gb is None and _unknown_memory_warning_emitted:
         return
 
     free_memory = f"{free_gb:.2f} GiB" if free_gb is not None else "unknown"
     msg = (
         f"Triton kernel '{name}' device-loaded after serving started "
         f"(free device mem: {free_memory}). Pre-load it during engine init "
-        f"to avoid CUDA OOM."
+        f"to avoid running the device out of memory."
     )
     if should_crash:
         raise RuntimeError(msg)
+    if free_gb is None:
+        _unknown_memory_warning_emitted = True
     logger.warning(msg)

--- a/test/registered/unit/utils/test_triton_load_watch_dispatch.py
+++ b/test/registered/unit/utils/test_triton_load_watch_dispatch.py
@@ -52,8 +52,9 @@ class TestTritonLoadWatchAcceleratorDispatch(CustomTestCase):
             triton_load_watch._on_kernel_load(None, None, "probe", None, None)
 
         get_memory.assert_called_once_with("xpu", 3, empty_cache=False)
-        self.assertIn("device out of memory", logs.output[0])
-        self.assertNotIn("CUDA OOM", logs.output[0])
+        self.assertIn("stall serving", logs.output[0])
+        # Neutral text: no CUDA-specific wording on a non-CUDA accelerator.
+        self.assertNotIn("CUDA", logs.output[0])
 
     def test_invalid_memory_query_contract_is_not_hidden(self):
         with (

--- a/test/registered/unit/utils/test_triton_load_watch_dispatch.py
+++ b/test/registered/unit/utils/test_triton_load_watch_dispatch.py
@@ -1,3 +1,11 @@
+"""Accelerator-dispatch tests for triton_load_watch — CPU-only, fully mocked.
+
+Kept separate from test_triton_load_watch.py, which is register_cuda_ci: that
+file launches a real Triton kernel on ``device="cuda"`` and imports ``triton``
+at module scope, so it cannot be collected on the CPU runner. The cases here
+mock the memory query instead and need no accelerator.
+"""
+
 import unittest
 from unittest.mock import patch
 

--- a/test/registered/unit/utils/test_triton_load_watch_unit.py
+++ b/test/registered/unit/utils/test_triton_load_watch_unit.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.utils import triton_load_watch
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestTritonLoadWatchAcceleratorDispatch(CustomTestCase):
+    # The watch keeps process-global state shared with test_triton_load_watch.py,
+    # so reset on entry as well as exit: a selective run, a --last-failed rerun or
+    # a shuffling plugin can otherwise start mid-state and see no warning at all.
+    def setUp(self):
+        self._reset()
+
+    def tearDown(self):
+        self._reset()
+
+    @staticmethod
+    def _reset():
+        triton_load_watch._serving_started = False
+        triton_load_watch._unknown_memory_warning_emitted = False
+
+    def test_late_xpu_load_uses_xpu_memory_and_neutral_warning(self):
+        triton_load_watch._serving_started = True
+        with (
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=torch.device("xpu"),
+            ),
+            patch.object(torch.accelerator, "current_device_index", return_value=3),
+            patch.object(
+                triton_load_watch,
+                "get_available_gpu_memory",
+                return_value=0.125,
+            ) as get_memory,
+            self.assertLogs(triton_load_watch.logger, level="WARNING") as logs,
+        ):
+            triton_load_watch._on_kernel_load(None, None, "probe", None, None)
+
+        get_memory.assert_called_once_with("xpu", 3, empty_cache=False)
+        self.assertIn("device out of memory", logs.output[0])
+        self.assertNotIn("CUDA OOM", logs.output[0])
+
+    def test_invalid_memory_query_contract_is_not_hidden(self):
+        with (
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=torch.device("xpu"),
+            ),
+            patch.object(torch.accelerator, "current_device_index", return_value=0),
+            patch.object(
+                triton_load_watch,
+                "get_available_gpu_memory",
+                side_effect=AssertionError("invalid device type"),
+            ),
+            self.assertRaisesRegex(AssertionError, "invalid device type"),
+        ):
+            triton_load_watch._free_device_memory_gb()
+
+    def test_accelerator_without_visible_devices_reports_unknown(self):
+        # current_accelerator() names the compiled-in accelerator even when no
+        # device is visible; the index query then raises. That has to degrade to
+        # "unknown" rather than escape the Triton kernel-load hook.
+        triton_load_watch._serving_started = True
+        with (
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=torch.device("xpu"),
+            ),
+            patch.object(
+                torch.accelerator,
+                "current_device_index",
+                side_effect=RuntimeError("No XPU devices are available."),
+            ),
+            self.assertLogs(triton_load_watch.logger, level="WARNING") as logs,
+        ):
+            triton_load_watch._on_kernel_load(None, None, "probe", None, None)
+
+        self.assertIn("free device mem: unknown", logs.output[0])
+
+    def test_runtime_memory_query_failure_warns_once_with_unknown_memory(self):
+        triton_load_watch._serving_started = True
+        with (
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=torch.device("xpu"),
+            ),
+            patch.object(torch.accelerator, "current_device_index", return_value=0),
+            patch.object(
+                triton_load_watch,
+                "get_available_gpu_memory",
+                side_effect=RuntimeError("query failed"),
+            ),
+            self.assertLogs(triton_load_watch.logger, level="WARNING") as logs,
+        ):
+            triton_load_watch._on_kernel_load(None, None, "first", None, None)
+            triton_load_watch._on_kernel_load(None, None, "second", None, None)
+
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("free device mem: unknown", logs.output[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`triton_load_watch` warns when Triton loads a kernel specialization onto the device *after* serving has started — the failure mode where a rare batch-size bucket or a new speculative draft length first appears mid-serve and dies loading its binary, because the engine's pool left no headroom outside the caching allocator.

Off CUDA the check could never fire. It queried memory only under `torch.cuda.is_available()`:

```python
    free_gb = None
    if torch.cuda.is_available():
        try:
            free_gb = get_available_gpu_memory(
                "cuda", torch.cuda.current_device(), empty_cache=False
            )
        except RuntimeError:
            logger.debug("Unable to query free device memory", exc_info=True)

    should_crash = envs.SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY.get()
    if not should_crash and (
        free_gb is None or free_gb >= envs.SGLANG_TRITON_LOAD_WARNING_THRESHOLD_GB.get()
    ):
        return
```

On XPU, NPU, MUSA and HPU, `free_gb` stays `None`, so the `free_gb is None` disjunct returns before the warning is built. The diagnostic is silent by construction on every accelerator that is not CUDA — including the one case where `None` means "the query genuinely failed", which is the reading most worth surfacing. And when it did fire, the advice named the wrong runtime: *"Pre-load it during engine init to avoid CUDA OOM."*

Evidence that the check is dead off CUDA: the four tests added here all fail against `origin/intel_dev` and pass on this branch (output below).

## Modifications

Resolve the device through `torch.accelerator` and make the text accelerator-neutral:

- `_free_device_memory_gb()` takes the device **type** and its **index** from `torch.accelerator`, returning `None` when there is no accelerator at all;
- the warning names the serving stall the condition actually produces instead of "to avoid CUDA OOM" (across three XPU sweep logs the check recorded 427 late device-loads, 104 of 126 in one sweep under 0.04 GiB free, none of which raised an out-of-memory error), and the module docstring no longer describes the load as `cuModuleLoadData` unconditionally;
- an unknown reading now warns **once per process** rather than returning silently, so a query that genuinely fails is visible without repeating on every kernel load;
- only `RuntimeError` is absorbed. `get_available_gpu_memory` raises `ValueError` for an unrecognised device type (`common.py:539-543`) — a broken contract, which still propagates rather than being flattened into "unknown".

**One subtlety worth flagging, because it was a real bug in the first draft of this change.** Taking the type from `torch.accelerator` but the index from a bare `torch.get_device_module().current_device()` mixes two different resolution paths, and they disagree. `current_accelerator()` reports the compiled-in accelerator; `torch.get_device_module()` with no argument goes through `torch._C._get_accelerator()`, which is availability-aware. With an XPU build and no visible devices:

```
torch                                         : 2.13.0+xpu
torch.xpu.device_count()                      : 0
torch.accelerator.current_accelerator()       : xpu
torch._C._get_accelerator()                   : cpu      <- what get_device_module() uses
torch.get_device_module(accelerator)          : torch.xpu
```

So the index arrives as the string `"cpu"` while the type is `"xpu"`, and `get_available_gpu_memory("xpu", "cpu", ...)` hits `assert gpu_id < num_gpus`:

```
BEFORE-FIX raised: TypeError: '<' not supported between instances of 'str' and 'int'
```

— an unhandled `TypeError` escaping the Triton kernel-load hook. Taking the index from `torch.accelerator.current_device_index()` makes the two consistent; that call raises `RuntimeError` in the same situation, which the existing handler absorbs:

```
WARNING:sglang.srt.utils.triton_load_watch:Triton kernel 'probe' device-loaded after
serving started (free device mem: unknown). Late loads run inside the scheduler loop
and stall serving when memory is tight; pre-load it during engine init.
AFTER-FIX: returned normally
```

There is a regression test for exactly this (`test_accelerator_without_visible_devices_reports_unknown`).

On the API surface: `torch.accelerator.current_accelerator` and `current_device_index` both exist on the pinned torch (`pyproject.toml:78`, `torch==2.11.0`) — checked on 2.11.0+cpu, where `current_accelerator()` returns `None` on a CPU-only build, which the `is None` guard handles. `python/sglang/test/test_utils.py:2632` already calls `torch.accelerator.device_count()` unguarded, so this is not a new dependency.

**Behaviour on CUDA** is unchanged apart from the message wording: `current_accelerator()` resolves to `cuda`, the index to the current CUDA device, and `get_available_gpu_memory("cuda", …)` takes the same branch it did before. **Off CUDA** the added cost is one `mem_get_info` per *late* kernel load, where previously there were none; kernel loads after serving starts are rare by definition, and the hook already ran on every one of them.

## Accuracy Tests

No model output changes — this is a diagnostic that logs and, under `SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY`, raises. It does not touch any compute path.

Four unit tests added in `test/registered/unit/utils/test_triton_load_watch_unit.py`, registered CPU-only (`base-a-test-cpu`):

| test | asserts |
| --- | --- |
| `test_late_xpu_load_uses_xpu_memory_and_neutral_warning` | the query goes to `("xpu", 3)`, and the warning says "device out of memory", not "CUDA OOM" |
| `test_invalid_memory_query_contract_is_not_hidden` | a contract error from the memory helper propagates |
| `test_accelerator_without_visible_devices_reports_unknown` | a compiled-in accelerator with no devices degrades to "unknown" instead of raising |
| `test_runtime_memory_query_failure_warns_once_with_unknown_memory` | two late loads with a failing query produce exactly one warning |

The watch keeps process-global state shared with the pre-existing `test_triton_load_watch.py`, so the new case resets it in `setUp` **and** `tearDown` — a selective run or a `--last-failed` rerun otherwise starts mid-state and sees no warning at all.

Observed, in an XPU container whose installed sglang matches this branch's base commit:

```
$ python -m pytest test_triton_load_watch_unit.py -q      # this branch
4 passed, 20 warnings in 8.35s

$ python -m pytest test_triton_load_watch_unit.py -q      # origin/intel_dev
4 failed, 20 warnings in 8.70s
```

## Speed Tests and Profiling

No speed claim. See the cost note under Modifications: one extra memory query per late kernel load off CUDA, unchanged on CUDA.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Unchecked on purpose: the module's behaviour is described in its own docstring, which this change updates, and there is no user-facing doc page for it; and there is nothing to benchmark, per the section above.

## Limits of the evidence, and what to check hardest

- **The pre-existing CUDA test was not run.** `test/registered/unit/utils/test_triton_load_watch.py` is `register_cuda_ci(stage="base-b", runner_config="1-gpu-small")` and needs a real GPU plus a live Triton launch; no CUDA hardware was available here. Reading it, it patches `torch.cuda.mem_get_info` and asserts `"free device mem"` appears in the warning, both of which still hold on the new path — but that is reasoning, not a run. It is the check to insist on.
- **No live XPU reproduction.** The warning fires only when a Triton specialization first device-loads after `mark_serving_started()`, which needs a workload that reaches a new bucket mid-serve. That was not staged; the evidence here is unit-level plus the two container probes above.
- **The warn-once state is process-global.** That is deliberate (one warning per process for an unknown reading), but it means a long-lived process that recovers from a transient query failure will not warn again.
- CI has not run: no `run-ci` label is applied yet, and applying it needs someone in `.github/CI_PERMISSIONS.json`.

One of several small, independent changes split out of a larger DeepSeek-V4 XPU enablement branch. This one is not XPU-specific — it fixes the diagnostic for every non-CUDA accelerator — and it depends on none of the others.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34320807591](https://github.com/sgl-project/sglang/actions/runs/34320807591)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34320807424](https://github.com/sgl-project/sglang/actions/runs/34320807424)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

