### PR TITLE
[Examples] Prefer --cuda-graph-max-bs-decode in speculative playground scripts

### DIFF
--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -188,7 +188,7 @@ def main(args, server_args):
 
         other_args.extend(
             [
-                "--cuda-graph-max-bs",
+                "--cuda-graph-max-bs-decode",
                 batch_size,
                 "--mem-fraction-static",
                 server_args.mem_fraction_static,

--- a/scripts/playground/disaggregation/cli-so.py
+++ b/scripts/playground/disaggregation/cli-so.py
@@ -31,4 +31,4 @@ response = requests.post(
 print(response.json())
 
 
-# python3 -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --trust-remote-code --disaggregation-mode prefill --tp 2 --disaggregation-ib-device mlx5_roce0,mlx5_roce1 --speculative-algorithm EAGLE --speculative-draft-model-path lmsys/sglang-EAGLE-llama2-chat-7B --speculative-num-steps 3 --speculative-eagle-topk 4 --speculative-num-draft-tokens 16 --cuda-graph-max-bs 8 --host 127.0.0.1 --port 8100
+# python3 -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --trust-remote-code --disaggregation-mode prefill --tp 2 --disaggregation-ib-device mlx5_roce0,mlx5_roce1 --speculative-algorithm EAGLE --speculative-draft-model-path lmsys/sglang-EAGLE-llama2-chat-7B --speculative-num-steps 3 --speculative-eagle-topk 4 --speculative-num-draft-tokens 16 --cuda-graph-max-bs-decode 8 --host 127.0.0.1 --port 8100


### PR DESCRIPTION
## Summary
- Prefer `--cuda-graph-max-bs-decode` over the deprecated alias `--cuda-graph-max-bs` in `scripts/playground/bench_speculative.py` (active launch args).
- Update the matching `launch_server` comment in `scripts/playground/disaggregation/cli-so.py`.

`--cuda-graph-max-bs` is registered as a deprecated alias that stores into `cuda_graph_max_bs_decode`; playground scripts should use the current flag name.

## Test plan
- [ ] Confirm `python/sglang/srt/server_args.py` still documents `--cuda-graph-max-bs` as deprecated alias of `--cuda-graph-max-bs-decode`
- [ ] Smoke: `python scripts/playground/bench_speculative.py --help` (or dry-run arg construction) shows `--cuda-graph-max-bs-decode`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34082151479](https://github.com/sgl-project/sglang/actions/runs/34082151479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34082151408](https://github.com/sgl-project/sglang/actions/runs/34082151408)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->