### PR TITLE
[CI] Fix stale CP-v1 mock patches in NextN mm-embed test

### DIFF
--- a/test/registered/unit/models/test_deepseek_nextn_mm_embed.py
+++ b/test/registered/unit/models/test_deepseek_nextn_mm_embed.py
@@ -56,10 +56,6 @@ def _make_model_nextn(vocab_size: int, hidden_size: int):
     model.rot_weight = None
     model.alt_stream = None
     model.quant_config = None
-    model.cp_rank = None
-    model.cp_size = None
-    model.dsa_enable_prefill_cp = False
-    model.mla_enable_prefill_cp = False
     model.mtp_block = MagicMock(side_effect=lambda **kw: (kw["hidden_states"], None))
     return model
 
@@ -96,9 +92,6 @@ class TestDeepseekNextNMmEmbed(CustomTestCase):
         object.__setattr__(model, "embed_tokens", mock_embed)
 
         with (
-            patch(
-                "sglang.srt.models.deepseek_nextn.is_cp_v2_active", return_value=False
-            ),
             patch(
                 "sglang.srt.models.deepseek_nextn.dsa_use_prefill_cp",
                 return_value=False,
@@ -164,9 +157,6 @@ class TestDeepseekNextNMmEmbed(CustomTestCase):
         embed_calls = mock_embed.call_args_list
 
         with (
-            patch(
-                "sglang.srt.models.deepseek_nextn.is_cp_v2_active", return_value=False
-            ),
             patch(
                 "sglang.srt.models.deepseek_nextn.dsa_use_prefill_cp",
                 return_value=False,


### PR DESCRIPTION
Drop stale `is_cp_v2_active` patches and dead CP-v1 mock attrs broken by #36228, fixing base-a-test-cpu failure in test_deepseek_nextn_mm_embed.py

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34086410072](https://github.com/sgl-project/sglang/actions/runs/34086410072)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34086409876](https://github.com/sgl-project/sglang/actions/runs/34086409876)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34086409994](https://github.com/sgl-project/sglang/actions/runs/34086409994)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->