### PR TITLE
fix: use dynamic CU count instead of hardcoded 304 in tilelang DSA kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -44,6 +44,12 @@ elif hasattr(tilelang.PassConfigKey, "TL_ENABLE_FAST_MATH"):
     pass_configs[tilelang.PassConfigKey.TL_ENABLE_FAST_MATH] = False
 
 _is_hip = is_hip()
+
+# Cache the physical CU count for non-gfx95 GPUs.  The previous code
+# hardcoded 304 (MI300X) but gfx942 also includes MI308X with only 80 CUs;
+# using the wrong CU count causes _pick_inner_iter to under- or over-launch
+# waves, hurting throughput or failing to saturate the device.
+_cu_count = torch.cuda.get_device_properties(0).multi_processor_count if _is_hip else 0
 _is_gfx95_supported = is_gfx95_supported()
 _is_fp8_fnuz = is_fp8_fnuz()
 
@@ -1344,7 +1350,7 @@ def tilelang_sparse_fwd(
             if _is_gfx95_supported:
                 block_I, threads, block_per_cu, cu = 64, 256, 2, 256
             else:
-                block_I, threads, block_per_cu, cu = 64, 256, 1, 304
+                block_I, threads, block_per_cu, cu = 64, 256, 1, _cu_count
             ni = topk // block_I
             inner_iter = _pick_inner_iter(q.shape[0], ni, cu, block_per_cu)
             kernel_partial = sparse_mla_fwd_decode_partial_fp8(
@@ -1361,7 +1367,7 @@ def tilelang_sparse_fwd(
             if _is_gfx95_supported:
                 block_I, threads, block_per_cu, cu = 64, 256, 2, 256
             else:
-                block_I, threads, block_per_cu, cu = 32, 128, 1, 304
+                block_I, threads, block_per_cu, cu = 32, 128, 1, _cu_count
             ni = topk // block_I
             inner_iter = _pick_inner_iter(q.shape[0], ni, cu, block_per_cu)
             kernel_partial = sparse_mla_fwd_decode_partial(
@@ -2481,7 +2487,7 @@ def dpsk_v4_fp8_attention_fwd(
     if _is_gfx95_supported:
         block_I, threads, num_stages, block_per_cu, cu = 64, 512, 0, 2, 256
     else:
-        block_I, threads, num_stages, block_per_cu, cu = 32, 128, 1, 1, 304
+        block_I, threads, num_stages, block_per_cu, cu = 32, 128, 1, 1, _cu_count
 
     batch, seq_len, num_heads, _ = q.shape
     # Partial grid is (seq_len * REPLICATE_H * n_groups, batch, kv_group); the


### PR DESCRIPTION
## Problem

tilelang_kernel.py hardcodes `cu = 304` for non-gfx95 GPUs in 3 locations. This is the CU count for MI300X (gfx942, 304 CUs), but gfx942 also includes **MI308X with only 80 CUs**. Using 304 on MI308X causes `_pick_inner_iter` to miscalculate the wave count, hurting throughput or failing to saturate the device.

## Fix

Cache `torch.cuda.get_device_properties(0).multi_processor_count` at module load and use it instead of the hardcoded 304. This is the same pattern already used in other sglang kernels (`tiny_gemm.py`, `sgemm_lora_a.py`, `seg_la.py`, etc.).

The gfx95 branch (`cu = 256`) is left unchanged, as 256 may be a tuned value rather than the physical CU count.

## Testing

Validated on 8×MI308X (gfx942, 80 CUs) where the hardcoded 304 was replaced with the actual CU count. DSA attention kernels correctly launch the right number of waves.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34543109426](https://github.com/sgl-project/sglang/actions/runs/34543109426)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34543109245](https://github.com/sgl-project/sglang/actions/runs/34543109245)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34543109448](https://github.com/sgl-project/sglang/actions/runs/34543109448)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->