### PR TITLE
[Intel GPU] Map the generic profiler activity to XPU on Intel GPUs

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -18,11 +18,13 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.managers.io_struct import ProfileReq, ProfileReqOutput, ProfileReqType
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
-from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_device
 from sglang.srt.utils import is_mps, is_npu
 from sglang.srt.utils.profile_merger import ProfileMerger
-from sglang.srt.utils.profile_utils import ProfileManager
+from sglang.srt.utils.profile_utils import (
+    ProfileManager,
+    resolve_torch_profiler_activities,
+)
 from sglang.srt.utils.torch_npu_patch_utils import apply_torch_npu_patches
 
 if TYPE_CHECKING:
@@ -167,24 +169,7 @@ class SchedulerProfilerManager:
         with_stack = self.torch_profiler_with_stack
         record_shapes = self.torch_profiler_record_shapes
 
-        activity_map = {
-            "CPU": torch.profiler.ProfilerActivity.CPU,
-            "GPU": torch.profiler.ProfilerActivity.CUDA,
-        }
-
-        if current_platform.is_out_of_tree():
-            if hasattr(
-                torch.profiler.ProfilerActivity,
-                current_platform.get_torch_profiler_activity_str(),
-            ):
-                activity_map[current_platform.get_torch_profiler_activity_str()] = (
-                    current_platform.get_torch_profiler_activity()
-                )
-        if hasattr(torch.profiler.ProfilerActivity, "XPU"):
-            activity_map["XPU"] = torch.profiler.ProfilerActivity.XPU
-        torchprof_activities = [
-            activity_map[a] for a in activities if a in activity_map
-        ]
+        torchprof_activities = resolve_torch_profiler_activities(activities)
 
         if "RPD" in activities:  # for ROCM
             from rpdTracerControl import rpdTracerControl

--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -31,6 +31,41 @@ if _is_npu:
 logger = logging.getLogger(__name__)
 
 
