### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in models_with_ar

### DIFF
--- a/docs/docs/sglang-diffusion/models_with_ar.mdx
+++ b/docs/docs/sglang-diffusion/models_with_ar.mdx
@@ -124,7 +124,7 @@ export HCCL_HOST_SOCKET_PORT_RANGE="23000-23199"
 export HCCL_NPU_SOCKET_PORT_RANGE="23200-23399"
 sglang serve --model-path /path/to/zai-org/GLM-Image/vision_language_encoder/ \
 --tokenizer-path /path/to/zai-org/GLM-Image/processor/ --enable-multimodal \
---cuda-graph-bs 1 --device npu --attention-backend ascend --image-processor-backend pil \
+--cuda-graph-bs-decode 1 --device npu --attention-backend ascend --image-processor-backend pil \
 --tp-size 4 --port ${PORT} --mem-fraction-static 0.4
 ```
 Second terminal with diffusion server:


### PR DESCRIPTION
## Summary
- In the Ascend GLM-Image AR `sglang serve` example in `models_with_ar.mdx`, prefer `--cuda-graph-bs-decode` over the deprecated alias `--cuda-graph-bs`.

## Test plan
- [x] Confirmed in `python/sglang/srt/server_args.py` that `--cuda-graph-bs` is a `DeprecatedAliasStoreAction` for `--cuda-graph-bs-decode`
- [x] Docs-only change; single flag spelling update

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34082139383](https://github.com/sgl-project/sglang/actions/runs/34082139383)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34082139213](https://github.com/sgl-project/sglang/actions/runs/34082139213)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->