### PR TITLE
[Rust] Add API-key authorization to the embedded server

### DIFF
--- a/python/sglang/srt/rust_server/server.py
+++ b/python/sglang/srt/rust_server/server.py
@@ -77,11 +77,12 @@ class RustServer:
         os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
         server_args = scheduler.server_args
+        serving = get_serving()
         # Per-DP-rank HTTP port with client load balancing. `None` when DP is off,
         # so the rank is not conflated with rank 0 of a one-rank group.
         dp_rank = scheduler.ps.attn_dp_rank if scheduler.ps.dp_size > 1 else None
-        listen_port = get_serving().port + (dp_rank or 0)
-        listen_addr = NetworkAddress(get_serving().host, listen_port).to_host_port_str()
+        listen_port = serving.port + (dp_rank or 0)
+        listen_addr = NetworkAddress(serving.host, listen_port).to_host_port_str()
 
         launch_cores, server_cores = _partition_cores(
             mm_workers=(
@@ -96,6 +97,11 @@ class RustServer:
             # None -> run unpinned; the list carries the pinning decision.
             cores=server_cores,
             port_offset=dp_rank,
+            # Keep credentials out of the regular ServerArgs payload: they are
+            # consumed only by the Rust HTTP ingress and must not reach model,
+            # scheduler, or server-info configuration surfaces.
+            api_key=serving.api_key,
+            admin_api_key=serving.admin_api_key,
         )
 
         # Multimodal models must have a Rust pipeline — there is no Python

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3705,6 +3705,7 @@ dependencies = [
  "axum 0.8.9",
  "bytemuck",
  "bytes",
+ "constant_time_eq",
  "core_affinity",
  "dynamo-parsers",
  "dynamo-protocols",

--- a/rust/sglang-server/Cargo.toml
+++ b/rust/sglang-server/Cargo.toml
@@ -36,6 +36,7 @@ arc-swap = "1"
 axum = { version = "0.8.9", features = ["json", "tokio"] }
 # Safe POD slice casts (feature buffers viewed as bytes for the shm copy).
 bytemuck = "1"
+constant_time_eq = "0.4"
 core_affinity = "0.8"
 # the dynamo-tokenizers is deps on hf-hub, should bump version together.
 dynamo-tokenizers = "1.7.0"

--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -4,6 +4,7 @@
 //! frames (`data: {json}` … `[DONE]`), byte-compatible with Python
 //! `http_server.generate_request`; `/server_info` reuses it for one control result.
 pub mod app;
+pub(crate) mod auth;
 mod common;
 mod disaggregation;
 mod frame;

--- a/rust/sglang-server/src/api_server/app.rs
+++ b/rust/sglang-server/src/api_server/app.rs
@@ -4,10 +4,11 @@
 
 use std::sync::Arc;
 
-use axum::Router;
+use axum::{Router, http::StatusCode};
 
 use super::disaggregation::bootstrap as pd_bootstrap;
-use super::{common, log, native_api, openai};
+use super::{auth, common, log, native_api, openai};
+use crate::api_server::auth::{AuthConfig, AuthLevel};
 use crate::message::config::ServerArgs;
 use crate::tokenizer_manager::from_scheduler::ActivityCounter;
 use crate::tokenizer_manager::wiring::Senders;
@@ -33,6 +34,7 @@ pub async fn serve(
     senders: Senders,
     response_buf: usize,
     server_args: Arc<ServerArgs>,
+    auth_config: Arc<AuthConfig>,
     response_activity: ActivityCounter,
     // The runtime's shutdown signal, shared with every worker stage: it fires
     // (disconnects) when `Runtime::request_shutdown` drops the sender, at
@@ -49,24 +51,28 @@ pub async fn serve(
         response_activity,
     });
     // Each endpoint module registers its own routes and merges here.
-    let router = Router::new()
+    let public_router = Router::new()
         .merge(common::routes())
         .merge(native_api::routes())
-        .merge(openai::routes());
+        .merge(openai::routes())
+        // Python's global ASGI middleware authenticates unknown customer paths
+        // before they become a 404. Register the public fallback before the
+        // AuthZ layer to preserve that observable 401/404 ordering.
+        .fallback(public_not_found)
+        // No body limit, matching the Python server.
+        .layer(axum::extract::DefaultBodyLimit::disable());
 
-    // TODO(auth): no API-key boundary yet. Python gates every route (except
-    // /health*, /metrics*, OPTIONS) via `add_api_key_middleware`; until ported,
-    // a configured `api_key` does NOT protect these routes.
-    //
-    // No body limit, matching the Python server.
-    let mut app = router
-        .layer(axum::extract::DefaultBodyLimit::disable())
-        .with_state(state);
+    // Protect only customer-facing routes. This must happen before the PD
+    // bootstrap router is merged below: Axum layers wrap routes already present
+    // at the call site, which is the structural AuthZ boundary for v1.
+    let mut app = auth::protect(public_router, auth_config, AuthLevel::Normal).with_state(state);
 
     // Prefill-only KV bootstrap registry. Merged AFTER `with_state` — its
     // router carries its own Arc<Registry> state, so it cannot merge into the
     // Router<Arc<AppState>> above — and before `log::apply`, so bootstrap traffic
-    // shows in the access log.
+    // shows in the access log. The bootstrap router must keep Axum's default
+    // fallback: the public router already owns the custom, protected fallback,
+    // and Axum rejects merging two routers that both define one.
     if server_args.enable_pd_bootstrap() {
         let (routes, sweeper) = pd_bootstrap::router_and_sweeper();
         tokio::spawn(sweeper); // cancelled with the runtime on shutdown
@@ -101,4 +107,8 @@ pub async fn serve(
             tracing::info!("shutdown: stopping accepts, aborting in-flight handlers");
         }
     }
+}
+
+async fn public_not_found() -> StatusCode {
+    StatusCode::NOT_FOUND
 }

--- a/rust/sglang-server/src/api_server/auth.rs
+++ b/rust/sglang-server/src/api_server/auth.rs
@@ -1,0 +1,688 @@
+//! API-key authorization for the public HTTP router.
+//!
+//! The policy intentionally mirrors `sglang.srt.utils.auth`. Keep the pure
+//! decision function independent of handlers and model state so changes to the
+//! Python policy can be compared here directly.
+
+use std::{fmt, sync::Arc};
+
+use axum::{
+    Json, Router,
+    extract::{Request, State},
+    http::{HeaderValue, Method, StatusCode, header::AUTHORIZATION},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+};
+use constant_time_eq::constant_time_eq;
+use serde::Serialize;
+
+/// Secrets used only by the HTTP authorization layer.
+///
+/// This type deliberately does not implement `Serialize`, and its `Debug`
+/// implementation reports presence only. Empty strings are normalized to an
+/// unset key, matching Python's truthiness check; whitespace is preserved.
+#[derive(Clone, Default)]
+pub(crate) struct AuthConfig {
+    api_key: Option<Arc<str>>,
+    admin_api_key: Option<Arc<str>>,
+}
+
+impl AuthConfig {
+    pub(crate) fn new(api_key: Option<String>, admin_api_key: Option<String>) -> Self {
+        Self {
+            api_key: normalize_key(api_key),
+            admin_api_key: normalize_key(admin_api_key),
+        }
+    }
+
+    fn needs_layer(&self, level: AuthLevel) -> bool {
+        match level {
+            AuthLevel::Normal => self.api_key.is_some(),
+            AuthLevel::AdminOptional => self.api_key.is_some() || self.admin_api_key.is_some(),
+            // An unconfigured forced-admin route must still reject with 403.
+            AuthLevel::AdminForce => true,
+        }
+    }
+}
+
+fn normalize_key(key: Option<String>) -> Option<Arc<str>> {
+    key.filter(|key| !key.is_empty()).map(Arc::from)
+}
+
+impl fmt::Debug for AuthConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthConfig")
+            .field("api_key", &SecretPresence(self.api_key.is_some()))
+            .field(
+                "admin_api_key",
+                &SecretPresence(self.admin_api_key.is_some()),
+            )
+            .finish()
+    }
+}
+
+struct SecretPresence(bool);
+
+impl fmt::Debug for SecretPresence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(if self.0 { "<configured>" } else { "<unset>" })
+    }
+}
+
+/// Authorization policy attached to a group of endpoints.
+// The admin levels deliberately ship with the policy engine before Rust owns
+// any admin routes; keeping them here pins Python parity for those future route
+// groups without pretending they are mounted today.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AuthLevel {
+    /// Requires `api_key` when it is configured.
+    Normal,
+    /// Requires the admin key when present, otherwise the regular key when
+    /// present, and is public when neither exists.
+    AdminOptional,
+    /// Always requires an admin key; returns 403 if no admin key is configured.
+    AdminForce,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AuthDecision {
+    Allow,
+    Deny(StatusCode),
+}
+
+/// Decide whether one request is authorized without invoking any HTTP handler.
+pub(crate) fn decide_request_auth(
+    method: &Method,
+    path: &str,
+    authorization: Option<&HeaderValue>,
+    config: &AuthConfig,
+    level: AuthLevel,
+) -> AuthDecision {
+    // Kubernetes probes, Prometheus scraping, and CORS preflight stay public.
+    if method == Method::OPTIONS || path.starts_with("/health") || path.starts_with("/metrics") {
+        return AuthDecision::Allow;
+    }
+
+    match level {
+        AuthLevel::AdminForce => match &config.admin_api_key {
+            None => AuthDecision::Deny(StatusCode::FORBIDDEN),
+            Some(key) if bearer_matches(authorization, key) => AuthDecision::Allow,
+            Some(_) => AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+        },
+        AuthLevel::AdminOptional => {
+            let expected = config
+                .admin_api_key
+                .as_deref()
+                .or(config.api_key.as_deref());
+            match expected {
+                None => AuthDecision::Allow,
+                Some(key) if bearer_matches(authorization, key) => AuthDecision::Allow,
+                Some(_) => AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            }
+        }
+        AuthLevel::Normal => match &config.api_key {
+            None => AuthDecision::Allow,
+            Some(key) if bearer_matches(authorization, key) => AuthDecision::Allow,
+            Some(_) => AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+        },
+    }
+}
+
+/// Install authorization on all routes and the fallback already present in
+/// `router`. Callers must merge internal-only routers after this helper.
+///
+/// For policies that are unconditionally public under the current config, the
+/// router is returned unchanged so the default configuration has no per-request
+/// middleware cost.
+pub(crate) fn protect<S>(router: Router<S>, config: Arc<AuthConfig>, level: AuthLevel) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    if !config.needs_layer(level) {
+        return router;
+    }
+
+    router.layer(middleware::from_fn_with_state(
+        AuthMiddlewareState { config, level },
+        authorize,
+    ))
+}
+
+#[derive(Clone)]
+struct AuthMiddlewareState {
+    config: Arc<AuthConfig>,
+    level: AuthLevel,
+}
+
+async fn authorize(
+    State(state): State<AuthMiddlewareState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let decision = decide_request_auth(
+        request.method(),
+        request.uri().path(),
+        request.headers().get(AUTHORIZATION),
+        &state.config,
+        state.level,
+    );
+
+    match decision {
+        AuthDecision::Allow => next.run(request).await,
+        AuthDecision::Deny(status) => denial_response(status),
+    }
+}
+
+fn bearer_matches(authorization: Option<&HeaderValue>, expected: &str) -> bool {
+    let Some(value) = authorization else {
+        return false;
+    };
+    let bytes = value.as_bytes();
+    let Some(space) = bytes.iter().position(|byte| *byte == b' ') else {
+        return false;
+    };
+    let (scheme, token_with_separator) = bytes.split_at(space);
+    let token = &token_with_separator[1..];
+
+    scheme.eq_ignore_ascii_case(b"bearer") && constant_time_eq(token, expected.as_bytes())
+}
+
+#[derive(Serialize)]
+struct AuthError {
+    error: &'static str,
+}
+
+fn denial_response(status: StatusCode) -> Response {
+    let error = if status == StatusCode::FORBIDDEN {
+        "Forbidden"
+    } else {
+        "Unauthorized"
+    };
+    (status, Json(AuthError { error })).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request as HttpRequest, header::CONTENT_TYPE},
+        routing::{get, post},
+    };
+    use serde::Deserialize;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    const API_KEY: &str = "customer-secret";
+    const ADMIN_KEY: &str = "admin-secret";
+
+    fn config(api_key: Option<&str>, admin_api_key: Option<&str>) -> AuthConfig {
+        AuthConfig::new(
+            api_key.map(ToOwned::to_owned),
+            admin_api_key.map(ToOwned::to_owned),
+        )
+    }
+
+    fn header(value: &'static str) -> HeaderValue {
+        HeaderValue::from_static(value)
+    }
+
+    fn decide(
+        config: &AuthConfig,
+        level: AuthLevel,
+        authorization: Option<&HeaderValue>,
+    ) -> AuthDecision {
+        decide_request_auth(&Method::GET, "/v1/models", authorization, config, level)
+    }
+
+    #[test]
+    fn policy_matrix_matches_python() {
+        struct Case {
+            name: &'static str,
+            config: AuthConfig,
+            level: AuthLevel,
+            accepted_token: Option<&'static str>,
+            missing: AuthDecision,
+        }
+
+        let cases = [
+            Case {
+                name: "no keys normal",
+                config: config(None, None),
+                level: AuthLevel::Normal,
+                accepted_token: None,
+                missing: AuthDecision::Allow,
+            },
+            Case {
+                name: "no keys admin optional",
+                config: config(None, None),
+                level: AuthLevel::AdminOptional,
+                accepted_token: None,
+                missing: AuthDecision::Allow,
+            },
+            Case {
+                name: "no keys admin force",
+                config: config(None, None),
+                level: AuthLevel::AdminForce,
+                accepted_token: None,
+                missing: AuthDecision::Deny(StatusCode::FORBIDDEN),
+            },
+            Case {
+                name: "api key only normal",
+                config: config(Some(API_KEY), None),
+                level: AuthLevel::Normal,
+                accepted_token: Some(API_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "api key only admin optional",
+                config: config(Some(API_KEY), None),
+                level: AuthLevel::AdminOptional,
+                accepted_token: Some(API_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "api key only admin force",
+                config: config(Some(API_KEY), None),
+                level: AuthLevel::AdminForce,
+                accepted_token: None,
+                missing: AuthDecision::Deny(StatusCode::FORBIDDEN),
+            },
+            Case {
+                name: "admin key only normal",
+                config: config(None, Some(ADMIN_KEY)),
+                level: AuthLevel::Normal,
+                accepted_token: None,
+                missing: AuthDecision::Allow,
+            },
+            Case {
+                name: "admin key only admin optional",
+                config: config(None, Some(ADMIN_KEY)),
+                level: AuthLevel::AdminOptional,
+                accepted_token: Some(ADMIN_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "admin key only admin force",
+                config: config(None, Some(ADMIN_KEY)),
+                level: AuthLevel::AdminForce,
+                accepted_token: Some(ADMIN_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "both keys normal",
+                config: config(Some(API_KEY), Some(ADMIN_KEY)),
+                level: AuthLevel::Normal,
+                accepted_token: Some(API_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "both keys admin optional",
+                config: config(Some(API_KEY), Some(ADMIN_KEY)),
+                level: AuthLevel::AdminOptional,
+                accepted_token: Some(ADMIN_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+            Case {
+                name: "both keys admin force",
+                config: config(Some(API_KEY), Some(ADMIN_KEY)),
+                level: AuthLevel::AdminForce,
+                accepted_token: Some(ADMIN_KEY),
+                missing: AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                decide(&case.config, case.level, None),
+                case.missing,
+                "{} without a token",
+                case.name
+            );
+
+            if let Some(token) = case.accepted_token {
+                let authorization = HeaderValue::from_str(&format!("Bearer {token}")).unwrap();
+                assert_eq!(
+                    decide(&case.config, case.level, Some(&authorization)),
+                    AuthDecision::Allow,
+                    "{} with its required token",
+                    case.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn key_roles_are_not_interchangeable() {
+        let config = config(Some(API_KEY), Some(ADMIN_KEY));
+        let api = header("Bearer customer-secret");
+        let admin = header("Bearer admin-secret");
+
+        assert_eq!(
+            decide(&config, AuthLevel::Normal, Some(&admin)),
+            AuthDecision::Deny(StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            decide(&config, AuthLevel::AdminOptional, Some(&api)),
+            AuthDecision::Deny(StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            decide(&config, AuthLevel::AdminForce, Some(&api)),
+            AuthDecision::Deny(StatusCode::UNAUTHORIZED)
+        );
+    }
+
+    #[test]
+    fn public_prefixes_and_options_always_bypass_auth() {
+        let config = config(Some(API_KEY), None);
+        for path in [
+            "/health",
+            "/health_generate",
+            "/health/ready",
+            "/metrics",
+            "/metrics/prometheus",
+        ] {
+            assert_eq!(
+                decide_request_auth(&Method::GET, path, None, &config, AuthLevel::Normal),
+                AuthDecision::Allow,
+                "{path}"
+            );
+        }
+        assert_eq!(
+            decide_request_auth(
+                &Method::OPTIONS,
+                "/v1/models",
+                None,
+                &config,
+                AuthLevel::Normal
+            ),
+            AuthDecision::Allow
+        );
+    }
+
+    #[test]
+    fn public_bypass_precedes_forced_admin_rejection() {
+        let config = config(None, None);
+        for (method, path) in [
+            (Method::GET, "/health"),
+            (Method::GET, "/metrics"),
+            (Method::OPTIONS, "/admin"),
+        ] {
+            assert_eq!(
+                decide_request_auth(&method, path, None, &config, AuthLevel::AdminForce),
+                AuthDecision::Allow
+            );
+        }
+    }
+
+    #[test]
+    fn bearer_parsing_matches_python_split_semantics() {
+        let spaced_config = config(Some(" secret"), None);
+        let cases = [
+            ("Bearer  secret", AuthDecision::Allow),
+            ("bearer  secret", AuthDecision::Allow),
+            ("BEARER  secret", AuthDecision::Allow),
+            (
+                "Bearer secret",
+                AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            ),
+            (
+                "Bearer   secret",
+                AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            ),
+            (
+                "Basic  secret",
+                AuthDecision::Deny(StatusCode::UNAUTHORIZED),
+            ),
+            ("Bearer", AuthDecision::Deny(StatusCode::UNAUTHORIZED)),
+            ("", AuthDecision::Deny(StatusCode::UNAUTHORIZED)),
+        ];
+
+        for (value, expected) in cases {
+            let value = HeaderValue::from_str(value).unwrap();
+            assert_eq!(
+                decide(&spaced_config, AuthLevel::Normal, Some(&value)),
+                expected,
+                "{value:?}"
+            );
+        }
+
+        let trailing_config = config(Some("secret"), None);
+        let trailing = header("Bearer secret ");
+        assert_eq!(
+            decide(&trailing_config, AuthLevel::Normal, Some(&trailing)),
+            AuthDecision::Deny(StatusCode::UNAUTHORIZED)
+        );
+    }
+
+    #[test]
+    fn empty_keys_are_unset_but_whitespace_is_preserved() {
+        let empty = AuthConfig::new(Some(String::new()), Some(String::new()));
+        assert_eq!(decide(&empty, AuthLevel::Normal, None), AuthDecision::Allow);
+        assert_eq!(
+            decide(&empty, AuthLevel::AdminOptional, None),
+            AuthDecision::Allow
+        );
+        assert_eq!(
+            decide(&empty, AuthLevel::AdminForce, None),
+            AuthDecision::Deny(StatusCode::FORBIDDEN)
+        );
+
+        let whitespace = config(Some(" "), None);
+        let authorization = header("Bearer  ");
+        assert_eq!(
+            decide(&whitespace, AuthLevel::Normal, None),
+            AuthDecision::Deny(StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            decide(&whitespace, AuthLevel::Normal, Some(&authorization)),
+            AuthDecision::Allow
+        );
+    }
+
+    #[test]
+    fn debug_output_reports_presence_without_secrets() {
+        let config = config(Some(API_KEY), Some(ADMIN_KEY));
+        let debug = format!("{config:?}");
+        assert_eq!(
+            debug,
+            "AuthConfig { api_key: <configured>, admin_api_key: <configured> }"
+        );
+        assert!(!debug.contains(API_KEY));
+        assert!(!debug.contains(ADMIN_KEY));
+    }
+
+    async fn counted_handler(counter: Arc<AtomicUsize>) -> &'static str {
+        counter.fetch_add(1, Ordering::Relaxed);
+        "handled"
+    }
+
+    fn counted_router(counter: Arc<AtomicUsize>) -> Router {
+        Router::new()
+            .route(
+                "/protected",
+                get({
+                    let counter = counter.clone();
+                    move || counted_handler(counter.clone())
+                }),
+            )
+            .fallback(move || counted_handler(counter.clone()))
+    }
+
+    async fn call(app: Router, request: HttpRequest<Body>) -> Response {
+        app.oneshot(request).await.unwrap()
+    }
+
+    async fn body(response: Response) -> String {
+        String::from_utf8(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn layer_rejects_before_handler_and_returns_exact_json() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let app = protect(
+            counted_router(counter.clone()),
+            Arc::new(config(Some(API_KEY), None)),
+            AuthLevel::Normal,
+        );
+
+        let response = call(
+            app,
+            HttpRequest::builder()
+                .uri("/protected")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers()[CONTENT_TYPE], "application/json");
+        assert_eq!(body(response).await, r#"{"error":"Unauthorized"}"#);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn layer_allows_valid_token_exactly_once() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let app = protect(
+            counted_router(counter.clone()),
+            Arc::new(config(Some(API_KEY), None)),
+            AuthLevel::Normal,
+        );
+
+        let response = call(
+            app,
+            HttpRequest::builder()
+                .uri("/protected")
+                .header(AUTHORIZATION, "Bearer customer-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body(response).await, "handled");
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn layer_protects_existing_fallback() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let app = protect(
+            counted_router(counter.clone()),
+            Arc::new(config(Some(API_KEY), None)),
+            AuthLevel::Normal,
+        );
+
+        let unauthorized = call(
+            app.clone(),
+            HttpRequest::builder()
+                .uri("/unknown")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+
+        let authorized = call(
+            app,
+            HttpRequest::builder()
+                .uri("/unknown")
+                .header(AUTHORIZATION, "Bearer customer-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(authorized.status(), StatusCode::OK);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[derive(Deserialize)]
+    struct Payload {
+        value: String,
+    }
+
+    #[tokio::test]
+    async fn layer_rejects_before_json_extraction() {
+        async fn json_handler(Json(payload): Json<Payload>) -> String {
+            payload.value
+        }
+
+        let app = protect(
+            Router::new().route("/json", post(json_handler)),
+            Arc::new(config(Some(API_KEY), None)),
+            AuthLevel::Normal,
+        );
+        let response = call(
+            app,
+            HttpRequest::builder()
+                .method(Method::POST)
+                .uri("/json")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from("not-json"))
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(body(response).await, r#"{"error":"Unauthorized"}"#);
+    }
+
+    #[tokio::test]
+    async fn forced_admin_without_configuration_returns_exact_403() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let app = protect(
+            counted_router(counter.clone()),
+            Arc::new(config(Some(API_KEY), None)),
+            AuthLevel::AdminForce,
+        );
+        let response = call(
+            app,
+            HttpRequest::builder()
+                .uri("/protected")
+                .header(AUTHORIZATION, "Bearer customer-secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.headers()[CONTENT_TYPE], "application/json");
+        assert_eq!(body(response).await, r#"{"error":"Forbidden"}"#);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn normal_router_without_api_key_is_unchanged() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let app = protect(
+            counted_router(counter.clone()),
+            Arc::new(config(None, Some(ADMIN_KEY))),
+            AuthLevel::Normal,
+        );
+        let response = call(
+            app,
+            HttpRequest::builder()
+                .uri("/protected")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+}

--- a/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
+++ b/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
@@ -360,6 +360,7 @@ pub(crate) fn router_and_sweeper() -> (Router, impl std::future::Future<Output =
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api_server::auth::AuthConfig;
     use crate::message::config::{
         DisaggregationMode, RuntimeConfig, RustServerServerArgs, ServerArgs,
     };
@@ -375,10 +376,23 @@ mod tests {
         path_query: &str,
         body: Option<&serde_json::Value>,
     ) -> (u16, String) {
+        request_with_authorization(addr, method, path_query, body, None)
+    }
+
+    fn request_with_authorization(
+        addr: SocketAddr,
+        method: &str,
+        path_query: &str,
+        body: Option<&serde_json::Value>,
+        authorization: Option<&str>,
+    ) -> (u16, String) {
         let body = body.map(|b| b.to_string()).unwrap_or_default();
+        let authorization = authorization
+            .map(|value| format!("Authorization: {value}\r\n"))
+            .unwrap_or_default();
         let mut conn = std::net::TcpStream::connect(addr).expect("connect");
         let req = format!(
-            "{method} {path_query} HTTP/1.1\r\nHost: t\r\nContent-Type: application/json\r\n\
+            "{method} {path_query} HTTP/1.1\r\nHost: t\r\n{authorization}Content-Type: application/json\r\n\
              Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()
         );
@@ -440,6 +454,13 @@ mod tests {
     }
 
     fn start_runtime(server_args: ServerArgs) -> (Runtime, SocketAddr) {
+        start_runtime_with_auth(server_args, AuthConfig::default())
+    }
+
+    fn start_runtime_with_auth(
+        server_args: ServerArgs,
+        auth_config: AuthConfig,
+    ) -> (Runtime, SocketAddr) {
         let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = probe.local_addr().unwrap();
         drop(probe);
@@ -450,6 +471,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            auth_config: Arc::new(auth_config),
         };
         (crate::runtime::start(cfg).expect("start runtime"), addr)
     }
@@ -610,6 +632,121 @@ mod tests {
             "PUT",
             "/route",
             Some(&put_route(serde_json::json!({}))),
+        );
+        assert_eq!(status, 404);
+    }
+
+    /// The v1 trust boundary is structural: customer endpoints (and their
+    /// fallback) require the configured API key, while the prefill bootstrap
+    /// control plane is merged afterwards and remains available to legacy PD
+    /// clients without an Authorization header.
+    #[test]
+    fn api_key_protects_public_routes_but_not_pd_bootstrap() {
+        let mut server_args = test_server_args(DisaggregationMode::Prefill);
+        server_args.served_model_name = "test-model".into();
+        let (_rt, addr) = start_runtime_with_auth(
+            server_args,
+            AuthConfig::new(Some("customer-secret".into()), Some("admin-secret".into())),
+        );
+
+        let (status, body) = request(addr, "GET", "/v1/models", None);
+        assert_eq!(status, 401);
+        assert_eq!(body, r#"{"error":"Unauthorized"}"#);
+
+        let (status, _) = request_with_authorization(
+            addr,
+            "GET",
+            "/v1/models",
+            None,
+            Some("Bearer wrong-secret"),
+        );
+        assert_eq!(status, 401);
+        // The admin credential is deliberately not a super-key for normal APIs.
+        let (status, _) = request_with_authorization(
+            addr,
+            "GET",
+            "/v1/models",
+            None,
+            Some("Bearer admin-secret"),
+        );
+        assert_eq!(status, 401);
+        let (status, _) = request_with_authorization(
+            addr,
+            "GET",
+            "/v1/models",
+            None,
+            Some("Bearer customer-secret"),
+        );
+        assert_eq!(status, 200);
+
+        // Authorization runs before Axum's public MethodRouter decision.
+        let (status, _) = request(addr, "DELETE", "/v1/models", None);
+        assert_eq!(status, 401);
+        let (status, _) = request_with_authorization(
+            addr,
+            "DELETE",
+            "/v1/models",
+            None,
+            Some("Bearer customer-secret"),
+        );
+        assert_eq!(status, 405);
+        // OPTIONS bypasses AuthZ but still receives the downstream method result.
+        let (status, _) = request(addr, "OPTIONS", "/v1/models", None);
+        assert_eq!(status, 405);
+
+        // The public fallback is protected too, except for Python-compatible
+        // health/metrics prefix bypasses.
+        let (status, _) = request(addr, "GET", "/unknown", None);
+        assert_eq!(status, 401);
+        let (status, _) = request_with_authorization(
+            addr,
+            "GET",
+            "/unknown",
+            None,
+            Some("Bearer customer-secret"),
+        );
+        assert_eq!(status, 404);
+        let (status, _) = request(addr, "GET", "/health_unknown", None);
+        assert_eq!(status, 404);
+
+        // Every bootstrap endpoint stays usable without a customer credential.
+        let body = put_route(serde_json::json!({}));
+        let (status, _) = request(addr, "PUT", "/route", Some(&body));
+        assert_eq!(status, 200);
+        let (status, _) = request(addr, "GET", SENTINEL, None);
+        assert_eq!(status, 200);
+        let (status, _) = request(
+            addr,
+            "POST",
+            "/register_dp_rank",
+            Some(&serde_json::json!({"bootstrap_room": 42, "dp_rank": 3})),
+        );
+        assert_eq!(status, 200);
+        let (status, _) = request(
+            addr,
+            "POST",
+            "/query_dp_ranks",
+            Some(&serde_json::json!({"bootstrap_rooms": [42]})),
+        );
+        assert_eq!(status, 200);
+        let (status, _) = request(addr, "DELETE", "/route", None);
+        assert_eq!(status, 405);
+
+        // Off-prefill the same path is not an internal exception because no PD
+        // router owns it: it falls back through the customer boundary, then
+        // becomes a 404 only after a valid customer credential is supplied.
+        let (_null_rt, null_addr) = start_runtime_with_auth(
+            test_server_args(DisaggregationMode::Null),
+            AuthConfig::new(Some("customer-secret".into()), None),
+        );
+        let (status, _) = request(null_addr, "PUT", "/route", Some(&body));
+        assert_eq!(status, 401);
+        let (status, _) = request_with_authorization(
+            null_addr,
+            "PUT",
+            "/route",
+            Some(&body),
+            Some("Bearer customer-secret"),
         );
         assert_eq!(status, 404);
     }

--- a/rust/sglang-server/src/lib.rs
+++ b/rust/sglang-server/src/lib.rs
@@ -21,6 +21,7 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
 
+use crate::api_server::auth::AuthConfig;
 use crate::message::config::{
     DefaultSamplingParams, DisaggregationMode, MmFamily, MmResample, MmSpec, ModelConfig,
     RuntimeConfig, RustServerServerArgs, ServerArgs,
@@ -92,6 +93,8 @@ impl Server {
         from_scheduler_cap = 8192,
         stage_channel_cap = 8192,
         cores = None,
+        api_key = None,
+        admin_api_key = None,
     ))]
     // pyo3 `#[new]` constructor: the wide arg list is the Python-facing boot
     // surface (all optional overrides), not a call-site ergonomics problem.
@@ -103,6 +106,8 @@ impl Server {
         from_scheduler_cap: usize,
         stage_channel_cap: usize,
         cores: Option<Vec<usize>>,
+        api_key: Option<String>,
+        admin_api_key: Option<String>,
     ) -> PyResult<Self> {
         // `server_args` already arrived typed (pyo3 rejected any missing/extra/
         // mistyped field when Python constructed it); only value checks remain.
@@ -124,6 +129,7 @@ impl Server {
                 cores,
             },
             server_args: std::sync::Arc::new(server_args),
+            auth_config: std::sync::Arc::new(AuthConfig::new(api_key, admin_api_key)),
         };
         let rt = runtime::start(cfg).map_err(|e| value_error("runtime start failed", e))?;
         Ok(Server { rt })

--- a/rust/sglang-server/src/message/config.rs
+++ b/rust/sglang-server/src/message/config.rs
@@ -21,6 +21,8 @@ use std::sync::Arc;
 
 use serde::Serialize;
 
+use crate::api_server::auth::AuthConfig;
+
 /// Boot knobs specific to the embedded rust server — none of these exist in
 /// the Python-built [`ServerArgs`]; they arrive as explicit
 /// `Server::start` parameters.
@@ -57,6 +59,9 @@ pub struct RuntimeConfig {
     /// config-endpoint metadata). `Arc` so cloning the config (and, downstream,
     /// each `AppState`) is cheap; immutable after construction.
     pub server_args: Arc<ServerArgs>,
+    /// HTTP authorization policy, kept separate from scheduler/model arguments
+    /// so credentials never enter response shaping or scheduler messages.
+    pub(crate) auth_config: Arc<AuthConfig>,
 }
 
 impl Default for RuntimeConfig {
@@ -64,6 +69,7 @@ impl Default for RuntimeConfig {
         Self {
             rust_server_args: RustServerServerArgs::default(),
             server_args: Arc::new(ServerArgs::default()),
+            auth_config: Arc::new(AuthConfig::default()),
         }
     }
 }

--- a/rust/sglang-server/src/utils/runtime.rs
+++ b/rust/sglang-server/src/utils/runtime.rs
@@ -310,6 +310,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                     senders,
                     cfg.rust_server_args.stage_channel_cap,
                     cfg.server_args.clone(),
+                    cfg.auth_config.clone(),
                     // Response heartbeat watched by `/health_generate`.
                     response_activity,
                     shutdown_rx,
@@ -366,6 +367,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            ..Default::default()
         };
         // Bind is synchronous in `start`, so the port is already accepting.
         let rt = start(cfg).expect("start runtime");
@@ -402,6 +404,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            ..Default::default()
         };
         let rt = start(cfg).expect("start runtime");
 
@@ -447,6 +450,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            ..Default::default()
         };
         let rt = start(cfg).expect("start runtime");
 
@@ -508,6 +512,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            ..Default::default()
         };
         let err = match start(cfg) {
             Ok(_) => panic!("bind conflict must fail startup, got Ok"),

--- a/test/registered/openai_server/basic/test_openai_completion_rust.py
+++ b/test/registered/openai_server/basic/test_openai_completion_rust.py
@@ -41,6 +41,25 @@ class TestOpenAICompletionRustParity(CustomTestCase):
             ],
         )
         try:
+            for headers in (
+                None,
+                {"Authorization": "Bearer wrong-key"},
+            ):
+                unauthorized = requests.get(
+                    DEFAULT_URL_FOR_TEST + "/v1/models",
+                    headers=headers,
+                    timeout=30,
+                )
+                self.assertEqual(unauthorized.status_code, 401)
+                self.assertEqual(unauthorized.json(), {"error": "Unauthorized"})
+
+            # Health stays probe-friendly even when customer APIs require a key.
+            health = requests.get(
+                DEFAULT_URL_FOR_TEST + "/health",
+                timeout=30,
+            )
+            self.assertNotEqual(health.status_code, 401)
+
             response = requests.post(
                 DEFAULT_URL_FOR_TEST + "/v1/completions",
                 headers={"Authorization": f"Bearer {self.api_key}"},

--- a/test/registered/rust/test_rust_server_authz.py
+++ b/test/registered/rust/test_rust_server_authz.py
@@ -1,0 +1,246 @@
+"""API-key authorization on the embedded Rust HTTP frontend.
+
+The policy matrix (4 key configurations x 3 auth levels, Bearer parsing, empty-key
+normalization) is pinned by `api_server::auth`, and the router-assembly boundary
+by `api_server::disaggregation::bootstrap`; both already run in CPU CI through
+`test/registered/rust/test_run_rust_tests.py`, so this file does not re-test them
+on a GPU.
+
+What only a live server can prove is the wiring: the resolved keys survive the
+Python -> PyO3 handoff, and the observable HTTP surface matches the Python
+server. Everything below runs against ONE launch.
+"""
+
+import os
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    STDERR_FILENAME,
+    STDOUT_FILENAME,
+    CustomTestCase,
+    is_rust_server_built,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-small")
+
+UNAUTHORIZED_BODY = {"error": "Unauthorized"}
+# Presented by the rejection tests and never configured anywhere, so it can be
+# asserted absent from the whole log. The *configured* key cannot: the Python
+# scheduler prints its full `server_args=ServerArgs(...)` record at startup,
+# which is out of this layer's control (and identical under the Python server).
+REJECTED_TOKEN = "sk-rust-authz-never-logged"
+
+
+@unittest.skipUnless(
+    is_rust_server_built(),
+    "embedded rust server extension not built",
+)
+class TestRustServerAuthZ(CustomTestCase):
+    model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+    base_url = DEFAULT_URL_FOR_TEST
+    api_key = "sk-rust-authz-user"
+    # Configured so the "admin key is not a super-key for NORMAL endpoints"
+    # branch is reachable: with both keys set, only `api_key` opens /v1/*.
+    admin_api_key = "sk-rust-authz-admin"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stdout = open(STDOUT_FILENAME, "w")
+        cls.stderr = open(STDERR_FILENAME, "w")
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            env={"SGLANG_RUST_SERVER": "1"},
+            other_args=["--admin-api-key", cls.admin_api_key],
+            return_stdout_stderr=(cls.stdout, cls.stderr),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+        for stream, path in (
+            (getattr(cls, "stdout", None), STDOUT_FILENAME),
+            (getattr(cls, "stderr", None), STDERR_FILENAME),
+        ):
+            if stream:
+                stream.close()
+            if os.path.exists(path):
+                os.remove(path)
+
+    def _request(self, method, path, token=None, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        return requests.request(
+            method, self.base_url + path, headers=headers, timeout=60, **kwargs
+        )
+
+    def assert_unauthorized(self, response):
+        """The 401 contract Python emits via ORJSONResponse, byte for byte."""
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.headers.get("content-type", "").split(";")[0].strip(),
+            "application/json",
+        )
+        self.assertEqual(response.json(), UNAUTHORIZED_BODY)
+
+    def test_customer_routes_require_the_api_key(self):
+        """The key reaches the frontend: same route, three credentials."""
+        for token in (None, "wrong-key"):
+            with self.subTest(token=token):
+                self.assert_unauthorized(self._request("GET", "/v1/models", token))
+
+        self.assertEqual(
+            self._request("GET", "/v1/models", self.api_key).status_code, 200
+        )
+
+    def test_admin_key_is_not_a_super_key_for_normal_routes(self):
+        """Both keys configured: only `api_key` opens NORMAL endpoints -- the one
+        policy row that needs a real launch carrying both credentials."""
+        for path in ("/v1/models", "/server_info"):
+            with self.subTest(path=path):
+                self.assert_unauthorized(self._request("GET", path, self.admin_api_key))
+                self.assertEqual(
+                    self._request("GET", path, self.api_key).status_code, 200
+                )
+
+    def test_native_and_common_routes_are_protected(self):
+        """Protection is not OpenAI-only: it covers every customer router."""
+        self.assert_unauthorized(
+            self._request("POST", "/generate", json={"text": "hi"})
+        )
+        for path in ("/server_info", "/model_info", "/get_model_info"):
+            with self.subTest(path=path):
+                self.assert_unauthorized(self._request("GET", path))
+                self.assertEqual(
+                    self._request("GET", path, self.api_key).status_code, 200
+                )
+
+    def test_probe_endpoints_stay_public(self):
+        """k8s liveness and Prometheus scraping must not need a credential.
+        `/metrics` has no Rust handler yet, so its bypass is asserted as not-401."""
+        for path in ("/health", "/health_generate", "/metrics"):
+            with self.subTest(path=path):
+                self.assertNotEqual(self._request("GET", path).status_code, 401)
+
+    def test_unknown_paths_authenticate_before_they_404(self):
+        """Regression guard for the layer-before-merge assembly: an unauthenticated
+        caller must not be able to probe which paths exist."""
+        self.assert_unauthorized(self._request("GET", "/definitely_unknown"))
+        self.assertEqual(
+            self._request("GET", "/definitely_unknown", self.api_key).status_code, 404
+        )
+        # ... while the public prefixes keep bypassing it, so a mistyped probe
+        # path reports 404 rather than a misleading 401.
+        self.assertEqual(self._request("GET", "/health_unknown").status_code, 404)
+
+    def test_authz_precedes_the_method_router(self):
+        """A wrong method on a protected path is a 401, not a 405."""
+        self.assert_unauthorized(self._request("DELETE", "/v1/models"))
+        self.assertEqual(
+            self._request("DELETE", "/v1/models", self.api_key).status_code, 405
+        )
+        # OPTIONS bypasses AuthZ entirely and gets the downstream answer.
+        self.assertEqual(self._request("OPTIONS", "/v1/models").status_code, 405)
+
+    def test_authz_precedes_body_extraction(self):
+        """Malformed body plus no credential is a 401, never a 400/422: rejecting
+        first keeps unparsed bodies out of the tokenizer and scheduler."""
+        malformed = {
+            "data": "not-json-at-all",
+            "headers": {"Content-Type": "application/json"},
+        }
+        self.assert_unauthorized(self._request("POST", "/generate", **malformed))
+        self.assertEqual(
+            self._request("POST", "/generate", self.api_key, **malformed).status_code,
+            400,
+        )
+
+    def test_streaming_rejection_is_a_plain_json_error(self):
+        """Failing before the handler means no SSE stream is ever opened."""
+        response = self._request(
+            "POST",
+            "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 4,
+                "stream": True,
+            },
+            stream=True,
+        )
+        self.assert_unauthorized(response)
+        self.assertNotIn("text/event-stream", response.headers.get("content-type", ""))
+
+    def test_authorized_requests_still_generate(self):
+        """The layer must be transparent once the credential checks out."""
+        response = self._request(
+            "POST",
+            "/v1/completions",
+            self.api_key,
+            json={
+                "model": self.model,
+                "prompt": "The capital of France is",
+                "max_tokens": 8,
+                "temperature": 0,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["choices"][0]["text"])
+
+    def test_no_endpoint_discloses_a_configured_key(self):
+        """`/server_info` is NORMAL, so the customer key opens it: were it to echo
+        the raw server-args dump, that key would read out `admin_api_key`."""
+        for path in ("/server_info", "/model_info", "/get_model_info"):
+            with self.subTest(path=path):
+                body = self._request("GET", path, self.api_key).text
+                self.assertNotIn(self.api_key, body)
+                self.assertNotIn(self.admin_api_key, body)
+
+    def _read_server_log(self):
+        text = ""
+        for path in (STDOUT_FILENAME, STDERR_FILENAME):
+            if os.path.exists(path):
+                with open(path, errors="replace") as handle:
+                    text += handle.read()
+        return text
+
+    def test_access_log_records_rejections_without_the_token(self):
+        """401s belong in the access log; the credential that produced them does
+        not -- the two failure modes of logging an auth denial."""
+        self.assert_unauthorized(self._request("GET", "/v1/models", REJECTED_TOKEN))
+
+        # Rust's stdout is line-buffered, but give the writer a moment to land.
+        deadline = time.time() + 10
+        log = ""
+        while time.time() < deadline:
+            log = self._read_server_log()
+            if any(
+                "/v1/models" in line and "401" in line
+                for line in log.splitlines()
+                if 'HTTP/1.1"' in line
+            ):
+                break
+            time.sleep(0.5)
+        else:
+            self.fail("no 401 access-log line for /v1/models found in the server log")
+
+        self.assertNotIn(
+            REJECTED_TOKEN, log, "the presented credential was written to the log"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/rust_server/test_auth_config.py
+++ b/test/registered/unit/rust_server/test_auth_config.py
@@ -1,0 +1,69 @@
+"""Auth configuration handoff for the embedded Rust HTTP frontend."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch, sentinel
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.rust_server import server as rust_server_module  # noqa: E402
+from sglang.srt.rust_server.server import RustServer  # noqa: E402
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestRustServerAuthConfig(CustomTestCase):
+    def test_launch_passes_resolved_keys_only_to_server_constructor(self):
+        server_constructor = Mock(return_value=sentinel.server)
+        extension = SimpleNamespace(Server=server_constructor)
+        serving = SimpleNamespace(
+            host="127.0.0.1",
+            port=31000,
+            api_key="resolved-user-key",
+            admin_api_key="resolved-admin-key",
+        )
+        scheduler = SimpleNamespace(
+            # Deliberately different values: launch must consume the resolved
+            # serving namespace, not re-read the mutable ServerArgs record.
+            server_args=SimpleNamespace(
+                host="stale-host",
+                port=32000,
+                api_key="stale-user-key",
+                admin_api_key="stale-admin-key",
+            ),
+            ps=SimpleNamespace(dp_size=1),
+            model_config=SimpleNamespace(is_multimodal=False),
+        )
+
+        with (
+            patch(
+                "sglang.srt.rust_extensions.load_rust_extension",
+                return_value=extension,
+            ),
+            patch.object(rust_server_module, "get_serving", return_value=serving),
+            patch.object(
+                rust_server_module, "_partition_cores", return_value=(None, None)
+            ),
+            patch.object(
+                rust_server_module,
+                "_build_server_args",
+                return_value=sentinel.rust_server_args,
+            ),
+        ):
+            launched = RustServer.launch(scheduler)
+
+        self.assertIs(launched.server, sentinel.server)
+        server_constructor.assert_called_once_with(
+            sentinel.rust_server_args,
+            cores=None,
+            port_offset=None,
+            api_key="resolved-user-key",
+            admin_api_key="resolved-admin-key",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The embedded Rust HTTP frontend currently ignores `--api-key` and `--admin-api-key`. As a result, enabling `SGLANG_RUST_SERVER=1` can leave customer-facing endpoints unauthenticated even though the same configuration protects the Python server.

This PR implements item 14, AuthZ support, from RFC #23206 and restores API-key behavior parity without treating the user-facing key as an internal PD-bootstrap credential.

## Modifications

- Add an Axum AuthZ layer matching the Python server's `NORMAL`, `ADMIN_OPTIONAL`, and `ADMIN_FORCE` policies, including Bearer parsing, 401/403 response shapes, public probe prefixes, and `OPTIONS` handling.
- Protect native, OpenAI-compatible, common, and fallback customer routes while leaving the PD bootstrap router outside the user API-key boundary.
- Pass resolved API and admin keys directly through the Python/PyO3 launch boundary, keeping secrets out of serializable scheduler/model `ServerArgs` and server-info surfaces.
- Use constant-time key comparison and avoid installing the middleware when the active policy is unconditionally public.
- Add Rust policy/router tests, Python launch-handoff coverage, and one-launch GPU E2E coverage for observable authorization, routing order, generation, and secret redaction behavior.

## Accuracy Tests

Not applicable. This PR does not change model execution, sampling, scheduling, or generated-token semantics. The E2E suite includes an authenticated deterministic generation smoke test to verify that accepted requests remain transparent to inference.

## Speed Tests and Profiling

No GPU performance benchmark was run because this PR does not modify the model, scheduler, prefill, or decode paths. When `--api-key` is unset, `auth::protect` returns the original router without installing per-request middleware. With authentication enabled, the additional ingress work is limited to an authorization-header lookup, Bearer parsing, and a constant-time key comparison.

## Tests

- `cargo test --locked --manifest-path rust/Cargo.toml -p sglang-server --lib` — 272 passed.
- `cargo clippy --locked --manifest-path rust/Cargo.toml -p sglang-server --lib --tests -- -D warnings` — passed.
- `cargo fmt --all --manifest-path rust/Cargo.toml -- --check` — passed.
- `python3 -m py_compile` on all changed Python test/source files — passed.
- Changed-files `pre-commit` suite — passed.
- Live GPU E2E coverage is registered in `base-b` on `1-gpu-small` and will run in PR CI.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is required because the existing API-key flags and semantics are unchanged.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). The sections above document why model accuracy and GPU speed benchmarks are not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34085773713](https://github.com/sgl-project/sglang/actions/runs/34085773713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34085773124](https://github.com/sgl-project/sglang/actions/runs/34085773124)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34085773106](https://github.com/sgl-project/sglang/actions/runs/34085773106)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->