### PR TITLE
fix(dsv4): support R3 capture and MXFP4 online updates

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -127,6 +127,10 @@ def fused_topk_npu(
     if expert_location_dispatch_info is not None:
         topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
-    capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
+    capture_routed_experts_if_allowed(
+        topk_config.allow_routed_experts_capture,
+        layer_id,
+        topk_ids,
+    )
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -249,6 +249,7 @@ class HashTopK(nn.Module):
             self.allow_routed_experts_capture,
             self.layer_id,
             topk_ids,
+            num_token_non_padded,
         )
 
         num_fused_shared_experts = self.num_fused_shared_experts

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.moe.topk import (
     TopKConfig,
     _mask_topk_ids_padded_region,
     _zero_topk_weights_padded_region,
+    capture_routed_experts_if_allowed,
     remap_topk_for_per_rank_shared_slots,
 )
 from sglang.srt.layers.moe.utils import has_per_rank_fused_shared_slots
@@ -59,6 +60,7 @@ class HashTopK(nn.Module):
 
         self.num_experts = num_experts
         self.topk = topk
+        self.allow_routed_experts_capture = True
         self.routed_scaling_factor = routed_scaling_factor
         self.num_fused_shared_experts = num_fused_shared_experts
         self.score_func = scoring_func
@@ -242,6 +244,12 @@ class HashTopK(nn.Module):
 
         if self.apply_routed_scaling_factor_on_output:
             topk_weights = topk_weights * self.routed_scaling_factor
+
+        capture_routed_experts_if_allowed(
+            self.allow_routed_experts_capture,
+            self.layer_id,
+            topk_ids,
+        )
 
         num_fused_shared_experts = self.num_fused_shared_experts
         log2phy_prob = None

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -2069,7 +2069,7 @@ def remap_topk_for_per_rank_shared_slots(
 
 
 def capture_routed_experts_if_allowed(
-    topk_config: TopKConfig,
+    allow_capture: bool,
     layer_id: Optional[int],
     topk_ids: torch.Tensor,
     num_token_non_padded: Optional[torch.Tensor] = None,
@@ -2083,7 +2083,7 @@ def capture_routed_experts_if_allowed(
     (and ROCm's masks to 0, a valid expert id), so mask a copy here: replay skips
     -1 rows but reads a padded one as a real selection.
     """
-    if not topk_config.allow_routed_experts_capture:
+    if not allow_capture:
         return
     cap = get_global_experts_capturer()
     if cap is None:
@@ -2114,7 +2114,10 @@ def _post_process_topk_ids(
         topk_config.fused_shared_experts_scaling_factor
     )
     capture_routed_experts_if_allowed(
-        topk_config, layer_id, topk_ids, num_token_non_padded
+        topk_config.allow_routed_experts_capture,
+        layer_id,
+        topk_ids,
+        num_token_non_padded,
     )
     recorder_topk_ids = None
     _fold_pad_into_append = False
@@ -2574,7 +2577,9 @@ def build_precomputed_topk_output(
 
     Only valid when :func:`precomputed_topk_postprocess_is_noop` holds.
     """
-    capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
+    capture_routed_experts_if_allowed(
+        topk_config.allow_routed_experts_capture, layer_id, topk_ids
+    )
     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
     # router_logits is only read by the BYPASSED formats and by the
     # shared-expert append (excluded above); STANDARD consumers take ids/weights.

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -48,6 +48,29 @@ _USE_OFFICIAL_SHUFFLE = get_bool_env_var(
 )
 
 
+_EXPERT_PARAMS = (
+    "w13_weight",
+    "w2_weight",
+    "w13_weight_scale_inv",
+    "w2_weight_scale_inv",
+)
+
+
+def _rebind(layer: Module, name: str, value: torch.Tensor) -> None:
+    """Replace a parameter's payload, carrying over the attributes it was created with.
+
+    The kernel layout differs in dtype and extent from the layout weights are
+    loaded in, so the parameter object has to be replaced rather than written
+    through. ``create_weights`` installs the loader attributes that
+    ``load_weights`` dispatches on, and weights are loaded again on every
+    online update, so those attributes have to survive each rebuild.
+    """
+    old = getattr(layer, name)
+    new = Parameter(value, requires_grad=False)
+    new.__dict__.update(old.__dict__)
+    setattr(layer, name, new)
+
+
 class Mxfp4FlashinferTrtllmMoEMethod:
     fuse_routed_scaling_factor_in_topk = True
 
@@ -57,6 +80,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         # precision=fp8 is an SM90 knob (Humming W4A8); this SM100 trtllm path
         # already runs MXFP8 activations, so the flag is inert here rather than
         # an error -- one config can move across hardware.
+        self._kernel_layout: dict[str, torch.Tensor] = {}
         self.flashinfer_mxfp4_moe_precision = (
             get_exec().moe.flashinfer_mxfp4_moe_precision
         )
@@ -87,11 +111,20 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         hidden_size: int,
         intermediate_size_per_partition: int,
         params_dtype,
+        alloc_device=None,
         **extra_weight_attrs,
     ):
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
 
         fp4_block_k = 32
+
+        self._load_layout = (
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            params_dtype,
+            dict(extra_weight_attrs),
+        )
 
         w13_weight = Parameter(
             torch.empty(
@@ -99,6 +132,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 2 * intermediate_size_per_partition,
                 hidden_size // 2,
                 dtype=torch.int8,
+                device=alloc_device,
             ),
             requires_grad=False,
         )
@@ -108,6 +142,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 hidden_size,
                 intermediate_size_per_partition // 2,
                 dtype=torch.int8,
+                device=alloc_device,
             ),
             requires_grad=False,
         )
@@ -122,6 +157,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 2 * intermediate_size_per_partition,
                 hidden_size // fp4_block_k,
                 dtype=torch.float32,
+                device=alloc_device,
             ),
             requires_grad=False,
         )
