### PR TITLE
[DeepSeek] keep pending q_a_proj/kv_a_proj_with_mqa halves across load_weights calls

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -254,7 +254,18 @@ class DeepseekV2WeightLoaderMixin:
         fuse_qkv_a_proj = hasattr(self.config, "q_lora_rank") and (
             self.config.q_lora_rank is not None
         )
-        cached_a_proj = {} if fuse_qkv_a_proj else None
+        # The q_a_proj / kv_a_proj_with_mqa halves of a layer are fused into one
+        # parameter only once BOTH have been seen. Keep the pending halves on the
+        # model instead of in a per-call dict: online weight updates
+        # (update_weights_from_tensor, RL weight sync) call load_weights in
+        # chunks, and a pair split across two calls would otherwise never be
+        # written -- leaving that layer's fused projection at its initial value.
+        if fuse_qkv_a_proj:
+            if not hasattr(self, "_pending_fused_a_proj"):
+                self._pending_fused_a_proj = {}
+            cached_a_proj = self._pending_fused_a_proj
+        else:
+            cached_a_proj = None
 
         pending_indexer_wk: Dict[str, Dict[str, torch.Tensor]] = {}
 
@@ -412,9 +423,21 @@ class DeepseekV2WeightLoaderMixin:
                         if fuse_qkv_a_proj and (
                             "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                         ):
-                            cached_a_proj[name] = _clone_if_runai_streamed_tensor(
-                                loaded_weight
-                            )
+                            new_half = _clone_if_runai_streamed_tensor(loaded_weight)
+                            old_half = cached_a_proj.get(name)
+                            if (
+                                old_half is not None
+                                and old_half.shape == new_half.shape
+                                and new_half.is_floating_point()
+                            ):
+                                # A half that arrives again while its partner is
+                                # still pending is a sparse (NaN-masked) delta:
+                                # merge it into the pending copy instead of
+                                # overwriting, so no changed positions are lost.
+                                new_half = torch.where(
+                                    torch.isnan(new_half), old_half, new_half
+                                )
+                            cached_a_proj[name] = new_half
                             q_a_proj_name = (
                                 name
                                 if "q_a_proj" in name


### PR DESCRIPTION
## Motivation

DeepseekV2WeightLoaderMixin.do_load_weights fuses q_a_proj and kv_a_proj_with_mqa into fused_qkv_a_proj_with_mqa, but it keeps the not-yet- paired half in a dict local to the call: the fused parameter is written only when both halves of a layer arrive in the SAME load_weights call. That holds for a from-disk load (one call, all tensors) but not for online weight updates -- update_weights_from_tensor / RL weight sync (e.g. verl's delta_sharded engine) call load_weights in bounded chunks, so any layer whose pair straddled a chunk boundary silently kept its dummy-initialized attention projection. With load_format=dummy this produced a partly random model: coherent-looking but wrong generations, and trainer-vs-rollout log-prob KL ~1.5 instead of ~0.001 (DeepSeek-V3 671B, sglang 0.5.16, 2386 chunks per full sync).

## Modifications

Fix: keep the pending halves on the model object so a pair completes whenever its second half arrives, and when a still-unpaired half arrives again as a sparse (NaN-masked) delta, merge it into the pending copy instead of overwriting it so no changed positions are lost. No-op for models without q_lora_rank; from-disk loading is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34099989206](https://github.com/sgl-project/sglang/actions/runs/34099989206)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34099988949](https://github.com/sgl-project/sglang/actions/runs/34099988949)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34099989220](https://github.com/sgl-project/sglang/actions/runs/34099989220)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->