### PR TITLE
[Docs] Prefer current CUDA graph CLIs in multimodal Gemma-3 note

### DIFF
--- a/docs/docs/supported-models/multimodal_language_models.mdx
+++ b/docs/docs/supported-models/multimodal_language_models.mdx
@@ -431,7 +431,8 @@ python -m sglang.launch_server \
   --enable-multimodal \
   --dtype bfloat16 --triton-attention-reduce-in-fp32 \
   --attention-backend triton \ # Use Triton attention backend
-  --disable-cuda-graph \ # Disable Cuda Graph
+  --cuda-graph-backend-decode=disabled \ # Disable Cuda Graph
+  --cuda-graph-backend-prefill=disabled \
   --chunked-prefill-size -1 # Disable Chunked Prefill
 ```
 


### PR DESCRIPTION
## Summary
- Prefer `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` over deprecated `--disable-cuda-graph` in the Gemma-3 bidirectional-attention launch example (`multimodal_language_models.mdx`).

## Context
`server_args` registers `--disable-cuda-graph` as a deprecated alias that redirects to the current CUDA graph backend CLIs.

## Test plan
- [ ] Docs-only change; confirm the launch snippet still disables CUDA graph for the Triton bidirectional-attention path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34086199743](https://github.com/sgl-project/sglang/actions/runs/34086199743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34086199589](https://github.com/sgl-project/sglang/actions/runs/34086199589)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->