@@ -131,6 +167,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 hidden_size,
                 intermediate_size_per_partition // fp4_block_k,
                 dtype=torch.float32,
+                device=alloc_device,
             ),
             requires_grad=False,
         )
@@ -143,6 +180,55 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
         set_weight_attrs(w2_weight_scale, scale_attrs)
 
+    def _install_kernel_layout(
+        self, layer: Module, name: str, value: torch.Tensor
+    ) -> None:
+        """Publish a kernel-layout tensor, reusing the storage the kernel already reads.
+
+        A captured CUDA graph records the addresses of the tensors it reads, so a
+        rebuild has to land in the storage the capture saw. Allocating afresh
+        leaves the graph replaying against the previous weights while every
+        Python-visible view holds the new ones.
+        """
+        established = self._kernel_layout.get(name)
+        if (
+            established is not None
+            and established.shape == value.shape
+            and established.dtype == value.dtype
+        ):
+            established.copy_(value)
+            value = established
+        self._kernel_layout[name] = value
+        _rebind(layer, name, value)
+
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        """Put the expert parameters back in the layout weights are loaded in.
+
+        The kernel layout differs from the load layout in dtype, and for the
+        second-gemm scale in extent as well, so weights cannot be written
+        straight back into the parameters the kernel reads: a load would cast
+        each scale to the wrong value instead of failing. Each parameter is
+        released before its replacement is allocated, so the two layouts are
+        never both resident.
+        """
+        if not getattr(layer, "_mxfp4_kernel_layout", False):
+            return
+
+        device = layer.w13_weight.device
+        num_experts, hidden_size, intermediate, params_dtype, attrs = self._load_layout
+        for name in _EXPERT_PARAMS:
+            delattr(layer, name)
+        self.create_weights(
+            layer,
+            num_experts,
+            hidden_size,
+            intermediate,
+            params_dtype,
+            alloc_device=device,
+            **attrs,
+        )
+        layer._mxfp4_kernel_layout = False
+
     def process_weights_after_loading(self, layer: Module) -> None:
         from sglang.srt.layers.quantization.utils import reorder_w1w3_to_w3w1
 
