### PR TITLE
[AMD][CI] Skip Unsupported Rust TreeCore E2E Test on AMD

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_full.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_full.py
@@ -7,6 +7,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     popen_launch_server,
     terminate_and_kill_process_tree,
     unified_radix_tree_server_env,
@@ -49,6 +50,7 @@ class TestUnifiedFullRadixCache(UnifiedRadixTreeTestMixin, CustomTestCase):
         terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
+@unittest.skipIf(is_in_amd_ci(), "Rust TreeCore is not packaged in AMD CI")
 class TestRustUnifiedFullRadixCache(TestUnifiedFullRadixCache):
     tree_core_backend = "rust"
 


### PR DESCRIPTION
## Motivation

Rust TreeCore production deployment on AMD is explicitly outside the supported scope of #32710, and the ROCm package does not currently include the Rust TreeCore extension. However, `test_unified_radix_cache_kl_full.py` is registered in AMD CI and its Rust subclass is discovered there, causing the AMD shard to enter the source-build path for an unpackaged backend.

This PR does not add Rust TreeCore support on AMD. That requires a separate enablement effort covering ROCm packaging, the pinned Rust toolchain, libtorch compatibility, and AMD E2E validation.

Failure example: https://github.com/sgl-project/sglang/actions/runs/34070685413/job/101587367484

## Modifications


## Accuracy Tests

## Speed Tests and Profiling


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Existing E2E coverage is retained; the skip behavior was checked directly.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable as described above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

This change is intentionally a draft while coordinating with #37303. If this focused PR is preferred, the duplicate AMD skip commit can be dropped from #37303 during its rebase.

cc @Jialin @ispobock @alphabetc1

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34090027865](https://github.com/sgl-project/sglang/actions/runs/34090027865)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34090027684](https://github.com/sgl-project/sglang/actions/runs/34090027684)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34090028014](https://github.com/sgl-project/sglang/actions/runs/34090028014)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->