### PR TITLE
fix: prevent gloo same-group deadlock in prefetch progress check

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1628,7 +1628,20 @@ class HiRadixCache(RadixCache):
 
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:
-            # there is no ongoing prefetch for this request or it has been revoked
+            # This rank has no ongoing prefetch for req_id, but other TP/PP
+            # ranks may. We must still participate in the same all_reduce as
+            # can_terminate_prefetch to avoid a gloo same-group deadlock:
+            # ranks with ongoing block in all_reduce while ranks without
+            # ongoing skip it, causing a permanent hang on the shared
+            # ProcessGroup.
+            #
+            # can_terminate_prefetch does all_reduce for "wait_complete" and
+            # "timeout" policies (using _all_reduce_attn_groups with MAX). We
+            # match that here with a dummy [1, 0] contribution (can_terminate=
+            # False, terminated=0) so the MAX result is unaffected.
+            if self.prefetch_stop_policy in ("wait_complete", "timeout"):
+                dummy = torch.tensor([1, 0], dtype=torch.int)
+                self._all_reduce_attn_groups(dummy, torch.distributed.ReduceOp.MAX)
             return True
 
         last_host_node, prefetch_key, operation = self.ongoing_prefetch[req_id]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1333,6 +1333,20 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:
+            # This rank has no ongoing prefetch for req_id, but other TP/PP
+            # ranks may. We must still participate in the same all_reduce as
+            # can_terminate_prefetch to avoid a gloo same-group deadlock:
+            # ranks with ongoing block in all_reduce while ranks without
+            # ongoing skip it, causing a permanent hang on the shared
+            # ProcessGroup.
+            #
+            # can_terminate_prefetch does all_reduce for "wait_complete" and
+            # "timeout" policies (using _all_reduce_attn_groups with MAX). We
+            # match that here with a dummy [1, 0] contribution (can_terminate=
+            # False, terminated=0) so the MAX result is unaffected.
+            if self.prefetch_stop_policy in ("wait_complete", "timeout"):
+                dummy = torch.tensor([1, 0], dtype=torch.int)
+                self._all_reduce_attn_groups(dummy, torch.distributed.ReduceOp.MAX)
             return True
 
         (


### PR DESCRIPTION
## Problem

When a request's prefetch is not ongoing on some TP/PP ranks but is ongoing on others, `check_prefetch_progress` returns `True` early on the ranks without ongoing prefetch, skipping the `all_reduce` collective. Ranks with ongoing prefetch block waiting in `all_reduce` on the shared gloo `ProcessGroup`, causing a **permanent deadlock**.

## Root Cause

In `check_prefetch_progress`, the early return when `req_id not in self.ongoing_prefetch` skips the `all_reduce` that `can_terminate_prefetch` performs. When different TP/PP ranks have different `ongoing_prefetch` states for the same `req_id` (e.g., due to timing differences in prefetch completion), some ranks enter `all_reduce` and others skip it — a classic collective mismatch on a shared `ProcessGroup`.

## Fix

When `req_id` is not in `ongoing_prefetch`, still participate in the same `all_reduce` pattern with a **dummy contribution** that doesn't affect the result:

- **`unified_radix_cache.py`**: Match `can_terminate_prefetch`'s `all_reduce`, which fires for `"wait_complete"` and `"timeout"` policies using `_all_reduce_attn_groups` with a 2-element tensor `[1-int(can_terminate), int(operation_terminated)]`. The dummy contributes `[1, 0]` (can_terminate=False, terminated=0) so `MAX` is unaffected.

- **`hiradix_cache.py`**: Match the inline `all_reduce` in `can_terminate_prefetch`, same pattern.

## Note for upstream

Upstream's `_can_terminate_prefetch` uses `_all_reduce` (TP+PP sync) while this branch's `can_terminate_prefetch` uses `_all_reduce_attn_groups` (TP only). The dummy **must match whichever function the real `all_reduce` uses** on each code path. When merging into upstream, the dummy should use `_all_reduce` to match upstream's `_can_terminate_prefetch`.

## Testing

This fix was validated on a production 8×MI350X deployment (TP=8) where the deadlock occurred under mixed prefill/prefetch workloads. After the fix, no deadlock was observed over 48+ hours of continuous load testing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34087989137](https://github.com/sgl-project/sglang/actions/runs/34087989137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34087989107](https://github.com/sgl-project/sglang/actions/runs/34087989107)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34087989103](https://github.com/sgl-project/sglang/actions/runs/34087989103)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->