### PR TITLE
[Intel GPU] Use the fused bf16 x bf16 -> fp32 GEMM on XPU

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/gemm.py
+++ b/python/sglang/kernels/ops/attention/dsv4/gemm.py
@@ -112,8 +112,42 @@ def hpc_bf16xfp32_gemm_enabled() -> bool:
     return _linear_bf16_fp32_algo == "hpc" and _hpc_gemm_bf16xfp32_available()
 
 
+@functools.cache
+def _mm_out_dtype_supported(device_type: str) -> bool:
+    """Whether ``torch.mm(bf16, bf16, out_dtype=fp32)`` is registered here.
+
+    ``aten::mm.dtype`` is a per-backend overload, so naming a device is not the
+    same as having the kernel, and asking for it without one raises rather than
+    falling back to the plain overload. Which backends carry it is a property of
+    the torch build, so probe once and let a build without it keep the working
+    fp32 fallback.
+
+    Resolving this lazily is safe even though the caller sits in the forward
+    pass. Every decode graph backend runs two warmup forwards before capture,
+    so the probe and its one small allocation are paid outside the graph, and
+    the answer depends only on the torch build, so every rank agrees.
+    """
+    if device_type == "cuda":
+        return True
+    if device_type != "xpu":
+        return False
+    try:
+        probe = torch.ones(1, 1, dtype=torch.bfloat16, device=device_type)
+        return torch.mm(probe, probe, out_dtype=torch.float32).dtype == torch.float32
+    except (RuntimeError, NotImplementedError, TypeError):
+        return False
+
+
 def _linear_bf16_fp32_cublas(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-    if x.is_cuda and x.dtype == torch.bfloat16 and y.dtype == torch.bfloat16:
+    # Without the fused branch the fallback re-materializes the bf16 weight in
+    # fp32 on every call. For the DSv4 compressor wkv_gate (bf16 2048x4096 in
+    # CSA layers) that is a 32 MiB fp32 copy plus a 4x larger weight read, per
+    # layer, per decode step.
+    if (
+        x.dtype == torch.bfloat16
+        and y.dtype == torch.bfloat16
+        and _mm_out_dtype_supported(x.device.type)
+    ):
         return torch.mm(x, y.t(), out_dtype=torch.float32)
     return torch.mm(x.float(), y.float().t())
 

--- a/test/registered/gemm/test_linear_bf16_fp32_dispatch.py
+++ b/test/registered/gemm/test_linear_bf16_fp32_dispatch.py
@@ -1,0 +1,101 @@
+"""Dispatch tests for the bf16 x bf16 -> fp32 GEMM helper — no server, no model.
+
+Covers sglang.kernels.ops.attention.dsv4.gemm's choice between the fused
+``torch.mm(..., out_dtype=torch.float32)`` call and the fp32-materializing
+fallback. ``aten::mm.dtype`` is a per-backend overload, so the choice has to be
+probed rather than assumed from the device name; these run on CPU, where the
+overload is deliberately absent.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import gemm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestLinearBf16Fp32Dispatch(CustomTestCase):
+    def setUp(self):
+        # functools.cache is process-global; clear on the way in and out so
+        # neither ordering nor a selective run can see a stale answer.
+        gemm._mm_out_dtype_supported.cache_clear()
+
+    def tearDown(self):
+        gemm._mm_out_dtype_supported.cache_clear()
+
+    def test_cpu_bf16_falls_back_and_matches_the_fp32_reference(self):
+        # Regression guard for the device gate: CPU has no aten::mm.dtype
+        # kernel, so treating it as supported would raise instead of returning
+        # fp32. This is the case an XPU-only test can never reach.
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        y = torch.randn(6, 8, dtype=torch.bfloat16)
+
+        out = gemm._linear_bf16_fp32_cublas(x, y)
+
+        self.assertEqual(out.dtype, torch.float32)
+        torch.testing.assert_close(out, torch.mm(x.float(), y.float().t()))
+
+    def test_probe_declines_backends_without_the_overload(self):
+        self.assertFalse(gemm._mm_out_dtype_supported("cpu"))
+        self.assertFalse(gemm._mm_out_dtype_supported("privateuseone"))
+        self.assertTrue(gemm._mm_out_dtype_supported("cuda"))
+
+    def test_probe_declines_when_the_fused_call_raises(self):
+        # The exact failure a wheel without the XPU kernel produces.
+        stub = torch.ones(1, 1, dtype=torch.bfloat16)
+        with patch.object(torch, "ones", return_value=stub), patch.object(
+            torch, "mm", side_effect=NotImplementedError("no kernel for this backend")
+        ):
+            self.assertFalse(gemm._mm_out_dtype_supported("xpu"))
+
+    def test_probe_declines_when_the_keyword_is_unknown(self):
+        stub = torch.ones(1, 1, dtype=torch.bfloat16)
+        with patch.object(torch, "ones", return_value=stub), patch.object(
+            torch, "mm", side_effect=TypeError("unexpected keyword argument")
+        ):
+            self.assertFalse(gemm._mm_out_dtype_supported("xpu"))
+
+    def test_probe_runs_once_and_caches_its_answer(self):
+        stub = torch.ones(1, 1, dtype=torch.bfloat16)
+        with patch.object(torch, "ones", return_value=stub) as allocate, patch.object(
+            torch, "mm", side_effect=NotImplementedError("no kernel")
+        ):
+            self.assertFalse(gemm._mm_out_dtype_supported("xpu"))
+            self.assertFalse(gemm._mm_out_dtype_supported("xpu"))
+
+        self.assertEqual(allocate.call_count, 1)
+
+    def test_fused_path_is_taken_when_the_probe_accepts(self):
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        y = torch.randn(6, 8, dtype=torch.bfloat16)
+        expected = torch.mm(x.float(), y.float().t())
+
+        with patch.object(
+            gemm, "_mm_out_dtype_supported", return_value=True
+        ), patch.object(torch, "mm", return_value=expected) as fused:
+            out = gemm._linear_bf16_fp32_cublas(x, y)
+
+        self.assertIs(out, expected)
+        self.assertEqual(fused.call_args.kwargs["out_dtype"], torch.float32)
+
+    def test_mixed_dtypes_use_the_fallback_without_probing(self):
+        # bf16 activations against an fp32 weight must not reach the fused
+        # branch, and must not pay for the probe either.
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        y = torch.randn(6, 8, dtype=torch.float32)
+
+        with patch.object(gemm, "_mm_out_dtype_supported") as probe:
+            out = gemm._linear_bf16_fp32_cublas(x, y)
+
+        probe.assert_not_called()
+        self.assertEqual(out.dtype, torch.float32)
+        torch.testing.assert_close(out, torch.mm(x.float(), y.float().t()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/xpu/test_dsv4_bf16_fp32_gemm.py
+++ b/test/registered/xpu/test_dsv4_bf16_fp32_gemm.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.gemm import (
+    _linear_bf16_fp32_cublas,
+)
+from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_xpu_ci(est_time=10, suite="stage-b-test-1-gpu-xpu")
+
+
+class TestDsv4Bf16Fp32GemmXpu(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.xpu.is_available():
+            raise unittest.SkipTest("XPU required")
+        cls.device = torch.device("xpu")
+
+    def test_matches_fp32_reference_without_materializing_inputs(self):
+        torch.manual_seed(0)
+        x = torch.randn(1, 256, device=self.device, dtype=torch.bfloat16)
+        weight = torch.randn(128, 256, device=self.device, dtype=torch.bfloat16)
+        original_mm = torch.mm
+        with patch.object(torch, "mm", wraps=original_mm) as mm:
+            actual = _linear_bf16_fp32_cublas(x, weight)
+        expected = original_mm(x.float(), weight.float().t())
+
+        self.assertEqual(actual.dtype, torch.float32)
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+        self.assertEqual(len(mm.call_args_list), 1)
+        self.assertIs(mm.call_args.kwargs["out_dtype"], torch.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`_linear_bf16_fp32_cublas` in `python/sglang/kernels/ops/attention/dsv4/gemm.py` picked the fused `torch.mm(..., out_dtype=torch.float32)` path only when the activation was on CUDA:

```python
def _linear_bf16_fp32_cublas(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
    if x.is_cuda and x.dtype == torch.bfloat16 and y.dtype == torch.bfloat16:
        return torch.mm(x, y.t(), out_dtype=torch.float32)
    return torch.mm(x.float(), y.float().t())
```

On Intel GPUs `x.is_cuda` is false, so every call took the fallback — which re-materializes **both** operands in fp32 before multiplying. One of those operands is a weight. The helper has three callers across three model families:

| call site | operand |
| --- | --- |
| `srt/layers/attention/dsv4/compressor.py:425` | `self.wkv_gate.weight` (replicated bf16) |
| `srt/models/deepseek_v2.py:520,546` | MoE gate `self.weight` |
| `srt/models/longcat_flash.py:237` | gate weight |

The weight is replicated and never changes, so the fp32 copy was rebuilt identically on every token. Re-profiling with input shapes and dtypes recorded — rather than by kernel name — counted roughly fifty-six such conversions per decode step, 4.47 ms of a 28.33 ms step. Labelling launches by kernel name alone had filed that work under attention preparation for two rounds.

## Modifications

Select the fused path by **capability** rather than by device name: a cached probe, `_mm_out_dtype_supported(device_type)`. CUDA short-circuits to `True` without allocating; XPU actually tries the call once; everything else declines.

### Why a probe rather than adding `"xpu"` to the allowlist

`aten::mm.dtype` is a per-backend dispatcher overload, so naming a device is not the same as having the kernel, and asking for it without one **raises** rather than falling back to the plain `mm`. Both halves are observable. On the version this project pins (`python/pyproject.toml:78`, `torch==2.11.0`) the op has a schema and no backend kernel at all:

```
$ python -c "import torch; print(torch.__version__); print(torch._C._dispatch_dump('aten::mm.dtype'))"
2.11.0+cpu
name: aten::mm.dtype
schema: aten::mm.dtype(Tensor self, Tensor mat2, ScalarType out_dtype) -> Tensor
Tracer:          registered at .../TraceType_3.cpp:15245
Meta:            registered at .../torch/_meta_registrations.py:53
Autograd[alias]: registered at .../VariableType_3.cpp:20155
```

— no `CPU`, no `CUDA` entry on this wheel. Calling it is a hard error, not a degradation:

```
$ python -c "import torch; a=torch.ones(2,2,dtype=torch.bfloat16); torch.mm(a,a,out_dtype=torch.float32)"
NotImplementedError: Could not run 'aten::mm.dtype' with arguments from the 'CPU' backend.
```

Whereas the XPU wheel used for the measurements below does carry it:

```
$ python -c "import torch; print(torch.__version__); print(torch._C._dispatch_dump('aten::mm.dtype'))"
2.13.0+xpu
...
XPU: registered at .../build/aten/src/ATen/RegisterXPU_0.cpp:942
```

So which backends have the kernel is a property of the torch build. A hard-coded `"xpu"` in the allowlist would turn a build without it into a `NotImplementedError` inside the forward pass; the probe turns it into the working fp32 fallback.

### Why resolving it lazily is acceptable

The probe runs on first use, which is inside the forward pass — something this file's other capability flags deliberately avoid. The reasons to accept it here:

- The helper has three callers across three model families. An init-time declaration needs a call site in each, and a **missed one is a silent slowdown rather than an error** — the worse failure mode, and exactly the bug being fixed.
- `functools.cache` means one probe per process per device type; the allocation is a single `1x1` bf16 tensor.
- Every decode graph backend runs two warmup forwards before capture, so the probe and its allocation land outside the graph:
  - `srt/model_executor/runner_backend/full_cuda_graph_backend.py:87-89` — `# Two warmups so kernels are loaded and one-time setup is paid before capture.` / `for _ in range(2):`
  - `srt/model_executor/runner_backend/breakable_cuda_graph_backend.py:115` — `for _ in range(2):`
  - `srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py:237` — `for _ in range(2):`
- The answer depends only on the torch build, so all ranks agree without communication.

**Behaviour on CUDA is unchanged.** `_mm_out_dtype_supported("cuda")` returns `True` on the first branch, before any allocation, so CUDA takes the same fused path it did before. Mixed dtypes short-circuit ahead of the probe, so an fp32 weight never pays for it.

## Accuracy Tests

`test/registered/gemm/test_linear_bf16_fp32_dispatch.py` (new, 7 tests, `register_cpu_ci(est_time=1, suite="base-a-test-cpu")`) covers the case the existing XPU test structurally cannot reach — a backend without the kernel:

| test | asserts |
| --- | --- |
| `test_cpu_bf16_falls_back_and_matches_the_fp32_reference` | bf16 on CPU takes the fallback and matches the fp32 reference |
| `test_probe_declines_backends_without_the_overload` | `cpu` and `privateuseone` decline; `cuda` accepts |
| `test_probe_declines_when_the_fused_call_raises` | `NotImplementedError` from the fused call is absorbed |
| `test_probe_declines_when_the_keyword_is_unknown` | `TypeError` on an unknown kwarg is absorbed |
| `test_probe_runs_once_and_caches_its_answer` | exactly one probe allocation for two queries |
| `test_fused_path_is_taken_when_the_probe_accepts` | the fused branch passes `out_dtype=torch.float32` |
| `test_mixed_dtypes_use_the_fallback_without_probing` | bf16 x fp32 does not reach the probe at all |

`functools.cache` is process-global, so `cache_clear()` runs in **both** `setUp` and `tearDown` — otherwise ordering or a selective run can see a stale answer.

`test/registered/xpu/test_dsv4_bf16_fp32_gemm.py` (new, `register_xpu_ci(est_time=10, suite="stage-b-test-1-gpu-xpu")`) asserts on real hardware that the result matches the fp32 reference and that `torch.mm` is called exactly once with `out_dtype=torch.float32` — i.e. no operand was materialized.

### Observed

Run in an XPU container whose installed `gemm.py` was first confirmed byte-identical to this PR's base (`sha256[:16] = 7d08628d9f298c40` on both sides), then bind-mounted per arm so the file under test is the only difference:

```
gemm.py       (this PR)        7 passed
gemm_base.py  (origin/intel_dev)  7 failed
gemm_m1.py    (mutant 1)       1 failed, 6 passed
gemm_m2.py    (mutant 2)       5 failed, 2 passed
```

Two notes so the numbers are not read as stronger than they are:

- **`7 failed` on base is a weak signal on its own.** `setUp` calls `gemm._mm_out_dtype_supported.cache_clear()`, and that symbol does not exist on base, so the whole class errors in setup. It shows the tests are new, not that each behaviour regressed. The mutants are the real evidence.
- **Mutant 1 turns exactly one test red**, not the suite. Reverting only the call-site gate to `if x.is_cuda and ...` while leaving the probe in place fails `test_fused_path_is_taken_when_the_probe_accepts` (the fused branch is never entered, so `out_dtype` is absent from the recorded kwargs). The other six pass by design — on CPU the correct answer is the fallback either way. That is a thin margin and worth knowing.
- **Mutant 2 is the one that matters**: replacing the probe body with `return device_type in ("cuda", "xpu", "cpu")` — trusting the device name, which is what an allowlist does — fails five of seven, including `test_cpu_bf16_falls_back_and_matches_the_fp32_reference` with the `NotImplementedError` quoted above.

Numerical accuracy: in the campaign profile that found this, output was exact to within `7.6e-5` against an fp32 reference. The fused overload accumulates in fp32 and writes fp32, so the difference from the fallback is the absence of an intermediate widening, not a change in accumulation width.

## Speed Tests and Profiling

Eight Intel Arc Pro B70 at TP8, DeepSeek-V4-Flash-0731, 1024 tokens in / 1024 out at concurrency 1, six requests plus one warmup, `ignore_eos` so output length holds. **Three consecutive runs per arm, one server launch per arm.** The full source tree was staged onto the host and verified byte-for-byte against the local copy (3,135 Python files, identical manifest hash), then bind-mounted over the installed package in one image. The control arm additionally bind-mounted the pre-change `gemm.py` in place of this PR's, which is the only source difference between the two arms.

One nominal difference worth stating rather than glossing: the control arm set `SGLANG_OPT_FP8_WO_A_GEMM=0` explicitly, while the PR arm left it unset and relied on the companion XPU change to disable it. Both arms therefore ran with that flag off, so the comparison isolates `gemm.py` — but the launch commands were not character-identical, and the equivalence rests on that other change behaving as claimed rather than on the two invocations matching.

| arm | `gemm.py` | tok/s/user | range of 3 | spread | ITL |
| --- | --- | --- | --- | --- | --- |
| C | pre-change (`x.is_cuda`) | 33.80 | 33.60–33.97 | 1.1% | 29.59 ms |
| A | this PR (probed) | **40.82** | 40.72–40.89 | 0.4% | **24.50 ms** |

**+20.8% tok/s/user, inter-token latency −17.2%.** The largest within-arm spread is 1.1%, against a 20.8% gap; noise does not account for it. The control arm's helper was confirmed from inside the running container rather than trusted from the mount.

Per-step profile (campaign, from which the diagnosis came): attention preparation falls from 3.62 ms to 0.20 ms once the conversions are gone.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Unchecked on purpose: this is an internal dispatch decision with no user-facing surface — no flag, no argument, no changed default — so there is no doc page to update. The reasoning lives in the function's own docstring.

## Limits of the evidence, and what to check hardest

- **Throughput was measured at one shape only** — 1024 in, 1024 out, concurrency 1. Long context and higher concurrency were not re-measured on this branch.
- **Three runs from one launch per arm** captures measurement noise but not launch-to-launch variance from graph capture and memory layout. As a partial check, one arm was measured hours earlier from a separate launch and landed within 0.1% of its mean here.
- **The XPU test gets no CI coverage on this branch.** `pr-test-xpu.yml`'s trigger names only the default branch, and no workflow mentions `intel_dev`, so a green check here should not be read as having run `test/registered/xpu/test_dsv4_bf16_fp32_gemm.py`. A one-line workflow change would fix it; it is deliberately not in this PR.
- **The lazy probe is the design decision worth a second opinion.** The trade-off is spelled out above; moving it behind an explicit init-time hook is a defensible alternative, at the cost of three call sites that can each be forgotten.
- **`+20.8%` is this configuration, not a general figure**, and it is not the wider campaign headline — most of that came from configuration rather than from this diff.
- CI has not run: no `run-ci` label is applied yet, and applying it needs someone in `.github/CI_PERMISSIONS.json`.

One of several small, independent changes split out of a larger DeepSeek-V4 XPU enablement branch. This one depends on none of the others.
