### PR TITLE
fix: Prevent gloo same-group deadlock in check_prefetch_progress

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1627,8 +1627,20 @@ class HiRadixCache(RadixCache):
         )
 
     def check_prefetch_progress(self, req_id: str) -> bool:
-        if req_id not in self.ongoing_prefetch:
-            # there is no ongoing prefetch for this request or it has been revoked
+        has_ongoing = req_id in self.ongoing_prefetch
+
+        if not has_ongoing:
+            # This rank has no ongoing prefetch for req_id, but other TP/PP
+            # ranks may. We must still participate in the same all_reduce as
+            # can_terminate_prefetch to avoid a gloo same-group deadlock:
+            # ranks with ongoing block in all_reduce while ranks without
+            # ongoing skip it, causing a permanent hang on the shared
+            # ProcessGroup.
+            #
+            # Contribute [0, 1] (can_terminate=True, terminated=True) to the
+            # MAX all_reduce so we don't block other ranks from terminating.
+            states = torch.tensor([0, 1], dtype=torch.int)
+            self._all_reduce_attn_groups(states, torch.distributed.ReduceOp.MAX)
             return True
 
         last_host_node, prefetch_key, operation = self.ongoing_prefetch[req_id]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1332,7 +1332,20 @@ class UnifiedRadixCache(BasePrefixCache):
         return can_terminate or operation_terminated
 
     def check_prefetch_progress(self, req_id: str) -> bool:
-        if req_id not in self.ongoing_prefetch:
+        has_ongoing = req_id in self.ongoing_prefetch
+
+        if not has_ongoing:
+            # This rank has no ongoing prefetch for req_id, but other TP/PP
+            # ranks may. We must still participate in the same all_reduce as
+            # can_terminate_prefetch to avoid a gloo same-group deadlock:
+            # ranks with ongoing block in all_reduce while ranks without
+            # ongoing skip it, causing a permanent hang on the shared
+            # ProcessGroup.
+            #
+            # Contribute [0, 1] (can_terminate=True, terminated=True) to the
+            # MAX all_reduce so we don't block other ranks from terminating.
+            states = torch.tensor([0, 1], dtype=torch.int)
+            self._all_reduce_attn_groups(states, torch.distributed.ReduceOp.MAX)
             return True
 
         (


### PR DESCRIPTION
## Problem

`check_prefetch_progress` in both `unified_radix_cache.py` and `hiradix_cache.py` returns `True` immediately when `req_id` is not in the rank's `ongoing_prefetch`, skipping the `all_reduce` that `can_terminate_prefetch` would perform.

When `ongoing_prefetch` differs across TP/PP ranks (some ranks have the request in their prefetch map, others don't), this creates a **permanent deadlock** on the shared gloo `ProcessGroup`:

1. Ranks **with** ongoing prefetch enter `can_terminate_prefetch` → `all_reduce` (MAX on `[1-can_terminate, terminated]`)
2. Ranks **without** ongoing prefetch return `True` immediately → skip the `all_reduce`
3. The mismatched collective on the same gloo group hangs forever — all ranks freeze

This was observed in production on MI350X (gfx950) with GLM-5.2/5.3 using HiCache with NIXL storage backend and TP=8. The scheduler event loop freezes with all ranks stuck in `futex_wait` (gloo collective), with no logs, no traceback, and GPU util at 0%.

## Root Cause

`can_terminate_prefetch` (in both `unified_radix_cache.py` and `hiradix_cache.py`) performs an `all_reduce` on the TP/PP group to synchronize the termination decision across ranks. However, `check_prefetch_progress` short-circuits with `return True` when `req_id` is not in the local `ongoing_prefetch`, **before** reaching `can_terminate_prefetch`. This means:

- Ranks that **have** the prefetch: enter the `all_reduce` and block
- Ranks that **don't have** the prefetch: skip it entirely
- The `all_reduce` on the shared gloo `ProcessGroup` never completes because not all ranks participate

## Fix

When `req_id` is not in `ongoing_prefetch`, still participate in the same `all_reduce` with dummy values (`[0, 1]` = `can_terminate=True, terminated=True`) to maintain collective symmetry across all TP/PP ranks. The dummy contribution does not affect the result:
- `states[0] = max(1-can_terminate, 0)` — our 0 doesn't block other ranks from terminating
- `states[1] = max(terminated, 1)` — our 1 ensures `terminated` propagates correctly

### `unified_radix_cache.py`

`can_terminate_prefetch` does `all_reduce` for all non-`best_effort`/`wait_complete` policies. The fix adds a dummy `all_reduce` with `[0, 1]` when the rank has no ongoing, matching the same 2-element tensor and `MAX` op.

### `hiradix_cache.py`

`check_prefetch_progress` does `all_reduce` inline (always, for all policies). The fix adds a dummy `all_reduce` with `[0, 1]` when the rank has no ongoing, matching the same 2-element tensor and `MAX` op.

## Testing

Validated on MI350X (gfx950) with GLM-5.2/5.3, TP=8, HiCache with NIXL storage backend. The deadlock was reproduced with the old code and confirmed resolved with the fix. The scheduler event loop remains stable under cold-long-sequence workloads that trigger prefetch divergence across ranks.

> Note: This is a re-creation of #38268 and #38270 (closed due to branch recreation).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34085070833](https://github.com/sgl-project/sglang/actions/runs/34085070833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34085070406](https://github.com/sgl-project/sglang/actions/runs/34085070406)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34085070919](https://github.com/sgl-project/sglang/actions/runs/34085070919)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->