### PR TITLE
[AMD][CI] Remove obsolete split-dim check from Kimi-K3 prefill test

### DIFF
--- a/test/registered/unit/layers/attention/test_triton_mla_prefill_gfx950.py
+++ b/test/registered/unit/layers/attention/test_triton_mla_prefill_gfx950.py
@@ -3,9 +3,6 @@ import unittest
 import torch
 
 from sglang.kernels.ops.attention.extend_attention import extend_attention_fwd
-from sglang.kernels.ops.attention.extend_attention_split_dim import (
-    can_use_split_dim_absorbed_extend,
-)
 from sglang.srt.environ import envs
 from sglang.srt.utils import get_device, is_gfx95_supported, is_hip
 from sglang.test.ci.ci_register import register_amd_ci
@@ -97,82 +94,6 @@ class TestKimiK3TritonPrefill(unittest.TestCase):
                 )
 
         torch.testing.assert_close(output.float(), reference, rtol=1e-2, atol=1e-2)
-
-    def test_split_dim_dispatch_gates(self):
-        device = get_device()
-        q = torch.empty(1, 12, 576, dtype=torch.bfloat16, device=device)
-        k = torch.empty(1, 1, 576, dtype=torch.bfloat16, device=device)
-        v = torch.empty(1, 1, 512, dtype=torch.bfloat16, device=device)
-        o = torch.empty(1, 12, 512, dtype=torch.bfloat16, device=device)
-        k_buffer = torch.empty(1, 1, 576, dtype=torch.bfloat16, device=device)
-        v_buffer = torch.empty(1, 1, 512, dtype=torch.bfloat16, device=device)
-        kwargs = dict(
-            lse=None,
-            sinks=None,
-            k_scale=1.0,
-            v_scale=1.0,
-            custom_mask=None,
-            is_causal=True,
-            sliding_window_size=-1,
-            logit_cap=0.0,
-            xai_temperature_len=-1,
-            skip_prefix=False,
-            skip_extend=False,
-            page_size=1,
-            score_mod=None,
-            aux_tensors=None,
-        )
-        self.assertTrue(
-            can_use_split_dim_absorbed_extend(q, k, v, o, k_buffer, v_buffer, **kwargs)
-        )
-
-        fp8_k_buffer = k_buffer.to(torch.float8_e4m3fn)
-        fp8_v_buffer = v_buffer.to(torch.float8_e4m3fn)
-        with envs.SGLANG_TRITON_FP8_PREFILL_ATTN.override(False):
-            self.assertFalse(
-                can_use_split_dim_absorbed_extend(
-                    q, k, v, o, fp8_k_buffer, fp8_v_buffer, **kwargs
-                )
-            )
-        with envs.SGLANG_TRITON_FP8_PREFILL_ATTN.override(True):
-            self.assertTrue(
-                can_use_split_dim_absorbed_extend(
-                    q, k, v, o, fp8_k_buffer, fp8_v_buffer, **kwargs
-                )
-            )
-            self.assertTrue(
-                can_use_split_dim_absorbed_extend(
-                    q,
-                    k,
-                    v,
-                    o,
-                    fp8_k_buffer,
-                    fp8_v_buffer,
-                    **{**kwargs, "k_scale": 0.5, "v_scale": 0.25},
-                )
-            )
-
-        for override in (
-            {"page_size": 2},
-            {"logit_cap": 1.0},
-            {"sliding_window_size": 128},
-            {"skip_prefix": True},
-            {"is_causal": False},
-            {"lse": torch.empty(1, 12, dtype=torch.float32, device=device)},
-            {"sinks": torch.empty(12, dtype=torch.float32, device=device)},
-            {"k_scale": 0.5},
-        ):
-            self.assertFalse(
-                can_use_split_dim_absorbed_extend(
-                    q,
-                    k,
-                    v,
-                    o,
-                    k_buffer,
-                    v_buffer,
-                    **{**kwargs, **override},
-                )
-            )
 
     def test_zero_prefix_fp8_flag(self):
         device = get_device()


### PR DESCRIPTION
## Motivation

The MI35x stage-b test fails during collection because `test_triton_mla_prefill_gfx950.py` still imports the deleted `extend_attention_split_dim` module. The dedicated split-dim kernel and its dispatch predicate were removed in `4e2fd9f1e9`; the general `extend_attention_fwd` path now serves these Kimi-K3 shapes. The leftover import prevents all live numerical tests in this file from running.

Failing job: https://github.com/sgl-project/sglang/actions/runs/34070685413/job/101587367463

## Modifications

- Remove the stale import and the dispatch-gate test for the deleted split-dim implementation.
- Keep the three numerical tests for the current `extend_attention_fwd` path: BF16 ragged prefill, zero-prefix FP8 prefill, and absorbed FP8 cached-prefix prefill.

This is a test-only change. It does not change kernels, runtime dispatch, accuracy thresholds, or model behavior.

## Accuracy Tests

No model behavior changes.

<img width="1984" height="1478" alt="image" src="https://github.com/user-attachments/assets/24a681d9-2bb6-41bc-bde0-e4e2e3c5c900" />


## Speed Tests and Profiling

Not applicable. Runtime code is unchanged.

## Checklist

- [x] Format your code according to the [contribution guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add or update tests according to the contribution guide, or explain why not applicable.
- [x] Update documentation according to the contribution guide, or explain why not applicable.
- [x] Provide accuracy and speed benchmark results, or explain why not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34090399165](https://github.com/sgl-project/sglang/actions/runs/34090399165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34090398694](https://github.com/sgl-project/sglang/actions/runs/34090398694)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34090399112](https://github.com/sgl-project/sglang/actions/runs/34090399112)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->