### PR TITLE
[AMD] Restore DeepSeek-V4 DSpark token acceptance

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -483,9 +483,8 @@ class DeepseekV4HipRadixBackend(
         self.speculative_num_steps = speculative_num_steps
         self.speculative_num_draft_tokens: int = get_spec().speculative_num_draft_tokens
         self.is_draft_worker = getattr(model_runner, "is_draft_worker", False)
-        self.is_dspark_draft = (
-            self.is_draft_worker and model_runner.spec_algorithm.is_dspark()
-        )
+        self.is_dspark = model_runner.spec_algorithm.is_dspark()
+        self.is_dspark_draft = self.is_draft_worker and self.is_dspark
         self.target_verify_num_draft_tokens = self.speculative_num_draft_tokens
         if self.is_dspark_draft:
             assert self.speculative_num_draft_tokens is not None
@@ -719,7 +718,7 @@ class DeepseekV4HipRadixBackend(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             compress_gpu_plan=ragged_layout is not None,
             extend_start_loc=extend_start_loc,
-            attach_decode_streams=True,
+            attach_decode_streams=not self.is_dspark,
         )
 
     def make_forward_metadata_from_raw_verify(
@@ -1350,9 +1349,11 @@ class DeepseekV4HipRadixBackend(
         c128_pi = getattr(core_attn_metadata, "c128_page_indices", None)
         c4_pi = getattr(core_attn_metadata, "c4_sparse_page_indices", None)
 
-        # Target-verify runs through the unified_kv DECODE kernel, same path as
-        # decode; its per-token decode streams were built in metadata.
-        verify_as_decode = forward_batch.forward_mode.is_target_verify()
+        # Non-DSpark target-verify runs through the unified_kv DECODE kernel,
+        # same path as decode; its per-token decode streams were built in metadata.
+        verify_as_decode = (
+            forward_batch.forward_mode.is_target_verify() and not self.is_dspark
+        )
         is_decode = forward_batch.forward_mode.is_decode_or_idle() or verify_as_decode
         if is_decode:
             if verify_as_decode:


### PR DESCRIPTION
## What broke

PR #34597 (`34206c00175a`) introduced this regression. Its goal was to speed up MTP/EAGLE by moving target verification from the prefill route to the decode route.

The new check asked only whether a request was in the shared `TARGET_VERIFY` phase. DSpark uses that same phase name for both its target and draft workers, so both DSpark workers were moved to the MTP/EAGLE route by accident.

The target model still corrects rejected draft tokens, so final GSM8K accuracy stayed healthy. However, the changed route made fewer DSpark draft tokens match the target model, reducing average accepted tokens by about 29%:

- Before #34597, Aug 12: 3.805896
- After #34597, Aug 14: 2.695138 to 2.723954

## Fix

Keep both DSpark workers on their previous prefill route and avoid preparing decode-only metadata that they do not use. MTP/EAGLE keep the decode optimization from #34597.

## Validation

A controlled ROCm 7.2.0 test on 8x MI355X restored average accepted tokens from 2.711824 to 3.803670 while accuracy remained healthy.

Focused CI on the exact PR head passed all 3 registered tests on ROCm 10, 7.2.4, and 7.2.0:

https://github.com/sgl-project/sglang/actions/runs/34093280972

## Checklist

- [x] Pre-commit passed
- [x] No user-facing API change

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34093266550](https://github.com/sgl-project/sglang/actions/runs/34093266550)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34093266329](https://github.com/sgl-project/sglang/actions/runs/34093266329)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34093266421](https://github.com/sgl-project/sglang/actions/runs/34093266421)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
