### PR TITLE
[gRPC] Support standard health checks on the native server

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4236,6 +4237,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { workspace = true }
 prost = "0.13"
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 tonic = { version = "0.12", features = ["gzip", "transport"] }
+tonic-health = "0.12"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/rust/sglang-grpc/README.md
+++ b/rust/sglang-grpc/README.md
@@ -1,0 +1,42 @@
+# Native gRPC health checks
+
+The native gRPC listener enabled by `--grpc-port` exposes
+`grpc.health.v1.Health/Check` on the same port as
+`sglang.runtime.v1.SglangService`. The existing SGLang `HealthCheck` RPC is also
+available.
+
+Both the empty service name (overall health) and
+`sglang.runtime.v1.SglangService` report runtime readiness. They return
+`NOT_SERVING` during startup, when the runtime is unhealthy, or during shutdown,
+and `SERVING` when the runtime is ready. Checks read runtime state without
+submitting inference requests. A runtime check failure returns `NOT_SERVING`.
+
+An unknown service name returns `NOT_FOUND` from `Check`. Streaming `Watch`
+returns `UNIMPLEMENTED`; the server does not poll runtime health in the
+background.
+
+For a Kubernetes container running SGLang with `--grpc-port 50051`, add these
+fields to its container spec. Native
+[gRPC probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe)
+are stable in Kubernetes 1.27 and later:
+
+```yaml
+startupProbe:
+  grpc:
+    port: 50051
+    service: sglang.runtime.v1.SglangService
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 120
+readinessProbe:
+  grpc:
+    port: 50051
+    service: sglang.runtime.v1.SglangService
+  periodSeconds: 5
+  timeoutSeconds: 2
+```
+
+Set SGLang's `--host` to an address reachable through the Pod IP, such as
+`0.0.0.0`. Adjust the startup probe's failure threshold for your model's load
+and warmup time. These probes describe readiness; they do not execute a model
+inference to test GPU responsiveness.