@@ -154,8 +240,8 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         w13_w, w13_s = reorder_w1w3_to_w3w1(
             layer.w13_weight.data, layer.w13_weight_scale_inv.data
         )
-        layer.w13_weight = Parameter(w13_w, requires_grad=False)
-        layer.w13_weight_scale_inv = Parameter(w13_s, requires_grad=False)
+        _rebind(layer, "w13_weight", w13_w)
+        _rebind(layer, "w13_weight_scale_inv", w13_s)
 
         log_info_on_rank0(
             logger,
@@ -229,21 +315,24 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                     shuffle_matrix_sf_a(w2_scale[i].view(torch.uint8), epilogue_tile_m)
                 )
 
-        layer.w13_weight = Parameter(torch.stack(g1_w), requires_grad=False)
-        layer.w13_weight_scale_inv = Parameter(
+        self._install_kernel_layout(layer, "w13_weight", torch.stack(g1_w))
+        self._install_kernel_layout(
+            layer,
+            "w13_weight_scale_inv",
             torch.stack(g1_s)
             .view(torch.float8_e4m3fn)
             .reshape(num_experts, w13.shape[1], -1),
-            requires_grad=False,
         )
-        layer.w2_weight = Parameter(torch.stack(g2_w), requires_grad=False)
-        layer.w2_weight_scale_inv = Parameter(
+        self._install_kernel_layout(layer, "w2_weight", torch.stack(g2_w))
+        self._install_kernel_layout(
+            layer,
+            "w2_weight_scale_inv",
             torch.stack(g2_s)
             .view(torch.float8_e4m3fn)
             .reshape(num_experts, w2.shape[1], -1),
-            requires_grad=False,
         )
 
+        layer._mxfp4_kernel_layout = True
         self._register_static_scale_ones(layer)
         torch.cuda.empty_cache()
 

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -103,6 +103,11 @@ class Mxfp4FlashinferTrtllmMoEMethod:
             if swiglu_limit is not None
             else None
         )
+        layer.register_buffer(
+            "_gemm1_clamp_limit_tensor",
+            self._gemm1_clamp_limit_tensor,
+            persistent=False,
+        )
 
     def create_weights(
         self,

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -348,6 +348,9 @@ class SchedulerWeightUpdaterManager:
                         break
                 if success:
                     self._weight_update_loaded = True
+            if recv_req.load_format == "flattened_bucket":
+                # Finish reads from imported CUDA IPC storage before returning.
+                torch.get_device_module().synchronize()
             if success:
                 self.flush_cache_after_weight_update(recv_req)
                 self.record_weight_version_after_update(recv_req.weight_version)

--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -158,14 +158,15 @@ def extract_routed_experts_from_meta_info(data):
 def disable_routed_experts_capture_for_draft(model: Any) -> None:
     """Opt every draft MoE ``TopK`` out of routed-experts (R3) capture.
 
-    Capture is target-only; a draft ``TopK`` must never write the target's
-    process-global buffer. ``HashTopK`` has no ``topk_config`` and never
-    captures, so it is left untouched.
+    Capture is target-only; draft ``TopK`` and ``HashTopK`` modules must never
+    write the target's process-global buffer.
     """
-    # Lazy import: ``layers.moe.topk`` imports ``get_global_experts_capturer``
-    # from this module, so a top-level import here would be circular.
+    # Lazy imports avoid circular dependencies with the capture call sites.
+    from sglang.srt.layers.moe.hash_topk import HashTopK
     from sglang.srt.layers.moe.topk import TopK
 
     for module in model.modules():
         if isinstance(module, TopK):
             module.topk_config.allow_routed_experts_capture = False
+        elif isinstance(module, HashTopK):
+            module.allow_routed_experts_capture = False

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -140,6 +140,13 @@ def test_hash_topk_capture_masks_padded_tokens(monkeypatch):
         topk_module, "get_global_experts_capturer", lambda: FakeCapturer()
     )
 
+    def mask_padded_rows(topk_ids, num_token_non_padded, fill_value=-1):
+        topk_ids[int(num_token_non_padded.item()) :].fill_(fill_value)
+
+    monkeypatch.setattr(
+        topk_module, "_mask_topk_ids_padded_region", mask_padded_rows
+    )
+
     topk = HashTopK(
         topk=2,
         num_experts=8,

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.moe import hash_topk as hash_topk_module
+from sglang.srt.layers.moe import topk as topk_module
 from sglang.srt.layers.moe.hash_topk import HashTopK
 from sglang.srt.layers.moe.topk import (
     StandardTopKOutput,
@@ -94,7 +95,7 @@ def test_hash_topk_captures_logical_expert_ids(monkeypatch):
     monkeypatch.setattr(
         hash_topk_module,
         "capture_routed_experts_if_allowed",
-        lambda allow_capture, layer_id, topk_ids: (
+        lambda allow_capture, layer_id, topk_ids, _num_token_non_padded=None: (
             FakeCapturer().capture(layer_id=layer_id, topk_indices=topk_ids)
             if allow_capture
             else None
@@ -124,6 +125,44 @@ def test_hash_topk_captures_logical_expert_ids(monkeypatch):
     assert torch.equal(
         captured["topk_ids"],
         torch.tensor([[1, 5], [2, 7]], dtype=torch.int32),
+    )
+
+
+def test_hash_topk_capture_masks_padded_tokens(monkeypatch):
+    captured = {}
+
+    class FakeCapturer:
+        def capture(self, *, layer_id, topk_indices):
+            captured["layer_id"] = layer_id
+            captured["topk_ids"] = topk_indices.clone()
+
+    monkeypatch.setattr(
+        topk_module, "get_global_experts_capturer", lambda: FakeCapturer()
+    )
+
+    topk = HashTopK(
+        topk=2,
+        num_experts=8,
+        num_fused_shared_experts=0,
+        vocab_size=2,
+        scoring_func="sqrtsoftplus",
+        layer_id=4,
+    )
+    with torch.no_grad():
+        topk.tid2eid.copy_(torch.tensor([[1, 5], [2, 7]], dtype=torch.int32))
+
+    with hash_topk_module.envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.override(False):
+        topk(
+            hidden_states=torch.empty(2, 4),
+            router_logits=torch.ones(2, 8),
+            input_ids=torch.tensor([0, 1], dtype=torch.int64),
+            num_token_non_padded=torch.tensor(1),
+        )
+
+    assert captured["layer_id"] == 4
+    assert torch.equal(
+        captured["topk_ids"],
+        torch.tensor([[1, 5], [-1, -1]], dtype=torch.int32),
     )
 
 

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -13,6 +13,9 @@ from sglang.srt.layers.moe.topk import (
 from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.state_capturer.routed_experts import (
+    disable_routed_experts_capture_for_draft,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-b-test-cpu")
@@ -78,6 +81,91 @@ def test_hash_topk_remaps_per_rank_fused_shared_slots(monkeypatch):
     assert output.topk_ids.tolist() == [[0, 66, 194], [63, 128, 194]]
     assert torch.allclose(output.topk_weights[:, -1], torch.full((2,), 0.4))
     assert recorded["topk_ids"].tolist() == [[0, 65], [63, 127]]
+
+
+def test_hash_topk_captures_logical_expert_ids(monkeypatch):
+    captured = {}
+
+    class FakeCapturer:
+        def capture(self, *, layer_id, topk_indices):
+            captured["layer_id"] = layer_id
+            captured["topk_ids"] = topk_indices.clone()
+
+    monkeypatch.setattr(
+        hash_topk_module,
+        "capture_routed_experts_if_allowed",
+        lambda allow_capture, layer_id, topk_ids: (
+            FakeCapturer().capture(layer_id=layer_id, topk_indices=topk_ids)
+            if allow_capture
+            else None
+        ),
+    )
+
+    topk = HashTopK(
+        topk=2,
+        num_experts=8,
+        num_fused_shared_experts=0,
+        vocab_size=2,
+        scoring_func="sqrtsoftplus",
+        layer_id=3,
+    )
+    with torch.no_grad():
+        topk.tid2eid.copy_(torch.tensor([[1, 5], [2, 7]], dtype=torch.int32))
+
+    with hash_topk_module.envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.override(False):
+        output = topk(
+            hidden_states=torch.empty(2, 4),
+            router_logits=torch.ones(2, 8),
+            input_ids=torch.tensor([0, 1], dtype=torch.int64),
+        )
+
+    assert output.topk_ids.tolist() == [[1, 5], [2, 7]]
+    assert captured["layer_id"] == 3
+    assert torch.equal(
+        captured["topk_ids"],
+        torch.tensor([[1, 5], [2, 7]], dtype=torch.int32),
+    )
+
+
+def test_hash_topk_capture_can_be_disabled(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        hash_topk_module,
+        "capture_routed_experts_if_allowed",
+        lambda allow_capture, *_args: captured.append(True) if allow_capture else None,
+    )
+
+    topk = HashTopK(
+        topk=2,
+        num_experts=8,
+        num_fused_shared_experts=0,
+        vocab_size=2,
+        layer_id=0,
+    )
+    topk.allow_routed_experts_capture = False
+    with hash_topk_module.envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.override(False):
+        topk(
+            hidden_states=torch.empty(1, 4),
+            router_logits=torch.ones(1, 8),
+            input_ids=torch.tensor([0], dtype=torch.int64),
+        )
+
+    assert captured == []
+
+
+def test_draft_hash_topk_capture_is_disabled():
+    topk = HashTopK(
+        topk=2,
+        num_experts=8,
+        num_fused_shared_experts=0,
+        vocab_size=2,
+        layer_id=0,
+    )
+    model = torch.nn.Sequential(topk)
+
+    disable_routed_experts_capture_for_draft(model)
+
+    assert not topk.allow_routed_experts_capture
 
 
 def test_hash_topk_empty_output_keeps_per_rank_shared_slot(monkeypatch):

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -143,9 +143,7 @@ def test_hash_topk_capture_masks_padded_tokens(monkeypatch):
     def mask_padded_rows(topk_ids, num_token_non_padded, fill_value=-1):
         topk_ids[int(num_token_non_padded.item()) :].fill_(fill_value)
 
-    monkeypatch.setattr(
-        topk_module, "_mask_topk_ids_padded_region", mask_padded_rows
-    )
+    monkeypatch.setattr(topk_module, "_mask_topk_ids_padded_region", mask_padded_rows)
 
     topk = HashTopK(
         topk=2,

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_trtllm_hot_reload.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_trtllm_hot_reload.py
@@ -1,0 +1,122 @@
+"""Online reload contract for the FlashInfer TRT-LLM MXFP4 MoE layout."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.nn import Module
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
+    Mxfp4FlashinferTrtllmMoEMethod,
+)
+from sglang.srt.model_loader.loader import postprocess_weight, restore_weight
+from sglang.srt.utils import is_sm100_supported
+
+if not is_sm100_supported():
+    pytest.skip("FlashInfer TRT-LLM MXFP4 MoE requires SM100+", allow_module_level=True)
+
+
+EXPERT_PARAMS = (
+    "w13_weight",
+    "w2_weight",
+    "w13_weight_scale_inv",
+    "w2_weight_scale_inv",
+)
+NUM_EXPERTS = 2
+HIDDEN_SIZE = 128
+INTERMEDIATE_SIZE = 64
+
+
+class _NoOpFp8:
+    def process_weights_after_loading(self, layer: Module) -> None:
+        pass
+
+
+def _build_layer() -> Module:
+    layer = Module().to("cuda")
+    layer.num_local_experts = NUM_EXPERTS
+    method = Mxfp4FlashinferTrtllmMoEMethod.__new__(Mxfp4FlashinferTrtllmMoEMethod)
+    method._fp8 = _NoOpFp8()
+    method.prefix = "test"
+    method._kernel_layout = {}
+    layer.quant_method = method
+    method.create_weights(
+        layer,
+        NUM_EXPERTS,
+        HIDDEN_SIZE,
+        INTERMEDIATE_SIZE,
+        torch.bfloat16,
+        alloc_device="cuda",
+        weight_loader=lambda *args, **kwargs: None,
+    )
+    return layer
+
+
+def _load_weights(layer: Module, seed: int) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    for name, param in layer.named_parameters():
+        if "scale" in name:
+            encoded = torch.randint(
+                100,
+                140,
+                param.shape,
+                generator=generator,
+                device="cuda",
+                dtype=torch.uint8,
+            )
+            param.data.copy_(encoded.view(torch.float8_e8m0fnu))
+        else:
+            param.data.copy_(
+                torch.randint(
+                    -128,
+                    127,
+                    param.shape,
+                    generator=generator,
+                    device="cuda",
+                    dtype=torch.int8,
+                )
+            )
+
+
+def _layout(layer: Module) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+    return {
+        name: (tuple(param.shape), param.dtype)
+        for name, param in layer.named_parameters()
+    }
+
+
+def test_hot_reload_matches_fresh_load_and_preserves_kernel_addresses():
+    layer = _build_layer()
+    load_layout = _layout(layer)
+
+    _load_weights(layer, seed=0)
+    postprocess_weight(layer, torch.device("cuda"))
+    initial = {name: param.detach().clone() for name, param in layer.named_parameters()}
+    addresses = {name: param.data_ptr() for name, param in layer.named_parameters()}
+
+    reference = _build_layer()
+    _load_weights(reference, seed=1)
+    postprocess_weight(reference, torch.device("cuda"))
+    expected = {
+        name: param.detach().clone() for name, param in reference.named_parameters()
+    }
+
+    restore_weight(layer, torch.device("cuda"))
+    assert _layout(layer) == load_layout
+    for name in EXPERT_PARAMS:
+        assert hasattr(getattr(layer, name), "weight_loader")
+
+    _load_weights(layer, seed=1)
+    postprocess_weight(layer, torch.device("cuda"))
+
+    for name, param in layer.named_parameters():
+        assert param.data_ptr() == addresses[name]
+        assert not torch.equal(initial[name].view(torch.uint8), param.view(torch.uint8))
+        assert torch.equal(expected[name].view(torch.uint8), param.view(torch.uint8))


### PR DESCRIPTION
## Summary

- capture logical expert IDs from DeepSeek V4 HashTopK for R3 replay, while masking CUDA-graph padding and disabling target-model capture from the draft model
- synchronize flattened CUDA IPC weight imports before the RPC returns
- restore packed MXFP4 routed-expert parameters to load layout before online updates and rebuild the TRT-LLM kernel layout afterward
- preserve CUDA graph tensor addresses across repeated repacks and keep the GEMM1 clamp limit valid across memory offload

This is a consolidated, non-stacked PR based directly on the current `sglang-miles` branch.

## Tests

Rebased head:

- `SKIP=no-commit-to-branch uvx pre-commit run --show-diff-on-failure --files <changed-files>`
- `python3 -m py_compile <changed-python-files>`
- `git diff --check origin/sglang-miles...HEAD`

The equivalent pre-rebase changes also passed:

- `python -m pytest -q test/registered/moe/test_hash_topk.py` (7 passed, run in two groups)
- `python -m pytest -vv -s test/registered/unit/layers/quantization/test_mxfp4_flashinfer_trtllm_hot_reload.py` (1 passed on B300)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34090201152](https://github.com/sgl-project/sglang/actions/runs/34090201152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34090201006](https://github.com/sgl-project/sglang/actions/runs/34090201006)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34090201140](https://github.com/sgl-project/sglang/actions/runs/34090201140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->