+def get_torch_profiler_activity_map() -> dict[str, torch.profiler.ProfilerActivity]:
+    activity_map = {
+        "CPU": torch.profiler.ProfilerActivity.CPU,
+        "GPU": torch.profiler.ProfilerActivity.CUDA,
+    }
+    if current_platform.is_xpu():
+        xpu_activity = torch.profiler.ProfilerActivity.XPU
+        activity_map["GPU"] = xpu_activity
+        activity_map["XPU"] = xpu_activity
+    elif hasattr(torch.profiler.ProfilerActivity, "XPU"):
+        activity_map["XPU"] = torch.profiler.ProfilerActivity.XPU
+
+    if current_platform.is_out_of_tree():
+        activity_name = current_platform.get_torch_profiler_activity_str()
+        if hasattr(torch.profiler.ProfilerActivity, activity_name):
+            activity_map[activity_name] = current_platform.get_torch_profiler_activity()
+    return activity_map
+
+
+def resolve_torch_profiler_activities(
+    activities: List[str],
+) -> List[torch.profiler.ProfilerActivity]:
+    """Translate requested activity names into torch activities, in request order.
+
+    Two names can resolve to the same activity: on XPU the generic ``GPU`` and
+    the explicit ``XPU`` both mean XPU. ``torch.profiler.profile`` deduplicated
+    a repeated activity silently up to torch 2.11 (``set(activities)``) and
+    raises ``ValueError`` on it by 2.13, so collapse duplicates here rather than
+    depending on which version is installed.
+    """
+    activity_map = get_torch_profiler_activity_map()
+    resolved = [activity_map[a] for a in activities if a in activity_map]
+    return list(dict.fromkeys(resolved))
+
+
 def export_cuda_graph_capture_trace(prof_context, *, runner_name: str, tp_rank: int):
     """Persist a CUDA-graph capture profiler trace (chrome trace) to disk.
 
@@ -298,19 +333,7 @@ class _ProfilerTorch(_ProfilerConcreteBase):
         self.activities = activities
 
     def start(self):
-        activity_map = {
-            "CPU": torch.profiler.ProfilerActivity.CPU,
-            "GPU": torch.profiler.ProfilerActivity.CUDA,
-        }
-
-        if current_platform.is_out_of_tree():
-            activity_map[current_platform.get_torch_profiler_activity_str()] = (
-                current_platform.get_torch_profiler_activity()
-            )
-
-        torchprof_activities = [
-            activity_map[a] for a in self.activities if a in activity_map
-        ]
+        torchprof_activities = resolve_torch_profiler_activities(self.activities)
 
         self.torch_profiler = torch.profiler.profile(
             activities=torchprof_activities,

--- a/test/registered/unit/utils/test_profile_utils.py
+++ b/test/registered/unit/utils/test_profile_utils.py
@@ -1,0 +1,142 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.managers.scheduler_components.profiler_manager import (
+    SchedulerProfilerManager,
+)
+from sglang.srt.utils import profile_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _platform(*, xpu: bool, out_of_tree: bool = False):
+    return SimpleNamespace(
+        is_xpu=lambda: xpu,
+        is_out_of_tree=lambda: out_of_tree,
+        get_torch_profiler_activity_str=lambda: "XPU",
+        get_torch_profiler_activity=lambda: torch.profiler.ProfilerActivity.XPU,
+    )
+
+
+class TestTorchProfilerActivityMap(CustomTestCase):
+    def test_missing_out_of_tree_activity_is_ignored(self):
+        platform = SimpleNamespace(
+            is_xpu=lambda: False,
+            is_out_of_tree=lambda: True,
+            get_torch_profiler_activity_str=lambda: "PRIVATEUSE1",
+            get_torch_profiler_activity=Mock(
+                side_effect=AssertionError("unsupported activity")
+            ),
+        )
+
+        with patch.object(profile_utils, "current_platform", platform):
+            activity_map = profile_utils.get_torch_profiler_activity_map()
+
+        self.assertNotIn("PRIVATEUSE1", activity_map)
+        platform.get_torch_profiler_activity.assert_not_called()
+
+    def test_explicit_xpu_key_survives_on_a_non_xpu_platform(self):
+        # The generic "GPU" stays CUDA off XPU, but a caller naming "XPU"
+        # explicitly must still resolve when the build exposes that activity.
+        with patch.object(profile_utils, "current_platform", _platform(xpu=False)):
+            activity_map = profile_utils.get_torch_profiler_activity_map()
+
+        self.assertIs(activity_map["GPU"], torch.profiler.ProfilerActivity.CUDA)
+        if hasattr(torch.profiler.ProfilerActivity, "XPU"):
+            self.assertIs(activity_map["XPU"], torch.profiler.ProfilerActivity.XPU)
+
+
+class TestResolveTorchProfilerActivities(CustomTestCase):
+    def test_aliased_names_collapse_to_one_activity(self):
+        # On XPU both "GPU" and "XPU" mean the XPU activity. torch.profiler
+        # raises on a repeated activity by 2.13, so the duplicate has to be
+        # gone before the list reaches the constructor.
+        with patch.object(profile_utils, "current_platform", _platform(xpu=True)):
+            resolved = profile_utils.resolve_torch_profiler_activities(
+                ["CPU", "GPU", "XPU"]
+            )
+
+        self.assertEqual(
+            resolved,
+            [
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.XPU,
+            ],
+        )
+
+    def test_request_order_is_preserved_and_unknown_names_dropped(self):
+        with patch.object(profile_utils, "current_platform", _platform(xpu=True)):
+            resolved = profile_utils.resolve_torch_profiler_activities(
+                ["GPU", "MEM", "CPU"]
+            )
+
+        self.assertEqual(
+            resolved,
+            [
+                torch.profiler.ProfilerActivity.XPU,
+                torch.profiler.ProfilerActivity.CPU,
+            ],
+        )
+
+
+class TestTorchProfilerRouting(CustomTestCase):
+    def test_legacy_profiler_routes_generic_gpu_to_xpu(self):
+        manager = object.__new__(SchedulerProfilerManager)
+        manager.profiler_activities = ["GPU"]
+        manager.torch_profiler_with_stack = False
+        manager.torch_profiler_record_shapes = False
+        manager.torch_profiler_output_dir = Path("/tmp")
+        manager.profile_id = "xpu-test"
+        manager.ps = SimpleNamespace(tp_rank=0, gpu_id=0)
+        manager.profile_in_progress = False
+        profiler = Mock()
+
+        with (
+            patch.object(profile_utils, "current_platform", _platform(xpu=True)),
+            patch.object(torch.profiler, "profile", return_value=profiler) as create,
+        ):
+            result = manager._start_profile()
+
+        self.assertTrue(result.success)
+        self.assertEqual(
+            create.call_args.kwargs["activities"],
+            [torch.profiler.ProfilerActivity.XPU],
+        )
+        profiler.start.assert_called_once_with()
+
+    def test_v2_profiler_routes_generic_gpu_to_xpu(self):
+        profiler_impl = profile_utils._ProfilerTorch(
+            output_dir="/tmp",
+            output_prefix="",
+            output_suffix="",
+            profile_id="xpu-test",
+            ps=SimpleNamespace(tp_rank=0),
+            cpu_group=None,
+            first_rank_in_node=True,
+            activities=["GPU"],
+            with_stack=False,
+            record_shapes=False,
+        )
+        profiler = Mock()
+
+        with (
+            patch.object(profile_utils, "current_platform", _platform(xpu=True)),
+            patch.object(torch.profiler, "profile", return_value=profiler) as create,
+        ):
+            profiler_impl.start()
+
+        self.assertEqual(
+            create.call_args.kwargs["activities"],
+            [torch.profiler.ProfilerActivity.XPU],
+        )
+        profiler.start.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Requesting a profile with the generic `GPU` activity on an Intel GPU produced a trace that opened fine, had a plausible size, and contained **no device kernels**. The profiler appeared to work and the data was empty of the thing being profiled.

Two independent code paths each built the same name-to-activity map by hand, and both hardcoded `GPU` to the CUDA activity:

`srt/managers/scheduler_components/profiler_manager.py` (scheduler path):
```python
        activity_map = {
            "CPU": torch.profiler.ProfilerActivity.CPU,
            "GPU": torch.profiler.ProfilerActivity.CUDA,
        }
        if current_platform.is_out_of_tree():
            if hasattr(torch.profiler.ProfilerActivity, current_platform.get_torch_profiler_activity_str()):
                activity_map[...] = current_platform.get_torch_profiler_activity()
        if hasattr(torch.profiler.ProfilerActivity, "XPU"):
            activity_map["XPU"] = torch.profiler.ProfilerActivity.XPU
```

`srt/utils/profile_utils.py`, `_ProfilerTorch.start()` (v2 path) — the same map, minus the `XPU` key and minus the `hasattr` guard on the out-of-tree name.

The `CUDA` activity collects nothing on XPU, so the request resolved to a tracer with nothing to record. A caller who knew to pass `XPU` explicitly could get device events out of the scheduler path, but not out of the v2 path, and the generic name — which is what the profile endpoints default to — was broken on both.

## Modifications

Replace both hand-written maps with one shared resolver in `profile_utils.py` and route both implementations through it:

- `get_torch_profiler_activity_map()` — on XPU, **both** `GPU` and `XPU` map to `ProfilerActivity.XPU`; off XPU, `GPU` stays `CUDA` and the explicit `XPU` key is still offered when the build exposes that activity.
- `resolve_torch_profiler_activities(activities)` — names to activities, in request order, unknown names dropped, **duplicates collapsed**.

Two side effects of folding the copies together, both intentional:

**1. The v2 path gains the `hasattr` guard the scheduler path already had.** An out-of-tree platform naming an activity this torch does not expose is now skipped instead of raising an `AttributeError` from `get_torch_profiler_activity()`. `test_missing_out_of_tree_activity_is_ignored` covers it, and asserts the platform hook is not even called.

**2. Duplicate collapsing changes behaviour on every platform, not only XPU.** It has to, because on XPU two names now resolve to one activity — and `torch.profiler.profile` does not tolerate that on current torch. The version behaviour is split:

```
# torch 2.11.0+cpu (what python/pyproject.toml:78 pins)
torch/profiler/profiler.py:162:  self.activities = set(activities) if activities else supported_activities()
>>> torch.profiler.profile(activities=[A.CPU, A.CPU])   # accepted, silently deduped

# torch 2.13.0+xpu (the image these measurements ran on)
>>> torch.profiler.profile(activities=[A.CPU, A.CPU])
ValueError: Activity ProfilerActivity.CPU specified more than once
```

So on the XPU image this is not forward-looking hygiene — without the collapse, a `["CPU", "GPU", "XPU"]` request is a hard failure today. Demonstrated by removing `dict.fromkeys` and running the resolver in that container:

```
torch 2.13.0+xpu
NO-DEDUP resolved: [<ProfilerActivity.CPU: 0>, <ProfilerActivity.XPU: 1>, <ProfilerActivity.XPU: 1>]
profile() RAISED: ValueError: Activity ProfilerActivity.XPU specified more than once
```

Collapsing in the resolver keeps an explicit both-names request working on either version instead of depending on which one is installed.

**Behaviour on CUDA is unchanged.** `current_platform.is_xpu()` is false, so `GPU` still resolves to `CUDA` and the map is what it was, except that a repeated name now collapses instead of reaching the constructor — which on torch 2.11 the constructor did itself.

## Accuracy Tests

No model output changes — this touches only how requested profiler activity *names* become torch activities.

`test/registered/unit/utils/test_profile_utils.py` (new, 6 tests, `register_cpu_ci(est_time=1, suite="base-a-test-cpu")`):

| test | asserts |
| --- | --- |
| `test_legacy_profiler_routes_generic_gpu_to_xpu` | the scheduler path passes `[ProfilerActivity.XPU]` for a `["GPU"]` request on XPU |
| `test_v2_profiler_routes_generic_gpu_to_xpu` | the v2 path does the same |
| `test_aliased_names_collapse_to_one_activity` | `["CPU","GPU","XPU"]` on XPU yields `[CPU, XPU]`, not `[CPU, XPU, XPU]` |
| `test_request_order_is_preserved_and_unknown_names_dropped` | `["GPU","MEM","CPU"]` yields `[XPU, CPU]` |
| `test_explicit_xpu_key_survives_on_a_non_xpu_platform` | off XPU, `GPU` is still `CUDA` and `XPU` still resolves |
| `test_missing_out_of_tree_activity_is_ignored` | an absent activity name is skipped and the platform hook is not called |

These run on a CPU runner. `ProfilerActivity.XPU` is a compile-time enum member present even on a CPU-only wheel, so the XPU assertions are constructible there — checked on the pinned version:

```
$ python -c "import torch; A=torch.profiler.ProfilerActivity; print(torch.__version__, [m for m in dir(A) if m.isupper()], hasattr(A,'XPU'))"
2.11.0+cpu ['CPU', 'CUDA', 'HPU', 'MTIA', 'XPU'] True
```

### Observed

Run in an XPU container whose two installed files were first confirmed byte-identical to this PR's base:

```
srt/utils/profile_utils.py                              installed=5f108fc3ae8a3a0e base=5f108fc3ae8a3a0e  identical
srt/managers/.../profiler_manager.py                    installed=8c6fc26c182ec36a base=8c6fc26c182ec36a  identical
```

then bind-mounted per arm so the files under test are the only difference:

```
this PR                                     6 passed
origin/intel_dev                            6 failed
mutant 1: GPU stays CUDA on XPU             4 failed, 2 passed
mutant 2: no duplicate collapsing           1 failed, 5 passed
```

- **Mutant 1** removes the single line `activity_map["GPU"] = xpu_activity`, i.e. lets the original bug survive the refactor. Both routing tests, the collapse test and the order test go red. This is the regression the PR exists to prevent.
- **Mutant 2** replaces `list(dict.fromkeys(resolved))` with `return resolved`. Exactly one test goes red — `test_aliased_names_collapse_to_one_activity` — which is the intended coverage, and the `ValueError` quoted above is what that single test stands in for.
- **`6 failed` on base is a weak signal on its own**: four of the six reference `get_torch_profiler_activity_map` / `resolve_torch_profiler_activities`, which do not exist there. The mutants are the real evidence.

## Speed Tests and Profiling

**No speed claim.** This changes what the profiler records, not how the model runs. The resolver runs once per profile start.

What was verified on hardware — eight Intel Arc Pro B70 at TP8, DeepSeek-V4-Flash-0731 — is that the trace now contains device work. A generic `GPU` request produced eight traces, one per rank, 37.0 to 51.6 MB each. A full scan of one trace found:

| category | events |
| --- | --- |
| `kernel` | 1,936 |
| `ac2g` (correlation arrows) | 12,128 |
| `gpu_memcpy` | 45 |

**An earlier version of this evidence was retracted and should not be reintroduced.** It cited host-side `xpu_driver` and `xpu_runtime` records as proof the fix worked. Those appear whether or not the fix is present — they are collected under the CPU activity — so they prove nothing. Only the device-side categories in the table above distinguish the two states.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Unchecked on purpose: no argument, flag or default changes, and the activity names accepted by the profile endpoints are the same set as before — there is no doc page whose contents this alters. And there is nothing to benchmark, per the section above.

## Limits of the evidence, and what to check hardest

- **The duplicate-collapsing change is not Intel-only** and deserves a look from whoever owns the profiler paths. It is intended, and on the pinned torch 2.11 it is a no-op because the constructor deduped anyway — but it does mean the resolver, not torch, now owns that behaviour.
- **A third copy of the same mapping remains** at `srt/disaggregation/encode_server.py:2539`. Deliberately out of scope so this change stays to the two paths the scheduler uses, and so it does not pull in another owner group. It is called out in the commit message too.
- **The exact torch version where the `ValueError` was introduced is not pinned down.** Observed: 2.11.0 accepts a duplicate, 2.13.0 raises. 2.12 was not tested. The fix does not depend on which of the two it was.
- **`request-order preservation` is the resolver's own contract, not an observable torch behaviour on the pinned version** — 2.11's constructor does `set(activities)`, which discards order regardless. The test guards the resolver so a future refactor cannot quietly start reordering.
- **Stopping the profile returned an internal server error** on the hardware run, although all eight traces were written correctly. That was not chased and is not known to be related to this change.
- CI has not run: no `run-ci` label is applied yet, and applying it needs someone in `.github/CI_PERMISSIONS.json`.

One of several small, independent changes split out of a larger DeepSeek-V4 XPU enablement branch. This one depends on none of the others.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34083072036](https://github.com/sgl-project/sglang/actions/runs/34083072036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34083071852](https://github.com/sgl-project/sglang/actions/runs/34083071852)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->