--- a/rust/sglang-grpc/src/health.rs
+++ b/rust/sglang-grpc/src/health.rs
@@ -1,0 +1,82 @@
+//! Standard gRPC health checks backed by the same runtime state as HealthCheck.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use tonic::server::NamedService;
+use tonic::{Request, Response, Status};
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::health_server::Health;
+use tonic_health::pb::{HealthCheckRequest, HealthCheckResponse};
+
+use crate::bridge::PyBridge;
+use crate::proto::sglang_service_server::SglangServiceServer;
+use crate::server::SglangServiceImpl;
+
+const SGLANG_SERVICE: &str = <SglangServiceServer<SglangServiceImpl> as NamedService>::NAME;
+
+pub(crate) struct StandardHealthService {
+    check: Arc<dyn Fn() -> bool + Send + Sync>,
+    stopping: watch::Receiver<bool>,
+}
+
+impl StandardHealthService {
+    pub(crate) fn new(bridge: Arc<PyBridge>, stopping: watch::Receiver<bool>) -> Self {
+        Self {
+            check: Arc::new(move || match bridge.health_check() {
+                Ok(healthy) => healthy,
+                Err(err) => {
+                    tracing::warn!("gRPC health check failed: {err}");
+                    false
+                }
+            }),
+            stopping,
+        }
+    }
+
+    async fn serving_status(&self) -> ServingStatus {
+        let mut stopping = self.stopping.clone();
+        tokio::select! {
+            biased;
+            _ = stopping.wait_for(|stopping| *stopping) => ServingStatus::NotServing,
+            result = async {
+                let check = self.check.clone();
+                tokio::task::spawn_blocking(move || check()).await
+            } => match result {
+                Ok(true) => ServingStatus::Serving,
+                Ok(false) => ServingStatus::NotServing,
+                Err(err) => {
+                    tracing::warn!("gRPC health check task failed: {err}");
+                    ServingStatus::NotServing
+                }
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Health for StandardHealthService {
+    async fn check(
+        &self,
+        request: Request<HealthCheckRequest>,
+    ) -> Result<Response<HealthCheckResponse>, Status> {
+        if !matches!(request.get_ref().service.as_str(), "" | SGLANG_SERVICE) {
+            return Err(Status::not_found("service not registered"));
+        }
+        Ok(Response::new(HealthCheckResponse {
+            status: self.serving_status().await as i32,
+        }))
+    }
+
+    type WatchStream = tokio_stream::Empty<Result<HealthCheckResponse, Status>>;
+
+    async fn watch(
+        &self,
+        _request: Request<HealthCheckRequest>,
+    ) -> Result<Response<Self::WatchStream>, Status> {
+        Err(Status::unimplemented("Watch is not supported; use Check"))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/sglang-grpc/src/health/tests.rs
+++ b/rust/sglang-grpc/src/health/tests.rs
@@ -1,0 +1,73 @@
+use super::*;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tonic::Code;
+
+#[derive(Default)]
+struct TestRuntime {
+    healthy: AtomicBool,
+    calls: AtomicUsize,
+}
+
+fn test_service() -> (StandardHealthService, Arc<TestRuntime>, watch::Sender<bool>) {
+    let runtime = Arc::new(TestRuntime::default());
+    let state = runtime.clone();
+    let (shutdown, stopping) = watch::channel(false);
+    let service = StandardHealthService {
+        check: Arc::new(move || {
+            state.calls.fetch_add(1, Ordering::SeqCst);
+            state.healthy.load(Ordering::SeqCst)
+        }),
+        stopping,
+    };
+    (service, runtime, shutdown)
+}
+
+fn request(service: &str) -> Request<HealthCheckRequest> {
+    Request::new(HealthCheckRequest {
+        service: service.to_owned(),
+    })
+}
+
+#[tokio::test]
+async fn check_tracks_runtime_readiness_for_overall_and_named_service() {
+    let (service, runtime, _shutdown) = test_service();
+    for (ready, expected) in [
+        (false, ServingStatus::NotServing),
+        (true, ServingStatus::Serving),
+        (false, ServingStatus::NotServing),
+    ] {
+        runtime.healthy.store(ready, Ordering::SeqCst);
+        for name in ["", SGLANG_SERVICE] {
+            let response = service.check(request(name)).await.unwrap().into_inner();
+            assert_eq!(response.status, expected as i32);
+        }
+    }
+}
+
+#[tokio::test]
+async fn check_rejects_unknown_service_without_calling_runtime() {
+    let (service, runtime, _shutdown) = test_service();
+    let err = service.check(request("unknown")).await.unwrap_err();
+    assert_eq!(err.code(), Code::NotFound);
+    assert_eq!(runtime.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn check_reports_not_serving_when_runtime_task_panics() {
+    let (mut service, _, _shutdown) = test_service();
+    service.check = Arc::new(|| panic!("runtime failed"));
+    let response = service.check(request("")).await.unwrap().into_inner();
+    assert_eq!(response.status, ServingStatus::NotServing as i32);
+}
+
+#[tokio::test]
+async fn shutdown_overrides_runtime_readiness_without_calling_runtime() {
+    let (service, runtime, shutdown) = test_service();
+    runtime.healthy.store(true, Ordering::SeqCst);
+    shutdown.send(true).unwrap();
+    for name in ["", SGLANG_SERVICE] {
+        let response = service.check(request(name)).await.unwrap().into_inner();
+        assert_eq!(response.status, ServingStatus::NotServing as i32);
+    }
+    assert_eq!(runtime.calls.load(Ordering::SeqCst), 0);
+}

--- a/rust/sglang-grpc/src/lib.rs
+++ b/rust/sglang-grpc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bridge;
+mod health;
 pub mod server;
 pub mod tokenizers;
 pub(crate) mod utils;
@@ -27,10 +28,13 @@ struct GrpcServerHandle {
 #[pymethods]
 impl GrpcServerHandle {
     /// Gracefully shut down the gRPC server.
-    fn shutdown(&mut self) {
+    fn shutdown(&mut self, py: Python<'_>) {
         self.shutdown.notify_one();
         if let Some(handle) = self.join_handle.take() {
-            let _ = handle.join();
+            // In-flight health checks may need the GIL before the server can exit.
+            py.detach(move || {
+                let _ = handle.join();
+            });
         }
     }
 

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -5,13 +5,15 @@ use std::sync::Arc;
 use pyo3::PyErr;
 use pyo3::Python;
 use pyo3::exceptions::{PyTypeError, PyValueError};
-use tokio::sync::{Notify, mpsc::Receiver};
+use tokio::sync::{Notify, mpsc::Receiver, watch};
 use tokio::time::{Duration, timeout};
 use tokio_stream::Stream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
+use tonic_health::pb::health_server::HealthServer;
 
 use crate::bridge::{PyBridge, ResponseChunk, TerminalError};
+use crate::health::StandardHealthService;
 use crate::proto;
 use crate::utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
@@ -984,6 +986,8 @@ pub async fn run_grpc_server(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let addr = listener.local_addr()?;
     let listener = tokio::net::TcpListener::from_std(listener)?;
+    let (health_shutdown, health_stopping) = watch::channel(false);
+    let health_service = StandardHealthService::new(bridge.clone(), health_stopping);
     let service = SglangServiceImpl {
         bridge,
         response_timeout,
@@ -998,8 +1002,11 @@ pub async fn run_grpc_server(
 
     tonic::transport::Server::builder()
         .add_service(svc)
+        .add_service(HealthServer::new(health_service))
         .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
             shutdown.notified().await;
+            // Report NOT_SERVING before draining in-flight health checks.
+            let _ = health_shutdown.send(true);
             tracing::info!("gRPC server shutting down");
         })
         .await?;

--- a/test/registered/rust/test_native_grpc_health.py
+++ b/test/registered/rust/test_native_grpc_health.py
@@ -1,0 +1,145 @@
+"""Exercise standard health checks against the native Rust gRPC listener on CPU."""
+
+import socket
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+
+import grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+
+from sglang.srt.rust_extensions import load_rust_extension
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+SERVICE = "sglang.runtime.v1.SglangService"
+
+
+class _Runtime:
+    def __init__(self):
+        self.tokenizer_manager = SimpleNamespace()
+        self.healthy = False
+        self.fail = False
+        self.check_calls = 0
+
+    def health_check(self):
+        self.check_calls += 1
+        if self.fail:
+            raise RuntimeError("runtime unavailable")
+        return self.healthy
+
+
+class TestNativeGrpcHealth(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.grpc_native = load_rust_extension("sglang.srt.rust_extensions._grpc")
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        cls.runtime = _Runtime()
+        cls.server = cls.grpc_native.start_server(
+            host="127.0.0.1", port=port, runtime_handle=cls.runtime
+        )
+        cls.addClassCleanup(cls.server.shutdown)
+        cls.channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+        cls.addClassCleanup(cls.channel.close)
+        grpc.channel_ready_future(cls.channel).result(timeout=5)
+        cls.health = health_pb2_grpc.HealthStub(cls.channel)
+
+    def setUp(self):
+        self.runtime.healthy = False
+        self.runtime.fail = False
+        self.runtime.check_calls = 0
+
+    def test_check_tracks_readiness_and_preserves_native_rpc(self):
+        native_check = self.channel.unary_unary(f"/{SERVICE}/HealthCheck")
+        for ready in (False, True, False):
+            self.runtime.healthy = ready
+            expected = (
+                health_pb2.HealthCheckResponse.SERVING
+                if ready
+                else health_pb2.HealthCheckResponse.NOT_SERVING
+            )
+            for name in ("", SERVICE):
+                response = self.health.Check(
+                    health_pb2.HealthCheckRequest(service=name), timeout=5
+                )
+                self.assertEqual(response.status, expected)
+            # Native HealthCheck has an empty request and bool healthy at field 1.
+            self.assertEqual(
+                native_check(b"", timeout=5), b"\x08\x01" if ready else b""
+            )
+
+    def test_check_handles_runtime_error_and_unknown_service(self):
+        self.runtime.fail = True
+        response = self.health.Check(health_pb2.HealthCheckRequest(), timeout=5)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.NOT_SERVING)
+        with self.assertRaises(grpc.RpcError) as caught:
+            self.health.Check(
+                health_pb2.HealthCheckRequest(service="unknown"), timeout=5
+            )
+        self.assertEqual(caught.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_watch_is_unimplemented_without_calling_runtime(self):
+        for name in ("", SERVICE, "unknown"):
+            with self.assertRaises(grpc.RpcError) as caught:
+                next(
+                    self.health.Watch(
+                        health_pb2.HealthCheckRequest(service=name), timeout=5
+                    )
+                )
+            self.assertEqual(caught.exception.code(), grpc.StatusCode.UNIMPLEMENTED)
+        self.assertEqual(self.runtime.check_calls, 0)
+
+    def test_shutdown_releases_gil_for_inflight_health_check(self):
+        # Isolate a potential GIL deadlock so a regression fails with a timeout
+        # instead of hanging the entire test process.
+        code = r"""
+import importlib.util
+import socket
+import sys
+import threading
+from types import SimpleNamespace
+
+import grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+
+spec = importlib.util.spec_from_file_location("_grpc", sys.argv[1])
+native = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(native)
+started, release = threading.Event(), threading.Event()
+
+def health_check():
+    started.set()
+    release.wait()
+    return True
+
+runtime = SimpleNamespace(
+    tokenizer_manager=SimpleNamespace(), health_check=health_check
+)
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+server = native.start_server(host="127.0.0.1", port=port, runtime_handle=runtime)
+with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
+    stub = health_pb2_grpc.HealthStub(channel)
+    pending = stub.Check.future(health_pb2.HealthCheckRequest(), timeout=5)
+    assert started.wait(5), "health check did not start"
+    threading.Timer(0.1, release.set).start()
+    server.shutdown()
+    assert not server.is_alive()
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code, self.grpc_native.__file__],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

The native gRPC listener exposes SGLang's `HealthCheck` RPC, but Kubernetes startup and readiness probes require `grpc.health.v1.Health/Check`. Add this standard endpoint so probes can read runtime readiness without submitting inference requests.

Fixes sgl-project/sglang#38075.

## Modifications

- Register standard `Health/Check` on the native gRPC listener for both the empty service name and `sglang.runtime.v1.SglangService`.
- Report `SERVING` or `NOT_SERVING` from the existing runtime health state, including startup, runtime failures, and shutdown. Unknown services return `NOT_FOUND`.
- Keep the existing native `HealthCheck` RPC. Streaming `Watch` returns `UNIMPLEMENTED`; no background health polling is added.
- Release the GIL while waiting for server shutdown, allowing in-flight Python health checks to finish.
- Add Rust state tests, CPU gRPC integration tests, and Kubernetes probe examples.

## Validation

- `cd rust && cargo test --locked --workspace`: 304 tests passed.
- `SGLANG_RUST_BUILD_MODE=auto python3 test/registered/rust/test_native_grpc_health.py`: 4 tests passed using the release extension built from source.
- `pre-commit run --all-files --hook-stage pre-commit`: passed in a clean worktree at the submitted commit.
- `cargo fmt --all -- --check` and the radix-tree formatting check: passed.
- `cargo clippy --locked -p sglang-grpc --all-targets -- -D warnings`: passed.

## Accuracy Tests

Not applicable: this change does not modify model execution or model outputs. Runtime state mapping, protocol responses, and native RPC compatibility are covered by the tests above.

## Speed Tests and Profiling

Not applicable to model inference performance. Health is queried only when a client calls `Check`; no periodic polling is introduced.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused regression tests and register the Python integration tests for CPU CI.
- [x] Update documentation with health semantics and Kubernetes probe examples.
- [x] Assess accuracy and speed benchmarks: not applicable to this endpoint change.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

Upstream CI and maintainer/codeowner review remain to be requested after opening the PR. No GPU inference run or Kubernetes cluster deployment was performed locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34086836051](https://github.com/sgl-project/sglang/actions/runs/34086836051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34086835814](https://github.com/sgl-project/sglang/actions/runs/34086835814)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34086836084](https://github.com/sgl-project/sglang/actions/runs/34086836084)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->